### PR TITLE
docs: add crates section to the manual

### DIFF
--- a/docs/user/manual.adoc
+++ b/docs/user/manual.adoc
@@ -487,6 +487,12 @@ https://docs.helix-editor.com/[Helix] supports LSP by default.
 However, it won't install `rust-analyzer` automatically.
 You can follow instructions for installing <<rust-analyzer-language-server-binary,`rust-analyzer` binary>>.
 
+=== Crates
+
+There is a package named `ra_ap_rust_analyzer` available on [crates.io](https://crates.io/crates/ra_ap_rust-analyzer), for someone who wants to use it programmatically.
+
+For more details, see [the publish workflow](https://github.com/rust-lang/rust-analyzer/blob/master/.github/workflows/publish.yml).
+
 == Troubleshooting
 
 Start with looking at the rust-analyzer version.


### PR DESCRIPTION
closes #13533

Added a section to the user manual, to make it easier for users to find the correct crate.
