### PR TITLE
Fix `character` semantic token type definition

### DIFF
--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -1216,9 +1216,9 @@
                 "superType": "type"
             },
             {
-                "id": "char",
+                "id": "character",
                 "description": "Style for character literals",
-                "superType": "type"
+                "superType": "string"
             },
             {
                 "id": "colon",


### PR DESCRIPTION
The semantic token type for character literals is called `character`:

https://github.com/rust-lang/rust-analyzer/blob/94fa8a6534cf93276ad7e205026402f24d41a0b2/crates/rust-analyzer/src/semantic_tokens.rs#L51

and yet the definition in `package.json` uses `char`. In practice this means trying to highlight `char` doesn’t have any effect, while `character` doesn’t have any hover documentation and doesn’t appear in autocomplete. The definition also defines the fallback semantic token type as `type`; luckily since it currently references the non-existent `char` this doesn’t have any effect, since it doesn’t really make sense to highlight character literals as types.

This PR fixes the definition in `package.json` to correctly reference `character`, and also defines the fallback type as `number`. I’d say character literals are closer to a shorthand for writing a number than a string, though this is debatable and I’d be happy to change it to `string`, or anything else.