### PR TITLE
fix typo in package.json

### DIFF
--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -1430,7 +1430,7 @@
             },
             {
                 "id": "public",
-                "description": "Style tems that are from the current crate and are `pub`"
+                "description": "Style for items that are from the current crate and are `pub`"
             },
             {
                 "id": "reference",


### PR DESCRIPTION
Fixes a small typo in `package.json`.