### PR TITLE
minor: Remove macro ABI version from doc comment

### DIFF
--- a/crates/proc-macro-srv/src/abis/abi_1_64/mod.rs
+++ b/crates/proc-macro-srv/src/abis/abi_1_64/mod.rs
@@ -1,4 +1,4 @@
-//! Macro ABI for version 1.63 of rustc
+//! Proc macro ABI.
 
 #[allow(dead_code)]
 #[doc(hidden)]


### PR DESCRIPTION
It's hard to remember to keep this in sync, but since the file path already contains the version, this comment is pretty unnecessary.