### PR TITLE
minor: Bump `zip` to avoid `time-macros`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1832,10 +1832,8 @@ version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a561bf4617eebd33bca6434b988f39ed798e527f51a1e797d0ee4f61c0a38376"
 dependencies = [
- "itoa",
  "serde",
  "time-core",
- "time-macros",
 ]
 
 [[package]]
@@ -1843,15 +1841,6 @@ name = "time-core"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
-
-[[package]]
-name = "time-macros"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d967f99f534ca7e495c575c62638eebc2898a8c84c119b89e250477bc4ba16b2"
-dependencies = [
- "time-core",
-]
 
 [[package]]
 name = "tinyvec"
@@ -2205,6 +2194,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "flate2",
+ "time",
  "write-json",
  "xflags",
  "xshell",
@@ -2213,9 +2203,9 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "537ce7411d25e54e8ae21a7ce0b15840e7bfcff15b51d697ec3266cc76bdf080"
+checksum = "0445d0fbc924bb93539b4316c11afb121ea39296f99a3c4c9edad09e3658cdef"
 dependencies = [
  "byteorder",
  "crc32fast",

--- a/crates/proc-macro-api/src/lib.rs
+++ b/crates/proc-macro-api/src/lib.rs
@@ -71,7 +71,7 @@ impl MacroDylib {
 
 /// A handle to a specific macro (a `#[proc_macro]` annotated function).
 ///
-/// It exists withing a context of a specific [`ProcMacroProcess`] -- currently
+/// It exists within a context of a specific [`ProcMacroProcess`] -- currently
 /// we share a single expander process for all macros.
 #[derive(Debug, Clone)]
 pub struct ProcMacro {

--- a/crates/profile/src/lib.rs
+++ b/crates/profile/src/lib.rs
@@ -26,7 +26,7 @@ pub use countme::Count;
 
 thread_local!(static IN_SCOPE: RefCell<bool> = RefCell::new(false));
 
-/// Allows to check if the current code is withing some dynamic scope, can be
+/// Allows to check if the current code is within some dynamic scope, can be
 /// useful during debugging to figure out why a function is called.
 pub struct Scope {
     prev: bool,

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -12,5 +12,6 @@ flate2 = "1.0.24"
 write-json = "0.1.2"
 xshell = "0.2.2"
 xflags = "0.3.0"
+time = { version = "0.3", default-features = false }
 zip = { version = "0.6", default-features = false, features = ["deflate", "time"] }
 # Avoid adding more dependencies to this crate

--- a/xtask/src/dist.rs
+++ b/xtask/src/dist.rs
@@ -6,6 +6,7 @@ use std::{
 };
 
 use flate2::{write::GzEncoder, Compression};
+use time::OffsetDateTime;
 use xshell::{cmd, Shell};
 use zip::{write::FileOptions, DateTime, ZipWriter};
 
@@ -112,7 +113,8 @@ fn zip(src_path: &Path, symbols_path: Option<&PathBuf>, dest_path: &Path) -> any
         src_path.file_name().unwrap().to_str().unwrap(),
         FileOptions::default()
             .last_modified_time(
-                DateTime::from_time(std::fs::metadata(src_path)?.modified()?.into()).unwrap(),
+                DateTime::try_from(OffsetDateTime::from(std::fs::metadata(src_path)?.modified()?))
+                    .unwrap(),
             )
             .unix_permissions(0o755)
             .compression_method(zip::CompressionMethod::Deflated)
@@ -125,7 +127,10 @@ fn zip(src_path: &Path, symbols_path: Option<&PathBuf>, dest_path: &Path) -> any
             symbols_path.file_name().unwrap().to_str().unwrap(),
             FileOptions::default()
                 .last_modified_time(
-                    DateTime::from_time(std::fs::metadata(src_path)?.modified()?.into()).unwrap(),
+                    DateTime::try_from(OffsetDateTime::from(
+                        std::fs::metadata(src_path)?.modified()?,
+                    ))
+                    .unwrap(),
                 )
                 .compression_method(zip::CompressionMethod::Deflated)
                 .compression_level(Some(9)),


### PR DESCRIPTION
This fixes the compile time regression in #13876 and sneaks in two typo fixes spotted by @cuishuang (sorry for not preserving the commit attribution, but it's a little hard to manage it across repositories).