### PR TITLE
internal: Update remaining GitHub URLs

### DIFF
--- a/crates/base-db/src/input.rs
+++ b/crates/base-db/src/input.rs
@@ -69,7 +69,7 @@ impl SourceRoot {
 /// `CrateGraph` by lowering `cargo metadata` output.
 ///
 /// `CrateGraph` is `!Serialize` by design, see
-/// <https://github.com/rust-analyzer/rust-analyzer/blob/master/docs/dev/architecture.md#serialization>
+/// <https://github.com/rust-lang/rust-analyzer/blob/master/docs/dev/architecture.md#serialization>
 #[derive(Debug, Clone, Default /* Serialize, Deserialize */)]
 pub struct CrateGraph {
     arena: FxHashMap<CrateId, CrateData>,
@@ -482,7 +482,7 @@ impl CrateGraph {
         None
     }
 
-    // Work around for https://github.com/rust-analyzer/rust-analyzer/issues/6038.
+    // Work around for https://github.com/rust-lang/rust-analyzer/issues/6038.
     // As hacky as it gets.
     pub fn patch_cfg_if(&mut self) -> bool {
         let cfg_if = self.hacky_find_crate("cfg_if");

--- a/crates/hir-def/src/body/tests/block.rs
+++ b/crates/hir-def/src/body/tests/block.rs
@@ -345,7 +345,7 @@ fn foo() {
 
 #[test]
 fn is_visible_from_same_def_map() {
-    // Regression test for https://github.com/rust-analyzer/rust-analyzer/issues/9481
+    // Regression test for https://github.com/rust-lang/rust-analyzer/issues/9481
     cov_mark::check!(is_visible_from_same_block_def_map);
     check_at(
         r#"

--- a/crates/hir-def/src/macro_expansion_tests.rs
+++ b/crates/hir-def/src/macro_expansion_tests.rs
@@ -72,7 +72,7 @@ pub fn identity_when_valid(_attr: TokenStream, item: TokenStream) -> TokenStream
     // fact.
     //
     // This is the usual
-    // <https://github.com/rust-analyzer/rust-analyzer/issues/3407>
+    // <https://github.com/rust-lang/rust-analyzer/issues/3407>
     // resolve/record tension!
     //
     // So here we try to do a resolve, which is necessary a heuristic. For macro

--- a/crates/hir-def/src/macro_expansion_tests/mbe.rs
+++ b/crates/hir-def/src/macro_expansion_tests/mbe.rs
@@ -1178,7 +1178,7 @@ abs!( = > #);
 #[test]
 fn test_tt_with_composite_without_space() {
     // Test macro input without any spaces
-    // See https://github.com/rust-analyzer/rust-analyzer/issues/6692
+    // See https://github.com/rust-lang/rust-analyzer/issues/6692
     check(
         r#"
 macro_rules! m { ($ op:tt, $j:path) => ( ok!(); ) }

--- a/crates/hir-def/src/nameres/tests/macros.rs
+++ b/crates/hir-def/src/nameres/tests/macros.rs
@@ -759,7 +759,7 @@ fn unresolved_attributes_fall_back_track_per_file_moditems() {
 
 #[test]
 fn unresolved_attrs_extern_block_hang() {
-    // Regression test for https://github.com/rust-analyzer/rust-analyzer/issues/8905
+    // Regression test for https://github.com/rust-lang/rust-analyzer/issues/8905
     check(
         r#"
 #[unresolved]
@@ -823,7 +823,7 @@ fn derive() {}
 
 #[test]
 fn unresolved_attr_with_cfg_attr_hang() {
-    // Another regression test for https://github.com/rust-analyzer/rust-analyzer/issues/8905
+    // Another regression test for https://github.com/rust-lang/rust-analyzer/issues/8905
     check(
         r#"
 #[cfg_attr(not(off), unresolved, unresolved)]

--- a/crates/hir-def/src/type_ref.rs
+++ b/crates/hir-def/src/type_ref.rs
@@ -434,7 +434,7 @@ pub enum ConstScalar {
     /// Case of an unknown value that rustc might know but we don't
     // FIXME: this is a hack to get around chalk not being able to represent unevaluatable
     // constants
-    // https://github.com/rust-analyzer/rust-analyzer/pull/8813#issuecomment-840679177
+    // https://github.com/rust-lang/rust-analyzer/pull/8813#issuecomment-840679177
     // https://rust-lang.zulipchat.com/#narrow/stream/144729-wg-traits/topic/Handling.20non.20evaluatable.20constants'.20equality/near/238386348
     Unknown,
 }

--- a/crates/hir-expand/src/builtin_fn_macro.rs
+++ b/crates/hir-expand/src/builtin_fn_macro.rs
@@ -400,7 +400,7 @@ fn concat_expand(
     for (i, mut t) in tt.token_trees.iter().enumerate() {
         // FIXME: hack on top of a hack: `$e:expr` captures get surrounded in parentheses
         // to ensure the right parsing order, so skip the parentheses here. Ideally we'd
-        // implement rustc's model. cc https://github.com/rust-analyzer/rust-analyzer/pull/10623
+        // implement rustc's model. cc https://github.com/rust-lang/rust-analyzer/pull/10623
         if let tt::TokenTree::Subtree(tt::Subtree { delimiter: Some(delim), token_trees }) = t {
             if let [tt] = &**token_trees {
                 if delim.kind == tt::DelimiterKind::Parenthesis {

--- a/crates/hir-ty/src/tests/regression.rs
+++ b/crates/hir-ty/src/tests/regression.rs
@@ -985,7 +985,7 @@ fn test() {
 
 #[test]
 fn cfg_tail() {
-    // https://github.com/rust-analyzer/rust-analyzer/issues/8378
+    // https://github.com/rust-lang/rust-analyzer/issues/8378
     check_infer(
         r#"
         fn fake_tail(){

--- a/crates/ide-assists/src/handlers/add_explicit_type.rs
+++ b/crates/ide-assists/src/handlers/add_explicit_type.rs
@@ -187,7 +187,7 @@ fn f() {
         )
     }
 
-    /// https://github.com/rust-analyzer/rust-analyzer/issues/2922
+    /// https://github.com/rust-lang/rust-analyzer/issues/2922
     #[test]
     fn regression_issue_2922() {
         check_assist(

--- a/crates/ide-assists/src/handlers/apply_demorgan.rs
+++ b/crates/ide-assists/src/handlers/apply_demorgan.rs
@@ -222,7 +222,7 @@ fn f() { !(S <= S || S < S) }
         check_assist(apply_demorgan, "fn f() { (x ||$0 x) }", "fn f() { !(!x && !x) }")
     }
 
-    // https://github.com/rust-analyzer/rust-analyzer/issues/10963
+    // https://github.com/rust-lang/rust-analyzer/issues/10963
     #[test]
     fn demorgan_doesnt_hang() {
         check_assist(

--- a/crates/ide-assists/src/handlers/destructure_tuple_binding.rs
+++ b/crates/ide-assists/src/handlers/destructure_tuple_binding.rs
@@ -1793,7 +1793,7 @@ fn foo() -> Option<()> {
     let v: &i32 = &t.0;         // no deref, no parens, remove `&`
     f1(t.0);                    // deref, no parens
     f2(&t.0);                   // `&*` -> cancel out -> no deref, no parens
-    // https://github.com/rust-analyzer/rust-analyzer/issues/1109#issuecomment-658868639
+    // https://github.com/rust-lang/rust-analyzer/issues/1109#issuecomment-658868639
     // let v: i32 = t.1.0;      // no deref, no parens
     let v: i32 = t.4.value;     // no deref, no parens
     t.0.do_stuff();             // deref, parens
@@ -1827,7 +1827,7 @@ fn foo() -> Option<()> {
     let v: &i32 = _0;         // no deref, no parens, remove `&`
     f1(*_0);                    // deref, no parens
     f2(_0);                   // `&*` -> cancel out -> no deref, no parens
-    // https://github.com/rust-analyzer/rust-analyzer/issues/1109#issuecomment-658868639
+    // https://github.com/rust-lang/rust-analyzer/issues/1109#issuecomment-658868639
     // let v: i32 = t.1.0;      // no deref, no parens
     let v: i32 = _4.value;     // no deref, no parens
     (*_0).do_stuff();             // deref, parens

--- a/crates/ide-assists/src/handlers/extract_function.rs
+++ b/crates/ide-assists/src/handlers/extract_function.rs
@@ -1053,7 +1053,7 @@ fn locals_defined_in_body(
     body: &FunctionBody,
 ) -> FxIndexSet<Local> {
     // FIXME: this doesn't work well with macros
-    //        see https://github.com/rust-analyzer/rust-analyzer/pull/7535#discussion_r570048550
+    //        see https://github.com/rust-lang/rust-analyzer/pull/7535#discussion_r570048550
     let mut res = FxIndexSet::default();
     body.walk_pat(&mut |pat| {
         if let ast::Pat::IdentPat(pat) = pat {

--- a/crates/ide-assists/src/handlers/flip_comma.rs
+++ b/crates/ide-assists/src/handlers/flip_comma.rs
@@ -67,7 +67,7 @@ mod tests {
 
     #[test]
     fn flip_comma_before_punct() {
-        // See https://github.com/rust-analyzer/rust-analyzer/issues/1619
+        // See https://github.com/rust-lang/rust-analyzer/issues/1619
         // "Flip comma" assist shouldn't be applicable to the last comma in enum or struct
         // declaration body.
         check_assist_not_applicable(flip_comma, "pub enum Test { A,$0 }");
@@ -86,7 +86,7 @@ mod tests {
     #[test]
     fn flip_comma_not_applicable_for_macro_input() {
         // "Flip comma" assist shouldn't be applicable inside the macro call
-        // See https://github.com/rust-analyzer/rust-analyzer/issues/7693
+        // See https://github.com/rust-lang/rust-analyzer/issues/7693
         check_assist_not_applicable(flip_comma, r#"bar!(a,$0 b)"#);
     }
 }

--- a/crates/ide-assists/src/handlers/remove_dbg.rs
+++ b/crates/ide-assists/src/handlers/remove_dbg.rs
@@ -150,7 +150,7 @@ mod tests {
 
     #[test]
     fn test_remove_dbg_keep_semicolon_in_let() {
-        // https://github.com/rust-analyzer/rust-analyzer/issues/5129#issuecomment-651399779
+        // https://github.com/rust-lang/rust-analyzer/issues/5129#issuecomment-651399779
         check(
             r#"let res = $0dbg!(1 * 20); // needless comment"#,
             r#"let res = 1 * 20; // needless comment"#,

--- a/crates/ide-completion/src/completions/item_list/trait_impl.rs
+++ b/crates/ide-completion/src/completions/item_list/trait_impl.rs
@@ -411,7 +411,7 @@ impl Test for T {
             expect![[""]],
         );
 
-        // https://github.com/rust-analyzer/rust-analyzer/pull/5976#issuecomment-692332191
+        // https://github.com/rust-lang/rust-analyzer/pull/5976#issuecomment-692332191
         check(
             r"
 trait Test { fn test(); fn test2(); }

--- a/crates/ide-completion/src/render/macro_.rs
+++ b/crates/ide-completion/src/render/macro_.rs
@@ -243,7 +243,7 @@ fn main() { foo! {$0} }
 
     #[test]
     fn completes_macro_call_if_cursor_at_bang_token() {
-        // Regression test for https://github.com/rust-analyzer/rust-analyzer/issues/9904
+        // Regression test for https://github.com/rust-lang/rust-analyzer/issues/9904
         cov_mark::check!(completes_macro_call_if_cursor_at_bang_token);
         check_edit(
             "foo!",

--- a/crates/ide-db/src/rename.rs
+++ b/crates/ide-db/src/rename.rs
@@ -372,7 +372,7 @@ fn source_edit_from_name(edit: &mut TextEditBuilder, name: &ast::Name, new_name:
             //      ^ insert `new_name: `
 
             // FIXME: instead of splitting the shorthand, recursively trigger a rename of the
-            // other name https://github.com/rust-analyzer/rust-analyzer/issues/6547
+            // other name https://github.com/rust-lang/rust-analyzer/issues/6547
             edit.insert(ident_pat.syntax().text_range().start(), format!("{}: ", new_name));
             return true;
         }

--- a/crates/ide-diagnostics/src/handlers/macro_error.rs
+++ b/crates/ide-diagnostics/src/handlers/macro_error.rs
@@ -41,7 +41,7 @@ macro_rules! compile_error { () => {} }
     #[test]
     fn eager_macro_concat() {
         // FIXME: this is incorrectly handling `$crate`, resulting in a wrong diagnostic.
-        // See: https://github.com/rust-analyzer/rust-analyzer/issues/10300
+        // See: https://github.com/rust-lang/rust-analyzer/issues/10300
 
         check_diagnostics(
             r#"

--- a/crates/ide/src/syntax_highlighting.rs
+++ b/crates/ide/src/syntax_highlighting.rs
@@ -357,7 +357,7 @@ fn traverse(
             element
         };
 
-        // FIXME: do proper macro def highlighting https://github.com/rust-analyzer/rust-analyzer/issues/6232
+        // FIXME: do proper macro def highlighting https://github.com/rust-lang/rust-analyzer/issues/6232
         // Skip metavariables from being highlighted to prevent keyword highlighting in them
         if descended_element.as_token().and_then(|t| macro_highlighter.highlight(t)).is_some() {
             continue;

--- a/crates/parser/test_data/parser/ok/0035_weird_exprs.rast
+++ b/crates/parser/test_data/parser/ok/0035_weird_exprs.rast
@@ -5,7 +5,7 @@ SOURCE_FILE
   WHITESPACE "\n"
   COMMENT "//! "
   WHITESPACE "\n"
-  COMMENT "//! Reported to rust-analyzer in https://github.com/rust-analyzer/rust-analyzer/issues/290"
+  COMMENT "//! Reported to rust-analyzer in https://github.com/rust-lang/rust-analyzer/issues/290"
   WHITESPACE "\n\n"
   ATTR
     POUND "#"

--- a/crates/parser/test_data/parser/ok/0035_weird_exprs.rs
+++ b/crates/parser/test_data/parser/ok/0035_weird_exprs.rs
@@ -1,7 +1,7 @@
 //! Adapted from a `rustc` test, which can be found at 
 //! https://github.com/rust-lang/rust/blob/6d34ec18c7d7e574553f6347ecf08e1e1c45c13d/src/test/run-pass/weird-exprs.rs.
 //! 
-//! Reported to rust-analyzer in https://github.com/rust-analyzer/rust-analyzer/issues/290
+//! Reported to rust-analyzer in https://github.com/rust-lang/rust-analyzer/issues/290
 
 #![allow(non_camel_case_types)]
 #![allow(dead_code)]

--- a/crates/parser/test_data/parser/ok/0036_fully_qualified.rast
+++ b/crates/parser/test_data/parser/ok/0036_fully_qualified.rast
@@ -1,5 +1,5 @@
 SOURCE_FILE
-  COMMENT "// https://github.com/rust-analyzer/rust-analyzer/issues/311"
+  COMMENT "// https://github.com/rust-lang/rust-analyzer/issues/311"
   WHITESPACE "\n\n"
   FN
     VISIBILITY

--- a/crates/parser/test_data/parser/ok/0036_fully_qualified.rs
+++ b/crates/parser/test_data/parser/ok/0036_fully_qualified.rs
@@ -1,4 +1,4 @@
-// https://github.com/rust-analyzer/rust-analyzer/issues/311
+// https://github.com/rust-lang/rust-analyzer/issues/311
 
 pub fn foo<S: Iterator>() -> String
 where

--- a/crates/parser/test_data/parser/ok/0037_mod.rast
+++ b/crates/parser/test_data/parser/ok/0037_mod.rast
@@ -1,5 +1,5 @@
 SOURCE_FILE
-  COMMENT "// https://github.com/rust-analyzer/rust-analyzer/issues/357"
+  COMMENT "// https://github.com/rust-lang/rust-analyzer/issues/357"
   WHITESPACE "\n\n"
   COMMENT "//! docs"
   WHITESPACE "\n"

--- a/crates/parser/test_data/parser/ok/0037_mod.rs
+++ b/crates/parser/test_data/parser/ok/0037_mod.rs
@@ -1,4 +1,4 @@
-// https://github.com/rust-analyzer/rust-analyzer/issues/357
+// https://github.com/rust-lang/rust-analyzer/issues/357
 
 //! docs
 // non-docs

--- a/crates/parser/test_data/parser/ok/0042_ufcs_call_list.rast
+++ b/crates/parser/test_data/parser/ok/0042_ufcs_call_list.rast
@@ -1,5 +1,5 @@
 SOURCE_FILE
-  COMMENT "// https://github.com/rust-analyzer/rust-analyzer/issues/596"
+  COMMENT "// https://github.com/rust-lang/rust-analyzer/issues/596"
   WHITESPACE "\n\n"
   STRUCT
     STRUCT_KW "struct"

--- a/crates/parser/test_data/parser/ok/0042_ufcs_call_list.rs
+++ b/crates/parser/test_data/parser/ok/0042_ufcs_call_list.rs
@@ -1,4 +1,4 @@
-// https://github.com/rust-analyzer/rust-analyzer/issues/596
+// https://github.com/rust-lang/rust-analyzer/issues/596
 
 struct Foo;
 

--- a/crates/parser/test_data/parser/ok/0043_complex_assignment.rast
+++ b/crates/parser/test_data/parser/ok/0043_complex_assignment.rast
@@ -1,5 +1,5 @@
 SOURCE_FILE
-  COMMENT "// https://github.com/rust-analyzer/rust-analyzer/issues/674"
+  COMMENT "// https://github.com/rust-lang/rust-analyzer/issues/674"
   WHITESPACE "\n\n"
   STRUCT
     STRUCT_KW "struct"

--- a/crates/parser/test_data/parser/ok/0043_complex_assignment.rs
+++ b/crates/parser/test_data/parser/ok/0043_complex_assignment.rs
@@ -1,4 +1,4 @@
-// https://github.com/rust-analyzer/rust-analyzer/issues/674
+// https://github.com/rust-lang/rust-analyzer/issues/674
 
 struct Repr { raw: [u8; 1] }
 

--- a/crates/parser/test_data/parser/ok/0044_let_attrs.rast
+++ b/crates/parser/test_data/parser/ok/0044_let_attrs.rast
@@ -1,6 +1,6 @@
 SOURCE_FILE
   FN
-    COMMENT "// https://github.com/rust-analyzer/rust-analyzer/issues/677"
+    COMMENT "// https://github.com/rust-lang/rust-analyzer/issues/677"
     WHITESPACE "\n"
     FN_KW "fn"
     WHITESPACE " "

--- a/crates/parser/test_data/parser/ok/0044_let_attrs.rs
+++ b/crates/parser/test_data/parser/ok/0044_let_attrs.rs
@@ -1,4 +1,4 @@
-// https://github.com/rust-analyzer/rust-analyzer/issues/677
+// https://github.com/rust-lang/rust-analyzer/issues/677
 fn main() {
     #[cfg(feature = "backtrace")]
     let exit_code = panic::catch_unwind(move || main());

--- a/crates/parser/test_data/parser/ok/0045_block_attrs.rast
+++ b/crates/parser/test_data/parser/ok/0045_block_attrs.rast
@@ -138,7 +138,7 @@ SOURCE_FILE
         R_CURLY "}"
   WHITESPACE "\n\n"
   IMPL
-    COMMENT "// https://github.com/rust-analyzer/rust-analyzer/issues/689"
+    COMMENT "// https://github.com/rust-lang/rust-analyzer/issues/689"
     WHITESPACE "\n"
     IMPL_KW "impl"
     WHITESPACE " "

--- a/crates/parser/test_data/parser/ok/0045_block_attrs.rs
+++ b/crates/parser/test_data/parser/ok/0045_block_attrs.rs
@@ -16,7 +16,7 @@ fn outer() {
     let _ = #[doc("Outer attributes are always allowed")] {};
 }
 
-// https://github.com/rust-analyzer/rust-analyzer/issues/689
+// https://github.com/rust-lang/rust-analyzer/issues/689
 impl Whatever {
     fn salsa_event(&self, event_fn: impl Fn() -> Event<Self>) {
         #![allow(unused_variables)] // this is  `inner_attr` of the block

--- a/crates/parser/test_data/parser/ok/0047_minus_in_inner_pattern.rast
+++ b/crates/parser/test_data/parser/ok/0047_minus_in_inner_pattern.rast
@@ -1,5 +1,5 @@
 SOURCE_FILE
-  COMMENT "// https://github.com/rust-analyzer/rust-analyzer/issues/972"
+  COMMENT "// https://github.com/rust-lang/rust-analyzer/issues/972"
   WHITESPACE "\n\n"
   FN
     FN_KW "fn"

--- a/crates/parser/test_data/parser/ok/0047_minus_in_inner_pattern.rs
+++ b/crates/parser/test_data/parser/ok/0047_minus_in_inner_pattern.rs
@@ -1,4 +1,4 @@
-// https://github.com/rust-analyzer/rust-analyzer/issues/972
+// https://github.com/rust-lang/rust-analyzer/issues/972
 
 fn main() {
     match Some(-1) {

--- a/crates/parser/test_data/parser/ok/0048_compound_assignment.rast
+++ b/crates/parser/test_data/parser/ok/0048_compound_assignment.rast
@@ -1,5 +1,5 @@
 SOURCE_FILE
-  COMMENT "// https://github.com/rust-analyzer/rust-analyzer/pull/983"
+  COMMENT "// https://github.com/rust-lang/rust-analyzer/pull/983"
   WHITESPACE "\n\n"
   FN
     FN_KW "fn"

--- a/crates/parser/test_data/parser/ok/0048_compound_assignment.rs
+++ b/crates/parser/test_data/parser/ok/0048_compound_assignment.rs
@@ -1,4 +1,4 @@
-// https://github.com/rust-analyzer/rust-analyzer/pull/983
+// https://github.com/rust-lang/rust-analyzer/pull/983
 
 fn compound_assignment() {
     let mut a = 0;

--- a/crates/proc-macro-api/src/version.rs
+++ b/crates/proc-macro-api/src/version.rs
@@ -101,7 +101,7 @@ fn read_section<'a>(dylib_binary: &'a [u8], section_name: &str) -> io::Result<&'
 /// * [version string bytes encoded in utf8] <- GET THIS BOI
 /// * [some more bytes that we don't really care but about still there] :-)
 /// Check this issue for more about the bytes layout:
-/// <https://github.com/rust-analyzer/rust-analyzer/issues/6174>
+/// <https://github.com/rust-lang/rust-analyzer/issues/6174>
 fn read_version(dylib_path: &AbsPath) -> io::Result<String> {
     let dylib_file = File::open(dylib_path)?;
     let dylib_mmaped = unsafe { Mmap::map(&dylib_file) }?;

--- a/crates/profile/src/lib.rs
+++ b/crates/profile/src/lib.rs
@@ -75,7 +75,7 @@ impl Drop for Scope {
 ///
 /// See this diff for how to profile completions:
 ///
-/// <https://github.com/rust-analyzer/rust-analyzer/pull/5306>
+/// <https://github.com/rust-lang/rust-analyzer/pull/5306>
 #[derive(Debug)]
 pub struct CpuSpan {
     _private: (),

--- a/crates/project-model/src/workspace.rs
+++ b/crates/project-model/src/workspace.rs
@@ -579,7 +579,7 @@ fn cargo_to_crate_graph(
                 // add any targets except the library target, since those will not work correctly if
                 // they use dev-dependencies.
                 // In fact, they can break quite badly if multiple client workspaces get merged:
-                // https://github.com/rust-analyzer/rust-analyzer/issues/11300
+                // https://github.com/rust-lang/rust-analyzer/issues/11300
                 continue;
             }
 

--- a/crates/rust-analyzer/src/main_loop.rs
+++ b/crates/rust-analyzer/src/main_loop.rs
@@ -38,7 +38,7 @@ pub fn main_loop(config: Config, connection: Connection) -> Result<()> {
     //
     // https://docs.microsoft.com/en-us/windows/win32/procthread/scheduling-priorities
     // https://docs.microsoft.com/en-us/windows/win32/procthread/priority-boosts
-    // https://github.com/rust-analyzer/rust-analyzer/issues/2835
+    // https://github.com/rust-lang/rust-analyzer/issues/2835
     #[cfg(windows)]
     unsafe {
         use winapi::um::processthreadsapi::*;

--- a/crates/rust-analyzer/tests/slow-tests/tidy.rs
+++ b/crates/rust-analyzer/tests/slow-tests/tidy.rs
@@ -344,7 +344,7 @@ fn check_dbg(path: &Path, text: &str) {
 
 fn check_test_attrs(path: &Path, text: &str) {
     let ignore_rule =
-        "https://github.com/rust-analyzer/rust-analyzer/blob/master/docs/dev/style.md#ignore";
+        "https://github.com/rust-lang/rust-analyzer/blob/master/docs/dev/style.md#ignore";
     let need_ignore: &[&str] = &[
         // This file.
         "slow-tests/tidy.rs",
@@ -365,7 +365,7 @@ fn check_test_attrs(path: &Path, text: &str) {
     }
 
     let panic_rule =
-        "https://github.com/rust-analyzer/rust-analyzer/blob/master/docs/dev/style.md#should_panic";
+        "https://github.com/rust-lang/rust-analyzer/blob/master/docs/dev/style.md#should_panic";
     let need_panic: &[&str] = &[
         // This file.
         "slow-tests/tidy.rs",

--- a/crates/sourcegen/src/lib.rs
+++ b/crates/sourcegen/src/lib.rs
@@ -125,7 +125,7 @@ impl fmt::Display for Location {
         let name = self.file.file_name().unwrap();
         write!(
             f,
-            "https://github.com/rust-analyzer/rust-analyzer/blob/master/{}#L{}[{}]",
+            "https://github.com/rust-lang/rust-analyzer/blob/master/{}#L{}[{}]",
             path,
             self.line,
             name.to_str().unwrap()

--- a/crates/syntax/src/syntax_error.rs
+++ b/crates/syntax/src/syntax_error.rs
@@ -10,7 +10,7 @@ use crate::{TextRange, TextSize};
 pub struct SyntaxError(String, TextRange);
 
 // FIXME: there was an unused SyntaxErrorKind previously (before this enum was removed)
-// It was introduced in this PR: https://github.com/rust-analyzer/rust-analyzer/pull/846/files#diff-827da9b03b8f9faa1bade5cdd44d5dafR95
+// It was introduced in this PR: https://github.com/rust-lang/rust-analyzer/pull/846/files#diff-827da9b03b8f9faa1bade5cdd44d5dafR95
 // but it was not removed by a mistake.
 //
 // So, we need to find a place where to stick validation for attributes in match clauses.

--- a/crates/syntax/src/syntax_node.rs
+++ b/crates/syntax/src/syntax_node.rs
@@ -47,7 +47,7 @@ impl SyntaxTreeBuilder {
 
     pub fn finish(self) -> Parse<SyntaxNode> {
         let (green, errors) = self.finish_raw();
-        // Disable block validation, see https://github.com/rust-analyzer/rust-analyzer/pull/10357
+        // Disable block validation, see https://github.com/rust-lang/rust-analyzer/pull/10357
         if cfg!(debug_assertions) && false {
             let node = SyntaxNode::new_root(green.clone());
             crate::validation::validate_block_structure(&node);

--- a/crates/syntax/src/validation.rs
+++ b/crates/syntax/src/validation.rs
@@ -114,7 +114,7 @@ fn rustc_unescape_error_to_string(err: unescape::EscapeError) -> &'static str {
 }
 
 fn validate_literal(literal: ast::Literal, acc: &mut Vec<SyntaxError>) {
-    // FIXME: move this function to outer scope (https://github.com/rust-analyzer/rust-analyzer/pull/2834#discussion_r366196658)
+    // FIXME: move this function to outer scope (https://github.com/rust-lang/rust-analyzer/pull/2834#discussion_r366196658)
     fn unquote(text: &str, prefix_len: usize, end_delimiter: char) -> Option<&str> {
         text.rfind(end_delimiter).and_then(|end| text.get(prefix_len..end))
     }
@@ -122,7 +122,7 @@ fn validate_literal(literal: ast::Literal, acc: &mut Vec<SyntaxError>) {
     let token = literal.token();
     let text = token.text();
 
-    // FIXME: lift this lambda refactor to `fn` (https://github.com/rust-analyzer/rust-analyzer/pull/2834#discussion_r366199205)
+    // FIXME: lift this lambda refactor to `fn` (https://github.com/rust-lang/rust-analyzer/pull/2834#discussion_r366199205)
     let mut push_err = |prefix_len, (off, err): (usize, unescape::EscapeError)| {
         let off = token.text_range().start() + TextSize::try_from(off + prefix_len).unwrap();
         acc.push(SyntaxError::new_at_offset(rustc_unescape_error_to_string(err), off));

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -28,26 +28,26 @@ https://rust-lang.zulipchat.com/#narrow/stream/185405-t-compiler.2Frust-analyzer
 
 # Issue Labels
 
-* [good-first-issue](https://github.com/rust-analyzer/rust-analyzer/labels/good%20first%20issue)
+* [good-first-issue](https://github.com/rust-lang/rust-analyzer/labels/good%20first%20issue)
   are good issues to get into the project.
-* [E-has-instructions](https://github.com/rust-analyzer/rust-analyzer/issues?q=is%3Aopen+is%3Aissue+label%3AE-has-instructions)
+* [E-has-instructions](https://github.com/rust-lang/rust-analyzer/issues?q=is%3Aopen+is%3Aissue+label%3AE-has-instructions)
   issues have links to the code in question and tests.
-* [Broken Window](https://github.com/rust-analyzer/rust-analyzer/issues?q=is:issue+is:open+label:%22Broken+Window%22)
+* [Broken Window](https://github.com/rust-lang/rust-analyzer/issues?q=is:issue+is:open+label:%22Broken+Window%22)
   are issues which are not necessarily critical by themselves, but which should be fixed ASAP regardless, to avoid accumulation of technical debt.
-* [E-easy](https://github.com/rust-analyzer/rust-analyzer/issues?q=is%3Aopen+is%3Aissue+label%3AE-easy),
-  [E-medium](https://github.com/rust-analyzer/rust-analyzer/issues?q=is%3Aopen+is%3Aissue+label%3AE-medium),
-  [E-hard](https://github.com/rust-analyzer/rust-analyzer/issues?q=is%3Aopen+is%3Aissue+label%3AE-hard),
-  [E-unknown](https://github.com/rust-analyzer/rust-analyzer/issues?q=is%3Aopen+is%3Aissue+label%3AE-unknown),
+* [E-easy](https://github.com/rust-lang/rust-analyzer/issues?q=is%3Aopen+is%3Aissue+label%3AE-easy),
+  [E-medium](https://github.com/rust-lang/rust-analyzer/issues?q=is%3Aopen+is%3Aissue+label%3AE-medium),
+  [E-hard](https://github.com/rust-lang/rust-analyzer/issues?q=is%3Aopen+is%3Aissue+label%3AE-hard),
+  [E-unknown](https://github.com/rust-lang/rust-analyzer/issues?q=is%3Aopen+is%3Aissue+label%3AE-unknown),
   labels are *estimates* for how hard would be to write a fix. Each triaged issue should have one of these labels.
-* [S-actionable](https://github.com/rust-analyzer/rust-analyzer/issues?q=is%3Aopen+is%3Aissue+label%3AS-actionable) and
-  [S-unactionable](https://github.com/rust-analyzer/rust-analyzer/issues?q=is%3Aopen+is%3Aissue+label%3AS-unactionable)
+* [S-actionable](https://github.com/rust-lang/rust-analyzer/issues?q=is%3Aopen+is%3Aissue+label%3AS-actionable) and
+  [S-unactionable](https://github.com/rust-lang/rust-analyzer/issues?q=is%3Aopen+is%3Aissue+label%3AS-unactionable)
   specify if there are concrete steps to resolve or advance an issue. Roughly, actionable issues need only work to be fixed,
   while unactionable ones are blocked either on user feedback (providing a reproducible example), or on larger architectural
   work or decisions. This classification is descriptive, not prescriptive, and might be wrong: Any unactionable issue might have a simple fix that we missed.
   Each triaged issue should have one of these labels.
-* [fun](https://github.com/rust-analyzer/rust-analyzer/issues?q=is%3Aopen+is%3Aissue+label%3Afun)
+* [fun](https://github.com/rust-lang/rust-analyzer/issues?q=is%3Aopen+is%3Aissue+label%3Afun)
   is for cool, but probably hard stuff.
-* [Design](https://github.com/rust-analyzer/rust-analyzer/issues?q=is%3Aopen+is%3Aissue+label%Design)
+* [Design](https://github.com/rust-lang/rust-analyzer/issues?q=is%3Aopen+is%3Aissue+label%Design)
   is for moderate/large scale architecture discussion.
   Also a kind of fun.
   These issues should generally include a link to a Zulip discussion thread.
@@ -119,11 +119,11 @@ npm run lint
 ```
 ## How to ...
 
-* ... add an assist? [#7535](https://github.com/rust-analyzer/rust-analyzer/pull/7535)
-* ... add a new protocol extension? [#4569](https://github.com/rust-analyzer/rust-analyzer/pull/4569)
-* ... add a new configuration option? [#7451](https://github.com/rust-analyzer/rust-analyzer/pull/7451)
-* ... add a new completion? [#6964](https://github.com/rust-analyzer/rust-analyzer/pull/6964)
-* ... allow new syntax in the parser? [#7338](https://github.com/rust-analyzer/rust-analyzer/pull/7338)
+* ... add an assist? [#7535](https://github.com/rust-lang/rust-analyzer/pull/7535)
+* ... add a new protocol extension? [#4569](https://github.com/rust-lang/rust-analyzer/pull/4569)
+* ... add a new configuration option? [#7451](https://github.com/rust-lang/rust-analyzer/pull/7451)
+* ... add a new completion? [#6964](https://github.com/rust-lang/rust-analyzer/pull/6964)
+* ... allow new syntax in the parser? [#7338](https://github.com/rust-lang/rust-analyzer/pull/7338)
 
 ## Logging
 

--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -111,10 +111,10 @@ env UPDATE_EXPECT=1 cargo qt
 
 After adding a new inline test you need to run `cargo test -p xtask` and also update the test data as described above.
 
-Note [`api_walkthrough`](https://github.com/rust-analyzer/rust-analyzer/blob/2fb6af89eb794f775de60b82afe56b6f986c2a40/crates/ra_syntax/src/lib.rs#L190-L348)
+Note [`api_walkthrough`](https://github.com/rust-lang/rust-analyzer/blob/2fb6af89eb794f775de60b82afe56b6f986c2a40/crates/ra_syntax/src/lib.rs#L190-L348)
 in particular: it shows off various methods of working with syntax tree.
 
-See [#93](https://github.com/rust-analyzer/rust-analyzer/pull/93) for an example PR which fixes a bug in the grammar.
+See [#93](https://github.com/rust-lang/rust-analyzer/pull/93) for an example PR which fixes a bug in the grammar.
 
 **Architecture Invariant:** `syntax` crate is completely independent from the rest of rust-analyzer. It knows nothing about salsa or LSP.
 This is important because it is possible to make useful tooling using only the syntax tree.

--- a/docs/dev/guide.md
+++ b/docs/dev/guide.md
@@ -8,7 +8,7 @@ architectural solutions related to the problem of building IDE-first compiler
 for Rust. There is a video version of this guide as well:
 https://youtu.be/ANKBNiSWyfc.
 
-[guide-2019-01]: https://github.com/rust-analyzer/rust-analyzer/tree/guide-2019-01
+[guide-2019-01]: https://github.com/rust-lang/rust-analyzer/tree/guide-2019-01
 
 ## The big picture
 
@@ -40,8 +40,8 @@ terms of files and offsets, and **not** in terms of Rust concepts like structs,
 traits, etc. The "typed" API with Rust specific types is slightly lower in the
 stack, we'll talk about it later.
 
-[`AnalysisHost`]: https://github.com/rust-analyzer/rust-analyzer/blob/guide-2019-01/crates/ide_api/src/lib.rs#L265-L284
-[`Analysis`]: https://github.com/rust-analyzer/rust-analyzer/blob/guide-2019-01/crates/ide_api/src/lib.rs#L291-L478
+[`AnalysisHost`]: https://github.com/rust-lang/rust-analyzer/blob/guide-2019-01/crates/ide_api/src/lib.rs#L265-L284
+[`Analysis`]: https://github.com/rust-lang/rust-analyzer/blob/guide-2019-01/crates/ide_api/src/lib.rs#L291-L478
 
 The reason for this separation of `Analysis` and `AnalysisHost` is that we want to apply
 changes "uniquely", but we might also want to fork an `Analysis` and send it to
@@ -69,7 +69,7 @@ the `AnalysisHost::apply_change` method, which accepts a single argument, a
 "transaction", so it suffices to study its methods to understand all of the
 input data.
 
-[`Change`]: https://github.com/rust-analyzer/rust-analyzer/blob/master/crates/base_db/src/change.rs#L14-L89
+[`Change`]: https://github.com/rust-lang/rust-analyzer/blob/master/crates/base_db/src/change.rs#L14-L89
 
 The `(add|change|remove)_file` methods control the set of the input files, where
 each file has an integer id (`FileId`, picked by the client), text (`String`)
@@ -142,8 +142,8 @@ like syntax highlighting). We use the event loop pattern to manage the zoo, and
 the loop is the [`main_loop_inner`] function. The [`main_loop`] does a one-time
 initialization and tearing down of the resources.
 
-[`main_loop`]: https://github.com/rust-analyzer/rust-analyzer/blob/guide-2019-01/crates/ra_lsp_server/src/main_loop.rs#L51-L110
-[`main_loop_inner`]: https://github.com/rust-analyzer/rust-analyzer/blob/guide-2019-01/crates/ra_lsp_server/src/main_loop.rs#L156-L258
+[`main_loop`]: https://github.com/rust-lang/rust-analyzer/blob/guide-2019-01/crates/ra_lsp_server/src/main_loop.rs#L51-L110
+[`main_loop_inner`]: https://github.com/rust-lang/rust-analyzer/blob/guide-2019-01/crates/ra_lsp_server/src/main_loop.rs#L156-L258
 
 
 Let's walk through a typical analyzer session!
@@ -154,7 +154,7 @@ and we run `rustc --print sysroot` and scan the "sysroot" (the directory contain
 `std`. Currently we load this configuration once at the start of the server, but
 it should be possible to dynamically reconfigure it later without restart.
 
-[main_loop.rs#L62-L70](https://github.com/rust-analyzer/rust-analyzer/blob/guide-2019-01/crates/ra_lsp_server/src/main_loop.rs#L62-L70)
+[main_loop.rs#L62-L70](https://github.com/rust-lang/rust-analyzer/blob/guide-2019-01/crates/ra_lsp_server/src/main_loop.rs#L62-L70)
 
 The [`ProjectModel`] we get after this step is very Cargo and sysroot specific,
 it needs to be lowered to get the input in the form of `Change`. This
@@ -165,19 +165,19 @@ happens in [`ServerWorldState::new`] method. Specifically
 * Create an analyzer's `Crate` for each Cargo **target** and sysroot crate.
 * Setup dependencies between the crates.
 
-[`ProjectModel`]: https://github.com/rust-analyzer/rust-analyzer/blob/guide-2019-01/crates/ra_lsp_server/src/project_model.rs#L16-L20
-[`ServerWorldState::new`]: https://github.com/rust-analyzer/rust-analyzer/blob/guide-2019-01/crates/ra_lsp_server/src/server_world.rs#L38-L160
+[`ProjectModel`]: https://github.com/rust-lang/rust-analyzer/blob/guide-2019-01/crates/ra_lsp_server/src/project_model.rs#L16-L20
+[`ServerWorldState::new`]: https://github.com/rust-lang/rust-analyzer/blob/guide-2019-01/crates/ra_lsp_server/src/server_world.rs#L38-L160
 
 The results of the scan (which may take a while) will be processed in the body
 of the main loop, just like any other change. Here's where we handle:
 
-* [File system changes](https://github.com/rust-analyzer/rust-analyzer/blob/guide-2019-01/crates/ra_lsp_server/src/main_loop.rs#L194)
-* [Changes from the editor](https://github.com/rust-analyzer/rust-analyzer/blob/guide-2019-01/crates/ra_lsp_server/src/main_loop.rs#L377)
+* [File system changes](https://github.com/rust-lang/rust-analyzer/blob/guide-2019-01/crates/ra_lsp_server/src/main_loop.rs#L194)
+* [Changes from the editor](https://github.com/rust-lang/rust-analyzer/blob/guide-2019-01/crates/ra_lsp_server/src/main_loop.rs#L377)
 
 After a single loop's turn, we group the changes into one `Change` and
 [apply] it. This always happens on the main thread and blocks the loop.
 
-[apply]: https://github.com/rust-analyzer/rust-analyzer/blob/guide-2019-01/crates/ra_lsp_server/src/server_world.rs#L216
+[apply]: https://github.com/rust-lang/rust-analyzer/blob/guide-2019-01/crates/ra_lsp_server/src/server_world.rs#L216
 
 To handle requests, like ["goto definition"], we create an instance of the
 `Analysis` and [`schedule`] the task (which consumes `Analysis`) on the
@@ -187,9 +187,9 @@ executing "goto definition" on the threadpool and a new change comes in, the
 task will be canceled as soon as the main loop calls `apply_change` on the
 `AnalysisHost`.
 
-["goto definition"]: https://github.com/rust-analyzer/rust-analyzer/blob/guide-2019-01/crates/ra_lsp_server/src/server_world.rs#L216
-[`schedule`]: https://github.com/rust-analyzer/rust-analyzer/blob/guide-2019-01/crates/ra_lsp_server/src/main_loop.rs#L426-L455
-[The task]: https://github.com/rust-analyzer/rust-analyzer/blob/guide-2019-01/crates/ra_lsp_server/src/main_loop/handlers.rs#L205-L223
+["goto definition"]: https://github.com/rust-lang/rust-analyzer/blob/guide-2019-01/crates/ra_lsp_server/src/server_world.rs#L216
+[`schedule`]: https://github.com/rust-lang/rust-analyzer/blob/guide-2019-01/crates/ra_lsp_server/src/main_loop.rs#L426-L455
+[The task]: https://github.com/rust-lang/rust-analyzer/blob/guide-2019-01/crates/ra_lsp_server/src/main_loop/handlers.rs#L205-L223
 
 This concludes the overview of the analyzer's programing *interface*. Next, let's
 dig into the implementation!
@@ -251,13 +251,13 @@ All analyzer information is stored in a salsa database. `Analysis` and
 `AnalysisHost` types are newtype wrappers for [`RootDatabase`] -- a salsa
 database.
 
-[`RootDatabase`]: https://github.com/rust-analyzer/rust-analyzer/blob/guide-2019-01/crates/ide_api/src/db.rs#L88-L134
+[`RootDatabase`]: https://github.com/rust-lang/rust-analyzer/blob/guide-2019-01/crates/ide_api/src/db.rs#L88-L134
 
 Salsa input queries are defined in [`FilesDatabase`] (which is a part of
 `RootDatabase`). They closely mirror the familiar `Change` structure:
 indeed, what `apply_change` does is it sets the values of input queries.
 
-[`FilesDatabase`]: https://github.com/rust-analyzer/rust-analyzer/blob/guide-2019-01/crates/base_db/src/input.rs#L150-L174
+[`FilesDatabase`]: https://github.com/rust-lang/rust-analyzer/blob/guide-2019-01/crates/base_db/src/input.rs#L150-L174
 
 ## From text to semantic model
 
@@ -273,7 +273,7 @@ several times, with different sets of `cfg`s enabled. The IDE-specific task of
 mapping source code into a semantic model is inherently imprecise for
 this reason and gets handled by the [`source_binder`].
 
-[`source_binder`]: https://github.com/rust-analyzer/rust-analyzer/blob/guide-2019-01/crates/hir/src/source_binder.rs
+[`source_binder`]: https://github.com/rust-lang/rust-analyzer/blob/guide-2019-01/crates/hir/src/source_binder.rs
 
 The semantic interface is declared in the [`code_model_api`] module. Each entity is
 identified by an integer ID and has a bunch of methods which take a salsa database
@@ -281,8 +281,8 @@ as an argument and returns other entities (which are also IDs). Internally, thes
 methods invoke various queries on the database to build the model on demand.
 Here's [the list of queries].
 
-[`code_model_api`]: https://github.com/rust-analyzer/rust-analyzer/blob/guide-2019-01/crates/hir/src/code_model_api.rs
-[the list of queries]: https://github.com/rust-analyzer/rust-analyzer/blob/7e84440e25e19529e4ff8a66e521d1b06349c6ec/crates/hir/src/db.rs#L20-L106
+[`code_model_api`]: https://github.com/rust-lang/rust-analyzer/blob/guide-2019-01/crates/hir/src/code_model_api.rs
+[the list of queries]: https://github.com/rust-lang/rust-analyzer/blob/7e84440e25e19529e4ff8a66e521d1b06349c6ec/crates/hir/src/db.rs#L20-L106
 
 The first step of building the model is parsing the source code.
 
@@ -328,7 +328,7 @@ The implementation is based on the generic [rowan] crate on top of which a
 
 [libsyntax]: https://github.com/apple/swift/tree/5e2c815edfd758f9b1309ce07bfc01c4bc20ec23/lib/Syntax
 [rowan]: https://github.com/rust-analyzer/rowan/tree/100a36dc820eb393b74abe0d20ddf99077b61f88
-[rust-specific]: https://github.com/rust-analyzer/rust-analyzer/blob/guide-2019-01/crates/ra_syntax/src/ast/generated.rs
+[rust-specific]: https://github.com/rust-lang/rust-analyzer/blob/guide-2019-01/crates/ra_syntax/src/ast/generated.rs
 
 The next step in constructing the semantic model is ...
 
@@ -339,7 +339,7 @@ The algorithm for building a tree of modules is to start with a crate root
 declarations and recursively process child modules. This is handled by the
 [`module_tree_query`], with two slight variations.
 
-[`module_tree_query`]: https://github.com/rust-analyzer/rust-analyzer/blob/guide-2019-01/crates/hir/src/module_tree.rs#L116-L123
+[`module_tree_query`]: https://github.com/rust-lang/rust-analyzer/blob/guide-2019-01/crates/hir/src/module_tree.rs#L116-L123
 
 First, rust-analyzer builds a module tree for all crates in a source root
 simultaneously. The main reason for this is historical (`module_tree` predates
@@ -362,7 +362,7 @@ the same, we don't have to re-execute [`module_tree_query`]. In fact, we only
 need to re-execute it when we add/remove new files or when we change mod
 declarations.
 
-[`submodules_query`]: https://github.com/rust-analyzer/rust-analyzer/blob/guide-2019-01/crates/hir/src/module_tree.rs#L41
+[`submodules_query`]: https://github.com/rust-lang/rust-analyzer/blob/guide-2019-01/crates/hir/src/module_tree.rs#L41
 
 We store the resulting modules in a `Vec`-based indexed arena. The indices in
 the arena becomes module IDs. And this brings us to the next topic:
@@ -390,8 +390,8 @@ integers which can "intern" a location and return an integer ID back. The salsa
 database we use includes a couple of [interners]. How to "garbage collect"
 unused locations is an open question.
 
-[`LocationInterner`]: https://github.com/rust-analyzer/rust-analyzer/blob/guide-2019-01/crates/base_db/src/loc2id.rs#L65-L71
-[interners]: https://github.com/rust-analyzer/rust-analyzer/blob/guide-2019-01/crates/hir/src/db.rs#L22-L23
+[`LocationInterner`]: https://github.com/rust-lang/rust-analyzer/blob/guide-2019-01/crates/base_db/src/loc2id.rs#L65-L71
+[interners]: https://github.com/rust-lang/rust-analyzer/blob/guide-2019-01/crates/hir/src/db.rs#L22-L23
 
 For example, we use `LocationInterner` to assign IDs to definitions of functions,
 structs, enums, etc. The location, [`DefLoc`] contains two bits of information:
@@ -405,7 +405,7 @@ using offsets, text ranges or syntax trees as keys and values for queries. What
 we do instead is we store "index" of the item among all of the items of a file
 (so, a positional based ID, but localized to a single file).
 
-[`DefLoc`]: https://github.com/rust-analyzer/rust-analyzer/blob/guide-2019-01/crates/hir/src/ids.rs#L127-L139
+[`DefLoc`]: https://github.com/rust-lang/rust-analyzer/blob/guide-2019-01/crates/hir/src/ids.rs#L127-L139
 
 One thing we've glossed over for the time being is support for macros. We have
 only proof of concept handling of macros at the moment, but they are extremely
@@ -438,7 +438,7 @@ terms of `HirFileId`! This does not recur infinitely though: any chain of
 `HirFileId`s bottoms out in `HirFileId::FileId`, that is, some source file
 actually written by the user.
 
-[`HirFileId`]: https://github.com/rust-analyzer/rust-analyzer/blob/guide-2019-01/crates/hir/src/ids.rs#L18-L125
+[`HirFileId`]: https://github.com/rust-lang/rust-analyzer/blob/guide-2019-01/crates/hir/src/ids.rs#L18-L125
 
 Now that we understand how to identify a definition, in a source or in a
 macro-generated file, we can discuss name resolution a bit.
@@ -452,14 +452,14 @@ each module into a position-independent representation which does not change if
 we modify bodies of the items. After that we [loop] resolving all imports until
 we've reached a fixed point.
 
-[lower]: https://github.com/rust-analyzer/rust-analyzer/blob/guide-2019-01/crates/hir/src/nameres/lower.rs#L113-L117
-[loop]: https://github.com/rust-analyzer/rust-analyzer/blob/guide-2019-01/crates/hir/src/nameres.rs#L186-L196
+[lower]: https://github.com/rust-lang/rust-analyzer/blob/guide-2019-01/crates/hir/src/nameres/lower.rs#L113-L117
+[loop]: https://github.com/rust-lang/rust-analyzer/blob/guide-2019-01/crates/hir/src/nameres.rs#L186-L196
 
 And, given all our preparation with IDs and a position-independent representation,
 it is satisfying to [test] that typing inside function body does not invalidate
 name resolution results.
 
-[test]: https://github.com/rust-analyzer/rust-analyzer/blob/guide-2019-01/crates/hir/src/nameres/tests.rs#L376
+[test]: https://github.com/rust-lang/rust-analyzer/blob/guide-2019-01/crates/hir/src/nameres/tests.rs#L376
 
 An interesting fact about name resolution is that it "erases" all of the
 intermediate paths from the imports: in the end, we know which items are defined
@@ -494,10 +494,10 @@ there's an intermediate [projection query] which returns only the first
 position-independent part of the lowering. The result of this query is stable.
 Naturally, name resolution [uses] this stable projection query.
 
-[imports]: https://github.com/rust-analyzer/rust-analyzer/blob/guide-2019-01/crates/hir/src/nameres/lower.rs#L52-L59
-[`SourceMap`]: https://github.com/rust-analyzer/rust-analyzer/blob/guide-2019-01/crates/hir/src/nameres/lower.rs#L52-L59
-[projection query]: https://github.com/rust-analyzer/rust-analyzer/blob/guide-2019-01/crates/hir/src/nameres/lower.rs#L97-L103
-[uses]: https://github.com/rust-analyzer/rust-analyzer/blob/guide-2019-01/crates/hir/src/query_definitions.rs#L49
+[imports]: https://github.com/rust-lang/rust-analyzer/blob/guide-2019-01/crates/hir/src/nameres/lower.rs#L52-L59
+[`SourceMap`]: https://github.com/rust-lang/rust-analyzer/blob/guide-2019-01/crates/hir/src/nameres/lower.rs#L52-L59
+[projection query]: https://github.com/rust-lang/rust-analyzer/blob/guide-2019-01/crates/hir/src/nameres/lower.rs#L97-L103
+[uses]: https://github.com/rust-lang/rust-analyzer/blob/guide-2019-01/crates/hir/src/query_definitions.rs#L49
 
 ## Type inference
 
@@ -518,11 +518,11 @@ Given the lowered body of the function, we can now run [type inference] and
 construct a mapping from `ExprId`s to types.
 
 [@flodiebold]: https://github.com/flodiebold
-[#327]: https://github.com/rust-analyzer/rust-analyzer/pull/327
-[lower the AST]: https://github.com/rust-analyzer/rust-analyzer/blob/guide-2019-01/crates/hir/src/expr.rs
-[positional ID]: https://github.com/rust-analyzer/rust-analyzer/blob/guide-2019-01/crates/hir/src/expr.rs#L13-L15
-[a source map]: https://github.com/rust-analyzer/rust-analyzer/blob/guide-2019-01/crates/hir/src/expr.rs#L41-L44
-[type inference]: https://github.com/rust-analyzer/rust-analyzer/blob/guide-2019-01/crates/hir/src/ty.rs#L1208-L1223
+[#327]: https://github.com/rust-lang/rust-analyzer/pull/327
+[lower the AST]: https://github.com/rust-lang/rust-analyzer/blob/guide-2019-01/crates/hir/src/expr.rs
+[positional ID]: https://github.com/rust-lang/rust-analyzer/blob/guide-2019-01/crates/hir/src/expr.rs#L13-L15
+[a source map]: https://github.com/rust-lang/rust-analyzer/blob/guide-2019-01/crates/hir/src/expr.rs#L41-L44
+[type inference]: https://github.com/rust-lang/rust-analyzer/blob/guide-2019-01/crates/hir/src/ty.rs#L1208-L1223
 
 ## Tying it all together: completion
 
@@ -559,15 +559,15 @@ function and map our syntactic expression to `ExprId`. Using the ID, we figure
 out the type of the receiver expression. Then we add all fields & methods from
 the type to completion.
 
-[receiving a message]: https://github.com/rust-analyzer/rust-analyzer/blob/guide-2019-01/crates/ra_lsp_server/src/main_loop.rs#L203
-[schedule it on the threadpool]: https://github.com/rust-analyzer/rust-analyzer/blob/guide-2019-01/crates/ra_lsp_server/src/main_loop.rs#L428
-[catch]: https://github.com/rust-analyzer/rust-analyzer/blob/guide-2019-01/crates/ra_lsp_server/src/main_loop.rs#L436-L442
+[receiving a message]: https://github.com/rust-lang/rust-analyzer/blob/guide-2019-01/crates/ra_lsp_server/src/main_loop.rs#L203
+[schedule it on the threadpool]: https://github.com/rust-lang/rust-analyzer/blob/guide-2019-01/crates/ra_lsp_server/src/main_loop.rs#L428
+[catch]: https://github.com/rust-lang/rust-analyzer/blob/guide-2019-01/crates/ra_lsp_server/src/main_loop.rs#L436-L442
 [the handler]: https://salsa.zulipchat.com/#narrow/stream/181542-rfcs.2Fsalsa-query-group/topic/design.20next.20steps
-[ask analysis for completion]: https://github.com/rust-analyzer/rust-analyzer/blob/guide-2019-01/crates/ide_api/src/lib.rs#L439-L444
-[completion implementation]: https://github.com/rust-analyzer/rust-analyzer/blob/guide-2019-01/crates/ide_api/src/completion.rs#L46-L62
-[`CompletionContext`]: https://github.com/rust-analyzer/rust-analyzer/blob/guide-2019-01/crates/ide_api/src/completion/completion_context.rs#L14-L37
-["IntelliJ Trick"]: https://github.com/rust-analyzer/rust-analyzer/blob/guide-2019-01/crates/ide_api/src/completion/completion_context.rs#L72-L75
-[find an ancestor `fn` node]: https://github.com/rust-analyzer/rust-analyzer/blob/guide-2019-01/crates/ide_api/src/completion/completion_context.rs#L116-L120
-[semantic model]: https://github.com/rust-analyzer/rust-analyzer/blob/guide-2019-01/crates/ide_api/src/completion/completion_context.rs#L123
-[series of independent completion routines]: https://github.com/rust-analyzer/rust-analyzer/blob/guide-2019-01/crates/ide_api/src/completion.rs#L52-L59
-[`complete_dot`]: https://github.com/rust-analyzer/rust-analyzer/blob/guide-2019-01/crates/ide_api/src/completion/complete_dot.rs#L6-L22
+[ask analysis for completion]: https://github.com/rust-lang/rust-analyzer/blob/guide-2019-01/crates/ide_api/src/lib.rs#L439-L444
+[completion implementation]: https://github.com/rust-lang/rust-analyzer/blob/guide-2019-01/crates/ide_api/src/completion.rs#L46-L62
+[`CompletionContext`]: https://github.com/rust-lang/rust-analyzer/blob/guide-2019-01/crates/ide_api/src/completion/completion_context.rs#L14-L37
+["IntelliJ Trick"]: https://github.com/rust-lang/rust-analyzer/blob/guide-2019-01/crates/ide_api/src/completion/completion_context.rs#L72-L75
+[find an ancestor `fn` node]: https://github.com/rust-lang/rust-analyzer/blob/guide-2019-01/crates/ide_api/src/completion/completion_context.rs#L116-L120
+[semantic model]: https://github.com/rust-lang/rust-analyzer/blob/guide-2019-01/crates/ide_api/src/completion/completion_context.rs#L123
+[series of independent completion routines]: https://github.com/rust-lang/rust-analyzer/blob/guide-2019-01/crates/ide_api/src/completion.rs#L52-L59
+[`complete_dot`]: https://github.com/rust-lang/rust-analyzer/blob/guide-2019-01/crates/ide_api/src/completion/complete_dot.rs#L6-L22

--- a/docs/dev/lsp-extensions.md
+++ b/docs/dev/lsp-extensions.md
@@ -4,7 +4,7 @@ lsp_ext.rs hash: 2a188defec26cc7c
 If you need to change the above hash to make the test pass, please check if you
 need to adjust this doc as well and ping this issue:
 
-  https://github.com/rust-analyzer/rust-analyzer/issues/4604
+  https://github.com/rust-lang/rust-analyzer/issues/4604
 
 --->
 
@@ -17,7 +17,7 @@ All capabilities are enabled via the `experimental` field of `ClientCapabilities
 Requests which we hope to upstream live under `experimental/` namespace.
 Requests, which are likely to always remain specific to `rust-analyzer` are under `rust-analyzer/` namespace.
 
-If you want to be notified about the changes to this document, subscribe to [#4604](https://github.com/rust-analyzer/rust-analyzer/issues/4604).
+If you want to be notified about the changes to this document, subscribe to [#4604](https://github.com/rust-lang/rust-analyzer/issues/4604).
 
 ## UTF-8 offsets
 
@@ -611,7 +611,7 @@ Such actions on the client side are appended to a hover bottom as command links:
 
 ## Open Cargo.toml
 
-**Upstream Issue:** https://github.com/rust-analyzer/rust-analyzer/issues/6462
+**Upstream Issue:** https://github.com/rust-lang/rust-analyzer/issues/6462
 
 **Experimental Server Capability:** `{ "openCargoToml": boolean }`
 
@@ -681,7 +681,7 @@ Triggering a hover inside the selection above will show a result of `i32`.
 
 ## Move Item
 
-**Upstream Issue:** https://github.com/rust-analyzer/rust-analyzer/issues/6823
+**Upstream Issue:** https://github.com/rust-lang/rust-analyzer/issues/6823
 
 This request is sent from client to server to move item under cursor or selection in some direction.
 

--- a/docs/dev/style.md
+++ b/docs/dev/style.md
@@ -281,7 +281,7 @@ fn f() {
 Assert liberally.
 Prefer [`stdx::never!`](https://docs.rs/always-assert/0.1.2/always_assert/macro.never.html) to standard `assert!`.
 
-**Rationale:** See [cross cutting concern: error handling](https://github.com/rust-analyzer/rust-analyzer/blob/master/docs/dev/architecture.md#error-handling).
+**Rationale:** See [cross cutting concern: error handling](https://github.com/rust-lang/rust-analyzer/blob/master/docs/dev/architecture.md#error-handling).
 
 ## Getters & Setters
 
@@ -840,7 +840,7 @@ Context-first works better when non-context parameter is a lambda.
 
 ## Variable Naming
 
-Use boring and long names for local variables ([yay code completion](https://github.com/rust-analyzer/rust-analyzer/pull/4162#discussion_r417130973)).
+Use boring and long names for local variables ([yay code completion](https://github.com/rust-lang/rust-analyzer/pull/4162#discussion_r417130973)).
 The default name is a lowercased name of the type: `global_state: GlobalState`.
 Avoid ad-hoc acronyms and contractions, but use the ones that exist consistently (`db`, `ctx`, `acc`).
 Prefer American spelling (color, behavior).

--- a/docs/dev/syntax.md
+++ b/docs/dev/syntax.md
@@ -2,16 +2,16 @@
 
 ## About the guide
 
-This guide describes the current state of syntax trees and parsing in rust-analyzer as of 2020-01-09 ([link to commit](https://github.com/rust-analyzer/rust-analyzer/tree/cf5bdf464cad7ceb9a67e07985a3f4d3799ec0b6)).
+This guide describes the current state of syntax trees and parsing in rust-analyzer as of 2020-01-09 ([link to commit](https://github.com/rust-lang/rust-analyzer/tree/cf5bdf464cad7ceb9a67e07985a3f4d3799ec0b6)).
 
 ## Source Code
 
 The things described are implemented in three places
 
 * [rowan](https://github.com/rust-analyzer/rowan/tree/v0.9.0) -- a generic library for rowan syntax trees.
-* [ra_syntax](https://github.com/rust-analyzer/rust-analyzer/tree/cf5bdf464cad7ceb9a67e07985a3f4d3799ec0b6/crates/ra_syntax) crate inside rust-analyzer which wraps `rowan` into rust-analyzer specific API.
+* [ra_syntax](https://github.com/rust-lang/rust-analyzer/tree/cf5bdf464cad7ceb9a67e07985a3f4d3799ec0b6/crates/ra_syntax) crate inside rust-analyzer which wraps `rowan` into rust-analyzer specific API.
   Nothing in rust-analyzer except this crate knows about `rowan`.
-* [parser](https://github.com/rust-analyzer/rust-analyzer/tree/cf5bdf464cad7ceb9a67e07985a3f4d3799ec0b6/crates/parser) crate parses input tokens into an `ra_syntax` tree
+* [parser](https://github.com/rust-lang/rust-analyzer/tree/cf5bdf464cad7ceb9a67e07985a3f4d3799ec0b6/crates/parser) crate parses input tokens into an `ra_syntax` tree
 
 ## Design Goals
 

--- a/docs/user/manual.adoc
+++ b/docs/user/manual.adoc
@@ -7,7 +7,7 @@
 :experimental:
 
 ////
-IMPORTANT: the master copy of this document lives in the https://github.com/rust-analyzer/rust-analyzer repository
+IMPORTANT: the master copy of this document lives in the https://github.com/rust-lang/rust-analyzer repository
 ////
 
 At its core, rust-analyzer is a *library* for semantic analysis of Rust code as it changes over time.
@@ -19,7 +19,7 @@ The LSP allows various code editors, like VS Code, Emacs or Vim, to implement se
 ====
 [.lead]
 To improve this document, send a pull request: +
-https://github.com/rust-analyzer/rust-analyzer/blob/master/docs/user/manual.adoc[https://github.com/rust-analyzer/.../manual.adoc]
+https://github.com/rust-lang/rust-analyzer/blob/master/docs/user/manual.adoc[https://github.com/rust-analyzer/.../manual.adoc]
 
 The manual is written in https://asciidoc.org[AsciiDoc] and includes some extra files which are generated from the source code. Run `cargo test` and `cargo test -p xtask` to create these and then `asciidoctor manual.adoc` to create an HTML copy.
 ====
@@ -58,7 +58,7 @@ For example, with VS Code or coc-rust-analyzer:
 
 This is the best supported editor at the moment.
 The rust-analyzer plugin for VS Code is maintained
-https://github.com/rust-analyzer/rust-analyzer/tree/master/editors/code[in tree].
+https://github.com/rust-lang/rust-analyzer/tree/master/editors/code[in tree].
 
 You can install the latest release of the plugin from
 https://marketplace.visualstudio.com/items?itemName=rust-lang.rust-analyzer[the marketplace].
@@ -105,7 +105,7 @@ To help us out by testing the newest code, you can enable pre-release versions i
 ==== Manual installation
 
 Alternatively, download a VSIX corresponding to your platform from the
-https://github.com/rust-analyzer/rust-analyzer/releases[releases] page.
+https://github.com/rust-lang/rust-analyzer/releases[releases] page.
 
 Install the extension with the `Extensions: Install from VSIX` command within VS Code, or from the command line via:
 [source]
@@ -126,7 +126,7 @@ Both the server and the Code plugin can be installed from source:
 
 [source]
 ----
-$ git clone https://github.com/rust-analyzer/rust-analyzer.git && cd rust-analyzer
+$ git clone https://github.com/rust-lang/rust-analyzer.git && cd rust-analyzer
 $ cargo xtask install
 ----
 
@@ -144,7 +144,7 @@ $ cargo xtask install --server
 === rust-analyzer Language Server Binary
 
 Other editors generally require the `rust-analyzer` binary to be in `$PATH`.
-You can download pre-built binaries from the https://github.com/rust-analyzer/rust-analyzer/releases[releases] page.
+You can download pre-built binaries from the https://github.com/rust-lang/rust-analyzer/releases[releases] page.
 You will need to uncompress and rename the binary for your platform, e.g. from `rust-analyzer-aarch64-apple-darwin.gz` on Mac OS to `rust-analyzer`, make it executable, then move it into a directory in your `$PATH`.
 
 On Linux to install the `rust-analyzer` binary into `~/.local/bin`, these commands should work:
@@ -152,7 +152,7 @@ On Linux to install the `rust-analyzer` binary into `~/.local/bin`, these comman
 [source,bash]
 ----
 $ mkdir -p ~/.local/bin
-$ curl -L https://github.com/rust-analyzer/rust-analyzer/releases/latest/download/rust-analyzer-x86_64-unknown-linux-gnu.gz | gunzip -c - > ~/.local/bin/rust-analyzer
+$ curl -L https://github.com/rust-lang/rust-analyzer/releases/latest/download/rust-analyzer-x86_64-unknown-linux-gnu.gz | gunzip -c - > ~/.local/bin/rust-analyzer
 $ chmod +x ~/.local/bin/rust-analyzer
 ----
 
@@ -165,11 +165,11 @@ You'll need the latest stable version of the Rust toolchain.
 
 [source,bash]
 ----
-$ git clone https://github.com/rust-analyzer/rust-analyzer.git && cd rust-analyzer
+$ git clone https://github.com/rust-lang/rust-analyzer.git && cd rust-analyzer
 $ cargo xtask install --server
 ----
 
-If your editor can't find the binary even though the binary is on your `$PATH`, the likely explanation is that it doesn't see the same `$PATH` as the shell, see https://github.com/rust-analyzer/rust-analyzer/issues/1811[this issue].
+If your editor can't find the binary even though the binary is on your `$PATH`, the likely explanation is that it doesn't see the same `$PATH` as the shell, see https://github.com/rust-lang/rust-analyzer/issues/1811[this issue].
 On Unix, running the editor from a shell or changing the `.desktop` file to set the environment should help.
 
 ==== `rustup`
@@ -426,7 +426,7 @@ With
         "rust": {
             "command": ["rust-analyzer"],
             "rootIndicationFileNames": ["Cargo.lock", "Cargo.toml"],
-            "url": "https://github.com/rust-analyzer/rust-analyzer",
+            "url": "https://github.com/rust-lang/rust-analyzer",
             "highlightingModeRegex": "^Rust$"
         },
 ----
@@ -506,11 +506,11 @@ $ rust-analyzer analysis-stats .
 It is especially useful when the `repo` doesn't use external crates or the standard library.
 
 If you want to go as far as to modify the source code to debug the problem, be sure to take a look at the
-https://github.com/rust-analyzer/rust-analyzer/tree/master/docs/dev[dev docs]!
+https://github.com/rust-lang/rust-analyzer/tree/master/docs/dev[dev docs]!
 
 == Configuration
 
-**Source:** https://github.com/rust-analyzer/rust-analyzer/blob/master/crates/rust-analyzer/src/config.rs[config.rs]
+**Source:** https://github.com/rust-lang/rust-analyzer/blob/master/crates/rust-analyzer/src/config.rs[config.rs]
 
 The <<_installation,Installation>> section contains details on configuration for some of the editors.
 In general `rust-analyzer` is configured via LSP messages, which means that it's up to the editor to decide on the exact format and location of configuration files.

--- a/editors/code/src/debug.ts
+++ b/editors/code/src/debug.ts
@@ -114,7 +114,7 @@ async function getDebugConfiguration(
     const wsFolder = path.normalize(workspace.uri.fsPath);
     const workspaceQualifier = isMultiFolderWorkspace ? `:${workspace.name}` : "";
     function simplifyPath(p: string): string {
-        // see https://github.com/rust-analyzer/rust-analyzer/pull/5513#issuecomment-663458818 for why this is needed
+        // see https://github.com/rust-lang/rust-analyzer/pull/5513#issuecomment-663458818 for why this is needed
         return path.normalize(p).replace(wsFolder, "${workspaceFolder" + workspaceQualifier + "}");
     }
 

--- a/editors/code/src/main.ts
+++ b/editors/code/src/main.ts
@@ -316,7 +316,7 @@ async function getServer(
             "You need to manually clone the rust-analyzer repository and " +
             "run `cargo xtask install --server` to build the language server from sources. " +
             "If you feel that your platform should be supported, please create an issue " +
-            "about that [here](https://github.com/rust-analyzer/rust-analyzer/issues) and we " +
+            "about that [here](https://github.com/rust-lang/rust-analyzer/issues) and we " +
             "will consider it."
     );
     return undefined;

--- a/lib/lsp-server/Cargo.toml
+++ b/lib/lsp-server/Cargo.toml
@@ -3,7 +3,7 @@ name = "lsp-server"
 version = "0.6.0"
 description = "Generic LSP server scaffold."
 license = "MIT OR Apache-2.0"
-repository = "https://github.com/rust-analyzer/rust-analyzer/tree/master/lib/lsp-server"
+repository = "https://github.com/rust-lang/rust-analyzer/tree/master/lib/lsp-server"
 edition = "2021"
 
 [dependencies]

--- a/xtask/src/metrics.rs
+++ b/xtask/src/metrics.rs
@@ -33,7 +33,7 @@ impl flags::Metrics {
         let _env = sh.push_env("RA_METRICS", "1");
 
         {
-            // https://github.com/rust-analyzer/rust-analyzer/issues/9997
+            // https://github.com/rust-lang/rust-analyzer/issues/9997
             let _d = sh.push_dir("target/rustc-perf/collector/benchmarks/webrender");
             cmd!(sh, "cargo update -p url --precise 1.6.1").run()?;
         }


### PR DESCRIPTION
The old links still work, but it seems less confusing to have them point to the right repo