### PR TITLE
Revert "fix: in VSCode, correctly resolve relative paths to errors"

### DIFF
--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -1301,15 +1301,6 @@
                     "endsPattern": "^\\[Finished running\\b"
                 },
                 "pattern": "$rustc"
-            },
-            {
-                "name": "rustc-run",
-                "base": "$rustc",
-                "fileLocation": [
-                    "autoDetect",
-                    "${command:rust-analyzer.cargoWorkspaceRootForCurrentRun}"
-                ],
-                "pattern": "$rustc-run"
             }
         ],
         "colors": [

--- a/editors/code/src/commands.ts
+++ b/editors/code/src/commands.ts
@@ -842,7 +842,6 @@ export function run(ctx: Ctx): Cmd {
         item.detail = "rerun";
         prevRunnable = item;
         const task = await createTask(item.runnable, ctx.config);
-        ctx.cargoWorkspaceRootForCurrentRun = item.cargoWorkspaceRoot;
         return await vscode.tasks.executeTask(task);
     };
 }
@@ -946,7 +945,4 @@ export function linkToCommand(ctx: Ctx): Cmd {
             await vscode.commands.executeCommand(command, ...args);
         }
     };
-}
-export function getCargoWorkspaceDir(ctx: Ctx): Cmd {
-    return async () => ctx.cargoWorkspaceRootForCurrentRun;
 }

--- a/editors/code/src/ctx.ts
+++ b/editors/code/src/ctx.ts
@@ -17,10 +17,6 @@ export type Workspace =
       };
 
 export class Ctx {
-    // Helps VS Code to correctly link problems from runnables. This is used by
-    // `rust-analyzer.cargoWorkspaceRootForCurrentRun` command of $rustc-run problem matcher.
-    cargoWorkspaceRootForCurrentRun?: string = undefined;
-
     private constructor(
         readonly config: Config,
         private readonly extCtx: vscode.ExtensionContext,

--- a/editors/code/src/main.ts
+++ b/editors/code/src/main.ts
@@ -189,7 +189,6 @@ async function initCommonContext(context: vscode.ExtensionContext, ctx: Ctx) {
     ctx.registerCommand("resolveCodeAction", commands.resolveCodeAction);
     ctx.registerCommand("applyActionGroup", commands.applyActionGroup);
     ctx.registerCommand("gotoLocation", commands.gotoLocation);
-    ctx.registerCommand("cargoWorkspaceRootForCurrentRun", commands.getCargoWorkspaceDir);
 
     ctx.registerCommand("linkToCommand", commands.linkToCommand);
 }

--- a/editors/code/src/run.ts
+++ b/editors/code/src/run.ts
@@ -89,14 +89,12 @@ export async function selectRunnable(
 
 export class RunnableQuickPick implements vscode.QuickPickItem {
     public label: string;
-    public cargoWorkspaceRoot?: string;
     public description?: string | undefined;
     public detail?: string | undefined;
     public picked?: boolean | undefined;
 
     constructor(public runnable: ra.Runnable) {
         this.label = runnable.label;
-        this.cargoWorkspaceRoot = runnable.args.workspaceRoot;
     }
 }
 

--- a/editors/code/src/tasks.ts
+++ b/editors/code/src/tasks.ts
@@ -128,7 +128,7 @@ export async function buildCargoTask(
         name,
         TASK_SOURCE,
         exec,
-        ["$rustc-run"]
+        ["$rustc"]
     );
 }
 


### PR DESCRIPTION
Reverts rust-lang/rust-analyzer#13367

I didn't manage to figure out what exactly is the issue, so reverting this to fix https://github.com/rust-lang/rust-analyzer/issues/13404 before monday.