### PR TITLE
Add commeent

### DIFF
--- a/crates/syntax/src/syntax_node.rs
+++ b/crates/syntax/src/syntax_node.rs
@@ -47,7 +47,7 @@ impl SyntaxTreeBuilder {
 
     pub fn finish(self) -> Parse<SyntaxNode> {
         let (green, errors) = self.finish_raw();
-        // NOTE Why you're disabling assertions.
+        // NOTE Why disabling assertions.
         // ref: https://github.com/rust-analyzer/rust-analyzer/pull/10357
         if cfg!(debug_assertions) && false {
             let node = SyntaxNode::new_root(green.clone());


### PR DESCRIPTION
## Why


This code looks logic-bug ...


https://github.com/rust-analyzer/rust-analyzer/blob/ce86534e1cb22685e83c3f91ea89025edbfcbc98/crates/syntax/src/syntax_node.rs#L50


However, this code has been intentionally disabled.
It's a good idea to write a comment

ref: https://github.com/rust-analyzer/rust-analyzer/pull/10357

## What

- I added comment