### PR TITLE
Set MSRV

### DIFF
--- a/crates/base_db/Cargo.toml
+++ b/crates/base_db/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.0"
 description = "TBD"
 license = "MIT OR Apache-2.0"
 edition = "2021"
+rust-version = "1.56"
 
 [lib]
 doctest = false

--- a/crates/cfg/Cargo.toml
+++ b/crates/cfg/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.0"
 description = "TBD"
 license = "MIT OR Apache-2.0"
 edition = "2021"
+rust-version = "1.56"
 
 [lib]
 doctest = false

--- a/crates/flycheck/Cargo.toml
+++ b/crates/flycheck/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.0"
 description = "TBD"
 license = "MIT OR Apache-2.0"
 edition = "2021"
+rust-version = "1.56"
 
 [lib]
 doctest = false

--- a/crates/hir/Cargo.toml
+++ b/crates/hir/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.0"
 description = "TBD"
 license = "MIT OR Apache-2.0"
 edition = "2021"
+rust-version = "1.56"
 
 [lib]
 doctest = false

--- a/crates/hir_def/Cargo.toml
+++ b/crates/hir_def/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.0"
 description = "TBD"
 license = "MIT OR Apache-2.0"
 edition = "2021"
+rust-version = "1.56"
 
 [lib]
 doctest = false

--- a/crates/hir_expand/Cargo.toml
+++ b/crates/hir_expand/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.0"
 description = "TBD"
 license = "MIT OR Apache-2.0"
 edition = "2021"
+rust-version = "1.56"
 
 [lib]
 doctest = false

--- a/crates/hir_ty/Cargo.toml
+++ b/crates/hir_ty/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.0"
 description = "TBD"
 license = "MIT OR Apache-2.0"
 edition = "2021"
+rust-version = "1.56"
 
 [lib]
 doctest = false

--- a/crates/ide/Cargo.toml
+++ b/crates/ide/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.0"
 description = "TBD"
 license = "MIT OR Apache-2.0"
 edition = "2021"
+rust-version = "1.56"
 
 [lib]
 doctest = false

--- a/crates/ide_assists/Cargo.toml
+++ b/crates/ide_assists/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.0"
 description = "TBD"
 license = "MIT OR Apache-2.0"
 edition = "2021"
+rust-version = "1.56"
 
 [lib]
 doctest = false

--- a/crates/ide_completion/Cargo.toml
+++ b/crates/ide_completion/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.0"
 description = "TBD"
 license = "MIT OR Apache-2.0"
 edition = "2021"
+rust-version = "1.56"
 
 [lib]
 doctest = false

--- a/crates/ide_db/Cargo.toml
+++ b/crates/ide_db/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.0"
 description = "TBD"
 license = "MIT OR Apache-2.0"
 edition = "2021"
+rust-version = "1.56"
 
 [lib]
 doctest = false

--- a/crates/ide_diagnostics/Cargo.toml
+++ b/crates/ide_diagnostics/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.0"
 description = "TBD"
 license = "MIT OR Apache-2.0"
 edition = "2021"
+rust-version = "1.56"
 
 [lib]
 doctest = false

--- a/crates/ide_ssr/Cargo.toml
+++ b/crates/ide_ssr/Cargo.toml
@@ -5,6 +5,7 @@ description = "Structural search and replace of Rust code"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-analyzer/rust-analyzer"
 edition = "2021"
+rust-version = "1.56"
 
 [lib]
 doctest = false

--- a/crates/limit/Cargo.toml
+++ b/crates/limit/Cargo.toml
@@ -5,6 +5,7 @@ description = "TBD"
 license = "MIT OR Apache-2.0"
 authors = ["rust-analyzer developers"]
 edition = "2021"
+rust-version = "1.56"
 
 [features]
 tracking = []

--- a/crates/mbe/Cargo.toml
+++ b/crates/mbe/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.0"
 description = "TBD"
 license = "MIT OR Apache-2.0"
 edition = "2021"
+rust-version = "1.56"
 
 [lib]
 doctest = false

--- a/crates/parser/Cargo.toml
+++ b/crates/parser/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.0"
 description = "TBD"
 license = "MIT OR Apache-2.0"
 edition = "2021"
+rust-version = "1.56"
 
 [lib]
 doctest = false

--- a/crates/paths/Cargo.toml
+++ b/crates/paths/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.0"
 description = "TBD"
 license = "MIT OR Apache-2.0"
 edition = "2021"
+rust-version = "1.56"
 
 [lib]
 doctest = false

--- a/crates/proc_macro_api/Cargo.toml
+++ b/crates/proc_macro_api/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.0"
 description = "TBD"
 license = "MIT OR Apache-2.0"
 edition = "2021"
+rust-version = "1.56"
 
 [lib]
 doctest = false

--- a/crates/proc_macro_srv/Cargo.toml
+++ b/crates/proc_macro_srv/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.0"
 description = "TBD"
 license = "MIT OR Apache-2.0"
 edition = "2021"
+rust-version = "1.56"
 
 [lib]
 doctest = false

--- a/crates/proc_macro_test/Cargo.toml
+++ b/crates/proc_macro_test/Cargo.toml
@@ -3,6 +3,7 @@ name = "proc_macro_test"
 version = "0.0.0"
 license = "MIT OR Apache-2.0"
 edition = "2021"
