### PR TITLE
minor: Make some functions non-generic

### DIFF
--- a/crates/hir_def/src/item_tree/lower.rs
+++ b/crates/hir_def/src/item_tree/lower.rs
@@ -645,7 +645,7 @@ impl<'a> Ctx<'a> {
     fn lower_generic_params_and_inner_items(
         &mut self,
         owner: GenericsOwner<'_>,
-        node: &impl ast::HasGenericParams,
+        node: &dyn ast::HasGenericParams,
     ) -> Interned<GenericParams> {
         // Generics are part of item headers and may contain inner items we need to collect.
         if let Some(params) = node.generic_param_list() {
@@ -661,7 +661,7 @@ impl<'a> Ctx<'a> {
     fn lower_generic_params(
         &mut self,
         owner: GenericsOwner<'_>,
-        node: &impl ast::HasGenericParams,
+        node: &dyn ast::HasGenericParams,
     ) -> Interned<GenericParams> {
         let mut generics = GenericParams::default();
         match owner {
@@ -697,7 +697,7 @@ impl<'a> Ctx<'a> {
         Interned::new(generics)
     }
 
-    fn lower_type_bounds(&mut self, node: &impl ast::HasTypeBounds) -> Vec<Interned<TypeBound>> {
+    fn lower_type_bounds(&mut self, node: &dyn ast::HasTypeBounds) -> Vec<Interned<TypeBound>> {
         match node.type_bound_list() {
             Some(bound_list) => bound_list
                 .bounds()
@@ -707,7 +707,7 @@ impl<'a> Ctx<'a> {
         }
     }
 
-    fn lower_visibility(&mut self, item: &impl ast::HasVisibility) -> RawVisibilityId {
+    fn lower_visibility(&mut self, item: &dyn ast::HasVisibility) -> RawVisibilityId {
         let vis = match self.forced_visibility {
             Some(vis) => return vis,
             None => RawVisibility::from_ast_with_hygiene(self.db, item.visibility(), &self.hygiene),

--- a/crates/hir_ty/src/infer/expr.rs
+++ b/crates/hir_ty/src/infer/expr.rs
@@ -1037,7 +1037,7 @@ impl<'a> InferenceContext<'a> {
         if let Some(expected_ty) = expected_output.to_option(&mut self.table) {
             self.table.fudge_inference(|table| {
                 if table.try_unify(&expected_ty, &output).is_ok() {
-                    table.resolve_with_fallback(inputs, |var, kind, _, _| match kind {
+                    table.resolve_with_fallback(inputs, &|var, kind, _, _| match kind {
                         chalk_ir::VariableKind::Ty(tk) => var.to_ty(&Interner, tk).cast(&Interner),
                         chalk_ir::VariableKind::Lifetime => {
                             var.to_lifetime(&Interner).cast(&Interner)

--- a/crates/hir_ty/src/infer/unify.rs
+++ b/crates/hir_ty/src/infer/unify.rs
@@ -128,7 +128,7 @@ pub(crate) fn unify(
     Some(Substitution::from_iter(
         &Interner,
         vars.iter(&Interner)
-            .map(|v| table.resolve_with_fallback(v.assert_ty_ref(&Interner).clone(), fallback)),
+            .map(|v| table.resolve_with_fallback(v.assert_ty_ref(&Interner).clone(), &fallback)),
     ))
 }
 
@@ -291,7 +291,7 @@ impl<'a> InferenceTable<'a> {
     pub(crate) fn resolve_with_fallback<T>(
         &mut self,
         t: T,
-        fallback: impl Fn(InferenceVar, VariableKind, GenericArg, DebruijnIndex) -> GenericArg,
+        fallback: &dyn Fn(InferenceVar, VariableKind, GenericArg, DebruijnIndex) -> GenericArg,
     ) -> T::Result
     where
         T: HasInterner<Interner = Interner> + Fold<Interner>,
@@ -303,7 +303,7 @@ impl<'a> InferenceTable<'a> {
         &mut self,
         var_stack: &mut Vec<InferenceVar>,
         t: T,
-        fallback: &impl Fn(InferenceVar, VariableKind, GenericArg, DebruijnIndex) -> GenericArg,
+        fallback: &dyn Fn(InferenceVar, VariableKind, GenericArg, DebruijnIndex) -> GenericArg,
     ) -> T::Result
     where
         T: HasInterner<Interner = Interner> + Fold<Interner>,
@@ -319,7 +319,7 @@ impl<'a> InferenceTable<'a> {
     where
         T: HasInterner<Interner = Interner> + Fold<Interner>,
     {
-        self.resolve_with_fallback(t, |_, _, d, _| d)
+        self.resolve_with_fallback(t, &|_, _, d, _| d)
     }
 
     /// Unify two types and register new trait goals that arise from that.


### PR DESCRIPTION
This reduces `text` size by 10192 bytes (0.064% :cry:), with no apparent change in performance.