### PR TITLE
fix: Prevent `add_missing_match_arms` assist from ignoring existing variants prefixed with `Self::`

### DIFF
--- a/crates/ide-assists/src/handlers/add_missing_match_arms.rs
+++ b/crates/ide-assists/src/handlers/add_missing_match_arms.rs
@@ -1137,6 +1137,56 @@ fn main() {
     }
 
     #[test]
+    fn add_missing_match_arms_with_self_in_pattern() {
+        check_assist(
+            add_missing_match_arms,
+            r#"
+pub(crate) enum Foo {A, B, C, D, E, F}
+type Bar = Foo;
+mod Mod {
+    pub(crate) use super::Foo as ModFoo;
+}
+
+impl Foo {
+    fn match_assist(self) {
+        use Foo::*;
+
+        match self$0 {
+            Foo::A => {},
+            Self::B => {},
+            Bar::C => {},
+            Mod::ModFoo::D => {}
+            E => {},
+        }
+    }
+}
+"#,
+            r#"
+pub(crate) enum Foo {A, B, C, D, E, F}
+type Bar = Foo;
+mod Mod {
+    pub(crate) use super::Foo as ModFoo;
+}
+
+impl Foo {
+    fn match_assist(self) {
+        use Foo::*;
+
+        match self {
+            Foo::A => {},
+            Self::B => {},
+            Bar::C => {},
+            Mod::ModFoo::D => {}
+            E => {},
+            $0F => todo!(),
+        }
+    }
+}
+"#,
+        );
+    }
+
+    #[test]
     fn add_missing_match_arms_preserves_comments() {
         check_assist(
             add_missing_match_arms,


### PR DESCRIPTION
This PR provides an ad hoc fix (first aid solution) of #4650.

Currently, the variant notation itself is used for missing match arm checking, so that, for example, `A`, `Self::A`, and `Bar::A` are considered different, even though they originally refer to the same variant.

This PR takes an approach that if a variant has a prefix, the check uses only the last segment for comparison, so that the check is not affected by differences in prefix.

The appropriate fix would be to use `hir_ty::diagnostics::match_check`, as discussed in #8493 and as written in a comment for `ide_assists::handlers::add_missing_match_arms::does_pat_match_variant`.