### PR TITLE
fix(assists): remove `item_const` which had default value when implement missing members

### DIFF
--- a/crates/ide-assists/src/handlers/add_missing_impl_members.rs
+++ b/crates/ide-assists/src/handlers/add_missing_impl_members.rs
@@ -196,6 +196,7 @@ trait Foo {
     type Output;
 
     const CONST: usize = 42;
+    const CONST_2: i32;
 
     fn foo(&self);
     fn bar(&self);
@@ -213,6 +214,7 @@ trait Foo {
     type Output;
 
     const CONST: usize = 42;
+    const CONST_2: i32;
 
     fn foo(&self);
     fn bar(&self);
@@ -226,7 +228,7 @@ impl Foo for S {
 
     $0type Output;
 
-    const CONST: usize = 42;
+    const CONST_2: i32;
 
     fn foo(&self) {
         todo!()
@@ -658,6 +660,7 @@ trait Foo {
     type Output;
 
     const CONST: usize = 42;
+    const CONST_2: i32;
 
     fn valid(some: u32) -> bool { false }
     fn foo(some: u32) -> bool;
@@ -669,13 +672,16 @@ trait Foo {
     type Output;
 
     const CONST: usize = 42;
+    const CONST_2: i32;
 
     fn valid(some: u32) -> bool { false }
     fn foo(some: u32) -> bool;
 }
 struct S;
 impl Foo for S {
-    $0fn valid(some: u32) -> bool { false }
+    $0const CONST: usize = 42;
+
+    fn valid(some: u32) -> bool { false }
 }"#,
         )
     }

--- a/crates/ide-assists/src/handlers/replace_derive_with_manual_impl.rs
+++ b/crates/ide-assists/src/handlers/replace_derive_with_manual_impl.rs
@@ -1019,8 +1019,6 @@ struct Foo {
 impl foo::Bar for Foo {
     $0type Qux;
 
-    const Baz: usize = 42;
-
     const Fez: usize;
 
     fn foo() {

--- a/crates/ide-assists/src/utils.rs
+++ b/crates/ide-assists/src/utils.rs
@@ -119,6 +119,10 @@ pub fn filter_assoc_items(
                 (default_methods, def.body()),
                 (DefaultMethods::Only, Some(_)) | (DefaultMethods::No, None)
             ),
+            ast::AssocItem::Const(def) => matches!(
+                (default_methods, def.body()),
+                (DefaultMethods::Only, Some(_)) | (DefaultMethods::No, None)
+            ),
             _ => default_methods == DefaultMethods::No,
         })
         .collect::<Vec<_>>()


### PR DESCRIPTION
Fixed https://github.com/rust-lang/rust-analyzer/issues/13292