### PR TITLE
Provide a cache for Chalk RecursiveSolver

### DIFF
--- a/crates/hir_ty/src/db.rs
+++ b/crates/hir_ty/src/db.rs
@@ -13,6 +13,7 @@ use la_arena::ArenaMap;
 use crate::{
     chalk_db,
     method_resolution::{InherentImpls, TraitImpls},
+    traits::ChalkCache,
     Binders, CallableDefId, FnDefId, ImplTraitId, InferenceResult, Interner, PolyFnSig,
     QuantifiedWhereClause, ReturnTypeImplTraits, TraitRef, Ty, TyDefId, ValueTyDefId,
 };
@@ -159,6 +160,9 @@ pub trait HirDatabase: DefDatabase + Upcast<dyn DefDatabase> {
         krate: CrateId,
         env: chalk_ir::Environment<Interner>,
     ) -> chalk_ir::ProgramClauses<Interner>;
+
+    #[salsa::invoke(crate::traits::chalk_cache)]
+    fn chalk_cache(&self) -> ChalkCache;
 }
 
 fn infer_wait(db: &dyn HirDatabase, def: DefWithBodyId) -> Arc<InferenceResult> {

--- a/crates/hir_ty/src/db.rs
+++ b/crates/hir_ty/src/db.rs
@@ -13,7 +13,7 @@ use la_arena::ArenaMap;
 use crate::{
     chalk_db,
     method_resolution::{InherentImpls, TraitImpls},
-    traits::ChalkCache,
+    traits::{ChalkCache, ChalkCacheKey},
     Binders, CallableDefId, FnDefId, ImplTraitId, InferenceResult, Interner, PolyFnSig,
     QuantifiedWhereClause, ReturnTypeImplTraits, TraitRef, Ty, TyDefId, ValueTyDefId,
 };
@@ -162,7 +162,7 @@ pub trait HirDatabase: DefDatabase + Upcast<dyn DefDatabase> {
     ) -> chalk_ir::ProgramClauses<Interner>;
 
     #[salsa::invoke(crate::traits::chalk_cache)]
-    fn chalk_cache(&self) -> ChalkCache;
+    fn chalk_cache(&self, cache_key: ChalkCacheKey) -> ChalkCache;
 }
 
 fn infer_wait(db: &dyn HirDatabase, def: DefWithBodyId) -> Arc<InferenceResult> {


### PR DESCRIPTION
I've tested this with `DEFAULT_QUERY_SEARCH_LIMIT` set to 400000, and with automatic imports enabled without a minimum length. The first completion request takes around 1000ms, but repeating the same completion takes around 100ms using the cache.

One problem with this implementation is using `ChalkCache` as a wrapper. `ChalkCache` contains `Arc<Cache<...>>`, and `Cache` itself contains `Arc<...>`, resulting in 2 nested `Arc`s. This doesn't seem like a major concern, though.

Also, I'm not sure how to structure this. For one, calling `chalk_cache` seems to bounce back and forth between different files.

#7542