### PR TITLE
fix: make signature info response conform to spec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -863,9 +863,9 @@ dependencies = [
 
 [[package]]
 name = "lsp-types"
-version = "0.90.0"
+version = "0.90.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7404037aab080771c90b0a499836d9d8a10336ecd07badf969567b65c6d51a1"
+checksum = "6f3734ab1d7d157fc0c45110e06b587c31cd82bea2ccfd6b563cbff0aaeeb1d3"
 dependencies = [
  "bitflags",
  "serde",

--- a/crates/rust-analyzer/Cargo.toml
+++ b/crates/rust-analyzer/Cargo.toml
@@ -22,7 +22,7 @@ crossbeam-channel = "0.5.0"
 dissimilar = "1.0.2"
 itertools = "0.10.0"
 jod-thread = "0.1.0"
-lsp-types = { version = "0.90.0", features = ["proposed"] }
+lsp-types = { version = "0.90.1", features = ["proposed"] }
 parking_lot = "0.11.0"
 xflags = "0.2.1"
 oorandom = "11.1.2"

--- a/crates/rust-analyzer/src/to_proto.rs
+++ b/crates/rust-analyzer/src/to_proto.rs
@@ -399,7 +399,7 @@ pub(crate) fn signature_help(
     };
     lsp_types::SignatureHelp {
         signatures: vec![signature],
-        active_signature: None,
+        active_signature: Some(0),
         active_parameter,
     }
 }


### PR DESCRIPTION
This addreses https://github.com/rust-analyzer/rust-analyzer/issues/10464.

This patch picks up `lsp-types` 0.90.1, which serialises the `SignatureInformation` and `ParameterInformation` with the right casing. It also adds `activeSignature` field as part of the top-level signature response. It keeps `activeParameter` at the top-level for backwards compatibility.