### PR TITLE
Make tt generic over the span data

### DIFF
--- a/crates/base-db/src/fixture.rs
+++ b/crates/base-db/src/fixture.rs
@@ -6,7 +6,7 @@ use rustc_hash::FxHashMap;
 use test_utils::{
     extract_range_or_offset, Fixture, RangeOrOffset, CURSOR_MARKER, ESCAPED_CURSOR_MARKER,
 };
-use tt::Subtree;
+use tt::token_id::Subtree;
 use vfs::{file_set::FileSet, VfsPath};
 
 use crate::{
@@ -495,16 +495,15 @@ impl ProcMacroExpander for MirrorProcMacroExpander {
         _: &Env,
     ) -> Result<Subtree, ProcMacroExpansionError> {
         fn traverse(input: &Subtree) -> Subtree {
-            let mut res = Subtree::default();
-            res.delimiter = input.delimiter;
+            let mut token_trees = vec![];
             for tt in input.token_trees.iter().rev() {
                 let tt = match tt {
                     tt::TokenTree::Leaf(leaf) => tt::TokenTree::Leaf(leaf.clone()),
                     tt::TokenTree::Subtree(sub) => tt::TokenTree::Subtree(traverse(sub)),
                 };
-                res.token_trees.push(tt);
+                token_trees.push(tt);
             }
-            res
+            Subtree { delimiter: input.delimiter, token_trees }
         }
         Ok(traverse(input))
     }

--- a/crates/base-db/src/input.rs
+++ b/crates/base-db/src/input.rs
@@ -12,7 +12,7 @@ use cfg::CfgOptions;
 use rustc_hash::FxHashMap;
 use stdx::hash::{NoHashHashMap, NoHashHashSet};
 use syntax::SmolStr;
-use tt::Subtree;
+use tt::token_id::Subtree;
 use vfs::{file_set::FileSet, AnchoredPath, FileId, VfsPath};
 
 /// Files are grouped into source roots. A source root is a directory on the

--- a/crates/cfg/src/cfg_expr.rs
+++ b/crates/cfg/src/cfg_expr.rs
@@ -66,7 +66,7 @@ impl From<CfgAtom> for CfgExpr {
 }
 
 impl CfgExpr {
-    pub fn parse(tt: &tt::Subtree) -> CfgExpr {
+    pub fn parse<S>(tt: &tt::Subtree<S>) -> CfgExpr {
         next_cfg_expr(&mut tt.token_trees.iter()).unwrap_or(CfgExpr::Invalid)
     }
     /// Fold the cfg by querying all basic `Atom` and `KeyValue` predicates.
@@ -85,7 +85,7 @@ impl CfgExpr {
     }
 }
 
-fn next_cfg_expr(it: &mut SliceIter<'_, tt::TokenTree>) -> Option<CfgExpr> {
+fn next_cfg_expr<S>(it: &mut SliceIter<'_, tt::TokenTree<S>>) -> Option<CfgExpr> {
     let name = match it.next() {
         None => return None,
         Some(tt::TokenTree::Leaf(tt::Leaf::Ident(ident))) => ident.text.clone(),

--- a/crates/hir-def/src/adt.rs
+++ b/crates/hir-def/src/adt.rs
@@ -2,6 +2,7 @@
 
 use std::sync::Arc;
 
+use crate::tt::{Delimiter, DelimiterKind, Leaf, Subtree, TokenTree};
 use base_db::CrateId;
 use either::Either;
 use hir_expand::{
@@ -12,7 +13,6 @@ use intern::Interned;
 use la_arena::{Arena, ArenaMap};
 use rustc_abi::{Integer, IntegerType};
 use syntax::ast::{self, HasName, HasVisibility};
-use tt::{Delimiter, DelimiterKind, Leaf, Subtree, TokenTree};
 
 use crate::{
     body::{CfgExpander, LowerCtx},
@@ -82,7 +82,7 @@ fn repr_from_value(
 
 fn parse_repr_tt(tt: &Subtree) -> Option<ReprOptions> {
     match tt.delimiter {
-        Some(Delimiter { kind: DelimiterKind::Parenthesis, .. }) => {}
+        Delimiter { kind: DelimiterKind::Parenthesis, .. } => {}
         _ => return None,
     }
 

--- a/crates/hir-def/src/attr.rs
+++ b/crates/hir-def/src/attr.rs
@@ -16,7 +16,6 @@ use syntax::{
     ast::{self, HasAttrs, IsString},
     AstPtr, AstToken, SmolStr, TextRange, TextSize,
 };
-use tt::Subtree;
 
 use crate::{
     db::DefDatabase,
@@ -234,7 +233,7 @@ impl Attrs {
 
     pub fn has_doc_hidden(&self) -> bool {
         self.by_key("doc").tt_values().any(|tt| {
-            tt.delimiter_kind() == Some(DelimiterKind::Parenthesis) &&
+            tt.delimiter.kind == DelimiterKind::Parenthesis &&
                 matches!(&*tt.token_trees, [tt::TokenTree::Leaf(tt::Leaf::Ident(ident))] if ident.text == "hidden")
         })
     }
@@ -628,7 +627,7 @@ pub struct AttrQuery<'attr> {
 }
 
 impl<'attr> AttrQuery<'attr> {
-    pub fn tt_values(self) -> impl Iterator<Item = &'attr Subtree> {
+    pub fn tt_values(self) -> impl Iterator<Item = &'attr crate::tt::Subtree> {
         self.attrs().filter_map(|attr| attr.token_tree_value())
     }
 

--- a/crates/hir-def/src/data.rs
+++ b/crates/hir-def/src/data.rs
@@ -142,7 +142,7 @@ impl FunctionData {
     }
 }
 
-fn parse_rustc_legacy_const_generics(tt: &tt::Subtree) -> Box<[u32]> {
+fn parse_rustc_legacy_const_generics(tt: &crate::tt::Subtree) -> Box<[u32]> {
     let mut indices = Vec::new();
     for args in tt.token_trees.chunks(2) {
         match &args[0] {

--- a/crates/hir-def/src/macro_expansion_tests.rs
+++ b/crates/hir-def/src/macro_expansion_tests.rs
@@ -30,7 +30,7 @@ use syntax::{
     SyntaxKind::{self, COMMENT, EOF, IDENT, LIFETIME_IDENT},
     SyntaxNode, TextRange, T,
 };
-use tt::{Subtree, TokenId};
+use tt::token_id::{Subtree, TokenId};
 
 use crate::{
     db::DefDatabase, macro_id_to_def_id, nameres::ModuleSource, resolver::HasResolver,
@@ -253,9 +253,9 @@ fn extract_id_ranges(ranges: &mut Vec<(TextRange, TokenId)>, map: &TokenMap, tre
     tree.token_trees.iter().for_each(|tree| match tree {
         tt::TokenTree::Leaf(leaf) => {
             let id = match leaf {
-                tt::Leaf::Literal(it) => it.id,
-                tt::Leaf::Punct(it) => it.id,
-                tt::Leaf::Ident(it) => it.id,
+                tt::Leaf::Literal(it) => it.span,
+                tt::Leaf::Punct(it) => it.span,
+                tt::Leaf::Ident(it) => it.span,
             };
             ranges.extend(map.ranges_by_token(id, SyntaxKind::ERROR).map(|range| (range, id)));
         }

--- a/crates/hir-def/src/nameres/proc_macro.rs
+++ b/crates/hir-def/src/nameres/proc_macro.rs
@@ -1,9 +1,9 @@
 //! Nameres-specific procedural macro data and helpers.
 
 use hir_expand::name::{AsName, Name};
-use tt::{Leaf, TokenTree};
 
 use crate::attr::Attrs;
+use crate::tt::{Leaf, TokenTree};
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct ProcMacroDef {

--- a/crates/hir-expand/src/builtin_attr_macro.rs
+++ b/crates/hir-expand/src/builtin_attr_macro.rs
@@ -1,6 +1,6 @@
 //! Builtin attributes.
 
-use crate::{db::AstDatabase, name, ExpandResult, MacroCallId, MacroCallKind};
+use crate::{db::AstDatabase, name, tt, ExpandResult, MacroCallId, MacroCallKind};
 
 macro_rules! register_builtin {
     ( $(($name:ident, $variant:ident) => $expand:ident),* ) => {
@@ -97,7 +97,7 @@ fn derive_attr_expand(
     let loc = db.lookup_intern_macro_call(id);
     let derives = match &loc.kind {
         MacroCallKind::Attr { attr_args, is_derive: true, .. } => &attr_args.0,
-        _ => return ExpandResult::ok(Default::default()),
+        _ => return ExpandResult::ok(tt::Subtree::empty()),
     };
     pseudo_derive_attr_expansion(tt, derives)
 }
@@ -110,7 +110,7 @@ pub fn pseudo_derive_attr_expansion(
         tt::TokenTree::Leaf(tt::Leaf::Punct(tt::Punct {
             char,
             spacing: tt::Spacing::Alone,
-            id: tt::TokenId::unspecified(),
+            span: tt::TokenId::unspecified(),
         }))
     };
 

--- a/crates/hir-expand/src/eager.rs
+++ b/crates/hir-expand/src/eager.rs
@@ -108,7 +108,7 @@ pub fn expand_eager_macro(
         .value
         .token_tree()
         .map(|tt| mbe::syntax_node_to_token_tree(tt.syntax()).0)
-        .unwrap_or_default();
+        .unwrap_or_else(tt::Subtree::empty);
 
     let ast_map = db.ast_id_map(macro_call.file_id);
     let call_id = InFile::new(macro_call.file_id, ast_map.ast_id(&macro_call.value));
@@ -165,9 +165,9 @@ pub fn expand_eager_macro(
     }
 }
 
-fn to_subtree(node: &SyntaxNode) -> tt::Subtree {
+fn to_subtree(node: &SyntaxNode) -> crate::tt::Subtree {
     let mut subtree = mbe::syntax_node_to_token_tree(node).0;
-    subtree.delimiter = None;
+    subtree.delimiter = crate::tt::Delimiter::unspecified();
     subtree
 }
 

--- a/crates/hir-expand/src/hygiene.rs
+++ b/crates/hir-expand/src/hygiene.rs
@@ -128,7 +128,7 @@ struct HygieneInfo {
     attr_input_or_mac_def_start: Option<InFile<TextSize>>,
 
     macro_def: Arc<TokenExpander>,
-    macro_arg: Arc<(tt::Subtree, mbe::TokenMap, fixup::SyntaxFixupUndoInfo)>,
+    macro_arg: Arc<(crate::tt::Subtree, mbe::TokenMap, fixup::SyntaxFixupUndoInfo)>,
     macro_arg_shift: mbe::Shift,
     exp_map: Arc<mbe::TokenMap>,
 }

--- a/crates/hir-expand/src/lib.rs
+++ b/crates/hir-expand/src/lib.rs
@@ -22,6 +22,8 @@ mod fixup;
 
 pub use mbe::{Origin, ValueResult};
 
+use ::tt::token_id as tt;
+
 use std::{fmt, hash::Hash, iter, sync::Arc};
 
 use base_db::{

--- a/crates/hir-expand/src/name.rs
+++ b/crates/hir-expand/src/name.rs
@@ -191,7 +191,7 @@ impl AsName for ast::NameOrNameRef {
     }
 }
 
-impl AsName for tt::Ident {
+impl<Span> AsName for tt::Ident<Span> {
     fn as_name(&self) -> Name {
         Name::resolve(&self.text)
     }

--- a/crates/mbe/src/benchmark.rs
+++ b/crates/mbe/src/benchmark.rs
@@ -9,7 +9,7 @@ use test_utils::{bench, bench_fixture, skip_slow_tests};
 
 use crate::{
     parser::{MetaVarKind, Op, RepeatKind, Separator},
-    syntax_node_to_token_tree, DeclarativeMacro,
+    syntax_node_to_token_tree, tt, DeclarativeMacro,
 };
 
 #[test]
@@ -91,7 +91,14 @@ fn invocation_fixtures(rules: &FxHashMap<String, DeclarativeMacro>) -> Vec<(Stri
                 // So we just skip any error cases and try again
                 let mut try_cnt = 0;
                 loop {
-                    let mut subtree = tt::Subtree::default();
+                    let mut subtree = tt::Subtree {
+                        delimiter: tt::Delimiter {
+                            open: tt::TokenId::UNSPECIFIED,
+                            close: tt::TokenId::UNSPECIFIED,
+                            kind: tt::DelimiterKind::Invisible,
+                        },
+                        token_trees: vec![],
+                    };
                     for op in rule.lhs.iter() {
                         collect_from_op(op, &mut subtree, &mut seed);
                     }
@@ -196,12 +203,15 @@ fn invocation_fixtures(rules: &FxHashMap<String, DeclarativeMacro>) -> Vec<(Stri
             *seed
         }
         fn make_ident(ident: &str) -> tt::TokenTree {
-            tt::Leaf::Ident(tt::Ident { id: tt::TokenId::unspecified(), text: SmolStr::new(ident) })
-                .into()
+            tt::Leaf::Ident(tt::Ident {
+                span: tt::TokenId::unspecified(),
+                text: SmolStr::new(ident),
+            })
+            .into()
         }
         fn make_punct(char: char) -> tt::TokenTree {
             tt::Leaf::Punct(tt::Punct {
-                id: tt::TokenId::unspecified(),
+                span: tt::TokenId::unspecified(),
                 char,
                 spacing: tt::Spacing::Alone,
             })
@@ -209,7 +219,7 @@ fn invocation_fixtures(rules: &FxHashMap<String, DeclarativeMacro>) -> Vec<(Stri
         }
         fn make_literal(lit: &str) -> tt::TokenTree {
             tt::Leaf::Literal(tt::Literal {
-                id: tt::TokenId::unspecified(),
+                span: tt::TokenId::unspecified(),
                 text: SmolStr::new(lit),
             })
             .into()
@@ -219,7 +229,11 @@ fn invocation_fixtures(rules: &FxHashMap<String, DeclarativeMacro>) -> Vec<(Stri
             token_trees: Option<Vec<tt::TokenTree>>,
         ) -> tt::TokenTree {
             tt::Subtree {
-                delimiter: Some(tt::Delimiter { id: tt::TokenId::unspecified(), kind }),
+                delimiter: tt::Delimiter {
+                    open: tt::TokenId::unspecified(),
+                    close: tt::TokenId::unspecified(),
+                    kind,
+                },
                 token_trees: token_trees.unwrap_or_default(),
             }
             .into()

--- a/crates/mbe/src/expander.rs
+++ b/crates/mbe/src/expander.rs
@@ -8,7 +8,7 @@ mod transcriber;
 use rustc_hash::FxHashMap;
 use syntax::SmolStr;
 
-use crate::{parser::MetaVarKind, ExpandError, ExpandResult};
+use crate::{parser::MetaVarKind, tt, ExpandError, ExpandResult};
 
 pub(crate) fn expand_rules(
     rules: &[crate::Rule],
@@ -45,7 +45,10 @@ pub(crate) fn expand_rules(
             transcriber::transcribe(&rule.rhs, &match_.bindings);
         ExpandResult { value, err: match_.err.or(transcribe_err) }
     } else {
-        ExpandResult::only_err(ExpandError::NoMatchingRule)
+        ExpandResult::with_err(
+            tt::Subtree { delimiter: tt::Delimiter::unspecified(), token_trees: vec![] },
+            ExpandError::NoMatchingRule,
+        )
     }
 }
 

--- a/crates/mbe/src/expander/transcriber.rs
+++ b/crates/mbe/src/expander/transcriber.rs
@@ -2,11 +2,11 @@
 //! `$ident => foo`, interpolates variables in the template, to get `fn foo() {}`
 
 use syntax::SmolStr;
-use tt::{Delimiter, Subtree};
 
 use crate::{
     expander::{Binding, Bindings, Fragment},
     parser::{MetaVarKind, Op, RepeatKind, Separator},
+    tt::{self, Delimiter},
     ExpandError, ExpandResult, MetaTemplate,
 };
 
@@ -44,22 +44,23 @@ impl Bindings {
             Binding::Missing(it) => Ok(match it {
                 MetaVarKind::Stmt => {
                     Fragment::Tokens(tt::TokenTree::Leaf(tt::Leaf::Punct(tt::Punct {
-                        id: tt::TokenId::unspecified(),
+                        span: tt::TokenId::unspecified(),
                         char: ';',
                         spacing: tt::Spacing::Alone,
                     })))
                 }
                 MetaVarKind::Block => Fragment::Tokens(tt::TokenTree::Subtree(tt::Subtree {
-                    delimiter: Some(tt::Delimiter {
-                        id: tt::TokenId::unspecified(),
+                    delimiter: tt::Delimiter {
+                        open: tt::TokenId::unspecified(),
+                        close: tt::TokenId::unspecified(),
                         kind: tt::DelimiterKind::Brace,
-                    }),
+                    },
                     token_trees: vec![],
                 })),
                 // FIXME: Meta and Item should get proper defaults
                 MetaVarKind::Meta | MetaVarKind::Item | MetaVarKind::Tt | MetaVarKind::Vis => {
                     Fragment::Tokens(tt::TokenTree::Subtree(tt::Subtree {
-                        delimiter: None,
+                        delimiter: tt::Delimiter::UNSPECIFIED,
                         token_trees: vec![],
                     }))
                 }
@@ -71,19 +72,19 @@ impl Bindings {
                 | MetaVarKind::Ident => {
                     Fragment::Tokens(tt::TokenTree::Leaf(tt::Leaf::Ident(tt::Ident {
                         text: SmolStr::new_inline("missing"),
-                        id: tt::TokenId::unspecified(),
+                        span: tt::TokenId::unspecified(),
                     })))
                 }
                 MetaVarKind::Lifetime => {
                     Fragment::Tokens(tt::TokenTree::Leaf(tt::Leaf::Ident(tt::Ident {
                         text: SmolStr::new_inline("'missing"),
-                        id: tt::TokenId::unspecified(),
+                        span: tt::TokenId::unspecified(),
                     })))
                 }
                 MetaVarKind::Literal => {
                     Fragment::Tokens(tt::TokenTree::Leaf(tt::Leaf::Ident(tt::Ident {
                         text: SmolStr::new_inline("\"missing\""),
-                        id: tt::TokenId::unspecified(),
+                        span: tt::TokenId::unspecified(),
                     })))
                 }
             }),
@@ -143,7 +144,7 @@ fn expand_subtree(
             }
             Op::Subtree { tokens, delimiter } => {
                 let ExpandResult { value: tt, err: e } =
-                    expand_subtree(ctx, tokens, *delimiter, arena);
+                    expand_subtree(ctx, tokens, Some(*delimiter), arena);
                 err = err.or(e);
                 arena.push(tt.into());
             }
@@ -170,7 +171,7 @@ fn expand_subtree(
                 arena.push(
                     tt::Leaf::Literal(tt::Literal {
                         text: index.to_string().into(),
-                        id: tt::TokenId::unspecified(),
+                        span: tt::TokenId::unspecified(),
                     })
                     .into(),
                 );
@@ -179,7 +180,13 @@ fn expand_subtree(
     }
     // drain the elements added in this instance of expand_subtree
     let tts = arena.drain(start_elements..).collect();
-    ExpandResult { value: tt::Subtree { delimiter, token_trees: tts }, err }
+    ExpandResult {
+        value: tt::Subtree {
+            delimiter: delimiter.unwrap_or_else(tt::Delimiter::unspecified),
+            token_trees: tts,
+        },
+        err,
+    }
 }
 
 fn expand_var(ctx: &mut ExpandCtx<'_>, v: &SmolStr, id: tt::TokenId) -> ExpandResult<Fragment> {
@@ -201,17 +208,24 @@ fn expand_var(ctx: &mut ExpandCtx<'_>, v: &SmolStr, id: tt::TokenId) -> ExpandRe
         // ```
         // We just treat it a normal tokens
         let tt = tt::Subtree {
-            delimiter: None,
+            delimiter: tt::Delimiter::UNSPECIFIED,
             token_trees: vec![
-                tt::Leaf::from(tt::Punct { char: '$', spacing: tt::Spacing::Alone, id }).into(),
-                tt::Leaf::from(tt::Ident { text: v.clone(), id }).into(),
+                tt::Leaf::from(tt::Punct { char: '$', spacing: tt::Spacing::Alone, span: id })
+                    .into(),
+                tt::Leaf::from(tt::Ident { text: v.clone(), span: id }).into(),
             ],
         }
         .into();
         ExpandResult::ok(Fragment::Tokens(tt))
     } else {
         ctx.bindings.get(v, &mut ctx.nesting).map_or_else(
-            |e| ExpandResult { value: Fragment::Tokens(tt::TokenTree::empty()), err: Some(e) },
+            |e| ExpandResult {
+                value: Fragment::Tokens(tt::TokenTree::Subtree(tt::Subtree {
+                    delimiter: tt::Delimiter::unspecified(),
+                    token_trees: vec![],
+                })),
+                err: Some(e),
+            },
             ExpandResult::ok,
         )
     }
@@ -249,7 +263,10 @@ fn expand_repeat(
                 ctx
             );
             return ExpandResult {
-                value: Fragment::Tokens(Subtree::default().into()),
+                value: Fragment::Tokens(
+                    tt::Subtree { delimiter: tt::Delimiter::unspecified(), token_trees: vec![] }
+                        .into(),
+                ),
                 err: Some(ExpandError::LimitExceeded),
             };
         }
@@ -258,7 +275,7 @@ fn expand_repeat(
             continue;
         }
 
-        t.delimiter = None;
+        t.delimiter = tt::Delimiter::unspecified();
         push_subtree(&mut buf, t);
 
         if let Some(sep) = separator {
@@ -292,7 +309,7 @@ fn expand_repeat(
 
     // Check if it is a single token subtree without any delimiter
     // e.g {Delimiter:None> ['>'] /Delimiter:None>}
-    let tt = tt::Subtree { delimiter: None, token_trees: buf }.into();
+    let tt = tt::Subtree { delimiter: tt::Delimiter::unspecified(), token_trees: buf }.into();
 
     if RepeatKind::OneOrMore == kind && counter == 0 {
         return ExpandResult {
@@ -307,11 +324,12 @@ fn push_fragment(buf: &mut Vec<tt::TokenTree>, fragment: Fragment) {
     match fragment {
         Fragment::Tokens(tt::TokenTree::Subtree(tt)) => push_subtree(buf, tt),
         Fragment::Expr(tt::TokenTree::Subtree(mut tt)) => {
-            if tt.delimiter.is_none() {
-                tt.delimiter = Some(tt::Delimiter {
-                    id: tt::TokenId::unspecified(),
+            if tt.delimiter.kind == tt::DelimiterKind::Invisible {
+                tt.delimiter = tt::Delimiter {
+                    open: tt::TokenId::UNSPECIFIED,
+                    close: tt::TokenId::UNSPECIFIED,
                     kind: tt::DelimiterKind::Parenthesis,
-                })
+                };
             }
             buf.push(tt.into())
         }
@@ -320,8 +338,8 @@ fn push_fragment(buf: &mut Vec<tt::TokenTree>, fragment: Fragment) {
 }
 
 fn push_subtree(buf: &mut Vec<tt::TokenTree>, tt: tt::Subtree) {
-    match tt.delimiter {
-        None => buf.extend(tt.token_trees),
-        Some(_) => buf.push(tt.into()),
+    match tt.delimiter.kind {
+        tt::DelimiterKind::Invisible => buf.extend(tt.token_trees),
+        _ => buf.push(tt.into()),
     }
 }

--- a/crates/mbe/src/parser.rs
+++ b/crates/mbe/src/parser.rs
@@ -4,7 +4,7 @@
 use smallvec::{smallvec, SmallVec};
 use syntax::SmolStr;
 
-use crate::{tt_iter::TtIter, ParseError};
+use crate::{tt, tt_iter::TtIter, ParseError};
 
 /// Consider
 ///
@@ -54,7 +54,7 @@ pub(crate) enum Op {
     Ignore { name: SmolStr, id: tt::TokenId },
     Index { depth: u32 },
     Repeat { tokens: MetaTemplate, kind: RepeatKind, separator: Option<Separator> },
-    Subtree { tokens: MetaTemplate, delimiter: Option<tt::Delimiter> },
+    Subtree { tokens: MetaTemplate, delimiter: tt::Delimiter },
     Literal(tt::Literal),
     Punct(SmallVec<[tt::Punct; 3]>),
     Ident(tt::Ident),
@@ -130,13 +130,13 @@ fn next_op(
                 Some(it) => it,
             };
             match second {
-                tt::TokenTree::Subtree(subtree) => match subtree.delimiter_kind() {
-                    Some(tt::DelimiterKind::Parenthesis) => {
+                tt::TokenTree::Subtree(subtree) => match subtree.delimiter.kind {
+                    tt::DelimiterKind::Parenthesis => {
                         let (separator, kind) = parse_repeat(src)?;
                         let tokens = MetaTemplate::parse(subtree, mode)?;
                         Op::Repeat { tokens, separator, kind }
                     }
-                    Some(tt::DelimiterKind::Brace) => match mode {
+                    tt::DelimiterKind::Brace => match mode {
                         Mode::Template => {
                             parse_metavar_expr(&mut TtIter::new(subtree)).map_err(|()| {
                                 ParseError::unexpected("invalid metavariable expression")
@@ -157,18 +157,18 @@ fn next_op(
                 tt::TokenTree::Leaf(leaf) => match leaf {
                     tt::Leaf::Ident(ident) if ident.text == "crate" => {
                         // We simply produce identifier `$crate` here. And it will be resolved when lowering ast to Path.
-                        Op::Ident(tt::Ident { text: "$crate".into(), id: ident.id })
+                        Op::Ident(tt::Ident { text: "$crate".into(), span: ident.span })
                     }
                     tt::Leaf::Ident(ident) => {
                         let kind = eat_fragment_kind(src, mode)?;
                         let name = ident.text.clone();
-                        let id = ident.id;
+                        let id = ident.span;
                         Op::Var { name, kind, id }
                     }
                     tt::Leaf::Literal(lit) if is_boolean_literal(lit) => {
                         let kind = eat_fragment_kind(src, mode)?;
                         let name = lit.text.clone();
-                        let id = lit.id;
+                        let id = lit.span;
                         Op::Var { name, kind, id }
                     }
                     tt::Leaf::Punct(punct @ tt::Punct { char: '$', .. }) => match mode {
@@ -284,7 +284,7 @@ fn parse_metavar_expr(src: &mut TtIter<'_>) -> Result<Op, ()> {
     let func = src.expect_ident()?;
     let args = src.expect_subtree()?;
 
-    if args.delimiter_kind() != Some(tt::DelimiterKind::Parenthesis) {
+    if args.delimiter.kind != tt::DelimiterKind::Parenthesis {
         return Err(());
     }
 
@@ -293,7 +293,7 @@ fn parse_metavar_expr(src: &mut TtIter<'_>) -> Result<Op, ()> {
     let op = match &*func.text {
         "ignore" => {
             let ident = args.expect_ident()?;
-            Op::Ignore { name: ident.text.clone(), id: ident.id }
+            Op::Ignore { name: ident.text.clone(), id: ident.span }
         }
         "index" => {
             let depth = if args.len() == 0 { 0 } else { args.expect_u32_literal()? };

--- a/crates/mbe/src/syntax_bridge.rs
+++ b/crates/mbe/src/syntax_bridge.rs
@@ -8,9 +8,16 @@ use syntax::{
     SyntaxKind::*,
     SyntaxNode, SyntaxToken, SyntaxTreeBuilder, TextRange, TextSize, WalkEvent, T,
 };
-use tt::buffer::{Cursor, TokenBuffer};
 
-use crate::{to_parser_input::to_parser_input, tt_iter::TtIter, TokenMap};
+use crate::{
+    to_parser_input::to_parser_input,
+    tt::{
+        self,
+        buffer::{Cursor, TokenBuffer},
+    },
+    tt_iter::TtIter,
+    TokenMap,
+};
 
 #[cfg(test)]
 mod tests;
@@ -74,9 +81,10 @@ pub fn token_tree_to_syntax_node(
     entry_point: parser::TopEntryPoint,
 ) -> (Parse<SyntaxNode>, TokenMap) {
     let buffer = match tt {
-        tt::Subtree { delimiter: None, token_trees } => {
-            TokenBuffer::from_tokens(token_trees.as_slice())
-        }
+        tt::Subtree {
+            delimiter: tt::Delimiter { kind: tt::DelimiterKind::Invisible, .. },
+            token_trees,
+        } => TokenBuffer::from_tokens(token_trees.as_slice()),
         _ => TokenBuffer::from_subtree(tt),
     };
     let parser_input = to_parser_input(&buffer);
@@ -92,8 +100,7 @@ pub fn token_tree_to_syntax_node(
             parser::Step::Error { msg } => tree_sink.error(msg.to_string()),
         }
     }
-    let (parse, range_map) = tree_sink.finish();
-    (parse, range_map)
+    tree_sink.finish()
 }
 
 /// Convert a string to a `TokenTree`
@@ -132,7 +139,7 @@ pub fn parse_exprs_with_sep(tt: &tt::Subtree, sep: char) -> Vec<tt::Subtree> {
         res.push(match expanded.value {
             None => break,
             Some(tt @ tt::TokenTree::Leaf(_)) => {
-                tt::Subtree { delimiter: None, token_trees: vec![tt] }
+                tt::Subtree { delimiter: tt::Delimiter::unspecified(), token_trees: vec![tt] }
             }
             Some(tt::TokenTree::Subtree(tt)) => tt,
         });
@@ -145,7 +152,10 @@ pub fn parse_exprs_with_sep(tt: &tt::Subtree, sep: char) -> Vec<tt::Subtree> {
     }
 
     if iter.peek_n(0).is_some() {
-        res.push(tt::Subtree { delimiter: None, token_trees: iter.cloned().collect() });
+        res.push(tt::Subtree {
+            delimiter: tt::Delimiter::unspecified(),
+            token_trees: iter.cloned().collect(),
+        });
     }
 
     res
@@ -159,7 +169,7 @@ fn convert_tokens<C: TokenConverter>(conv: &mut C) -> tt::Subtree {
     }
 
     let entry = StackEntry {
-        subtree: tt::Subtree { delimiter: None, ..Default::default() },
+        subtree: tt::Subtree { delimiter: tt::Delimiter::unspecified(), token_trees: vec![] },
         // never used (delimiter is `None`)
         idx: !0,
         open_range: TextRange::empty(TextSize::of('.')),
@@ -186,7 +196,7 @@ fn convert_tokens<C: TokenConverter>(conv: &mut C) -> tt::Subtree {
                         if let Some(tt::TokenTree::Leaf(tt::Leaf::Literal(lit))) =
                             sub.token_trees.get_mut(2)
                         {
-                            lit.id = id
+                            lit.span = id
                         }
                     }
                     tt
@@ -199,13 +209,14 @@ fn convert_tokens<C: TokenConverter>(conv: &mut C) -> tt::Subtree {
                 assert_eq!(range.len(), TextSize::of('.'));
             }
 
-            if let Some(delim) = subtree.delimiter {
-                let expected = match delim.kind {
-                    tt::DelimiterKind::Parenthesis => T![')'],
-                    tt::DelimiterKind::Brace => T!['}'],
-                    tt::DelimiterKind::Bracket => T![']'],
-                };
+            let expected = match subtree.delimiter.kind {
+                tt::DelimiterKind::Parenthesis => Some(T![')']),
+                tt::DelimiterKind::Brace => Some(T!['}']),
+                tt::DelimiterKind::Bracket => Some(T![']']),
+                tt::DelimiterKind::Invisible => None,
+            };
 
+            if let Some(expected) = expected {
                 if kind == expected {
                     if let Some(entry) = stack.pop() {
                         conv.id_alloc().close_delim(entry.idx, Some(range));
@@ -223,9 +234,11 @@ fn convert_tokens<C: TokenConverter>(conv: &mut C) -> tt::Subtree {
             };
 
             if let Some(kind) = delim {
-                let mut subtree = tt::Subtree::default();
                 let (id, idx) = conv.id_alloc().open_delim(range, synth_id);
-                subtree.delimiter = Some(tt::Delimiter { id, kind });
+                let subtree = tt::Subtree {
+                    delimiter: tt::Delimiter { open: id, close: tt::TokenId::UNSPECIFIED, kind },
+                    token_trees: vec![],
+                };
                 stack.push(StackEntry { subtree, idx, open_range: range });
                 continue;
             }
@@ -240,13 +253,20 @@ fn convert_tokens<C: TokenConverter>(conv: &mut C) -> tt::Subtree {
                     panic!("Token from lexer must be single char: token = {token:#?}");
                 }
             };
-            tt::Leaf::from(tt::Punct { char, spacing, id: conv.id_alloc().alloc(range, synth_id) })
-                .into()
+            tt::Leaf::from(tt::Punct {
+                char,
+                spacing,
+                span: conv.id_alloc().alloc(range, synth_id),
+            })
+            .into()
         } else {
             macro_rules! make_leaf {
                 ($i:ident) => {
-                    tt::$i { id: conv.id_alloc().alloc(range, synth_id), text: token.to_text(conv) }
-                        .into()
+                    tt::$i {
+                        span: conv.id_alloc().alloc(range, synth_id),
+                        text: token.to_text(conv),
+                    }
+                    .into()
                 };
             }
             let leaf: tt::Leaf = match kind {
@@ -261,14 +281,14 @@ fn convert_tokens<C: TokenConverter>(conv: &mut C) -> tt::Subtree {
                     let apostrophe = tt::Leaf::from(tt::Punct {
                         char: '\'',
                         spacing: tt::Spacing::Joint,
-                        id: conv.id_alloc().alloc(r, synth_id),
+                        span: conv.id_alloc().alloc(r, synth_id),
                     });
                     result.push(apostrophe.into());
 
                     let r = TextRange::at(range.start() + char_unit, range.len() - char_unit);
                     let ident = tt::Leaf::from(tt::Ident {
                         text: SmolStr::new(&token.to_text(conv)[1..]),
-                        id: conv.id_alloc().alloc(r, synth_id),
+                        span: conv.id_alloc().alloc(r, synth_id),
                     });
                     result.push(ident.into());
                     continue;
@@ -289,11 +309,12 @@ fn convert_tokens<C: TokenConverter>(conv: &mut C) -> tt::Subtree {
 
         conv.id_alloc().close_delim(entry.idx, None);
         let leaf: tt::Leaf = tt::Punct {
-            id: conv.id_alloc().alloc(entry.open_range, None),
-            char: match entry.subtree.delimiter.unwrap().kind {
+            span: conv.id_alloc().alloc(entry.open_range, None),
+            char: match entry.subtree.delimiter.kind {
                 tt::DelimiterKind::Parenthesis => '(',
                 tt::DelimiterKind::Brace => '{',
                 tt::DelimiterKind::Bracket => '[',
+                tt::DelimiterKind::Invisible => '$',
             },
             spacing: tt::Spacing::Alone,
         }
@@ -373,10 +394,11 @@ fn convert_doc_comment(token: &syntax::SyntaxToken) -> Option<Vec<tt::TokenTree>
         token_trees.push(mk_punct('!'));
     }
     token_trees.push(tt::TokenTree::from(tt::Subtree {
-        delimiter: Some(tt::Delimiter {
+        delimiter: tt::Delimiter {
+            open: tt::TokenId::UNSPECIFIED,
+            close: tt::TokenId::UNSPECIFIED,
             kind: tt::DelimiterKind::Bracket,
-            id: tt::TokenId::unspecified(),
-        }),
+        },
         token_trees: meta_tkns,
     }));
 
@@ -386,7 +408,7 @@ fn convert_doc_comment(token: &syntax::SyntaxToken) -> Option<Vec<tt::TokenTree>
     fn mk_ident(s: &str) -> tt::TokenTree {
         tt::TokenTree::from(tt::Leaf::from(tt::Ident {
             text: s.into(),
-            id: tt::TokenId::unspecified(),
+            span: tt::TokenId::unspecified(),
         }))
     }
 
@@ -394,12 +416,12 @@ fn convert_doc_comment(token: &syntax::SyntaxToken) -> Option<Vec<tt::TokenTree>
         tt::TokenTree::from(tt::Leaf::from(tt::Punct {
             char: c,
             spacing: tt::Spacing::Alone,
-            id: tt::TokenId::unspecified(),
+            span: tt::TokenId::unspecified(),
         }))
     }
 
     fn mk_doc_literal(comment: &ast::Comment) -> tt::TokenTree {
-        let lit = tt::Literal { text: doc_comment_text(comment), id: tt::TokenId::unspecified() };
+        let lit = tt::Literal { text: doc_comment_text(comment), span: tt::TokenId::unspecified() };
 
         tt::TokenTree::from(tt::Leaf::from(lit))
     }
@@ -761,15 +783,16 @@ impl<'a> TtTreeSink<'a> {
     }
 }
 
-fn delim_to_str(d: tt::DelimiterKind, closing: bool) -> &'static str {
+fn delim_to_str(d: tt::DelimiterKind, closing: bool) -> Option<&'static str> {
     let texts = match d {
         tt::DelimiterKind::Parenthesis => "()",
         tt::DelimiterKind::Brace => "{}",
         tt::DelimiterKind::Bracket => "[]",
+        tt::DelimiterKind::Invisible => return None,
     };
 
     let idx = closing as usize;
-    &texts[idx..texts.len() - (1 - idx)]
+    Some(&texts[idx..texts.len() - (1 - idx)])
 }
 
 impl<'a> TtTreeSink<'a> {
@@ -790,13 +813,16 @@ impl<'a> TtTreeSink<'a> {
                     Some(tt::buffer::TokenTreeRef::Leaf(leaf, _)) => {
                         // Mark the range if needed
                         let (text, id) = match leaf {
-                            tt::Leaf::Ident(ident) => (ident.text.as_str(), ident.id),
+                            tt::Leaf::Ident(ident) => (ident.text.as_str(), ident.span),
                             tt::Leaf::Punct(punct) => {
                                 assert!(punct.char.is_ascii());
                                 tmp = punct.char as u8;
-                                (std::str::from_utf8(std::slice::from_ref(&tmp)).unwrap(), punct.id)
+                                (
+                                    std::str::from_utf8(std::slice::from_ref(&tmp)).unwrap(),
+                                    punct.span,
+                                )
                             }
-                            tt::Leaf::Literal(lit) => (lit.text.as_str(), lit.id),
+                            tt::Leaf::Literal(lit) => (lit.text.as_str(), lit.span),
                         };
                         let range = TextRange::at(self.text_pos, TextSize::of(text));
                         self.token_map.insert(id, range);
@@ -805,10 +831,10 @@ impl<'a> TtTreeSink<'a> {
                     }
                     Some(tt::buffer::TokenTreeRef::Subtree(subtree, _)) => {
                         self.cursor = self.cursor.subtree().unwrap();
-                        match subtree.delimiter {
-                            Some(d) => {
-                                self.open_delims.insert(d.id, self.text_pos);
-                                delim_to_str(d.kind, false)
+                        match delim_to_str(subtree.delimiter.kind, false) {
+                            Some(it) => {
+                                self.open_delims.insert(subtree.delimiter.open, self.text_pos);
+                                it
                             }
                             None => continue,
                         }
@@ -816,15 +842,21 @@ impl<'a> TtTreeSink<'a> {
                     None => {
                         let parent = self.cursor.end().unwrap();
                         self.cursor = self.cursor.bump();
-                        match parent.delimiter {
-                            Some(d) => {
-                                if let Some(open_delim) = self.open_delims.get(&d.id) {
+                        match delim_to_str(parent.delimiter.kind, true) {
+                            Some(it) => {
+                                if let Some(open_delim) =
+                                    self.open_delims.get(&parent.delimiter.open)
+                                {
                                     let open_range = TextRange::at(*open_delim, TextSize::of('('));
                                     let close_range =
                                         TextRange::at(self.text_pos, TextSize::of('('));
-                                    self.token_map.insert_delim(d.id, open_range, close_range);
+                                    self.token_map.insert_delim(
+                                        parent.delimiter.open,
+                                        open_range,
+                                        close_range,
+                                    );
                                 }
-                                delim_to_str(d.kind, true)
+                                it
                             }
                             None => continue,
                         }

--- a/crates/mbe/src/syntax_bridge/tests.rs
+++ b/crates/mbe/src/syntax_bridge/tests.rs
@@ -29,8 +29,8 @@ fn check_punct_spacing(fixture: &str) {
     let mut cursor = buf.begin();
     while !cursor.eof() {
         while let Some(token_tree) = cursor.token_tree() {
-            if let TokenTreeRef::Leaf(Leaf::Punct(Punct { spacing, id, .. }), _) = token_tree {
-                if let Some(expected) = annotations.remove(id) {
+            if let TokenTreeRef::Leaf(Leaf::Punct(Punct { spacing, span, .. }), _) = token_tree {
+                if let Some(expected) = annotations.remove(span) {
                     assert_eq!(expected, *spacing);
                 }
             }

--- a/crates/mbe/src/to_parser_input.rs
+++ b/crates/mbe/src/to_parser_input.rs
@@ -2,7 +2,8 @@
 //! format that works for our parser.
 
 use syntax::{SyntaxKind, SyntaxKind::*, T};
-use tt::buffer::TokenBuffer;
+
+use crate::tt::buffer::TokenBuffer;
 
 pub(crate) fn to_parser_input(buffer: &TokenBuffer<'_>) -> parser::Input {
     let mut res = parser::Input::default();
@@ -70,23 +71,25 @@ pub(crate) fn to_parser_input(buffer: &TokenBuffer<'_>) -> parser::Input {
                 cursor.bump()
             }
             Some(tt::buffer::TokenTreeRef::Subtree(subtree, _)) => {
-                if let Some(d) = subtree.delimiter_kind() {
-                    res.push(match d {
-                        tt::DelimiterKind::Parenthesis => T!['('],
-                        tt::DelimiterKind::Brace => T!['{'],
-                        tt::DelimiterKind::Bracket => T!['['],
-                    });
+                if let Some(kind) = match subtree.delimiter.kind {
+                    tt::DelimiterKind::Parenthesis => Some(T!['(']),
+                    tt::DelimiterKind::Brace => Some(T!['{']),
+                    tt::DelimiterKind::Bracket => Some(T!['[']),
+                    tt::DelimiterKind::Invisible => None,
+                } {
+                    res.push(kind);
                 }
                 cursor.subtree().unwrap()
             }
             None => match cursor.end() {
                 Some(subtree) => {
-                    if let Some(d) = subtree.delimiter_kind() {
-                        res.push(match d {
-                            tt::DelimiterKind::Parenthesis => T![')'],
-                            tt::DelimiterKind::Brace => T!['}'],
-                            tt::DelimiterKind::Bracket => T![']'],
-                        })
+                    if let Some(kind) = match subtree.delimiter.kind {
+                        tt::DelimiterKind::Parenthesis => Some(T![')']),
+                        tt::DelimiterKind::Brace => Some(T!['}']),
+                        tt::DelimiterKind::Bracket => Some(T![']']),
+                        tt::DelimiterKind::Invisible => None,
+                    } {
+                        res.push(kind);
                     }
                     cursor.bump()
                 }

--- a/crates/mbe/src/tt_iter.rs
+++ b/crates/mbe/src/tt_iter.rs
@@ -3,9 +3,8 @@
 
 use smallvec::{smallvec, SmallVec};
 use syntax::SyntaxKind;
-use tt::buffer::TokenBuffer;
 
-use crate::{to_parser_input::to_parser_input, ExpandError, ExpandResult};
+use crate::{to_parser_input::to_parser_input, tt, ExpandError, ExpandResult};
 
 #[derive(Debug, Clone)]
 pub(crate) struct TtIter<'a> {
@@ -135,7 +134,7 @@ impl<'a> TtIter<'a> {
         &mut self,
         entry_point: parser::PrefixEntryPoint,
     ) -> ExpandResult<Option<tt::TokenTree>> {
-        let buffer = TokenBuffer::from_tokens(self.inner.as_slice());
+        let buffer = tt::buffer::TokenBuffer::from_tokens(self.inner.as_slice());
         let parser_input = to_parser_input(&buffer);
         let tree_traversal = entry_point.parse(&parser_input);
 
@@ -178,7 +177,7 @@ impl<'a> TtIter<'a> {
             1 => Some(res[0].cloned()),
             0 => None,
             _ => Some(tt::TokenTree::Subtree(tt::Subtree {
-                delimiter: None,
+                delimiter: tt::Delimiter::unspecified(),
                 token_trees: res.into_iter().map(|it| it.cloned()).collect(),
             })),
         };

--- a/crates/proc-macro-api/src/lib.rs
+++ b/crates/proc-macro-api/src/lib.rs
@@ -19,7 +19,8 @@ use std::{
 };
 
 use serde::{Deserialize, Serialize};
-use tt::Subtree;
+
+use ::tt::token_id as tt;
 
 use crate::{
     msg::{ExpandMacro, FlatTree, PanicMessage},
@@ -151,10 +152,10 @@ impl ProcMacro {
 
     pub fn expand(
         &self,
-        subtree: &Subtree,
-        attr: Option<&Subtree>,
+        subtree: &tt::Subtree,
+        attr: Option<&tt::Subtree>,
         env: Vec<(String, String)>,
-    ) -> Result<Result<Subtree, PanicMessage>, ServerError> {
+    ) -> Result<Result<tt::Subtree, PanicMessage>, ServerError> {
         let current_dir = env
             .iter()
             .find(|(name, _)| name == "CARGO_MANIFEST_DIR")

--- a/crates/proc-macro-api/src/msg.rs
+++ b/crates/proc-macro-api/src/msg.rs
@@ -107,27 +107,31 @@ fn write_json(out: &mut impl Write, msg: &str) -> io::Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tt::*;
+    use crate::tt::*;
 
     fn fixture_token_tree() -> Subtree {
-        let mut subtree = Subtree::default();
+        let mut subtree = Subtree { delimiter: Delimiter::unspecified(), token_trees: Vec::new() };
         subtree
             .token_trees
-            .push(TokenTree::Leaf(Ident { text: "struct".into(), id: TokenId(0) }.into()));
+            .push(TokenTree::Leaf(Ident { text: "struct".into(), span: TokenId(0) }.into()));
         subtree
             .token_trees
-            .push(TokenTree::Leaf(Ident { text: "Foo".into(), id: TokenId(1) }.into()));
+            .push(TokenTree::Leaf(Ident { text: "Foo".into(), span: TokenId(1) }.into()));
         subtree.token_trees.push(TokenTree::Leaf(Leaf::Literal(Literal {
             text: "Foo".into(),
-            id: TokenId::unspecified(),
+            span: TokenId::unspecified(),
         })));
         subtree.token_trees.push(TokenTree::Leaf(Leaf::Punct(Punct {
             char: '@',
-            id: TokenId::unspecified(),
+            span: TokenId::unspecified(),
             spacing: Spacing::Joint,
         })));
         subtree.token_trees.push(TokenTree::Subtree(Subtree {
-            delimiter: Some(Delimiter { id: TokenId(2), kind: DelimiterKind::Brace }),
+            delimiter: Delimiter {
+                open: TokenId(2),
+                close: TokenId::UNSPECIFIED,
+                kind: DelimiterKind::Brace,
+            },
             token_trees: vec![],
         }));
         subtree

--- a/crates/proc-macro-srv/src/abis/abi_1_63/mod.rs
+++ b/crates/proc-macro-srv/src/abis/abi_1_63/mod.rs
@@ -11,6 +11,7 @@ mod ra_server;
 use libloading::Library;
 use proc_macro_api::ProcMacroKind;
 
+use super::tt;
 use super::PanicMessage;
 
 pub use ra_server::TokenStream;

--- a/crates/proc-macro-srv/src/abis/abi_sysroot/mod.rs
+++ b/crates/proc-macro-srv/src/abis/abi_sysroot/mod.rs
@@ -9,7 +9,7 @@ mod ra_server;
 use libloading::Library;
 use proc_macro_api::ProcMacroKind;
 
-use super::PanicMessage;
+use super::{tt, PanicMessage};
 
 pub use ra_server::TokenStream;
 

--- a/crates/proc-macro-srv/src/abis/abi_sysroot/ra_server.rs
+++ b/crates/proc-macro-srv/src/abis/abi_sysroot/ra_server.rs
@@ -22,6 +22,8 @@ pub use symbol::*;
 
 use std::ops::Bound;
 
+use crate::tt;
+
 type Group = tt::Subtree;
 type TokenTree = tt::TokenTree;
 type Punct = tt::Punct;
@@ -108,8 +110,9 @@ impl server::TokenStream for RustAnalyzer {
 
             bridge::TokenTree::Ident(ident) => {
                 let text = ident.sym.text();
-                let text = if ident.is_raw { tt::SmolStr::from_iter(["r#", &text]) } else { text };
-                let ident: tt::Ident = tt::Ident { text, id: ident.span };
+                let text =
+                    if ident.is_raw { ::tt::SmolStr::from_iter(["r#", &text]) } else { text };
+                let ident: tt::Ident = tt::Ident { text, span: ident.span };
                 let leaf = tt::Leaf::from(ident);
                 let tree = TokenTree::from(leaf);
                 Self::TokenStream::from_iter(vec![tree])
@@ -118,9 +121,9 @@ impl server::TokenStream for RustAnalyzer {
             bridge::TokenTree::Literal(literal) => {
                 let literal = LiteralFormatter(literal);
                 let text = literal
-                    .with_stringify_parts(|parts| tt::SmolStr::from_iter(parts.iter().copied()));
+                    .with_stringify_parts(|parts| ::tt::SmolStr::from_iter(parts.iter().copied()));
 
-                let literal = tt::Literal { text, id: literal.0.span };
+                let literal = tt::Literal { text, span: literal.0.span };
                 let leaf = tt::Leaf::from(literal);
                 let tree = TokenTree::from(leaf);
                 Self::TokenStream::from_iter(vec![tree])
@@ -130,7 +133,7 @@ impl server::TokenStream for RustAnalyzer {
                 let punct = tt::Punct {
                     char: p.ch as char,
                     spacing: if p.joint { Spacing::Joint } else { Spacing::Alone },
-                    id: p.span,
+                    span: p.span,
                 };
                 let leaf = tt::Leaf::from(punct);
                 let tree = TokenTree::from(leaf);
@@ -184,7 +187,7 @@ impl server::TokenStream for RustAnalyzer {
                     bridge::TokenTree::Ident(bridge::Ident {
                         sym: Symbol::intern(ident.text.trim_start_matches("r#")),
                         is_raw: ident.text.starts_with("r#"),
-                        span: ident.id,
+                        span: ident.span,
                     })
                 }
                 tt::TokenTree::Leaf(tt::Leaf::Literal(lit)) => {
@@ -194,14 +197,14 @@ impl server::TokenStream for RustAnalyzer {
                         symbol: Symbol::intern(&lit.text),
                         // FIXME: handle suffixes
                         suffix: None,
-                        span: lit.id,
+                        span: lit.span,
                     })
                 }
                 tt::TokenTree::Leaf(tt::Leaf::Punct(punct)) => {
                     bridge::TokenTree::Punct(bridge::Punct {
                         ch: punct.char as u8,
                         joint: punct.spacing == Spacing::Joint,
-                        span: punct.id,
+                        span: punct.span,
                     })
                 }
                 tt::TokenTree::Subtree(subtree) => bridge::TokenTree::Group(bridge::Group {
@@ -211,31 +214,29 @@ impl server::TokenStream for RustAnalyzer {
                     } else {
                         Some(subtree.token_trees.into_iter().collect())
                     },
-                    span: bridge::DelimSpan::from_single(
-                        subtree.delimiter.map_or(Span::unspecified(), |del| del.id),
-                    ),
+                    span: bridge::DelimSpan::from_single(subtree.delimiter.open),
                 }),
             })
             .collect()
     }
 }
 
-fn delim_to_internal(d: proc_macro::Delimiter) -> Option<tt::Delimiter> {
+fn delim_to_internal(d: proc_macro::Delimiter) -> tt::Delimiter {
     let kind = match d {
         proc_macro::Delimiter::Parenthesis => tt::DelimiterKind::Parenthesis,
         proc_macro::Delimiter::Brace => tt::DelimiterKind::Brace,
         proc_macro::Delimiter::Bracket => tt::DelimiterKind::Bracket,
-        proc_macro::Delimiter::None => return None,
+        proc_macro::Delimiter::None => tt::DelimiterKind::Invisible,
     };
-    Some(tt::Delimiter { id: tt::TokenId::unspecified(), kind })
+    tt::Delimiter { open: tt::TokenId::unspecified(), close: tt::TokenId::unspecified(), kind }
 }
 
-fn delim_to_external(d: Option<tt::Delimiter>) -> proc_macro::Delimiter {
-    match d.map(|it| it.kind) {
-        Some(tt::DelimiterKind::Parenthesis) => proc_macro::Delimiter::Parenthesis,
-        Some(tt::DelimiterKind::Brace) => proc_macro::Delimiter::Brace,
-        Some(tt::DelimiterKind::Bracket) => proc_macro::Delimiter::Bracket,
-        None => proc_macro::Delimiter::None,
+fn delim_to_external(d: tt::Delimiter) -> proc_macro::Delimiter {
+    match d.kind {
+        tt::DelimiterKind::Parenthesis => proc_macro::Delimiter::Parenthesis,
+        tt::DelimiterKind::Brace => proc_macro::Delimiter::Brace,
+        tt::DelimiterKind::Bracket => proc_macro::Delimiter::Bracket,
+        tt::DelimiterKind::Invisible => proc_macro::Delimiter::None,
     }
 }
 
@@ -349,7 +350,7 @@ impl server::Server for RustAnalyzer {
     }
 
     fn intern_symbol(ident: &str) -> Self::Symbol {
-        Symbol::intern(&tt::SmolStr::from(ident))
+        Symbol::intern(&::tt::SmolStr::from(ident))
     }
 
     fn with_symbol_string(symbol: &Self::Symbol, f: impl FnOnce(&str)) {
@@ -413,17 +414,18 @@ mod tests {
             token_trees: vec![
                 tt::TokenTree::Leaf(tt::Leaf::Ident(tt::Ident {
                     text: "struct".into(),
-                    id: tt::TokenId::unspecified(),
+                    span: tt::TokenId::unspecified(),
                 })),
                 tt::TokenTree::Leaf(tt::Leaf::Ident(tt::Ident {
                     text: "T".into(),
-                    id: tt::TokenId::unspecified(),
+                    span: tt::TokenId::unspecified(),
                 })),
                 tt::TokenTree::Subtree(tt::Subtree {
-                    delimiter: Some(tt::Delimiter {
-                        id: tt::TokenId::unspecified(),
+                    delimiter: tt::Delimiter {
+                        open: tt::TokenId::unspecified(),
+                        close: tt::TokenId::unspecified(),
                         kind: tt::DelimiterKind::Brace,
-                    }),
+                    },
                     token_trees: vec![],
                 }),
             ],
@@ -436,13 +438,14 @@ mod tests {
     fn test_ra_server_from_str() {
         use std::str::FromStr;
         let subtree_paren_a = tt::TokenTree::Subtree(tt::Subtree {
-            delimiter: Some(tt::Delimiter {
-                id: tt::TokenId::unspecified(),
+            delimiter: tt::Delimiter {
+                open: tt::TokenId::unspecified(),
+                close: tt::TokenId::unspecified(),
                 kind: tt::DelimiterKind::Parenthesis,
-            }),
+            },
             token_trees: vec![tt::TokenTree::Leaf(tt::Leaf::Ident(tt::Ident {
                 text: "a".into(),
-                id: tt::TokenId::unspecified(),
+                span: tt::TokenId::unspecified(),
             }))],
         });
 
@@ -459,7 +462,7 @@ mod tests {
             underscore.token_trees[0],
             tt::TokenTree::Leaf(tt::Leaf::Ident(tt::Ident {
                 text: "_".into(),
-                id: tt::TokenId::unspecified(),
+                span: tt::TokenId::unspecified(),
             }))
         );
     }

--- a/crates/proc-macro-srv/src/abis/abi_sysroot/ra_server/token_stream.rs
+++ b/crates/proc-macro-srv/src/abis/abi_sysroot/ra_server/token_stream.rs
@@ -1,6 +1,6 @@
 //! TokenStream implementation used by sysroot ABI
 
-use tt::TokenTree;
+use crate::tt::{self, TokenTree};
 
 #[derive(Debug, Default, Clone)]
 pub struct TokenStream {
@@ -13,7 +13,7 @@ impl TokenStream {
     }
 
     pub fn with_subtree(subtree: tt::Subtree) -> Self {
-        if subtree.delimiter.is_some() {
+        if subtree.delimiter.kind != tt::DelimiterKind::Invisible {
             TokenStream { token_trees: vec![TokenTree::Subtree(subtree)] }
         } else {
             TokenStream { token_trees: subtree.token_trees }
@@ -21,7 +21,7 @@ impl TokenStream {
     }
 
     pub fn into_subtree(self) -> tt::Subtree {
-        tt::Subtree { delimiter: None, token_trees: self.token_trees }
+        tt::Subtree { delimiter: tt::Delimiter::UNSPECIFIED, token_trees: self.token_trees }
     }
 
     pub fn is_empty(&self) -> bool {
@@ -64,7 +64,9 @@ impl Extend<TokenStream> for TokenStream {
         for item in streams {
             for tkn in item {
                 match tkn {
-                    tt::TokenTree::Subtree(subtree) if subtree.delimiter.is_none() => {
+                    tt::TokenTree::Subtree(subtree)
+                        if subtree.delimiter.kind != tt::DelimiterKind::Invisible =>
+                    {
                         self.token_trees.extend(subtree.token_trees);
                     }
                     _ => {
@@ -84,7 +86,7 @@ pub struct TokenStreamBuilder {
 pub mod token_stream {
     use std::str::FromStr;
 
-    use super::{TokenStream, TokenTree};
+    use super::{tt, TokenStream, TokenTree};
 
     /// An iterator over `TokenStream`'s `TokenTree`s.
     /// The iteration is "shallow", e.g., the iterator doesn't recurse into delimited groups,
@@ -121,15 +123,17 @@ pub mod token_stream {
 
     impl ToString for TokenStream {
         fn to_string(&self) -> String {
-            tt::pretty(&self.token_trees)
+            ::tt::pretty(&self.token_trees)
         }
     }
 
     fn subtree_replace_token_ids_with_unspecified(subtree: tt::Subtree) -> tt::Subtree {
         tt::Subtree {
-            delimiter: subtree
-                .delimiter
-                .map(|d| tt::Delimiter { id: tt::TokenId::unspecified(), ..d }),
+            delimiter: tt::Delimiter {
+                open: tt::TokenId::UNSPECIFIED,
+                close: tt::TokenId::UNSPECIFIED,
+                ..subtree.delimiter
+            },
             token_trees: subtree
                 .token_trees
                 .into_iter()
@@ -152,13 +156,13 @@ pub mod token_stream {
     fn leaf_replace_token_ids_with_unspecified(leaf: tt::Leaf) -> tt::Leaf {
         match leaf {
             tt::Leaf::Literal(lit) => {
-                tt::Leaf::Literal(tt::Literal { id: tt::TokenId::unspecified(), ..lit })
+                tt::Leaf::Literal(tt::Literal { span: tt::TokenId::unspecified(), ..lit })
             }
             tt::Leaf::Punct(punct) => {
-                tt::Leaf::Punct(tt::Punct { id: tt::TokenId::unspecified(), ..punct })
+                tt::Leaf::Punct(tt::Punct { span: tt::TokenId::unspecified(), ..punct })
             }
             tt::Leaf::Ident(ident) => {
-                tt::Leaf::Ident(tt::Ident { id: tt::TokenId::unspecified(), ..ident })
+                tt::Leaf::Ident(tt::Ident { span: tt::TokenId::unspecified(), ..ident })
             }
         }
     }

--- a/crates/proc-macro-srv/src/abis/mod.rs
+++ b/crates/proc-macro-srv/src/abis/mod.rs
@@ -41,6 +41,8 @@ pub(crate) use abi_sysroot::Abi as Abi_Sysroot;
 use libloading::Library;
 use proc_macro_api::{ProcMacroKind, RustCInfo};
 
+use crate::tt;
+
 pub struct PanicMessage {
     message: Option<String>,
 }

--- a/crates/proc-macro-srv/src/dylib.rs
+++ b/crates/proc-macro-srv/src/dylib.rs
@@ -13,6 +13,8 @@ use object::Object;
 use paths::AbsPath;
 use proc_macro_api::{read_dylib_info, ProcMacroKind};
 
+use crate::tt;
+
 use super::abis::Abi;
 
 const NEW_REGISTRAR_SYMBOL: &str = "_rustc_proc_macro_decls_";

--- a/crates/proc-macro-srv/src/lib.rs
+++ b/crates/proc-macro-srv/src/lib.rs
@@ -37,6 +37,8 @@ use proc_macro_api::{
     ProcMacroKind,
 };
 
+use ::tt::token_id as tt;
+
 #[derive(Default)]
 pub(crate) struct ProcMacroSrv {
     expanders: HashMap<(PathBuf, SystemTime), dylib::Expander>,

--- a/crates/proc-macro-srv/src/tests/mod.rs
+++ b/crates/proc-macro-srv/src/tests/mod.rs
@@ -8,7 +8,7 @@ use expect_test::expect;
 
 #[test]
 fn test_derive_empty() {
-    assert_expand("DeriveEmpty", r#"struct S;"#, expect![[r#"SUBTREE $"#]]);
+    assert_expand("DeriveEmpty", r#"struct S;"#, expect!["SUBTREE $$ 4294967295 4294967295"]);
 }
 
 #[test]
@@ -17,10 +17,10 @@ fn test_derive_error() {
         "DeriveError",
         r#"struct S;"#,
         expect![[r##"
-            SUBTREE $
+            SUBTREE $$ 4294967295 4294967295
               IDENT   compile_error 4294967295
               PUNCH   ! [alone] 4294967295
-              SUBTREE () 4294967295
+              SUBTREE () 4294967295 4294967295
                 LITERAL "#[derive(DeriveError)] struct S ;" 4294967295
               PUNCH   ; [alone] 4294967295"##]],
     );
@@ -32,14 +32,14 @@ fn test_fn_like_macro_noop() {
         "fn_like_noop",
         r#"ident, 0, 1, []"#,
         expect![[r#"
-            SUBTREE $
+            SUBTREE $$ 4294967295 4294967295
               IDENT   ident 4294967295
               PUNCH   , [alone] 4294967295
               LITERAL 0 4294967295
               PUNCH   , [alone] 4294967295
               LITERAL 1 4294967295
               PUNCH   , [alone] 4294967295
-              SUBTREE [] 4294967295"#]],
+              SUBTREE [] 4294967295 4294967295"#]],
     );
 }
 
@@ -49,10 +49,10 @@ fn test_fn_like_macro_clone_ident_subtree() {
         "fn_like_clone_tokens",
         r#"ident, []"#,
         expect![[r#"
-            SUBTREE $
+            SUBTREE $$ 4294967295 4294967295
               IDENT   ident 4294967295
               PUNCH   , [alone] 4294967295
-              SUBTREE [] 4294967295"#]],
+              SUBTREE [] 4294967295 4294967295"#]],
     );
 }
 
@@ -62,7 +62,7 @@ fn test_fn_like_macro_clone_raw_ident() {
         "fn_like_clone_tokens",
         "r#async",
         expect![[r#"
-            SUBTREE $
+            SUBTREE $$ 4294967295 4294967295
               IDENT   r#async 4294967295"#]],
     );
 }
@@ -73,7 +73,7 @@ fn test_fn_like_mk_literals() {
         "fn_like_mk_literals",
         r#""#,
         expect![[r#"
-            SUBTREE $
+            SUBTREE $$ 4294967295 4294967295
               LITERAL b"byte_string" 4294967295
               LITERAL 'c' 4294967295
               LITERAL "string" 4294967295
@@ -90,7 +90,7 @@ fn test_fn_like_mk_idents() {
         "fn_like_mk_idents",
         r#""#,
         expect![[r#"
-            SUBTREE $
+            SUBTREE $$ 4294967295 4294967295
               IDENT   standard 4294967295
               IDENT   r#raw 4294967295"#]],
     );
@@ -102,7 +102,7 @@ fn test_fn_like_macro_clone_literals() {
         "fn_like_clone_tokens",
         r#"1u16, 2_u32, -4i64, 3.14f32, "hello bridge""#,
         expect![[r#"
-            SUBTREE $
+            SUBTREE $$ 4294967295 4294967295
               LITERAL 1u16 4294967295
               PUNCH   , [alone] 4294967295
               LITERAL 2_u32 4294967295
@@ -126,10 +126,10 @@ fn test_attr_macro() {
         r#"mod m {}"#,
         r#"some arguments"#,
         expect![[r##"
-            SUBTREE $
+            SUBTREE $$ 4294967295 4294967295
               IDENT   compile_error 4294967295
               PUNCH   ! [alone] 4294967295
-              SUBTREE () 4294967295
+              SUBTREE () 4294967295 4294967295
                 LITERAL "#[attr_error(some arguments)] mod m {}" 4294967295
               PUNCH   ; [alone] 4294967295"##]],
     );

--- a/crates/rust-analyzer/src/reload.rs
+++ b/crates/rust-analyzer/src/reload.rs
@@ -34,6 +34,8 @@ use crate::{
     op_queue::Cause,
 };
 
+use ::tt::token_id as tt;
+
 #[derive(Debug)]
 pub(crate) enum ProjectWorkspaceProgress {
     Begin,
@@ -656,7 +658,7 @@ pub(crate) fn load_proc_macro(
             _: Option<&tt::Subtree>,
             _: &Env,
         ) -> Result<tt::Subtree, ProcMacroExpansionError> {
-            Ok(tt::Subtree::default())
+            Ok(tt::Subtree::empty())
         }
     }
 }

--- a/crates/stdx/src/macros.rs
+++ b/crates/stdx/src/macros.rs
@@ -43,5 +43,14 @@ macro_rules! impl_from {
                 }
             )*)?
         )*
+    };
+    ($($variant:ident$(<$V:ident>)?),* for $enum:ident) => {
+        $(
+            impl$(<$V>)? From<$variant$(<$V>)?> for $enum$(<$V>)? {
+                fn from(it: $variant$(<$V>)?) -> $enum$(<$V>)? {
+                    $enum::$variant(it)
+                }
+            }
+        )*
     }
 }


### PR DESCRIPTION
This also fixes up our delimiter representation in tt, it is no longer optional (we use invisible delims in the same way as before, that is still incorrectly) and we now store two spans instead of one.

These changes should help with adjusting our token map. Though this will probably break proc-macros in some ways, will need to test that for now.