### PR TITLE
feat: adds hover hint to ".." in record pattern

### DIFF
--- a/crates/ide/src/hover.rs
+++ b/crates/ide/src/hover.rs
@@ -127,6 +127,7 @@ pub(crate) fn hover(
             original_token.parent().and_then(ast::TokenTree::cast),
             Some(tt) if tt.syntax().ancestors().any(|it| ast::Meta::can_cast(it.kind()))
         );
+        
     // prefer descending the same token kind in attribute expansions, in normal macros text
     // equivalency is more important
     let descended = if in_attr {
@@ -135,54 +136,68 @@ pub(crate) fn hover(
         sema.descend_into_macros_with_same_text(original_token.clone())
     };
 
-    // FIXME: Definition should include known lints and the like instead of having this special case here
-    let hovered_lint = descended.iter().find_map(|token| {
-        let attr = token.parent_ancestors().find_map(ast::Attr::cast)?;
-        render::try_for_lint(&attr, token)
-    });
-    if let Some(res) = hovered_lint {
-        return Some(RangeInfo::new(original_token.text_range(), res));
-    }
-
+    // try lint hover
     let result = descended
         .iter()
-        .filter_map(|token| {
-            let node = token.parent()?;
-            let class = IdentClass::classify_token(sema, token)?;
-            if let IdentClass::Operator(OperatorClass::Await(_)) = class {
-                // It's better for us to fall back to the keyword hover here,
-                // rendering poll is very confusing
-                return None;
-            }
-            Some(class.definitions().into_iter().zip(iter::once(node).cycle()))
+        .find_map(|token| {
+            // FIXME: Definition should include known lints and the like instead of having this special case here
+            let attr = token.parent_ancestors().find_map(ast::Attr::cast)?;
+            render::try_for_lint(&attr, token)
         })
-        .flatten()
-        .unique_by(|&(def, _)| def)
-        .filter_map(|(def, node)| hover_for_definition(sema, file_id, def, &node, config))
-        .reduce(|mut acc: HoverResult, HoverResult { markup, actions }| {
-            acc.actions.extend(actions);
-            acc.markup = Markup::from(format!("{}\n---\n{}", acc.markup, markup));
-            acc
+        // try item definitions
+        .or_else(|| {
+            descended
+                .iter()
+                .filter_map(|token| {
+                    let node = token.parent()?;
+                    let class = IdentClass::classify_token(sema, token)?;
+                    if let IdentClass::Operator(OperatorClass::Await(_)) = class {
+                        // It's better for us to fall back to the keyword hover here,
+                        // rendering poll is very confusing
+                        return None;
+                    }
+                    Some(class.definitions().into_iter().zip(iter::once(node).cycle()))
+                })
+                .flatten()
+                .unique_by(|&(def, _)| def)
+                .filter_map(|(def, node)| hover_for_definition(sema, file_id, def, &node, config))
+                .reduce(|mut acc: HoverResult, HoverResult { markup, actions }| {
+                    acc.actions.extend(actions);
+                    acc.markup = Markup::from(format!("{}\n---\n{}", acc.markup, markup));
+                    acc
+                })
+        })
+        // try keywords
+        .or_else(|| {
+            descended.iter().find_map(|token| render::keyword(sema, config, token))
+        })
+        // try rest item hover
+        .or_else(|| {
+            descended.iter().find_map(|token| {
+                if token.kind() != DOT2 {
+                    return None;
+                }
+
+                let record_pat_field_list =
+                    token.parent_ancestors().find_map(ast::RecordPatFieldList::cast)?;
+
+                let record_pat =
+                    record_pat_field_list.syntax().parent().and_then(ast::RecordPat::cast)?;
+
+                Some(render::struct_rest_pat(sema, config, &record_pat))
+            })
         });
 
-    if result.is_none() {
-        // fallbacks, show keywords or types
-
-        let res = descended.iter().find_map(|token| render::keyword(sema, config, token));
-        if let Some(res) = res {
-            return Some(RangeInfo::new(original_token.text_range(), res));
-        }
-        let res = descended
-            .iter()
-            .find_map(|token| hover_type_fallback(sema, config, token, &original_token));
-        if let Some(_) = res {
-            return res;
-        }
-    }
-    result.map(|mut res: HoverResult| {
-        res.actions = dedupe_or_merge_hover_actions(res.actions);
-        RangeInfo::new(original_token.text_range(), res)
-    })
+    result
+        .map(|mut res: HoverResult| {
+            res.actions = dedupe_or_merge_hover_actions(res.actions);
+            RangeInfo::new(original_token.text_range(), res)
+        })
+        // fallback to type hover if there aren't any other suggestions
+        // this finds its own range instead of using the closest token's range
+        .or_else(|| {
+            descended.iter().find_map(|token| hover_type_fallback(sema, config, token, &token))
+        })
 }
 
 pub(crate) fn hover_for_definition(
@@ -268,8 +283,7 @@ fn hover_type_fallback(
         }
     };
 
-    let res = render::type_info(sema, config, &expr_or_pat)
-        .or_else(|| render::struct_rest_pat(sema, config, &expr_or_pat))?;
+    let res = render::type_info(sema, config, &expr_or_pat)?;
 
     let range = sema
         .original_range_opt(&node)

--- a/crates/ide/src/hover.rs
+++ b/crates/ide/src/hover.rs
@@ -176,8 +176,8 @@ pub(crate) fn hover(
                     return None;
                 }
 
-                let record_pat_field_list =
-                    token.parent_ancestors().find_map(ast::RecordPatFieldList::cast)?;
+                let rest_pat = token.syntax().parent().and_then(ast::RestPat::cast)?;
+                let record_pat_field_list = rest_pat.syntax().parent().and_then(ast::RecordPatFieldList::cast)?;
 
                 let record_pat =
                     record_pat_field_list.syntax().parent().and_then(ast::RecordPat::cast)?;

--- a/crates/ide/src/hover.rs
+++ b/crates/ide/src/hover.rs
@@ -87,7 +87,7 @@ pub struct HoverResult {
 // Shows additional information, like the type of an expression or the documentation for a definition when "focusing" code.
 // Focusing is usually hovering with a mouse, but can also be triggered with a shortcut.
 //
-// image::https://user-images.githubusercontent.com/48062697/113020658-b5f98b80-917a-11eb-9f88-3dbc27320c95.gif[]
+// image::https://user-images.githubusercontent.com/48062697/113020658-b5f98b80-917a-11eb-9f88-3dbc27320c95.gif
 pub(crate) fn hover(
     db: &RootDatabase,
     FileRange { file_id, range }: FileRange,
@@ -268,7 +268,10 @@ fn hover_type_fallback(
         }
     };
 
-    let res = render::type_info(sema, config, &expr_or_pat)?;
+    let res =
+        render::type_info(sema, config, &expr_or_pat)
+        .or_else(|| render::struct_rest_pat(sema, config, &expr_or_pat))?;
+
     let range = sema
         .original_range_opt(&node)
         .map(|frange| frange.range)

--- a/crates/ide/src/hover.rs
+++ b/crates/ide/src/hover.rs
@@ -176,7 +176,7 @@ pub(crate) fn hover(
                     return None;
                 }
 
-                let rest_pat = token.syntax().parent().and_then(ast::RestPat::cast)?;
+                let rest_pat = token.parent().and_then(ast::RestPat::cast)?;
                 let record_pat_field_list = rest_pat.syntax().parent().and_then(ast::RecordPatFieldList::cast)?;
 
                 let record_pat =

--- a/crates/ide/src/hover.rs
+++ b/crates/ide/src/hover.rs
@@ -177,7 +177,8 @@ pub(crate) fn hover(
                 }
 
                 let rest_pat = token.parent().and_then(ast::RestPat::cast)?;
-                let record_pat_field_list = rest_pat.syntax().parent().and_then(ast::RecordPatFieldList::cast)?;
+                let record_pat_field_list =
+                    rest_pat.syntax().parent().and_then(ast::RecordPatFieldList::cast)?;
 
                 let record_pat =
                     record_pat_field_list.syntax().parent().and_then(ast::RecordPat::cast)?;

--- a/crates/ide/src/hover.rs
+++ b/crates/ide/src/hover.rs
@@ -127,7 +127,7 @@ pub(crate) fn hover(
             original_token.parent().and_then(ast::TokenTree::cast),
             Some(tt) if tt.syntax().ancestors().any(|it| ast::Meta::can_cast(it.kind()))
         );
-        
+
     // prefer descending the same token kind in attribute expansions, in normal macros text
     // equivalency is more important
     let descended = if in_attr {
@@ -168,9 +168,7 @@ pub(crate) fn hover(
                 })
         })
         // try keywords
-        .or_else(|| {
-            descended.iter().find_map(|token| render::keyword(sema, config, token))
-        })
+        .or_else(|| descended.iter().find_map(|token| render::keyword(sema, config, token)))
         // try rest item hover
         .or_else(|| {
             descended.iter().find_map(|token| {

--- a/crates/ide/src/hover.rs
+++ b/crates/ide/src/hover.rs
@@ -268,8 +268,7 @@ fn hover_type_fallback(
         }
     };
 
-    let res =
-        render::type_info(sema, config, &expr_or_pat)
+    let res = render::type_info(sema, config, &expr_or_pat)
         .or_else(|| render::struct_rest_pat(sema, config, &expr_or_pat))?;
 
     let range = sema

--- a/crates/ide/src/hover.rs
+++ b/crates/ide/src/hover.rs
@@ -87,7 +87,7 @@ pub struct HoverResult {
 // Shows additional information, like the type of an expression or the documentation for a definition when "focusing" code.
 // Focusing is usually hovering with a mouse, but can also be triggered with a shortcut.
 //
-// image::https://user-images.githubusercontent.com/48062697/113020658-b5f98b80-917a-11eb-9f88-3dbc27320c95.gif
+// image::https://user-images.githubusercontent.com/48062697/113020658-b5f98b80-917a-11eb-9f88-3dbc27320c95.gif[]
 pub(crate) fn hover(
     db: &RootDatabase,
     FileRange { file_id, range }: FileRange,

--- a/crates/ide/src/hover/render.rs
+++ b/crates/ide/src/hover/render.rs
@@ -257,7 +257,7 @@ pub(super) fn struct_rest_pat(
 ) -> Option<HoverResult> {
     let pat = expr_or_pat.as_ref().right()?;
 
-    let mut ancestors = sema.ancestors_with_macros(pat.syntax().clone());
+    let mut ancestors = pat.syntax().ancestors();
     let _record_pat_field_list = ancestors.next()?;
     let record_pat = ancestors.next()?;
     let pattern = sema

--- a/crates/ide/src/hover/render.rs
+++ b/crates/ide/src/hover/render.rs
@@ -14,7 +14,9 @@ use ide_db::{
 use itertools::Itertools;
 use stdx::format_to;
 use syntax::{
-    algo, ast::{self, RecordPat}, match_ast, AstNode, Direction,
+    algo,
+    ast::{self, RecordPat},
+    match_ast, AstNode, Direction,
     SyntaxKind::{LET_EXPR, LET_STMT},
     SyntaxToken, T,
 };
@@ -263,7 +265,8 @@ pub(super) fn struct_rest_pat(
     let pattern = sema
         .find_nodes_at_offset_with_descend::<RecordPat>(
             &record_pat,
-        record_pat.text_range().start())
+            record_pat.text_range().start(),
+        )
         .next()?;
 
     let missing_fields = sema.record_pattern_missing_fields(&pattern);
@@ -290,7 +293,7 @@ pub(super) fn struct_rest_pat(
             s += ", ";
         }
         // get rid of trailing comma
-        if s.len() > 0 {s.truncate(s.len() - 2);}
+        s.truncate(s.len() - 2);
 
         if config.markdown() {
             Markup::fenced_block(&s)

--- a/crates/ide/src/hover/tests.rs
+++ b/crates/ide/src/hover/tests.rs
@@ -5307,3 +5307,38 @@ fn main() { $0V; }
         "#]],
     );
 }
+
+#[test]
+fn hover_rest_pat() {
+    check(
+        r#"
+struct Struct {a: u32, b: u32, c: u8, d: u16};
+
+fn main() {
+    let Struct {a, c, .$0.} = Struct {a: 1, b: 2, c: 3, d: 4};
+}
+"#,
+        expect![[r#"
+            *..*
+            ```rust
+            .., b: u32, d: u16
+            ```
+        "#]],
+    );
+
+    check(
+        r#"
+struct Struct {a: u32, b: u32, c: u8, d: u16};
+
+fn main() {
+    let Struct {a, b, c, d, .$0.} = Struct {a: 1, b: 2, c: 3, d: 4};
+}
+"#,
+        expect![[r#"
+            *..*
+            ```rust
+            ..
+            ```
+        "#]],
+    );
+}


### PR DESCRIPTION
Hovering on the "rest" pattern in struct destructuring,
```rust
struct Baz {
    a: u32,
    b: u32,
    c: u32,
    d: u32
}

let Baz { a, b, ..$0} = Baz { a: 1, b: 2, c: 3, d: 4 };
```
shows:

```
.., c: u32, d: u32
```

Currently only works with struct patterns.

![image](https://user-images.githubusercontent.com/51814158/202837115-f424cc26-c2d7-4027-8eea-eeb7749ad146.png)
