### PR TITLE
Workaround the python vscode extension's polyfill

### DIFF
--- a/editors/code/src/config.ts
+++ b/editors/code/src/config.ts
@@ -191,7 +191,7 @@ export class Config {
 const VarRegex = new RegExp(/\$\{(.+?)\}/g);
 
 export function substituteVSCodeVariableInString(val: string): string {
-    return val.replaceAll(VarRegex, (substring: string, varName) => {
+    return val.replace(VarRegex, (substring: string, varName) => {
         if (typeof varName === "string") {
             return computeVscodeVar(varName) || substring;
         } else {


### PR DESCRIPTION
Fixes #13442

`String.replaceAll` and `String.replace` behave the same when given a (/g-flagged) Regex, so fix is very simple.