### PR TITLE
ide: Move crate_for_file to ide-db.

### DIFF
--- a/crates/ide-db/src/lib.rs
+++ b/crates/ide-db/src/lib.rs
@@ -150,6 +150,18 @@ impl RootDatabase {
         hir::db::ParseMacroExpansionQuery.in_db_mut(self).set_lru_capacity(lru_capacity);
         hir::db::MacroExpandQuery.in_db_mut(self).set_lru_capacity(lru_capacity);
     }
+
+    pub fn crate_for_file(&self, file_id: FileId) -> Option<CrateId> {
+        for &krate in self.relevant_crates(file_id).iter() {
+            let crate_def_map = self.crate_def_map(krate);
+            for (_, data) in crate_def_map.modules() {
+                if data.origin.file_id() == Some(file_id) {
+                    return Some(krate);
+                }
+            }
+        }
+        None
+    }
 }
 
 impl salsa::ParallelDatabase for RootDatabase {

--- a/crates/ide/src/moniker.rs
+++ b/crates/ide/src/moniker.rs
@@ -1,9 +1,9 @@
 //! This module generates [moniker](https://microsoft.github.io/language-server-protocol/specifications/lsif/0.6.0/specification/#exportsImports)
 //! for LSIF and LSP.
 
-use hir::{db::DefDatabase, AsAssocItem, AssocItemContainer, Crate, Name, Semantics};
+use hir::{AsAssocItem, AssocItemContainer, Crate, Name, Semantics};
 use ide_db::{
-    base_db::{CrateOrigin, FileId, FileLoader, FilePosition, LangCrateOrigin},
+    base_db::{CrateOrigin, FilePosition, LangCrateOrigin},
     defs::{Definition, IdentClass},
     helpers::pick_best_token,
     RootDatabase,
@@ -77,25 +77,13 @@ pub struct PackageInformation {
     pub version: String,
 }
 
-pub(crate) fn crate_for_file(db: &RootDatabase, file_id: FileId) -> Option<Crate> {
-    for &krate in db.relevant_crates(file_id).iter() {
-        let crate_def_map = db.crate_def_map(krate);
-        for (_, data) in crate_def_map.modules() {
-            if data.origin.file_id() == Some(file_id) {
-                return Some(krate.into());
-            }
-        }
-    }
-    None
-}
-
 pub(crate) fn moniker(
     db: &RootDatabase,
     FilePosition { file_id, offset }: FilePosition,
 ) -> Option<RangeInfo<Vec<MonikerResult>>> {
     let sema = &Semantics::new(db);
     let file = sema.parse(file_id).syntax().clone();
-    let current_crate = crate_for_file(db, file_id)?;
+    let current_crate = db.crate_for_file(file_id)?.into();
     let original_token = pick_best_token(file.token_at_offset(offset), |kind| match kind {
         IDENT
         | INT_NUMBER

--- a/crates/ide/src/static_index.rs
+++ b/crates/ide/src/static_index.rs
@@ -13,7 +13,7 @@ use syntax::{AstNode, SyntaxKind::*, SyntaxToken, TextRange, T};
 
 use crate::{
     hover::hover_for_definition,
-    moniker::{crate_for_file, def_to_moniker, MonikerResult},
+    moniker::{def_to_moniker, MonikerResult},
     Analysis, Fold, HoverConfig, HoverDocFormat, HoverResult, InlayHint, InlayHintsConfig,
     TryToNav,
 };
@@ -99,7 +99,7 @@ fn all_modules(db: &dyn HirDatabase) -> Vec<Module> {
 
 impl StaticIndex<'_> {
     fn add_file(&mut self, file_id: FileId) {
-        let current_crate = crate_for_file(self.db, file_id);
+        let current_crate = self.db.crate_for_file(file_id).map(|crate_id| crate_id.into());
         let folds = self.analysis.folding_ranges(file_id).unwrap();
         let inlay_hints = self
             .analysis


### PR DESCRIPTION
This is something I wrote because I thought I was going to use it for the scip code, but it ended up not being necessary.

Feel free to not take this patch.