### PR TITLE
fix: escape keywords used as names in earlier editions

### DIFF
--- a/crates/hir-expand/src/name.rs
+++ b/crates/hir-expand/src/name.rs
@@ -90,10 +90,16 @@ impl Name {
 
     /// Resolve a name from the text of token.
     fn resolve(raw_text: &str) -> Name {
-        // When `raw_text` starts with "r#" but the name does not coincide with any
-        // keyword, we never need the prefix so we strip it.
         match raw_text.strip_prefix("r#") {
+            // When `raw_text` starts with "r#" but the name does not coincide with any
+            // keyword, we never need the prefix so we strip it.
             Some(text) if !is_raw_identifier(text) => Name::new_text(SmolStr::new(text)),
+            // Keywords (in the current edition) *can* be used as a name in earlier editions of
+            // Rust, e.g. "try" in Rust 2015. Even in such cases, we keep track of them in their
+            // escaped form.
+            None if is_raw_identifier(raw_text) => {
+                Name::new_text(SmolStr::from_iter(["r#", raw_text]))
+            }
             _ => Name::new_text(raw_text.into()),
         }
     }

--- a/crates/ide-db/src/search.rs
+++ b/crates/ide-db/src/search.rs
@@ -402,7 +402,9 @@ impl<'a> FindUsages<'a> {
                             .or_else(|| ty.as_builtin().map(|builtin| builtin.name()))
                     })
                 };
-                self.def.name(sema.db).or_else(self_kw_refs).map(|it| it.to_smol_str())
+                // We need to unescape the name in case it is written without "r#" in earlier
+                // editions of Rust where it isn't a keyword.
+                self.def.name(sema.db).or_else(self_kw_refs).map(|it| it.unescaped().to_smol_str())
             }
         };
         let name = match &name {


### PR DESCRIPTION
Fixes #13030 

There are keywords in Rust 2018+ that you can use as names without escaping when your crate is in Rust 2015 e.g. "try". We need to be consistent on how to keep track of the names regardless of how they are actually written in each crate. This patch attempts at it by taking such names into account and storing them uniformly in their escaped form.