### PR TITLE
Build proc-macro-test-impl out-of-tree

### DIFF
--- a/crates/proc-macro-test/build.rs
+++ b/crates/proc-macro-test/build.rs
@@ -35,7 +35,7 @@ fn main() {
     println!("Creating {}", src_dir.display());
     std::fs::create_dir_all(src_dir).unwrap();
 
-    for item_els in [&["Cargo.toml"][..], &["Cargo.lock"], &["src", "lib.rs"]] {
+    for item_els in [&["Cargo.toml"][..], &["src", "lib.rs"]] {
         let mut src = imp_dir.clone();
         let mut dst = staging_dir.clone();
         for el in item_els {

--- a/crates/proc-macro-test/build.rs
+++ b/crates/proc-macro-test/build.rs
@@ -23,7 +23,7 @@ fn main() {
     let imp_dir = std::env::current_dir().unwrap().join("imp");
 
     let staging_dir = out_dir.join("proc-macro-test-imp-staging");
-    // this'll error out if the staging dir didn't previously. using
+    // this'll error out if the staging dir didn't previously exist. using
     // `std::fs::exists` would suffer from TOCTOU so just do our best to
     // wipe it and ignore errors.
     let _ = std::fs::remove_dir_all(&staging_dir);

--- a/crates/proc-macro-test/build.rs
+++ b/crates/proc-macro-test/build.rs
@@ -25,7 +25,7 @@ fn main() {
     let staging_dir = out_dir.join("proc-macro-test-imp-staging");
     // this'll error out if the staging dir didn't previously. using
     // `std::fs::exists` would suffer from TOCTOU so just do our best to
-    // wip it and ignore errors.
+    // wipe it and ignore errors.
     let _ = std::fs::remove_dir_all(&staging_dir);
 
     println!("Creating {}", staging_dir.display());


### PR DESCRIPTION
Building it in-place fails in rust CI because the source directory is read-only. This changes `proc-macro-test`'s build script to first
copy `imp` under `OUT_DIR` (which is read-write).

It also prints stdout/stderr for the nested cargo invocation, should it fail. (I've seen failures in rust CI that I couldn't explain, and
when they take 25 minutes to reproduce, you want to have that info)

This change is tracked in:

  * https://github.com/rust-lang/rust-analyzer/issues/12818

Maintainer impact: none.