### PR TITLE
Ubuntu 21.10 compat

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -865,7 +865,9 @@ dependencies = [
 
 [[package]]
 name = "lsp-server"
-version = "0.6.0"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c351c75989da23b355226dc188dc2b52538a7f4f218d70fd7393c6b62b110444"
 dependencies = [
  "crossbeam-channel",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2043,18 +2043,18 @@ checksum = "45d11d5fc2a97287eded8b170ca80533b3c42646dd7fa386a5eb045817921022"
 
 [[package]]
 name = "xshell"
-version = "0.2.1"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4884417669886d3abff14feec797179526ade713f212e54ec08b19bc6bdc86aa"
+checksum = "eaad2035244c56da05573d4d7fda5f903c60a5f35b9110e157a14a1df45a9f14"
 dependencies = [
  "xshell-macros",
 ]
 
 [[package]]
 name = "xshell-macros"
-version = "0.2.1"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37d92065701c3611323f96eac5475b995421fc7eb2bcba1336cdd80b9b2fb68f"
+checksum = "4916a4a3cad759e499a3620523bf9545cc162d7a06163727dde97ce9aaa4cf39"
 
 [[package]]
 name = "xtask"

--- a/crates/hir-expand/src/builtin_fn_macro.rs
+++ b/crates/hir-expand/src/builtin_fn_macro.rs
@@ -532,10 +532,10 @@ fn relative_file(
     let path = AnchoredPath { anchor: call_site, path: path_str };
     let res = db
         .resolve_path(path)
-        .ok_or_else(|| ExpandError::Other(format!("failed to load file `{path_str}`").into()))?;
+        .ok_or_else(|| ExpandError::Other(format!("failed to load file `{}`", path_str).into()))?;
     // Prevent include itself
     if res == call_site && !allow_recursion {
-        Err(ExpandError::Other(format!("recursive inclusion of `{path_str}`").into()))
+        Err(ExpandError::Other(format!("recursive inclusion of `{}`", path_str).into()))
     } else {
         Ok(res)
     }

--- a/crates/hir-ty/src/display.rs
+++ b/crates/hir-ty/src/display.rs
@@ -1226,7 +1226,7 @@ impl HirDisplay for Path {
                     .as_ref()
                     .map(|name| name.canonical_name())
                     .unwrap_or("$crate");
-                write!(f, "{name}")?
+                write!(f, "{}", name)?
             }
         }
 

--- a/crates/ide-assists/src/handlers/convert_let_else_to_match.rs
+++ b/crates/ide-assists/src/handlers/convert_let_else_to_match.rs
@@ -147,7 +147,7 @@ pub(crate) fn convert_let_else_to_match(acc: &mut Assists, ctx: &AssistContext) 
             // remove the mut from the pattern
             for (b, ismut) in binders.iter() {
                 if *ismut {
-                    pat_no_mut = pat_no_mut.replace(&format!("mut {b}"), &b.to_string());
+                    pat_no_mut = pat_no_mut.replace(&format!("mut {}", b), &b.to_string());
                 }
             }
 
@@ -158,17 +158,17 @@ pub(crate) fn convert_let_else_to_match(acc: &mut Assists, ctx: &AssistContext) 
             };
             let replace = if binders.is_empty() {
                 format!(
-                    "match {init_expr} {{
-{indent1}{pat_no_mut} => {binders_str}
-{indent1}_ => {branch2}
-{indent}}}"
+                    "match {} {{
+{}{} => {}
+{}_ => {}
+{}}}", init_expr, indent1, pat_no_mut, binders_str, indent1, branch2, indent
                 )
             } else {
                 format!(
-                    "let {binders_str_mut} = match {init_expr} {{
-{indent1}{pat_no_mut} => {binders_str},
-{indent1}_ => {branch2}
-{indent}}};"
+                    "let {} = match {} {{
+{}{} => {},
+{}_ => {}
+{}}};", binders_str_mut, init_expr, indent1, pat_no_mut, binders_str, indent1, branch2, indent
                 )
             };
             edit.replace(target, replace);

--- a/crates/ide-assists/src/handlers/generate_documentation_template.rs
+++ b/crates/ide-assists/src/handlers/generate_documentation_template.rs
@@ -214,7 +214,7 @@ fn introduction_builder(ast_func: &ast::Fn, ctx: &AssistContext) -> Option<Strin
                 } else {
                     ""
                 };
-                Some(format!("Returns{reference} the {what} of this [`{}`].", linkable_self_ty?))
+                Some(format!("Returns{} the {} of this [`{}`].", reference, what, linkable_self_ty?))
             }
             _ => None,
         };
@@ -228,7 +228,7 @@ fn introduction_builder(ast_func: &ast::Fn, ctx: &AssistContext) -> Option<Strin
             if what == "len" {
                 what = "length".into()
             };
