### PR TITLE
Revert "Use ZWNJ to prevent VSCode from forming ligatures between hints and code"

### DIFF
--- a/editors/code/src/client.ts
+++ b/editors/code/src/client.ts
@@ -102,24 +102,6 @@ export async function createClient(
                     }
                 },
             },
-            async provideInlayHints(document, viewPort, token, next) {
-                const inlays = await next(document, viewPort, token);
-                if (!inlays) {
-                    return inlays;
-                }
-                // U+200C is a zero-width non-joiner to prevent the editor from forming a ligature
-                // between code and hints
-                for (const inlay of inlays) {
-                    if (typeof inlay.label === "string") {
-                        inlay.label = `\u{200c}${inlay.label}\u{200c}`;
-                    } else if (Array.isArray(inlay.label)) {
-                        for (const it of inlay.label) {
-                            it.value = `\u{200c}${it.value}\u{200c}`;
-                        }
-                    }
-                }
-                return inlays;
-            },
             async handleDiagnostics(
                 uri: vscode.Uri,
                 diagnosticList: vscode.Diagnostic[],


### PR DESCRIPTION
Doesn't actually seem to fix the bug, it seems to be theme dependent and I am not sure what causes it
Reverts rust-lang/rust-analyzer#13886