### PR TITLE
fix: Improve suggested names for extracted variables

### DIFF
--- a/crates/ide-assists/src/handlers/extract_variable.rs
+++ b/crates/ide-assists/src/handlers/extract_variable.rs
@@ -943,8 +943,8 @@ struct S {
 }
 
 fn foo(s: &mut S) {
-    let $0var_name = &mut s.vec;
-    var_name.push(0);
+    let $0vec = &mut s.vec;
+    vec.push(0);
 }"#,
         );
     }
@@ -979,8 +979,8 @@ struct S {
 }
 
 fn foo(f: &mut Y) {
-    let $0var_name = &mut f.field.field.vec;
-    var_name.push(0);
+    let $0vec = &mut f.field.field.vec;
+    vec.push(0);
 }"#,
         );
     }


### PR DESCRIPTION
When extracting a field expression, if RA was unable to resolve the type of the
field, we would previously fall back to using "var_name" as the variable name.

Now, when the `Expr` being extracted matches a `FieldExpr`, we can use the
`NameRef`'s ident token as a fallback option.

fixes #10035