### PR TITLE
Switch to Prettier for TypeScript Code formatting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,19 @@
+# https://EditorConfig.org
+root = true
+
+[*]
+charset = utf-8
+trim_trailing_whitespace = true
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+
+[*.{rs,toml}]
+indent_size = 4
+
+[*.ts]
+indent_size = 4
+[*.js]
+indent_size = 4
+[*.json]
+indent_size = 4

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,8 @@
+# for this file to take effect make sure you use git ^2.23 and
+# add ignoreFile to your git configuration:
+# ```
+# git config --global blame.ignoreRevsFile .git-blame-ignore-revs
+# ```
+
+# prettier format
+f247090558c9ba3c551566eae5882b7ca865225f

--- a/editors/code/.eslintrc.js
+++ b/editors/code/.eslintrc.js
@@ -1,41 +1,36 @@
 module.exports = {
-    "env": {
-        "es6": true,
-        "node": true
+    env: {
+        es6: true,
+        node: true,
     },
-    "extends": ["prettier"],
-    "parser": "@typescript-eslint/parser",
-    "parserOptions": {
-        "project": "tsconfig.eslint.json",
-        "tsconfigRootDir": __dirname,
-        "sourceType": "module"
+    extends: ["prettier"],
+    parser: "@typescript-eslint/parser",
+    parserOptions: {
+        project: "tsconfig.eslint.json",
+        tsconfigRootDir: __dirname,
+        sourceType: "module",
     },
-    "plugins": [
-        "@typescript-eslint"
-    ],
-    "rules": {
-        "camelcase": ["error"],
-        "eqeqeq": ["error", "always", { "null": "ignore" }],
+    plugins: ["@typescript-eslint"],
+    rules: {
+        camelcase: ["error"],
+        eqeqeq: ["error", "always", { null: "ignore" }],
         "no-console": ["error", { allow: ["warn", "error"] }],
         "prefer-const": "error",
         "@typescript-eslint/member-delimiter-style": [
             "error",
             {
-                "multiline": {
-                    "delimiter": "semi",
-                    "requireLast": true
+                multiline: {
+                    delimiter: "semi",
+                    requireLast: true,
                 },
-                "singleline": {
-                    "delimiter": "semi",
-                    "requireLast": false
-                }
-            }
+                singleline: {
+                    delimiter: "semi",
+                    requireLast: false,
+                },
+            },
         ],
-        "@typescript-eslint/semi": [
-            "error",
-            "always"
-        ],
+        "@typescript-eslint/semi": ["error", "always"],
         "@typescript-eslint/no-unnecessary-type-assertion": "error",
-        "@typescript-eslint/no-floating-promises": "error"
-    }
+        "@typescript-eslint/no-floating-promises": "error",
+    },
 };

--- a/editors/code/.eslintrc.js
+++ b/editors/code/.eslintrc.js
@@ -14,6 +14,7 @@ module.exports = {
     rules: {
         camelcase: ["error"],
         eqeqeq: ["error", "always", { null: "ignore" }],
+        curly: ["error", "multi-line"],
         "no-console": ["error", { allow: ["warn", "error"] }],
         "prefer-const": "error",
         "@typescript-eslint/member-delimiter-style": [

--- a/editors/code/.eslintrc.js
+++ b/editors/code/.eslintrc.js
@@ -3,6 +3,7 @@ module.exports = {
         "es6": true,
         "node": true
     },
+    "extends": ["prettier"],
     "parser": "@typescript-eslint/parser",
     "parserOptions": {
         "project": "tsconfig.eslint.json",

--- a/editors/code/.prettierignore
+++ b/editors/code/.prettierignore
@@ -1,0 +1,3 @@
+node_modules
+.vscode-test
+out

--- a/editors/code/.prettierrc.js
+++ b/editors/code/.prettierrc.js
@@ -1,0 +1,5 @@
+module.exports = {
+    // use 100 because it's Rustfmt's default
+    // https://rust-lang.github.io/rustfmt/?version=v1.4.38&search=#max_width
+    printWidth: 100,
+};

--- a/editors/code/language-configuration.json
+++ b/editors/code/language-configuration.json
@@ -1,7 +1,7 @@
 {
     "comments": {
         "lineComment": "//",
-        "blockComment": [ "/*", "*/" ]
+        "blockComment": ["/*", "*/"]
     },
     "brackets": [
         ["{", "}"],
@@ -9,10 +9,10 @@
         ["(", ")"]
     ],
     "colorizedBracketPairs": [
-		["{", "}"],
-		["[", "]"],
-		["(", ")"]
-	],
+        ["{", "}"],
+        ["[", "]"],
+        ["(", ")"]
+    ],
     "autoClosingPairs": [
         { "open": "{", "close": "}" },
         { "open": "[", "close": "]" },

--- a/editors/code/package-lock.json
+++ b/editors/code/package-lock.json
@@ -22,6 +22,8 @@
                 "cross-env": "^7.0.3",
                 "esbuild": "^0.14.27",
                 "eslint": "^8.11.0",
+                "eslint-config-prettier": "^8.5.0",
+                "prettier": "^2.6.2",
                 "tslib": "^2.3.0",
                 "typescript": "^4.6.3",
                 "typescript-formatter": "^7.2.2",
@@ -1988,6 +1990,18 @@
                 "url": "https://opencollective.com/eslint"
             }
         },
+        "node_modules/eslint-config-prettier": {
+            "version": "8.5.0",
+            "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
+            "integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
+            "dev": true,
+            "bin": {
+                "eslint-config-prettier": "bin/cli.js"
+            },
+            "peerDependencies": {
+                "eslint": ">=7.0.0"
+            }
+        },
         "node_modules/eslint-scope": {
             "version": "5.1.1",
             "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
@@ -3128,6 +3142,21 @@
             "dev": true,
             "engines": {
                 "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/prettier": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.2.tgz",
+            "integrity": "sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==",
+            "dev": true,
+            "bin": {
+                "prettier": "bin-prettier.js"
+            },
+            "engines": {
+                "node": ">=10.13.0"
+            },
+            "funding": {
+                "url": "https://github.com/prettier/prettier?sponsor=1"
             }
         },
         "node_modules/process-nextick-args": {
@@ -5509,6 +5538,13 @@
                 }
             }
         },
+        "eslint-config-prettier": {
+            "version": "8.5.0",
+            "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
+            "integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
+            "dev": true,
+            "requires": {}
+        },
         "eslint-scope": {
             "version": "5.1.1",
             "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
@@ -6384,6 +6420,12 @@
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
             "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+            "dev": true
+        },
+        "prettier": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.2.tgz",
+            "integrity": "sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==",
             "dev": true
         },
         "process-nextick-args": {

--- a/editors/code/package-lock.json
+++ b/editors/code/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "rust-analyzer",
-    "version": "0.4.0-dev",
+    "version": "0.5.0-dev",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "rust-analyzer",
-            "version": "0.4.0-dev",
+            "version": "0.5.0-dev",
             "license": "MIT OR Apache-2.0",
             "dependencies": {
                 "d3": "^7.3.0",
@@ -26,7 +26,6 @@
                 "prettier": "^2.6.2",
                 "tslib": "^2.3.0",
                 "typescript": "^4.6.3",
-                "typescript-formatter": "^7.2.2",
                 "vsce": "^2.7.0"
             },
             "engines": {
@@ -770,12 +769,6 @@
                 "node": ">= 10"
             }
         },
-        "node_modules/commandpost": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/commandpost/-/commandpost-1.4.0.tgz",
-            "integrity": "sha512-aE2Y4MTFJ870NuB/+2z1cXBhSBBzRydVVjzhFC4gtenEhpnj15yu0qptWGJsO9YGrcPZ3ezX8AWb1VA391MKpQ==",
-            "dev": true
-        },
         "node_modules/concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -1493,52 +1486,6 @@
             "dependencies": {
                 "readable-stream": "^2.0.2"
             }
-        },
-        "node_modules/editorconfig": {
-            "version": "0.15.3",
-            "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-0.15.3.tgz",
-            "integrity": "sha512-M9wIMFx96vq0R4F+gRpY3o2exzb8hEj/n9S8unZtHSvYjibBp/iMufSzvmOcV/laG0ZtuTVGtiJggPOSW2r93g==",
-            "dev": true,
-            "dependencies": {
-                "commander": "^2.19.0",
-                "lru-cache": "^4.1.5",
-                "semver": "^5.6.0",
-                "sigmund": "^1.0.1"
-            },
-            "bin": {
-                "editorconfig": "bin/editorconfig"
-            }
-        },
-        "node_modules/editorconfig/node_modules/commander": {
-            "version": "2.20.3",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-            "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-            "dev": true
-        },
-        "node_modules/editorconfig/node_modules/lru-cache": {
-            "version": "4.1.5",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-            "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
-            "dev": true,
-            "dependencies": {
-                "pseudomap": "^1.0.2",
-                "yallist": "^2.1.2"
-            }
-        },
-        "node_modules/editorconfig/node_modules/semver": {
-            "version": "5.7.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-            "dev": true,
-            "bin": {
-                "semver": "bin/semver"
-            }
-        },
-        "node_modules/editorconfig/node_modules/yallist": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-            "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
-            "dev": true
         },
         "node_modules/emoji-regex": {
             "version": "8.0.0",
@@ -3165,12 +3112,6 @@
             "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
             "dev": true
         },
-        "node_modules/pseudomap": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-            "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
-            "dev": true
-        },
         "node_modules/pump": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
@@ -3440,12 +3381,6 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
-        },
-        "node_modules/sigmund": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-            "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
-            "dev": true
         },
         "node_modules/signal-exit": {
             "version": "3.0.7",
@@ -3761,25 +3696,6 @@
             },
             "engines": {
                 "node": ">=4.2.0"
-            }
-        },
-        "node_modules/typescript-formatter": {
-            "version": "7.2.2",
-            "resolved": "https://registry.npmjs.org/typescript-formatter/-/typescript-formatter-7.2.2.tgz",
-            "integrity": "sha512-V7vfI9XArVhriOTYHPzMU2WUnm5IMdu9X/CPxs8mIMGxmTBFpDABlbkBka64PZJ9/xgQeRpK8KzzAG4MPzxBDQ==",
-            "dev": true,
-            "dependencies": {
-                "commandpost": "^1.0.0",
-                "editorconfig": "^0.15.0"
-            },
-            "bin": {
-                "tsfmt": "bin/tsfmt"
-            },
-            "engines": {
-                "node": ">= 4.2.0"
-            },
-            "peerDependencies": {
-                "typescript": "^2.1.6 || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >=3.0.0-dev"
             }
         },
         "node_modules/uc.micro": {
@@ -4688,12 +4604,6 @@
             "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
             "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="
         },
-        "commandpost": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/commandpost/-/commandpost-1.4.0.tgz",
-            "integrity": "sha512-aE2Y4MTFJ870NuB/+2z1cXBhSBBzRydVVjzhFC4gtenEhpnj15yu0qptWGJsO9YGrcPZ3ezX8AWb1VA391MKpQ==",
-            "dev": true
-        },
         "concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -5234,48 +5144,6 @@
             "dev": true,
             "requires": {
                 "readable-stream": "^2.0.2"
-            }
-        },
-        "editorconfig": {
-            "version": "0.15.3",
-            "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-0.15.3.tgz",
-            "integrity": "sha512-M9wIMFx96vq0R4F+gRpY3o2exzb8hEj/n9S8unZtHSvYjibBp/iMufSzvmOcV/laG0ZtuTVGtiJggPOSW2r93g==",
-            "dev": true,
-            "requires": {
-                "commander": "^2.19.0",
-                "lru-cache": "^4.1.5",
-                "semver": "^5.6.0",
-                "sigmund": "^1.0.1"
-            },
-            "dependencies": {
-                "commander": {
-                    "version": "2.20.3",
-                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-                    "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-                    "dev": true
-                },
-                "lru-cache": {
-                    "version": "4.1.5",
-                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-                    "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
-                    "dev": true,
-                    "requires": {
-                        "pseudomap": "^1.0.2",
-                        "yallist": "^2.1.2"
-                    }
-                },
-                "semver": {
-                    "version": "5.7.1",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-                    "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-                    "dev": true
-                },
-                "yallist": {
-                    "version": "2.1.2",
-                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-                    "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
-                    "dev": true
-                }
             }
         },
         "emoji-regex": {
@@ -6434,12 +6302,6 @@
             "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
             "dev": true
         },
