### PR TITLE
Implement location link for type inlay hints

### DIFF
--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -114,12 +114,20 @@ pub use {
         path::{ModPath, PathKind},
         type_ref::{Mutability, TypeRef},
         visibility::Visibility,
+        // FIXME: This is here since it is input of a method in `HirWrite`
+        // and things outside of hir need to implement that trait. We probably
+        // should move whole `hir_ty::display` to this crate so we will become
+        // able to use `ModuleDef` or `Definition` instead of `ModuleDefId`.
+        ModuleDefId,
     },
     hir_expand::{
         name::{known, Name},
         ExpandResult, HirFileId, InFile, MacroFile, Origin,
     },
-    hir_ty::{display::HirDisplay, PointerCast, Safety},
+    hir_ty::{
+        display::{HirDisplay, HirWrite},
+        PointerCast, Safety,
+    },
 };
 
 // These are negative re-exports: pub using these names is forbidden, they

--- a/crates/ide/src/inlay_hints.rs
+++ b/crates/ide/src/inlay_hints.rs
@@ -1,15 +1,19 @@
-use std::fmt;
+use std::{
+    fmt::{self, Write},
+    mem::take,
+};
 
 use either::Either;
-use hir::{known, HasVisibility, HirDisplay, Semantics};
+use hir::{known, HasVisibility, HirDisplay, HirWrite, ModuleDef, ModuleDefId, Semantics};
 use ide_db::{base_db::FileRange, famous_defs::FamousDefs, RootDatabase};
 use itertools::Itertools;
+use stdx::never;
 use syntax::{
     ast::{self, AstNode},
     match_ast, NodeOrToken, SyntaxNode, TextRange, TextSize,
 };
 
-use crate::FileId;
+use crate::{navigation_target::TryToNav, FileId};
 
 mod closing_brace;
 mod implicit_static;
@@ -89,6 +93,7 @@ pub enum InlayTooltip {
     HoverOffset(FileId, TextSize),
 }
 
+#[derive(Default)]
 pub struct InlayHintLabel {
     pub parts: Vec<InlayHintLabelPart>,
 }
@@ -172,6 +177,96 @@ impl fmt::Debug for InlayHintLabelPart {
     }
 }
 
+#[derive(Debug)]
+struct InlayHintLabelBuilder<'a> {
+    db: &'a RootDatabase,
+    result: InlayHintLabel,
+    last_part: String,
+    location: Option<FileRange>,
+}
+
+impl fmt::Write for InlayHintLabelBuilder<'_> {
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        self.last_part.write_str(s)
+    }
+}
+
+impl HirWrite for InlayHintLabelBuilder<'_> {
+    fn start_location_link(&mut self, def: ModuleDefId) {
+        if self.location.is_some() {
+            never!("location link is already started");
+        }
+        self.make_new_part();
+        let Some(location) = ModuleDef::from(def).try_to_nav(self.db) else { return };
+        let location =
+            FileRange { file_id: location.file_id, range: location.focus_or_full_range() };
+        self.location = Some(location);
+    }
+
+    fn end_location_link(&mut self) {
+        self.make_new_part();
+    }
+}
+
+impl InlayHintLabelBuilder<'_> {
+    fn make_new_part(&mut self) {
+        self.result.parts.push(InlayHintLabelPart {
+            text: take(&mut self.last_part),
+            linked_location: self.location.take(),
+        });
+    }
+
+    fn finish(mut self) -> InlayHintLabel {
+        self.make_new_part();
+        self.result
+    }
+}
+
+fn label_of_ty(
+    sema: &Semantics<'_, RootDatabase>,
+    desc_pat: &impl AstNode,
+    config: &InlayHintsConfig,
+    ty: hir::Type,
+) -> Option<InlayHintLabel> {
+    fn rec(
+        sema: &Semantics<'_, RootDatabase>,
+        famous_defs: &FamousDefs<'_, '_>,
+        mut max_length: Option<usize>,
+        ty: hir::Type,
+        label_builder: &mut InlayHintLabelBuilder<'_>,
+    ) {
+        let iter_item_type = hint_iterator(sema, &famous_defs, &ty);
+        match iter_item_type {
+            Some(ty) => {
+                const LABEL_START: &str = "impl Iterator<Item = ";
+                const LABEL_END: &str = ">";
+
+                max_length =
+                    max_length.map(|len| len.saturating_sub(LABEL_START.len() + LABEL_END.len()));
+
+                label_builder.write_str(LABEL_START).unwrap();
+                rec(sema, famous_defs, max_length, ty, label_builder);
+                label_builder.write_str(LABEL_END).unwrap();
+            }
+            None => {
+                let _ = ty.display_truncated(sema.db, max_length).write_to(label_builder);
+            }
+        };
+    }
+
+    let krate = sema.scope(desc_pat.syntax())?.krate();
+    let famous_defs = FamousDefs(sema, krate);
+    let mut label_builder = InlayHintLabelBuilder {
+        db: sema.db,
+        last_part: String::new(),
+        location: None,
+        result: InlayHintLabel::default(),
+    };
+    rec(sema, &famous_defs, config.max_length, ty, &mut label_builder);
+    let r = label_builder.finish();
+    Some(r)
+}
+
 // Feature: Inlay Hints
 //
 // rust-analyzer shows additional information inline with the source code.
