### PR TITLE
fix: Increase token limit of proc macro

### DIFF
--- a/crates/hir-expand/src/db.rs
+++ b/crates/hir-expand/src/db.rs
@@ -25,7 +25,7 @@ use crate::{
 /// an error will be emitted.
 ///
 /// Actual max for `analysis-stats .` at some point: 30672.
-static TOKEN_LIMIT: Limit = Limit::new(524_288);
+static TOKEN_LIMIT: Limit = Limit::new(1_048_576);
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum TokenExpander {


### PR DESCRIPTION
Fixes #13738

[The swc project](https://swc.rs) has lots of type definitions, and the current limit is too low for the ECMAScript/CSS visitors.

[rustdoc](https://rustdoc.swc.rs/swc_ecma_visit)


---

With this fix, the rust-analyzer shows trait-related actions.

<img width="1840" alt="image" src="https://user-images.githubusercontent.com/29931815/206839269-d7a04589-7dba-449b-ad0b-1f69d52bd039.png">