-        "pseudomap": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-            "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
-            "dev": true
-        },
         "pump": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
@@ -6628,12 +6490,6 @@
                 "get-intrinsic": "^1.0.2",
                 "object-inspect": "^1.9.0"
             }
-        },
-        "sigmund": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-            "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
-            "dev": true
         },
         "signal-exit": {
             "version": "3.0.7",
@@ -6861,16 +6717,6 @@
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
             "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
             "dev": true
-        },
-        "typescript-formatter": {
-            "version": "7.2.2",
-            "resolved": "https://registry.npmjs.org/typescript-formatter/-/typescript-formatter-7.2.2.tgz",
-            "integrity": "sha512-V7vfI9XArVhriOTYHPzMU2WUnm5IMdu9X/CPxs8mIMGxmTBFpDABlbkBka64PZJ9/xgQeRpK8KzzAG4MPzxBDQ==",
-            "dev": true,
-            "requires": {
-                "commandpost": "^1.0.0",
-                "editorconfig": "^0.15.0"
-            }
         },
         "uc.micro": {
             "version": "1.0.6",

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -48,6 +48,8 @@
         "cross-env": "^7.0.3",
         "esbuild": "^0.14.27",
         "eslint": "^8.11.0",
+        "eslint-config-prettier": "^8.5.0",
+        "prettier": "^2.6.2",
         "tslib": "^2.3.0",
         "typescript": "^4.6.3",
         "typescript-formatter": "^7.2.2",

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -52,7 +52,6 @@
         "prettier": "^2.6.2",
         "tslib": "^2.3.0",
         "typescript": "^4.6.3",
-        "typescript-formatter": "^7.2.2",
         "vsce": "^2.7.0"
     },
     "activationEvents": [

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -29,8 +29,8 @@
         "build-base": "esbuild ./src/main.ts --bundle --outfile=out/main.js --external:vscode --format=cjs --platform=node --target=node16",
         "build": "npm run build-base -- --sourcemap",
         "watch": "npm run build-base -- --sourcemap --watch",
-        "lint": "tsfmt --verify && eslint -c .eslintrc.js --ext ts ./src ./tests",
-        "fix": " tsfmt -r       && eslint -c .eslintrc.js --ext ts ./src ./tests --fix",
+        "lint": "prettier --check . && eslint -c .eslintrc.js --ext ts ./src ./tests",
+        "fix": "prettier --write . && eslint -c .eslintrc.js --ext ts ./src ./tests --fix",
         "pretest": "tsc && npm run build",
         "test": "cross-env TEST_VARIABLE=test node ./out/tests/runTests.js"
     },

--- a/editors/code/ra_syntax_tree.tmGrammar.json
+++ b/editors/code/ra_syntax_tree.tmGrammar.json
@@ -25,7 +25,5 @@
             "name": "string"
         }
     },
-    "fileTypes": [
-        "rast"
-    ]
+    "fileTypes": ["rast"]
 }

--- a/editors/code/src/ast_inspector.ts
+++ b/editors/code/src/ast_inspector.ts
@@ -101,8 +101,9 @@ export class AstInspector implements vscode.HoverProvider, vscode.DefinitionProv
         doc: vscode.TextDocument,
         pos: vscode.Position
     ): vscode.ProviderResult<vscode.DefinitionLink[]> {
-        if (!this.rustEditor || doc.uri.toString() !== this.rustEditor.document.uri.toString())
+        if (!this.rustEditor || doc.uri.toString() !== this.rustEditor.document.uri.toString()) {
             return;
+        }
 
         const astEditor = this.findAstTextEditor();
         if (!astEditor) return;

--- a/editors/code/src/ast_inspector.ts
+++ b/editors/code/src/ast_inspector.ts
@@ -1,13 +1,13 @@
-import * as vscode from 'vscode';
+import * as vscode from "vscode";
 
-import { Ctx, Disposable } from './ctx';
-import { RustEditor, isRustEditor } from './util';
+import { Ctx, Disposable } from "./ctx";
+import { RustEditor, isRustEditor } from "./util";
 
 // FIXME: consider implementing this via the Tree View API?
 // https://code.visualstudio.com/api/extension-guides/tree-view
 export class AstInspector implements vscode.HoverProvider, vscode.DefinitionProvider, Disposable {
     private readonly astDecorationType = vscode.window.createTextEditorDecorationType({
-        borderColor: new vscode.ThemeColor('rust_analyzer.syntaxTreeBorder'),
+        borderColor: new vscode.ThemeColor("rust_analyzer.syntaxTreeBorder"),
         borderStyle: "solid",
         borderWidth: "2px",
     });
@@ -35,11 +35,23 @@ export class AstInspector implements vscode.HoverProvider, vscode.DefinitionProv
     });
 
     constructor(ctx: Ctx) {
-        ctx.pushCleanup(vscode.languages.registerHoverProvider({ scheme: 'rust-analyzer' }, this));
+        ctx.pushCleanup(vscode.languages.registerHoverProvider({ scheme: "rust-analyzer" }, this));
         ctx.pushCleanup(vscode.languages.registerDefinitionProvider({ language: "rust" }, this));
-        vscode.workspace.onDidCloseTextDocument(this.onDidCloseTextDocument, this, ctx.subscriptions);
-        vscode.workspace.onDidChangeTextDocument(this.onDidChangeTextDocument, this, ctx.subscriptions);
-        vscode.window.onDidChangeVisibleTextEditors(this.onDidChangeVisibleTextEditors, this, ctx.subscriptions);
+        vscode.workspace.onDidCloseTextDocument(
+            this.onDidCloseTextDocument,
+            this,
+            ctx.subscriptions
+        );
+        vscode.workspace.onDidChangeTextDocument(
+            this.onDidChangeTextDocument,
+            this,
+            ctx.subscriptions
+        );
+        vscode.window.onDidChangeVisibleTextEditors(
+            this.onDidChangeVisibleTextEditors,
+            this,
+            ctx.subscriptions
+        );
 
         ctx.pushCleanup(this);
     }
@@ -48,7 +60,10 @@ export class AstInspector implements vscode.HoverProvider, vscode.DefinitionProv
     }
 
     private onDidChangeTextDocument(event: vscode.TextDocumentChangeEvent) {
-        if (this.rustEditor && event.document.uri.toString() === this.rustEditor.document.uri.toString()) {
+        if (
+            this.rustEditor &&
+            event.document.uri.toString() === this.rustEditor.document.uri.toString()
+        ) {
             this.rust2Ast.reset();
         }
     }
@@ -68,7 +83,9 @@ export class AstInspector implements vscode.HoverProvider, vscode.DefinitionProv
     }
 
     private findAstTextEditor(): undefined | vscode.TextEditor {
-        return vscode.window.visibleTextEditors.find(it => it.document.uri.scheme === 'rust-analyzer');
+        return vscode.window.visibleTextEditors.find(
+            (it) => it.document.uri.scheme === "rust-analyzer"
+        );
     }
 
     private setRustEditor(newRustEditor: undefined | RustEditor) {
@@ -80,13 +97,19 @@ export class AstInspector implements vscode.HoverProvider, vscode.DefinitionProv
     }
 
     // additional positional params are omitted
