### PR TITLE
fix: generate async delegate methods

### DIFF
--- a/crates/ide-assists/src/handlers/generate_delegate_methods.rs
+++ b/crates/ide-assists/src/handlers/generate_delegate_methods.rs
@@ -104,9 +104,11 @@ pub(crate) fn generate_delegate_methods(acc: &mut Assists, ctx: &AssistContext<'
                     make::name_ref(&method_name.to_string()),
                     arg_list,
                 );
-                let body = make::block_expr([], Some(tail_expr));
                 let ret_type = method_source.ret_type();
                 let is_async = method_source.async_token().is_some();
+                let tail_expr_finished =
+                    if is_async { make::expr_await(tail_expr) } else { tail_expr };
+                let body = make::block_expr([], Some(tail_expr_finished));
                 let f = make::fn_(vis, name, type_params, params, body, ret_type, is_async)
                     .indent(ast::edit::IndentLevel(1))
                     .clone_for_update();
@@ -306,7 +308,7 @@ struct Person<T> {
 
 impl<T> Person<T> {
     $0pub(crate) async fn age<J, 'a>(&'a mut self, ty: T, arg: J) -> T {
-        self.age.age(ty, arg)
+        self.age.age(ty, arg).await
     }
 }"#,
         );


### PR DESCRIPTION
Fixes a bug where the generated async method doesn't await the result before returning it.

This is an example of what the output looked like:
```rust
struct Age<T>(T);
impl<T> Age<T> {
    pub(crate) async fn age<J, 'a>(&'a mut self, ty: T, arg: J) -> T {
        self.0
    }
}
struct Person<T> {
    age: Age<T>,
}
impl<T> Person<T> {
    pub(crate) async fn age<J, 'a>(&'a mut self, ty: T, arg: J) -> T {
        self.age.age(ty, arg) // .await is missing
    }
}
```
The `.await` is missing, so the return type is `impl Future<Output = T>` instead of `T`
