### PR TITLE
fix: When reference searching macro inputs, don't search everything that was downmapped

### DIFF
--- a/crates/hir/src/semantics.rs
+++ b/crates/hir/src/semantics.rs
@@ -208,14 +208,14 @@ impl<'db, DB: HirDatabase> Semantics<'db, DB> {
         self.imp.descend_into_macros(token)
     }
 
-    /// Descend the token into macrocalls to all its mapped counterparts.
+    /// Descend the token into macrocalls to all its mapped counterparts that have the same text as the input token.
     ///
-    /// Returns the original non descended token if none of the mapped counterparts have the same syntax kind.
-    pub fn descend_into_macros_with_same_kind(
+    /// Returns the original non descended token if none of the mapped counterparts have the same text.
+    pub fn descend_into_macros_with_same_text(
         &self,
         token: SyntaxToken,
     ) -> SmallVec<[SyntaxToken; 1]> {
-        self.imp.descend_into_macros_with_same_kind(token)
+        self.imp.descend_into_macros_with_same_text(token)
     }
 
     /// Maps a node down by mapping its first and last token down.
@@ -666,11 +666,11 @@ impl<'db> SemanticsImpl<'db> {
         res
     }
 
-    fn descend_into_macros_with_same_kind(&self, token: SyntaxToken) -> SmallVec<[SyntaxToken; 1]> {
-        let kind = token.kind();
+    fn descend_into_macros_with_same_text(&self, token: SyntaxToken) -> SmallVec<[SyntaxToken; 1]> {
+        let text = token.text();
         let mut res = smallvec![];
         self.descend_into_macros_impl(token.clone(), &mut |InFile { value, .. }| {
-            if value.kind() == kind {
+            if value.text() == text {
                 res.push(value);
             }
             false

--- a/crates/ide/src/hover.rs
+++ b/crates/ide/src/hover.rs
@@ -115,7 +115,7 @@ pub(crate) fn hover(
         });
     }
 
-    let descended = sema.descend_into_macros(original_token.clone());
+    let descended = sema.descend_into_macros_with_same_text(original_token.clone());
 
     // FIXME: Definition should include known lints and the like instead of having this special case here
     let hovered_lint = descended.iter().find_map(|token| {

--- a/crates/ide/src/references.rs
+++ b/crates/ide/src/references.rs
@@ -122,7 +122,7 @@ pub(crate) fn find_defs<'a>(
         )
     });
     token.map(|token| {
-        sema.descend_into_macros_with_same_kind(token)
+        sema.descend_into_macros_with_same_text(token)
             .into_iter()
             .filter_map(|it| ast::NameLike::cast(it.parent()?))
             .filter_map(move |name_like| {

--- a/crates/syntax/src/ast/node_ext.rs
+++ b/crates/syntax/src/ast/node_ext.rs
@@ -432,6 +432,13 @@ impl NameLike {
             _ => None,
         }
     }
+    pub fn text(&self) -> TokenText {
+        match self {
+            NameLike::NameRef(name_ref) => name_ref.text(),
+            NameLike::Name(name) => name.text(),
+            NameLike::Lifetime(lifetime) => lifetime.text(),
+        }
+    }
 }
 
 impl ast::AstNode for NameLike {


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust-analyzer/issues/11668