-            Some(format!("Sets the {what} of this [`{}`].", linkable_self_ty?))
+            Some(format!("Sets the {} of this [`{}`].", what, linkable_self_ty?))
         };
 
         if let Some(intro) = intro_for_new() {

--- a/crates/ide-completion/src/completions/fn_param.rs
+++ b/crates/ide-completion/src/completions/fn_param.rs
@@ -46,7 +46,7 @@ pub(crate) fn complete_fn_param(acc: &mut Completions, ctx: &CompletionContext) 
         ParamKind::Closure(closure) => {
             let stmt_list = closure.syntax().ancestors().find_map(ast::StmtList::cast)?;
             params_from_stmt_list_scope(ctx, stmt_list, |name, ty| {
-                add_new_item_to_acc(&format!("{name}: {ty}"));
+                add_new_item_to_acc(&format!("{}: {}", name, ty));
             });
         }
     }
@@ -95,7 +95,7 @@ fn fill_fn_params(
 
     if let Some(stmt_list) = function.syntax().parent().and_then(ast::StmtList::cast) {
         params_from_stmt_list_scope(ctx, stmt_list, |name, ty| {
-            file_params.entry(format!("{name}: {ty}")).or_insert(name.to_string());
+            file_params.entry(format!("{}: {}", name, ty)).or_insert(name.to_string());
         });
     }
     remove_duplicated(&mut file_params, param_list.params());

--- a/crates/ide-completion/src/context.rs
+++ b/crates/ide-completion/src/context.rs
@@ -893,7 +893,9 @@ impl<'a> CompletionContext<'a> {
                 it.syntax().text_range().end() == syntax_element.text_range().end()
             });
 
