### PR TITLE
feat: Support variable substitution in VSCode settings

### DIFF
--- a/editors/code/package-lock.json
+++ b/editors/code/package-lock.json
@@ -19,6 +19,7 @@
                 "@typescript-eslint/eslint-plugin": "^5.16.0",
                 "@typescript-eslint/parser": "^5.16.0",
                 "@vscode/test-electron": "^2.1.3",
+                "cross-env": "^7.0.3",
                 "esbuild": "^0.14.27",
                 "eslint": "^8.11.0",
                 "tslib": "^2.3.0",
@@ -27,7 +28,7 @@
                 "vsce": "^2.7.0"
             },
             "engines": {
-                "vscode": "^1.65.0"
+                "vscode": "^1.66.0"
             }
         },
         "node_modules/@eslint/eslintrc": {
@@ -789,6 +790,24 @@
             "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
             "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
             "dev": true
+        },
+        "node_modules/cross-env": {
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+            "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+            "dev": true,
+            "dependencies": {
+                "cross-spawn": "^7.0.1"
+            },
+            "bin": {
+                "cross-env": "src/bin/cross-env.js",
+                "cross-env-shell": "src/bin/cross-env-shell.js"
+            },
+            "engines": {
+                "node": ">=10.14",
+                "npm": ">=6",
+                "yarn": ">=1"
+            }
         },
         "node_modules/cross-spawn": {
             "version": "7.0.3",
@@ -4662,6 +4681,15 @@
             "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
             "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
             "dev": true
+        },
+        "cross-env": {
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+            "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+            "dev": true,
+            "requires": {
+                "cross-spawn": "^7.0.1"
+            }
         },
         "cross-spawn": {
             "version": "7.0.3",

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -33,12 +33,12 @@
         "lint": "tsfmt --verify && eslint -c .eslintrc.js --ext ts ./src ./tests",
         "fix": " tsfmt -r       && eslint -c .eslintrc.js --ext ts ./src ./tests --fix",
         "pretest": "tsc && npm run build",
-        "test": "node ./out/tests/runTests.js"
+        "test": "cross-env TEST_VARIABLE=test node ./out/tests/runTests.js"
     },
     "dependencies": {
-        "vscode-languageclient": "8.0.0-next.14",
         "d3": "^7.3.0",
-        "d3-graphviz": "^4.1.0"
+        "d3-graphviz": "^4.1.0",
+        "vscode-languageclient": "8.0.0-next.14"
     },
     "devDependencies": {
         "@types/node": "~14.17.5",
@@ -46,6 +46,7 @@
         "@typescript-eslint/eslint-plugin": "^5.16.0",
         "@typescript-eslint/parser": "^5.16.0",
         "@vscode/test-electron": "^2.1.3",
+        "cross-env": "^7.0.3",
         "esbuild": "^0.14.27",
         "eslint": "^8.11.0",
         "tslib": "^2.3.0",

--- a/editors/code/src/client.ts
+++ b/editors/code/src/client.ts
@@ -6,6 +6,7 @@ import { assert } from './util';
 import { WorkspaceEdit } from 'vscode';
 import { Workspace } from './ctx';
 import { updateConfig } from './config';
+import { substituteVariablesInEnv } from './config';
 
 export interface Env {
     [name: string]: string;
@@ -30,9 +31,9 @@ export async function createClient(serverPath: string, workspace: Workspace, ext
     // TODO?: Workspace folders support Uri's (eg: file://test.txt).
     // It might be a good idea to test if the uri points to a file.
 
-    const newEnv = Object.assign({}, process.env);
-    Object.assign(newEnv, extraEnv);
-
+    const newEnv = substituteVariablesInEnv(Object.assign(
+        {}, process.env, extraEnv
+    ));
     const run: lc.Executable = {
         command: serverPath,
         options: { env: newEnv },

--- a/editors/code/src/config.ts
+++ b/editors/code/src/config.ts
@@ -232,7 +232,30 @@ export function substituteVariablesInEnv(env: Env): Env {
     }));
 
     const resolved = new Set<string>();
-    // TODO: handle missing dependencies
+    for (const dep of missingDeps) {
+        const match = /(?<prefix>.*?):(?<body>.+)/.exec(dep);
+        if (match) {
+            const { prefix, body } = match.groups!;
+            if (prefix === 'env') {
+                const envName = body;
+                envWithDeps[dep] = {
+                    value: process.env[envName] ?? '',
+                    deps: []
+                };
+                resolved.add(dep);
+            } else {
+                // we can't handle other prefixes at the moment
+                // leave values as is, but still mark them as resolved
+                envWithDeps[dep] = {
+                    value: '${' + dep + '}',
+                    deps: []
+                };
+                resolved.add(dep);
+            }
+        } else {
+            // TODO: handle VSCode variables
+        }
+    }
     const toResolve = new Set(Object.keys(envWithDeps));
 
     let leftToResolveSize;

--- a/editors/code/tests/runTests.ts
+++ b/editors/code/tests/runTests.ts
@@ -14,7 +14,7 @@ async function main() {
     let minimalVersion: string = json.engines.vscode;
     if (minimalVersion.startsWith('^')) minimalVersion = minimalVersion.slice(1);
 
-    const launchArgs = ["--disable-extensions"];
+    const launchArgs = ["--disable-extensions", extensionDevelopmentPath];
 
     // All test suites (either unit tests or integration tests) should be in subfolders.
     const extensionTestsPath = path.resolve(__dirname, './unit/index');

--- a/editors/code/tests/unit/index.ts
+++ b/editors/code/tests/unit/index.ts
@@ -1,3 +1,4 @@
+import { readdir } from 'fs/promises';
 import * as path from 'path';
 
 class Test {
@@ -57,7 +58,8 @@ export class Context {
 
 export async function run(): Promise<void> {
     const context = new Context();
-    const testFiles = ["launch_config.test.js", "runnable_env.test.js"];
+
+    const testFiles = (await readdir(path.resolve(__dirname))).filter(name => name.endsWith('.test.js'));
     for (const testFile of testFiles) {
         try {
             const testModule = require(path.resolve(__dirname, testFile));

--- a/editors/code/tests/unit/settings.test.ts
+++ b/editors/code/tests/unit/settings.test.ts
@@ -37,5 +37,17 @@ export async function getTests(ctx: Context) {
             const actualEnv = await substituteVariablesInEnv(envJson);
             assert.deepStrictEqual(actualEnv, expectedEnv);
         });
+
+        suite.addTest('Should support external variables', async () => {
+            const envJson = {
+                USING_EXTERNAL_VAR: "${env:TEST_VARIABLE} test ${env:TEST_VARIABLE}"
+            };
+            const expectedEnv = {
+                USING_EXTERNAL_VAR: "test test test"
+            };
+
+            const actualEnv = await substituteVariablesInEnv(envJson);
+            assert.deepStrictEqual(actualEnv, expectedEnv);
+        });
     });
 }

--- a/editors/code/tests/unit/settings.test.ts
+++ b/editors/code/tests/unit/settings.test.ts
@@ -1,0 +1,41 @@
+import * as assert from 'assert';
+import { Context } from '.';
+import { substituteVariablesInEnv } from '../../src/config';
+
+export async function getTests(ctx: Context) {
+    await ctx.suite('Server Env Settings', suite => {
+        suite.addTest('Replacing Env Variables', async () => {
+            const envJson = {
+                USING_MY_VAR: "${env:MY_VAR} test ${env:MY_VAR}",
+                MY_VAR: "test"
+            };
+            const expectedEnv = {
+                USING_MY_VAR: "test test test",
+                MY_VAR: "test"
+            };
+            const actualEnv = await substituteVariablesInEnv(envJson);
+            assert.deepStrictEqual(actualEnv, expectedEnv);
+        });
+
+        suite.addTest('Circular dependencies remain as is', async () => {
+            const envJson = {
+                A_USES_B: "${env:B_USES_A}",
+                B_USES_A: "${env:A_USES_B}",
+                C_USES_ITSELF: "${env:C_USES_ITSELF}",
+                D_USES_C: "${env:C_USES_ITSELF}",
+                E_IS_ISOLATED: "test",
+                F_USES_E: "${env:E_IS_ISOLATED}"
+            };
+            const expectedEnv = {
+                A_USES_B: "${env:B_USES_A}",
+                B_USES_A: "${env:A_USES_B}",
+                C_USES_ITSELF: "${env:C_USES_ITSELF}",
+                D_USES_C: "${env:C_USES_ITSELF}",
+                E_IS_ISOLATED: "test",
+                F_USES_E: "test"
+            };
+            const actualEnv = await substituteVariablesInEnv(envJson);
+            assert.deepStrictEqual(actualEnv, expectedEnv);
+        });
+    });
+}

--- a/editors/code/tests/unit/settings.test.ts
+++ b/editors/code/tests/unit/settings.test.ts
@@ -49,5 +49,13 @@ export async function getTests(ctx: Context) {
             const actualEnv = await substituteVariablesInEnv(envJson);
             assert.deepStrictEqual(actualEnv, expectedEnv);
         });
+
+        suite.addTest('should support VSCode variables', async () => {
+            const envJson = {
+                USING_VSCODE_VAR: "${workspaceFolderBasename}"
+            };
+            const actualEnv = await substituteVariablesInEnv(envJson);
+            assert.deepStrictEqual(actualEnv.USING_VSCODE_VAR, 'code');
+        });
     });
 }


### PR DESCRIPTION
Currently support a subset of [variables provided by VSCode](https://code.visualstudio.com/docs/editor/variables-reference) in `server.extraEnv` section of Rust-Analyzer settings:

  * `workspaceFolder`
  * `workspaceFolderBasename`
  * `cwd`
  * `execPath`
  * `pathSeparator`

Also, this PR adds support for general environment variables resolution. You can declare environment variables and reference them from other variables like this:

```JSON
"rust-analyzer.server.extraEnv": {
    "RUSTFLAGS": "-L${env:OPEN_XR_SDK_PATH}",
    "OPEN_XR_SDK_PATH": "${workspaceFolder}\\..\\OpenXR-SDK\\build\\src\\loader\\Release"
},
```
The order of variable declaration doesn't matter, you can reference variables before defining them. If the variable is not present in `extraEnv` section, VSCode will search for them in your environment. Missing variables will be replaced with empty string. Circular references won't be resolved and will be passed to rust-analyzer server process as is.

Closes #9626, but doesn't address use cases where people want to use values provided by `rustc` or `cargo`, such as `${targetTriple}` proposal #11649