### PR TITLE
Beginning of MIR

### DIFF
--- a/crates/hir-def/src/expr.rs
+++ b/crates/hir-def/src/expr.rs
@@ -52,12 +52,20 @@ pub type LabelId = Idx<Label>;
 // We convert float values into bits and that's how we don't need to deal with f32 and f64.
 // For PartialEq, bits comparison should work, as ordering is not important
 // https://github.com/rust-lang/rust-analyzer/issues/12380#issuecomment-1137284360
-#[derive(Default, Debug, Clone, Eq, PartialEq)]
+#[derive(Default, Debug, Clone, Copy, Eq, PartialEq)]
 pub struct FloatTypeWrapper(u64);
 
 impl FloatTypeWrapper {
     pub fn new(value: f64) -> Self {
         Self(value.to_bits())
+    }
+
+    pub fn into_f64(self) -> f64 {
+        f64::from_bits(self.0)
+    }
+
+    pub fn into_f32(self) -> f32 {
+        f64::from_bits(self.0) as f32
     }
 }
 

--- a/crates/hir-def/src/lang_item.rs
+++ b/crates/hir-def/src/lang_item.rs
@@ -181,15 +181,15 @@ impl LangItems {
         T: Into<AttrDefId> + Copy,
     {
         let _p = profile::span("collect_lang_item");
-        if let Some(lang_item) = lang_attr(db, item).and_then(|it| LangItem::from_str(&it)) {
+        if let Some(lang_item) = lang_attr(db, item) {
             self.items.entry(lang_item).or_insert_with(|| constructor(item));
         }
     }
 }
 
-pub fn lang_attr(db: &dyn DefDatabase, item: impl Into<AttrDefId> + Copy) -> Option<SmolStr> {
+pub fn lang_attr(db: &dyn DefDatabase, item: impl Into<AttrDefId> + Copy) -> Option<LangItem> {
     let attrs = db.attrs(item.into());
-    attrs.by_key("lang").string_value().cloned()
+    attrs.by_key("lang").string_value().cloned().and_then(|it| LangItem::from_str(&it))
 }
 
 pub enum GenericRequirement {

--- a/crates/hir-def/src/macro_expansion_tests/builtin_fn_macro.rs
+++ b/crates/hir-def/src/macro_expansion_tests/builtin_fn_macro.rs
@@ -143,7 +143,7 @@ macro_rules! assert {
 
 fn main() {
      {
-        if !true {
+        if !(true ) {
             $crate::panic!("{} {:?}", arg1(a, b, c), arg2);
         }
     };

--- a/crates/hir-def/src/path.rs
+++ b/crates/hir-def/src/path.rs
@@ -8,7 +8,7 @@ use std::{
 
 use crate::{
     body::LowerCtx,
-    type_ref::{ConstScalarOrPath, LifetimeRef},
+    type_ref::{ConstRefOrPath, LifetimeRef},
 };
 use hir_expand::name::Name;
 use intern::Interned;
@@ -85,7 +85,7 @@ pub struct AssociatedTypeBinding {
 pub enum GenericArg {
     Type(TypeRef),
     Lifetime(LifetimeRef),
-    Const(ConstScalarOrPath),
+    Const(ConstRefOrPath),
 }
 
 impl Path {

--- a/crates/hir-def/src/path/lower.rs
+++ b/crates/hir-def/src/path/lower.rs
@@ -2,7 +2,7 @@
 
 use std::iter;
 
-use crate::type_ref::ConstScalarOrPath;
+use crate::type_ref::ConstRefOrPath;
 
 use either::Either;
 use hir_expand::name::{name, AsName};
@@ -212,7 +212,7 @@ pub(super) fn lower_generic_args(
                 }
             }
             ast::GenericArg::ConstArg(arg) => {
-                let arg = ConstScalarOrPath::from_expr_opt(arg.expr());
+                let arg = ConstRefOrPath::from_expr_opt(arg.expr());
                 args.push(GenericArg::Const(arg))
             }
         }

--- a/crates/hir-expand/src/builtin_fn_macro.rs
+++ b/crates/hir-expand/src/builtin_fn_macro.rs
@@ -206,7 +206,7 @@ fn assert_expand(
             let cond = cond.clone();
             let panic_args = itertools::Itertools::intersperse(panic_args.iter().cloned(), comma);
             quote! {{
-                if !#cond {
+                if !(#cond) {
                     #DOLLAR_CRATE::panic!(##panic_args);
                 }
             }}

--- a/crates/hir-ty/src/builder.rs
+++ b/crates/hir-ty/src/builder.rs
@@ -152,6 +152,15 @@ impl TyBuilder<()> {
         TyKind::Tuple(0, Substitution::empty(Interner)).intern(Interner)
     }
 
+    // FIXME: rustc's ty is dependent on the adt type, maybe we need to do that as well
+    pub fn discr_ty() -> Ty {
+        TyKind::Scalar(chalk_ir::Scalar::Int(chalk_ir::IntTy::I128)).intern(Interner)
+    }
+
+    pub fn bool() -> Ty {
+        TyKind::Scalar(chalk_ir::Scalar::Bool).intern(Interner)
+    }
+
     pub fn usize() -> Ty {
         TyKind::Scalar(chalk_ir::Scalar::Uint(chalk_ir::UintTy::Usize)).intern(Interner)
     }

--- a/crates/hir-ty/src/chalk_db.rs
+++ b/crates/hir-ty/src/chalk_db.rs
@@ -540,8 +540,7 @@ pub(crate) fn trait_datum_query(
     let where_clauses = convert_where_clauses(db, trait_.into(), &bound_vars);
     let associated_ty_ids = trait_data.associated_types().map(to_assoc_type_id).collect();
     let trait_datum_bound = rust_ir::TraitDatumBound { where_clauses };
-    let well_known = lang_attr(db.upcast(), trait_)
-        .and_then(|name| well_known_trait_from_lang_item(LangItem::from_str(&name)?));
+    let well_known = lang_attr(db.upcast(), trait_).and_then(well_known_trait_from_lang_item);
     let trait_datum = TraitDatum {
         id: trait_id,
         binders: make_binders(db, &generic_params, trait_datum_bound),

--- a/crates/hir-ty/src/db.rs
+++ b/crates/hir-ty/src/db.rs
@@ -16,10 +16,12 @@ use smallvec::SmallVec;
 
 use crate::{
     chalk_db,
-    consteval::{ComputedExpr, ConstEvalError},
+    consteval::ConstEvalError,
     method_resolution::{InherentImpls, TraitImpls, TyFingerprint},
-    Binders, CallableDefId, FnDefId, GenericArg, ImplTraitId, InferenceResult, Interner, PolyFnSig,
-    QuantifiedWhereClause, ReturnTypeImplTraits, Substitution, TraitRef, Ty, TyDefId, ValueTyDefId,
+    mir::{MirBody, MirLowerError},
+    Binders, CallableDefId, Const, FnDefId, GenericArg, ImplTraitId, InferenceResult, Interner,
+    PolyFnSig, QuantifiedWhereClause, ReturnTypeImplTraits, Substitution, TraitRef, Ty, TyDefId,
+    ValueTyDefId,
 };
 use hir_expand::name::Name;
 
@@ -31,6 +33,10 @@ pub trait HirDatabase: DefDatabase + Upcast<dyn DefDatabase> {
 
     #[salsa::invoke(crate::infer::infer_query)]
     fn infer_query(&self, def: DefWithBodyId) -> Arc<InferenceResult>;
+
+    #[salsa::invoke(crate::mir::mir_body_query)]
+    #[salsa::cycle(crate::mir::mir_body_recover)]
+    fn mir_body(&self, def: DefWithBodyId) -> Result<Arc<MirBody>, MirLowerError>;
 
     #[salsa::invoke(crate::lower::ty_query)]
     #[salsa::cycle(crate::lower::ty_recover)]
@@ -46,13 +52,13 @@ pub trait HirDatabase: DefDatabase + Upcast<dyn DefDatabase> {
     #[salsa::invoke(crate::lower::const_param_ty_query)]
     fn const_param_ty(&self, def: ConstParamId) -> Ty;
 
-    #[salsa::invoke(crate::consteval::const_eval_variant_query)]
+    #[salsa::invoke(crate::consteval::const_eval_query)]
     #[salsa::cycle(crate::consteval::const_eval_recover)]
-    fn const_eval(&self, def: ConstId) -> Result<ComputedExpr, ConstEvalError>;
+    fn const_eval(&self, def: ConstId) -> Result<Const, ConstEvalError>;
 
-    #[salsa::invoke(crate::consteval::const_eval_query_variant)]
-    #[salsa::cycle(crate::consteval::const_eval_variant_recover)]
-    fn const_eval_variant(&self, def: EnumVariantId) -> Result<ComputedExpr, ConstEvalError>;
+    #[salsa::invoke(crate::consteval::const_eval_discriminant_variant)]
+    #[salsa::cycle(crate::consteval::const_eval_discriminant_recover)]
+    fn const_eval_discriminant(&self, def: EnumVariantId) -> Result<i128, ConstEvalError>;
 
     #[salsa::invoke(crate::lower::impl_trait_query)]
     fn impl_trait(&self, def: ImplId) -> Option<Binders<TraitRef>>;

--- a/crates/hir-ty/src/infer/unify.rs
+++ b/crates/hir-ty/src/infer/unify.rs
@@ -704,14 +704,13 @@ impl<'a> fmt::Debug for InferenceTable<'a> {
 mod resolve {
     use super::InferenceTable;
     use crate::{
-        ConcreteConst, Const, ConstData, ConstValue, DebruijnIndex, GenericArg, InferenceVar,
-        Interner, Lifetime, Ty, TyVariableKind, VariableKind,
+        ConcreteConst, Const, ConstData, ConstScalar, ConstValue, DebruijnIndex, GenericArg,
+        InferenceVar, Interner, Lifetime, Ty, TyVariableKind, VariableKind,
     };
     use chalk_ir::{
         cast::Cast,
         fold::{TypeFoldable, TypeFolder},
     };
-    use hir_def::type_ref::ConstScalar;
 
     #[derive(chalk_derive::FallibleTypeFolder)]
     #[has_interner(Interner)]

--- a/crates/hir-ty/src/interner.rs
+++ b/crates/hir-ty/src/interner.rs
@@ -1,10 +1,10 @@
 //! Implementation of the Chalk `Interner` trait, which allows customizing the
 //! representation of the various objects Chalk deals with (types, goals etc.).
 
-use crate::{chalk_db, tls, GenericArg};
+use crate::{chalk_db, tls, ConstScalar, GenericArg};
 use base_db::salsa::InternId;
 use chalk_ir::{Goal, GoalData};
-use hir_def::{type_ref::ConstScalar, TypeAliasId};
+use hir_def::TypeAliasId;
 use intern::{impl_internable, Interned};
 use smallvec::SmallVec;
 use std::{fmt, sync::Arc};

--- a/crates/hir-ty/src/layout.rs
+++ b/crates/hir-ty/src/layout.rs
@@ -11,7 +11,7 @@ use hir_def::{
 };
 use stdx::never;
 
-use crate::{db::HirDatabase, Interner, Substitution, Ty};
+use crate::{consteval::try_const_usize, db::HirDatabase, Interner, Substitution, Ty};
 
 use self::adt::struct_variant_idx;
 pub use self::{
@@ -122,17 +122,9 @@ pub fn layout_of_ty(db: &dyn HirDatabase, ty: &Ty, krate: CrateId) -> Result<Lay
             cx.univariant(dl, &fields, &ReprOptions::default(), kind).ok_or(LayoutError::Unknown)?
         }
         TyKind::Array(element, count) => {
-            let count = match count.data(Interner).value {
-                chalk_ir::ConstValue::Concrete(c) => match c.interned {
-                    hir_def::type_ref::ConstScalar::Int(x) => x as u64,
-                    hir_def::type_ref::ConstScalar::UInt(x) => x as u64,
-                    hir_def::type_ref::ConstScalar::Unknown => {
-                        user_error!("unknown const generic parameter")
-                    }
-                    _ => user_error!("mismatched type of const generic parameter"),
-                },
-                _ => return Err(LayoutError::HasPlaceholder),
-            };
+            let count = try_const_usize(&count).ok_or(LayoutError::UserError(
+                "mismatched type of const generic parameter".to_string(),
+            ))? as u64;
             let element = layout_of_ty(db, element, krate)?;
             let size = element.size.checked_mul(count, dl).ok_or(LayoutError::SizeOverflow)?;
 

--- a/crates/hir-ty/src/layout/adt.rs
+++ b/crates/hir-ty/src/layout/adt.rs
@@ -76,17 +76,8 @@ pub fn layout_of_adt_query(
             |min, max| Integer::repr_discr(&dl, &repr, min, max).unwrap_or((Integer::I8, false)),
             variants.iter_enumerated().filter_map(|(id, _)| {
                 let AdtId::EnumId(e) = def else { return None };
-                let d = match db
-                    .const_eval_variant(EnumVariantId { parent: e, local_id: id.0 })
-                    .ok()?
-                {
-                    crate::consteval::ComputedExpr::Literal(l) => match l {
-                        hir_def::expr::Literal::Int(i, _) => i,
-                        hir_def::expr::Literal::Uint(i, _) => i as i128,
-                        _ => return None,
-                    },
-                    _ => return None,
-                };
+                let d =
+                    db.const_eval_discriminant(EnumVariantId { parent: e, local_id: id.0 }).ok()?;
                 Some((id, d))
             }),
             // FIXME: The current code for niche-filling relies on variant indices

--- a/crates/hir-ty/src/layout/tests.rs
+++ b/crates/hir-ty/src/layout/tests.rs
@@ -82,8 +82,8 @@ fn eval_expr(ra_fixture: &str, minicore: &str) -> Result<Layout, LayoutError> {
 #[track_caller]
 fn check_size_and_align(ra_fixture: &str, minicore: &str, size: u64, align: u64) {
     let l = eval_goal(ra_fixture, minicore).unwrap();
-    assert_eq!(l.size.bytes(), size);
-    assert_eq!(l.align.abi.bytes(), align);
+    assert_eq!(l.size.bytes(), size, "size mismatch");
+    assert_eq!(l.align.abi.bytes(), align, "align mismatch");
 }
 
 #[track_caller]
@@ -298,6 +298,11 @@ fn enums_with_discriminants() {
             A = 254,
             B,
             C, // implicitly becomes 256, so we need two bytes
+        }
+    }
+    size_and_align! {
+        enum Goal {
+            A = 1, // This one is (perhaps surprisingly) zero sized.
         }
     }
 }

--- a/crates/hir-ty/src/lib.rs
+++ b/crates/hir-ty/src/lib.rs
@@ -13,6 +13,7 @@ mod builder;
 mod chalk_db;
 mod chalk_ext;
 pub mod consteval;
+pub mod mir;
 mod infer;
 mod inhabitedness;
 mod interner;
@@ -34,7 +35,7 @@ mod tests;
 #[cfg(test)]
 mod test_db;
 
-use std::sync::Arc;
+use std::{collections::HashMap, hash::Hash, sync::Arc};
 
 use chalk_ir::{
     fold::{Shift, TypeFoldable},
@@ -46,6 +47,7 @@ use hir_def::{expr::ExprId, type_ref::Rawness, TypeOrConstParamId};
 use hir_expand::name;
 use itertools::Either;
 use la_arena::{Arena, Idx};
+use mir::MirEvalError;
 use rustc_hash::FxHashSet;
 use traits::FnTrait;
 use utils::Generics;
@@ -144,6 +146,49 @@ pub type Solution = chalk_solve::Solution<Interner>;
 pub type ConstrainedSubst = chalk_ir::ConstrainedSubst<Interner>;
 pub type Guidance = chalk_solve::Guidance<Interner>;
 pub type WhereClause = chalk_ir::WhereClause<Interner>;
+
+/// A constant can have reference to other things. Memory map job is holding
+/// the neccessary bits of memory of the const eval session to keep the constant
+/// meaningful.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct MemoryMap(pub HashMap<usize, Vec<u8>>);
+
+impl MemoryMap {
+    fn insert(&mut self, addr: usize, x: Vec<u8>) {
+        self.0.insert(addr, x);
+    }
+
+    /// This functions convert each address by a function `f` which gets the byte intervals and assign an address
+    /// to them. It is useful when you want to load a constant with a memory map in a new memory. You can pass an
+    /// allocator function as `f` and it will return a mapping of old addresses to new addresses.
+    fn transform_addresses(
+        &self,
+        mut f: impl FnMut(&[u8]) -> Result<usize, MirEvalError>,
+    ) -> Result<HashMap<usize, usize>, MirEvalError> {
+        self.0.iter().map(|x| Ok((*x.0, f(x.1)?))).collect()
+    }
+}
+
+/// A concrete constant value
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ConstScalar {
+    Bytes(Vec<u8>, MemoryMap),
+    /// Case of an unknown value that rustc might know but we don't
+    // FIXME: this is a hack to get around chalk not being able to represent unevaluatable
+    // constants
+    // https://github.com/rust-lang/rust-analyzer/pull/8813#issuecomment-840679177
+    // https://rust-lang.zulipchat.com/#narrow/stream/144729-wg-traits/topic/Handling.20non.20evaluatable.20constants'.20equality/near/238386348
+    Unknown,
+}
+
+impl Hash for ConstScalar {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        core::mem::discriminant(self).hash(state);
+        if let ConstScalar::Bytes(b, _) = self {
+            b.hash(state)
+        }
+    }
+}
 
 /// Return an index of a parameter in the generic type parameter list by it's id.
 pub fn param_idx(db: &dyn HirDatabase, id: TypeOrConstParamId) -> Option<usize> {

--- a/crates/hir-ty/src/mir.rs
+++ b/crates/hir-ty/src/mir.rs
@@ -1,0 +1,811 @@
+//! MIR definitions and implementation
+
+use std::iter;
+
+use crate::{
+    infer::PointerCast, Const, ConstScalar, InferenceResult, Interner, MemoryMap, Substitution, Ty,
+};
+use chalk_ir::Mutability;
+use hir_def::{
+    expr::{Expr, Ordering},
+    DefWithBodyId, FieldId, UnionId, VariantId,
+};
+use la_arena::{Arena, Idx, RawIdx};
+
+mod eval;
+mod lower;
+
+pub use eval::{interpret_mir, pad16, Evaluator, MirEvalError};
+pub use lower::{lower_to_mir, mir_body_query, mir_body_recover, MirLowerError};
+use smallvec::{smallvec, SmallVec};
+
+use super::consteval::{intern_const_scalar, try_const_usize};
+
+pub type BasicBlockId = Idx<BasicBlock>;
+pub type LocalId = Idx<Local>;
+
+fn return_slot() -> LocalId {
+    LocalId::from_raw(RawIdx::from(0))
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct Local {
+    pub mutability: Mutability,
+    //pub local_info: Option<Box<LocalInfo>>,
+    //pub internal: bool,
+    //pub is_block_tail: Option<BlockTailInfo>,
+    pub ty: Ty,
+    //pub user_ty: Option<Box<UserTypeProjections>>,
+    //pub source_info: SourceInfo,
+}
+
+/// An operand in MIR represents a "value" in Rust, the definition of which is undecided and part of
+/// the memory model. One proposal for a definition of values can be found [on UCG][value-def].
+///
+/// [value-def]: https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/value-domain.md
+///
+/// The most common way to create values is via loading a place. Loading a place is an operation
+/// which reads the memory of the place and converts it to a value. This is a fundamentally *typed*
+/// operation. The nature of the value produced depends on the type of the conversion. Furthermore,
+/// there may be other effects: if the type has a validity constraint loading the place might be UB
+/// if the validity constraint is not met.
+///
+/// **Needs clarification:** Ralf proposes that loading a place not have side-effects.
+/// This is what is implemented in miri today. Are these the semantics we want for MIR? Is this
+/// something we can even decide without knowing more about Rust's memory model?
+///
+/// **Needs clarifiation:** Is loading a place that has its variant index set well-formed? Miri
+/// currently implements it, but it seems like this may be something to check against in the
+/// validator.
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum Operand {
+    /// Creates a value by loading the given place.
+    ///
+    /// Before drop elaboration, the type of the place must be `Copy`. After drop elaboration there
+    /// is no such requirement.
+    Copy(Place),
+
+    /// Creates a value by performing loading the place, just like the `Copy` operand.
+    ///
+    /// This *may* additionally overwrite the place with `uninit` bytes, depending on how we decide
+    /// in [UCG#188]. You should not emit MIR that may attempt a subsequent second load of this
+    /// place without first re-initializing it.
+    ///
+    /// [UCG#188]: https://github.com/rust-lang/unsafe-code-guidelines/issues/188
+    Move(Place),
+    /// Constants are already semantically values, and remain unchanged.
+    Constant(Const),
+}
+
+impl Operand {
+    fn from_concrete_const(data: Vec<u8>, memory_map: MemoryMap, ty: Ty) -> Self {
+        Operand::Constant(intern_const_scalar(ConstScalar::Bytes(data, memory_map), ty))
+    }
+
+    fn from_bytes(data: Vec<u8>, ty: Ty) -> Self {
+        Operand::from_concrete_const(data, MemoryMap::default(), ty)
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum ProjectionElem<V, T> {
+    Deref,
+    Field(FieldId),
+    TupleField(usize),
+    Index(V),
+    ConstantIndex { offset: u64, min_length: u64, from_end: bool },
+    Subslice { from: u64, to: u64, from_end: bool },
+    //Downcast(Option<Symbol>, VariantIdx),
+    OpaqueCast(T),
+}
+
+type PlaceElem = ProjectionElem<LocalId, Ty>;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Place {
+    pub local: LocalId,
+    pub projection: Vec<PlaceElem>,
+}
+
+impl From<LocalId> for Place {
+    fn from(local: LocalId) -> Self {
+        Self { local, projection: vec![] }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum AggregateKind {
+    /// The type is of the element
+    Array(Ty),
+    /// The type is of the tuple
+    Tuple(Ty),
+    Adt(VariantId, Substitution),
+    Union(UnionId, FieldId),
+    //Closure(LocalDefId, SubstsRef),
+    //Generator(LocalDefId, SubstsRef, Movability),
+}
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+pub struct SwitchTargets {
+    /// Possible values. The locations to branch to in each case
+    /// are found in the corresponding indices from the `targets` vector.
+    values: SmallVec<[u128; 1]>,
+
+    /// Possible branch sites. The last element of this vector is used
+    /// for the otherwise branch, so targets.len() == values.len() + 1
+    /// should hold.
+    //
+    // This invariant is quite non-obvious and also could be improved.
+    // One way to make this invariant is to have something like this instead:
+    //
+    // branches: Vec<(ConstInt, BasicBlock)>,
+    // otherwise: Option<BasicBlock> // exhaustive if None
+    //
+    // However we’ve decided to keep this as-is until we figure a case
+    // where some other approach seems to be strictly better than other.
+    targets: SmallVec<[BasicBlockId; 2]>,
+}
+
+impl SwitchTargets {
+    /// Creates switch targets from an iterator of values and target blocks.
+    ///
+    /// The iterator may be empty, in which case the `SwitchInt` instruction is equivalent to
+    /// `goto otherwise;`.
+    pub fn new(
+        targets: impl Iterator<Item = (u128, BasicBlockId)>,
+        otherwise: BasicBlockId,
+    ) -> Self {
+        let (values, mut targets): (SmallVec<_>, SmallVec<_>) = targets.unzip();
+        targets.push(otherwise);
+        Self { values, targets }
+    }
+
+    /// Builds a switch targets definition that jumps to `then` if the tested value equals `value`,
+    /// and to `else_` if not.
+    pub fn static_if(value: u128, then: BasicBlockId, else_: BasicBlockId) -> Self {
+        Self { values: smallvec![value], targets: smallvec![then, else_] }
+    }
+
+    /// Returns the fallback target that is jumped to when none of the values match the operand.
+    pub fn otherwise(&self) -> BasicBlockId {
+        *self.targets.last().unwrap()
+    }
+
+    /// Returns an iterator over the switch targets.
+    ///
+    /// The iterator will yield tuples containing the value and corresponding target to jump to, not
+    /// including the `otherwise` fallback target.
+    ///
+    /// Note that this may yield 0 elements. Only the `otherwise` branch is mandatory.
+    pub fn iter(&self) -> impl Iterator<Item = (u128, BasicBlockId)> + '_ {
+        iter::zip(&self.values, &self.targets).map(|(x, y)| (*x, *y))
+    }
+
+    /// Finds the `BasicBlock` to which this `SwitchInt` will branch given the
+    /// specific value. This cannot fail, as it'll return the `otherwise`
+    /// branch if there's not a specific match for the value.
+    pub fn target_for_value(&self, value: u128) -> BasicBlockId {
+        self.iter().find_map(|(v, t)| (v == value).then_some(t)).unwrap_or_else(|| self.otherwise())
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum Terminator {
+    /// Block has one successor; we continue execution there.
+    Goto { target: BasicBlockId },
+
+    /// Switches based on the computed value.
+    ///
+    /// First, evaluates the `discr` operand. The type of the operand must be a signed or unsigned
+    /// integer, char, or bool, and must match the given type. Then, if the list of switch targets
+    /// contains the computed value, continues execution at the associated basic block. Otherwise,
+    /// continues execution at the "otherwise" basic block.
+    ///
+    /// Target values may not appear more than once.
+    SwitchInt {
+        /// The discriminant value being tested.
+        discr: Operand,
+
+        targets: SwitchTargets,
+    },
+
+    /// Indicates that the landing pad is finished and that the process should continue unwinding.
+    ///
+    /// Like a return, this marks the end of this invocation of the function.
+    ///
+    /// Only permitted in cleanup blocks. `Resume` is not permitted with `-C unwind=abort` after
+    /// deaggregation runs.
+    Resume,
+
+    /// Indicates that the landing pad is finished and that the process should abort.
+    ///
+    /// Used to prevent unwinding for foreign items or with `-C unwind=abort`. Only permitted in
+    /// cleanup blocks.
+    Abort,
+
+    /// Returns from the function.
+    ///
+    /// Like function calls, the exact semantics of returns in Rust are unclear. Returning very
+    /// likely at least assigns the value currently in the return place (`_0`) to the place
+    /// specified in the associated `Call` terminator in the calling function, as if assigned via
+    /// `dest = move _0`. It might additionally do other things, like have side-effects in the
+    /// aliasing model.
+    ///
+    /// If the body is a generator body, this has slightly different semantics; it instead causes a
+    /// `GeneratorState::Returned(_0)` to be created (as if by an `Aggregate` rvalue) and assigned
+    /// to the return place.
+    Return,
+
+    /// Indicates a terminator that can never be reached.
+    ///
+    /// Executing this terminator is UB.
+    Unreachable,
+
+    /// The behavior of this statement differs significantly before and after drop elaboration.
+    /// After drop elaboration, `Drop` executes the drop glue for the specified place, after which
+    /// it continues execution/unwinds at the given basic blocks. It is possible that executing drop
+    /// glue is special - this would be part of Rust's memory model. (**FIXME**: due we have an
+    /// issue tracking if drop glue has any interesting semantics in addition to those of a function
+    /// call?)
+    ///
+    /// `Drop` before drop elaboration is a *conditional* execution of the drop glue. Specifically, the
+    /// `Drop` will be executed if...
+    ///
+    /// **Needs clarification**: End of that sentence. This in effect should document the exact
+    /// behavior of drop elaboration. The following sounds vaguely right, but I'm not quite sure:
+    ///
+    /// > The drop glue is executed if, among all statements executed within this `Body`, an assignment to
+    /// > the place or one of its "parents" occurred more recently than a move out of it. This does not
+    /// > consider indirect assignments.
+    Drop { place: Place, target: BasicBlockId, unwind: Option<BasicBlockId> },
+
+    /// Drops the place and assigns a new value to it.
+    ///
+    /// This first performs the exact same operation as the pre drop-elaboration `Drop` terminator;
+    /// it then additionally assigns the `value` to the `place` as if by an assignment statement.
+    /// This assignment occurs both in the unwind and the regular code paths. The semantics are best
+    /// explained by the elaboration:
+    ///
+    /// ```ignore (MIR)
+    /// BB0 {
+    ///   DropAndReplace(P <- V, goto BB1, unwind BB2)
+    /// }
+    /// ```
+    ///
+    /// becomes
+    ///
+    /// ```ignore (MIR)
+    /// BB0 {
+    ///   Drop(P, goto BB1, unwind BB2)
+    /// }
+    /// BB1 {
+    ///   // P is now uninitialized
+    ///   P <- V
+    /// }
+    /// BB2 {
+    ///   // P is now uninitialized -- its dtor panicked
+    ///   P <- V
+    /// }
+    /// ```
+    ///
+    /// Disallowed after drop elaboration.
+    DropAndReplace {
+        place: Place,
+        value: Operand,
+        target: BasicBlockId,
+        unwind: Option<BasicBlockId>,
+    },
+
+    /// Roughly speaking, evaluates the `func` operand and the arguments, and starts execution of
+    /// the referred to function. The operand types must match the argument types of the function.
+    /// The return place type must match the return type. The type of the `func` operand must be
+    /// callable, meaning either a function pointer, a function type, or a closure type.
+    ///
+    /// **Needs clarification**: The exact semantics of this. Current backends rely on `move`
+    /// operands not aliasing the return place. It is unclear how this is justified in MIR, see
+    /// [#71117].
+    ///
+    /// [#71117]: https://github.com/rust-lang/rust/issues/71117
+    Call {
+        /// The function that’s being called.
+        func: Operand,
+        /// Arguments the function is called with.
+        /// These are owned by the callee, which is free to modify them.
+        /// This allows the memory occupied by "by-value" arguments to be
+        /// reused across function calls without duplicating the contents.
+        args: Vec<Operand>,
+        /// Where the returned value will be written
+        destination: Place,
+        /// Where to go after this call returns. If none, the call necessarily diverges.
+        target: Option<BasicBlockId>,
+        /// Cleanups to be done if the call unwinds.
+        cleanup: Option<BasicBlockId>,
+        /// `true` if this is from a call in HIR rather than from an overloaded
+        /// operator. True for overloaded function call.
+        from_hir_call: bool,
+        // This `Span` is the span of the function, without the dot and receiver
+        // (e.g. `foo(a, b)` in `x.foo(a, b)`
+        //fn_span: Span,
+    },
+
+    /// Evaluates the operand, which must have type `bool`. If it is not equal to `expected`,
+    /// initiates a panic. Initiating a panic corresponds to a `Call` terminator with some
+    /// unspecified constant as the function to call, all the operands stored in the `AssertMessage`
+    /// as parameters, and `None` for the destination. Keep in mind that the `cleanup` path is not
+    /// necessarily executed even in the case of a panic, for example in `-C panic=abort`. If the
+    /// assertion does not fail, execution continues at the specified basic block.
+    Assert {
+        cond: Operand,
+        expected: bool,
+        //msg: AssertMessage,
+        target: BasicBlockId,
+        cleanup: Option<BasicBlockId>,
+    },
+
+    /// Marks a suspend point.
+    ///
+    /// Like `Return` terminators in generator bodies, this computes `value` and then a
+    /// `GeneratorState::Yielded(value)` as if by `Aggregate` rvalue. That value is then assigned to
+    /// the return place of the function calling this one, and execution continues in the calling
+    /// function. When next invoked with the same first argument, execution of this function
+    /// continues at the `resume` basic block, with the second argument written to the `resume_arg`
+    /// place. If the generator is dropped before then, the `drop` basic block is invoked.
+    ///
+    /// Not permitted in bodies that are not generator bodies, or after generator lowering.
+    ///
+    /// **Needs clarification**: What about the evaluation order of the `resume_arg` and `value`?
+    Yield {
+        /// The value to return.
+        value: Operand,
+        /// Where to resume to.
+        resume: BasicBlockId,
+        /// The place to store the resume argument in.
+        resume_arg: Place,
+        /// Cleanup to be done if the generator is dropped at this suspend point.
+        drop: Option<BasicBlockId>,
+    },
+
+    /// Indicates the end of dropping a generator.
+    ///
+    /// Semantically just a `return` (from the generators drop glue). Only permitted in the same situations
+    /// as `yield`.
+    ///
+    /// **Needs clarification**: Is that even correct? The generator drop code is always confusing
+    /// to me, because it's not even really in the current body.
+    ///
+    /// **Needs clarification**: Are there type system constraints on these terminators? Should
+    /// there be a "block type" like `cleanup` blocks for them?
+    GeneratorDrop,
+
+    /// A block where control flow only ever takes one real path, but borrowck needs to be more
+    /// conservative.
+    ///
+    /// At runtime this is semantically just a goto.
+    ///
+    /// Disallowed after drop elaboration.
+    FalseEdge {
+        /// The target normal control flow will take.
+        real_target: BasicBlockId,
+        /// A block control flow could conceptually jump to, but won't in
+        /// practice.
+        imaginary_target: BasicBlockId,
+    },
+
+    /// A terminator for blocks that only take one path in reality, but where we reserve the right
+    /// to unwind in borrowck, even if it won't happen in practice. This can arise in infinite loops
+    /// with no function calls for example.
+    ///
+    /// At runtime this is semantically just a goto.
+    ///
+    /// Disallowed after drop elaboration.
+    FalseUnwind {
+        /// The target normal control flow will take.
+        real_target: BasicBlockId,
+        /// The imaginary cleanup block link. This particular path will never be taken
+        /// in practice, but in order to avoid fragility we want to always
+        /// consider it in borrowck. We don't want to accept programs which
+        /// pass borrowck only when `panic=abort` or some assertions are disabled
+        /// due to release vs. debug mode builds. This needs to be an `Option` because
+        /// of the `remove_noop_landing_pads` and `abort_unwinding_calls` passes.
+        unwind: Option<BasicBlockId>,
+    },
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum BorrowKind {
+    /// Data must be immutable and is aliasable.
+    Shared,
+
+    /// The immediately borrowed place must be immutable, but projections from
+    /// it don't need to be. For example, a shallow borrow of `a.b` doesn't
+    /// conflict with a mutable borrow of `a.b.c`.
+    ///
+    /// This is used when lowering matches: when matching on a place we want to
+    /// ensure that place have the same value from the start of the match until
+    /// an arm is selected. This prevents this code from compiling:
+    /// ```compile_fail,E0510
+    /// let mut x = &Some(0);
+    /// match *x {
+    ///     None => (),
+    ///     Some(_) if { x = &None; false } => (),
+    ///     Some(_) => (),
+    /// }
+    /// ```
+    /// This can't be a shared borrow because mutably borrowing (*x as Some).0
+    /// should not prevent `if let None = x { ... }`, for example, because the
+    /// mutating `(*x as Some).0` can't affect the discriminant of `x`.
+    /// We can also report errors with this kind of borrow differently.
+    Shallow,
+
+    /// Data must be immutable but not aliasable. This kind of borrow
+    /// cannot currently be expressed by the user and is used only in
+    /// implicit closure bindings. It is needed when the closure is
+    /// borrowing or mutating a mutable referent, e.g.:
+    /// ```
+    /// let mut z = 3;
+    /// let x: &mut isize = &mut z;
+    /// let y = || *x += 5;
+    /// ```
+    /// If we were to try to translate this closure into a more explicit
+    /// form, we'd encounter an error with the code as written:
+    /// ```compile_fail,E0594
+    /// struct Env<'a> { x: &'a &'a mut isize }
+    /// let mut z = 3;
+    /// let x: &mut isize = &mut z;
+    /// let y = (&mut Env { x: &x }, fn_ptr);  // Closure is pair of env and fn
+    /// fn fn_ptr(env: &mut Env) { **env.x += 5; }
+    /// ```
+    /// This is then illegal because you cannot mutate an `&mut` found
+    /// in an aliasable location. To solve, you'd have to translate with
+    /// an `&mut` borrow:
+    /// ```compile_fail,E0596
+    /// struct Env<'a> { x: &'a mut &'a mut isize }
+    /// let mut z = 3;
+    /// let x: &mut isize = &mut z;
+    /// let y = (&mut Env { x: &mut x }, fn_ptr); // changed from &x to &mut x
+    /// fn fn_ptr(env: &mut Env) { **env.x += 5; }
+    /// ```
+    /// Now the assignment to `**env.x` is legal, but creating a
+    /// mutable pointer to `x` is not because `x` is not mutable. We
+    /// could fix this by declaring `x` as `let mut x`. This is ok in
+    /// user code, if awkward, but extra weird for closures, since the
+    /// borrow is hidden.
+    ///
+    /// So we introduce a "unique imm" borrow -- the referent is
+    /// immutable, but not aliasable. This solves the problem. For
+    /// simplicity, we don't give users the way to express this
+    /// borrow, it's just used when translating closures.
+    Unique,
+
+    /// Data is mutable and not aliasable.
+    Mut {
+        /// `true` if this borrow arose from method-call auto-ref
+        /// (i.e., `adjustment::Adjust::Borrow`).
+        allow_two_phase_borrow: bool,
+    },
+}
+
+impl BorrowKind {
+    fn from_hir(m: hir_def::type_ref::Mutability) -> Self {
+        match m {
+            hir_def::type_ref::Mutability::Shared => BorrowKind::Shared,
+            hir_def::type_ref::Mutability::Mut => BorrowKind::Mut { allow_two_phase_borrow: false },
+        }
+    }
+
+    fn from_chalk(m: Mutability) -> Self {
+        match m {
+            Mutability::Not => BorrowKind::Shared,
+            Mutability::Mut => BorrowKind::Mut { allow_two_phase_borrow: false },
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum UnOp {
+    /// The `!` operator for logical inversion
+    Not,
+    /// The `-` operator for negation
+    Neg,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum BinOp {
+    /// The `+` operator (addition)
+    Add,
+    /// The `-` operator (subtraction)
+    Sub,
+    /// The `*` operator (multiplication)
+    Mul,
+    /// The `/` operator (division)
+    ///
+    /// Division by zero is UB, because the compiler should have inserted checks
+    /// prior to this.
+    Div,
+    /// The `%` operator (modulus)
+    ///
+    /// Using zero as the modulus (second operand) is UB, because the compiler
+    /// should have inserted checks prior to this.
+    Rem,
+    /// The `^` operator (bitwise xor)
+    BitXor,
+    /// The `&` operator (bitwise and)
+    BitAnd,
+    /// The `|` operator (bitwise or)
+    BitOr,
+    /// The `<<` operator (shift left)
+    ///
+    /// The offset is truncated to the size of the first operand before shifting.
+    Shl,
+    /// The `>>` operator (shift right)
+    ///
+    /// The offset is truncated to the size of the first operand before shifting.
+    Shr,
+    /// The `==` operator (equality)
+    Eq,
+    /// The `<` operator (less than)
+    Lt,
+    /// The `<=` operator (less than or equal to)
+    Le,
+    /// The `!=` operator (not equal to)
+    Ne,
+    /// The `>=` operator (greater than or equal to)
+    Ge,
+    /// The `>` operator (greater than)
+    Gt,
+    /// The `ptr.offset` operator
+    Offset,
+}
+
+impl From<hir_def::expr::ArithOp> for BinOp {
+    fn from(value: hir_def::expr::ArithOp) -> Self {
+        match value {
+            hir_def::expr::ArithOp::Add => BinOp::Add,
+            hir_def::expr::ArithOp::Mul => BinOp::Mul,
+            hir_def::expr::ArithOp::Sub => BinOp::Sub,
+            hir_def::expr::ArithOp::Div => BinOp::Div,
+            hir_def::expr::ArithOp::Rem => BinOp::Rem,
+            hir_def::expr::ArithOp::Shl => BinOp::Shl,
+            hir_def::expr::ArithOp::Shr => BinOp::Shr,
+            hir_def::expr::ArithOp::BitXor => BinOp::BitXor,
+            hir_def::expr::ArithOp::BitOr => BinOp::BitOr,
+            hir_def::expr::ArithOp::BitAnd => BinOp::BitAnd,
+        }
+    }
+}
+
+impl From<hir_def::expr::CmpOp> for BinOp {
+    fn from(value: hir_def::expr::CmpOp) -> Self {
+        match value {
+            hir_def::expr::CmpOp::Eq { negated: false } => BinOp::Eq,
+            hir_def::expr::CmpOp::Eq { negated: true } => BinOp::Ne,
+            hir_def::expr::CmpOp::Ord { ordering: Ordering::Greater, strict: false } => BinOp::Ge,
+            hir_def::expr::CmpOp::Ord { ordering: Ordering::Greater, strict: true } => BinOp::Gt,
+            hir_def::expr::CmpOp::Ord { ordering: Ordering::Less, strict: false } => BinOp::Le,
+            hir_def::expr::CmpOp::Ord { ordering: Ordering::Less, strict: true } => BinOp::Lt,
+        }
+    }
+}
+
+impl From<Operand> for Rvalue {
+    fn from(x: Operand) -> Self {
+        Self::Use(x)
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum CastKind {
+    /// An exposing pointer to address cast. A cast between a pointer and an integer type, or
+    /// between a function pointer and an integer type.
+    /// See the docs on `expose_addr` for more details.
+    PointerExposeAddress,
+    /// An address-to-pointer cast that picks up an exposed provenance.
+    /// See the docs on `from_exposed_addr` for more details.
+    PointerFromExposedAddress,
+    /// All sorts of pointer-to-pointer casts. Note that reference-to-raw-ptr casts are
+    /// translated into `&raw mut/const *r`, i.e., they are not actually casts.
+    Pointer(PointerCast),
+    /// Cast into a dyn* object.
+    DynStar,
+    IntToInt,
+    FloatToInt,
+    FloatToFloat,
+    IntToFloat,
+    PtrToPtr,
+    FnPtrToPtr,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum Rvalue {
+    /// Yields the operand unchanged
+    Use(Operand),
+
+    /// Creates an array where each element is the value of the operand.
+    ///
+    /// This is the cause of a bug in the case where the repetition count is zero because the value
+    /// is not dropped, see [#74836].
+    ///
+    /// Corresponds to source code like `[x; 32]`.
+    ///
+    /// [#74836]: https://github.com/rust-lang/rust/issues/74836
+    //Repeat(Operand, ty::Const),
+
+    /// Creates a reference of the indicated kind to the place.
+    ///
+    /// There is not much to document here, because besides the obvious parts the semantics of this
+    /// are essentially entirely a part of the aliasing model. There are many UCG issues discussing
+    /// exactly what the behavior of this operation should be.
+    ///
+    /// `Shallow` borrows are disallowed after drop lowering.
+    Ref(BorrowKind, Place),
+
+    /// Creates a pointer/reference to the given thread local.
+    ///
+    /// The yielded type is a `*mut T` if the static is mutable, otherwise if the static is extern a
+    /// `*const T`, and if neither of those apply a `&T`.
+    ///
+    /// **Note:** This is a runtime operation that actually executes code and is in this sense more
+    /// like a function call. Also, eliminating dead stores of this rvalue causes `fn main() {}` to
+    /// SIGILL for some reason that I (JakobDegen) never got a chance to look into.
+    ///
+    /// **Needs clarification**: Are there weird additional semantics here related to the runtime
+    /// nature of this operation?
+    //ThreadLocalRef(DefId),
+
+    /// Creates a pointer with the indicated mutability to the place.
+    ///
+    /// This is generated by pointer casts like `&v as *const _` or raw address of expressions like
+    /// `&raw v` or `addr_of!(v)`.
+    ///
+    /// Like with references, the semantics of this operation are heavily dependent on the aliasing
+    /// model.
+    //AddressOf(Mutability, Place),
+
+    /// Yields the length of the place, as a `usize`.
+    ///
+    /// If the type of the place is an array, this is the array length. For slices (`[T]`, not
+    /// `&[T]`) this accesses the place's metadata to determine the length. This rvalue is
+    /// ill-formed for places of other types.
+    Len(Place),
+
+    /// Performs essentially all of the casts that can be performed via `as`.
+    ///
+    /// This allows for casts from/to a variety of types.
+    ///
+    /// **FIXME**: Document exactly which `CastKind`s allow which types of casts. Figure out why
+    /// `ArrayToPointer` and `MutToConstPointer` are special.
+    Cast(CastKind, Operand, Ty),
+
+    /// * `Offset` has the same semantics as [`offset`](pointer::offset), except that the second
+    ///   parameter may be a `usize` as well.
+    /// * The comparison operations accept `bool`s, `char`s, signed or unsigned integers, floats,
+    ///   raw pointers, or function pointers and return a `bool`. The types of the operands must be
+    ///   matching, up to the usual caveat of the lifetimes in function pointers.
+    /// * Left and right shift operations accept signed or unsigned integers not necessarily of the
+    ///   same type and return a value of the same type as their LHS. Like in Rust, the RHS is
+    ///   truncated as needed.
+    /// * The `Bit*` operations accept signed integers, unsigned integers, or bools with matching
+    ///   types and return a value of that type.
+    /// * The remaining operations accept signed integers, unsigned integers, or floats with
+    ///   matching types and return a value of that type.
+    //BinaryOp(BinOp, Box<(Operand, Operand)>),
+
+    /// Same as `BinaryOp`, but yields `(T, bool)` with a `bool` indicating an error condition.
+    ///
+    /// When overflow checking is disabled and we are generating run-time code, the error condition
+    /// is false. Otherwise, and always during CTFE, the error condition is determined as described
+    /// below.
+    ///
+    /// For addition, subtraction, and multiplication on integers the error condition is set when
+    /// the infinite precision result would be unequal to the actual result.
+    ///
+    /// For shift operations on integers the error condition is set when the value of right-hand
+    /// side is greater than or equal to the number of bits in the type of the left-hand side, or
+    /// when the value of right-hand side is negative.
+    ///
+    /// Other combinations of types and operators are unsupported.
+    CheckedBinaryOp(BinOp, Operand, Operand),
+
+    /// Computes a value as described by the operation.
+    //NullaryOp(NullOp, Ty),
+
+    /// Exactly like `BinaryOp`, but less operands.
+    ///
+    /// Also does two's-complement arithmetic. Negation requires a signed integer or a float;
+    /// bitwise not requires a signed integer, unsigned integer, or bool. Both operation kinds
+    /// return a value with the same type as their operand.
+    UnaryOp(UnOp, Operand),
+
+    /// Computes the discriminant of the place, returning it as an integer of type
+    /// [`discriminant_ty`]. Returns zero for types without discriminant.
+    ///
+    /// The validity requirements for the underlying value are undecided for this rvalue, see
+    /// [#91095]. Note too that the value of the discriminant is not the same thing as the
+    /// variant index; use [`discriminant_for_variant`] to convert.
+    ///
+    /// [`discriminant_ty`]: crate::ty::Ty::discriminant_ty
+    /// [#91095]: https://github.com/rust-lang/rust/issues/91095
+    /// [`discriminant_for_variant`]: crate::ty::Ty::discriminant_for_variant
+    Discriminant(Place),
+
+    /// Creates an aggregate value, like a tuple or struct.
+    ///
+    /// This is needed because dataflow analysis needs to distinguish
+    /// `dest = Foo { x: ..., y: ... }` from `dest.x = ...; dest.y = ...;` in the case that `Foo`
+    /// has a destructor.
+    ///
+    /// Disallowed after deaggregation for all aggregate kinds except `Array` and `Generator`. After
+    /// generator lowering, `Generator` aggregate kinds are disallowed too.
+    Aggregate(AggregateKind, Vec<Operand>),
+
+    /// Transmutes a `*mut u8` into shallow-initialized `Box<T>`.
+    ///
+    /// This is different from a normal transmute because dataflow analysis will treat the box as
+    /// initialized but its content as uninitialized. Like other pointer casts, this in general
+    /// affects alias analysis.
+    ShallowInitBox(Operand, Ty),
+
+    /// A CopyForDeref is equivalent to a read from a place at the
+    /// codegen level, but is treated specially by drop elaboration. When such a read happens, it
+    /// is guaranteed (via nature of the mir_opt `Derefer` in rustc_mir_transform/src/deref_separator)
+    /// that the only use of the returned value is a deref operation, immediately
+    /// followed by one or more projections. Drop elaboration treats this rvalue as if the
+    /// read never happened and just projects further. This allows simplifying various MIR
+    /// optimizations and codegen backends that previously had to handle deref operations anywhere
+    /// in a place.
+    CopyForDeref(Place),
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum Statement {
+    Assign(Place, Rvalue),
+    //FakeRead(Box<(FakeReadCause, Place)>),
+    //SetDiscriminant {
+    //    place: Box<Place>,
+    //    variant_index: VariantIdx,
+    //},
+    Deinit(Place),
+    StorageLive(LocalId),
+    StorageDead(LocalId),
+    //Retag(RetagKind, Box<Place>),
+    //AscribeUserType(Place, UserTypeProjection, Variance),
+    //Intrinsic(Box<NonDivergingIntrinsic>),
+    Nop,
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct BasicBlock {
+    /// List of statements in this block.
+    pub statements: Vec<Statement>,
+
+    /// Terminator for this block.
+    ///
+    /// N.B., this should generally ONLY be `None` during construction.
+    /// Therefore, you should generally access it via the
+    /// `terminator()` or `terminator_mut()` methods. The only
+    /// exception is that certain passes, such as `simplify_cfg`, swap
+    /// out the terminator temporarily with `None` while they continue
+    /// to recurse over the set of basic blocks.
+    pub terminator: Option<Terminator>,
+
+    /// If true, this block lies on an unwind path. This is used
+    /// during codegen where distinct kinds of basic blocks may be
+    /// generated (particularly for MSVC cleanup). Unwind blocks must
+    /// only branch to other unwind blocks.
+    pub is_cleanup: bool,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct MirBody {
+    pub basic_blocks: Arena<BasicBlock>,
+    pub locals: Arena<Local>,
+    pub start_block: BasicBlockId,
+    pub owner: DefWithBodyId,
+    pub arg_count: usize,
+}
+
+impl MirBody {}
+
+fn const_as_usize(c: &Const) -> usize {
+    try_const_usize(c).unwrap() as usize
+}

--- a/crates/hir-ty/src/mir/eval.rs
+++ b/crates/hir-ty/src/mir/eval.rs
@@ -1,0 +1,1245 @@
+//! This module provides a MIR interpreter, which is used in const eval.
+
+use std::{borrow::Cow, collections::HashMap, iter};
+
+use base_db::CrateId;
+use chalk_ir::{
+    fold::{FallibleTypeFolder, TypeFoldable, TypeSuperFoldable},
+    DebruijnIndex, TyKind,
+};
+use hir_def::{
+    builtin_type::BuiltinType,
+    lang_item::{lang_attr, LangItem},
+    layout::{Layout, LayoutError, RustcEnumVariantIdx, TagEncoding, Variants},
+    AdtId, DefWithBodyId, EnumVariantId, FunctionId, HasModule, Lookup, VariantId,
+};
+use intern::Interned;
+use la_arena::ArenaMap;
+
+use crate::{
+    consteval::{intern_const_scalar, ConstEvalError},
+    db::HirDatabase,
+    from_placeholder_idx,
+    infer::{normalize, PointerCast},
+    layout::layout_of_ty,
+    mapping::from_chalk,
+    method_resolution::lookup_impl_method,
+    CallableDefId, Const, ConstScalar, Interner, MemoryMap, Substitution, Ty, TyBuilder, TyExt,
+};
+
+use super::{
+    const_as_usize, return_slot, AggregateKind, BinOp, CastKind, LocalId, MirBody, MirLowerError,
+    Operand, Place, ProjectionElem, Rvalue, Statement, Terminator, UnOp,
+};
+
+pub struct Evaluator<'a> {
+    db: &'a dyn HirDatabase,
+    stack: Vec<u8>,
+    heap: Vec<u8>,
+    crate_id: CrateId,
+    // FIXME: This is a workaround, see the comment on `interpret_mir`
+    assert_placeholder_ty_is_unused: bool,
+    /// A general limit on execution, to prevent non terminating programs from breaking r-a main process
+    execution_limit: usize,
+    /// An additional limit on stack depth, to prevent stack overflow
+    stack_depth_limit: usize,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum Address {
+    Stack(usize),
+    Heap(usize),
+}
+
+use Address::*;
+
+struct Interval {
+    addr: Address,
+    size: usize,
+}
+
+impl Interval {
+    fn new(addr: Address, size: usize) -> Self {
+        Self { addr, size }
+    }
+
+    fn get<'a>(&self, memory: &'a Evaluator<'a>) -> Result<&'a [u8]> {
+        memory.read_memory(self.addr, self.size)
+    }
+}
+
+enum IntervalOrOwned {
+    Owned(Vec<u8>),
+    Borrowed(Interval),
+}
+impl IntervalOrOwned {
+    pub(crate) fn to_vec(self, memory: &Evaluator<'_>) -> Result<Vec<u8>> {
+        Ok(match self {
+            IntervalOrOwned::Owned(o) => o,
+            IntervalOrOwned::Borrowed(b) => b.get(memory)?.to_vec(),
+        })
+    }
+}
+
+macro_rules! from_bytes {
+    ($ty:tt, $value:expr) => {
+        ($ty::from_le_bytes(match ($value).try_into() {
+            Ok(x) => x,
+            Err(_) => return Err(MirEvalError::TypeError("mismatched size")),
+        }))
+    };
+}
+
+impl Address {
+    fn from_bytes(x: &[u8]) -> Result<Self> {
+        Ok(Address::from_usize(from_bytes!(usize, x)))
+    }
+
+    fn from_usize(x: usize) -> Self {
+        if x > usize::MAX / 2 {
+            Stack(usize::MAX - x)
+        } else {
+            Heap(x)
+        }
+    }
+
+    fn to_bytes(&self) -> Vec<u8> {
+        usize::to_le_bytes(self.to_usize()).to_vec()
+    }
+
+    fn to_usize(&self) -> usize {
+        let as_num = match self {
+            Stack(x) => usize::MAX - *x,
+            Heap(x) => *x,
+        };
+        as_num
+    }
+
+    fn map(&self, f: impl FnOnce(usize) -> usize) -> Address {
+        match self {
+            Stack(x) => Stack(f(*x)),
+            Heap(x) => Heap(f(*x)),
+        }
+    }
+
+    fn offset(&self, offset: usize) -> Address {
+        self.map(|x| x + offset)
+    }
+}
+
+#[derive(Clone, PartialEq, Eq)]
+pub enum MirEvalError {
+    ConstEvalError(Box<ConstEvalError>),
+    LayoutError(LayoutError, Ty),
+    /// Means that code had type errors (or mismatched args) and we shouldn't generate mir in first place.
+    TypeError(&'static str),
+    /// Means that code had undefined behavior. We don't try to actively detect UB, but if it was detected
+    /// then use this type of error.
+    UndefinedBehavior(&'static str),
+    Panic,
+    MirLowerError(FunctionId, MirLowerError),
+    TypeIsUnsized(Ty, &'static str),
+    NotSupported(String),
+    InvalidConst(Const),
+    InFunction(FunctionId, Box<MirEvalError>),
+    ExecutionLimitExceeded,
+    StackOverflow,
+    TargetDataLayoutNotAvailable,
+}
+
+impl std::fmt::Debug for MirEvalError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ConstEvalError(arg0) => f.debug_tuple("ConstEvalError").field(arg0).finish(),
+            Self::LayoutError(arg0, arg1) => {
+                f.debug_tuple("LayoutError").field(arg0).field(arg1).finish()
+            }
+            Self::TypeError(arg0) => f.debug_tuple("TypeError").field(arg0).finish(),
+            Self::UndefinedBehavior(arg0) => {
+                f.debug_tuple("UndefinedBehavior").field(arg0).finish()
+            }
+            Self::Panic => write!(f, "Panic"),
+            Self::TargetDataLayoutNotAvailable => write!(f, "TargetDataLayoutNotAvailable"),
+            Self::TypeIsUnsized(ty, it) => write!(f, "{ty:?} is unsized. {it} should be sized."),
+            Self::ExecutionLimitExceeded => write!(f, "execution limit exceeded"),
+            Self::StackOverflow => write!(f, "stack overflow"),
+            Self::MirLowerError(arg0, arg1) => {
+                f.debug_tuple("MirLowerError").field(arg0).field(arg1).finish()
+            }
+            Self::NotSupported(arg0) => f.debug_tuple("NotSupported").field(arg0).finish(),
+            Self::InvalidConst(arg0) => {
+                let data = &arg0.data(Interner);
+                f.debug_struct("InvalidConst").field("ty", &data.ty).field("value", &arg0).finish()
+            }
+            Self::InFunction(func, e) => {
+                let mut e = &**e;
+                let mut stack = vec![*func];
+                while let Self::InFunction(f, next_e) = e {
+                    e = &next_e;
+                    stack.push(*f);
+                }
+                f.debug_struct("WithStack").field("error", e).field("stack", &stack).finish()
+            }
+        }
+    }
+}
+
+macro_rules! not_supported {
+    ($x: expr) => {
+        return Err(MirEvalError::NotSupported(format!($x)))
+    };
+}
+
+impl From<ConstEvalError> for MirEvalError {
+    fn from(value: ConstEvalError) -> Self {
+        match value {
+            _ => MirEvalError::ConstEvalError(Box::new(value)),
+        }
+    }
+}
+
+type Result<T> = std::result::Result<T, MirEvalError>;
+
+struct Locals<'a> {
+    ptr: &'a ArenaMap<LocalId, Address>,
+    body: &'a MirBody,
+    subst: &'a Substitution,
+}
+
+pub fn interpret_mir(
+    db: &dyn HirDatabase,
+    body: &MirBody,
+    // FIXME: This is workaround. Ideally, const generics should have a separate body (issue #7434), but now
+    // they share their body with their parent, so in MIR lowering we have locals of the parent body, which
+    // might have placeholders. With this argument, we (wrongly) assume that every placeholder type has
+    // a zero size, hoping that they are all outside of our current body. Even without a fix for #7434, we can
+    // (and probably should) do better here, for example by excluding bindings outside of the target expression.
+    assert_placeholder_ty_is_unused: bool,
+) -> Result<Const> {
+    let ty = body.locals[return_slot()].ty.clone();
+    let mut evaluator =
+        Evaluator::new(db, body.owner.module(db.upcast()).krate(), assert_placeholder_ty_is_unused);
+    let bytes = evaluator.interpret_mir_with_no_arg(&body)?;
+    let memory_map = evaluator.create_memory_map(
+        &bytes,
+        &ty,
+        &Locals { ptr: &ArenaMap::new(), body: &body, subst: &Substitution::empty(Interner) },
+    )?;
+    return Ok(intern_const_scalar(ConstScalar::Bytes(bytes, memory_map), ty));
+}
+
+impl Evaluator<'_> {
+    pub fn new<'a>(
+        db: &'a dyn HirDatabase,
+        crate_id: CrateId,
+        assert_placeholder_ty_is_unused: bool,
+    ) -> Evaluator<'a> {
+        Evaluator {
+            stack: vec![0],
+            heap: vec![0],
+            db,
+            crate_id,
+            assert_placeholder_ty_is_unused,
+            stack_depth_limit: 100,
+            execution_limit: 100_000,
+        }
+    }
+
+    fn place_addr(&self, p: &Place, locals: &Locals<'_>) -> Result<Address> {
+        Ok(self.place_addr_and_ty(p, locals)?.0)
+    }
+
+    fn ptr_size(&self) -> usize {
+        match self.db.target_data_layout(self.crate_id) {
+            Some(x) => x.pointer_size.bytes_usize(),
+            None => 8,
+        }
+    }
+
+    fn place_addr_and_ty<'a>(&'a self, p: &Place, locals: &'a Locals<'a>) -> Result<(Address, Ty)> {
+        let mut addr = locals.ptr[p.local];
+        let mut ty: Ty =
+            self.ty_filler(&locals.body.locals[p.local].ty, locals.subst, locals.body.owner)?;
+        for proj in &p.projection {
+            match proj {
+                ProjectionElem::Deref => {
+                    match &ty.data(Interner).kind {
+                        TyKind::Ref(_, _, inner) => {
+                            ty = inner.clone();
+                        }
+                        _ => not_supported!("dereferencing smart pointers"),
+                    }
+                    let x = from_bytes!(usize, self.read_memory(addr, self.ptr_size())?);
+                    addr = Address::from_usize(x);
+                }
+                ProjectionElem::Index(op) => {
+                    let offset =
+                        from_bytes!(usize, self.read_memory(locals.ptr[*op], self.ptr_size())?);
+                    match &ty.data(Interner).kind {
+                        TyKind::Ref(_, _, inner) => match &inner.data(Interner).kind {
+                            TyKind::Slice(inner) => {
+                                ty = inner.clone();
+                                let ty_size = self.size_of_sized(
+                                    &ty,
+                                    locals,
+                                    "slice inner type should be sized",
+                                )?;
+                                let value = self.read_memory(addr, self.ptr_size() * 2)?;
+                                addr = Address::from_bytes(&value[0..8])?.offset(ty_size * offset);
+                            }
+                            x => not_supported!("MIR index for ref type {x:?}"),
+                        },
+                        TyKind::Array(inner, _) | TyKind::Slice(inner) => {
+                            ty = inner.clone();
+                            let ty_size = self.size_of_sized(
+                                &ty,
+                                locals,
+                                "array inner type should be sized",
+                            )?;
+                            addr = addr.offset(ty_size * offset);
+                        }
+                        x => not_supported!("MIR index for type {x:?}"),
+                    }
+                }
+                &ProjectionElem::TupleField(f) => match &ty.data(Interner).kind {
+                    TyKind::Tuple(_, subst) => {
+                        let layout = self.layout(&ty)?;
+                        ty = subst
+                            .as_slice(Interner)
+                            .get(f)
+                            .ok_or(MirEvalError::TypeError("not enough tuple fields"))?
+                            .assert_ty_ref(Interner)
+                            .clone();
+                        let offset = layout.fields.offset(f).bytes_usize();
+                        addr = addr.offset(offset);
+                    }
+                    _ => return Err(MirEvalError::TypeError("Only tuple has tuple fields")),
+                },
+                ProjectionElem::Field(f) => match &ty.data(Interner).kind {
+                    TyKind::Adt(adt, subst) => {
+                        let layout = self.layout_adt(adt.0, subst.clone())?;
+                        let variant_layout = match &layout.variants {
+                            Variants::Single { .. } => &layout,
+                            Variants::Multiple { variants, .. } => {
+                                &variants[match f.parent {
+                                    hir_def::VariantId::EnumVariantId(x) => {
+                                        RustcEnumVariantIdx(x.local_id)
+                                    }
+                                    _ => {
+                                        return Err(MirEvalError::TypeError(
+                                            "Multivariant layout only happens for enums",
+                                        ))
+                                    }
+                                }]
+                            }
+                        };
+                        ty = self.db.field_types(f.parent)[f.local_id]
+                            .clone()
+                            .substitute(Interner, subst);
+                        let offset = variant_layout
+                            .fields
+                            .offset(u32::from(f.local_id.into_raw()) as usize)
+                            .bytes_usize();
+                        addr = addr.offset(offset);
+                    }
+                    _ => return Err(MirEvalError::TypeError("Only adt has fields")),
+                },
+                ProjectionElem::ConstantIndex { .. } => {
+                    not_supported!("constant index")
+                }
+                ProjectionElem::Subslice { .. } => not_supported!("subslice"),
+                ProjectionElem::OpaqueCast(_) => not_supported!("opaque cast"),
+            }
+        }
+        Ok((addr, ty))
+    }
+
+    fn layout(&self, ty: &Ty) -> Result<Layout> {
+        layout_of_ty(self.db, ty, self.crate_id)
+            .map_err(|e| MirEvalError::LayoutError(e, ty.clone()))
+    }
+
+    fn layout_adt(&self, adt: AdtId, subst: Substitution) -> Result<Layout> {
+        self.db.layout_of_adt(adt, subst.clone()).map_err(|e| {
+            MirEvalError::LayoutError(e, TyKind::Adt(chalk_ir::AdtId(adt), subst).intern(Interner))
+        })
+    }
+
+    fn place_ty<'a>(&'a self, p: &Place, locals: &'a Locals<'a>) -> Result<Ty> {
+        Ok(self.place_addr_and_ty(p, locals)?.1)
+    }
+
+    fn operand_ty<'a>(&'a self, o: &'a Operand, locals: &'a Locals<'a>) -> Result<Ty> {
+        Ok(match o {
+            Operand::Copy(p) | Operand::Move(p) => self.place_ty(p, locals)?,
+            Operand::Constant(c) => c.data(Interner).ty.clone(),
+        })
+    }
+
+    fn interpret_mir(
+        &mut self,
+        body: &MirBody,
+        args: impl Iterator<Item = Vec<u8>>,
+        subst: Substitution,
+    ) -> Result<Vec<u8>> {
+        if let Some(x) = self.stack_depth_limit.checked_sub(1) {
+            self.stack_depth_limit = x;
+        } else {
+            return Err(MirEvalError::StackOverflow);
+        }
+        let mut current_block_idx = body.start_block;
+        let mut locals = Locals { ptr: &ArenaMap::new(), body: &body, subst: &subst };
+        let (locals_ptr, stack_size) = {
+            let mut stack_ptr = self.stack.len();
+            let addr = body
+                .locals
+                .iter()
+                .map(|(id, x)| {
+                    let size = self.size_of_sized(&x.ty, &locals, "no unsized local")?;
+                    let my_ptr = stack_ptr;
+                    stack_ptr += size;
+                    Ok((id, Stack(my_ptr)))
+                })
+                .collect::<Result<ArenaMap<LocalId, _>>>()?;
+            let stack_size = stack_ptr - self.stack.len();
+            (addr, stack_size)
+        };
+        locals.ptr = &locals_ptr;
+        self.stack.extend(iter::repeat(0).take(stack_size));
+        let mut remain_args = body.arg_count;
+        for ((_, addr), value) in locals_ptr.iter().skip(1).zip(args) {
+            self.write_memory(*addr, &value)?;
+            if remain_args == 0 {
+                return Err(MirEvalError::TypeError("more arguments provided"));
+            }
+            remain_args -= 1;
+        }
+        if remain_args > 0 {
+            return Err(MirEvalError::TypeError("not enough arguments provided"));
+        }
+        loop {
+            let current_block = &body.basic_blocks[current_block_idx];
+            if let Some(x) = self.execution_limit.checked_sub(1) {
+                self.execution_limit = x;
+            } else {
+                return Err(MirEvalError::ExecutionLimitExceeded);
+            }
+            for statement in &current_block.statements {
+                match statement {
+                    Statement::Assign(l, r) => {
+                        let addr = self.place_addr(l, &locals)?;
+                        let result = self.eval_rvalue(r, &locals)?.to_vec(&self)?;
+                        self.write_memory(addr, &result)?;
+                    }
+                    Statement::Deinit(_) => not_supported!("de-init statement"),
+                    Statement::StorageLive(_) => not_supported!("storage-live statement"),
+                    Statement::StorageDead(_) => not_supported!("storage-dead statement"),
+                    Statement::Nop => (),
+                }
+            }
+            let Some(terminator) = current_block.terminator.as_ref() else {
+                not_supported!("block without terminator");
+            };
+            match terminator {
+                Terminator::Goto { target } => {
+                    current_block_idx = *target;
+                }
+                Terminator::Call {
+                    func,
+                    args,
+                    destination,
+                    target,
+                    cleanup: _,
+                    from_hir_call: _,
+                } => {
+                    let fn_ty = self.operand_ty(func, &locals)?;
+                    match &fn_ty.data(Interner).kind {
+                        TyKind::FnDef(def, generic_args) => {
+                            let def: CallableDefId = from_chalk(self.db, *def);
+                            let generic_args = self.subst_filler(generic_args, &locals);
+                            match def {
+                                CallableDefId::FunctionId(def) => {
+                                    let arg_bytes = args
+                                        .iter()
+                                        .map(|x| {
+                                            Ok(self
+                                                .eval_operand(x, &locals)?
+                                                .get(&self)?
+                                                .to_owned())
+                                        })
+                                        .collect::<Result<Vec<_>>>()?
+                                        .into_iter();
+                                    let function_data = self.db.function_data(def);
+                                    let is_intrinsic = match &function_data.abi {
+                                        Some(abi) => *abi == Interned::new_str("rust-intrinsic"),
+                                        None => match def.lookup(self.db.upcast()).container {
+                                            hir_def::ItemContainerId::ExternBlockId(block) => {
+                                                let id = block.lookup(self.db.upcast()).id;
+                                                id.item_tree(self.db.upcast())[id.value]
+                                                    .abi
+                                                    .as_deref()
+                                                    == Some("rust-intrinsic")
+                                            }
+                                            _ => false,
+                                        },
+                                    };
+                                    let result = if is_intrinsic {
+                                        self.exec_intrinsic(
+                                            function_data
+                                                .name
+                                                .as_text()
+                                                .unwrap_or_default()
+                                                .as_str(),
+                                            arg_bytes,
+                                            generic_args,
+                                            &locals,
+                                        )?
+                                    } else if let Some(x) = self.detect_lang_function(def) {
+                                        self.exec_lang_item(x, arg_bytes)?
+                                    } else {
+                                        let trait_env = {
+                                            let Some(d) = body.owner.as_generic_def_id() else {
+                                                not_supported!("trait resolving in non generic def id");
+                                            };
+                                            self.db.trait_environment(d)
+                                        };
+                                        let (imp, generic_args) = lookup_impl_method(
+                                            self.db,
+                                            trait_env,
+                                            def,
+                                            generic_args.clone(),
+                                        );
+                                        let generic_args =
+                                            self.subst_filler(&generic_args, &locals);
+                                        let def = imp.into();
+                                        let mir_body = self
+                                            .db
+                                            .mir_body(def)
+                                            .map_err(|e| MirEvalError::MirLowerError(imp, e))?;
+                                        self.interpret_mir(&mir_body, arg_bytes, generic_args)
+                                            .map_err(|e| {
+                                                MirEvalError::InFunction(imp, Box::new(e))
+                                            })?
+                                    };
+                                    let dest_addr = self.place_addr(destination, &locals)?;
+                                    self.write_memory(dest_addr, &result)?;
+                                }
+                                CallableDefId::StructId(id) => {
+                                    let (size, variant_layout, tag) = self.layout_of_variant(
+                                        id.into(),
+                                        generic_args.clone(),
+                                        &locals,
+                                    )?;
+                                    let result = self.make_by_layout(
+                                        size,
+                                        &variant_layout,
+                                        tag,
+                                        args,
+                                        &locals,
+                                    )?;
+                                    let dest_addr = self.place_addr(destination, &locals)?;
+                                    self.write_memory(dest_addr, &result)?;
+                                }
+                                CallableDefId::EnumVariantId(id) => {
+                                    let (size, variant_layout, tag) = self.layout_of_variant(
+                                        id.into(),
+                                        generic_args.clone(),
+                                        &locals,
+                                    )?;
+                                    let result = self.make_by_layout(
+                                        size,
+                                        &variant_layout,
+                                        tag,
+                                        args,
+                                        &locals,
+                                    )?;
+                                    let dest_addr = self.place_addr(destination, &locals)?;
+                                    self.write_memory(dest_addr, &result)?;
+                                }
+                            }
+                            current_block_idx =
+                                target.expect("broken mir, function without target");
+                        }
+                        _ => not_supported!("unknown function type"),
+                    }
+                }
+                Terminator::SwitchInt { discr, targets } => {
+                    let val = u128::from_le_bytes(pad16(
+                        self.eval_operand(discr, &locals)?.get(&self)?,
+                        false,
+                    ));
+                    current_block_idx = targets.target_for_value(val);
+                }
+                Terminator::Return => {
+                    let ty = body.locals[return_slot()].ty.clone();
+                    self.stack_depth_limit += 1;
+                    return Ok(self
+                        .read_memory(
+                            locals.ptr[return_slot()],
+                            self.size_of_sized(&ty, &locals, "return type")?,
+                        )?
+                        .to_owned());
+                }
+                Terminator::Unreachable => {
+                    return Err(MirEvalError::UndefinedBehavior("unreachable executed"))
+                }
+                _ => not_supported!("unknown terminator"),
+            }
+        }
+    }
+
+    fn eval_rvalue<'a>(
+        &'a mut self,
+        r: &'a Rvalue,
+        locals: &'a Locals<'a>,
+    ) -> Result<IntervalOrOwned> {
+        use IntervalOrOwned::*;
+        Ok(match r {
+            Rvalue::Use(x) => Borrowed(self.eval_operand(x, locals)?),
+            Rvalue::Ref(_, p) => {
+                let addr = self.place_addr(p, locals)?;
+                Owned(addr.to_bytes())
+            }
+            Rvalue::Len(_) => not_supported!("rvalue len"),
+            Rvalue::UnaryOp(op, val) => {
+                let mut c = self.eval_operand(val, locals)?.get(&self)?;
+                let mut ty = self.operand_ty(val, locals)?;
+                while let TyKind::Ref(_, _, z) = ty.kind(Interner) {
+                    ty = z.clone();
+                    let size = self.size_of_sized(&ty, locals, "operand of unary op")?;
+                    c = self.read_memory(Address::from_bytes(c)?, size)?;
+                }
+                let mut c = c.to_vec();
+                if ty.as_builtin() == Some(BuiltinType::Bool) {
+                    c[0] = 1 - c[0];
+                } else {
+                    match op {
+                        UnOp::Not => c.iter_mut().for_each(|x| *x = !*x),
+                        UnOp::Neg => {
+                            c.iter_mut().for_each(|x| *x = !*x);
+                            for k in c.iter_mut() {
+                                let o;
+                                (*k, o) = k.overflowing_add(1);
+                                if !o {
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                }
+                Owned(c)
+            }
+            Rvalue::CheckedBinaryOp(op, lhs, rhs) => {
+                let lc = self.eval_operand(lhs, locals)?;
+                let rc = self.eval_operand(rhs, locals)?;
+                let mut lc = lc.get(&self)?;
+                let mut rc = rc.get(&self)?;
+                let mut ty = self.operand_ty(lhs, locals)?;
+                while let TyKind::Ref(_, _, z) = ty.kind(Interner) {
+                    ty = z.clone();
+                    let size = self.size_of_sized(&ty, locals, "operand of binary op")?;
+                    lc = self.read_memory(Address::from_bytes(lc)?, size)?;
+                    rc = self.read_memory(Address::from_bytes(rc)?, size)?;
+                }
+                let is_signed = matches!(ty.as_builtin(), Some(BuiltinType::Int(_)));
+                let l128 = i128::from_le_bytes(pad16(lc, is_signed));
+                let r128 = i128::from_le_bytes(pad16(rc, is_signed));
+                match op {
+                    BinOp::Ge | BinOp::Gt | BinOp::Le | BinOp::Lt | BinOp::Eq | BinOp::Ne => {
+                        let r = match op {
+                            BinOp::Ge => l128 >= r128,
+                            BinOp::Gt => l128 > r128,
+                            BinOp::Le => l128 <= r128,
+                            BinOp::Lt => l128 < r128,
+                            BinOp::Eq => l128 == r128,
+                            BinOp::Ne => l128 != r128,
+                            _ => unreachable!(),
+                        };
+                        let r = r as u8;
+                        Owned(vec![r])
+                    }
+                    BinOp::BitAnd
+                    | BinOp::BitOr
+                    | BinOp::BitXor
+                    | BinOp::Add
+                    | BinOp::Mul
+                    | BinOp::Div
+                    | BinOp::Rem
+                    | BinOp::Sub => {
+                        let r = match op {
+                            BinOp::Add => l128.overflowing_add(r128).0,
+                            BinOp::Mul => l128.overflowing_mul(r128).0,
+                            BinOp::Div => l128.checked_div(r128).ok_or(MirEvalError::Panic)?,
+                            BinOp::Rem => l128.checked_rem(r128).ok_or(MirEvalError::Panic)?,
+                            BinOp::Sub => l128.overflowing_sub(r128).0,
+                            BinOp::BitAnd => l128 & r128,
+                            BinOp::BitOr => l128 | r128,
+                            BinOp::BitXor => l128 ^ r128,
+                            _ => unreachable!(),
+                        };
+                        let r = r.to_le_bytes();
+                        for &k in &r[lc.len()..] {
+                            if k != 0 && (k != 255 || !is_signed) {
+                                return Err(MirEvalError::Panic);
+                            }
+                        }
+                        Owned(r[0..lc.len()].into())
+                    }
+                    BinOp::Shl | BinOp::Shr => {
+                        let shift_amout = if r128 < 0 {
+                            return Err(MirEvalError::Panic);
+                        } else if r128 > 128 {
+                            return Err(MirEvalError::Panic);
+                        } else {
+                            r128 as u8
+                        };
+                        let r = match op {
+                            BinOp::Shl => l128 << shift_amout,
+                            BinOp::Shr => l128 >> shift_amout,
+                            _ => unreachable!(),
+                        };
+                        Owned(r.to_le_bytes()[0..lc.len()].into())
+                    }
+                    BinOp::Offset => not_supported!("offset binop"),
+                }
+            }
+            Rvalue::Discriminant(p) => {
+                let ty = self.place_ty(p, locals)?;
+                let bytes = self.eval_place(p, locals)?.get(&self)?;
+                let layout = self.layout(&ty)?;
+                match layout.variants {
+                    Variants::Single { .. } => Owned(0u128.to_le_bytes().to_vec()),
+                    Variants::Multiple { tag, tag_encoding, .. } => {
+                        let Some(target_data_layout) = self.db.target_data_layout(self.crate_id) else {
+                            not_supported!("missing target data layout");
+                        };
+                        let size = tag.size(&*target_data_layout).bytes_usize();
+                        let offset = layout.fields.offset(0).bytes_usize(); // The only field on enum variants is the tag field
+                        match tag_encoding {
+                            TagEncoding::Direct => {
+                                let tag = &bytes[offset..offset + size];
+                                Owned(pad16(tag, false).to_vec())
+                            }
+                            TagEncoding::Niche { untagged_variant, niche_start, .. } => {
+                                let tag = &bytes[offset..offset + size];
+                                let candidate_discriminant = i128::from_le_bytes(pad16(tag, false))
+                                    .wrapping_sub(niche_start as i128);
+                                let enum_id = match ty.kind(Interner) {
+                                    TyKind::Adt(e, _) => match e.0 {
+                                        AdtId::EnumId(e) => e,
+                                        _ => not_supported!("Non enum with multi variant layout"),
+                                    },
+                                    _ => not_supported!("Non adt with multi variant layout"),
+                                };
+                                let enum_data = self.db.enum_data(enum_id);
+                                let result = 'b: {
+                                    for (local_id, _) in enum_data.variants.iter() {
+                                        if candidate_discriminant
+                                            == self.db.const_eval_discriminant(EnumVariantId {
+                                                parent: enum_id,
+                                                local_id,
+                                            })?
+                                        {
+                                            break 'b candidate_discriminant;
+                                        }
+                                    }
+                                    self.db.const_eval_discriminant(EnumVariantId {
+                                        parent: enum_id,
+                                        local_id: untagged_variant.0,
+                                    })?
+                                };
+                                Owned(result.to_le_bytes().to_vec())
+                            }
+                        }
+                    }
+                }
+            }
+            Rvalue::ShallowInitBox(_, _) => not_supported!("shallow init box"),
+            Rvalue::CopyForDeref(_) => not_supported!("copy for deref"),
+            Rvalue::Aggregate(kind, values) => match kind {
+                AggregateKind::Array(_) => {
+                    let mut r = vec![];
+                    for x in values {
+                        let value = self.eval_operand(x, locals)?.get(&self)?;
+                        r.extend(value);
+                    }
+                    Owned(r)
+                }
+                AggregateKind::Tuple(ty) => {
+                    let layout = self.layout(&ty)?;
+                    Owned(self.make_by_layout(
+                        layout.size.bytes_usize(),
+                        &layout,
+                        None,
+                        values,
+                        locals,
+                    )?)
+                }
+                AggregateKind::Union(x, f) => {
+                    let layout = self.layout_adt((*x).into(), Substitution::empty(Interner))?;
+                    let offset = layout
+                        .fields
+                        .offset(u32::from(f.local_id.into_raw()) as usize)
+                        .bytes_usize();
+                    let op = self.eval_operand(&values[0], locals)?.get(&self)?;
+                    let mut result = vec![0; layout.size.bytes_usize()];
+                    result[offset..offset + op.len()].copy_from_slice(op);
+                    Owned(result)
+                }
+                AggregateKind::Adt(x, subst) => {
+                    let (size, variant_layout, tag) =
+                        self.layout_of_variant(*x, subst.clone(), locals)?;
+                    Owned(self.make_by_layout(size, &variant_layout, tag, values, locals)?)
+                }
+            },
+            Rvalue::Cast(kind, operand, target_ty) => match kind {
+                CastKind::PointerExposeAddress => not_supported!("exposing pointer address"),
+                CastKind::PointerFromExposedAddress => {
+                    not_supported!("creating pointer from exposed address")
+                }
+                CastKind::Pointer(cast) => match cast {
+                    PointerCast::Unsize => {
+                        let current_ty = self.operand_ty(operand, locals)?;
+                        match &target_ty.data(Interner).kind {
+                            TyKind::Raw(_, ty) | TyKind::Ref(_, _, ty) => {
+                                match &ty.data(Interner).kind {
+                                    TyKind::Slice(_) => match &current_ty.data(Interner).kind {
+                                        TyKind::Raw(_, ty) | TyKind::Ref(_, _, ty) => {
+                                            match &ty.data(Interner).kind {
+                                                TyKind::Array(_, size) => {
+                                                    let addr = self
+                                                        .eval_operand(operand, locals)?
+                                                        .get(&self)?;
+                                                    let len = const_as_usize(size);
+                                                    let mut r = Vec::with_capacity(16);
+                                                    r.extend(addr.iter().copied());
+                                                    r.extend(len.to_le_bytes().into_iter());
+                                                    Owned(r)
+                                                }
+                                                _ => {
+                                                    not_supported!("slice unsizing from non arrays")
+                                                }
+                                            }
+                                        }
+                                        _ => not_supported!("slice unsizing from non pointers"),
+                                    },
+                                    TyKind::Dyn(_) => not_supported!("dyn pointer unsize cast"),
+                                    _ => not_supported!("unknown unsized cast"),
+                                }
+                            }
+                            _ => not_supported!("unsized cast on unknown pointer type"),
+                        }
+                    }
+                    x => not_supported!("pointer cast {x:?}"),
+                },
+                CastKind::DynStar => not_supported!("dyn star cast"),
+                CastKind::IntToInt => {
+                    // FIXME: handle signed cast
+                    let current = pad16(self.eval_operand(operand, locals)?.get(&self)?, false);
+                    let dest_size =
+                        self.size_of_sized(target_ty, locals, "destination of int to int cast")?;
+                    Owned(current[0..dest_size].to_vec())
+                }
+                CastKind::FloatToInt => not_supported!("float to int cast"),
+                CastKind::FloatToFloat => not_supported!("float to float cast"),
+                CastKind::IntToFloat => not_supported!("float to int cast"),
+                CastKind::PtrToPtr => not_supported!("ptr to ptr cast"),
+                CastKind::FnPtrToPtr => not_supported!("fn ptr to ptr cast"),
+            },
+        })
+    }
+
+    fn layout_of_variant(
+        &mut self,
+        x: VariantId,
+        subst: Substitution,
+        locals: &Locals<'_>,
+    ) -> Result<(usize, Layout, Option<(usize, usize, i128)>)> {
+        let adt = x.adt_id();
+        if let DefWithBodyId::VariantId(f) = locals.body.owner {
+            if let VariantId::EnumVariantId(x) = x {
+                if AdtId::from(f.parent) == adt {
+                    // Computing the exact size of enums require resolving the enum discriminants. In order to prevent loops (and
+                    // infinite sized type errors) we use a dummy layout
+                    let i = self.db.const_eval_discriminant(x)?;
+                    return Ok((16, self.layout(&TyBuilder::unit())?, Some((0, 16, i))));
+                }
+            }
+        }
+        let layout = self.layout_adt(adt, subst)?;
+        Ok(match layout.variants {
+            Variants::Single { .. } => (layout.size.bytes_usize(), layout, None),
+            Variants::Multiple { variants, tag, tag_encoding, .. } => {
+                let cx = self
+                    .db
+                    .target_data_layout(self.crate_id)
+                    .ok_or(MirEvalError::TargetDataLayoutNotAvailable)?;
+                let enum_variant_id = match x {
+                    VariantId::EnumVariantId(x) => x,
+                    _ => not_supported!("multi variant layout for non-enums"),
+                };
+                let rustc_enum_variant_idx = RustcEnumVariantIdx(enum_variant_id.local_id);
+                let mut discriminant = self.db.const_eval_discriminant(enum_variant_id)?;
+                let variant_layout = variants[rustc_enum_variant_idx].clone();
+                let have_tag = match tag_encoding {
+                    TagEncoding::Direct => true,
+                    TagEncoding::Niche { untagged_variant, niche_variants: _, niche_start } => {
+                        discriminant = discriminant.wrapping_add(niche_start as i128);
+                        untagged_variant != rustc_enum_variant_idx
+                    }
+                };
+                (
+                    layout.size.bytes_usize(),
+                    variant_layout,
+                    if have_tag {
+                        Some((
+                            layout.fields.offset(0).bytes_usize(),
+                            tag.size(&*cx).bytes_usize(),
+                            discriminant,
+                        ))
+                    } else {
+                        None
+                    },
+                )
+            }
+        })
+    }
+
+    fn make_by_layout(
+        &mut self,
+        size: usize, // Not neccessarily equal to variant_layout.size
+        variant_layout: &Layout,
+        tag: Option<(usize, usize, i128)>,
+        values: &Vec<Operand>,
+        locals: &Locals<'_>,
+    ) -> Result<Vec<u8>> {
+        let mut result = vec![0; size];
+        if let Some((offset, size, value)) = tag {
+            result[offset..offset + size].copy_from_slice(&value.to_le_bytes()[0..size]);
+        }
+        for (i, op) in values.iter().enumerate() {
+            let offset = variant_layout.fields.offset(i).bytes_usize();
+            let op = self.eval_operand(op, locals)?.get(&self)?;
+            result[offset..offset + op.len()].copy_from_slice(op);
+        }
+        Ok(result)
+    }
+
+    fn eval_operand(&mut self, x: &Operand, locals: &Locals<'_>) -> Result<Interval> {
+        Ok(match x {
+            Operand::Copy(p) | Operand::Move(p) => self.eval_place(p, locals)?,
+            Operand::Constant(konst) => {
+                let data = &konst.data(Interner);
+                match &data.value {
+                    chalk_ir::ConstValue::BoundVar(b) => {
+                        let c = locals
+                            .subst
+                            .as_slice(Interner)
+                            .get(b.index)
+                            .ok_or(MirEvalError::TypeError("missing generic arg"))?
+                            .assert_const_ref(Interner);
+                        self.eval_operand(&Operand::Constant(c.clone()), locals)?
+                    }
+                    chalk_ir::ConstValue::InferenceVar(_) => {
+                        not_supported!("inference var constant")
+                    }
+                    chalk_ir::ConstValue::Placeholder(_) => not_supported!("placeholder constant"),
+                    chalk_ir::ConstValue::Concrete(c) => match &c.interned {
+                        ConstScalar::Bytes(v, memory_map) => {
+                            let mut v: Cow<'_, [u8]> = Cow::Borrowed(v);
+                            let patch_map = memory_map.transform_addresses(|b| {
+                                let addr = self.heap_allocate(b.len());
+                                self.write_memory(addr, b)?;
+                                Ok(addr.to_usize())
+                            })?;
+                            let size = self.size_of(&data.ty, locals)?.unwrap_or(v.len());
+                            if size != v.len() {
+                                // Handle self enum
+                                if size == 16 && v.len() < 16 {
+                                    v = Cow::Owned(pad16(&v, false).to_vec());
+                                } else if size < 16 && v.len() == 16 {
+                                    v = Cow::Owned(v[0..size].to_vec());
+                                } else {
+                                    return Err(MirEvalError::InvalidConst(konst.clone()));
+                                }
+                            }
+                            let addr = self.heap_allocate(size);
+                            self.write_memory(addr, &v)?;
+                            self.patch_addresses(&patch_map, addr, &data.ty, locals)?;
+                            Interval::new(addr, size)
+                        }
+                        ConstScalar::Unknown => not_supported!("evaluating unknown const"),
+                    },
+                }
+            }
+        })
+    }
+
+    fn eval_place(&mut self, p: &Place, locals: &Locals<'_>) -> Result<Interval> {
+        let addr = self.place_addr(p, locals)?;
+        Ok(Interval::new(
+            addr,
+            self.size_of_sized(&self.place_ty(p, locals)?, locals, "type of this place")?,
+        ))
+    }
+
+    fn read_memory(&self, addr: Address, size: usize) -> Result<&[u8]> {
+        let (mem, pos) = match addr {
+            Stack(x) => (&self.stack, x),
+            Heap(x) => (&self.heap, x),
+        };
+        mem.get(pos..pos + size).ok_or(MirEvalError::UndefinedBehavior("out of bound memory read"))
+    }
+
+    fn write_memory(&mut self, addr: Address, r: &[u8]) -> Result<()> {
+        let (mem, pos) = match addr {
+            Stack(x) => (&mut self.stack, x),
+            Heap(x) => (&mut self.heap, x),
+        };
+        mem.get_mut(pos..pos + r.len())
+            .ok_or(MirEvalError::UndefinedBehavior("out of bound memory write"))?
+            .copy_from_slice(r);
+        Ok(())
+    }
+
+    fn size_of(&self, ty: &Ty, locals: &Locals<'_>) -> Result<Option<usize>> {
+        if let DefWithBodyId::VariantId(f) = locals.body.owner {
+            if let Some((adt, _)) = ty.as_adt() {
+                if AdtId::from(f.parent) == adt {
+                    // Computing the exact size of enums require resolving the enum discriminants. In order to prevent loops (and
+                    // infinite sized type errors) we use a dummy size
+                    return Ok(Some(16));
+                }
+            }
+        }
+        let ty = &self.ty_filler(ty, locals.subst, locals.body.owner)?;
+        let layout = self.layout(ty);
+        if self.assert_placeholder_ty_is_unused {
+            if matches!(layout, Err(MirEvalError::LayoutError(LayoutError::HasPlaceholder, _))) {
+                return Ok(Some(0));
+            }
+        }
+        let layout = layout?;
+        Ok(layout.is_sized().then(|| layout.size.bytes_usize()))
+    }
+
+    /// A version of `self.size_of` which returns error if the type is unsized. `what` argument should
+    /// be something that complete this: `error: type {ty} was unsized. {what} should be sized`
+    fn size_of_sized(&self, ty: &Ty, locals: &Locals<'_>, what: &'static str) -> Result<usize> {
+        match self.size_of(ty, locals)? {
+            Some(x) => Ok(x),
+            None => Err(MirEvalError::TypeIsUnsized(ty.clone(), what)),
+        }
+    }
+
+    /// Uses `ty_filler` to fill an entire subst
+    fn subst_filler(&self, subst: &Substitution, locals: &Locals<'_>) -> Substitution {
+        Substitution::from_iter(
+            Interner,
+            subst.iter(Interner).map(|x| match x.data(Interner) {
+                chalk_ir::GenericArgData::Ty(ty) => {
+                    let Ok(ty) = self.ty_filler(ty, locals.subst, locals.body.owner) else {
+                        return x.clone();
+                    };
+                    chalk_ir::GenericArgData::Ty(ty).intern(Interner)
+                }
+                _ => x.clone(),
+            }),
+        )
+    }
+
+    /// This function substitutes placeholders of the body with the provided subst, effectively plays
+    /// the rule of monomorphization. In addition to placeholders, it substitutes opaque types (return
+    /// position impl traits) with their underlying type.
+    fn ty_filler(&self, ty: &Ty, subst: &Substitution, owner: DefWithBodyId) -> Result<Ty> {
+        struct Filler<'a> {
+            db: &'a dyn HirDatabase,
+            subst: &'a Substitution,
+            skip_params: usize,
+        }
+        impl FallibleTypeFolder<Interner> for Filler<'_> {
+            type Error = MirEvalError;
+
+            fn as_dyn(&mut self) -> &mut dyn FallibleTypeFolder<Interner, Error = Self::Error> {
+                self
+            }
+
+            fn interner(&self) -> Interner {
+                Interner
+            }
+
+            fn try_fold_ty(
+                &mut self,
+                ty: Ty,
+                outer_binder: DebruijnIndex,
+            ) -> std::result::Result<Ty, Self::Error> {
+                match ty.kind(Interner) {
+                    TyKind::OpaqueType(id, subst) => {
+                        let impl_trait_id = self.db.lookup_intern_impl_trait_id((*id).into());
+                        match impl_trait_id {
+                            crate::ImplTraitId::ReturnTypeImplTrait(func, idx) => {
+                                let infer = self.db.infer(func.into());
+                                let filler = &mut Filler { db: self.db, subst, skip_params: 0 };
+                                filler.try_fold_ty(infer.type_of_rpit[idx].clone(), outer_binder)
+                            }
+                            crate::ImplTraitId::AsyncBlockTypeImplTrait(_, _) => {
+                                not_supported!("async block impl trait");
+                            }
+                        }
+                    }
+                    _ => ty.try_super_fold_with(self.as_dyn(), outer_binder),
+                }
+            }
+
+            fn try_fold_free_placeholder_ty(
+                &mut self,
+                idx: chalk_ir::PlaceholderIndex,
+                _outer_binder: DebruijnIndex,
+            ) -> std::result::Result<Ty, Self::Error> {
+                let x = from_placeholder_idx(self.db, idx);
+                Ok(self
+                    .subst
+                    .as_slice(Interner)
+                    .get((u32::from(x.local_id.into_raw()) as usize) + self.skip_params)
+                    .and_then(|x| x.ty(Interner))
+                    .ok_or(MirEvalError::TypeError("Generic arg not provided"))?
+                    .clone())
+            }
+        }
+        let filler = &mut Filler { db: self.db, subst, skip_params: 0 };
+        Ok(normalize(self.db, owner, ty.clone().try_fold_with(filler, DebruijnIndex::INNERMOST)?))
+    }
+
+    fn heap_allocate(&mut self, s: usize) -> Address {
+        let pos = self.heap.len();
+        self.heap.extend(iter::repeat(0).take(s));
+        Address::Heap(pos)
+    }
+
+    pub fn interpret_mir_with_no_arg(&mut self, body: &MirBody) -> Result<Vec<u8>> {
+        self.interpret_mir(&body, vec![].into_iter(), Substitution::empty(Interner))
+    }
+
+    fn detect_lang_function(&self, def: FunctionId) -> Option<LangItem> {
+        lang_attr(self.db.upcast(), def)
+    }
+
+    fn create_memory_map(&self, bytes: &[u8], ty: &Ty, locals: &Locals<'_>) -> Result<MemoryMap> {
+        // FIXME: support indirect references
+        let mut mm = MemoryMap::default();
+        match ty.kind(Interner) {
+            TyKind::Ref(_, _, t) => {
+                let size = self.size_of(t, locals)?;
+                match size {
+                    Some(size) => {
+                        let addr_usize = from_bytes!(usize, bytes);
+                        mm.insert(
+                            addr_usize,
+                            self.read_memory(Address::from_usize(addr_usize), size)?.to_vec(),
+                        )
+                    }
+                    None => {
+                        let element_size = match t.kind(Interner) {
+                            TyKind::Str => 1,
+                            TyKind::Slice(t) => {
+                                self.size_of_sized(t, locals, "slice inner type")?
+                            }
+                            _ => return Ok(mm), // FIXME: support other kind of unsized types
+                        };
+                        let (addr, meta) = bytes.split_at(bytes.len() / 2);
+                        let size = element_size * from_bytes!(usize, meta);
+                        let addr = Address::from_bytes(addr)?;
+                        mm.insert(addr.to_usize(), self.read_memory(addr, size)?.to_vec());
+                    }
+                }
+            }
+            _ => (),
+        }
+        Ok(mm)
+    }
+
+    fn patch_addresses(
+        &mut self,
+        patch_map: &HashMap<usize, usize>,
+        addr: Address,
+        ty: &Ty,
+        locals: &Locals<'_>,
+    ) -> Result<()> {
+        // FIXME: support indirect references
+        let my_size = self.size_of_sized(ty, locals, "value to patch address")?;
+        match ty.kind(Interner) {
+            TyKind::Ref(_, _, t) => {
+                let size = self.size_of(t, locals)?;
+                match size {
+                    Some(_) => {
+                        let current = from_bytes!(usize, self.read_memory(addr, my_size)?);
+                        if let Some(x) = patch_map.get(&current) {
+                            self.write_memory(addr, &x.to_le_bytes())?;
+                        }
+                    }
+                    None => {
+                        let current = from_bytes!(usize, self.read_memory(addr, my_size / 2)?);
+                        if let Some(x) = patch_map.get(&current) {
+                            self.write_memory(addr, &x.to_le_bytes())?;
+                        }
+                    }
+                }
+            }
+            _ => (),
+        }
+        Ok(())
+    }
+
+    fn exec_intrinsic(
+        &self,
+        as_str: &str,
+        _arg_bytes: impl Iterator<Item = Vec<u8>>,
+        generic_args: Substitution,
+        locals: &Locals<'_>,
+    ) -> Result<Vec<u8>> {
+        match as_str {
+            "size_of" => {
+                let Some(ty) = generic_args.as_slice(Interner).get(0).and_then(|x| x.ty(Interner)) else {
+                    return Err(MirEvalError::TypeError("size_of generic arg is not provided"));
+                };
+                let size = self.size_of(ty, locals)?;
+                match size {
+                    Some(x) => Ok(x.to_le_bytes().to_vec()),
+                    None => return Err(MirEvalError::TypeError("size_of arg is unsized")),
+                }
+            }
+            _ => not_supported!("unknown intrinsic {as_str}"),
+        }
+    }
+
+    pub(crate) fn exec_lang_item(
+        &self,
+        x: LangItem,
+        mut args: std::vec::IntoIter<Vec<u8>>,
+    ) -> Result<Vec<u8>> {
+        use LangItem::*;
+        match x {
+            PanicFmt | BeginPanic => Err(MirEvalError::Panic),
+            SliceLen => {
+                let arg = args
+                    .next()
+                    .ok_or(MirEvalError::TypeError("argument of <[T]>::len() is not provided"))?;
+                let ptr_size = arg.len() / 2;
+                Ok(arg[ptr_size..].into())
+            }
+            x => not_supported!("Executing lang item {x:?}"),
+        }
+    }
+}
+
+pub fn pad16(x: &[u8], is_signed: bool) -> [u8; 16] {
+    let is_negative = is_signed && x.last().unwrap_or(&0) > &128;
+    let fill_with = if is_negative { 255 } else { 0 };
+    x.iter()
+        .copied()
+        .chain(iter::repeat(fill_with))
+        .take(16)
+        .collect::<Vec<u8>>()
+        .try_into()
+        .expect("iterator take is not working")
+}

--- a/crates/hir-ty/src/mir/lower.rs
+++ b/crates/hir-ty/src/mir/lower.rs
@@ -1,0 +1,1209 @@
+//! This module generates a polymorphic MIR from a hir body
+
+use std::{iter, mem, sync::Arc};
+
+use chalk_ir::{BoundVar, ConstData, DebruijnIndex, TyKind};
+use hir_def::{
+    body::Body,
+    expr::{
+        Array, BindingAnnotation, ExprId, LabelId, Literal, MatchArm, Pat, PatId, RecordLitField,
+    },
+    layout::LayoutError,
+    resolver::{resolver_for_expr, ResolveValueResult, ValueNs},
+    DefWithBodyId, EnumVariantId, HasModule,
+};
+use la_arena::ArenaMap;
+
+use crate::{
+    consteval::ConstEvalError, db::HirDatabase, layout::layout_of_ty, mapping::ToChalk,
+    utils::generics, Adjust, AutoBorrow, CallableDefId, TyBuilder, TyExt,
+};
+
+use super::*;
+
+#[derive(Debug, Clone, Copy)]
+struct LoopBlocks {
+    begin: BasicBlockId,
+    end: BasicBlockId,
+}
+
+struct MirLowerCtx<'a> {
+    result: MirBody,
+    owner: DefWithBodyId,
+    binding_locals: ArenaMap<PatId, LocalId>,
+    current_loop_blocks: Option<LoopBlocks>,
+    discr_temp: Option<Place>,
+    db: &'a dyn HirDatabase,
+    body: &'a Body,
+    infer: &'a InferenceResult,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MirLowerError {
+    ConstEvalError(Box<ConstEvalError>),
+    LayoutError(LayoutError),
+    IncompleteExpr,
+    UnresolvedName,
+    MissingFunctionDefinition,
+    TypeError(&'static str),
+    NotSupported(String),
+    ContinueWithoutLoop,
+    BreakWithoutLoop,
+    Loop,
+}
+
+macro_rules! not_supported {
+    ($x: expr) => {
+        return Err(MirLowerError::NotSupported(format!($x)))
+    };
+}
+
+impl From<ConstEvalError> for MirLowerError {
+    fn from(value: ConstEvalError) -> Self {
+        match value {
+            ConstEvalError::MirLowerError(e) => e,
+            _ => MirLowerError::ConstEvalError(Box::new(value)),
+        }
+    }
+}
+
+impl From<LayoutError> for MirLowerError {
+    fn from(value: LayoutError) -> Self {
+        MirLowerError::LayoutError(value)
+    }
+}
+
+type Result<T> = std::result::Result<T, MirLowerError>;
+
+impl MirLowerCtx<'_> {
+    fn temp(&mut self, ty: Ty) -> Result<LocalId> {
+        if matches!(ty.kind(Interner), TyKind::Slice(_) | TyKind::Dyn(_)) {
+            not_supported!("unsized temporaries");
+        }
+        Ok(self.result.locals.alloc(Local { mutability: Mutability::Not, ty }))
+    }
+
+    fn lower_expr_as_place(&self, expr_id: ExprId) -> Option<Place> {
+        let adjustments = self.infer.expr_adjustments.get(&expr_id);
+        let mut r = self.lower_expr_as_place_without_adjust(expr_id)?;
+        for adjustment in adjustments.iter().flat_map(|x| x.iter()) {
+            match adjustment.kind {
+                Adjust::NeverToAny => return Some(r),
+                Adjust::Deref(None) => {
+                    r.projection.push(ProjectionElem::Deref);
+                }
+                Adjust::Deref(Some(_)) => return None,
+                Adjust::Borrow(_) => return None,
+                Adjust::Pointer(_) => return None,
+            }
+        }
+        Some(r)
+    }
+
+    fn lower_expr_as_place_without_adjust(&self, expr_id: ExprId) -> Option<Place> {
+        match &self.body.exprs[expr_id] {
+            Expr::Path(p) => {
+                let resolver = resolver_for_expr(self.db.upcast(), self.owner, expr_id);
+                let pr = resolver.resolve_path_in_value_ns(self.db.upcast(), p.mod_path())?;
+                let pr = match pr {
+                    ResolveValueResult::ValueNs(v) => v,
+                    ResolveValueResult::Partial(..) => return None,
+                };
+                match pr {
+                    ValueNs::LocalBinding(pat_id) => Some(self.binding_locals[pat_id].into()),
+                    _ => None,
+                }
+            }
+            Expr::UnaryOp { expr, op } => match op {
+                hir_def::expr::UnaryOp::Deref => {
+                    let mut r = self.lower_expr_as_place(*expr)?;
+                    r.projection.push(ProjectionElem::Deref);
+                    Some(r)
+                }
+                _ => None,
+            },
+            _ => None,
+        }
+    }
+
+    fn lower_expr_to_some_operand(
+        &mut self,
+        expr_id: ExprId,
+        current: BasicBlockId,
+    ) -> Result<(Operand, BasicBlockId)> {
+        if !self.has_adjustments(expr_id) {
+            match &self.body.exprs[expr_id] {
+                Expr::Literal(l) => {
+                    let ty = self.expr_ty(expr_id);
+                    return Ok((self.lower_literal_to_operand(ty, l)?, current));
+                }
+                _ => (),
+            }
+        }
+        let (p, current) = self.lower_expr_to_some_place(expr_id, current)?;
+        Ok((Operand::Copy(p), current))
+    }
+
+    fn lower_expr_to_some_place(
+        &mut self,
+        expr_id: ExprId,
+        prev_block: BasicBlockId,
+    ) -> Result<(Place, BasicBlockId)> {
+        if let Some(p) = self.lower_expr_as_place(expr_id) {
+            return Ok((p, prev_block));
+        }
+        let mut ty = self.expr_ty(expr_id);
+        if let Some(x) = self.infer.expr_adjustments.get(&expr_id) {
+            if let Some(x) = x.last() {
+                ty = x.target.clone();
+            }
+        }
+        let place = self.temp(ty)?;
+        Ok((place.into(), self.lower_expr_to_place(expr_id, place.into(), prev_block)?))
+    }
+
+    fn lower_expr_to_place(
+        &mut self,
+        expr_id: ExprId,
+        place: Place,
+        prev_block: BasicBlockId,
+    ) -> Result<BasicBlockId> {
+        if let Some(x) = self.infer.expr_adjustments.get(&expr_id) {
+            if x.len() > 0 {
+                let tmp = self.temp(self.expr_ty(expr_id))?;
+                let current =
+                    self.lower_expr_to_place_without_adjust(expr_id, tmp.into(), prev_block)?;
+                let mut r = Place::from(tmp);
+                for adjustment in x {
+                    match &adjustment.kind {
+                        Adjust::NeverToAny => (),
+                        Adjust::Deref(None) => {
+                            r.projection.push(ProjectionElem::Deref);
+                        }
+                        Adjust::Deref(Some(_)) => not_supported!("overloaded dereference"),
+                        Adjust::Borrow(AutoBorrow::Ref(m) | AutoBorrow::RawPtr(m)) => {
+                            let tmp = self.temp(adjustment.target.clone())?;
+                            self.push_assignment(
+                                current,
+                                tmp.into(),
+                                Rvalue::Ref(BorrowKind::from_chalk(*m), r),
+                            );
+                            r = tmp.into();
+                        }
+                        Adjust::Pointer(cast) => {
+                            let target = &adjustment.target;
+                            let tmp = self.temp(target.clone())?;
+                            self.push_assignment(
+                                current,
+                                tmp.into(),
+                                Rvalue::Cast(
+                                    CastKind::Pointer(cast.clone()),
+                                    Operand::Copy(r).into(),
+                                    target.clone(),
+                                ),
+                            );
+                            r = tmp.into();
+                        }
+                    }
+                }
+                self.push_assignment(current, place, Operand::Copy(r).into());
+                return Ok(current);
+            }
+        }
+        self.lower_expr_to_place_without_adjust(expr_id, place, prev_block)
+    }
+
+    fn lower_expr_to_place_without_adjust(
+        &mut self,
+        expr_id: ExprId,
+        place: Place,
+        mut current: BasicBlockId,
+    ) -> Result<BasicBlockId> {
+        match &self.body.exprs[expr_id] {
+            Expr::Missing => Err(MirLowerError::IncompleteExpr),
+            Expr::Path(p) => {
+                let resolver = resolver_for_expr(self.db.upcast(), self.owner, expr_id);
+                let pr = resolver
+                    .resolve_path_in_value_ns(self.db.upcast(), p.mod_path())
+                    .ok_or(MirLowerError::UnresolvedName)?;
+                let pr = match pr {
+                    ResolveValueResult::ValueNs(v) => v,
+                    ResolveValueResult::Partial(..) => {
+                        return match self
+                            .infer
+                            .assoc_resolutions_for_expr(expr_id)
+                            .ok_or(MirLowerError::UnresolvedName)?
+                            .0
+                            //.ok_or(ConstEvalError::SemanticError("unresolved assoc item"))?
+                        {
+                            hir_def::AssocItemId::ConstId(c) => self.lower_const(c, current, place),
+                            _ => return Err(MirLowerError::UnresolvedName),
+                        };
+                    }
+                };
+                match pr {
+                    ValueNs::LocalBinding(pat_id) => {
+                        self.push_assignment(
+                            current,
+                            place,
+                            Operand::Copy(self.binding_locals[pat_id].into()).into(),
+                        );
+                        Ok(current)
+                    }
+                    ValueNs::ConstId(const_id) => self.lower_const(const_id, current, place),
+                    ValueNs::EnumVariantId(variant_id) => {
+                        let ty = self.infer.type_of_expr[expr_id].clone();
+                        self.lower_enum_variant(variant_id, current, place, ty, vec![])
+                    }
+                    ValueNs::GenericParam(p) => {
+                        let Some(def) = self.owner.as_generic_def_id() else {
+                            not_supported!("owner without generic def id");
+                        };
+                        let gen = generics(self.db.upcast(), def);
+                        let ty = self.expr_ty(expr_id);
+                        self.push_assignment(
+                            current,
+                            place,
+                            Operand::Constant(
+                                ConstData {
+                                    ty,
+                                    value: chalk_ir::ConstValue::BoundVar(BoundVar::new(
+                                        DebruijnIndex::INNERMOST,
+                                        gen.param_idx(p.into()).ok_or(MirLowerError::TypeError(
+                                            "fail to lower const generic param",
+                                        ))?,
+                                    )),
+                                }
+                                .intern(Interner),
+                            )
+                            .into(),
+                        );
+                        Ok(current)
+                    }
+                    ValueNs::StructId(_) => {
+                        // It's probably a unit struct or a zero sized function, so no action is needed.
+                        Ok(current)
+                    }
+                    x => {
+                        not_supported!("unknown name {x:?} in value name space");
+                    }
+                }
+            }
+            Expr::If { condition, then_branch, else_branch } => {
+                let (discr, current) = self.lower_expr_to_some_operand(*condition, current)?;
+                let start_of_then = self.new_basic_block();
+                let end = self.new_basic_block();
+                let end_of_then =
+                    self.lower_expr_to_place(*then_branch, place.clone(), start_of_then)?;
+                self.set_goto(end_of_then, end);
+                let mut start_of_else = end;
+                if let Some(else_branch) = else_branch {
+                    start_of_else = self.new_basic_block();
+                    let end_of_else =
+                        self.lower_expr_to_place(*else_branch, place, start_of_else)?;
+                    self.set_goto(end_of_else, end);
+                }
+                self.set_terminator(
+                    current,
+                    Terminator::SwitchInt {
+                        discr,
+                        targets: SwitchTargets::static_if(1, start_of_then, start_of_else),
+                    },
+                );
+                Ok(end)
+            }
+            Expr::Let { pat, expr } => {
+                let (cond_place, current) = self.lower_expr_to_some_place(*expr, current)?;
+                let result = self.new_basic_block();
+                let (then_target, else_target) = self.pattern_match(
+                    current,
+                    None,
+                    cond_place,
+                    self.expr_ty(*expr),
+                    *pat,
+                    BindingAnnotation::Unannotated,
+                )?;
+                self.write_bytes_to_place(then_target, place.clone(), vec![1], TyBuilder::bool())?;
+                self.set_goto(then_target, result);
+                if let Some(else_target) = else_target {
+                    self.write_bytes_to_place(else_target, place, vec![0], TyBuilder::bool())?;
+                    self.set_goto(else_target, result);
+                }
+                Ok(result)
+            }
+            Expr::Block { id: _, statements, tail, label } => {
+                if label.is_some() {
+                    not_supported!("block with label");
+                }
+                for statement in statements.iter() {
+                    match statement {
+                        hir_def::expr::Statement::Let {
+                            pat,
+                            initializer,
+                            else_branch,
+                            type_ref: _,
+                        } => match initializer {
+                            Some(expr_id) => {
+                                let else_block;
+                                let init_place;
+                                (init_place, current) =
+                                    self.lower_expr_to_some_place(*expr_id, current)?;
+                                (current, else_block) = self.pattern_match(
+                                    current,
+                                    None,
+                                    init_place,
+                                    self.expr_ty(*expr_id),
+                                    *pat,
+                                    BindingAnnotation::Unannotated,
+                                )?;
+                                match (else_block, else_branch) {
+                                    (None, _) => (),
+                                    (Some(else_block), None) => {
+                                        self.set_terminator(else_block, Terminator::Unreachable);
+                                    }
+                                    (Some(else_block), Some(else_branch)) => {
+                                        let (_, b) = self
+                                            .lower_expr_to_some_place(*else_branch, else_block)?;
+                                        self.set_terminator(b, Terminator::Unreachable);
+                                    }
+                                }
+                            }
+                            None => continue,
+                        },
+                        hir_def::expr::Statement::Expr { expr, has_semi: _ } => {
+                            let ty = self.expr_ty(*expr);
+                            let temp = self.temp(ty)?;
+                            current = self.lower_expr_to_place(*expr, temp.into(), current)?;
+                        }
+                    }
+                }
+                match tail {
+                    Some(tail) => self.lower_expr_to_place(*tail, place, current),
+                    None => Ok(current),
+                }
+            }
+            Expr::Loop { body, label } => self.lower_loop(current, *label, |this, begin, _| {
+                let (_, block) = this.lower_expr_to_some_place(*body, begin)?;
+                this.set_goto(block, begin);
+                Ok(())
+            }),
+            Expr::While { condition, body, label } => {
+                self.lower_loop(current, *label, |this, begin, end| {
+                    let (discr, to_switch) = this.lower_expr_to_some_operand(*condition, begin)?;
+                    let after_cond = this.new_basic_block();
+                    this.set_terminator(
+                        to_switch,
+                        Terminator::SwitchInt {
+                            discr,
+                            targets: SwitchTargets::static_if(1, after_cond, end),
+                        },
+                    );
+                    let (_, block) = this.lower_expr_to_some_place(*body, after_cond)?;
+                    this.set_goto(block, begin);
+                    Ok(())
+                })
+            }
+            Expr::For { .. } => not_supported!("for loop"),
+            Expr::Call { callee, args, .. } => {
+                let callee_ty = self.expr_ty(*callee);
+                match &callee_ty.data(Interner).kind {
+                    chalk_ir::TyKind::FnDef(..) => {
+                        let func = Operand::from_bytes(vec![], callee_ty.clone());
+                        self.lower_call(func, args.iter().copied(), place, current)
+                    }
+                    TyKind::Scalar(_)
+                    | TyKind::Tuple(_, _)
+                    | TyKind::Array(_, _)
+                    | TyKind::Adt(_, _)
+                    | TyKind::Str
+                    | TyKind::Foreign(_)
+                    | TyKind::Slice(_) => {
+                        return Err(MirLowerError::TypeError("function call on data type"))
+                    }
+                    TyKind::Error => return Err(MirLowerError::MissingFunctionDefinition),
+                    TyKind::AssociatedType(_, _)
+                    | TyKind::Raw(_, _)
+                    | TyKind::Ref(_, _, _)
+                    | TyKind::OpaqueType(_, _)
+                    | TyKind::Never
+                    | TyKind::Closure(_, _)
+                    | TyKind::Generator(_, _)
+                    | TyKind::GeneratorWitness(_, _)
+                    | TyKind::Placeholder(_)
+                    | TyKind::Dyn(_)
+                    | TyKind::Alias(_)
+                    | TyKind::Function(_)
+                    | TyKind::BoundVar(_)
+                    | TyKind::InferenceVar(_, _) => not_supported!("dynamic function call"),
+                }
+            }
+            Expr::MethodCall { receiver, args, .. } => {
+                let (func_id, generic_args) =
+                    self.infer.method_resolution(expr_id).ok_or(MirLowerError::UnresolvedName)?;
+                let ty = chalk_ir::TyKind::FnDef(
+                    CallableDefId::FunctionId(func_id).to_chalk(self.db),
+                    generic_args,
+                )
+                .intern(Interner);
+                let func = Operand::from_bytes(vec![], ty);
+                self.lower_call(
+                    func,
+                    iter::once(*receiver).chain(args.iter().copied()),
+                    place,
+                    current,
+                )
+            }
+            Expr::Match { expr, arms } => {
+                let (cond_place, mut current) = self.lower_expr_to_some_place(*expr, current)?;
+                let cond_ty = self.expr_ty(*expr);
+                let end = self.new_basic_block();
+                for MatchArm { pat, guard, expr } in arms.iter() {
+                    if guard.is_some() {
+                        not_supported!("pattern matching with guard");
+                    }
+                    let (then, otherwise) = self.pattern_match(
+                        current,
+                        None,
+                        cond_place.clone(),
+                        cond_ty.clone(),
+                        *pat,
+                        BindingAnnotation::Unannotated,
+                    )?;
+                    let block = self.lower_expr_to_place(*expr, place.clone(), then)?;
+                    self.set_goto(block, end);
+                    match otherwise {
+                        Some(o) => current = o,
+                        None => {
+                            // The current pattern was irrefutable, so there is no need to generate code
+                            // for the rest of patterns
+                            break;
+                        }
+                    }
+                }
+                if self.is_unterminated(current) {
+                    self.set_terminator(current, Terminator::Unreachable);
+                }
+                Ok(end)
+            }
+            Expr::Continue { label } => match label {
+                Some(_) => not_supported!("continue with label"),
+                None => {
+                    let loop_data =
+                        self.current_loop_blocks.ok_or(MirLowerError::ContinueWithoutLoop)?;
+                    self.set_goto(current, loop_data.begin);
+                    let otherwise = self.new_basic_block();
+                    Ok(otherwise)
+                }
+            },
+            Expr::Break { expr, label } => {
+                if expr.is_some() {
+                    not_supported!("break with value");
+                }
+                match label {
+                    Some(_) => not_supported!("break with label"),
+                    None => {
+                        let loop_data =
+                            self.current_loop_blocks.ok_or(MirLowerError::BreakWithoutLoop)?;
+                        self.set_goto(current, loop_data.end);
+                        Ok(self.new_basic_block())
+                    }
+                }
+            }
+            Expr::Return { expr } => {
+                if let Some(expr) = expr {
+                    current = self.lower_expr_to_place(*expr, return_slot().into(), current)?;
+                }
+                self.set_terminator(current, Terminator::Return);
+                Ok(self.new_basic_block())
+            }
+            Expr::Yield { .. } => not_supported!("yield"),
+            Expr::RecordLit { fields, .. } => {
+                let variant_id = self
+                    .infer
+                    .variant_resolution_for_expr(expr_id)
+                    .ok_or(MirLowerError::UnresolvedName)?;
+                let subst = match self.expr_ty(expr_id).kind(Interner) {
+                    TyKind::Adt(_, s) => s.clone(),
+                    _ => not_supported!("Non ADT record literal"),
+                };
+                let variant_data = variant_id.variant_data(self.db.upcast());
+                match variant_id {
+                    VariantId::EnumVariantId(_) | VariantId::StructId(_) => {
+                        let mut operands = vec![None; variant_data.fields().len()];
+                        for RecordLitField { name, expr } in fields.iter() {
+                            let field_id =
+                                variant_data.field(name).ok_or(MirLowerError::UnresolvedName)?;
+                            let op;
+                            (op, current) = self.lower_expr_to_some_operand(*expr, current)?;
+                            operands[u32::from(field_id.into_raw()) as usize] = Some(op);
+                        }
+                        self.push_assignment(
+                            current,
+                            place,
+                            Rvalue::Aggregate(
+                                AggregateKind::Adt(variant_id, subst),
+                                operands.into_iter().map(|x| x).collect::<Option<_>>().ok_or(
+                                    MirLowerError::TypeError("missing field in record literal"),
+                                )?,
+                            ),
+                        );
+                        Ok(current)
+                    }
+                    VariantId::UnionId(union_id) => {
+                        let [RecordLitField { name, expr }] = fields.as_ref() else {
+                            not_supported!("Union record literal with more than one field");
+                        };
+                        let local_id =
+                            variant_data.field(name).ok_or(MirLowerError::UnresolvedName)?;
+                        let mut place = place;
+                        place
+                            .projection
+                            .push(PlaceElem::Field(FieldId { parent: union_id.into(), local_id }));
+                        self.lower_expr_to_place(*expr, place, current)
+                    }
+                }
+            }
+            Expr::Field { expr, name } => {
+                let (mut current_place, current) = self.lower_expr_to_some_place(*expr, current)?;
+                if let TyKind::Tuple(..) = self.expr_ty(*expr).kind(Interner) {
+                    let index = name
+                        .as_tuple_index()
+                        .ok_or(MirLowerError::TypeError("named field on tuple"))?;
+                    current_place.projection.push(ProjectionElem::TupleField(index))
+                } else {
+                    let field = self
+                        .infer
+                        .field_resolution(expr_id)
+                        .ok_or(MirLowerError::UnresolvedName)?;
+                    current_place.projection.push(ProjectionElem::Field(field));
+                }
+                self.push_assignment(current, place, Operand::Copy(current_place).into());
+                Ok(current)
+            }
+            Expr::Await { .. } => not_supported!("await"),
+            Expr::Try { .. } => not_supported!("? operator"),
+            Expr::Yeet { .. } => not_supported!("yeet"),
+            Expr::TryBlock { .. } => not_supported!("try block"),
+            Expr::Async { .. } => not_supported!("async block"),
+            Expr::Const { .. } => not_supported!("anonymous const block"),
+            Expr::Cast { expr, type_ref: _ } => {
+                let (x, current) = self.lower_expr_to_some_operand(*expr, current)?;
+                let source_ty = self.infer[*expr].clone();
+                let target_ty = self.infer[expr_id].clone();
+                self.push_assignment(
+                    current,
+                    place,
+                    Rvalue::Cast(cast_kind(&source_ty, &target_ty)?, x, target_ty),
+                );
+                Ok(current)
+            }
+            Expr::Ref { expr, rawness: _, mutability } => {
+                let p;
+                (p, current) = self.lower_expr_to_some_place(*expr, current)?;
+                let bk = BorrowKind::from_hir(*mutability);
+                self.push_assignment(current, place, Rvalue::Ref(bk, p));
+                Ok(current)
+            }
+            Expr::Box { .. } => not_supported!("box expression"),
+            Expr::UnaryOp { expr, op } => match op {
+                hir_def::expr::UnaryOp::Deref => {
+                    let (mut tmp, current) = self.lower_expr_to_some_place(*expr, current)?;
+                    tmp.projection.push(ProjectionElem::Deref);
+                    self.push_assignment(current, place, Operand::Copy(tmp).into());
+                    Ok(current)
+                }
+                hir_def::expr::UnaryOp::Not => {
+                    let (op, current) = self.lower_expr_to_some_operand(*expr, current)?;
+                    self.push_assignment(current, place, Rvalue::UnaryOp(UnOp::Not, op));
+                    Ok(current)
+                }
+                hir_def::expr::UnaryOp::Neg => {
+                    let (op, current) = self.lower_expr_to_some_operand(*expr, current)?;
+                    self.push_assignment(current, place, Rvalue::UnaryOp(UnOp::Neg, op));
+                    Ok(current)
+                }
+            },
+            Expr::BinaryOp { lhs, rhs, op } => {
+                let op = op.ok_or(MirLowerError::IncompleteExpr)?;
+                if let hir_def::expr::BinaryOp::Assignment { op } = op {
+                    if op.is_some() {
+                        not_supported!("assignment with arith op (like +=)");
+                    }
+                    let Some(lhs_place) = self.lower_expr_as_place(*lhs) else {
+                        not_supported!("assignment to complex place");
+                    };
+                    let rhs_op;
+                    (rhs_op, current) = self.lower_expr_to_some_operand(*rhs, current)?;
+                    self.push_assignment(current, lhs_place, rhs_op.into());
+                    return Ok(current);
+                }
+                let lhs_op;
+                (lhs_op, current) = self.lower_expr_to_some_operand(*lhs, current)?;
+                let rhs_op;
+                (rhs_op, current) = self.lower_expr_to_some_operand(*rhs, current)?;
+                self.push_assignment(
+                    current,
+                    place,
+                    Rvalue::CheckedBinaryOp(
+                        match op {
+                            hir_def::expr::BinaryOp::LogicOp(op) => match op {
+                                hir_def::expr::LogicOp::And => BinOp::BitAnd, // FIXME: make these short circuit
+                                hir_def::expr::LogicOp::Or => BinOp::BitOr,
+                            },
+                            hir_def::expr::BinaryOp::ArithOp(op) => BinOp::from(op),
+                            hir_def::expr::BinaryOp::CmpOp(op) => BinOp::from(op),
+                            hir_def::expr::BinaryOp::Assignment { .. } => unreachable!(), // handled above
+                        },
+                        lhs_op,
+                        rhs_op,
+                    ),
+                );
+                Ok(current)
+            }
+            Expr::Range { .. } => not_supported!("range"),
+            Expr::Index { base, index } => {
+                let mut p_base;
+                (p_base, current) = self.lower_expr_to_some_place(*base, current)?;
+                let l_index = self.temp(self.expr_ty(*index))?;
+                current = self.lower_expr_to_place(*index, l_index.into(), current)?;
+                p_base.projection.push(ProjectionElem::Index(l_index));
+                self.push_assignment(current, place, Operand::Copy(p_base).into());
+                Ok(current)
+            }
+            Expr::Closure { .. } => not_supported!("closure"),
+            Expr::Tuple { exprs, is_assignee_expr: _ } => {
+                let r = Rvalue::Aggregate(
+                    AggregateKind::Tuple(self.expr_ty(expr_id)),
+                    exprs
+                        .iter()
+                        .map(|x| {
+                            let o;
+                            (o, current) = self.lower_expr_to_some_operand(*x, current)?;
+                            Ok(o)
+                        })
+                        .collect::<Result<_>>()?,
+                );
+                self.push_assignment(current, place, r);
+                Ok(current)
+            }
+            Expr::Unsafe { body } => self.lower_expr_to_place(*body, place, current),
+            Expr::Array(l) => match l {
+                Array::ElementList { elements, .. } => {
+                    let elem_ty = match &self.expr_ty(expr_id).data(Interner).kind {
+                        TyKind::Array(ty, _) => ty.clone(),
+                        _ => {
+                            return Err(MirLowerError::TypeError(
+                                "Array expression with non array type",
+                            ))
+                        }
+                    };
+                    let r = Rvalue::Aggregate(
+                        AggregateKind::Array(elem_ty),
+                        elements
+                            .iter()
+                            .map(|x| {
+                                let o;
+                                (o, current) = self.lower_expr_to_some_operand(*x, current)?;
+                                Ok(o)
+                            })
+                            .collect::<Result<_>>()?,
+                    );
+                    self.push_assignment(current, place, r);
+                    Ok(current)
+                }
+                Array::Repeat { .. } => not_supported!("array repeat"),
+            },
+            Expr::Literal(l) => {
+                let ty = self.expr_ty(expr_id);
+                let op = self.lower_literal_to_operand(ty, l)?;
+                self.push_assignment(current, place, op.into());
+                Ok(current)
+            }
+            Expr::Underscore => not_supported!("underscore"),
+        }
+    }
+
+    fn lower_literal_to_operand(&mut self, ty: Ty, l: &Literal) -> Result<Operand> {
+        let size = layout_of_ty(self.db, &ty, self.owner.module(self.db.upcast()).krate())?
+            .size
+            .bytes_usize();
+        let bytes = match l {
+            hir_def::expr::Literal::String(b) => {
+                let b = b.as_bytes();
+                let mut data = vec![];
+                data.extend(0usize.to_le_bytes());
+                data.extend(b.len().to_le_bytes());
+                let mut mm = MemoryMap::default();
+                mm.insert(0, b.to_vec());
+                return Ok(Operand::from_concrete_const(data, mm, ty));
+            }
+            hir_def::expr::Literal::ByteString(b) => {
+                let mut data = vec![];
+                data.extend(0usize.to_le_bytes());
+                data.extend(b.len().to_le_bytes());
+                let mut mm = MemoryMap::default();
+                mm.insert(0, b.to_vec());
+                return Ok(Operand::from_concrete_const(data, mm, ty));
+            }
+            hir_def::expr::Literal::Char(c) => u32::from(*c).to_le_bytes().into(),
+            hir_def::expr::Literal::Bool(b) => vec![*b as u8],
+            hir_def::expr::Literal::Int(x, _) => x.to_le_bytes()[0..size].into(),
+            hir_def::expr::Literal::Uint(x, _) => x.to_le_bytes()[0..size].into(),
+            hir_def::expr::Literal::Float(f, _) => match size {
+                8 => f.into_f64().to_le_bytes().into(),
+                4 => f.into_f32().to_le_bytes().into(),
+                _ => {
+                    return Err(MirLowerError::TypeError("float with size other than 4 or 8 bytes"))
+                }
+            },
+        };
+        Ok(Operand::from_concrete_const(bytes, MemoryMap::default(), ty))
+    }
+
+    fn new_basic_block(&mut self) -> BasicBlockId {
+        self.result.basic_blocks.alloc(BasicBlock::default())
+    }
+
+    fn lower_const(
+        &mut self,
+        const_id: hir_def::ConstId,
+        prev_block: BasicBlockId,
+        place: Place,
+    ) -> Result<BasicBlockId> {
+        let c = self.db.const_eval(const_id)?;
+        self.write_const_to_place(c, prev_block, place)
+    }
+
+    fn write_const_to_place(
+        &mut self,
+        c: Const,
+        prev_block: BasicBlockId,
+        place: Place,
+    ) -> Result<BasicBlockId> {
+        self.push_assignment(prev_block, place, Operand::Constant(c).into());
+        Ok(prev_block)
+    }
+
+    fn write_bytes_to_place(
+        &mut self,
+        prev_block: BasicBlockId,
+        place: Place,
+        cv: Vec<u8>,
+        ty: Ty,
+    ) -> Result<BasicBlockId> {
+        self.push_assignment(prev_block, place, Operand::from_bytes(cv, ty).into());
+        Ok(prev_block)
+    }
+
+    fn lower_enum_variant(
+        &mut self,
+        variant_id: EnumVariantId,
+        prev_block: BasicBlockId,
+        place: Place,
+        ty: Ty,
+        fields: Vec<Operand>,
+    ) -> Result<BasicBlockId> {
+        let subst = match ty.kind(Interner) {
+            TyKind::Adt(_, subst) => subst.clone(),
+            _ => not_supported!("Non ADT enum"),
+        };
+        self.push_assignment(
+            prev_block,
+            place,
+            Rvalue::Aggregate(AggregateKind::Adt(variant_id.into(), subst), fields),
+        );
+        Ok(prev_block)
+    }
+
+    fn lower_call(
+        &mut self,
+        func: Operand,
+        args: impl Iterator<Item = ExprId>,
+        place: Place,
+        mut current: BasicBlockId,
+    ) -> Result<BasicBlockId> {
+        let args = args
+            .map(|arg| {
+                let temp;
+                (temp, current) = self.lower_expr_to_some_operand(arg, current)?;
+                Ok(temp)
+            })
+            .collect::<Result<Vec<_>>>()?;
+        let b = self.result.basic_blocks.alloc(BasicBlock {
+            statements: vec![],
+            terminator: None,
+            is_cleanup: false,
+        });
+        self.set_terminator(
+            current,
+            Terminator::Call {
+                func,
+                args,
+                destination: place,
+                target: Some(b),
+                cleanup: None,
+                from_hir_call: true,
+            },
+        );
+        Ok(b)
+    }
+
+    fn is_unterminated(&mut self, source: BasicBlockId) -> bool {
+        self.result.basic_blocks[source].terminator.is_none()
+    }
+
+    fn set_terminator(&mut self, source: BasicBlockId, terminator: Terminator) {
+        self.result.basic_blocks[source].terminator = Some(terminator);
+    }
+
+    fn set_goto(&mut self, source: BasicBlockId, target: BasicBlockId) {
+        self.set_terminator(source, Terminator::Goto { target });
+    }
+
+    fn expr_ty(&self, e: ExprId) -> Ty {
+        self.infer[e].clone()
+    }
+
+    fn push_assignment(&mut self, block: BasicBlockId, place: Place, rvalue: Rvalue) {
+        self.result.basic_blocks[block].statements.push(Statement::Assign(place, rvalue));
+    }
+
+    /// It gets a `current` unterminated block, appends some statements and possibly a terminator to it to check if
+    /// the pattern matches and write bindings, and returns two unterminated blocks, one for the matched path (which
+    /// can be the `current` block) and one for the mismatched path. If the input pattern is irrefutable, the
+    /// mismatched path block is `None`.
+    ///
+    /// By default, it will create a new block for mismatched path. If you already have one, you can provide it with
+    /// `current_else` argument to save an unneccessary jump. If `current_else` isn't `None`, the result mismatched path
+    /// wouldn't be `None` as well. Note that this function will add jumps to the beginning of the `current_else` block,
+    /// so it should be an empty block.
+    fn pattern_match(
+        &mut self,
+        mut current: BasicBlockId,
+        mut current_else: Option<BasicBlockId>,
+        mut cond_place: Place,
+        mut cond_ty: Ty,
+        pattern: PatId,
+        mut binding_mode: BindingAnnotation,
+    ) -> Result<(BasicBlockId, Option<BasicBlockId>)> {
+        Ok(match &self.body.pats[pattern] {
+            Pat::Missing => return Err(MirLowerError::IncompleteExpr),
+            Pat::Wild => (current, current_else),
+            Pat::Tuple { args, ellipsis } => {
+                pattern_matching_dereference(&mut cond_ty, &mut binding_mode, &mut cond_place);
+                let subst = match cond_ty.kind(Interner) {
+                    TyKind::Tuple(_, s) => s,
+                    _ => {
+                        return Err(MirLowerError::TypeError(
+                            "non tuple type matched with tuple pattern",
+                        ))
+                    }
+                };
+                self.pattern_match_tuple_like(
+                    current,
+                    current_else,
+                    args.iter().enumerate().map(|(i, x)| {
+                        (
+                            PlaceElem::TupleField(i),
+                            *x,
+                            subst.at(Interner, i).assert_ty_ref(Interner).clone(),
+                        )
+                    }),
+                    *ellipsis,
+                    &cond_place,
+                    binding_mode,
+                )?
+            }
+            Pat::Or(_) => not_supported!("or pattern"),
+            Pat::Record { .. } => not_supported!("record pattern"),
+            Pat::Range { .. } => not_supported!("range pattern"),
+            Pat::Slice { .. } => not_supported!("slice pattern"),
+            Pat::Path(_) => not_supported!("path pattern"),
+            Pat::Lit(l) => {
+                let then_target = self.new_basic_block();
+                let else_target = current_else.unwrap_or_else(|| self.new_basic_block());
+                match &self.body.exprs[*l] {
+                    Expr::Literal(l) => match l {
+                        hir_def::expr::Literal::Int(x, _) => {
+                            self.set_terminator(
+                                current,
+                                Terminator::SwitchInt {
+                                    discr: Operand::Copy(cond_place),
+                                    targets: SwitchTargets::static_if(
+                                        *x as u128,
+                                        then_target,
+                                        else_target,
+                                    ),
+                                },
+                            );
+                        }
+                        hir_def::expr::Literal::Uint(x, _) => {
+                            self.set_terminator(
+                                current,
+                                Terminator::SwitchInt {
+                                    discr: Operand::Copy(cond_place),
+                                    targets: SwitchTargets::static_if(*x, then_target, else_target),
+                                },
+                            );
+                        }
+                        _ => not_supported!("non int path literal"),
+                    },
+                    _ => not_supported!("expression path literal"),
+                }
+                (then_target, Some(else_target))
+            }
+            Pat::Bind { mode, name: _, subpat } => {
+                let target_place = self.binding_locals[pattern];
+                if let Some(subpat) = subpat {
+                    (current, current_else) = self.pattern_match(
+                        current,
+                        current_else,
+                        cond_place.clone(),
+                        cond_ty,
+                        *subpat,
+                        binding_mode,
+                    )?
+                }
+                if matches!(mode, BindingAnnotation::Ref | BindingAnnotation::RefMut) {
+                    binding_mode = *mode;
+                }
+                self.push_assignment(
+                    current,
+                    target_place.into(),
+                    match binding_mode {
+                        BindingAnnotation::Unannotated | BindingAnnotation::Mutable => {
+                            Operand::Copy(cond_place).into()
+                        }
+                        BindingAnnotation::Ref => Rvalue::Ref(BorrowKind::Shared, cond_place),
+                        BindingAnnotation::RefMut => Rvalue::Ref(
+                            BorrowKind::Mut { allow_two_phase_borrow: false },
+                            cond_place,
+                        ),
+                    },
+                );
+                (current, current_else)
+            }
+            Pat::TupleStruct { path: _, args, ellipsis } => {
+                let Some(variant) = self.infer.variant_resolution_for_pat(pattern) else {
+                    not_supported!("unresolved variant");
+                };
+                pattern_matching_dereference(&mut cond_ty, &mut binding_mode, &mut cond_place);
+                let subst = match cond_ty.kind(Interner) {
+                    TyKind::Adt(_, s) => s,
+                    _ => {
+                        return Err(MirLowerError::TypeError(
+                            "non adt type matched with tuple struct",
+                        ))
+                    }
+                };
+                let fields_type = self.db.field_types(variant);
+                match variant {
+                    VariantId::EnumVariantId(v) => {
+                        let e = self.db.const_eval_discriminant(v)? as u128;
+                        let next = self.new_basic_block();
+                        let tmp = self.discr_temp_place();
+                        self.push_assignment(
+                            current,
+                            tmp.clone(),
+                            Rvalue::Discriminant(cond_place.clone()),
+                        );
+                        let else_target = current_else.unwrap_or_else(|| self.new_basic_block());
+                        self.set_terminator(
+                            current,
+                            Terminator::SwitchInt {
+                                discr: Operand::Copy(tmp),
+                                targets: SwitchTargets::static_if(e, next, else_target),
+                            },
+                        );
+                        let enum_data = self.db.enum_data(v.parent);
+                        let fields =
+                            enum_data.variants[v.local_id].variant_data.fields().iter().map(
+                                |(x, _)| {
+                                    (
+                                        PlaceElem::Field(FieldId { parent: v.into(), local_id: x }),
+                                        fields_type[x].clone().substitute(Interner, subst),
+                                    )
+                                },
+                            );
+                        self.pattern_match_tuple_like(
+                            next,
+                            Some(else_target),
+                            args.iter().zip(fields).map(|(x, y)| (y.0, *x, y.1)),
+                            *ellipsis,
+                            &cond_place,
+                            binding_mode,
+                        )?
+                    }
+                    VariantId::StructId(s) => {
+                        let struct_data = self.db.struct_data(s);
+                        let fields = struct_data.variant_data.fields().iter().map(|(x, _)| {
+                            (
+                                PlaceElem::Field(FieldId { parent: s.into(), local_id: x }),
+                                fields_type[x].clone().substitute(Interner, subst),
+                            )
+                        });
+                        self.pattern_match_tuple_like(
+                            current,
+                            current_else,
+                            args.iter().zip(fields).map(|(x, y)| (y.0, *x, y.1)),
+                            *ellipsis,
+                            &cond_place,
+                            binding_mode,
+                        )?
+                    }
+                    VariantId::UnionId(_) => {
+                        return Err(MirLowerError::TypeError("pattern matching on union"))
+                    }
+                }
+            }
+            Pat::Ref { .. } => not_supported!("& pattern"),
+            Pat::Box { .. } => not_supported!("box pattern"),
+            Pat::ConstBlock(_) => not_supported!("const block pattern"),
+        })
+    }
+
+    fn pattern_match_tuple_like(
+        &mut self,
+        mut current: BasicBlockId,
+        mut current_else: Option<BasicBlockId>,
+        args: impl Iterator<Item = (PlaceElem, PatId, Ty)>,
+        ellipsis: Option<usize>,
+        cond_place: &Place,
+        binding_mode: BindingAnnotation,
+    ) -> Result<(BasicBlockId, Option<BasicBlockId>)> {
+        if ellipsis.is_some() {
+            not_supported!("tuple like pattern with ellipsis");
+        }
+        for (proj, arg, ty) in args {
+            let mut cond_place = cond_place.clone();
+            cond_place.projection.push(proj);
+            (current, current_else) =
+                self.pattern_match(current, current_else, cond_place, ty, arg, binding_mode)?;
+        }
+        Ok((current, current_else))
+    }
+
+    fn discr_temp_place(&mut self) -> Place {
+        match &self.discr_temp {
+            Some(x) => x.clone(),
+            None => {
+                let tmp: Place =
+                    self.temp(TyBuilder::discr_ty()).expect("discr_ty is never unsized").into();
+                self.discr_temp = Some(tmp.clone());
+                tmp
+            }
+        }
+    }
+
+    fn lower_loop(
+        &mut self,
+        prev_block: BasicBlockId,
+        label: Option<LabelId>,
+        f: impl FnOnce(&mut MirLowerCtx<'_>, BasicBlockId, BasicBlockId) -> Result<()>,
+    ) -> Result<BasicBlockId> {
+        if label.is_some() {
+            not_supported!("loop with label");
+        }
+        let begin = self.new_basic_block();
+        let end = self.new_basic_block();
+        let prev = mem::replace(&mut self.current_loop_blocks, Some(LoopBlocks { begin, end }));
+        self.set_goto(prev_block, begin);
+        f(self, begin, end)?;
+        self.current_loop_blocks = prev;
+        Ok(end)
+    }
+
+    fn has_adjustments(&self, expr_id: ExprId) -> bool {
+        !self.infer.expr_adjustments.get(&expr_id).map(|x| x.is_empty()).unwrap_or(true)
+    }
+}
+
+fn pattern_matching_dereference(
+    cond_ty: &mut Ty,
+    binding_mode: &mut BindingAnnotation,
+    cond_place: &mut Place,
+) {
+    while let Some((ty, _, mu)) = cond_ty.as_reference() {
+        if mu == Mutability::Mut && *binding_mode != BindingAnnotation::Ref {
+            *binding_mode = BindingAnnotation::RefMut;
+        } else {
+            *binding_mode = BindingAnnotation::Ref;
+        }
+        *cond_ty = ty.clone();
+        cond_place.projection.push(ProjectionElem::Deref);
+    }
+}
+
+fn cast_kind(source_ty: &Ty, target_ty: &Ty) -> Result<CastKind> {
+    Ok(match (source_ty.kind(Interner), target_ty.kind(Interner)) {
+        (TyKind::Scalar(s), TyKind::Scalar(t)) => match (s, t) {
+            (chalk_ir::Scalar::Float(_), chalk_ir::Scalar::Float(_)) => CastKind::FloatToFloat,
+            (chalk_ir::Scalar::Float(_), _) => CastKind::FloatToInt,
+            (_, chalk_ir::Scalar::Float(_)) => CastKind::IntToFloat,
+            (_, _) => CastKind::IntToInt,
+        },
+        // Enum to int casts
+        (TyKind::Scalar(_), TyKind::Adt(..)) | (TyKind::Adt(..), TyKind::Scalar(_)) => {
+            CastKind::IntToInt
+        }
+        (a, b) => not_supported!("Unknown cast between {a:?} and {b:?}"),
+    })
+}
+
+pub fn mir_body_query(db: &dyn HirDatabase, def: DefWithBodyId) -> Result<Arc<MirBody>> {
+    let body = db.body(def);
+    let infer = db.infer(def);
+    Ok(Arc::new(lower_to_mir(db, def, &body, &infer, body.body_expr)?))
+}
+
+pub fn mir_body_recover(
+    _db: &dyn HirDatabase,
+    _cycle: &[String],
+    _def: &DefWithBodyId,
+) -> Result<Arc<MirBody>> {
+    Err(MirLowerError::Loop)
+}
+
+pub fn lower_to_mir(
+    db: &dyn HirDatabase,
+    owner: DefWithBodyId,
+    body: &Body,
+    infer: &InferenceResult,
+    // FIXME: root_expr should always be the body.body_expr, but since `X` in `[(); X]` doesn't have its own specific body yet, we
+    // need to take this input explicitly.
+    root_expr: ExprId,
+) -> Result<MirBody> {
+    let mut basic_blocks = Arena::new();
+    let start_block =
+        basic_blocks.alloc(BasicBlock { statements: vec![], terminator: None, is_cleanup: false });
+    let mut locals = Arena::new();
+    // 0 is return local
+    locals.alloc(Local { mutability: Mutability::Mut, ty: infer[root_expr].clone() });
+    let mut create_local_of_path = |p: PatId| {
+        // FIXME: mutablity is broken
+        locals.alloc(Local { mutability: Mutability::Not, ty: infer[p].clone() })
+    };
+    // 1 to param_len is for params
+    let mut binding_locals: ArenaMap<PatId, LocalId> =
+        body.params.iter().map(|&x| (x, create_local_of_path(x))).collect();
+    // and then rest of bindings
+    for (pat_id, _) in body.pats.iter() {
+        if !binding_locals.contains_idx(pat_id) {
+            binding_locals.insert(pat_id, create_local_of_path(pat_id));
+        }
+    }
+    let mir = MirBody { basic_blocks, locals, start_block, owner, arg_count: body.params.len() };
+    let mut ctx = MirLowerCtx {
+        result: mir,
+        db,
+        infer,
+        body,
+        binding_locals,
+        owner,
+        current_loop_blocks: None,
+        discr_temp: None,
+    };
+    let b = ctx.lower_expr_to_place(root_expr, return_slot().into(), start_block)?;
+    ctx.result.basic_blocks[b].terminator = Some(Terminator::Return);
+    Ok(ctx.result)
+}

--- a/crates/hir/src/source_analyzer.rs
+++ b/crates/hir/src/source_analyzer.rs
@@ -791,7 +791,7 @@ impl SourceAnalyzer {
             || Arc::new(hir_ty::TraitEnvironment::empty(krate)),
             |d| db.trait_environment(d),
         );
-        method_resolution::lookup_impl_method(db, env, func, substs)
+        method_resolution::lookup_impl_method(db, env, func, substs).0
     }
 
     fn resolve_impl_const_or_trait_def(
@@ -809,7 +809,7 @@ impl SourceAnalyzer {
             || Arc::new(hir_ty::TraitEnvironment::empty(krate)),
             |d| db.trait_environment(d),
         );
-        method_resolution::lookup_impl_const(db, env, const_id, subs)
+        method_resolution::lookup_impl_const(db, env, const_id, subs).0
     }
 
     fn lang_trait_fn(

--- a/crates/ide-assists/src/handlers/add_explicit_type.rs
+++ b/crates/ide-assists/src/handlers/add_explicit_type.rs
@@ -211,10 +211,8 @@ fn main() {
         check_assist_not_applicable(
             add_explicit_type,
             r#"
-//- minicore: option
-
 fn main() {
-    let $0l = [0.0; Some(2).unwrap()];
+    let $0l = [0.0; unresolved_function(5)];
 }
 "#,
         );

--- a/crates/ide/src/hover.rs
+++ b/crates/ide/src/hover.rs
@@ -30,6 +30,7 @@ pub struct HoverConfig {
     pub documentation: bool,
     pub keywords: bool,
     pub format: HoverDocFormat,
+    pub interpret_tests: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/crates/ide/src/inlay_hints/discriminant.rs
+++ b/crates/ide/src/inlay_hints/discriminant.rs
@@ -59,8 +59,14 @@ fn variant_hints(
         },
         kind: InlayKind::Discriminant,
         label: InlayHintLabel::simple(
-            match &d {
-                Ok(v) => format!("{}", v),
+            match d {
+                Ok(x) => {
+                    if x >= 10 {
+                        format!("{x} ({x:#X})")
+                    } else {
+                        format!("{x}")
+                    }
+                }
                 Err(_) => "?".into(),
             },
             Some(InlayTooltip::String(match &d {

--- a/crates/ide/src/static_index.rs
+++ b/crates/ide/src/static_index.rs
@@ -139,6 +139,7 @@ impl StaticIndex<'_> {
             documentation: true,
             keywords: true,
             format: crate::HoverDocFormat::Markdown,
+            interpret_tests: false,
         };
         let tokens = tokens.filter(|token| {
             matches!(

--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -366,6 +366,8 @@ config_data! {
         inlayHints_typeHints_hideClosureInitialization: bool       = "false",
         /// Whether to hide inlay type hints for constructors.
         inlayHints_typeHints_hideNamedConstructor: bool            = "false",
+        /// Enables the experimental support for interpreting tests.
+        interpret_tests: bool                                      = "false",
 
         /// Join lines merges consecutive declaration and initialization of an assignment.
         joinLines_joinAssignments: bool = "true",
@@ -1441,6 +1443,7 @@ impl Config {
                 }
             },
             keywords: self.data.hover_documentation_keywords_enable,
+            interpret_tests: self.data.interpret_tests,
         }
     }
 

--- a/crates/test-utils/src/fixture.rs
+++ b/crates/test-utils/src/fixture.rs
@@ -180,7 +180,9 @@ impl Fixture {
         let mut cfg_key_values = Vec::new();
         let mut env = FxHashMap::default();
         let mut introduce_new_source_root = None;
-        let mut target_data_layout = None;
+        let mut target_data_layout = Some(
+            "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128".to_string(),
+        );
         for component in components[1..].iter() {
             let (key, value) =
                 component.split_once(':').unwrap_or_else(|| panic!("invalid meta line: {meta:?}"));

--- a/crates/test-utils/src/minicore.rs
+++ b/crates/test-utils/src/minicore.rs
@@ -510,6 +510,7 @@ pub mod fmt {
 pub mod slice {
     #[lang = "slice"]
     impl<T> [T] {
+        #[lang = "slice_len_fn"]
         pub fn len(&self) -> usize {
             loop {}
         }

--- a/docs/user/generated_config.adoc
+++ b/docs/user/generated_config.adoc
@@ -537,6 +537,11 @@ Only applies to closures with blocks, same as `#rust-analyzer.inlayHints.closure
 --
 Whether to hide inlay type hints for constructors.
 --
+[[rust-analyzer.interpret.tests]]rust-analyzer.interpret.tests (default: `false`)::
++
+--
+Enables the experimental support for interpreting tests.
+--
 [[rust-analyzer.joinLines.joinAssignments]]rust-analyzer.joinLines.joinAssignments (default: `true`)::
 +
 --

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -1110,6 +1110,11 @@
                     "default": false,
                     "type": "boolean"
                 },
+                "rust-analyzer.interpret.tests": {
+                    "markdownDescription": "Enables the experimental support for interpreting tests.",
+                    "default": false,
+                    "type": "boolean"
+                },
                 "rust-analyzer.joinLines.joinAssignments": {
                     "markdownDescription": "Join lines merges consecutive declaration and initialization of an assignment.",
                     "default": true,


### PR DESCRIPTION
This pull request introduces the initial implementation of MIR lowering and interpreting in Rust Analyzer.

The implementation of MIR has potential to bring several benefits:
- Executing a unit test without compiling it: This is my main goal. It can be useful for quickly testing code changes and print-debugging unit tests without the need for a full compilation (ideally in almost zero time, similar to languages like python and js). There is a probability that it goes nowhere, it might become slower than rustc, or it might need some unreasonable amount of memory, or we may fail to support a common pattern/function that make it unusable for most of the codes.
- Constant evaluation: MIR allows for easier and more correct constant evaluation, on par with rustc. If r-a wants to fully support the type system, it needs full const eval, which means arbitrary code execution, which needs MIR or something similar.
- Supporting more diagnostics: MIR can be used to detect errors, most famously borrow checker and lifetime errors,  but also mutability errors and uninitialized variables, which can be difficult/impossible to detect in HIR.
- Lowering closures: With MIR we can find out closure capture modes, which is useful in detecting if a closure implements the `FnMut` or `Fn` traits, and calculating its size and data layout.

But the current PR implements no diagnostics and doesn't support closures. About const eval, I removed the old const eval code and it now uses the mir interpreter. Everything that is supported in stable rustc is either implemented or is super easy to implement. About interpreting unit tests, I added an experimental config, disabled by default, that shows a `pass` or `fail` on hover of unit tests (ideally it should be a button similar to `Run test` button, but I didn't figured out how to add them). Currently, no real world test works, due to missing features including closures, heap allocation, `dyn Trait` and ... so at this point it is only useful for me selecting what to implement next.

The implementation of MIR is based on the design of rustc, the data structures are almost copy paste (so it should be easy to migrate it to a possible future stable-mir), but the lowering and interpreting code is from me.