### PR TITLE
Parse macros `allow_internal_unsafe` attribute

### DIFF
--- a/crates/hir-def/src/lib.rs
+++ b/crates/hir-def/src/lib.rs
@@ -290,6 +290,7 @@ pub struct Macro2Loc {
     pub container: ModuleId,
     pub id: ItemTreeId<MacroDef>,
     pub expander: MacroExpander,
+    pub allow_internal_unsafe: bool,
 }
 impl_intern!(Macro2Id, Macro2Loc, intern_macro2, lookup_intern_macro2);
 
@@ -299,8 +300,9 @@ pub struct MacroRulesId(salsa::InternId);
 pub struct MacroRulesLoc {
     pub container: ModuleId,
     pub id: ItemTreeId<MacroRules>,
-    pub local_inner: bool,
     pub expander: MacroExpander,
+    pub allow_internal_unsafe: bool,
+    pub local_inner: bool,
 }
 impl_intern!(MacroRulesId, MacroRulesLoc, intern_macro_rules, lookup_intern_macro_rules);
 
@@ -894,6 +896,7 @@ pub fn macro_id_to_def_id(db: &dyn db::DefDatabase, id: MacroId) -> MacroDefId {
                     }
                 },
                 local_inner: false,
+                allow_internal_unsafe: loc.allow_internal_unsafe,
             }
         }
         MacroId::MacroRulesId(it) => {
@@ -918,6 +921,7 @@ pub fn macro_id_to_def_id(db: &dyn db::DefDatabase, id: MacroId) -> MacroDefId {
                     }
                 },
                 local_inner: loc.local_inner,
+                allow_internal_unsafe: loc.allow_internal_unsafe,
             }
         }
         MacroId::ProcMacroId(it) => {
@@ -933,6 +937,7 @@ pub fn macro_id_to_def_id(db: &dyn db::DefDatabase, id: MacroId) -> MacroDefId {
                     InFile::new(loc.id.file_id(), makro.ast_id),
                 ),
                 local_inner: false,
+                allow_internal_unsafe: false,
             }
         }
     }

--- a/crates/hir-def/src/macro_expansion_tests.rs
+++ b/crates/hir-def/src/macro_expansion_tests.rs
@@ -97,7 +97,9 @@ pub fn identity_when_valid(_attr: TokenStream, item: TokenStream) -> TokenStream
         let ast_id = AstId::new(source.file_id, file_ast_id.upcast());
         let kind = MacroDefKind::Declarative(ast_id);
 
-        let macro_def = db.macro_def(MacroDefId { krate, kind, local_inner: false }).unwrap();
+        let macro_def = db
+            .macro_def(MacroDefId { krate, kind, local_inner: false, allow_internal_unsafe: false })
+            .unwrap();
         if let TokenExpander::DeclarativeMacro { mac, def_site_token_map } = &*macro_def {
             let tt = match &macro_ {
                 ast::Macro::MacroRules(mac) => mac.token_tree().unwrap(),

--- a/crates/hir-def/src/nameres/collector.rs
+++ b/crates/hir-def/src/nameres/collector.rs
@@ -1982,11 +1982,13 @@ impl ModCollector<'_, '_> {
             // Case 2: normal `macro_rules!` macro
             MacroExpander::Declarative
         };
+        let allow_internal_unsafe = attrs.by_key("allow_internal_unsafe").exists();
 
         let macro_id = MacroRulesLoc {
             container: module,
             id: ItemTreeId::new(self.tree_id, id),
             local_inner,
+            allow_internal_unsafe,
             expander,
         }
         .intern(self.def_collector.db);
@@ -2046,10 +2048,15 @@ impl ModCollector<'_, '_> {
             // Case 2: normal `macro`
             MacroExpander::Declarative
         };
+        let allow_internal_unsafe = attrs.by_key("allow_internal_unsafe").exists();
 
-        let macro_id =
-            Macro2Loc { container: module, id: ItemTreeId::new(self.tree_id, id), expander }
-                .intern(self.def_collector.db);
+        let macro_id = Macro2Loc {
+            container: module,
+            id: ItemTreeId::new(self.tree_id, id),
+            expander,
+            allow_internal_unsafe,
+        }
+        .intern(self.def_collector.db);
         self.def_collector.define_macro_def(
             self.module_id,
             mac.name.clone(),

--- a/crates/hir-expand/src/lib.rs
+++ b/crates/hir-expand/src/lib.rs
@@ -116,6 +116,7 @@ pub struct MacroDefId {
     pub krate: CrateId,
     pub kind: MacroDefKind,
     pub local_inner: bool,
+    pub allow_internal_unsafe: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]


### PR DESCRIPTION
We don't use it for anything yet but it might become part of hygiene