### PR TITLE
minor: Set the `experimental` AsciiDoc document attribute to generated draft changelog

### DIFF
--- a/xtask/src/release/changelog.rs
+++ b/xtask/src/release/changelog.rs
@@ -65,6 +65,7 @@ pub(crate) fn get_changelog(
         "\
 = Changelog #{}
 :sectanchors:
+:experimental:
 :page-layout: post
 
 Commit: commit:{}[] +


### PR DESCRIPTION
This PR sets the `experimental` AsciiDoc document attribute to generated draft changelog.

That attribute is required by the keyboard macro (`kbd:[...]`).
This change of the draft will prevent issues like https://github.com/rust-analyzer/rust-analyzer.github.io/pull/191 .