@@ -224,7 +319,7 @@ pub(crate) fn inlay_hints(
 
 fn hints(
     hints: &mut Vec<InlayHint>,
-    famous_defs @ FamousDefs(sema, _): &FamousDefs<'_, '_>,
+    FamousDefs(sema, _): &FamousDefs<'_, '_>,
     config: &InlayHintsConfig,
     file_id: FileId,
     node: SyntaxNode,
@@ -233,14 +328,14 @@ fn hints(
     match_ast! {
         match node {
             ast::Expr(expr) => {
-                chaining::hints(hints, sema, &famous_defs, config, file_id, &expr);
+                chaining::hints(hints, sema, config, file_id, &expr);
                 adjustment::hints(hints, sema, config, &expr);
                 match expr {
                     ast::Expr::CallExpr(it) => param_name::hints(hints, sema, config, ast::Expr::from(it)),
                     ast::Expr::MethodCallExpr(it) => {
                         param_name::hints(hints, sema, config, ast::Expr::from(it))
                     }
-                    ast::Expr::ClosureExpr(it) => closure_ret::hints(hints, sema, &famous_defs, config, file_id, it),
+                    ast::Expr::ClosureExpr(it) => closure_ret::hints(hints, sema, config, file_id, it),
                     // We could show reborrows for all expressions, but usually that is just noise to the user
                     // and the main point here is to show why "moving" a mutable reference doesn't necessarily move it
                     // ast::Expr::PathExpr(_) => reborrow_hints(hints, sema, config, &expr),
@@ -270,13 +365,12 @@ fn hints(
     };
 }
 
-/// Checks if the type is an Iterator from std::iter and replaces its hint with an `impl Iterator<Item = Ty>`.
+/// Checks if the type is an Iterator from std::iter and returns its item type.
 fn hint_iterator(
     sema: &Semantics<'_, RootDatabase>,
     famous_defs: &FamousDefs<'_, '_>,
-    config: &InlayHintsConfig,
     ty: &hir::Type,
-) -> Option<String> {
+) -> Option<hir::Type> {
     let db = sema.db;
     let strukt = ty.strip_references().as_adt()?;
     let krate = strukt.module(db).krate();
@@ -299,21 +393,7 @@ fn hint_iterator(
             _ => None,
         })?;
         if let Some(ty) = ty.normalize_trait_assoc_type(db, &[], assoc_type_item) {
-            const LABEL_START: &str = "impl Iterator<Item = ";
-            const LABEL_END: &str = ">";
-
-            let ty_display = hint_iterator(sema, famous_defs, config, &ty)
-                .map(|assoc_type_impl| assoc_type_impl.to_string())
-                .unwrap_or_else(|| {
-                    ty.display_truncated(
-                        db,
-                        config
-                            .max_length
-                            .map(|len| len.saturating_sub(LABEL_START.len() + LABEL_END.len())),
-                    )
-                    .to_string()
-                });
-            return Some(format!("{}{}{}", LABEL_START, ty_display, LABEL_END));
+            return Some(ty);
         }
     }
 

--- a/crates/ide/src/inlay_hints/bind_pat.rs
+++ b/crates/ide/src/inlay_hints/bind_pat.rs
@@ -194,7 +194,8 @@ mod tests {
     use crate::{fixture, inlay_hints::InlayHintsConfig};
 
     use crate::inlay_hints::tests::{
-        check, check_expect, check_with_config, DISABLED_CONFIG, TEST_CONFIG,
+        check, check_expect, check_with_config, DISABLED_CONFIG, DISABLED_CONFIG_WITH_LINKS,
+        TEST_CONFIG,
     };
     use crate::ClosureReturnTypeHints;
 
@@ -290,7 +291,7 @@ fn main() {
     fn iterator_hint_regression_issue_12674() {
         // Ensure we don't crash while solving the projection type of iterators.
         check_expect(
-            InlayHintsConfig { chaining_hints: true, ..DISABLED_CONFIG },
+            InlayHintsConfig { chaining_hints: true, ..DISABLED_CONFIG_WITH_LINKS },
             r#"
 //- minicore: iterators
 struct S<T>(T);

--- a/crates/ide/src/inlay_hints/bind_pat.rs
+++ b/crates/ide/src/inlay_hints/bind_pat.rs
@@ -3,8 +3,8 @@
 //! fn f(a: i32, b: i32) -> i32 { a + b }
 //! let _x /* i32 */= f(4, 4);
 //! ```
-use hir::{HirDisplay, Semantics, TypeInfo};
-use ide_db::{base_db::FileId, famous_defs::FamousDefs, RootDatabase};
+use hir::{Semantics, TypeInfo};
+use ide_db::{base_db::FileId, RootDatabase};
 
 use itertools::Itertools;
 use syntax::{
@@ -13,9 +13,10 @@ use syntax::{
 };
 
 use crate::{
-    inlay_hints::{closure_has_block_body, hint_iterator},
-    InlayHint, InlayHintsConfig, InlayKind, InlayTooltip,
+    inlay_hints::closure_has_block_body, InlayHint, InlayHintsConfig, InlayKind, InlayTooltip,
 };
+
+use super::label_of_ty;
 
 pub(super) fn hints(
     acc: &mut Vec<InlayHint>,
@@ -36,22 +37,13 @@ pub(super) fn hints(
         return None;
     }
 
-    let krate = sema.scope(desc_pat.syntax())?.krate();
-    let famous_defs = FamousDefs(sema, krate);
-    let label = hint_iterator(sema, &famous_defs, config, &ty);
+    let label = label_of_ty(sema, desc_pat, config, ty)?;
 
-    let label = match label {
-        Some(label) => label,
-        None => {
-            let ty_name = ty.display_truncated(sema.db, config.max_length).to_string();
-            if config.hide_named_constructor_hints
-                && is_named_constructor(sema, pat, &ty_name).is_some()
-            {
-                return None;
-            }
-            ty_name
-        }
-    };
+    if config.hide_named_constructor_hints
+        && is_named_constructor(sema, pat, &label.to_string()).is_some()
+    {
+        return None;
+    }
 
     acc.push(InlayHint {
         range: match pat.name() {
@@ -59,7 +51,7 @@ pub(super) fn hints(
             None => pat.syntax().text_range(),
         },
         kind: InlayKind::TypeHint,
-        label: label.into(),
+        label,
         tooltip: pat
             .name()
             .map(|it| it.syntax().text_range())
@@ -346,7 +338,31 @@ fn main(a: SliceIter<'_, Container>) {
                         range: 484..485,
                         kind: ChainingHint,
                         label: [
-                            "SliceIter<Container>",
+                            "",
+                            InlayHintLabelPart {
+                                text: "SliceIter",
+                                linked_location: Some(
+                                    FileRange {
+                                        file_id: FileId(
+                                            0,
+                                        ),
+                                        range: 289..298,
+                                    },
+                                ),
+                            },
+                            "<",
+                            InlayHintLabelPart {
+                                text: "Container",
+                                linked_location: Some(
+                                    FileRange {
+                                        file_id: FileId(
+                                            0,
+                                        ),
+                                        range: 238..247,
+                                    },
+                                ),
+                            },
+                            ">",
                         ],
                         tooltip: Some(
                             HoverRanged(

--- a/crates/ide/src/inlay_hints/chaining.rs
+++ b/crates/ide/src/inlay_hints/chaining.rs
@@ -1,19 +1,18 @@
 //! Implementation of "chaining" inlay hints.
-use hir::{HirDisplay, Semantics};
-use ide_db::{famous_defs::FamousDefs, RootDatabase};
+use hir::Semantics;
+use ide_db::RootDatabase;
 use syntax::{
     ast::{self, AstNode},
     Direction, NodeOrToken, SyntaxKind, T,
 };
 
-use crate::{
-    inlay_hints::hint_iterator, FileId, InlayHint, InlayHintsConfig, InlayKind, InlayTooltip,
-};
+use crate::{FileId, InlayHint, InlayHintsConfig, InlayKind, InlayTooltip};
+
+use super::label_of_ty;
 
 pub(super) fn hints(
     acc: &mut Vec<InlayHint>,
     sema: &Semantics<'_, RootDatabase>,
-    famous_defs: &FamousDefs<'_, '_>,
     config: &InlayHintsConfig,
     file_id: FileId,
     expr: &ast::Expr,
@@ -62,9 +61,7 @@ pub(super) fn hints(
             acc.push(InlayHint {
                 range: expr.syntax().text_range(),
                 kind: InlayKind::ChainingHint,
-                label: hint_iterator(sema, &famous_defs, config, &ty)
-                    .unwrap_or_else(|| ty.display_truncated(sema.db, config.max_length).to_string())
-                    .into(),
+                label: label_of_ty(sema, desc_expr, config, ty)?,
                 tooltip: Some(InlayTooltip::HoverRanged(file_id, expr.syntax().text_range())),
             });
         }
@@ -110,7 +107,19 @@ fn main() {
                         range: 147..172,
                         kind: ChainingHint,
                         label: [
-                            "B",
+                            "",
+                            InlayHintLabelPart {
+                                text: "B",
+                                linked_location: Some(
+                                    FileRange {
+                                        file_id: FileId(
+                                            0,
+                                        ),
+                                        range: 63..64,
+                                    },
+                                ),
+                            },
+                            "",
                         ],
                         tooltip: Some(
                             HoverRanged(
@@ -125,7 +134,19 @@ fn main() {
                         range: 147..154,
                         kind: ChainingHint,
                         label: [
-                            "A",
+                            "",
+                            InlayHintLabelPart {
+                                text: "A",
+                                linked_location: Some(
+                                    FileRange {
+                                        file_id: FileId(
+                                            0,
+                                        ),
+                                        range: 7..8,
+                                    },
+                                ),
+                            },
+                            "",
                         ],
                         tooltip: Some(
                             HoverRanged(
@@ -185,7 +206,19 @@ fn main() {
                         range: 143..190,
                         kind: ChainingHint,
                         label: [
-                            "C",
+                            "",
+                            InlayHintLabelPart {
+                                text: "C",
+                                linked_location: Some(
+                                    FileRange {
+                                        file_id: FileId(
+                                            0,
+                                        ),
+                                        range: 51..52,
+                                    },
+                                ),
+                            },
+                            "",
                         ],
                         tooltip: Some(
                             HoverRanged(
@@ -200,7 +233,19 @@ fn main() {
                         range: 143..179,
                         kind: ChainingHint,
                         label: [
-                            "B",
+                            "",
+                            InlayHintLabelPart {
+                                text: "B",
+                                linked_location: Some(
+                                    FileRange {
+                                        file_id: FileId(
+                                            0,
+                                        ),
+                                        range: 29..30,
+                                    },
+                                ),
+                            },
+                            "",
                         ],
                         tooltip: Some(
                             HoverRanged(
@@ -245,7 +290,31 @@ fn main() {
                         range: 246..283,
                         kind: ChainingHint,
                         label: [
-                            "B<X<i32, bool>>",
+                            "",
+                            InlayHintLabelPart {
+                                text: "B",
+                                linked_location: Some(
+                                    FileRange {
+                                        file_id: FileId(
+                                            0,
+                                        ),
+                                        range: 23..24,
+                                    },
+                                ),
+                            },
+                            "<",
+                            InlayHintLabelPart {
+                                text: "X",
+                                linked_location: Some(
+                                    FileRange {
+                                        file_id: FileId(
+                                            0,
+                                        ),
+                                        range: 55..56,
+                                    },
+                                ),
+                            },
+                            "<i32, bool>>",
                         ],
                         tooltip: Some(
                             HoverRanged(
@@ -260,7 +329,31 @@ fn main() {
                         range: 246..265,
                         kind: ChainingHint,
                         label: [
-                            "A<X<i32, bool>>",
+                            "",
+                            InlayHintLabelPart {
+                                text: "A",
+                                linked_location: Some(
+                                    FileRange {
+                                        file_id: FileId(
+                                            0,
+                                        ),
+                                        range: 7..8,
+                                    },
+                                ),
+                            },
+                            "<",
+                            InlayHintLabelPart {
+                                text: "X",
+                                linked_location: Some(
+                                    FileRange {
+                                        file_id: FileId(
+                                            0,
+                                        ),
+                                        range: 55..56,
+                                    },
+                                ),
+                            },
+                            "<i32, bool>>",
                         ],
                         tooltip: Some(
                             HoverRanged(
@@ -352,7 +445,19 @@ fn main() {
                         range: 174..189,
                         kind: ChainingHint,
                         label: [
-                            "&mut MyIter",
+                            "&mut ",
+                            InlayHintLabelPart {
+                                text: "MyIter",
+                                linked_location: Some(
+                                    FileRange {
+                                        file_id: FileId(
+                                            0,
+                                        ),
+                                        range: 24..30,
+                                    },
+                                ),
+                            },
+                            "",
                         ],
                         tooltip: Some(
                             HoverRanged(
@@ -396,7 +501,19 @@ fn main() {
                         range: 124..130,
                         kind: TypeHint,
                         label: [
-                            "Struct",
+                            "",
+                            InlayHintLabelPart {
+                                text: "Struct",
+                                linked_location: Some(
+                                    FileRange {
+                                        file_id: FileId(
+                                            0,
+                                        ),
+                                        range: 7..13,
+                                    },
+                                ),
+                            },
+                            "",
                         ],
                         tooltip: Some(
                             HoverRanged(
@@ -411,7 +528,19 @@ fn main() {
                         range: 145..185,
                         kind: ChainingHint,
                         label: [
-                            "Struct",
+                            "",
+                            InlayHintLabelPart {
+                                text: "Struct",
+                                linked_location: Some(
+                                    FileRange {
+                                        file_id: FileId(
+                                            0,
+                                        ),
+                                        range: 7..13,
+                                    },
+                                ),
+                            },
+                            "",
                         ],
                         tooltip: Some(
                             HoverRanged(
@@ -426,7 +555,19 @@ fn main() {
                         range: 145..168,
                         kind: ChainingHint,
                         label: [
-                            "Struct",
+                            "",
+                            InlayHintLabelPart {
+                                text: "Struct",
+                                linked_location: Some(
+                                    FileRange {
+                                        file_id: FileId(
+                                            0,
+                                        ),
+                                        range: 7..13,
+                                    },
+                                ),
+                            },
+                            "",
                         ],
                         tooltip: Some(
                             HoverRanged(

--- a/crates/ide/src/inlay_hints/closing_brace.rs
+++ b/crates/ide/src/inlay_hints/closing_brace.rs
@@ -109,7 +109,10 @@ pub(super) fn hints(
         return None;
     }
 
-    let linked_location = name_range.map(|range| FileRange { file_id, range });
+    let linked_location = config
+        .location_links
+        .then(|| name_range.map(|range| FileRange { file_id, range }))
+        .flatten();
     acc.push(InlayHint {
         range: closing_token.text_range(),
         kind: InlayKind::ClosingBraceHint,

--- a/crates/ide/src/inlay_hints/closure_ret.rs
+++ b/crates/ide/src/inlay_hints/closure_ret.rs
@@ -1,17 +1,18 @@
 //! Implementation of "closure return type" inlay hints.
-use hir::{HirDisplay, Semantics};
-use ide_db::{base_db::FileId, famous_defs::FamousDefs, RootDatabase};
+use hir::Semantics;
+use ide_db::{base_db::FileId, RootDatabase};
 use syntax::ast::{self, AstNode};
 
 use crate::{
-    inlay_hints::{closure_has_block_body, hint_iterator},
-    ClosureReturnTypeHints, InlayHint, InlayHintsConfig, InlayKind, InlayTooltip,
+    inlay_hints::closure_has_block_body, ClosureReturnTypeHints, InlayHint, InlayHintsConfig,
+    InlayKind, InlayTooltip,
 };
+
+use super::label_of_ty;
 
 pub(super) fn hints(
     acc: &mut Vec<InlayHint>,
     sema: &Semantics<'_, RootDatabase>,
-    famous_defs: &FamousDefs<'_, '_>,
     config: &InlayHintsConfig,
     file_id: FileId,
     closure: ast::ClosureExpr,
@@ -42,9 +43,7 @@ pub(super) fn hints(
     acc.push(InlayHint {
         range: param_list.syntax().text_range(),
         kind: InlayKind::ClosureReturnTypeHint,
-        label: hint_iterator(sema, &famous_defs, config, &ty)
-            .unwrap_or_else(|| ty.display_truncated(sema.db, config.max_length).to_string())
-            .into(),
+        label: label_of_ty(sema, &param_list, config, ty)?,
         tooltip: Some(InlayTooltip::HoverRanged(file_id, param_list.syntax().text_range())),
     });
     Some(())

--- a/crates/ide/src/static_index.rs
+++ b/crates/ide/src/static_index.rs
@@ -106,6 +106,7 @@ impl StaticIndex<'_> {
             .analysis
             .inlay_hints(
                 &InlayHintsConfig {
+                    location_links: true,
                     render_colons: true,
                     type_hints: true,
                     parameter_hints: true,

--- a/crates/rust-analyzer/src/bin/main.rs
+++ b/crates/rust-analyzer/src/bin/main.rs
@@ -183,6 +183,8 @@ fn run_server() -> Result<()> {
         }
     }
 
+    config.client_specific_adjustments(&initialize_params.client_info);
+
     let server_capabilities = rust_analyzer::server_capabilities(&config);
 
     let initialize_result = lsp_types::InitializeResult {

--- a/docs/user/generated_config.adoc
+++ b/docs/user/generated_config.adoc
@@ -469,6 +469,11 @@ Whether to show inlay type hints for elided lifetimes in function signatures.
 --
 Whether to prefer using parameter names as the name for elided lifetime hints if possible.
 --
+[[rust-analyzer.inlayHints.locationLinks]]rust-analyzer.inlayHints.locationLinks (default: `true`)::
++
+--
+Whether to use location links for parts of type mentioned in inlay hints.
+--
 [[rust-analyzer.inlayHints.maxLength]]rust-analyzer.inlayHints.maxLength (default: `25`)::
 +
 --

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -995,6 +995,11 @@
                     "default": false,
                     "type": "boolean"
                 },
+                "rust-analyzer.inlayHints.locationLinks": {
+                    "markdownDescription": "Whether to use location links for parts of type mentioned in inlay hints.",
+                    "default": true,
+                    "type": "boolean"
+                },
                 "rust-analyzer.inlayHints.maxLength": {
                     "markdownDescription": "Maximum length for inlay hints. Set to null to have an unlimited length.",
                     "default": 25,


### PR DESCRIPTION
fix #11701 

This actually doesn't work due a problem in vscode: https://github.com/microsoft/vscode/issues/167564

changelog note: The vscode issue is now fixed, but won't land until the january release, so the feature is disabled serverside for VSCode until then