### PR TITLE
improve the default constructor mode when filling fields

### DIFF
--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -1780,6 +1780,10 @@ impl BuiltinType {
         matches!(self.inner, hir_def::builtin_type::BuiltinType::Char)
     }
 
+    pub fn is_bool(&self) -> bool {
+        matches!(self.inner, hir_def::builtin_type::BuiltinType::Bool)
+    }
+
     pub fn is_str(&self) -> bool {
         matches!(self.inner, hir_def::builtin_type::BuiltinType::Str)
     }

--- a/crates/syntax/src/ast/make.rs
+++ b/crates/syntax/src/ast/make.rs
@@ -81,6 +81,9 @@ pub mod ext {
     pub fn default_bool() -> ast::Expr {
         expr_from_text("false")
     }
+    pub fn option_none() -> ast::Expr {
+        expr_from_text("None")
+    }
     pub fn empty_block_expr() -> ast::BlockExpr {
         block_expr(None, None)
     }


### PR DESCRIPTION
Instead of filling a boolean field with `bool::default()` it's not `false` and same for `Option` instead of using `Option::default()` it will be `None`