### PR TITLE
fix: Only apply `cfg(test)` for local crates

### DIFF
--- a/crates/project-model/src/tests.rs
+++ b/crates/project-model/src/tests.rs
@@ -1041,7 +1041,6 @@ fn cargo_hello_world_project_model() {
                                 "debug_assertions",
                                 "feature=default",
                                 "feature=std",
-                                "test",
                             ],
                         ),
                         potential_cfg_options: CfgOptions(
@@ -1054,7 +1053,6 @@ fn cargo_hello_world_project_model() {
                                 "feature=rustc-dep-of-std",
                                 "feature=std",
                                 "feature=use_std",
-                                "test",
                             ],
                         ),
                         env: Env {

--- a/crates/project-model/src/workspace.rs
+++ b/crates/project-model/src/workspace.rs
@@ -541,8 +541,6 @@ fn cargo_to_crate_graph(
 
     let mut pkg_to_lib_crate = FxHashMap::default();
 
-    // Add test cfg for non-sysroot crates
-    cfg_options.insert_atom("test".into());
     cfg_options.insert_atom("debug_assertions".into());
 
     let mut pkg_crates = FxHashMap::default();
@@ -557,6 +555,13 @@ fn cargo_to_crate_graph(
             CfgOverrides::Wildcard(cfg_diff) => Some(cfg_diff),
             CfgOverrides::Selective(cfg_overrides) => cfg_overrides.get(&cargo[pkg].name),
         };
+
+        // Add test cfg for local crates
+        if cargo[pkg].is_local {
+            replaced_cfg_options = cfg_options.clone();
+            replaced_cfg_options.insert_atom("test".into());
+            cfg_options = &replaced_cfg_options;
+        }
 
         if let Some(overrides) = overrides {
             // FIXME: this is sort of a hack to deal with #![cfg(not(test))] vanishing such as seen


### PR DESCRIPTION
Don't analyze dependencies with `test`; this should fix various cases where crates use `cfg(not(test))` and so we didn't find things.

"Local" here currently means anything that's not from the registry, so anything inside the workspace, but also path dependencies. So this isn't perfect, and users might still need to use `rust-analyzer.cargo.unsetTest` for these in some cases.