### PR TITLE
Fix inference when pattern matching a tuple field with a wildcard

### DIFF
--- a/crates/hir-ty/src/tests/patterns.rs
+++ b/crates/hir-ty/src/tests/patterns.rs
@@ -969,3 +969,23 @@ fn main() {
     "#,
     );
 }
+
+#[test]
+fn tuple_wildcard() {
+    check_types(
+        r#"
+fn main() {
+    enum Option<T> {Some(T), None}
+    use Option::*;
+
+    let mut x = None;
+    x;
+  //^ Option<(i32, i32)>
+
+    if let Some((_, _a)) = x {}
+
+    x = Some((1, 2));
+}
+        "#,
+    );
+}


### PR DESCRIPTION
This should fix the following issue:  https://github.com/rust-lang/rust-analyzer/issues/12331

* Replaced the `err_ty` in `infer_pat()` with a new type variable.
* Had to change the iterator code a bit, to get around multiple mutable borrows of `self` in `infer_pat()`.
Also added a test 
* Also added a test