### PR TITLE
fix: Ignore auto-import assist on parameter names

### DIFF
--- a/crates/ide-assists/src/handlers/auto_import.rs
+++ b/crates/ide-assists/src/handlers/auto_import.rs
@@ -156,6 +156,8 @@ pub(super) fn find_importable_node(
     {
         ImportAssets::for_method_call(&method_under_caret, &ctx.sema)
             .zip(Some(method_under_caret.syntax().clone().into()))
+    } else if let Some(_) = ctx.find_node_at_offset_with_descend::<ast::Param>() {
+        None
     } else if let Some(pat) = ctx
         .find_node_at_offset_with_descend::<ast::IdentPat>()
         .filter(ast::IdentPat::is_simple_ident)
@@ -266,6 +268,20 @@ mod tests {
         let labels = assists.iter().map(|assist| assist.label.to_string()).collect::<Vec<_>>();
 
         assert_eq!(labels, order);
+    }
+
+    #[test]
+    fn ignore_parameter_name() {
+        check_assist_not_applicable(
+            auto_import,
+            r"
+            mod foo {
+                pub mod bar {}
+            }
+
+            fn foo(bar$0: &str) {}
+            ",
+        );
     }
 
     #[test]


### PR DESCRIPTION
Fixes #13105; before & after

https://user-images.githubusercontent.com/29666622/195999489-0474c93a-b2bf-41c4-b7da-a4242a8082d8.mov


https://user-images.githubusercontent.com/29666622/195999571-605ee09c-bc6f-4ee5-bfe4-73e37254c647.mov

