### PR TITLE
fix: support `associated_const_equality` in parser

### DIFF
--- a/crates/parser/src/grammar/generic_args.rs
+++ b/crates/parser/src/grammar/generic_args.rs
@@ -40,11 +40,19 @@ fn generic_arg(p: &mut Parser) {
             name_ref(p);
             opt_generic_arg_list(p, false);
             match p.current() {
-                // test assoc_type_eq
-                // type T = StreamingIterator<Item<'a> = &'a T>;
                 T![=] => {
                     p.bump_any();
-                    types::type_(p);
+                    if types::TYPE_FIRST.contains(p.current()) {
+                        // test assoc_type_eq
+                        // type T = StreamingIterator<Item<'a> = &'a T>;
+                        types::type_(p);
+                    } else {
+                        // test assoc_const_eq
+                        // fn foo<F: Foo<N=3>>() {}
+                        // const TEST: usize = 3;
+                        // fn bar<F: Foo<N={TEST}>>() {}
+                        const_arg(p);
+                    }
                     m.complete(p, ASSOC_TYPE_ARG);
                 }
                 // test assoc_type_bound

--- a/crates/parser/test_data/parser/inline/ok/0200_assoc_const_eq.rast
+++ b/crates/parser/test_data/parser/inline/ok/0200_assoc_const_eq.rast
@@ -1,0 +1,105 @@
+SOURCE_FILE
+  FN
+    FN_KW "fn"
+    WHITESPACE " "
+    NAME
+      IDENT "foo"
+    GENERIC_PARAM_LIST
+      L_ANGLE "<"
+      TYPE_PARAM
+        NAME
+          IDENT "F"
+        COLON ":"
+        WHITESPACE " "
+        TYPE_BOUND_LIST
+          TYPE_BOUND
+            PATH_TYPE
+              PATH
+                PATH_SEGMENT
+                  NAME_REF
+                    IDENT "Foo"
+                  GENERIC_ARG_LIST
+                    L_ANGLE "<"
+                    ASSOC_TYPE_ARG
+                      NAME_REF
+                        IDENT "N"
+                      EQ "="
+                      CONST_ARG
+                        LITERAL
+                          INT_NUMBER "3"
+                    R_ANGLE ">"
+      R_ANGLE ">"
+    PARAM_LIST
+      L_PAREN "("
+      R_PAREN ")"
+    WHITESPACE " "
+    BLOCK_EXPR
+      STMT_LIST
+        L_CURLY "{"
+        R_CURLY "}"
+  WHITESPACE "\n"
+  CONST
+    CONST_KW "const"
+    WHITESPACE " "
+    NAME
+      IDENT "TEST"
+    COLON ":"
+    WHITESPACE " "
+    PATH_TYPE
+      PATH
+        PATH_SEGMENT
+          NAME_REF
+            IDENT "usize"
+    WHITESPACE " "
+    EQ "="
+    WHITESPACE " "
+    LITERAL
+      INT_NUMBER "3"
+    SEMICOLON ";"
+  WHITESPACE "\n"
+  FN
+    FN_KW "fn"
+    WHITESPACE " "
+    NAME
+      IDENT "bar"
+    GENERIC_PARAM_LIST
+      L_ANGLE "<"
+      TYPE_PARAM
+        NAME
+          IDENT "F"
+        COLON ":"
+        WHITESPACE " "
+        TYPE_BOUND_LIST
+          TYPE_BOUND
+            PATH_TYPE
+              PATH
+                PATH_SEGMENT
+                  NAME_REF
+                    IDENT "Foo"
+                  GENERIC_ARG_LIST
+                    L_ANGLE "<"
+                    ASSOC_TYPE_ARG
+                      NAME_REF
+                        IDENT "N"
+                      EQ "="
+                      CONST_ARG
+                        BLOCK_EXPR
+                          STMT_LIST
+                            L_CURLY "{"
+                            PATH_EXPR
+                              PATH
+                                PATH_SEGMENT
+                                  NAME_REF
+                                    IDENT "TEST"
+                            R_CURLY "}"
+                    R_ANGLE ">"
+      R_ANGLE ">"
+    PARAM_LIST
+      L_PAREN "("
+      R_PAREN ")"
+    WHITESPACE " "
+    BLOCK_EXPR
+      STMT_LIST
+        L_CURLY "{"
+        R_CURLY "}"
+  WHITESPACE "\n"

--- a/crates/parser/test_data/parser/inline/ok/0200_assoc_const_eq.rs
+++ b/crates/parser/test_data/parser/inline/ok/0200_assoc_const_eq.rs
@@ -1,0 +1,3 @@
+fn foo<F: Foo<N=3>>() {}
+const TEST: usize = 3;
+fn bar<F: Foo<N={TEST}>>() {}

--- a/crates/syntax/rust.ungram
+++ b/crates/syntax/rust.ungram
@@ -51,7 +51,7 @@ TypeArg =
   Type
 
 AssocTypeArg =
-  NameRef GenericParamList? (':' TypeBoundList | '=' Type)
+  NameRef GenericParamList? (':' TypeBoundList | ('=' Type | ConstArg))
 
 LifetimeArg =
   Lifetime

--- a/crates/syntax/src/ast/generated/nodes.rs
+++ b/crates/syntax/src/ast/generated/nodes.rs
@@ -123,6 +123,7 @@ impl AssocTypeArg {
     pub fn generic_param_list(&self) -> Option<GenericParamList> { support::child(&self.syntax) }
     pub fn eq_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![=]) }
     pub fn ty(&self) -> Option<Type> { support::child(&self.syntax) }
+    pub fn const_arg(&self) -> Option<ConstArg> { support::child(&self.syntax) }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]


### PR DESCRIPTION
This pr fixes #11965.  The parser now allows eq constraints on associated constants.  

I've added tests for `HasCount<Count = {N}>` and `HasCount<Count = 0>`