### PR TITLE
Use diagnostic code as link to full message

### DIFF
--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -411,6 +411,11 @@
                     "default": false,
                     "type": "boolean"
                 },
+                "rust-analyzer.diagnostics.useRustcErrorCode": {
+                    "markdownDescription": "Whether to use the rustc error code.",
+                    "default": false,
+                    "type": "boolean"
+                },
                 "$generated-start": {},
                 "rust-analyzer.assist.emitMustUse": {
                     "markdownDescription": "Whether to insert #[must_use] when generating `as_` methods\nfor enum variants.",

--- a/editors/code/src/client.ts
+++ b/editors/code/src/client.ts
@@ -106,6 +106,7 @@ export async function createClient(
                 next: lc.HandleDiagnosticsSignature
             ) {
                 const preview = config.previewRustcOutput;
+                const errorCode = config.useRustcErrorCode;
                 diagnostics.forEach((diag, idx) => {
                     // Abuse the fact that VSCode leaks the LSP diagnostics data field through the
                     // Diagnostic class, if they ever break this we are out of luck and have to go
@@ -119,10 +120,19 @@ export async function createClient(
                         ?.rendered;
                     if (rendered) {
                         if (preview) {
-                            const index = rendered.match(/^(note|help):/m)?.index || 0;
+                            const index =
+                                rendered.match(/^(note|help):/m)?.index || rendered.length;
                             diag.message = rendered
                                 .substring(0, index)
                                 .replace(/^ -->[^\n]+\n/m, "");
+                        }
+                        let value;
+                        if (errorCode) {
+                            if (typeof diag.code === "string" || typeof diag.code === "number") {
+                                value = diag.code;
+                            } else {
+                                value = diag.code?.value;
+                            }
                         }
                         diag.code = {
                             target: vscode.Uri.from({
@@ -131,7 +141,7 @@ export async function createClient(
                                 fragment: uri.toString(),
                                 query: idx.toString(),
                             }),
-                            value: "Click for full compiler diagnostic",
+                            value: value ?? "Click for full compiler diagnostic",
                         };
                     }
                 });

--- a/editors/code/src/config.ts
+++ b/editors/code/src/config.ts
@@ -241,6 +241,10 @@ export class Config {
     get previewRustcOutput() {
         return this.get<boolean>("diagnostics.previewRustcOutput");
     }
+
+    get useRustcErrorCode() {
+        return this.get<boolean>("diagnostics.useRustcErrorCode");
+    }
 }
 
 const VarRegex = new RegExp(/\$\{(.+?)\}/g);


### PR DESCRIPTION
fixes #13823 by adding a vscode setting that will keeping the existing diagnostic code and use it as a link to the full compiler error message.
While I was there I also fixed `index` to fallback to `rendered.length` to make the previewRustcOutput feature work.