### PR TITLE
minor: Don't auto-publish lib crates

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,8 +2,8 @@ name: publish
 on:
   workflow_dispatch: # We can add version input when 1.0 is released and scheduled releases are removed
 
-#   schedule:
-#     - cron: "0 0 * * *" # midnight UTC
+  #   schedule:
+  #     - cron: "0 0 * * *" # midnight UTC
 
   push:
     branches:
@@ -50,5 +50,7 @@ jobs:
           cargo workspaces rename --from test-utils test_utils
           cargo workspaces rename --from text-edit text_edit
           cargo workspaces rename ra_ap_%n
+          # Remove library crates from the workspaces so we don't auto-publish them as well
+          sed -i 's/ "lib\/\*",//' ./Cargo.toml
           find crates/rust-analyzer -type f -name '*.rs' -exec sed -i 's/rust_analyzer/ra_ap_rust_analyzer/g' {} +
           cargo workspaces publish --yes --force '*' --exact --no-git-commit --allow-dirty --skip-published custom 0.0.$PATCH


### PR DESCRIPTION
I believe this should *just* work? With this cargo-workspaces should not consider them