### PR TITLE
assists: a better heuristic on whether to apply auto-import to an ident pat

### DIFF
--- a/crates/ide-assists/src/handlers/auto_import.rs
+++ b/crates/ide-assists/src/handlers/auto_import.rs
@@ -1247,6 +1247,24 @@ fn foo() {
     }
 
     #[test]
+    fn not_applicable_in_probable_variable_name() {
+        check_assist_not_applicable(
+            auto_import,
+            r"
+mod bar {
+    pub mod foo {
+        pub fn baz() {}
+    }
+}
+
+fn qux() {
+    let baz$0;
+}
+",
+        );
+    }
+
+    #[test]
     fn works_in_derives() {
         check_assist(
             auto_import,

--- a/crates/ide-assists/src/handlers/auto_import.rs
+++ b/crates/ide-assists/src/handlers/auto_import.rs
@@ -1247,7 +1247,8 @@ fn foo() {
     }
 
     #[test]
-    fn not_applicable_in_probable_variable_name() {
+    fn not_applicable_in_ident_pat_that_is_probable_variable_name() {
+        cov_mark::check!(import_assist_ident_pat_variable_name_heuristic);
         check_assist_not_applicable(
             auto_import,
             r"

--- a/crates/ide-db/src/imports/import_assets.rs
+++ b/crates/ide-db/src/imports/import_assets.rs
@@ -134,6 +134,15 @@ impl ImportAssets {
             return None;
         }
         let name = pat.name()?;
+
+        // The heuristic here is that variable names usually start with lower case, whereas something you might want to
+        // destructure (a struct or enum), of where this assist would probably apply would start with an upper case
+        // letter. So, we should not try to provide an assist for an ident pat whose first letter is not a capital,
+        // as it is probably referring to a variable, and not something we should try and find an import for.
+        if !name.text().starts_with(|c: char| c.is_uppercase()) {
+            return None;
+        }
+
         let candidate_node = pat.syntax().clone();
         Some(Self {
             import_candidate: ImportCandidate::for_name(sema, &name)?,

--- a/crates/ide-db/src/imports/import_assets.rs
+++ b/crates/ide-db/src/imports/import_assets.rs
@@ -140,6 +140,7 @@ impl ImportAssets {
         // letter. So, we should not try to provide an assist for an ident pat whose first letter is not a capital,
         // as it is probably referring to a variable, and not something we should try and find an import for.
         if !name.text().starts_with(|c: char| c.is_uppercase()) {
+            cov_mark::hit!(import_assist_ident_pat_variable_name_heuristic);
             return None;
         }
 


### PR DESCRIPTION
I was writing some code earlier that looked like:

```rust
fn foo() {
    let channel$0 = todo!();
}
```

And noticed that the auto import assist came up and offered to try and import `std::sync::mpsc::channel` (among other things). Looking into why it did this I stumbled upon #9555 - which aimed to enable auto imports for structs that may be dereferenced.

I think that however, we can refine this to only apply to IdentPats whos name starts with a capital letter, as a good heuristic to determine whether the user means to import some destructurable type, versus just being a plain ole variable name. Of course, if you're starting variable names with capital letters, or you have lower case struct names you might want to auto-import while destructuring, you're somewhat out of luck if this change lands. However, I think both those cases are practically pretty rare given rustc and rust-analyzer warns you when you use a non-snake cased variable name, and non-camel cased types. 
