### PR TITLE
Add proc-macro-srv integration test that clones literals

### DIFF
--- a/crates/proc-macro-srv/src/tests/mod.rs
+++ b/crates/proc-macro-srv/src/tests/mod.rs
@@ -27,7 +27,7 @@ fn test_derive_error() {
 }
 
 #[test]
-fn test_fn_like_macro() {
+fn test_fn_like_macro_noop() {
     assert_expand(
         "fn_like_noop",
         r#"ident, 0, 1, []"#,
@@ -44,7 +44,7 @@ fn test_fn_like_macro() {
 }
 
 #[test]
-fn test_fn_like_macro2() {
+fn test_fn_like_macro_clone_ident_subtree() {
     assert_expand(
         "fn_like_clone_tokens",
         r#"ident, []"#,
@@ -53,6 +53,26 @@ fn test_fn_like_macro2() {
               IDENT   ident 4294967295
               PUNCH   , [alone] 4294967295
               SUBTREE [] 4294967295"#]],
+    );
+}
+
+#[test]
+fn test_fn_like_macro_clone_literals() {
+    assert_expand(
+        "fn_like_clone_tokens",
+        r#"1u16, 2_u32, -4i64, 3.14f32, "hello bridge""#,
+        expect![[r#"
+            SUBTREE $
+              LITERAL 1u16 4294967295
+              PUNCH   , [alone] 4294967295
+              LITERAL 2_u32 4294967295
+              PUNCH   , [alone] 4294967295
+              PUNCH   - [alone] 4294967295
+              LITERAL 4i64 4294967295
+              PUNCH   , [alone] 4294967295
+              LITERAL 3.14f32 4294967295
+              PUNCH   , [alone] 4294967295
+              LITERAL "hello bridge" 4294967295"#]],
     );
 }
 

--- a/crates/proc-macro-test/imp/src/lib.rs
+++ b/crates/proc-macro-test/imp/src/lib.rs
@@ -2,7 +2,7 @@
 
 #![warn(rust_2018_idioms, unused_lifetimes, semicolon_in_expressions_from_macros)]
 
-use proc_macro::{Group, Ident, Punct, TokenStream, TokenTree};
+use proc_macro::{Group, Ident, Literal, Punct, TokenStream, TokenTree};
 
 #[proc_macro]
 pub fn fn_like_noop(args: TokenStream) -> TokenStream {
@@ -71,6 +71,12 @@ fn clone_tree(t: TokenTree) -> TokenTree {
             new.set_span(orig.span());
             TokenTree::Punct(new)
         }
-        TokenTree::Literal(_orig) => unimplemented!(),
+        TokenTree::Literal(orig) => {
+            // this goes through `literal_from_str` as of 2022-07-18, cf.
+            // https://github.com/rust-lang/rust/commit/b34c79f8f1ef4d0149ad4bf77e1759c07a9a01a8
+            let mut new: Literal = orig.to_string().parse().unwrap();
+            new.set_span(orig.span());
+            TokenTree::Literal(new)
+        }
     }
 }


### PR DESCRIPTION
This exercises some of the upcoming proc_macro bridge changes. It should also pass for all supported ABIs, with the older-style bridge.

This changed is tracked in:

  * https://github.com/rust-lang/rust-analyzer/issues/12818