### PR TITLE
fix: substitute vscode variables in `config.serverPath`

### DIFF
--- a/editors/code/src/bootstrap.ts
+++ b/editors/code/src/bootstrap.ts
@@ -1,6 +1,6 @@
 import * as vscode from "vscode";
 import * as os from "os";
-import { Config } from "./config";
+import { Config, substituteVSCodeVariables } from "./config";
 import { log, isValidExecutable } from "./util";
 import { PersistentState } from "./persistent_state";
 import { exec } from "child_process";
@@ -132,7 +132,7 @@ async function getServer(
     return undefined;
 }
 function serverPath(config: Config): string | null {
-    return process.env.__RA_LSP_SERVER_DEBUG ?? config.serverPath;
+    return process.env.__RA_LSP_SERVER_DEBUG ?? substituteVSCodeVariables(config.serverPath);
 }
 
 async function isNixOs(): Promise<boolean> {


### PR DESCRIPTION
From comment by @Veykril in https://github.com/rust-lang/rust-analyzer/issues/13939#issuecomment-1398187320:

> Yep, we pull the server path first, then substitute the configs, that's the wrong order.

https://github.com/rust-lang/rust-analyzer/blob/6e52c64031825920983515b9e975e93232739f7f/editors/code/src/ctx.ts#L155-L161

Fixes #13939