### PR TITLE
Add fixups for incomplete in proc-macros

### DIFF
--- a/crates/hir-expand/src/fixup.rs
+++ b/crates/hir-expand/src/fixup.rs
@@ -240,10 +240,9 @@ pub(crate) fn fixup_syntax(node: &SyntaxNode) -> SyntaxFixups {
 
                     if it.pat().is_none() && it.in_token().is_none() && it.iterable().is_none() {
                         append.insert(for_token.into(), vec![pat, in_token, iter]);
+                    // does something funky -- see test case for_no_pat
                     } else if it.pat().is_none() {
                         append.insert(for_token.into(), vec![pat]);
-                    } else if it.pat().is_none() && it.in_token().is_none() {
-                        append.insert(for_token.into(), vec![pat, in_token]);
                     }
 
                     if it.loop_body().is_none() {
@@ -356,7 +355,7 @@ mod tests {
     }
 
     #[test]
-    fn for_no_iter_no_body() {
+    fn just_for_token() {
         check(
             r#"
 fn foo() {
@@ -369,20 +368,8 @@ fn foo () {for _ in __ra_fixup {}}
         )
     }
 
-    fn for_no_iter_no_in() {
-        check(
-            r#"
-fn foo() {
-    for _ {}
-}
-"#,
-            expect![[r#"
-fn foo () {for _ in __ra_fixup {}}
-"#]],
-        )
-    }
     #[test]
-    fn for_no_iter() {
+    fn for_no_iter_pattern() {
         check(
             r#"
 fn foo() {
@@ -405,6 +392,23 @@ fn foo() {
 "#,
             expect![[r#"
 fn foo () {for bar in qux {}}
+"#]],
+        )
+    }
+
+    // FIXME: https://github.com/rust-lang/rust-analyzer/pull/12937#discussion_r937633695
+    #[test]
+    fn for_no_pat() {
+        check(
+            r#"
+fn foo() {
+    for in qux {
+
+    }
+}
+"#,
+            expect![[r#"
+fn foo () {__ra_fixup}
 "#]],
         )
     }

--- a/crates/hir-expand/src/fixup.rs
+++ b/crates/hir-expand/src/fixup.rs
@@ -218,36 +218,6 @@ pub(crate) fn fixup_syntax(node: &SyntaxNode) -> SyntaxFixups {
                                 id: EMPTY_ID,
                             },
                             SyntheticToken {
-                                kind: SyntaxKind::UNDERSCORE,
-                                text: "_".into(),
-                                range: end_range,
-                                id: EMPTY_ID
-                            },
-                            SyntheticToken {
-                                kind: SyntaxKind::EQ,
-                                text: "=".into(),
-                                range: end_range,
-                                id: EMPTY_ID
-                            },
-                            SyntheticToken {
-                                kind: SyntaxKind::R_ANGLE,
-                                text: ">".into(),
-                                range: end_range,
-                                id: EMPTY_ID
-                            },
-                            SyntheticToken {
-                                kind: SyntaxKind::L_CURLY,
-                                text: "{".into(),
-                                range: end_range,
-                                id: EMPTY_ID,
-                            },
-                            SyntheticToken {
-                                kind: SyntaxKind::R_CURLY,
-                                text: "}".into(),
-                                range: end_range,
-                                id: EMPTY_ID,
-                            },
-                            SyntheticToken {
                                 kind: SyntaxKind::R_CURLY,
                                 text: "}".into(),
                                 range: end_range,
@@ -270,10 +240,11 @@ pub(crate) fn fixup_syntax(node: &SyntaxNode) -> SyntaxFixups {
 
                     if it.pat().is_none() && it.in_token().is_none() && it.iterable().is_none() {
                         append.insert(for_token.into(), vec![pat, in_token, iter]);
+                    } else if it.pat().is_none() {
+                        append.insert(for_token.into(), vec![pat]);
+                    } else if it.pat().is_none() && it.in_token().is_none() {
+                        append.insert(for_token.into(), vec![pat, in_token]);
                     }
-
-                    // Tricky: add logic to add in just a pattern or iterable if not all
-                    // the pieces are missing
 
                     if it.loop_body().is_none() {
                         append.insert(node.clone().into(), vec![
@@ -398,6 +369,18 @@ fn foo () {for _ in __ra_fixup {}}
         )
     }
 
+    fn for_no_iter_no_in() {
+        check(
+            r#"
+fn foo() {
+    for _ {}
+}
+"#,
+            expect![[r#"
+fn foo () {for _ in __ra_fixup {}}
+"#]],
+        )
+    }
     #[test]
     fn for_no_iter() {
         check(
@@ -435,7 +418,7 @@ fn foo() {
 }
 "#,
             expect![[r#"
-fn foo () {match __ra_fixup {_ => {}}}
+fn foo () {match __ra_fixup {}}
 "#]],
         )
     }
@@ -467,7 +450,7 @@ fn foo() {
 }
 "#,
             expect![[r#"
-fn foo () {match __ra_fixup {_ => {}}}
+fn foo () {match __ra_fixup {}}
 "#]],
         )
     }

--- a/crates/hir-expand/src/fixup.rs
+++ b/crates/hir-expand/src/fixup.rs
@@ -263,14 +263,14 @@ pub(crate) fn fixup_syntax(node: &SyntaxNode) -> SyntaxFixups {
                     };
 
                     let [pat, in_token, iter] = [
-                        (SyntaxKind::UNDERSCORE, "_"), 
-                        (SyntaxKind::IN_KW, "in"), 
+                        (SyntaxKind::UNDERSCORE, "_"),
+                        (SyntaxKind::IN_KW, "in"),
                         (SyntaxKind::IDENT, "__ra_fixup")
                     ].map(|(kind, text)| SyntheticToken { kind, text: text.into(), range: end_range, id: EMPTY_ID});
 
                     if it.pat().is_none() && it.in_token().is_none() && it.iterable().is_none() {
                         append.insert(for_token.into(), vec![pat, in_token, iter]);
-                    } 
+                    }
 
                     // Tricky: add logic to add in just a pattern or iterable if not all
                     // the pieces are missing


### PR DESCRIPTION
Partially implements https://github.com/rust-lang/rust-analyzer/issues/12777. 

Added support for for loops and match statements.

I couldn't do paths like `crate::foo::` as I wasn't able to add `SyntheticTokens` to the end of `foo::`, they always ended up after `crate::`

This is my first contribution so please don't be shy about letting me know if I've done anything wrong!