### PR TITLE
fix: Don't ask the user to reload when chaning HoverAction configs in VSCode

### DIFF
--- a/editors/code/src/config.ts
+++ b/editors/code/src/config.ts
@@ -21,7 +21,6 @@ export class Config {
         "highlighting",
         "updates.channel",
         "lens", // works as lens.*
-        "hoverActions", // works as hoverActions.*
     ]
         .map(opt => `${this.rootSection}.${opt}`);
 


### PR DESCRIPTION
To my knowledge, all of these are re-read on hover requests so there is no longer a reason to reload when changing these.
bors r+