### PR TITLE
fix: resolve `uN::method` even when `use std::uN;` is present

### DIFF
--- a/crates/hir_def/src/builtin_type.rs
+++ b/crates/hir_def/src/builtin_type.rs
@@ -68,6 +68,10 @@ impl BuiltinType {
         (name![f32], BuiltinType::Float(BuiltinFloat::F32)),
         (name![f64], BuiltinType::Float(BuiltinFloat::F64)),
     ];
+
+    pub fn by_name(name: &Name) -> Option<Self> {
+        Self::ALL.iter().find_map(|(n, ty)| if n == name { Some(*ty) } else { None })
+    }
 }
 
 impl AsName for BuiltinType {

--- a/crates/hir_def/src/resolver.rs
+++ b/crates/hir_def/src/resolver.rs
@@ -317,6 +317,18 @@ impl Resolver {
             }
         }
 
+        // If a path of the shape `u16::from_le_bytes` failed to resolve at all, then we fall back
+        // to resolving to the primitive type, to allow this to still work in the presence of
+        // `use core::u16;`.
+        if path.kind == PathKind::Plain && path.segments().len() > 1 {
+            match BuiltinType::by_name(&path.segments()[0]) {
+                Some(builtin) => {
+                    return Some(ResolveValueResult::Partial(TypeNs::BuiltinType(builtin), 1));
+                }
+                None => {}
+            }
+        }
+
         None
     }
 

--- a/crates/hir_ty/src/tests/method_resolution.rs
+++ b/crates/hir_ty/src/tests/method_resolution.rs
@@ -1767,3 +1767,26 @@ fn foo() {
 "#,
     );
 }
+
+#[test]
+fn primitive_assoc_fn_shadowed_by_use() {
+    check_types(
+        r#"
+//- /lib.rs crate:lib deps:core
+use core::u16;
+
+fn f() -> u16 {
+    let x = u16::from_le_bytes();
+      x
+    //^ u16
+}
+
+//- /core.rs crate:core
+pub mod u16 {}
+
+impl u16 {
+    pub fn from_le_bytes() -> Self { 0 }
+}
+        "#,
+    )
+}


### PR DESCRIPTION
Closes https://github.com/rust-analyzer/rust-analyzer/issues/6082