### PR TITLE
fix: Fix parsing of nested tuple field accesses in a cursed way

### DIFF
--- a/crates/hir-def/src/item_tree.rs
+++ b/crates/hir-def/src/item_tree.rs
@@ -111,7 +111,8 @@ impl ItemTree {
             Some(node) => node,
             None => return Default::default(),
         };
-        if never!(syntax.kind() == SyntaxKind::ERROR) {
+        if never!(syntax.kind() == SyntaxKind::ERROR, "{:?} from {:?} {}", file_id, syntax, syntax)
+        {
             // FIXME: not 100% sure why these crop up, but return an empty tree to avoid a panic
             return Default::default();
         }
@@ -133,7 +134,7 @@ impl ItemTree {
                     ctx.lower_macro_stmts(stmts)
                 },
                 _ => {
-                    panic!("cannot create item tree from {syntax:?} {syntax}");
+                    panic!("cannot create item tree for file {file_id:?} from {syntax:?} {syntax}");
                 },
             }
         };

--- a/crates/hir-def/src/macro_expansion_tests/mbe.rs
+++ b/crates/hir-def/src/macro_expansion_tests/mbe.rs
@@ -97,6 +97,41 @@ fn#19 main#20(#21)#21 {#22
 "##]],
     );
 }
+#[test]
+fn float_field_acces_macro_input() {
+    check(
+        r#"
+macro_rules! foo {
+    ($expr:expr) => {
+        fn foo() {
+            $expr;
+        }
+    };
+}
+foo!(x .0.1);
+foo!(x .2. 3);
+foo!(x .4 .5);
+"#,
+        expect![[r#"
+macro_rules! foo {
+    ($expr:expr) => {
+        fn foo() {
+            $expr;
+        }
+    };
+}
+fn foo() {
+    (x.0.1);
+}
+fn foo() {
+    (x.2.3);
+}
+fn foo() {
+    (x.4.5);
+}
+"#]],
+    );
+}
 
 #[test]
 fn mbe_smoke_test() {

--- a/crates/hir-def/src/macro_expansion_tests/proc_macros.rs
+++ b/crates/hir-def/src/macro_expansion_tests/proc_macros.rs
@@ -104,7 +104,7 @@ macro_rules! id {
         $($t)*
     };
 }
-id /*+errors*/! {
+id! {
     #[proc_macros::identity]
     impl Foo for WrapBj {
         async fn foo(&self) {
@@ -113,18 +113,17 @@ id /*+errors*/! {
     }
 }
 "#,
-        expect![[r##"
+        expect![[r#"
 macro_rules! id {
     ($($t:tt)*) => {
         $($t)*
     };
 }
-/* parse error: expected SEMICOLON */
 #[proc_macros::identity] impl Foo for WrapBj {
     async fn foo(&self ) {
         self .0.id().await ;
     }
 }
-"##]],
+"#]],
     );
 }

--- a/crates/mbe/src/syntax_bridge.rs
+++ b/crates/mbe/src/syntax_bridge.rs
@@ -817,7 +817,7 @@ impl<'a> TtTreeSink<'a> {
                 self.inner.token(SyntaxKind::DOT, ".");
 
                 if has_pseudo_dot {
-                    assert!(right.is_empty());
+                    assert!(right.is_empty(), "{left}.{right}");
                 } else {
                     self.inner.start_node(SyntaxKind::NAME_REF);
                     self.inner.token(SyntaxKind::INT_NUMBER, right);

--- a/crates/mbe/src/syntax_bridge.rs
+++ b/crates/mbe/src/syntax_bridge.rs
@@ -95,6 +95,7 @@ pub fn token_tree_to_syntax_node(
             parser::Step::Token { kind, n_input_tokens: n_raw_tokens } => {
                 tree_sink.token(kind, n_raw_tokens)
             }
+            parser::Step::FloatSplit { .. } => tree_sink.token(SyntaxKind::FLOAT_NUMBER, 1),
             parser::Step::Enter { kind } => tree_sink.start_node(kind),
             parser::Step::Exit => tree_sink.finish_node(),
             parser::Step::Error { msg } => tree_sink.error(msg.to_string()),

--- a/crates/mbe/src/syntax_bridge.rs
+++ b/crates/mbe/src/syntax_bridge.rs
@@ -95,7 +95,9 @@ pub fn token_tree_to_syntax_node(
             parser::Step::Token { kind, n_input_tokens: n_raw_tokens } => {
                 tree_sink.token(kind, n_raw_tokens)
             }
-            parser::Step::FloatSplit { has_pseudo_dot } => tree_sink.float_split(has_pseudo_dot),
+            parser::Step::FloatSplit { ends_in_dot: has_pseudo_dot } => {
+                tree_sink.float_split(has_pseudo_dot)
+            }
             parser::Step::Enter { kind } => tree_sink.start_node(kind),
             parser::Step::Exit => tree_sink.finish_node(),
             parser::Step::Error { msg } => tree_sink.error(msg.to_string()),
@@ -797,6 +799,8 @@ fn delim_to_str(d: tt::DelimiterKind, closing: bool) -> Option<&'static str> {
 }
 
 impl<'a> TtTreeSink<'a> {
+    /// Parses a float literal as if it was a one to two name ref nodes with a dot inbetween.
+    /// This occurs when a float literal is used as a field access.
     fn float_split(&mut self, has_pseudo_dot: bool) {
         let (text, _span) = match self.cursor.token_tree() {
             Some(tt::buffer::TokenTreeRef::Leaf(tt::Leaf::Literal(lit), _)) => {

--- a/crates/mbe/src/to_parser_input.rs
+++ b/crates/mbe/src/to_parser_input.rs
@@ -45,6 +45,10 @@ pub(crate) fn to_parser_input(buffer: &TokenBuffer<'_>) -> parser::Input {
                             .unwrap_or_else(|| panic!("Fail to convert given literal {:#?}", &lit));
 
                         res.push(kind);
+
+                        if kind == FLOAT_NUMBER && !inner_text.ends_with('.') {
+                            res.was_joint();
+                        }
                     }
                     tt::Leaf::Ident(ident) => match ident.text.as_ref() {
                         "_" => res.push(T![_]),

--- a/crates/mbe/src/to_parser_input.rs
+++ b/crates/mbe/src/to_parser_input.rs
@@ -47,6 +47,9 @@ pub(crate) fn to_parser_input(buffer: &TokenBuffer<'_>) -> parser::Input {
                         res.push(kind);
 
                         if kind == FLOAT_NUMBER && !inner_text.ends_with('.') {
+                            // Tag the token as joint if it is float with a fractional part
+                            // we use this jointness to inform the parser about what token split
+                            // event to emit when we encounter a float literal in a field access
                             res.was_joint();
                         }
                     }

--- a/crates/mbe/src/tt_iter.rs
+++ b/crates/mbe/src/tt_iter.rs
@@ -170,11 +170,38 @@ impl<'a> TtIter<'a> {
         let mut res = vec![];
 
         if cursor.is_root() {
-            while curr != cursor {
-                if let Some(token) = curr.token_tree() {
-                    res.push(token.cloned());
+            if float_splits.is_empty() {
+                while curr != cursor {
+                    if let Some(token) = curr.token_tree() {
+                        res.push(token.cloned());
+                    }
+                    curr = curr.bump();
                 }
-                curr = curr.bump();
+            } else {
+                // let mut float_splits = float_splits.into_iter().peekable();
+                // while let Some(tt) = curr.token_tree() {
+                //     let mut tt = tt.cloned();
+                //     let mut tt_mut_ref = &mut tt;
+                //     if let Some(fs) = float_splits.peek() {
+                //         loop {
+                //             curr = curr.bump_subtree();
+                //             if curr == *fs {
+                //                 float_splits.next();
+                //             }
+                //             if curr.is_root() {
+                //                 break;
+                //             }
+                //         }
+                //     }
+                //     res.push(tt);
+                // }
+
+                while curr != cursor {
+                    if let Some(token) = curr.token_tree() {
+                        res.push(token.cloned());
+                    }
+                    curr = curr.bump();
+                }
             }
         }
         self.inner = self.inner.as_slice()[res.len()..].iter();

--- a/crates/parser/src/event.rs
+++ b/crates/parser/src/event.rs
@@ -72,9 +72,12 @@ pub(crate) enum Event {
     /// `n_raw_tokens = 2` is used to produced a single `>>`.
     Token {
         kind: SyntaxKind,
+        // Consider custom enum here?
         n_raw_tokens: u8,
     },
-
+    FloatSplitHack {
+        has_pseudo_dot: bool,
+    },
     Error {
         msg: String,
     },
@@ -124,6 +127,11 @@ pub(super) fn process(mut events: Vec<Event>) -> Output {
             Event::Finish => res.leave_node(),
             Event::Token { kind, n_raw_tokens } => {
                 res.token(kind, n_raw_tokens);
+            }
+            Event::FloatSplitHack { has_pseudo_dot } => {
+                res.float_split_hack(has_pseudo_dot);
+                let ev = mem::replace(&mut events[i + 1], Event::tombstone());
+                assert!(matches!(ev, Event::Finish), "{ev:?}");
             }
             Event::Error { msg } => res.error(msg),
         }

--- a/crates/parser/src/lib.rs
+++ b/crates/parser/src/lib.rs
@@ -102,7 +102,9 @@ impl TopEntryPoint {
                 match step {
                     Step::Enter { .. } => depth += 1,
                     Step::Exit => depth -= 1,
-                    Step::FloatSplit { has_pseudo_dot } => depth -= 1 + !has_pseudo_dot as usize,
+                    Step::FloatSplit { ends_in_dot: has_pseudo_dot } => {
+                        depth -= 1 + !has_pseudo_dot as usize
+                    }
                     Step::Token { .. } | Step::Error { .. } => (),
                 }
             }

--- a/crates/parser/src/lib.rs
+++ b/crates/parser/src/lib.rs
@@ -102,7 +102,7 @@ impl TopEntryPoint {
                 match step {
                     Step::Enter { .. } => depth += 1,
                     Step::Exit => depth -= 1,
-                    Step::Token { .. } | Step::Error { .. } => (),
+                    Step::FloatSplit { .. } | Step::Token { .. } | Step::Error { .. } => (),
                 }
             }
             assert!(!first, "no tree at all");

--- a/crates/parser/src/lib.rs
+++ b/crates/parser/src/lib.rs
@@ -102,10 +102,12 @@ impl TopEntryPoint {
                 match step {
                     Step::Enter { .. } => depth += 1,
                     Step::Exit => depth -= 1,
-                    Step::FloatSplit { .. } | Step::Token { .. } | Step::Error { .. } => (),
+                    Step::FloatSplit { .. } => depth -= 1,
+                    Step::Token { .. } | Step::Error { .. } => (),
                 }
             }
             assert!(!first, "no tree at all");
+            assert_eq!(depth, 0, "unbalanced tree");
         }
 
         res

--- a/crates/parser/src/lib.rs
+++ b/crates/parser/src/lib.rs
@@ -102,7 +102,7 @@ impl TopEntryPoint {
                 match step {
                     Step::Enter { .. } => depth += 1,
                     Step::Exit => depth -= 1,
-                    Step::FloatSplit { .. } => depth -= 1,
+                    Step::FloatSplit { has_pseudo_dot } => depth -= 1 + !has_pseudo_dot as usize,
                     Step::Token { .. } | Step::Error { .. } => (),
                 }
             }

--- a/crates/parser/src/output.rs
+++ b/crates/parser/src/output.rs
@@ -31,47 +31,70 @@ pub enum Step<'a> {
 }
 
 impl Output {
+    const EVENT_MASK: u32 = 0b1;
+    const TAG_MASK: u32 = 0x0000_00F0;
+    const N_INPUT_TOKEN_MASK: u32 = 0x0000_FF00;
+    const KIND_MASK: u32 = 0xFFFF_0000;
+
+    const ERROR_SHIFT: u32 = Self::EVENT_MASK.trailing_ones();
+    const TAG_SHIFT: u32 = Self::TAG_MASK.trailing_zeros();
+    const N_INPUT_TOKEN_SHIFT: u32 = Self::N_INPUT_TOKEN_MASK.trailing_zeros();
+    const KIND_SHIFT: u32 = Self::KIND_MASK.trailing_zeros();
+
+    const TOKEN_EVENT: u8 = 0;
+    const ENTER_EVENT: u8 = 1;
+    const EXIT_EVENT: u8 = 2;
+
     pub fn iter(&self) -> impl Iterator<Item = Step<'_>> {
         self.event.iter().map(|&event| {
-            if event & 0b1 == 0 {
-                return Step::Error { msg: self.error[(event as usize) >> 1].as_str() };
+            if event & Self::EVENT_MASK == 0 {
+                return Step::Error {
+                    msg: self.error[(event as usize) >> Self::ERROR_SHIFT].as_str(),
+                };
             }
-            let tag = ((event & 0x0000_00F0) >> 4) as u8;
+            let tag = ((event & Self::TAG_MASK) >> Self::TAG_SHIFT) as u8;
             match tag {
-                0 => {
-                    let kind: SyntaxKind = (((event & 0xFFFF_0000) >> 16) as u16).into();
-                    let n_input_tokens = ((event & 0x0000_FF00) >> 8) as u8;
+                Self::TOKEN_EVENT => {
+                    let kind: SyntaxKind =
+                        (((event & Self::KIND_MASK) >> Self::KIND_SHIFT) as u16).into();
+                    let n_input_tokens =
+                        ((event & Self::N_INPUT_TOKEN_MASK) >> Self::N_INPUT_TOKEN_SHIFT) as u8;
                     Step::Token { kind, n_input_tokens }
                 }
-                1 => {
-                    let kind: SyntaxKind = (((event & 0xFFFF_0000) >> 16) as u16).into();
+                Self::ENTER_EVENT => {
+                    let kind: SyntaxKind =
+                        (((event & Self::KIND_MASK) >> Self::KIND_SHIFT) as u16).into();
                     Step::Enter { kind }
                 }
-                2 => Step::Exit,
+                Self::EXIT_EVENT => Step::Exit,
                 _ => unreachable!(),
             }
         })
     }
 
     pub(crate) fn token(&mut self, kind: SyntaxKind, n_tokens: u8) {
-        let e = ((kind as u16 as u32) << 16) | ((n_tokens as u32) << 8) | 1;
+        let e = ((kind as u16 as u32) << Self::KIND_SHIFT)
+            | ((n_tokens as u32) << Self::N_INPUT_TOKEN_SHIFT)
+            | Self::EVENT_MASK;
         self.event.push(e)
     }
 
     pub(crate) fn enter_node(&mut self, kind: SyntaxKind) {
-        let e = ((kind as u16 as u32) << 16) | (1 << 4) | 1;
+        let e = ((kind as u16 as u32) << Self::KIND_SHIFT)
+            | ((Self::ENTER_EVENT as u32) << Self::TAG_SHIFT)
+            | Self::EVENT_MASK;
         self.event.push(e)
     }
 
     pub(crate) fn leave_node(&mut self) {
-        let e = 2 << 4 | 1;
+        let e = (Self::EXIT_EVENT as u32) << Self::TAG_SHIFT | Self::EVENT_MASK;
         self.event.push(e)
     }
 
     pub(crate) fn error(&mut self, error: String) {
         let idx = self.error.len();
         self.error.push(error);
-        let e = (idx as u32) << 1;
+        let e = (idx as u32) << Self::ERROR_SHIFT;
         self.event.push(e);
     }
 }

--- a/crates/parser/src/output.rs
+++ b/crates/parser/src/output.rs
@@ -25,7 +25,7 @@ pub struct Output {
 #[derive(Debug)]
 pub enum Step<'a> {
     Token { kind: SyntaxKind, n_input_tokens: u8 },
-    FloatSplit { has_pseudo_dot: bool },
+    FloatSplit { ends_in_dot: bool },
     Enter { kind: SyntaxKind },
     Exit,
     Error { msg: &'a str },
@@ -70,7 +70,7 @@ impl Output {
                 }
                 Self::EXIT_EVENT => Step::Exit,
                 Self::SPLIT_EVENT => {
-                    Step::FloatSplit { has_pseudo_dot: event & Self::N_INPUT_TOKEN_MASK != 0 }
+                    Step::FloatSplit { ends_in_dot: event & Self::N_INPUT_TOKEN_MASK != 0 }
                 }
                 _ => unreachable!(),
             }
@@ -84,9 +84,9 @@ impl Output {
         self.event.push(e)
     }
 
-    pub(crate) fn float_split_hack(&mut self, has_pseudo_dot: bool) {
+    pub(crate) fn float_split_hack(&mut self, ends_in_dot: bool) {
         let e = (Self::SPLIT_EVENT as u32) << Self::TAG_SHIFT
-            | ((has_pseudo_dot as u32) << Self::N_INPUT_TOKEN_SHIFT)
+            | ((ends_in_dot as u32) << Self::N_INPUT_TOKEN_SHIFT)
             | Self::EVENT_MASK;
         self.event.push(e);
     }

--- a/crates/parser/src/shortcuts.rs
+++ b/crates/parser/src/shortcuts.rs
@@ -44,7 +44,17 @@ impl<'a> LexedStr<'a> {
                     }
                     res.push(kind);
                 }
-                was_joint = true;
+                if kind == SyntaxKind::FLOAT_NUMBER {
+                    // we set jointness for floating point numbers as a hack to inform the
+                    // parser about whether we have a `0.` or `0.1` style float
+                    if self.text(i).split_once('.').map_or(false, |(_, it)| it.is_empty()) {
+                        was_joint = false;
+                    } else {
+                        was_joint = true;
+                    }
+                } else {
+                    was_joint = true;
+                }
             }
         }
         res
@@ -63,6 +73,7 @@ impl<'a> LexedStr<'a> {
                 Step::Token { kind, n_input_tokens: n_raw_tokens } => {
                     builder.token(kind, n_raw_tokens)
                 }
+                Step::FloatSplit { has_pseudo_dot } => builder.float_split(has_pseudo_dot),
                 Step::Enter { kind } => builder.enter(kind),
                 Step::Exit => builder.exit(),
                 Step::Error { msg } => {
@@ -107,6 +118,16 @@ impl Builder<'_, '_> {
         }
         self.eat_trivias();
         self.do_token(kind, n_tokens as usize);
+    }
+
+    fn float_split(&mut self, has_pseudo_dot: bool) {
+        match mem::replace(&mut self.state, State::Normal) {
+            State::PendingEnter => unreachable!(),
+            State::PendingExit => (self.sink)(StrStep::Exit),
+            State::Normal => (),
+        }
+        self.eat_trivias();
+        self.do_float_split(has_pseudo_dot);
     }
 
     fn enter(&mut self, kind: SyntaxKind) {
@@ -163,6 +184,37 @@ impl Builder<'_, '_> {
         let text = &self.lexed.range_text(self.pos..self.pos + n_tokens);
         self.pos += n_tokens;
         (self.sink)(StrStep::Token { kind, text });
+    }
+
+    fn do_float_split(&mut self, has_pseudo_dot: bool) {
+        let text = &self.lexed.range_text(self.pos..self.pos + 1);
+        self.pos += 1;
+        match text.split_once('.') {
+            Some((left, right)) => {
+                assert!(!left.is_empty());
+                (self.sink)(StrStep::Enter { kind: SyntaxKind::NAME_REF });
+                (self.sink)(StrStep::Token { kind: SyntaxKind::INT_NUMBER, text: left });
+                (self.sink)(StrStep::Exit);
+
+                // here we move the exit up, the original exit has been deleted in process
+                (self.sink)(StrStep::Exit);
+
+                (self.sink)(StrStep::Token { kind: SyntaxKind::DOT, text: "." });
+
+                if has_pseudo_dot {
+                    assert!(right.is_empty());
+                    self.state = State::Normal;
+                } else {
+                    (self.sink)(StrStep::Enter { kind: SyntaxKind::NAME_REF });
+                    (self.sink)(StrStep::Token { kind: SyntaxKind::INT_NUMBER, text: right });
+                    (self.sink)(StrStep::Exit);
+
+                    // the parser creates an unbalanced start node, we are required to close it here
+                    self.state = State::PendingExit;
+                }
+            }
+            None => unreachable!(),
+        }
     }
 }
 

--- a/crates/parser/src/shortcuts.rs
+++ b/crates/parser/src/shortcuts.rs
@@ -43,18 +43,16 @@ impl<'a> LexedStr<'a> {
                         res.was_joint();
                     }
                     res.push(kind);
-                }
-                if kind == SyntaxKind::FLOAT_NUMBER {
                     // we set jointness for floating point numbers as a hack to inform the
                     // parser about whether we have a `0.` or `0.1` style float
-                    if self.text(i).split_once('.').map_or(false, |(_, it)| it.is_empty()) {
-                        was_joint = false;
-                    } else {
-                        was_joint = true;
+                    if kind == SyntaxKind::FLOAT_NUMBER {
+                        if !self.text(i).split_once('.').map_or(true, |(_, it)| it.is_empty()) {
+                            res.was_joint();
+                        }
                     }
-                } else {
-                    was_joint = true;
                 }
+
+                was_joint = true;
             }
         }
         res
@@ -202,7 +200,7 @@ impl Builder<'_, '_> {
                 (self.sink)(StrStep::Token { kind: SyntaxKind::DOT, text: "." });
 
                 if has_pseudo_dot {
-                    assert!(right.is_empty());
+                    assert!(right.is_empty(), "{left}.{right}");
                     self.state = State::Normal;
                 } else {
                     (self.sink)(StrStep::Enter { kind: SyntaxKind::NAME_REF });

--- a/crates/parser/src/tests/prefix_entries.rs
+++ b/crates/parser/src/tests/prefix_entries.rs
@@ -51,6 +51,9 @@ fn expr() {
     check(PrefixEntryPoint::Expr, "-1", "-1");
     check(PrefixEntryPoint::Expr, "fn foo() {}", "fn");
     check(PrefixEntryPoint::Expr, "#[attr] ()", "#[attr] ()");
+    check(PrefixEntryPoint::Expr, "foo.0", "foo.0");
+    check(PrefixEntryPoint::Expr, "foo.0.1", "foo.0.1");
+    check(PrefixEntryPoint::Expr, "foo.0. foo", "foo.0. foo");
 }
 
 #[test]
@@ -88,6 +91,7 @@ fn check(entry: PrefixEntryPoint, input: &str, prefix: &str) {
     for step in entry.parse(&input).iter() {
         match step {
             Step::Token { n_input_tokens, .. } => n_tokens += n_input_tokens as usize,
+            Step::FloatSplit { .. } => n_tokens += 1,
             Step::Enter { .. } | Step::Exit | Step::Error { .. } => (),
         }
     }

--- a/crates/parser/test_data/parser/inline/ok/0011_field_expr.rast
+++ b/crates/parser/test_data/parser/inline/ok/0011_field_expr.rast
@@ -41,6 +41,39 @@ SOURCE_FILE
           SEMICOLON ";"
         WHITESPACE "\n    "
         EXPR_STMT
+          FIELD_EXPR
+            FIELD_EXPR
+              PATH_EXPR
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      IDENT "x"
+              DOT "."
+              NAME_REF
+                INT_NUMBER "0"
+            DOT "."
+            NAME_REF
+              INT_NUMBER "1"
+          SEMICOLON ";"
+        WHITESPACE "\n    "
+        EXPR_STMT
+          FIELD_EXPR
+            FIELD_EXPR
+              PATH_EXPR
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      IDENT "x"
+              DOT "."
+              NAME_REF
+                INT_NUMBER "0"
+            DOT "."
+            WHITESPACE " "
+            NAME_REF
+              IDENT "bar"
+          SEMICOLON ";"
+        WHITESPACE "\n    "
+        EXPR_STMT
           CALL_EXPR
             FIELD_EXPR
               PATH_EXPR

--- a/crates/parser/test_data/parser/inline/ok/0011_field_expr.rs
+++ b/crates/parser/test_data/parser/inline/ok/0011_field_expr.rs
@@ -1,5 +1,7 @@
 fn foo() {
     x.foo;
     x.0.bar;
+    x.0.1;
+    x.0. bar;
     x.0();
 }

--- a/crates/parser/test_data/parser/inline/ok/0107_method_call_expr.rast
+++ b/crates/parser/test_data/parser/inline/ok/0107_method_call_expr.rast
@@ -58,6 +58,49 @@ SOURCE_FILE
               COMMA ","
               R_PAREN ")"
           SEMICOLON ";"
+        WHITESPACE "\n    "
+        EXPR_STMT
+          METHOD_CALL_EXPR
+            FIELD_EXPR
+              FIELD_EXPR
+                PATH_EXPR
+                  PATH
+                    PATH_SEGMENT
+                      NAME_REF
+                        IDENT "x"
+                DOT "."
+                NAME_REF
+                  INT_NUMBER "0"
+              DOT "."
+              NAME_REF
+                INT_NUMBER "0"
+            DOT "."
+            NAME_REF
+              IDENT "call"
+            ARG_LIST
+              L_PAREN "("
+              R_PAREN ")"
+          SEMICOLON ";"
+        WHITESPACE "\n    "
+        EXPR_STMT
+          METHOD_CALL_EXPR
+            FIELD_EXPR
+              PATH_EXPR
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      IDENT "x"
+              DOT "."
+              NAME_REF
+                INT_NUMBER "0"
+            DOT "."
+            WHITESPACE " "
+            NAME_REF
+              IDENT "call"
+            ARG_LIST
+              L_PAREN "("
+              R_PAREN ")"
+          SEMICOLON ";"
         WHITESPACE "\n"
         R_CURLY "}"
   WHITESPACE "\n"

--- a/crates/parser/test_data/parser/inline/ok/0107_method_call_expr.rs
+++ b/crates/parser/test_data/parser/inline/ok/0107_method_call_expr.rs
@@ -1,4 +1,6 @@
 fn foo() {
     x.foo();
     y.bar::<T>(1, 2,);
+    x.0.0.call();
+    x.0. call();
 }

--- a/crates/parser/test_data/parser/inline/ok/0137_await_expr.rast
+++ b/crates/parser/test_data/parser/inline/ok/0137_await_expr.rast
@@ -65,6 +65,41 @@ SOURCE_FILE
               L_PAREN "("
               R_PAREN ")"
           SEMICOLON ";"
+        WHITESPACE "\n    "
+        EXPR_STMT
+          AWAIT_EXPR
+            FIELD_EXPR
+              FIELD_EXPR
+                PATH_EXPR
+                  PATH
+                    PATH_SEGMENT
+                      NAME_REF
+                        IDENT "x"
+                DOT "."
+                NAME_REF
+                  INT_NUMBER "0"
+              DOT "."
+              NAME_REF
+                INT_NUMBER "0"
+            DOT "."
+            AWAIT_KW "await"
+          SEMICOLON ";"
+        WHITESPACE "\n    "
+        EXPR_STMT
+          AWAIT_EXPR
+            FIELD_EXPR
+              PATH_EXPR
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      IDENT "x"
+              DOT "."
+              NAME_REF
+                INT_NUMBER "0"
+            DOT "."
+            WHITESPACE " "
+            AWAIT_KW "await"
+          SEMICOLON ";"
         WHITESPACE "\n"
         R_CURLY "}"
   WHITESPACE "\n"

--- a/crates/parser/test_data/parser/inline/ok/0137_await_expr.rs
+++ b/crates/parser/test_data/parser/inline/ok/0137_await_expr.rs
@@ -2,4 +2,6 @@ fn foo() {
     x.await;
     x.0.await;
     x.0().await?.hello();
+    x.0.0.await;
+    x.0. await;
 }

--- a/crates/tt/src/buffer.rs
+++ b/crates/tt/src/buffer.rs
@@ -16,8 +16,8 @@ enum Entry<'t, Span> {
     // Mimicking types from proc-macro.
     Subtree(Option<&'t TokenTree<Span>>, &'t Subtree<Span>, EntryId),
     Leaf(&'t TokenTree<Span>),
-    // End entries contain a pointer to the entry from the containing
-    // token tree, or None if this is the outermost level.
+    /// End entries contain a pointer to the entry from the containing
+    /// token tree, or [`None`] if this is the outermost level.
     End(Option<EntryPtr>),
 }
 
@@ -226,7 +226,9 @@ impl<'a, Span> Cursor<'a, Span> {
     /// a cursor into that subtree
     pub fn bump_subtree(self) -> Cursor<'a, Span> {
         match self.entry() {
-            Some(Entry::Subtree(_, _, _)) => self.subtree().unwrap(),
+            Some(&Entry::Subtree(_, _, entry_id)) => {
+                Cursor::create(self.buffer, EntryPtr(entry_id, 0))
+            }
             _ => self.bump(),
         }
     }

--- a/crates/tt/src/buffer.rs
+++ b/crates/tt/src/buffer.rs
@@ -7,7 +7,12 @@ use crate::{Leaf, Subtree, TokenTree};
 struct EntryId(usize);
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
-struct EntryPtr(EntryId, usize);
+struct EntryPtr(
+    /// The index of the buffer containing the entry.
+    EntryId,
+    /// The index of the entry within the buffer.
+    usize,
+);
 
 /// Internal type which is used instead of `TokenTree` to represent a token tree
 /// within a `TokenBuffer`.
@@ -229,7 +234,11 @@ impl<'a, Span> Cursor<'a, Span> {
             Some(&Entry::Subtree(_, _, entry_id)) => {
                 Cursor::create(self.buffer, EntryPtr(entry_id, 0))
             }
-            _ => self.bump(),
+            Some(Entry::End(exit)) => match exit {
+                Some(exit) => Cursor::create(self.buffer, *exit),
+                None => self,
+            },
+            _ => Cursor::create(self.buffer, EntryPtr(self.ptr.0, self.ptr.1 + 1)),
         }
     }
 


### PR DESCRIPTION
This is absolutely terrible but seems to work. Macro fragment parsing comes next.