### PR TITLE
Remove `check_merge_commits` test

### DIFF
--- a/crates/rust-analyzer/Cargo.toml
+++ b/crates/rust-analyzer/Cargo.toml
@@ -84,3 +84,4 @@ mbe = { path = "../mbe" }
 [features]
 jemalloc = ["jemallocator", "profile/jemalloc"]
 force-always-assert = ["always-assert/force"]
+in-rust-tree = []

--- a/crates/rust-analyzer/Cargo.toml
+++ b/crates/rust-analyzer/Cargo.toml
@@ -84,4 +84,3 @@ mbe = { path = "../mbe" }
 [features]
 jemalloc = ["jemallocator", "profile/jemalloc"]
 force-always-assert = ["always-assert/force"]
-in-rust-tree = []

--- a/crates/rust-analyzer/tests/slow-tests/tidy.rs
+++ b/crates/rust-analyzer/tests/slow-tests/tidy.rs
@@ -142,57 +142,6 @@ fn check_cargo_toml(path: &Path, text: String) {
     }
 }
 
-#[cfg(not(feature = "in-rust-tree"))]
-#[test]
-fn check_merge_commits() {
-    let sh = &Shell::new().unwrap();
-
-    let bors = cmd!(sh, "git rev-list --merges --author 'bors' HEAD~19..").read().unwrap();
-    let all = cmd!(sh, "git rev-list --merges HEAD~19..").read().unwrap();
-    if bors != all {
-        panic!(
-            "
-Merge commits are not allowed in the history.
-
-When updating a pull-request, please rebase your feature branch
-on top of master by running `git rebase master`. If rebase fails,
-you can re-apply your changes like this:
-
-  # Just look around to see the current state.
-  $ git status
-  $ git log
-
-  # Abort in-progress rebase and merges, if any.
-  $ git rebase --abort
-  $ git merge --abort
-
-  # Make the branch point to the latest commit from master,
-  # while maintaining your local changes uncommited.
-  $ git reset --soft origin/master
-
-  # Commit all changes in a single batch.
-  $ git commit -am'My changes'
-
-  # Verify that everything looks alright.
-  $ git status
-  $ git log
-
-  # Push the changes. We did a rebase, so we need `--force` option.
-  # `--force-with-lease` is a more safe (Rusty) version of `--force`.
-  $ git push --force-with-lease
-
-  # Verify that both local and remote branch point to the same commit.
-  $ git log
-
-And don't fear to mess something up during a rebase -- you can
-always restore the previous state using `git ref-log`:
-
-https://github.blog/2015-06-08-how-to-undo-almost-anything-with-git/#redo-after-undo-local
-"
-        );
-    }
-}
-
 fn deny_clippy(path: &Path, text: &str) {
     let ignore = &[
         // The documentation in string literals may contain anything for its own purposes

--- a/crates/rust-analyzer/tests/slow-tests/tidy.rs
+++ b/crates/rust-analyzer/tests/slow-tests/tidy.rs
@@ -142,6 +142,7 @@ fn check_cargo_toml(path: &Path, text: String) {
     }
 }
 
+#[cfg(not(feature = "in-rust-tree"))]
 #[test]
 fn check_merge_commits() {
     let sh = &Shell::new().unwrap();


### PR DESCRIPTION
Due to the way "git subtree" works, the `check_merge_commits` test _will_ find merge commits and fail, so we simply skip it.

This changed is tracked in:

  * https://github.com/rust-lang/rust-analyzer/issues/12818

Maintainer impact: none
