### PR TITLE
fix: index the correct CargoWorkspace with rustc_private

### DIFF
--- a/crates/project_model/src/workspace.rs
+++ b/crates/project_model/src/workspace.rs
@@ -759,7 +759,9 @@ fn handle_rustc_crates(
 
             let overrides = match override_cfg {
                 CfgOverrides::Wildcard(cfg_diff) => Some(cfg_diff),
-                CfgOverrides::Selective(cfg_overrides) => cfg_overrides.get(&cargo[pkg].name),
+                CfgOverrides::Selective(cfg_overrides) => {
+                    cfg_overrides.get(&rustc_workspace[pkg].name)
+                }
             };
 
             if let Some(overrides) = overrides {


### PR DESCRIPTION
I believe this fixes #12043, but I'm not sufficiently setup/familiar with working on rust-analyzer to test it locally. :/

This section of code is iterating on `rustc_workspace.packages()` but then indexes `cargo[pkg]`, which is likely the source of the bug.