### PR TITLE
Complete type param/associated type in trait generic arg per arg index

### DIFF
--- a/crates/hir-def/src/generics.rs
+++ b/crates/hir-def/src/generics.rs
@@ -47,6 +47,7 @@ pub struct LifetimeParamData {
 pub struct ConstParamData {
     pub name: Name,
     pub ty: Interned<TypeRef>,
+    pub has_default: bool,
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Hash)]
@@ -67,6 +68,13 @@ impl TypeOrConstParamData {
         match self {
             TypeOrConstParamData::TypeParamData(x) => x.name.as_ref(),
             TypeOrConstParamData::ConstParamData(x) => Some(&x.name),
+        }
+    }
+
+    pub fn has_default(&self) -> bool {
+        match self {
+            TypeOrConstParamData::TypeParamData(x) => x.default.is_some(),
+            TypeOrConstParamData::ConstParamData(x) => x.has_default,
         }
     }
 
@@ -232,7 +240,11 @@ impl GenericParams {
                     let ty = const_param
                         .ty()
                         .map_or(TypeRef::Error, |it| TypeRef::from_ast(lower_ctx, it));
-                    let param = ConstParamData { name, ty: Interned::new(ty) };
+                    let param = ConstParamData {
+                        name,
+                        ty: Interned::new(ty),
+                        has_default: const_param.default_val().is_some(),
+                    };
                     self.type_or_consts.alloc(param.into());
                 }
             }

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -41,6 +41,7 @@ use hir_def::{
     adt::{ReprKind, VariantData},
     body::{BodyDiagnostic, SyntheticSyntax},
     expr::{BindingAnnotation, LabelId, Pat, PatId},
+    generics::{TypeOrConstParamData, TypeParamProvenance},
     item_tree::ItemTreeNode,
     lang_item::LangItemTarget,
     nameres::{self, diagnostics::DefDiagnostic},
@@ -1707,6 +1708,22 @@ impl Trait {
     pub fn is_unsafe(&self, db: &dyn HirDatabase) -> bool {
         db.trait_data(self.id).is_unsafe
     }
+
+    pub fn type_parameters(&self, db: &dyn HirDatabase) -> Vec<TypeOrConstParamData> {
+        db.generic_params(GenericDefId::from(self.id))
+            .type_or_consts
+            .iter()
+            .filter(|(_, ty)| match ty {
+                TypeOrConstParamData::TypeParamData(ty)
+                    if ty.provenance != TypeParamProvenance::TypeParamList =>
+                {
+                    false
+                }
+                _ => true,
+            })
+            .map(|(_, ty)|ty.clone())
+            .collect()
+        }
 }
 
 impl HasVisibility for Trait {

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -1709,7 +1709,11 @@ impl Trait {
         db.trait_data(self.id).is_unsafe
     }
 
-    pub fn type_parameters(&self, db: &dyn HirDatabase) -> Vec<TypeOrConstParamData> {
+    pub fn type_or_const_param_count(
+        &self,
+        db: &dyn HirDatabase,
+        count_required_only: bool,
+    ) -> usize {
         db.generic_params(GenericDefId::from(self.id))
             .type_or_consts
             .iter()
@@ -1721,9 +1725,9 @@ impl Trait {
                 }
                 _ => true,
             })
-            .map(|(_, ty)|ty.clone())
-            .collect()
-        }
+            .filter(|(_, ty)| !count_required_only || !ty.has_default())
+            .count()
+    }
 }
 
 impl HasVisibility for Trait {

--- a/crates/ide-completion/src/completions/type.rs
+++ b/crates/ide-completion/src/completions/type.rs
@@ -120,39 +120,64 @@ pub(crate) fn complete_type_path(
         }
         Qualified::Absolute => acc.add_crate_roots(ctx, path_ctx),
         Qualified::No => {
-            acc.add_nameref_keywords_with_colon(ctx);
-            if let TypeLocation::TypeBound = location {
-                ctx.process_all_names(&mut |name, res| {
-                    let add_resolution = match res {
-                        ScopeDef::ModuleDef(hir::ModuleDef::Macro(mac)) => mac.is_fn_like(ctx.db),
-                        ScopeDef::ModuleDef(
-                            hir::ModuleDef::Trait(_) | hir::ModuleDef::Module(_),
-                        ) => true,
-                        _ => false,
-                    };
-                    if add_resolution {
-                        acc.add_path_resolution(ctx, path_ctx, name, res);
-                    }
-                });
-                return;
-            }
-            if let TypeLocation::GenericArgList(Some(arg_list)) = location {
-                if let Some(path_seg) = arg_list.syntax().parent().and_then(ast::PathSegment::cast)
-                {
-                    if path_seg.syntax().ancestors().find_map(ast::TypeBound::cast).is_some() {
-                        if let Some(hir::PathResolution::Def(hir::ModuleDef::Trait(trait_))) =
-                            ctx.sema.resolve_path(&path_seg.parent_path())
-                        {
-                            trait_.items_with_supertraits(ctx.sema.db).into_iter().for_each(|it| {
-                                if let hir::AssocItem::TypeAlias(alias) = it {
-                                    cov_mark::hit!(complete_assoc_type_in_generics_list);
-                                    acc.add_type_alias_with_eq(ctx, alias)
+            match location {
+                TypeLocation::TypeBound => {
+                    acc.add_nameref_keywords_with_colon(ctx);
+                    ctx.process_all_names(&mut |name, res| {
+                        let add_resolution = match res {
+                            ScopeDef::ModuleDef(hir::ModuleDef::Macro(mac)) => {
+                                mac.is_fn_like(ctx.db)
+                            }
+                            ScopeDef::ModuleDef(
+                                hir::ModuleDef::Trait(_) | hir::ModuleDef::Module(_),
+                            ) => true,
+                            _ => false,
+                        };
+                        if add_resolution {
+                            acc.add_path_resolution(ctx, path_ctx, name, res);
+                        }
+                    });
+                    return;
+                }
+                TypeLocation::GenericArgList(Some(arg_list)) => {
+                    match arg_list.generic_args().next() {
+                        Some(ast::GenericArg::AssocTypeArg(_)) => {}
+                        _ => {
+                            if let Some(path_seg) =
+                                arg_list.syntax().parent().and_then(ast::PathSegment::cast)
+                            {
+                                if path_seg
+                                    .syntax()
+                                    .ancestors()
+                                    .find_map(ast::TypeBound::cast)
+                                    .is_some()
+                                {
+                                    if let Some(hir::PathResolution::Def(hir::ModuleDef::Trait(
+                                        trait_,
+                                    ))) = ctx.sema.resolve_path(&path_seg.parent_path())
+                                    {
+                                        trait_
+                                            .items_with_supertraits(ctx.sema.db)
+                                            .into_iter()
+                                            .for_each(|it| {
+                                                if let hir::AssocItem::TypeAlias(alias) = it {
+                                                    cov_mark::hit!(
+                                                        complete_assoc_type_in_generics_list
+                                                    );
+                                                    acc.add_type_alias_with_eq(ctx, alias);
+                                                }
+                                            });
+                                        return; // only AssocTypeArgs make sense
+                                    }
                                 }
-                            });
+                            }
                         }
                     }
                 }
-            }
+                _ => {}
+            };
+
+            acc.add_nameref_keywords_with_colon(ctx);
             ctx.process_all_names(&mut |name, def| {
                 if scope_def_applicable(def) {
                     acc.add_path_resolution(ctx, path_ctx, name, def);

--- a/crates/ide-completion/src/completions/type.rs
+++ b/crates/ide-completion/src/completions/type.rs
@@ -181,12 +181,12 @@ pub(crate) fn complete_type_path(
                                                     acc.add_type_alias_with_eq(ctx, alias);
                                                 }
                                             });
-                                    }
 
-                                    let n_params =
-                                        trait_.type_or_const_param_count(ctx.sema.db, false);
-                                    if arg_idx >= n_params {
-                                        return; // only show assoc types
+                                        let n_params =
+                                            trait_.type_or_const_param_count(ctx.sema.db, false);
+                                        if arg_idx >= n_params {
+                                            return; // only show assoc types
+                                        }
                                     }
                                 }
                             }

--- a/crates/ide-completion/src/tests/type_pos.rs
+++ b/crates/ide-completion/src/tests/type_pos.rs
@@ -386,6 +386,39 @@ fn foo<'lt, T: Trait2<$0>, const CONST_PARAM: usize>(_: T) {}
     );
     check(
         r#"
+trait Trait1 {
+    type Super;
+}
+trait Trait2<T>: Trait1 {
+    type Foo;
+}
+
+fn foo<'lt, T: Trait2<$0>, const CONST_PARAM: usize>(_: T) {}
+"#,
+        expect![[r#"
+            ct CONST
+            cp CONST_PARAM
+            en Enum
+            ma makro!(…)            macro_rules! makro
+            md module
+            st Record
+            st Tuple
+            st Unit
+            tt Trait
+            tt Trait1
+            tt Trait2
+            ta Foo =  (as Trait2)   type Foo
+            ta Super =  (as Trait1) type Super
+            tp T
+            un Union
+            bt u32
+            kw crate::
+            kw self::
+            kw super::
+        "#]],
+    );
+    check(
+        r#"
 trait Trait2 {
     type Foo;
 }
@@ -460,11 +493,11 @@ fn func(_: Enum::$0) {}
 fn completes_associated_type_only() {
     check(
         r#"
-trait MyTrait {
+trait MyTrait<T> {
     type Item;
 };
 
-fn f(t: impl MyTrait<I$0
+fn f(t: impl MyTrait<u8,I$0
 "#,
         expect![[r#"
             ta Item =  (as MyTrait) type Item

--- a/crates/ide-completion/src/tests/type_pos.rs
+++ b/crates/ide-completion/src/tests/type_pos.rs
@@ -380,25 +380,8 @@ trait Trait2: Trait1 {
 fn foo<'lt, T: Trait2<$0>, const CONST_PARAM: usize>(_: T) {}
 "#,
         expect![[r#"
-            ct CONST
-            cp CONST_PARAM
-            en Enum
-            ma makro!(…)            macro_rules! makro
-            md module
-            st Record
-            st Tuple
-            st Unit
-            tt Trait
-            tt Trait1
-            tt Trait2
             ta Foo =  (as Trait2)   type Foo
             ta Super =  (as Trait1) type Super
-            tp T
-            un Union
-            bt u32
-            kw crate::
-            kw self::
-            kw super::
         "#]],
     );
     check(
@@ -469,6 +452,51 @@ fn func(_: Enum::$0) {}
 "#,
         expect![[r#"
             ta AssocType type AssocType = ()
+        "#]],
+    );
+}
+
+#[test]
+fn completes_associated_type_only() {
+    check(
+        r#"
+trait MyTrait {
+    type Item;
+};
+
+fn f(t: impl MyTrait<I$0
+"#,
+        expect![[r#"
+            ta Item =  (as MyTrait) type Item
+        "#]],
+    );
+}
+
+#[test]
+fn completes_types_after_associated_type() {
+    check(
+        r#"
+trait MyTrait {
+    type Item;
+};
+
+fn f(t: impl MyTrait<Item = $0
+"#,
+        expect![[r#"
+            ct CONST
+            en Enum
+            ma makro!(…) macro_rules! makro
+            md module
+            st Record
+            st Tuple
+            st Unit
+            tt MyTrait
+            tt Trait
+            un Union
+            bt u32
+            kw crate::
+            kw self::
+            kw super::
         "#]],
     );
 }

--- a/crates/ide-completion/src/tests/type_pos.rs
+++ b/crates/ide-completion/src/tests/type_pos.rs
@@ -563,7 +563,7 @@ fn f(t: impl MyTrait<u8, u8, I$0
 fn completes_type_parameter_or_associated_type_with_default_value() {
     check(
         r#"
-trait MyTrait<T = u8, U> {
+trait MyTrait<T, U = u8> {
     type Item1;
     type Item2;
 };
@@ -590,7 +590,7 @@ fn f(t: impl MyTrait<u$0
 
     check(
         r#"
-trait MyTrait<T = u8, U> {
+trait MyTrait<T, U = u8> {
     type Item1;
     type Item2;
 };
@@ -619,7 +619,7 @@ fn f(t: impl MyTrait<u8, u$0
 
     check(
         r#"
-trait MyTrait<T = u8, U> {
+trait MyTrait<T, U = u8> {
     type Item1;
     type Item2;
 };

--- a/crates/ide-completion/src/tests/type_pos.rs
+++ b/crates/ide-completion/src/tests/type_pos.rs
@@ -399,7 +399,7 @@ fn foo<'lt, T: Trait2<$0>, const CONST_PARAM: usize>(_: T) {}
             ct CONST
             cp CONST_PARAM
             en Enum
-            ma makro!(…)            macro_rules! makro
+            ma makro!(…)   macro_rules! makro
             md module
             st Record
             st Tuple
@@ -407,8 +407,6 @@ fn foo<'lt, T: Trait2<$0>, const CONST_PARAM: usize>(_: T) {}
             tt Trait
             tt Trait1
             tt Trait2
-            ta Foo =  (as Trait2)   type Foo
-            ta Super =  (as Trait1) type Super
             tp T
             un Union
             bt u32
@@ -490,17 +488,147 @@ fn func(_: Enum::$0) {}
 }
 
 #[test]
-fn completes_associated_type_only() {
+fn completes_type_parameter_or_associated_type() {
     check(
         r#"
-trait MyTrait<T> {
-    type Item;
+trait MyTrait<T, U> {
+    type Item1;
+    type Item2;
 };
 
-fn f(t: impl MyTrait<u8,I$0
+fn f(t: impl MyTrait<u$0
 "#,
         expect![[r#"
-            ta Item =  (as MyTrait) type Item
+            ct CONST
+            en Enum
+            ma makro!(…) macro_rules! makro
+            md module
+            st Record
+            st Tuple
+            st Unit
+            tt MyTrait
+            tt Trait
+            un Union
+            bt u32
+            kw crate::
+            kw self::
+            kw super::
+        "#]],
+    );
+
+    check(
+        r#"
+trait MyTrait<T, U> {
+    type Item1;
+    type Item2;
+};
+
+fn f(t: impl MyTrait<u8, u$0
+"#,
+        expect![[r#"
+            ct CONST
+            en Enum
+            ma makro!(…) macro_rules! makro
+            md module
+            st Record
+            st Tuple
+            st Unit
+            tt MyTrait
+            tt Trait
+            un Union
+            bt u32
+            kw crate::
+            kw self::
+            kw super::
+        "#]],
+    );
+
+    check(
+        r#"
+trait MyTrait<T, U> {
+    type Item1;
+    type Item2;
+};
+
+fn f(t: impl MyTrait<u8, u8, I$0
+"#,
+        expect![[r#"
+            ta Item1 =  (as MyTrait) type Item1
+            ta Item2 =  (as MyTrait) type Item2
+        "#]],
+    );
+}
+
+#[test]
+fn completes_type_parameter_or_associated_type_with_default_value() {
+    check(
+        r#"
+trait MyTrait<T = u8, U> {
+    type Item1;
+    type Item2;
+};
+
+fn f(t: impl MyTrait<u$0
+"#,
+        expect![[r#"
+            ct CONST
+            en Enum
+            ma makro!(…) macro_rules! makro
+            md module
+            st Record
+            st Tuple
+            st Unit
+            tt MyTrait
+            tt Trait
+            un Union
+            bt u32
+            kw crate::
+            kw self::
+            kw super::
+        "#]],
+    );
+
+    check(
+        r#"
+trait MyTrait<T = u8, U> {
+    type Item1;
+    type Item2;
+};
+
+fn f(t: impl MyTrait<u8, u$0
+"#,
+        expect![[r#"
+            ct CONST
+            en Enum
+            ma makro!(…)             macro_rules! makro
+            md module
+            st Record
+            st Tuple
+            st Unit
+            tt MyTrait
+            tt Trait
+            ta Item1 =  (as MyTrait) type Item1
+            ta Item2 =  (as MyTrait) type Item2
+            un Union
+            bt u32
+            kw crate::
+            kw self::
+            kw super::
+        "#]],
+    );
+
+    check(
+        r#"
+trait MyTrait<T = u8, U> {
+    type Item1;
+    type Item2;
+};
+
+fn f(t: impl MyTrait<u8, u8, I$0
+"#,
+        expect![[r#"
+            ta Item1 =  (as MyTrait) type Item1
+            ta Item2 =  (as MyTrait) type Item2
         "#]],
     );
 }
@@ -510,10 +638,38 @@ fn completes_types_after_associated_type() {
     check(
         r#"
 trait MyTrait {
-    type Item;
+    type Item1;
+    type Item2;
 };
 
-fn f(t: impl MyTrait<Item = $0
+fn f(t: impl MyTrait<Item1 = $0
+"#,
+        expect![[r#"
+            ct CONST
+            en Enum
+            ma makro!(…) macro_rules! makro
+            md module
+            st Record
+            st Tuple
+            st Unit
+            tt MyTrait
+            tt Trait
+            un Union
+            bt u32
+            kw crate::
+            kw self::
+            kw super::
+        "#]],
+    );
+
+    check(
+        r#"
+trait MyTrait {
+    type Item1;
+    type Item2;
+};
+
+fn f(t: impl MyTrait<Item1 = u8, Item2 = $0
 "#,
         expect![[r#"
             ct CONST


### PR DESCRIPTION
- Fix #12140
- Also fix tidy check does not work for marks in multiline