### PR TITLE
internal: Rename `Expr::Lambda` to `Expr::Closure`

### DIFF
--- a/crates/hir-def/src/body/lower.rs
+++ b/crates/hir-def/src/body/lower.rs
@@ -452,7 +452,12 @@ impl ExprCollector<'_> {
                     .map(|it| Interned::new(TypeRef::from_ast(&self.ctx(), it)));
                 let body = self.collect_expr_opt(e.body());
                 self.alloc_expr(
-                    Expr::Lambda { args: args.into(), arg_types: arg_types.into(), ret_type, body },
+                    Expr::Closure {
+                        args: args.into(),
+                        arg_types: arg_types.into(),
+                        ret_type,
+                        body,
+                    },
                     syntax_ptr,
                 )
             }

--- a/crates/hir-def/src/body/scope.rs
+++ b/crates/hir-def/src/body/scope.rs
@@ -197,7 +197,7 @@ fn compute_expr_scopes(expr: ExprId, body: &Body, scopes: &mut ExprScopes, scope
             let mut scope = scopes.new_labeled_scope(*scope, make_label(label));
             compute_expr_scopes(*body_expr, body, scopes, &mut scope);
         }
-        Expr::Lambda { args, body: body_expr, .. } => {
+        Expr::Closure { args, body: body_expr, .. } => {
             let mut scope = scopes.new_scope(*scope);
             scopes.add_params_bindings(body, scope, args);
             compute_expr_scopes(*body_expr, body, scopes, &mut scope);

--- a/crates/hir-def/src/expr.rs
+++ b/crates/hir-def/src/expr.rs
@@ -165,7 +165,7 @@ pub enum Expr {
         base: ExprId,
         index: ExprId,
     },
-    Lambda {
+    Closure {
         args: Box<[PatId]>,
         arg_types: Box<[Option<Interned<TypeRef>>]>,
         ret_type: Option<Interned<TypeRef>>,
@@ -286,7 +286,7 @@ impl Expr {
                     f(expr);
                 }
             }
-            Expr::Lambda { body, .. } => {
+            Expr::Closure { body, .. } => {
                 f(*body);
             }
             Expr::BinaryOp { lhs, rhs, .. } => {

--- a/crates/hir-ty/src/infer/expr.rs
+++ b/crates/hir-ty/src/infer/expr.rs
@@ -218,7 +218,7 @@ impl<'a> InferenceContext<'a> {
                 self.diverges = Diverges::Maybe;
                 TyBuilder::unit()
             }
-            Expr::Lambda { body, args, ret_type, arg_types } => {
+            Expr::Closure { body, args, ret_type, arg_types } => {
                 assert_eq!(args.len(), arg_types.len());
 
                 let mut sig_tys = Vec::new();
@@ -1058,7 +1058,7 @@ impl<'a> InferenceContext<'a> {
             for (idx, ((&arg, param_ty), expected_ty)) in
                 args.iter().zip(param_iter).zip(expected_iter).enumerate()
             {
-                let is_closure = matches!(&self.body[arg], Expr::Lambda { .. });
+                let is_closure = matches!(&self.body[arg], Expr::Closure { .. });
                 if is_closure != check_closures {
                     continue;
                 }


### PR DESCRIPTION
They're never really called "Lambda"s in Rust, so let's call them "Closures" consistently.