### PR TITLE
Implement support for ${targetTriple}

### DIFF
--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -800,7 +800,7 @@ impl Config {
             Some(args) if !args.is_empty() => {
                 let mut args = args.clone();
                 let mut command = args.remove(0);
-                command = command.replace("$TARGET_TRIPLE", &self.host);
+                command = command.replace("${targetTriple}", &self.host);
                 RustfmtConfig::CustomCommand { command, args }
             }
             Some(_) | None => RustfmtConfig::Rustfmt {
@@ -817,7 +817,7 @@ impl Config {
             Some(args) if !args.is_empty() => {
                 let mut args = args.clone();
                 let mut command = args.remove(0);
-                command = command.replace("$TARGET_TRIPLE", &self.host);
+                command = command.replace("${targetTriple}", &self.host);
 
                 FlycheckConfig::CustomCommand { command, args }
             }


### PR DESCRIPTION
Hey! 

Came from the contribtuting guide [here](https://rustc-dev-guide.rust-lang.org/building/suggested.html#configuring-rust-analyzer-for-rustc) for rustc and saw they used a `$TARGET_TRIPLE` stock value. I thought I'd implement support for it, because I know other people who put this in configurations and contribution guides so that if they forget, they have a fallback.