### PR TITLE
fix: Fix completions for locals not working properly inside macro calls

### DIFF
--- a/crates/ide-completion/src/context.rs
+++ b/crates/ide-completion/src/context.rs
@@ -506,7 +506,11 @@ impl<'a> CompletionContext<'a> {
 
         let original_token = original_file.syntax().token_at_offset(offset).left_biased()?;
         let token = sema.descend_into_macros_single(original_token.clone());
-        let scope = sema.scope_at_offset(&token.parent()?, offset)?;
+
+        // adjust for macro input, this still fails if there is no token written yet
+        let scope_offset = if original_token == token { offset } else { token.text_range().end() };
+        let scope = sema.scope_at_offset(&token.parent()?, scope_offset)?;
+
         let krate = scope.krate();
         let module = scope.module();
 

--- a/crates/ide-completion/src/tests/special.rs
+++ b/crates/ide-completion/src/tests/special.rs
@@ -782,3 +782,31 @@ fn main() {
         "#]],
     )
 }
+
+#[test]
+fn completes_locals_from_macros() {
+    check(
+        r#"
+
+macro_rules! x {
+    ($x:ident, $expr:expr) => {
+        let $x = 0;
+        $expr
+    };
+}
+fn main() {
+    x! {
+        foobar, {
+            f$0
+        }
+    };
+}
+"#,
+        expect![[r#"
+            fn main() fn()
+            lc foobar i32
+            ma x!(…)  macro_rules! x
+            bt u32
+        "#]],
+    )
+}


### PR DESCRIPTION
This doesn't fix the issue with completions not working correctly in attribute macros when completions for an empty token are requested though.