### PR TITLE
fix: Improve proc macro errors a bit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -538,6 +538,7 @@ dependencies = [
  "mbe",
  "profile",
  "rustc-hash",
+ "stdx",
  "syntax",
  "tracing",
  "tt",

--- a/crates/hir-def/src/nameres/collector.rs
+++ b/crates/hir-def/src/nameres/collector.rs
@@ -436,7 +436,7 @@ impl DefCollector<'_> {
         let mut unresolved_macros = mem::take(&mut self.unresolved_macros);
         let pos = unresolved_macros.iter().position(|directive| {
             if let MacroDirectiveKind::Attr { ast_id, mod_item, attr, tree } = &directive.kind {
-                self.def_map.diagnostics.push(DefDiagnostic::unresolved_proc_macro(
+                self.def_map.diagnostics.push(DefDiagnostic::unresolved_macro_call(
                     directive.module_id,
                     MacroCallKind::Attr {
                         ast_id: ast_id.ast_id,
@@ -444,7 +444,7 @@ impl DefCollector<'_> {
                         invoc_attr_index: attr.id.ast_index,
                         is_derive: false,
                     },
-                    None,
+                    attr.path().clone(),
                 ));
 
                 self.skip_attrs.insert(ast_id.ast_id.with_value(*mod_item), attr.id);
@@ -1218,10 +1218,6 @@ impl DefCollector<'_> {
                         return recollect_without(self);
                     }
 
-                    if !self.db.enable_proc_attr_macros() {
-                        return true;
-                    }
-
                     // Not resolved to a derive helper or the derive attribute, so try to treat as a normal attribute.
                     let call_id = attr_macro_as_call_id(
                         self.db,
@@ -1232,6 +1228,15 @@ impl DefCollector<'_> {
                         false,
                     );
                     let loc: MacroCallLoc = self.db.lookup_intern_macro_call(call_id);
+
+                    if !self.db.enable_proc_attr_macros() {
+                        self.def_map.diagnostics.push(DefDiagnostic::unresolved_proc_macro(
+                            directive.module_id,
+                            loc.kind,
+                            Some(loc.def.krate),
+                        ));
+                        return recollect_without(self);
+                    }
 
                     // Skip #[test]/#[bench] expansion, which would merely result in more memory usage
                     // due to duplicating functions into macro expansions

--- a/crates/hir-expand/Cargo.toml
+++ b/crates/hir-expand/Cargo.toml
@@ -20,6 +20,7 @@ hashbrown = { version = "0.12.1", features = [
     "inline-more",
 ], default-features = false }
 
+stdx = { path = "../stdx", version = "0.0.0" }
 base-db = { path = "../base-db", version = "0.0.0" }
 cfg = { path = "../cfg", version = "0.0.0" }
 syntax = { path = "../syntax", version = "0.0.0" }

--- a/crates/hir-expand/src/proc_macro.rs
+++ b/crates/hir-expand/src/proc_macro.rs
@@ -1,6 +1,7 @@
 //! Proc Macro Expander stub
 
 use base_db::{CrateId, ProcMacroExpansionError, ProcMacroId, ProcMacroKind};
+use stdx::never;
 
 use crate::{db::AstDatabase, ExpandError, ExpandResult};
 
@@ -36,18 +37,20 @@ impl ProcMacroExpander {
                 let krate_graph = db.crate_graph();
                 let proc_macros = match &krate_graph[self.krate].proc_macro {
                     Ok(proc_macros) => proc_macros,
-                    Err(e) => {
-                        return ExpandResult::only_err(ExpandError::Other(
-                            e.clone().into_boxed_str(),
-                        ))
+                    Err(_) => {
+                        never!("Non-dummy expander even though there are no proc macros");
+                        return ExpandResult::only_err(ExpandError::Other("Internal error".into()));
                     }
                 };
                 let proc_macro = match proc_macros.get(id.0 as usize) {
                     Some(proc_macro) => proc_macro,
                     None => {
-                        return ExpandResult::only_err(ExpandError::Other(
-                            "No proc-macro found.".into(),
-                        ))
+                        never!(
+                            "Proc macro index out of bounds: the length is {} but the index is {}",
+                            proc_macros.len(),
+                            id.0
+                        );
+                        return ExpandResult::only_err(ExpandError::Other("Internal error".into()));
                     }
                 };
 

--- a/crates/hir/src/diagnostics.rs
+++ b/crates/hir/src/diagnostics.rs
@@ -69,6 +69,7 @@ pub struct UnresolvedImport {
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct UnresolvedMacroCall {
     pub macro_call: InFile<SyntaxNodePtr>,
+    pub precise_location: Option<TextRange>,
     pub path: ModPath,
     pub is_bang: bool,
 }
@@ -95,6 +96,7 @@ pub struct UnresolvedProcMacro {
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct MacroError {
     pub node: InFile<SyntaxNodePtr>,
+    pub precise_location: Option<TextRange>,
     pub message: String,
 }
 

--- a/crates/ide-diagnostics/src/handlers/unresolved_macro_call.rs
+++ b/crates/ide-diagnostics/src/handlers/unresolved_macro_call.rs
@@ -1,6 +1,3 @@
-use hir::{db::AstDatabase, InFile};
-use syntax::{ast, AstNode, SyntaxNodePtr};
-
 use crate::{Diagnostic, DiagnosticsContext};
 
 // Diagnostic: unresolved-macro-call
@@ -11,25 +8,16 @@ pub(crate) fn unresolved_macro_call(
     ctx: &DiagnosticsContext<'_>,
     d: &hir::UnresolvedMacroCall,
 ) -> Diagnostic {
-    let last_path_segment = ctx.sema.db.parse_or_expand(d.macro_call.file_id).and_then(|root| {
-        let node = d.macro_call.value.to_node(&root);
-        if let Some(macro_call) = ast::MacroCall::cast(node) {
-            macro_call
-                .path()
-                .and_then(|it| it.segment())
-                .and_then(|it| it.name_ref())
-                .map(|it| InFile::new(d.macro_call.file_id, SyntaxNodePtr::new(it.syntax())))
-        } else {
-            None
-        }
-    });
-    let diagnostics = last_path_segment.unwrap_or_else(|| d.macro_call.clone().map(|it| it.into()));
+    // Use more accurate position if available.
+    let display_range = d
+        .precise_location
+        .unwrap_or_else(|| ctx.sema.diagnostics_display_range(d.macro_call.clone()).range);
 
     let bang = if d.is_bang { "!" } else { "" };
     Diagnostic::new(
         "unresolved-macro-call",
         format!("unresolved macro `{}{}`", d.path, bang),
-        ctx.sema.diagnostics_display_range(diagnostics).range,
+        display_range,
     )
     .experimental()
 }

--- a/crates/project-model/src/tests.rs
+++ b/crates/project-model/src/tests.rs
@@ -172,8 +172,8 @@ fn cargo_hello_world_project_model_with_wildcard_overrides() {
                                 prelude: true,
                             },
                         ],
-                        proc_macro: Ok(
-                            [],
+                        proc_macro: Err(
+                            "no build data",
                         ),
                         origin: CratesIo {
                             repo: None,
@@ -247,8 +247,8 @@ fn cargo_hello_world_project_model_with_wildcard_overrides() {
                                 prelude: true,
                             },
                         ],
-                        proc_macro: Ok(
-                            [],
+                        proc_macro: Err(
+                            "no build data",
                         ),
                         origin: CratesIo {
                             repo: None,
@@ -312,8 +312,8 @@ fn cargo_hello_world_project_model_with_wildcard_overrides() {
                             },
                         },
                         dependencies: [],
-                        proc_macro: Ok(
-                            [],
+                        proc_macro: Err(
+                            "no build data",
                         ),
                         origin: CratesIo {
                             repo: Some(
@@ -389,8 +389,8 @@ fn cargo_hello_world_project_model_with_wildcard_overrides() {
                                 prelude: true,
                             },
                         ],
-                        proc_macro: Ok(
-                            [],
+                        proc_macro: Err(
+                            "no build data",
                         ),
                         origin: CratesIo {
                             repo: None,
@@ -464,8 +464,8 @@ fn cargo_hello_world_project_model_with_wildcard_overrides() {
                                 prelude: true,
                             },
                         ],
-                        proc_macro: Ok(
-                            [],
+                        proc_macro: Err(
+                            "no build data",
                         ),
                         origin: CratesIo {
                             repo: None,
@@ -554,8 +554,8 @@ fn cargo_hello_world_project_model_with_selective_overrides() {
                                 prelude: true,
                             },
                         ],
-                        proc_macro: Ok(
-                            [],
+                        proc_macro: Err(
+                            "no build data",
                         ),
                         origin: CratesIo {
                             repo: None,
@@ -631,8 +631,8 @@ fn cargo_hello_world_project_model_with_selective_overrides() {
                                 prelude: true,
                             },
                         ],
-                        proc_macro: Ok(
-                            [],
+                        proc_macro: Err(
+                            "no build data",
                         ),
                         origin: CratesIo {
                             repo: None,
@@ -696,8 +696,8 @@ fn cargo_hello_world_project_model_with_selective_overrides() {
                             },
                         },
                         dependencies: [],
-                        proc_macro: Ok(
-                            [],
+                        proc_macro: Err(
+                            "no build data",
                         ),
                         origin: CratesIo {
                             repo: Some(
@@ -775,8 +775,8 @@ fn cargo_hello_world_project_model_with_selective_overrides() {
                                 prelude: true,
                             },
                         ],
-                        proc_macro: Ok(
-                            [],
+                        proc_macro: Err(
+                            "no build data",
                         ),
                         origin: CratesIo {
                             repo: None,
@@ -852,8 +852,8 @@ fn cargo_hello_world_project_model_with_selective_overrides() {
                                 prelude: true,
                             },
                         ],
-                        proc_macro: Ok(
-                            [],
+                        proc_macro: Err(
+                            "no build data",
                         ),
                         origin: CratesIo {
                             repo: None,
@@ -933,8 +933,8 @@ fn cargo_hello_world_project_model() {
                                 prelude: true,
                             },
                         ],
-                        proc_macro: Ok(
-                            [],
+                        proc_macro: Err(
+                            "no build data",
                         ),
                         origin: CratesIo {
                             repo: None,
@@ -1010,8 +1010,8 @@ fn cargo_hello_world_project_model() {
                                 prelude: true,
                             },
                         ],
-                        proc_macro: Ok(
-                            [],
+                        proc_macro: Err(
+                            "no build data",
                         ),
                         origin: CratesIo {
                             repo: None,
@@ -1075,8 +1075,8 @@ fn cargo_hello_world_project_model() {
                             },
                         },
                         dependencies: [],
-                        proc_macro: Ok(
-                            [],
+                        proc_macro: Err(
+                            "no build data",
                         ),
                         origin: CratesIo {
                             repo: Some(
@@ -1154,8 +1154,8 @@ fn cargo_hello_world_project_model() {
                                 prelude: true,
                             },
                         ],
-                        proc_macro: Ok(
-                            [],
+                        proc_macro: Err(
+                            "no build data",
                         ),
                         origin: CratesIo {
                             repo: None,
@@ -1231,8 +1231,8 @@ fn cargo_hello_world_project_model() {
                                 prelude: true,
                             },
                         ],
-                        proc_macro: Ok(
-                            [],
+                        proc_macro: Err(
+                            "no build data",
                         ),
                         origin: CratesIo {
                             repo: None,
@@ -1505,8 +1505,8 @@ fn rust_project_hello_world_project_model() {
                                 prelude: false,
                             },
                         ],
-                        proc_macro: Ok(
-                            [],
+                        proc_macro: Err(
+                            "no proc macro dylib present",
                         ),
                         origin: CratesIo {
                             repo: None,

--- a/crates/project-model/src/workspace.rs
+++ b/crates/project-model/src/workspace.rs
@@ -459,7 +459,7 @@ fn project_json_to_crate_graph(
                     krate.display_name.as_ref().map(|it| it.canonical_name()).unwrap_or(""),
                     &it,
                 ),
-                None => Ok(Vec::new()),
+                None => Err("no proc macro dylib present".into()),
             };
 
             let target_cfgs = match krate.target.as_deref() {
@@ -870,9 +870,10 @@ fn add_target_crate_root(
         }
     }
 
-    let proc_macro = match build_data.as_ref().and_then(|it| it.proc_macro_dylib_path.as_ref()) {
-        Some(it) => load_proc_macro(it),
-        None => Ok(Vec::new()),
+    let proc_macro = match build_data.as_ref().map(|it| it.proc_macro_dylib_path.as_ref()) {
+        Some(Some(it)) => load_proc_macro(it),
+        Some(None) => Err("no proc macro dylib present".into()),
+        None => Err("no build data".into()),
     };
 
     let display_name = CrateDisplayName::from_canonical_name(cargo_name.to_string());


### PR DESCRIPTION
Distinguish between
 - there is no build data (for some reason?)
 - there is build data, but the cargo package didn't build a proc macro dylib
 - there is a proc macro dylib, but it didn't contain the proc macro we expected
 - the name did not resolve to any macro (this is now an
 unresolved_macro_call even for attributes)

I changed the handling of disabled attribute macro expansion to
immediately ignore the macro and report an unresolved_proc_macro,
because otherwise they would now result in loud unresolved_macro_call
errors. I hope this doesn't break anything.

Also try to improve error ranges for unresolved_macro_call / macro_error
by reusing the code for unresolved_proc_macro. It's not perfect but
probably better than before.