### PR TITLE
feat: Display the value of enum variant on hover

### DIFF
--- a/crates/hir-def/src/body.rs
+++ b/crates/hir-def/src/body.rs
@@ -28,8 +28,8 @@ use crate::{
     nameres::DefMap,
     path::{ModPath, Path},
     src::{HasChildSource, HasSource},
-    AsMacroCall, BlockId, DefWithBodyId, HasModule, LocalModuleId, Lookup, MacroId,
-    ModuleId, UnresolvedMacro,
+    AsMacroCall, BlockId, DefWithBodyId, HasModule, LocalModuleId, Lookup, MacroId, ModuleId,
+    UnresolvedMacro,
 };
 
 pub use lower::LowerCtx;
@@ -328,7 +328,6 @@ impl Body {
                 let e = v.parent.lookup(db);
                 let src = v.parent.child_source(db);
                 let variant = &src.value[v.local_id];
-                // TODO(ole): Handle missing exprs (+1 to the prev)
                 (src.file_id, e.container, variant.expr())
             }
         };

--- a/crates/hir-def/src/body.rs
+++ b/crates/hir-def/src/body.rs
@@ -27,7 +27,7 @@ use crate::{
     macro_id_to_def_id,
     nameres::DefMap,
     path::{ModPath, Path},
-    src::HasSource,
+    src::{HasChildSource, HasSource},
     AsMacroCall, BlockId, DefWithBodyId, HasModule, LocalModuleId, Lookup, MacroId, ModuleId,
     UnresolvedMacro,
 };
@@ -323,6 +323,13 @@ impl Body {
                 let s = s.lookup(db);
                 let src = s.source(db);
                 (src.file_id, s.module(db), src.value.body())
+            }
+            DefWithBodyId::VariantId(v) => {
+                let e = v.parent.lookup(db);
+                let src = v.parent.child_source(db);
+                let variant = &src.value[v.local_id];
+                // TODO(ole): Handle missing exprs (+1 to the prev)
+                (src.file_id, e.container, variant.expr())
             }
         };
         let expander = Expander::new(db, file_id, module);

--- a/crates/hir-def/src/body.rs
+++ b/crates/hir-def/src/body.rs
@@ -28,8 +28,8 @@ use crate::{
     nameres::DefMap,
     path::{ModPath, Path},
     src::{HasChildSource, HasSource},
-    AsMacroCall, BlockId, DefWithBodyId, HasModule, LocalModuleId, Lookup, MacroId, ModuleId,
-    UnresolvedMacro,
+    AsMacroCall, BlockId, DefWithBodyId, HasModule, LocalModuleId, Lookup, MacroId,
+    ModuleId, UnresolvedMacro,
 };
 
 pub use lower::LowerCtx;

--- a/crates/hir-def/src/body/pretty.rs
+++ b/crates/hir-def/src/body/pretty.rs
@@ -2,6 +2,8 @@
 
 use std::fmt::{self, Write};
 
+use syntax::ast::HasName;
+
 use crate::{
     expr::{Array, BindingAnnotation, Literal, Statement},
     pretty::{print_generic_args, print_path, print_type_ref},
@@ -31,6 +33,16 @@ pub(super) fn print_body_hir(db: &dyn DefDatabase, body: &Body, owner: DefWithBo
                 None => "_".to_string(),
             };
             format!("const {} = ", name)
+        }
+        DefWithBodyId::VariantId(it) => {
+            needs_semi = false;
+            let src = it.parent.child_source(db);
+            let variant = &src.value[it.local_id];
+            let name = match &variant.name() {
+                Some(name) => name.to_string(),
+                None => "_".to_string(),
+            };
+            format!("{}", name)
         }
     };
 

--- a/crates/hir-def/src/lib.rs
+++ b/crates/hir-def/src/lib.rs
@@ -474,9 +474,17 @@ pub enum DefWithBodyId {
     FunctionId(FunctionId),
     StaticId(StaticId),
     ConstId(ConstId),
+    VariantId(EnumVariantId),
 }
 
 impl_from!(FunctionId, ConstId, StaticId for DefWithBodyId);
+
+// FIXME: Rename EnumVariantId to VariantId so that the macro above can be used
+impl From<EnumVariantId> for DefWithBodyId {
+    fn from(id: EnumVariantId) -> Self {
+        DefWithBodyId::VariantId(id)
+    }
+}
 
 impl DefWithBodyId {
     pub fn as_generic_def_id(self) -> Option<GenericDefId> {
@@ -484,6 +492,7 @@ impl DefWithBodyId {
             DefWithBodyId::FunctionId(f) => Some(f.into()),
             DefWithBodyId::StaticId(_) => None,
             DefWithBodyId::ConstId(c) => Some(c.into()),
+            DefWithBodyId::VariantId(c) => Some(c.into()),
         }
     }
 }
