### PR TITLE
fix: don't let mbe expr fragments match let exprs and inline consts

### DIFF
--- a/crates/hir-def/src/macro_expansion_tests/mbe/matching.rs
+++ b/crates/hir-def/src/macro_expansion_tests/mbe/matching.rs
@@ -136,3 +136,52 @@ macro_rules! m { ($($i:ident)? $vis:vis) => () }
 "#]],
     )
 }
+
+// For this test and the one below, see rust-lang/rust#86730.
+#[test]
+fn expr_dont_match_let_expr() {
+    check(
+        r#"
+macro_rules! foo {
+    ($e:expr) => { $e }
+}
+
+fn test() {
+    foo!(let a = 3);
+}
+"#,
+        expect![[r#"
+macro_rules! foo {
+    ($e:expr) => { $e }
+}
+
+fn test() {
+    /* error: no rule matches input tokens */missing;
+}
+"#]],
+    );
+}
+
+#[test]
+fn expr_dont_match_inline_const() {
+    check(
+        r#"
+macro_rules! foo {
+    ($e:expr) => { $e }
+}
+
+fn test() {
+    foo!(const { 3 });
+}
+"#,
+        expect![[r#"
+macro_rules! foo {
+    ($e:expr) => { $e }
+}
+
+fn test() {
+    /* error: no rule matches input tokens */missing;
+}
+"#]],
+    );
+}


### PR DESCRIPTION
Fixes #11729

`expr` fragment in mbe should not match let expressions and inline consts for backwards compatibility. See rust-lang/rust#86730 for details.

This patch is porting [this logic in rustc](https://github.com/rust-lang/rust/blob/f0c4da49983aa699f715caf681e3154b445fb60b/compiler/rustc_parse/src/parser/nonterminal.rs#L28-L34) (which is called [here in rustc's mbe engine](https://github.com/rust-lang/rust/blob/f0c4da49983aa699f715caf681e3154b445fb60b/compiler/rustc_expand/src/mbe/macro_parser.rs#L576)) to our mbe engine.