### PR TITLE
fix: Correctly generate default `PartialEq::ne`

### DIFF
--- a/crates/ide-assists/src/handlers/add_missing_impl_members.rs
+++ b/crates/ide-assists/src/handlers/add_missing_impl_members.rs
@@ -1305,4 +1305,30 @@ impl Trait<u32> for Impl {
 }"#,
         );
     }
+
+    #[test]
+    fn test_default_partial_eq() {
+        check_assist(
+            add_missing_default_members,
+            r#"
+//- minicore: eq
+struct SomeStruct {
+    data: usize,
+    field: (usize, usize),
+}
+impl PartialEq for SomeStruct {$0}
+"#,
+            r#"
+struct SomeStruct {
+    data: usize,
+    field: (usize, usize),
+}
+impl PartialEq for SomeStruct {
+    $0fn ne(&self, other: &Self) -> bool {
+            !self.eq(other)
+        }
+}
+"#,
+        );
+    }
 }

--- a/crates/ide-assists/src/utils/gen_trait_fn_body.rs
+++ b/crates/ide-assists/src/utils/gen_trait_fn_body.rs
@@ -394,6 +394,9 @@ fn gen_hash_impl(adt: &ast::Adt, func: &ast::Fn) -> Option<()> {
 
 /// Generate a `PartialEq` impl based on the fields and members of the target type.
 fn gen_partial_eq(adt: &ast::Adt, func: &ast::Fn) -> Option<()> {
+    if func.name().map_or(false, |name| name.text() == "ne") {
+        return None;
+    }
     fn gen_eq_chain(expr: Option<ast::Expr>, cmp: ast::Expr) -> Option<ast::Expr> {
         match expr {
             Some(expr) => Some(make::expr_bin_op(expr, BinaryOp::LogicOp(LogicOp::And), cmp)),
@@ -424,7 +427,7 @@ fn gen_partial_eq(adt: &ast::Adt, func: &ast::Fn) -> Option<()> {
     // generate this code `Self` for the time being.
 
     let body = match adt {
-        // `Hash` cannot be derived for unions, so no default impl can be provided.
+        // `PartialEq` cannot be derived for unions, so no default impl can be provided.
         ast::Adt::Union(_) => return None,
 
         ast::Adt::Enum(enum_) => {

--- a/crates/test-utils/src/minicore.rs
+++ b/crates/test-utils/src/minicore.rs
@@ -354,6 +354,9 @@ pub mod cmp {
     #[lang = "eq"]
     pub trait PartialEq<Rhs: ?Sized = Self> {
         fn eq(&self, other: &Rhs) -> bool;
+        fn ne(&self, other: &Rhs) -> bool {
+            !self.eq(other)
+        }
     }
 
     pub trait Eq: PartialEq<Self> {}


### PR DESCRIPTION
Fixes #12779 

For the `Generate default members` assist on the `PartialEq` trait, the assist will now give the default implementation instead of generating a function.