### PR TITLE
fix: Insert spaces when inlining macros

### DIFF
--- a/crates/ide-assists/src/handlers/add_missing_impl_members.rs
+++ b/crates/ide-assists/src/handlers/add_missing_impl_members.rs
@@ -135,7 +135,9 @@ fn add_missing_impl_members_inner(
             .into_iter()
             .map(|it| {
                 if ctx.sema.hir_file_for(it.syntax()).is_macro() {
-                    if let Some(it) = ast::AssocItem::cast(insert_ws_into(it.syntax().clone())) {
+                    if let Some(it) =
+                        ast::AssocItem::cast(insert_ws_into(it.syntax().clone(), true))
+                    {
                         return it;
                     }
                 }

--- a/crates/ide-assists/src/handlers/inline_call.rs
+++ b/crates/ide-assists/src/handlers/inline_call.rs
@@ -308,7 +308,7 @@ fn inline(
 ) -> ast::Expr {
     let body = if sema.hir_file_for(fn_body.syntax()).is_macro() {
         cov_mark::hit!(inline_call_defined_in_macro);
-        if let Some(body) = ast::BlockExpr::cast(insert_ws_into(fn_body.syntax().clone())) {
+        if let Some(body) = ast::BlockExpr::cast(insert_ws_into(fn_body.syntax().clone(), true)) {
             body
         } else {
             fn_body.clone_for_update()

--- a/crates/ide-assists/src/handlers/inline_macro.rs
+++ b/crates/ide-assists/src/handlers/inline_macro.rs
@@ -1,3 +1,4 @@
+use ide_db::syntax_helpers::insert_whitespace_into_node::insert_ws_into;
 use syntax::ast::{self, AstNode};
 
 use crate::{AssistContext, AssistId, AssistKind, Assists};
@@ -35,8 +36,7 @@ use crate::{AssistContext, AssistId, AssistKind, Assists};
 // ```
 pub(crate) fn inline_macro(acc: &mut Assists, ctx: &AssistContext<'_>) -> Option<()> {
     let unexpanded = ctx.find_node_at_offset::<ast::MacroCall>()?;
-    let expanded = ctx.sema.expand(&unexpanded)?.clone_for_update();
-
+    let expanded = insert_ws_into(ctx.sema.expand(&unexpanded)?.clone_for_update(), false);
     let text_range = unexpanded.syntax().text_range();
 
     acc.add(
@@ -229,5 +229,28 @@ fn f() { let result = foo$0!(); }
 fn f() { let result = foo$0(); }
 "#,
         );
+    }
+
+    #[test]
+    fn inline_macro_with_whitespace() {
+        check_assist(
+            inline_macro,
+            r#"
+macro_rules! whitespace {
+    () => {
+        if true {}
+    };
+}
+fn f() { whitespace$0!(); }
+"#,
+            r#"
+macro_rules! whitespace {
+    () => {
+        if true {}
+    };
+}
+fn f() { if true{}; }
+"#,
+        )
     }
 }

--- a/crates/ide-assists/src/handlers/replace_derive_with_manual_impl.rs
+++ b/crates/ide-assists/src/handlers/replace_derive_with_manual_impl.rs
@@ -202,7 +202,7 @@ fn impl_def_from_trait(
         .into_iter()
         .map(|it| {
             if sema.hir_file_for(it.syntax()).is_macro() {
-                if let Some(it) = ast::AssocItem::cast(insert_ws_into(it.syntax().clone())) {
+                if let Some(it) = ast::AssocItem::cast(insert_ws_into(it.syntax().clone(), true)) {
                     return it;
                 }
             }

--- a/crates/ide-completion/src/completions/item_list/trait_impl.rs
+++ b/crates/ide-completion/src/completions/item_list/trait_impl.rs
@@ -345,7 +345,7 @@ fn add_const_impl(
 
 fn make_const_compl_syntax(const_: &ast::Const, needs_whitespace: bool) -> String {
     let const_ = if needs_whitespace {
-        insert_whitespace_into_node::insert_ws_into(const_.syntax().clone())
+        insert_whitespace_into_node::insert_ws_into(const_.syntax().clone(), true)
     } else {
         const_.syntax().clone()
     };
@@ -368,7 +368,7 @@ fn make_const_compl_syntax(const_: &ast::Const, needs_whitespace: bool) -> Strin
 
 fn function_declaration(node: &ast::Fn, needs_whitespace: bool) -> String {
     let node = if needs_whitespace {
-        insert_whitespace_into_node::insert_ws_into(node.syntax().clone())
+        insert_whitespace_into_node::insert_ws_into(node.syntax().clone(), true)
     } else {
         node.syntax().clone()
     };

--- a/crates/ide/src/expand_macro.rs
+++ b/crates/ide/src/expand_macro.rs
@@ -139,7 +139,7 @@ fn expand<T: AstNode>(
 }
 
 fn format(db: &RootDatabase, kind: SyntaxKind, file_id: FileId, expanded: SyntaxNode) -> String {
-    let expansion = insert_ws_into(expanded).to_string();
+    let expansion = insert_ws_into(expanded, true).to_string();
 
     _format(db, kind, file_id, &expansion).unwrap_or(expansion)
 }

--- a/crates/ide/src/hover/render.rs
+++ b/crates/ide/src/hover/render.rs
@@ -425,7 +425,7 @@ pub(super) fn definition(
                     let source = it.source(db)?;
                     let mut body = source.value.body()?.syntax().clone();
                     if source.file_id.is_macro() {
-                        body = insert_whitespace_into_node::insert_ws_into(body);
+                        body = insert_whitespace_into_node::insert_ws_into(body, true);
                     }
                     Some(body.to_string())
                 }
@@ -435,7 +435,7 @@ pub(super) fn definition(
             let source = it.source(db)?;
             let mut body = source.value.body()?.syntax().clone();
             if source.file_id.is_macro() {
-                body = insert_whitespace_into_node::insert_ws_into(body);
+                body = insert_whitespace_into_node::insert_ws_into(body, true);
             }
             Some(body.to_string())
         }),


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust-analyzer/issues/14108