### PR TITLE
Order auto-imports by relevance

### DIFF
--- a/crates/ide-assists/src/handlers/auto_import.rs
+++ b/crates/ide-assists/src/handlers/auto_import.rs
@@ -189,10 +189,12 @@ fn relevance_score(ctx: &AssistContext, import: &LocatedImport) -> i32 {
         }
     }
 
-    match item_module.zip(current_node) {
+    let current_scope = current_node.as_ref().and_then(|node| ctx.sema.scope(node));
+
+    match item_module.zip(current_scope) {
         // get the distance between the modules (prefer items that are more local)
-        Some((item_module, current_node)) => {
-            let current_module = ctx.sema.scope(&current_node).unwrap().module();
+        Some((item_module, current_scope)) => {
+            let current_module = current_scope.module();
             score -= module_distance_hueristic(&current_module, &item_module, db) as i32;
         }
 


### PR DESCRIPTION
Fixes #10337.

Basically we sort the imports according to how "far away" the imported item is from where we want to import it to. This change makes it so that imports from the current crate are sorted before any third-party crates. Additionally, we make an exception for builtin crates (`std`, `core`, etc.) so that they are sorted before any third-party crates.

There are probably other heuristics that should be added to improve the experience (such as preferring imports that are common elsewhere in the same crate, and ranking crates depending on the dependency graph). However, I think this is a first good step. 

PS. This is my first time contributing here, so please be gentle if I have missed something obvious :-)