### PR TITLE
fix: filter unnecessary completions after colon

### DIFF
--- a/crates/ide-completion/src/context.rs
+++ b/crates/ide-completion/src/context.rs
@@ -585,9 +585,6 @@ impl<'a> CompletionContext<'a> {
                     return None;
                 }
             }
-            T![::] if !is_prev_token_valid_path_start_or_segment(&original_token) => {
-                return None;
-            }
             _ => {}
         }
 

--- a/crates/ide-completion/src/context.rs
+++ b/crates/ide-completion/src/context.rs
@@ -581,9 +581,14 @@ impl<'a> CompletionContext<'a> {
                     return None;
                 }
 
-                // has 3 colon in a row
+                // has 3 colon or 2 coloncolon in a row
                 // special casing this as per discussion in https://github.com/rust-lang/rust-analyzer/pull/13611#discussion_r1031845205
-                if prev_token.prev_token().map(|t| t.kind() == T![:]).unwrap_or(false) {
+                // and https://github.com/rust-lang/rust-analyzer/pull/13611#discussion_r1032812751
+                if prev_token
+                    .prev_token()
+                    .map(|t| t.kind() == T![:] || t.kind() == T![::])
+                    .unwrap_or(false)
+                {
                     return None;
                 }
             }

--- a/crates/ide-completion/src/context.rs
+++ b/crates/ide-completion/src/context.rs
@@ -569,7 +569,7 @@ impl<'a> CompletionContext<'a> {
         // completing on
         let original_token = original_file.syntax().token_at_offset(offset).left_biased()?;
 
-        // try to skip completions on path with qinvalid colons
+        // try to skip completions on path with invalid colons
         // this approach works in normal path and inside token tree
         match original_token.kind() {
             T![:] => {

--- a/crates/ide-completion/src/context.rs
+++ b/crates/ide-completion/src/context.rs
@@ -581,7 +581,9 @@ impl<'a> CompletionContext<'a> {
                     return None;
                 }
 
-                if !is_prev_token_valid_path_start_or_segment(&prev_token) {
+                // has 3 colon in a row
+                // special casing this as per discussion in https://github.com/rust-lang/rust-analyzer/pull/13611#discussion_r1031845205
+                if prev_token.prev_token().map(|t| t.kind() == T![:]).unwrap_or(false) {
                     return None;
                 }
             }
@@ -635,24 +637,6 @@ impl<'a> CompletionContext<'a> {
         };
         Some((ctx, analysis))
     }
-}
-
-fn is_prev_token_valid_path_start_or_segment(token: &SyntaxToken) -> bool {
-    if let Some(prev_token) = token.prev_token() {
-        // token before coloncolon is invalid
-        if !matches!(
-            prev_token.kind(),
-            // trival
-            WHITESPACE | COMMENT
-            // PathIdentSegment
-            | IDENT | T![super] | T![self] | T![Self] | T![crate]
-            // QualifiedPath
-            | T![>]
-        ) {
-            return false;
-        }
-    }
-    true
 }
 
 const OP_TRAIT_LANG_NAMES: &[&str] = &[

--- a/crates/ide-completion/src/lib.rs
+++ b/crates/ide-completion/src/lib.rs
@@ -164,7 +164,6 @@ pub fn completions(
                 completions::vis::complete_vis_path(&mut completions, ctx, path_ctx, has_in_token);
             }
         }
-        // prevent `(` from triggering unwanted completion noise
         return Some(completions.into());
     }
 

--- a/crates/ide-completion/src/tests/attribute.rs
+++ b/crates/ide-completion/src/tests/attribute.rs
@@ -607,6 +607,30 @@ fn attr_in_source_file_end() {
     );
 }
 
