### PR TITLE
minor: Rename `descend_into_macros` Function per FIXME comment

### DIFF
--- a/crates/hir/src/semantics.rs
+++ b/crates/hir/src/semantics.rs
@@ -175,13 +175,11 @@ impl<'db, DB: HirDatabase> Semantics<'db, DB> {
         self.imp.speculative_expand_attr(actual_macro_call, speculative_args, token_to_map)
     }
 
-    // FIXME: Rename to descend_into_macros_single
-    pub fn descend_into_macros(&self, token: SyntaxToken) -> SyntaxToken {
+    pub fn descend_into_macros_single(&self, token: SyntaxToken) -> SyntaxToken {
         self.imp.descend_into_macros(token).pop().unwrap()
     }
 
-    // FIXME: Rename to descend_into_macros
-    pub fn descend_into_macros_many(&self, token: SyntaxToken) -> SmallVec<[SyntaxToken; 1]> {
+    pub fn descend_into_macros(&self, token: SyntaxToken) -> SmallVec<[SyntaxToken; 1]> {
         self.imp.descend_into_macros(token)
     }
 

--- a/crates/ide/src/call_hierarchy.rs
+++ b/crates/ide/src/call_hierarchy.rs
@@ -90,7 +90,7 @@ pub(crate) fn outgoing_calls(db: &RootDatabase, position: FilePosition) -> Optio
     })?;
     let mut calls = CallLocations::default();
 
