### PR TITLE
fix: local items should not be completed in parent signature

### DIFF
--- a/crates/hir/src/source_analyzer.rs
+++ b/crates/hir/src/source_analyzer.rs
@@ -600,13 +600,11 @@ fn scope_for_offset(
             .filter(|it| it.value.kind() == SyntaxKind::MACRO_CALL)?;
             Some((source.value.text_range(), scope))
         })
-        // find containing scope
-        .min_by_key(|(expr_range, _scope)| {
-            (
-                !(expr_range.start() <= offset.value && offset.value <= expr_range.end()),
-                expr_range.len(),
-            )
+        .filter(|(expr_range, _scope)| {
+            expr_range.start() <= offset.value && offset.value <= expr_range.end()
         })
+        // find containing scope
+        .min_by_key(|(expr_range, _scope)| expr_range.len())
         .map(|(expr_range, scope)| {
             adjust(db, scopes, source_map, expr_range, offset).unwrap_or(*scope)
         })

--- a/crates/hir/src/source_analyzer.rs
+++ b/crates/hir/src/source_analyzer.rs
@@ -67,7 +67,10 @@ impl SourceAnalyzer {
         let scopes = db.expr_scopes(def);
         let scope = match offset {
             None => scope_for(&scopes, &source_map, node),
-            Some(offset) => scope_for_offset(db, &scopes, &source_map, node.with_value(offset)),
+            Some(offset) => {
+                let file_id = node.file_id.original_file(db.upcast());
+                scope_for_offset(db, &scopes, &source_map, InFile::new(file_id.into(), offset))
+            }
         };
         let resolver = resolver_for_scope(db.upcast(), def, scope);
         SourceAnalyzer {
@@ -88,7 +91,10 @@ impl SourceAnalyzer {
         let scopes = db.expr_scopes(def);
         let scope = match offset {
             None => scope_for(&scopes, &source_map, node),
-            Some(offset) => scope_for_offset(db, &scopes, &source_map, node.with_value(offset)),
+            Some(offset) => {
+                let file_id = node.file_id.original_file(db.upcast());
+                scope_for_offset(db, &scopes, &source_map, InFile::new(file_id.into(), offset))
+            }
         };
         let resolver = resolver_for_scope(db.upcast(), def, scope);
         SourceAnalyzer { resolver, def: Some((def, body, source_map)), infer: None, file_id }

--- a/crates/ide-completion/src/tests/expression.rs
+++ b/crates/ide-completion/src/tests/expression.rs
@@ -513,7 +513,6 @@ fn quux(x: i32) {
 ",
         expect![[r#"
             fn quux(…)   fn(i32)
-            lc x         i32
             ma m!(…)     macro_rules! m
             bt u32
             kw crate::

--- a/crates/ide-completion/src/tests/expression.rs
+++ b/crates/ide-completion/src/tests/expression.rs
@@ -513,6 +513,7 @@ fn quux(x: i32) {
 ",
         expect![[r#"
             fn quux(…)   fn(i32)
+            lc x         i32
             ma m!(…)     macro_rules! m
             bt u32
             kw crate::

--- a/crates/ide-completion/src/tests/type_pos.rs
+++ b/crates/ide-completion/src/tests/type_pos.rs
@@ -90,11 +90,16 @@ fn x<'lt, T, const C: usize>() -> $0
 }
 
 #[test]
-fn fn_return_type2() {
+fn fn_return_type_no_local_items() {
     check(
         r#"
 fn foo() -> B$0 {
     struct Bar;
+    enum Baz {}
+    union Bax {
+        i: i32,
+        f: f32
+    }
 }
 "#,
         expect![[r#"

--- a/crates/ide-completion/src/tests/type_pos.rs
+++ b/crates/ide-completion/src/tests/type_pos.rs
@@ -90,6 +90,32 @@ fn x<'lt, T, const C: usize>() -> $0
 }
 
 #[test]
+fn fn_return_type2() {
+    check(
+        r#"
+fn foo() -> B$0 {
+    struct Bar;
+}
+"#,
+        expect![[r#"
+        en Enum
+        ma makro!(…) macro_rules! makro
+        md module
+        st Record
+        st Tuple
+        st Unit
+        tt Trait
+        un Union
+        bt u32
+        it ()
+        kw crate::
+        kw self::
+        kw super::
+    "#]],
+    )
+}
+
+#[test]
 fn inferred_type_const() {
     check(
         r#"


### PR DESCRIPTION
fixes #11959 

> We get a Bar completion for the following snippet which is wrong as the item is not visible in that position.
> ``` rust
> fn foo() -> $0 {
>    struct Bar;
> }
> ```

I investigated the problem and found that the scope of the cursor offset, also `CompletionContext.scope` is the body of the function
