### PR TITLE
fix: Remove `rust-analyzer.inlayHints.enable` and set language scope

### DIFF
--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -293,11 +293,6 @@
                     "default": null,
                     "markdownDescription": "Environment variables passed to the runnable launched using `Test` or `Debug` lens or `rust-analyzer.run` command."
                 },
-                "rust-analyzer.inlayHints.enable": {
-                    "type": "boolean",
-                    "default": true,
-                    "description": "Whether to show inlay hints."
-                },
                 "rust-analyzer.server.path": {
                     "type": [
                         "null",

--- a/editors/code/src/commands.ts
+++ b/editors/code/src/commands.ts
@@ -300,10 +300,9 @@ export function serverVersion(ctx: Ctx): Cmd {
 
 export function toggleInlayHints(_ctx: Ctx): Cmd {
     return async () => {
-        const scope = vscode.ConfigurationTarget.Global;
-        const config = vscode.workspace.getConfiguration("editor.inlayHints");
+        const config = vscode.workspace.getConfiguration("editor.inlayHints", { languageId: "rust" });
         const value = !config.get("enabled");
-        await config.update('enabled', value, scope);
+        await config.update('enabled', value, vscode.ConfigurationTarget.Global);
     };
 }
 


### PR DESCRIPTION
Closes #12036
CC https://github.com/rust-lang/rust-analyzer/issues/12027#issuecomment-1102990324

The key was left there by mistake in #12006.

Setting the configuration scope only works if you already have it created, which is fine, but unfortunately not quite discoverable.