### PR TITLE
feat: Only flycheck workspace that belongs to saved file

### DIFF
--- a/crates/flycheck/src/lib.rs
+++ b/crates/flycheck/src/lib.rs
@@ -55,6 +55,7 @@ pub struct FlycheckHandle {
     // XXX: drop order is significant
     sender: Sender<Restart>,
     _thread: jod_thread::JoinHandle,
+    id: usize,
 }
 
 impl FlycheckHandle {
@@ -70,12 +71,16 @@ impl FlycheckHandle {
             .name("Flycheck".to_owned())
             .spawn(move || actor.run(receiver))
             .expect("failed to spawn thread");
-        FlycheckHandle { sender, _thread: thread }
+        FlycheckHandle { id, sender, _thread: thread }
     }
 
     /// Schedule a re-start of the cargo check worker.
     pub fn update(&self) {
         self.sender.send(Restart).unwrap();
+    }
+
+    pub fn id(&self) -> usize {
+        self.id
     }
 }
 

--- a/crates/paths/src/lib.rs
+++ b/crates/paths/src/lib.rs
@@ -103,6 +103,14 @@ impl AsRef<Path> for AbsPath {
     }
 }
 
+impl ToOwned for AbsPath {
+    type Owned = AbsPathBuf;
+
+    fn to_owned(&self) -> Self::Owned {
+        AbsPathBuf(self.0.to_owned())
+    }
+}
+
 impl<'a> TryFrom<&'a Path> for &'a AbsPath {
     type Error = &'a Path;
     fn try_from(path: &'a Path) -> Result<&'a AbsPath, &'a Path> {

--- a/crates/rust-analyzer/src/diagnostics.rs
+++ b/crates/rust-analyzer/src/diagnostics.rs
@@ -8,7 +8,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::lsp_ext;
 
-pub(crate) type CheckFixes = Arc<FxHashMap<FileId, Vec<Fix>>>;
+pub(crate) type CheckFixes = Arc<FxHashMap<usize, FxHashMap<FileId, Vec<Fix>>>>;
 
 #[derive(Debug, Default, Clone)]
 pub struct DiagnosticsMapConfig {
@@ -22,7 +22,7 @@ pub(crate) struct DiagnosticCollection {
     // FIXME: should be FxHashMap<FileId, Vec<ra_id::Diagnostic>>
     pub(crate) native: FxHashMap<FileId, Vec<lsp_types::Diagnostic>>,
     // FIXME: should be Vec<flycheck::Diagnostic>
-    pub(crate) check: FxHashMap<FileId, Vec<lsp_types::Diagnostic>>,
+    pub(crate) check: FxHashMap<usize, FxHashMap<FileId, Vec<lsp_types::Diagnostic>>>,
     pub(crate) check_fixes: CheckFixes,
     changes: FxHashSet<FileId>,
 }
@@ -35,9 +35,19 @@ pub(crate) struct Fix {
 }
 
 impl DiagnosticCollection {
-    pub(crate) fn clear_check(&mut self) {
+    pub(crate) fn clear_check(&mut self, flycheck_id: usize) {
+        if let Some(it) = Arc::make_mut(&mut self.check_fixes).get_mut(&flycheck_id) {
+            it.clear();
+        }
+        if let Some(it) = self.check.get_mut(&flycheck_id) {
+            self.changes.extend(it.drain().map(|(key, _value)| key));
+        }
+    }
+
+    pub(crate) fn clear_check_all(&mut self) {
         Arc::make_mut(&mut self.check_fixes).clear();
-        self.changes.extend(self.check.drain().map(|(key, _value)| key))
+        self.changes
+            .extend(self.check.values_mut().flat_map(|it| it.drain().map(|(key, _value)| key)))
     }
 
     pub(crate) fn clear_native_for(&mut self, file_id: FileId) {
@@ -47,11 +57,12 @@ impl DiagnosticCollection {
 
     pub(crate) fn add_check_diagnostic(
         &mut self,
+        flycheck_id: usize,
         file_id: FileId,
         diagnostic: lsp_types::Diagnostic,
         fix: Option<Fix>,
     ) {
-        let diagnostics = self.check.entry(file_id).or_default();
+        let diagnostics = self.check.entry(flycheck_id).or_default().entry(file_id).or_default();
         for existing_diagnostic in diagnostics.iter() {
             if are_diagnostics_equal(existing_diagnostic, &diagnostic) {
                 return;
@@ -59,8 +70,9 @@ impl DiagnosticCollection {
         }
 
         let check_fixes = Arc::make_mut(&mut self.check_fixes);
-        check_fixes.entry(file_id).or_default().extend(fix);
+        check_fixes.entry(flycheck_id).or_default().entry(file_id).or_default().extend(fix);
         diagnostics.push(diagnostic);
+        tracing::warn!(?flycheck_id, ?file_id, "add_check_diagnostic changes pushed");
         self.changes.insert(file_id);
     }
 
@@ -89,7 +101,8 @@ impl DiagnosticCollection {
         file_id: FileId,
     ) -> impl Iterator<Item = &lsp_types::Diagnostic> {
         let native = self.native.get(&file_id).into_iter().flatten();
-        let check = self.check.get(&file_id).into_iter().flatten();
+        let check =
+            self.check.values().filter_map(move |it| it.get(&file_id)).into_iter().flatten();
         native.chain(check)
     }
 

--- a/crates/rust-analyzer/src/diagnostics.rs
+++ b/crates/rust-analyzer/src/diagnostics.rs
@@ -72,7 +72,6 @@ impl DiagnosticCollection {
         let check_fixes = Arc::make_mut(&mut self.check_fixes);
         check_fixes.entry(flycheck_id).or_default().entry(file_id).or_default().extend(fix);
         diagnostics.push(diagnostic);
-        tracing::warn!(?flycheck_id, ?file_id, "add_check_diagnostic changes pushed");
         self.changes.insert(file_id);
     }
 

--- a/crates/rust-analyzer/src/global_state.rs
+++ b/crates/rust-analyzer/src/global_state.rs
@@ -201,6 +201,7 @@ impl GlobalState {
                     }
                 }
 
+                // Clear native diagnostics when their file gets deleted
                 if !file.exists() {
                     self.diagnostics.clear_native_for(file.file_id);
                 }

--- a/crates/rust-analyzer/src/global_state.rs
+++ b/crates/rust-analyzer/src/global_state.rs
@@ -192,6 +192,7 @@ impl GlobalState {
                 if let Some(path) = vfs.file_path(file.file_id).as_path() {
                     let path = path.to_path_buf();
                     if reload::should_refresh_for_change(&path, file.change_kind) {
+                        tracing::warn!("fetch-fiel_change");
                         self.fetch_workspaces_queue
                             .request_op(format!("vfs file change: {}", path.display()));
                     }

--- a/crates/rust-analyzer/src/handlers.rs
+++ b/crates/rust-analyzer/src/handlers.rs
@@ -1094,7 +1094,9 @@ pub(crate) fn handle_code_action(
     }
 
     // Fixes from `cargo check`.
-    for fix in snap.check_fixes.get(&frange.file_id).into_iter().flatten() {
+    for fix in
+        snap.check_fixes.values().filter_map(|it| it.get(&frange.file_id)).into_iter().flatten()
+    {
         // FIXME: this mapping is awkward and shouldn't exist. Refactor
         // `snap.check_fixes` to not convert to LSP prematurely.
         let intersect_fix_range = fix

--- a/crates/rust-analyzer/src/main_loop.rs
+++ b/crates/rust-analyzer/src/main_loop.rs
@@ -745,25 +745,24 @@ impl GlobalState {
                         let workspace_ids =
                             this.workspaces.iter().enumerate().filter(|(_, ws)| match ws {
                                 project_model::ProjectWorkspace::Cargo { cargo, .. } => {
-                                    cargo.packages().filter(|&pkg| cargo[pkg].is_member).any(
-                                        |pkg| {
-                                            cargo[pkg].targets.iter().any(|&it| {
-                                                paths.contains(&cargo[it].root.as_path())
-                                            })
-                                        },
-                                    )
+                                    cargo.packages().any(|pkg| {
+                                        cargo[pkg]
+                                            .targets
+                                            .iter()
+                                            .any(|&it| paths.contains(&cargo[it].root.as_path()))
+                                    })
                                 }
                                 project_model::ProjectWorkspace::Json { project, .. } => project
                                     .crates()
                                     .any(|(c, _)| crate_ids.iter().any(|&crate_id| crate_id == c)),
                                 project_model::ProjectWorkspace::DetachedFiles { .. } => false,
                             });
-                        'workspace: for (id, _) in workspace_ids {
-                            for flycheck in &this.flycheck {
+                        for flycheck in &this.flycheck {
+                            for (id, _) in workspace_ids.clone() {
                                 if id == flycheck.id() {
                                     updated = true;
                                     flycheck.update();
-                                    continue 'workspace;
+                                    continue;
                                 }
                             }
                         }

--- a/crates/rust-analyzer/src/main_loop.rs
+++ b/crates/rust-analyzer/src/main_loop.rs
@@ -372,7 +372,7 @@ impl GlobalState {
                 let _p = profile::span("GlobalState::handle_event/flycheck");
                 loop {
                     match task {
-                        flycheck::Message::AddDiagnostic { workspace_root, diagnostic } => {
+                        flycheck::Message::AddDiagnostic { id, workspace_root, diagnostic } => {
                             let snap = self.snapshot();
                             let diagnostics =
                                 crate::diagnostics::to_proto::map_rust_diagnostic_to_lsp(
@@ -384,6 +384,7 @@ impl GlobalState {
                             for diag in diagnostics {
                                 match url_to_file_id(&self.vfs.read().0, &diag.url) {
                                     Ok(file_id) => self.diagnostics.add_check_diagnostic(
+                                        id,
                                         file_id,
                                         diag.diagnostic,
                                         diag.fix,
@@ -401,7 +402,7 @@ impl GlobalState {
                         flycheck::Message::Progress { id, progress } => {
                             let (state, message) = match progress {
                                 flycheck::Progress::DidStart => {
-                                    self.diagnostics.clear_check();
+                                    self.diagnostics.clear_check(id);
                                     (Progress::Begin, None)
                                 }
                                 flycheck::Progress::DidCheckCrate(target) => {

--- a/crates/rust-analyzer/src/main_loop.rs
+++ b/crates/rust-analyzer/src/main_loop.rs
@@ -447,7 +447,10 @@ impl GlobalState {
         let memdocs_added_or_removed = self.mem_docs.take_changes();
 
         if self.is_quiescent() {
-            if !was_quiescent {
+            if !was_quiescent
+                && !self.fetch_workspaces_queue.op_requested()
+                && !self.fetch_build_data_queue.op_requested()
+            {
                 for flycheck in &self.flycheck {
                     flycheck.update();
                 }

--- a/crates/rust-analyzer/src/reload.rs
+++ b/crates/rust-analyzer/src/reload.rs
@@ -417,7 +417,7 @@ impl GlobalState {
             Some(it) => it,
             None => {
                 self.flycheck = Vec::new();
-                self.diagnostics.clear_check();
+                self.diagnostics.clear_check_all();
                 return;
             }
         };


### PR DESCRIPTION
Supercedes https://github.com/rust-lang/rust-analyzer/pull/11038

There is still the problem that all the diagnostics are cleared, only clearing diagnostics of the relevant workspace isn't easily doable though I think, will have to dig into that