### PR TITLE
fix: doc_links link type - Determine link type at start (fixes #12601)

### DIFF
--- a/crates/ide/src/doc_links.rs
+++ b/crates/ide/src/doc_links.rs
@@ -362,14 +362,15 @@ fn map_links<'e>(
     // holds the origin link target on start event and the rewritten one on end event
     let mut end_link_target: Option<CowStr> = None;
     // normally link's type is determined by the type of link tag in the end event,
-    // however in same cases we want to change the link type, for example,
+    // however in some cases we want to change the link type, for example,
     // `Shortcut` type doesn't make sense for url links
     let mut end_link_type: Option<LinkType> = None;
 
     events.map(move |evt| match evt {
-        Event::Start(Tag::Link(_, ref target, _)) => {
+        Event::Start(Tag::Link(link_type, ref target, _)) => {
             in_link = true;
             end_link_target = Some(target.clone());
+            end_link_type = Some(link_type);
             evt
         }
         Event::End(Tag::Link(link_type, target, _)) => {
@@ -381,17 +382,13 @@ fn map_links<'e>(
             ))
         }
         Event::Text(s) if in_link => {
-            let (link_type, link_target_s, link_name) =
-                callback(&end_link_target.take().unwrap(), &s);
+            let (_, link_target_s, link_name) = callback(&end_link_target.take().unwrap(), &s);
             end_link_target = Some(CowStr::Boxed(link_target_s.into()));
-            end_link_type = link_type;
             Event::Text(CowStr::Boxed(link_name.into()))
         }
         Event::Code(s) if in_link => {
-            let (link_type, link_target_s, link_name) =
-                callback(&end_link_target.take().unwrap(), &s);
+            let (_, link_target_s, link_name) = callback(&end_link_target.take().unwrap(), &s);
             end_link_target = Some(CowStr::Boxed(link_target_s.into()));
-            end_link_type = link_type;
             Event::Code(CowStr::Boxed(link_name.into()))
         }
         _ => evt,

--- a/crates/ide/src/doc_links.rs
+++ b/crates/ide/src/doc_links.rs
@@ -382,13 +382,21 @@ fn map_links<'e>(
             ))
         }
         Event::Text(s) if in_link => {
-            let (_, link_target_s, link_name) = callback(&end_link_target.take().unwrap(), &s);
+            let (link_type, link_target_s, link_name) =
+                callback(&end_link_target.take().unwrap(), &s);
             end_link_target = Some(CowStr::Boxed(link_target_s.into()));
+            if !matches!(end_link_type, Some(link) if link == LinkType::Autolink) {
+                end_link_type = link_type;
+            }
             Event::Text(CowStr::Boxed(link_name.into()))
         }
         Event::Code(s) if in_link => {
-            let (_, link_target_s, link_name) = callback(&end_link_target.take().unwrap(), &s);
+            let (link_type, link_target_s, link_name) =
+                callback(&end_link_target.take().unwrap(), &s);
             end_link_target = Some(CowStr::Boxed(link_target_s.into()));
+            if !matches!(end_link_type, Some(link) if link == LinkType::Autolink) {
+                end_link_type = link_type;
+            }
             Event::Code(CowStr::Boxed(link_name.into()))
         }
         _ => evt,

--- a/crates/ide/src/doc_links.rs
+++ b/crates/ide/src/doc_links.rs
@@ -385,7 +385,7 @@ fn map_links<'e>(
             let (link_type, link_target_s, link_name) =
                 callback(&end_link_target.take().unwrap(), &s);
             end_link_target = Some(CowStr::Boxed(link_target_s.into()));
-            if !matches!(end_link_type, Some(link) if link == LinkType::Autolink) {
+            if !matches!(end_link_type, Some(LinkType::Autolink)) {
                 end_link_type = link_type;
             }
             Event::Text(CowStr::Boxed(link_name.into()))
@@ -394,7 +394,7 @@ fn map_links<'e>(
             let (link_type, link_target_s, link_name) =
                 callback(&end_link_target.take().unwrap(), &s);
             end_link_target = Some(CowStr::Boxed(link_target_s.into()));
-            if !matches!(end_link_type, Some(link) if link == LinkType::Autolink) {
+            if !matches!(end_link_type, Some(LinkType::Autolink)) {
                 end_link_type = link_type;
             }
             Event::Code(CowStr::Boxed(link_name.into()))

--- a/crates/ide/src/doc_links.rs
+++ b/crates/ide/src/doc_links.rs
@@ -363,7 +363,7 @@ fn map_links<'e>(
     let mut end_link_target: Option<CowStr> = None;
     // normally link's type is determined by the type of link tag in the end event,
     // however in some cases we want to change the link type, for example,
-    // `Shortcut` type doesn't make sense for url links
+    // `Shortcut` type parsed from Start/End tags doesn't make sense for url links
     let mut end_link_type: Option<LinkType> = None;
 
     events.map(move |evt| match evt {

--- a/crates/ide/src/hover/tests.rs
+++ b/crates/ide/src/hover/tests.rs
@@ -3808,6 +3808,7 @@ fn foo() {
 /// [closure]
 /// [closures][closure]
 /// [threads]
+/// <https://doc.rust-lang.org/nightly/book/ch13-01-closures.html>
 ///
 /// [closure]: ../book/ch13-01-closures.html
 /// [threads]: ../book/ch16-01-threads.html#using-move-closures-with-threads
@@ -3825,6 +3826,7 @@ mod move_keyword {}
             [closure](https://doc.rust-lang.org/nightly/book/ch13-01-closures.html)
             [closures](https://doc.rust-lang.org/nightly/book/ch13-01-closures.html)
             [threads](https://doc.rust-lang.org/nightly/book/ch16-01-threads.html#using-move-closures-with-threads)
+            <https://doc.rust-lang.org/nightly/book/ch13-01-closures.html>
         "##]],
     );
 }


### PR DESCRIPTION
fixes #12601
Looked like autolink/inline mismatch happened because end_link_type was parsed from the Text/Code events.
I changed it to be determined from the Start event, which should hopefully remain accurate while staying true to the cases where link type may need to be changed, according to the comment 
```
// normally link's type is determined by the type of link tag in the end event,
// however in some cases we want to change the link type, for example,
// `Shortcut` type doesn't make sense for url links
```
Hopefully this is the desired behavior?
![Untitled](https://user-images.githubusercontent.com/59463268/174696581-3b1140a5-cdf0-4eda-9a11-ec648e4e7d21.gif)

