### PR TITLE
fix: improve whitespace insertion in pretty printer

### DIFF
--- a/crates/ide/src/expand_macro.rs
+++ b/crates/ide/src/expand_macro.rs
@@ -361,6 +361,38 @@ fn main() {
     }
 
     #[test]
+    fn macro_expand_inner_macro_rules() {
+        check(
+            r#"
+macro_rules! foo {
+    ($t:tt) => {{
+        macro_rules! bar {
+            () => {
+                $t
+            }
+        }
+        bar!()
+    }};
+}
+
+fn main() {
+    foo$0!(42);
+}
+            "#,
+            expect![[r#"
+                foo
+                {
+                  macro_rules! bar {
+                    () => {
+                      42
+                    }
+                  }
+                  42
+                }"#]],
+        );
+    }
+
+    #[test]
     fn macro_expand_inner_macro_fail_to_expand() {
         check(
             r#"


### PR DESCRIPTION
Fixes #12591 

The `=>` token in the macro_rules! should be parsed as one fat arrow, but it ["requires a lot of changes in r-a"](https://github.com/rust-analyzer/ungrammar/commit/143cc528b11290bf2463de1fb5a97a15f9b2ed44), so I left it for the larger refactoring in the future and put a FIXME note.