### PR TITLE
fix: config substitution failing extension activation

### DIFF
--- a/editors/code/src/config.ts
+++ b/editors/code/src/config.ts
@@ -268,8 +268,6 @@ export function substituteVSCodeVariables<T>(resp: T): T {
             res[key] = substituteVSCodeVariables(val);
         }
         return res as T;
-    } else if (Is.func(resp)) {
-        throw new Error("Unexpected function type in substitution");
     }
     return resp;
 }


### PR DESCRIPTION
Closes https://github.com/rust-lang/rust-analyzer/issues/14022

Not sure how a function can appear there, but there is also no reason for us to care about it anyways.