### PR TITLE
fix: Remap float parts as integers when parsed as indices

### DIFF
--- a/crates/parser/src/grammar.rs
+++ b/crates/parser/src/grammar.rs
@@ -323,8 +323,8 @@ fn name_ref_or_index(p: &mut Parser) {
         p.at(IDENT) || p.at(INT_NUMBER) || p.at(FLOAT_NUMBER_PART) || p.at_ts(FLOAT_LITERAL_FIRST)
     );
     let m = p.start();
-    if p.at_ts(FLOAT_LITERAL_FIRST) {
-        p.bump_remap(FLOAT_NUMBER_PART);
+    if p.at(FLOAT_NUMBER_PART) || p.at_ts(FLOAT_LITERAL_FIRST) {
+        p.bump_remap(INT_NUMBER);
     } else {
         p.bump_any();
     }

--- a/crates/parser/test_data/parser/inline/ok/0011_field_expr.rast
+++ b/crates/parser/test_data/parser/inline/ok/0011_field_expr.rast
@@ -50,7 +50,7 @@ SOURCE_FILE
                       IDENT "x"
               DOT "."
               NAME_REF
-                FLOAT_NUMBER_PART "0"
+                INT_NUMBER "0"
             DOT "."
             WHITESPACE " "
             NAME_REF
@@ -67,10 +67,10 @@ SOURCE_FILE
                       IDENT "x"
               DOT "."
               NAME_REF
-                FLOAT_NUMBER_PART "0"
+                INT_NUMBER "0"
             DOT "."
             NAME_REF
-              FLOAT_NUMBER_PART "1"
+              INT_NUMBER "1"
           SEMICOLON ";"
         WHITESPACE "\n    "
         EXPR_STMT


### PR DESCRIPTION
`NameRef`s should only contain integers and identifiers
cc https://github.com/rust-lang/rust-analyzer/pull/12149