### PR TITLE
Remove reference to Toggle inlay hints

### DIFF
--- a/crates/ide/src/inlay_hints.rs
+++ b/crates/ide/src/inlay_hints.rs
@@ -176,12 +176,6 @@ impl fmt::Debug for InlayHintLabelPart {
 // * elided lifetimes
 // * compiler inserted reborrows
 //
-// |===
-// | Editor  | Action Name
-//
-// | VS Code | **rust-analyzer: Toggle inlay hints*
-// |===
-//
 // image::https://user-images.githubusercontent.com/48062697/113020660-b5f98b80-917a-11eb-8d70-3be3fd558cdd.png[]
 pub(crate) fn inlay_hints(
     db: &RootDatabase,


### PR DESCRIPTION
This simply removes the reference to the `Toggle inlay hints` action after its removal in https://github.com/rust-lang/rust-analyzer/pull/13215.
In fact, this reference is still visible [in the User Manual here](https://rust-analyzer.github.io/manual.html#inlay-hints).

