### PR TITLE
Return bool instead of Result<(),()> for limit::check

### DIFF
--- a/crates/hir-def/src/body.rs
+++ b/crates/hir-def/src/body.rs
@@ -91,7 +91,7 @@ impl Expander {
         db: &dyn DefDatabase,
         macro_call: ast::MacroCall,
     ) -> Result<ExpandResult<Option<(Mark, T)>>, UnresolvedMacro> {
-        if self.recursion_limit(db).check(self.recursion_limit + 1).is_err() {
+        if !self.recursion_limit(db).check(self.recursion_limit + 1) {
             cov_mark::hit!(your_stack_belongs_to_me);
             return Ok(ExpandResult::only_err(ExpandError::Other(
                 "reached recursion limit during macro expansion".into(),

--- a/crates/hir-def/src/nameres/collector.rs
+++ b/crates/hir-def/src/nameres/collector.rs
@@ -382,7 +382,7 @@ impl DefCollector<'_> {
                 }
 
                 i += 1;
-                if FIXED_POINT_LIMIT.check(i).is_err() {
+                if !FIXED_POINT_LIMIT.check(i) {
                     tracing::error!("name resolution is stuck");
                     break 'resolve_attr;
                 }
@@ -986,7 +986,7 @@ impl DefCollector<'_> {
         import_type: ImportType,
         depth: usize,
     ) {
-        if GLOB_RECURSION_LIMIT.check(depth).is_err() {
+        if !GLOB_RECURSION_LIMIT.check(depth) {
             // prevent stack overflows (but this shouldn't be possible)
             panic!("infinite recursion in glob imports!");
         }
@@ -1326,7 +1326,7 @@ impl DefCollector<'_> {
         depth: usize,
         container: ItemContainerId,
     ) {
-        if EXPANSION_DEPTH_LIMIT.check(depth).is_err() {
+        if !EXPANSION_DEPTH_LIMIT.check(depth) {
             cov_mark::hit!(macro_expansion_overflow);
             tracing::warn!("macro expansion is too deep");
             return;

--- a/crates/hir-def/src/nameres/mod_resolution.rs
+++ b/crates/hir-def/src/nameres/mod_resolution.rs
@@ -50,7 +50,7 @@ impl ModDir {
 
     fn child(&self, dir_path: DirPath, root_non_dir_owner: bool) -> Option<ModDir> {
         let depth = self.depth + 1;
-        if MOD_DEPTH_LIMIT.check(depth as usize).is_err() {
+        if !MOD_DEPTH_LIMIT.check(depth as usize) {
             tracing::error!("MOD_DEPTH_LIMIT exceeded");
             cov_mark::hit!(circular_mods);
             return None;

--- a/crates/hir-expand/src/db.rs
+++ b/crates/hir-expand/src/db.rs
@@ -451,7 +451,7 @@ fn macro_expand(db: &dyn AstDatabase, id: MacroCallId) -> ExpandResult<Option<Ar
     let ExpandResult { value: mut tt, err } = expander.expand(db, id, &macro_arg.0);
     // Set a hard limit for the expanded tt
     let count = tt.count();
-    if TOKEN_LIMIT.check(count).is_err() {
+    if !TOKEN_LIMIT.check(count) {
         return ExpandResult::only_err(ExpandError::Other(
             format!(
                 "macro invocation exceeds token limit: produced {} tokens, limit is {}",

--- a/crates/hir-ty/src/autoderef.rs
+++ b/crates/hir-ty/src/autoderef.rs
@@ -57,7 +57,7 @@ impl Iterator for Autoderef<'_, '_> {
             return Some((self.ty.clone(), 0));
         }
 
-        if AUTODEREF_RECURSION_LIMIT.check(self.steps.len() + 1).is_err() {
+        if !AUTODEREF_RECURSION_LIMIT.check(self.steps.len() + 1) {
             return None;
         }
 

--- a/crates/limit/src/lib.rs
+++ b/crates/limit/src/lib.rs
@@ -41,11 +41,12 @@ impl Limit {
     }
 
     /// Checks whether the given value is below the limit.
-    /// Returns `Ok` when `other` is below `self`, and `Err` otherwise.
+    /// Returns `true` when `other` is below `self`, and `false` otherwise.
+    #[must_use]
     #[inline]
-    pub fn check(&self, other: usize) -> Result<(), ()> {
+    pub fn check(&self, other: usize) -> bool {
         if other > self.upper_bound {
-            Err(())
+            false
         } else {
             #[cfg(feature = "tracking")]
             loop {
@@ -63,7 +64,7 @@ impl Limit {
                 }
             }
 
-            Ok(())
+            true
         }
     }
 }

--- a/crates/parser/src/parser.rs
+++ b/crates/parser/src/parser.rs
@@ -52,7 +52,7 @@ impl<'t> Parser<'t> {
         assert!(n <= 3);
 
         let steps = self.steps.get();
-        assert!(PARSER_STEP_LIMIT.check(steps as usize).is_ok(), "the parser seems stuck");
+        assert!(PARSER_STEP_LIMIT.check(steps as usize), "the parser seems stuck");
         self.steps.set(steps + 1);
 
         self.inp.kind(self.pos + n)


### PR DESCRIPTION
The `Result<(),()>` is a very strange construct,
and even Clippy is unhappy about it :)

This PR only changes that API to return a bool.

I did a cursory check in intellij rust plugin,
and didn't find any reference to this func,
so I suspect it is mostly used internally.