### PR TITLE
fix: enable ADT keyword completions in block expressions

### DIFF
--- a/crates/ide_completion/src/completions/keyword.rs
+++ b/crates/ide_completion/src/completions/keyword.rs
@@ -86,7 +86,7 @@ pub(crate) fn complete_expr_keyword(acc: &mut Completions, ctx: &CompletionConte
         add_keyword("mod", "mod $0");
     }
 
-    if expects_item {
+    if expects_item || has_block_expr_parent {
         add_keyword("enum", "enum $1 {\n    $0\n}");
         add_keyword("struct", "struct $0");
         add_keyword("union", "union $1 {\n    $0\n}");

--- a/crates/ide_completion/src/tests/expression.rs
+++ b/crates/ide_completion/src/tests/expression.rs
@@ -137,6 +137,9 @@ impl Unit {
             kw trait
             kw static
             kw mod
+            kw enum
+            kw struct
+            kw union
             kw match
             kw while
             kw while let
@@ -227,6 +230,9 @@ fn complete_in_block() {
             kw trait
             kw static
             kw mod
+            kw enum
+            kw struct
+            kw union
             kw match
             kw while
             kw while let
@@ -269,6 +275,9 @@ fn complete_after_if_expr() {
             kw trait
             kw static
             kw mod
+            kw enum
+            kw struct
+            kw union
             kw match
             kw while
             kw while let
@@ -339,6 +348,9 @@ fn completes_in_loop_ctx() {
             kw trait
             kw static
             kw mod
+            kw enum
+            kw struct
+            kw union
             kw match
             kw while
             kw while let


### PR DESCRIPTION
fixes https://github.com/rust-lang/rust-analyzer/issues/11576