### PR TITLE
Remove deprecate action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,21 +37,8 @@ jobs:
         ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 20
 
-    # We need to disable the existing toolchain to avoid updating rust-docs
-    # which takes a long time. The fastest way to do this is to rename the
-    # existing folder, as deleting it takes about as much time as not doing
-    # anything and just updating rust-docs.
-    - name: Rename existing rust toolchain (Windows)
-      if: matrix.os == 'windows-latest'
-      run: Rename-Item C:\Users\runneradmin\.rustup\toolchains\stable-x86_64-pc-windows-msvc C:\Users\runneradmin\.rustup\toolchains\stable-x86_64-pc-windows-msvc.old
-
     - name: Install Rust toolchain
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        profile: minimal
-        override: true
-        components: rustfmt, rust-src
+      run: rustup update stable && rustup component add rustfmt rust-src
 
     - name: Cache Dependencies
       uses: Swatinem/rust-cache@ce325b60658c1b38465c06cc965b79baf32c1e72
@@ -79,11 +66,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Install Rust toolchain
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        profile: minimal
-        override: true
+      run: rustup update stable
 
     - name: Install Rust targets
       run: rustup target add ${{ env.targets }} ${{ env.targets_ide }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,7 +38,9 @@ jobs:
         fetch-depth: 20
 
     - name: Install Rust toolchain
-      run: rustup update stable && rustup component add rustfmt rust-src
+      run: |
+        rustup update stable
+        rustup component add rustfmt rust-src
 
     - name: Cache Dependencies
       uses: Swatinem/rust-cache@ce325b60658c1b38465c06cc965b79baf32c1e72
@@ -66,10 +68,9 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Install Rust toolchain
-      run: rustup update stable
-
-    - name: Install Rust targets
-      run: rustup target add ${{ env.targets }} ${{ env.targets_ide }}
+      run: |
+        rustup update stable
+        rustup target add ${{ env.targets }} ${{ env.targets_ide }}
 
     - name: Cache Dependencies
       uses: Swatinem/rust-cache@ce325b60658c1b38465c06cc965b79baf32c1e72

--- a/.github/workflows/metrics.yaml
+++ b/.github/workflows/metrics.yaml
@@ -20,7 +20,9 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Install Rust toolchain
-      run: rustup update stable && rustup component add rustfmt rust-src
+      run: |
+        rustup update stable
+        rustup component add rustfmt rust-src
 
     - name: Collect metrics
       run: cargo xtask metrics

--- a/.github/workflows/metrics.yaml
+++ b/.github/workflows/metrics.yaml
@@ -20,12 +20,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Install Rust toolchain
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        profile: minimal
-        override: true
-        components: rust-src
+      run: rustup update stable && rustup component add rustfmt rust-src
 
     - name: Collect metrics
       run: cargo xtask metrics

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,16 +20,10 @@ jobs:
           fetch-depth: 0
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
+        run: rustup update stable
 
       - name: Install cargo-workspaces
-        uses: actions-rs/install@v0.1
-        with:
-          crate: cargo-workspaces
+        run: cargo install cargo-workspaces
 
       - name: Release
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -64,7 +64,7 @@ jobs:
         run: Rename-Item C:\Users\runneradmin\.rustup\toolchains\stable-x86_64-pc-windows-msvc C:\Users\runneradmin\.rustup\toolchains\stable-x86_64-pc-windows-msvc.old
 
       - name: Install Rust toolchain
-        run: rustup update stable && rustup target add ${{ matrix.target }} && rustup component add  rust-src
+        run: rustup update stable && rustup target add ${{ matrix.target }} && rustup component add rust-src
 
       - name: Install Node.js
         uses: actions/setup-node@v1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -55,16 +55,11 @@ jobs:
         with:
           fetch-depth: ${{ env.FETCH_DEPTH }}
 
-      # We need to disable the existing toolchain to avoid updating rust-docs
-      # which takes a long time. The fastest way to do this is to rename the
-      # existing folder, as deleting it takes about as much time as not doing
-      # anything and just updating rust-docs.
-      - name: Rename existing Rust toolchain
-        if: matrix.os == 'windows-latest'
-        run: Rename-Item C:\Users\runneradmin\.rustup\toolchains\stable-x86_64-pc-windows-msvc C:\Users\runneradmin\.rustup\toolchains\stable-x86_64-pc-windows-msvc.old
-
       - name: Install Rust toolchain
-        run: rustup update stable && rustup target add ${{ matrix.target }} && rustup component add rust-src
+        run: |
+          rustup update stable
+          rustup target add ${{ matrix.target }}
+          rustup component add rust-src
 
       - name: Install Node.js
         uses: actions/setup-node@v1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -64,22 +64,7 @@ jobs:
         run: Rename-Item C:\Users\runneradmin\.rustup\toolchains\stable-x86_64-pc-windows-msvc C:\Users\runneradmin\.rustup\toolchains\stable-x86_64-pc-windows-msvc.old
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          target: ${{ matrix.target }}
-          profile: minimal
-          override: true
-
-      - name: Install Rust library source
-        if: matrix.target == 'x86_64-unknown-linux-gnu'
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          target: ${{ matrix.target }}
-          profile: minimal
-          override: true
-          components: rust-src
+        run: rustup update stable && rustup target add ${{ matrix.target }} && rustup component add  rust-src
 
       - name: Install Node.js
         uses: actions/setup-node@v1

--- a/.github/workflows/rustdoc.yaml
+++ b/.github/workflows/rustdoc.yaml
@@ -20,12 +20,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Install Rust toolchain
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        profile: minimal
-        override: true
-        components: rustfmt, rust-src
+      run: rustup update stable
 
     - name: Build Documentation
       run: cargo doc --all --no-deps


### PR DESCRIPTION
https://old.reddit.com/r/rust/comments/vyx4oj/actionsrs_organization_became_unmaintained/

Looking at this holistically, I don't fully understand *why* we need an
action here? Seems like we can just use rustup? nowadays github runners
come with rustup pre-installed.