### PR TITLE
fix: reorder dyn bounds on render

### DIFF
--- a/crates/hir-ty/src/tests/display_source_code.rs
+++ b/crates/hir-ty/src/tests/display_source_code.rs
@@ -56,6 +56,28 @@ fn main() {
 }
 
 #[test]
+fn render_dyn_ty_independent_of_order() {
+    check_types_source_code(
+        r#"
+auto trait Send {}
+trait A {
+    type Assoc;
+}
+trait B: A {}
+
+fn test(
+    _: &(dyn A<Assoc = ()> + Send),
+  //^ &(dyn A<Assoc = ()> + Send)
+    _: &(dyn Send + A<Assoc = ()>),
+  //^ &(dyn A<Assoc = ()> + Send)
+    _: &dyn B<Assoc = ()>,
+  //^ &(dyn B<Assoc = ()>)
+) {}
+        "#,
+    );
+}
+
+#[test]
 fn render_dyn_for_ty() {
     // FIXME
     check_types_source_code(


### PR DESCRIPTION
Fixes #13368

#13192 changed the order of dyn bounds, violating the [contract](https://github.com/rust-lang/rust-analyzer/blob/3a69435af7a1e6273744085cb251adb2b9c30a03/crates/hir-ty/src/display.rs#L896-L901) with `write_bounds_like_dyn_trait()` on render. The projection bounds are expected to come right after the trait bound they are accompanied with.

Although the reordering procedure can be made a bit more efficient, I opted for relying only on the [invariants](https://github.com/rust-lang/rust-analyzer/blob/3a69435af7a1e6273744085cb251adb2b9c30a03/crates/hir-ty/src/lower.rs#L995-L998) currently documented in `lower_dyn_trait()`. It's not the hottest path and dyn bounds tend to be short so I believe it shouldn't hurt performance noticeably.