### PR TITLE
minor: assume valid identifier

### DIFF
--- a/crates/ide/src/goto_type_definition.rs
+++ b/crates/ide/src/goto_type_definition.rs
@@ -81,11 +81,7 @@ pub(crate) fn goto_type_definition(
                 }
             });
         });
-    if res.is_empty() {
-        None
-    } else {
-        Some(RangeInfo::new(range, res))
-    }
+    Some(RangeInfo::new(range, res))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
improve https://github.com/rust-analyzer/rust-analyzer/pull/10637/ by always returning `Some(potentially_empty_vec)` instead of `None` in the empty case