### PR TITLE
Fix panicking Option unwraping in match arm analysis

### DIFF
--- a/crates/ide-assists/src/handlers/convert_match_to_let_else.rs
+++ b/crates/ide-assists/src/handlers/convert_match_to_let_else.rs
@@ -87,7 +87,7 @@ fn find_arms(
     let mut extracting = None;
     let mut diverging = None;
     for arm in arms {
-        if ctx.sema.type_of_expr(&arm.expr().unwrap()).unwrap().original().is_never() {
+        if ctx.sema.type_of_expr(&arm.expr()?)?.original().is_never() {
             diverging = Some(arm);
         } else {
             extracting = Some(arm);


### PR DESCRIPTION
Hi, first PR here!

I've noticed my IDE sometimes briefly becoming pretty slow to respond while writing Rust. When checking the logs I found reams of this same error repeating itself.

```
thread 'Worker' panicked at 'called `Option::unwrap()` on a `None` value'
crates/ide-assists/src/handlers/convert_match_to_let_else.rs:90:46
```

RA seemed to have been panicking on virtually every keystroke I made whenever I was part way through writing/refactoring a match statement of relevance to this assist.

The fix in this PR should be self-explanatory.