### PR TITLE
Cast runnableEnv items to string

### DIFF
--- a/editors/code/src/config.ts
+++ b/editors/code/src/config.ts
@@ -133,7 +133,21 @@ export class Config {
     }
 
     get runnableEnv() {
-        return this.get<RunnableEnvCfg>("runnableEnv");
+        const item = this.get<any>("runnableEnv");
+        if (!item) return item;
+        const fixRecord = (r: Record<string, any>) => {
+            for (const key in r) {
+                if (typeof r[key] !== 'string') {
+                    r[key] = String(r[key]);
+                }
+            }
+        };
+        if (item instanceof Array) {
+            item.forEach((x) => fixRecord(x.env));
+        } else {
+            fixRecord(item);
+        }
+        return item;
     }
 
     get restartServerOnConfigChange() {

--- a/editors/code/src/config.ts
+++ b/editors/code/src/config.ts
@@ -137,7 +137,7 @@ export class Config {
         if (!item) return item;
         const fixRecord = (r: Record<string, any>) => {
             for (const key in r) {
-                if (typeof r[key] !== 'string') {
+                if (typeof r[key] !== "string") {
                     r[key] = String(r[key]);
                 }
             }


### PR DESCRIPTION
fix #13390 

An alternative approach could be raising an error if there is non string values.