### PR TITLE
Generate enum variant assist

### DIFF
--- a/crates/ide-assists/src/handlers/generate_enum_variant.rs
+++ b/crates/ide-assists/src/handlers/generate_enum_variant.rs
@@ -42,7 +42,7 @@ pub(crate) fn generate_enum_variant(acc: &mut Assists, ctx: &AssistContext) -> O
 
     let name_ref = path.segment()?.name_ref()?;
     if name_ref.text().as_str().chars().next()?.is_ascii_lowercase() {
-        // No need to generate anything if the name starts with a lowercase letter
+        // Don't suggest generating variant if the name starts with a lowercase letter
         return None;
     }
 

--- a/crates/ide-assists/src/handlers/generate_enum_variant.rs
+++ b/crates/ide-assists/src/handlers/generate_enum_variant.rs
@@ -59,7 +59,7 @@ fn add_variant_to_accumulator(
     adt: hir::Enum,
     name_ref: &ast::NameRef,
 ) -> Option<()> {
-    let adt_ast = get_enum_ast(ctx, adt)?;
+    let adt_ast = adt.source(ctx.db())?.original_ast_node(ctx.db())?.value;
 
     let enum_indent_level = IndentLevel::from_node(&adt_ast.syntax());
 
@@ -78,15 +78,6 @@ fn add_variant_to_accumulator(
         target,
         |builder| builder.insert(offset, text),
     )
-}
-
-fn get_enum_ast(ctx: &AssistContext, adt: hir::Enum) -> Option<ast::Enum> {
-    let range = adt.source(ctx.db())?.syntax().original_file_range(ctx.db());
-    let file = ctx.sema.parse(range.file_id);
-    let adt_ast: ast::Enum =
-        ctx.sema.find_node_at_offset_with_macros(file.syntax(), range.range.start())?;
-
-    Some(adt_ast)
 }
 
 #[cfg(test)]

