### PR TITLE
fix: escape replacement text for var/func extraction

### DIFF
--- a/crates/ide-assists/src/handlers/extract_function.rs
+++ b/crates/ide-assists/src/handlers/extract_function.rs
@@ -1325,8 +1325,7 @@ fn make_call(ctx: &AssistContext<'_>, fun: &Function, indent: IndentLevel) -> St
     //
     // Note that we don't need to escape the other characters that can be escaped,
     // because they wouldn't be treated as snippet-specific constructs without '$'.
-    buf.replace('\\', "\\\\").replace('$', "\\$");
-    buf
+    buf.replace('\\', "\\\\").replace('$', "\\$")
 }
 
 enum FlowHandler {

--- a/crates/ide-assists/src/handlers/extract_function.rs
+++ b/crates/ide-assists/src/handlers/extract_function.rs
@@ -5341,13 +5341,12 @@ fn foo() {
 }"#,
             r#"
 fn foo(){
-    fun_name();
+    let v = fun_name();
 }
 
-fn $0fun_name() {
-    let v = "\\ $1";
-}
-"#,
+fn $0fun_name() -> &str {
+    "\\\\ \$1"
+}"#,
         );
     }
 }

--- a/crates/ide-assists/src/handlers/extract_variable.rs
+++ b/crates/ide-assists/src/handlers/extract_variable.rs
@@ -1295,7 +1295,7 @@ fn foo() {
 }"#,
             r#"
 fn foo() {
-    let $0var_name = "\\ $1";
+    let $0var_name = &"\\\\ \$1";
     let v = var_name;
 }"#,
         );

--- a/crates/ide-assists/src/handlers/extract_variable.rs
+++ b/crates/ide-assists/src/handlers/extract_variable.rs
@@ -136,7 +136,7 @@ pub(crate) fn extract_variable(acc: &mut Assists, ctx: &AssistContext<'_>) -> Op
             //
             // Note that we don't need to escape the other characters that can be escaped,
             // because they wouldn't be treated as snippet-specific constructs without '$'.
-            buf.replace('\\', "\\\\").replace('$', "\\$");
+            buf = buf.replace('\\', "\\\\").replace('$', "\\$");
 
             edit.replace(expr_range, var_name.clone());
             let offset = anchor.syntax().text_range().start();


### PR DESCRIPTION
This closes #13558, making sure that `\\` and `$0` in extracted strings are preserved.

Possibly this should also be done for `extract_module`? The other two extractions, `extract_type_alias` and `extract_struct_from_enum_variant` probably don't?

Please review this carefully -- I simply copied #12646 in a way that looks reasonable and added some tests. I didn't actually run it locally.

The tests may need more escaping in both the input and/or output snippets.