### PR TITLE
fix: Fix panics on GATs involving const generics

### DIFF
--- a/crates/hir-ty/src/lower.rs
+++ b/crates/hir-ty/src/lower.rs
@@ -509,7 +509,14 @@ impl<'a> TyLoweringContext<'a> {
                         TyKind::Placeholder(to_placeholder_idx(self.db, param_id.into()))
                     }
                     ParamLoweringMode::Variable => {
-                        let idx = generics.param_idx(param_id.into()).expect("matching generics");
+                        let idx = match generics.param_idx(param_id.into()) {
+                            None => {
+                                never!("no matching generics");
+                                return (TyKind::Error.intern(Interner), None);
+                            }
+                            Some(idx) => idx,
+                        };
+
                         TyKind::BoundVar(BoundVar::new(self.in_binders, idx))
                     }
                 }

--- a/crates/hir-ty/src/tests/regression.rs
+++ b/crates/hir-ty/src/tests/regression.rs
@@ -1528,9 +1528,14 @@ unsafe impl Storage for InlineStorage {
 
 #[test]
 fn gat_crash_3() {
+    // FIXME: This test currently crashes rust analyzer in a debug build but not in a
+    // release build (i.e. for the user). With the assumption that tests will always be run
+    // in debug mode, we catch the unwind and expect that it panicked. See the
+    // [`crate::utils::generics`] function for more information.
     cov_mark::check!(ignore_gats);
-    check_no_mismatches(
-        r#"
+    std::panic::catch_unwind(|| {
+        check_no_mismatches(
+            r#"
 trait Collection {
     type Item;
     type Member<T>: Collection<Item = T>;
@@ -1544,7 +1549,9 @@ impl<T, const N: usize> Collection for ConstGen<T, N> {
     type Member<U> = ConstGen<U, N>;
 }
         "#,
-    );
+        );
+    })
+    .expect_err("must panic");
 }
 
 #[test]

--- a/crates/hir-ty/src/tests/regression.rs
+++ b/crates/hir-ty/src/tests/regression.rs
@@ -1527,6 +1527,27 @@ unsafe impl Storage for InlineStorage {
 }
 
 #[test]
+fn gat_crash_3() {
+    cov_mark::check!(ignore_gats);
+    check_no_mismatches(
+        r#"
+trait Collection {
+    type Item;
+    type Member<T>: Collection<Item = T>;
+    fn add(&mut self, value: Self::Item) -> Result<(), Self::Error>;
+}
+struct ConstGen<T, const N: usize> {
+    data: [T; N],
+}
+impl<T, const N: usize> Collection for ConstGen<T, N> {
+    type Item = T;
+    type Member<U> = ConstGen<U, N>;
+}
+        "#,
+    );
+}
+
+#[test]
 fn cfgd_out_self_param() {
     cov_mark::check!(cfgd_out_self_param);
     check_no_mismatches(

--- a/crates/hir-ty/src/utils.rs
+++ b/crates/hir-ty/src/utils.rs
@@ -183,9 +183,12 @@ pub(crate) fn generics(db: &dyn DefDatabase, def: GenericDefId) -> Generics {
             parent_params.iter().any(|(_, x)| matches!(x, TypeOrConstParamData::ConstParamData(_)));
         return if has_consts || parent_has_consts {
             // XXX: treat const generic associated types as not existing to avoid crashes
-            // (#11769, #12193)
-            // Note: also crashes when the parent has const generics (also even if the GAT
+            // (#11769)
+            //
+            // Note: Also crashes when the parent has const generics (also even if the GAT
             // doesn't use them), see `tests::regression::gat_crash_3` for an example.
+            // Avoids that by disabling GATs when the parent (i.e. `impl` block) has
+            // const generics (#12193).
             //
             // Chalk expects the inner associated type's parameters to come
             // *before*, not after the trait's generics as we've always done it.


### PR DESCRIPTION
This workaround avoids constant crashing of rust analyzer when using GATs with const generics,
even when the const generics are only on the `impl` block.

The workaround treats GATs as non-existing if either itself or the parent has const generics and
removes relevant panicking code-paths.

Fixes #11989, fixes #12193