### PR TITLE
internal: Use ItemTree for variant, field and module attribute collection in attrs_query

### DIFF
--- a/crates/hir-def/src/adt.rs
+++ b/crates/hir-def/src/adt.rs
@@ -136,9 +136,9 @@ impl EnumData {
 
         let enum_ = &item_tree[loc.id.value];
         let mut variants = Arena::new();
-        for var_id in enum_.variants.clone() {
-            if item_tree.attrs(db, krate, var_id.into()).is_cfg_enabled(&cfg_options) {
-                let var = &item_tree[var_id];
+        for tree_id in enum_.variants.clone() {
+            if item_tree.attrs(db, krate, tree_id.into()).is_cfg_enabled(&cfg_options) {
+                let var = &item_tree[tree_id];
                 let var_data = lower_fields(
                     db,
                     krate,

--- a/crates/hir-def/src/nameres.rs
+++ b/crates/hir-def/src/nameres.rs
@@ -70,7 +70,7 @@ use syntax::{ast, SmolStr};
 use crate::{
     db::DefDatabase,
     item_scope::{BuiltinShadowMode, ItemScope},
-    item_tree::TreeId,
+    item_tree::{ItemTreeId, Mod, TreeId},
     nameres::{diagnostics::DefDiagnostic, path_resolution::ResolveMode},
     path::ModPath,
     per_ns::PerNs,
@@ -141,9 +141,11 @@ pub enum ModuleOrigin {
     File {
         is_mod_rs: bool,
         declaration: AstId<ast::Module>,
+        declaration_tree_id: ItemTreeId<Mod>,
         definition: FileId,
     },
     Inline {
+        definition_tree_id: ItemTreeId<Mod>,
         definition: AstId<ast::Module>,
     },
     /// Pseudo-module introduced by a block scope (contains only inner items).
@@ -186,7 +188,7 @@ impl ModuleOrigin {
                 let sf = db.parse(file_id).tree();
                 InFile::new(file_id.into(), ModuleSource::SourceFile(sf))
             }
-            ModuleOrigin::Inline { definition } => InFile::new(
+            ModuleOrigin::Inline { definition, .. } => InFile::new(
                 definition.file_id,
                 ModuleSource::Module(definition.to_node(db.upcast())),
             ),


### PR DESCRIPTION
Less parsing = very good, should speed up lang item collection as that basically probes attributes of all enum variants which currently triggers parsing

Not fond of how this is searching for the correct index, ideally we'd map between HIR and item tree Id here but I am not sure how, storing the item tree ids in the HIR version doesn't work due to the usage of `Trace`...