### PR TITLE
fix: Clear `cargo check` diagnostics when flycheck is turned off

### DIFF
--- a/crates/rust-analyzer/src/reload.rs
+++ b/crates/rust-analyzer/src/reload.rs
@@ -404,6 +404,7 @@ impl GlobalState {
             Some(it) => it,
             None => {
                 self.flycheck = Vec::new();
+                self.diagnostics.clear_check();
                 return;
             }
         };


### PR DESCRIPTION
Previously stale diagnostics were left over indefinitely when turning off "Check on Save" while diagnostics are present.