### PR TITLE
fix: make file watcher config a drop-down (and clarify the options)

### DIFF
--- a/crates/rust-analyzer/src/reload.rs
+++ b/crates/rust-analyzer/src/reload.rs
@@ -320,7 +320,7 @@ impl GlobalState {
 
         let watch = match files_config.watcher {
             FilesWatcher::Client => vec![],
-            FilesWatcher::Notify => project_folders.watch,
+            FilesWatcher::Server => project_folders.watch,
         };
         self.vfs_config_version += 1;
         self.loader.handle.set_config(vfs::loader::Config {

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -686,7 +686,15 @@
                 "rust-analyzer.files.watcher": {
                     "markdownDescription": "Controls file watching implementation.",
                     "default": "client",
-                    "type": "string"
+                    "type": "string",
+                    "enum": [
+                        "client",
+                        "server"
+                    ],
+                    "enumDescriptions": [
+                        "Use the client (editor) to watch files for changes",
+                        "Use server-side file watching"
+                    ]
                 },
                 "rust-analyzer.highlightRelated.breakPoints.enable": {
                     "markdownDescription": "Enables highlighting of related references while the cursor is on `break`, `loop`, `while`, or `for` keywords.",


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust-analyzer/issues/12794

Also renames "notify" to "server", since that's clearer ("notify" is still accepted for compatibility).