### PR TITLE
make `files.excludeDirs` work

### DIFF
--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -694,7 +694,22 @@ impl Config {
         match self.data.linkedProjects.as_slice() {
             [] => match self.discovered_projects.as_ref() {
                 Some(discovered_projects) => {
-                    discovered_projects.iter().cloned().map(LinkedProject::from).collect()
+                    let exclude_dirs: Vec<_> = self
+                        .data
+                        .files_excludeDirs
+                        .iter()
+                        .map(|p| self.root_path.join(p))
+                        .collect();
+                    discovered_projects
+                        .iter()
+                        .filter(|p| {
+                            let (ProjectManifest::ProjectJson(path)
+                            | ProjectManifest::CargoToml(path)) = p;
+                            !exclude_dirs.iter().any(|p| path.starts_with(p))
+                        })
+                        .cloned()
+                        .map(LinkedProject::from)
+                        .collect()
                 }
                 None => Vec::new(),
             },


### PR DESCRIPTION
There's a small issue because if all projects are excluded, this: https://github.com/rust-lang/rust-analyzer/blob/01d412f4d7bd7ef21a7e8f0461e9ba3439e3c4bf/crates/rust-analyzer/src/main_loop.rs#L114 will be shown.
I thought about not showing it if `files.excludeDirs` is set, but that is not necessarily correct.

Fixes #7755