-        (self.expected_type, self.expected_name) = self.expected_type_and_name();
+        let (expected_type, expected_name) = self.expected_type_and_name();
+        self.expected_type = expected_type;
+        self.expected_name = expected_name;
 
         // Overwrite the path kind for derives
         if let Some((original_file, file_with_fake_ident, offset, origin_attr)) = derive_ctx {

--- a/crates/ide-db/Cargo.toml
+++ b/crates/ide-db/Cargo.toml
@@ -35,5 +35,5 @@ limit = { path = "../limit", version = "0.0.0" }
 [dev-dependencies]
 test-utils = { path = "../test-utils" }
 sourcegen = { path = "../sourcegen" }
-xshell = "0.2.1"
+xshell = "0.1"
 expect-test = "1.2.2"

--- a/crates/ide-db/src/tests/sourcegen_lints.rs
+++ b/crates/ide-db/src/tests/sourcegen_lints.rs
@@ -4,20 +4,16 @@ use std::{borrow::Cow, fs, path::Path};
 use itertools::Itertools;
 use stdx::format_to;
 use test_utils::project_root;
-use xshell::{cmd, Shell};
+use xshell::cmd;
 
 /// This clones rustc repo, and so is not worth to keep up-to-date. We update
 /// manually by un-ignoring the test from time to time.
 #[test]
 #[ignore]
 fn sourcegen_lint_completions() {
-    let sh = &Shell::new().unwrap();
-
     let rust_repo = project_root().join("./target/rust");
     if !rust_repo.exists() {
-        cmd!(sh, "git clone --depth=1 https://github.com/rust-lang/rust {rust_repo}")
-            .run()
-            .unwrap();
+        cmd!("git clone --depth=1 https://github.com/rust-lang/rust {rust_repo}").run().unwrap();
     }
 
     let mut contents = String::from(
@@ -34,19 +30,16 @@ pub struct LintGroup {
 ",
     );
 
-    generate_lint_descriptor(sh, &mut contents);
+    generate_lint_descriptor(&mut contents);
     contents.push('\n');
 
     generate_feature_descriptor(&mut contents, &rust_repo.join("src/doc/unstable-book/src"));
     contents.push('\n');
 
     let lints_json = project_root().join("./target/clippy_lints.json");
-    cmd!(
-        sh,
-        "curl https://rust-lang.github.io/rust-clippy/master/lints.json --output {lints_json}"
-    )
-    .run()
-    .unwrap();
+    cmd!("curl https://rust-lang.github.io/rust-clippy/master/lints.json --output {lints_json}")
+        .run()
+        .unwrap();
     generate_descriptor_clippy(&mut contents, &lints_json);
 
     let contents = sourcegen::add_preamble("sourcegen_lints", sourcegen::reformat(contents));
@@ -55,10 +48,10 @@ pub struct LintGroup {
     sourcegen::ensure_file_contents(destination.as_path(), &contents);
 }
 
-fn generate_lint_descriptor(sh: &Shell, buf: &mut String) {
+fn generate_lint_descriptor(buf: &mut String) {
     // FIXME: rustdoc currently requires an input file for -Whelp cc https://github.com/rust-lang/rust/pull/88831
     let file = project_root().join(file!());
-    let stdout = cmd!(sh, "rustdoc -W help {file}").read().unwrap();
+    let stdout = cmd!("rustdoc -W help {file}").read().unwrap();
     let start_lints = stdout.find("----  -------  -------").unwrap();
     let start_lint_groups = stdout.find("----  ---------").unwrap();
     let start_lints_rustdoc =

--- a/crates/ide-diagnostics/src/handlers/unresolved_module.rs
+++ b/crates/ide-diagnostics/src/handlers/unresolved_module.rs
@@ -39,7 +39,7 @@ fn fixes(ctx: &DiagnosticsContext<'_>, d: &hir::UnresolvedModule) -> Option<Vec<
             .map(|candidate| {
                 fix(
                     "create_module",
-                    &format!("Create module at `{candidate}`"),
+                    &format!("Create module at `{}`", candidate),
                     FileSystemEdit::CreateFile {
                         dst: AnchoredPathBuf {
                             anchor: d.decl.file_id.original_file(ctx.sema.db),

--- a/crates/ide/src/doc_links.rs
+++ b/crates/ide/src/doc_links.rs
@@ -424,7 +424,7 @@ fn get_doc_base_url(db: &RootDatabase, def: Definition) -> Option<Url> {
             | LangCrateOrigin::Std
             | LangCrateOrigin::Test),
         ) => {
-            format!("https://doc.rust-lang.org/nightly/{origin}")
+            format!("https://doc.rust-lang.org/nightly/{}", origin)
         }
         _ => {
             krate.get_html_root_url(db).or_else(|| {

--- a/crates/ide/src/expand_macro.rs
+++ b/crates/ide/src/expand_macro.rs
@@ -168,7 +168,7 @@ fn _format(
         SyntaxKind::MACRO_TYPE => ("type __ =", ";"),
         _ => ("", ""),
     };
-    let expansion = format!("{prefix}{expansion}{suffix}");
+    let expansion = format!("{}{}{}", prefix, expansion, suffix);
 
     let &crate_id = db.relevant_crates(file_id).iter().next()?;
     let edition = db.crate_graph()[crate_id].edition;

--- a/crates/ide/src/inlay_hints.rs
+++ b/crates/ide/src/inlay_hints.rs
@@ -412,7 +412,7 @@ fn fn_lifetime_fn_hints(
                 Some(it) if config.param_names_for_lifetime_elision_hints => {
                     if let Some(c) = used_names.get_mut(it.text().as_str()) {
                         *c += 1;
-                        SmolStr::from(format!("'{text}{c}", text = it.text().as_str()))
+                        SmolStr::from(format!("'{text}{c}", text = it.text().as_str(), c=c))
                     } else {
                         used_names.insert(it.text().as_str().into(), 0);
                         SmolStr::from_iter(["\'", it.text().as_str()])

--- a/crates/ide/src/inlay_hints.rs
+++ b/crates/ide/src/inlay_hints.rs
@@ -379,7 +379,7 @@ fn fn_lifetime_fn_hints(
     let mut gen_idx_name = {
         let mut gen = (0u8..).map(|idx| match idx {
             idx if idx < 10 => SmolStr::from_iter(['\'', (idx + 48) as char]),
-            idx => format!("'{idx}").into(),
+            idx => format!("'{}", idx).into(),
         });
         move || gen.next().unwrap_or_default()
     };

--- a/crates/ide/src/moniker.rs
+++ b/crates/ide/src/moniker.rs
@@ -157,7 +157,7 @@ pub(crate) fn def_to_moniker(
                         LangCrateOrigin::Other => {
                             "https://github.com/rust-lang/rust/library/".into()
                         }
-                        lang => format!("https://github.com/rust-lang/rust/library/{lang}",),
+                        lang => format!("https://github.com/rust-lang/rust/library/{}", lang),
                     },
                 ),
             };

--- a/crates/mbe/src/expander/matcher.rs
+++ b/crates/mbe/src/expander/matcher.rs
@@ -658,7 +658,7 @@ fn match_loop(pattern: &MetaTemplate, src: &tt::Subtree) -> Match {
 fn match_leaf(lhs: &tt::Leaf, src: &mut TtIter) -> Result<(), ExpandError> {
     let rhs = src
         .expect_leaf()
-        .map_err(|()| ExpandError::binding_error(format!("expected leaf: `{lhs}`")))?;
+        .map_err(|()| ExpandError::binding_error(format!("expected leaf: `{}`", lhs)))?;
     match (lhs, rhs) {
         (
             tt::Leaf::Punct(tt::Punct { char: lhs, .. }),

--- a/crates/mbe/src/expander/transcriber.rs
+++ b/crates/mbe/src/expander/transcriber.rs
@@ -21,28 +21,28 @@ impl Bindings {
         }
 
         let mut b: &Binding =
-            self.inner.get(name).ok_or_else(|| binding_err!("could not find binding `{name}`"))?;
+            self.inner.get(name).ok_or_else(|| binding_err!("could not find binding `{}`", name))?;
         for nesting_state in nesting.iter_mut() {
             nesting_state.hit = true;
             b = match b {
                 Binding::Fragment(_) => break,
                 Binding::Nested(bs) => bs.get(nesting_state.idx).ok_or_else(|| {
                     nesting_state.at_end = true;
-                    binding_err!("could not find nested binding `{name}`")
+                    binding_err!("could not find nested binding `{}`", name)
                 })?,
                 Binding::Empty => {
                     nesting_state.at_end = true;
-                    return Err(binding_err!("could not find empty binding `{name}`"));
+                    return Err(binding_err!("could not find empty binding `{}`", name));
                 }
             };
         }
         match b {
             Binding::Fragment(it) => Ok(it),
             Binding::Nested(_) => {
-                Err(binding_err!("expected simple binding, found nested binding `{name}`"))
+                Err(binding_err!("expected simple binding, found nested binding `{}`", name))
             }
             Binding::Empty => {
-                Err(binding_err!("expected simple binding, found empty binding `{name}`"))
+                Err(binding_err!("expected simple binding, found empty binding `{}`", name))
             }
         }
     }

--- a/crates/mbe/src/tt_iter.rs
+++ b/crates/mbe/src/tt_iter.rs
@@ -106,7 +106,7 @@ impl<'a> TtIter<'a> {
         }
 
         let err = if error || !cursor.is_root() {
-            Some(ExpandError::binding_error(format!("expected {entry_point:?}")))
+            Some(ExpandError::binding_error(format!("expected {:?}", entry_point)))
         } else {
             None
         };

--- a/crates/project-model/src/rustc_cfg.rs
+++ b/crates/project-model/src/rustc_cfg.rs
@@ -29,7 +29,7 @@ pub(crate) fn get(cargo_toml: Option<&ManifestPath>, target: Option<&str>) -> Ve
             );
             res.extend(rustc_cfgs.lines().filter_map(|it| it.parse().ok()));
         }
-        Err(e) => tracing::error!("failed to get rustc cfgs: {e:?}"),
+        Err(e) => tracing::error!("failed to get rustc cfgs: {:?}", e),
     }
 
     res
@@ -47,7 +47,7 @@ fn get_rust_cfgs(cargo_toml: Option<&ManifestPath>, target: Option<&str>) -> Res
         }
         match utf8_stdout(cargo_config) {
             Ok(it) => return Ok(it),
-            Err(e) => tracing::debug!("{e:?}: falling back to querying rustc for cfgs"),
+            Err(e) => tracing::debug!("{:?}: falling back to querying rustc for cfgs", e),
         }
     }
     // using unstable cargo features failed, fall back to using plain rustc

--- a/crates/rust-analyzer/Cargo.toml
+++ b/crates/rust-analyzer/Cargo.toml
@@ -75,7 +75,7 @@ jemallocator = { version = "0.4.3", package = "tikv-jemallocator", optional = tr
 [dev-dependencies]
 expect-test = "1.2.2"
 jod-thread = "0.1.2"
-xshell = "0.2.1"
+xshell = "0.1"
 
 test-utils = { path = "../test-utils" }
 sourcegen = { path = "../sourcegen" }

--- a/crates/rust-analyzer/Cargo.toml
+++ b/crates/rust-analyzer/Cargo.toml
@@ -33,7 +33,7 @@ threadpool = "1.8.1"
 rayon = "1.5.1"
 num_cpus = "1.13.1"
 mimalloc = { version = "0.1.28", default-features = false, optional = true }
-lsp-server = { version = "0.6.0", path = "../../lib/lsp-server" }
+lsp-server = "0.5.2"
 tracing = "0.1.32"
 tracing-subscriber = { version = "0.3.9", default-features = false, features = [
     "env-filter",

--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -631,7 +631,7 @@ impl Config {
             ) {
                 Some(snippet) => self.snippets.push(snippet),
                 None => errors.push((
-                    format!("snippet {name} is invalid"),
+                    format!("snippet {} is invalid", name),
                     <serde_json::Error as serde::de::Error>::custom(
                         "snippet path is invalid or triggers are missing",
                     ),

--- a/crates/rust-analyzer/src/dispatch.rs
+++ b/crates/rust-analyzer/src/dispatch.rs
@@ -1,7 +1,6 @@
 //! See [RequestDispatcher].
 use std::{fmt, panic, thread};
 
-use lsp_server::ExtractError;
 use serde::{de::DeserializeOwned, Serialize};
 
 use crate::{
@@ -235,10 +234,7 @@ impl<'a> NotificationDispatcher<'a> {
         };
         let params = match not.extract::<N::Params>(N::METHOD) {
             Ok(it) => it,
-            Err(ExtractError::JsonError { method, error }) => {
-                panic!("Invalid request\nMethod: {method}\n error: {error}",)
-            }
-            Err(ExtractError::MethodMismatch(not)) => {
+            Err(not) => {
                 self.not = Some(not);
                 return Ok(self);
             }

--- a/crates/rust-analyzer/src/global_state.rs
+++ b/crates/rust-analyzer/src/global_state.rs
@@ -259,11 +259,7 @@ impl GlobalState {
     }
 
     pub(crate) fn complete_request(&mut self, response: lsp_server::Response) {
-        let handler = self
-            .req_queue
-            .outgoing
-            .complete(response.id.clone())
-            .expect("received response for unknown request");
+        let handler = self.req_queue.outgoing.complete(response.id.clone());
         handler(self, response)
     }
 

--- a/crates/rust-analyzer/tests/slow-tests/tidy.rs
+++ b/crates/rust-analyzer/tests/slow-tests/tidy.rs
@@ -3,15 +3,14 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use xshell::{cmd, Shell};
+use xshell::{cmd, pushd, pushenv, read_file};
 
 #[test]
 fn check_code_formatting() {
-    let sh = &Shell::new().unwrap();
-    sh.change_dir(sourcegen::project_root());
-    sh.set_var("RUSTUP_TOOLCHAIN", "stable");
+    let _dir = pushd(sourcegen::project_root()).unwrap();
+    let _e = pushenv("RUSTUP_TOOLCHAIN", "stable");
 
-    let out = cmd!(sh, "rustfmt --version").read().unwrap();
+    let out = cmd!("rustfmt --version").read().unwrap();
     if !out.contains("stable") {
         panic!(
             "Failed to run rustfmt from toolchain 'stable'. \
@@ -19,27 +18,25 @@ fn check_code_formatting() {
         )
     }
 
-    let res = cmd!(sh, "cargo fmt -- --check").run();
+    let res = cmd!("cargo fmt -- --check").run();
     if res.is_err() {
-        let _ = cmd!(sh, "cargo fmt").run();
+        let _ = cmd!("cargo fmt").run();
     }
     res.unwrap()
 }
 
 #[test]
 fn check_lsp_extensions_docs() {
-    let sh = &Shell::new().unwrap();
-
     let expected_hash = {
-        let lsp_ext_rs = sh
-            .read_file(sourcegen::project_root().join("crates/rust-analyzer/src/lsp_ext.rs"))
-            .unwrap();
+        let lsp_ext_rs =
+            read_file(sourcegen::project_root().join("crates/rust-analyzer/src/lsp_ext.rs"))
+                .unwrap();
         stable_hash(lsp_ext_rs.as_str())
     };
 
     let actual_hash = {
         let lsp_extensions_md =
-            sh.read_file(sourcegen::project_root().join("docs/dev/lsp-extensions.md")).unwrap();
+            read_file(sourcegen::project_root().join("docs/dev/lsp-extensions.md")).unwrap();
         let text = lsp_extensions_md
             .lines()
             .find_map(|line| line.strip_prefix("lsp_ext.rs hash:"))
@@ -65,8 +62,6 @@ Please adjust docs/dev/lsp-extensions.md.
 
 #[test]
 fn files_are_tidy() {
-    let sh = &Shell::new().unwrap();
-
     let files = sourcegen::list_files(&sourcegen::project_root().join("crates"));
 
     let mut tidy_docs = TidyDocs::default();
@@ -75,7 +70,7 @@ fn files_are_tidy() {
         let extension = path.extension().unwrap_or_default().to_str().unwrap_or_default();
         match extension {
             "rs" => {
-                let text = sh.read_file(&path).unwrap();
+                let text = read_file(&path).unwrap();
                 check_todo(&path, &text);
                 check_dbg(&path, &text);
                 check_test_attrs(&path, &text);
@@ -85,7 +80,7 @@ fn files_are_tidy() {
                 tidy_marks.visit(&path, &text);
             }
             "toml" => {
-                let text = sh.read_file(&path).unwrap();
+                let text = read_file(&path).unwrap();
                 check_cargo_toml(&path, text);
             }
             _ => (),
@@ -144,10 +139,8 @@ fn check_cargo_toml(path: &Path, text: String) {
 
 #[test]
 fn check_merge_commits() {
-    let sh = &Shell::new().unwrap();
-
-    let bors = cmd!(sh, "git rev-list --merges --author 'bors' HEAD~19..").read().unwrap();
-    let all = cmd!(sh, "git rev-list --merges HEAD~19..").read().unwrap();
+    let bors = cmd!("git rev-list --merges --author 'bors' HEAD~19..").read().unwrap();
+    let all = cmd!("git rev-list --merges HEAD~19..").read().unwrap();
     if bors != all {
         panic!(
             "
@@ -220,8 +213,6 @@ See https://github.com/rust-lang/rust-clippy/issues/5537 for discussion.
 
 #[test]
 fn check_licenses() {
-    let sh = &Shell::new().unwrap();
-
     let expected = "
 0BSD OR MIT OR Apache-2.0
 Apache-2.0
@@ -245,7 +236,7 @@ Zlib OR Apache-2.0 OR MIT
     .filter(|it| !it.is_empty())
     .collect::<Vec<_>>();
 
-    let meta = cmd!(sh, "cargo metadata --format-version 1").read().unwrap();
+    let meta = cmd!("cargo metadata --format-version 1").read().unwrap();
     let mut licenses = meta
         .split(|c| c == ',' || c == '{' || c == '}')
         .filter(|it| it.contains(r#""license""#))

--- a/crates/sourcegen/Cargo.toml
+++ b/crates/sourcegen/Cargo.toml
@@ -10,4 +10,4 @@ rust-version = "1.57"
 doctest = false
 
 [dependencies]
-xshell = "0.2.1"
+xshell = "0.1"

--- a/crates/sourcegen/src/lib.rs
+++ b/crates/sourcegen/src/lib.rs
@@ -11,7 +11,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use xshell::{cmd, Shell};
+use xshell::{cmd, pushenv};
 
 pub fn list_rust_files(dir: &Path) -> Vec<PathBuf> {
     let mut res = list_files(dir);
@@ -133,8 +133,8 @@ impl fmt::Display for Location {
     }
 }
 
-fn ensure_rustfmt(sh: &Shell) {
-    let version = cmd!(sh, "rustfmt --version").read().unwrap_or_default();
+fn ensure_rustfmt() {
+    let version = cmd!("rustfmt --version").read().unwrap_or_default();
     if !version.contains("stable") {
         panic!(
             "Failed to run rustfmt from toolchain 'stable'. \
@@ -144,11 +144,10 @@ fn ensure_rustfmt(sh: &Shell) {
 }
 
 pub fn reformat(text: String) -> String {
-    let sh = Shell::new().unwrap();
-    sh.set_var("RUSTUP_TOOLCHAIN", "stable");
-    ensure_rustfmt(&sh);
+    let _e = pushenv("RUSTUP_TOOLCHAIN", "stable");
+    ensure_rustfmt();
     let rustfmt_toml = project_root().join("rustfmt.toml");
-    let mut stdout = cmd!(sh, "rustfmt --config-path {rustfmt_toml} --config fn_single_line=true")
+    let mut stdout = cmd!("rustfmt --config-path {rustfmt_toml} --config fn_single_line=true")
         .stdin(text)
         .read()
         .unwrap();

--- a/lib/lsp-server/src/error.rs
+++ b/lib/lsp-server/src/error.rs
@@ -29,7 +29,7 @@ impl fmt::Display for ExtractError<Request> {
                 write!(f, "Method mismatch for request '{}'", req.method)
             }
             ExtractError::JsonError { method, error } => {
-                write!(f, "Invalid request\nMethod: {method}\n error: {error}",)
+                write!(f, "Invalid request\nMethod: {}\n error: {}", method, error)
             }
         }
     }
@@ -43,7 +43,7 @@ impl fmt::Display for ExtractError<Notification> {
                 write!(f, "Method mismatch for notification '{}'", req.method)
             }
             ExtractError::JsonError { method, error } => {
-                write!(f, "Invalid notification\nMethod: {method}\n error: {error}")
+                write!(f, "Invalid notification\nMethod: {}\n error: {}", method, error)
             }
         }
     }

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -10,6 +10,6 @@ rust-version = "1.57"
 anyhow = "1.0.56"
 flate2 = "1.0.22"
 write-json = "0.1.2"
-xshell = "0.2.1"
+xshell = "0.1"
 xflags = "0.2.4"
 # Avoid adding more dependencies to this crate

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -14,16 +14,15 @@ mod release;
 mod dist;
 mod metrics;
 
-use anyhow::bail;
+use anyhow::{bail, Result};
 use std::{
     env,
     path::{Path, PathBuf},
 };
-use xshell::{cmd, Shell};
+use xshell::{cmd, cp, pushd, pushenv};
 
-fn main() -> anyhow::Result<()> {
-    let sh = &Shell::new()?;
-    sh.change_dir(project_root());
+fn main() -> Result<()> {
+    let _d = pushd(project_root())?;
 
     let flags = flags::Xtask::from_env()?;
     match flags.subcommand {
@@ -31,21 +30,18 @@ fn main() -> anyhow::Result<()> {
             println!("{}", flags::Xtask::HELP);
             Ok(())
         }
-        flags::XtaskCmd::Install(cmd) => cmd.run(sh),
-        flags::XtaskCmd::FuzzTests(_) => run_fuzzer(sh),
-        flags::XtaskCmd::Release(cmd) => cmd.run(sh),
-        flags::XtaskCmd::Promote(cmd) => cmd.run(sh),
-        flags::XtaskCmd::Dist(cmd) => cmd.run(sh),
-        flags::XtaskCmd::Metrics(cmd) => cmd.run(sh),
+        flags::XtaskCmd::Install(cmd) => cmd.run(),
+        flags::XtaskCmd::FuzzTests(_) => run_fuzzer(),
+        flags::XtaskCmd::Release(cmd) => cmd.run(),
+        flags::XtaskCmd::Promote(cmd) => cmd.run(),
+        flags::XtaskCmd::Dist(cmd) => cmd.run(),
+        flags::XtaskCmd::Metrics(cmd) => cmd.run(),
         flags::XtaskCmd::Bb(cmd) => {
             {
-                let _d = sh.push_dir("./crates/rust-analyzer");
-                cmd!(sh, "cargo build --release --features jemalloc").run()?;
+                let _d = pushd("./crates/rust-analyzer")?;
+                cmd!("cargo build --release --features jemalloc").run()?;
             }
-            sh.copy_file(
-                "./target/release/rust-analyzer",
-                format!("./target/rust-analyzer-{}", cmd.suffix),
-            )?;
+            cp("./target/release/rust-analyzer", format!("./target/rust-analyzer-{}", cmd.suffix))?;
             Ok(())
         }
     }
@@ -61,25 +57,25 @@ fn project_root() -> PathBuf {
     .to_path_buf()
 }
 
-fn run_fuzzer(sh: &Shell) -> anyhow::Result<()> {
-    let _d = sh.push_dir("./crates/syntax");
-    let _e = sh.push_env("RUSTUP_TOOLCHAIN", "nightly");
-    if cmd!(sh, "cargo fuzz --help").read().is_err() {
-        cmd!(sh, "cargo install cargo-fuzz").run()?;
+fn run_fuzzer() -> Result<()> {
+    let _d = pushd("./crates/syntax")?;
+    let _e = pushenv("RUSTUP_TOOLCHAIN", "nightly");
+    if cmd!("cargo fuzz --help").read().is_err() {
+        cmd!("cargo install cargo-fuzz").run()?;
     };
 
     // Expecting nightly rustc
-    let out = cmd!(sh, "rustc --version").read()?;
+    let out = cmd!("rustc --version").read()?;
     if !out.contains("nightly") {
         bail!("fuzz tests require nightly rustc")
     }
 
-    cmd!(sh, "cargo fuzz run parser").run()?;
+    cmd!("cargo fuzz run parser").run()?;
     Ok(())
 }
 
-fn date_iso(sh: &Shell) -> anyhow::Result<String> {
-    let res = cmd!(sh, "date -u +%Y-%m-%d").read()?;
+fn date_iso() -> Result<String> {
+    let res = cmd!("date -u +%Y-%m-%d").read()?;
     Ok(res)
 }
 

--- a/xtask/src/release.rs
+++ b/xtask/src/release.rs
@@ -1,15 +1,15 @@
 mod changelog;
 
-use xshell::{cmd, Shell};
+use xshell::{cmd, pushd, read_dir, read_file, write_file};
 
-use crate::{date_iso, flags, is_release_tag, project_root};
+use crate::{date_iso, flags, is_release_tag, project_root, Result};
 
 impl flags::Release {
-    pub(crate) fn run(self, sh: &Shell) -> anyhow::Result<()> {
+    pub(crate) fn run(self) -> Result<()> {
         if !self.dry_run {
-            cmd!(sh, "git switch release").run()?;
-            cmd!(sh, "git fetch upstream --tags --force").run()?;
-            cmd!(sh, "git reset --hard tags/nightly").run()?;
+            cmd!("git switch release").run()?;
+            cmd!("git fetch upstream --tags --force").run()?;
+            cmd!("git reset --hard tags/nightly").run()?;
             // The `release` branch sometimes has a couple of cherry-picked
             // commits for patch releases. If that's the case, just overwrite
             // it. As we are setting `release` branch to an up-to-date `nightly`
@@ -19,24 +19,24 @@ impl flags::Release {
             // commits -- they'll be kept alive by the tag. More generally, we
             // don't care about historic releases all that much, it's fine even
             // to delete old tags.
-            cmd!(sh, "git push --force").run()?;
+            cmd!("git push --force").run()?;
         }
 
         // Generates bits of manual.adoc.
-        cmd!(sh, "cargo test -p ide-assists -p ide-diagnostics -p rust-analyzer -- sourcegen_")
+        cmd!("cargo test -p ide-assists -p ide-diagnostics -p rust-analyzer -- sourcegen_")
             .run()?;
 
         let website_root = project_root().join("../rust-analyzer.github.io");
         {
-            let _dir = sh.push_dir(&website_root);
-            cmd!(sh, "git switch src").run()?;
-            cmd!(sh, "git pull").run()?;
+            let _dir = pushd(&website_root)?;
+            cmd!("git switch src").run()?;
+            cmd!("git pull").run()?;
         }
         let changelog_dir = website_root.join("./thisweek/_posts");
 
-        let today = date_iso(sh)?;
-        let commit = cmd!(sh, "git rev-parse HEAD").read()?;
-        let changelog_n = sh.read_dir(changelog_dir.as_path())?.len();
+        let today = date_iso()?;
+        let commit = cmd!("git rev-parse HEAD").read()?;
+        let changelog_n = read_dir(changelog_dir.as_path())?.len();
 
         for adoc in [
             "manual.adoc",
@@ -48,46 +48,42 @@ impl flags::Release {
             let src = project_root().join("./docs/user/").join(adoc);
             let dst = website_root.join(adoc);
 
-            let contents = sh.read_file(src)?;
-            sh.write_file(dst, contents)?;
+            let contents = read_file(src)?;
+            write_file(dst, contents)?;
         }
 
-        let tags = cmd!(sh, "git tag --list").read()?;
+        let tags = cmd!("git tag --list").read()?;
         let prev_tag = tags.lines().filter(|line| is_release_tag(line)).last().unwrap();
 
-        let contents = changelog::get_changelog(sh, changelog_n, &commit, prev_tag, &today)?;
+        let contents = changelog::get_changelog(changelog_n, &commit, prev_tag, &today)?;
         let path = changelog_dir.join(format!("{}-changelog-{}.adoc", today, changelog_n));
-        sh.write_file(&path, &contents)?;
+        write_file(&path, &contents)?;
 
         Ok(())
     }
 }
 
 impl flags::Promote {
-    pub(crate) fn run(self, sh: &Shell) -> anyhow::Result<()> {
-        let _dir = sh.push_dir("../rust-rust-analyzer");
-        cmd!(sh, "git switch master").run()?;
-        cmd!(sh, "git fetch upstream").run()?;
-        cmd!(sh, "git reset --hard upstream/master").run()?;
-        cmd!(sh, "git submodule update --recursive").run()?;
+    pub(crate) fn run(self) -> Result<()> {
+        let _dir = pushd("../rust-rust-analyzer")?;
+        cmd!("git switch master").run()?;
+        cmd!("git fetch upstream").run()?;
+        cmd!("git reset --hard upstream/master").run()?;
+        cmd!("git submodule update --recursive").run()?;
 
-        let date = date_iso(sh)?;
-        let branch = format!("rust-analyzer-{date}");
-        cmd!(sh, "git switch -c {branch}").run()?;
+        let branch = format!("rust-analyzer-{}", date_iso()?);
+        cmd!("git switch -c {branch}").run()?;
         {
-            let _dir = sh.push_dir("src/tools/rust-analyzer");
-            cmd!(sh, "git fetch origin").run()?;
-            cmd!(sh, "git reset --hard origin/release").run()?;
+            let _dir = pushd("src/tools/rust-analyzer")?;
+            cmd!("git fetch origin").run()?;
+            cmd!("git reset --hard origin/release").run()?;
         }
-        cmd!(sh, "git add src/tools/rust-analyzer").run()?;
-        cmd!(sh, "git commit -m':arrow_up: rust-analyzer'").run()?;
+        cmd!("git add src/tools/rust-analyzer").run()?;
+        cmd!("git commit -m':arrow_up: rust-analyzer'").run()?;
         if !self.dry_run {
-            cmd!(sh, "git push -u origin {branch}").run()?;
-            cmd!(
-                sh,
-                "xdg-open https://github.com/matklad/rust/pull/new/{branch}?body=r%3F%20%40ghost"
-            )
-            .run()?;
+            cmd!("git push -u origin {branch}").run()?;
+            cmd!("xdg-open https://github.com/matklad/rust/pull/new/{branch}?body=r%3F%20%40ghost")
+                .run()?;
         }
         Ok(())
     }

--- a/xtask/src/release/changelog.rs
+++ b/xtask/src/release/changelog.rs
@@ -1,11 +1,10 @@
 use std::fmt::Write;
 use std::{env, iter};
 
-use anyhow::bail;
-use xshell::{cmd, Shell};
+use anyhow::{bail};
+use xshell::cmd;
 
 pub(crate) fn get_changelog(
-    sh: &Shell,
     changelog_n: usize,
     commit: &str,
     prev_tag: &str,
@@ -16,7 +15,7 @@ pub(crate) fn get_changelog(
         Err(_) => bail!("Please obtain a personal access token from https://github.com/settings/tokens and set the `GITHUB_TOKEN` environment variable."),
     };
 
-    let git_log = cmd!(sh, "git log {prev_tag}..HEAD --reverse").read()?;
+    let git_log = cmd!("git log {prev_tag}..HEAD --reverse").read()?;
     let mut features = String::new();
     let mut fixes = String::new();
     let mut internal = String::new();
@@ -31,14 +30,14 @@ pub(crate) fn get_changelog(
             // we don't use an HTTPS client or JSON parser to keep the build times low
             let pr = pr_num.to_string();
             let pr_json =
-                cmd!(sh, "curl -s -H {accept} -H {authorization} {pr_url}/{pr}").read()?;
-            let pr_title = cmd!(sh, "jq .title").stdin(&pr_json).read()?;
+                cmd!("curl -s -H {accept} -H {authorization} {pr_url}/{pr}").read()?;
+            let pr_title = cmd!("jq .title").stdin(&pr_json).read()?;
             let pr_title = unescape(&pr_title[1..pr_title.len() - 1]);
-            let pr_comment = cmd!(sh, "jq .body").stdin(pr_json).read()?;
+            let pr_comment = cmd!("jq .body").stdin(pr_json).read()?;
 
             let comments_json =
-                cmd!(sh, "curl -s -H {accept} -H {authorization} {pr_url}/{pr}/comments").read()?;
-            let pr_comments = cmd!(sh, "jq .[].body").stdin(comments_json).read()?;
+                cmd!("curl -s -H {accept} -H {authorization} {pr_url}/{pr}/comments").read()?;
+            let pr_comments = cmd!("jq .[].body").stdin(comments_json).read()?;
 
             let l = iter::once(pr_comment.as_str())
                 .chain(pr_comments.lines())


### PR DESCRIPTION
Yet another backport PR like #9629 (not expected to be merged, is here just to increase its visibility). Makes `rust-analyzer` buildable on Ubuntu `21.10` `impish`.