### PR TITLE
minor: Fix typo in style guide

### DIFF
--- a/docs/dev/style.md
+++ b/docs/dev/style.md
@@ -971,7 +971,7 @@ Between `ref` and mach ergonomics, the latter is more ergonomic in most cases, a
 
 ## Empty Match Arms
 
-Ues `=> (),` when a match arm is intentionally empty:
+Use `=> (),` when a match arm is intentionally empty:
 
 ```rust
 // GOOD


### PR DESCRIPTION
Fix type `Ues` -> `Use` in `style.md`