### PR TITLE
Ensure at least one trait bound in `TyKind::DynTy`

### DIFF
--- a/crates/hir-ty/src/chalk_ext.rs
+++ b/crates/hir-ty/src/chalk_ext.rs
@@ -166,6 +166,8 @@ impl TyExt for Ty {
         let trait_ref = match self.kind(Interner) {
             // The principal trait bound should be the first element of the bounds. This is an
             // invariant ensured by `TyLoweringContext::lower_dyn_trait()`.
+            // FIXME: dyn types may not have principal trait and we don't want to return auto trait
+            // here.
             TyKind::Dyn(dyn_ty) => dyn_ty.bounds.skip_binders().interned().get(0).and_then(|b| {
                 match b.skip_binders() {
                     WhereClause::Implemented(trait_ref) => Some(trait_ref),

--- a/crates/hir-ty/src/tests/regression.rs
+++ b/crates/hir-ty/src/tests/regression.rs
@@ -1691,3 +1691,15 @@ fn macrostmts() -> u8 {
     "#,
     );
 }
+
+#[test]
+fn dyn_with_unresolved_trait() {
+    check_types(
+        r#"
+fn foo(a: &dyn DoesNotExist) {
+    a.bar();
+  //^&{unknown}
+}
+        "#,
+    );
+}


### PR DESCRIPTION
One would expect `TyKind::DynTy` to have at least one trait bound, but we may produce a dyn type with no trait bounds at all. This patch prevents it by returning `TyKind::Error` in such cases.

An "empty" dyn type would have caused panic during method resolution without #13257. Although already fixed, I think an invariant to never produce such types would help prevent similar problems in the future.