### PR TITLE
feat: hide type inlay hints for initializations of closures

### DIFF
--- a/crates/ide/src/static_index.rs
+++ b/crates/ide/src/static_index.rs
@@ -113,6 +113,7 @@ impl StaticIndex<'_> {
                     lifetime_elision_hints: crate::LifetimeElisionHints::Never,
                     reborrow_hints: crate::ReborrowHints::Never,
                     hide_named_constructor_hints: false,
+                    hide_closure_initialization_hints: false,
                     param_names_for_lifetime_elision_hints: false,
                     binding_mode_hints: false,
                     max_length: Some(25),

--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -281,6 +281,9 @@ config_data! {
         inlayHints_renderColons: bool                              = "true",
         /// Whether to show inlay type hints for variables.
         inlayHints_typeHints_enable: bool                          = "true",
+        /// Whether to hide inlay type hints for `let` statements that initialize to a closure.
+        /// Only applies to closures with blocks, same as `#rust-analyzer.inlayHints.closureReturnTypeHints.enable#`.
+        inlayHints_typeHints_hideClosureInitialization: bool       = "false",
         /// Whether to hide inlay type hints for constructors.
         inlayHints_typeHints_hideNamedConstructor: bool            = "false",
 
@@ -1000,6 +1003,9 @@ impl Config {
                 LifetimeElisionDef::SkipTrivial => ide::LifetimeElisionHints::SkipTrivial,
             },
             hide_named_constructor_hints: self.data.inlayHints_typeHints_hideNamedConstructor,
+            hide_closure_initialization_hints: self
+                .data
+                .inlayHints_typeHints_hideClosureInitialization,
             reborrow_hints: match self.data.inlayHints_reborrowHints_enable {
                 ReborrowHintsDef::Always => ide::ReborrowHints::Always,
                 ReborrowHintsDef::Never => ide::ReborrowHints::Never,

--- a/docs/user/generated_config.adoc
+++ b/docs/user/generated_config.adoc
@@ -407,6 +407,12 @@ Whether to render leading colons for type hints, and trailing colons for paramet
 --
 Whether to show inlay type hints for variables.
 --
+[[rust-analyzer.inlayHints.typeHints.hideClosureInitialization]]rust-analyzer.inlayHints.typeHints.hideClosureInitialization (default: `false`)::
++
+--
+Whether to hide inlay type hints for `let` statements that initialize to a closure.
+Only applies to closures with blocks, same as `#rust-analyzer.inlayHints.closureReturnTypeHints.enable#`.
+--
 [[rust-analyzer.inlayHints.typeHints.hideNamedConstructor]]rust-analyzer.inlayHints.typeHints.hideNamedConstructor (default: `false`)::
 +
 --

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -868,6 +868,11 @@
                     "default": true,
                     "type": "boolean"
                 },
+                "rust-analyzer.inlayHints.typeHints.hideClosureInitialization": {
+                    "markdownDescription": "Whether to hide inlay type hints for `let` statements that initialize to a closure.\nOnly applies to closures with blocks, same as `#rust-analyzer.inlayHints.closureReturnTypeHints.enable#`.",
+                    "default": false,
+                    "type": "boolean"
+                },
                 "rust-analyzer.inlayHints.typeHints.hideNamedConstructor": {
                     "markdownDescription": "Whether to hide inlay type hints for constructors.",
                     "default": false,


### PR DESCRIPTION
![hide_closure_initialization](https://user-images.githubusercontent.com/12008103/168470158-6cb77b18-068e-4431-a8b5-e2b22d50d263.gif)

This PR adds an option to hide the inlay hints for `let IDENT_PAT = CLOSURE_EXPR;`, which is a somewhat common coding pattern. Currently the inlay hints for the assigned variable and the closure expression itself are both displayed, making it rather repetitive.

In order to be consistent with closure return type hints, only closures with block bodies will be hid by this option.

Personally I'd feel comfortable making it always enabled (or at least when closure return type hints are enabled), but considering the precedent set in #10761, I introduced an off-by-default option for this.

changelog feature: option to hide type inlay hints for `let` statements that initialize to a closure