+rust-version = "1.56"
 publish = false
 
 [lib]

--- a/crates/proc_macro_test/imp/Cargo.toml
+++ b/crates/proc_macro_test/imp/Cargo.toml
@@ -3,6 +3,7 @@ name = "proc_macro_test_impl"
 version = "0.0.0"
 license = "MIT OR Apache-2.0"
 edition = "2021"
+rust-version = "1.56"
 publish = false
 
 [lib]

--- a/crates/profile/Cargo.toml
+++ b/crates/profile/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.0"
 description = "TBD"
 license = "MIT OR Apache-2.0"
 edition = "2021"
+rust-version = "1.56"
 
 [lib]
 doctest = false

--- a/crates/project_model/Cargo.toml
+++ b/crates/project_model/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.0"
 description = "TBD"
 license = "MIT OR Apache-2.0"
 edition = "2021"
+rust-version = "1.56"
 
 [lib]
 doctest = false

--- a/crates/rust-analyzer/Cargo.toml
+++ b/crates/rust-analyzer/Cargo.toml
@@ -8,6 +8,7 @@ documentation = "https://rust-analyzer.github.io/manual.html"
 license = "MIT OR Apache-2.0"
 autobins = false
 edition = "2021"
+rust-version = "1.56"
 
 [lib]
 doctest = false

--- a/crates/sourcegen/Cargo.toml
+++ b/crates/sourcegen/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.0"
 description = "TBD"
 license = "MIT OR Apache-2.0"
 edition = "2021"
+rust-version = "1.56"
 
 [lib]
 doctest = false

--- a/crates/stdx/Cargo.toml
+++ b/crates/stdx/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.0"
 description = "TBD"
 license = "MIT OR Apache-2.0"
 edition = "2021"
+rust-version = "1.56"
 
 [lib]
 doctest = false

--- a/crates/syntax/Cargo.toml
+++ b/crates/syntax/Cargo.toml
@@ -5,6 +5,7 @@ description = "Comment and whitespace preserving parser for the Rust language"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-analyzer/rust-analyzer"
 edition = "2021"
+rust-version = "1.56"
 
 [lib]
 doctest = false

--- a/crates/syntax/fuzz/Cargo.toml
+++ b/crates/syntax/fuzz/Cargo.toml
@@ -4,6 +4,7 @@ name = "syntax-fuzz"
 version = "0.0.1"
 publish = false
 edition = "2021"
+rust-version = "1.56"
 
 [package.metadata]
 cargo-fuzz = true

--- a/crates/test_utils/Cargo.toml
+++ b/crates/test_utils/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.0"
 description = "TBD"
 license = "MIT OR Apache-2.0"
 edition = "2021"
+rust-version = "1.56"
 
 [lib]
 doctest = false

--- a/crates/text_edit/Cargo.toml
+++ b/crates/text_edit/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.0"
 description = "TBD"
 license = "MIT OR Apache-2.0"
 edition = "2021"
+rust-version = "1.56"
 
 [lib]
 doctest = false

--- a/crates/toolchain/Cargo.toml
+++ b/crates/toolchain/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.0"
 description = "TBD"
 license = "MIT OR Apache-2.0"
 edition = "2021"
+rust-version = "1.56"
 
 [lib]
 doctest = false

--- a/crates/tt/Cargo.toml
+++ b/crates/tt/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.0"
 description = "TBD"
 license = "MIT OR Apache-2.0"
 edition = "2021"
+rust-version = "1.56"
 
 [lib]
 doctest = false

--- a/crates/vfs-notify/Cargo.toml
+++ b/crates/vfs-notify/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.0"
 description = "TBD"
 license = "MIT OR Apache-2.0"
 edition = "2021"
+rust-version = "1.56"
 
 [lib]
 doctest = false

--- a/crates/vfs/Cargo.toml
+++ b/crates/vfs/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.0"
 description = "TBD"
 license = "MIT OR Apache-2.0"
 edition = "2021"
+rust-version = "1.56"
 
 [lib]
 doctest = false

--- a/lib/arena/Cargo.toml
+++ b/lib/arena/Cargo.toml
@@ -7,3 +7,4 @@ repository = "https://github.com/rust-analyzer/rust-analyzer"
 documentation = "https://docs.rs/la-arena"
 categories = ["data-structures", "memory-management", "rust-patterns"]
 edition = "2021"
+rust-version = "1.56"

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
-edition = "2021"
 name = "xtask"
 version = "0.1.0"
 publish = false
 license = "MIT OR Apache-2.0"
+edition = "2021"
+rust-version = "1.56"
 
 [dependencies]
 anyhow = "1.0.26"


### PR DESCRIPTION
Set the MSRV to `1.56` since we're already on the 2021 edition and building with older version fails.

From now on, there'll be a change in behavior: `xtask install` used to warn on old toolchains, but now the user will get an error. This isn't so bad because:

 - the check in `xtask install` wasn't always working (because sometimes `xtask` itself required a newer toolchain)
 - we generally bump the required version for a reason (when using a newer feature). We might forget to bump it, but when we do, older toolchains won't work