### PR TITLE
Use memmem when searching for usages in ide-db

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -660,6 +660,7 @@ dependencies = [
  "indexmap",
  "itertools",
  "limit",
+ "memchr",
  "once_cell",
  "parser",
  "profile",

--- a/crates/ide-db/Cargo.toml
+++ b/crates/ide-db/Cargo.toml
@@ -20,6 +20,7 @@ either = "1.7.0"
 itertools = "0.10.3"
 arrayvec = "0.7.2"
 indexmap = "1.9.1"
+memchr = "2.5.0"
 
 stdx = { path = "../stdx", version = "0.0.0" }
 parser = { path = "../parser", version = "0.0.0" }


### PR DESCRIPTION
We already have this dependency, so there is no reason not to use it as it is generally faster than std in our use case.