### PR TITLE
Fix: expand unused glob import into `{}`

### DIFF
--- a/crates/ide_assists/src/handlers/expand_glob_import.rs
+++ b/crates/ide_assists/src/handlers/expand_glob_import.rs
@@ -327,7 +327,6 @@ fn qux() {}
         )
     }
 
-
     #[test]
     fn expanding_glob_import_with_existing_explicit_names() {
         check_assist(


### PR DESCRIPTION
close #10524 

I think the second `expand into {}` behavior is genuinely better. (maybe this should been labeled with good first issue xd)