### PR TITLE
feat: allow customizing the command for running build scripts

### DIFF
--- a/crates/project_model/src/cargo_workspace.rs
+++ b/crates/project_model/src/cargo_workspace.rs
@@ -96,6 +96,8 @@ pub struct CargoConfig {
     pub unset_test_crates: UnsetTestCrates,
 
     pub wrap_rustc_in_build_scripts: bool,
+
+    pub run_build_script_command: Option<Vec<String>>,
 }
 
 impl CargoConfig {

--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -79,6 +79,10 @@ config_data! {
         /// Run build scripts (`build.rs`) for more precise code analysis.
         cargo_runBuildScripts |
         cargo_loadOutDirsFromCheck: bool = "true",
+        /// Advanced option, fully override the command rust-analyzer uses to
+        /// run build scripts and build procedural macros. The command should
+        /// include `--message-format=json` or a similar option.
+        cargo_runBuildScriptsCommand: Option<Vec<String>> = "null",
         /// Use `RUSTC_WRAPPER=rust-analyzer` when running build scripts to
         /// avoid compiling unnecessary things.
         cargo_useRustcWrapperForBuildScripts: bool = "true",
@@ -803,6 +807,7 @@ impl Config {
             rustc_source,
             unset_test_crates: UnsetTestCrates::Only(self.data.cargo_unsetTest.clone()),
             wrap_rustc_in_build_scripts: self.data.cargo_useRustcWrapperForBuildScripts,
+            run_build_script_command: self.data.cargo_runBuildScriptsCommand.clone(),
         }
     }
 

--- a/docs/user/generated_config.adoc
+++ b/docs/user/generated_config.adoc
@@ -64,6 +64,13 @@ List of features to activate.
 --
 Run build scripts (`build.rs`) for more precise code analysis.
 --
+[[rust-analyzer.cargo.runBuildScriptsCommand]]rust-analyzer.cargo.runBuildScriptsCommand (default: `null`)::
++
+--
+Advanced option, fully override the command rust-analyzer uses to
+run build scripts and build procedural macros. The command should
+include `--message-format=json` or a similar option.
+--
 [[rust-analyzer.cargo.useRustcWrapperForBuildScripts]]rust-analyzer.cargo.useRustcWrapperForBuildScripts (default: `true`)::
 +
 --

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -476,6 +476,17 @@
                     "default": true,
                     "type": "boolean"
                 },
+                "rust-analyzer.cargo.runBuildScriptsCommand": {
+                    "markdownDescription": "Advanced option, fully override the command rust-analyzer uses to\nrun build scripts and build procedural macros. The command should\ninclude `--message-format=json` or a similar option.",
+                    "default": null,
+                    "type": [
+                        "null",
+                        "array"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "rust-analyzer.cargo.useRustcWrapperForBuildScripts": {
                     "markdownDescription": "Use `RUSTC_WRAPPER=rust-analyzer` when running build scripts to\navoid compiling unnecessary things.",
                     "default": true,


### PR DESCRIPTION
I have tested this locally and it fixed #9201 with some small changes on the compiler side with suggestions from https://github.com/rust-analyzer/rust-analyzer/issues/9201#issuecomment-1019554086.

I have also added an environment variable `IS_RA_BUILDSCRIPT_CHECK` for crates to detect that it is a check for buildscripts, and allows defaulting to bogus values for expected environment variables.