### PR TITLE
fix: Fix multiple derives in one attribute not expanding all in expand_macro

### DIFF
--- a/crates/hir/src/semantics/source_to_def.rs
+++ b/crates/hir/src/semantics/source_to_def.rs
@@ -246,9 +246,9 @@ impl SourceToDefCtx<'_, '_> {
         &mut self,
         item: InFile<&ast::Item>,
         src: InFile<ast::Attr>,
-    ) -> Option<MacroCallId> {
+    ) -> Option<&[MacroCallId]> {
         let map = self.dyn_map(item)?;
-        map[keys::DERIVE_MACRO].get(&src).copied()
+        map[keys::DERIVE_MACRO].get(&src).map(AsRef::as_ref)
     }
 
     fn to_def<Ast: AstNode + 'static, ID: Copy + 'static>(

--- a/crates/hir_def/src/item_scope.rs
+++ b/crates/hir_def/src/item_scope.rs
@@ -195,8 +195,8 @@ impl ItemScope {
 
     pub(crate) fn derive_macro_invocs(
         &self,
-    ) -> impl Iterator<Item = (AstId<ast::Item>, (AttrId, MacroCallId))> + '_ {
-        self.derive_macros.iter().flat_map(|(k, v)| v.iter().map(move |v| (*k, *v)))
+    ) -> impl Iterator<Item = (AstId<ast::Item>, &[(AttrId, MacroCallId)])> + '_ {
+        self.derive_macros.iter().map(|(k, v)| (*k, v.as_ref()))
     }
 
     pub(crate) fn unnamed_trait_vis(&self, tr: TraitId) -> Option<Visibility> {

--- a/crates/hir_def/src/keys.rs
+++ b/crates/hir_def/src/keys.rs
@@ -33,7 +33,7 @@ pub const CONST_PARAM: Key<ast::ConstParam, ConstParamId> = Key::new();
 
 pub const MACRO: Key<ast::MacroCall, MacroDefId> = Key::new();
 pub const ATTR_MACRO: Key<ast::Item, MacroCallId> = Key::new();
-pub const DERIVE_MACRO: Key<ast::Attr, MacroCallId> = Key::new();
+pub const DERIVE_MACRO: Key<ast::Attr, Box<[MacroCallId]>> = Key::new();
 
 /// XXX: AST Nodes and SyntaxNodes have identity equality semantics: nodes are
 /// equal if they point to exactly the same object.


### PR DESCRIPTION
It's probably better to only expand the exact derive the cursor is on(if possible) instead of all derives in the attribute the cursor is one.
follow up to #10029
bors r+