### PR TITLE
fix: resolve associated types of bare dyn types

### DIFF
--- a/crates/hir-ty/src/tests/traits.rs
+++ b/crates/hir-ty/src/tests/traits.rs
@@ -1476,6 +1476,34 @@ fn test(x: Trait, y: &Trait) -> u64 {
             165..172 'z.foo()': u64
         "#]],
     );
+
+    check_infer_with_mismatches(
+        r#"
+//- minicore: fn, coerce_unsized
+struct S;
+impl S {
+    fn foo(&self) {}
+}
+fn f(_: &Fn(S)) {}
+fn main() {
+    f(&|number| number.foo());
+}
+        "#,
+        expect![[r#"
+            31..35 'self': &S
+            37..39 '{}': ()
+            47..48 '_': &dyn Fn(S)
+            58..60 '{}': ()
+            71..105 '{     ...()); }': ()
+            77..78 'f': fn f(&dyn Fn(S))
+            77..102 'f(&|nu...foo())': ()
+            79..101 '&|numb....foo()': &|S| -> ()
+            80..101 '|numbe....foo()': |S| -> ()
+            81..87 'number': S
+            89..95 'number': S
+            89..101 'number.foo()': ()
+        "#]],
+    )
 }
 
 #[test]


### PR DESCRIPTION
Fixes #13031

We've been dropping the associated type bindings of trait object types that were written without the `dyn` keyword. This patch reuses the lowering logic for `TypeRef::DynTrait` so the associated type bindings are properly lowered.