### PR TITLE
internal: Make autoclosing angle brackets configurable, disabled by default

### DIFF
--- a/crates/ide/src/lib.rs
+++ b/crates/ide/src/lib.rs
@@ -342,11 +342,16 @@ impl Analysis {
         &self,
         position: FilePosition,
         char_typed: char,
+        autoclose: bool,
     ) -> Cancellable<Option<SourceChange>> {
         // Fast path to not even parse the file.
         if !typing::TRIGGER_CHARS.contains(char_typed) {
             return Ok(None);
         }
+        if char_typed == '<' && !autoclose {
+            return Ok(None);
+        }
+
         self.with_db(|db| typing::on_char_typed(db, position, char_typed))
     }
 

--- a/crates/ide/src/typing.rs
+++ b/crates/ide/src/typing.rs
@@ -92,7 +92,7 @@ fn on_char_typed_inner(
         '<' => on_left_angle_typed(&file.tree(), offset),
         '>' => conv(on_right_angle_typed(&file.tree(), offset)),
         '{' => conv(on_opening_brace_typed(file, offset)),
-        _ => unreachable!(),
+        _ => return None,
     };
 
     fn conv(text_edit: Option<TextEdit>) -> Option<ExtendedTextEdit> {

--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -386,6 +386,9 @@ config_data! {
         /// Show documentation.
         signatureInfo_documentation_enable: bool                       = "true",
 
+        /// Whether to insert closing angle brackets when typing an opening angle bracket of a generic argument list.
+        typing_autoClosingAngleBrackets_enable: bool = "false",
+
         /// Workspace symbol search kind.
         workspace_symbol_search_kind: WorkspaceSymbolSearchKindDef = "\"only_types\"",
         /// Limits the number of items returned from a workspace symbol search (Defaults to 128).
@@ -1219,6 +1222,10 @@ impl Config {
             0 => num_cpus::get_physical().try_into().unwrap_or(u8::MAX),
             n => n,
         }
+    }
+
+    pub fn typing_autoclose_angle(&self) -> bool {
+        self.data.typing_autoClosingAngleBrackets_enable
     }
 }
 // Deserialization definitions

--- a/crates/rust-analyzer/src/handlers.rs
+++ b/crates/rust-analyzer/src/handlers.rs
@@ -299,7 +299,8 @@ pub(crate) fn handle_on_type_formatting(
         return Ok(None);
     }
 
-    let edit = snap.analysis.on_char_typed(position, char_typed)?;
+    let edit =
+        snap.analysis.on_char_typed(position, char_typed, snap.config.typing_autoclose_angle())?;
     let edit = match edit {
         Some(it) => it,
         None => return Ok(None),

--- a/docs/user/generated_config.adoc
+++ b/docs/user/generated_config.adoc
@@ -593,6 +593,11 @@ Show full signature of the callable. Only shows parameters if disabled.
 --
 Show documentation.
 --
+[[rust-analyzer.typing.autoClosingAngleBrackets.enable]]rust-analyzer.typing.autoClosingAngleBrackets.enable (default: `false`)::
++
+--
+Whether to insert closing angle brackets when typing an opening angle bracket of a generic argument list.
+--
 [[rust-analyzer.workspace.symbol.search.kind]]rust-analyzer.workspace.symbol.search.kind (default: `"only_types"`)::
 +
 --

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -1068,6 +1068,11 @@
                     "default": true,
                     "type": "boolean"
                 },
+                "rust-analyzer.typing.autoClosingAngleBrackets.enable": {
+                    "markdownDescription": "Whether to insert closing angle brackets when typing an opening angle bracket of a generic argument list.",
+                    "default": false,
+                    "type": "boolean"
+                },
                 "rust-analyzer.workspace.symbol.search.kind": {
                     "markdownDescription": "Workspace symbol search kind.",
                     "default": "only_types",


### PR DESCRIPTION
cc https://github.com/rust-lang/rust-analyzer/issues/12379