### PR TITLE
Move dummy edits to code action resolve so that commands get executed

### DIFF
--- a/editors/code/src/client.ts
+++ b/editors/code/src/client.ts
@@ -3,6 +3,7 @@ import * as vscode from "vscode";
 import * as ra from "../src/lsp_ext";
 import * as Is from "vscode-languageclient/lib/common/utils/is";
 import { assert } from "./util";
+import { WorkspaceEdit } from "vscode";
 import { Config, substituteVSCodeVariables } from "./config";
 import { randomUUID } from "crypto";
 
@@ -266,6 +267,16 @@ export async function createClient(
                     (_error) => undefined
                 );
             },
+            resolveCodeAction(
+                codeAction: vscode.CodeAction,
+                token: vscode.CancellationToken,
+                next: lc.ResolveCodeActionSignature
+            ) {
+                // VS Code resolves code actions if they're missing the edit property,
+                // so we set a dummy one and do the actual work when executing the command.
+                codeAction.edit = new WorkspaceEdit();
+                return next(codeAction, token);
+            }
         },
         markdown: {
             supportHtml: true,

--- a/editors/code/src/client.ts
+++ b/editors/code/src/client.ts
@@ -3,7 +3,6 @@ import * as vscode from "vscode";
 import * as ra from "../src/lsp_ext";
 import * as Is from "vscode-languageclient/lib/common/utils/is";
 import { assert } from "./util";
-import { WorkspaceEdit } from "vscode";
 import { Config, substituteVSCodeVariables } from "./config";
 import { randomUUID } from "crypto";
 
@@ -228,9 +227,6 @@ export async function createClient(
                                 arguments: [item],
                             };
 
-                            // Set a dummy edit, so that VS Code doesn't try to resolve this.
-                            action.edit = new WorkspaceEdit();
-
                             if (group) {
                                 let entry = groups.get(group);
                                 if (!entry) {
@@ -261,9 +257,6 @@ export async function createClient(
                                         }),
                                     ],
                                 };
-
-                                // Set a dummy edit, so that VS Code doesn't try to resolve this.
-                                action.edit = new WorkspaceEdit();
 
                                 result[index] = action;
                             }

--- a/editors/code/src/client.ts
+++ b/editors/code/src/client.ts
@@ -276,7 +276,7 @@ export async function createClient(
                 // so we set a dummy one and do the actual work when executing the command.
                 codeAction.edit = new WorkspaceEdit();
                 return next(codeAction, token);
-            }
+            },
         },
         markdown: {
             supportHtml: true,


### PR DESCRIPTION
Fixes #13759

Not sure of why VS Code is no longer executing commands included in a code action after applying its workspace edit (you can read more about my investigation on the issue) but moving the dummy edit to the code action resolve fixes the problem and works both in the latest VS Code and VS Code Insiders versions.