### PR TITLE
Fix unexpected handling of nullish request param

### DIFF
--- a/crates/rust-analyzer/src/dispatch.rs
+++ b/crates/rust-analyzer/src/dispatch.rs
@@ -136,8 +136,15 @@ impl<'a> RequestDispatcher<'a> {
         R: lsp_types::request::Request,
         R::Params: DeserializeOwned + fmt::Debug,
     {
+        use serde_json::json;
         let req = match &self.req {
-            Some(req) if req.method == R::METHOD => self.req.take()?,
+            Some(req) if req.method == R::METHOD => {
+                let mut req = self.req.take()?;
+                if req.params == json!({}) {
+                    req.params = json!(());
+                }
+                req
+            }
             _ => return None,
         };
 


### PR DESCRIPTION
This PR aims to fix a major (possibly edge case) issue I've been running into related to RA's handling of `shutdown` requests; the lack thereof actually.

For whatever reason, my editor's built-in LSP system appears hardcoded to send shutdown requests with `"params": {}`, which causes RA to disregard the entire request:

```
// request
{"jsonrpc":"2.0","id":21,"method":"shutdown","params":{}}

// response
{"jsonrpc":"2.0","id":21,"error":{"code":-32602,"message":"Failed to deserialize shutdown: invalid type: map, expected unit; {}"}}
```

This leads to situations where, under certain circumstances, there are *many* simultaneous instances of RA analyzing the same workspace, even after closing the project in the editor. With the amount of memory one instance of RA requires, this can easily get out of hand. I've occasionally had my system (16GB memory) completely lock up under the load of dozens of rust analyzer processes.

I’ve added a fix here which may or may not be the most ideal place to put this. It “manually” applies a simple filter to convert `“{}”` to `()` on all incoming request parameters, which seems to work as expected now.