### PR TITLE
Fix build on OpenBSD (and probably other BSDs too)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -982,9 +982,9 @@ dependencies = [
 
 [[package]]
 name = "notify"
-version = "5.0.0-pre.14"
+version = "5.0.0-pre.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d13c22db70a63592e098fb51735bab36646821e6389a0ba171f3549facdf0b74"
+checksum = "553f9844ad0b0824605c20fb55a661679782680410abfb1a8144c2e7e437e7a7"
 dependencies = [
  "bitflags",
  "crossbeam-channel",

--- a/crates/vfs-notify/Cargo.toml
+++ b/crates/vfs-notify/Cargo.toml
@@ -14,7 +14,7 @@ tracing = "0.1.32"
 jod-thread = "0.1.2"
 walkdir = "2.3.2"
 crossbeam-channel = "0.5.4"
-notify = "=5.0.0-pre.14"
+notify = "=5.0.0-pre.15"
 
 vfs = { path = "../vfs", version = "0.0.0" }
 paths = { path = "../paths", version = "0.0.0" }


### PR DESCRIPTION
notify-5.0.0-pre.14 does not build on these systems; this was fixed in
https://github.com/notify-rs/notify/commit/41a74f0e98a1af386749ad3be4a197865054f17f , which landed in pre.15.