### PR TITLE
fix: Fix incorrect type mismatch with `cfg_if!` and other macros in expression position

### DIFF
--- a/crates/hir-ty/src/tests/regression.rs
+++ b/crates/hir-ty/src/tests/regression.rs
@@ -1648,3 +1648,20 @@ fn main() {
         "#]],
     );
 }
+
+#[test]
+fn trailing_empty_macro() {
+    cov_mark::check!(empty_macro_in_trailing_position_is_removed);
+    check_no_mismatches(
+        r#"
+macro_rules! m2 {
+    ($($t:tt)*) => {$($t)*};
+}
+
+fn macrostmts() -> u8 {
+    m2! { 0 }
+    m2! {}
+}
+    "#,
+    );
+}


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust-analyzer/issues/12940

This is a bit of a hack, ideally `MacroStmts` would not exist at all after HIR lowering, but that requires changing how the lowering code works.