### PR TITLE
Upgrade to expect-test@1.4.0, add CARGO_WORKSPACE_DIR env var

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -6,3 +6,6 @@ lint = "clippy --all-targets -- -Aclippy::collapsible_if -Aclippy::needless_pass
 
 [target.x86_64-pc-windows-msvc]
 linker = "rust-lld"
+
+[env]
+CARGO_WORKSPACE_DIR = { value = "", relative = true }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -350,9 +350,9 @@ dependencies = [
 
 [[package]]
 name = "expect-test"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dced95c9dcd4e3241f95841aad395f9c8d7933a3b0b524bdeb2440885c72a271"
+checksum = "1d4661aca38d826eb7c72fe128e4238220616de4c0cc00db7bfc38e2e1364dd3"
 dependencies = [
  "dissimilar",
  "once_cell",

--- a/crates/cfg/Cargo.toml
+++ b/crates/cfg/Cargo.toml
@@ -17,7 +17,7 @@ tt = { path = "../tt", version = "0.0.0" }
 [dev-dependencies]
 mbe = { path = "../mbe" }
 syntax = { path = "../syntax" }
-expect-test = "1.3.0"
+expect-test = "1.4.0"
 oorandom = "11.1.3"
 # We depend on both individually instead of using `features = ["derive"]` to microoptimize the
 # build graph: if the feature was enabled, syn would be built early on in the graph if `smolstr`

--- a/crates/hir-def/Cargo.toml
+++ b/crates/hir-def/Cargo.toml
@@ -40,4 +40,4 @@ limit = { path = "../limit", version = "0.0.0" }
 
 [dev-dependencies]
 test-utils = { path = "../test-utils" }
-expect-test = "1.3.0"
+expect-test = "1.4.0"

--- a/crates/hir-expand/Cargo.toml
+++ b/crates/hir-expand/Cargo.toml
@@ -31,4 +31,4 @@ mbe = { path = "../mbe", version = "0.0.0" }
 limit = { path = "../limit", version = "0.0.0" }
 
 [dev-dependencies]
-expect-test = "1.3.0"
+expect-test = "1.4.0"

--- a/crates/hir-ty/Cargo.toml
+++ b/crates/hir-ty/Cargo.toml
@@ -35,7 +35,7 @@ limit = { path = "../limit", version = "0.0.0" }
 
 [dev-dependencies]
 test-utils = { path = "../test-utils" }
-expect-test = "1.3.0"
+expect-test = "1.4.0"
 tracing = "0.1.35"
 tracing-subscriber = { version = "0.3.14", default-features = false, features = [
     "env-filter",

--- a/crates/ide-assists/Cargo.toml
+++ b/crates/ide-assists/Cargo.toml
@@ -25,4 +25,4 @@ hir = { path = "../hir", version = "0.0.0" }
 [dev-dependencies]
 test-utils = { path = "../test-utils" }
 sourcegen = { path = "../sourcegen" }
-expect-test = "1.3.0"
+expect-test = "1.4.0"

--- a/crates/ide-completion/Cargo.toml
+++ b/crates/ide-completion/Cargo.toml
@@ -28,6 +28,6 @@ profile = { path = "../profile", version = "0.0.0" }
 hir = { path = "../hir", version = "0.0.0" }
 
 [dev-dependencies]
-expect-test = "1.3.0"
+expect-test = "1.4.0"
 
 test-utils = { path = "../test-utils" }

--- a/crates/ide-db/Cargo.toml
+++ b/crates/ide-db/Cargo.toml
@@ -36,4 +36,4 @@ limit = { path = "../limit", version = "0.0.0" }
 test-utils = { path = "../test-utils" }
 sourcegen = { path = "../sourcegen" }
 xshell = "0.2.2"
-expect-test = "1.3.0"
+expect-test = "1.4.0"

--- a/crates/ide-diagnostics/Cargo.toml
+++ b/crates/ide-diagnostics/Cargo.toml
@@ -25,7 +25,7 @@ hir = { path = "../hir", version = "0.0.0" }
 ide-db = { path = "../ide-db", version = "0.0.0" }
 
 [dev-dependencies]
-expect-test = "1.3.0"
+expect-test = "1.4.0"
 
 test-utils = { path = "../test-utils" }
 sourcegen = { path = "../sourcegen" }

--- a/crates/ide-ssr/Cargo.toml
+++ b/crates/ide-ssr/Cargo.toml
@@ -23,4 +23,4 @@ hir = { path = "../hir", version = "0.0.0" }
 
 [dev-dependencies]
 test-utils = { path = "../test-utils" }
-expect-test = "1.3.0"
+expect-test = "1.4.0"

--- a/crates/ide/Cargo.toml
+++ b/crates/ide/Cargo.toml
@@ -41,4 +41,4 @@ toolchain = { path = "../toolchain", version = "0.0.0" }
 
 [dev-dependencies]
 test-utils = { path = "../test-utils" }
-expect-test = "1.3.0"
+expect-test = "1.4.0"

--- a/crates/parser/Cargo.toml
+++ b/crates/parser/Cargo.toml
@@ -15,5 +15,5 @@ rustc_lexer = { version = "725.0.0", package = "rustc-ap-rustc_lexer" }
 limit = { path = "../limit", version = "0.0.0" }
 
 [dev-dependencies]
-expect-test = "1.3.0"
+expect-test = "1.4.0"
 sourcegen = { path = "../sourcegen" }

--- a/crates/proc-macro-srv/Cargo.toml
+++ b/crates/proc-macro-srv/Cargo.toml
@@ -26,7 +26,7 @@ paths = { path = "../paths", version = "0.0.0" }
 proc-macro-api = { path = "../proc-macro-api", version = "0.0.0" }
 
 [dev-dependencies]
-expect-test = "1.3.0"
+expect-test = "1.4.0"
 
 # used as proc macro test targets
 proc-macro-test = { path = "../proc-macro-test" }

--- a/crates/project-model/Cargo.toml
+++ b/crates/project-model/Cargo.toml
@@ -17,7 +17,7 @@ semver = "1.0.10"
 serde = { version = "1.0.137", features = ["derive"] }
 serde_json = "1.0.81"
 anyhow = "1.0.57"
-expect-test = "1.3.0"
+expect-test = "1.4.0"
 la-arena = { version = "0.3.0", path = "../../lib/la-arena" }
 
 cfg = { path = "../cfg", version = "0.0.0" }

--- a/crates/rust-analyzer/Cargo.toml
+++ b/crates/rust-analyzer/Cargo.toml
@@ -73,7 +73,7 @@ winapi = "0.3.9"
 jemallocator = { version = "0.5.0", package = "tikv-jemallocator", optional = true }
 
 [dev-dependencies]
-expect-test = "1.3.0"
+expect-test = "1.4.0"
 jod-thread = "0.1.2"
 xshell = "0.2.2"
 

--- a/crates/syntax/Cargo.toml
+++ b/crates/syntax/Cargo.toml
@@ -27,7 +27,7 @@ profile = { path = "../profile", version = "0.0.0" }
 
 [dev-dependencies]
 rayon = "1.5.3"
-expect-test = "1.3.0"
+expect-test = "1.4.0"
 proc-macro2 = "1.0.39"
 quote = "1.0.20"
 ungrammar = "1.16.1"


### PR DESCRIPTION
This should make ra's test suite runnable from within `rust-analyzer/rust`.

@cuviper ran into that when trying to run RA tests from rust CI: https://github.com/rust-lang/rust/pull/99444#issuecomment-1188844202