-    sema.descend_into_macros_many(token)
+    sema.descend_into_macros(token)
         .into_iter()
         .filter_map(|it| it.ancestors().nth(1).and_then(ast::Item::cast))
         .filter_map(|item| match item {

--- a/crates/ide/src/doc_links.rs
+++ b/crates/ide/src/doc_links.rs
@@ -124,7 +124,7 @@ pub(crate) fn external_docs(
         kind if kind.is_trivia() => 0,
         _ => 1,
     })?;
-    let token = sema.descend_into_macros(token);
+    let token = sema.descend_into_macros_single(token);
 
     let node = token.parent()?;
     let definition = match_ast! {
@@ -254,7 +254,7 @@ impl DocCommentToken {
         let original_start = doc_token.text_range().start();
         let relative_comment_offset = offset - original_start - prefix_len;
 
-        sema.descend_into_macros_many(doc_token).into_iter().find_map(|t| {
+        sema.descend_into_macros(doc_token).into_iter().find_map(|t| {
             let (node, descended_prefix_len) = match_ast! {
                 match t {
                     ast::Comment(comment) => (t.parent()?, TextSize::try_from(comment.prefix().len()).ok()?),

--- a/crates/ide/src/expand_macro.rs
+++ b/crates/ide/src/expand_macro.rs
@@ -32,7 +32,7 @@ pub(crate) fn expand_macro(db: &RootDatabase, position: FilePosition) -> Option<
         _ => 0,
     })?;
 
-    let descended = sema.descend_into_macros(tok.clone());
+    let descended = sema.descend_into_macros_single(tok.clone());
     if let Some(attr) = descended.ancestors().find_map(ast::Attr::cast) {
         if let Some((path, tt)) = attr.as_simple_call() {
             if path == "derive" {

--- a/crates/ide/src/extend_selection.rs
+++ b/crates/ide/src/extend_selection.rs
@@ -142,8 +142,8 @@ fn extend_tokens_from_range(
 
     // compute original mapped token range
     let extended = {
-        let fst_expanded = sema.descend_into_macros(first_token.clone());
-        let lst_expanded = sema.descend_into_macros(last_token.clone());
+        let fst_expanded = sema.descend_into_macros_single(first_token.clone());
+        let lst_expanded = sema.descend_into_macros_single(last_token.clone());
         let mut lca =
             algo::least_common_ancestor(&fst_expanded.parent()?, &lst_expanded.parent()?)?;
         lca = shallowest_node(&lca);
@@ -155,7 +155,7 @@ fn extend_tokens_from_range(
 
     // Compute parent node range
     let validate = |token: &SyntaxToken| -> bool {
-        let expanded = sema.descend_into_macros(token.clone());
+        let expanded = sema.descend_into_macros_single(token.clone());
         let parent = match expanded.parent() {
             Some(it) => it,
             None => return false,

--- a/crates/ide/src/goto_declaration.rs
+++ b/crates/ide/src/goto_declaration.rs
@@ -19,7 +19,7 @@ pub(crate) fn goto_declaration(
     let original_token = file
         .token_at_offset(position.offset)
         .find(|it| matches!(it.kind(), IDENT | T![self] | T![super] | T![crate]))?;
-    let token = sema.descend_into_macros(original_token.clone());
+    let token = sema.descend_into_macros_single(original_token.clone());
     let parent = token.parent()?;
     let def = match_ast! {
         match parent {

--- a/crates/ide/src/goto_definition.rs
+++ b/crates/ide/src/goto_definition.rs
@@ -43,7 +43,7 @@ pub(crate) fn goto_definition(
         });
     }
     let navs = sema
-        .descend_into_macros_many(original_token.clone())
+        .descend_into_macros(original_token.clone())
         .into_iter()
         .filter_map(|token| {
             let parent = token.parent()?;

--- a/crates/ide/src/goto_implementation.rs
+++ b/crates/ide/src/goto_implementation.rs
@@ -35,7 +35,7 @@ pub(crate) fn goto_implementation(
         })?;
     let range = original_token.text_range();
     let navs =
-        sema.descend_into_macros_many(original_token)
+        sema.descend_into_macros(original_token)
             .into_iter()
             .filter_map(|token| token.parent().and_then(ast::NameLike::cast))
             .filter_map(|node| {

--- a/crates/ide/src/goto_type_definition.rs
+++ b/crates/ide/src/goto_type_definition.rs
@@ -27,7 +27,7 @@ pub(crate) fn goto_type_definition(
             kind if kind.is_trivia() => 0,
             _ => 1,
         })?;
-    let token: SyntaxToken = sema.descend_into_macros(token);
+    let token: SyntaxToken = sema.descend_into_macros_single(token);
 
     let (ty, node) = sema.token_ancestors_with_macros(token).find_map(|node| {
         let ty = match_ast! {

--- a/crates/ide/src/hover.rs
+++ b/crates/ide/src/hover.rs
@@ -116,7 +116,7 @@ pub(crate) fn hover(
         });
     }
 
-    let descended = sema.descend_into_macros_many(original_token.clone());
+    let descended = sema.descend_into_macros(original_token.clone());
 
     // FIXME: Definition should include known lints and the like instead of having this special case here
     if let Some(res) = descended.iter().find_map(|token| {

--- a/crates/ide/src/runnables.rs
+++ b/crates/ide/src/runnables.rs
@@ -233,7 +233,7 @@ fn find_related_tests(
             // create flattened vec of tokens
             let tokens = refs.iter().flat_map(|(range, _)| {
                 match file.token_at_offset(range.start()).next() {
-                    Some(token) => sema.descend_into_macros_many(token),
+                    Some(token) => sema.descend_into_macros(token),
                     None => Default::default(),
                 }
             });

--- a/crates/ide/src/static_index.rs
+++ b/crates/ide/src/static_index.rs
@@ -162,7 +162,7 @@ impl StaticIndex<'_> {
 }
 
 fn get_definition(sema: &Semantics<RootDatabase>, token: SyntaxToken) -> Option<Definition> {
-    for token in sema.descend_into_macros_many(token) {
+    for token in sema.descend_into_macros(token) {
         let def = Definition::from_token(&sema, &token);
         if let [x] = def.as_slice() {
             return Some(*x);

--- a/crates/ide/src/syntax_highlighting.rs
+++ b/crates/ide/src/syntax_highlighting.rs
@@ -303,7 +303,7 @@ fn traverse(
                 Some(it) => it,
                 _ => continue,
             };
-            let token = sema.descend_into_macros(token);
+            let token = sema.descend_into_macros_single(token);
             match token.parent() {
                 Some(parent) => {
                     // We only care Name and Name_ref

--- a/crates/ide_assists/src/handlers/extract_function.rs
+++ b/crates/ide_assists/src/handlers/extract_function.rs
@@ -623,7 +623,7 @@ impl FunctionBody {
                         .children_with_tokens()
                         .flat_map(SyntaxElement::into_token)
                         .filter(|it| it.kind() == SyntaxKind::IDENT)
-                        .flat_map(|t| sema.descend_into_macros_many(t))
+                        .flat_map(|t| sema.descend_into_macros(t))
                         .for_each(|t| cb(t.parent().and_then(ast::NameRef::cast)));
                 }
             }

--- a/crates/ide_completion/src/context.rs
+++ b/crates/ide_completion/src/context.rs
@@ -138,7 +138,7 @@ impl<'a> CompletionContext<'a> {
 
         let original_token =
             original_file.syntax().token_at_offset(position.offset).left_biased()?;
-        let token = sema.descend_into_macros(original_token.clone());
+        let token = sema.descend_into_macros_single(original_token.clone());
         let scope = sema.scope_at_offset(&token, position.offset);
         let krate = scope.krate();
         let mut locals = vec![];

--- a/crates/ide_db/src/call_info.rs
+++ b/crates/ide_db/src/call_info.rs
@@ -52,7 +52,7 @@ pub fn call_info(db: &RootDatabase, position: FilePosition) -> Option<CallInfo> 
         // if the cursor is sandwiched between two space tokens and the call is unclosed
         // this prevents us from leaving the CallExpression
         .and_then(|tok| algo::skip_trivia_token(tok, Direction::Prev))?;
-    let token = sema.descend_into_macros(token);
+    let token = sema.descend_into_macros_single(token);
 
     let (callable, active_parameter) = call_info_impl(&sema, token)?;
 


### PR DESCRIPTION
This renames `descend_into_macros` to  `descend_into_macros_single` and `descend_into_macros_many` into `descend_into_macros`.
 However, this does not touch a function in `SemanticsImpl` of same name.

I was prompted to do this per a FIXME comment, which is removed in this PR.