### PR TITLE
Complete record enum variants without parens when snippets are disabled

### DIFF
--- a/crates/ide-completion/src/completions/record.rs
+++ b/crates/ide-completion/src/completions/record.rs
@@ -159,8 +159,9 @@ fn baz() {
     #[test]
     fn enum_variant_no_snippets() {
         let conf = CompletionConfig { snippet_cap: SnippetCap::new(false), ..TEST_CONFIG };
+        // tuple variant
         check_edit_with_config(
-            conf,
+            conf.clone(),
             "Variant()",
             r#"
 enum Enum {
@@ -176,6 +177,34 @@ impl Enum {
             r#"
 enum Enum {
     Variant(usize),
+}
+
+impl Enum {
+    fn new(u: usize) -> Self {
+        Self::Variant
+    }
+}
+"#,
+        );
+
+        // record variant
+        check_edit_with_config(
+            conf,
+            "Variant{}",
+            r#"
+enum Enum {
+    Variant{u: usize},
+}
+
+impl Enum {
+    fn new(u: usize) -> Self {
+        Self::Va$0
+    }
+}
+"#,
+            r#"
+enum Enum {
+    Variant{u: usize},
 }
 
 impl Enum {

--- a/crates/ide-completion/src/render/variant.rs
+++ b/crates/ide-completion/src/render/variant.rs
@@ -22,6 +22,9 @@ pub(crate) fn render_record_lit(
     fields: &[hir::Field],
     path: &str,
 ) -> RenderedLiteral {
+    if snippet_cap.is_none() {
+        return RenderedLiteral { literal: path.to_string(), detail: path.to_string() };
+    }
     let completions = fields.iter().enumerate().format_with(", ", |(idx, field), f| {
         if snippet_cap.is_some() {
             f(&format_args!("{}: ${{{}:()}}", field.name(db), idx + 1))


### PR DESCRIPTION
I didn't realize I only handled this for tuple variants in #13805. This is the same change but for record variants.