### PR TITLE
Fix a typo in the `inlayHints.renderColons` option description

### DIFF
--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -264,7 +264,7 @@ config_data! {
         inlayHints_parameterHints_enable: bool                     = "true",
         /// Whether to show inlay type hints for compiler inserted reborrows.
         inlayHints_reborrowHints_enable: bool                      = "false",
-        /// Whether to render trailing colons for parameter hints, and trailing colons for parameter hints.
+        /// Whether to render leading colons for type hints, and trailing colons for parameter hints.
         inlayHints_renderColons: bool                              = "true",
         /// Whether to show inlay type hints for variables.
         inlayHints_typeHints_enable: bool                          = "true",

--- a/docs/user/generated_config.adoc
+++ b/docs/user/generated_config.adoc
@@ -373,7 +373,7 @@ Whether to show inlay type hints for compiler inserted reborrows.
 [[rust-analyzer.inlayHints.renderColons]]rust-analyzer.inlayHints.renderColons (default: `true`)::
 +
 --
-Whether to render trailing colons for parameter hints, and trailing colons for parameter hints.
+Whether to render leading colons for type hints, and trailing colons for parameter hints.
 --
 [[rust-analyzer.inlayHints.typeHints.enable]]rust-analyzer.inlayHints.typeHints.enable (default: `true`)::
 +

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -814,7 +814,7 @@
                     "type": "boolean"
                 },
                 "rust-analyzer.inlayHints.renderColons": {
-                    "markdownDescription": "Whether to render trailing colons for parameter hints, and trailing colons for parameter hints.",
+                    "markdownDescription": "Whether to render leading colons for type hints, and trailing colons for parameter hints.",
                     "default": true,
                     "type": "boolean"
                 },


### PR DESCRIPTION
The description said the same thing twice: "trailing colons for parameter hints, and trailing colons for parameter hints".
I'm assuming one of those is supposed to be about the leading colon for type hints.

Also, I wasn't sure how to regenerate the generated file(s?) so I just manually updated them. Hopefully that isn't a problem. If how to do that is in the documentation somewhere I'd love to know.