### PR TITLE
Add simple support for completion item details

### DIFF
--- a/crates/rust-analyzer/src/caps.rs
+++ b/crates/rust-analyzer/src/caps.rs
@@ -1,16 +1,16 @@
 //! Advertises the capabilities of the LSP Server.
 use lsp_types::{
     CallHierarchyServerCapability, ClientCapabilities, CodeActionKind, CodeActionOptions,
-    CodeActionProviderCapability, CodeLensOptions, CompletionOptions, DeclarationCapability,
-    DocumentOnTypeFormattingOptions, FileOperationFilter, FileOperationPattern,
-    FileOperationPatternKind, FileOperationRegistrationOptions, FoldingRangeProviderCapability,
-    HoverProviderCapability, ImplementationProviderCapability, InlayHintOptions,
-    InlayHintServerCapabilities, OneOf, RenameOptions, SaveOptions,
-    SelectionRangeProviderCapability, SemanticTokensFullOptions, SemanticTokensLegend,
-    SemanticTokensOptions, ServerCapabilities, SignatureHelpOptions, TextDocumentSyncCapability,
-    TextDocumentSyncKind, TextDocumentSyncOptions, TypeDefinitionProviderCapability,
-    WorkDoneProgressOptions, WorkspaceFileOperationsServerCapabilities,
-    WorkspaceServerCapabilities,
+    CodeActionProviderCapability, CodeLensOptions, CompletionOptions,
+    CompletionOptionsCompletionItem, DeclarationCapability, DocumentOnTypeFormattingOptions,
+    FileOperationFilter, FileOperationPattern, FileOperationPatternKind,
+    FileOperationRegistrationOptions, FoldingRangeProviderCapability, HoverProviderCapability,
+    ImplementationProviderCapability, InlayHintOptions, InlayHintServerCapabilities, OneOf,
+    RenameOptions, SaveOptions, SelectionRangeProviderCapability, SemanticTokensFullOptions,
+    SemanticTokensLegend, SemanticTokensOptions, ServerCapabilities, SignatureHelpOptions,
+    TextDocumentSyncCapability, TextDocumentSyncKind, TextDocumentSyncOptions,
+    TypeDefinitionProviderCapability, WorkDoneProgressOptions,
+    WorkspaceFileOperationsServerCapabilities, WorkspaceServerCapabilities,
 };
 use serde_json::json;
 
@@ -36,7 +36,7 @@ pub fn server_capabilities(config: &Config) -> ServerCapabilities {
                 "(".to_string(),
             ]),
             all_commit_characters: None,
-            completion_item: None,
+            completion_item: completion_item(&config),
             work_done_progress_options: WorkDoneProgressOptions { work_done_progress: None },
         }),
         signature_help_provider: Some(SignatureHelpOptions {
@@ -168,6 +168,12 @@ pub(crate) fn completion_item_edit_resolve(caps: &ClientCapabilities) -> bool {
                 .any(|cap_string| cap_string.as_str() == "additionalTextEdits"),
         )
     })() == Some(true)
+}
+
+fn completion_item(config: &Config) -> Option<CompletionOptionsCompletionItem> {
+    Some(CompletionOptionsCompletionItem {
+        label_details_support: Some(config.completion_label_details_support()),
+    })
 }
 
 fn code_action_capabilities(client_caps: &ClientCapabilities) -> CodeActionProviderCapability {

--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -833,6 +833,20 @@ impl Config {
         )
     }
 
+    pub fn completion_label_details_support(&self) -> bool {
+        try_!(self
+            .caps
+            .text_document
+            .as_ref()?
+            .completion
+            .as_ref()?
+            .completion_item
+            .as_ref()?
+            .label_details_support
+            .as_ref()?)
+        .is_some()
+    }
+
     pub fn offset_encoding(&self) -> OffsetEncoding {
         if supports_utf8(&self.caps) {
             OffsetEncoding::Utf8

--- a/crates/rust-analyzer/src/to_proto.rs
+++ b/crates/rust-analyzer/src/to_proto.rs
@@ -277,6 +277,13 @@ fn completion_item(
         ..Default::default()
     };
 
+    if config.completion_label_details_support() {
+        lsp_item.label_details = Some(lsp_types::CompletionItemLabelDetails {
+            detail: None,
+            description: lsp_item.detail.clone(),
+        });
+    }
+
     set_score(&mut lsp_item, max_relevance, item.relevance());
 
     if config.completion().enable_imports_on_the_fly {


### PR DESCRIPTION
Supercedes https://github.com/rust-lang/rust-analyzer/pull/9891, this doesn't yet fix the linked issue since there is a lot of fancy things we can do there now.

This doesn't yet really implement anything new, it just adds the scaffolding for the protocol conversion