@@ -681,6 +690,7 @@ impl HasModule for DefWithBodyId {
             DefWithBodyId::FunctionId(it) => it.lookup(db).module(db),
             DefWithBodyId::StaticId(it) => it.lookup(db).module(db),
             DefWithBodyId::ConstId(it) => it.lookup(db).module(db),
+            DefWithBodyId::VariantId(it) => it.parent.lookup(db).container,
         }
     }
 }
@@ -691,6 +701,7 @@ impl DefWithBodyId {
             DefWithBodyId::FunctionId(it) => it.lookup(db).id.value.into(),
             DefWithBodyId::StaticId(it) => it.lookup(db).id.value.into(),
             DefWithBodyId::ConstId(it) => it.lookup(db).id.value.into(),
+            DefWithBodyId::VariantId(it) => it.parent.lookup(db).id.value.into(),
         }
     }
 }

--- a/crates/hir-def/src/resolver.rs
+++ b/crates/hir-def/src/resolver.rs
@@ -839,6 +839,7 @@ impl HasResolver for DefWithBodyId {
             DefWithBodyId::ConstId(c) => c.resolver(db),
             DefWithBodyId::FunctionId(f) => f.resolver(db),
             DefWithBodyId::StaticId(s) => s.resolver(db),
+            DefWithBodyId::VariantId(v) => v.parent.resolver(db),
         }
     }
 }

--- a/crates/hir-ty/src/consteval.rs
+++ b/crates/hir-ty/src/consteval.rs
@@ -339,7 +339,7 @@ pub fn eval_const(
                 ValueNs::GenericParam(_) => {
                     Err(ConstEvalError::NotSupported("const generic without substitution"))
                 }
-                ValueNs::EnumVariantId(id) => ctx.db.const_eval_variant(id), // TODO(ole): Assuming this is all that has to happen?
+                ValueNs::EnumVariantId(id) => ctx.db.const_eval_variant(id),
                 _ => Err(ConstEvalError::NotSupported("path that are not const or local")),
             }
         }

--- a/crates/hir-ty/src/consteval.rs
+++ b/crates/hir-ty/src/consteval.rs
@@ -203,7 +203,7 @@ pub fn eval_const(
                 Ok(ComputedExpr::Enum(
                     get_name(variant, ctx),
                     variant,
-                    Literal::Int(value + 1, Some(BuiltinInt::I128)),
+                    Literal::Int(value, Some(BuiltinInt::I128)),
                 ))
             }
             _ => Err(ConstEvalError::IncompleteExpr),

--- a/crates/hir-ty/src/consteval.rs
+++ b/crates/hir-ty/src/consteval.rs
@@ -121,15 +121,6 @@ impl Display for ComputedExpr {
     }
 }
 
-impl ComputedExpr {
-    pub fn enum_value(&self) -> Option<ComputedExpr> {
-        match self {
-            ComputedExpr::Enum(_, _, lit) => Some(ComputedExpr::Literal(lit.clone())),
-            _ => None,
-        }
-    }
-}
-
 fn scalar_max(scalar: &Scalar) -> i128 {
     match scalar {
         Scalar::Bool => 1,
@@ -200,11 +191,7 @@ pub fn eval_const(
                     }
                     _ => 0,
                 };
-                Ok(ComputedExpr::Enum(
-                    get_name(variant, ctx),
-                    variant,
-                    Literal::Int(value, Some(BuiltinInt::I128)),
-                ))
+                Ok(ComputedExpr::Literal(Literal::Int(value, Some(BuiltinInt::I128))))
             }
             _ => Err(ConstEvalError::IncompleteExpr),
         },
@@ -403,12 +390,9 @@ pub fn eval_const(
                 _ => Err(ConstEvalError::NotSupported("path that are not const or local")),
             }
         }
-        Expr::Cast { expr, .. } => match eval_const(*expr, ctx, None)? {
+        &Expr::Cast { expr, .. } => match eval_const(expr, ctx, None)? {
             ComputedExpr::Enum(_, _, lit) => Ok(ComputedExpr::Literal(lit)),
-            expr => Err(ConstEvalError::NotSupported(Box::leak(Box::new(format!(
-                "Can't cast type: {:?}",
-                expr
-            ))))),
+            _ => Err(ConstEvalError::NotSupported("Can't cast these types")),
         },
         _ => Err(ConstEvalError::NotSupported("This kind of expression")),
     }

--- a/crates/hir-ty/src/consteval/tests.rs
+++ b/crates/hir-ty/src/consteval/tests.rs
@@ -88,6 +88,35 @@ fn consts() {
 }
 
 #[test]
