### PR TITLE
If inside for_each to filter() code assist

### DIFF
--- a/crates/ide_assists/src/handlers/lambdify_for_each.rs
+++ b/crates/ide_assists/src/handlers/lambdify_for_each.rs
@@ -1,0 +1,162 @@
+use ide_db::helpers::FamousDefs;
+use stdx::format_to;
+use syntax::{
+    SyntaxKind,
+    ast::{self, edit_in_place::Indent, HasArgList, Pat, Expr},
+    AstNode,
+};
+
+use crate::{AssistContext, AssistId, AssistKind, Assists};
+
+// Assist: convert_if_to_filter
+//
+// Converts a if into a filter when placed in a for_each().
+// ```
+// # //- minicore: iterators
+// # use core::iter;
+// fn main() {
+//     let it = core::iter::repeat(92);
+//     it.for_each$0(|x| {
+//         if x > 4 {
+//             println!("{}", x);
+//         };
+//     });
+// }
+// ```
+// ->
+// ```
+// # use core::iter;
+// fn main() {
+//     let it = core::iter::repeat(92);
+//     it.filter(|&x| x > 4).for_each(|x| {
+//         println!("{}", x);
+//     });
+// }
+// ```
+pub(crate) fn convert_if_to_filter(acc: &mut Assists, ctx: &AssistContext) -> Option<()> {
+    let method = ctx.find_node_at_offset::<ast::MethodCallExpr>()?;
+
+    let closure = match method.arg_list()?.args().next()? {
+        ast::Expr::ClosureExpr(expr) => expr,
+        _ => return None,
+    };
+
+    let (method, receiver) = validate_method_call_expr(ctx, method)?;
+
+    let param_list = closure.param_list()?;
+    let param = param_list.params().next()?.pat()?;
+    let body = closure.body()?;
+
+    let range = method.syntax().text_range();
+
+    let if_expr = match body.clone() {
+        Expr::IfExpr(if_expr) => {
+            if_expr
+        },
+        Expr::BlockExpr(block) => {
+            let mut stmts = block.statements();
+            let fst_stmt = stmts.next()?;
+            continue_iff(stmts.next().is_none())?; // Only one statement
+            // First statement is an expression...
+            let expr_stmt = match fst_stmt {
+                ast::Stmt::ExprStmt(expr_stmt) => expr_stmt,
+                _ => return None,
+            };
+
+            // ...and even an if clause...
+            let expr = expr_stmt.expr()?;
+            let if_expr = match expr {
+                ast::Expr::IfExpr(my_if_expr) => my_if_expr,
+                _ => return None,
+            };
+            if_expr
+        },
+        _ => return None,
+    };
+
+    let condition = if_expr.condition()?; // ... with a condition...
+    continue_iff(if_expr.else_branch().is_none()); // ... and no else branch...
+    let then_branch = if_expr.then_branch()?; // ... and a then branch
+    // ... and the pattern in the for loop is an ident pattern
+    let ident_pat = match param {
+        Pat::IdentPat(ref ident_pat) => ident_pat.clone(),
+        _ => return None,
+    };
+
+    acc.add(
+        AssistId("convert_if_to_filter", AssistKind::RefactorRewrite),
+        "Replace this `if { ... }` with a `filter()`",
+        range,
+        |builder| {
+            let indent = method.indent_level();
+            
+            let mut buf = String::new();
+            // Remove unnecessary `mut` in the pattern if used in a filter
+            let pat_filter = ident_pat.clone_for_update();
+            if let Some(mut_token) = pat_filter.mut_token() {
+                if let Some(ws) = mut_token.next_token().filter(|it| it.kind() == SyntaxKind::WHITESPACE) {
+                    ws.detach();
+                }
+                mut_token.detach();
+            }
+            format_to!(buf, "{}.filter(|&{}| {})", receiver, pat_filter, condition);
+
+            // Because we removed a if block, reident accordingly the rest of the block
+            let block = then_branch.clone_for_update();
+            block.reindent_to(indent);
+
+            format_to!(buf, ".for_each(|{}| {})", param, block);
+
+            builder.replace(range, buf)
+        },
+    )
+}
+
+fn validate_method_call_expr(
+    ctx: &AssistContext,
+    expr: ast::MethodCallExpr,
+) -> Option<(ast::Expr, ast::Expr)> {
+    let name_ref = expr.name_ref()?;
+    if name_ref.text() != "for_each" {
+        return None;
+    }
+
+    let receiver = expr.receiver()?;
+    let expr = ast::Expr::MethodCallExpr(expr);
+
+    Some((expr, receiver))
+}
+
+fn continue_iff(b: bool) -> Option<()> {
+    if b { Some(()) } else { None }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::tests::check_assist;
+
+    use super::*;
+
+    #[test]
+    fn if_to_filter() {
+        check_assist(
+            convert_if_to_filter,
+            r#"
+fn main() {
+    let it = core::iter::repeat(92);
+    it.for_each$0(|mut i| {
+        if (i*i)%3 == 2 {
+            i *= 2;
+        };
+    });
+}"#,
+            r#"
+fn main() {
+    let it = core::iter::repeat(92);
+    it.filter(|&i| (i*i)%3 == 2).for_each(|mut i| {
+        i *= 2;
+    });
+}"#,
+        )
+    }
+}

