### PR TITLE
Fix typo on 'configuration' anchor

### DIFF
--- a/docs/user/manual.adoc
+++ b/docs/user/manual.adoc
@@ -367,7 +367,7 @@ if executable('rust-analyzer')
 endif
 ----
 
-There is no dedicated UI for the server configuration, so you would need to send any options as a value of the `initialization_options` field, as described in the <<_configuration,Configuration>> section.
+There is no dedicated UI for the server configuration, so you would need to send any options as a value of the `initialization_options` field, as described in the <<configuration,Configuration>> section.
 Here is an example of how to enable the proc-macro support:
 
 [source,vim]


### PR DESCRIPTION
https://rust-analyzer.github.io/manual.html#_configuration lands you at
the start of the page, while
https://rust-analyzer.github.io/manual.html#configuration correctly puts
you at the correct anchor