+fn enums() {
+    check_number(
+        r#"
+    enum E {
+        F1 = 1,
+        F2 = 2 * E::F1 as u8,
+        F3 = 3 * E::F2 as u8,
+    }
+    const GOAL: i32 = E::F3 as u8;
+    "#,
+        6,
+    );
+    let r = eval_goal(
+        r#"
+        enum E { A = 1, }
+        const GOAL: E = E::A;
+        "#,
+    )
+    .unwrap();
+    match r {
+        ComputedExpr::Enum(name, _, Literal::Uint(val, _)) => {
+            assert_eq!(name, "E::A");
+            assert_eq!(val, 1);
+        }
+        x => panic!("Expected enum but found {:?}", x),
+    }
+}
+
+#[test]
 fn const_loop() {
     check_fail(
         r#"

--- a/crates/hir-ty/src/consteval/tests.rs
+++ b/crates/hir-ty/src/consteval/tests.rs
@@ -100,6 +100,20 @@ fn enums() {
     "#,
         6,
     );
+    check_number(
+        r#"
+    enum E { F1 = 1, F2, }
+    const GOAL: i32 = E::F2 as u8;
+    "#,
+        2,
+    );
+    check_number(
+        r#"
+    enum E { F1, }
+    const GOAL: i32 = E::F1 as u8;
+    "#,
+        0,
+    );
     let r = eval_goal(
         r#"
         enum E { A = 1, }

--- a/crates/hir-ty/src/diagnostics/unsafe_check.rs
+++ b/crates/hir-ty/src/diagnostics/unsafe_check.rs
@@ -18,7 +18,9 @@ pub fn missing_unsafe(db: &dyn HirDatabase, def: DefWithBodyId) -> Vec<ExprId> {
 
     let is_unsafe = match def {
         DefWithBodyId::FunctionId(it) => db.function_data(it).has_unsafe_kw(),
-        DefWithBodyId::StaticId(_) | DefWithBodyId::ConstId(_) => false,
+        DefWithBodyId::StaticId(_) | DefWithBodyId::ConstId(_) | DefWithBodyId::VariantId(_) => {
+            false
+        }
     };
     if is_unsafe {
         return res;

--- a/crates/hir-ty/src/infer.rs
+++ b/crates/hir-ty/src/infer.rs
@@ -67,6 +67,14 @@ pub(crate) fn infer_query(db: &dyn HirDatabase, def: DefWithBodyId) -> Arc<Infer
         DefWithBodyId::ConstId(c) => ctx.collect_const(&db.const_data(c)),
         DefWithBodyId::FunctionId(f) => ctx.collect_fn(f),
         DefWithBodyId::StaticId(s) => ctx.collect_static(&db.static_data(s)),
+        DefWithBodyId::VariantId(v) => {
+            //let def = AttrDefId::EnumVariantId(v);
+            //let attrs = db.attrs(def);
+            //let repr = attrs.by_key("repr").attrs().next().unwrap();
+            //let ident = repr.single_ident_value().unwrap().text;
+            // TODO(ole): Get the real type
+            ctx.return_ty = TyBuilder::def_ty(db, v.parent.into()).fill_with_unknown().build()
+        }
     }
 
     ctx.infer_body();

--- a/crates/hir-ty/src/infer.rs
+++ b/crates/hir-ty/src/infer.rs
@@ -26,7 +26,7 @@ use hir_def::{
     resolver::{HasResolver, ResolveValueResult, Resolver, TypeNs, ValueNs},
     type_ref::TypeRef,
     AdtId, AssocItemId, DefWithBodyId, EnumVariantId, FieldId, FunctionId, HasModule, Lookup,
-    TraitId, TypeAliasId, VariantId,
+    TraitId, TypeAliasId, VariantId
 };
 use hir_expand::name::{name, Name};
 use itertools::Either;
@@ -68,10 +68,6 @@ pub(crate) fn infer_query(db: &dyn HirDatabase, def: DefWithBodyId) -> Arc<Infer
         DefWithBodyId::FunctionId(f) => ctx.collect_fn(f),
         DefWithBodyId::StaticId(s) => ctx.collect_static(&db.static_data(s)),
         DefWithBodyId::VariantId(v) => {
-            //let def = AttrDefId::EnumVariantId(v);
-            //let attrs = db.attrs(def);
-            //let repr = attrs.by_key("repr").attrs().next().unwrap();
-            //let ident = repr.single_ident_value().unwrap().text;
             // TODO(ole): Get the real type
             ctx.return_ty = TyBuilder::def_ty(db, v.parent.into()).fill_with_unknown().build()
         }

--- a/crates/hir-ty/src/infer.rs
+++ b/crates/hir-ty/src/infer.rs
@@ -68,6 +68,7 @@ pub(crate) fn infer_query(db: &dyn HirDatabase, def: DefWithBodyId) -> Arc<Infer
         DefWithBodyId::FunctionId(f) => ctx.collect_fn(f),
         DefWithBodyId::StaticId(s) => ctx.collect_static(&db.static_data(s)),
         DefWithBodyId::VariantId(v) => {
+            // FIXME: This should return the `repr(...)` type of the enum
             ctx.return_ty = TyBuilder::def_ty(db, v.parent.into()).fill_with_unknown().build()
         }
     }

--- a/crates/hir-ty/src/infer.rs
+++ b/crates/hir-ty/src/infer.rs
@@ -26,7 +26,7 @@ use hir_def::{
     resolver::{HasResolver, ResolveValueResult, Resolver, TypeNs, ValueNs},
     type_ref::TypeRef,
     AdtId, AssocItemId, DefWithBodyId, EnumVariantId, FieldId, FunctionId, HasModule, Lookup,
-    TraitId, TypeAliasId, VariantId
+    TraitId, TypeAliasId, VariantId,
 };
 use hir_expand::name::{name, Name};
 use itertools::Either;
@@ -68,7 +68,6 @@ pub(crate) fn infer_query(db: &dyn HirDatabase, def: DefWithBodyId) -> Arc<Infer
         DefWithBodyId::FunctionId(f) => ctx.collect_fn(f),
         DefWithBodyId::StaticId(s) => ctx.collect_static(&db.static_data(s)),
         DefWithBodyId::VariantId(v) => {
-            // TODO(ole): Get the real type
             ctx.return_ty = TyBuilder::def_ty(db, v.parent.into()).fill_with_unknown().build()
         }
     }

--- a/crates/hir-ty/src/tests.rs
+++ b/crates/hir-ty/src/tests.rs
@@ -16,7 +16,7 @@ use base_db::{fixture::WithFixture, FileRange, SourceDatabaseExt};
 use expect_test::Expect;
 use hir_def::{
     body::{Body, BodySourceMap, SyntheticSyntax},
-    db::DefDatabase,
+    db::{DefDatabase, InternDatabase},
     expr::{ExprId, PatId},
     item_scope::ItemScope,
     nameres::DefMap,
@@ -133,6 +133,10 @@ fn check_impl(ra_fixture: &str, allow_none: bool, only_types: bool, display_sour
         }
         DefWithBodyId::StaticId(it) => {
             let loc = it.lookup(&db);
+            loc.source(&db).value.syntax().text_range().start()
+        }
+        DefWithBodyId::VariantId(it) => {
+            let loc = db.lookup_intern_enum(it.parent);
             loc.source(&db).value.syntax().text_range().start()
         }
     });
@@ -386,6 +390,10 @@ fn infer_with_mismatches(content: &str, include_mismatches: bool) -> String {
         }
         DefWithBodyId::StaticId(it) => {
             let loc = it.lookup(&db);
+            loc.source(&db).value.syntax().text_range().start()
+        }
+        DefWithBodyId::VariantId(it) => {
+            let loc = db.lookup_intern_enum(it.parent);
             loc.source(&db).value.syntax().text_range().start()
         }
     });