--- a/crates/ide_assists/src/lib.rs
+++ b/crates/ide_assists/src/lib.rs
@@ -151,6 +151,7 @@ mod handlers {
     mod inline_call;
     mod inline_local_variable;
     mod introduce_named_lifetime;
+    mod lambdify_for_each;
     mod invert_if;
     mod merge_imports;
     mod merge_match_arms;
@@ -234,6 +235,7 @@ mod handlers {
             introduce_named_generic::introduce_named_generic,
             introduce_named_lifetime::introduce_named_lifetime,
             invert_if::invert_if,
+            lambdify_for_each::convert_if_to_filter,
             merge_imports::merge_imports,
             merge_match_arms::merge_match_arms,
             move_bounds::move_bounds_to_where_clause,

--- a/crates/ide_assists/src/lib.rs
+++ b/crates/ide_assists/src/lib.rs
@@ -236,6 +236,8 @@ mod handlers {
             introduce_named_lifetime::introduce_named_lifetime,
             invert_if::invert_if,
             lambdify_for_each::convert_if_to_filter,
+            lambdify_for_each::convert_sum_call,
+            lambdify_for_each::convert_all_call,
             merge_imports::merge_imports,
             merge_match_arms::merge_match_arms,
             move_bounds::move_bounds_to_where_clause,

--- a/crates/ide_assists/src/tests/generated.rs
+++ b/crates/ide_assists/src/tests/generated.rs
@@ -298,6 +298,34 @@ fn main() {
 }
 
 #[test]
+fn doctest_convert_if_to_filter() {
+    check_doc_test(
+        "convert_if_to_filter",
+        r#####"
+//- minicore: iterators
+use core::iter;
+fn main() {
+    let it = core::iter::repeat(92);
+    it.for_each$0(|x| {
+        if x > 4 {
+            println!("{}", x);
+        };
+    });
+}
+"#####,
+        r#####"
+use core::iter;
+fn main() {
+    let it = core::iter::repeat(92);
+    it.filter(|&x| x > 4).for_each(|x| {
+        println!("{}", x);
+    });
+}
+"#####,
+    )
+}
+
+#[test]
 fn doctest_convert_integer_literal() {
     check_doc_test(
         "convert_integer_literal",

--- a/crates/ide_assists/src/tests/generated.rs
+++ b/crates/ide_assists/src/tests/generated.rs
@@ -231,6 +231,30 @@ pub(crate) fn frobnicate() {}
 }
 
 #[test]
+fn doctest_convert_all_call() {
+    check_doc_test(
+        "convert_all_call",
+        r#####"
+//- minicore: iterators
+use core::iter;
+fn main() {
+    let it = core::iter::repeat(92);
+    let mut val: usize = 0;
+    it.for_each$0(|x| val &= x > 0);
+}
+"#####,
+        r#####"
+use core::iter;
+fn main() {
+    let it = core::iter::repeat(92);
+    let mut val: usize = 0;
+    val &= it.all(|&x| x > 0);
+}
+"#####,
+    )
+}
+
+#[test]
 fn doctest_convert_bool_then_to_if() {
     check_doc_test(
         "convert_bool_then_to_if",
@@ -387,6 +411,30 @@ fn main() {
     for (x, y) in iter {
         println!("x: {}, y: {}", x, y);
     }
+}
+"#####,
+    )
+}
+
+#[test]
+fn doctest_convert_sum_call() {
+    check_doc_test(
+        "convert_sum_call",
+        r#####"
+//- minicore: iterators
+use core::iter;
+fn main() {
+    let it = core::iter::repeat(92);
+    let mut val: usize = 0;
+    it.for_each$0(|x| val += x);
+}
+"#####,
+        r#####"
+use core::iter;
+fn main() {
+    let it = core::iter::repeat(92);
+    let mut val: usize = 0;
+    val += it.sum::<usize>();
 }
 "#####,
     )


### PR DESCRIPTION
Hi everyone,
One of my first MR so I'm not really experienced yet in that thing.
I've been coding a code assist which could "lambdify" for statements in Rust. At this point, it replaces `if` inside `.for_each()` closures with the corresponding `.filter()`.
I could go even further with more asists (ex. sums) but I wanted to have feedback first on the code.

At the moment I still have one problem: I copied the validate_method_call_expr from `modify_for_each.rs` but needed to remove this part:
```rust

    let it_type = sema.type_of_expr(&receiver)?.adjusted();
    let module = sema.scope(receiver.syntax()).module()?;
    let krate = module.krate();

    let iter_trait = FamousDefs(sema, Some(krate)).core_iter_Iterator()?;
    it_type.impls_trait(sema.db, iter_trait, &[]).then(|| (expr, receiver))
```
for the code assist to work (without me understanding why).

I created a test case which works (which the small tweak mentioned above)

Any comments welcome!