--- a/crates/ide-assists/src/handlers/generate_enum_variant.rs
+++ b/crates/ide-assists/src/handlers/generate_enum_variant.rs
@@ -1,0 +1,185 @@
+use hir::HasSource;
+use ide_db::assists::{AssistId, AssistKind};
+use syntax::{
+    ast::{self, edit::IndentLevel},
+    AstNode, TextSize,
+};
+
+use crate::assist_context::{AssistContext, Assists};
+
+// Assist: generate_enum_variant
+//
+// Adds a variant to an enum.
+//
+// ```
+// enum Countries {
+//     Ghana,
+// }
+//
+// fn main() {
+//     let country = Countries::Lesotho$0;
+// }
+// ```
+// ->
+// ```
+// enum Countries {
+//     Ghana,
+//     Lesotho,
+// }
+//
+// fn main() {
+//     let country = Countries::Lesotho;
+// }
+// ```
+pub(crate) fn generate_enum_variant(acc: &mut Assists, ctx: &AssistContext) -> Option<()> {
+    let path_expr: ast::PathExpr = ctx.find_node_at_offset()?;
+    let path = path_expr.path()?;
+
+    if ctx.sema.resolve_path(&path).is_some() {
+        // No need to generate anything if the path resolves
+        return None;
+    }
+
+    let name_ref = path.segment()?.name_ref()?;
+
+    if let Some(hir::PathResolution::Def(hir::ModuleDef::Adt(hir::Adt::Enum(e)))) =
+        ctx.sema.resolve_path(&path.qualifier()?)
+    {
+        let target = path.syntax().text_range();
+        return add_variant_to_accumulator(acc, ctx, target, e, &name_ref);
+    }
+
+    None
+}
+
+fn add_variant_to_accumulator(
+    acc: &mut Assists,
+    ctx: &AssistContext,
+    target: syntax::TextRange,
+    adt: hir::Enum,
+    name_ref: &ast::NameRef,
+) -> Option<()> {
+    let adt_ast = get_enum_ast(ctx, adt)?;
+
+    let enum_indent_level = IndentLevel::from_node(&adt_ast.syntax());
+
+    let offset = adt_ast.variant_list()?.syntax().text_range().end() - TextSize::of('}');
+
+    let prefix = if adt_ast.variant_list()?.variants().next().is_none() {
+        format!("\n{}", IndentLevel(1))
+    } else {
+        format!("{}", IndentLevel(1))
+    };
+    let text = format!("{}{},\n{}", prefix, name_ref, enum_indent_level);
+
+    acc.add(
+        AssistId("generate_enum_variant", AssistKind::Generate),
+        "Generate variant",
+        target,
+        |builder| builder.insert(offset, text),
+    )
+}
+
+fn get_enum_ast(ctx: &AssistContext, adt: hir::Enum) -> Option<ast::Enum> {
+    let range = adt.source(ctx.db())?.syntax().original_file_range(ctx.db());
+    let file = ctx.sema.parse(range.file_id);
+    let adt_ast: ast::Enum =
+        ctx.sema.find_node_at_offset_with_macros(file.syntax(), range.range.start())?;
+
+    Some(adt_ast)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::tests::{check_assist, check_assist_not_applicable};
+
+    use super::*;
+
+    #[test]
+    fn generate_basic_enum_variant_in_empty_enum() {
+        check_assist(
+            generate_enum_variant,
+            r"
+enum Foo {}
+fn main() {
+    Foo::Bar$0
+}
+",
+            r"
+enum Foo {
+    Bar,
+}
+fn main() {
+    Foo::Bar
+}
+",
+        )
+    }
+
+    #[test]
+    fn generate_basic_enum_variant_in_non_empty_enum() {
+        check_assist(
+            generate_enum_variant,
+            r"
+enum Foo {
+    Bar,
+}
+fn main() {
+    Foo::Baz$0
+}
+",
+            r"
+enum Foo {
+    Bar,
+    Baz,
+}
+fn main() {
+    Foo::Baz
+}
+",
+        )
+    }
+
+    #[test]
+    fn not_applicable_for_existing_variant() {
+        check_assist_not_applicable(
+            generate_enum_variant,
+            r"
+enum Foo {
+    Bar,
+}
+fn main() {
+    Foo::Bar$0
+}
+",
+        )
+    }
+
+    #[test]
+    fn indentation_level_is_correct() {
+        check_assist(
+            generate_enum_variant,
+            r"
+mod m {
+    enum Foo {
+        Bar,
+    }
+}
+fn main() {
+    m::Foo::Baz$0
+}
+",
+            r"
+mod m {
+    enum Foo {
+        Bar,
+        Baz,
+    }
+}
+fn main() {
+    m::Foo::Baz
+}
+",
+        )
+    }
+}

--- a/crates/ide-assists/src/handlers/generate_enum_variant.rs
+++ b/crates/ide-assists/src/handlers/generate_enum_variant.rs
@@ -41,6 +41,10 @@ pub(crate) fn generate_enum_variant(acc: &mut Assists, ctx: &AssistContext) -> O
     }
 
     let name_ref = path.segment()?.name_ref()?;
+    if name_ref.text().as_str().chars().next()?.is_ascii_lowercase() {
+        // No need to generate anything if the name starts with a lowercase letter
+        return None;
+    }
 
     if let Some(hir::PathResolution::Def(hir::ModuleDef::Adt(hir::Adt::Enum(e)))) =
         ctx.sema.resolve_path(&path.qualifier()?)
@@ -141,6 +145,21 @@ enum Foo {
 }
 fn main() {
     Foo::Bar$0
+}
+",
+        )
+    }
+
+    #[test]
+    fn not_applicable_for_lowercase() {
+        check_assist_not_applicable(
+            generate_enum_variant,
+            r"
+enum Foo {
+    Bar,
+}
+fn main() {
+    Foo::new$0
 }
 ",
         )

--- a/crates/ide-assists/src/handlers/generate_enum_variant.rs
+++ b/crates/ide-assists/src/handlers/generate_enum_variant.rs
@@ -41,7 +41,7 @@ pub(crate) fn generate_enum_variant(acc: &mut Assists, ctx: &AssistContext) -> O
     }
 
     let name_ref = path.segment()?.name_ref()?;
