### PR TITLE
More methods and traits for `la_arena::ArenaMap`

### DIFF
--- a/crates/hir-def/src/generics.rs
+++ b/crates/hir-def/src/generics.rs
@@ -451,7 +451,7 @@ impl HasChildSource<LocalTypeOrConstParamId> for GenericDefId {
         if let GenericDefId::TraitId(id) = *self {
             let trait_ref = id.lookup(db).source(db).value;
             let idx = idx_iter.next().unwrap();
-            params.insert(idx, Either::Right(trait_ref))
+            params.insert(idx, Either::Right(trait_ref));
         }
 
         if let Some(generic_params_list) = generic_params_list {

--- a/crates/hir-def/src/visibility.rs
+++ b/crates/hir-def/src/visibility.rs
@@ -224,7 +224,7 @@ pub(crate) fn field_visibilities_query(
     let resolver = variant_id.module(db).resolver(db);
     let mut res = ArenaMap::default();
     for (field_id, field_data) in var_data.fields().iter() {
-        res.insert(field_id, field_data.visibility.resolve(db, &resolver))
+        res.insert(field_id, field_data.visibility.resolve(db, &resolver));
     }
     Arc::new(res)
 }

--- a/crates/hir-ty/src/lower.rs
+++ b/crates/hir-ty/src/lower.rs
@@ -1126,7 +1126,7 @@ pub(crate) fn field_types_query(
     let ctx =
         TyLoweringContext::new(db, &resolver).with_type_param_mode(ParamLoweringMode::Variable);
     for (field_id, field_data) in var_data.fields().iter() {
-        res.insert(field_id, make_binders(db, &generics, ctx.lower_ty(&field_data.type_ref)))
+        res.insert(field_id, make_binders(db, &generics, ctx.lower_ty(&field_data.type_ref)));
     }
     Arc::new(res)
 }

--- a/lib/la-arena/src/map.rs
+++ b/lib/la-arena/src/map.rs
@@ -49,11 +49,14 @@ impl<T, V> ArenaMap<Idx<T>, V> {
     }
 
     /// Inserts a value associated with a given arena index into the map.
-    pub fn insert(&mut self, idx: Idx<T>, t: V) {
+    ///
+    /// If the map did not have this index present, None is returned.
+    /// Otherwise, the value is updated, and the old value is returned.
+    pub fn insert(&mut self, idx: Idx<T>, t: V) -> Option<V> {
         let idx = Self::to_idx(idx);
 
         self.v.resize_with((idx + 1).max(self.v.len()), || None);
-        self.v[idx] = Some(t);
+        self.v[idx].replace(t)
     }
 
     /// Returns a reference to the value associated with the provided index


### PR DESCRIPTION
Continue of #12931. Seems that I forgot some methods in the previous PR :(

I also changed `ArenaMap::insert` to return the old value, to match the map-like collection API of std. **So this is a breaking change.**

r? @lnicola