### PR TITLE
feat: Handle getters and setters in documentation template assist

### DIFF
--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -1466,6 +1466,7 @@ impl Function {
 }
 
 // Note: logically, this belongs to `hir_ty`, but we are not using it there yet.
+#[derive(Clone, Copy, PartialEq, Eq)]
 pub enum Access {
     Shared,
     Exclusive,

--- a/crates/ide-assists/src/handlers/generate_getter.rs
+++ b/crates/ide-assists/src/handlers/generate_getter.rs
@@ -38,7 +38,6 @@ use crate::{
 // }
 //
 // impl Person {
-//     /// Get a reference to the person's name.
 //     #[must_use]
 //     fn $0name(&self) -> &str {
 //         self.name.as_ref()
@@ -65,7 +64,6 @@ pub(crate) fn generate_getter(acc: &mut Assists, ctx: &AssistContext) -> Option<
 // }
 //
 // impl Person {
-//     /// Get a mutable reference to the person's name.
 //     #[must_use]
 //     fn $0name_mut(&mut self) -> &mut String {
 //         &mut self.name
@@ -84,7 +82,6 @@ pub(crate) fn generate_getter_impl(
     let strukt = ctx.find_node_at_offset::<ast::Struct>()?;
     let field = ctx.find_node_at_offset::<ast::RecordField>()?;
 
-    let strukt_name = strukt.name()?;
     let field_name = field.name()?;
     let field_ty = field.ty()?;
 
@@ -114,12 +111,8 @@ pub(crate) fn generate_getter_impl(
             }
 
             let vis = strukt.visibility().map_or(String::new(), |v| format!("{} ", v));
-            let (ty, body, description) = if mutable {
-                (
-                    format!("&mut {}", field_ty),
-                    format!("&mut self.{}", field_name),
-                    "a mutable reference to ",
-                )
+            let (ty, body) = if mutable {
+                (format!("&mut {}", field_ty), format!("&mut self.{}", field_name))
             } else {
                 (|| {
                     let krate = ctx.sema.scope(field_ty.syntax())?.krate();
@@ -132,25 +125,18 @@ pub(crate) fn generate_getter_impl(
                             (
                                 conversion.convert_type(ctx.db()),
                                 conversion.getter(field_name.to_string()),
-                                if conversion.is_copy() { "" } else { "a reference to " },
                             )
                         })
                 })()
-                .unwrap_or_else(|| {
-                    (format!("&{}", field_ty), format!("&self.{}", field_name), "a reference to ")
-                })
+                .unwrap_or_else(|| (format!("&{}", field_ty), format!("&self.{}", field_name)))
             };
 
             format_to!(
                 buf,
-                "    /// Get {}the {}'s {}.
-    #[must_use]
+                "    #[must_use]
     {}fn {}(&{}self) -> {} {{
         {}
     }}",
-                description,
-                to_lower_snake_case(&strukt_name.to_string()).replace('_', " "),
-                fn_name.trim_end_matches("_mut").replace('_', " "),
                 vis,
                 fn_name,
                 mutable.then(|| "mut ").unwrap_or_default(),
@@ -196,7 +182,6 @@ struct Context {
 }
 
 impl Context {
-    /// Get a reference to the context's data.
     #[must_use]
     fn $0data(&self) -> &Data {
         &self.data
@@ -218,7 +203,6 @@ struct Context {
 }
 
 impl Context {
-    /// Get a mutable reference to the context's data.
     #[must_use]
     fn $0data_mut(&mut self) -> &mut Data {
         &mut self.data
@@ -277,7 +261,6 @@ pub(crate) struct Context {
 }
 
 impl Context {
-    /// Get a reference to the context's data.
     #[must_use]
     pub(crate) fn $0data(&self) -> &Data {
         &self.data
@@ -298,7 +281,6 @@ struct Context {
 }
 
 impl Context {
-    /// Get a reference to the context's data.
     #[must_use]
     fn data(&self) -> &Data {
         &self.data
@@ -312,13 +294,11 @@ struct Context {
 }
 
 impl Context {
-    /// Get a reference to the context's data.
     #[must_use]
     fn data(&self) -> &Data {
         &self.data
     }
 
-    /// Get a reference to the context's count.
     #[must_use]
     fn $0count(&self) -> &usize {
         &self.count
@@ -345,7 +325,6 @@ pub struct String;
 struct S { foo: String }
 
 impl S {
-    /// Get a reference to the s's foo.
     #[must_use]
     fn $0foo(&self) -> &String {
         &self.foo
@@ -370,7 +349,6 @@ struct S { foo: $0bool }
 struct S { foo: bool }
 
 impl S {
-    /// Get the s's foo.
     #[must_use]
     fn $0foo(&self) -> bool {
         self.foo
@@ -404,7 +382,6 @@ impl AsRef<str> for String {
 struct S { foo: String }
 
 impl S {
-    /// Get a reference to the s's foo.
     #[must_use]
     fn $0foo(&self) -> &str {
         self.foo.as_ref()
@@ -442,7 +419,6 @@ impl<T> AsRef<T> for Box<T> {
 struct S { foo: Box<Sweets> }
 
 impl S {
-    /// Get a reference to the s's foo.
     #[must_use]
     fn $0foo(&self) -> &Sweets {
         self.foo.as_ref()
@@ -476,7 +452,6 @@ impl<T> AsRef<[T]> for Vec<T> {
 struct S { foo: Vec<()> }
 
 impl S {
-    /// Get a reference to the s's foo.
     #[must_use]
     fn $0foo(&self) -> &[()] {
         self.foo.as_ref()
@@ -500,7 +475,6 @@ struct Failure;
 struct S { foo: Option<Failure> }
 
 impl S {
-    /// Get a reference to the s's foo.
     #[must_use]
     fn $0foo(&self) -> Option<&Failure> {
         self.foo.as_ref()
@@ -524,7 +498,6 @@ struct Context {
 }
 
 impl Context {
-    /// Get a reference to the context's data.
     #[must_use]
     fn $0data(&self) -> Result<&bool, &i32> {
         self.data.as_ref()

--- a/crates/ide-assists/src/tests/generated.rs
+++ b/crates/ide-assists/src/tests/generated.rs
@@ -1036,7 +1036,6 @@ struct Person {
 }
 
 impl Person {
-    /// Get a reference to the person's name.
     #[must_use]
     fn $0name(&self) -> &str {
         self.name.as_ref()
@@ -1061,7 +1060,6 @@ struct Person {
 }
 
 impl Person {
-    /// Get a mutable reference to the person's name.
     #[must_use]
     fn $0name_mut(&mut self) -> &mut String {
         &mut self.name

--- a/crates/ide-assists/src/utils.rs
+++ b/crates/ide-assists/src/utils.rs
@@ -568,10 +568,6 @@ impl ReferenceConversion {
             | ReferenceConversionType::Result => format!("self.{}.as_ref()", field_name),
         }
     }
-
-    pub(crate) fn is_copy(&self) -> bool {
-        matches!(self.conversion, ReferenceConversionType::Copy)
-    }
 }
 
 // FIXME: It should return a new hir::Type, but currently constructing new types is too cumbersome


### PR DESCRIPTION
The assist can now turn this:

```rust
pub struct S;
impl S {
    pub fn data_mut$0(&mut self) -> &mut [u8] { &mut [] }
}
```

into

```rust
pub struct S;
impl S {
    /// Returns a mutable reference to the data.
    ///
    /// # Examples
    ///
    /// ```
    /// use test::S;
    ///
    /// let mut s = ;
    /// assert_eq!(s.data_mut(), );
    /// assert_eq!(s, );
    /// ```
    pub fn data_mut(&mut self) -> &mut [u8] { &mut [] }
}
```

And similarly for by-value or immutable getters, and for setters. Previously the intro line would be empty.

This PR also removes the documentation generation function from the "Generate getter/setter" assist, since that is better handled by applying the 2 assists in sequence. cc https://github.com/rust-lang/rust-analyzer/issues/12273