### PR TITLE
chore: remove unused `currentExtensionIsNightly()` in `config.ts`

### DIFF
--- a/editors/code/src/config.ts
+++ b/editors/code/src/config.ts
@@ -5,8 +5,6 @@ import { log } from "./util";
 
 export type UpdatesChannel = "stable" | "nightly";
 
-const NIGHTLY_TAG = "nightly";
-
 export type RunnableEnvCfg =
     | undefined
     | Record<string, string>
@@ -174,10 +172,6 @@ export class Config {
             debug: this.get<boolean>("hover.actions.debug.enable"),
             gotoTypeDef: this.get<boolean>("hover.actions.gotoTypeDef.enable"),
         };
-    }
-
-    get currentExtensionIsNightly() {
-        return this.package.releaseTag === NIGHTLY_TAG;
     }
 }
 


### PR DESCRIPTION
I was debugging an unrelated issue in rust-analyzer, but came across this unused code and figured that it's fine to send a fully red PR :)