### PR TITLE
fix: Fix fn proc macro input again

### DIFF
--- a/crates/hir_expand/src/lib.rs
+++ b/crates/hir_expand/src/lib.rs
@@ -272,6 +272,10 @@ impl MacroDefId {
         };
         Either::Left(*id)
     }
+
+    pub fn is_proc_macro(&self) -> bool {
+        matches!(self.kind, MacroDefKind::ProcMacro(..))
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]


### PR DESCRIPTION
https://github.com/rust-analyzer/rust-analyzer/pull/8806 broke the `TokenMap`, so none of the tokens in fn-like proc macro inputs could be related to the output (presumably this is because of the `clone_for_update`).

This PR instead just sets `delimiter = None;` after the `TokenMap` and `Subtree` are already created.

We should probably have more tests for fn-like proc macros, and consider making the behavior consistent with MBE (which *require* the delimiters to be present).

bors r+