### PR TITLE
Use proc-macro-srv from sysroot in rust-project.json workspaces

### DIFF
--- a/crates/rust-analyzer/src/reload.rs
+++ b/crates/rust-analyzer/src/reload.rs
@@ -314,7 +314,9 @@ impl GlobalState {
                         let mut args = args.clone();
                         let mut path = path.clone();
 
-                        if let ProjectWorkspace::Cargo { sysroot, .. } = ws {
+                        if let ProjectWorkspace::Cargo { sysroot, .. }
+                        | ProjectWorkspace::Json { sysroot, .. } = ws
+                        {
                             tracing::debug!("Found a cargo workspace...");
                             if let Some(sysroot) = sysroot.as_ref() {
                                 tracing::debug!("Found a cargo workspace with a sysroot...");


### PR DESCRIPTION
This was discussed [on zulip](https://rust-lang.zulipchat.com/#narrow/stream/185405-t-compiler.2Frust-analyzer/topic/.60sysroot.60.20vs.20.60sysroot_src.60.20for.20.60rust-project.2Ejson.60.3F/near/293023920), basically in `rust-project.json` workspaces RA doesn't respect the `sysroot` setting when picking which `proc-macro-srv` to launch, and this causes abi mismatches in practice.

This is the simple fix that @Veykril suggested, and I've verified that it works on Fuchsia by inspecting the cmdline with `pgrep rust-analyzer | xargs ps -fp` to check that it's using the `proc-macro-srv` from our prebuilts which matches the `sysroot` specified in our `rust-project.json`.

Can this be merged as is, or do we need to add tests that exercise this?