### PR TITLE
fix: fix Plaintext textDocument/hover content type

### DIFF
--- a/crates/rust-analyzer/src/cli/lsif.rs
+++ b/crates/rust-analyzer/src/cli/lsif.rs
@@ -136,6 +136,7 @@ impl LsifManager<'_> {
                 result: lsp_types::Hover {
                     contents: lsp_types::HoverContents::Markup(to_proto::markup_content(
                         hover.markup,
+                        ide::HoverDocFormat::Markdown,
                     )),
                     range: None,
                 },

--- a/crates/rust-analyzer/src/handlers.rs
+++ b/crates/rust-analyzer/src/handlers.rs
@@ -920,9 +920,14 @@ pub(crate) fn handle_hover(
 
     let line_index = snap.file_line_index(file_range.file_id)?;
     let range = to_proto::range(&line_index, info.range);
+    let markup_kind =
+        snap.config.hover().documentation.map_or(ide::HoverDocFormat::Markdown, |kind| kind);
     let hover = lsp_ext::Hover {
         hover: lsp_types::Hover {
-            contents: HoverContents::Markup(to_proto::markup_content(info.info.markup)),
+            contents: HoverContents::Markup(to_proto::markup_content(
+                info.info.markup,
+                markup_kind,
+            )),
             range: Some(range),
         },
         actions: if snap.config.hover_actions().none() {

--- a/crates/rust-analyzer/src/to_proto.rs
+++ b/crates/rust-analyzer/src/to_proto.rs
@@ -1202,9 +1202,16 @@ pub(crate) fn reference_title(count: usize) -> String {
     }
 }
 
-pub(crate) fn markup_content(markup: Markup) -> lsp_types::MarkupContent {
+pub(crate) fn markup_content(
+    markup: Markup,
+    kind: ide::HoverDocFormat,
+) -> lsp_types::MarkupContent {
+    let kind = match kind {
+        ide::HoverDocFormat::Markdown => lsp_types::MarkupKind::Markdown,
+        ide::HoverDocFormat::PlainText => lsp_types::MarkupKind::PlainText,
+    };
     let value = crate::markdown::format_docs(markup.as_str());
-    lsp_types::MarkupContent { kind: lsp_types::MarkupKind::Markdown, value }
+    lsp_types::MarkupContent { kind, value }
 }
 
 pub(crate) fn rename_error(err: RenameError) -> crate::LspError {


### PR DESCRIPTION
Relates to #10028

Note: the PR corrects only invalid content kind, not formatting.