### PR TITLE
interior-mutable types should be 'static' rather than 'const

### DIFF
--- a/crates/hir-def/src/nameres/mod_resolution.rs
+++ b/crates/hir-def/src/nameres/mod_resolution.rs
@@ -7,7 +7,7 @@ use syntax::SmolStr;
 
 use crate::{db::DefDatabase, HirFileId};
 
-const MOD_DEPTH_LIMIT: Limit = Limit::new(32);
+static MOD_DEPTH_LIMIT: Limit = Limit::new(32);
 
 #[derive(Clone, Debug)]
 pub(super) struct ModDir {


### PR DESCRIPTION
with the 'tracking' feature enabled, `limit::Limit` is interior mutable, so the `const` `hir_def::nameres::mod_resolution::MOD_DEPTH_LIMIT` is probably meant to be `static` rather than `const`.

with `const` you get a new copy of it everywhere it's used, instead of the shared, global value that seems to be the intent.

This fix brought to you by the catchily-named `clippy::declare_interior_mutable_const` lint.