### PR TITLE
fix: Fix signature help LSP offset conversion

### DIFF
--- a/crates/rust-analyzer/src/to_proto.rs
+++ b/crates/rust-analyzer/src/to_proto.rs
@@ -358,7 +358,11 @@ pub(crate) fn signature_help(
             let params = call_info
                 .parameter_ranges()
                 .iter()
-                .map(|it| [u32::from(it.start()), u32::from(it.end())])
+                .map(|it| {
+                    let start = call_info.signature[..it.start().into()].chars().count() as u32;
+                    let end = call_info.signature[..it.end().into()].chars().count() as u32;
+                    [start, end]
+                })
                 .map(|label_offsets| lsp_types::ParameterInformation {
                     label: lsp_types::ParameterLabel::LabelOffsets(label_offsets),
                     documentation: None,
@@ -375,9 +379,9 @@ pub(crate) fn signature_help(
                     label.push_str(", ");
                 }
                 first = false;
-                let start = label.len() as u32;
+                let start = label.chars().count() as u32;
                 label.push_str(param);
-                let end = label.len() as u32;
+                let end = label.chars().count() as u32;
                 params.push(lsp_types::ParameterInformation {
                     label: lsp_types::ParameterLabel::LabelOffsets([start, end]),
                     documentation: None,


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust-analyzer/issues/12270

I don't think we really handle this correctly anywhere (eg. surrogates probably aren't counted right), but this at least fixes the immediately visible bug.