### PR TITLE
fix: escape receiver texts in completion

### DIFF
--- a/crates/ide-completion/src/completions/postfix.rs
+++ b/crates/ide-completion/src/completions/postfix.rs
@@ -529,6 +529,11 @@ fn main() { ControlFlow::Break(42) }
 "#,
         );
 
+        // The receiver texts should be escaped, see comments in `get_receiver_text()`
+        // for detail.
+        //
+        // Note that the last argument is what *lsp clients would see* rather than
+        // what users would see. Unescaping happens thereafter.
         check_edit_with_config(
             config.clone(),
             "break",

--- a/crates/ide-completion/src/snippet.rs
+++ b/crates/ide-completion/src/snippet.rs
@@ -17,7 +17,7 @@
 //       "body": [
 //         "thread::spawn(move || {",
 //         "\t$0",
-//         ")};",
+//         "});",
 //       ],
 //       "description": "Insert a thread::spawn call",
 //       "requires": "std::thread",


### PR DESCRIPTION
This PR fixes #11897 by escaping '\\' and '$' in the text of the receiver position expression. See [here](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#snippet_syntax) for the specification of the snippet syntax (especially [this section](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#grammar) discusses escaping).

Although not all occurrences of '\\' and '$' have to be replaced, I chose to replace all as that's simpler and easier to understand. There *are* more clever ways to implement it, but I thought they were premature optimization for the time being (maybe I should put FIXME notes?).