### PR TITLE
Complete enum variants without parens when snippets are disabled

### DIFF
--- a/crates/ide-completion/src/completions/record.rs
+++ b/crates/ide-completion/src/completions/record.rs
@@ -124,7 +124,12 @@ fn complete_fields(
 
 #[cfg(test)]
 mod tests {
-    use crate::tests::check_edit;
+    use ide_db::SnippetCap;
+
+    use crate::{
+        tests::{check_edit, check_edit_with_config, TEST_CONFIG},
+        CompletionConfig,
+    };
 
     #[test]
     fn literal_struct_completion_edit() {
@@ -148,6 +153,37 @@ fn baz() {
     let foo = create_foo(&FooDesc { bar: ${1:()} }$0);
 }
             "#,
+        )
+    }
+
+    #[test]
+    fn enum_variant_no_snippets() {
+        let conf = CompletionConfig { snippet_cap: SnippetCap::new(false), ..TEST_CONFIG };
+        check_edit_with_config(
+            conf,
+            "Variant()",
+            r#"
+enum Enum {
+    Variant(usize),
+}
+
+impl Enum {
+    fn new(u: usize) -> Self {
+        Self::Va$0
+    }
+}
+"#,
+            r#"
+enum Enum {
+    Variant(usize),
+}
+
+impl Enum {
+    fn new(u: usize) -> Self {
+        Self::Variant
+    }
+}
+"#,
         )
     }
 

--- a/crates/ide-completion/src/render/literal.rs
+++ b/crates/ide-completion/src/render/literal.rs
@@ -96,7 +96,7 @@ fn render(
     if !should_add_parens {
         kind = StructKind::Unit;
     }
-    let label = format_literal_label(&qualified_name, kind);
+    let label = format_literal_label(&qualified_name, kind, snippet_cap);
     let lookup = if qualified {
         format_literal_lookup(&short_qualified_name.to_string(), kind)
     } else {

--- a/crates/ide-completion/src/render/pattern.rs
+++ b/crates/ide-completion/src/render/pattern.rs
@@ -33,7 +33,7 @@ pub(crate) fn render_struct_pat(
     let name = local_name.unwrap_or_else(|| strukt.name(ctx.db()));
     let (name, escaped_name) = (name.unescaped().to_smol_str(), name.to_smol_str());
     let kind = strukt.kind(ctx.db());
-    let label = format_literal_label(name.as_str(), kind);
+    let label = format_literal_label(name.as_str(), kind, ctx.snippet_cap());
     let lookup = format_literal_lookup(name.as_str(), kind);
     let pat = render_pat(&ctx, pattern_ctx, &escaped_name, kind, &visible_fields, fields_omitted)?;
 
@@ -67,7 +67,7 @@ pub(crate) fn render_variant_pat(
         }
         _ => {
             let kind = variant.kind(ctx.db());
-            let label = format_literal_label(name.as_str(), kind);
+            let label = format_literal_label(name.as_str(), kind, ctx.snippet_cap());
             let lookup = format_literal_lookup(name.as_str(), kind);
             let pat = render_pat(
                 &ctx,

--- a/crates/ide-completion/src/render/union_literal.rs
+++ b/crates/ide-completion/src/render/union_literal.rs
@@ -24,7 +24,7 @@ pub(crate) fn render_union_literal(
         Some(p) => (p.unescaped().to_string(), p.to_string()),
         None => (name.unescaped().to_string(), name.to_string()),
     };
-    let label = format_literal_label(&name.to_smol_str(), StructKind::Record);
+    let label = format_literal_label(&name.to_smol_str(), StructKind::Record, ctx.snippet_cap());
     let lookup = format_literal_lookup(&name.to_smol_str(), StructKind::Record);
     let mut item = CompletionItem::new(
         CompletionItemKind::SymbolKind(SymbolKind::Union),

--- a/crates/ide-completion/src/render/variant.rs
+++ b/crates/ide-completion/src/render/variant.rs
@@ -90,7 +90,14 @@ pub(crate) fn visible_fields(
 }
 
 /// Format a struct, etc. literal option for display in the completions menu.
-pub(crate) fn format_literal_label(name: &str, kind: StructKind) -> SmolStr {
+pub(crate) fn format_literal_label(
+    name: &str,
+    kind: StructKind,
+    snippet_cap: Option<SnippetCap>,
+) -> SmolStr {
+    if snippet_cap.is_none() {
+        return name.into();
+    }
     match kind {
         StructKind::Tuple => SmolStr::from_iter([name, "(…)"]),
         StructKind::Record => SmolStr::from_iter([name, " {…}"]),

--- a/crates/ide-completion/src/render/variant.rs
+++ b/crates/ide-completion/src/render/variant.rs
@@ -48,6 +48,9 @@ pub(crate) fn render_tuple_lit(
     fields: &[hir::Field],
     path: &str,
 ) -> RenderedLiteral {
+    if snippet_cap.is_none() {
+        return RenderedLiteral { literal: format!("{}", path), detail: format!("{}", path) };
+    }
     let completions = fields.iter().enumerate().format_with(", ", |(idx, _), f| {
         if snippet_cap.is_some() {
             f(&format_args!("${{{}:()}}", idx + 1))


### PR DESCRIPTION
This handles the portion of #13767 that bothered me, but I can try to work on the other parts we discussed if needed.