### PR TITLE
fix: Pass the build data to rustc_private crates

### DIFF
--- a/crates/project-model/src/workspace.rs
+++ b/crates/project-model/src/workspace.rs
@@ -667,6 +667,7 @@ fn cargo_to_crate_graph(
                 &public_deps,
                 cargo,
                 &pkg_crates,
+                build_scripts,
             );
         }
     }
@@ -728,6 +729,7 @@ fn handle_rustc_crates(
     public_deps: &SysrootPublicDeps,
     cargo: &CargoWorkspace,
     pkg_crates: &FxHashMap<la_arena::Idx<crate::PackageData>, Vec<(CrateId, TargetKind)>>,
+    build_scripts: &WorkspaceBuildScripts,
 ) {
     let mut rustc_pkg_crates = FxHashMap::default();
     // The root package of the rustc-dev component is rustc_driver, so we match that
@@ -781,7 +783,7 @@ fn handle_rustc_crates(
                     let crate_id = add_target_crate_root(
                         crate_graph,
                         &rustc_workspace[pkg],
-                        None,
+                        build_scripts.get_output(pkg),
                         cfg_options,
                         &mut |path| load_proc_macro(&rustc_workspace[tgt].name, path),
                         file_id,

--- a/crates/rust-analyzer/src/reload.rs
+++ b/crates/rust-analyzer/src/reload.rs
@@ -550,7 +550,7 @@ pub(crate) fn load_proc_macro(
         }
     };
 
-    return client
+    let proc_macros: Vec<_> = client
         .map(|it| it.load_dylib(dylib))
         .into_iter()
         .flat_map(|it| match it {
@@ -568,6 +568,12 @@ pub(crate) fn load_proc_macro(
         })
         .map(|expander| expander_to_proc_macro(expander, dummy_replace))
         .collect();
+    tracing::info!(
+        "Loaded proc-macros for {}: {:?}",
+        path.display(),
+        proc_macros.iter().map(|it| it.name.clone()).collect::<Vec<_>>()
+    );
+    return proc_macros;
 
     fn expander_to_proc_macro(
         expander: proc_macro_api::ProcMacro,


### PR DESCRIPTION
With this all proc-macros should resolve in rustc now when setting up the build script running command properly.