### PR TITLE
Fix prelude injection

### DIFF
--- a/crates/hir-def/src/nameres/collector.rs
+++ b/crates/hir-def/src/nameres/collector.rs
@@ -534,6 +534,7 @@ impl DefCollector<'_> {
             match per_ns.types {
                 Some((ModuleDefId::ModuleId(m), _)) => {
                     self.def_map.prelude = Some(m);
+                    break;
                 }
                 types => {
                     tracing::debug!(


### PR DESCRIPTION
Fixes the regression of unknown types introduced in https://github.com/rust-lang/rust-analyzer/pull/13175