-    provideDefinition(doc: vscode.TextDocument, pos: vscode.Position): vscode.ProviderResult<vscode.DefinitionLink[]> {
-        if (!this.rustEditor || doc.uri.toString() !== this.rustEditor.document.uri.toString()) return;
+    provideDefinition(
+        doc: vscode.TextDocument,
+        pos: vscode.Position
+    ): vscode.ProviderResult<vscode.DefinitionLink[]> {
+        if (!this.rustEditor || doc.uri.toString() !== this.rustEditor.document.uri.toString())
+            return;
 
         const astEditor = this.findAstTextEditor();
         if (!astEditor) return;
 
-        const rust2AstRanges = this.rust2Ast.get()?.find(([rustRange, _]) => rustRange.contains(pos));
+        const rust2AstRanges = this.rust2Ast
+            .get()
+            ?.find(([rustRange, _]) => rustRange.contains(pos));
         if (!rust2AstRanges) return;
 
         const [rustFileRange, astFileRange] = rust2AstRanges;
@@ -94,16 +117,21 @@ export class AstInspector implements vscode.HoverProvider, vscode.DefinitionProv
         astEditor.revealRange(astFileRange);
         astEditor.selection = new vscode.Selection(astFileRange.start, astFileRange.end);
 
-        return [{
-            targetRange: astFileRange,
-            targetUri: astEditor.document.uri,
-            originSelectionRange: rustFileRange,
-            targetSelectionRange: astFileRange,
-        }];
+        return [
+            {
+                targetRange: astFileRange,
+                targetUri: astEditor.document.uri,
+                originSelectionRange: rustFileRange,
+                targetSelectionRange: astFileRange,
+            },
+        ];
     }
 
     // additional positional params are omitted
-    provideHover(doc: vscode.TextDocument, hoverPosition: vscode.Position): vscode.ProviderResult<vscode.Hover> {
+    provideHover(
+        doc: vscode.TextDocument,
+        hoverPosition: vscode.Position
+    ): vscode.ProviderResult<vscode.Hover> {
         if (!this.rustEditor) return;
 
         const astFileLine = doc.lineAt(hoverPosition.line);
@@ -127,13 +155,14 @@ export class AstInspector implements vscode.HoverProvider, vscode.DefinitionProv
         return new vscode.Range(begin, end);
     }
 
-    private parseRustTextRange(doc: vscode.TextDocument, astLine: string): undefined | vscode.Range {
+    private parseRustTextRange(
+        doc: vscode.TextDocument,
+        astLine: string
+    ): undefined | vscode.Range {
         const parsedRange = /(\d+)\.\.(\d+)/.exec(astLine);
         if (!parsedRange) return;
 
-        const [begin, end] = parsedRange
-            .slice(1)
-            .map(off => this.positionAt(doc, +off));
+        const [begin, end] = parsedRange.slice(1).map((off) => this.positionAt(doc, +off));
 
         return new vscode.Range(begin, end);
     }
@@ -173,7 +202,7 @@ export class AstInspector implements vscode.HoverProvider, vscode.DefinitionProv
 class Lazy<T> {
     val: undefined | T;
 
-    constructor(private readonly compute: () => undefined | T) { }
+    constructor(private readonly compute: () => undefined | T) {}
 
     get() {
         return this.val ?? (this.val = this.compute());

--- a/editors/code/src/client.ts
+++ b/editors/code/src/client.ts
@@ -1,39 +1,47 @@
-import * as lc from 'vscode-languageclient/node';
-import * as vscode from 'vscode';
-import * as ra from '../src/lsp_ext';
-import * as Is from 'vscode-languageclient/lib/common/utils/is';
-import { assert } from './util';
-import { WorkspaceEdit } from 'vscode';
-import { Workspace } from './ctx';
-import { updateConfig } from './config';
-import { substituteVariablesInEnv } from './config';
+import * as lc from "vscode-languageclient/node";
+import * as vscode from "vscode";
+import * as ra from "../src/lsp_ext";
+import * as Is from "vscode-languageclient/lib/common/utils/is";
+import { assert } from "./util";
+import { WorkspaceEdit } from "vscode";
+import { Workspace } from "./ctx";
+import { updateConfig } from "./config";
+import { substituteVariablesInEnv } from "./config";
 
 export interface Env {
     [name: string]: string;
 }
 
 function renderCommand(cmd: ra.CommandLink) {
-    return `[${cmd.title}](command:${cmd.command}?${encodeURIComponent(JSON.stringify(cmd.arguments))} '${cmd.tooltip}')`;
+    return `[${cmd.title}](command:${cmd.command}?${encodeURIComponent(
+        JSON.stringify(cmd.arguments)
+    )} '${cmd.tooltip}')`;
 }
 
 function renderHoverActions(actions: ra.CommandLinkGroup[]): vscode.MarkdownString {
-    const text = actions.map(group =>
-        (group.title ? (group.title + " ") : "") + group.commands.map(renderCommand).join(' | ')
-    ).join('___');
+    const text = actions
+        .map(
+            (group) =>
+                (group.title ? group.title + " " : "") +
+                group.commands.map(renderCommand).join(" | ")
+        )
+        .join("___");
 
     const result = new vscode.MarkdownString(text);
     result.isTrusted = true;
     return result;
 }
 
-export async function createClient(serverPath: string, workspace: Workspace, extraEnv: Env): Promise<lc.LanguageClient> {
+export async function createClient(
+    serverPath: string,
+    workspace: Workspace,
+    extraEnv: Env
+): Promise<lc.LanguageClient> {
     // '.' Is the fallback if no folder is open
     // TODO?: Workspace folders support Uri's (eg: file://test.txt).
     // It might be a good idea to test if the uri points to a file.
 
-    const newEnv = substituteVariablesInEnv(Object.assign(
-        {}, process.env, extraEnv
-    ));
+    const newEnv = substituteVariablesInEnv(Object.assign({}, process.env, extraEnv));
     const run: lc.Executable = {
         command: serverPath,
         options: { env: newEnv },
@@ -43,137 +51,176 @@ export async function createClient(serverPath: string, workspace: Workspace, ext
         debug: run,
     };
     const traceOutputChannel = vscode.window.createOutputChannel(
-        'Rust Analyzer Language Server Trace',
+        "Rust Analyzer Language Server Trace"
     );
 
     let initializationOptions = vscode.workspace.getConfiguration("rust-analyzer");
 
     // Update outdated user configs
-    await updateConfig(initializationOptions).catch(err => {
+    await updateConfig(initializationOptions).catch((err) => {
         void vscode.window.showErrorMessage(`Failed updating old config keys: ${err.message}`);
     });
 
     if (workspace.kind === "Detached Files") {
-        initializationOptions = { "detachedFiles": workspace.files.map(file => file.uri.fsPath), ...initializationOptions };
+        initializationOptions = {
+            detachedFiles: workspace.files.map((file) => file.uri.fsPath),
+            ...initializationOptions,
+        };
     }
 
     const clientOptions: lc.LanguageClientOptions = {
-        documentSelector: [{ scheme: 'file', language: 'rust' }],
+        documentSelector: [{ scheme: "file", language: "rust" }],
         initializationOptions,
         diagnosticCollectionName: "rustc",
         traceOutputChannel,
         middleware: {
-            async provideHover(document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken, _next: lc.ProvideHoverSignature) {
+            async provideHover(
+                document: vscode.TextDocument,
+                position: vscode.Position,
+                token: vscode.CancellationToken,
+                _next: lc.ProvideHoverSignature
+            ) {
                 const editor = vscode.window.activeTextEditor;
-                const positionOrRange = editor?.selection?.contains(position) ? client.code2ProtocolConverter.asRange(editor.selection) : client.code2ProtocolConverter.asPosition(position);
-                return client.sendRequest(ra.hover, {
-                    textDocument: client.code2ProtocolConverter.asTextDocumentIdentifier(document),
-                    position: positionOrRange
-                }, token).then(
-                    (result) => {
-                        const hover =
-                            client.protocol2CodeConverter.asHover(result);
-                        if (hover) {
-                            const actions = (<any>result).actions;
-                            if (actions) {
-                                hover.contents.push(renderHoverActions(actions));
+                const positionOrRange = editor?.selection?.contains(position)
+                    ? client.code2ProtocolConverter.asRange(editor.selection)
+                    : client.code2ProtocolConverter.asPosition(position);
+                return client
+                    .sendRequest(
+                        ra.hover,
+                        {
+                            textDocument:
+                                client.code2ProtocolConverter.asTextDocumentIdentifier(document),
+                            position: positionOrRange,
+                        },
+                        token
+                    )
+                    .then(
+                        (result) => {
+                            const hover = client.protocol2CodeConverter.asHover(result);
+                            if (hover) {
+                                const actions = (<any>result).actions;
+                                if (actions) {
+                                    hover.contents.push(renderHoverActions(actions));
+                                }
                             }
+                            return hover;
+                        },
+                        (error) => {
+                            client.handleFailedRequest(lc.HoverRequest.type, token, error, null);
+                            return Promise.resolve(null);
                         }
-                        return hover;
-                    },
-                    (error) => {
-                        client.handleFailedRequest(
-                            lc.HoverRequest.type,
-                            token,
-                            error,
-                            null
-                        );
-                        return Promise.resolve(null);
-                    }
-                );
+                    );
             },
             // Using custom handling of CodeActions to support action groups and snippet edits.
             // Note that this means we have to re-implement lazy edit resolving ourselves as well.
-            async provideCodeActions(document: vscode.TextDocument, range: vscode.Range, context: vscode.CodeActionContext, token: vscode.CancellationToken, _next: lc.ProvideCodeActionsSignature) {
+            async provideCodeActions(
+                document: vscode.TextDocument,
+                range: vscode.Range,
+                context: vscode.CodeActionContext,
+                token: vscode.CancellationToken,
+                _next: lc.ProvideCodeActionsSignature
+            ) {
                 const params: lc.CodeActionParams = {
                     textDocument: client.code2ProtocolConverter.asTextDocumentIdentifier(document),
                     range: client.code2ProtocolConverter.asRange(range),
-                    context: await client.code2ProtocolConverter.asCodeActionContext(context, token)
+                    context: await client.code2ProtocolConverter.asCodeActionContext(
+                        context,
+                        token
+                    ),
                 };
-                return client.sendRequest(lc.CodeActionRequest.type, params, token).then(async (values) => {
-                    if (values === null) return undefined;
-                    const result: (vscode.CodeAction | vscode.Command)[] = [];
-                    const groups = new Map<string, { index: number; items: vscode.CodeAction[] }>();
-                    for (const item of values) {
-                        // In our case we expect to get code edits only from diagnostics
-                        if (lc.CodeAction.is(item)) {
-                            assert(!item.command, "We don't expect to receive commands in CodeActions");
-                            const action = await client.protocol2CodeConverter.asCodeAction(item, token);
-                            result.push(action);
-                            continue;
-                        }
-                        assert(isCodeActionWithoutEditsAndCommands(item), "We don't expect edits or commands here");
-                        const kind = client.protocol2CodeConverter.asCodeActionKind((item as any).kind);
-                        const action = new vscode.CodeAction(item.title, kind);
-                        const group = (item as any).group;
-                        action.command = {
-                            command: "rust-analyzer.resolveCodeAction",
-                            title: item.title,
-                            arguments: [item],
-                        };
-
-                        // Set a dummy edit, so that VS Code doesn't try to resolve this.
-                        action.edit = new WorkspaceEdit();
-
-                        if (group) {
-                            let entry = groups.get(group);
-                            if (!entry) {
-                                entry = { index: result.length, items: [] };
-                                groups.set(group, entry);
+                return client.sendRequest(lc.CodeActionRequest.type, params, token).then(
+                    async (values) => {
+                        if (values === null) return undefined;
+                        const result: (vscode.CodeAction | vscode.Command)[] = [];
+                        const groups = new Map<
+                            string,
+                            { index: number; items: vscode.CodeAction[] }
+                        >();
+                        for (const item of values) {
+                            // In our case we expect to get code edits only from diagnostics
+                            if (lc.CodeAction.is(item)) {
+                                assert(
+                                    !item.command,
+                                    "We don't expect to receive commands in CodeActions"
+                                );
+                                const action = await client.protocol2CodeConverter.asCodeAction(
+                                    item,
+                                    token
+                                );
                                 result.push(action);
+                                continue;
                             }
-                            entry.items.push(action);
-                        } else {
-                            result.push(action);
-                        }
-                    }
-                    for (const [group, { index, items }] of groups) {
-                        if (items.length === 1) {
-                            result[index] = items[0];
-                        } else {
-                            const action = new vscode.CodeAction(group);
-                            action.kind = items[0].kind;
+                            assert(
+                                isCodeActionWithoutEditsAndCommands(item),
+                                "We don't expect edits or commands here"
+                            );
+                            const kind = client.protocol2CodeConverter.asCodeActionKind(
+                                (item as any).kind
+                            );
+                            const action = new vscode.CodeAction(item.title, kind);
+                            const group = (item as any).group;
                             action.command = {
-                                command: "rust-analyzer.applyActionGroup",
-                                title: "",
-                                arguments: [items.map((item) => {
-                                    return { label: item.title, arguments: item.command!.arguments![0] };
-                                })],
+                                command: "rust-analyzer.resolveCodeAction",
+                                title: item.title,
+                                arguments: [item],
                             };
 
                             // Set a dummy edit, so that VS Code doesn't try to resolve this.
                             action.edit = new WorkspaceEdit();
 
-                            result[index] = action;
+                            if (group) {
+                                let entry = groups.get(group);
+                                if (!entry) {
+                                    entry = { index: result.length, items: [] };
+                                    groups.set(group, entry);
+                                    result.push(action);
+                                }
+                                entry.items.push(action);
+                            } else {
+                                result.push(action);
+                            }
                         }
-                    }
-                    return result;
-                },
+                        for (const [group, { index, items }] of groups) {
+                            if (items.length === 1) {
+                                result[index] = items[0];
+                            } else {
+                                const action = new vscode.CodeAction(group);
+                                action.kind = items[0].kind;
+                                action.command = {
+                                    command: "rust-analyzer.applyActionGroup",
+                                    title: "",
+                                    arguments: [
+                                        items.map((item) => {
+                                            return {
+                                                label: item.title,
+                                                arguments: item.command!.arguments![0],
+                                            };
+                                        }),
+                                    ],
+                                };
+
+                                // Set a dummy edit, so that VS Code doesn't try to resolve this.
+                                action.edit = new WorkspaceEdit();
+
+                                result[index] = action;
+                            }
+                        }
+                        return result;
+                    },
                     (_error) => undefined
                 );
-            }
-
+            },
         },
         markdown: {
             supportHtml: true,
-        }
+        },
     };
 
     const client = new lc.LanguageClient(
-        'rust-analyzer',
-        'Rust Analyzer Language Server',
+        "rust-analyzer",
+        "Rust Analyzer Language Server",
         serverOptions,
-        clientOptions,
+        clientOptions
     );
 
     // To turn on all proposed features use: client.registerProposedFeatures();
@@ -196,20 +243,26 @@ class ExperimentalFeatures implements lc.StaticFeature {
                 "rust-analyzer.showReferences",
                 "rust-analyzer.gotoLocation",
                 "editor.action.triggerParameterHints",
-            ]
+            ],
         };
         capabilities.experimental = caps;
     }
-    initialize(_capabilities: lc.ServerCapabilities<any>, _documentSelector: lc.DocumentSelector | undefined): void {
-    }
-    dispose(): void {
-    }
+    initialize(
+        _capabilities: lc.ServerCapabilities<any>,
+        _documentSelector: lc.DocumentSelector | undefined
+    ): void {}
+    dispose(): void {}
 }
 
 function isCodeActionWithoutEditsAndCommands(value: any): boolean {
     const candidate: lc.CodeAction = value;
-    return candidate && Is.string(candidate.title) &&
-        (candidate.diagnostics === void 0 || Is.typedArray(candidate.diagnostics, lc.Diagnostic.is)) &&
+    return (
+        candidate &&
+        Is.string(candidate.title) &&
+        (candidate.diagnostics === void 0 ||
+            Is.typedArray(candidate.diagnostics, lc.Diagnostic.is)) &&
         (candidate.kind === void 0 || Is.string(candidate.kind)) &&
-        (candidate.edit === void 0 && candidate.command === void 0);
+        candidate.edit === void 0 &&
+        candidate.command === void 0
+    );
 }

--- a/editors/code/src/config.ts
+++ b/editors/code/src/config.ts
@@ -1,13 +1,16 @@
-import path = require('path');
-import * as vscode from 'vscode';
-import { Env } from './client';
+import path = require("path");
+import * as vscode from "vscode";
+import { Env } from "./client";
 import { log } from "./util";
 
 export type UpdatesChannel = "stable" | "nightly";
 
 const NIGHTLY_TAG = "nightly";
 
-export type RunnableEnvCfg = undefined | Record<string, string> | { mask?: string; env: Record<string, string> }[];
+export type RunnableEnvCfg =
+    | undefined
+    | Record<string, string>
+    | { mask?: string; env: Record<string, string> }[];
 
 export class Config {
     readonly extensionId = "rust-lang.rust-analyzer";
@@ -20,8 +23,7 @@ export class Config {
         "procMacro",
         "files",
         "lens", // works as lens.*
-    ]
-        .map(opt => `${this.rootSection}.${opt}`);
+    ].map((opt) => `${this.rootSection}.${opt}`);
 
     readonly package: {
         version: string;
@@ -33,7 +35,11 @@ export class Config {
 
     constructor(ctx: vscode.ExtensionContext) {
         this.globalStorageUri = ctx.globalStorageUri;
-        vscode.workspace.onDidChangeConfiguration(this.onDidChangeConfiguration, this, ctx.subscriptions);
+        vscode.workspace.onDidChangeConfiguration(
+            this.onDidChangeConfiguration,
+            this,
+            ctx.subscriptions
+        );
         this.refreshLogging();
     }
 
@@ -48,8 +54,8 @@ export class Config {
     private async onDidChangeConfiguration(event: vscode.ConfigurationChangeEvent) {
         this.refreshLogging();
 
-        const requiresReloadOpt = this.requiresReloadOpts.find(
-            opt => event.affectsConfiguration(opt)
+        const requiresReloadOpt = this.requiresReloadOpts.find((opt) =>
+            event.affectsConfiguration(opt)
         );
 
         if (!requiresReloadOpt) return;
@@ -94,8 +100,12 @@ export class Config {
     get serverPath() {
         return this.get<null | string>("server.path") ?? this.get<null | string>("serverPath");
     }
-    get serverExtraEnv() { return this.get<Env | null>("server.extraEnv") ?? {}; }
-    get traceExtension() { return this.get<boolean>("trace.extension"); }
+    get serverExtraEnv() {
+        return this.get<Env | null>("server.extraEnv") ?? {};
+    }
+    get traceExtension() {
+        return this.get<boolean>("trace.extension");
+    }
 
     get cargoRunner() {
         return this.get<string | undefined>("cargoRunner");
@@ -109,7 +119,8 @@ export class Config {
         let sourceFileMap = this.get<Record<string, string> | "auto">("debug.sourceFileMap");
         if (sourceFileMap !== "auto") {
             // "/rustc/<id>" used by suggestions only.
-            const { ["/rustc/<id>"]: _, ...trimmed } = this.get<Record<string, string>>("debug.sourceFileMap");
+            const { ["/rustc/<id>"]: _, ...trimmed } =
+                this.get<Record<string, string>>("debug.sourceFileMap");
             sourceFileMap = trimmed;
         }
 
@@ -117,7 +128,7 @@ export class Config {
             engine: this.get<string>("debug.engine"),
             engineSettings: this.get<object>("debug.engineSettings"),
             openDebugPane: this.get<boolean>("debug.openDebugPane"),
-            sourceFileMap: sourceFileMap
+            sourceFileMap: sourceFileMap,
         };
     }
 
@@ -139,57 +150,69 @@ export class Config {
 
 export async function updateConfig(config: vscode.WorkspaceConfiguration) {
     const renames = [
-        ["assist.allowMergingIntoGlobImports", "imports.merge.glob",],
-        ["assist.exprFillDefault", "assist.expressionFillDefault",],
-        ["assist.importEnforceGranularity", "imports.granularity.enforce",],
-        ["assist.importGranularity", "imports.granularity.group",],
-        ["assist.importMergeBehavior", "imports.granularity.group",],
-        ["assist.importMergeBehaviour", "imports.granularity.group",],
-        ["assist.importGroup", "imports.group.enable",],
-        ["assist.importPrefix", "imports.prefix",],
-        ["primeCaches.enable", "cachePriming.enable",],
-        ["cache.warmup", "cachePriming.enable",],
-        ["cargo.loadOutDirsFromCheck", "cargo.buildScripts.enable",],
-        ["cargo.runBuildScripts", "cargo.buildScripts.enable",],
-        ["cargo.runBuildScriptsCommand", "cargo.buildScripts.overrideCommand",],
-        ["cargo.useRustcWrapperForBuildScripts", "cargo.buildScripts.useRustcWrapper",],
-        ["completion.snippets", "completion.snippets.custom",],
-        ["diagnostics.enableExperimental", "diagnostics.experimental.enable",],
-        ["experimental.procAttrMacros", "procMacro.attributes.enable",],
-        ["highlighting.strings", "semanticHighlighting.strings.enable",],
-        ["highlightRelated.breakPoints", "highlightRelated.breakPoints.enable",],
-        ["highlightRelated.exitPoints", "highlightRelated.exitPoints.enable",],
-        ["highlightRelated.yieldPoints", "highlightRelated.yieldPoints.enable",],
-        ["highlightRelated.references", "highlightRelated.references.enable",],
-        ["hover.documentation", "hover.documentation.enable",],
-        ["hover.linksInHover", "hover.links.enable",],
-        ["hoverActions.linksInHover", "hover.links.enable",],
-        ["hoverActions.debug", "hover.actions.debug.enable",],
-        ["hoverActions.enable", "hover.actions.enable.enable",],
-        ["hoverActions.gotoTypeDef", "hover.actions.gotoTypeDef.enable",],
-        ["hoverActions.implementations", "hover.actions.implementations.enable",],
-        ["hoverActions.references", "hover.actions.references.enable",],
-        ["hoverActions.run", "hover.actions.run.enable",],
-        ["inlayHints.chainingHints", "inlayHints.chainingHints.enable",],
-        ["inlayHints.closureReturnTypeHints", "inlayHints.closureReturnTypeHints.enable",],
-        ["inlayHints.hideNamedConstructorHints", "inlayHints.typeHints.hideNamedConstructor",],
-        ["inlayHints.parameterHints", "inlayHints.parameterHints.enable",],
-        ["inlayHints.reborrowHints", "inlayHints.reborrowHints.enable",],
-        ["inlayHints.typeHints", "inlayHints.typeHints.enable",],
-        ["lruCapacity", "lru.capacity",],
-        ["runnables.cargoExtraArgs", "runnables.extraArgs",],
-        ["runnables.overrideCargo", "runnables.command",],
-        ["rustcSource", "rustc.source",],
-        ["rustfmt.enableRangeFormatting", "rustfmt.rangeFormatting.enable"]
+        ["assist.allowMergingIntoGlobImports", "imports.merge.glob"],
+        ["assist.exprFillDefault", "assist.expressionFillDefault"],
+        ["assist.importEnforceGranularity", "imports.granularity.enforce"],
+        ["assist.importGranularity", "imports.granularity.group"],
+        ["assist.importMergeBehavior", "imports.granularity.group"],
+        ["assist.importMergeBehaviour", "imports.granularity.group"],
+        ["assist.importGroup", "imports.group.enable"],
+        ["assist.importPrefix", "imports.prefix"],
+        ["primeCaches.enable", "cachePriming.enable"],
+        ["cache.warmup", "cachePriming.enable"],
+        ["cargo.loadOutDirsFromCheck", "cargo.buildScripts.enable"],
+        ["cargo.runBuildScripts", "cargo.buildScripts.enable"],
+        ["cargo.runBuildScriptsCommand", "cargo.buildScripts.overrideCommand"],
+        ["cargo.useRustcWrapperForBuildScripts", "cargo.buildScripts.useRustcWrapper"],
+        ["completion.snippets", "completion.snippets.custom"],
+        ["diagnostics.enableExperimental", "diagnostics.experimental.enable"],
+        ["experimental.procAttrMacros", "procMacro.attributes.enable"],
+        ["highlighting.strings", "semanticHighlighting.strings.enable"],
+        ["highlightRelated.breakPoints", "highlightRelated.breakPoints.enable"],
+        ["highlightRelated.exitPoints", "highlightRelated.exitPoints.enable"],
+        ["highlightRelated.yieldPoints", "highlightRelated.yieldPoints.enable"],
+        ["highlightRelated.references", "highlightRelated.references.enable"],
+        ["hover.documentation", "hover.documentation.enable"],
+        ["hover.linksInHover", "hover.links.enable"],
+        ["hoverActions.linksInHover", "hover.links.enable"],
+        ["hoverActions.debug", "hover.actions.debug.enable"],
+        ["hoverActions.enable", "hover.actions.enable.enable"],
+        ["hoverActions.gotoTypeDef", "hover.actions.gotoTypeDef.enable"],
+        ["hoverActions.implementations", "hover.actions.implementations.enable"],
+        ["hoverActions.references", "hover.actions.references.enable"],
+        ["hoverActions.run", "hover.actions.run.enable"],
+        ["inlayHints.chainingHints", "inlayHints.chainingHints.enable"],
+        ["inlayHints.closureReturnTypeHints", "inlayHints.closureReturnTypeHints.enable"],
+        ["inlayHints.hideNamedConstructorHints", "inlayHints.typeHints.hideNamedConstructor"],
+        ["inlayHints.parameterHints", "inlayHints.parameterHints.enable"],
+        ["inlayHints.reborrowHints", "inlayHints.reborrowHints.enable"],
+        ["inlayHints.typeHints", "inlayHints.typeHints.enable"],
+        ["lruCapacity", "lru.capacity"],
+        ["runnables.cargoExtraArgs", "runnables.extraArgs"],
+        ["runnables.overrideCargo", "runnables.command"],
+        ["rustcSource", "rustc.source"],
+        ["rustfmt.enableRangeFormatting", "rustfmt.rangeFormatting.enable"],
     ];
 
     for (const [oldKey, newKey] of renames) {
         const inspect = config.inspect(oldKey);
         if (inspect !== undefined) {
             const valMatrix = [
-                { val: inspect.globalValue, langVal: inspect.globalLanguageValue, target: vscode.ConfigurationTarget.Global },
-                { val: inspect.workspaceFolderValue, langVal: inspect.workspaceFolderLanguageValue, target: vscode.ConfigurationTarget.WorkspaceFolder },
-                { val: inspect.workspaceValue, langVal: inspect.workspaceLanguageValue, target: vscode.ConfigurationTarget.Workspace }
+                {
+                    val: inspect.globalValue,
+                    langVal: inspect.globalLanguageValue,
+                    target: vscode.ConfigurationTarget.Global,
+                },
+                {
+                    val: inspect.workspaceFolderValue,
+                    langVal: inspect.workspaceFolderLanguageValue,
+                    target: vscode.ConfigurationTarget.WorkspaceFolder,
+                },
+                {
+                    val: inspect.workspaceValue,
+                    langVal: inspect.workspaceLanguageValue,
+                    target: vscode.ConfigurationTarget.Workspace,
+                },
             ];
             for (const { val, langVal, target } of valMatrix) {
                 const pred = (val: unknown) => {
@@ -197,7 +220,14 @@ export async function updateConfig(config: vscode.WorkspaceConfiguration) {
                     // that means on the next run we would find these again, but as objects with
                     // these properties causing us to destroy the config
                     // so filter those already updated ones out
-                    return val !== undefined && !(typeof val === "object" && val !== null && (val.hasOwnProperty("enable") || val.hasOwnProperty("custom")));
+                    return (
+                        val !== undefined &&
+                        !(
+                            typeof val === "object" &&
+                            val !== null &&
+                            (val.hasOwnProperty("enable") || val.hasOwnProperty("custom"))
+                        )
+                    );
                 };
                 if (pred(val)) {
                     await config.update(newKey, val, target, false);
@@ -216,48 +246,50 @@ export function substituteVariablesInEnv(env: Env): Env {
     const missingDeps = new Set<string>();
     // vscode uses `env:ENV_NAME` for env vars resolution, and it's easier
     // to follow the same convention for our dependency tracking
-    const definedEnvKeys = new Set(Object.keys(env).map(key => `env:${key}`));
-    const envWithDeps = Object.fromEntries(Object.entries(env).map(([key, value]) => {
-        const deps = new Set<string>();
-        const depRe = new RegExp(/\${(?<depName>.+?)}/g);
-        let match = undefined;
-        while ((match = depRe.exec(value))) {
-            const depName = match.groups!.depName;
-            deps.add(depName);
-            // `depName` at this point can have a form of `expression` or
-            // `prefix:expression`
-            if (!definedEnvKeys.has(depName)) {
-                missingDeps.add(depName);
+    const definedEnvKeys = new Set(Object.keys(env).map((key) => `env:${key}`));
+    const envWithDeps = Object.fromEntries(
+        Object.entries(env).map(([key, value]) => {
+            const deps = new Set<string>();
+            const depRe = new RegExp(/\${(?<depName>.+?)}/g);
+            let match = undefined;
+            while ((match = depRe.exec(value))) {
+                const depName = match.groups!.depName;
+                deps.add(depName);
+                // `depName` at this point can have a form of `expression` or
+                // `prefix:expression`
+                if (!definedEnvKeys.has(depName)) {
+                    missingDeps.add(depName);
+                }
             }
-        }
-        return [`env:${key}`, { deps: [...deps], value }];
-    }));
+            return [`env:${key}`, { deps: [...deps], value }];
+        })
+    );
 
     const resolved = new Set<string>();
     for (const dep of missingDeps) {
         const match = /(?<prefix>.*?):(?<body>.+)/.exec(dep);
         if (match) {
             const { prefix, body } = match.groups!;
-            if (prefix === 'env') {
+            if (prefix === "env") {
                 const envName = body;
                 envWithDeps[dep] = {
-                    value: process.env[envName] ?? '',
-                    deps: []
+                    value: process.env[envName] ?? "",
+                    deps: [],
                 };
                 resolved.add(dep);
             } else {
                 // we can't handle other prefixes at the moment
                 // leave values as is, but still mark them as resolved
                 envWithDeps[dep] = {
-                    value: '${' + dep + '}',
-                    deps: []
+                    value: "${" + dep + "}",
+                    deps: [],
                 };
                 resolved.add(dep);
             }
         } else {
             envWithDeps[dep] = {
                 value: computeVscodeVar(dep),
-                deps: []
+                deps: [],
             };
         }
     }
@@ -267,11 +299,13 @@ export function substituteVariablesInEnv(env: Env): Env {
     do {
         leftToResolveSize = toResolve.size;
         for (const key of toResolve) {
-            if (envWithDeps[key].deps.every(dep => resolved.has(dep))) {
+            if (envWithDeps[key].deps.every((dep) => resolved.has(dep))) {
                 envWithDeps[key].value = envWithDeps[key].value.replace(
-                    /\${(?<depName>.+?)}/g, (_wholeMatch, depName) => {
+                    /\${(?<depName>.+?)}/g,
+                    (_wholeMatch, depName) => {
                         return envWithDeps[depName].value;
-                    });
+                    }
+                );
                 resolved.add(key);
                 toResolve.delete(key);
             }
@@ -302,16 +336,16 @@ function computeVscodeVar(varName: string): string {
                 return folders[0].uri.fsPath;
             } else {
                 // no workspace opened
-                return '';
+                return "";
             }
         },
 
         workspaceFolderBasename: () => {
-            const workspaceFolder = computeVscodeVar('workspaceFolder');
+            const workspaceFolder = computeVscodeVar("workspaceFolder");
             if (workspaceFolder) {
                 return path.basename(workspaceFolder);
             } else {
-                return '';
+                return "";
             }
         },
 
@@ -323,13 +357,13 @@ function computeVscodeVar(varName: string): string {
         // https://github.com/microsoft/vscode/blob/29eb316bb9f154b7870eb5204ec7f2e7cf649bec/src/vs/server/node/remoteTerminalChannel.ts#L56
         execPath: () => process.env.VSCODE_EXEC_PATH ?? process.execPath,
 
-        pathSeparator: () => path.sep
+        pathSeparator: () => path.sep,
     };
 
     if (varName in supportedVariables) {
         return supportedVariables[varName]();
     } else {
         // can't resolve, keep the expression as is
-        return '${' + varName + '}';
+        return "${" + varName + "}";
     }
 }

--- a/editors/code/src/ctx.ts
+++ b/editors/code/src/ctx.ts
@@ -1,20 +1,20 @@
-import * as vscode from 'vscode';
-import * as lc from 'vscode-languageclient/node';
-import * as ra from './lsp_ext';
+import * as vscode from "vscode";
+import * as lc from "vscode-languageclient/node";
+import * as ra from "./lsp_ext";
 
-import { Config } from './config';
-import { createClient } from './client';
-import { isRustEditor, RustEditor } from './util';
-import { ServerStatusParams } from './lsp_ext';
+import { Config } from "./config";
+import { createClient } from "./client";
+import { isRustEditor, RustEditor } from "./util";
+import { ServerStatusParams } from "./lsp_ext";
 
 export type Workspace =
-    {
-        kind: 'Workspace Folder';
-    }
     | {
-        kind: 'Detached Files';
-        files: vscode.TextDocument[];
-    };
+          kind: "Workspace Folder";
+      }
+    | {
+          kind: "Detached Files";
+          files: vscode.TextDocument[];
+      };
 
 export class Ctx {
     private constructor(
@@ -22,16 +22,14 @@ export class Ctx {
         private readonly extCtx: vscode.ExtensionContext,
         readonly client: lc.LanguageClient,
         readonly serverPath: string,
-        readonly statusBar: vscode.StatusBarItem,
-    ) {
-
-    }
+        readonly statusBar: vscode.StatusBarItem
+    ) {}
 
     static async create(
         config: Config,
         extCtx: vscode.ExtensionContext,
         serverPath: string,
-        workspace: Workspace,
+        workspace: Workspace
     ): Promise<Ctx> {
         const client = await createClient(serverPath, workspace, config.serverExtraEnv);
 
@@ -52,9 +50,7 @@ export class Ctx {
 
     get activeRustEditor(): RustEditor | undefined {
         const editor = vscode.window.activeTextEditor;
-        return editor && isRustEditor(editor)
-            ? editor
-            : undefined;
+        return editor && isRustEditor(editor) ? editor : undefined;
     }
 
     get visibleRustEditors(): RustEditor[] {

--- a/editors/code/src/lsp_ext.ts
+++ b/editors/code/src/lsp_ext.ts
@@ -7,7 +7,9 @@ import * as lc from "vscode-languageclient";
 export interface AnalyzerStatusParams {
     textDocument?: lc.TextDocumentIdentifier;
 }
-export const analyzerStatus = new lc.RequestType<AnalyzerStatusParams, string, void>("rust-analyzer/analyzerStatus");
+export const analyzerStatus = new lc.RequestType<AnalyzerStatusParams, string, void>(
+    "rust-analyzer/analyzerStatus"
+);
 export const memoryUsage = new lc.RequestType0<string, void>("rust-analyzer/memoryUsage");
 export const shuffleCrateGraph = new lc.RequestType0<null, void>("rust-analyzer/shuffleCrateGraph");
 
@@ -16,7 +18,9 @@ export interface ServerStatusParams {
     quiescent: boolean;
     message?: string;
 }
-export const serverStatus = new lc.NotificationType<ServerStatusParams>("experimental/serverStatus");
+export const serverStatus = new lc.NotificationType<ServerStatusParams>(
+    "experimental/serverStatus"
+);
 
 export const reloadWorkspace = new lc.RequestType0<null, void>("rust-analyzer/reloadWorkspace");
 
@@ -31,23 +35,33 @@ export interface SyntaxTreeParams {
     textDocument: lc.TextDocumentIdentifier;
     range: lc.Range | null;
 }
-export const syntaxTree = new lc.RequestType<SyntaxTreeParams, string, void>("rust-analyzer/syntaxTree");
+export const syntaxTree = new lc.RequestType<SyntaxTreeParams, string, void>(
+    "rust-analyzer/syntaxTree"
+);
 
-export const viewHir = new lc.RequestType<lc.TextDocumentPositionParams, string, void>("rust-analyzer/viewHir");
+export const viewHir = new lc.RequestType<lc.TextDocumentPositionParams, string, void>(
+    "rust-analyzer/viewHir"
+);
 
-export const viewFileText = new lc.RequestType<lc.TextDocumentIdentifier, string, void>("rust-analyzer/viewFileText");
+export const viewFileText = new lc.RequestType<lc.TextDocumentIdentifier, string, void>(
+    "rust-analyzer/viewFileText"
+);
 
 export interface ViewItemTreeParams {
     textDocument: lc.TextDocumentIdentifier;
 }
 
-export const viewItemTree = new lc.RequestType<ViewItemTreeParams, string, void>("rust-analyzer/viewItemTree");
+export const viewItemTree = new lc.RequestType<ViewItemTreeParams, string, void>(
+    "rust-analyzer/viewItemTree"
+);
 
 export interface ViewCrateGraphParams {
     full: boolean;
 }
 
-export const viewCrateGraph = new lc.RequestType<ViewCrateGraphParams, string, void>("rust-analyzer/viewCrateGraph");
+export const viewCrateGraph = new lc.RequestType<ViewCrateGraphParams, string, void>(
+    "rust-analyzer/viewCrateGraph"
+);
 
 export interface ExpandMacroParams {
     textDocument: lc.TextDocumentIdentifier;
@@ -57,23 +71,35 @@ export interface ExpandedMacro {
     name: string;
     expansion: string;
 }
-export const expandMacro = new lc.RequestType<ExpandMacroParams, ExpandedMacro | null, void>("rust-analyzer/expandMacro");
+export const expandMacro = new lc.RequestType<ExpandMacroParams, ExpandedMacro | null, void>(
+    "rust-analyzer/expandMacro"
+);
 
 export interface MatchingBraceParams {
     textDocument: lc.TextDocumentIdentifier;
     positions: lc.Position[];
 }
-export const matchingBrace = new lc.RequestType<MatchingBraceParams, lc.Position[], void>("experimental/matchingBrace");
+export const matchingBrace = new lc.RequestType<MatchingBraceParams, lc.Position[], void>(
+    "experimental/matchingBrace"
+);
 
-export const parentModule = new lc.RequestType<lc.TextDocumentPositionParams, lc.LocationLink[] | null, void>("experimental/parentModule");
+export const parentModule = new lc.RequestType<
+    lc.TextDocumentPositionParams,
+    lc.LocationLink[] | null,
+    void
+>("experimental/parentModule");
 
 export interface JoinLinesParams {
     textDocument: lc.TextDocumentIdentifier;
     ranges: lc.Range[];
 }
-export const joinLines = new lc.RequestType<JoinLinesParams, lc.TextEdit[], void>("experimental/joinLines");
+export const joinLines = new lc.RequestType<JoinLinesParams, lc.TextEdit[], void>(
+    "experimental/joinLines"
+);
 
-export const onEnter = new lc.RequestType<lc.TextDocumentPositionParams, lc.TextEdit[], void>("experimental/onEnter");
+export const onEnter = new lc.RequestType<lc.TextDocumentPositionParams, lc.TextEdit[], void>(
+    "experimental/onEnter"
+);
 
 export interface RunnablesParams {
     textDocument: lc.TextDocumentIdentifier;
@@ -93,13 +119,17 @@ export interface Runnable {
         overrideCargo?: string;
     };
 }
-export const runnables = new lc.RequestType<RunnablesParams, Runnable[], void>("experimental/runnables");
+export const runnables = new lc.RequestType<RunnablesParams, Runnable[], void>(
+    "experimental/runnables"
+);
 
 export interface TestInfo {
     runnable: Runnable;
 }
 
-export const relatedTests = new lc.RequestType<lc.TextDocumentPositionParams, TestInfo[], void>("rust-analyzer/relatedTests");
+export const relatedTests = new lc.RequestType<lc.TextDocumentPositionParams, TestInfo[], void>(
+    "rust-analyzer/relatedTests"
+);
 
 export interface SsrParams {
     query: string;
@@ -108,7 +138,7 @@ export interface SsrParams {
     position: lc.Position;
     selections: readonly lc.Range[];
 }
-export const ssr = new lc.RequestType<SsrParams, lc.WorkspaceEdit, void>('experimental/ssr');
+export const ssr = new lc.RequestType<SsrParams, lc.WorkspaceEdit, void>("experimental/ssr");
 
 export interface CommandLink extends lc.Command {
     /**
@@ -122,15 +152,21 @@ export interface CommandLinkGroup {
     commands: CommandLink[];
 }
 
-export const openDocs = new lc.RequestType<lc.TextDocumentPositionParams, string | void, void>('experimental/externalDocs');
+export const openDocs = new lc.RequestType<lc.TextDocumentPositionParams, string | void, void>(
+    "experimental/externalDocs"
+);
 
-export const openCargoToml = new lc.RequestType<OpenCargoTomlParams, lc.Location, void>("experimental/openCargoToml");
+export const openCargoToml = new lc.RequestType<OpenCargoTomlParams, lc.Location, void>(
+    "experimental/openCargoToml"
+);
 
 export interface OpenCargoTomlParams {
     textDocument: lc.TextDocumentIdentifier;
 }
 
-export const moveItem = new lc.RequestType<MoveItemParams, lc.TextEdit[], void>("experimental/moveItem");
+export const moveItem = new lc.RequestType<MoveItemParams, lc.TextEdit[], void>(
+    "experimental/moveItem"
+);
 
 export interface MoveItemParams {
     textDocument: lc.TextDocumentIdentifier;
@@ -140,5 +176,5 @@ export interface MoveItemParams {
 
 export const enum Direction {
     Up = "Up",
-    Down = "Down"
+    Down = "Down",
 }

--- a/editors/code/src/persistent_state.ts
+++ b/editors/code/src/persistent_state.ts
@@ -1,5 +1,5 @@
-import * as vscode from 'vscode';
-import { log } from './util';
+import * as vscode from "vscode";
+import { log } from "./util";
 
 export class PersistentState {
     constructor(private readonly globalState: vscode.Memento) {

--- a/editors/code/src/run.ts
+++ b/editors/code/src/run.ts
@@ -1,15 +1,22 @@
-import * as vscode from 'vscode';
-import * as lc from 'vscode-languageclient';
-import * as ra from './lsp_ext';
-import * as tasks from './tasks';
+import * as vscode from "vscode";
+import * as lc from "vscode-languageclient";
+import * as ra from "./lsp_ext";
+import * as tasks from "./tasks";
 
-import { Ctx } from './ctx';
-import { makeDebugConfig } from './debug';
-import { Config, RunnableEnvCfg } from './config';
+import { Ctx } from "./ctx";
+import { makeDebugConfig } from "./debug";
+import { Config, RunnableEnvCfg } from "./config";
 
-const quickPickButtons = [{ iconPath: new vscode.ThemeIcon("save"), tooltip: "Save as a launch.json configurtation." }];
+const quickPickButtons = [
+    { iconPath: new vscode.ThemeIcon("save"), tooltip: "Save as a launch.json configurtation." },
+];
 
-export async function selectRunnable(ctx: Ctx, prevRunnable?: RunnableQuickPick, debuggeeOnly = false, showButtons: boolean = true): Promise<RunnableQuickPick | undefined> {
+export async function selectRunnable(
+    ctx: Ctx,
+    prevRunnable?: RunnableQuickPick,
+    debuggeeOnly = false,
+    showButtons: boolean = true
+): Promise<RunnableQuickPick | undefined> {
     const editor = ctx.activeRustEditor;
     const client = ctx.client;
     if (!editor || !client) return;
@@ -20,23 +27,18 @@ export async function selectRunnable(ctx: Ctx, prevRunnable?: RunnableQuickPick,
 
     const runnables = await client.sendRequest(ra.runnables, {
         textDocument,
-        position: client.code2ProtocolConverter.asPosition(
-            editor.selection.active,
-        ),
+        position: client.code2ProtocolConverter.asPosition(editor.selection.active),
     });
     const items: RunnableQuickPick[] = [];
     if (prevRunnable) {
         items.push(prevRunnable);
     }
     for (const r of runnables) {
-        if (
-            prevRunnable &&
-            JSON.stringify(prevRunnable.runnable) === JSON.stringify(r)
-        ) {
+        if (prevRunnable && JSON.stringify(prevRunnable.runnable) === JSON.stringify(r)) {
             continue;
         }
 
-        if (debuggeeOnly && (r.label.startsWith('doctest') || r.label.startsWith('cargo'))) {
+        if (debuggeeOnly && (r.label.startsWith("doctest") || r.label.startsWith("cargo"))) {
             continue;
         }
         items.push(new RunnableQuickPick(r));
@@ -53,7 +55,7 @@ export async function selectRunnable(ctx: Ctx, prevRunnable?: RunnableQuickPick,
         const disposables: vscode.Disposable[] = [];
         const close = (result?: RunnableQuickPick) => {
             resolve(result);
-            disposables.forEach(d => d.dispose());
+            disposables.forEach((d) => d.dispose());
         };
 
         const quickPick = vscode.window.createQuickPick<RunnableQuickPick>();
@@ -71,7 +73,7 @@ export async function selectRunnable(ctx: Ctx, prevRunnable?: RunnableQuickPick,
             }),
             quickPick.onDidChangeActive((active) => {
                 if (showButtons && active.length > 0) {
-                    if (active[0].label.startsWith('cargo')) {
+                    if (active[0].label.startsWith("cargo")) {
                         // save button makes no sense for `cargo test` or `cargo check`
                         quickPick.buttons = [];
                     } else if (quickPick.buttons.length === 0) {
@@ -96,8 +98,11 @@ export class RunnableQuickPick implements vscode.QuickPickItem {
     }
 }
 
-export function prepareEnv(runnable: ra.Runnable, runnableEnvCfg: RunnableEnvCfg): Record<string, string> {
-    const env: Record<string, string> = { "RUST_BACKTRACE": "short" };
+export function prepareEnv(
+    runnable: ra.Runnable,
+    runnableEnvCfg: RunnableEnvCfg
+): Record<string, string> {
+    const env: Record<string, string> = { RUST_BACKTRACE: "short" };
 
     if (runnable.args.expectTest) {
         env["UPDATE_EXPECT"] = "1";
@@ -141,7 +146,14 @@ export async function createTask(runnable: ra.Runnable, config: Config): Promise
 
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
     const target = vscode.workspace.workspaceFolders![0]; // safe, see main activate()
-    const cargoTask = await tasks.buildCargoTask(target, definition, runnable.label, args, config.cargoRunner, true);
+    const cargoTask = await tasks.buildCargoTask(
+        target,
+        definition,
+        runnable.label,
+        args,
+        config.cargoRunner,
+        true
+    );
 
     cargoTask.presentationOptions.clear = true;
     // Sadly, this doesn't prevent focus stealing if the terminal is currently
@@ -157,7 +169,7 @@ export function createArgs(runnable: ra.Runnable): string[] {
         args.push(...runnable.args.cargoExtraArgs); // Append user-specified cargo options.
     }
     if (runnable.args.executableArgs.length > 0) {
-        args.push('--', ...runnable.args.executableArgs);
+        args.push("--", ...runnable.args.executableArgs);
     }
     return args;
 }

--- a/editors/code/src/snippets.ts
+++ b/editors/code/src/snippets.ts
@@ -11,7 +11,7 @@ export async function applySnippetWorkspaceEdit(edit: vscode.WorkspaceEdit) {
     }
     for (const [uri, edits] of edit.entries()) {
         const editor = await editorFromUri(uri);
-        if (editor)
+        if (editor) {
             await editor.edit((builder) => {
                 for (const indel of edits) {
                     assert(
@@ -21,6 +21,7 @@ export async function applySnippetWorkspaceEdit(edit: vscode.WorkspaceEdit) {
                     builder.replace(indel.range, indel.newText);
                 }
             });
+        }
     }
 }
 

--- a/editors/code/src/snippets.ts
+++ b/editors/code/src/snippets.ts
@@ -1,6 +1,6 @@
-import * as vscode from 'vscode';
+import * as vscode from "vscode";
 
-import { assert } from './util';
+import { assert } from "./util";
 
 export async function applySnippetWorkspaceEdit(edit: vscode.WorkspaceEdit) {
     if (edit.entries().length === 1) {
@@ -11,12 +11,16 @@ export async function applySnippetWorkspaceEdit(edit: vscode.WorkspaceEdit) {
     }
     for (const [uri, edits] of edit.entries()) {
         const editor = await editorFromUri(uri);
-        if (editor) await editor.edit((builder) => {
-            for (const indel of edits) {
-                assert(!parseSnippet(indel.newText), `bad ws edit: snippet received with multiple edits: ${JSON.stringify(edit)}`);
-                builder.replace(indel.range, indel.newText);
-            }
-        });
+        if (editor)
+            await editor.edit((builder) => {
+                for (const indel of edits) {
+                    assert(
+                        !parseSnippet(indel.newText),
+                        `bad ws edit: snippet received with multiple edits: ${JSON.stringify(edit)}`
+                    );
+                    builder.replace(indel.range, indel.newText);
+                }
+            });
     }
 }
 
@@ -25,7 +29,9 @@ async function editorFromUri(uri: vscode.Uri): Promise<vscode.TextEditor | undef
         // `vscode.window.visibleTextEditors` only contains editors whose contents are being displayed
         await vscode.window.showTextDocument(uri, {});
     }
-    return vscode.window.visibleTextEditors.find((it) => it.document.uri.toString() === uri.toString());
+    return vscode.window.visibleTextEditors.find(
+        (it) => it.document.uri.toString() === uri.toString()
+    );
 }
 
 export async function applySnippetTextEdits(editor: vscode.TextEditor, edits: vscode.TextEdit[]) {
@@ -37,22 +43,26 @@ export async function applySnippetTextEdits(editor: vscode.TextEditor, edits: vs
             if (parsed) {
                 const [newText, [placeholderStart, placeholderLength]] = parsed;
                 const prefix = newText.substr(0, placeholderStart);
-                const lastNewline = prefix.lastIndexOf('\n');
+                const lastNewline = prefix.lastIndexOf("\n");
 
                 const startLine = indel.range.start.line + lineDelta + countLines(prefix);
-                const startColumn = lastNewline === -1 ?
-                    indel.range.start.character + placeholderStart
-                    : prefix.length - lastNewline - 1;
+                const startColumn =
+                    lastNewline === -1
+                        ? indel.range.start.character + placeholderStart
+                        : prefix.length - lastNewline - 1;
                 const endColumn = startColumn + placeholderLength;
-                selections.push(new vscode.Selection(
-                    new vscode.Position(startLine, startColumn),
-                    new vscode.Position(startLine, endColumn),
-                ));
+                selections.push(
+                    new vscode.Selection(
+                        new vscode.Position(startLine, startColumn),
+                        new vscode.Position(startLine, endColumn)
+                    )
+                );
                 builder.replace(indel.range, newText);
             } else {
                 builder.replace(indel.range, indel.newText);
             }
-            lineDelta += countLines(indel.newText) - (indel.range.end.line - indel.range.start.line);
+            lineDelta +=
+                countLines(indel.newText) - (indel.range.end.line - indel.range.start.line);
         }
     });
     if (selections.length > 0) editor.selections = selections;
@@ -65,8 +75,7 @@ function parseSnippet(snip: string): [string, [number, number]] | undefined {
     const m = snip.match(/\$(0|\{0:([^}]*)\})/);
     if (!m) return undefined;
     const placeholder = m[2] ?? "";
-    if (m.index == null)
-        return undefined;
+    if (m.index == null) return undefined;
     const range: [number, number] = [m.index, placeholder.length];
     const insert = snip.replace(m[0], placeholder);
     return [insert, range];

--- a/editors/code/src/tasks.ts
+++ b/editors/code/src/tasks.ts
@@ -1,12 +1,12 @@
-import * as vscode from 'vscode';
+import * as vscode from "vscode";
 import * as toolchain from "./toolchain";
-import { Config } from './config';
-import { log } from './util';
+import { Config } from "./config";
+import { log } from "./util";
 
 // This ends up as the `type` key in tasks.json. RLS also uses `cargo` and
 // our configuration should be compatible with it so use the same key.
-export const TASK_TYPE = 'cargo';
-export const TASK_SOURCE = 'rust';
+export const TASK_TYPE = "cargo";
+export const TASK_SOURCE = "rust";
 
 export interface CargoTaskDefinition extends vscode.TaskDefinition {
     command?: string;
@@ -30,17 +30,23 @@ class CargoTaskProvider implements vscode.TaskProvider {
         // tasks.json - only tweaked.
 
         const defs = [
-            { command: 'build', group: vscode.TaskGroup.Build },
-            { command: 'check', group: vscode.TaskGroup.Build },
-            { command: 'test', group: vscode.TaskGroup.Test },
-            { command: 'clean', group: vscode.TaskGroup.Clean },
-            { command: 'run', group: undefined },
+            { command: "build", group: vscode.TaskGroup.Build },
+            { command: "check", group: vscode.TaskGroup.Build },
+            { command: "test", group: vscode.TaskGroup.Test },
+            { command: "clean", group: vscode.TaskGroup.Clean },
+            { command: "run", group: undefined },
         ];
 
         const tasks: vscode.Task[] = [];
         for (const workspaceTarget of vscode.workspace.workspaceFolders || []) {
             for (const def of defs) {
-                const vscodeTask = await buildCargoTask(workspaceTarget, { type: TASK_TYPE, command: def.command }, `cargo ${def.command}`, [def.command], this.config.cargoRunner);
+                const vscodeTask = await buildCargoTask(
+                    workspaceTarget,
+                    { type: TASK_TYPE, command: def.command },
+                    `cargo ${def.command}`,
+                    [def.command],
+                    this.config.cargoRunner
+                );
                 vscodeTask.group = def.group;
                 tasks.push(vscodeTask);
             }
@@ -58,7 +64,13 @@ class CargoTaskProvider implements vscode.TaskProvider {
 
         if (definition.type === TASK_TYPE && definition.command) {
             const args = [definition.command].concat(definition.args ?? []);
-            return await buildCargoTask(task.scope, definition, task.name, args, this.config.cargoRunner);
+            return await buildCargoTask(
+                task.scope,
+                definition,
+                task.name,
+                args,
+                this.config.cargoRunner
+            );
         }
 
         return undefined;
@@ -73,7 +85,6 @@ export async function buildCargoTask(
     customRunner?: string,
     throwOnError: boolean = false
 ): Promise<vscode.Task> {
-
     let exec: vscode.ProcessExecution | vscode.ShellExecution | undefined = undefined;
 
     if (customRunner) {
@@ -90,7 +101,6 @@ export async function buildCargoTask(
                 }
             }
             // fallback to default processing
-
         } catch (e) {
             if (throwOnError) throw `Cargo runner '${customRunner}' failed! ${e}`;
             // fallback to default processing
@@ -117,7 +127,7 @@ export async function buildCargoTask(
         name,
         TASK_SOURCE,
         exec,
-        ['$rustc']
+        ["$rustc"]
     );
 }
 

--- a/editors/code/tests/runTests.ts
+++ b/editors/code/tests/runTests.ts
@@ -1,43 +1,43 @@
-import * as path from 'path';
-import * as fs from 'fs';
+import * as path from "path";
+import * as fs from "fs";
 
-import { runTests } from '@vscode/test-electron';
+import { runTests } from "@vscode/test-electron";
 
 async function main() {
     // The folder containing the Extension Manifest package.json
     // Passed to `--extensionDevelopmentPath`
-    const extensionDevelopmentPath = path.resolve(__dirname, '../../');
+    const extensionDevelopmentPath = path.resolve(__dirname, "../../");
 
     // Minimum supported version.
-    const jsonData = fs.readFileSync(path.join(extensionDevelopmentPath, 'package.json'));
+    const jsonData = fs.readFileSync(path.join(extensionDevelopmentPath, "package.json"));
     const json = JSON.parse(jsonData.toString());
     let minimalVersion: string = json.engines.vscode;
-    if (minimalVersion.startsWith('^')) minimalVersion = minimalVersion.slice(1);
+    if (minimalVersion.startsWith("^")) minimalVersion = minimalVersion.slice(1);
 
     const launchArgs = ["--disable-extensions", extensionDevelopmentPath];
 
     // All test suites (either unit tests or integration tests) should be in subfolders.
-    const extensionTestsPath = path.resolve(__dirname, './unit/index');
+    const extensionTestsPath = path.resolve(__dirname, "./unit/index");
 
     // Run tests using the minimal supported version.
     await runTests({
         version: minimalVersion,
         launchArgs,
         extensionDevelopmentPath,
-        extensionTestsPath
+        extensionTestsPath,
     });
 
     // and the latest one
     await runTests({
-        version: 'stable',
+        version: "stable",
         launchArgs,
         extensionDevelopmentPath,
-        extensionTestsPath
+        extensionTestsPath,
     });
 }
 
-main().catch(err => {
+main().catch((err) => {
     // eslint-disable-next-line no-console
-    console.error('Failed to run tests', err);
+    console.error("Failed to run tests", err);
     process.exit(1);
 });

--- a/editors/code/tests/unit/index.ts
+++ b/editors/code/tests/unit/index.ts
@@ -1,5 +1,5 @@
-import { readdir } from 'fs/promises';
-import * as path from 'path';
+import { readdir } from "fs/promises";
+import * as path from "path";
 
 class Test {
     readonly name: string;
@@ -59,7 +59,9 @@ export class Context {
 export async function run(): Promise<void> {
     const context = new Context();
 
-    const testFiles = (await readdir(path.resolve(__dirname))).filter(name => name.endsWith('.test.js'));
+    const testFiles = (await readdir(path.resolve(__dirname))).filter((name) =>
+        name.endsWith(".test.js")
+    );
     for (const testFile of testFiles) {
         try {
             const testModule = require(path.resolve(__dirname, testFile));

--- a/editors/code/tests/unit/launch_config.test.ts
+++ b/editors/code/tests/unit/launch_config.test.ts
@@ -1,51 +1,98 @@
-import * as assert from 'assert';
-import { Cargo } from '../../src/toolchain';
-import { Context } from '.';
+import * as assert from "assert";
+import { Cargo } from "../../src/toolchain";
+import { Context } from ".";
 
 export async function getTests(ctx: Context) {
-    await ctx.suite('Launch configuration/Lens', suite => {
-        suite.addTest('A binary', async () => {
-            const args = Cargo.artifactSpec(["build", "--package", "pkg_name", "--bin", "pkg_name"]);
+    await ctx.suite("Launch configuration/Lens", (suite) => {
+        suite.addTest("A binary", async () => {
+            const args = Cargo.artifactSpec([
+                "build",
+                "--package",
+                "pkg_name",
+                "--bin",
+                "pkg_name",
+            ]);
 
-            assert.deepStrictEqual(args.cargoArgs, ["build", "--package", "pkg_name", "--bin", "pkg_name", "--message-format=json"]);
+            assert.deepStrictEqual(args.cargoArgs, [
+                "build",
+                "--package",
+                "pkg_name",
+                "--bin",
+                "pkg_name",
+                "--message-format=json",
+            ]);
             assert.deepStrictEqual(args.filter, undefined);
         });
 
-        suite.addTest('One of Multiple Binaries', async () => {
+        suite.addTest("One of Multiple Binaries", async () => {
             const args = Cargo.artifactSpec(["build", "--package", "pkg_name", "--bin", "bin1"]);
 
-            assert.deepStrictEqual(args.cargoArgs, ["build", "--package", "pkg_name", "--bin", "bin1", "--message-format=json"]);
+            assert.deepStrictEqual(args.cargoArgs, [
+                "build",
+                "--package",
+                "pkg_name",
+                "--bin",
+                "bin1",
+                "--message-format=json",
+            ]);
             assert.deepStrictEqual(args.filter, undefined);
         });
 
-        suite.addTest('A test', async () => {
+        suite.addTest("A test", async () => {
             const args = Cargo.artifactSpec(["test", "--package", "pkg_name", "--lib", "--no-run"]);
 
-            assert.deepStrictEqual(args.cargoArgs, ["test", "--package", "pkg_name", "--lib", "--no-run", "--message-format=json"]);
+            assert.deepStrictEqual(args.cargoArgs, [
+                "test",
+                "--package",
+                "pkg_name",
+                "--lib",
+                "--no-run",
+                "--message-format=json",
+            ]);
             assert.notDeepStrictEqual(args.filter, undefined);
         });
     });
 
-    await ctx.suite('Launch configuration/QuickPick', suite => {
-        suite.addTest('A binary', async () => {
+    await ctx.suite("Launch configuration/QuickPick", (suite) => {
+        suite.addTest("A binary", async () => {
             const args = Cargo.artifactSpec(["run", "--package", "pkg_name", "--bin", "pkg_name"]);
 
-            assert.deepStrictEqual(args.cargoArgs, ["build", "--package", "pkg_name", "--bin", "pkg_name", "--message-format=json"]);
+            assert.deepStrictEqual(args.cargoArgs, [
+                "build",
+                "--package",
+                "pkg_name",
+                "--bin",
+                "pkg_name",
+                "--message-format=json",
+            ]);
             assert.deepStrictEqual(args.filter, undefined);
         });
 
-
-        suite.addTest('One of Multiple Binaries', async () => {
+        suite.addTest("One of Multiple Binaries", async () => {
             const args = Cargo.artifactSpec(["run", "--package", "pkg_name", "--bin", "bin2"]);
 
-            assert.deepStrictEqual(args.cargoArgs, ["build", "--package", "pkg_name", "--bin", "bin2", "--message-format=json"]);
+            assert.deepStrictEqual(args.cargoArgs, [
+                "build",
+                "--package",
+                "pkg_name",
+                "--bin",
+                "bin2",
+                "--message-format=json",
+            ]);
             assert.deepStrictEqual(args.filter, undefined);
         });
 
-        suite.addTest('A test', async () => {
+        suite.addTest("A test", async () => {
             const args = Cargo.artifactSpec(["test", "--package", "pkg_name", "--lib"]);
 
-            assert.deepStrictEqual(args.cargoArgs, ["test", "--package", "pkg_name", "--lib", "--message-format=json", "--no-run"]);
+            assert.deepStrictEqual(args.cargoArgs, [
+                "test",
+                "--package",
+                "pkg_name",
+                "--lib",
+                "--message-format=json",
+                "--no-run",
+            ]);
             assert.notDeepStrictEqual(args.filter, undefined);
         });
     });

--- a/editors/code/tests/unit/runnable_env.test.ts
+++ b/editors/code/tests/unit/runnable_env.test.ts
@@ -1,8 +1,8 @@
-import * as assert from 'assert';
-import { prepareEnv } from '../../src/run';
-import { RunnableEnvCfg } from '../../src/config';
-import { Context } from '.';
-import * as ra from '../../src/lsp_ext';
+import * as assert from "assert";
+import { prepareEnv } from "../../src/run";
+import { RunnableEnvCfg } from "../../src/config";
+import { Context } from ".";
+import * as ra from "../../src/lsp_ext";
 
 function makeRunnable(label: string): ra.Runnable {
     return {
@@ -11,8 +11,8 @@ function makeRunnable(label: string): ra.Runnable {
         args: {
             cargoArgs: [],
             executableArgs: [],
-            cargoExtraArgs: []
-        }
+            cargoExtraArgs: [],
+        },
     };
 }
 
@@ -22,20 +22,20 @@ function fakePrepareEnv(runnableName: string, config: RunnableEnvCfg): Record<st
 }
 
 export async function getTests(ctx: Context) {
-    await ctx.suite('Runnable env', suite => {
-        suite.addTest('Global config works', async () => {
-            const binEnv = fakePrepareEnv("run project_name", { "GLOBAL": "g" });
+    await ctx.suite("Runnable env", (suite) => {
+        suite.addTest("Global config works", async () => {
+            const binEnv = fakePrepareEnv("run project_name", { GLOBAL: "g" });
             assert.strictEqual(binEnv["GLOBAL"], "g");
 
-            const testEnv = fakePrepareEnv("test some::mod::test_name", { "GLOBAL": "g" });
+            const testEnv = fakePrepareEnv("test some::mod::test_name", { GLOBAL: "g" });
             assert.strictEqual(testEnv["GLOBAL"], "g");
         });
 
-        suite.addTest('null mask works', async () => {
+        suite.addTest("null mask works", async () => {
             const config = [
                 {
-                    env: { DATA: "data" }
-                }
+                    env: { DATA: "data" },
+                },
             ];
             const binEnv = fakePrepareEnv("run project_name", config);
             assert.strictEqual(binEnv["DATA"], "data");
@@ -44,14 +44,14 @@ export async function getTests(ctx: Context) {
             assert.strictEqual(testEnv["DATA"], "data");
         });
 
-        suite.addTest('order works', async () => {
+        suite.addTest("order works", async () => {
             const config = [
                 {
-                    env: { DATA: "data" }
+                    env: { DATA: "data" },
                 },
                 {
-                    env: { DATA: "newdata" }
-                }
+                    env: { DATA: "newdata" },
+                },
             ];
             const binEnv = fakePrepareEnv("run project_name", config);
             assert.strictEqual(binEnv["DATA"], "newdata");
@@ -60,19 +60,19 @@ export async function getTests(ctx: Context) {
             assert.strictEqual(testEnv["DATA"], "newdata");
         });
 
-        suite.addTest('mask works', async () => {
+        suite.addTest("mask works", async () => {
             const config = [
                 {
-                    env: { DATA: "data" }
+                    env: { DATA: "data" },
                 },
                 {
                     mask: "^run",
-                    env: { DATA: "rundata" }
+                    env: { DATA: "rundata" },
                 },
                 {
                     mask: "special_test$",
-                    env: { DATA: "special_test" }
-                }
+                    env: { DATA: "special_test" },
+                },
             ];
             const binEnv = fakePrepareEnv("run project_name", config);
             assert.strictEqual(binEnv["DATA"], "rundata");
@@ -84,15 +84,15 @@ export async function getTests(ctx: Context) {
             assert.strictEqual(specialTestEnv["DATA"], "special_test");
         });
 
-        suite.addTest('exact test name works', async () => {
+        suite.addTest("exact test name works", async () => {
             const config = [
                 {
-                    env: { DATA: "data" }
+                    env: { DATA: "data" },
                 },
                 {
                     mask: "some::mod::test_name",
-                    env: { DATA: "test special" }
-                }
+                    env: { DATA: "test special" },
+                },
             ];
             const testEnv = fakePrepareEnv("test some::mod::test_name", config);
             assert.strictEqual(testEnv["DATA"], "test special");
@@ -101,15 +101,15 @@ export async function getTests(ctx: Context) {
             assert.strictEqual(specialTestEnv["DATA"], "data");
         });
 
-        suite.addTest('test mod name works', async () => {
+        suite.addTest("test mod name works", async () => {
             const config = [
                 {
-                    env: { DATA: "data" }
+                    env: { DATA: "data" },
                 },
                 {
                     mask: "some::mod",
-                    env: { DATA: "mod special" }
-                }
+                    env: { DATA: "mod special" },
+                },
             ];
             const testEnv = fakePrepareEnv("test some::mod::test_name", config);
             assert.strictEqual(testEnv["DATA"], "mod special");

--- a/editors/code/tests/unit/settings.test.ts
+++ b/editors/code/tests/unit/settings.test.ts
@@ -1,30 +1,30 @@
-import * as assert from 'assert';
-import { Context } from '.';
-import { substituteVariablesInEnv } from '../../src/config';
+import * as assert from "assert";
+import { Context } from ".";
+import { substituteVariablesInEnv } from "../../src/config";
 
 export async function getTests(ctx: Context) {
-    await ctx.suite('Server Env Settings', suite => {
-        suite.addTest('Replacing Env Variables', async () => {
+    await ctx.suite("Server Env Settings", (suite) => {
+        suite.addTest("Replacing Env Variables", async () => {
             const envJson = {
                 USING_MY_VAR: "${env:MY_VAR} test ${env:MY_VAR}",
-                MY_VAR: "test"
+                MY_VAR: "test",
             };
             const expectedEnv = {
                 USING_MY_VAR: "test test test",
-                MY_VAR: "test"
+                MY_VAR: "test",
             };
             const actualEnv = await substituteVariablesInEnv(envJson);
             assert.deepStrictEqual(actualEnv, expectedEnv);
         });
 
-        suite.addTest('Circular dependencies remain as is', async () => {
+        suite.addTest("Circular dependencies remain as is", async () => {
             const envJson = {
                 A_USES_B: "${env:B_USES_A}",
                 B_USES_A: "${env:A_USES_B}",
                 C_USES_ITSELF: "${env:C_USES_ITSELF}",
                 D_USES_C: "${env:C_USES_ITSELF}",
                 E_IS_ISOLATED: "test",
-                F_USES_E: "${env:E_IS_ISOLATED}"
+                F_USES_E: "${env:E_IS_ISOLATED}",
             };
             const expectedEnv = {
                 A_USES_B: "${env:B_USES_A}",
@@ -32,30 +32,30 @@ export async function getTests(ctx: Context) {
                 C_USES_ITSELF: "${env:C_USES_ITSELF}",
                 D_USES_C: "${env:C_USES_ITSELF}",
                 E_IS_ISOLATED: "test",
-                F_USES_E: "test"
+                F_USES_E: "test",
             };
             const actualEnv = await substituteVariablesInEnv(envJson);
             assert.deepStrictEqual(actualEnv, expectedEnv);
         });
 
-        suite.addTest('Should support external variables', async () => {
+        suite.addTest("Should support external variables", async () => {
             const envJson = {
-                USING_EXTERNAL_VAR: "${env:TEST_VARIABLE} test ${env:TEST_VARIABLE}"
+                USING_EXTERNAL_VAR: "${env:TEST_VARIABLE} test ${env:TEST_VARIABLE}",
             };
             const expectedEnv = {
-                USING_EXTERNAL_VAR: "test test test"
+                USING_EXTERNAL_VAR: "test test test",
             };
 
             const actualEnv = await substituteVariablesInEnv(envJson);
             assert.deepStrictEqual(actualEnv, expectedEnv);
         });
 
-        suite.addTest('should support VSCode variables', async () => {
+        suite.addTest("should support VSCode variables", async () => {
             const envJson = {
-                USING_VSCODE_VAR: "${workspaceFolderBasename}"
+                USING_VSCODE_VAR: "${workspaceFolderBasename}",
             };
             const actualEnv = await substituteVariablesInEnv(envJson);
-            assert.deepStrictEqual(actualEnv.USING_VSCODE_VAR, 'code');
+            assert.deepStrictEqual(actualEnv.USING_VSCODE_VAR, "code");
         });
     });
 }

--- a/editors/code/tsconfig.eslint.json
+++ b/editors/code/tsconfig.eslint.json
@@ -1,11 +1,11 @@
 // Special typescript project file, used by eslint only.
 {
-	"extends": "./tsconfig.json",
-	"include": [
-		// repeated from base config's "include" setting
-		"src",
-		"tests",
-		// these are the eslint-only inclusions
-		".eslintrc.js",
-	]
+    "extends": "./tsconfig.json",
+    "include": [
+        // repeated from base config's "include" setting
+        "src",
+        "tests",
+        // these are the eslint-only inclusions
+        ".eslintrc.js"
+    ]
 }

--- a/editors/code/tsconfig.json
+++ b/editors/code/tsconfig.json
@@ -3,9 +3,7 @@
         "module": "commonjs",
         "target": "es2021",
         "outDir": "out",
-        "lib": [
-            "es2021"
-        ],
+        "lib": ["es2021"],
         "sourceMap": true,
         "rootDir": ".",
         "strict": true,
@@ -16,12 +14,6 @@
         "noFallthroughCasesInSwitch": true,
         "newLine": "LF"
     },
-    "exclude": [
-        "node_modules",
-        ".vscode-test"
-    ],
-    "include": [
-        "src",
-        "tests"
-    ]
+    "exclude": ["node_modules", ".vscode-test"],
+    "include": ["src", "tests"]
 }


### PR DESCRIPTION
## Summary of changes:

 1. Added [`.editorconfig` file](https://editorconfig.org) to dictate general hygienic stuff like character encoding, no trailing whitespace, new line symbols etc. for all files (e.g. Markdown). Install an editor plugin to get this rudimentary formatting assistance automatically. Prettier can read this file and, for example, use it for indentation style and size. 
 2. Added a minimal prettier config file. All options are default except line width, which per [Veykril](https://github.com/Veykril) suggestion is set to 100 instead of 80, because [that's what `Rustfmt` uses](https://rust-lang.github.io/rustfmt/?version=v1.4.38&search=#max_width). 
 3. Change `package.json` to use Prettier instead of `tsfmt` for code formatting. 
 4. Performed initial formatting in a separate commit, per [bjorn3](https://github.com/bjorn3) suggestion added its hash to a `.git-blame-ignore-revs` file. For it to work you need to add a configuration to your git installation: 
    ```Shell
    git config --global blame.ignoreRevsFile .git-blame-ignore-revs
    ```
 5. Finally, removed `typescript-formatter` from the list of dependencies. 

----
What follows below is summary of the discussion we had on Zulip about the formatter switch:

## Background 

For the context, there are three reasons why we went with `tsfmt` originally:
* stick to vscode default/built-in
* don't add extra deps to package.json.lock
* follow upstream (language server node I think still uses `tsfmt`)

And the meta reason here was that we didn't have anyone familiar with frontend, so went for the simplest option, at the expense of features and convenience.

Meanwhile, [**Prettier**](https://prettier.io) became a formatter project that JS community consolidated on a few years ago. It's similar to `go fmt` / `cargo fmt` in spirit: minimal to no configuration to promote general uniformity in the ecosystem. There are some options, that were needed early on to make sure the project gained momentum, but by no means it's a customizable formatter that is easy to adjust to reduce the number of changes for adoption.

## Overview of changes performed by Prettier

Some of the changes are acceptable. Prettier dictates a unified string quoting style, and as a result half of our imports at the top are changed. No one would mind that. Some one-line changes are due to string quotes, too, and although these a re numerous, the surrounding lines aren't changed, and git blame / GitLens will still show relevant context.

Some are toss ups. `trailingComma` option - set it to `none`, and get a bunch of meaningless changes in half of the code. set it to `all` and get a bunch of changes in the other half of the code. Same with using parentheses around single parameters in arrow functions: `x => x + 1` vs `(x) => x + 1`. Perrier forces one style or the other, but we use both in our code.

Like I said, the changes above are Ok - they take a single line, don't disrupt GitLens / git blame much. **The big one is line width**. Prettier wants you to choose one and stick to it. The default is 80 and it forces some reformatting to squish deeply nested code or long function type declarations. If I set it to 100-120, then Prettier finds other parts of code where a multi-line expression can be smashed into a single long line. The problem is that in both cases some of the lines that get changed are interesting, they contain somewhat non-trivial logic, and if I were to work on them in future I would love to see the commit annotations that tell me something relevant. Alas, we use some of that.

## Project impact

Though Prettier is a mainstream JS project it has no dependencies. We add another package so that it and ESLint work together nicely, and that's it.
