### PR TITLE
[Documentation]: Update developer documentation link.

### DIFF
--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -13,7 +13,7 @@ To learn more about how rust-analyzer works, see [./architecture.md](./architect
 It also explains the high-level layout of the source code.
 Do skim through that document.
 
-We also publish rustdoc docs to pages: https://rust-analyzer.github.io/rust-analyzer/ide/.
+We also publish rustdoc docs to pages: https://rust-lang.github.io/rust-analyzer/ide/.
 Note though, that the internal documentation is very incomplete.
 
 Various organizational and process issues are discussed in this document.


### PR DESCRIPTION
Just noticed the docs links broken. The current doc link was broken. replaced with the updated version as found on the front page. Should the rest of the links be updated?