### PR TITLE
minor: Explicitly disable the rust-analyzer extension in untrusted workspaces

### DIFF
--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -19,6 +19,12 @@
     "categories": [
         "Programming Languages"
     ],
+    "capabilities": {
+        "untrustedWorkspaces": {
+            "supported": false,
+            "description": "rust-analyzer invokes binaries set up by its configuration as well as the Rust toolchain's binaries. A malicious actor could exploit this to run arbitrary code on your machine."
+        }
+    },
     "engines": {
         "vscode": "^1.66.0"
     },


### PR DESCRIPTION
This is the default, but its always better to be explicit here + we can add a small note as to why.