### PR TITLE
fix: in VSCode, correctly resolve relative paths to errors

### DIFF
--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -1301,6 +1301,15 @@
                     "endsPattern": "^\\[Finished running\\b"
                 },
                 "pattern": "$rustc"
+            },
+            {
+                "name": "rustc-run",
+                "base": "$rustc",
+                "fileLocation": [
+                    "autoDetect",
+                    "${command:rust-analyzer.cargoWorkspaceRootForCurrentRun}"
+                ],
+                "pattern": "$rustc-run"
             }
         ],
         "colors": [

--- a/editors/code/src/commands.ts
+++ b/editors/code/src/commands.ts
@@ -842,6 +842,7 @@ export function run(ctx: Ctx): Cmd {
         item.detail = "rerun";
         prevRunnable = item;
         const task = await createTask(item.runnable, ctx.config);
+        ctx.cargoWorkspaceRootForCurrentRun = item.cargoWorkspaceRoot;
         return await vscode.tasks.executeTask(task);
     };
 }
@@ -945,4 +946,7 @@ export function linkToCommand(ctx: Ctx): Cmd {
             await vscode.commands.executeCommand(command, ...args);
         }
     };
+}
+export function getCargoWorkspaceDir(ctx: Ctx): Cmd {
+    return async () => ctx.cargoWorkspaceRootForCurrentRun;
 }

--- a/editors/code/src/ctx.ts
+++ b/editors/code/src/ctx.ts
@@ -17,6 +17,10 @@ export type Workspace =
       };
 
 export class Ctx {
+    // Helps VS Code to correctly link problems from runnables. This is used by
+    // `rust-analyzer.cargoWorkspaceRootForCurrentRun` command of $rustc-run problem matcher.
+    cargoWorkspaceRootForCurrentRun?: string = undefined;
+
     private constructor(
         readonly config: Config,
         private readonly extCtx: vscode.ExtensionContext,

--- a/editors/code/src/main.ts
+++ b/editors/code/src/main.ts
@@ -189,6 +189,7 @@ async function initCommonContext(context: vscode.ExtensionContext, ctx: Ctx) {
     ctx.registerCommand("resolveCodeAction", commands.resolveCodeAction);
     ctx.registerCommand("applyActionGroup", commands.applyActionGroup);
     ctx.registerCommand("gotoLocation", commands.gotoLocation);
+    ctx.registerCommand("cargoWorkspaceRootForCurrentRun", commands.getCargoWorkspaceDir);
 
     ctx.registerCommand("linkToCommand", commands.linkToCommand);
 }

--- a/editors/code/src/run.ts
+++ b/editors/code/src/run.ts
@@ -89,12 +89,14 @@ export async function selectRunnable(
 
 export class RunnableQuickPick implements vscode.QuickPickItem {
     public label: string;
+    public cargoWorkspaceRoot?: string;
     public description?: string | undefined;
     public detail?: string | undefined;
     public picked?: boolean | undefined;
 
     constructor(public runnable: ra.Runnable) {
         this.label = runnable.label;
+        this.cargoWorkspaceRoot = runnable.args.workspaceRoot;
     }
 }
 

--- a/editors/code/src/tasks.ts
+++ b/editors/code/src/tasks.ts
@@ -128,7 +128,7 @@ export async function buildCargoTask(
         name,
         TASK_SOURCE,
         exec,
-        ["$rustc"]
+        ["$rustc-run"]
     );
 }
 


### PR DESCRIPTION
VS Code problem matcher are restricted to be static "regexes". You can't create a problem matcher dynamically, and you can't use custom code in lieu of problem matcher.

This creates a problem for rust/cargo compiler errors. They use paths relative to the root of the Cargo workspace, but VS Code doesn't necessary know where that root is.

Luckily, there's a way out: our current problem matcher is defined like this:

    "fileLocation": [ "autoDetect", "${workspaceRoot}" ],

That means that relative pahts would be resoleved relative to workspace root. VS Code allows to specify a command inside `${}`. So we can plug custom logic there to fetch Cargo's workspace root!

And that's exactly what this PR is doing!