### PR TITLE
fix(ide-db): correct single-file module rename

### DIFF
--- a/crates/hir/src/has_source.rs
+++ b/crates/hir/src/has_source.rs
@@ -39,6 +39,11 @@ impl Module {
         }
     }
 
+    pub fn is_inline(self, db: &dyn HirDatabase) -> bool {
+        let def_map = self.id.def_map(db.upcast());
+        def_map[self.id.local_id].origin.is_inline()
+    }
+
     /// Returns a node which declares this module, either a `mod foo;` or a `mod foo {}`.
     /// `None` for the crate root.
     pub fn declaration_source(self, db: &dyn HirDatabase) -> Option<InFile<ast::Module>> {

--- a/crates/ide/src/rename.rs
+++ b/crates/ide/src/rename.rs
@@ -973,7 +973,7 @@ mod fo$0o;
                                 anchor: FileId(
                                     1,
                                 ),
-                                path: "foo",
+                                path: "../foo",
                             },
                             src_id: FileId(
                                 1,
@@ -982,7 +982,7 @@ mod fo$0o;
                                 anchor: FileId(
                                     1,
                                 ),
-                                path: "foo2",
+                                path: "../foo2",
                             },
                         },
                     ],
@@ -1158,6 +1158,17 @@ mod quux;
                         },
                     },
                     file_system_edits: [
+                        MoveFile {
+                            src: FileId(
+                                1,
+                            ),
+                            dst: AnchoredPathBuf {
+                                anchor: FileId(
+                                    1,
+                                ),
+                                path: "foo2.rs",
+                            },
+                        },
                         MoveDir {
                             src: AnchoredPathBuf {
                                 anchor: FileId(


### PR DESCRIPTION
Fixes a bug where rust-analyzer would emit `WorkspaceEdit`s with paths to dirs instead of files for the following project layout. 

lib.rs
```rust
mod foo;
```

foo.rs
```rust
mod bar {
    struct Bar;
}
```
Also fixes emitted paths for modules with mod.rs.
The bug resulted in panic in helix editor when attempting to rename a module.