### PR TITLE
fix: completion detail shows `{unknown}` for async functions and for RPITs

### DIFF
--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -1358,9 +1358,9 @@ impl Function {
     /// Get this function's return type
     pub fn ret_type(self, db: &dyn HirDatabase) -> Type {
         let resolver = self.id.resolver(db.upcast());
-        let ret_type = &db.function_data(self.id).ret_type;
-        let ctx = hir_ty::TyLoweringContext::new(db, &resolver);
-        let ty = ctx.lower_ty(ret_type);
+        let substs = TyBuilder::placeholder_subst(db, self.id);
+        let callable_sig = db.callable_item_signature(self.id.into()).substitute(Interner, &substs);
+        let ty = callable_sig.ret().clone();
         Type::new_with_resolver_inner(db, &resolver, ty)
     }
 

--- a/crates/ide_completion/src/render/function.rs
+++ b/crates/ide_completion/src/render/function.rs
@@ -228,7 +228,7 @@ fn should_add_parens(ctx: &CompletionContext) -> bool {
 }
 
 fn detail(db: &dyn HirDatabase, func: hir::Function) -> String {
-    let ret_ty = func.async_ret_type(db).unwrap_or_else(|| func.ret_type(db));
+    let mut ret_ty = func.ret_type(db);
     let mut detail = String::new();
 
     if func.is_const(db) {
@@ -236,6 +236,9 @@ fn detail(db: &dyn HirDatabase, func: hir::Function) -> String {
     }
     if func.is_async(db) {
         format_to!(detail, "async ");
+        if let Some(async_ret) = func.async_ret_type(db) {
+            ret_ty = async_ret;
+        }
     }
     if func.is_unsafe_to_call(db) {
         format_to!(detail, "unsafe ");

--- a/crates/ide_completion/src/render/function.rs
+++ b/crates/ide_completion/src/render/function.rs
@@ -228,7 +228,7 @@ fn should_add_parens(ctx: &CompletionContext) -> bool {
 }
 
 fn detail(db: &dyn HirDatabase, func: hir::Function) -> String {
-    let ret_ty = func.ret_type(db);
+    let ret_ty = func.async_ret_type(db).unwrap_or_else(|| func.ret_type(db));
     let mut detail = String::new();
 
     if func.is_const(db) {

--- a/crates/ide_completion/src/tests/expression.rs
+++ b/crates/ide_completion/src/tests/expression.rs
@@ -602,3 +602,42 @@ fn func() {
         "#]],
     );
 }
+
+#[test]
+fn detail_impl_trait_in_return_position() {
+    check_empty(
+        r"
+//- minicore: sized
+trait Trait<T> {}
+fn foo<U>() -> impl Trait<U> {}
+fn main() {
+    self::$0
+}
+",
+        expect![[r"
+            tt Trait
+            fn main() fn()
+            fn foo()  fn() -> impl Trait<U>
+        "]],
+    );
+}
+
+#[test]
+fn detail_async_fn() {
+    // FIXME: #11438
+    check_empty(
+        r#"
+//- minicore: future, sized
+trait Trait<T> {}
+async fn foo() -> u8 {}
+fn main() {
+    self::$0
+}
+"#,
+        expect![[r"
+            tt Trait
+            fn main() fn()
+            fn foo()  async fn() -> impl Future<Output = u8>
+        "]],
+    );
+}

--- a/crates/ide_completion/src/tests/expression.rs
+++ b/crates/ide_completion/src/tests/expression.rs
@@ -624,12 +624,12 @@ fn main() {
 
 #[test]
 fn detail_async_fn() {
-    // FIXME: #11438
     check_empty(
         r#"
 //- minicore: future, sized
 trait Trait<T> {}
 async fn foo() -> u8 {}
+async fn bar<U>() -> impl Trait<U> {}
 fn main() {
     self::$0
 }
@@ -637,7 +637,8 @@ fn main() {
         expect![[r"
             tt Trait
             fn main() fn()
-            fn foo()  async fn() -> impl Future<Output = u8>
+            fn bar()  async fn() -> impl Trait<U>
+            fn foo()  async fn() -> u8
         "]],
     );
 }


### PR DESCRIPTION
Fix: completion detail shows `{unknown}` for `impl Trait` in return position.
Fix #11438 : completion detail shows `{unknown}` for return types in async functions.

#### API changes
Add `hir::Function::async_ret_type` method