-    if name_ref.text().as_str().chars().next()?.is_ascii_lowercase() {
+    if name_ref.text().starts_with(char::is_lowercase) {
         // Don't suggest generating variant if the name starts with a lowercase letter
         return None;
     }

--- a/crates/ide-assists/src/handlers/generate_function.rs
+++ b/crates/ide-assists/src/handlers/generate_function.rs
@@ -73,7 +73,7 @@ fn gen_fn(acc: &mut Assists, ctx: &AssistContext) -> Option<()> {
             Some(hir::PathResolution::Def(hir::ModuleDef::Adt(adt))) => {
                 if let hir::Adt::Enum(_) = adt {
                     // Don't suggest generating function if the name starts with an uppercase letter
-                    if name_ref.text().chars().next()?.is_uppercase() {
+                    if name_ref.text().starts_with(char::is_uppercase) {
                         return None;
                     }
                 }

--- a/crates/ide-assists/src/lib.rs
+++ b/crates/ide-assists/src/lib.rs
@@ -139,6 +139,7 @@ mod handlers {
     mod generate_documentation_template;
     mod generate_enum_is_method;
     mod generate_enum_projection_method;
+    mod generate_enum_variant;
     mod generate_from_impl_for_enum;
     mod generate_function;
     mod generate_getter;
@@ -227,6 +228,7 @@ mod handlers {
             generate_enum_is_method::generate_enum_is_method,
             generate_enum_projection_method::generate_enum_as_method,
             generate_enum_projection_method::generate_enum_try_into_method,
+            generate_enum_variant::generate_enum_variant,
             generate_from_impl_for_enum::generate_from_impl_for_enum,
             generate_function::generate_function,
             generate_impl::generate_impl,

--- a/crates/ide-assists/src/tests/generated.rs
+++ b/crates/ide-assists/src/tests/generated.rs
@@ -1007,6 +1007,32 @@ impl Value {
 }
 
 #[test]
+fn doctest_generate_enum_variant() {
+    check_doc_test(
+        "generate_enum_variant",
+        r#####"
+enum Countries {
+    Ghana,
+}
+
+fn main() {
+    let country = Countries::Lesotho$0;
+}
+"#####,
+        r#####"
+enum Countries {
+    Ghana,
+    Lesotho,
+}
+
+fn main() {
+    let country = Countries::Lesotho;
+}
+"#####,
+    )
+}
+
+#[test]
 fn doctest_generate_from_impl_for_enum() {
     check_doc_test(
         "generate_from_impl_for_enum",


### PR DESCRIPTION
So, this is kind of a weird PR!

I'm a complete newcomer to the `rust-analyzer` codebase, and so I browsed the "good first issue" tag, and found #11635. Then I found two separate folks had taken stabs at it, most recently @maartenflippo — and there had been a review 3 days ago, but no activity in a little while, and the PR needed to be rebased since the crates were renamed from `snake_case` to `kebab-case`.

So to get acquainted with the codebase I typed this PR by hand, looking at the diff in #11995, and I also added a doc-test (that passes).

I haven't taken into account the comments @Veykril left in #11995, but I don't want to steal any of @maartenflippo's thunder! Closing this PR is perfectly fine. Or Maarten could use it as a "restart point"? Or I could finish it up, whichever feels best to everyone.

I think what remains to be done in this PR, at least, is:

  * [x] Only disable the "generate function" assist if the name is `PascalCase`
  * [x] Only enable the "generate variant" assistant if the name is `PascalCase`
  * [x] Simplify with `adt.source()` as mentioned here: https://github.com/rust-lang/rust-analyzer/pull/11995#discussion_r875134175
  * [ ] Add more tests for edge cases? Are there cases where simply adding one more indent level than the enum's indent level is not good enough? Some nested trickery I'm not thinking of right now?

Anyway. This PR can go in any direction. You can tell me "no, tackle your own issue!" And I'll go do that and still be happy I got to take a look at rust-analyzer some by doing this. Or you can tell me "okay, now _you_ finish it", and I guess I'll try and finish it :)

Closes #11635