### PR TITLE
fix: Skip adjustment hints if the adjustment is identity (`T` -> `T`)

### DIFF
--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -3691,6 +3691,13 @@ impl From<ItemInNs> for ScopeDef {
     }
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Adjustment {
+    pub source: Type,
+    pub target: Type,
+    pub kind: Adjust,
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum Adjust {
     /// Go from ! to any type.

--- a/crates/ide/src/inlay_hints/adjustment.rs
+++ b/crates/ide/src/inlay_hints/adjustment.rs
@@ -60,7 +60,7 @@ pub(super) fn hints(
     }
     for adjustment in adjustments.into_iter().rev() {
         // FIXME: Add some nicer tooltips to each of these
-        let text = match adjustment {
+        let text = match adjustment.kind {
             Adjust::NeverToAny if config.adjustment_hints == AdjustmentHints::Always => {
                 "<never-to-any>"
             }

--- a/crates/ide/src/inlay_hints/adjustment.rs
+++ b/crates/ide/src/inlay_hints/adjustment.rs
@@ -59,6 +59,10 @@ pub(super) fn hints(
         });
     }
     for adjustment in adjustments.into_iter().rev() {
+        if adjustment.source == adjustment.target {
+            continue;
+        }
+
         // FIXME: Add some nicer tooltips to each of these
         let text = match adjustment.kind {
             Adjust::NeverToAny if config.adjustment_hints == AdjustmentHints::Always => {
@@ -211,6 +215,22 @@ impl Struct {
 trait Trait {}
 impl Trait for Struct {}
 "#,
+        )
+    }
+
+    #[test]
+    fn never_to_never_is_never_shown() {
+        check_with_config(
+            InlayHintsConfig { adjustment_hints: AdjustmentHints::Always, ..DISABLED_CONFIG },
+            r#"
+fn never() -> ! {
+    return loop {};
+}
+
+fn or_else() {
+    let () = () else { return };
+}
+            "#,
         )
     }
 }


### PR DESCRIPTION
Supersedes https://github.com/rust-lang/rust-analyzer/pull/13765