### PR TITLE
fix: Fix r-a spelling in some places

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -19,7 +19,7 @@ Before submitting, please make sure that you're not running into one of these kn
 Otherwise please try to provide information which will help us to fix the issue faster. Minimal reproducible examples with few dependencies are especially lovely <3.
 -->
 
-**rust-analyzer version**: (eg. output of "Rust Analyzer: Show RA Version" command)
+**rust-analyzer version**: (eg. output of "rust-analyzer: Show RA Version" command)
 
 **rustc version**: (eg. output of `rustc -V`)
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ https://rust-lang.zulipchat.com/#narrow/stream/185405-t-compiler.2Frust-analyzer
 
 ## License
 
-Rust analyzer is primarily distributed under the terms of both the MIT
+rust-analyzer is primarily distributed under the terms of both the MIT
 license and the Apache License (Version 2.0).
 
 See LICENSE-APACHE and LICENSE-MIT for details.

--- a/crates/hir-def/src/item_tree.rs
+++ b/crates/hir-def/src/item_tree.rs
@@ -14,7 +14,7 @@
 //! unaffected, so we don't have to recompute name resolution results or item data (see `data.rs`).
 //!
 //! The `ItemTree` for the currently open file can be displayed by using the VS Code command
-//! "Rust Analyzer: Debug ItemTree".
+//! "rust-analyzer: Debug ItemTree".
 //!
 //! Compared to rustc's architecture, `ItemTree` has properties from both rustc's AST and HIR: many
 //! syntax-level Rust features are already desugared to simpler forms in the `ItemTree`, but name

