### PR TITLE
fixup: remove unnecessary `Option`

### DIFF
--- a/crates/hir-ty/src/db.rs
+++ b/crates/hir-ty/src/db.rs
@@ -156,7 +156,7 @@ pub trait HirDatabase: DefDatabase + Upcast<dyn DefDatabase> {
         &self,
         projection: crate::ProjectionTy,
         env: Arc<crate::TraitEnvironment>,
-    ) -> Option<crate::Ty>;
+    ) -> Ty;
 
     #[salsa::invoke(trait_solve_wait)]
     #[salsa::transparent]

--- a/crates/hir-ty/src/traits.rs
+++ b/crates/hir-ty/src/traits.rs
@@ -69,10 +69,10 @@ pub(crate) fn normalize_projection_query(
     db: &dyn HirDatabase,
     projection: ProjectionTy,
     env: Arc<TraitEnvironment>,
-) -> Option<Ty> {
-    let mut table = InferenceTable::new(db, env.clone());
+) -> Ty {
+    let mut table = InferenceTable::new(db, env);
     let ty = table.normalize_projection_ty(projection);
-    Some(table.resolve_completely(ty))
+    table.resolve_completely(ty)
 }
 
 /// Solve a trait goal using Chalk.

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -2880,7 +2880,12 @@ impl Type {
             })
             .build();
 
-        db.normalize_projection(projection, self.env.clone()).map(|ty| self.derived(ty))
+        let ty = db.normalize_projection(projection, self.env.clone());
+        if ty.is_unknown() {
+            None
+        } else {
+            Some(self.derived(ty))
+        }
     }
 
     pub fn is_copy(&self, db: &dyn HirDatabase) -> bool {


### PR DESCRIPTION
Fixup for #13223, two things:

- `normalize_projection_query()` (and consequently `HirDatabase::normalize_projection()`) never returns `None` (well, it used to when I first wrote it...), so just return `Ty` instead of `Option<Ty>`
- When chalk cannot normalize projection uniquely, `normalize_trait_assoc_type()` used to return `None` before #13223, but not anymore because of the first point. I restored the behavior so its callers work as before.