### PR TITLE
Remove non-needed clones

### DIFF
--- a/crates/hir-def/src/nameres/collector.rs
+++ b/crates/hir-def/src/nameres/collector.rs
@@ -1345,7 +1345,7 @@ impl DefCollector<'_> {
                     // Missing proc macros are non-fatal, so they are handled specially.
                     DefDiagnostic::unresolved_proc_macro(module_id, loc.kind.clone(), loc.def.krate)
                 }
-                _ => DefDiagnostic::macro_error(module_id, loc.kind.clone(), err.to_string()),
+                _ => DefDiagnostic::macro_error(module_id, loc.kind, err.to_string()),
             };
 
             self.def_map.diagnostics.push(diag);

--- a/crates/hir-ty/src/lib.rs
+++ b/crates/hir-ty/src/lib.rs
@@ -577,10 +577,9 @@ pub fn callable_sig_from_fnonce(
     let fn_once =
         TyBuilder::trait_ref(db, fn_once_trait).push(self_ty.clone()).push(args.clone()).build();
     let projection =
-        TyBuilder::assoc_type_projection(db, output_assoc_type, Some(fn_once.substitution.clone()))
-            .build();
+        TyBuilder::assoc_type_projection(db, output_assoc_type, Some(fn_once.substitution)).build();
 
     let ret_ty = db.normalize_projection(projection, env);
 
-    Some(CallableSig::from_params_and_return(params, ret_ty.clone(), false, Safety::Safe))
+    Some(CallableSig::from_params_and_return(params, ret_ty, false, Safety::Safe))
 }

--- a/crates/hir-ty/src/lower.rs
+++ b/crates/hir-ty/src/lower.rs
@@ -1983,7 +1983,7 @@ fn fallback_bound_vars<T: TypeFoldable<Interner> + HasInterner<Interner = Intern
             if bound.index_if_innermost().map_or(true, is_allowed) {
                 bound.shifted_in_from(binders).to_const(Interner, ty)
             } else {
-                unknown_const(ty.clone())
+                unknown_const(ty)
             }
         },
     )

--- a/crates/hir/src/semantics.rs
+++ b/crates/hir/src/semantics.rs
@@ -847,7 +847,7 @@ impl<'db> SemanticsImpl<'db> {
                         }
                     };
                     process_expansion_for_token(&mut stack, file_id, None, token.as_ref())
