### PR TITLE
fix: trailing ':' on empty inactive reasons

### DIFF
--- a/crates/ide-diagnostics/src/handlers/inactive_code.rs
+++ b/crates/ide-diagnostics/src/handlers/inactive_code.rs
@@ -19,7 +19,13 @@ pub(crate) fn inactive_code(
     let mut message = "code is inactive due to #[cfg] directives".to_string();
 
     if let Some(inactive) = inactive {
-        format_to!(message, ": {}", inactive);
+        let inactive_reasons = inactive.to_string();
+
+        if inactive_reasons.is_empty() {
+            format_to!(message);
+        } else {
+            format_to!(message, ": {}", inactive);
+        }
     }
 
     let res = Diagnostic::new(
@@ -91,6 +97,9 @@ fn f() {
 
     #[cfg(feature = "std")] use std;
   //^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ weak: code is inactive due to #[cfg] directives: feature = "std" is disabled
+
+    #[cfg(any())] pub fn f() {}
+  //^^^^^^^^^^^^^^^^^^^^^^^^^^^ weak: code is inactive due to #[cfg] directives
 "#,
         );
     }


### PR DESCRIPTION
## Description
Fixes trailing ':' even when there is no explanation. e.g.
``` sh
code is inactive due to #[cfg] directives: 
```
## Issue
Fixes: #12615