### PR TITLE
Corrected order of printing op and `=`

### DIFF
--- a/crates/syntax/src/ast/operators.rs
+++ b/crates/syntax/src/ast/operators.rs
@@ -111,10 +111,10 @@ impl fmt::Display for BinaryOp {
             BinaryOp::ArithOp(op) => fmt::Display::fmt(op, f),
             BinaryOp::CmpOp(op) => fmt::Display::fmt(op, f),
             BinaryOp::Assignment { op } => {
-                f.write_str("=")?;
                 if let Some(op) = op {
                     fmt::Display::fmt(op, f)?;
                 }
+                f.write_str("=")?;
                 Ok(())
             }
         }


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust-analyzer/issues/12971 where `Display` impl for assignment operators does `=+` instead of `+=`