### PR TITLE
feat: Generate static method using Self::assoc() syntax

### DIFF
--- a/crates/ide-assists/src/handlers/generate_function.rs
+++ b/crates/ide-assists/src/handlers/generate_function.rs
@@ -61,7 +61,7 @@ fn gen_fn(acc: &mut Assists, ctx: &AssistContext<'_>) -> Option<()> {
     }
 
     let fn_name = &*name_ref.text();
-    let (target_module, adt_name, target, file, insert_offset) =
+    let TargetInfo { target_module, adt_name, target, file, insert_offset } =
         fn_target_info(path, ctx, &call, fn_name)?;
     let function_builder = FunctionBuilder::from_call(ctx, &call, fn_name, target_module, target)?;
     let text_range = call.syntax().text_range();
@@ -78,12 +78,20 @@ fn gen_fn(acc: &mut Assists, ctx: &AssistContext<'_>) -> Option<()> {
     )
 }
 
+struct TargetInfo {
+    target_module: Option<Module>,
+    adt_name: Option<hir::Name>,
+    target: GeneratedFunctionTarget,
+    file: FileId,
+    insert_offset: TextSize,
+}
+
 fn fn_target_info(
     path: ast::Path,
     ctx: &AssistContext<'_>,
     call: &CallExpr,
     fn_name: &str,
-) -> Option<(Option<Module>, Option<hir::Name>, GeneratedFunctionTarget, FileId, TextSize)> {
+) -> Option<TargetInfo> {
     let mut target_module = None;
     let mut adt_name = None;
     let (target, file, insert_offset) = match path.qualifier() {
@@ -115,7 +123,7 @@ fn fn_target_info(
             get_fn_target(ctx, &target_module, call.clone())?
         }
     };
-    Some((target_module, adt_name, target, file, insert_offset))
+    Some(TargetInfo { target_module, adt_name, target, file, insert_offset })
 }
 
 fn gen_method(acc: &mut Assists, ctx: &AssistContext<'_>) -> Option<()> {

--- a/crates/ide-assists/src/handlers/generate_function.rs
+++ b/crates/ide-assists/src/handlers/generate_function.rs
@@ -73,7 +73,7 @@ fn gen_fn(acc: &mut Assists, ctx: &AssistContext<'_>) -> Option<()> {
             Some(hir::PathResolution::Def(hir::ModuleDef::Adt(adt))) => {
                 if let hir::Adt::Enum(_) = adt {
                     // Don't suggest generating function if the name starts with an uppercase letter
-                    if name_ref.text().starts_with(char::is_uppercase) {
+                    if fn_name.starts_with(char::is_uppercase) {
                         return None;
                     }
                 }

--- a/crates/ide-assists/src/handlers/generate_function.rs
+++ b/crates/ide-assists/src/handlers/generate_function.rs
@@ -418,22 +418,15 @@ fn assoc_fn_target_info(
     adt: hir::Adt,
     fn_name: &str,
 ) -> Option<TargetInfo> {
-    let mut target_module = None;
-    let mut adt_name = None;
-    let (target, file, insert_offset) = {
-        let target_module: &mut Option<Module> = &mut target_module;
-        let adt_name: &mut Option<hir::Name> = &mut adt_name;
-        let current_module = ctx.sema.scope(call.syntax())?.module();
-        let module = adt.module(ctx.sema.db);
-        *target_module = if current_module == module { None } else { Some(module) };
-        if current_module.krate() != module.krate() {
-            return None;
-        }
-        let (impl_, file) = get_adt_source(ctx, &adt, fn_name)?;
-        let (target, insert_offset) = get_method_target(ctx, &module, &impl_)?;
-        *adt_name = if impl_.is_none() { Some(adt.name(ctx.sema.db)) } else { None };
-        Some((target, file, insert_offset))
-    }?;
+    let current_module = ctx.sema.scope(call.syntax())?.module();
+    let module = adt.module(ctx.sema.db);
+    let target_module = if current_module == module { None } else { Some(module) };
+    if current_module.krate() != module.krate() {
+        return None;
+    }
+    let (impl_, file) = get_adt_source(ctx, &adt, fn_name)?;
+    let (target, insert_offset) = get_method_target(ctx, &module, &impl_)?;
+    let adt_name = if impl_.is_none() { Some(adt.name(ctx.sema.db)) } else { None };
     Some(TargetInfo { target_module, adt_name, target, file, insert_offset })
 }
 

--- a/crates/ide-assists/src/handlers/generate_function.rs
+++ b/crates/ide-assists/src/handlers/generate_function.rs
@@ -62,7 +62,7 @@ fn gen_fn(acc: &mut Assists, ctx: &AssistContext<'_>) -> Option<()> {
 
     let fn_name = &*name_ref.text();
     let TargetInfo { target_module, adt_name, target, file, insert_offset } =
-        fn_target_info(path, ctx, &call, fn_name)?;
+        fn_target_info(ctx, path, &call, fn_name)?;
     let function_builder = FunctionBuilder::from_call(ctx, &call, fn_name, target_module, target)?;
     let text_range = call.syntax().text_range();
     let label = format!("Generate {} function", function_builder.fn_name);
@@ -87,8 +87,8 @@ struct TargetInfo {
 }
 
 fn fn_target_info(
-    path: ast::Path,
     ctx: &AssistContext<'_>,
+    path: ast::Path,
     call: &CallExpr,
     fn_name: &str,
 ) -> Option<TargetInfo> {

--- a/crates/ide-assists/src/handlers/generate_function.rs
+++ b/crates/ide-assists/src/handlers/generate_function.rs
@@ -92,8 +92,8 @@ fn fn_target_info(
     call: &CallExpr,
     fn_name: &str,
 ) -> Option<TargetInfo> {
-    let mut target_module = None;
-    let mut adt_name = None;
+    let target_module;
+    let adt_name = None;
     let (target, file, insert_offset) = match path.qualifier() {
         Some(qualifier) => match ctx.sema.resolve_path(&qualifier) {
             Some(hir::PathResolution::Def(hir::ModuleDef::Module(module))) => {
@@ -108,11 +108,11 @@ fn fn_target_info(
                     }
                 }
 
-                assoc_fn_target(ctx, call, adt, &mut target_module, fn_name, &mut adt_name)?
+                return assoc_fn_target_info(ctx, call, adt, fn_name);
             }
             Some(hir::PathResolution::SelfType(impl_)) => {
                 let adt = impl_.self_ty(ctx.db()).as_adt()?;
-                assoc_fn_target(ctx, call, adt, &mut target_module, fn_name, &mut adt_name)?
+                return assoc_fn_target_info(ctx, call, adt, fn_name);
             }
             _ => {
                 return None;
@@ -412,6 +412,18 @@ fn get_method_target(
     Some((target.clone(), get_insert_offset(&target)))
 }
 
+fn assoc_fn_target_info(
+    ctx: &AssistContext<'_>,
+    call: &CallExpr,
+    adt: hir::Adt,
+    fn_name: &str,
+) -> Option<TargetInfo> {
+    let mut target_module = None;
+    let mut adt_name = None;
+    let (target, file, insert_offset) =
+        assoc_fn_target(ctx, call, adt, &mut target_module, fn_name, &mut adt_name)?;
+    Some(TargetInfo { target_module, adt_name, target, file, insert_offset })
+}
 fn assoc_fn_target(
     ctx: &AssistContext<'_>,
     call: &CallExpr,

--- a/crates/ide-assists/src/handlers/generate_function.rs
+++ b/crates/ide-assists/src/handlers/generate_function.rs
@@ -78,11 +78,11 @@ fn gen_fn(acc: &mut Assists, ctx: &AssistContext<'_>) -> Option<()> {
                     }
                 }
 
-                static_method_target(ctx, &call, adt, &mut target_module, fn_name, &mut adt_name)?
+                assoc_fn_target(ctx, &call, adt, &mut target_module, fn_name, &mut adt_name)?
             }
             Some(hir::PathResolution::SelfType(impl_)) => {
                 let adt = impl_.self_ty(ctx.db()).as_adt()?;
-                static_method_target(ctx, &call, adt, &mut target_module, fn_name, &mut adt_name)?
+                assoc_fn_target(ctx, &call, adt, &mut target_module, fn_name, &mut adt_name)?
             }
             _ => {
                 return None;
@@ -394,7 +394,7 @@ fn get_method_target(
     Some((target.clone(), get_insert_offset(&target)))
 }
 
-fn static_method_target(
+fn assoc_fn_target(
     ctx: &AssistContext<'_>,
     call: &CallExpr,
     adt: hir::Adt,

--- a/crates/ide-assists/src/handlers/generate_function.rs
+++ b/crates/ide-assists/src/handlers/generate_function.rs
@@ -420,28 +420,21 @@ fn assoc_fn_target_info(
 ) -> Option<TargetInfo> {
     let mut target_module = None;
     let mut adt_name = None;
-    let (target, file, insert_offset) =
-        assoc_fn_target(ctx, call, adt, &mut target_module, fn_name, &mut adt_name)?;
+    let (target, file, insert_offset) = {
+        let target_module: &mut Option<Module> = &mut target_module;
+        let adt_name: &mut Option<hir::Name> = &mut adt_name;
+        let current_module = ctx.sema.scope(call.syntax())?.module();
+        let module = adt.module(ctx.sema.db);
+        *target_module = if current_module == module { None } else { Some(module) };
+        if current_module.krate() != module.krate() {
+            return None;
+        }
+        let (impl_, file) = get_adt_source(ctx, &adt, fn_name)?;
+        let (target, insert_offset) = get_method_target(ctx, &module, &impl_)?;
+        *adt_name = if impl_.is_none() { Some(adt.name(ctx.sema.db)) } else { None };
+        Some((target, file, insert_offset))
+    }?;
     Some(TargetInfo { target_module, adt_name, target, file, insert_offset })
-}
-fn assoc_fn_target(
-    ctx: &AssistContext<'_>,
-    call: &CallExpr,
-    adt: hir::Adt,
-    target_module: &mut Option<Module>,
-    fn_name: &str,
-    adt_name: &mut Option<hir::Name>,
-) -> Option<(GeneratedFunctionTarget, FileId, TextSize)> {
-    let current_module = ctx.sema.scope(call.syntax())?.module();
-    let module = adt.module(ctx.sema.db);
-    *target_module = if current_module == module { None } else { Some(module) };
-    if current_module.krate() != module.krate() {
-        return None;
-    }
-    let (impl_, file) = get_adt_source(ctx, &adt, fn_name)?;
-    let (target, insert_offset) = get_method_target(ctx, &module, &impl_)?;
-    *adt_name = if impl_.is_none() { Some(adt.name(ctx.sema.db)) } else { None };
-    Some((target, file, insert_offset))
 }
 
 fn get_insert_offset(target: &GeneratedFunctionTarget) -> TextSize {

--- a/crates/ide-assists/src/handlers/generate_function.rs
+++ b/crates/ide-assists/src/handlers/generate_function.rs
@@ -86,6 +86,18 @@ struct TargetInfo {
     insert_offset: TextSize,
 }
 
+impl TargetInfo {
+    fn new(
+        target_module: Option<Module>,
+        adt_name: Option<hir::Name>,
+        target: GeneratedFunctionTarget,
+        file: FileId,
+        insert_offset: TextSize,
+    ) -> Self {
+        Self { target_module, adt_name, target, file, insert_offset }
+    }
+}
+
 fn fn_target_info(
     ctx: &AssistContext<'_>,
     path: ast::Path,
@@ -123,7 +135,7 @@ fn fn_target_info(
             get_fn_target(ctx, &target_module, call.clone())?
         }
     };
-    Some(TargetInfo { target_module, adt_name, target, file, insert_offset })
+    Some(TargetInfo::new(target_module, adt_name, target, file, insert_offset))
 }
 
 fn gen_method(acc: &mut Assists, ctx: &AssistContext<'_>) -> Option<()> {
@@ -427,7 +439,7 @@ fn assoc_fn_target_info(
     let (impl_, file) = get_adt_source(ctx, &adt, fn_name)?;
     let (target, insert_offset) = get_method_target(ctx, &module, &impl_)?;
     let adt_name = if impl_.is_none() { Some(adt.name(ctx.sema.db)) } else { None };
-    Some(TargetInfo { target_module, adt_name, target, file, insert_offset })
+    Some(TargetInfo::new(target_module, adt_name, target, file, insert_offset))
 }
 
 fn get_insert_offset(target: &GeneratedFunctionTarget) -> TextSize {


### PR DESCRIPTION
This change improves the `generate_function` assist to support generating static methods/associated functions using the `Self::assoc()` syntax. Previously, one could generate a static method, but only when specifying the type name directly (like `Foo::assoc()`). After this change, `Self` is supported as well as the type name.

Fixes #13012