--- a/crates/hir/src/from_id.rs
+++ b/crates/hir/src/from_id.rs
@@ -140,6 +140,7 @@ impl From<DefWithBody> for DefWithBodyId {
             DefWithBody::Function(it) => DefWithBodyId::FunctionId(it.id),
             DefWithBody::Static(it) => DefWithBodyId::StaticId(it.id),
             DefWithBody::Const(it) => DefWithBodyId::ConstId(it.id),
+            DefWithBody::Variant(it) => DefWithBodyId::VariantId(it.into()),
         }
     }
 }
@@ -150,6 +151,7 @@ impl From<DefWithBodyId> for DefWithBody {
             DefWithBodyId::FunctionId(it) => DefWithBody::Function(it.into()),
             DefWithBodyId::StaticId(it) => DefWithBody::Static(it.into()),
             DefWithBodyId::ConstId(it) => DefWithBody::Const(it.into()),
+            DefWithBodyId::VariantId(it) => DefWithBody::Variant(it.into()),
         }
     }
 }
@@ -172,9 +174,7 @@ impl From<GenericDef> for GenericDefId {
             GenericDef::Trait(it) => GenericDefId::TraitId(it.id),
             GenericDef::TypeAlias(it) => GenericDefId::TypeAliasId(it.id),
             GenericDef::Impl(it) => GenericDefId::ImplId(it.id),
-            GenericDef::Variant(it) => {
-                GenericDefId::EnumVariantId(EnumVariantId { parent: it.parent.id, local_id: it.id })
-            }
+            GenericDef::Variant(it) => GenericDefId::EnumVariantId(it.into()),
             GenericDef::Const(it) => GenericDefId::ConstId(it.id),
         }
     }
@@ -188,9 +188,7 @@ impl From<GenericDefId> for GenericDef {
             GenericDefId::TraitId(it) => GenericDef::Trait(it.into()),
             GenericDefId::TypeAliasId(it) => GenericDef::TypeAlias(it.into()),
             GenericDefId::ImplId(it) => GenericDef::Impl(it.into()),
-            GenericDefId::EnumVariantId(it) => {
-                GenericDef::Variant(Variant { parent: it.parent.into(), id: it.local_id })
-            }
+            GenericDefId::EnumVariantId(it) => GenericDef::Variant(it.into()),
             GenericDefId::ConstId(it) => GenericDef::Const(it.into()),
         }
     }

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -954,7 +954,7 @@ impl Enum {
     }
 
     pub fn is_data_carrying(self, db: &dyn HirDatabase) -> bool {
-        self.variants(db).iter().all(|v| matches!(v.kind(db), StructKind::Unit))
+        self.variants(db).iter().any(|v| !matches!(v.kind(db), StructKind::Unit))
     }
 }
 
