### PR TITLE
fix: Don't trigger pattern completions when typing a wildcard pattern

### DIFF
--- a/crates/ide-completion/src/completions.rs
+++ b/crates/ide-completion/src/completions.rs
@@ -489,7 +489,11 @@ pub(super) fn complete_name(
         NameKind::Function => {
             item_list::trait_impl::complete_trait_impl_fn(acc, ctx, name);
         }
-        NameKind::IdentPat(pattern_ctx) => complete_patterns(acc, ctx, pattern_ctx),
+        NameKind::IdentPat(pattern_ctx) => {
+            if ctx.token.kind() != syntax::T![_] {
+                complete_patterns(acc, ctx, pattern_ctx)
+            }
+        }
         NameKind::Module(mod_under_caret) => {
             mod_::complete_mod(acc, ctx, mod_under_caret);
         }

--- a/crates/ide-completion/src/tests/pattern.rs
+++ b/crates/ide-completion/src/tests/pattern.rs
@@ -14,6 +14,18 @@ fn check(ra_fixture: &str, expect: Expect) {
 }
 
 #[test]
+fn wildcard() {
+    check(
+        r#"
+fn quux() {
+    let _$0
+}
+"#,
+        expect![""],
+    );
+}
+
+#[test]
 fn ident_rebind_pat() {
     check_empty(
         r#"


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust-analyzer/issues/12592