### PR TITLE
intern: begin extracting trival identifiers from format_string strings

### DIFF
--- a/crates/hir-def/src/macro_expansion_tests/builtin_fn_macro.rs
+++ b/crates/hir-def/src/macro_expansion_tests/builtin_fn_macro.rs
@@ -208,6 +208,38 @@ fn main() {
 }
 
 #[test]
+fn test_format_args_expand_with_captured_variables() {
+    check(
+        r#"
+#[rustc_builtin_macro]
+macro_rules! format_args {
+    ($fmt:expr) => ({ /* compiler built-in */ });
+    ($fmt:expr, $($args:tt)*) => ({ /* compiler built-in */ })
+}
+
+fn main() {
+    let a = "foo";
+    format_args!("{a}");
+}
+"#,
+        expect![[r##"
+#[rustc_builtin_macro]
+macro_rules! format_args {
+    ($fmt:expr) => ({ /* compiler built-in */ });
+    ($fmt:expr, $($args:tt)*) => ({ /* compiler built-in */ })
+}
+
+fn main() {
+    let a = "foo";
+    unsafe {
+        std::fmt::Arguments::new_v1(&[], &[std::fmt::ArgumentV1::new(&(a), std::fmt::Display::fmt), ])
+    };
+}
+"##]],
+    );
+}
+
+#[test]
 fn test_format_args_expand_with_comma_exprs() {
     check(
         r#"

--- a/crates/hir-def/src/macro_expansion_tests/builtin_fn_macro.rs
+++ b/crates/hir-def/src/macro_expansion_tests/builtin_fn_macro.rs
@@ -240,6 +240,74 @@ fn main() {
 }
 
 #[test]
+fn test_format_args_expand_with_multiple_captured_variables() {
+    check(
+        r#"
+#[rustc_builtin_macro]
+macro_rules! format_args {
+    ($fmt:expr) => ({ /* compiler built-in */ });
+    ($fmt:expr, $($args:tt)*) => ({ /* compiler built-in */ })
+}
+
+fn main() {
+    let a = "foo";
+    let bar = "bar";
+    format_args!("{a} {bar:?}");
+}
+"#,
+        expect![[r##"
+#[rustc_builtin_macro]
+macro_rules! format_args {
+    ($fmt:expr) => ({ /* compiler built-in */ });
+    ($fmt:expr, $($args:tt)*) => ({ /* compiler built-in */ })
+}
+
+fn main() {
+    let a = "foo";
+    let bar = "bar";
+    unsafe {
+        std::fmt::Arguments::new_v1(&[], &[std::fmt::ArgumentV1::new(&(a), std::fmt::Display::fmt), std::fmt::ArgumentV1::new(&(bar), std::fmt::Display::fmt), ])
+    };
+}
+"##]],
+    );
+}
+
+#[test]
+fn test_format_args_expand_with_mixed_variables() {
+    check(
+        r#"
+#[rustc_builtin_macro]
+macro_rules! format_args {
+    ($fmt:expr) => ({ /* compiler built-in */ });
+    ($fmt:expr, $($args:tt)*) => ({ /* compiler built-in */ })
+}
+
+fn main() {
+    let a = "foo";
+    let bar = "bar";
+    format_args!("{a} {:04} {bar:?}", 42);
+}
+"#,
+        expect![[r##"
+#[rustc_builtin_macro]
+macro_rules! format_args {
+    ($fmt:expr) => ({ /* compiler built-in */ });
+    ($fmt:expr, $($args:tt)*) => ({ /* compiler built-in */ })
+}
+
+fn main() {
+    let a = "foo";
+    let bar = "bar";
+    unsafe {
+        std::fmt::Arguments::new_v1(&[], &[std::fmt::ArgumentV1::new(&(a), std::fmt::Display::fmt), std::fmt::ArgumentV1::new(&(42), std::fmt::Display::fmt), std::fmt::ArgumentV1::new(&(bar), std::fmt::Display::fmt), ])
+    };
+}
+"##]],
+    );
+}
+
+#[test]
 fn test_format_args_expand_with_comma_exprs() {
     check(
         r#"


### PR DESCRIPTION
When expanding `format_args` we will use the first argument and try to find trivial identifiers such as 
`foo` and `bar` in `"something {foo} and {bar}"`.