### PR TITLE
feat: add a new config that limits workspace checks to single crates

### DIFF
--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -148,6 +148,18 @@ config_data! {
         /// `#rust-analyzer.cargo.target#`.
         checkOnSave_target: Option<String>               = "null",
 
+        /// Only check the currently opened crate of a workspace.
+        ///
+        /// Lets Rust analyzer perform less work by only checking the currently
+        /// opened crate when a crate of a workspace is opened alone. This
+        /// means you won't receive diagnostics about the entire workspace, but
+        /// can significantly improve performance when single crates are modified
+        /// as part of a much larger workspace.
+        ///
+        ///  Defaults to
+        /// `#rust-analyzer.cargo.target#`.
+        checkSingleCrate_enable: bool = "false",
+
         /// Toggles the additional completions that automatically add imports when completed.
         /// Note that your client must specify the `additionalTextEdits` LSP client capability to truly have this feature enabled.
         completion_autoimport_enable: bool       = "true",
@@ -455,9 +467,6 @@ config_data! {
         workspace_symbol_search_limit: usize = "128",
         /// Workspace symbol search scope.
         workspace_symbol_search_scope: WorkspaceSymbolSearchScopeDef = "\"workspace\"",
-
-        /// Only check the current crate
-        checkSingleCrate_enable: bool = "false",
     }
 }
 

--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -455,6 +455,9 @@ config_data! {
         workspace_symbol_search_limit: usize = "128",
         /// Workspace symbol search scope.
         workspace_symbol_search_scope: WorkspaceSymbolSearchScopeDef = "\"workspace\"",
+
+        /// Only check the current crate
+        checkSingleCrate_enable: bool = "false",
     }
 }
 
@@ -1116,9 +1119,17 @@ impl Config {
                 },
                 extra_args: self.data.checkOnSave_extraArgs.clone(),
                 extra_env: self.check_on_save_extra_env(),
+                single_crate: self.get_crate_for_check(),
             },
         };
         Some(flycheck_config)
+    }
+
+    fn get_crate_for_check(&self) -> Option<AbsPathBuf> {
+        match self.data.checkSingleCrate_enable {
+            true => Some(self.root_path().clone()),
+            false => None,
+        }
     }
 
     pub fn runnables(&self) -> RunnablesConfig {

--- a/docs/user/generated_config.adoc
+++ b/docs/user/generated_config.adoc
@@ -152,6 +152,20 @@ cargo check --workspace --message-format=json --all-targets
 Check for a specific target. Defaults to
 `#rust-analyzer.cargo.target#`.
 --
+[[rust-analyzer.checkSingleCrate.enable]]rust-analyzer.checkSingleCrate.enable (default: `false`)::
++
+--
+Only check the currently opened crate of a workspace.
+
+Lets Rust analyzer perform less work by only checking the currently
+opened crate when a crate of a workspace is opened alone. This
+means you won't receive diagnostics about the entire workspace, but
+can significantly improve performance when single crates are modified
+as part of a much larger workspace.
+
+ Defaults to
+`#rust-analyzer.cargo.target#`.
+--
 [[rust-analyzer.completion.autoimport.enable]]rust-analyzer.completion.autoimport.enable (default: `true`)::
 +
 --

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -573,6 +573,11 @@
                         "string"
                     ]
                 },
+                "rust-analyzer.checkSingleCrate.enable": {
+                    "markdownDescription": "Only check the currently opened crate of a workspace.\n\nLets Rust analyzer perform less work by only checking the currently\nopened crate when a crate of a workspace is opened alone. This\nmeans you won't receive diagnostics about the entire workspace, but\ncan significantly improve performance when single crates are modified\nas part of a much larger workspace.\n\n Defaults to\n`#rust-analyzer.cargo.target#`.",
+                    "default": false,
+                    "type": "boolean"
+                },
                 "rust-analyzer.completion.autoimport.enable": {
                     "markdownDescription": "Toggles the additional completions that automatically add imports when completed.\nNote that your client must specify the `additionalTextEdits` LSP client capability to truly have this feature enabled.",
                     "default": true,


### PR DESCRIPTION
Allow RA to ignore checking workspaces when single subcrates are open.

When the workspace is open, RA will still check the entire workspace.

But, now when a single crate is open, RA won't check those.

When working in subcrates on large workspaces, my checks go from:

https://user-images.githubusercontent.com/10237910/193480748-c5df981a-3d56-446a-a25d-6b5caf256712.mov



To:


https://user-images.githubusercontent.com/10237910/193480768-f54600ed-471b-4624-a396-eeb57476abab.mov



Solves #12882, #10669


Adds the config flag `checkSingleCrate.enable` which is passed to flycheck
