### PR TITLE
feat: Improve "Generate `Deref` impl" assist

### DIFF
--- a/crates/ide-assists/src/tests.rs
+++ b/crates/ide-assists/src/tests.rs
@@ -226,7 +226,6 @@ fn assist_order_field_struct() {
     assert_eq!(assists.next().expect("expected assist").label, "Generate a getter method");
     assert_eq!(assists.next().expect("expected assist").label, "Generate a mut getter method");
     assert_eq!(assists.next().expect("expected assist").label, "Generate a setter method");
-    assert_eq!(assists.next().expect("expected assist").label, "Generate `Deref` impl using `bar`");
     assert_eq!(assists.next().expect("expected assist").label, "Add `#[derive]`");
 }
 

--- a/crates/ide-assists/src/tests/generated.rs
+++ b/crates/ide-assists/src/tests/generated.rs
@@ -799,6 +799,7 @@ fn doctest_generate_deref() {
     check_doc_test(
         "generate_deref",
         r#####"
+//- minicore: deref, deref_mut
 struct A;
 struct B {
    $0a: A
@@ -810,7 +811,7 @@ struct B {
    a: A
 }
 
-impl std::ops::Deref for B {
+impl core::ops::Deref for B {
     type Target = A;
 
     fn deref(&self) -> &Self::Target {

--- a/crates/ide-db/src/famous_defs.rs
+++ b/crates/ide-db/src/famous_defs.rs
@@ -82,6 +82,10 @@ impl FamousDefs<'_, '_> {
         self.find_trait("core:ops:Deref")
     }
 
+    pub fn core_ops_DerefMut(&self) -> Option<Trait> {
+        self.find_trait("core:ops:DerefMut")
+    }
+
     pub fn core_convert_AsRef(&self) -> Option<Trait> {
         self.find_trait("core:convert:AsRef")
     }


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust-analyzer/issues/12265
Fixes https://github.com/rust-lang/rust-analyzer/issues/12266

The assist will now generate a `DerefMut` impl if a `Deref` impl is already present.