### PR TITLE
internal: Reduce the size of `HirFileId` from 8 to 4 bytes

### DIFF
--- a/crates/hir-expand/src/db.rs
+++ b/crates/hir-expand/src/db.rs
@@ -240,7 +240,7 @@ fn ast_id_map(db: &dyn AstDatabase, file_id: HirFileId) -> Arc<AstIdMap> {
 }
 
 fn parse_or_expand(db: &dyn AstDatabase, file_id: HirFileId) -> Option<SyntaxNode> {
-    match file_id.0 {
+    match file_id.repr() {
         HirFileIdRepr::FileId(file_id) => Some(db.parse(file_id).tree().syntax().clone()),
         HirFileIdRepr::MacroFile(macro_file) => {
             // FIXME: Note how we convert from `Parse` to `SyntaxNode` here,

--- a/crates/hir-expand/src/hygiene.rs
+++ b/crates/hir-expand/src/hygiene.rs
@@ -17,7 +17,7 @@ use crate::{
     db::{self, AstDatabase},
     fixup,
     name::{AsName, Name},
-    HirFileId, HirFileIdRepr, InFile, MacroCallKind, MacroCallLoc, MacroDefKind, MacroFile,
+    HirFileId, InFile, MacroCallKind, MacroCallLoc, MacroDefKind, MacroFile,
 };
 
 #[derive(Clone, Debug)]
@@ -216,9 +216,9 @@ fn make_hygiene_info(
 
 impl HygieneFrame {
     pub(crate) fn new(db: &dyn AstDatabase, file_id: HirFileId) -> HygieneFrame {
-        let (info, krate, local_inner) = match file_id.0 {
-            HirFileIdRepr::FileId(_) => (None, None, false),
-            HirFileIdRepr::MacroFile(macro_file) => {
+        let (info, krate, local_inner) = match file_id.macro_file() {
+            None => (None, None, false),
+            Some(macro_file) => {
                 let loc = db.lookup_intern_macro_call(macro_file.macro_call_id);
                 let info =
                     make_hygiene_info(db, macro_file, &loc).map(|info| (loc.kind.file_id(), info));

--- a/crates/ide-db/src/test_data/test_symbol_index_collection.txt
+++ b/crates/ide-db/src/test_data/test_symbol_index_collection.txt
@@ -14,11 +14,7 @@
                 name: "Alias",
                 loc: DeclarationLocation {
                     hir_file_id: HirFileId(
-                        FileId(
-                            FileId(
-                                0,
-                            ),
-                        ),
+                        0,
                     ),
                     ptr: SyntaxNodePtr {
                         kind: TYPE_ALIAS,
@@ -36,11 +32,7 @@
                 name: "CONST",
                 loc: DeclarationLocation {
                     hir_file_id: HirFileId(
-                        FileId(
-                            FileId(
-                                0,
-                            ),
-                        ),
+                        0,
                     ),
                     ptr: SyntaxNodePtr {
                         kind: CONST,
@@ -58,11 +50,7 @@
                 name: "CONST_WITH_INNER",
                 loc: DeclarationLocation {
                     hir_file_id: HirFileId(
-                        FileId(
-                            FileId(
-                                0,
-                            ),
-                        ),
+                        0,
                     ),
                     ptr: SyntaxNodePtr {
                         kind: CONST,
@@ -80,11 +68,7 @@
                 name: "Enum",
                 loc: DeclarationLocation {
                     hir_file_id: HirFileId(
-                        FileId(
-                            FileId(
-                                0,
-                            ),
-                        ),
+                        0,
                     ),
                     ptr: SyntaxNodePtr {
                         kind: ENUM,
@@ -102,11 +86,7 @@
                 name: "Macro",
                 loc: DeclarationLocation {
                     hir_file_id: HirFileId(
-                        FileId(
-                            FileId(
-                                0,
-                            ),
-                        ),
+                        0,
                     ),
                     ptr: SyntaxNodePtr {
                         kind: MACRO_DEF,
@@ -124,11 +104,7 @@
                 name: "STATIC",
                 loc: DeclarationLocation {
                     hir_file_id: HirFileId(
-                        FileId(
-                            FileId(
-                                0,
-                            ),
-                        ),
+                        0,
                     ),
                     ptr: SyntaxNodePtr {
                         kind: STATIC,
@@ -146,11 +122,7 @@
                 name: "Struct",
                 loc: DeclarationLocation {
                     hir_file_id: HirFileId(
-                        FileId(
-                            FileId(
-                                0,
-                            ),
-                        ),
+                        0,
                     ),
                     ptr: SyntaxNodePtr {
                         kind: STRUCT,
@@ -168,13 +140,7 @@
                 name: "StructFromMacro",
                 loc: DeclarationLocation {
                     hir_file_id: HirFileId(
-                        MacroFile(
-                            MacroFile {
-                                macro_call_id: MacroCallId(
-                                    0,
-                                ),
-                            },
-                        ),
+                        2147483648,
                     ),
                     ptr: SyntaxNodePtr {
                         kind: STRUCT,
@@ -192,11 +158,7 @@
                 name: "StructInFn",
                 loc: DeclarationLocation {
                     hir_file_id: HirFileId(
-                        FileId(
-                            FileId(
-                                0,
-                            ),
-                        ),
+                        0,
                     ),
                     ptr: SyntaxNodePtr {
                         kind: STRUCT,
@@ -216,11 +178,7 @@
                 name: "StructInNamedConst",
                 loc: DeclarationLocation {
                     hir_file_id: HirFileId(
-                        FileId(
-                            FileId(
-                                0,
-                            ),
-                        ),
+                        0,
                     ),
                     ptr: SyntaxNodePtr {
                         kind: STRUCT,
@@ -240,11 +198,7 @@
                 name: "StructInUnnamedConst",
                 loc: DeclarationLocation {
                     hir_file_id: HirFileId(
-                        FileId(
-                            FileId(
-                                0,
-                            ),
-                        ),
+                        0,
                     ),
                     ptr: SyntaxNodePtr {
                         kind: STRUCT,
@@ -262,11 +216,7 @@
                 name: "Trait",
                 loc: DeclarationLocation {
                     hir_file_id: HirFileId(
-                        FileId(
-                            FileId(
-                                0,
-                            ),
-                        ),
+                        0,
                     ),
                     ptr: SyntaxNodePtr {
                         kind: TRAIT,
@@ -284,11 +234,7 @@
                 name: "Union",
                 loc: DeclarationLocation {
                     hir_file_id: HirFileId(
-                        FileId(
-                            FileId(
-                                0,
-                            ),
-                        ),
+                        0,
                     ),
                     ptr: SyntaxNodePtr {
                         kind: UNION,
@@ -306,11 +252,7 @@
                 name: "a_mod",
                 loc: DeclarationLocation {
                     hir_file_id: HirFileId(
-                        FileId(
-                            FileId(
-                                0,
-                            ),
-                        ),
+                        0,
                     ),
                     ptr: SyntaxNodePtr {
                         kind: MODULE,
@@ -328,11 +270,7 @@
                 name: "b_mod",
                 loc: DeclarationLocation {
                     hir_file_id: HirFileId(
-                        FileId(
-                            FileId(
-                                0,
-                            ),
-                        ),
+                        0,
                     ),
                     ptr: SyntaxNodePtr {
                         kind: MODULE,
@@ -350,11 +288,7 @@
                 name: "define_struct",
                 loc: DeclarationLocation {
                     hir_file_id: HirFileId(
-                        FileId(
-                            FileId(
-                                0,
-                            ),
-                        ),
+                        0,
                     ),
                     ptr: SyntaxNodePtr {
                         kind: MACRO_RULES,
@@ -372,11 +306,7 @@
                 name: "impl_fn",
                 loc: DeclarationLocation {
                     hir_file_id: HirFileId(
-                        FileId(
-                            FileId(
-                                0,
-                            ),
-                        ),
+                        0,
                     ),
                     ptr: SyntaxNodePtr {
                         kind: FN,
@@ -394,11 +324,7 @@
                 name: "macro_rules_macro",
                 loc: DeclarationLocation {
                     hir_file_id: HirFileId(
-                        FileId(
-                            FileId(
-                                0,
-                            ),
-                        ),
+                        0,
                     ),
                     ptr: SyntaxNodePtr {
                         kind: MACRO_RULES,
@@ -416,11 +342,7 @@
                 name: "main",
                 loc: DeclarationLocation {
                     hir_file_id: HirFileId(
-                        FileId(
-                            FileId(
-                                0,
-                            ),
-                        ),
+                        0,
                     ),
                     ptr: SyntaxNodePtr {
                         kind: FN,
@@ -438,11 +360,7 @@
                 name: "trait_fn",
                 loc: DeclarationLocation {
                     hir_file_id: HirFileId(
-                        FileId(
-                            FileId(
-                                0,
-                            ),
-                        ),
+                        0,
                     ),
                     ptr: SyntaxNodePtr {
                         kind: FN,
@@ -475,11 +393,7 @@
                 name: "StructInModA",
                 loc: DeclarationLocation {
                     hir_file_id: HirFileId(
-                        FileId(
-                            FileId(
-                                0,
-                            ),
-                        ),
+                        0,
                     ),
                     ptr: SyntaxNodePtr {
                         kind: STRUCT,
@@ -510,11 +424,7 @@
                 name: "StructInModB",
                 loc: DeclarationLocation {
                     hir_file_id: HirFileId(
-                        FileId(
-                            FileId(
-                                1,
-                            ),
-                        ),
+                        1,
                     ),
                     ptr: SyntaxNodePtr {
                         kind: STRUCT,


### PR DESCRIPTION
This saves 10mb on `self` analysis, while this does limit us to 2billion real files and 2 billion macro expansions, I doubt we will ever hit that limit :) `HirFileId` is used a lot, so going from 8 bytes to 4 is a decent win.