### PR TITLE
fix generate_new doc

### DIFF
--- a/crates/ide-assists/src/handlers/generate_new.rs
+++ b/crates/ide-assists/src/handlers/generate_new.rs
@@ -12,7 +12,7 @@ use crate::{
 
 // Assist: generate_new
 //
-// Adds a new inherent impl for a type.
+// Adds a `fn new` for a type.
 //
 // ```
 // struct Ctx<T: Clone> {


### PR DESCRIPTION
Looks like this got copied from `generate_impl` without adjusting the description.