### PR TITLE
fix: Don't resolve attributes to non attribute macros

### DIFF
--- a/crates/hir_def/src/body.rs
+++ b/crates/hir_def/src/body.rs
@@ -54,10 +54,10 @@ pub struct Expander {
 }
 
 #[cfg(test)]
-const EXPANSION_RECURSION_LIMIT: Limit = Limit::new(32);
+static EXPANSION_RECURSION_LIMIT: Limit = Limit::new(32);
 
 #[cfg(not(test))]
-const EXPANSION_RECURSION_LIMIT: Limit = Limit::new(128);
+static EXPANSION_RECURSION_LIMIT: Limit = Limit::new(128);
 
 impl CfgExpander {
     pub(crate) fn new(

--- a/crates/hir_def/src/lib.rs
+++ b/crates/hir_def/src/lib.rs
@@ -779,6 +779,7 @@ fn attr_macro_as_call_id(
     resolver: impl Fn(path::ModPath) -> Option<MacroDefId>,
 ) -> Result<MacroCallId, UnresolvedMacro> {
     let def: MacroDefId = resolver(item_attr.path.clone())
+        .filter(MacroDefId::is_attribute)
         .ok_or_else(|| UnresolvedMacro { path: item_attr.path.clone() })?;
     let last_segment = item_attr
         .path

--- a/crates/hir_def/src/macro_expansion_tests/mbe.rs
+++ b/crates/hir_def/src/macro_expansion_tests/mbe.rs
@@ -1446,3 +1446,25 @@ fn f() {
 "#]],
     )
 }
+
+#[test]
+fn mbe_are_not_attributes() {
+    check(
+        r#"
+macro_rules! error {
+    () => {struct Bar}
+}
+
+#[error]
+struct Foo;
+"#,
+        expect![[r##"
+macro_rules! error {
+    () => {struct Bar}
+}
+
+#[error]
+struct Foo;
+"##]],
+    )
+}

--- a/crates/hir_def/src/nameres/collector.rs
+++ b/crates/hir_def/src/nameres/collector.rs
@@ -50,9 +50,9 @@ use crate::{
     UnresolvedMacro,
 };
 
-const GLOB_RECURSION_LIMIT: Limit = Limit::new(100);
-const EXPANSION_DEPTH_LIMIT: Limit = Limit::new(128);
-const FIXED_POINT_LIMIT: Limit = Limit::new(8192);
+static GLOB_RECURSION_LIMIT: Limit = Limit::new(100);
+static EXPANSION_DEPTH_LIMIT: Limit = Limit::new(128);
+static FIXED_POINT_LIMIT: Limit = Limit::new(8192);
 
 pub(super) fn collect_defs(
     db: &dyn DefDatabase,
@@ -1705,7 +1705,7 @@ impl ModCollector<'_, '_> {
     /// Returns `Err` when some attributes could not be resolved to builtins and have been
     /// registered as unresolved.
     ///
-    /// If `ignore_up_to` is `Some`, attributes precending and including that attribute will be
+    /// If `ignore_up_to` is `Some`, attributes preceding and including that attribute will be
     /// assumed to be resolved already.
     fn resolve_attributes(&mut self, attrs: &Attrs, mod_item: ModItem) -> Result<(), ()> {
         let mut ignore_up_to =

--- a/crates/hir_expand/src/lib.rs
+++ b/crates/hir_expand/src/lib.rs
@@ -306,6 +306,13 @@ impl MacroDefId {
     pub fn is_proc_macro(&self) -> bool {
         matches!(self.kind, MacroDefKind::ProcMacro(..))
     }
+
+    pub fn is_attribute(&self) -> bool {
+        matches!(
+            self.kind,
+            MacroDefKind::BuiltInAttr(..) | MacroDefKind::ProcMacro(_, ProcMacroKind::Attr, _)
+        )
+    }
 }
 
 // FIXME: attribute indices do not account for `cfg_attr`, which means that we'll strip the whole

--- a/crates/hir_ty/src/autoderef.rs
+++ b/crates/hir_ty/src/autoderef.rs
@@ -18,7 +18,7 @@ use crate::{
     ProjectionTyExt, Solution, Substitution, Ty, TyBuilder, TyKind,
 };
 
-const AUTODEREF_RECURSION_LIMIT: Limit = Limit::new(10);
+static AUTODEREF_RECURSION_LIMIT: Limit = Limit::new(10);
 
 pub(crate) enum AutoderefKind {
     Builtin,

--- a/crates/ide_db/src/items_locator.rs
+++ b/crates/ide_db/src/items_locator.rs
@@ -18,7 +18,7 @@ use crate::{
 };
 
 /// A value to use, when uncertain which limit to pick.
-pub const DEFAULT_QUERY_SEARCH_LIMIT: Limit = Limit::new(40);
+pub static DEFAULT_QUERY_SEARCH_LIMIT: Limit = Limit::new(40);
 
 /// Three possible ways to search for the name in associated and/or other items.
 #[derive(Debug, Clone, Copy)]


### PR DESCRIPTION
Also changes `const`s to `static`s for `Limit`s as we have interior mutability in those(though only used with a certain feature flag enabled).