### PR TITLE
Creating rust dependencies tree explorer based on #11557

### DIFF
--- a/crates/hir/src/source_analyzer.rs
+++ b/crates/hir/src/source_analyzer.rs
@@ -652,7 +652,13 @@ fn resolve_hir_path_(
                 let (ty, remaining) =
                     resolver.resolve_path_in_type_ns(db.upcast(), path.mod_path())?;
                 match remaining {
-                    Some(remaining) if remaining > 1 => None,
+                    Some(remaining) if remaining > 1 => {
+                        if remaining + 1 == path.segments().len() {
+                            Some((ty, path.segments().last()))
+                        } else {
+                            None
+                        }
+                    }
                     _ => Some((ty, path.segments().get(1))),
                 }
             }

--- a/crates/ide/src/hover/tests.rs
+++ b/crates/ide/src/hover/tests.rs
@@ -3765,6 +3765,49 @@ pub fn gimme() -> theitem::TheItem {
 }
 
 #[test]
+fn test_hover_trait_assoc_typealias() {
+    check(
+        r#"
+        fn main() {}
+
+trait T1 {
+    type Bar;
+    type Baz;
+}
+
+struct Foo;
+
+mod t2 {
+    pub trait T2 {
+        type Bar;
+    }
+}
+
+use t2::T2;
+
+impl T2 for Foo {
+    type Bar = String;
+}
+
+impl T1 for Foo {
+    type Bar = <Foo as t2::T2>::Ba$0r;
+    //                          ^^^ unresolvedReference
+}
+        "#,
+        expect![[r#"
+*Bar*
+
+```rust
+test::t2
+```
+
+```rust
+pub type Bar
+```
+"#]],
+    );
+}
+#[test]
 fn hover_generic_assoc() {
     check(
         r#"


### PR DESCRIPTION
based on [#11557](https://github.com/rust-analyzer/rust-analyzer/pull/11557).

1. deps info get from rust-server,  workspace packages or json project crates, exclude workspace member
2.  auto refresh when indexing end 