### PR TITLE
Add test for #12372 (generate enum variant in different file)

### DIFF
--- a/crates/ide-assists/src/handlers/generate_enum_variant.rs
+++ b/crates/ide-assists/src/handlers/generate_enum_variant.rs
@@ -141,6 +141,43 @@ fn main() {
     }
 
     #[test]
+    fn generate_basic_enum_variant_in_different_file() {
+        check_assist(
+            generate_enum_variant,
+            r"
+//- /main.rs
+mod foo;
+use foo::Foo;
+
+fn main() {
+    Foo::Baz$0
+}
+
+//- /foo.rs
+enum Foo {
+    Bar,
+}
+",
+            r"
+//- /main.rs
+mod foo;
+use foo::Foo;
+
+fn main() {
+    Foo::Baz
+}
+
+//- /foo.rs
+enum Foo {
+    Bar,
+    Baz,
+}
+
+",
+        )
+    }
+
+    #[test]
     fn not_applicable_for_existing_variant() {
         check_assist_not_applicable(
             generate_enum_variant,


### PR DESCRIPTION
The test currently fails but I'm not sure why.

The "Right" output seems to contain only the contents of `foo.rs`, without the magic comments:

<img width="967" alt="image" src="https://user-images.githubusercontent.com/7998310/170310707-e69b21eb-d4f8-46c1-8a0a-9b4071289e26.png">

cc @Veykril 