### PR TITLE
internal: Run `analysis-stats` on CI, with `opt-level = 1`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,6 +45,10 @@ jobs:
       - name: Cache Dependencies
         uses: Swatinem/rust-cache@ce325b60658c1b38465c06cc965b79baf32c1e72
 
+      - name: Bump opt-level
+        if: matrix.os == 'ubuntu-latest'
+        run: sed -i '/\[profile.dev]/a opt-level=1' Cargo.toml
+
       - name: Compile
         run: cargo test --no-run --locked
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,11 +49,24 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: sed -i '/\[profile.dev]/a opt-level=1' Cargo.toml
 
-      - name: Compile
+      - name: Compile (tests)
         run: cargo test --no-run --locked
+
+      # It's faster to `test` before `build` ¯\_(ツ)_/¯
+      - name: Compile (rust-analyzer)
+        if: matrix.os == 'ubuntu-latest'
+        run: cargo build --quiet
 
       - name: Test
         run: cargo test -- --nocapture --quiet
+
+      - name: Run analysis-stats on rust-analyzer
+        if: matrix.os == 'ubuntu-latest'
+        run: target/${{ matrix.target }}/debug/rust-analyzer analysis-stats .
+
+      - name: Run analysis-stats on rust std library
+        if: matrix.os == 'ubuntu-latest'
+        run: target/${{ matrix.target }}/debug/rust-analyzer analysis-stats --with-deps $(rustc --print sysroot)/lib/rustlib/src/rust/library/std
 
   # Weird targets to catch non-portable code
   rust-cross:

--- a/crates/syntax/src/ast/make.rs
+++ b/crates/syntax/src/ast/make.rs
@@ -89,7 +89,7 @@ pub mod ext {
     }
 
     pub fn ty_name(name: ast::Name) -> ast::Type {
-        ty_path(ident_path(&format!("{name}")))
+        ty_path(ident_path(&name.to_string()))
     }
     pub fn ty_bool() -> ast::Type {
         ty_path(ident_path("bool"))


### PR DESCRIPTION
We might want to run `analysis-stats` on PRs, and this makes it less unbearable.