@@ -966,8 +966,8 @@ impl HasVisibility for Enum {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Variant {
-    pub parent: Enum,
-    pub id: LocalEnumVariantId,
+    pub(crate) parent: Enum,
+    pub(crate) id: LocalEnumVariantId,
 }
 
 impl Variant {

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -952,6 +952,10 @@ impl Enum {
     pub fn ty(self, db: &dyn HirDatabase) -> Type {
         Type::from_def(db, self.id)
     }
+
+    pub fn is_data_carrying(self, db: &dyn HirDatabase) -> bool {
+        self.variants(db).iter().all(|v| matches!(v.kind(db), StructKind::Unit))
+    }
 }
 
 impl HasVisibility for Enum {
@@ -996,7 +1000,6 @@ impl Variant {
     }
 
     pub fn value(self, db: &dyn HirDatabase) -> Option<Expr> {
-        // TODO(ole): Handle missing exprs (+1 to the prev)
         self.source(db)?.value.expr()
     }
 

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -73,7 +73,7 @@ use once_cell::unsync::Lazy;
 use rustc_hash::FxHashSet;
 use stdx::{impl_from, never};
 use syntax::{
-    ast::{self, HasAttrs as _, HasDocComments, HasName},
+    ast::{self, Expr, HasAttrs as _, HasDocComments, HasName},
     AstNode, AstPtr, SmolStr, SyntaxNodePtr, TextRange, T,
 };
 
@@ -962,11 +962,16 @@ impl HasVisibility for Enum {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Variant {
-    pub(crate) parent: Enum,
-    pub(crate) id: LocalEnumVariantId,
+    pub parent: Enum,
+    pub id: LocalEnumVariantId,
 }
 
 impl Variant {
+    pub fn value(self, db: &dyn HirDatabase) -> Option<Expr> {
+        // TODO(ole): Handle missing exprs (+1 to the prev)
+        self.source(db)?.value.expr()
+    }
+
     pub fn module(self, db: &dyn HirDatabase) -> Module {
         self.parent.module(db)
     }
@@ -1129,6 +1134,7 @@ pub enum DefWithBody {
     Function(Function),
     Static(Static),
     Const(Const),
+    Variant(Variant),
 }
 impl_from!(Function, Const, Static for DefWithBody);
 
@@ -1138,6 +1144,7 @@ impl DefWithBody {
             DefWithBody::Const(c) => c.module(db),
             DefWithBody::Function(f) => f.module(db),
             DefWithBody::Static(s) => s.module(db),
+            DefWithBody::Variant(v) => v.module(db),
         }
     }
 
@@ -1146,6 +1153,7 @@ impl DefWithBody {
             DefWithBody::Function(f) => Some(f.name(db)),
             DefWithBody::Static(s) => Some(s.name(db)),
             DefWithBody::Const(c) => c.name(db),
+            DefWithBody::Variant(v) => Some(v.name(db)),
         }
     }
 
@@ -1155,6 +1163,7 @@ impl DefWithBody {
             DefWithBody::Function(it) => it.ret_type(db),
             DefWithBody::Static(it) => it.ty(db),
             DefWithBody::Const(it) => it.ty(db),
+            DefWithBody::Variant(it) => it.parent.ty(db),
         }
     }
 
@@ -1379,6 +1388,7 @@ impl DefWithBody {
             DefWithBody::Function(it) => it.into(),
             DefWithBody::Static(it) => it.into(),
             DefWithBody::Const(it) => it.into(),
+            DefWithBody::Variant(it) => it.into(),
         };
         for diag in hir_ty::diagnostics::incorrect_case(db, krate, def.into()) {
             acc.push(diag.into())

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -964,6 +964,12 @@ impl HasVisibility for Enum {
     }
 }
 
+impl From<&Variant> for DefWithBodyId {
+    fn from(&v: &Variant) -> Self {
+        DefWithBodyId::VariantId(v.into())
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Variant {
     pub(crate) parent: Enum,
@@ -1179,6 +1185,7 @@ impl DefWithBody {
             DefWithBody::Function(it) => it.id.into(),
             DefWithBody::Static(it) => it.id.into(),
             DefWithBody::Const(it) => it.id.into(),
+            DefWithBody::Variant(it) => it.into(),
         }
     }
 

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -967,11 +967,6 @@ pub struct Variant {
 }
 
 impl Variant {
-    pub fn value(self, db: &dyn HirDatabase) -> Option<Expr> {
-        // TODO(ole): Handle missing exprs (+1 to the prev)
-        self.source(db)?.value.expr()
-    }
-
     pub fn module(self, db: &dyn HirDatabase) -> Module {
         self.parent.module(db)
     }
@@ -998,6 +993,15 @@ impl Variant {
 
     pub(crate) fn variant_data(self, db: &dyn HirDatabase) -> Arc<VariantData> {
         db.enum_data(self.parent.id).variants[self.id].variant_data.clone()
+    }
+
+    pub fn value(self, db: &dyn HirDatabase) -> Option<Expr> {
+        // TODO(ole): Handle missing exprs (+1 to the prev)
+        self.source(db)?.value.expr()
+    }
+
+    pub fn eval(self, db: &dyn HirDatabase) -> Result<ComputedExpr, ConstEvalError> {
+        db.const_eval_variant(self.into())
     }
 }
 

--- a/crates/hir/src/symbols.rs
+++ b/crates/hir/src/symbols.rs
@@ -1,7 +1,6 @@
 //! File symbol extraction.
 
 use base_db::FileRange;
-use hir_def::db::DefDatabase;
 use hir_def::{
     item_tree::ItemTreeNode, src::HasSource, AdtId, AssocItemId, AssocItemLoc, DefWithBodyId,
     HasModule, ImplId, ItemContainerId, Lookup, MacroId, ModuleDefId, ModuleId, TraitId,
@@ -246,8 +245,8 @@ impl<'a> SymbolCollector<'a> {
                 id.lookup(self.db.upcast()).source(self.db.upcast()).value.name()?.text().into(),
             ),
             DefWithBodyId::VariantId(id) => Some({
-                let up_db: &dyn DefDatabase = self.db.upcast();
-                up_db.lookup_intern_enum(id.parent).source(up_db).value.name()?.text().into()
+                let db = self.db.upcast();
+                id.parent.lookup(db).source(db).value.name()?.text().into()
             }),
         }
     }

--- a/crates/hir/src/symbols.rs
+++ b/crates/hir/src/symbols.rs
@@ -1,6 +1,7 @@
 //! File symbol extraction.
 
 use base_db::FileRange;
+use hir_def::db::DefDatabase;
 use hir_def::{
     item_tree::ItemTreeNode, src::HasSource, AdtId, AssocItemId, AssocItemLoc, DefWithBodyId,
     HasModule, ImplId, ItemContainerId, Lookup, MacroId, ModuleDefId, ModuleId, TraitId,
@@ -244,6 +245,10 @@ impl<'a> SymbolCollector<'a> {
             DefWithBodyId::ConstId(id) => Some(
                 id.lookup(self.db.upcast()).source(self.db.upcast()).value.name()?.text().into(),
             ),
+            DefWithBodyId::VariantId(id) => Some({
+                let up_db: &dyn DefDatabase = self.db.upcast();
+                up_db.lookup_intern_enum(id.parent).source(up_db).value.name()?.text().into()
+            }),
         }
     }
 

--- a/crates/ide-db/src/search.rs
+++ b/crates/ide-db/src/search.rs
@@ -236,6 +236,7 @@ impl Definition {
                 DefWithBody::Function(f) => f.source(db).map(|src| src.syntax().cloned()),
                 DefWithBody::Const(c) => c.source(db).map(|src| src.syntax().cloned()),
                 DefWithBody::Static(s) => s.source(db).map(|src| src.syntax().cloned()),
+                DefWithBody::Variant(v) => v.source(db).map(|src| src.syntax().cloned()),
             };
             return match def {
                 Some(def) => SearchScope::file_range(def.as_ref().original_file_range(db)),

--- a/crates/ide/src/hover/render.rs
+++ b/crates/ide/src/hover/render.rs
@@ -3,7 +3,8 @@ use std::fmt::Display;
 
 use either::Either;
 use hir::{
-    db::HirDatabase, AsAssocItem, AttributeTemplate, HasAttrs, HasSource, HirDisplay, Semantics, StructKind, TypeInfo,
+    db::HirDatabase, AsAssocItem, AttributeTemplate, HasAttrs, HasSource, HirDisplay, Semantics,
+    StructKind, TypeInfo,
 };
 use ide_db::{
     base_db::SourceDatabase,

--- a/crates/ide/src/hover/render.rs
+++ b/crates/ide/src/hover/render.rs
@@ -351,7 +351,7 @@ pub(super) fn definition(
         Definition::Variant(it) => label_value_and_docs(db, it, |&it| {
             if it.parent.is_data_carrying(db) {
                 match it.eval(db) {
-                    Ok(x) => Some(format!("{}", x.enum_value().unwrap_or(x))),
+                    Ok(x) => Some(format!("{}", x)),
                     Err(_) => it.value(db).map(|x| format!("{:?}", x)),
                 }
             } else {

--- a/crates/ide/src/hover/render.rs
+++ b/crates/ide/src/hover/render.rs
@@ -2,7 +2,9 @@
 use std::fmt::Display;
 
 use either::Either;
-use hir::{AsAssocItem, AttributeTemplate, HasAttrs, HasSource, HirDisplay, Semantics, TypeInfo};
+use hir::{
+    db::HirDatabase, AsAssocItem, AttributeTemplate, HasAttrs, HasSource, HirDisplay, Semantics, TypeInfo,
+};
 use ide_db::{
     base_db::SourceDatabase,
     defs::Definition,
@@ -346,7 +348,14 @@ pub(super) fn definition(
         Definition::Module(it) => label_and_docs(db, it),
         Definition::Function(it) => label_and_docs(db, it),
         Definition::Adt(it) => label_and_docs(db, it),
-        Definition::Variant(it) => label_and_docs(db, it),
+        Definition::Variant(it) => label_value_and_docs(db, it, |&it| {
+            let hir_db: &dyn HirDatabase = db;
+            let body = hir_db.const_eval_variant(it.into());
+            match body {
+                Ok(x) => Some(format!("{}", x)),
+                Err(_) => it.value(db).map(|s| format!("{}", s)),
+            }
+        }),
         Definition::Const(it) => label_value_and_docs(db, it, |it| {
             let body = it.eval(db);
             match body {

--- a/crates/ide/src/hover/render.rs
+++ b/crates/ide/src/hover/render.rs
@@ -348,12 +348,15 @@ pub(super) fn definition(
         Definition::Module(it) => label_and_docs(db, it),
         Definition::Function(it) => label_and_docs(db, it),
         Definition::Adt(it) => label_and_docs(db, it),
-        Definition::Variant(it) => label_value_and_docs(db, it, |&it| match it.kind(db) {
-            StructKind::Unit => match it.eval(db) {
-                Ok(x) => Some(format!("{}", x.enum_value().unwrap_or(x))),
-                Err(_) => it.value(db).map(|x| format!("{:?}", x)),
-            },
-            _ => None,
+        Definition::Variant(it) => label_value_and_docs(db, it, |&it| {
+            if it.parent.is_data_carrying(db) {
+                match it.eval(db) {
+                    Ok(x) => Some(format!("{}", x.enum_value().unwrap_or(x))),
+                    Err(_) => it.value(db).map(|x| format!("{:?}", x)),
+                }
+            } else {
+                None
+            }
         }),
         Definition::Const(it) => label_value_and_docs(db, it, |it| {
             let body = it.eval(db);

--- a/crates/ide/src/hover/render.rs
+++ b/crates/ide/src/hover/render.rs
@@ -349,7 +349,7 @@ pub(super) fn definition(
         Definition::Function(it) => label_and_docs(db, it),
         Definition::Adt(it) => label_and_docs(db, it),
         Definition::Variant(it) => label_value_and_docs(db, it, |&it| {
-            if it.parent.is_data_carrying(db) {
+            if !it.parent_enum(db).is_data_carrying(db) {
                 match it.eval(db) {
                     Ok(x) => Some(format!("{}", x)),
                     Err(_) => it.value(db).map(|x| format!("{:?}", x)),

--- a/crates/ide/src/hover/render.rs
+++ b/crates/ide/src/hover/render.rs
@@ -2,10 +2,7 @@
 use std::fmt::Display;
 
 use either::Either;
-use hir::{
-    db::HirDatabase, AsAssocItem, AttributeTemplate, HasAttrs, HasSource, HirDisplay, Semantics,
-    StructKind, TypeInfo,
-};
+use hir::{AsAssocItem, AttributeTemplate, HasAttrs, HasSource, HirDisplay, Semantics, TypeInfo};
 use ide_db::{
     base_db::SourceDatabase,
     defs::Definition,

--- a/crates/ide/src/hover/render.rs
+++ b/crates/ide/src/hover/render.rs
@@ -349,11 +349,10 @@ pub(super) fn definition(
         Definition::Function(it) => label_and_docs(db, it),
         Definition::Adt(it) => label_and_docs(db, it),
         Definition::Variant(it) => label_value_and_docs(db, it, |&it| {
-            let hir_db: &dyn HirDatabase = db;
-            let body = hir_db.const_eval_variant(it.into());
+            let body = it.eval(db);
             match body {
                 Ok(x) => Some(format!("{}", x)),
-                Err(_) => it.value(db).map(|s| format!("{}", s)),
+                Err(_) => it.value(db).map(|x| format!("{}", x)),
             }
         }),
         Definition::Const(it) => label_value_and_docs(db, it, |it| {

--- a/crates/ide/src/hover/tests.rs
+++ b/crates/ide/src/hover/tests.rs
@@ -3530,31 +3530,6 @@ impl<const LEN: usize> Foo<LEN$0> {}
 
 #[test]
 fn hover_const_eval_variant() {
-    check(
-        r#"
-#[repr(u8)]
-enum E {
-    A = 4,
-    /// This is a doc
-    B$0 = E::A as u8 + 1,
-}
-"#,
-        expect![[r#"
-            *B*
-
-            ```rust
-            test::E
-            ```
-
-            ```rust
-            B = 5
-            ```
-
-            ---
-
-            This is a doc
-        "#]],
-    );
     // show hex for <10
     check(
         r#"

--- a/crates/ide/src/hover/tests.rs
+++ b/crates/ide/src/hover/tests.rs
@@ -3529,6 +3529,31 @@ impl<const LEN: usize> Foo<LEN$0> {}
 
 #[test]
 fn hover_const_eval_variant() {
+    check(
+        r#"
+#[repr(u8)]
+enum E {
+    A = 4,
+    /// This is a doc
+    B$0 = E::A as u8 + 1,
+}
+"#,
+        expect![[r#"
+            *B*
+
+            ```rust
+            test::E
+            ```
+
+            ```rust
+            B = 5
+            ```
+
+            ---
+
+            This is a doc
+        "#]],
+    );
     // show hex for <10
     check(
         r#"
@@ -3586,7 +3611,7 @@ enum E {
 enum E {
     A = 1,
     /// This is a doc
-    B$0 = E::A + 1,
+    B$0 = E::A as u8 + 1,
 }
 "#,
         expect![[r#"
@@ -3598,6 +3623,32 @@ enum E {
 
             ```rust
             B = 2
+            ```
+
+            ---
+
+            This is a doc
+        "#]],
+    );
+    // unspecified variant should increment by one
+    check(
+        r#"
+#[repr(u8)]
+enum E {
+    A = 4,
+    /// This is a doc
+    B$0,
+}
+"#,
+        expect![[r#"
+            *B*
+
+            ```rust
+            test::E
+            ```
+
+            ```rust
+            B = 5
             ```
 
             ---

--- a/crates/ide/src/hover/tests.rs
+++ b/crates/ide/src/hover/tests.rs
@@ -698,6 +698,7 @@ fn hover_enum_variant() {
     check(
         r#"
 enum Option<T> {
+    Some(T)
     /// The None variant
     Non$0e
 }

--- a/crates/ide/src/hover/tests.rs
+++ b/crates/ide/src/hover/tests.rs
@@ -3528,6 +3528,86 @@ impl<const LEN: usize> Foo<LEN$0> {}
 }
 
 #[test]
+fn hover_const_eval_variant() {
+    // show hex for <10
+    check(
+        r#"
+#[repr(u8)]
+enum E {
+    /// This is a doc
+    A$0 = 1 << 3,
+}
+"#,
+        expect![[r#"
+            *A*
+
+            ```rust
+            test::E
+            ```
+
+            ```rust
+            A = 8
+            ```
+
+            ---
+
+            This is a doc
+        "#]],
+    );
+    // show hex for >10
+    check(
+        r#"
+#[repr(u8)]
+enum E {
+    /// This is a doc
+    A$0 = (1 << 3) + (1 << 2),
+}
+"#,
+        expect![[r#"
+            *A*
+
+            ```rust
+            test::E
+            ```
+
+            ```rust
+            A = 12 (0xC)
+            ```
+
+            ---
+
+            This is a doc
+        "#]],
+    );
+    // enums in const eval
+    check(
+        r#"
+#[repr(u8)]
+enum E {
+    A = 1,
+    /// This is a doc
+    B$0 = E::A + 1,
+}
+"#,
+        expect![[r#"
+            *B*
+
+            ```rust
+            test::E
+            ```
+
+            ```rust
+            B = 2
+            ```
+
+            ---
+
+            This is a doc
+        "#]],
+    );
+}
+
+#[test]
 fn hover_const_eval() {
     // show hex for <10
     check(
@@ -3816,6 +3896,35 @@ fn foo() {
 
             ```rust
             const FOO: usize = 3
+            ```
+
+            ---
+
+            This is a doc
+        "#]],
+    );
+    check(
+        r#"
+enum E {
+    /// This is a doc
+    A = 3,
+}
+fn foo(e: E) {
+    match e {
+        E::A$0 => (),
+        _ => ()
+    }
+}
+"#,
+        expect![[r#"
+            *A*
+
+            ```rust
+            test::E
+            ```
+
+            ```rust
+            A = 3
             ```
 
             ---


### PR DESCRIPTION
fixes #12955 

This PR adds const eval support for enums, as well as showing their value on hover, just as consts currently have.

I developed these two things at the same time, but I've realized now that they are separate. However since the hover is just a 10 line change (not including tests), I figured I may as well put them in the same PR. Though if you want them split up into "enum const eval support"  and "show enum variant value on hover", I think that's reasonable too.

Since this adds const eval support for enums this also allows consts that reference enums to have their values computed now too.

The const evaluation itself is quite rudimentary, it doesn't keep track of the actual type of the enum, but it turns out that Rust doesn't actually either, and `E::A as u8` is valid regardless of the `repr` on `E`.

It also doesn't really care about what expression the enum variant contains, it could for example be a string, despite that not being allowed, but I guess it's up to the `cargo check` diagnostics to inform of such issues anyway?
