### PR TITLE
minor: Add version placeholder to changelog template

### DIFF
--- a/xtask/src/publish.rs
+++ b/xtask/src/publish.rs
@@ -13,7 +13,7 @@ impl flags::PublishReleaseNotes {
         let tag_name = &file_name[0..10];
         let original_changelog_url = create_original_changelog_url(&file_name);
         let additional_paragraph =
-            format!("\nSee also [original changelog]({original_changelog_url}).");
+            format!("\nSee also the [changelog post]({original_changelog_url}).");
         markdown.push_str(&additional_paragraph);
         if self.dry_run {
             println!("{markdown}");

--- a/xtask/src/release/changelog.rs
+++ b/xtask/src/release/changelog.rs
@@ -69,7 +69,7 @@ pub(crate) fn get_changelog(
 :page-layout: post
 
 Commit: commit:{commit}[] +
-Release: release:{today}[]
+Release: release:{today}[] (`TBD`)
 
 == New Features
 


### PR DESCRIPTION
Closes #13967

This isn't great because we need to fill it in manually, but getting the version number from GitHub Actions is a bit annoying.