### PR TITLE
vscode: fix extraEnv handling numeric values

### DIFF
--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -308,6 +308,9 @@
                         "null",
                         "object"
                     ],
+                    "additionalProperties": {
+                        "type": ["string", "number"]
+                    },
                     "default": null,
                     "markdownDescription": "Extra environment variables that will be passed to the rust-analyzer executable. Useful for passing e.g. `RA_LOG` for debugging."
                 },

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -309,7 +309,10 @@
                         "object"
                     ],
                     "additionalProperties": {
-                        "type": ["string", "number"]
+                        "type": [
+                            "string",
+                            "number"
+                        ]
                     },
                     "default": null,
                     "markdownDescription": "Extra environment variables that will be passed to the rust-analyzer executable. Useful for passing e.g. `RA_LOG` for debugging."

--- a/editors/code/src/config.ts
+++ b/editors/code/src/config.ts
@@ -100,8 +100,9 @@ export class Config {
     get serverPath() {
         return this.get<null | string>("server.path") ?? this.get<null | string>("serverPath");
     }
-    get serverExtraEnv() {
-        return this.get<Env | null>("server.extraEnv") ?? {};
+    get serverExtraEnv(): Env {
+        const extraEnv = this.get<{[key: string]: string | number} | null>("server.extraEnv") ?? {};
+        return Object.fromEntries(Object.entries(extraEnv).map(([k, v]) => [k, typeof v !== "string" ? v.toString(): v]));
     }
     get traceExtension() {
         return this.get<boolean>("trace.extension");

--- a/editors/code/src/config.ts
+++ b/editors/code/src/config.ts
@@ -101,8 +101,11 @@ export class Config {
         return this.get<null | string>("server.path") ?? this.get<null | string>("serverPath");
     }
     get serverExtraEnv(): Env {
-        const extraEnv = this.get<{[key: string]: string | number} | null>("server.extraEnv") ?? {};
-        return Object.fromEntries(Object.entries(extraEnv).map(([k, v]) => [k, typeof v !== "string" ? v.toString(): v]));
+        const extraEnv =
+            this.get<{ [key: string]: string | number } | null>("server.extraEnv") ?? {};
+        return Object.fromEntries(
+            Object.entries(extraEnv).map(([k, v]) => [k, typeof v !== "string" ? v.toString() : v])
+        );
     }
     get traceExtension() {
         return this.get<boolean>("trace.extension");


### PR DESCRIPTION
fixes #12363 by bringing the types more inline with the reality, and making `Env` not a lie. 