### PR TITLE
derive completions take existing derives into count

### DIFF
--- a/crates/ide_completion/src/tests/attribute.rs
+++ b/crates/ide_completion/src/tests/attribute.rs
@@ -748,6 +748,27 @@ mod derive {
     }
 
     #[test]
+    fn derive_with_existing_derives() {
+        check_derive(
+            r#"
+//- minicore: derive, copy, clone, ord, eq, default, fmt
+#[derive(PartialEq, Eq, Or$0)] struct Test;
+"#,
+            expect![[r#"
+                md core
+                de Default         macro Default
+                de Clone, Copy
+                de PartialOrd, Ord
+                de Clone           macro Clone
+                de PartialOrd
+                kw self::
+                kw super::
+                kw crate::
+            "#]],
+        );
+    }
+
+    #[test]
     fn derive_flyimport() {
         check_derive(
             r#"


### PR DESCRIPTION
fixes #12019 

The immediate reason is that when we are doing derive completion, [`ctx.existing_derives`](https://github.com/rust-lang/rust-analyzer/blob/d1f6b4e2a0ab1a1343ab4a381c89b186a76fd001/crates/ide_completion/src/completions/attribute/derive.rs#L82) is empty, this is because we expand the macro when looking for the ancestors of the token to be completed. Take the following code as an example, we find the first `SyntaxNode` with kind `Attr` based on the ancestors of the token, but the parent of `Attr` is not a `Struct` as we [expect](https://github.com/rust-lang/rust-analyzer/blob/d1f6b4e2a0ab1a1343ab4a381c89b186a76fd001/crates/hir/src/semantics.rs#L518).  
```rust
#[derive(PartialEq, Eq, Or$0)]
struct S;
```
The ancestors of the token to be completed above.
```
    NAME_REF@24..26
      IDENT@24..26 "Or"
    ,
    PATH_SEGMENT@24..26
      NAME_REF@24..26
        IDENT@24..26 "Or"
    ,
    PATH@24..26
      PATH_SEGMENT@24..26
        NAME_REF@24..26
          IDENT@24..26 "Or"
    ,
    META@24..26
      PATH@24..26
        PATH_SEGMENT@24..26
          NAME_REF@24..26
            IDENT@24..26 "Or"
    ,
    ATTR@21..28
      POUND@21..22 "#"
      WHITESPACE@22..23 " "
      L_BRACK@23..24 "["
      META@24..26
        PATH@24..26
          PATH_SEGMENT@24..26
            NAME_REF@24..26
              IDENT@24..26 "Or"
      R_BRACK@26..27 "]"
      WHITESPACE@27..28 " "
    ,
    TUPLE_EXPR@0..32
      ATTR@0..14
        POUND@0..1 "#"
        WHITESPACE@1..2 " "
        L_BRACK@2..3 "["
        META@3..12
          PATH@3..12
            PATH_SEGMENT@3..12
              NAME_REF@3..12
                IDENT@3..12 "PartialEq"
        R_BRACK@12..13 "]"
        WHITESPACE@13..14 " "
      ATTR@14..21
        POUND@14..15 "#"
        WHITESPACE@15..16 " "
        L_BRACK@16..17 "["
        META@17..19
          PATH@17..19
            PATH_SEGMENT@17..19
              NAME_REF@17..19
                IDENT@17..19 "Eq"
        R_BRACK@19..20 "]"
        WHITESPACE@20..21 " "
      ATTR@21..28
        POUND@21..22 "#"
        WHITESPACE@22..23 " "
        L_BRACK@23..24 "["
        META@24..26
          PATH@24..26
            PATH_SEGMENT@24..26
              NAME_REF@24..26
                IDENT@24..26 "Or"
        R_BRACK@26..27 "]"
        WHITESPACE@27..28 " "
      L_PAREN@28..29 "("
      WHITESPACE@29..30 " "
      R_PAREN@30..31 ")"
      WHITESPACE@31..32 " "
...
```

I make a small change to not do macro expansion when looking up the ancestors of the token.  

What I don't understand is that `self.sema.token_ancestors_with_macros(self.token.clone())` doesn't seem to expand the macro if the derive completion triggered without any prefix, like `#[derive(PartialEq, Eq, $0)]`.  

The ancestors of the token with  `#[derive(PartialEq, Eq, $0)]`.    
```
    TOKEN_TREE@8..25
      L_PAREN@8..9 "("
      IDENT@9..18 "PartialEq"
      COMMA@18..19 ","
      WHITESPACE@19..20 " "
      IDENT@20..22 "Eq"
      COMMA@22..23 ","
      WHITESPACE@23..24 " "
      R_PAREN@24..25 ")"
    ,
    META@2..25
      PATH@2..8
        PATH_SEGMENT@2..8
          NAME_REF@2..8
            IDENT@2..8 "derive"
      TOKEN_TREE@8..25
        L_PAREN@8..9 "("
        IDENT@9..18 "PartialEq"
        COMMA@18..19 ","
        WHITESPACE@19..20 " "
        IDENT@20..22 "Eq"
        COMMA@22..23 ","
        WHITESPACE@23..24 " "
        R_PAREN@24..25 ")"
    ,
    ATTR@0..26
      POUND@0..1 "#"
      L_BRACK@1..2 "["
      META@2..25
        PATH@2..8
          PATH_SEGMENT@2..8
            NAME_REF@2..8
              IDENT@2..8 "derive"
        TOKEN_TREE@8..25
          L_PAREN@8..9 "("
          IDENT@9..18 "PartialEq"
          COMMA@18..19 ","
          WHITESPACE@19..20 " "
          IDENT@20..22 "Eq"
          COMMA@22..23 ","
          WHITESPACE@23..24 " "
          R_PAREN@24..25 ")"
      R_BRACK@25..26 "]"
    ,
    STRUCT@0..39
      ATTR@0..26
        POUND@0..1 "#"
        L_BRACK@1..2 "["
        META@2..25
          PATH@2..8
            PATH_SEGMENT@2..8
              NAME_REF@2..8
                IDENT@2..8 "derive"
          TOKEN_TREE@8..25
            L_PAREN@8..9 "("
            IDENT@9..18 "PartialEq"
            COMMA@18..19 ","
            WHITESPACE@19..20 " "
            IDENT@20..22 "Eq"
            COMMA@22..23 ","
            WHITESPACE@23..24 " "
            R_PAREN@24..25 ")"
        R_BRACK@25..26 "]"
      WHITESPACE@26..27 " "
      STRUCT_KW@27..33 "struct"
      WHITESPACE@33..34 " "
      NAME@34..38
        IDENT@34..38 "Test"
      SEMICOLON@38..39 ";"
...
```