### PR TITLE
Fix partialord codegen take 2

### DIFF
--- a/crates/ide_assists/src/handlers/replace_derive_with_manual_impl.rs
+++ b/crates/ide_assists/src/handlers/replace_derive_with_manual_impl.rs
@@ -723,11 +723,11 @@ struct Foo {
 impl PartialOrd for Foo {
     $0fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
         match self.bin.partial_cmp(&other.bin) {
-            Some(core::cmp::Ordering::Eq) => {}
+            Some(core::cmp::Ordering::Equal) => {}
             ord => return ord,
         }
         match self.bar.partial_cmp(&other.bar) {
-            Some(core::cmp::Ordering::Eq) => {}
+            Some(core::cmp::Ordering::Equal) => {}
             ord => return ord,
         }
         self.baz.partial_cmp(&other.baz)
@@ -752,11 +752,11 @@ struct Foo(usize, usize, usize);
 impl PartialOrd for Foo {
     $0fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
         match self.0.partial_cmp(&other.0) {
-            Some(core::cmp::Ordering::Eq) => {}
+            Some(core::cmp::Ordering::Equal) => {}
             ord => return ord,
         }
         match self.1.partial_cmp(&other.1) {
-            Some(core::cmp::Ordering::Eq) => {}
+            Some(core::cmp::Ordering::Equal) => {}
             ord => return ord,
         }
         self.2.partial_cmp(&other.2)

--- a/crates/ide_assists/src/utils/gen_trait_fn_body.rs
+++ b/crates/ide_assists/src/utils/gen_trait_fn_body.rs
@@ -578,7 +578,7 @@ fn gen_partial_ord(adt: &ast::Adt, func: &ast::Fn) -> Option<()> {
         let mut arms = vec![];
 
         let variant_name =
-            make::path_pat(make::ext::path_from_idents(["core", "cmp", "Ordering", "Eq"])?);
+            make::path_pat(make::ext::path_from_idents(["core", "cmp", "Ordering", "Equal"])?);
         let lhs = make::tuple_struct_pat(make::ext::path_from_idents(["Some"])?, [variant_name]);
         arms.push(make::match_arm(Some(lhs.into()), None, make::expr_empty_block()));
 


### PR DESCRIPTION
Fixes https://github.com/rust-analyzer/rust-analyzer/issues/10576. This reverts "generate `PartialOrd` to our previous match-based design, and in turn uses that to correctly take references for multi-value comparisons. This is a bit more verbose, but it should be more readable and easier to edit by end-users than multiple nested layers of borrows. I also manually verified every example in the Rust playground to ensure it works. Thanks!

cc/ @WaffleLapkin 