### PR TITLE
Add support for impl traits in type aliases

### DIFF
--- a/crates/hir-ty/src/chalk_db.rs
+++ b/crates/hir-ty/src/chalk_db.rs
@@ -213,6 +213,19 @@ impl<'a> chalk_solve::RustIrDatabase<Interner> for ChalkContext<'a> {
                 };
                 chalk_ir::Binders::new(binders, bound)
             }
+            crate::ImplTraitId::TypeAliasImplTrait(type_alias, idx) => {
+                let datas = self
+                    .db
+                    .type_alias_impl_traits(type_alias)
+                    .expect("impl trait id without impl traits");
+                let (datas, binders) = (*datas).as_ref().into_value_and_skipped_binders();
+                let data = &datas.impl_traits[idx as usize];
+                let bound = OpaqueTyDatumBound {
+                    bounds: make_single_type_binders(data.bounds.skip_binders().to_vec()),
+                    where_clauses: chalk_ir::Binders::empty(Interner, vec![]),
+                };
+                chalk_ir::Binders::new(binders, bound)
+            }
             crate::ImplTraitId::AsyncBlockTypeImplTrait(..) => {
                 if let Some((future_trait, future_output)) = self
                     .db

--- a/crates/hir-ty/src/chalk_ext.rs
+++ b/crates/hir-ty/src/chalk_ext.rs
@@ -224,6 +224,14 @@ impl TyExt for Ty {
                             data.substitute(Interner, &subst).into_value_and_skipped_binders().0
                         })
                     }
