### PR TITLE
fix: Insert `pub(crate)` after doc comments and attribute macros

### DIFF
--- a/crates/ide-assists/src/handlers/extract_module.rs
+++ b/crates/ide-assists/src/handlers/extract_module.rs
@@ -19,7 +19,7 @@ use syntax::{
         make, HasName, HasVisibility,
     },
     match_ast, ted, AstNode, SourceFile,
-    SyntaxKind::WHITESPACE,
+    SyntaxKind::{self, WHITESPACE},
     SyntaxNode, TextRange,
 };
 
@@ -380,7 +380,24 @@ impl Module {
         }
 
         for (vis, syntax) in replacements {
-            add_change_vis(vis, syntax.first_child_or_token());
+            let item = syntax.children_with_tokens().find(|node_or_token| {
+                match node_or_token.kind() {
+                    // We're looking for the start of functions, impls, structs, traits, and other documentable/attribute
+                    // macroable items that would have pub(crate) in front of it
+                    SyntaxKind::FN_KW
+                    | SyntaxKind::IMPL_KW
+                    | SyntaxKind::STRUCT_KW
+                    | SyntaxKind::TRAIT_KW
+                    | SyntaxKind::TYPE_KW
+                    | SyntaxKind::MOD_KW => true,
+                    // If we didn't find a keyword, we want to cover the record fields
+                    SyntaxKind::NAME => true,
+                    // Otherwise, the token shouldn't have pub(crate) before it
+                    _ => false,
+                }
+            });
+
+            add_change_vis(vis, item);
         }
     }
 
