### PR TITLE
Revert #11490

### DIFF
--- a/crates/ide/src/runnables.rs
+++ b/crates/ide/src/runnables.rs
@@ -435,7 +435,8 @@ fn module_def_doctest(db: &RootDatabase, def: Definition) -> Option<Runnable> {
                             ty_args.format_with(", ", |ty, cb| cb(&ty.display(db)))
                         );
                     }
-                    return Some(format!(r#""{}::{}""#, path, def_name));
+                    format_to!(path, "::{}\"", def_name);
+                    return Some(format!("\"{}", path));
                 }
             }
         }

--- a/crates/ide/src/runnables.rs
+++ b/crates/ide/src/runnables.rs
@@ -435,8 +435,8 @@ fn module_def_doctest(db: &RootDatabase, def: Definition) -> Option<Runnable> {
                             ty_args.format_with(", ", |ty, cb| cb(&ty.display(db)))
                         );
                     }
-                    format_to!(path, "::{}\"", def_name);
-                    return Some(format!("\"{}", path));
+                    format_to!(path, "::{}", def_name);
+                    return Some(path);
                 }
             }
         }
@@ -978,7 +978,7 @@ impl Data {
                         },
                         kind: DocTest {
                             test_id: Path(
-                                "\"Data::foo\"",
+                                "Data::foo",
                             ),
                         },
                         cfg: None,
@@ -1372,7 +1372,7 @@ impl Foo {
                         },
                         kind: DocTest {
                             test_id: Path(
-                                "\"foo::Foo::foo\"",
+                                "foo::Foo::foo",
                             ),
                         },
                         cfg: None,
@@ -2078,7 +2078,7 @@ impl<T, U> Foo<T, U> {
                         },
                         kind: DocTest {
                             test_id: Path(
-                                "\"Foo<T, U>::t\"",
+                                "Foo<T, U>::t",
                             ),
                         },
                         cfg: None,


### PR DESCRIPTION
Closes #11725

#11490 was a little misguided. Quoting the test name should be a client concern, since it's the client that actually runs `cargo`.