### PR TITLE
specify type of field when filling with todo!()

### DIFF
--- a/crates/ide-diagnostics/src/lib.rs
+++ b/crates/ide-diagnostics/src/lib.rs
@@ -144,6 +144,7 @@ pub struct DiagnosticsConfig {
     pub disable_experimental: bool,
     pub disabled: FxHashSet<String>,
     pub expr_fill_default: ExprFillDefaultMode,
+    pub expr_fill_type_hints: bool,
 }
 
 struct DiagnosticsContext<'a> {

--- a/crates/ide-diagnostics/src/tests.rs
+++ b/crates/ide-diagnostics/src/tests.rs
@@ -38,6 +38,7 @@ fn check_nth_fix(nth: usize, ra_fixture_before: &str, ra_fixture_after: &str) {
     let (db, file_position) = RootDatabase::with_position(ra_fixture_before);
     let mut conf = DiagnosticsConfig::default();
     conf.expr_fill_default = ExprFillDefaultMode::Default;
+    conf.expr_fill_type_hints = true;
     let diagnostic =
         super::diagnostics(&db, &conf, &AssistResolveStrategy::All, file_position.file_id)
             .pop()

--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -57,7 +57,7 @@ config_data! {
         /// Placeholder expression to use for missing expressions in assists.
         assist_expressionFillDefault: ExprFillDefaultDef              = "\"todo\"",
         /// Specify type of missing expression inside generated todo macro invocation.
-        assist_expressionFillTypeHints_enable: bool = "true",
+        assist_expressionFillTypeHints_enable: bool = "false",
 
         /// Warm up caches on project load.
         cachePriming_enable: bool = "true",

--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -56,6 +56,8 @@ config_data! {
     struct ConfigData {
         /// Placeholder expression to use for missing expressions in assists.
         assist_expressionFillDefault: ExprFillDefaultDef              = "\"todo\"",
+        /// Specify type of missing expression inside generated todo macro invocation.
+        assist_expressionFillTypeHints_enable: bool = "true",
 
         /// Warm up caches on project load.
         cachePriming_enable: bool = "true",
@@ -867,6 +869,7 @@ impl Config {
                 ExprFillDefaultDef::Todo => ExprFillDefaultMode::Todo,
                 ExprFillDefaultDef::Default => ExprFillDefaultMode::Default,
             },
+            expr_fill_type_hints: self.data.assist_expressionFillTypeHints_enable,
         }
     }
 

--- a/crates/syntax/src/ast/make.rs
+++ b/crates/syntax/src/ast/make.rs
@@ -59,6 +59,9 @@ pub mod ext {
     pub fn expr_todo() -> ast::Expr {
         expr_from_text("todo!()")
     }
+    pub fn expr_todo_msg(msg: &str) -> ast::Expr {
+        expr_from_text(&format!(r#"todo!("{}")"#, msg))
+    }
     pub fn expr_ty_default(ty: &ast::Type) -> ast::Expr {
         expr_from_text(&format!("{}::default()", ty))
     }

--- a/docs/user/generated_config.adoc
+++ b/docs/user/generated_config.adoc
@@ -3,6 +3,11 @@
 --
 Placeholder expression to use for missing expressions in assists.
 --
+[[rust-analyzer.assist.expressionFillTypeHints.enable]]rust-analyzer.assist.expressionFillTypeHints.enable (default: `true`)::
++
+--
+Specify type of missing expression inside generated todo macro invocation.
+--
 [[rust-analyzer.cachePriming.enable]]rust-analyzer.cachePriming.enable (default: `true`)::
 +
 --

--- a/docs/user/generated_config.adoc
+++ b/docs/user/generated_config.adoc
@@ -3,7 +3,7 @@
 --
 Placeholder expression to use for missing expressions in assists.
 --
-[[rust-analyzer.assist.expressionFillTypeHints.enable]]rust-analyzer.assist.expressionFillTypeHints.enable (default: `true`)::
+[[rust-analyzer.assist.expressionFillTypeHints.enable]]rust-analyzer.assist.expressionFillTypeHints.enable (default: `false`)::
 +
 --
 Specify type of missing expression inside generated todo macro invocation.

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -394,6 +394,11 @@
                         "Fill missing expressions with reasonable defaults, `new` or `default` constructors."
                     ]
                 },
+                "rust-analyzer.assist.expressionFillTypeHints.enable": {
+                    "markdownDescription": "Specify type of missing expression inside generated todo macro invocation.",
+                    "default": true,
+                    "type": "boolean"
+                },
                 "rust-analyzer.cachePriming.enable": {
                     "markdownDescription": "Warm up caches on project load.",
                     "default": true,

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -396,7 +396,7 @@
                 },
                 "rust-analyzer.assist.expressionFillTypeHints.enable": {
                     "markdownDescription": "Specify type of missing expression inside generated todo macro invocation.",
-                    "default": true,
+                    "default": false,
                     "type": "boolean"
                 },
                 "rust-analyzer.cachePriming.enable": {


### PR DESCRIPTION
i.e. after "Fill struct fields", instead of
```rust
S { a: todo!() }
```
now we can do
```rust
S { a: todo!("provide HashMap<String, Option<usize>>") }
```