### PR TITLE
Remove the toggleInlayHints command from VSCode

### DIFF
--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -207,11 +207,6 @@
                 "category": "rust-analyzer"
             },
             {
-                "command": "rust-analyzer.toggleInlayHints",
-                "title": "Toggle inlay hints",
-                "category": "rust-analyzer"
-            },
-            {
                 "command": "rust-analyzer.openDocs",
                 "title": "Open docs under cursor",
                 "category": "rust-analyzer"
@@ -1631,10 +1626,6 @@
                 },
                 {
                     "command": "rust-analyzer.serverVersion",
-                    "when": "inRustProject"
-                },
-                {
-                    "command": "rust-analyzer.toggleInlayHints",
                     "when": "inRustProject"
                 },
                 {

--- a/editors/code/src/commands.ts
+++ b/editors/code/src/commands.ts
@@ -321,30 +321,6 @@ export function serverVersion(ctx: Ctx): Cmd {
     };
 }
 
-export function toggleInlayHints(_ctx: Ctx): Cmd {
-    return async () => {
-        const config = vscode.workspace.getConfiguration("editor.inlayHints", {
-            languageId: "rust",
-        });
-
-        const value = config.get("enabled");
-        let stringValue;
-        if (typeof value === "string") {
-            stringValue = value;
-        } else {
-            stringValue = value ? "on" : "off";
-        }
-        const nextValues: Record<string, string> = {
-            on: "off",
-            off: "on",
-            onUnlessPressed: "offUnlessPressed",
-            offUnlessPressed: "onUnlessPressed",
-        };
-        const nextValue = nextValues[stringValue] ?? "on";
-        await config.update("enabled", nextValue, vscode.ConfigurationTarget.Global);
-    };
-}
-
 // Opens the virtual file that will show the syntax tree
 //
 // The contents of the file come from the `TextDocumentContentProvider`

--- a/editors/code/src/main.ts
+++ b/editors/code/src/main.ts
@@ -180,7 +180,6 @@ async function initCommonContext(context: vscode.ExtensionContext, ctx: Ctx) {
 
     ctx.registerCommand("ssr", commands.ssr);
     ctx.registerCommand("serverVersion", commands.serverVersion);
-    ctx.registerCommand("toggleInlayHints", commands.toggleInlayHints);
 
     // Internal commands which are invoked by the server.
     ctx.registerCommand("runSingle", commands.runSingle);


### PR DESCRIPTION
Inlay hints are no longer something specifc to r-a as it has been upstreamed into the LSP, we don't have a reason to give the config for this feature special treatment in regards to toggling. There are plenty of other options out there in the VSCode marketplace to create toggle commands/hotkeys for configurations in general which I believe we should nudge people towards instead.