### PR TITLE
fix: Fix standard library doclinks not going to the correct page

### DIFF
--- a/crates/base_db/src/input.rs
+++ b/crates/base_db/src/input.rs
@@ -120,6 +120,15 @@ pub struct CrateDisplayName {
     canonical_name: String,
 }
 
+impl CrateDisplayName {
+    pub fn canonical_name(&self) -> &str {
+        &self.canonical_name
+    }
+    pub fn crate_name(&self) -> &CrateName {
+        &self.crate_name
+    }
+}
+
 impl From<CrateName> for CrateDisplayName {
     fn from(crate_name: CrateName) -> CrateDisplayName {
         let canonical_name = crate_name.to_string();

--- a/crates/ide/src/hover/tests.rs
+++ b/crates/ide/src/hover/tests.rs
@@ -4125,20 +4125,20 @@ foo_macro!(
 );
 "#,
         expect![[r#"
-                *[`Foo`]*
+            *[`Foo`]*
 
-                ```rust
-                test
-                ```
+            ```rust
+            test
+            ```
 
-                ```rust
-                pub struct Foo
-                ```
+            ```rust
+            pub struct Foo
+            ```
 
-                ---
+            ---
 
-                Doc comment for [`Foo`](https://docs.rs/test/*/test/struct.Foo.html)
-            "#]],
+            Doc comment for [`Foo`](https://doc.rust-lang.org/nightly/test/struct.Foo.html)
+        "#]],
     );
 }
 
@@ -4150,19 +4150,19 @@ fn hover_intra_in_attr() {
 pub struct Foo;
 "#,
         expect![[r#"
-                *[`Foo`]*
+            *[`Foo`]*
 
-                ```rust
-                test
-                ```
+            ```rust
+            test
+            ```
 
-                ```rust
-                pub struct Foo
-                ```
+            ```rust
+            pub struct Foo
+            ```
 
-                ---
+            ---
 
-                Doc comment for [`Foo`](https://docs.rs/test/*/test/struct.Foo.html)
-            "#]],
+            Doc comment for [`Foo`](https://doc.rust-lang.org/nightly/test/struct.Foo.html)
+        "#]],
     );
 }


### PR DESCRIPTION
Fixes https://github.com/rust-analyzer/rust-analyzer/issues/10082
bors r+