### PR TITLE
fix: handle lifetime variables in projection normalization

### DIFF
--- a/crates/hir-ty/src/db.rs
+++ b/crates/hir-ty/src/db.rs
@@ -150,6 +150,14 @@ pub trait HirDatabase: DefDatabase + Upcast<dyn DefDatabase> {
         id: chalk_db::AssociatedTyValueId,
     ) -> Arc<chalk_db::AssociatedTyValue>;
 
+    #[salsa::invoke(crate::traits::normalize_projection_query)]
+    #[salsa::transparent]
+    fn normalize_projection(
+        &self,
+        projection: crate::ProjectionTy,
+        env: Arc<crate::TraitEnvironment>,
+    ) -> Option<crate::Ty>;
+
     #[salsa::invoke(trait_solve_wait)]
     #[salsa::transparent]
     fn trait_solve(

--- a/crates/hir-ty/src/lib.rs
+++ b/crates/hir-ty/src/lib.rs
@@ -196,20 +196,6 @@ pub(crate) fn make_binders<T: HasInterner<Interner = Interner>>(
     make_binders_with_count(db, usize::MAX, generics, value)
 }
 
-// FIXME: get rid of this
-pub fn make_canonical<T: HasInterner<Interner = Interner>>(
-    value: T,
-    kinds: impl IntoIterator<Item = TyVariableKind>,
-) -> Canonical<T> {
-    let kinds = kinds.into_iter().map(|tk| {
-        chalk_ir::CanonicalVarKind::new(
-            chalk_ir::VariableKind::Ty(tk),
-            chalk_ir::UniverseIndex::ROOT,
-        )
-    });
-    Canonical { value, binders: chalk_ir::CanonicalVarKinds::from_iter(Interner, kinds) }
-}
-
 // FIXME: get rid of this, just replace it by FnPointer
 /// A function signature as seen by type inference: Several parameter types and
 /// one return type.

--- a/crates/hir-ty/src/traits.rs
+++ b/crates/hir-ty/src/traits.rs
@@ -1,6 +1,6 @@
 //! Trait solving using Chalk.
 
-use std::env::var;
+use std::{env::var, sync::Arc};
 
 use chalk_ir::GoalData;
 use chalk_recursive::Cache;
@@ -12,8 +12,9 @@ use stdx::panic_context;
 use syntax::SmolStr;
 
 use crate::{
-    db::HirDatabase, AliasEq, AliasTy, Canonical, DomainGoal, Goal, Guidance, InEnvironment,
-    Interner, Solution, TraitRefExt, Ty, TyKind, WhereClause,
+    db::HirDatabase, infer::unify::InferenceTable, AliasEq, AliasTy, Canonical, DomainGoal, Goal,
+    Guidance, InEnvironment, Interner, ProjectionTy, Solution, TraitRefExt, Ty, TyKind,
+    WhereClause,
 };
 
 /// This controls how much 'time' we give the Chalk solver before giving up.
@@ -62,6 +63,16 @@ impl TraitEnvironment {
             .iter()
             .filter_map(move |(self_ty, trait_id)| (*self_ty == ty).then(|| *trait_id))
     }
+}
+
+pub(crate) fn normalize_projection_query(
+    db: &dyn HirDatabase,
+    projection: ProjectionTy,
+    env: Arc<TraitEnvironment>,
+) -> Option<Ty> {
+    let mut table = InferenceTable::new(db, env.clone());
+    let ty = table.normalize_projection_ty(projection);
+    Some(table.resolve_completely(ty))
 }
 
 /// Solve a trait goal using Chalk.


### PR DESCRIPTION
Fixes #12674

The problem is that we've been skipping the binders of normalized projections assuming they should be empty, but the assumption is unfortunately wrong. We may get back lifetime variables and should handle them before returning them as normalized projections. For those who are curious why we get those even though we treat all lifetimes as 'static, [this comment in chalk](https://github.com/rust-lang/chalk/blob/d875af0ff196dd6430b5f5fd87a640fa5ab59d1e/chalk-solve/src/infer/unify.rs#L888-L908) may be interesting.

I thought using `InferenceTable` would be cleaner than the other ways as it already has the methods for canonicalization, normalizing projection, and resolving variables, so moved goal building and trait solving logic to a new `HirDatabase` query. I made it transparent query as the query itself doesn't do much work but the eventual call to `HirDatabase::trait_solve_query()` does.