### PR TITLE
Shorten projection types in inlay hints

### DIFF
--- a/crates/hir-ty/src/display.rs
+++ b/crates/hir-ty/src/display.rs
@@ -343,8 +343,7 @@ impl HirDisplay for ProjectionTy {
             return write!(f, "{TYPE_HINT_TRUNCATION}");
         }
 
-        let assoc_name =
-            f.db.type_alias_data(from_assoc_type_id(self.associated_ty_id)).name.to_string();
+        let assoc_name = &f.db.type_alias_data(from_assoc_type_id(self.associated_ty_id)).name;
         let trait_ref = self.trait_ref(f.db);
 
         let trait_id = self.trait_(f.db);
@@ -363,8 +362,7 @@ impl HirDisplay for ProjectionTy {
                     })
                     .filter(|&tr| {
                         f.db.trait_data(tr).items.iter().any(|(name, item)| {
-                            matches!(item, AssocItemId::TypeAliasId(_))
-                                && name.to_string() == assoc_name
+                            matches!(item, AssocItemId::TypeAliasId(_)) && name == assoc_name
                         })
                     })
                     .eq([trait_id])

--- a/crates/ide/src/inlay_hints/bind_pat.rs
+++ b/crates/ide/src/inlay_hints/bind_pat.rs
@@ -37,7 +37,7 @@ pub(super) fn hints(
         return None;
     }
 
-    let label = label_of_ty(famous_defs, config, ty)?;
+    let label = label_of_ty(famous_defs, config, ty, sema.scope(pat.syntax()).unwrap().module())?;
 
     if config.hide_named_constructor_hints
         && is_named_constructor(sema, pat, &label.to_string()).is_some()
@@ -388,13 +388,20 @@ fn main(a: SliceIter<'_, Container>) {
             }
             pub trait Foo {
                 type Bar: Default;
+                type Baz: Default;
             }
 
-            pub fn quux<T: Foo>() -> T::Bar {
-                let y = Default::default();
-                  //^ <T as Foo>::Bar
+            pub trait Overlapping {
+                type Baz;
+            }
 
-                y
+            pub fn quux<T: Foo>() -> (T::Bar, T::Baz) {
+                let x = Default::default();
+                  //^ T::Bar
+                let y = Default::default();
+                  //^ <T as Foo>::Baz
+
+                (x, y)
             }
             "#,
         );

--- a/crates/ide/src/inlay_hints/chaining.rs
+++ b/crates/ide/src/inlay_hints/chaining.rs
@@ -60,7 +60,12 @@ pub(super) fn hints(
             acc.push(InlayHint {
                 range: expr.syntax().text_range(),
                 kind: InlayKind::ChainingHint,
-                label: label_of_ty(famous_defs, config, ty)?,
+                label: label_of_ty(
+                    famous_defs,
+                    config,
+                    ty,
+                    sema.scope(expr.syntax()).unwrap().module(),
+                )?,
                 tooltip: Some(InlayTooltip::HoverRanged(file_id, expr.syntax().text_range())),
             });
         }

--- a/crates/ide/src/inlay_hints/closure_ret.rs
+++ b/crates/ide/src/inlay_hints/closure_ret.rs
@@ -33,7 +33,7 @@ pub(super) fn hints(
     let param_list = closure.param_list()?;
 
     let closure = sema.descend_node_into_attributes(closure).pop()?;
-    let ty = sema.type_of_expr(&ast::Expr::ClosureExpr(closure))?.adjusted();
+    let ty = sema.type_of_expr(&ast::Expr::ClosureExpr(closure.clone()))?.adjusted();
     let callable = ty.as_callable(sema.db)?;
     let ty = callable.return_type();
     if ty.is_unit() {
@@ -42,7 +42,12 @@ pub(super) fn hints(
     acc.push(InlayHint {
         range: param_list.syntax().text_range(),
         kind: InlayKind::ClosureReturnTypeHint,
-        label: label_of_ty(famous_defs, config, ty)?,
+        label: label_of_ty(
+            famous_defs,
+            config,
+            ty,
+            sema.scope(closure.syntax()).unwrap().module(),
+        )?,
         tooltip: Some(InlayTooltip::HoverRanged(file_id, param_list.syntax().text_range())),
     });
     Some(())


### PR DESCRIPTION
In examples like this, where we have a projection type, which is the only associated item with its name in a trait that is in scope:
```rust
trait Trait {
    type Assoc;

    fn f(self) -> Self::Assoc;
}

fn f<T: Trait>(x: T) {
    let y /*here*/ = x.f();
    _ = y;
}
```
Show `T::Assoc` instead of `<T as Trait>::Assoc`.

Rationale: making inlay hints less verbose is generally good, `Trait` is not that useful there.

-----

I'm not sure if the implementation is good and correct, but it seems to be working at least 😅 