### PR TITLE
Do not unconditionally succeed RUSTC_WRAPPER checks when run by build scripts

### DIFF
--- a/crates/rust-analyzer/src/bin/rustc_wrapper.rs
+++ b/crates/rust-analyzer/src/bin/rustc_wrapper.rs
@@ -17,6 +17,11 @@ pub(crate) fn run_rustc_skipping_cargo_checking(
     rustc_executable: OsString,
     args: Vec<OsString>,
 ) -> io::Result<ExitCode> {
+    // `CARGO_CFG_TARGET_ARCH` is only set by cargo when executing build scripts
+    // We don't want to exit out checks unconditionally with success if a build
+    // script tries to invoke checks themselves
+    // See https://github.com/rust-lang/rust-analyzer/issues/12973 for context
+    let not_invoked_by_build_script = std::env::var_os("CARGO_CFG_TARGET_ARCH").is_none();
     let is_cargo_check = args.iter().any(|arg| {
         let arg = arg.to_string_lossy();
         // `cargo check` invokes `rustc` with `--emit=metadata` argument.
@@ -29,7 +34,7 @@ pub(crate) fn run_rustc_skipping_cargo_checking(
         //            The default output filename is CRATE_NAME.rmeta.
         arg.starts_with("--emit=") && arg.contains("metadata") && !arg.contains("link")
     });
-    if is_cargo_check {
+    if not_invoked_by_build_script && is_cargo_check {
         return Ok(ExitCode(Some(0)));
     }
     run_rustc(rustc_executable, args)


### PR DESCRIPTION
rust-analyzer's RUSTC_WRAPPER unconditionally succeeds `cargo check`
invocations tripping up build scripts using `cargo check` to probe for
successful compilations. To prevent this from happening the RUSTC_WRAPPER
now checks if it's run from a build script by looking for the
`CARGO_CFG_TARGET_ARCH` env var that cargo sets only when running build
scripts.