### PR TITLE
Don't show runnable code lenses in libraries outside of the workspace

### DIFF
--- a/crates/rust-analyzer/src/to_proto.rs
+++ b/crates/rust-analyzer/src/to_proto.rs
@@ -1164,7 +1164,7 @@ pub(crate) fn code_lens(
             let r = runnable(snap, run)?;
 
             let lens_config = snap.config.lens();
-            if lens_config.run && client_commands_config.run_single {
+            if lens_config.run && client_commands_config.run_single && r.args.workspace_root.is_some() {
                 let command = command::run_single(&r, &title);
                 acc.push(lsp_types::CodeLens {
                     range: annotation_range,

--- a/crates/rust-analyzer/src/to_proto.rs
+++ b/crates/rust-analyzer/src/to_proto.rs
@@ -1164,7 +1164,10 @@ pub(crate) fn code_lens(
             let r = runnable(snap, run)?;
 
             let lens_config = snap.config.lens();
-            if lens_config.run && client_commands_config.run_single && r.args.workspace_root.is_some() {
+            if lens_config.run
+                && client_commands_config.run_single
+                && r.args.workspace_root.is_some()
+            {
                 let command = command::run_single(&r, &title);
                 acc.push(lsp_types::CodeLens {
                     range: annotation_range,

--- a/editors/code/src/main.ts
+++ b/editors/code/src/main.ts
@@ -79,7 +79,7 @@ async function activateServer(ctx: Ctx): Promise<RustAnalyzerExtensionApi> {
     );
     vscode.workspace.onDidChangeConfiguration(
         async (_) => {
-            await ctx.client?.sendNotification("workspace/didChangeConfiguration", {
+            await ctx.client?.sendNotification(lc.DidChangeConfigurationNotification.type, {
                 settings: "",
             });
         },


### PR DESCRIPTION
Addresses #13664. For now I'm just disabling runnable code lenses since the ones that display the number of references and implementations do work correctly with external code.

Also made a tiny TypeScript change to use the typed `sendNotification` overload. 