### PR TITLE
internal: Lift out IdentContext from CompletionContext

### DIFF
--- a/crates/ide-completion/src/completions.rs
+++ b/crates/ide-completion/src/completions.rs
@@ -541,8 +541,8 @@ pub(super) fn complete_name_ref(
         NameRefKind::Keyword(item) => {
             keyword::complete_for_and_where(acc, ctx, item);
         }
-        NameRefKind::RecordExpr(record_expr) => {
-            record::complete_record_expr_fields(acc, ctx, record_expr);
+        NameRefKind::RecordExpr { dot_prefix, expr } => {
+            record::complete_record_expr_fields(acc, ctx, expr, dot_prefix);
         }
         NameRefKind::Pattern(pattern_ctx) => complete_patterns(acc, ctx, pattern_ctx),
     }

--- a/crates/ide-completion/src/completions.rs
+++ b/crates/ide-completion/src/completions.rs
@@ -23,13 +23,13 @@ pub(crate) mod vis;
 use std::iter;
 
 use hir::{known, ScopeDef};
-use ide_db::SymbolKind;
+use ide_db::{imports::import_assets::LocatedImport, SymbolKind};
 use syntax::ast;
 
 use crate::{
     context::{
-        ItemListKind, NameContext, NameKind, NameRefContext, NameRefKind, PathKind, PatternContext,
-        TypeLocation, Visible,
+        DotAccess, ItemListKind, NameContext, NameKind, NameRefContext, NameRefKind,
+        PathCompletionCtx, PathKind, PatternContext, TypeLocation, Visible,
     },
     item::Builder,
     render::{
@@ -38,7 +38,7 @@ use crate::{
         literal::{render_struct_literal, render_variant_lit},
         macro_::render_macro,
         pattern::{render_struct_pat, render_variant_pat},
-        render_field, render_resolution, render_resolution_simple, render_tuple_field,
+        render_field, render_path_resolution, render_resolution_simple, render_tuple_field,
         type_alias::{render_type_alias, render_type_alias_with_eq},
         union_literal::render_union_literal,
         RenderContext,
@@ -137,15 +137,16 @@ impl Completions {
     pub(crate) fn add_crate_roots(&mut self, ctx: &CompletionContext) {
         ctx.process_all_names(&mut |name, res| match res {
             ScopeDef::ModuleDef(hir::ModuleDef::Module(m)) if m.is_crate_root(ctx.db) => {
-                self.add_resolution(ctx, name, res);
+                self.add_module(ctx, m, name);
             }
             _ => (),
         });
     }
 
-    pub(crate) fn add_resolution(
+    pub(crate) fn add_path_resolution(
         &mut self,
         ctx: &CompletionContext,
+        path_ctx: &PathCompletionCtx,
         local_name: hir::Name,
         resolution: hir::ScopeDef,
     ) {
@@ -153,7 +154,10 @@ impl Completions {
             cov_mark::hit!(qualified_path_doc_hidden);
             return;
         }
-        self.add(render_resolution(RenderContext::new(ctx), local_name, resolution).build());
+        self.add(
+            render_path_resolution(RenderContext::new(ctx), path_ctx, local_name, resolution)
+                .build(),
+        );
     }
 
     pub(crate) fn add_resolution_simple(
@@ -174,12 +178,13 @@ impl Completions {
         module: hir::Module,
         local_name: hir::Name,
     ) {
-        self.add_resolution(ctx, local_name, hir::ScopeDef::ModuleDef(module.into()));
+        self.add_resolution_simple(ctx, local_name, hir::ScopeDef::ModuleDef(module.into()));
     }
 
     pub(crate) fn add_macro(
         &mut self,
         ctx: &CompletionContext,
+        path_ctx: &PathCompletionCtx,
         mac: hir::Macro,
         local_name: hir::Name,
     ) {
@@ -191,6 +196,7 @@ impl Completions {
         self.add(
             render_macro(
                 RenderContext::new(ctx).private_editable(is_private_editable),
+                path_ctx,
                 local_name,
                 mac,
             )
@@ -201,6 +207,7 @@ impl Completions {
     pub(crate) fn add_function(
         &mut self,
         ctx: &CompletionContext,
+        path_ctx: &PathCompletionCtx,
         func: hir::Function,
         local_name: Option<hir::Name>,
     ) {
@@ -212,6 +219,7 @@ impl Completions {
         self.add(
             render_fn(
                 RenderContext::new(ctx).private_editable(is_private_editable),
+                path_ctx,
                 local_name,
                 func,
             )
@@ -222,6 +230,7 @@ impl Completions {
     pub(crate) fn add_method(
         &mut self,
         ctx: &CompletionContext,
+        dot_access: &DotAccess,
         func: hir::Function,
         receiver: Option<hir::Name>,
         local_name: Option<hir::Name>,
@@ -234,8 +243,35 @@ impl Completions {
         self.add(
             render_method(
                 RenderContext::new(ctx).private_editable(is_private_editable),
+                dot_access,
                 receiver,
                 local_name,
+                func,
+            )
+            .build(),
+        );
+    }
+
+    pub(crate) fn add_method_with_import(
+        &mut self,
+        ctx: &CompletionContext,
+        dot_access: &DotAccess,
+        func: hir::Function,
+        import: LocatedImport,
+    ) {
+        let is_private_editable = match ctx.is_visible(&func) {
+            Visible::Yes => false,
+            Visible::Editable => true,
+            Visible::No => return,
+        };
+        self.add(
+            render_method(
+                RenderContext::new(ctx)
+                    .private_editable(is_private_editable)
+                    .import_to_add(Some(import)),
+                dot_access,
+                None,
+                None,
                 func,
             )
             .build(),
@@ -277,11 +313,12 @@ impl Completions {
     pub(crate) fn add_qualified_enum_variant(
         &mut self,
         ctx: &CompletionContext,
+        path_ctx: &PathCompletionCtx,
         variant: hir::Variant,
         path: hir::ModPath,
     ) {
         if let Some(builder) =
-            render_variant_lit(RenderContext::new(ctx), None, variant, Some(path))
+            render_variant_lit(RenderContext::new(ctx), path_ctx, None, variant, Some(path))
         {
             self.add(builder.build());
         }
@@ -290,11 +327,12 @@ impl Completions {
     pub(crate) fn add_enum_variant(
         &mut self,
         ctx: &CompletionContext,
+        path_ctx: &PathCompletionCtx,
         variant: hir::Variant,
         local_name: Option<hir::Name>,
     ) {
         if let Some(builder) =
-            render_variant_lit(RenderContext::new(ctx), local_name, variant, None)
+            render_variant_lit(RenderContext::new(ctx), path_ctx, local_name, variant, None)
         {
             self.add(builder.build());
         }
@@ -324,12 +362,13 @@ impl Completions {
     pub(crate) fn add_struct_literal(
         &mut self,
         ctx: &CompletionContext,
+        path_ctx: &PathCompletionCtx,
         strukt: hir::Struct,
         path: Option<hir::ModPath>,
         local_name: Option<hir::Name>,
     ) {
         if let Some(builder) =
-            render_struct_literal(RenderContext::new(ctx), strukt, path, local_name)
+            render_struct_literal(RenderContext::new(ctx), path_ctx, strukt, path, local_name)
         {
             self.add(builder.build());
         }
@@ -369,11 +408,13 @@ impl Completions {
     pub(crate) fn add_variant_pat(
         &mut self,
         ctx: &CompletionContext,
+        pattern_ctx: &PatternContext,
         variant: hir::Variant,
         local_name: Option<hir::Name>,
     ) {
         self.add_opt(render_variant_pat(
             RenderContext::new(ctx),
+            pattern_ctx,
             variant,
             local_name.clone(),
             None,
@@ -383,20 +424,22 @@ impl Completions {
     pub(crate) fn add_qualified_variant_pat(
         &mut self,
         ctx: &CompletionContext,
+        pattern_ctx: &PatternContext,
         variant: hir::Variant,
         path: hir::ModPath,
     ) {
         let path = Some(&path);
-        self.add_opt(render_variant_pat(RenderContext::new(ctx), variant, None, path));
+        self.add_opt(render_variant_pat(RenderContext::new(ctx), pattern_ctx, variant, None, path));
     }
 
     pub(crate) fn add_struct_pat(
         &mut self,
         ctx: &CompletionContext,
+        pattern_ctx: &PatternContext,
         strukt: hir::Struct,
         local_name: Option<hir::Name>,
     ) {
-        self.add_opt(render_struct_pat(RenderContext::new(ctx), strukt, local_name));
+        self.add_opt(render_struct_pat(RenderContext::new(ctx), pattern_ctx, strukt, local_name));
     }
 }
 

--- a/crates/ide-completion/src/completions/attribute.rs
+++ b/crates/ide-completion/src/completions/attribute.rs
@@ -33,6 +33,7 @@ pub(crate) use self::derive::complete_derive_path;
 pub(crate) fn complete_known_attribute_input(
     acc: &mut Completions,
     ctx: &CompletionContext,
+    &colon_prefix: &bool,
     fake_attribute_under_caret: &ast::Attr,
 ) -> Option<()> {
     let attribute = fake_attribute_under_caret;
@@ -47,7 +48,9 @@ pub(crate) fn complete_known_attribute_input(
 
     match path.text().as_str() {
         "repr" => repr::complete_repr(acc, ctx, tt),
-        "feature" => lint::complete_lint(acc, ctx, &parse_tt_as_comma_sep_paths(tt)?, FEATURES),
+        "feature" => {
+            lint::complete_lint(acc, ctx, colon_prefix, &parse_tt_as_comma_sep_paths(tt)?, FEATURES)
+        }
         "allow" | "warn" | "deny" | "forbid" => {
             let existing_lints = parse_tt_as_comma_sep_paths(tt)?;
 
@@ -60,7 +63,7 @@ pub(crate) fn complete_known_attribute_input(
                 .cloned()
                 .collect();
 
-            lint::complete_lint(acc, ctx, &existing_lints, &lints);
+            lint::complete_lint(acc, ctx, colon_prefix, &existing_lints, &lints);
         }
         "cfg" => cfg::complete_cfg(acc, ctx),
         _ => (),

--- a/crates/ide-completion/src/completions/attribute.rs
+++ b/crates/ide-completion/src/completions/attribute.rs
@@ -74,7 +74,7 @@ pub(crate) fn complete_known_attribute_input(
 pub(crate) fn complete_attribute_path(
     acc: &mut Completions,
     ctx: &CompletionContext,
-    PathCompletionCtx { qualified, .. }: &PathCompletionCtx,
+    path_ctx @ PathCompletionCtx { qualified, .. }: &PathCompletionCtx,
     &AttrCtx { kind, annotated_item_kind }: &AttrCtx,
 ) {
     let is_inner = kind == AttrKind::Inner;
@@ -92,7 +92,7 @@ pub(crate) fn complete_attribute_path(
             for (name, def) in module.scope(ctx.db, Some(ctx.module)) {
                 match def {
                     hir::ScopeDef::ModuleDef(hir::ModuleDef::Macro(m)) if m.is_attr(ctx.db) => {
-                        acc.add_macro(ctx, m, name)
+                        acc.add_macro(ctx, path_ctx, m, name)
                     }
                     hir::ScopeDef::ModuleDef(hir::ModuleDef::Module(m)) => {
                         acc.add_module(ctx, m, name)
@@ -108,7 +108,7 @@ pub(crate) fn complete_attribute_path(
         Qualified::No => {
             ctx.process_all_names(&mut |name, def| match def {
                 hir::ScopeDef::ModuleDef(hir::ModuleDef::Macro(m)) if m.is_attr(ctx.db) => {
-                    acc.add_macro(ctx, m, name)
+                    acc.add_macro(ctx, path_ctx, m, name)
                 }
                 hir::ScopeDef::ModuleDef(hir::ModuleDef::Module(m)) => acc.add_module(ctx, m, name),
                 _ => (),

--- a/crates/ide-completion/src/completions/attribute/derive.rs
+++ b/crates/ide-completion/src/completions/attribute/derive.rs
@@ -13,7 +13,7 @@ use crate::{
 pub(crate) fn complete_derive_path(
     acc: &mut Completions,
     ctx: &CompletionContext,
-    PathCompletionCtx { qualified, .. }: &PathCompletionCtx,
+    path_ctx @ PathCompletionCtx { qualified, .. }: &PathCompletionCtx,
     existing_derives: &ExistingDerives,
 ) {
     let core = ctx.famous_defs().core();
@@ -33,7 +33,7 @@ pub(crate) fn complete_derive_path(
                     ScopeDef::ModuleDef(hir::ModuleDef::Macro(mac))
                         if !existing_derives.contains(&mac) && mac.is_derive(ctx.db) =>
                     {
-                        acc.add_macro(ctx, mac, name)
+                        acc.add_macro(ctx, path_ctx, mac, name)
                     }
                     ScopeDef::ModuleDef(hir::ModuleDef::Module(m)) => acc.add_module(ctx, m, name),
                     _ => (),
@@ -59,7 +59,7 @@ pub(crate) fn complete_derive_path(
                 match (core, mac.module(ctx.db).krate()) {
                     // show derive dependencies for `core`/`std` derives
                     (Some(core), mac_krate) if core == mac_krate => {}
-                    _ => return acc.add_macro(ctx, mac, name),
+                    _ => return acc.add_macro(ctx, path_ctx, mac, name),
                 };
 
                 let name_ = name.to_smol_str();
@@ -92,7 +92,7 @@ pub(crate) fn complete_derive_path(
                         item.lookup_by(lookup);
                         item.add_to(acc);
                     }
-                    None => acc.add_macro(ctx, mac, name),
+                    None => acc.add_macro(ctx, path_ctx, mac, name),
                 }
             });
             acc.add_nameref_keywords_with_colon(ctx);

--- a/crates/ide-completion/src/completions/attribute/lint.rs
+++ b/crates/ide-completion/src/completions/attribute/lint.rs
@@ -1,16 +1,16 @@
 //! Completion for lints
 use ide_db::{generated::lints::Lint, SymbolKind};
-use syntax::{ast, T};
+use syntax::ast;
 
 use crate::{context::CompletionContext, item::CompletionItem, Completions};
 
 pub(super) fn complete_lint(
     acc: &mut Completions,
     ctx: &CompletionContext,
+    is_qualified: bool,
     existing_lints: &[ast::Path],
     lints_completions: &[Lint],
 ) {
-    let is_qualified = ctx.previous_token_is(T![:]);
     for &Lint { label, description } in lints_completions {
         let (qual, name) = {
             // FIXME: change `Lint`'s label to not store a path in it but split the prefix off instead?

--- a/crates/ide-completion/src/completions/dot.rs
+++ b/crates/ide-completion/src/completions/dot.rs
@@ -33,7 +33,7 @@ pub(crate) fn complete_dot(acc: &mut Completions, ctx: &CompletionContext, dot_a
             |acc, field, ty| acc.add_tuple_field(ctx, None, field, &ty),
         );
     }
-    complete_methods(ctx, &receiver_ty, |func| acc.add_method(ctx, func, None, None));
+    complete_methods(ctx, &receiver_ty, |func| acc.add_method(ctx, dot_access, func, None, None));
 }
 
 pub(crate) fn complete_undotted_self(
@@ -68,7 +68,17 @@ pub(crate) fn complete_undotted_self(
         |acc, field, ty| acc.add_tuple_field(ctx, Some(hir::known::SELF_PARAM), field, &ty),
     );
     complete_methods(ctx, &ty, |func| {
-        acc.add_method(ctx, func, Some(hir::known::SELF_PARAM), None)
+        acc.add_method(
+            ctx,
+            &DotAccess {
+                receiver: None,
+                receiver_ty: None,
+                kind: DotAccessKind::Method { has_parens: false },
+            },
+            func,
+            Some(hir::known::SELF_PARAM),
+            None,
+        )
     });
 }
 

--- a/crates/ide-completion/src/completions/expr.rs
+++ b/crates/ide-completion/src/completions/expr.rs
@@ -11,7 +11,7 @@ use crate::{
 pub(crate) fn complete_expr_path(
     acc: &mut Completions,
     ctx: &CompletionContext,
-    PathCompletionCtx { qualified, .. }: &PathCompletionCtx,
+    path_ctx @ PathCompletionCtx { qualified, .. }: &PathCompletionCtx,
     &ExprCtx {
         in_block_expr,
         in_loop_body,
@@ -34,11 +34,12 @@ pub(crate) fn complete_expr_path(
         ref_expr_parent.as_ref().map(|it| it.mut_token().is_none()).unwrap_or(false);
 
     let scope_def_applicable = |def| {
-        use hir::{GenericParam::*, ModuleDef::*};
         match def {
-            ScopeDef::GenericParam(LifetimeParam(_)) | ScopeDef::Label(_) => false,
+            ScopeDef::GenericParam(hir::GenericParam::LifetimeParam(_)) | ScopeDef::Label(_) => {
+                false
+            }
             // Don't suggest attribute macros and derives.
-            ScopeDef::ModuleDef(Macro(mac)) => mac.is_fn_like(ctx.db),
+            ScopeDef::ModuleDef(hir::ModuleDef::Macro(mac)) => mac.is_fn_like(ctx.db),
             _ => true,
         }
     };
@@ -49,7 +50,7 @@ pub(crate) fn complete_expr_path(
             .0
             .into_iter()
             .flat_map(|it| hir::Trait::from(it).items(ctx.sema.db))
-            .for_each(|item| add_assoc_item(acc, ctx, item)),
+            .for_each(|item| add_assoc_item(acc, ctx, path_ctx, item)),
         Qualified::With { resolution: None, .. } => {}
         Qualified::With { resolution: Some(resolution), .. } => {
             // Add associated types on type parameters and `Self`.
@@ -62,7 +63,7 @@ pub(crate) fn complete_expr_path(
                     let module_scope = module.scope(ctx.db, Some(ctx.module));
                     for (name, def) in module_scope {
                         if scope_def_applicable(def) {
-                            acc.add_resolution(ctx, name, def);
+                            acc.add_path_resolution(ctx, path_ctx, name, def);
                         }
                     }
                 }
@@ -73,7 +74,7 @@ pub(crate) fn complete_expr_path(
                     | hir::ModuleDef::BuiltinType(_)),
                 ) => {
                     if let &hir::ModuleDef::Adt(hir::Adt::Enum(e)) = def {
-                        add_enum_variants(acc, ctx, e);
+                        add_enum_variants(acc, ctx, path_ctx, e);
                     }
                     let ty = match def {
                         hir::ModuleDef::Adt(adt) => adt.ty(ctx.db),
@@ -81,7 +82,7 @@ pub(crate) fn complete_expr_path(
                             let ty = a.ty(ctx.db);
                             if let Some(hir::Adt::Enum(e)) = ty.as_adt() {
                                 cov_mark::hit!(completes_variant_through_alias);
-                                add_enum_variants(acc, ctx, e);
+                                add_enum_variants(acc, ctx, path_ctx, e);
                             }
                             ty
                         }
@@ -102,7 +103,7 @@ pub(crate) fn complete_expr_path(
                         Some(ctx.module),
                         None,
                         |item| {
-                            add_assoc_item(acc, ctx, item);
+                            add_assoc_item(acc, ctx, path_ctx, item);
                             None::<()>
                         },
                     );
@@ -118,7 +119,7 @@ pub(crate) fn complete_expr_path(
                 hir::PathResolution::Def(hir::ModuleDef::Trait(t)) => {
                     // Handles `Trait::assoc` as well as `<Ty as Trait>::assoc`.
                     for item in t.items(ctx.db) {
-                        add_assoc_item(acc, ctx, item);
+                        add_assoc_item(acc, ctx, path_ctx, item);
                     }
                 }
                 hir::PathResolution::TypeParam(_) | hir::PathResolution::SelfType(_) => {
@@ -129,7 +130,7 @@ pub(crate) fn complete_expr_path(
                     };
 
                     if let Some(hir::Adt::Enum(e)) = ty.as_adt() {
-                        add_enum_variants(acc, ctx, e);
+                        add_enum_variants(acc, ctx, path_ctx, e);
                     }
                     let mut seen = FxHashSet::default();
                     ty.iterate_path_candidates(
@@ -142,7 +143,7 @@ pub(crate) fn complete_expr_path(
                             // We might iterate candidates of a trait multiple times here, so deduplicate
                             // them.
                             if seen.insert(item) {
-                                add_assoc_item(acc, ctx, item);
+                                add_assoc_item(acc, ctx, path_ctx, item);
                             }
                             None::<()>
                         },
@@ -167,10 +168,16 @@ pub(crate) fn complete_expr_path(
                             .find_use_path(ctx.db, hir::ModuleDef::from(strukt))
                             .filter(|it| it.len() > 1);
 
-                        acc.add_struct_literal(ctx, strukt, path, None);
+                        acc.add_struct_literal(ctx, path_ctx, strukt, path, None);
 
                         if complete_self {
-                            acc.add_struct_literal(ctx, strukt, None, Some(hir::known::SELF_TYPE));
+                            acc.add_struct_literal(
+                                ctx,
+                                path_ctx,
+                                strukt,
+                                None,
+                                Some(hir::known::SELF_TYPE),
+                            );
                         }
                     }
                     hir::Adt::Union(un) => {
@@ -191,7 +198,7 @@ pub(crate) fn complete_expr_path(
                             e,
                             impl_,
                             |acc, ctx, variant, path| {
-                                acc.add_qualified_enum_variant(ctx, variant, path)
+                                acc.add_qualified_enum_variant(ctx, path_ctx, variant, path)
                             },
                         );
                     }
@@ -199,7 +206,7 @@ pub(crate) fn complete_expr_path(
             }
             ctx.process_all_names(&mut |name, def| {
                 if scope_def_applicable(def) {
-                    acc.add_resolution(ctx, name, def);
+                    acc.add_path_resolution(ctx, path_ctx, name, def);
                 }
             });
 
@@ -259,14 +266,26 @@ pub(crate) fn complete_expr_path(
     }
 }
 
-fn add_assoc_item(acc: &mut Completions, ctx: &CompletionContext, item: hir::AssocItem) {
+fn add_assoc_item(
+    acc: &mut Completions,
+    ctx: &CompletionContext,
+    path_ctx: &PathCompletionCtx,
+    item: hir::AssocItem,
+) {
     match item {
-        hir::AssocItem::Function(func) => acc.add_function(ctx, func, None),
+        hir::AssocItem::Function(func) => acc.add_function(ctx, path_ctx, func, None),
         hir::AssocItem::Const(ct) => acc.add_const(ctx, ct),
         hir::AssocItem::TypeAlias(ty) => acc.add_type_alias(ctx, ty),
     }
 }
 
-fn add_enum_variants(acc: &mut Completions, ctx: &CompletionContext, e: hir::Enum) {
-    e.variants(ctx.db).into_iter().for_each(|variant| acc.add_enum_variant(ctx, variant, None));
+fn add_enum_variants(
+    acc: &mut Completions,
+    ctx: &CompletionContext,
+    path_ctx: &PathCompletionCtx,
+    e: hir::Enum,
+) {
+    e.variants(ctx.db)
+        .into_iter()
+        .for_each(|variant| acc.add_enum_variant(ctx, path_ctx, variant, None));
 }

--- a/crates/ide-completion/src/completions/item_list.rs
+++ b/crates/ide-completion/src/completions/item_list.rs
@@ -42,7 +42,7 @@ pub(crate) fn complete_item_list(
             for (name, def) in module.scope(ctx.db, Some(ctx.module)) {
                 match def {
                     hir::ScopeDef::ModuleDef(hir::ModuleDef::Macro(m)) if m.is_fn_like(ctx.db) => {
-                        acc.add_macro(ctx, m, name)
+                        acc.add_macro(ctx, path_ctx, m, name)
                     }
                     hir::ScopeDef::ModuleDef(hir::ModuleDef::Module(m)) => {
                         acc.add_module(ctx, m, name)
@@ -59,7 +59,7 @@ pub(crate) fn complete_item_list(
         Qualified::No if ctx.qualifier_ctx.none() => {
             ctx.process_all_names(&mut |name, def| match def {
                 hir::ScopeDef::ModuleDef(hir::ModuleDef::Macro(m)) if m.is_fn_like(ctx.db) => {
-                    acc.add_macro(ctx, m, name)
+                    acc.add_macro(ctx, path_ctx, m, name)
                 }
                 hir::ScopeDef::ModuleDef(hir::ModuleDef::Module(m)) => acc.add_module(ctx, m, name),
                 _ => (),

--- a/crates/ide-completion/src/completions/pattern.rs
+++ b/crates/ide-completion/src/completions/pattern.rs
@@ -13,9 +13,9 @@ use crate::{
 pub(crate) fn complete_pattern(
     acc: &mut Completions,
     ctx: &CompletionContext,
-    patctx: &PatternContext,
+    pattern_ctx: &PatternContext,
 ) {
-    match patctx.parent_pat.as_ref() {
+    match pattern_ctx.parent_pat.as_ref() {
         Some(Pat::RangePat(_) | Pat::BoxPat(_)) => (),
         Some(Pat::RefPat(r)) => {
             if r.mut_token().is_none() {
@@ -24,7 +24,7 @@ pub(crate) fn complete_pattern(
         }
         _ => {
             let tok = ctx.token.text_range().start();
-            match (patctx.ref_token.as_ref(), patctx.mut_token.as_ref()) {
+            match (pattern_ctx.ref_token.as_ref(), pattern_ctx.mut_token.as_ref()) {
                 (None, None) => {
                     acc.add_keyword(ctx, "ref");
                     acc.add_keyword(ctx, "mut");
@@ -40,11 +40,11 @@ pub(crate) fn complete_pattern(
         }
     }
 
-    if patctx.record_pat.is_some() {
+    if pattern_ctx.record_pat.is_some() {
         return;
     }
 
-    let refutable = patctx.refutability == PatternRefutability::Refutable;
+    let refutable = pattern_ctx.refutability == PatternRefutability::Refutable;
     let single_variant_enum = |enum_: hir::Enum| ctx.db.enum_data(enum_.into()).variants.len() == 1;
 
     if let Some(hir::Adt::Enum(e)) =
@@ -55,9 +55,9 @@ pub(crate) fn complete_pattern(
                 acc,
                 ctx,
                 e,
-                &patctx.impl_,
+                &pattern_ctx.impl_,
                 |acc, ctx, variant, path| {
-                    acc.add_qualified_variant_pat(ctx, variant, path);
+                    acc.add_qualified_variant_pat(ctx, pattern_ctx, variant, path);
                 },
             );
         }
@@ -69,26 +69,39 @@ pub(crate) fn complete_pattern(
         let add_simple_path = match res {
             hir::ScopeDef::ModuleDef(def) => match def {
                 hir::ModuleDef::Adt(hir::Adt::Struct(strukt)) => {
-                    acc.add_struct_pat(ctx, strukt, Some(name.clone()));
+                    acc.add_struct_pat(ctx, pattern_ctx, strukt, Some(name.clone()));
                     true
                 }
                 hir::ModuleDef::Variant(variant)
                     if refutable || single_variant_enum(variant.parent_enum(ctx.db)) =>
                 {
-                    acc.add_variant_pat(ctx, variant, Some(name.clone()));
+                    acc.add_variant_pat(ctx, pattern_ctx, variant, Some(name.clone()));
                     true
                 }
                 hir::ModuleDef::Adt(hir::Adt::Enum(e)) => refutable || single_variant_enum(e),
                 hir::ModuleDef::Const(..) => refutable,
                 hir::ModuleDef::Module(..) => true,
                 hir::ModuleDef::Macro(mac) if mac.is_fn_like(ctx.db) => {
-                    return acc.add_macro(ctx, mac, name)
+                    return acc.add_macro(
+                        ctx,
+                        &PathCompletionCtx {
+                            has_call_parens: false,
+                            has_macro_bang: false,
+                            qualified: Qualified::No,
+                            parent: None,
+                            kind: crate::context::PathKind::Pat { pat_ctx: pattern_ctx.clone() },
+                            has_type_args: false,
+                            use_tree_parent: false,
+                        },
+                        mac,
+                        name,
+                    )
                 }
                 _ => false,
             },
             hir::ScopeDef::ImplSelfType(impl_) => match impl_.self_ty(ctx.db).as_adt() {
                 Some(hir::Adt::Struct(strukt)) => {
-                    acc.add_struct_pat(ctx, strukt, Some(name.clone()));
+                    acc.add_struct_pat(ctx, pattern_ctx, strukt, Some(name.clone()));
                     true
                 }
                 Some(hir::Adt::Enum(e)) => refutable || single_variant_enum(e),
@@ -111,7 +124,7 @@ pub(crate) fn complete_pattern(
 pub(crate) fn complete_pattern_path(
     acc: &mut Completions,
     ctx: &CompletionContext,
-    PathCompletionCtx { qualified, .. }: &PathCompletionCtx,
+    path_ctx @ PathCompletionCtx { qualified, .. }: &PathCompletionCtx,
 ) {
     match qualified {
         Qualified::With { resolution: Some(resolution), is_super_chain, .. } => {
@@ -132,7 +145,7 @@ pub(crate) fn complete_pattern_path(
                         };
 
                         if add_resolution {
-                            acc.add_resolution(ctx, name, def);
+                            acc.add_path_resolution(ctx, path_ctx, name, def);
                         }
                     }
                 }
@@ -150,9 +163,9 @@ pub(crate) fn complete_pattern_path(
                         }
                         hir::PathResolution::Def(hir::ModuleDef::Adt(hir::Adt::Enum(e))) => {
                             cov_mark::hit!(enum_plain_qualified_use_tree);
-                            e.variants(ctx.db)
-                                .into_iter()
-                                .for_each(|variant| acc.add_enum_variant(ctx, variant, None));
+                            e.variants(ctx.db).into_iter().for_each(|variant| {
+                                acc.add_enum_variant(ctx, path_ctx, variant, None)
+                            });
                             e.ty(ctx.db)
                         }
                         hir::PathResolution::Def(hir::ModuleDef::Adt(hir::Adt::Union(u))) => {
@@ -197,7 +210,7 @@ pub(crate) fn complete_pattern_path(
             ctx.process_all_names(&mut |name, res| {
                 // FIXME: properly filter here
                 if let ScopeDef::ModuleDef(_) = res {
-                    acc.add_resolution(ctx, name, res);
+                    acc.add_path_resolution(ctx, path_ctx, name, res);
                 }
             });
 

--- a/crates/ide-completion/src/completions/record.rs
+++ b/crates/ide-completion/src/completions/record.rs
@@ -1,9 +1,6 @@
 //! Complete fields in record literals and patterns.
 use ide_db::SymbolKind;
-use syntax::{
-    ast::{self, Expr},
-    T,
-};
+use syntax::ast::{self, Expr};
 
 use crate::{
     context::{ExprCtx, PathCompletionCtx, PatternContext, Qualified},
@@ -24,6 +21,7 @@ pub(crate) fn complete_record_expr_fields(
     acc: &mut Completions,
     ctx: &CompletionContext,
     record_expr: &ast::RecordExpr,
+    &dot_prefix: &bool,
 ) {
     let ty = ctx.sema.type_of_expr(&Expr::RecordExpr(record_expr.clone()));
 
@@ -45,7 +43,7 @@ pub(crate) fn complete_record_expr_fields(
             let missing_fields = ctx.sema.record_literal_missing_fields(record_expr);
 
             add_default_update(acc, ctx, ty, &missing_fields);
-            if ctx.previous_token_is(T![.]) {
+            if dot_prefix {
                 let mut item =
                     CompletionItem::new(CompletionItemKind::Snippet, ctx.source_range(), "..");
                 item.insert_text(".");

--- a/crates/ide-completion/src/completions/type.rs
+++ b/crates/ide-completion/src/completions/type.rs
@@ -13,7 +13,7 @@ use crate::{
 pub(crate) fn complete_type_path(
     acc: &mut Completions,
     ctx: &CompletionContext,
-    PathCompletionCtx { qualified, .. }: &PathCompletionCtx,
+    path_ctx @ PathCompletionCtx { qualified, .. }: &PathCompletionCtx,
     location: &TypeLocation,
 ) {
     let _p = profile::span("complete_type_path");
@@ -69,7 +69,7 @@ pub(crate) fn complete_type_path(
                     let module_scope = module.scope(ctx.db, Some(ctx.module));
                     for (name, def) in module_scope {
                         if scope_def_applicable(def) {
-                            acc.add_resolution(ctx, name, def);
+                            acc.add_path_resolution(ctx, path_ctx, name, def);
                         }
                     }
                 }
@@ -154,7 +154,7 @@ pub(crate) fn complete_type_path(
                         _ => false,
                     };
                     if add_resolution {
-                        acc.add_resolution(ctx, name, res);
+                        acc.add_path_resolution(ctx, path_ctx, name, res);
                     }
                 });
                 return;
@@ -178,7 +178,7 @@ pub(crate) fn complete_type_path(
             }
             ctx.process_all_names(&mut |name, def| {
                 if scope_def_applicable(def) {
-                    acc.add_resolution(ctx, name, def);
+                    acc.add_path_resolution(ctx, path_ctx, name, def);
                 }
             });
         }

--- a/crates/ide-completion/src/completions/use_.rs
+++ b/crates/ide-completion/src/completions/use_.rs
@@ -13,7 +13,7 @@ use crate::{
 pub(crate) fn complete_use_path(
     acc: &mut Completions,
     ctx: &CompletionContext,
-    PathCompletionCtx { qualified, use_tree_parent, .. }: &PathCompletionCtx,
+    path_ctx @ PathCompletionCtx { qualified, use_tree_parent, .. }: &PathCompletionCtx,
     name_ref: &Option<ast::NameRef>,
 ) {
     match qualified {
@@ -68,7 +68,7 @@ pub(crate) fn complete_use_path(
                         };
 
                         if add_resolution {
-                            let mut builder = Builder::from_resolution(ctx, name, def);
+                            let mut builder = Builder::from_resolution(ctx, path_ctx, name, def);
                             builder.set_relevance(CompletionRelevance {
                                 is_name_already_imported,
                                 ..Default::default()
@@ -81,7 +81,7 @@ pub(crate) fn complete_use_path(
                     cov_mark::hit!(enum_plain_qualified_use_tree);
                     e.variants(ctx.db)
                         .into_iter()
-                        .for_each(|variant| acc.add_enum_variant(ctx, variant, None));
+                        .for_each(|variant| acc.add_enum_variant(ctx, path_ctx, variant, None));
                 }
                 _ => {}
             }

--- a/crates/ide-completion/src/context/analysis.rs
+++ b/crates/ide-completion/src/context/analysis.rs
@@ -11,23 +11,23 @@ use syntax::{
 };
 
 use crate::context::{
-    AttrCtx, CompletionContext, DotAccess, DotAccessKind, ExprCtx, IdentContext, ItemListKind,
-    LifetimeContext, LifetimeKind, NameContext, NameKind, NameRefContext, NameRefKind, ParamKind,
-    PathCompletionCtx, PathKind, PatternContext, PatternRefutability, Qualified, QualifierCtx,
-    TypeAscriptionTarget, TypeLocation, COMPLETION_MARKER,
+    AttrCtx, CompletionAnalysis, CompletionContext, DotAccess, DotAccessKind, ExprCtx,
+    ItemListKind, LifetimeContext, LifetimeKind, NameContext, NameKind, NameRefContext,
+    NameRefKind, ParamKind, PathCompletionCtx, PathKind, PatternContext, PatternRefutability,
+    Qualified, QualifierCtx, TypeAscriptionTarget, TypeLocation, COMPLETION_MARKER,
 };
 
 impl<'a> CompletionContext<'a> {
     /// Expand attributes and macro calls at the current cursor position for both the original file
     /// and fake file repeatedly. As soon as one of the two expansions fail we stop so the original
     /// and speculative states stay in sync.
-    pub(super) fn expand_and_fill(
+    pub(super) fn expand_and_analyze(
         &mut self,
         mut original_file: SyntaxNode,
         mut speculative_file: SyntaxNode,
         mut offset: TextSize,
         mut fake_ident_token: SyntaxToken,
-    ) -> Option<()> {
+    ) -> Option<CompletionAnalysis> {
         let _p = profile::span("CompletionContext::expand_and_fill");
         let mut derive_ctx = None;
 
@@ -157,7 +157,7 @@ impl<'a> CompletionContext<'a> {
             break 'expansion;
         }
 
-        self.fill(&original_file, speculative_file, offset, derive_ctx)
+        self.analyze(&original_file, speculative_file, offset, derive_ctx)
     }
 
     /// Calculate the expected type and name of the cursor position.
@@ -311,13 +311,13 @@ impl<'a> CompletionContext<'a> {
 
     /// Fill the completion context, this is what does semantic reasoning about the surrounding context
     /// of the completion location.
-    fn fill(
+    fn analyze(
         &mut self,
         original_file: &SyntaxNode,
         file_with_fake_ident: SyntaxNode,
         offset: TextSize,
         derive_ctx: Option<(SyntaxNode, SyntaxNode, TextSize, ast::Attr)>,
-    ) -> Option<()> {
+    ) -> Option<CompletionAnalysis> {
         let fake_ident_token = file_with_fake_ident.token_at_offset(offset).right_biased()?;
         let syntax_element = NodeOrToken::Token(fake_ident_token);
         if is_in_token_of_for_loop(syntax_element.clone()) {
@@ -350,8 +350,7 @@ impl<'a> CompletionContext<'a> {
                             .collect(),
                     };
                 }
-                self.ident_ctx = IdentContext::NameRef(nameref_ctx);
-                return Some(());
+                return Some(CompletionAnalysis::NameRef(nameref_ctx));
             }
             return None;
         }
@@ -359,58 +358,54 @@ impl<'a> CompletionContext<'a> {
         let name_like = match find_node_at_offset(&file_with_fake_ident, offset) {
             Some(it) => it,
             None => {
-                if let Some(original) = ast::String::cast(self.original_token.clone()) {
-                    self.ident_ctx = IdentContext::String {
-                        original,
-                        expanded: ast::String::cast(self.token.clone()),
-                    };
-                } else {
-                    // Fix up trailing whitespace problem
-                    // #[attr(foo = $0
-                    let token =
-                        syntax::algo::skip_trivia_token(self.token.clone(), Direction::Prev)?;
-                    let p = token.parent()?;
-                    if p.kind() == SyntaxKind::TOKEN_TREE
-                        && p.ancestors().any(|it| it.kind() == SyntaxKind::META)
-                    {
-                        let colon_prefix = previous_non_trivia_token(self.token.clone())
-                            .map_or(false, |it| T![:] == it.kind());
-                        self.ident_ctx = IdentContext::UnexpandedAttrTT {
-                            fake_attribute_under_caret: syntax_element
-                                .ancestors()
-                                .find_map(ast::Attr::cast),
-                            colon_prefix,
-                        };
+                let analysis =
+                    if let Some(original) = ast::String::cast(self.original_token.clone()) {
+                        CompletionAnalysis::String {
+                            original,
+                            expanded: ast::String::cast(self.token.clone()),
+                        }
                     } else {
-                        return None;
-                    }
-                }
-                return Some(());
+                        // Fix up trailing whitespace problem
+                        // #[attr(foo = $0
+                        let token =
+                            syntax::algo::skip_trivia_token(self.token.clone(), Direction::Prev)?;
+                        let p = token.parent()?;
+                        if p.kind() == SyntaxKind::TOKEN_TREE
+                            && p.ancestors().any(|it| it.kind() == SyntaxKind::META)
+                        {
+                            let colon_prefix = previous_non_trivia_token(self.token.clone())
+                                .map_or(false, |it| T![:] == it.kind());
+                            CompletionAnalysis::UnexpandedAttrTT {
+                                fake_attribute_under_caret: syntax_element
+                                    .ancestors()
+                                    .find_map(ast::Attr::cast),
+                                colon_prefix,
+                            }
+                        } else {
+                            return None;
+                        }
+                    };
+                return Some(analysis);
             }
         };
-
-        match name_like {
-            ast::NameLike::Lifetime(lifetime) => {
-                self.ident_ctx = IdentContext::Lifetime(Self::classify_lifetime(
-                    &self.sema,
-                    original_file,
-                    lifetime,
-                )?);
-            }
+        let analysis = match name_like {
+            ast::NameLike::Lifetime(lifetime) => CompletionAnalysis::Lifetime(
+                Self::classify_lifetime(&self.sema, original_file, lifetime)?,
+            ),
             ast::NameLike::NameRef(name_ref) => {
                 let parent = name_ref.syntax().parent()?;
                 let (nameref_ctx, qualifier_ctx) =
                     Self::classify_name_ref(&self.sema, &original_file, name_ref, parent.clone())?;
 
                 self.qualifier_ctx = qualifier_ctx;
-                self.ident_ctx = IdentContext::NameRef(nameref_ctx);
+                CompletionAnalysis::NameRef(nameref_ctx)
             }
             ast::NameLike::Name(name) => {
                 let name_ctx = Self::classify_name(&self.sema, original_file, name)?;
-                self.ident_ctx = IdentContext::Name(name_ctx);
+                CompletionAnalysis::Name(name_ctx)
             }
-        }
-        Some(())
+        };
+        Some(analysis)
     }
 
     fn classify_lifetime(

--- a/crates/ide-completion/src/context/tests.rs
+++ b/crates/ide-completion/src/context/tests.rs
@@ -9,7 +9,7 @@ use crate::{
 fn check_expected_type_and_name(ra_fixture: &str, expect: Expect) {
     let (db, pos) = position(ra_fixture);
     let config = TEST_CONFIG;
-    let completion_context = CompletionContext::new(&db, pos, &config).unwrap();
+    let (completion_context, _analysis) = CompletionContext::new(&db, pos, &config).unwrap();
 
     let ty = completion_context
         .expected_type

--- a/crates/ide-completion/src/item.rs
+++ b/crates/ide-completion/src/item.rs
@@ -10,8 +10,8 @@ use syntax::{SmolStr, TextRange};
 use text_edit::TextEdit;
 
 use crate::{
-    context::CompletionContext,
-    render::{render_resolution, RenderContext},
+    context::{CompletionContext, PathCompletionCtx},
+    render::{render_path_resolution, RenderContext},
 };
 
 /// `CompletionItem` describes a single completion variant in the editor pop-up.
@@ -434,10 +434,11 @@ pub(crate) struct Builder {
 impl Builder {
     pub(crate) fn from_resolution(
         ctx: &CompletionContext,
+        path_ctx: &PathCompletionCtx,
         local_name: hir::Name,
         resolution: hir::ScopeDef,
     ) -> Self {
-        render_resolution(RenderContext::new(ctx), local_name, resolution)
+        render_path_resolution(RenderContext::new(ctx), path_ctx, local_name, resolution)
     }
 
     pub(crate) fn build(self) -> CompletionItem {

--- a/crates/ide-completion/src/lib.rs
+++ b/crates/ide-completion/src/lib.rs
@@ -181,8 +181,16 @@ pub fn completions(
                 completions::extern_abi::complete_extern_abi(acc, ctx, expanded);
                 completions::format_string::format_string(acc, ctx, original, expanded);
             }
-            IdentContext::UnexpandedAttrTT { fake_attribute_under_caret: Some(attr) } => {
-                completions::attribute::complete_known_attribute_input(acc, ctx, attr);
+            IdentContext::UnexpandedAttrTT {
+                colon_prefix,
+                fake_attribute_under_caret: Some(attr),
+            } => {
+                completions::attribute::complete_known_attribute_input(
+                    acc,
+                    ctx,
+                    colon_prefix,
+                    attr,
+                );
             }
             IdentContext::UnexpandedAttrTT { .. } | IdentContext::String { .. } => (),
         }

--- a/crates/ide-completion/src/tests/flyimport.rs
+++ b/crates/ide-completion/src/tests/flyimport.rs
@@ -1,22 +1,22 @@
 use expect_test::{expect, Expect};
 
 use crate::{
-    context::{IdentContext, NameContext, NameKind, NameRefKind},
+    context::{CompletionAnalysis, NameContext, NameKind, NameRefKind},
     tests::{check_edit, check_edit_with_config, TEST_CONFIG},
 };
 
 fn check(ra_fixture: &str, expect: Expect) {
     let config = TEST_CONFIG;
     let (db, position) = crate::tests::position(ra_fixture);
-    let ctx = crate::context::CompletionContext::new(&db, position, &config).unwrap();
+    let (ctx, analysis) = crate::context::CompletionContext::new(&db, position, &config).unwrap();
 
     let mut acc = crate::completions::Completions::default();
-    if let IdentContext::Name(NameContext { kind: NameKind::IdentPat(pat_ctx), .. }) =
-        &ctx.ident_ctx
+    if let CompletionAnalysis::Name(NameContext { kind: NameKind::IdentPat(pat_ctx), .. }) =
+        &analysis
     {
         crate::completions::flyimport::import_on_the_fly_pat(&mut acc, &ctx, pat_ctx);
     }
-    if let IdentContext::NameRef(name_ref_ctx) = &ctx.ident_ctx {
+    if let CompletionAnalysis::NameRef(name_ref_ctx) = &analysis {
         match &name_ref_ctx.kind {
             NameRefKind::Path(path) => {
                 crate::completions::flyimport::import_on_the_fly_path(&mut acc, &ctx, path);


### PR DESCRIPTION
Makes things a bit messy overall, but with this I can start cleaning up the render functions properly now.
cc https://github.com/rust-lang/rust-analyzer/issues/12571