### PR TITLE
fix: Suppress extra indent after the end of field and function chains

### DIFF
--- a/editors/code/src/config.ts
+++ b/editors/code/src/config.ts
@@ -11,9 +11,7 @@ export type RunnableEnvCfg =
 
 export class Config {
     readonly extensionId = "rust-lang.rust-analyzer";
-    configureLang:
-        | { handle: vscode.Disposable; typingContinueCommentsOnNewline: boolean }
-        | undefined;
+    configureLang: vscode.Disposable | undefined;
 
     readonly rootSection = "rust-analyzer";
     private readonly requiresReloadOpts = [
@@ -45,7 +43,7 @@ export class Config {
     }
 
     dispose() {
-        this.configureLang?.handle.dispose();
+        this.configureLang?.dispose();
     }
 
     private refreshLogging() {
@@ -89,12 +87,8 @@ export class Config {
      */
     private configureLanguage() {
         // Only need to dispose of the config if there's a change
-        if (
-            this.configureLang &&
-            this.typingContinueCommentsOnNewline !==
-                this.configureLang.typingContinueCommentsOnNewline
-        ) {
-            this.configureLang.handle.dispose();
+        if (this.configureLang) {
+            this.configureLang.dispose();
             this.configureLang = undefined;
         }
 
@@ -167,12 +161,9 @@ export class Config {
             ];
         }
 
-        this.configureLang = {
-            handle: vscode.languages.setLanguageConfiguration("rust", {
-                onEnterRules,
-            }),
-            typingContinueCommentsOnNewline: this.typingContinueCommentsOnNewline,
-        };
+        this.configureLang = vscode.languages.setLanguageConfiguration("rust", {
+            onEnterRules,
+        });
     }
 
     // We don't do runtime config validation here for simplicity. More on stackoverflow:

--- a/editors/code/src/config.ts
+++ b/editors/code/src/config.ts
@@ -86,58 +86,80 @@ export class Config {
      * [1]: https://github.com/Microsoft/vscode/issues/11514#issuecomment-244707076
      */
     private configureLanguage() {
-        if (this.typingContinueCommentsOnNewline && !this.configureLang) {
+        if (this.configureLang) return;
+
+        let onEnterRules: vscode.OnEnterRule[] = [
+            {
+                // Carry indentation from the previous line
+                beforeText: /^\s*$/,
+                action: { indentAction: vscode.IndentAction.None },
+            },
+            {
+                // After the end of a function/field chain,
+                // with the semicolon on the same line
+                beforeText: /^\s+\..*;/,
+                action: { indentAction: vscode.IndentAction.Outdent },
+            },
+            {
+                // After the end of a function/field chain,
+                // with semicolon detached from the rest
+                beforeText: /^\s+;/,
+                previousLineText: /^\s+\..*/,
+                action: { indentAction: vscode.IndentAction.Outdent },
+            },
+        ];
+
+        if (this.typingContinueCommentsOnNewline) {
             const indentAction = vscode.IndentAction.None;
 
-            this.configureLang = vscode.languages.setLanguageConfiguration("rust", {
-                onEnterRules: [
-                    {
-                        // Doc single-line comment
-                        // e.g. ///|
-                        beforeText: /^\s*\/{3}.*$/,
-                        action: { indentAction, appendText: "/// " },
+            onEnterRules = [
+                ...onEnterRules,
+                {
+                    // Doc single-line comment
+                    // e.g. ///|
+                    beforeText: /^\s*\/{3}.*$/,
+                    action: { indentAction, appendText: "/// " },
+                },
+                {
+                    // Parent doc single-line comment
+                    // e.g. //!|
+                    beforeText: /^\s*\/{2}\!.*$/,
+                    action: { indentAction, appendText: "//! " },
+                },
+                {
+                    // Begins an auto-closed multi-line comment (standard or parent doc)
+                    // e.g. /** | */ or /*! | */
+                    beforeText: /^\s*\/\*(\*|\!)(?!\/)([^\*]|\*(?!\/))*$/,
+                    afterText: /^\s*\*\/$/,
+                    action: {
+                        indentAction: vscode.IndentAction.IndentOutdent,
+                        appendText: " * ",
                     },
-                    {
-                        // Parent doc single-line comment
-                        // e.g. //!|
-                        beforeText: /^\s*\/{2}\!.*$/,
-                        action: { indentAction, appendText: "//! " },
-                    },
-                    {
-                        // Begins an auto-closed multi-line comment (standard or parent doc)
-                        // e.g. /** | */ or /*! | */
-                        beforeText: /^\s*\/\*(\*|\!)(?!\/)([^\*]|\*(?!\/))*$/,
-                        afterText: /^\s*\*\/$/,
-                        action: {
-                            indentAction: vscode.IndentAction.IndentOutdent,
-                            appendText: " * ",
-                        },
-                    },
-                    {
-                        // Begins a multi-line comment (standard or parent doc)
-                        // e.g. /** ...| or /*! ...|
-                        beforeText: /^\s*\/\*(\*|\!)(?!\/)([^\*]|\*(?!\/))*$/,
-                        action: { indentAction, appendText: " * " },
-                    },
-                    {
-                        // Continues a multi-line comment
-                        // e.g.  * ...|
-                        beforeText: /^(\ \ )*\ \*(\ ([^\*]|\*(?!\/))*)?$/,
-                        action: { indentAction, appendText: "* " },
-                    },
-                    {
-                        // Dedents after closing a multi-line comment
-                        // e.g.  */|
-                        beforeText: /^(\ \ )*\ \*\/\s*$/,
-                        action: { indentAction, removeText: 1 },
-                    },
-                ],
-            });
+                },
+                {
+                    // Begins a multi-line comment (standard or parent doc)
+                    // e.g. /** ...| or /*! ...|
+                    beforeText: /^\s*\/\*(\*|\!)(?!\/)([^\*]|\*(?!\/))*$/,
+                    action: { indentAction, appendText: " * " },
+                },
+                {
+                    // Continues a multi-line comment
+                    // e.g.  * ...|
+                    beforeText: /^(\ \ )*\ \*(\ ([^\*]|\*(?!\/))*)?$/,
+                    action: { indentAction, appendText: "* " },
+                },
+                {
+                    // Dedents after closing a multi-line comment
+                    // e.g.  */|
+                    beforeText: /^(\ \ )*\ \*\/\s*$/,
+                    action: { indentAction, removeText: 1 },
+                },
+            ];
         }
-        if (!this.typingContinueCommentsOnNewline && this.configureLang) {
-            this.configureLang.dispose();
-            this.configureLang = undefined;
-        }
+
+        this.configureLang = vscode.languages.setLanguageConfiguration("rust", {
+            onEnterRules,
+        });
     }
 
     // We don't do runtime config validation here for simplicity. More on stackoverflow:


### PR DESCRIPTION
(spurred on by <https://github.com/rust-lang/rust-analyzer/issues/4182#issuecomment-671275652>)

Caveat that this doesn't work for after tail expressions, although there shouldn't be anything after those anyways.

This also complicates when to reload the language configuration by nature of now always having a language configuration applicable.

Examples of indentation fixes:

```rs
fn main() {
    println!("Hello!"); // < enter here!
    // ... indents down here

    fs::read_to_string("soup") // < enter here!
    // ... still indents down here :(
        .map(|_| ())
        .map(|_| ()) // < enter here!
        // ... still indents down here :D
        .map_err(|_| ())
        .unwrap(); // < enter here!
    // ... indents down here :D

    // ... and subsequent enters stay at the same indent

    0.0f64
        .to_radians()
        .to_radians()
        .to_radians() // force semi on a new line
        ; // < enter here!
    // ... indents down here :D
}

fn tail_end() -> i32 {
    0i32.wrapping_abs()
        .wrapping_abs()
        .wrapping_abs()
        .wrapping_abs() // < enter here!
        // ... still indents here :shrug:
}
```