### PR TITLE
fix: Don't use fake text range in original node search as is in completions

### DIFF
--- a/crates/ide_completion/src/patterns.rs
+++ b/crates/ide_completion/src/patterns.rs
@@ -285,6 +285,7 @@ fn maximize_name_ref(name_ref: &ast::NameRef) -> SyntaxNode {
 }
 
 fn find_node_with_range<N: AstNode>(syntax: &SyntaxNode, range: TextRange) -> Option<N> {
+    let range = syntax.text_range().intersect(range)?;
     syntax.covering_element(range).ancestors().find_map(N::cast)
 }
 

--- a/crates/ide_completion/src/tests.rs
+++ b/crates/ide_completion/src/tests.rs
@@ -75,13 +75,13 @@ pub(crate) const TEST_CONFIG: CompletionConfig = CompletionConfig {
     },
 };
 
-pub(crate) fn completion_list(code: &str) -> String {
-    completion_list_with_config(TEST_CONFIG, code)
+pub(crate) fn completion_list(ra_fixture: &str) -> String {
+    completion_list_with_config(TEST_CONFIG, ra_fixture)
 }
 
-fn completion_list_with_config(config: CompletionConfig, code: &str) -> String {
+fn completion_list_with_config(config: CompletionConfig, ra_fixture: &str) -> String {
     // filter out all but one builtintype completion for smaller test outputs
-    let items = get_all_items(config, code);
+    let items = get_all_items(config, ra_fixture);
     let mut bt_seen = false;
     let items = items
         .into_iter()
@@ -226,4 +226,27 @@ fn check_no_completion(ra_fixture: &str) {
 fn test_no_completions_required() {
     cov_mark::check!(no_completion_required);
     check_no_completion(r#"fn foo() { for i i$0 }"#);
+}
+
+#[test]
+fn regression_10042() {
+    completion_list(
+        r#"
+macro_rules! preset {
+    ($($x:ident)&&*) => {
+        {
+            let mut v = Vec::new();
+            $(
+                v.push($x.into());
+            )*
+            v
+        }
+    };
+}
+
+fn foo() {
+    preset!(foo$0);
+}
+"#,
+    );
 }


### PR DESCRIPTION
Since we insert some extra characters for the fake file the corresponding fake range can overshoot the end of the original node in some cases, this mainly can happen in macro expanded files.

Note that this range fetching approach in general is brittle and fails with macros like the one in this test(the code just assumed our insertion would not affect the text ranges prior to our insertion).
Fixes https://github.com/rust-analyzer/rust-analyzer/issues/10042
bors r+