### PR TITLE
fix: Fix panic when a macro passes a float token to another macro

### DIFF
--- a/crates/hir-def/src/macro_expansion_tests/mbe/tt_conversion.rs
+++ b/crates/hir-def/src/macro_expansion_tests/mbe/tt_conversion.rs
@@ -175,3 +175,33 @@ const _: () = 0e0;
 "#]],
     );
 }
+
+#[test]
+fn float_literal_in_tt() {
+    check(
+        r#"
+macro_rules! constant {
+    ($( $ret:expr; )*) => {};
+}
+
+macro_rules! float_const_impl {
+    () => ( constant!(0.3; 3.3;); );
+}
+
+float_const_impl! {}
+"#,
+        expect![[r#"
+macro_rules! constant {
+    ($( $ret:expr; )*) => {};
+}
+
+macro_rules! float_const_impl {
+    () => ( constant!(0.3; 3.3;); );
+}
+
+constant!(0.3;
+3.3;
+);
+"#]],
+    );
+}


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust-analyzer/issues/12170 (num-traits no longer causes a panic)