### PR TITLE
Remove handling of `#[rustc_deprecated]`

### DIFF
--- a/crates/hir-def/src/builtin_attr.rs
+++ b/crates/hir-def/src/builtin_attr.rs
@@ -274,6 +274,7 @@ pub const INERT_ATTRIBUTES: &[BuiltinAttribute] = &[
     ungated!(feature, CrateLevel, template!(List: "name1, name1, ...")),
     // FIXME(#14407) -- only looked at on-demand so we can't
     // guarantee they'll have already been checked.
+    // FIXME(jhpratt) remove this when #[rustc_deprecated] is fully removed from the compiler
     ungated!(
         rustc_deprecated, AssumedUsed,
         template!(List: r#"since = "version", reason = "...""#)

--- a/crates/ide-completion/src/render.rs
+++ b/crates/ide-completion/src/render.rs
@@ -67,7 +67,7 @@ impl<'a> RenderContext<'a> {
 
     fn is_deprecated(&self, def: impl HasAttrs) -> bool {
         let attrs = def.attrs(self.db());
-        attrs.by_key("deprecated").exists() || attrs.by_key("rustc_deprecated").exists()
+        attrs.by_key("deprecated").exists()
     }
 
     fn is_deprecated_assoc_item(&self, as_assoc_item: impl AsAssocItem) -> bool {
@@ -675,8 +675,6 @@ fn main() { let _: m::Spam = S$0 }
             r#"
 #[deprecated]
 fn something_deprecated() {}
-#[rustc_deprecated(since = "1.0.0")]
-fn something_else_deprecated() {}
 
 fn main() { som$0 }
 "#,
@@ -685,8 +683,8 @@ fn main() { som$0 }
                 [
                     CompletionItem {
                         label: "main()",
-                        source_range: 127..130,
-                        delete: 127..130,
+                        source_range: 56..59,
+                        delete: 56..59,
                         insert: "main()$0",
                         kind: SymbolKind(
                             Function,
@@ -696,25 +694,13 @@ fn main() { som$0 }
                     },
                     CompletionItem {
                         label: "something_deprecated()",
-                        source_range: 127..130,
-                        delete: 127..130,
+                        source_range: 56..59,
+                        delete: 56..59,
                         insert: "something_deprecated()$0",
                         kind: SymbolKind(
                             Function,
                         ),
                         lookup: "something_deprecated",
-                        detail: "fn()",
-                        deprecated: true,
-                    },
-                    CompletionItem {
-                        label: "something_else_deprecated()",
-                        source_range: 127..130,
-                        delete: 127..130,
-                        insert: "something_else_deprecated()$0",
-                        kind: SymbolKind(
-                            Function,
-                        ),
-                        lookup: "something_else_deprecated",
                         detail: "fn()",
                         deprecated: true,
                     },


### PR DESCRIPTION
This should be merged along with rust-lang/rust#95960.

Because the attribute still exists in rustc, I've left the definition here. With that said, any use of it is an error, so I've removed any handling of `#[rustc_deprecated]`.