### PR TITLE
Fix obsolete config keys

### DIFF
--- a/crates/ide-assists/src/handlers/auto_import.rs
+++ b/crates/ide-assists/src/handlers/auto_import.rs
@@ -40,7 +40,7 @@ use crate::{AssistContext, AssistId, AssistKind, Assists, GroupLabel};
 //
 // .Import Granularity
 //
-// It is possible to configure how use-trees are merged with the `importGranularity` setting.
+// It is possible to configure how use-trees are merged with the `imports.granularity.group` setting.
 // It has the following configurations:
 //
 // - `crate`: Merge imports from the same crate into a single use statement. This kind of
@@ -50,11 +50,11 @@ use crate::{AssistContext, AssistId, AssistKind, Assists, GroupLabel};
 // - `preserve`: Do not change the granularity of any imports. For auto-import this has the same
 //  effect as `item`.
 //
-// In `VS Code` the configuration for this is `rust-analyzer.assist.importGranularity`.
+// In `VS Code` the configuration for this is `rust-analyzer.imports.granularity.group`.
 //
 // .Import Prefix
 //
-// The style of imports in the same crate is configurable through the `importPrefix` setting.
+// The style of imports in the same crate is configurable through the `imports.prefix` setting.
 // It has the following configurations:
 //
 // - `crate`: This setting will force paths to be always absolute, starting with the `crate`
@@ -64,7 +64,7 @@ use crate::{AssistContext, AssistId, AssistKind, Assists, GroupLabel};
 //  `super` or an extern crate identifier.
 // - `plain`: This setting does not impose any restrictions in imports.
 //
-// In `VS Code` the configuration for this is `rust-analyzer.assist.importPrefix`.
+// In `VS Code` the configuration for this is `rust-analyzer.imports.prefix`.
 //
 // image::https://user-images.githubusercontent.com/48062697/113020673-b85be580-917a-11eb-9022-59585f35d4f8.gif[]
 

--- a/crates/ide-completion/src/completions/flyimport.rs
+++ b/crates/ide-completion/src/completions/flyimport.rs
@@ -95,7 +95,7 @@ use super::Completions;
 //
 // .Import configuration
 //
-// It is possible to configure how use-trees are merged with the `importMergeBehavior` setting.
+// It is possible to configure how use-trees are merged with the `imports.granularity.group` setting.
 // Mimics the corresponding behavior of the `Auto Import` feature.
 //
 // .LSP and performance implications

--- a/crates/ide-completion/src/snippet.rs
+++ b/crates/ide-completion/src/snippet.rs
@@ -6,12 +6,12 @@
 //
 // rust-analyzer allows the user to define custom (postfix)-snippets that may depend on items to be accessible for the current scope to be applicable.
 //
-// A custom snippet can be defined by adding it to the `rust-analyzer.completion.snippets` object respectively.
+// A custom snippet can be defined by adding it to the `rust-analyzer.completion.snippets.custom` object respectively.
 //
 // [source,json]
 // ----
 // {
-//   "rust-analyzer.completion.snippets": {
+//   "rust-analyzer.completion.snippets.custom": {
 //     "thread spawn": {
 //       "prefix": ["spawn", "tspawn"],
 //       "body": [

