### PR TITLE
Add VS Code schema validation for `rust-project.json`

### DIFF
--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -1788,6 +1788,12 @@
                     "group": "navigation@1000"
                 }
             ]
-        }
+        },
+        "jsonValidation": [
+            {
+                "fileMatch": "rust-project.json",
+                "url": "https://json.schemastore.org/rust-project.json"
+            }
+        ]
     }
 }


### PR DESCRIPTION
Now that https://github.com/SchemaStore/schemastore/pull/2628 has been merged, adding the `jsonValidation` contribution to the VS Code extension for better editor support when modifying `rust-project.json` files.

Related issue: #13714