### PR TITLE
internal: Use `SmallVec` to slightly shrink `ModPath` size

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -532,6 +532,7 @@ dependencies = [
  "mbe",
  "profile",
  "rustc-hash",
+ "smallvec",
  "stdx",
  "syntax",
  "tracing",

--- a/crates/hir-expand/Cargo.toml
+++ b/crates/hir-expand/Cargo.toml
@@ -19,6 +19,7 @@ itertools = "0.10.3"
 hashbrown = { version = "0.12.1", features = [
     "inline-more",
 ], default-features = false }
+smallvec = { version = "1.9.0", features = ["const_new"] }
 
 stdx = { path = "../stdx", version = "0.0.0" }
 base-db = { path = "../base-db", version = "0.0.0" }

--- a/crates/hir-expand/src/mod_path.rs
+++ b/crates/hir-expand/src/mod_path.rs
@@ -12,12 +12,13 @@ use crate::{
 };
 use base_db::CrateId;
 use either::Either;
+use smallvec::SmallVec;
 use syntax::{ast, AstNode};
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ModPath {
     pub kind: PathKind,
-    segments: Vec<Name>,
+    segments: SmallVec<[Name; 1]>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -41,13 +42,13 @@ impl ModPath {
     }
 
     pub fn from_segments(kind: PathKind, segments: impl IntoIterator<Item = Name>) -> ModPath {
-        let segments = segments.into_iter().collect::<Vec<_>>();
+        let segments = segments.into_iter().collect();
         ModPath { kind, segments }
     }
 
     /// Creates a `ModPath` from a `PathKind`, with no extra path segments.
     pub const fn from_kind(kind: PathKind) -> ModPath {
-        ModPath { kind, segments: Vec::new() }
+        ModPath { kind, segments: SmallVec::new_const() }
     }
 
     pub fn segments(&self) -> &[Name] {


### PR DESCRIPTION
Saves like a megabyte on r-a itself.