### PR TITLE
Remove useless bors.toml

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -1,9 +1,0 @@
-status = [
-    "Rust (ubuntu-latest)",
-    "Rust (windows-latest)",
-    "Rust (macos-latest)",
-    "TypeScript (ubuntu-latest)",
-    "TypeScript (windows-latest)",
-]
-delete_merged_branches = true
-timeout_sec = 1200 # 20 min

--- a/crates/sourcegen/src/lib.rs
+++ b/crates/sourcegen/src/lib.rs
@@ -196,6 +196,6 @@ fn normalize_newlines(s: &str) -> String {
 pub fn project_root() -> PathBuf {
     let dir = env!("CARGO_MANIFEST_DIR");
     let res = PathBuf::from(dir).parent().unwrap().parent().unwrap().to_owned();
-    assert!(res.join("bors.toml").exists());
+    assert!(res.join("triagebot.toml").exists());
     res
 }


### PR DESCRIPTION
It seems we do not use bors-ng anymore. So maybe this is useless.