+                    ImplTraitId::TypeAliasImplTrait(type_alias, idx) => {
+                        db.type_alias_impl_traits(type_alias).map(|it| {
+                            let data = (*it)
+                                .as_ref()
+                                .map(|rpit| rpit.impl_traits[idx as usize].bounds.clone());
+                            data.substitute(Interner, &subst).into_value_and_skipped_binders().0
+                        })
+                    }
                 }
             }
             TyKind::Alias(AliasTy::Opaque(opaque_ty)) => {
@@ -231,6 +239,14 @@ impl TyExt for Ty {
                 {
                     ImplTraitId::ReturnTypeImplTrait(func, idx) => {
                         db.return_type_impl_traits(func).map(|it| {
+                            let data = (*it)
+                                .as_ref()
+                                .map(|rpit| rpit.impl_traits[idx as usize].bounds.clone());
+                            data.substitute(Interner, &opaque_ty.substitution)
+                        })
+                    }
+                    ImplTraitId::TypeAliasImplTrait(type_alias, idx) => {
+                        db.type_alias_impl_traits(type_alias).map(|it| {
                             let data = (*it)
                                 .as_ref()
                                 .map(|rpit| rpit.impl_traits[idx as usize].bounds.clone());

--- a/crates/hir-ty/src/db.rs
+++ b/crates/hir-ty/src/db.rs
@@ -9,7 +9,7 @@ use hir_def::{
     expr::ExprId,
     layout::{Layout, LayoutError, TargetDataLayout},
     AdtId, BlockId, ConstId, ConstParamId, DefWithBodyId, EnumVariantId, FunctionId, GenericDefId,
-    ImplId, LifetimeParamId, LocalFieldId, TypeOrConstParamId, VariantId,
+    ImplId, LifetimeParamId, LocalFieldId, TypeAliasId, TypeOrConstParamId, VariantId,
 };
 use la_arena::ArenaMap;
 use smallvec::SmallVec;
@@ -18,8 +18,8 @@ use crate::{
     chalk_db,
     consteval::{ComputedExpr, ConstEvalError},
     method_resolution::{InherentImpls, TraitImpls, TyFingerprint},
-    Binders, CallableDefId, FnDefId, GenericArg, ImplTraitId, InferenceResult, Interner, PolyFnSig,
-    QuantifiedWhereClause, ReturnTypeImplTraits, Substitution, TraitRef, Ty, TyDefId, ValueTyDefId,
+    Binders, CallableDefId, FnDefId, GenericArg, ImplTraitId, ImplTraits, InferenceResult,
+    Interner, PolyFnSig, QuantifiedWhereClause, Substitution, TraitRef, Ty, TyDefId, ValueTyDefId,
 };
 use hir_expand::name::Name;
 
@@ -71,10 +71,10 @@ pub trait HirDatabase: DefDatabase + Upcast<dyn DefDatabase> {
     fn callable_item_signature(&self, def: CallableDefId) -> PolyFnSig;
 
     #[salsa::invoke(crate::lower::return_type_impl_traits)]
-    fn return_type_impl_traits(
-        &self,
-        def: FunctionId,
-    ) -> Option<Arc<Binders<ReturnTypeImplTraits>>>;
+    fn return_type_impl_traits(&self, def: FunctionId) -> Option<Arc<Binders<ImplTraits>>>;
+
+    #[salsa::invoke(crate::lower::type_alias_impl_traits)]
+    fn type_alias_impl_traits(&self, def: TypeAliasId) -> Option<Arc<Binders<ImplTraits>>>;
 
     #[salsa::invoke(crate::lower::generic_predicates_for_param_query)]
     #[salsa::cycle(crate::lower::generic_predicates_for_param_recover)]

--- a/crates/hir-ty/src/display.rs
+++ b/crates/hir-ty/src/display.rs
@@ -719,6 +719,22 @@ impl HirDisplay for Ty {
                         )?;
                         // FIXME: it would maybe be good to distinguish this from the alias type (when debug printing), and to show the substitution
                     }
+                    ImplTraitId::TypeAliasImplTrait(type_alias, idx) => {
+                        let datas =
+                            f.db.type_alias_impl_traits(type_alias)
+                                .expect("impl trait id without data");
+                        let data = (*datas)
+                            .as_ref()
+                            .map(|rpit| rpit.impl_traits[idx as usize].bounds.clone());
+                        let bounds = data.substitute(Interner, &parameters);
+                        let krate = type_alias.lookup(f.db.upcast()).module(f.db.upcast()).krate();
+                        write_bounds_like_dyn_trait_with_prefix(
+                            "impl",
+                            bounds.skip_binders(),
+                            SizedByDefault::Sized { anchor: krate },
+                            f,
+                        )?;
+                    }
                     ImplTraitId::AsyncBlockTypeImplTrait(..) => {
                         write!(f, "impl Future<Output = ")?;
                         parameters.at(Interner, 0).hir_fmt(f)?;
@@ -821,6 +837,22 @@ impl HirDisplay for Ty {
                             .map(|rpit| rpit.impl_traits[idx as usize].bounds.clone());
                         let bounds = data.substitute(Interner, &opaque_ty.substitution);
                         let krate = func.lookup(f.db.upcast()).module(f.db.upcast()).krate();
+                        write_bounds_like_dyn_trait_with_prefix(
+                            "impl",
+                            bounds.skip_binders(),
+                            SizedByDefault::Sized { anchor: krate },
+                            f,
+                        )?;
+                    }
+                    ImplTraitId::TypeAliasImplTrait(type_alias, idx) => {
+                        let datas =
+                            f.db.type_alias_impl_traits(type_alias)
+                                .expect("impl trait id without data");
+                        let data = (*datas)
+                            .as_ref()
+                            .map(|rpit| rpit.impl_traits[idx as usize].bounds.clone());
+                        let bounds = data.substitute(Interner, &opaque_ty.substitution);
+                        let krate = type_alias.lookup(f.db.upcast()).module(f.db.upcast()).krate();
                         write_bounds_like_dyn_trait_with_prefix(
                             "impl",
                             bounds.skip_binders(),

--- a/crates/hir-ty/src/lib.rs
+++ b/crates/hir-ty/src/lib.rs
@@ -290,18 +290,19 @@ impl TypeFoldable<Interner> for CallableSig {
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Hash)]
 pub enum ImplTraitId {
     ReturnTypeImplTrait(hir_def::FunctionId, u16),
+    TypeAliasImplTrait(hir_def::TypeAliasId, u16),
     AsyncBlockTypeImplTrait(hir_def::DefWithBodyId, ExprId),
 }
 
 #[derive(Clone, PartialEq, Eq, Debug, Hash)]
-pub struct ReturnTypeImplTraits {
-    pub(crate) impl_traits: Vec<ReturnTypeImplTrait>,
+pub struct ImplTraits {
+    pub(crate) impl_traits: Vec<ImplTrait>,
 }
 
-has_interner!(ReturnTypeImplTraits);
+has_interner!(ImplTraits);
 
 #[derive(Clone, PartialEq, Eq, Debug, Hash)]
-pub(crate) struct ReturnTypeImplTrait {
+pub(crate) struct ImplTrait {
     pub(crate) bounds: Binders<Vec<QuantifiedWhereClause>>,
 }
 

--- a/crates/hir-ty/src/tests/display_source_code.rs
+++ b/crates/hir-ty/src/tests/display_source_code.rs
@@ -227,3 +227,24 @@ fn f(a: impl Foo<i8, Assoc<i16> = i32>) {
         "#,
     );
 }
+
+#[test]
+fn type_alias_impl_trait() {
+    check_types_source_code(
+        r#"
+//- minicore: sized
+trait Foo {}
+type Bar = impl Foo;
+struct Baz(Bar);
+fn test(
+    a: Bar,
+    b: Baz,
+) {
+    a;
+  //^ impl Foo
+    b.0;
+  //^^^ impl Foo
+}
+"#,
+    );
+}

--- a/crates/ide-completion/src/completions/dot.rs
+++ b/crates/ide-completion/src/completions/dot.rs
@@ -944,4 +944,25 @@ fn test(thing: impl Encrypt) {
             "#]],
         )
     }
+
+    #[test]
+    fn completes_trait_methods_for_type_alias_to_impl_trait() {
+        check(
+            r#"
+//- minicore: iterator
+type Output = impl IntoIterator<Item = ()>;
+
+fn foo() -> Output {
+    Some(())
+}
+
+fn main() {
+    foo().$0;
+}
+"#,
+            expect![[r#"
+                me into_iter() (as IntoIterator) fn(self) -> <Self as IntoIterator>::IntoIter
+            "#]],
+        );
+    }
 }

--- a/crates/ide-diagnostics/src/handlers/type_mismatch.rs
+++ b/crates/ide-diagnostics/src/handlers/type_mismatch.rs
@@ -595,4 +595,27 @@ fn f() -> i32 {
 "#,
         );
     }
+
+    #[test]
+    fn type_alias_impl_trait_no_diagnostic_for_defining_use() {
+        check_diagnostics(
+            r#"
+//- minicore: copy
+mod inner {
+    pub type Opaque = impl Copy;
+    pub fn defining_scope() -> Opaque {
+        let x: Opaque = 0i32;
+        let x: Opaque = true; // FIXME: This should be also an error.
+        x
+    }
+}
+
+fn non_defining_scope() {
+    let _: inner::Opaque = inner::defining_scope();
+    let _: inner::Opaque = true;
+                        // ^^^^ error: expected impl Copy, found bool
+}
+"#,
+        );
+    }
 }


### PR DESCRIPTION
Fore more detail about impl traits in type aliases you can see the [RFC](https://rust-lang.github.io/rfcs/2515-type_alias_impl_trait.html).

I've mostly copied related functions for return type impl traits for type alias impl traits and modified accordingly.

Fixes https://github.com/rust-lang/rust-analyzer/issues/13824