--- a/crates/ide-db/src/apply_change.rs
+++ b/crates/ide-db/src/apply_change.rs
@@ -45,7 +45,7 @@ impl RootDatabase {
     // |===
     // | Editor  | Action Name
     //
-    // | VS Code | **Rust Analyzer: Memory Usage (Clears Database)**
+    // | VS Code | **rust-analyzer: Memory Usage (Clears Database)**
     // |===
     // image::https://user-images.githubusercontent.com/48062697/113065592-08559f00-91b1-11eb-8c96-64b88068ec02.gif[]
     pub fn per_query_memory_usage(&mut self) -> Vec<(String, Bytes)> {

--- a/crates/ide-ssr/src/lib.rs
+++ b/crates/ide-ssr/src/lib.rs
@@ -57,7 +57,7 @@
 // |===
 // | Editor  | Action Name
 //
-// | VS Code | **Rust Analyzer: Structural Search Replace**
+// | VS Code | **rust-analyzer: Structural Search Replace**
 // |===
 //
 // Also available as an assist, by writing a comment containing the structural

--- a/crates/ide/src/expand_macro.rs
+++ b/crates/ide/src/expand_macro.rs
@@ -19,7 +19,7 @@ pub struct ExpandedMacro {
 // |===
 // | Editor  | Action Name
 //
-// | VS Code | **Rust Analyzer: Expand macro recursively**
+// | VS Code | **rust-analyzer: Expand macro recursively**
 // |===
 //
 // image::https://user-images.githubusercontent.com/48062697/113020648-b3973180-917a-11eb-84a9-ecb921293dc5.gif[]
@@ -32,7 +32,7 @@ pub(crate) fn expand_macro(db: &RootDatabase, position: FilePosition) -> Option<
         _ => 0,
     })?;
 
-    // due to how Rust Analyzer works internally, we need to special case derive attributes,
+    // due to how rust-analyzer works internally, we need to special case derive attributes,
     // otherwise they might not get found, e.g. here with the cursor at $0 `#[attr]` would expand:
     // ```
     // #[attr]

--- a/crates/ide/src/inlay_hints.rs
+++ b/crates/ide/src/inlay_hints.rs
@@ -100,7 +100,7 @@ pub enum InlayTooltip {
 // |===
 // | Editor  | Action Name
 //
-// | VS Code | **Rust Analyzer: Toggle inlay hints*
+// | VS Code | **rust-analyzer: Toggle inlay hints*
 // |===
 //
 // image::https://user-images.githubusercontent.com/48062697/113020660-b5f98b80-917a-11eb-8d70-3be3fd558cdd.png[]

--- a/crates/ide/src/join_lines.rs
+++ b/crates/ide/src/join_lines.rs
@@ -28,7 +28,7 @@ pub struct JoinLinesConfig {
 // |===
 // | Editor  | Action Name
 //
-// | VS Code | **Rust Analyzer: Join lines**
+// | VS Code | **rust-analyzer: Join lines**
 // |===
 //
 // image::https://user-images.githubusercontent.com/48062697/113020661-b6922200-917a-11eb-87c4-b75acc028f11.gif[]

--- a/crates/ide/src/matching_brace.rs
+++ b/crates/ide/src/matching_brace.rs
@@ -12,7 +12,7 @@ use syntax::{
 // |===
 // | Editor  | Action Name
 //
-// | VS Code | **Rust Analyzer: Find matching brace**
+// | VS Code | **rust-analyzer: Find matching brace**
 // |===
 //
 // image::https://user-images.githubusercontent.com/48062697/113065573-04298180-91b1-11eb-8dec-d4e2a202f304.gif[]

--- a/crates/ide/src/move_item.rs
+++ b/crates/ide/src/move_item.rs
@@ -19,8 +19,8 @@ pub enum Direction {
 // |===
 // | Editor  | Action Name
 //
-// | VS Code | **Rust Analyzer: Move item up**
-// | VS Code | **Rust Analyzer: Move item down**
+// | VS Code | **rust-analyzer: Move item up**
+// | VS Code | **rust-analyzer: Move item down**
 // |===
 //
 // image::https://user-images.githubusercontent.com/48062697/113065576-04298180-91b1-11eb-91ce-4505e99ed598.gif[]

--- a/crates/ide/src/parent_module.rs
+++ b/crates/ide/src/parent_module.rs
@@ -18,7 +18,7 @@ use crate::NavigationTarget;
 // |===
 // | Editor  | Action Name
 //
-// | VS Code | **Rust Analyzer: Locate parent module**
+// | VS Code | **rust-analyzer: Locate parent module**
 // |===
 //
 // image::https://user-images.githubusercontent.com/48062697/113065580-04c21800-91b1-11eb-9a32-00086161c0bd.gif[]

--- a/crates/ide/src/runnables.rs
+++ b/crates/ide/src/runnables.rs
@@ -116,7 +116,7 @@ impl Runnable {
 // |===
 // | Editor  | Action Name
 //
-// | VS Code | **Rust Analyzer: Run**
+// | VS Code | **rust-analyzer: Run**
 // |===
 // image::https://user-images.githubusercontent.com/48062697/113065583-055aae80-91b1-11eb-958f-d67efcaf6a2f.gif[]
 pub(crate) fn runnables(db: &RootDatabase, file_id: FileId) -> Vec<Runnable> {
@@ -202,7 +202,7 @@ pub(crate) fn runnables(db: &RootDatabase, file_id: FileId) -> Vec<Runnable> {
 // |===
 // | Editor  | Action Name
 //
-// | VS Code | **Rust Analyzer: Peek related tests**
+// | VS Code | **rust-analyzer: Peek related tests**
 // |===
 pub(crate) fn related_tests(
     db: &RootDatabase,

--- a/crates/ide/src/shuffle_crate_graph.rs
+++ b/crates/ide/src/shuffle_crate_graph.rs
@@ -12,7 +12,7 @@ use ide_db::{
 // |===
 // | Editor  | Action Name
 //
-// | VS Code | **Rust Analyzer: Shuffle Crate Graph**
+// | VS Code | **rust-analyzer: Shuffle Crate Graph**
 // |===
 pub(crate) fn shuffle_crate_graph(db: &mut RootDatabase) {
     let crate_graph = db.crate_graph();

--- a/crates/ide/src/status.rs
+++ b/crates/ide/src/status.rs
@@ -29,7 +29,7 @@ fn macro_syntax_tree_stats(db: &RootDatabase) -> SyntaxTreeStats {
 // |===
 // | Editor  | Action Name
 //
-// | VS Code | **Rust Analyzer: Status**
+// | VS Code | **rust-analyzer: Status**
 // |===
 // image::https://user-images.githubusercontent.com/48062697/113065584-05f34500-91b1-11eb-98cc-5c196f76be7f.gif[]
 pub(crate) fn status(db: &RootDatabase, file_id: Option<FileId>) -> String {

--- a/crates/ide/src/syntax_tree.rs
+++ b/crates/ide/src/syntax_tree.rs
@@ -12,7 +12,7 @@ use syntax::{
 // |===
 // | Editor  | Action Name
 //
-// | VS Code | **Rust Analyzer: Show Syntax Tree**
+// | VS Code | **rust-analyzer: Show Syntax Tree**
 // |===
 // image::https://user-images.githubusercontent.com/48062697/113065586-068bdb80-91b1-11eb-9507-fee67f9f45a0.gif[]
 pub(crate) fn syntax_tree(

--- a/crates/ide/src/view_crate_graph.rs
+++ b/crates/ide/src/view_crate_graph.rs
@@ -16,7 +16,7 @@ use ide_db::{
 // |===
 // | Editor  | Action Name
 //
-// | VS Code | **Rust Analyzer: View Crate Graph**
+// | VS Code | **rust-analyzer: View Crate Graph**
 // |===
 pub(crate) fn view_crate_graph(db: &RootDatabase, full: bool) -> Result<String, String> {
     let crate_graph = db.crate_graph();

--- a/crates/ide/src/view_hir.rs
+++ b/crates/ide/src/view_hir.rs
@@ -8,7 +8,7 @@ use syntax::{algo::find_node_at_offset, ast, AstNode};
 // |===
 // | Editor  | Action Name
 //
-// | VS Code | **Rust Analyzer: View Hir**
+// | VS Code | **rust-analyzer: View Hir**
 // |===
 // image::https://user-images.githubusercontent.com/48062697/113065588-068bdb80-91b1-11eb-9a78-0b4ef1e972fb.gif[]
 pub(crate) fn view_hir(db: &RootDatabase, position: FilePosition) -> String {

--- a/crates/ide/src/view_item_tree.rs
+++ b/crates/ide/src/view_item_tree.rs
@@ -9,7 +9,7 @@ use ide_db::RootDatabase;
 // |===
 // | Editor  | Action Name
 //
-// | VS Code | **Rust Analyzer: Debug ItemTree**
+// | VS Code | **rust-analyzer: Debug ItemTree**
 // |===
 pub(crate) fn view_item_tree(db: &RootDatabase, file_id: FileId) -> String {
     db.file_item_tree(file_id.into()).pretty_print()

--- a/crates/proc-macro-api/src/lib.rs
+++ b/crates/proc-macro-api/src/lib.rs
@@ -60,7 +60,7 @@ impl MacroDylib {
 
         let info = version::read_dylib_info(&path)?;
         if info.version.0 < 1 || info.version.1 < 47 {
-            let msg = format!("proc-macro {} built by {:#?} is not supported by Rust Analyzer, please update your rust version.", path.display(), info);
+            let msg = format!("proc-macro {} built by {:#?} is not supported by rust-analyzer, please update your Rust version.", path.display(), info);
             return Err(io::Error::new(io::ErrorKind::InvalidData, msg));
         }
 

--- a/crates/proc-macro-srv/src/abis/mod.rs
+++ b/crates/proc-macro-srv/src/abis/mod.rs
@@ -5,7 +5,7 @@
 //! compiler into submodules of this module (e.g proc_macro_srv::abis::abi_1_47).
 //!
 //! All of these ABIs are subsumed in the `Abi` enum, which exposes a simple
-//! interface the rest of rust analyzer can use to talk to the macro
+//! interface the rest of rust-analyzer can use to talk to the macro
 //! provider.
 //!
 //! # Adding a new ABI

--- a/crates/project-model/src/cargo_workspace.rs
+++ b/crates/project-model/src/cargo_workspace.rs
@@ -19,7 +19,7 @@ use crate::{utf8_stdout, ManifestPath};
 /// [`CargoWorkspace`] represents the logical structure of, well, a Cargo
 /// workspace. It pretty closely mirrors `cargo metadata` output.
 ///
-/// Note that internally, rust analyzer uses a different structure:
+/// Note that internally, rust-analyzer uses a different structure:
 /// `CrateGraph`. `CrateGraph` is lower-level: it knows only about the crates,
 /// while this knows about `Packages` & `Targets`: purely cargo-related
 /// concepts.

--- a/crates/rust-analyzer/src/integrated_benchmarks.rs
+++ b/crates/rust-analyzer/src/integrated_benchmarks.rs
@@ -6,8 +6,8 @@
 //! code here exercise this specific completion, and thus have a fast
 //! edit/compile/test cycle.
 //!
-//! Note that "Rust Analyzer: Run" action does not allow running a single test
-//! in release mode in VS Code. There's however "Rust Analyzer: Copy Run Command Line"
+//! Note that "rust-analyzer: Run" action does not allow running a single test
+//! in release mode in VS Code. There's however "rust-analyzer: Copy Run Command Line"
 //! which you can use to paste the command in terminal and add `--release` manually.
 
 use std::sync::Arc;

--- a/crates/syntax/src/lib.rs
+++ b/crates/syntax/src/lib.rs
@@ -1,4 +1,4 @@
-//! Syntax Tree library used throughout the rust analyzer.
+//! Syntax Tree library used throughout the rust-analyzer.
 //!
 //! Properties:
 //!   - easy and fast incremental re-parsing

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -82,7 +82,7 @@ There's **"Run Extension (Debug Build)"** launch configuration for this in VS Co
 In general, I use one of the following workflows for fixing bugs and implementing features:
 
 If the problem concerns only internal parts of rust-analyzer (i.e. I don't need to touch the `rust-analyzer` crate or TypeScript code), there is a unit-test for it.
-So, I use **Rust Analyzer: Run** action in VS Code to run this single test, and then just do printf-driven development/debugging.
+So, I use **rust-analyzer: Run** action in VS Code to run this single test, and then just do printf-driven development/debugging.
 As a sanity check after I'm done, I use `cargo xtask install --server` and **Reload Window** action in VS Code to verify that the thing works as I expect.
 
 If the problem concerns only the VS Code extension, I use **Run Installed Extension** launch configuration from `launch.json`.
@@ -152,11 +152,11 @@ To log all communication between the server and the client, there are two choice
 
 There are also several VS Code commands which might be of interest:
 
-* `Rust Analyzer: Status` shows some memory-usage statistics.
+* `rust-analyzer: Status` shows some memory-usage statistics.
 
-* `Rust Analyzer: Syntax Tree` shows syntax tree of the current file/selection.
+* `rust-analyzer: Syntax Tree` shows syntax tree of the current file/selection.
 
-* `Rust Analyzer: View Hir` shows the HIR expressions within the function containing the cursor.
+* `rust-analyzer: View Hir` shows the HIR expressions within the function containing the cursor.
 
   You can hover over syntax nodes in the opened text file to see the appropriate
   rust code that it refers to and the rust editor will also highlight the proper

--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -371,7 +371,7 @@ That is, rust-analyzer requires unwinding.
 
 ### Testing
 
-Rust Analyzer has three interesting [system boundaries](https://www.tedinski.com/2018/04/10/making-tests-a-positive-influence-on-design.html) to concentrate tests on.
+rust-analyzer has three interesting [system boundaries](https://www.tedinski.com/2018/04/10/making-tests-a-positive-influence-on-design.html) to concentrate tests on.
 
 The outermost boundary is the `rust-analyzer` crate, which defines an LSP interface in terms of stdio.
 We do integration testing of this component, by feeding it with a stream of LSP requests and checking responses.

--- a/docs/dev/guide.md
+++ b/docs/dev/guide.md
@@ -63,7 +63,7 @@ Next, let's talk about what the inputs to the `Analysis` are, precisely.
 
 ## Inputs
 
-Rust Analyzer never does any I/O itself, all inputs get passed explicitly via
+rust-analyzer never does any I/O itself, all inputs get passed explicitly via
 the `AnalysisHost::apply_change` method, which accepts a single argument, a
 `Change`. [`Change`] is a builder for a single change
 "transaction", so it suffices to study its methods to understand all of the

--- a/docs/user/manual.adoc
+++ b/docs/user/manual.adoc
@@ -479,7 +479,7 @@ You can follow instructions for installing <<rust-analyzer-language-server-binar
 == Troubleshooting
 
 Start with looking at the rust-analyzer version.
-Try **Rust Analyzer: Show RA Version** in VS Code (using **Command Palette** feature typically activated by Ctrl+Shift+P) or `rust-analyzer --version` in the command line.
+Try **rust-analyzer: Show RA Version** in VS Code (using **Command Palette** feature typically activated by Ctrl+Shift+P) or `rust-analyzer --version` in the command line.
 If the date is more than a week ago, it's better to update rust-analyzer version.
 
 The next thing to check would be panic messages in rust-analyzer's log.
@@ -492,7 +492,7 @@ To fully capture LSP messages between the editor and the server, set `"rust-anal
 The root cause for many "`nothing works`" problems is that rust-analyzer fails to understand the project structure.
 To debug that, first note the `rust-analyzer` section in the status bar.
 If it has an error icon and red, that's the problem (hover will have somewhat helpful error message).
-**Rust Analyzer: Status** prints dependency information for the current file.
+**rust-analyzer: Status** prints dependency information for the current file.
 Finally, `RA_LOG=project_model=debug` enables verbose logs during project loading.
 
 If rust-analyzer outright crashes, try running `rust-analyzer analysis-stats /path/to/project/directory/` on the command line.

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -99,142 +99,142 @@
             {
                 "command": "rust-analyzer.syntaxTree",
                 "title": "Show Syntax Tree",
-                "category": "Rust Analyzer"
+                "category": "rust-analyzer"
             },
             {
                 "command": "rust-analyzer.viewHir",
                 "title": "View Hir",
-                "category": "Rust Analyzer"
+                "category": "rust-analyzer"
             },
             {
                 "command": "rust-analyzer.viewFileText",
                 "title": "View File Text (as seen by the server)",
-                "category": "Rust Analyzer"
+                "category": "rust-analyzer"
             },
             {
                 "command": "rust-analyzer.viewItemTree",
                 "title": "Debug ItemTree",
-                "category": "Rust Analyzer"
+                "category": "rust-analyzer"
             },
             {
                 "command": "rust-analyzer.viewCrateGraph",
                 "title": "View Crate Graph",
-                "category": "Rust Analyzer"
+                "category": "rust-analyzer"
             },
             {
                 "command": "rust-analyzer.viewFullCrateGraph",
                 "title": "View Crate Graph (Full)",
-                "category": "Rust Analyzer"
+                "category": "rust-analyzer"
             },
             {
                 "command": "rust-analyzer.expandMacro",
                 "title": "Expand macro recursively",
-                "category": "Rust Analyzer"
+                "category": "rust-analyzer"
             },
             {
                 "command": "rust-analyzer.matchingBrace",
                 "title": "Find matching brace",
-                "category": "Rust Analyzer"
+                "category": "rust-analyzer"
             },
             {
                 "command": "rust-analyzer.parentModule",
                 "title": "Locate parent module",
-                "category": "Rust Analyzer"
+                "category": "rust-analyzer"
             },
             {
                 "command": "rust-analyzer.joinLines",
                 "title": "Join lines",
-                "category": "Rust Analyzer"
+                "category": "rust-analyzer"
             },
             {
                 "command": "rust-analyzer.run",
                 "title": "Run",
-                "category": "Rust Analyzer"
+                "category": "rust-analyzer"
             },
             {
                 "command": "rust-analyzer.copyRunCommandLine",
                 "title": "Copy Run Command Line",
-                "category": "Rust Analyzer"
+                "category": "rust-analyzer"
             },
             {
                 "command": "rust-analyzer.debug",
                 "title": "Debug",
-                "category": "Rust Analyzer"
+                "category": "rust-analyzer"
             },
             {
                 "command": "rust-analyzer.newDebugConfig",
                 "title": "Generate launch configuration",
-                "category": "Rust Analyzer"
+                "category": "rust-analyzer"
             },
             {
                 "command": "rust-analyzer.analyzerStatus",
                 "title": "Status",
-                "category": "Rust Analyzer"
+                "category": "rust-analyzer"
             },
             {
                 "command": "rust-analyzer.memoryUsage",
                 "title": "Memory Usage (Clears Database)",
-                "category": "Rust Analyzer"
+                "category": "rust-analyzer"
             },
             {
                 "command": "rust-analyzer.shuffleCrateGraph",
                 "title": "Shuffle Crate Graph",
-                "category": "Rust Analyzer"
+                "category": "rust-analyzer"
             },
             {
                 "command": "rust-analyzer.reloadWorkspace",
                 "title": "Reload workspace",
-                "category": "Rust Analyzer"
+                "category": "rust-analyzer"
             },
             {
                 "command": "rust-analyzer.reload",
                 "title": "Restart server",
-                "category": "Rust Analyzer"
+                "category": "rust-analyzer"
             },
             {
                 "command": "rust-analyzer.onEnter",
                 "title": "Enhanced enter key",
-                "category": "Rust Analyzer"
+                "category": "rust-analyzer"
             },
             {
                 "command": "rust-analyzer.ssr",
                 "title": "Structural Search Replace",
-                "category": "Rust Analyzer"
+                "category": "rust-analyzer"
             },
             {
                 "command": "rust-analyzer.serverVersion",
                 "title": "Show RA Version",
-                "category": "Rust Analyzer"
+                "category": "rust-analyzer"
             },
             {
                 "command": "rust-analyzer.toggleInlayHints",
                 "title": "Toggle inlay hints",
-                "category": "Rust Analyzer"
+                "category": "rust-analyzer"
             },
             {
                 "command": "rust-analyzer.openDocs",
                 "title": "Open docs under cursor",
-                "category": "Rust Analyzer"
+                "category": "rust-analyzer"
             },
             {
                 "command": "rust-analyzer.openCargoToml",
                 "title": "Open Cargo.toml",
-                "category": "Rust Analyzer"
+                "category": "rust-analyzer"
             },
             {
                 "command": "rust-analyzer.peekTests",
                 "title": "Peek related tests",
-                "category": "Rust Analyzer"
+                "category": "rust-analyzer"
             },
             {
                 "command": "rust-analyzer.moveItemUp",
                 "title": "Move item up",
-                "category": "Rust Analyzer"
+                "category": "rust-analyzer"
             },
             {
                 "command": "rust-analyzer.moveItemDown",
                 "title": "Move item down",
-                "category": "Rust Analyzer"
+                "category": "rust-analyzer"
             }
         ],
         "keybindings": [
@@ -256,7 +256,7 @@
         ],
         "configuration": {
             "type": "object",
-            "title": "Rust Analyzer",
+            "title": "rust-analyzer",
             "properties": {
                 "rust-analyzer.cargoRunner": {
                     "type": [


### PR DESCRIPTION
User-facing change: All commands are now rendered as "rust-analyzer: Command" rather than "Rust Analyzer: Command".

Alternative to https://github.com/rust-lang/rust-analyzer/pull/12910

Potentially controversial, since other extensions don't do this, so I won't self-approve.