-                } else if let Some(meta) = ast::Meta::cast(parent.clone()) {
+                } else if let Some(meta) = ast::Meta::cast(parent) {
                     // attribute we failed expansion for earlier, this might be a derive invocation
                     // or derive helper attribute
                     let attr = meta.parent_attr()?;

--- a/crates/hir/src/source_analyzer.rs
+++ b/crates/hir/src/source_analyzer.rs
@@ -118,7 +118,7 @@ impl SourceAnalyzer {
     fn expr_id(&self, db: &dyn HirDatabase, expr: &ast::Expr) -> Option<ExprId> {
         let src = match expr {
             ast::Expr::MacroExpr(expr) => {
-                self.expand_expr(db, InFile::new(self.file_id, expr.macro_call()?.clone()))?
+                self.expand_expr(db, InFile::new(self.file_id, expr.macro_call()?))?
             }
             _ => InFile::new(self.file_id, expr.clone()),
         };

--- a/crates/ide-assists/src/handlers/replace_or_with_or_else.rs
+++ b/crates/ide-assists/src/handlers/replace_or_with_or_else.rs
@@ -75,7 +75,7 @@ fn into_closure(param: &Expr) -> Expr {
     (|| {
         if let ast::Expr::CallExpr(call) = param {
             if call.arg_list()?.args().count() == 0 {
-                Some(call.expr()?.clone())
+                Some(call.expr()?)
             } else {
                 None
             }
@@ -151,7 +151,7 @@ fn into_call(param: &Expr) -> Expr {
     (|| {
         if let ast::Expr::ClosureExpr(closure) = param {
             if closure.param_list()?.params().count() == 0 {
-                Some(closure.body()?.clone())
+                Some(closure.body()?)
             } else {
                 None
             }

--- a/crates/ide-completion/src/completions.rs
+++ b/crates/ide-completion/src/completions.rs
@@ -494,7 +494,7 @@ impl Completions {
             pattern_ctx,
             path_ctx,
             variant,
-            local_name.clone(),
+            local_name,
             None,
         ));
     }

--- a/crates/ide-completion/src/completions/postfix.rs
+++ b/crates/ide-completion/src/completions/postfix.rs
@@ -224,7 +224,7 @@ fn include_references(initial_element: &ast::Expr) -> (ast::Expr, ast::Expr) {
 
     if let Some(first_ref_expr) = resulting_element.syntax().parent().and_then(ast::RefExpr::cast) {
         if let Some(expr) = first_ref_expr.expr() {
-            resulting_element = expr.clone();
+            resulting_element = expr;
         }
 
         while let Some(parent_ref_element) =
@@ -571,7 +571,7 @@ fn main() { ControlFlow::Break('\\\\') }
         );
 
         check_edit_with_config(
-            config.clone(),
+            config,
             "break",
             r#"
 //- minicore: try

--- a/crates/ide-completion/src/context/analysis.rs
+++ b/crates/ide-completion/src/context/analysis.rs
@@ -286,7 +286,7 @@ fn analyze(
         ast::NameLike::NameRef(name_ref) => {
             let parent = name_ref.syntax().parent()?;
             let (nameref_ctx, qualifier_ctx) =
-                classify_name_ref(sema, &original_file, name_ref, parent.clone())?;
+                classify_name_ref(sema, &original_file, name_ref, parent)?;
             qual_ctx = qualifier_ctx;
             CompletionAnalysis::NameRef(nameref_ctx)
         }
@@ -585,11 +585,7 @@ fn classify_name_ref(
                 original_file,
                 &record_field.parent_record_pat(),
             ),
-            ..pattern_context_for(
-                sema,
-                original_file,
-                record_field.parent_record_pat().clone().into(),
-            )
+            ..pattern_context_for(sema, original_file, record_field.parent_record_pat().into())
         });
         return Some(make_res(kind));
     }

--- a/crates/ide-completion/src/render.rs
+++ b/crates/ide-completion/src/render.rs
@@ -131,7 +131,7 @@ pub(crate) fn render_field(
     item.detail(ty.display(ctx.db()).to_string())
         .set_documentation(field.docs(ctx.db()))
         .set_deprecated(is_deprecated)
-        .lookup_by(name.clone());
+        .lookup_by(name);
     item.insert_text(field_with_receiver(receiver.as_ref(), &escaped_name));
     if let Some(receiver) = &dot_access.receiver {
         if let Some(original) = ctx.completion.sema.original_ast_node(receiver.clone()) {

--- a/crates/ide-completion/src/render/const_.rs
+++ b/crates/ide-completion/src/render/const_.rs
@@ -16,7 +16,7 @@ fn render(ctx: RenderContext<'_>, const_: hir::Const) -> Option<CompletionItem> 
     let (name, escaped_name) = (name.unescaped().to_smol_str(), name.to_smol_str());
     let detail = const_.display(db).to_string();
 
-    let mut item = CompletionItem::new(SymbolKind::Const, ctx.source_range(), name.clone());
+    let mut item = CompletionItem::new(SymbolKind::Const, ctx.source_range(), name);
     item.set_documentation(ctx.docs(const_))
         .set_deprecated(ctx.is_deprecated(const_) || ctx.is_deprecated_assoc_item(const_))
         .detail(detail)

--- a/crates/ide-completion/src/render/literal.rs
+++ b/crates/ide-completion/src/render/literal.rs
@@ -84,7 +84,7 @@ fn render(
         }
         _ => RenderedLiteral {
             literal: escaped_qualified_name.clone(),
-            detail: escaped_qualified_name.clone(),
+            detail: escaped_qualified_name,
         },
     };
 

--- a/crates/ide-completion/src/render/type_alias.rs
+++ b/crates/ide-completion/src/render/type_alias.rs
@@ -40,7 +40,7 @@ fn render(
     };
     let detail = type_alias.display(db).to_string();
 
-    let mut item = CompletionItem::new(SymbolKind::TypeAlias, ctx.source_range(), name.clone());
+    let mut item = CompletionItem::new(SymbolKind::TypeAlias, ctx.source_range(), name);
     item.set_documentation(ctx.docs(type_alias))
         .set_deprecated(ctx.is_deprecated(type_alias) || ctx.is_deprecated_assoc_item(type_alias))
         .detail(detail)

--- a/crates/ide-completion/src/tests.rs
+++ b/crates/ide-completion/src/tests.rs
@@ -86,7 +86,7 @@ pub(crate) fn completion_list_no_kw(ra_fixture: &str) -> String {
 }
 
 pub(crate) fn completion_list_no_kw_with_private_editable(ra_fixture: &str) -> String {
-    let mut config = TEST_CONFIG.clone();
+    let mut config = TEST_CONFIG;
     config.enable_private_editable = true;
     completion_list_with_config(config, ra_fixture, false, None)
 }

--- a/crates/ide-diagnostics/src/handlers/json_is_not_rust.rs
+++ b/crates/ide-diagnostics/src/handlers/json_is_not_rust.rs
@@ -125,7 +125,7 @@ pub(crate) fn json_in_items(
                         .severity(Severity::WeakWarning)
                         .with_fixes(Some(vec![{
                             let mut scb = SourceChangeBuilder::new(file_id);
-                            let scope = match import_scope.clone() {
+                            let scope = match import_scope {
                                 ImportScope::File(it) => ImportScope::File(scb.make_mut(it)),
                                 ImportScope::Module(it) => ImportScope::Module(scb.make_mut(it)),
                                 ImportScope::Block(it) => ImportScope::Block(scb.make_mut(it)),

--- a/crates/ide/src/inlay_hints/bind_pat.rs
+++ b/crates/ide/src/inlay_hints/bind_pat.rs
@@ -81,7 +81,7 @@ fn should_not_display_type_hint(
 
     if config.hide_closure_initialization_hints {
         if let Some(parent) = bind_pat.syntax().parent() {
-            if let Some(it) = ast::LetStmt::cast(parent.clone()) {
+            if let Some(it) = ast::LetStmt::cast(parent) {
                 if let Some(ast::Expr::ClosureExpr(closure)) = it.initializer() {
                     if closure_has_block_body(&closure) {
                         return true;

--- a/crates/ide/src/inlay_hints/closure_ret.rs
+++ b/crates/ide/src/inlay_hints/closure_ret.rs
@@ -32,7 +32,7 @@ pub(super) fn hints(
 
     let param_list = closure.param_list()?;
 
-    let closure = sema.descend_node_into_attributes(closure.clone()).pop()?;
+    let closure = sema.descend_node_into_attributes(closure).pop()?;
     let ty = sema.type_of_expr(&ast::Expr::ClosureExpr(closure))?.adjusted();
     let callable = ty.as_callable(sema.db)?;
     let ty = callable.return_type();

--- a/crates/parser/src/lexed_str.rs
+++ b/crates/parser/src/lexed_str.rs
@@ -57,7 +57,7 @@ impl<'a> LexedStr<'a> {
         let mut conv = Converter::new(text);
         conv.extend_token(&token.kind, text);
         match &*conv.res.kind {
-            [kind] => Some((*kind, conv.res.error.pop().map(|it| it.msg.clone()))),
+            [kind] => Some((*kind, conv.res.error.pop().map(|it| it.msg))),
             _ => None,
         }
     }

--- a/crates/proc-macro-srv/src/abis/mod.rs
+++ b/crates/proc-macro-srv/src/abis/mod.rs
@@ -117,7 +117,7 @@ impl Abi {
                 let inner = unsafe { Abi_1_63::from_lib(lib, symbol_name) }?;
                 Ok(Abi::Abi1_63(inner))
             }
-            _ => Err(LoadProcMacroDylibError::UnsupportedABI(info.version_string.clone())),
+            _ => Err(LoadProcMacroDylibError::UnsupportedABI(info.version_string)),
         }
     }
 

--- a/crates/rust-analyzer/src/main_loop.rs
+++ b/crates/rust-analyzer/src/main_loop.rs
@@ -561,10 +561,7 @@ impl GlobalState {
                     flycheck::Progress::DidCheckCrate(target) => (Progress::Report, Some(target)),
                     flycheck::Progress::DidCancel => (Progress::End, None),
                     flycheck::Progress::DidFailToRestart(err) => {
-                        self.show_and_log_error(
-                            "cargo check failed".to_string(),
-                            Some(err.to_string()),
-                        );
+                        self.show_and_log_error("cargo check failed".to_string(), Some(err));
                         return;
                     }
                     flycheck::Progress::DidFinish(result) => {

--- a/crates/rust-analyzer/src/reload.rs
+++ b/crates/rust-analyzer/src/reload.rs
@@ -461,7 +461,7 @@ impl GlobalState {
             flycheck::InvocationStrategy::Once => vec![FlycheckHandle::spawn(
                 0,
                 Box::new(move |msg| sender.send(msg).unwrap()),
-                config.clone(),
+                config,
                 self.config.root_path().clone(),
             )],
             flycheck::InvocationStrategy::PerWorkspace => {


### PR DESCRIPTION
I am not certain if this will improve performance, but it seems having a .clone() without any need should be removed.

This was done with clippy, and manually reviewed:

```
cargo clippy --fix -- -A clippy::all -D clippy::redundant_clone
```