### PR TITLE
Update rust-analyzer.server.path name

### DIFF
--- a/docs/user/manual.adoc
+++ b/docs/user/manual.adoc
@@ -117,7 +117,7 @@ If you are running an unsupported platform, you can install `rust-analyzer-no-se
 Copy the server anywhere, then add the path to your settings.json, for example:
 [source,json]
 ----
-{ "rust-analyzer.server.path": "~/.local/bin/rust-analyzer-linux" }
+{ "rust-analyzer.serverPath": "~/.local/bin/rust-analyzer-linux" }
 ----
 
 ==== Building From Source


### PR DESCRIPTION
Update to rust-analyzer.serverPath, as the original name does not appear to work.