### PR TITLE
fix: treat enum variants as generic item on their own

### DIFF
--- a/crates/hir-ty/src/builder.rs
+++ b/crates/hir-ty/src/builder.rs
@@ -192,9 +192,7 @@ impl TyBuilder<()> {
         parent_subst: Option<Substitution>,
     ) -> TyBuilder<()> {
         let generics = generics(db.upcast(), def.into());
-        // FIXME: this assertion should hold but some adjustment around
-        // `ValueTyDefId::EnumVariantId` is needed.
-        // assert!(generics.parent_generics().is_some() == parent_subst.is_some());
+        assert!(generics.parent_generics().is_some() == parent_subst.is_some());
         let params = generics
             .iter_self()
             .map(|(id, data)| match data {


### PR DESCRIPTION
Fixup for #13335

It turns out I tried to merge two procedures into one utility function without noticing the incompatibility.

This time I *did* run analysis-stats on the four crates and confirmed it doesn't crash and this patch doesn't cause regression.