### PR TITLE
feat: Improve docs generation assist

### DIFF
--- a/crates/ide-assists/src/lib.rs
+++ b/crates/ide-assists/src/lib.rs
@@ -223,6 +223,7 @@ mod handlers {
             generate_default_from_enum_variant::generate_default_from_enum_variant,
             generate_default_from_new::generate_default_from_new,
             generate_documentation_template::generate_documentation_template,
+            generate_documentation_template::generate_doc_example,
             generate_enum_is_method::generate_enum_is_method,
             generate_enum_projection_method::generate_enum_as_method,
             generate_enum_projection_method::generate_enum_try_into_method,

--- a/crates/ide-assists/src/tests/generated.rs
+++ b/crates/ide-assists/src/tests/generated.rs
@@ -863,30 +863,55 @@ impl core::ops::Deref for B {
 }
 
 #[test]
-fn doctest_generate_documentation_template() {
+fn doctest_generate_doc_example() {
     check_doc_test(
-        "generate_documentation_template",
+        "generate_doc_example",
         r#####"
-pub fn my_$0func(a: i32, b: i32) -> Result<(), std::io::Error> {
-    unimplemented!()
-}
+/// Adds two numbers.$0
+pub fn add(a: i32, b: i32) -> i32 { a + b }
 "#####,
         r#####"
-/// .
+/// Adds two numbers.
 ///
 /// # Examples
 ///
 /// ```
-/// use test::my_func;
+/// use test::add;
 ///
-/// assert_eq!(my_func(a, b), );
+/// assert_eq!(add(a, b), );
 /// ```
-///
-/// # Errors
-///
-/// This function will return an error if .
-pub fn my_func(a: i32, b: i32) -> Result<(), std::io::Error> {
-    unimplemented!()
+pub fn add(a: i32, b: i32) -> i32 { a + b }
+"#####,
+    )
+}
+
+#[test]
+fn doctest_generate_documentation_template() {
+    check_doc_test(
+        "generate_documentation_template",
+        r#####"
+pub struct S;
+impl S {
+    pub unsafe fn set_len$0(&mut self, len: usize) -> Result<(), std::io::Error> {
+        /* ... */
+    }
+}
+"#####,
+        r#####"
+pub struct S;
+impl S {
+    /// Sets the length.
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if .
+    ///
+    /// # Safety
+    ///
+    /// .
+    pub unsafe fn set_len(&mut self, len: usize) -> Result<(), std::io::Error> {
+        /* ... */
+    }
 }
 "#####,
     )

--- a/crates/rust-analyzer/tests/slow-tests/main.rs
+++ b/crates/rust-analyzer/tests/slow-tests/main.rs
@@ -494,7 +494,7 @@ fn main() {}
     server.request::<CodeActionRequest>(
         CodeActionParams {
             text_document: server.doc_id("src/lib.rs"),
-            range: Range::new(Position::new(2, 4), Position::new(2, 7)),
+            range: Range::new(Position::new(2, 8), Position::new(2, 8)),
             context: CodeActionContext::default(),
             partial_result_params: PartialResultParams::default(),
             work_done_progress_params: WorkDoneProgressParams::default(),
@@ -578,7 +578,7 @@ fn main() {{}}
     server.request::<CodeActionRequest>(
         CodeActionParams {
             text_document: server.doc_id("src/lib.rs"),
-            range: Range::new(Position::new(2, 4), Position::new(2, 7)),
+            range: Range::new(Position::new(2, 8), Position::new(2, 8)),
             context: CodeActionContext::default(),
             partial_result_params: PartialResultParams::default(),
             work_done_progress_params: WorkDoneProgressParams::default(),


### PR DESCRIPTION
- Split into 2 assists: one generates basic docs structure, but no example, one generates an example
- Fix section ordering (the example comes last)
- Allow generating docs for private functions
- Expand `len` to `length` when generating an intro sentence