### PR TITLE
Avoid double text edits when renaming mod declaration

### DIFF
--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -305,7 +305,6 @@ impl ModuleDef {
             ModuleDef::Module(it) => it.name(db),
             ModuleDef::Const(it) => it.name(db),
             ModuleDef::Static(it) => it.name(db),
-
             ModuleDef::BuiltinType(it) => Some(it.name()),
         }
     }

--- a/crates/ide/src/references/rename.rs
+++ b/crates/ide/src/references/rename.rs
@@ -94,6 +94,7 @@ pub(crate) fn rename_with_semantics(
     }
 }
 
+/// Called by the client when it is about to rename a file.
 pub(crate) fn will_rename_file(
     db: &RootDatabase,
     file_id: FileId,

--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -395,6 +395,9 @@ impl Config {
     pub fn work_done_progress(&self) -> bool {
         try_or!(self.caps.window.as_ref()?.work_done_progress?, false)
     }
+    pub fn will_rename(&self) -> bool {
+        try_or!(self.caps.workspace.as_ref()?.file_operations.as_ref()?.will_rename?, false)
+    }
     pub fn code_action_resolve(&self) -> bool {
         try_or!(
             self.caps


### PR DESCRIPTION
Closes https://github.com/rust-analyzer/rust-analyzer/issues/7916

See https://github.com/microsoft/vscode-languageserver-node/issues/752 for context