### PR TITLE
Change tabs to spacs in macro_rules snippet

### DIFF
--- a/crates/ide_completion/src/completions/snippet.rs
+++ b/crates/ide_completion/src/completions/snippet.rs
@@ -94,7 +94,17 @@ fn ${1:feature}() {
     item.lookup_by("tfn");
     item.add_to(acc);
 
-    let item = snippet(ctx, cap, "macro_rules", "macro_rules! $1 {\n\t($2) => {\n\t\t$0\n\t};\n}");
+    let item = snippet(
+        ctx,
+        cap,
+        "macro_rules",
+        "\
+macro_rules! $1 {
+    ($2) => {
+        $0
+    };
+}",
+    );
     item.add_to(acc);
 }
 


### PR DESCRIPTION
This PR changes the `macro_rules!` snippet to use spaces instead of tabs. 
The other snippets like [this one][test-snippet] already use spaces.

The snippet was introduced in 5575588 where no reason is provided to use tabs.

[test-snippet]: https://github.com/rust-lang/rust-analyzer/blob/master/crates/ide_completion/src/completions/snippet.rs#L70=