### PR TITLE
fix: support non-ascii characters in case conversion

### DIFF
--- a/crates/hir-ty/src/diagnostics/decl_check/case_conv.rs
+++ b/crates/hir-ty/src/diagnostics/decl_check/case_conv.rs
@@ -162,6 +162,7 @@ mod tests {
         check(to_lower_snake_case, "a", expect![[""]]);
         check(to_lower_snake_case, "abc", expect![[""]]);
         check(to_lower_snake_case, "foo__bar", expect![["foo_bar"]]);
+        check(to_lower_snake_case, "Δ", expect!["δ"]);
     }
 
     #[test]
@@ -195,5 +196,6 @@ mod tests {
         check(to_upper_snake_case, "X86_64", expect![[""]]);
         check(to_upper_snake_case, "FOO_BAr", expect![["FOO_BAR"]]);
         check(to_upper_snake_case, "FOO__BAR", expect![["FOO_BAR"]]);
+        check(to_upper_snake_case, "ß", expect!["SS"]);
     }
 }

--- a/crates/stdx/src/lib.rs
+++ b/crates/stdx/src/lib.rs
@@ -2,9 +2,9 @@
 
 #![warn(rust_2018_idioms, unused_lifetimes, semicolon_in_expressions_from_macros)]
 
+use std::io as sio;
 use std::process::Command;
 use std::{cmp::Ordering, ops, time::Instant};
-use std::{io as sio, iter};
 
 mod macros;
 pub mod hash;
@@ -39,15 +39,19 @@ Uncomment `default = [ "backtrace" ]` in `crates/stdx/Cargo.toml`.
 }
 
 pub fn to_lower_snake_case(s: &str) -> String {
-    to_snake_case(s, char::to_ascii_lowercase)
+    to_snake_case(s, char::to_lowercase)
 }
 pub fn to_upper_snake_case(s: &str) -> String {
-    to_snake_case(s, char::to_ascii_uppercase)
+    to_snake_case(s, char::to_uppercase)
 }
 
 // Code partially taken from rust/compiler/rustc_lint/src/nonstandard_style.rs
 // commit: 9626f2b
-fn to_snake_case<F: Fn(&char) -> char>(mut s: &str, change_case: F) -> String {
+fn to_snake_case<F, I>(mut s: &str, change_case: F) -> String
+where
+    F: Fn(char) -> I,
+    I: Iterator<Item = char>,
+{
     let mut words = vec![];
 
     // Preserve leading underscores
@@ -75,7 +79,7 @@ fn to_snake_case<F: Fn(&char) -> char>(mut s: &str, change_case: F) -> String {
             }
 
             last_upper = ch.is_uppercase();
-            buf.extend(iter::once(change_case(&ch)));
+            buf.extend(change_case(ch));
         }
 
         words.push(buf);


### PR DESCRIPTION
Fixes #13521 (the attribute problem is tracked in another issue, as commented)

Note that other functions like `to_camel_case()` and `is_lower_snake_case()` already handle non-ascii characters.