### PR TITLE
Minor manual cleanup

### DIFF
--- a/crates/proc-macro-test/build.rs
+++ b/crates/proc-macro-test/build.rs
@@ -85,16 +85,13 @@ fn main() {
 
     let mut artifact_path = None;
     for message in Message::parse_stream(output.stdout.as_slice()) {
-        match message.unwrap() {
-            Message::CompilerArtifact(artifact) => {
-                if artifact.target.kind.contains(&"proc-macro".to_string()) {
-                    let repr = format!("{} {}", name, version);
-                    if artifact.package_id.repr.starts_with(&repr) {
-                        artifact_path = Some(PathBuf::from(&artifact.filenames[0]));
-                    }
+        if let Message::CompilerArtifact(artifact) = message.unwrap() {
+            if artifact.target.kind.contains(&"proc-macro".to_string()) {
+                let repr = format!("{} {}", name, version);
+                if artifact.package_id.repr.starts_with(&repr) {
+                    artifact_path = Some(PathBuf::from(&artifact.filenames[0]));
                 }
             }
-            _ => (), // Unknown message
         }
     }
 

--- a/crates/vfs/src/file_set.rs
+++ b/crates/vfs/src/file_set.rs
@@ -140,14 +140,9 @@ impl FileSetConfig {
 }
 
 /// Builder for [`FileSetConfig`].
+#[derive(Default)]
 pub struct FileSetConfigBuilder {
     roots: Vec<Vec<VfsPath>>,
-}
-
-impl Default for FileSetConfigBuilder {
-    fn default() -> Self {
-        FileSetConfigBuilder { roots: Vec::new() }
-    }
 }
 
 impl FileSetConfigBuilder {

--- a/crates/vfs/src/path_interner.rs
+++ b/crates/vfs/src/path_interner.rs
@@ -9,14 +9,9 @@ use rustc_hash::FxHasher;
 use crate::{FileId, VfsPath};
 
 /// Structure to map between [`VfsPath`] and [`FileId`].
+#[derive(Default)]
 pub(crate) struct PathInterner {
     map: IndexSet<VfsPath, BuildHasherDefault<FxHasher>>,
-}
-
-impl Default for PathInterner {
-    fn default() -> Self {
-        Self { map: IndexSet::default() }
-    }
 }
 
 impl PathInterner {

--- a/xtask/src/release/changelog.rs
+++ b/xtask/src/release/changelog.rs
@@ -113,11 +113,9 @@ fn unescape(s: &str) -> String {
 fn parse_pr_number(s: &str) -> Option<u32> {
     const BORS_PREFIX: &str = "Merge #";
     const HOMU_PREFIX: &str = "Auto merge of #";
-    if s.starts_with(BORS_PREFIX) {
-        let s = &s[BORS_PREFIX.len()..];
+    if let Some(s) = s.strip_prefix(BORS_PREFIX) {
         s.parse().ok()
-    } else if s.starts_with(HOMU_PREFIX) {
-        let s = &s[HOMU_PREFIX.len()..];
+    } else if let Some(s) = s.strip_prefix(HOMU_PREFIX) {
         if let Some(space) = s.find(' ') {
             s[..space].parse().ok()
         } else {


### PR DESCRIPTION
* use default derive
* use `strip_prefix` where possible to avoid dup work