### PR TITLE
hir-expand: fix compile_error! expansion not unquoting strings

### DIFF
--- a/crates/hir-def/src/macro_expansion_tests/builtin_fn_macro.rs
+++ b/crates/hir-def/src/macro_expansion_tests/builtin_fn_macro.rs
@@ -163,7 +163,8 @@ macro_rules! compile_error {
 }
 
 // This expands to nothing (since it's in item position), but emits an error.
-compile_error!("error!");
+compile_error!("error, with an escaped quote: \"");
+compile_error!(r"this is a raw string");
 "#,
         expect![[r##"
 #[rustc_builtin_macro]
@@ -172,7 +173,8 @@ macro_rules! compile_error {
     ($msg:expr,) => ({ /* compiler built-in */ })
 }
 
-/* error: error! */
+/* error: error, with an escaped quote: " */
+/* error: this is a raw string */
 "##]],
     );
 }

--- a/crates/hir-expand/src/builtin_fn_macro.rs
+++ b/crates/hir-expand/src/builtin_fn_macro.rs
@@ -379,15 +379,10 @@ fn compile_error_expand(
     tt: &tt::Subtree,
 ) -> ExpandResult<ExpandedEager> {
     let err = match &*tt.token_trees {
-        [tt::TokenTree::Leaf(tt::Leaf::Literal(it))] => {
-            let text = it.text.as_str();
-            if text.starts_with('"') && text.ends_with('"') {
-                // FIXME: does not handle raw strings
-                ExpandError::Other(text[1..text.len() - 1].into())
-            } else {
-                ExpandError::Other("`compile_error!` argument must be a string".into())
-            }
-        }
+        [tt::TokenTree::Leaf(tt::Leaf::Literal(it))] => match unquote_str(it) {
+            Some(unquoted) => ExpandError::Other(unquoted.into()),
+            None => ExpandError::Other("`compile_error!` argument must be a string".into()),
+        },
         _ => ExpandError::Other("`compile_error!` argument must be a string".into()),
     };
 


### PR DESCRIPTION
expanding `compile_error!` would not properly unquote strings, leading to quite ugly diagnostic messages:

![image](https://user-images.githubusercontent.com/5489149/202893481-2486ede8-c79a-4972-9713-416d6a704064.png)

this fixes it, using the conveniently placed `unquote_str` function, which now makes errors look like:

![image](https://user-images.githubusercontent.com/5489149/202893466-0763efad-9240-4d55-80a6-6c62000d5d2b.png)

additionally, using `unquote_str` has the cool side-effect of *also* handling raw strings, so this fixes a fixme too! 
