### PR TITLE
Removed duplicate 'to' in `cachePriming.numThreads` option description

### DIFF
--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -59,7 +59,7 @@ config_data! {
 
         /// Warm up caches on project load.
         cachePriming_enable: bool = "true",
-        /// How many worker threads to to handle priming caches. The default `0` means to pick automatically.
+        /// How many worker threads to handle priming caches. The default `0` means to pick automatically.
         cachePriming_numThreads: ParallelCachePrimingNumThreads = "0",
 
         /// Automatically refresh project info via `cargo metadata` on

--- a/docs/user/generated_config.adoc
+++ b/docs/user/generated_config.adoc
@@ -11,7 +11,7 @@ Warm up caches on project load.
 [[rust-analyzer.cachePriming.numThreads]]rust-analyzer.cachePriming.numThreads (default: `0`)::
 +
 --
-How many worker threads to to handle priming caches. The default `0` means to pick automatically.
+How many worker threads to handle priming caches. The default `0` means to pick automatically.
 --
 [[rust-analyzer.cargo.autoreload]]rust-analyzer.cargo.autoreload (default: `true`)::
 +

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -388,7 +388,7 @@
                     "type": "boolean"
                 },
                 "rust-analyzer.cachePriming.numThreads": {
-                    "markdownDescription": "How many worker threads to to handle priming caches. The default `0` means to pick automatically.",
+                    "markdownDescription": "How many worker threads to handle priming caches. The default `0` means to pick automatically.",
                     "default": 0,
                     "type": "number",
                     "minimum": 0,


### PR DESCRIPTION
One 'to' too many!