### PR TITLE
Expand unmatched mbe fragments to reasonable default token trees

### DIFF
--- a/crates/mbe/src/benchmark.rs
+++ b/crates/mbe/src/benchmark.rs
@@ -8,7 +8,7 @@ use syntax::{
 use test_utils::{bench, bench_fixture, skip_slow_tests};
 
 use crate::{
-    parser::{Op, RepeatKind, Separator},
+    parser::{MetaVarKind, Op, RepeatKind, Separator},
     syntax_node_to_token_tree, DeclarativeMacro,
 };
 
@@ -111,35 +111,35 @@ fn invocation_fixtures(rules: &FxHashMap<String, DeclarativeMacro>) -> Vec<(Stri
 
     fn collect_from_op(op: &Op, parent: &mut tt::Subtree, seed: &mut usize) {
         return match op {
-            Op::Var { kind, .. } => match kind.as_ref().map(|it| it.as_str()) {
-                Some("ident") => parent.token_trees.push(make_ident("foo")),
-                Some("ty") => parent.token_trees.push(make_ident("Foo")),
-                Some("tt") => parent.token_trees.push(make_ident("foo")),
-                Some("vis") => parent.token_trees.push(make_ident("pub")),
-                Some("pat") => parent.token_trees.push(make_ident("foo")),
-                Some("path") => parent.token_trees.push(make_ident("foo")),
-                Some("literal") => parent.token_trees.push(make_literal("1")),
-                Some("expr") => parent.token_trees.push(make_ident("foo")),
-                Some("lifetime") => {
+            Op::Var { kind, .. } => match kind.as_ref() {
+                Some(MetaVarKind::Ident) => parent.token_trees.push(make_ident("foo")),
+                Some(MetaVarKind::Ty) => parent.token_trees.push(make_ident("Foo")),
+                Some(MetaVarKind::Tt) => parent.token_trees.push(make_ident("foo")),
+                Some(MetaVarKind::Vis) => parent.token_trees.push(make_ident("pub")),
+                Some(MetaVarKind::Pat) => parent.token_trees.push(make_ident("foo")),
+                Some(MetaVarKind::Path) => parent.token_trees.push(make_ident("foo")),
+                Some(MetaVarKind::Literal) => parent.token_trees.push(make_literal("1")),
+                Some(MetaVarKind::Expr) => parent.token_trees.push(make_ident("foo")),
+                Some(MetaVarKind::Lifetime) => {
                     parent.token_trees.push(make_punct('\''));
                     parent.token_trees.push(make_ident("a"));
                 }
-                Some("block") => {
+                Some(MetaVarKind::Block) => {
                     parent.token_trees.push(make_subtree(tt::DelimiterKind::Brace, None))
                 }
-                Some("item") => {
+                Some(MetaVarKind::Item) => {
                     parent.token_trees.push(make_ident("fn"));
                     parent.token_trees.push(make_ident("foo"));
                     parent.token_trees.push(make_subtree(tt::DelimiterKind::Parenthesis, None));
                     parent.token_trees.push(make_subtree(tt::DelimiterKind::Brace, None));
                 }
-                Some("meta") => {
+                Some(MetaVarKind::Meta) => {
                     parent.token_trees.push(make_ident("foo"));
                     parent.token_trees.push(make_subtree(tt::DelimiterKind::Parenthesis, None));
                 }
 
                 None => (),
-                Some(kind) => panic!("Unhandled kind {}", kind),
+                Some(kind) => panic!("Unhandled kind {:?}", kind),
             },
             Op::Leaf(leaf) => parent.token_trees.push(leaf.clone().into()),
             Op::Repeat { tokens, kind, separator } => {

--- a/crates/mbe/src/expander.rs
+++ b/crates/mbe/src/expander.rs
@@ -8,7 +8,7 @@ mod transcriber;
 use rustc_hash::FxHashMap;
 use syntax::SmolStr;
 
-use crate::{ExpandError, ExpandResult};
+use crate::{parser::MetaVarKind, ExpandError, ExpandResult};
 
 pub(crate) fn expand_rules(
     rules: &[crate::Rule],
@@ -104,6 +104,7 @@ enum Binding {
     Fragment(Fragment),
     Nested(Vec<Binding>),
     Empty,
+    Missing(MetaVarKind),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/mbe/src/lib.rs
+++ b/crates/mbe/src/lib.rs
@@ -21,7 +21,7 @@ mod token_map;
 use std::fmt;
 
 use crate::{
-    parser::{MetaTemplate, Op},
+    parser::{MetaTemplate, MetaVarKind, Op},
     tt_iter::TtIter,
 };
 
@@ -291,9 +291,9 @@ fn validate(pattern: &MetaTemplate) -> Result<(), ParseError> {
                 // Checks that no repetition which could match an empty token
                 // https://github.com/rust-lang/rust/blob/a58b1ed44f5e06976de2bdc4d7dc81c36a96934f/src/librustc_expand/mbe/macro_rules.rs#L558
                 let lsh_is_empty_seq = separator.is_none() && subtree.iter().all(|child_op| {
-                    match child_op {
+                    match *child_op {
                         // vis is optional
-                        Op::Var { kind: Some(kind), .. } => kind == "vis",
+                        Op::Var { kind: Some(kind), .. } => kind == MetaVarKind::Vis,
                         Op::Repeat {
                             kind: parser::RepeatKind::ZeroOrMore | parser::RepeatKind::ZeroOrOne,
                             ..


### PR DESCRIPTION
Currently we expand unmatched fragments by not replacing them at all, leaving us with `$ident`. This trips up the parser or subsequent macro calls. Instead it makes more sense to replace these with some reasonable default depending on the fragment kind which should make more recursive macro calls work better for completions.