### PR TITLE
fix: Stack overflows and wrong type inference of associated type shorthands

### DIFF
--- a/crates/hir-ty/src/lower.rs
+++ b/crates/hir-ty/src/lower.rs
@@ -1161,8 +1161,9 @@ pub(crate) fn generic_predicates_for_param_query(
                             return false;
                         }
                     }
-                    WherePredicateTypeTarget::TypeOrConstParam(local_id) => {
-                        if *local_id != param_id.local_id {
+                    &WherePredicateTypeTarget::TypeOrConstParam(local_id) => {
+                        let target_id = TypeOrConstParamId { parent: def, local_id };
+                        if target_id != param_id {
                             return false;
                         }
                     }

--- a/crates/hir-ty/src/tests/traits.rs
+++ b/crates/hir-ty/src/tests/traits.rs
@@ -467,6 +467,23 @@ fn test<T: Iterable>() {
 }
 
 #[test]
+fn associated_type_shorthand_from_self_issue_12484() {
+    check_types(
+        r#"
+trait Bar {
+    type A;
+}
+trait Foo {
+    type A;
+    fn test(a: Self::A, _: impl Bar) {
+        a;
+      //^ Foo::A<Self>
+    }
+}"#,
+    );
+}
+
+#[test]
 fn infer_associated_type_bound() {
     check_types(
         r#"

--- a/crates/ide-completion/src/completions/dot.rs
+++ b/crates/ide-completion/src/completions/dot.rs
@@ -918,4 +918,26 @@ fn main() {
 ",
         )
     }
+
+    #[test]
+    fn issue_12484() {
+        check(
+            r#"
+//- minicore: sized
+trait SizeUser {
+    type Size;
+}
+trait Closure: SizeUser {}
+trait Encrypt: SizeUser {
+    fn encrypt(self, _: impl Closure<Size = Self::Size>);
+}
+fn test(thing: impl Encrypt) {
+    thing.$0;
+}
+        "#,
+            expect![[r#"
+                me encrypt(…) (as Encrypt) fn(self, impl Closure<Size = <Self as SizeUser>::Size>)
+            "#]],
+        )
+    }
 }


### PR DESCRIPTION
This fixes `generic_predicates_for_param_query` comparing local IDs that belong to different definitions.

As the query is used in multiple places this fix affects various r-a features when an associated type shorthand and `impl Trait` involved. Notably inference, goto, completion, hover.

Fixes #12484