### PR TITLE
fix: Retrigger visibility completion after parentheses

### DIFF
--- a/crates/ide-completion/src/lib.rs
+++ b/crates/ide-completion/src/lib.rs
@@ -143,36 +143,40 @@ pub fn completions(
     db: &RootDatabase,
     config: &CompletionConfig,
     position: FilePosition,
+    trigger_character: Option<&str>,
 ) -> Option<Completions> {
     let ctx = &CompletionContext::new(db, position, config)?;
     let mut acc = Completions::default();
 
     {
         let acc = &mut acc;
-        completions::attribute::complete_attribute(acc, ctx);
-        completions::attribute::complete_derive(acc, ctx);
-        completions::attribute::complete_known_attribute_input(acc, ctx);
-        completions::dot::complete_dot(acc, ctx);
-        completions::expr::complete_expr_path(acc, ctx);
-        completions::extern_abi::complete_extern_abi(acc, ctx);
-        completions::flyimport::import_on_the_fly(acc, ctx);
-        completions::fn_param::complete_fn_param(acc, ctx);
-        completions::format_string::format_string(acc, ctx);
-        completions::item_list::complete_item_list(acc, ctx);
-        completions::keyword::complete_expr_keyword(acc, ctx);
-        completions::lifetime::complete_label(acc, ctx);
-        completions::lifetime::complete_lifetime(acc, ctx);
-        completions::mod_::complete_mod(acc, ctx);
-        completions::pattern::complete_pattern(acc, ctx);
-        completions::postfix::complete_postfix(acc, ctx);
-        completions::record::complete_record_literal(acc, ctx);
-        completions::record::complete_record(acc, ctx);
-        completions::snippet::complete_expr_snippet(acc, ctx);
-        completions::snippet::complete_item_snippet(acc, ctx);
-        completions::trait_impl::complete_trait_impl(acc, ctx);
-        completions::r#type::complete_type_path(acc, ctx);
-        completions::r#type::complete_inferred_type(acc, ctx);
-        completions::use_::complete_use_tree(acc, ctx);
+        // prevent `(` from triggering unwanted completion noise
+        if trigger_character != Some("(") {
+            completions::attribute::complete_attribute(acc, ctx);
+            completions::attribute::complete_derive(acc, ctx);
+            completions::attribute::complete_known_attribute_input(acc, ctx);
+            completions::dot::complete_dot(acc, ctx);
+            completions::expr::complete_expr_path(acc, ctx);
+            completions::extern_abi::complete_extern_abi(acc, ctx);
+            completions::flyimport::import_on_the_fly(acc, ctx);
+            completions::fn_param::complete_fn_param(acc, ctx);
+            completions::format_string::format_string(acc, ctx);
+            completions::item_list::complete_item_list(acc, ctx);
+            completions::keyword::complete_expr_keyword(acc, ctx);
+            completions::lifetime::complete_label(acc, ctx);
+            completions::lifetime::complete_lifetime(acc, ctx);
+            completions::mod_::complete_mod(acc, ctx);
+            completions::pattern::complete_pattern(acc, ctx);
+            completions::postfix::complete_postfix(acc, ctx);
+            completions::record::complete_record_literal(acc, ctx);
+            completions::record::complete_record(acc, ctx);
+            completions::snippet::complete_expr_snippet(acc, ctx);
+            completions::snippet::complete_item_snippet(acc, ctx);
+            completions::trait_impl::complete_trait_impl(acc, ctx);
+            completions::r#type::complete_type_path(acc, ctx);
+            completions::r#type::complete_inferred_type(acc, ctx);
+            completions::use_::complete_use_tree(acc, ctx);
+        }
         completions::vis::complete_vis_path(acc, ctx);
     }
 

--- a/crates/ide-completion/src/render.rs
+++ b/crates/ide-completion/src/render.rs
@@ -410,7 +410,7 @@ mod tests {
 
     #[track_caller]
     fn check_relevance_for_kinds(ra_fixture: &str, kinds: &[CompletionItemKind], expect: Expect) {
-        let mut actual = get_all_items(TEST_CONFIG, ra_fixture);
+        let mut actual = get_all_items(TEST_CONFIG, ra_fixture, None);
         actual.retain(|it| kinds.contains(&it.kind()));
         actual.sort_by_key(|it| cmp::Reverse(it.relevance().score()));
         check_relevance_(actual, expect);
@@ -418,7 +418,7 @@ mod tests {
 
     #[track_caller]
     fn check_relevance(ra_fixture: &str, expect: Expect) {
-        let mut actual = get_all_items(TEST_CONFIG, ra_fixture);
+        let mut actual = get_all_items(TEST_CONFIG, ra_fixture, None);
         actual.retain(|it| it.kind() != CompletionItemKind::Snippet);
         actual.retain(|it| it.kind() != CompletionItemKind::Keyword);
         actual.retain(|it| it.kind() != CompletionItemKind::BuiltinType);

--- a/crates/ide-completion/src/tests/fn_param.rs
+++ b/crates/ide-completion/src/tests/fn_param.rs
@@ -1,10 +1,15 @@
 use expect_test::{expect, Expect};
 
-use crate::tests::completion_list;
+use crate::tests::{completion_list, completion_list_with_trigger_character};
 
 fn check(ra_fixture: &str, expect: Expect) {
     let actual = completion_list(ra_fixture);
     expect.assert_eq(&actual);
+}
+
+fn check_with_trigger_character(ra_fixture: &str, trigger_character: Option<&str>, expect: Expect) {
+    let actual = completion_list_with_trigger_character(ra_fixture, trigger_character);
+    expect.assert_eq(&actual)
 }
 
 #[test]
@@ -110,6 +115,17 @@ fn outer(text: &str) {
             kw mut
             kw ref
         "#]],
+    )
+}
+
+#[test]
+fn trigger_by_l_paren() {
+    check_with_trigger_character(
+        r#"
+fn foo($0)
+"#,
+        Some("("),
+        expect![[]],
     )
 }
 

--- a/crates/ide-completion/src/tests/visibility.rs
+++ b/crates/ide-completion/src/tests/visibility.rs
@@ -1,20 +1,26 @@
 //! Completion tests for visibility modifiers.
 use expect_test::{expect, Expect};
 
-use crate::tests::completion_list;
+use crate::tests::{completion_list, completion_list_with_trigger_character};
 
 fn check(ra_fixture: &str, expect: Expect) {
     let actual = completion_list(ra_fixture);
     expect.assert_eq(&actual)
 }
 
+fn check_with_trigger_character(ra_fixture: &str, trigger_character: Option<&str>, expect: Expect) {
+    let actual = completion_list_with_trigger_character(ra_fixture, trigger_character);
+    expect.assert_eq(&actual)
+}
+
 #[test]
 fn empty_pub() {
     cov_mark::check!(kw_completion_in);
-    check(
+    check_with_trigger_character(
         r#"
 pub($0)
 "#,
+        Some("("),
         expect![[r#"
             kw crate
             kw in

--- a/crates/ide/src/lib.rs
+++ b/crates/ide/src/lib.rs
@@ -547,8 +547,11 @@ impl Analysis {
         &self,
         config: &CompletionConfig,
         position: FilePosition,
+        trigger_character: Option<&str>,
     ) -> Cancellable<Option<Vec<CompletionItem>>> {
-        self.with_db(|db| ide_completion::completions(db, config, position).map(Into::into))
+        self.with_db(|db| {
+            ide_completion::completions(db, config, position, trigger_character).map(Into::into)
+        })
     }
 
     /// Resolves additional completion data at the position given.

--- a/crates/rust-analyzer/src/caps.rs
+++ b/crates/rust-analyzer/src/caps.rs
@@ -29,7 +29,12 @@ pub fn server_capabilities(config: &Config) -> ServerCapabilities {
         hover_provider: Some(HoverProviderCapability::Simple(true)),
         completion_provider: Some(CompletionOptions {
             resolve_provider: completions_resolve_provider(config.caps()),
-            trigger_characters: Some(vec![":".to_string(), ".".to_string(), "'".to_string()]),
+            trigger_characters: Some(vec![
+                ":".to_string(),
+                ".".to_string(),
+                "'".to_string(),
+                "(".to_string(),
+            ]),
             all_commit_characters: None,
             completion_item: None,
             work_done_progress_options: WorkDoneProgressOptions { work_done_progress: None },

--- a/crates/rust-analyzer/src/integrated_benchmarks.rs
+++ b/crates/rust-analyzer/src/integrated_benchmarks.rs
@@ -148,7 +148,7 @@ fn integrated_completion_benchmark() {
         };
         let position =
             FilePosition { file_id, offset: TextSize::try_from(completion_offset).unwrap() };
-        analysis.completions(&config, position).unwrap();
+        analysis.completions(&config, position, None).unwrap();
     }
 
     let completion_offset = {
@@ -185,7 +185,7 @@ fn integrated_completion_benchmark() {
         };
         let position =
             FilePosition { file_id, offset: TextSize::try_from(completion_offset).unwrap() };
-        analysis.completions(&config, position).unwrap();
+        analysis.completions(&config, position, None).unwrap();
     }
 }
 


### PR DESCRIPTION
close #12390

This PR add `(` to trigger_characters as discussed in original issue.

Some questions:

1. Is lsp's `ctx.trigger_character` from `params.context` is the same as `ctx.original_token` inside actually completions? 
    1. If not what's the difference?
    2. if they are the same, it's unnecessary to pass it down from handler at all.
    3.  if they are the same, maybe we could parse it from fixture directly instead of using the `check_with_trigger_character` I added.
2. Some completion fixtures written as `($0)` ( https://github.com/rust-lang/rust-analyzer/blob/master/crates/ide-completion/src/tests/fn_param.rs#L105 as an example), If I understand correctly they are not invoked outside tests at all?
    1. using `ctx.original_token` directly would break these tests as well as parsing trigger_character from fixture for now.
    2. I think it make sense to allow `(` triggering these cases?
3. I hope this line up with #12144