### PR TITLE
fix: Register decorator token type to avoid panic

### DIFF
--- a/crates/rust-analyzer/src/semantic_tokens.rs
+++ b/crates/rust-analyzer/src/semantic_tokens.rs
@@ -32,6 +32,7 @@ macro_rules! define_semantic_token_types {
             SemanticTokenType::TYPE_PARAMETER,
             SemanticTokenType::TYPE,
             SemanticTokenType::VARIABLE,
+            SemanticTokenType::DECORATOR,
             $($ident),*
         ];
     };


### PR DESCRIPTION
Followup to https://github.com/rust-lang/rust-analyzer/pull/13084