### PR TITLE
fix: fix "parser seems stuck" panic when parsing colossal files

### DIFF
--- a/crates/parser/src/parser.rs
+++ b/crates/parser/src/parser.rs
@@ -237,6 +237,7 @@ impl<'t> Parser<'t> {
 
     fn do_bump(&mut self, kind: SyntaxKind, n_raw_tokens: u8) {
         self.pos += n_raw_tokens as usize;
+        self.steps.set(0);
         self.push_event(Event::Token { kind, n_raw_tokens });
     }
 


### PR DESCRIPTION
The parser step count is incremented every time the parser inspects a token. It's purpose is to ensure the parser doesn't get stuck in infinite loops. But since `self.pos` grows monotonically when parsing source code, it gives a better idea for whether the parser is stuck or not: if `self.pos` is changed, we know that the parser cannot be stuck, so it is safe to reset the step count to 0. This makes the limit check scale with the size of the file, and so should fix https://github.com/rust-lang/rust-analyzer/issues/13788.