### PR TITLE
minor: suppress 'clippy::approx_constant' lint in test case

### DIFF
--- a/crates/syntax/src/ast/token_ext.rs
+++ b/crates/syntax/src/ast/token_ext.rs
@@ -481,8 +481,7 @@ bcde", b"abcde",
 
     #[test]
     fn test_value_underscores() {
-        #[allow(clippy::approx_constant)]
-        check_float_value("3.141592653589793_f64", 3.141592653589793_f64);
+        check_float_value("1.234567891011121_f64", 1.234567891011121_f64);
         check_float_value("1__0.__0__f32", 10.0);
         check_int_value("0b__1_0_", 2);
         check_int_value("1_1_1_1_1_1", 111111);

--- a/crates/syntax/src/ast/token_ext.rs
+++ b/crates/syntax/src/ast/token_ext.rs
@@ -481,6 +481,7 @@ bcde", b"abcde",
 
     #[test]
     fn test_value_underscores() {
+        #[allow(clippy::approx_constant)]
         check_float_value("3.141592653589793_f64", 3.141592653589793_f64);
         check_float_value("1__0.__0__f32", 10.0);
         check_int_value("0b__1_0_", 2);


### PR DESCRIPTION
suppresses a false positive clippy lint