### PR TITLE
#[target_feature = ...] completion is incorrect

### DIFF
--- a/crates/ide-completion/src/completions/attribute.rs
+++ b/crates/ide-completion/src/completions/attribute.rs
@@ -330,7 +330,7 @@ const ATTRIBUTES: &[AttrCompletion] = &[
     attr("repr(…)", Some("repr"), Some("repr(${0:C})")),
     attr("should_panic", Some("should_panic"), Some(r#"should_panic"#)),
     attr(
-        r#"target_feature = "…""#,
+        r#"target_feature(enable = "…")"#,
         Some("target_feature"),
         Some(r#"target_feature = "${0:feature}""#),
     ),

--- a/crates/ide-completion/src/completions/attribute.rs
+++ b/crates/ide-completion/src/completions/attribute.rs
@@ -330,9 +330,9 @@ const ATTRIBUTES: &[AttrCompletion] = &[
     attr("repr(…)", Some("repr"), Some("repr(${0:C})")),
     attr("should_panic", Some("should_panic"), Some(r#"should_panic"#)),
     attr(
-        r#"target_feature(enable = "…")"#,
+        r#"[target_feature(enable = "…")]"#,
         Some("target_feature"),
-        Some(r#[target_feature(enable = "...")]#),
+        Some(r#"target_feature = "${0:feature}""#),
     ),
     attr("test", None, None),
     attr("track_caller", None, None),

--- a/crates/ide-completion/src/completions/attribute.rs
+++ b/crates/ide-completion/src/completions/attribute.rs
@@ -332,7 +332,7 @@ const ATTRIBUTES: &[AttrCompletion] = &[
     attr(
         r#"target_feature(enable = "…")"#,
         Some("target_feature"),
-        Some(r#"target_feature = "${0:feature}""#),
+        Some(r#[target_feature(enable = "...")]#),
     ),
     attr("test", None, None),
     attr("track_caller", None, None),


### PR DESCRIPTION
https://github.com/rust-lang/rust-analyzer/issues/12616

We complete #[target_feature = "..."], but this form is not accepted. The correct form is #[target_feature(enable = "...")].