### PR TITLE
internal: More completions refactoring

### DIFF
--- a/crates/ide-completion/src/completions/dot.rs
+++ b/crates/ide-completion/src/completions/dot.rs
@@ -4,7 +4,8 @@ use ide_db::FxHashSet;
 
 use crate::{
     context::{
-        CompletionContext, DotAccess, DotAccessKind, NameRefContext, PathCompletionCtx, PathKind,
+        CompletionContext, DotAccess, DotAccessKind, NameRefContext, NameRefKind,
+        PathCompletionCtx, PathKind,
     },
     CompletionItem, CompletionItemKind, Completions,
 };
@@ -13,7 +14,8 @@ use crate::{
 pub(crate) fn complete_dot(acc: &mut Completions, ctx: &CompletionContext) {
     let (dot_access, receiver_ty) = match ctx.nameref_ctx() {
         Some(NameRefContext {
-            dot_access: Some(access @ DotAccess { receiver_ty: Some(receiver_ty), .. }),
+            kind:
+                Some(NameRefKind::DotAccess(access @ DotAccess { receiver_ty: Some(receiver_ty), .. })),
             ..
         }) => (access, &receiver_ty.original),
         _ => return complete_undotted_self(acc, ctx),

--- a/crates/ide-completion/src/completions/expr.rs
+++ b/crates/ide-completion/src/completions/expr.rs
@@ -5,7 +5,7 @@ use ide_db::FxHashSet;
 use syntax::T;
 
 use crate::{
-    context::{NameRefContext, PathCompletionCtx, PathKind, PathQualifierCtx},
+    context::{NameRefContext, NameRefKind, PathCompletionCtx, PathKind, PathQualifierCtx},
     CompletionContext, Completions,
 };
 
@@ -21,24 +21,29 @@ pub(crate) fn complete_expr_path(acc: &mut Completions, ctx: &CompletionContext)
         after_if_expr,
         wants_mut_token,
     ) = match ctx.nameref_ctx() {
-        Some(NameRefContext {
-            path_ctx:
-                Some(PathCompletionCtx {
+        Some(&NameRefContext {
+            kind:
+                Some(NameRefKind::Path(PathCompletionCtx {
                     kind:
-                        PathKind::Expr { in_block_expr, in_loop_body, after_if_expr, ref_expr_parent },
+                        PathKind::Expr {
+                            in_block_expr,
+                            in_loop_body,
+                            after_if_expr,
+                            ref ref_expr_parent,
+                            ref is_func_update,
+                        },
                     is_absolute_path,
-                    qualifier,
+                    ref qualifier,
                     ..
-                }),
-            record_expr,
+                })),
             ..
         }) if ctx.qualifier_ctx.none() => (
-            *is_absolute_path,
+            is_absolute_path,
             qualifier,
-            *in_block_expr,
-            *in_loop_body,
-            record_expr.as_ref().map_or(false, |&(_, it)| it),
-            *after_if_expr,
+            in_block_expr,
+            in_loop_body,
+            is_func_update.is_some(),
+            after_if_expr,
             ref_expr_parent.as_ref().map(|it| it.mut_token().is_none()).unwrap_or(false),
         ),
         _ => return,

--- a/crates/ide-completion/src/completions/field.rs
+++ b/crates/ide-completion/src/completions/field.rs
@@ -1,7 +1,10 @@
 //! Completion of field list position.
 
 use crate::{
-    context::{IdentContext, NameContext, NameKind, NameRefContext, PathCompletionCtx, PathKind},
+    context::{
+        IdentContext, NameContext, NameKind, NameRefContext, NameRefKind, PathCompletionCtx,
+        PathKind,
+    },
     CompletionContext, Completions,
 };
 
@@ -9,8 +12,8 @@ pub(crate) fn complete_field_list(acc: &mut Completions, ctx: &CompletionContext
     match &ctx.ident_ctx {
         IdentContext::Name(NameContext { kind: NameKind::RecordField, .. })
         | IdentContext::NameRef(NameRefContext {
-            path_ctx:
-                Some(PathCompletionCtx {
+            kind:
+                Some(NameRefKind::Path(PathCompletionCtx {
                     has_macro_bang: false,
                     is_absolute_path: false,
                     qualifier: None,
@@ -18,7 +21,7 @@ pub(crate) fn complete_field_list(acc: &mut Completions, ctx: &CompletionContext
                     kind: PathKind::Type { in_tuple_struct: true },
                     has_type_args: false,
                     ..
-                }),
+                })),
             ..
         }) => {
             if ctx.qualifier_ctx.vis_node.is_none() {

--- a/crates/ide-completion/src/completions/field.rs
+++ b/crates/ide-completion/src/completions/field.rs
@@ -3,7 +3,7 @@
 use crate::{
     context::{
         IdentContext, NameContext, NameKind, NameRefContext, NameRefKind, PathCompletionCtx,
-        PathKind,
+        PathKind, TypeLocation,
     },
     CompletionContext, Completions,
 };
@@ -18,7 +18,7 @@ pub(crate) fn complete_field_list(acc: &mut Completions, ctx: &CompletionContext
                     is_absolute_path: false,
                     qualifier: None,
                     parent: None,
-                    kind: PathKind::Type { in_tuple_struct: true, ascription: None },
+                    kind: PathKind::Type { location: TypeLocation::TupleField },
                     has_type_args: false,
                     ..
                 })),

--- a/crates/ide-completion/src/completions/field.rs
+++ b/crates/ide-completion/src/completions/field.rs
@@ -18,7 +18,7 @@ pub(crate) fn complete_field_list(acc: &mut Completions, ctx: &CompletionContext
                     is_absolute_path: false,
                     qualifier: None,
                     parent: None,
-                    kind: PathKind::Type { in_tuple_struct: true },
+                    kind: PathKind::Type { in_tuple_struct: true, ascription: None },
                     has_type_args: false,
                     ..
                 })),

--- a/crates/ide-completion/src/completions/flyimport.rs
+++ b/crates/ide-completion/src/completions/flyimport.rs
@@ -9,9 +9,9 @@ use syntax::{AstNode, SyntaxNode, T};
 
 use crate::{
     context::{
-        CompletionContext, NameRefContext, NameRefKind, PathCompletionCtx, PathKind, PatternContext,
+        CompletionContext, NameRefContext, NameRefKind, PathCompletionCtx, PathKind,
+        PatternContext, TypeLocation,
     },
-    patterns::ImmediateLocation,
     render::{render_resolution_with_import, RenderContext},
 };
 
@@ -112,7 +112,7 @@ pub(crate) fn import_on_the_fly(acc: &mut Completions, ctx: &CompletionContext) 
     if !ctx.config.enable_imports_on_the_fly {
         return None;
     }
-    let path_kind = match dbg!(ctx.nameref_ctx()) {
+    let path_kind = match ctx.nameref_ctx() {
         Some(NameRefContext {
             kind:
                 Some(NameRefKind::Path(PathCompletionCtx {
@@ -176,8 +176,8 @@ pub(crate) fn import_on_the_fly(acc: &mut Completions, ctx: &CompletionContext) 
             (PathKind::Pat, ItemInNs::Types(_)) => true,
             (PathKind::Pat, ItemInNs::Values(def)) => matches!(def, hir::ModuleDef::Const(_)),
 
-            (PathKind::Type { .. }, ItemInNs::Types(ty)) => {
-                if matches!(ctx.completion_location, Some(ImmediateLocation::TypeBound)) {
+            (PathKind::Type { location }, ItemInNs::Types(ty)) => {
+                if matches!(location, TypeLocation::TypeBound) {
                     matches!(ty, ModuleDef::Trait(_))
                 } else {
                     true

--- a/crates/ide-completion/src/completions/item_list/trait_impl.rs
+++ b/crates/ide-completion/src/completions/item_list/trait_impl.rs
@@ -44,8 +44,8 @@ use text_edit::TextEdit;
 
 use crate::{
     context::{
-        IdentContext, ItemListKind, NameContext, NameKind, NameRefContext, PathCompletionCtx,
-        PathKind,
+        IdentContext, ItemListKind, NameContext, NameKind, NameRefContext, NameRefKind,
+        PathCompletionCtx, PathKind,
     },
     CompletionContext, CompletionItem, CompletionItemKind, CompletionRelevance, Completions,
 };
@@ -106,14 +106,13 @@ fn completion_match(ctx: &CompletionContext) -> Option<(ImplCompletionKind, Text
         }
         IdentContext::NameRef(NameRefContext {
             nameref,
-            path_ctx:
-                Some(
+            kind:
+                Some(NameRefKind::Path(
                     path_ctx @ PathCompletionCtx {
                         kind: PathKind::Item { kind: ItemListKind::TraitImpl },
                         ..
                     },
-                ),
-            ..
+                )),
         }) if path_ctx.is_trivial_path() => Some((
             ImplCompletionKind::All,
             match nameref {

--- a/crates/ide-completion/src/completions/keyword.rs
+++ b/crates/ide-completion/src/completions/keyword.rs
@@ -4,11 +4,14 @@
 
 use syntax::ast::Item;
 
-use crate::{context::NameRefContext, CompletionContext, Completions};
+use crate::{
+    context::{NameRefContext, NameRefKind},
+    CompletionContext, Completions,
+};
 
 pub(crate) fn complete_expr_keyword(acc: &mut Completions, ctx: &CompletionContext) {
     let item = match ctx.nameref_ctx() {
-        Some(NameRefContext { keyword: Some(item), record_expr: None, .. }) => item,
+        Some(NameRefContext { kind: Some(NameRefKind::Keyword(item)), .. }) => item,
         _ => return,
     };
 

--- a/crates/ide-completion/src/completions/postfix.rs
+++ b/crates/ide-completion/src/completions/postfix.rs
@@ -13,7 +13,7 @@ use text_edit::TextEdit;
 
 use crate::{
     completions::postfix::format_like::add_format_like_completions,
-    context::{CompletionContext, DotAccess, DotAccessKind, NameRefContext},
+    context::{CompletionContext, DotAccess, DotAccessKind, NameRefContext, NameRefKind},
     item::{Builder, CompletionRelevancePostfixMatch},
     CompletionItem, CompletionItemKind, CompletionRelevance, Completions, SnippetScope,
 };
@@ -25,7 +25,13 @@ pub(crate) fn complete_postfix(acc: &mut Completions, ctx: &CompletionContext) {
 
     let (dot_receiver, receiver_ty, receiver_is_ambiguous_float_literal) = match ctx.nameref_ctx() {
         Some(NameRefContext {
-            dot_access: Some(DotAccess { receiver_ty: Some(ty), receiver: Some(it), kind, .. }),
+            kind:
+                Some(NameRefKind::DotAccess(DotAccess {
+                    receiver_ty: Some(ty),
+                    receiver: Some(it),
+                    kind,
+                    ..
+                })),
             ..
         }) => (
             it,

--- a/crates/ide-completion/src/completions/type.rs
+++ b/crates/ide-completion/src/completions/type.rs
@@ -5,8 +5,7 @@ use ide_db::FxHashSet;
 use syntax::{ast, AstNode};
 
 use crate::{
-    context::{PathCompletionCtx, PathKind, PathQualifierCtx, TypeAscriptionTarget},
-    patterns::ImmediateLocation,
+    context::{PathCompletionCtx, PathKind, PathQualifierCtx, TypeAscriptionTarget, TypeLocation},
     render::render_type_inference,
     CompletionContext, Completions,
 };
@@ -14,13 +13,13 @@ use crate::{
 pub(crate) fn complete_type_path(acc: &mut Completions, ctx: &CompletionContext) {
     let _p = profile::span("complete_type_path");
 
-    let (&is_absolute_path, qualifier) = match ctx.path_context() {
+    let (&is_absolute_path, location, qualifier) = match ctx.path_context() {
         Some(PathCompletionCtx {
-            kind: PathKind::Type { .. },
+            kind: PathKind::Type { location },
             is_absolute_path,
             qualifier,
             ..
-        }) => (is_absolute_path, qualifier),
+        }) => (is_absolute_path, location, qualifier),
         _ => return,
     };
 
@@ -32,7 +31,7 @@ pub(crate) fn complete_type_path(acc: &mut Completions, ctx: &CompletionContext)
             ScopeDef::ModuleDef(Function(_) | Variant(_) | Static(_)) | ScopeDef::Local(_) => false,
             // unless its a constant in a generic arg list position
             ScopeDef::ModuleDef(Const(_)) | ScopeDef::GenericParam(ConstParam(_)) => {
-                ctx.expects_generic_arg()
+                matches!(location, TypeLocation::GenericArgList(_))
             }
             ScopeDef::ImplSelfType(_) => {
                 !ctx.previous_token_is(syntax::T![impl]) && !ctx.previous_token_is(syntax::T![for])
@@ -47,6 +46,14 @@ pub(crate) fn complete_type_path(acc: &mut Completions, ctx: &CompletionContext)
         }
     };
 
+    let add_assoc_item = |acc: &mut Completions, item| match item {
+        hir::AssocItem::Const(ct) if matches!(location, TypeLocation::GenericArgList(_)) => {
+            acc.add_const(ctx, ct)
+        }
+        hir::AssocItem::Function(_) | hir::AssocItem::Const(_) => (),
+        hir::AssocItem::TypeAlias(ty) => acc.add_type_alias(ctx, ty),
+    };
+
     match qualifier {
         Some(PathQualifierCtx { is_infer_qualifier, resolution, .. }) => {
             if *is_infer_qualifier {
@@ -54,7 +61,7 @@ pub(crate) fn complete_type_path(acc: &mut Completions, ctx: &CompletionContext)
                     .0
                     .into_iter()
                     .flat_map(|it| hir::Trait::from(it).items(ctx.sema.db))
-                    .for_each(|item| add_assoc_item(acc, ctx, item));
+                    .for_each(|item| add_assoc_item(acc, item));
                 return;
             }
             let resolution = match resolution {
@@ -98,7 +105,7 @@ pub(crate) fn complete_type_path(acc: &mut Completions, ctx: &CompletionContext)
                         Some(ctx.module),
                         None,
                         |item| {
-                            add_assoc_item(acc, ctx, item);
+                            add_assoc_item(acc, item);
                             None::<()>
                         },
                     );
@@ -114,7 +121,7 @@ pub(crate) fn complete_type_path(acc: &mut Completions, ctx: &CompletionContext)
                 hir::PathResolution::Def(hir::ModuleDef::Trait(t)) => {
                     // Handles `Trait::assoc` as well as `<Ty as Trait>::assoc`.
                     for item in t.items(ctx.db) {
-                        add_assoc_item(acc, ctx, item);
+                        add_assoc_item(acc, item);
                     }
                 }
                 hir::PathResolution::TypeParam(_) | hir::PathResolution::SelfType(_) => {
@@ -135,7 +142,7 @@ pub(crate) fn complete_type_path(acc: &mut Completions, ctx: &CompletionContext)
                             // We might iterate candidates of a trait multiple times here, so deduplicate
                             // them.
                             if seen.insert(item) {
-                                add_assoc_item(acc, ctx, item);
+                                add_assoc_item(acc, item);
                             }
                             None::<()>
                         },
@@ -147,7 +154,7 @@ pub(crate) fn complete_type_path(acc: &mut Completions, ctx: &CompletionContext)
         None if is_absolute_path => acc.add_crate_roots(ctx),
         None => {
             acc.add_nameref_keywords_with_colon(ctx);
-            if let Some(ImmediateLocation::TypeBound) = &ctx.completion_location {
+            if let TypeLocation::TypeBound = location {
                 ctx.process_all_names(&mut |name, res| {
                     let add_resolution = match res {
                         ScopeDef::ModuleDef(hir::ModuleDef::Macro(mac)) => mac.is_fn_like(ctx.db),
@@ -162,7 +169,7 @@ pub(crate) fn complete_type_path(acc: &mut Completions, ctx: &CompletionContext)
                 });
                 return;
             }
-            if let Some(ImmediateLocation::GenericArgList(arg_list)) = &ctx.completion_location {
+            if let TypeLocation::GenericArgList(Some(arg_list)) = location {
                 if let Some(path_seg) = arg_list.syntax().parent().and_then(ast::PathSegment::cast)
                 {
                     if path_seg.syntax().ancestors().find_map(ast::TypeBound::cast).is_some() {
@@ -189,10 +196,10 @@ pub(crate) fn complete_type_path(acc: &mut Completions, ctx: &CompletionContext)
 }
 
 pub(crate) fn complete_inferred_type(acc: &mut Completions, ctx: &CompletionContext) -> Option<()> {
-    let pat = match dbg!(ctx.path_context()) {
+    let pat = match ctx.path_context() {
         Some(
             ctx @ PathCompletionCtx {
-                kind: PathKind::Type { ascription: Some(ascription), .. },
+                kind: PathKind::Type { location: TypeLocation::TypeAscription(ascription), .. },
                 ..
             },
         ) if ctx.is_trivial_path() => ascription,
@@ -210,12 +217,4 @@ pub(crate) fn complete_inferred_type(acc: &mut Completions, ctx: &CompletionCont
     let ty_string = x.display_source_code(ctx.db, ctx.module.into()).ok()?;
     acc.add(render_type_inference(ty_string, ctx));
     None
-}
-
-fn add_assoc_item(acc: &mut Completions, ctx: &CompletionContext, item: hir::AssocItem) {
-    match item {
-        hir::AssocItem::Const(ct) if ctx.expects_generic_arg() => acc.add_const(ctx, ct),
-        hir::AssocItem::Function(_) | hir::AssocItem::Const(_) => (),
-        hir::AssocItem::TypeAlias(ty) => acc.add_type_alias(ctx, ty),
-    }
 }

--- a/crates/ide-completion/src/completions/use_.rs
+++ b/crates/ide-completion/src/completions/use_.rs
@@ -5,7 +5,10 @@ use ide_db::{FxHashSet, SymbolKind};
 use syntax::{ast, AstNode};
 
 use crate::{
-    context::{CompletionContext, NameRefContext, PathCompletionCtx, PathKind, PathQualifierCtx},
+    context::{
+        CompletionContext, NameRefContext, NameRefKind, PathCompletionCtx, PathKind,
+        PathQualifierCtx,
+    },
     item::Builder,
     CompletionItem, CompletionItemKind, CompletionRelevance, Completions,
 };
@@ -13,8 +16,13 @@ use crate::{
 pub(crate) fn complete_use_tree(acc: &mut Completions, ctx: &CompletionContext) {
     let (&is_absolute_path, qualifier, name_ref) = match ctx.nameref_ctx() {
         Some(NameRefContext {
-            path_ctx:
-                Some(PathCompletionCtx { kind: PathKind::Use, is_absolute_path, qualifier, .. }),
+            kind:
+                Some(NameRefKind::Path(PathCompletionCtx {
+                    kind: PathKind::Use,
+                    is_absolute_path,
+                    qualifier,
+                    ..
+                })),
             nameref,
             ..
         }) => (is_absolute_path, qualifier, nameref),

--- a/crates/ide-completion/src/patterns.rs
+++ b/crates/ide-completion/src/patterns.rs
@@ -4,102 +4,15 @@
 //! This means we for example expand a NameRef token to its outermost Path node, as semantically these act in the same location
 //! and the completions usually query for path specific things on the Path context instead. This simplifies some location handling.
 
-use hir::Semantics;
-use ide_db::RootDatabase;
 use syntax::{
     ast::{self, HasLoopBody},
     match_ast, AstNode, SyntaxElement,
     SyntaxKind::*,
-    SyntaxNode, SyntaxToken, TextSize,
+    SyntaxNode, SyntaxToken,
 };
 
 #[cfg(test)]
 use crate::tests::check_pattern_is_applicable;
-
-/// Direct parent "thing" of what we are currently completing.
-///
-/// This may contain nodes of the fake file as well as the original, comments on the variants specify
-/// from which file the nodes are.
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) enum ImmediateLocation {
-    TypeBound,
-    // Only set from a type arg
-    /// Original file ast node
-    GenericArgList(ast::GenericArgList),
-}
-
-pub(crate) fn determine_location(
-    sema: &Semantics<RootDatabase>,
-    original_file: &SyntaxNode,
-    offset: TextSize,
-    name_like: &ast::NameLike,
-) -> Option<ImmediateLocation> {
-    let node = match name_like {
-        ast::NameLike::NameRef(name_ref) => maximize_name_ref(name_ref),
-        ast::NameLike::Name(name) => name.syntax().clone(),
-        ast::NameLike::Lifetime(lt) => lt.syntax().clone(),
-    };
-
-    match_ast! {
-        match node {
-            ast::TypeBoundList(_it) => return Some(ImmediateLocation::TypeBound),
-            _ => (),
-        }
-    };
-
-    let parent = match node.parent() {
-        Some(parent) => match ast::MacroCall::cast(parent.clone()) {
-            // When a path is being typed in an (Assoc)ItemList the parser will always emit a macro_call.
-            // This is usually fine as the node expansion code above already accounts for that with
-            // the ancestors call, but there is one exception to this which is that when an attribute
-            // precedes it the code above will not walk the Path to the parent MacroCall as their ranges differ.
-            // FIXME path expr and statement have a similar problem
-            Some(call)
-                if call.excl_token().is_none()
-                    && call.token_tree().is_none()
-                    && call.semicolon_token().is_none() =>
-            {
-                call.syntax().parent()?
-            }
-            _ => parent,
-        },
-        // SourceFile
-        None => return None,
-    };
-
-    let res = match_ast! {
-        match parent {
-            ast::TypeBound(_) => ImmediateLocation::TypeBound,
-            ast::TypeBoundList(_) => ImmediateLocation::TypeBound,
-            ast::GenericArgList(_) => sema
-                .find_node_at_offset_with_macros(original_file, offset)
-                .map(ImmediateLocation::GenericArgList)?,
-            _ => return None,
-        }
-    };
-    Some(res)
-}
-
-/// Maximize a nameref to its enclosing path if its the last segment of said path.
-/// That is, when completing a [`NameRef`] we actually handle it as the path it is part of when determining
-/// its location.
-fn maximize_name_ref(name_ref: &ast::NameRef) -> SyntaxNode {
-    if let Some(segment) = name_ref.syntax().parent().and_then(ast::PathSegment::cast) {
-        let p = segment.parent_path();
-        if p.parent_path().is_none() {
-            // Get rid of PathExpr, PathType, etc...
-            let path = p
-                .syntax()
-                .ancestors()
-                .take_while(|it| it.text_range() == p.syntax().text_range())
-                .last();
-            if let Some(it) = path {
-                return it;
-            }
-        }
-    }
-    name_ref.syntax().clone()
-}
 
 pub(crate) fn previous_token(element: SyntaxElement) -> Option<SyntaxToken> {
     element.into_token().and_then(previous_non_trivia_token)

--- a/crates/ide-completion/src/render/function.rs
+++ b/crates/ide-completion/src/render/function.rs
@@ -8,7 +8,8 @@ use syntax::SmolStr;
 
 use crate::{
     context::{
-        CompletionContext, DotAccess, DotAccessKind, NameRefContext, PathCompletionCtx, PathKind,
+        CompletionContext, DotAccess, DotAccessKind, NameRefContext, NameRefKind,
+        PathCompletionCtx, PathKind,
     },
     item::{Builder, CompletionItem, CompletionItemKind, CompletionRelevance},
     render::{compute_exact_name_match, compute_ref_match, compute_type_match, RenderContext},
@@ -212,7 +213,10 @@ fn should_add_parens(ctx: &CompletionContext) -> bool {
     if matches!(
         ctx.nameref_ctx(),
         Some(NameRefContext {
-            dot_access: Some(DotAccess { kind: DotAccessKind::Method { has_parens: true }, .. }),
+            kind: Some(NameRefKind::DotAccess(DotAccess {
+                kind: DotAccessKind::Method { has_parens: true },
+                ..
+            })),
             ..
         })
     ) {

--- a/crates/ide-completion/src/tests/record.rs
+++ b/crates/ide-completion/src/tests/record.rs
@@ -105,7 +105,6 @@ fn foo(f: Struct) {
 #[test]
 fn functional_update() {
     // FIXME: This should filter out all completions that do not have the type `Foo`
-    // FIXME: Fields should not show up after `.`
     check(
         r#"
 //- minicore:default
@@ -192,8 +191,6 @@ fn main() {
 }
 "#,
         expect![[r#"
-            fd foo1                   u32
-            fd foo2                   u32
             fn default() (as Default) fn() -> Self
         "#]],
     );


### PR DESCRIPTION
This gets rid of the remaining `ImmediateLocation` bits