### PR TITLE
feat: Add "cargo clippy" task preset

### DIFF
--- a/editors/code/src/tasks.ts
+++ b/editors/code/src/tasks.ts
@@ -32,6 +32,7 @@ class CargoTaskProvider implements vscode.TaskProvider {
         const defs = [
             { command: "build", group: vscode.TaskGroup.Build },
             { command: "check", group: vscode.TaskGroup.Build },
+            { command: "clippy", group: vscode.TaskGroup.Build },
             { command: "test", group: vscode.TaskGroup.Test },
             { command: "clean", group: vscode.TaskGroup.Clean },
             { command: "run", group: undefined },


### PR DESCRIPTION
We've had a couple of common presets in `Tasks: Run Task -> cargo -> cargo [check,build,test,...]` before. This PR adds `cargo clippy` to that list, which makes for a convenient way of occasionally running Clippy on your code without having to reconfigure the Check on Save command to clippy.

These presets all use the `cargo` task type that we provide, so diagnostics will show up in the editor. However, they don't go through the server-side parsing logic, so it's not possible to apply suggestions, and diagnostics are fairly "low-fidelity". It would be cool if we could somehow pass Cargo's JSON output through the LSP server and render it properly, for arbitrary tasks.

cc https://github.com/rust-lang/rust-analyzer/issues/12323