### PR TITLE
feat: Autocomplete Cargo-defined env vars in `env!` and `option_env!` (#12448) 

### DIFF
--- a/crates/ide-completion/src/completions.rs
+++ b/crates/ide-completion/src/completions.rs
@@ -19,6 +19,7 @@ pub(crate) mod snippet;
 pub(crate) mod r#type;
 pub(crate) mod use_;
 pub(crate) mod vis;
+pub(crate) mod env_vars;
 
 use std::iter;
 

--- a/crates/ide-completion/src/completions/env_vars.rs
+++ b/crates/ide-completion/src/completions/env_vars.rs
@@ -5,6 +5,27 @@ use syntax::{ast, AstToken, AstNode, TextRange, TextSize};
 use crate::{context::CompletionContext, CompletionItem, CompletionItemKind};
 
 use super::Completions;
+const CARGO_DEFINED_VARS: &[(&str, &str)] = &[
+("CARGO","Path to the cargo binary performing the build"),
+("CARGO_MANIFEST_DIR","The directory containing the manifest of your package"),
+("CARGO_PKG_VERSION","The full version of your package"),
+("CARGO_PKG_VERSION_MAJOR","The major version of your package"),
+("CARGO_PKG_VERSION_MINOR","The minor version of your package"),
+("CARGO_PKG_VERSION_PATCH","The patch version of your package"),
+("CARGO_PKG_VERSION_PRE","The pre-release version of your package"),
+("CARGO_PKG_AUTHORS","Colon separated list of authors from the manifest of your package"),
+("CARGO_PKG_NAME","The name of your package"),
+("CARGO_PKG_DESCRIPTION","The description from the manifest of your package"),
+("CARGO_PKG_HOMEPAGE","The home page from the manifest of your package"),
+("CARGO_PKG_REPOSITORY","The repository from the manifest of your package"),
+("CARGO_PKG_LICENSE","The license from the manifest of your package"),
+("CARGO_PKG_LICENSE_FILE","The license file from the manifest of your package"),
+("CARGO_PKG_RUST_VERSION","The Rust version from the manifest of your package. Note that this is the minimum Rust version supported by the package, not the current Rust version"),
+("CARGO_CRATE_NAME","The name of the crate that is currently being compiled"),
+("CARGO_BIN_NAME","The name of the binary that is currently being compiled (if it is a binary). This name does not include any file extension, such as .exe"),
+("CARGO_PRIMARY_PACKAGE","This environment variable will be set if the package being built is primary. Primary packages are the ones the user selected on the command-line, either with -p flags or the defaults based on the current directory and the default workspace members. This environment variable will not be set when building dependencies. This is only set when compiling the package (not when running binaries or tests)"),
+("CARGO_TARGET_TMPDIR","Only set when building integration test or benchmark code. This is a path to a directory inside the target directory where integration tests or benchmarks are free to put any data needed by the tests/benches. Cargo initially creates this directory but doesn't manage its content in any way, this is the responsibility of the test code")
+];
 
 pub(crate) fn complete_cargo_env_vars(
     acc: &mut Completions,

--- a/crates/ide-completion/src/completions/env_vars.rs
+++ b/crates/ide-completion/src/completions/env_vars.rs
@@ -1,8 +1,8 @@
 //! Completes environment variables defined by Cargo (https://doc.rust-lang.org/cargo/reference/environment-variables.html)
+use ide_db::syntax_helpers::node_ext::get_outer_macro_name;
+use syntax::ast::{self, IsString};
 
-use syntax::{ast, AstToken, AstNode, TextRange, TextSize};
-
-use crate::{context::CompletionContext, CompletionItem, CompletionItemKind};
+use crate::{CompletionItem, CompletionItemKind};
 
 use super::Completions;
 const CARGO_DEFINED_VARS: &[(&str, &str)] = &[
@@ -29,34 +29,27 @@ const CARGO_DEFINED_VARS: &[(&str, &str)] = &[
 
 pub(crate) fn complete_cargo_env_vars(
     acc: &mut Completions,
-    ctx: &CompletionContext<'_>,
-    original: &ast::String
-) {
-    if !is_env_macro(original) {
-        return;
-    }
+    expanded: &ast::String,
+) -> Option<()> {
+    guard_env_macro(expanded)?;
+    let range = expanded.text_range_between_quotes()?;
 
-    let start = ctx.original_token.text_range().start() + TextSize::from(1);
-    let cursor = ctx.position.offset;
+    CARGO_DEFINED_VARS.iter().for_each(|(var, detail)| {
+        let mut item = CompletionItem::new(CompletionItemKind::Keyword, range, *var);
+        item.detail(*detail);
+        item.add_to(acc);
+    });
 
-    CompletionItem::new(CompletionItemKind::Binding, TextRange::new(start, cursor), "CARGO").add_to(acc);
+    Some(())
 }
 
-fn is_env_macro(string: &ast::String) -> bool {
-    //todo: replace copypaste from format_string with separate function
-    (|| {
-        let macro_call = string.syntax().parent_ancestors().find_map(ast::MacroCall::cast)?;
-        let name = macro_call.path()?.segment()?.name_ref()?;
+fn guard_env_macro(string: &ast::String) -> Option<()> {
+    let name = get_outer_macro_name(string)?;
+    if !matches!(name.text().as_str(), "env" | "option_env") {
+        return None;
+    }
 
-        if !matches!(name.text().as_str(), 
-        "env" | "option_env") {
-            return None;
-        }
-
-
-        Some(())
-    })()
-    .is_some()
+    Some(())
 }
 
 #[cfg(test)]

--- a/crates/ide-completion/src/completions/env_vars.rs
+++ b/crates/ide-completion/src/completions/env_vars.rs
@@ -27,10 +27,7 @@ const CARGO_DEFINED_VARS: &[(&str, &str)] = &[
 ("CARGO_TARGET_TMPDIR","Only set when building integration test or benchmark code. This is a path to a directory inside the target directory where integration tests or benchmarks are free to put any data needed by the tests/benches. Cargo initially creates this directory but doesn't manage its content in any way, this is the responsibility of the test code")
 ];
 
-pub(crate) fn complete_cargo_env_vars(
-    acc: &mut Completions,
-    expanded: &ast::String,
-) -> Option<()> {
+pub(crate) fn complete_cargo_env_vars(acc: &mut Completions, expanded: &ast::String) -> Option<()> {
     guard_env_macro(expanded)?;
     let range = expanded.text_range_between_quotes()?;
 
@@ -57,15 +54,25 @@ mod tests {
     use crate::tests::{check_edit, completion_list};
 
     fn check(macro_name: &str) {
-        check_edit("CARGO_BIN_NAME",&format!(r#"
+        check_edit(
+            "CARGO_BIN_NAME",
+            &format!(
+                r#"
             fn main() {{
                 let foo = {}!("CAR$0");
             }}
-        "#, macro_name), &format!(r#"
+        "#,
+                macro_name
+            ),
+            &format!(
+                r#"
             fn main() {{
                 let foo = {}!("CARGO_BIN_NAME");
             }}
-        "#, macro_name));
+        "#,
+                macro_name
+            ),
+        );
     }
     #[test]
     fn completes_env_variable_in_env() {

--- a/crates/ide-completion/src/completions/env_vars.rs
+++ b/crates/ide-completion/src/completions/env_vars.rs
@@ -35,7 +35,7 @@ pub(crate) fn complete_cargo_env_vars(
     let range = expanded.text_range_between_quotes()?;
 
     CARGO_DEFINED_VARS.iter().for_each(|(var, detail)| {
-        let mut item = CompletionItem::new(CompletionItemKind::Keyword, range, *var);
+        let mut item = CompletionItem::new(CompletionItemKind::Keyword, range, var);
         item.detail(*detail);
         item.add_to(acc);
     });

--- a/crates/ide-completion/src/completions/env_vars.rs
+++ b/crates/ide-completion/src/completions/env_vars.rs
@@ -1,0 +1,60 @@
+//! Completes environment variables defined by Cargo (https://doc.rust-lang.org/cargo/reference/environment-variables.html)
+
+use syntax::{ast, AstToken, AstNode, TextRange, TextSize};
+
+use crate::{context::CompletionContext, CompletionItem, CompletionItemKind};
+
+use super::Completions;
+
+pub(crate) fn complete_cargo_env_vars(
+    acc: &mut Completions,
+    ctx: &CompletionContext<'_>,
+    original: &ast::String
+) {
+    if !is_env_macro(original) {
+        return;
+    }
+
+    let start = ctx.original_token.text_range().start() + TextSize::from(1);
+    let cursor = ctx.position.offset;
+
+    CompletionItem::new(CompletionItemKind::Binding, TextRange::new(start, cursor), "CARGO").add_to(acc);
+}
+
+fn is_env_macro(string: &ast::String) -> bool {
+    //todo: replace copypaste from format_string with separate function
+    (|| {
+        let macro_call = string.syntax().parent_ancestors().find_map(ast::MacroCall::cast)?;
+        let name = macro_call.path()?.segment()?.name_ref()?;
+
+        if !matches!(name.text().as_str(), 
+        "env" | "option_env") {
+            return None;
+        }
+
+
+        Some(())
+    })()
+    .is_some()
+}
+
+#[cfg(test)]
+mod tests {
+    use expect_test::{expect, Expect};
+    use crate::tests::{check_edit};
+
+    #[test]
+    fn completes_env_variables() {
+        check_edit("CARGO", 
+        r#"
+            fn main() {
+                let foo = env!("CA$0);
+            }
+        "#
+        ,r#"
+            fn main() {
+                let foo = env!("CARGO);
+            }
+        "#)
+    }
+}

--- a/crates/ide-completion/src/completions/env_vars.rs
+++ b/crates/ide-completion/src/completions/env_vars.rs
@@ -6,26 +6,25 @@ use syntax::ast::{self, IsString};
 use crate::{context::CompletionContext, CompletionItem, CompletionItemKind, completions::Completions};
 
 const CARGO_DEFINED_VARS: &[(&str, &str)] = &[
-("CARGO","Path to the cargo binary performing the build"),
-("CARGO_MANIFEST_DIR","The directory containing the manifest of your package"),
-("CARGO_PKG_VERSION","The full version of your package"),
-("CARGO_PKG_VERSION_MAJOR","The major version of your package"),
-("CARGO_PKG_VERSION_MINOR","The minor version of your package"),
-("CARGO_PKG_VERSION_PATCH","The patch version of your package"),
-("CARGO_PKG_VERSION_PRE","The pre-release version of your package"),
-("CARGO_PKG_AUTHORS","Colon separated list of authors from the manifest of your package"),
-("CARGO_PKG_NAME","The name of your package"),
-("CARGO_PKG_DESCRIPTION","The description from the manifest of your package"),
-("CARGO_PKG_HOMEPAGE","The home page from the manifest of your package"),
-        ("CARGO_PKG_REPOSITORY",
-"The repository from the manifest of your package"),
-("CARGO_PKG_LICENSE","The license from the manifest of your package"),
-("CARGO_PKG_LICENSE_FILE","The license file from the manifest of your package"),
-("CARGO_PKG_RUST_VERSION","The Rust version from the manifest of your package. Note that this is the minimum Rust version supported by the package, not the current Rust version"),
-("CARGO_CRATE_NAME","The name of the crate that is currently being compiled"),
-("CARGO_BIN_NAME","The name of the binary that is currently being compiled (if it is a binary). This name does not include any file extension, such as .exe"),
-("CARGO_PRIMARY_PACKAGE","This environment variable will be set if the package being built is primary. Primary packages are the ones the user selected on the command-line, either with -p flags or the defaults based on the current directory and the default workspace members. This environment variable will not be set when building dependencies. This is only set when compiling the package (not when running binaries or tests)"),
-("CARGO_TARGET_TMPDIR","Only set when building integration test or benchmark code. This is a path to a directory inside the target directory where integration tests or benchmarks are free to put any data needed by the tests/benches. Cargo initially creates this directory but doesn't manage its content in any way, this is the responsibility of the test code")
+    ("CARGO","Path to the cargo binary performing the build"),
+    ("CARGO_MANIFEST_DIR","The directory containing the manifest of your package"),
+    ("CARGO_PKG_VERSION","The full version of your package"),
+    ("CARGO_PKG_VERSION_MAJOR","The major version of your package"),
+    ("CARGO_PKG_VERSION_MINOR","The minor version of your package"),
+    ("CARGO_PKG_VERSION_PATCH","The patch version of your package"),
+    ("CARGO_PKG_VERSION_PRE","The pre-release version of your package"),
+    ("CARGO_PKG_AUTHORS","Colon separated list of authors from the manifest of your package"),
+    ("CARGO_PKG_NAME","The name of your package"),
+    ("CARGO_PKG_DESCRIPTION","The description from the manifest of your package"),
+    ("CARGO_PKG_HOMEPAGE","The home page from the manifest of your package"),
+    ("CARGO_PKG_REPOSITORY","The repository from the manifest of your package"),
+    ("CARGO_PKG_LICENSE","The license from the manifest of your package"),
+    ("CARGO_PKG_LICENSE_FILE","The license file from the manifest of your package"),
+    ("CARGO_PKG_RUST_VERSION","The Rust version from the manifest of your package. Note that this is the minimum Rust version supported by the package, not the current Rust version"),
+    ("CARGO_CRATE_NAME","The name of the crate that is currently being compiled"),
+    ("CARGO_BIN_NAME","The name of the binary that is currently being compiled (if it is a binary). This name does not include any file extension, such as .exe"),
+    ("CARGO_PRIMARY_PACKAGE","This environment variable will be set if the package being built is primary. Primary packages are the ones the user selected on the command-line, either with -p flags or the defaults based on the current directory and the default workspace members. This environment variable will not be set when building dependencies. This is only set when compiling the package (not when running binaries or tests)"),
+    ("CARGO_TARGET_TMPDIR","Only set when building integration test or benchmark code. This is a path to a directory inside the target directory where integration tests or benchmarks are free to put any data needed by the tests/benches. Cargo initially creates this directory but doesn't manage its content in any way, this is the responsibility of the test code")
 ];
 
 pub(crate) fn complete_cargo_env_vars(

--- a/crates/ide-completion/src/completions/env_vars.rs
+++ b/crates/ide-completion/src/completions/env_vars.rs
@@ -18,7 +18,8 @@ const CARGO_DEFINED_VARS: &[(&str, &str)] = &[
 ("CARGO_PKG_NAME","The name of your package"),
 ("CARGO_PKG_DESCRIPTION","The description from the manifest of your package"),
 ("CARGO_PKG_HOMEPAGE","The home page from the manifest of your package"),
-("CARGO_PKG_REPOSITORY","The repository from the manifest of your package"),
+        ("CARGO_PKG_REPOSITORY",
+"The repository from the manifest of your package"),
 ("CARGO_PKG_LICENSE","The license from the manifest of your package"),
 ("CARGO_PKG_LICENSE_FILE","The license file from the manifest of your package"),
 ("CARGO_PKG_RUST_VERSION","The Rust version from the manifest of your package. Note that this is the minimum Rust version supported by the package, not the current Rust version"),
@@ -33,7 +34,7 @@ pub(crate) fn complete_cargo_env_vars(
     ctx: &CompletionContext<'_>,
     expanded: &ast::String,
 ) -> Option<()> {
-    guard_env_macro(expanded, &ctx.sema, &ctx.db)?;
+    guard_env_macro(expanded, &ctx.sema)?;
     let range = expanded.text_range_between_quotes()?;
 
     CARGO_DEFINED_VARS.iter().for_each(|(var, detail)| {
@@ -48,11 +49,11 @@ pub(crate) fn complete_cargo_env_vars(
 fn guard_env_macro(
     string: &ast::String,
     semantics: &Semantics<'_, RootDatabase>,
-    db: &RootDatabase,
 ) -> Option<()> {
     let call = get_outer_macro(string)?;
     let name = call.path()?.segment()?.name_ref()?;
     let makro = semantics.resolve_macro_call(&call)?;
+    let db = semantics.db;
 
     match name.text().as_str() {
         "env" | "option_env" if makro.kind(db) == hir::MacroKind::BuiltIn => Some(()),

--- a/crates/ide-completion/src/completions/env_vars.rs
+++ b/crates/ide-completion/src/completions/env_vars.rs
@@ -3,7 +3,9 @@ use hir::Semantics;
 use ide_db::{syntax_helpers::node_ext::macro_call_for_string_token, RootDatabase};
 use syntax::ast::{self, IsString};
 
-use crate::{context::CompletionContext, CompletionItem, CompletionItemKind, completions::Completions};
+use crate::{
+    completions::Completions, context::CompletionContext, CompletionItem, CompletionItemKind,
+};
 
 const CARGO_DEFINED_VARS: &[(&str, &str)] = &[
     ("CARGO","Path to the cargo binary performing the build"),
@@ -44,10 +46,7 @@ pub(crate) fn complete_cargo_env_vars(
     Some(())
 }
 
-fn guard_env_macro(
-    string: &ast::String,
-    semantics: &Semantics<'_, RootDatabase>,
-) -> Option<()> {
+fn guard_env_macro(string: &ast::String, semantics: &Semantics<'_, RootDatabase>) -> Option<()> {
     let call = macro_call_for_string_token(string)?;
     let name = call.path()?.segment()?.name_ref()?;
     let makro = semantics.resolve_macro_call(&call)?;

--- a/crates/ide-completion/src/completions/env_vars.rs
+++ b/crates/ide-completion/src/completions/env_vars.rs
@@ -1,11 +1,10 @@
 //! Completes environment variables defined by Cargo (https://doc.rust-lang.org/cargo/reference/environment-variables.html)
 use hir::Semantics;
-use ide_db::{syntax_helpers::node_ext::get_outer_macro, RootDatabase};
+use ide_db::{syntax_helpers::node_ext::macro_call_for_string_token, RootDatabase};
 use syntax::ast::{self, IsString};
 
-use crate::{context::CompletionContext, CompletionItem, CompletionItemKind};
+use crate::{context::CompletionContext, CompletionItem, CompletionItemKind, completions::Completions};
 
-use super::Completions;
 const CARGO_DEFINED_VARS: &[(&str, &str)] = &[
 ("CARGO","Path to the cargo binary performing the build"),
 ("CARGO_MANIFEST_DIR","The directory containing the manifest of your package"),
@@ -50,7 +49,7 @@ fn guard_env_macro(
     string: &ast::String,
     semantics: &Semantics<'_, RootDatabase>,
 ) -> Option<()> {
-    let call = get_outer_macro(string)?;
+    let call = macro_call_for_string_token(string)?;
     let name = call.path()?.segment()?.name_ref()?;
     let makro = semantics.resolve_macro_call(&call)?;
     let db = semantics.db;

--- a/crates/ide-completion/src/lib.rs
+++ b/crates/ide-completion/src/lib.rs
@@ -183,6 +183,7 @@ pub fn completions(
             CompletionAnalysis::String { original, expanded: Some(expanded) } => {
                 completions::extern_abi::complete_extern_abi(acc, ctx, expanded);
                 completions::format_string::format_string(acc, ctx, original, expanded);
+                completions::env_vars::complete_cargo_env_vars(acc, ctx, original)
             }
             CompletionAnalysis::UnexpandedAttrTT {
                 colon_prefix,

--- a/crates/ide-completion/src/lib.rs
+++ b/crates/ide-completion/src/lib.rs
@@ -183,7 +183,7 @@ pub fn completions(
             CompletionAnalysis::String { original, expanded: Some(expanded) } => {
                 completions::extern_abi::complete_extern_abi(acc, ctx, expanded);
                 completions::format_string::format_string(acc, ctx, original, expanded);
-                completions::env_vars::complete_cargo_env_vars(acc, expanded);
+                completions::env_vars::complete_cargo_env_vars(acc, ctx, expanded);
             }
             CompletionAnalysis::UnexpandedAttrTT {
                 colon_prefix,

--- a/crates/ide-completion/src/lib.rs
+++ b/crates/ide-completion/src/lib.rs
@@ -183,7 +183,7 @@ pub fn completions(
             CompletionAnalysis::String { original, expanded: Some(expanded) } => {
                 completions::extern_abi::complete_extern_abi(acc, ctx, expanded);
                 completions::format_string::format_string(acc, ctx, original, expanded);
-                completions::env_vars::complete_cargo_env_vars(acc, ctx, original)
+                completions::env_vars::complete_cargo_env_vars(acc, expanded);
             }
             CompletionAnalysis::UnexpandedAttrTT {
                 colon_prefix,

--- a/crates/ide-db/src/syntax_helpers/format_string.rs
+++ b/crates/ide-db/src/syntax_helpers/format_string.rs
@@ -1,8 +1,9 @@
 //! Tools to work with format string literals for the `format_args!` family of macros.
 use syntax::{
-    ast::{self, IsString},
-    AstNode, AstToken, TextRange, TextSize,
+    ast::{self, IsString}, TextRange, TextSize,
 };
+
+use super::node_ext::get_outer_macro_name;
 
 pub fn is_format_string(string: &ast::String) -> bool {
     // Check if `string` is a format string argument of a macro invocation.
@@ -14,8 +15,7 @@ pub fn is_format_string(string: &ast::String) -> bool {
     // This setup lets us correctly highlight the components of `concat!("{}", "bla")` format
     // strings. It still fails for `concat!("{", "}")`, but that is rare.
     (|| {
-        let macro_call = string.syntax().parent_ancestors().find_map(ast::MacroCall::cast)?;
-        let name = macro_call.path()?.segment()?.name_ref()?;
+        let name = get_outer_macro_name(string)?;
 
         if !matches!(
             name.text().as_str(),

--- a/crates/ide-db/src/syntax_helpers/format_string.rs
+++ b/crates/ide-db/src/syntax_helpers/format_string.rs
@@ -1,6 +1,7 @@
 //! Tools to work with format string literals for the `format_args!` family of macros.
 use syntax::{
-    ast::{self, IsString}, TextRange, TextSize,
+    ast::{self, IsString},
+    TextRange, TextSize,
 };
 
 use super::node_ext::get_outer_macro_name;

--- a/crates/ide-db/src/syntax_helpers/format_string.rs
+++ b/crates/ide-db/src/syntax_helpers/format_string.rs
@@ -4,7 +4,7 @@ use syntax::{
     TextRange, TextSize,
 };
 
-use super::node_ext::get_outer_macro_name;
+use super::node_ext::get_outer_macro;
 
 pub fn is_format_string(string: &ast::String) -> bool {
     // Check if `string` is a format string argument of a macro invocation.
@@ -16,7 +16,7 @@ pub fn is_format_string(string: &ast::String) -> bool {
     // This setup lets us correctly highlight the components of `concat!("{}", "bla")` format
     // strings. It still fails for `concat!("{", "}")`, but that is rare.
     (|| {
-        let name = get_outer_macro_name(string)?;
+        let name = get_outer_macro(string)?.path()?.segment()?.name_ref()?;
 
         if !matches!(
             name.text().as_str(),

--- a/crates/ide-db/src/syntax_helpers/format_string.rs
+++ b/crates/ide-db/src/syntax_helpers/format_string.rs
@@ -1,9 +1,9 @@
 //! Tools to work with format string literals for the `format_args!` family of macros.
+use crate::syntax_helpers::node_ext::macro_call_for_string_token;
 use syntax::{
     ast::{self, IsString},
     TextRange, TextSize,
 };
-use crate::syntax_helpers::node_ext::macro_call_for_string_token;
 
 pub fn is_format_string(string: &ast::String) -> bool {
     // Check if `string` is a format string argument of a macro invocation.

--- a/crates/ide-db/src/syntax_helpers/format_string.rs
+++ b/crates/ide-db/src/syntax_helpers/format_string.rs
@@ -3,8 +3,7 @@ use syntax::{
     ast::{self, IsString},
     TextRange, TextSize,
 };
-
-use super::node_ext::get_outer_macro;
+use crate::syntax_helpers::node_ext::macro_call_for_string_token;
 
 pub fn is_format_string(string: &ast::String) -> bool {
     // Check if `string` is a format string argument of a macro invocation.
@@ -16,7 +15,7 @@ pub fn is_format_string(string: &ast::String) -> bool {
     // This setup lets us correctly highlight the components of `concat!("{}", "bla")` format
     // strings. It still fails for `concat!("{", "}")`, but that is rare.
     (|| {
-        let name = get_outer_macro(string)?.path()?.segment()?.name_ref()?;
+        let name = macro_call_for_string_token(string)?.path()?.segment()?.name_ref()?;
 
         if !matches!(
             name.text().as_str(),

--- a/crates/ide-db/src/syntax_helpers/node_ext.rs
+++ b/crates/ide-db/src/syntax_helpers/node_ext.rs
@@ -2,8 +2,8 @@
 use itertools::Itertools;
 use parser::T;
 use syntax::{
-    ast::{self, HasLoopBody, PathSegmentKind, VisibilityKind},
-    AstNode, Preorder, RustLanguage, WalkEvent,
+    ast::{self, HasLoopBody, PathSegmentKind, VisibilityKind, NameRef},
+    AstNode, Preorder, RustLanguage, WalkEvent, AstToken,
 };
 
 pub fn expr_as_name_ref(expr: &ast::Expr) -> Option<ast::NameRef> {
@@ -456,4 +456,11 @@ pub fn parse_tt_as_comma_sep_paths(input: ast::TokenTree) -> Option<Vec<ast::Pat
         })
         .collect();
     Some(paths)
+}
+
+pub fn get_outer_macro_name(string: &ast::String) -> Option<NameRef> {
+    let macro_call = string.syntax().parent_ancestors().find_map(ast::MacroCall::cast)?;
+    let name = macro_call.path()?.segment()?.name_ref()?;
+
+    Some(name)
 }

--- a/crates/ide-db/src/syntax_helpers/node_ext.rs
+++ b/crates/ide-db/src/syntax_helpers/node_ext.rs
@@ -2,7 +2,7 @@
 use itertools::Itertools;
 use parser::T;
 use syntax::{
-    ast::{self, HasLoopBody, NameRef, PathSegmentKind, VisibilityKind},
+    ast::{self, HasLoopBody, MacroCall, PathSegmentKind, VisibilityKind},
     AstNode, AstToken, Preorder, RustLanguage, WalkEvent,
 };
 
@@ -458,9 +458,7 @@ pub fn parse_tt_as_comma_sep_paths(input: ast::TokenTree) -> Option<Vec<ast::Pat
     Some(paths)
 }
 
-pub fn get_outer_macro_name(string: &ast::String) -> Option<NameRef> {
+pub fn get_outer_macro(string: &ast::String) -> Option<MacroCall> {
     let macro_call = string.syntax().parent_ancestors().find_map(ast::MacroCall::cast)?;
-    let name = macro_call.path()?.segment()?.name_ref()?;
-
-    Some(name)
+    Some(macro_call)
 }

--- a/crates/ide-db/src/syntax_helpers/node_ext.rs
+++ b/crates/ide-db/src/syntax_helpers/node_ext.rs
@@ -2,8 +2,8 @@
 use itertools::Itertools;
 use parser::T;
 use syntax::{
-    ast::{self, HasLoopBody, PathSegmentKind, VisibilityKind, NameRef},
-    AstNode, Preorder, RustLanguage, WalkEvent, AstToken,
+    ast::{self, HasLoopBody, NameRef, PathSegmentKind, VisibilityKind},
+    AstNode, AstToken, Preorder, RustLanguage, WalkEvent,
 };
 
 pub fn expr_as_name_ref(expr: &ast::Expr) -> Option<ast::NameRef> {

--- a/crates/ide-db/src/syntax_helpers/node_ext.rs
+++ b/crates/ide-db/src/syntax_helpers/node_ext.rs
@@ -458,7 +458,7 @@ pub fn parse_tt_as_comma_sep_paths(input: ast::TokenTree) -> Option<Vec<ast::Pat
     Some(paths)
 }
 
-pub fn get_outer_macro(string: &ast::String) -> Option<MacroCall> {
+pub fn macro_call_for_string_token(string: &ast::String) -> Option<MacroCall> {
     let macro_call = string.syntax().parent_ancestors().find_map(ast::MacroCall::cast)?;
     Some(macro_call)
 }


### PR DESCRIPTION
Closes #12448

Important to know:

- Variables are taken from https://doc.rust-lang.org/cargo/reference/environment-variables.html and hardcoded as a const array.
- For the sake of simplicity I didn't include the autocompletion of `CARGO_BIN_EXE_<name>` and `OUT_DIR` since it would require information about build.rs and binary name. If somebody knows an easy way of obtaining them I can add those vars as well :)