### PR TITLE
Fix: Handle empty `checkOnSave/target` values

### DIFF
--- a/docs/user/generated_config.adoc
+++ b/docs/user/generated_config.adoc
@@ -190,7 +190,7 @@ cargo check --workspace --message-format=json --all-targets
 ```
 .
 --
-[[rust-analyzer.checkOnSave.target]]rust-analyzer.checkOnSave.target (default: `[]`)::
+[[rust-analyzer.checkOnSave.target]]rust-analyzer.checkOnSave.target (default: `null`)::
 +
 --
 Check for specific targets. Defaults to `#rust-analyzer.cargo.target#` if empty.

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -640,8 +640,11 @@
                 },
                 "rust-analyzer.checkOnSave.target": {
                     "markdownDescription": "Check for specific targets. Defaults to `#rust-analyzer.cargo.target#` if empty.\n\nCan be a single target, e.g. `\"x86_64-unknown-linux-gnu\"` or a list of targets, e.g.\n`[\"aarch64-apple-darwin\", \"x86_64-apple-darwin\"]`.\n\nAliased as `\"checkOnSave.targets\"`.",
-                    "default": [],
+                    "default": null,
                     "anyOf": [
+                        {
+                            "type": "null"
+                        },
                         {
                             "type": "string"
                         },


### PR DESCRIPTION
This fixes a regression introduced by #13290, in which failing to set `checkOnSave/target` (or `checkOnSave/targets`) would lead to an invalid config.

[Fixes #13660]