### PR TITLE
fix: consider relative offset to fake ident token in expansion for completion

### DIFF
--- a/crates/ide-completion/src/context/analysis.rs
+++ b/crates/ide-completion/src/context/analysis.rs
@@ -48,7 +48,9 @@ pub(super) fn expand_and_analyze(
     // make the offset point to the start of the original token, as that is what the
     // intermediate offsets calculated in expansion always points to
     let offset = offset - relative_offset;
-    let expansion = expand(sema, original_file, speculative_file, offset, fake_ident_token);
+    let expansion =
+        expand(sema, original_file, speculative_file, offset, fake_ident_token, relative_offset);
+
     // add the relative offset back, so that left_biased finds the proper token
     let offset = expansion.offset + relative_offset;
     let token = expansion.original_file.token_at_offset(offset).left_biased()?;
@@ -67,6 +69,7 @@ fn expand(
     mut speculative_file: SyntaxNode,
     mut offset: TextSize,
     mut fake_ident_token: SyntaxToken,
+    relative_offset: TextSize,
 ) -> ExpansionResult {
     let _p = profile::span("CompletionContext::expand");
     let mut derive_ctx = None;
@@ -97,7 +100,7 @@ fn expand(
                 // successful expansions
                 (Some(actual_expansion), Some((fake_expansion, fake_mapped_token))) => {
                     let new_offset = fake_mapped_token.text_range().start();
-                    if new_offset > actual_expansion.text_range().end() {
+                    if new_offset + relative_offset > actual_expansion.text_range().end() {
                         // offset outside of bounds from the original expansion,
                         // stop here to prevent problems from happening
                         break 'expansion;
@@ -176,7 +179,7 @@ fn expand(
                 // successful expansions
                 (Some(actual_expansion), Some((fake_expansion, fake_mapped_token))) => {
                     let new_offset = fake_mapped_token.text_range().start();
-                    if new_offset > actual_expansion.text_range().end() {
+                    if new_offset + relative_offset > actual_expansion.text_range().end() {
                         // offset outside of bounds from the original expansion,
                         // stop here to prevent problems from happening
                         break 'expansion;

--- a/crates/ide-completion/src/tests/proc_macros.rs
+++ b/crates/ide-completion/src/tests/proc_macros.rs
@@ -131,3 +131,33 @@ fn main() {}
         "#]],
     )
 }
+
+#[test]
+fn issue_13836_str() {
+    check(
+        r#"
+//- proc_macros: shorten
+fn main() {
+    let s = proc_macros::shorten!("text.$0");
+}
+"#,
+        expect![[r#""#]],
+    )
+}
+
+#[test]
+fn issue_13836_ident() {
+    check(
+        r#"
+//- proc_macros: shorten
+struct S;
+impl S {
+    fn foo(&self) {}
+}
+fn main() {
+    let s = proc_macros::shorten!(S.fo$0);
+}
+"#,
+        expect![[r#""#]],
+    )
+}


### PR DESCRIPTION
Fixes #13836

When we check if the offset of fake ident token is out of bounds in the "actual expansion" (i.e. expansion without the fake ident token), we should take relative offset to it into account to match [how we'd get token after expansion](https://github.com/rust-lang/rust-analyzer/blob/f1b257f4eb4fef74b42fd7135d1cf3884e8b51c9/crates/ide-completion/src/context/analysis.rs#L53-L54).