+#[test]
+fn invalid_path() {
+    check(
+        r#"
+//- proc_macros: identity
+#[proc_macros:::$0]
+struct Foo;
+"#,
+        expect![[r#""#]],
+    );
+
+    check(
+        r#"
+//- minicore: derive, copy
+mod foo {
+    pub use Copy as Bar;
+}
+#[derive(foo:::::$0)]
+struct Foo;
+"#,
+        expect![""],
+    );
+}
+
 mod cfg {
     use super::*;
 

--- a/crates/ide-completion/src/tests/special.rs
+++ b/crates/ide-completion/src/tests/special.rs
@@ -967,16 +967,10 @@ fn foo { crate:$0 }
 }
 
 #[test]
-fn no_completions_in_invalid_path() {
+fn no_completions_in_after_tripple_colon() {
     check(
         r#"
 fn foo { crate:::$0 }
-"#,
-        expect![""],
-    );
-    check(
-        r#"
-fn foo { crate::::$0 }
 "#,
         expect![""],
     );

--- a/crates/ide-completion/src/tests/special.rs
+++ b/crates/ide-completion/src/tests/special.rs
@@ -967,11 +967,17 @@ fn foo { crate:$0 }
 }
 
 #[test]
-fn no_completions_in_after_tripple_colon() {
+fn no_completions_in_invalid_path() {
     check(
         r#"
 fn foo { crate:::$0 }
 "#,
         expect![""],
     );
+    check(
+        r#"
+fn foo { crate::::$0 }
+"#,
+        expect![""],
+    )
 }

--- a/crates/ide-completion/src/tests/special.rs
+++ b/crates/ide-completion/src/tests/special.rs
@@ -980,11 +980,4 @@ fn foo { crate::::$0 }
 "#,
         expect![""],
     );
-
-    check(
-        r#"
-fn foo { crate:::::$0 }
-"#,
-        expect![""],
-    );
 }

--- a/crates/ide-completion/src/tests/special.rs
+++ b/crates/ide-completion/src/tests/special.rs
@@ -2,10 +2,19 @@
 
 use expect_test::{expect, Expect};
 
-use crate::tests::{check_edit, completion_list_no_kw};
+use crate::tests::{check_edit, completion_list_no_kw, completion_list_with_trigger_character};
 
 fn check(ra_fixture: &str, expect: Expect) {
     let actual = completion_list_no_kw(ra_fixture);
+    expect.assert_eq(&actual)
+}
+
+pub(crate) fn check_with_trigger_character(
+    ra_fixture: &str,
+    trigger_character: Option<char>,
+    expect: Expect,
+) {
+    let actual = completion_list_with_trigger_character(ra_fixture, trigger_character);
     expect.assert_eq(&actual)
 }
 
@@ -891,5 +900,91 @@ fn f() {
         expect![[r#"
             me foo() fn(self)
         "#]],
+    );
+}
+
+#[test]
+fn completes_after_colon_with_trigger() {
+    check_with_trigger_character(
+        r#"
+//- minicore: option
+fn foo { ::$0 }
+"#,
+        Some(':'),
+        expect![[r#"
+            md core
+        "#]],
+    );
+    check_with_trigger_character(
+        r#"
+//- minicore: option
+fn foo { /* test */::$0 }
+"#,
+        Some(':'),
+        expect![[r#"
+            md core
+        "#]],
+    );
+
+    check_with_trigger_character(
+        r#"
+fn foo { crate::$0 }
+"#,
+        Some(':'),
+        expect![[r#"
+            fn foo() fn()
+        "#]],
+    );
+
+    check_with_trigger_character(
+        r#"
+fn foo { crate:$0 }
+"#,
+        Some(':'),
+        expect![""],
+    );
+}
+
+#[test]
+fn completes_after_colon_without_trigger() {
+    check_with_trigger_character(
+        r#"
+fn foo { crate::$0 }
+"#,
+        None,
+        expect![[r#"
+            fn foo() fn()
+        "#]],
+    );
+
+    check_with_trigger_character(
+        r#"
+fn foo { crate:$0 }
+"#,
+        None,
+        expect![""],
+    );
+}
+
+#[test]
+fn no_completions_in_invalid_path() {
+    check(
+        r#"
+fn foo { crate:::$0 }
+"#,
+        expect![""],
+    );
+    check(
+        r#"
+fn foo { crate::::$0 }
+"#,
+        expect![""],
+    );
+
+    check(
+        r#"
+fn foo { crate:::::$0 }
+"#,
+        expect![""],
     );
 }

--- a/crates/rust-analyzer/src/handlers.rs
+++ b/crates/rust-analyzer/src/handlers.rs
@@ -28,7 +28,7 @@ use lsp_types::{
 use project_model::{ManifestPath, ProjectWorkspace, TargetKind};
 use serde_json::json;
 use stdx::{format_to, never};
-use syntax::{algo, ast, AstNode, TextRange, TextSize, T};
+use syntax::{algo, ast, AstNode, TextRange, TextSize};
 use vfs::AbsPathBuf;
 
 use crate::{
@@ -811,18 +811,6 @@ pub(crate) fn handle_completion(
     let position = from_proto::file_position(&snap, params.text_document_position)?;
     let completion_trigger_character =
         params.context.and_then(|ctx| ctx.trigger_character).and_then(|s| s.chars().next());
-
-    if Some(':') == completion_trigger_character {
-        let source_file = snap.analysis.parse(position.file_id)?;
-        let left_token = source_file.syntax().token_at_offset(position.offset).left_biased();
-        let completion_triggered_after_single_colon = match left_token {
-            Some(left_token) => left_token.kind() == T![:],
-            None => true,
-        };
-        if completion_triggered_after_single_colon {
-            return Ok(None);
-        }
-    }
 
     let completion_config = &snap.config.completion();
     let items = match snap.analysis.completions(


### PR DESCRIPTION
close #13597
related: #10173

This PR also happens to fix two extra issues:

1. The test case in https://github.com/rust-lang/rust-analyzer/blob/master/crates/ide-completion/src/tests/attribute.rs#L778-L801 was never triggered in previous behavior.

after:

https://user-images.githubusercontent.com/26110087/201476995-56adf955-0fa7-4f75-ab32-28a8e6cb9504.mp4

<del>
2. completions were triggered even in invalid paths, like

```rust
fn main() {
    core:::::$0
}
```

```rust
#[:::::$0]
struct X;
```

</del>

only `:::` is excluded as discussed in https://github.com/rust-lang/rust-analyzer/pull/13611#discussion_r1031845205