### PR TITLE
Automatically instaciate trivially instaciable structs in "Generate new" and "Fill struct fields"

### DIFF
--- a/crates/ide-assists/src/handlers/generate_new.rs
+++ b/crates/ide-assists/src/handlers/generate_new.rs
@@ -116,8 +116,6 @@ pub(crate) fn generate_new(acc: &mut Assists, ctx: &AssistContext) -> Option<()>
             })
             .collect::<Vec<_>>();
 
-        dbg!(&trivial_constructors);
-
         let params = field_list
             .fields()
             .enumerate()

--- a/crates/ide-assists/src/handlers/generate_new.rs
+++ b/crates/ide-assists/src/handlers/generate_new.rs
@@ -8,7 +8,7 @@ use crate::{
     AssistContext, AssistId, AssistKind, Assists,
 };
 
-// TODO: how to depupicate with `ide-diagnostics/mssing_fields`
+// FIXME: how to depupicate with `ide-diagnostics/mssing_fields`
 fn use_trivial_constructor(
     db: &ide_db::RootDatabase,
     path: ast::Path,

--- a/crates/ide-assists/src/handlers/generate_new.rs
+++ b/crates/ide-assists/src/handlers/generate_new.rs
@@ -124,6 +124,97 @@ mod tests {
     use super::*;
 
     #[test]
+    fn test_generate_new_with_zst_fields() {
+        check_assist(
+            generate_new,
+            r#"
+struct Empty;
+
+struct Foo { empty: Empty $0}
+"#,
+            r#"
+struct Empty;
+
+struct Foo { empty: Empty }
+
+impl Foo {
+    fn $0new() -> Self { Self { empty: Empty } }
+}
+"#,
+        );
+        check_assist(
+            generate_new,
+            r#"
+struct Empty;
+
+struct Foo { baz: String, empty: Empty $0}
+"#,
+            r#"
+struct Empty;
+
+struct Foo { baz: String, empty: Empty }
+
+impl Foo {
+    fn $0new(baz: String) -> Self { Self { baz, empty: Empty } }
+}
+"#,
+        );
+        check_assist(
+            generate_new,
+            r#"
+enum Empty { Bar }
+
+struct Foo { empty: Empty $0}
+"#,
+            r#"
+enum Empty { Bar }
+
+struct Foo { empty: Empty }
+
+impl Foo {
+    fn $0new() -> Self { Self { empty: Empty::Bar } }
+}
+"#,
+        );
+
+        // make sure the assist only works on unit variants
+        check_assist(
+            generate_new,
+            r#"
+struct Empty {}
+
+struct Foo { empty: Empty $0}
+"#,
+            r#"
+struct Empty {}
+
+struct Foo { empty: Empty }
+
+impl Foo {
+    fn $0new(empty: Empty) -> Self { Self { empty } }
+}
+"#,
+        );
+        check_assist(
+            generate_new,
+            r#"
+enum Empty { Bar {} }
+
+struct Foo { empty: Empty $0}
+"#,
+            r#"
+enum Empty { Bar {} }
+
+struct Foo { empty: Empty }
+
+impl Foo {
+    fn $0new(empty: Empty) -> Self { Self { empty } }
+}
+"#,
+        );
+    }
+
+    #[test]
     fn test_generate_new() {
         check_assist(
             generate_new,

--- a/crates/ide-assists/src/handlers/generate_new.rs
+++ b/crates/ide-assists/src/handlers/generate_new.rs
@@ -29,12 +29,7 @@ pub fn use_trivial_constructor(
                         )),
                     );
 
-                    use hir::StructKind::*;
-                    let is_record = match variant.kind(db) {
-                        Record => true,
-                        Tuple => false,
-                        Unit => false,
-                    };
+                    let is_record = variant.kind(db) == hir::StructKind::Record;
 
                     return Some(if is_record {
                         ast::Expr::RecordExpr(syntax::ast::make::record_expr(
@@ -48,9 +43,7 @@ pub fn use_trivial_constructor(
             }
         }
         Some(hir::Adt::Struct(x)) => {
-            let fields = x.fields(db);
-
-            if fields.is_empty() {
+            if x.fields(db).is_empty() {
                 return Some(syntax::ast::make::expr_path(path));
             }
         }

--- a/crates/ide-assists/src/handlers/generate_new.rs
+++ b/crates/ide-assists/src/handlers/generate_new.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 
 // TODO: how to depupicate with `ide-diagnostics/mssing_fields`
-pub fn use_trivial_constructor(
+fn use_trivial_constructor(
     db: &ide_db::RootDatabase,
     path: ast::Path,
     ty: &hir::Type,

--- a/crates/ide-db/src/lib.rs
+++ b/crates/ide-db/src/lib.rs
@@ -20,6 +20,7 @@ pub mod source_change;
 pub mod symbol_index;
 pub mod traits;
 pub mod ty_filter;
+pub mod use_trivial_contructor;
 
 pub mod imports {
     pub mod import_assets;

--- a/crates/ide-db/src/use_trivial_contructor.rs
+++ b/crates/ide-db/src/use_trivial_contructor.rs
@@ -1,6 +1,9 @@
+//! Functionality for generating trivial contructors
+
 use hir::StructKind;
 use syntax::ast;
 
+/// given a type return the trivial contructor (if one exists)
 pub fn use_trivial_constructor(
     db: &crate::RootDatabase,
     path: ast::Path,

--- a/crates/ide-db/src/use_trivial_contructor.rs
+++ b/crates/ide-db/src/use_trivial_contructor.rs
@@ -1,0 +1,31 @@
+use hir::StructKind;
+use syntax::ast;
+
+pub fn use_trivial_constructor(
+    db: &crate::RootDatabase,
+    path: ast::Path,
+    ty: &hir::Type,
+) -> Option<ast::Expr> {
+    match ty.as_adt() {
+        Some(hir::Adt::Enum(x)) => {
+            if let &[variant] = &*x.variants(db) {
+                if variant.kind(db) == hir::StructKind::Unit {
+                    let path = ast::make::path_qualified(
+                        path,
+                        syntax::ast::make::path_segment(ast::make::name_ref(
+                            &variant.name(db).to_smol_str(),
+                        )),
+                    );
+
+                    return Some(syntax::ast::make::expr_path(path));
+                }
+            }
+        }
+        Some(hir::Adt::Struct(x)) if x.kind(db) == StructKind::Unit => {
+            return Some(syntax::ast::make::expr_path(path));
+        }
+        _ => {}
+    }
+
+    None
+}

--- a/crates/ide-diagnostics/src/handlers/missing_fields.rs
+++ b/crates/ide-diagnostics/src/handlers/missing_fields.rs
@@ -18,7 +18,7 @@ use text_edit::TextEdit;
 use crate::{fix, Diagnostic, DiagnosticsContext};
 
 // TODO: how to depupicate with `ide-assists/generate_new`
-pub fn use_trivial_constructor(
+fn use_trivial_constructor(
     db: &ide_db::RootDatabase,
     path: ast::Path,
     ty: &hir::Type,

--- a/crates/ide-diagnostics/src/handlers/missing_fields.rs
+++ b/crates/ide-diagnostics/src/handlers/missing_fields.rs
@@ -346,6 +346,92 @@ fn test_fn() {
     }
 
     #[test]
+    fn test_fill_struct_zst_fields() {
+        check_fix(
+            r#"
+struct Empty;
+
+struct TestStruct { one: i32, two: Empty }
+
+fn test_fn() {
+    let s = TestStruct {$0};
+}
+"#,
+            r#"
+struct Empty;
+
+struct TestStruct { one: i32, two: Empty }
+
+fn test_fn() {
+    let s = TestStruct { one: 0, two: Empty };
+}
+"#,
+        );
+        check_fix(
+            r#"
+enum Empty { Foo };
+
+struct TestStruct { one: i32, two: Empty }
+
+fn test_fn() {
+    let s = TestStruct {$0};
+}
+"#,
+            r#"
+enum Empty { Foo };
+
+struct TestStruct { one: i32, two: Empty }
+
+fn test_fn() {
+    let s = TestStruct { one: 0, two: Empty::Foo };
+}
+"#,
+        );
+
+        // make sure the assist doesn't fill non Unit variants
+        check_fix(
+            r#"
+struct Empty {};
+
+struct TestStruct { one: i32, two: Empty }
+
+fn test_fn() {
+    let s = TestStruct {$0};
+}
+"#,
+            r#"
+struct Empty {};
+
+struct TestStruct { one: i32, two: Empty }
+
+fn test_fn() {
+    let s = TestStruct { one: 0, two: todo!() };
+}
+"#,
+        );
+        check_fix(
+            r#"
+enum Empty { Foo {} };
+
+struct TestStruct { one: i32, two: Empty }
+
+fn test_fn() {
+    let s = TestStruct {$0};
+}
+"#,
+            r#"
+enum Empty { Foo {} };
+
+struct TestStruct { one: i32, two: Empty }
+
+fn test_fn() {
+    let s = TestStruct { one: 0, two: todo!() };
+}
+"#,
+        );
+    }
+
+    #[test]
     fn test_fill_struct_fields_self() {
         check_fix(
             r#"

--- a/crates/ide-diagnostics/src/handlers/missing_fields.rs
+++ b/crates/ide-diagnostics/src/handlers/missing_fields.rs
@@ -38,12 +38,7 @@ pub fn use_trivial_constructor(
                         )),
                     );
 
-                    use hir::StructKind::*;
-                    let is_record = match variant.kind(db) {
-                        Record => true,
-                        Tuple => false,
-                        Unit => false,
-                    };
+                    let is_record = variant.kind(db) == hir::StructKind::Record;
 
                     return Some(if is_record {
                         ast::Expr::RecordExpr(syntax::ast::make::record_expr(
@@ -57,9 +52,7 @@ pub fn use_trivial_constructor(
             }
         }
         Some(hir::Adt::Struct(x)) => {
-            let fields = x.fields(db);
-
-            if fields.is_empty() {
+            if x.fields(db).is_empty() {
                 return Some(syntax::ast::make::expr_path(path));
             }
         }

--- a/crates/ide-diagnostics/src/handlers/missing_fields.rs
+++ b/crates/ide-diagnostics/src/handlers/missing_fields.rs
@@ -17,7 +17,7 @@ use text_edit::TextEdit;
 
 use crate::{fix, Diagnostic, DiagnosticsContext};
 
-// TODO: how to depupicate with `ide-assists/generate_new`
+// FIXME: how to depupicate with `ide-assists/generate_new`
 fn use_trivial_constructor(
     db: &ide_db::RootDatabase,
     path: ast::Path,


### PR DESCRIPTION
As proposed in #12535 this PR changes the "Generate new" and "Fill struct fields" assist/diagnostic to instanciate structs with no fields and enums with a single empty variant.

For example:
```rust
pub enum Bar {
    Bar {},
}
struct Foo<T> {
    a: usize,
    bar: Bar,
    _phantom: std::marker::PhantomData<T>,
}
impl<T> Foo<T> {
    /* generate new */

    fn random() -> Self {
        Self { /* Fill struct fields */ }
    }
}
```

was previously:
```rust
impl<T> Foo<T> {
    fn new(a: usize, bar: Bar, _phantom: std::marker::PhantomData<T>) -> Self {
        Self { a, bar, _phantom }
    }

    fn random() -> Self {
        Self {
            a: todo!(),
            bar: todo!(),
            _phantom: todo!(),
        }
    }
}
```

and is now:
```rust
impl<T> Foo<T> {
  fn new(a: usize) -> Self {
      Self {
          a,
          bar: Bar::Bar {},
          _phantom: std::marker::PhantomData
      }
  }
    
  fn random() -> Self {
      Self {
          a: todo!(),
          bar: Bar::Bar {},
          _phantom: std::marker::PhantomData,
      }
  }
}
```

I'd be happy about any suggestions.

## TODO
   - [x]  deduplicate `use_trivial_constructor` (unclear how to do as it's used in two separate crates)
   - [x]  write tests

Closes #12535