### PR TITLE
feat: Support `$$` in macros.

### DIFF
--- a/crates/hir-def/src/macro_expansion_tests/mbe.rs
+++ b/crates/hir-def/src/macro_expansion_tests/mbe.rs
@@ -1544,3 +1544,71 @@ struct Foo;
 "##]],
     )
 }
+
+#[test]
+fn test_dollar_dollar() {
+    check(
+        r#"
+macro_rules! register_struct { ($Struct:ident) => {
+    macro_rules! register_methods { ($$($method:ident),*) => {
+        macro_rules! implement_methods { ($$$$($$val:expr),*) => {
+            struct $Struct;
+            impl $Struct { $$(fn $method() -> &'static [u32] { &[$$$$($$$$val),*] })*}
+        }}
+    }}
+}}
+
+register_struct!(Foo);
+register_methods!(alpha, beta);
+implement_methods!(1, 2, 3);
+"#,
+        expect![[r#"
+macro_rules! register_struct { ($Struct:ident) => {
+    macro_rules! register_methods { ($$($method:ident),*) => {
+        macro_rules! implement_methods { ($$$$($$val:expr),*) => {
+            struct $Struct;
+            impl $Struct { $$(fn $method() -> &'static [u32] { &[$$$$($$$$val),*] })*}
+        }}
+    }}
+}}
+
+macro_rules !register_methods {
+    ($($method: ident), *) = > {
+        macro_rules!implement_methods {
+            ($$($val: expr), *) = > {
+                struct Foo;
+                impl Foo {
+                    $(fn $method()-> & 'static[u32] {
+                        &[$$($$val), *]
+                    }
+                    )*
+                }
+            }
+        }
+    }
+}
+macro_rules !implement_methods {
+    ($($val: expr), *) = > {
+        struct Foo;
+        impl Foo {
+            fn alpha()-> & 'static[u32] {
+                &[$($val), *]
+            }
+            fn beta()-> & 'static[u32] {
+                &[$($val), *]
+            }
+        }
+    }
+}
+struct Foo;
+impl Foo {
+    fn alpha() -> & 'static[u32] {
+        &[1, 2, 3]
+    }
+    fn beta() -> & 'static[u32] {
+        &[1, 2, 3]
+    }
+}
+"#]],
+    )
+}

--- a/crates/hir-def/src/macro_expansion_tests/mbe/meta_syntax.rs
+++ b/crates/hir-def/src/macro_expansion_tests/mbe/meta_syntax.rs
@@ -56,6 +56,9 @@ macro_rules! f2 { ($i:) => ($i) }
 f2!();
 macro_rules! f3 { ($i:_) => () }
 f3!();
+
+macro_rules! m1 { ($$i) => () }
+m1!();
 "#,
         expect![[r#"
 macro_rules! i1 { invalid }
@@ -74,6 +77,9 @@ macro_rules! f2 { ($i:) => ($i) }
 /* error: invalid macro definition: missing fragment specifier */
 macro_rules! f3 { ($i:_) => () }
 /* error: invalid macro definition: missing fragment specifier */
+
+macro_rules! m1 { ($$i) => () }
+/* error: invalid macro definition: `$$` is not allowed on the pattern side */
 "#]],
     )
 }

--- a/crates/mbe/src/parser.rs
+++ b/crates/mbe/src/parser.rs
@@ -135,6 +135,14 @@ fn next_op<'a>(first: &tt::TokenTree, src: &mut TtIter<'a>, mode: Mode) -> Resul
                         let id = lit.id;
                         Op::Var { name, kind, id }
                     }
+                    tt::Leaf::Punct(punct @ tt::Punct { char: '$', .. }) => match mode {
+                        Mode::Pattern => {
+                            return Err(ParseError::unexpected(
+                                "`$$` is not allowed on the pattern side",
+                            ))
+                        }
+                        Mode::Template => Op::Leaf(tt::Leaf::Punct(*punct)),
+                    },
                     tt::Leaf::Punct(_) | tt::Leaf::Literal(_) => {
                         return Err(ParseError::expected("expected ident"))
                     }


### PR DESCRIPTION
The implementation mirrors what `rustc` currently does [1]. Part of #11952.

\[1]: https://github.com/rust-lang/rust/blob/0595ea1d12cf745e0a672d05341429ecb0917e66/compiler/rustc_expand/src/mbe/quoted.rs#L230-L241