### PR TITLE
Ignore the `bin` artifact for `bench` targets

### DIFF
--- a/editors/code/src/toolchain.ts
+++ b/editors/code/src/toolchain.ts
@@ -39,7 +39,7 @@ export class Cargo {
         }
 
         const result: ArtifactSpec = { cargoArgs: cargoArgs };
-        if (cargoArgs[0] === "test") {
+        if (cargoArgs[0] === "test" || cargoArgs[0] === "bench") {
             // for instance, `crates\rust-analyzer\tests\heavy_tests\main.rs` tests
             // produce 2 artifacts: {"kind": "bin"} and {"kind": "test"}
             result.filter = (artifacts) => artifacts.filter((it) => it.isTest);


### PR DESCRIPTION
Just like `test`.

Fixes #12645.

I don't know how to test that.