@@ -1577,6 +1594,131 @@ mod modname {
                 use super::x::Foo;
 
                 pub(crate) type A = (Foo, Bar);
+            }
+        ",
+        )
+    }
+
+    #[test]
+    fn test_issue_12790() {
+        check_assist(
+            extract_module,
+            r"
+            $0/// A documented function
+            fn documented_fn() {}
+            
+            // A commented function with a #[] attribute macro
+            #[cfg(test)]
+            fn attribute_fn() {}
+            
+            // A normally commented function
+            fn normal_fn() {}
+            
+            /// A documented Struct
+            struct DocumentedStruct {
+                // Normal field
+                x: i32,
+            
+                /// Documented field
+                y: i32,
+            
+                // Macroed field
+                #[cfg(test)]
+                z: i32,
+            }
+            
+            // A macroed Struct
+            #[cfg(test)]
+            struct MacroedStruct {
+                // Normal field
+                x: i32,
+            
+                /// Documented field
+                y: i32,
+            
+                // Macroed field
+                #[cfg(test)]
+                z: i32,
+            }
+            
+            // A normal Struct
+            struct NormalStruct {
+                // Normal field
+                x: i32,
+            
+                /// Documented field
+                y: i32,
+            
+                // Macroed field
+                #[cfg(test)]
+                z: i32,
+            }
+
+            /// A documented type
+            type DocumentedType = i32;
+
+            // A macroed type
+            #[cfg(test)]
+            type MacroedType = i32;$0
+        ",
+            r"
+            mod modname {
+                /// A documented function
+                pub(crate) fn documented_fn() {}
+            
+                // A commented function with a #[] attribute macro
+                #[cfg(test)]
+                pub(crate) fn attribute_fn() {}
+            
+                // A normally commented function
+                pub(crate) fn normal_fn() {}
+            
+                /// A documented Struct
+                pub(crate) struct DocumentedStruct {
+                    // Normal field
+                    pub(crate) x: i32,
+            
+                    /// Documented field
+                    pub(crate) y: i32,
+            
+                    // Macroed field
+                    #[cfg(test)]
+                    pub(crate) z: i32,
+                }
+            
+                // A macroed Struct
+                #[cfg(test)]
+                pub(crate) struct MacroedStruct {
+                    // Normal field
+                    pub(crate) x: i32,
+            
+                    /// Documented field
+                    pub(crate) y: i32,
+            
+                    // Macroed field
+                    #[cfg(test)]
+                    pub(crate) z: i32,
+                }
+            
+                // A normal Struct
+                pub(crate) struct NormalStruct {
+                    // Normal field
+                    pub(crate) x: i32,
+            
+                    /// Documented field
+                    pub(crate) y: i32,
+            
+                    // Macroed field
+                    #[cfg(test)]
+                    pub(crate) z: i32,
+                }
+
+                /// A documented type
+                pub(crate) type DocumentedType = i32;
+
+                // A macroed type
+                #[cfg(test)]
+                pub(crate) type MacroedType = i32;
             }
         ",
         )

--- a/crates/ide-assists/src/handlers/extract_module.rs
+++ b/crates/ide-assists/src/handlers/extract_module.rs
@@ -382,19 +382,10 @@ impl Module {
         for (vis, syntax) in replacements {
             let item = syntax.children_with_tokens().find(|node_or_token| {
                 match node_or_token.kind() {
-                    // We're looking for the start of functions, impls, structs, traits, and other documentable/attribute
-                    // macroable items that would have pub(crate) in front of it
-                    SyntaxKind::FN_KW
-                    | SyntaxKind::STRUCT_KW
-                    | SyntaxKind::ENUM_KW
-                    | SyntaxKind::TRAIT_KW
-                    | SyntaxKind::TYPE_KW
-                    | SyntaxKind::CONST_KW
-                    | SyntaxKind::MOD_KW => true,
-                    // If we didn't find a keyword, we want to cover the record fields in a struct
-                    SyntaxKind::NAME => true,
-                    // Otherwise, the token shouldn't have pub(crate) before it
-                    _ => false,
+                    // We're skipping comments, doc comments, and attribute macros that may precede the keyword
+                    // that the visibility should be placed before.
+                    SyntaxKind::COMMENT | SyntaxKind::ATTR | SyntaxKind::WHITESPACE => false,
+                    _ => true,
                 }
             });
 

--- a/crates/ide-assists/src/handlers/extract_module.rs
+++ b/crates/ide-assists/src/handlers/extract_module.rs
@@ -389,6 +389,7 @@ impl Module {
                     | SyntaxKind::ENUM_KW
                     | SyntaxKind::TRAIT_KW
                     | SyntaxKind::TYPE_KW
+                    | SyntaxKind::CONST_KW
                     | SyntaxKind::MOD_KW => true,
                     // If we didn't find a keyword, we want to cover the record fields in a struct
                     SyntaxKind::NAME => true,
@@ -1682,7 +1683,10 @@ mod modname {
                 A,
                 /// Another variant
                 B { x: i32, y: i32 }
-            }$0
+            }
+
+            /// Documented const
+            const MY_CONST: i32 = 0;$0
         ",
             r"
             mod modname {
@@ -1765,6 +1769,9 @@ mod modname {
                     /// Another variant
                     B { x: i32, y: i32 }
                 }
+
+                /// Documented const
+                pub(crate) const MY_CONST: i32 = 0;
             }
         ",
         )

--- a/crates/ide-assists/src/handlers/extract_module.rs
+++ b/crates/ide-assists/src/handlers/extract_module.rs
@@ -1606,49 +1606,49 @@ mod modname {
             r"
             $0/// A documented function
             fn documented_fn() {}
-            
+
             // A commented function with a #[] attribute macro
             #[cfg(test)]
             fn attribute_fn() {}
-            
+
             // A normally commented function
             fn normal_fn() {}
-            
+
             /// A documented Struct
             struct DocumentedStruct {
                 // Normal field
                 x: i32,
-            
+
                 /// Documented field
                 y: i32,
-            
+
                 // Macroed field
                 #[cfg(test)]
                 z: i32,
             }
-            
+
             // A macroed Struct
             #[cfg(test)]
             struct MacroedStruct {
                 // Normal field
                 x: i32,
-            
+
                 /// Documented field
                 y: i32,
-            
+
                 // Macroed field
                 #[cfg(test)]
                 z: i32,
             }
-            
+
             // A normal Struct
             struct NormalStruct {
                 // Normal field
                 x: i32,
-            
+
                 /// Documented field
                 y: i32,
-            
+
                 // Macroed field
                 #[cfg(test)]
                 z: i32,
@@ -1660,10 +1660,10 @@ mod modname {
             // A macroed type
             #[cfg(test)]
             type MacroedType = i32;
-            
+
             /// A module to move
             mod module {}
-            
+
             /// An impl to move
             impl NormalStruct {
                 /// A method
@@ -1688,49 +1688,49 @@ mod modname {
             mod modname {
                 /// A documented function
                 pub(crate) fn documented_fn() {}
-            
+
                 // A commented function with a #[] attribute macro
                 #[cfg(test)]
                 pub(crate) fn attribute_fn() {}
-            
+
                 // A normally commented function
                 pub(crate) fn normal_fn() {}
-            
+
                 /// A documented Struct
                 pub(crate) struct DocumentedStruct {
                     // Normal field
                     pub(crate) x: i32,
-            
+
                     /// Documented field
                     pub(crate) y: i32,
-            
+
                     // Macroed field
                     #[cfg(test)]
                     pub(crate) z: i32,
                 }
-            
+
                 // A macroed Struct
                 #[cfg(test)]
                 pub(crate) struct MacroedStruct {
                     // Normal field
                     pub(crate) x: i32,
-            
+
                     /// Documented field
                     pub(crate) y: i32,
-            
+
                     // Macroed field
                     #[cfg(test)]
                     pub(crate) z: i32,
                 }
-            
+
                 // A normal Struct
                 pub(crate) struct NormalStruct {
                     // Normal field
                     pub(crate) x: i32,
-            
+
                     /// Documented field
                     pub(crate) y: i32,
-            
+
                     // Macroed field
                     #[cfg(test)]
                     pub(crate) z: i32,

--- a/crates/ide-assists/src/handlers/extract_module.rs
+++ b/crates/ide-assists/src/handlers/extract_module.rs
@@ -385,12 +385,12 @@ impl Module {
                     // We're looking for the start of functions, impls, structs, traits, and other documentable/attribute
                     // macroable items that would have pub(crate) in front of it
                     SyntaxKind::FN_KW
-                    | SyntaxKind::IMPL_KW
                     | SyntaxKind::STRUCT_KW
+                    | SyntaxKind::ENUM_KW
                     | SyntaxKind::TRAIT_KW
                     | SyntaxKind::TYPE_KW
                     | SyntaxKind::MOD_KW => true,
-                    // If we didn't find a keyword, we want to cover the record fields
+                    // If we didn't find a keyword, we want to cover the record fields in a struct
                     SyntaxKind::NAME => true,
                     // Otherwise, the token shouldn't have pub(crate) before it
                     _ => false,
@@ -1659,7 +1659,30 @@ mod modname {
 
             // A macroed type
             #[cfg(test)]
-            type MacroedType = i32;$0
+            type MacroedType = i32;
+            
+            /// A module to move
+            mod module {}
+            
+            /// An impl to move
+            impl NormalStruct {
+                /// A method
+                fn new() {}
+            }
+
+            /// A documented trait
+            trait DocTrait {
+                /// Inner function
+                fn doc() {}
+            }
+
+            /// An enum
+            enum DocumentedEnum {
+                /// A variant
+                A,
+                /// Another variant
+                B { x: i32, y: i32 }
+            }$0
         ",
             r"
             mod modname {
@@ -1719,6 +1742,29 @@ mod modname {
                 // A macroed type
                 #[cfg(test)]
                 pub(crate) type MacroedType = i32;
+
+                /// A module to move
+                pub(crate) mod module {}
+
+                /// An impl to move
+                impl NormalStruct {
+                    /// A method
+                    pub(crate) fn new() {}
+                }
+
+                /// A documented trait
+                pub(crate) trait DocTrait {
+                    /// Inner function
+                    fn doc() {}
+                }
+
+                /// An enum
+                pub(crate) enum DocumentedEnum {
+                    /// A variant
+                    A,
+                    /// Another variant
+                    B { x: i32, y: i32 }
+                }
             }
         ",
         )


### PR DESCRIPTION
Fixes #12790 

Original behavior was to insert `pub(crate)` at the `first_child_or_token`, which for an item with a comment or attribute macro, would put the visibility marker before the comment or macro, instead of after.

This merge request alters the call to find the node with appropriate `SyntaxKind` in the `children_or_tokens`. It also adds a test case to the module to verify the behavior. Test case verifies function, module, records, enum, impl, trait, and type cases.