### PR TITLE
minor: Drop resolver and `authors` manifest entry in `limit`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,4 @@
 [workspace]
-resolver = "2"
 members = ["xtask/", "lib/*", "crates/*"]
 exclude = ["crates/proc_macro_test/imp"]
 

--- a/crates/limit/Cargo.toml
+++ b/crates/limit/Cargo.toml
@@ -3,7 +3,6 @@ name = "limit"
 version = "0.0.0"
 description = "TBD"
 license = "MIT OR Apache-2.0"
-authors = ["rust-analyzer developers"]
 edition = "2021"
 rust-version = "1.56"
 


### PR DESCRIPTION
The new resolver is on by default in the 2021 edition,

bors r+