### PR TITLE
Increase defalt chalk overflow depth to match max solver size

### DIFF
--- a/crates/hir-ty/src/traits.rs
+++ b/crates/hir-ty/src/traits.rs
@@ -27,7 +27,7 @@ pub(crate) struct ChalkContext<'a> {
 
 fn create_chalk_solver() -> chalk_recursive::RecursiveSolver<Interner> {
     let overflow_depth =
-        var("CHALK_OVERFLOW_DEPTH").ok().and_then(|s| s.parse().ok()).unwrap_or(300);
+        var("CHALK_OVERFLOW_DEPTH").ok().and_then(|s| s.parse().ok()).unwrap_or(500);
     let max_size = var("CHALK_SOLVER_MAX_SIZE").ok().and_then(|s| s.parse().ok()).unwrap_or(150);
     chalk_recursive::RecursiveSolver::new(overflow_depth, max_size, Some(Cache::new()))
 }


### PR DESCRIPTION
TBC:

 - #12279: ok above 480
 - ~~#12182~~
 - ~~#12095~~
 - #11902: ok above 350
 - ~~#11668~~
 - #11370: ok above 450
 - #9754: probably ok above 250 (!), and the code in cause and branch are gone

Closes #12279
Closes #11902
Closes #11370
Closes #9754