### PR TITLE
internal: Add `GenericParamList::to_generic_args` and `{TypeParam,ConstParam}::remove_default` APIs

### DIFF
--- a/crates/ide-assists/src/handlers/generate_impl.rs
+++ b/crates/ide-assists/src/handlers/generate_impl.rs
@@ -52,6 +52,7 @@ mod tests {
 
     use super::*;
 
+    // FIXME: break up into separate test fns
     #[test]
     fn test_add_impl() {
         check_assist(
@@ -130,6 +131,18 @@ mod tests {
             struct Defaulted<'a, 'b: 'a, T: Debug + Clone + 'a + 'b = String, const S: usize> {}
 
             impl<'a, 'b: 'a, T: Debug + Clone + 'a + 'b, const S: usize> Defaulted<'a, 'b, T, S> {
+                $0
+            }"#,
+        );
+
+        check_assist(
+            generate_impl,
+            r#"
+            struct Defaulted<const N: i32 = 0> {}$0"#,
+            r#"
+            struct Defaulted<const N: i32 = 0> {}
+
+            impl<const N: i32> Defaulted<N> {
                 $0
             }"#,
         );

--- a/crates/syntax/src/ast/edit_in_place.rs
+++ b/crates/syntax/src/ast/edit_in_place.rs
@@ -265,6 +265,42 @@ impl ast::WhereClause {
     }
 }
 
+impl ast::TypeParam {
+    pub fn remove_default(&self) {
+        if let Some((eq, last)) = self
+            .syntax()
+            .children_with_tokens()
+            .find(|it| it.kind() == T![=])
+            .zip(self.syntax().last_child_or_token())
+        {
+            ted::remove_all(eq..=last);
+
+            // remove any trailing ws
+            if let Some(last) = self.syntax().last_token().filter(|it| it.kind() == WHITESPACE) {
+                last.detach();
+            }
+        }
+    }
+}
+
+impl ast::ConstParam {
+    pub fn remove_default(&self) {
+        if let Some((eq, last)) = self
+            .syntax()
+            .children_with_tokens()
+            .find(|it| it.kind() == T![=])
+            .zip(self.syntax().last_child_or_token())
+        {
+            ted::remove_all(eq..=last);
+
+            // remove any trailing ws
+            if let Some(last) = self.syntax().last_token().filter(|it| it.kind() == WHITESPACE) {
+                last.detach();
+            }
+        }
+    }
+}
+
 pub trait Removable: AstNode {
     fn remove(&self);
 }

--- a/crates/syntax/src/ast/edit_in_place.rs
+++ b/crates/syntax/src/ast/edit_in_place.rs
@@ -235,6 +235,23 @@ impl ast::GenericParamList {
             }
         }
     }
+
+    /// Extracts the const, type, and lifetime names into a new [`ast::GenericParamList`]
+    pub fn to_generic_args(&self) -> ast::GenericParamList {
+        let params = self.generic_params().filter_map(|param| match param {
+            ast::GenericParam::ConstParam(it) => {
+                Some(ast::GenericParam::TypeParam(make::type_param(it.name()?, None)))
+            }
+            ast::GenericParam::LifetimeParam(it) => {
+                Some(ast::GenericParam::LifetimeParam(make::lifetime_param(it.lifetime()?)))
+            }
+            ast::GenericParam::TypeParam(it) => {
+                Some(ast::GenericParam::TypeParam(make::type_param(it.name()?, None)))
+            }
+        });
+
+        make::generic_param_list(params)
+    }
 }
 
 impl ast::WhereClause {

--- a/crates/syntax/src/ast/make.rs
+++ b/crates/syntax/src/ast/make.rs
@@ -88,6 +88,9 @@ pub mod ext {
         block_expr(None, None)
     }
 
+    pub fn ty_name(name: ast::Name) -> ast::Type {
+        ty_path(ident_path(&format!("{name}")))
+    }
     pub fn ty_bool() -> ast::Type {
         ty_path(ident_path("bool"))
     }
@@ -160,6 +163,7 @@ pub fn assoc_item_list() -> ast::AssocItemList {
     ast_from_text("impl C for D {}")
 }
 
+// FIXME: `ty_params` should be `ast::GenericArgList`
 pub fn impl_(
     ty: ast::Path,
     params: Option<ast::GenericParamList>,
@@ -183,10 +187,6 @@ pub fn impl_trait(
 ) -> ast::Impl {
     let ty_params = ty_params.map_or_else(String::new, |params| params.to_string());
     ast_from_text(&format!("impl{ty_params} {trait_} for {ty}{ty_params} {{}}"))
-}
-
-pub(crate) fn generic_arg_list() -> ast::GenericArgList {
-    ast_from_text("const S: T<> = ();")
 }
 
 pub fn path_segment(name_ref: ast::NameRef) -> ast::PathSegment {
@@ -716,6 +716,21 @@ pub fn generic_param_list(
 ) -> ast::GenericParamList {
     let args = pats.into_iter().join(", ");
     ast_from_text(&format!("fn f<{args}>() {{ }}"))
+}
+
+pub fn type_arg(ty: ast::Type) -> ast::TypeArg {
+    ast_from_text(&format!("const S: T<{ty}> = ();"))
+}
+
+pub fn lifetime_arg(lifetime: ast::Lifetime) -> ast::LifetimeArg {
+    ast_from_text(&format!("const S: T<{lifetime}> = ();"))
+}
+
+pub(crate) fn generic_arg_list(
+    args: impl IntoIterator<Item = ast::GenericArg>,
+) -> ast::GenericArgList {
+    let args = args.into_iter().join(", ");
+    ast_from_text(&format!("const S: T<{args}> = ();"))
 }
 
 pub fn visibility_pub_crate() -> ast::Visibility {


### PR DESCRIPTION
Also fixes `generate_impl` not removing the default const param value, though it seems that no one has encountered or reported that issue yet 😅

This initially started out as refactoring `utils::generate_impl_text_inner` to understand it better (which was the reason for adding `{TypeParam,ConstParam}::remove_default`), but ended up also finding another place that needed `GenericParamList::to_generic_args`, hence its addition in here.

