### PR TITLE
internal: More precise completion filtering with existing item qualifiers

### DIFF
--- a/crates/ide-completion/src/completions/item_list.rs
+++ b/crates/ide-completion/src/completions/item_list.rs
@@ -8,21 +8,18 @@ use crate::{
 
 pub(crate) fn complete_item_list(acc: &mut Completions, ctx: &CompletionContext) {
     let _p = profile::span("complete_item_list");
-    if ctx.is_path_disallowed() || ctx.has_unfinished_impl_or_trait_prev_sibling() {
-        return;
-    }
 
-    let (&is_absolute_path, qualifier) = match ctx.path_context() {
+    let (&is_absolute_path, path_qualifier, _kind) = match ctx.path_context() {
         Some(PathCompletionCtx {
-            kind: PathKind::Item { .. },
+            kind: PathKind::Item { kind },
             is_absolute_path,
             qualifier,
             ..
-        }) => (is_absolute_path, qualifier),
+        }) => (is_absolute_path, qualifier, kind),
         _ => return,
     };
 
-    match qualifier {
+    match path_qualifier {
         Some(PathQualifierCtx { resolution, is_super_chain, .. }) => {
             if let Some(hir::PathResolution::Def(hir::ModuleDef::Module(module))) = resolution {
                 for (name, def) in module.scope(ctx.db, Some(ctx.module)) {
@@ -39,7 +36,7 @@ pub(crate) fn complete_item_list(acc: &mut Completions, ctx: &CompletionContext)
         None if is_absolute_path => {
             acc.add_crate_roots(ctx);
         }
-        None => {
+        None if ctx.qualifier_ctx.none() => {
             ctx.process_all_names(&mut |name, def| {
                 if let Some(def) = module_or_fn_macro(ctx.db, def) {
                     acc.add_resolution(ctx, name, def);
@@ -47,5 +44,6 @@ pub(crate) fn complete_item_list(acc: &mut Completions, ctx: &CompletionContext)
             });
             acc.add_nameref_keywords_with_colon(ctx);
         }
+        None => {}
     }
 }

--- a/crates/ide-completion/src/completions/keyword.rs
+++ b/crates/ide-completion/src/completions/keyword.rs
@@ -51,7 +51,7 @@ pub(crate) fn complete_expr_keyword(acc: &mut Completions, ctx: &CompletionConte
         return;
     }
 
-    if !ctx.has_visibility_prev_sibling()
+    if ctx.qualifier_ctx.vis_node.is_none()
         && (expects_item || ctx.expects_non_trait_assoc_item() || ctx.expect_field())
     {
         add_keyword("pub(crate)", "pub(crate)");
@@ -67,7 +67,7 @@ pub(crate) fn complete_expr_keyword(acc: &mut Completions, ctx: &CompletionConte
     }
 
     if expects_item || has_block_expr_parent {
-        if !ctx.has_visibility_prev_sibling() {
+        if ctx.qualifier_ctx.vis_node.is_none() {
             add_keyword("impl", "impl $1 {\n    $0\n}");
             add_keyword("extern", "extern $0");
         }

--- a/crates/ide-completion/src/completions/snippet.rs
+++ b/crates/ide-completion/src/completions/snippet.rs
@@ -2,7 +2,6 @@
 
 use hir::Documentation;
 use ide_db::{imports::insert_use::ImportScope, SnippetCap};
-use syntax::T;
 
 use crate::{
     context::{ItemListKind, PathCompletionCtx, PathKind},
@@ -52,10 +51,10 @@ pub(crate) fn complete_item_snippet(acc: &mut Completions, ctx: &CompletionConte
         }) => kind,
         _ => return,
     };
-    if ctx.previous_token_is(T![unsafe]) || ctx.has_unfinished_impl_or_trait_prev_sibling() {
+    if !ctx.qualifier_ctx.none() {
         return;
     }
-    if ctx.has_visibility_prev_sibling() {
+    if ctx.qualifier_ctx.vis_node.is_some() {
         return; // technically we could do some of these snippet completions if we were to put the
                 // attributes before the vis node.
     }

--- a/crates/ide-completion/src/lib.rs
+++ b/crates/ide-completion/src/lib.rs
@@ -143,7 +143,7 @@ pub fn completions(
     db: &RootDatabase,
     config: &CompletionConfig,
     position: FilePosition,
-    trigger_character: Option<&str>,
+    trigger_character: Option<char>,
 ) -> Option<Completions> {
     let ctx = &CompletionContext::new(db, position, config)?;
     let mut acc = Completions::default();
@@ -151,7 +151,7 @@ pub fn completions(
     {
         let acc = &mut acc;
         // prevent `(` from triggering unwanted completion noise
-        if trigger_character != Some("(") {
+        if trigger_character != Some('(') {
             completions::attribute::complete_attribute(acc, ctx);
             completions::attribute::complete_derive(acc, ctx);
             completions::attribute::complete_known_attribute_input(acc, ctx);

--- a/crates/ide-completion/src/tests.rs
+++ b/crates/ide-completion/src/tests.rs
@@ -88,7 +88,7 @@ pub(crate) fn completion_list_no_kw(ra_fixture: &str) -> String {
 
 pub(crate) fn completion_list_with_trigger_character(
     ra_fixture: &str,
-    trigger_character: Option<&str>,
+    trigger_character: Option<char>,
 ) -> String {
     completion_list_with_config(TEST_CONFIG, ra_fixture, true, trigger_character)
 }
@@ -97,7 +97,7 @@ fn completion_list_with_config(
     config: CompletionConfig,
     ra_fixture: &str,
     include_keywords: bool,
-    trigger_character: Option<&str>,
+    trigger_character: Option<char>,
 ) -> String {
     // filter out all but one builtintype completion for smaller test outputs
     let items = get_all_items(config, ra_fixture, trigger_character);
@@ -225,7 +225,7 @@ pub(crate) fn check_pattern_is_applicable(code: &str, check: impl FnOnce(SyntaxE
 pub(crate) fn get_all_items(
     config: CompletionConfig,
     code: &str,
-    trigger_character: Option<&str>,
+    trigger_character: Option<char>,
 ) -> Vec<CompletionItem> {
     let (db, position) = position(code);
     let res = crate::completions(&db, &config, position, trigger_character)

--- a/crates/ide-completion/src/tests/fn_param.rs
+++ b/crates/ide-completion/src/tests/fn_param.rs
@@ -7,8 +7,8 @@ fn check(ra_fixture: &str, expect: Expect) {
     expect.assert_eq(&actual);
 }
 
-fn check_with_trigger_character(ra_fixture: &str, trigger_character: Option<&str>, expect: Expect) {
-    let actual = completion_list_with_trigger_character(ra_fixture, trigger_character);
+fn check_with_trigger_character(ra_fixture: &str, trigger_character: char, expect: Expect) {
+    let actual = completion_list_with_trigger_character(ra_fixture, Some(trigger_character));
     expect.assert_eq(&actual)
 }
 
@@ -124,7 +124,7 @@ fn trigger_by_l_paren() {
         r#"
 fn foo($0)
 "#,
-        Some("("),
+        '(',
         expect![[]],
     )
 }

--- a/crates/ide-completion/src/tests/item.rs
+++ b/crates/ide-completion/src/tests/item.rs
@@ -92,10 +92,7 @@ fn after_struct_name() {
     check(
         r"struct Struct $0",
         expect![[r#"
-            ma makro!(…)           macro_rules! makro
-            md module
             kw const
-            kw crate::
             kw enum
             kw extern
             kw fn
@@ -104,18 +101,13 @@ fn after_struct_name() {
             kw pub
             kw pub(crate)
             kw pub(super)
-            kw self::
             kw static
             kw struct
-            kw super::
             kw trait
             kw type
             kw union
             kw unsafe
             kw use
-            sn macro_rules
-            sn tfn (Test function)
-            sn tmod (Test module)
         "#]],
     );
 }
@@ -126,10 +118,7 @@ fn after_fn_name() {
     check(
         r"fn func() $0",
         expect![[r#"
-            ma makro!(…)           macro_rules! makro
-            md module
             kw const
-            kw crate::
             kw enum
             kw extern
             kw fn
@@ -138,18 +127,13 @@ fn after_fn_name() {
             kw pub
             kw pub(crate)
             kw pub(super)
-            kw self::
             kw static
             kw struct
-            kw super::
             kw trait
             kw type
             kw union
             kw unsafe
             kw use
-            sn macro_rules
-            sn tfn (Test function)
-            sn tmod (Test module)
         "#]],
     );
 }

--- a/crates/ide-completion/src/tests/visibility.rs
+++ b/crates/ide-completion/src/tests/visibility.rs
@@ -8,8 +8,8 @@ fn check(ra_fixture: &str, expect: Expect) {
     expect.assert_eq(&actual)
 }
 
-fn check_with_trigger_character(ra_fixture: &str, trigger_character: Option<&str>, expect: Expect) {
-    let actual = completion_list_with_trigger_character(ra_fixture, trigger_character);
+fn check_with_trigger_character(ra_fixture: &str, trigger_character: char, expect: Expect) {
+    let actual = completion_list_with_trigger_character(ra_fixture, Some(trigger_character));
     expect.assert_eq(&actual)
 }
 
@@ -20,7 +20,7 @@ fn empty_pub() {
         r#"
 pub($0)
 "#,
-        Some("("),
+        '(',
         expect![[r#"
             kw crate
             kw in

--- a/crates/ide/src/lib.rs
+++ b/crates/ide/src/lib.rs
@@ -548,7 +548,7 @@ impl Analysis {
         &self,
         config: &CompletionConfig,
         position: FilePosition,
-        trigger_character: Option<&str>,
+        trigger_character: Option<char>,
     ) -> Cancellable<Option<Vec<CompletionItem>>> {
         self.with_db(|db| {
             ide_completion::completions(db, config, position, trigger_character).map(Into::into)


### PR DESCRIPTION
Now we are unfortunately approaching the more complex cases for filtering completions where we have to deal with parser recovered nodes properly ...