### PR TITLE
fix: Fix proc-macro server not using the supplied span in Ident::new

### DIFF
--- a/crates/proc_macro_srv/src/abis/abi_1_47/rustc_server.rs
+++ b/crates/proc_macro_srv/src/abis/abi_1_47/rustc_server.rs
@@ -463,13 +463,8 @@ impl server::Punct for Rustc {
 }
 
 impl server::Ident for Rustc {
-    fn new(&mut self, string: &str, _span: Self::Span, _is_raw: bool) -> Self::Ident {
-        IdentId(
-            self.ident_interner.intern(&IdentData(tt::Ident {
-                text: string.into(),
-                id: tt::TokenId::unspecified(),
-            })),
-        )
+    fn new(&mut self, string: &str, span: Self::Span, _is_raw: bool) -> Self::Ident {
+        IdentId(self.ident_interner.intern(&IdentData(tt::Ident { text: string.into(), id: span })))
     }
 
     fn span(&mut self, ident: Self::Ident) -> Self::Span {

--- a/crates/proc_macro_srv/src/abis/abi_1_54/rustc_server.rs
+++ b/crates/proc_macro_srv/src/abis/abi_1_54/rustc_server.rs
@@ -463,13 +463,8 @@ impl server::Punct for Rustc {
 }
 
 impl server::Ident for Rustc {
-    fn new(&mut self, string: &str, _span: Self::Span, _is_raw: bool) -> Self::Ident {
-        IdentId(
-            self.ident_interner.intern(&IdentData(tt::Ident {
-                text: string.into(),
-                id: tt::TokenId::unspecified(),
-            })),
-        )
+    fn new(&mut self, string: &str, span: Self::Span, _is_raw: bool) -> Self::Ident {
+        IdentId(self.ident_interner.intern(&IdentData(tt::Ident { text: string.into(), id: span })))
     }
 
     fn span(&mut self, ident: Self::Ident) -> Self::Span {

--- a/crates/proc_macro_srv/src/abis/abi_1_56/rustc_server.rs
+++ b/crates/proc_macro_srv/src/abis/abi_1_56/rustc_server.rs
@@ -464,13 +464,8 @@ impl server::Punct for Rustc {
 }
 
 impl server::Ident for Rustc {
-    fn new(&mut self, string: &str, _span: Self::Span, _is_raw: bool) -> Self::Ident {
-        IdentId(
-            self.ident_interner.intern(&IdentData(tt::Ident {
-                text: string.into(),
-                id: tt::TokenId::unspecified(),
-            })),
-        )
+    fn new(&mut self, string: &str, span: Self::Span, _is_raw: bool) -> Self::Ident {
+        IdentId(self.ident_interner.intern(&IdentData(tt::Ident { text: string.into(), id: span })))
     }
 
     fn span(&mut self, ident: Self::Ident) -> Self::Span {

--- a/crates/proc_macro_srv/src/abis/abi_1_58/rustc_server.rs
+++ b/crates/proc_macro_srv/src/abis/abi_1_58/rustc_server.rs
@@ -468,13 +468,8 @@ impl server::Punct for Rustc {
 }
 
 impl server::Ident for Rustc {
-    fn new(&mut self, string: &str, _span: Self::Span, _is_raw: bool) -> Self::Ident {
-        IdentId(
-            self.ident_interner.intern(&IdentData(tt::Ident {
-                text: string.into(),
-                id: tt::TokenId::unspecified(),
-            })),
-        )
+    fn new(&mut self, string: &str, span: Self::Span, _is_raw: bool) -> Self::Ident {
+        IdentId(self.ident_interner.intern(&IdentData(tt::Ident { text: string.into(), id: span })))
     }
 
     fn span(&mut self, ident: Self::Ident) -> Self::Span {


### PR DESCRIPTION
This makes the hack introduced by https://github.com/rust-analyzer/rust-analyzer/pull/10899 obsolete.

For async-trait specifically, (unfortunately, but technically correct) due to how async-trait works, the self local now renders white, as it now resolves to the `__self` local introduced by the attribute.

![Code_0Ezw6PJAbh](https://user-images.githubusercontent.com/3757771/151827812-c03b8fc7-7ecf-4959-804a-2680d8e61e8b.png)
bors r+