--- a/crates/project-model/src/workspace.rs
+++ b/crates/project-model/src/workspace.rs
@@ -737,7 +737,7 @@ fn handle_rustc_crates(
     let root_pkg =
         rustc_workspace.packages().find(|package| rustc_workspace[*package].name == "rustc_driver");
     // The rustc workspace might be incomplete (such as if rustc-dev is not
-    // installed for the current toolchain) and `rustcSource` is set to discover.
+    // installed for the current toolchain) and `rustc_source` is set to discover.
     if let Some(root_pkg) = root_pkg {
         // Iterate through every crate in the dependency subtree of rustc_driver using BFS
         let mut queue = VecDeque::new();
@@ -822,7 +822,7 @@ fn handle_rustc_crates(
                 for (from, _) in pkg_crates.get(&pkg).into_iter().flatten() {
                     // Avoid creating duplicate dependencies
                     // This avoids the situation where `from` depends on e.g. `arrayvec`, but
-                    // `rust_analyzer` thinks that it should use the one from the `rustcSource`
+                    // `rust_analyzer` thinks that it should use the one from the `rustc_source`
                     // instead of the one from `crates.io`
                     if !crate_graph[*from].dependencies.iter().any(|d| d.name == name) {
                         add_dep(crate_graph, *from, name.clone(), to);

--- a/crates/rust-analyzer/src/handlers.rs
+++ b/crates/rust-analyzer/src/handlers.rs
@@ -1798,7 +1798,7 @@ fn run_rustfmt(
                         String::from(
                             "rustfmt range formatting is unstable. \
                             Opt-in by using a nightly build of rustfmt and setting \
-                            `rustfmt.enableRangeFormatting` to true in your LSP configuration",
+                            `rustfmt.rangeFormatting.enable` to true in your LSP configuration",
                         ),
                     )
                     .into());

--- a/docs/user/manual.adoc
+++ b/docs/user/manual.adoc
@@ -713,7 +713,7 @@ include::./generated_assists.adoc[]
 == Diagnostics
 
 While most errors and warnings provided by rust-analyzer come from the `cargo check` integration, there's a growing number of diagnostics implemented using rust-analyzer's own analysis.
-Some of these diagnostics don't respect `\#[allow]` or `\#[deny]` attributes yet, but can be turned off using the `rust-analyzer.diagnostics.enable`, `rust-analyzer.diagnostics.enableExperimental` or `rust-analyzer.diagnostics.disabled` settings.
+Some of these diagnostics don't respect `\#[allow]` or `\#[deny]` attributes yet, but can be turned off using the `rust-analyzer.diagnostics.enable`, `rust-analyzer.diagnostics.experimental.enable` or `rust-analyzer.diagnostics.disabled` settings.
 
 include::./generated_diagnostic.adoc[]
 

--- a/docs/user/manual.adoc
+++ b/docs/user/manual.adoc
@@ -308,9 +308,11 @@ nvim_lsp.rust_analyzer.setup({
     on_attach=on_attach,
     settings = {
         ["rust-analyzer"] = {
-            assist = {
-                importGranularity = "module",
-                importPrefix = "self",
+            imports = {
+                granularity = {
+                    group = "module",
+                },
+                prefix = "self",
             },
             cargo = {
                 loadOutDirsFromCheck = true

--- a/docs/user/manual.adoc
+++ b/docs/user/manual.adoc
@@ -315,7 +315,9 @@ nvim_lsp.rust_analyzer.setup({
                 prefix = "self",
             },
             cargo = {
-                loadOutDirsFromCheck = true
+                buildScripts = {
+                    enable = true,
+                },
             },
             procMacro = {
                 enable = true
@@ -366,7 +368,9 @@ if executable('rust-analyzer')
         \   'whitelist': ['rust'],
         \   'initialization_options': {
         \     'cargo': {
-        \       'loadOutDirsFromCheck': v:true,
+        \       'buildScripts': {
+        \         'enable': v:true,
+        \       },
         \     },
         \     'procMacro': {
         \       'enable': v:true,
@@ -529,7 +533,9 @@ For example, a very common configuration is to enable proc-macro support, can be
 ----
 {
   "cargo": {
-    "loadOutDirsFromCheck": true,
+    "buildScripts": {
+      "enable": true,
+    },
   },
   "procMacro": {
     "enable": true,


### PR DESCRIPTION
The config keys were drastically reorganized by #12010, but the docs don't reflect the updates, causing inconsistency and confusion.  I checked for such obsolete configuration keys and updated to the new one.  For reproducibility, I attach a small shell script that I used to examine the old keys.  Now the script only detects `cargoExtraArgs` and `overrideCargo`, which originates from other type definition in the code but not from the configuration.

<details><summary>script</summary>

```bash
echo "allowMergingIntoGlobImports
exprFillDefault
importEnforceGranularity
importGranularity
importMergeBehavior
importMergeBehaviour
importGroup
importPrefix
warmup
loadOutDirsFromCheck
runBuildScripts
runBuildScriptsCommand
useRustcWrapperForBuildScripts
enableExperimental
procAttrMacros
breakPoints
exitPoints
yieldPoints
linksInHover
linksInHover
gotoTypeDef
chainingHints
closureReturnTypeHints
hideNamedConstructorHints
parameterHints
reborrowHints
typeHints
lruCapacity
cargoExtraArgs
overrideCargo
rustcSource
enableRangeFormatting
assist\.allowMergingIntoGlobImports
assist\.exprFillDefault
assist\.importEnforceGranularity
assist\.importGranularity
assist\.importMergeBehavior
assist\.importMergeBehaviour
assist\.importGroup
assist\.importPrefix
primeCaches\.enable
cache\.warmup
cargo\.loadOutDirsFromCheck
cargo\.runBuildScripts
cargo\.runBuildScriptsCommand
cargo\.useRustcWrapperForBuildScripts
completion\.snippets
diagnostics\.enableExperimental
experimental\.procAttrMacros
highlighting\.strings
highlightRelated\.breakPoints
highlightRelated\.exitPoints
highlightRelated\.yieldPoints
highlightRelated\.references
hover\.documentation
hover\.linksInHover
hoverActions\.linksInHover
hoverActions\.debug
hoverActions\.enable
hoverActions\.gotoTypeDef
hoverActions\.implementations
hoverActions\.references
hoverActions\.run
inlayHints\.chainingHints
inlayHints\.closureReturnTypeHints
inlayHints\.hideNamedConstructorHints
inlayHints\.parameterHints
inlayHints\.reborrowHints
inlayHints\.typeHints
lruCapacity
runnables\.cargoExtraArgs
runnables\.overrideCargo
rustcSource
rustfmt\.enableRangeFormatting
allFeatures
addCallArgumentSnippets
addCallParenthesis
callInfo\.full
cargo\.allFeatures
checkOnSave\.allFeatures
completion\.addCallArgumentSnippets
completion\.addCallParenthesis" | while read -r pattern
do
  rg '\b'$pattern'\b([^.]|$)' . -g "!crates/rust-analyzer/src/config/patch_old_style.rs" -g "!editors/code/src/config.ts" -g "!a.sh" --no-heading --color=always --line-number
done

exit

excluded
# debug
# enable
# run
# implementations
# references
# documentation
# references
# snippets
# strings
# full
```

</details>