### PR TITLE
Fix add reference action on macros.

### DIFF
--- a/crates/ide-diagnostics/src/handlers/type_mismatch.rs
+++ b/crates/ide-diagnostics/src/handlers/type_mismatch.rs
@@ -59,9 +59,6 @@ fn add_reference(
     d: &hir::TypeMismatch,
     acc: &mut Vec<Assist>,
 ) -> Option<()> {
-    let root = ctx.sema.db.parse_or_expand(d.expr.file_id)?;
-    let expr_node = d.expr.value.to_node(&root);
-
     let range = ctx.sema.diagnostics_display_range(d.expr.clone().map(|it| it.into())).range;
 
     let (_, mutability) = d.expected.as_reference()?;
@@ -72,7 +69,7 @@ fn add_reference(
 
     let ampersands = format!("&{}", mutability.as_keyword_for_ref());
 
-    let edit = TextEdit::insert(expr_node.syntax().text_range().start(), ampersands);
+    let edit = TextEdit::insert(range.start(), ampersands);
     let source_change =
         SourceChange::from_text_edit(d.expr.file_id.original_file(ctx.sema.db), edit);
     acc.push(fix("add_reference_here", "Add reference here", source_change, range));
@@ -309,6 +306,34 @@ fn main() {
             r#"
 fn main() {
     let test: &i32 = &123;
+}
+            "#,
+        );
+    }
+
+    #[test]
+    fn test_add_reference_to_macro_call() {
+        check_fix(
+            r#"
+macro_rules! hello_world {
+    () => {
+        "Hello World".to_string()
+    };
+}
+fn test(foo: &String) {}
+fn main() {
+    test($0hello_world!());
+}
+            "#,
+            r#"
+macro_rules! hello_world {
+    () => {
+        "Hello World".to_string()
+    };
+}
+fn test(foo: &String) {}
+fn main() {
+    test(&hello_world!());
 }
             "#,
         );

--- a/crates/ide-diagnostics/src/handlers/type_mismatch.rs
+++ b/crates/ide-diagnostics/src/handlers/type_mismatch.rs
@@ -315,25 +315,25 @@ fn main() {
     fn test_add_reference_to_macro_call() {
         check_fix(
             r#"
-macro_rules! hello_world {
+macro_rules! thousand {
     () => {
-        "Hello World".to_string()
+        1000_u64
     };
 }
-fn test(foo: &String) {}
+fn test(foo: &u64) {}
 fn main() {
-    test($0hello_world!());
+    test($0thousand!());
 }
             "#,
             r#"
-macro_rules! hello_world {
+macro_rules! thousand {
     () => {
-        "Hello World".to_string()
+        1000_u64
     };
 }
-fn test(foo: &String) {}
+fn test(foo: &u64) {}
 fn main() {
-    test(&hello_world!());
+    test(&thousand!());
 }
             "#,
         );


### PR DESCRIPTION
Before we were using the range of the corresponding expression node in the macro expanded file, which is obviously incorrect as we are setting the text in the original source.

For some reason, the test I added is failing and I haven't found a way to fix it. Does anyone know why `check_fix` wouldn't work with macros? Getting this error:

```text
thread 'handlers::type_mismatch::tests::test_add_reference_to_macro_call' panicked at 'no diagnostics', crates/ide-diagnostics/src/handlers/type_mismatch.rs:317:9
```

closes #13219