### PR TITLE
Add rustbot features related to PR state labels

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1,1 +1,11 @@
 [assign]
+
+[shortcut]
+
+[relabel]
+allow-unauthenticated = [
+    "S-*",
+]
+
+[autolabel."S-waiting-on-review"]
+new_pr = true


### PR DESCRIPTION
It makes rustbot add `S-waiting-on-review` to every new PR, and `@rustbot author` and `@rustbot review` commands working.