### PR TITLE
fix: Don't catch the server activation error

### DIFF
--- a/editors/code/src/main.ts
+++ b/editors/code/src/main.ts
@@ -91,10 +91,7 @@ async function activateServer(ctx: Ctx): Promise<RustAnalyzerExtensionApi> {
         ctx.subscriptions
     );
 
-    await ctx.activate().catch((err) => {
-        void vscode.window.showErrorMessage(`Cannot activate rust-analyzer server: ${err.message}`);
-    });
-
+    await ctx.activate();
     return ctx.clientFetcher();
 }
 


### PR DESCRIPTION
We are are rethrowing and showing errors higher up in the call stack already. This just ate the error hiding the stacktrace unnecessarily.