### PR TITLE
fix: make "Extract type as type alias" assist work with const generics in array

### DIFF
--- a/crates/ide-assists/src/handlers/extract_type_alias.rs
+++ b/crates/ide-assists/src/handlers/extract_type_alias.rs
@@ -189,7 +189,7 @@ fn collect_used_generics<'gp>(
                     }
                 }
             }
-        },
+        }
         _ => (),
     });
     // stable resort to lifetime, type, const
@@ -378,8 +378,9 @@ impl<'outer, Outer, const OUTER: usize> () {
     }
 
     #[test]
-    fn issue_11197 () {
-        check_assist(extract_type_alias,
+    fn issue_11197() {
+        check_assist(
+            extract_type_alias,
             r#"
 struct Foo<T, const N: usize>
 where
@@ -397,6 +398,7 @@ where
 {
     arr: Type<T, N>,
 }
-            "#);
+            "#,
+        );
     }
 }

--- a/crates/ide-assists/src/handlers/extract_type_alias.rs
+++ b/crates/ide-assists/src/handlers/extract_type_alias.rs
@@ -171,6 +171,25 @@ fn collect_used_generics<'gp>(
         ast::Type::RefType(ref_) => generics.extend(
             ref_.lifetime().and_then(|lt| known_generics.iter().find(find_lifetime(&lt.text()))),
         ),
+        ast::Type::ArrayType(ar) => {
+            if let Some(expr) = ar.expr() {
+                if let ast::Expr::PathExpr(p) = expr {
+                    if let Some(path) = p.path() {
+                        if let Some(name_ref) = path.as_single_name_ref() {
+                            if let Some(param) = known_generics.iter().find(|gp| {
+                                if let ast::GenericParam::ConstParam(cp) = gp {
+                                    cp.name().map_or(false, |n| n.text() == name_ref.text())
+                                } else {
+                                    false
+                                }
+                            }) {
+                                generics.push(param);
+                            }
+                        }
+                    }
+                }
+            }
+        },
         _ => (),
     });
     // stable resort to lifetime, type, const

--- a/crates/ide-assists/src/handlers/extract_type_alias.rs
+++ b/crates/ide-assists/src/handlers/extract_type_alias.rs
@@ -357,4 +357,27 @@ impl<'outer, Outer, const OUTER: usize> () {
 "#,
         );
     }
+
+    #[test]
+    fn issue_11197 () {
+        check_assist(extract_type_alias,
+            r#"
+struct Foo<T, const N: usize>
+where
+    [T; N]: Sized,
+{
+    arr: $0[T; N]$0,
+}
+            "#,
+            r#"
+type $0Type<T, const N: usize> = [T; N];
+
+struct Foo<T, const N: usize>
+where
+    [T; N]: Sized,
+{
+    arr: Type<T, N>,
+}
+            "#);
+    }
 }


### PR DESCRIPTION
fixes #11197