### PR TITLE
Only add dev dependencies to the dependency list of dev targets

### DIFF
--- a/crates/project-model/src/tests.rs
+++ b/crates/project-model/src/tests.rs
@@ -176,7 +176,7 @@ fn cargo_hello_world_project_model_with_wildcard_overrides() {
                         dependencies: [
                             Dependency {
                                 crate_id: CrateId(
-                                    5,
+                                    4,
                                 ),
                                 name: CrateName(
                                     "libc",
@@ -199,7 +199,7 @@ fn cargo_hello_world_project_model_with_wildcard_overrides() {
                         1,
                     ): CrateData {
                         root_file_id: FileId(
-                            1,
+                            2,
                         ),
                         edition: Edition2018,
                         version: Some(
@@ -216,13 +216,11 @@ fn cargo_hello_world_project_model_with_wildcard_overrides() {
                         cfg_options: CfgOptions(
                             [
                                 "debug_assertions",
-                                "test",
                             ],
                         ),
                         potential_cfg_options: CfgOptions(
                             [
                                 "debug_assertions",
-                                "test",
                             ],
                         ),
                         target_layout: Err(
@@ -259,7 +257,7 @@ fn cargo_hello_world_project_model_with_wildcard_overrides() {
                             },
                             Dependency {
                                 crate_id: CrateId(
-                                    5,
+                                    4,
                                 ),
                                 name: CrateName(
                                     "libc",
@@ -280,89 +278,6 @@ fn cargo_hello_world_project_model_with_wildcard_overrides() {
                     },
                     CrateId(
                         2,
-                    ): CrateData {
-                        root_file_id: FileId(
-                            2,
-                        ),
-                        edition: Edition2018,
-                        version: Some(
-                            "0.1.0",
-                        ),
-                        display_name: Some(
-                            CrateDisplayName {
-                                crate_name: CrateName(
-                                    "hello_world",
-                                ),
-                                canonical_name: "hello-world",
-                            },
-                        ),
-                        cfg_options: CfgOptions(
-                            [
-                                "debug_assertions",
-                                "test",
-                            ],
-                        ),
-                        potential_cfg_options: CfgOptions(
-                            [
-                                "debug_assertions",
-                                "test",
-                            ],
-                        ),
-                        target_layout: Err(
-                            "target_data_layout not loaded",
-                        ),
-                        env: Env {
-                            entries: {
-                                "CARGO_PKG_LICENSE": "",
-                                "CARGO_PKG_VERSION_MAJOR": "0",
-                                "CARGO_MANIFEST_DIR": "$ROOT$hello-world",
-                                "CARGO_PKG_VERSION": "0.1.0",
-                                "CARGO_PKG_AUTHORS": "",
-                                "CARGO_CRATE_NAME": "hello_world",
-                                "CARGO_PKG_LICENSE_FILE": "",
-                                "CARGO_PKG_HOMEPAGE": "",
-                                "CARGO_PKG_DESCRIPTION": "",
-                                "CARGO_PKG_NAME": "hello-world",
-                                "CARGO_PKG_VERSION_PATCH": "0",
-                                "CARGO": "cargo",
-                                "CARGO_PKG_REPOSITORY": "",
-                                "CARGO_PKG_VERSION_MINOR": "1",
-                                "CARGO_PKG_VERSION_PRE": "",
-                            },
-                        },
-                        dependencies: [
-                            Dependency {
-                                crate_id: CrateId(
-                                    0,
-                                ),
-                                name: CrateName(
-                                    "hello_world",
-                                ),
-                                prelude: true,
-                            },
-                            Dependency {
-                                crate_id: CrateId(
-                                    5,
-                                ),
-                                name: CrateName(
-                                    "libc",
-                                ),
-                                prelude: true,
-                            },
-                        ],
-                        proc_macro: Err(
-                            "crate has not (yet) been built",
-                        ),
-                        origin: CratesIo {
-                            repo: None,
-                            name: Some(
-                                "hello-world",
-                            ),
-                        },
-                        is_proc_macro: false,
-                    },
-                    CrateId(
-                        3,
                     ): CrateData {
                         root_file_id: FileId(
                             3,
@@ -423,7 +338,7 @@ fn cargo_hello_world_project_model_with_wildcard_overrides() {
                             },
                             Dependency {
                                 crate_id: CrateId(
-                                    5,
+                                    4,
                                 ),
                                 name: CrateName(
                                     "libc",
@@ -443,7 +358,7 @@ fn cargo_hello_world_project_model_with_wildcard_overrides() {
                         is_proc_macro: false,
                     },
                     CrateId(
-                        4,
+                        3,
                     ): CrateData {
                         root_file_id: FileId(
                             4,
@@ -504,7 +419,7 @@ fn cargo_hello_world_project_model_with_wildcard_overrides() {
                             },
                             Dependency {
                                 crate_id: CrateId(
-                                    5,
+                                    4,
                                 ),
                                 name: CrateName(
                                     "libc",
@@ -524,7 +439,7 @@ fn cargo_hello_world_project_model_with_wildcard_overrides() {
                         is_proc_macro: false,
                     },
                     CrateId(
-                        5,
+                        4,
                     ): CrateData {
                         root_file_id: FileId(
                             5,

--- a/crates/project-model/src/tests.rs
+++ b/crates/project-model/src/tests.rs
@@ -660,15 +660,6 @@ fn cargo_hello_world_project_model_with_selective_overrides() {
                         dependencies: [
                             Dependency {
                                 crate_id: CrateId(
-                                    0,
-                                ),
-                                name: CrateName(
-                                    "hello_world",
-                                ),
-                                prelude: true,
-                            },
-                            Dependency {
-                                crate_id: CrateId(
                                     5,
                                 ),
                                 name: CrateName(
@@ -1144,15 +1135,6 @@ fn cargo_hello_world_project_model() {
                             },
                         },
                         dependencies: [
-                            Dependency {
-                                crate_id: CrateId(
-                                    0,
-                                ),
-                                name: CrateName(
-                                    "hello_world",
-                                ),
-                                prelude: true,
-                            },
                             Dependency {
                                 crate_id: CrateId(
                                     5,

--- a/crates/project-model/src/tests.rs
+++ b/crates/project-model/src/tests.rs
@@ -176,7 +176,7 @@ fn cargo_hello_world_project_model_with_wildcard_overrides() {
                         dependencies: [
                             Dependency {
                                 crate_id: CrateId(
-                                    4,
+                                    5,
                                 ),
                                 name: CrateName(
                                     "libc",
@@ -199,7 +199,7 @@ fn cargo_hello_world_project_model_with_wildcard_overrides() {
                         1,
                     ): CrateData {
                         root_file_id: FileId(
-                            2,
+                            1,
                         ),
                         edition: Edition2018,
                         version: Some(
@@ -216,11 +216,13 @@ fn cargo_hello_world_project_model_with_wildcard_overrides() {
                         cfg_options: CfgOptions(
                             [
                                 "debug_assertions",
+                                "test",
                             ],
                         ),
                         potential_cfg_options: CfgOptions(
                             [
                                 "debug_assertions",
+                                "test",
                             ],
                         ),
                         target_layout: Err(
@@ -257,7 +259,7 @@ fn cargo_hello_world_project_model_with_wildcard_overrides() {
                             },
                             Dependency {
                                 crate_id: CrateId(
-                                    4,
+                                    5,
                                 ),
                                 name: CrateName(
                                     "libc",
@@ -278,6 +280,89 @@ fn cargo_hello_world_project_model_with_wildcard_overrides() {
                     },
                     CrateId(
                         2,
+                    ): CrateData {
+                        root_file_id: FileId(
+                            2,
+                        ),
+                        edition: Edition2018,
+                        version: Some(
+                            "0.1.0",
+                        ),
+                        display_name: Some(
+                            CrateDisplayName {
+                                crate_name: CrateName(
+                                    "hello_world",
+                                ),
+                                canonical_name: "hello-world",
+                            },
+                        ),
+                        cfg_options: CfgOptions(
+                            [
+                                "debug_assertions",
+                                "test",
+                            ],
+                        ),
+                        potential_cfg_options: CfgOptions(
+                            [
+                                "debug_assertions",
+                                "test",
+                            ],
+                        ),
+                        target_layout: Err(
+                            "target_data_layout not loaded",
+                        ),
+                        env: Env {
+                            entries: {
+                                "CARGO_PKG_LICENSE": "",
+                                "CARGO_PKG_VERSION_MAJOR": "0",
+                                "CARGO_MANIFEST_DIR": "$ROOT$hello-world",
+                                "CARGO_PKG_VERSION": "0.1.0",
+                                "CARGO_PKG_AUTHORS": "",
+                                "CARGO_CRATE_NAME": "hello_world",
+                                "CARGO_PKG_LICENSE_FILE": "",
+                                "CARGO_PKG_HOMEPAGE": "",
+                                "CARGO_PKG_DESCRIPTION": "",
+                                "CARGO_PKG_NAME": "hello-world",
+                                "CARGO_PKG_VERSION_PATCH": "0",
+                                "CARGO": "cargo",
+                                "CARGO_PKG_REPOSITORY": "",
+                                "CARGO_PKG_VERSION_MINOR": "1",
+                                "CARGO_PKG_VERSION_PRE": "",
+                            },
+                        },
+                        dependencies: [
+                            Dependency {
+                                crate_id: CrateId(
+                                    0,
+                                ),
+                                name: CrateName(
+                                    "hello_world",
+                                ),
+                                prelude: true,
+                            },
+                            Dependency {
+                                crate_id: CrateId(
+                                    5,
+                                ),
+                                name: CrateName(
+                                    "libc",
+                                ),
+                                prelude: true,
+                            },
+                        ],
+                        proc_macro: Err(
+                            "crate has not (yet) been built",
+                        ),
+                        origin: CratesIo {
+                            repo: None,
+                            name: Some(
+                                "hello-world",
+                            ),
+                        },
+                        is_proc_macro: false,
+                    },
+                    CrateId(
+                        3,
                     ): CrateData {
                         root_file_id: FileId(
                             3,
@@ -338,7 +423,7 @@ fn cargo_hello_world_project_model_with_wildcard_overrides() {
                             },
                             Dependency {
                                 crate_id: CrateId(
-                                    4,
+                                    5,
                                 ),
                                 name: CrateName(
                                     "libc",
@@ -358,7 +443,7 @@ fn cargo_hello_world_project_model_with_wildcard_overrides() {
                         is_proc_macro: false,
                     },
                     CrateId(
-                        3,
+                        4,
                     ): CrateData {
                         root_file_id: FileId(
                             4,
@@ -419,7 +504,7 @@ fn cargo_hello_world_project_model_with_wildcard_overrides() {
                             },
                             Dependency {
                                 crate_id: CrateId(
-                                    4,
+                                    5,
                                 ),
                                 name: CrateName(
                                     "libc",
@@ -439,7 +524,7 @@ fn cargo_hello_world_project_model_with_wildcard_overrides() {
                         is_proc_macro: false,
                     },
                     CrateId(
-                        4,
+                        5,
                     ): CrateData {
                         root_file_id: FileId(
                             5,
@@ -554,6 +639,78 @@ fn cargo_hello_world_project_model_with_selective_overrides() {
                         cfg_options: CfgOptions(
                             [
                                 "debug_assertions",
+                            ],
+                        ),
+                        potential_cfg_options: CfgOptions(
+                            [
+                                "debug_assertions",
+                            ],
+                        ),
+                        target_layout: Err(
+                            "target_data_layout not loaded",
+                        ),
+                        env: Env {
+                            entries: {
+                                "CARGO_PKG_LICENSE": "",
+                                "CARGO_PKG_VERSION_MAJOR": "0",
+                                "CARGO_MANIFEST_DIR": "$ROOT$hello-world",
+                                "CARGO_PKG_VERSION": "0.1.0",
+                                "CARGO_PKG_AUTHORS": "",
+                                "CARGO_CRATE_NAME": "hello_world",
+                                "CARGO_PKG_LICENSE_FILE": "",
+                                "CARGO_PKG_HOMEPAGE": "",
+                                "CARGO_PKG_DESCRIPTION": "",
+                                "CARGO_PKG_NAME": "hello-world",
+                                "CARGO_PKG_VERSION_PATCH": "0",
+                                "CARGO": "cargo",
+                                "CARGO_PKG_REPOSITORY": "",
+                                "CARGO_PKG_VERSION_MINOR": "1",
+                                "CARGO_PKG_VERSION_PRE": "",
+                            },
+                        },
+                        dependencies: [
+                            Dependency {
+                                crate_id: CrateId(
+                                    5,
+                                ),
+                                name: CrateName(
+                                    "libc",
+                                ),
+                                prelude: true,
+                            },
+                        ],
+                        proc_macro: Err(
+                            "crate has not (yet) been built",
+                        ),
+                        origin: CratesIo {
+                            repo: None,
+                            name: Some(
+                                "hello-world",
+                            ),
+                        },
+                        is_proc_macro: false,
+                    },
+                    CrateId(
+                        1,
+                    ): CrateData {
+                        root_file_id: FileId(
+                            1,
+                        ),
+                        edition: Edition2018,
+                        version: Some(
+                            "0.1.0",
+                        ),
+                        display_name: Some(
+                            CrateDisplayName {
+                                crate_name: CrateName(
+                                    "hello_world",
+                                ),
+                                canonical_name: "hello-world",
+                            },
+                        ),
+                        cfg_options: CfgOptions(
+                            [
+                                "debug_assertions",
                                 "test",
                             ],
                         ),
@@ -588,7 +745,16 @@ fn cargo_hello_world_project_model_with_selective_overrides() {
                         dependencies: [
                             Dependency {
                                 crate_id: CrateId(
-                                    4,
+                                    0,
+                                ),
+                                name: CrateName(
+                                    "hello_world",
+                                ),
+                                prelude: true,
+                            },
+                            Dependency {
+                                crate_id: CrateId(
+                                    5,
                                 ),
                                 name: CrateName(
                                     "libc",
@@ -608,7 +774,7 @@ fn cargo_hello_world_project_model_with_selective_overrides() {
                         is_proc_macro: false,
                     },
                     CrateId(
-                        1,
+                        2,
                     ): CrateData {
                         root_file_id: FileId(
                             2,
@@ -671,90 +837,7 @@ fn cargo_hello_world_project_model_with_selective_overrides() {
                             },
                             Dependency {
                                 crate_id: CrateId(
-                                    4,
-                                ),
-                                name: CrateName(
-                                    "libc",
-                                ),
-                                prelude: true,
-                            },
-                        ],
-                        proc_macro: Err(
-                            "crate has not (yet) been built",
-                        ),
-                        origin: CratesIo {
-                            repo: None,
-                            name: Some(
-                                "hello-world",
-                            ),
-                        },
-                        is_proc_macro: false,
-                    },
-                    CrateId(
-                        2,
-                    ): CrateData {
-                        root_file_id: FileId(
-                            3,
-                        ),
-                        edition: Edition2018,
-                        version: Some(
-                            "0.1.0",
-                        ),
-                        display_name: Some(
-                            CrateDisplayName {
-                                crate_name: CrateName(
-                                    "an_example",
-                                ),
-                                canonical_name: "an-example",
-                            },
-                        ),
-                        cfg_options: CfgOptions(
-                            [
-                                "debug_assertions",
-                                "test",
-                            ],
-                        ),
-                        potential_cfg_options: CfgOptions(
-                            [
-                                "debug_assertions",
-                                "test",
-                            ],
-                        ),
-                        target_layout: Err(
-                            "target_data_layout not loaded",
-                        ),
-                        env: Env {
-                            entries: {
-                                "CARGO_PKG_LICENSE": "",
-                                "CARGO_PKG_VERSION_MAJOR": "0",
-                                "CARGO_MANIFEST_DIR": "$ROOT$hello-world",
-                                "CARGO_PKG_VERSION": "0.1.0",
-                                "CARGO_PKG_AUTHORS": "",
-                                "CARGO_CRATE_NAME": "hello_world",
-                                "CARGO_PKG_LICENSE_FILE": "",
-                                "CARGO_PKG_HOMEPAGE": "",
-                                "CARGO_PKG_DESCRIPTION": "",
-                                "CARGO_PKG_NAME": "hello-world",
-                                "CARGO_PKG_VERSION_PATCH": "0",
-                                "CARGO": "cargo",
-                                "CARGO_PKG_REPOSITORY": "",
-                                "CARGO_PKG_VERSION_MINOR": "1",
-                                "CARGO_PKG_VERSION_PRE": "",
-                            },
-                        },
-                        dependencies: [
-                            Dependency {
-                                crate_id: CrateId(
-                                    0,
-                                ),
-                                name: CrateName(
-                                    "hello_world",
-                                ),
-                                prelude: true,
-                            },
-                            Dependency {
-                                crate_id: CrateId(
-                                    4,
+                                    5,
                                 ),
                                 name: CrateName(
                                     "libc",
@@ -777,7 +860,7 @@ fn cargo_hello_world_project_model_with_selective_overrides() {
                         3,
                     ): CrateData {
                         root_file_id: FileId(
-                            4,
+                            3,
                         ),
                         edition: Edition2018,
                         version: Some(
@@ -786,21 +869,19 @@ fn cargo_hello_world_project_model_with_selective_overrides() {
                         display_name: Some(
                             CrateDisplayName {
                                 crate_name: CrateName(
-                                    "it",
+                                    "an_example",
                                 ),
-                                canonical_name: "it",
+                                canonical_name: "an-example",
                             },
                         ),
                         cfg_options: CfgOptions(
                             [
                                 "debug_assertions",
-                                "test",
                             ],
                         ),
                         potential_cfg_options: CfgOptions(
                             [
                                 "debug_assertions",
-                                "test",
                             ],
                         ),
                         target_layout: Err(
@@ -837,7 +918,7 @@ fn cargo_hello_world_project_model_with_selective_overrides() {
                             },
                             Dependency {
                                 crate_id: CrateId(
-                                    4,
+                                    5,
                                 ),
                                 name: CrateName(
                                     "libc",
@@ -858,6 +939,87 @@ fn cargo_hello_world_project_model_with_selective_overrides() {
                     },
                     CrateId(
                         4,
+                    ): CrateData {
+                        root_file_id: FileId(
+                            4,
+                        ),
+                        edition: Edition2018,
+                        version: Some(
+                            "0.1.0",
+                        ),
+                        display_name: Some(
+                            CrateDisplayName {
+                                crate_name: CrateName(
+                                    "it",
+                                ),
+                                canonical_name: "it",
+                            },
+                        ),
+                        cfg_options: CfgOptions(
+                            [
+                                "debug_assertions",
+                            ],
+                        ),
+                        potential_cfg_options: CfgOptions(
+                            [
+                                "debug_assertions",
+                            ],
+                        ),
+                        target_layout: Err(
+                            "target_data_layout not loaded",
+                        ),
+                        env: Env {
+                            entries: {
+                                "CARGO_PKG_LICENSE": "",
+                                "CARGO_PKG_VERSION_MAJOR": "0",
+                                "CARGO_MANIFEST_DIR": "$ROOT$hello-world",
+                                "CARGO_PKG_VERSION": "0.1.0",
+                                "CARGO_PKG_AUTHORS": "",
+                                "CARGO_CRATE_NAME": "hello_world",
+                                "CARGO_PKG_LICENSE_FILE": "",
+                                "CARGO_PKG_HOMEPAGE": "",
+                                "CARGO_PKG_DESCRIPTION": "",
+                                "CARGO_PKG_NAME": "hello-world",
+                                "CARGO_PKG_VERSION_PATCH": "0",
+                                "CARGO": "cargo",
+                                "CARGO_PKG_REPOSITORY": "",
+                                "CARGO_PKG_VERSION_MINOR": "1",
+                                "CARGO_PKG_VERSION_PRE": "",
+                            },
+                        },
+                        dependencies: [
+                            Dependency {
+                                crate_id: CrateId(
+                                    0,
+                                ),
+                                name: CrateName(
+                                    "hello_world",
+                                ),
+                                prelude: true,
+                            },
+                            Dependency {
+                                crate_id: CrateId(
+                                    5,
+                                ),
+                                name: CrateName(
+                                    "libc",
+                                ),
+                                prelude: true,
+                            },
+                        ],
+                        proc_macro: Err(
+                            "crate has not (yet) been built",
+                        ),
+                        origin: CratesIo {
+                            repo: None,
+                            name: Some(
+                                "hello-world",
+                            ),
+                        },
+                        is_proc_macro: false,
+                    },
+                    CrateId(
+                        5,
                     ): CrateData {
                         root_file_id: FileId(
                             5,
@@ -963,6 +1125,78 @@ fn cargo_hello_world_project_model() {
                         cfg_options: CfgOptions(
                             [
                                 "debug_assertions",
+                            ],
+                        ),
+                        potential_cfg_options: CfgOptions(
+                            [
+                                "debug_assertions",
+                            ],
+                        ),
+                        target_layout: Err(
+                            "target_data_layout not loaded",
+                        ),
+                        env: Env {
+                            entries: {
+                                "CARGO_PKG_LICENSE": "",
+                                "CARGO_PKG_VERSION_MAJOR": "0",
+                                "CARGO_MANIFEST_DIR": "$ROOT$hello-world",
+                                "CARGO_PKG_VERSION": "0.1.0",
+                                "CARGO_PKG_AUTHORS": "",
+                                "CARGO_CRATE_NAME": "hello_world",
+                                "CARGO_PKG_LICENSE_FILE": "",
+                                "CARGO_PKG_HOMEPAGE": "",
+                                "CARGO_PKG_DESCRIPTION": "",
+                                "CARGO_PKG_NAME": "hello-world",
+                                "CARGO_PKG_VERSION_PATCH": "0",
+                                "CARGO": "cargo",
+                                "CARGO_PKG_REPOSITORY": "",
+                                "CARGO_PKG_VERSION_MINOR": "1",
+                                "CARGO_PKG_VERSION_PRE": "",
+                            },
+                        },
+                        dependencies: [
+                            Dependency {
+                                crate_id: CrateId(
+                                    5,
+                                ),
+                                name: CrateName(
+                                    "libc",
+                                ),
+                                prelude: true,
+                            },
+                        ],
+                        proc_macro: Err(
+                            "crate has not (yet) been built",
+                        ),
+                        origin: CratesIo {
+                            repo: None,
+                            name: Some(
+                                "hello-world",
+                            ),
+                        },
+                        is_proc_macro: false,
+                    },
+                    CrateId(
+                        1,
+                    ): CrateData {
+                        root_file_id: FileId(
+                            1,
+                        ),
+                        edition: Edition2018,
+                        version: Some(
+                            "0.1.0",
+                        ),
+                        display_name: Some(
+                            CrateDisplayName {
+                                crate_name: CrateName(
+                                    "hello_world",
+                                ),
+                                canonical_name: "hello-world",
+                            },
+                        ),
+                        cfg_options: CfgOptions(
+                            [
+                                "debug_assertions",
                                 "test",
                             ],
                         ),
@@ -997,7 +1231,16 @@ fn cargo_hello_world_project_model() {
                         dependencies: [
                             Dependency {
                                 crate_id: CrateId(
-                                    4,
+                                    0,
+                                ),
+                                name: CrateName(
+                                    "hello_world",
+                                ),
+                                prelude: true,
+                            },
+                            Dependency {
+                                crate_id: CrateId(
+                                    5,
                                 ),
                                 name: CrateName(
                                     "libc",
@@ -1017,7 +1260,7 @@ fn cargo_hello_world_project_model() {
                         is_proc_macro: false,
                     },
                     CrateId(
-                        1,
+                        2,
                     ): CrateData {
                         root_file_id: FileId(
                             2,
@@ -1080,90 +1323,7 @@ fn cargo_hello_world_project_model() {
                             },
                             Dependency {
                                 crate_id: CrateId(
-                                    4,
-                                ),
-                                name: CrateName(
-                                    "libc",
-                                ),
-                                prelude: true,
-                            },
-                        ],
-                        proc_macro: Err(
-                            "crate has not (yet) been built",
-                        ),
-                        origin: CratesIo {
-                            repo: None,
-                            name: Some(
-                                "hello-world",
-                            ),
-                        },
-                        is_proc_macro: false,
-                    },
-                    CrateId(
-                        2,
-                    ): CrateData {
-                        root_file_id: FileId(
-                            3,
-                        ),
-                        edition: Edition2018,
-                        version: Some(
-                            "0.1.0",
-                        ),
-                        display_name: Some(
-                            CrateDisplayName {
-                                crate_name: CrateName(
-                                    "an_example",
-                                ),
-                                canonical_name: "an-example",
-                            },
-                        ),
-                        cfg_options: CfgOptions(
-                            [
-                                "debug_assertions",
-                                "test",
-                            ],
-                        ),
-                        potential_cfg_options: CfgOptions(
-                            [
-                                "debug_assertions",
-                                "test",
-                            ],
-                        ),
-                        target_layout: Err(
-                            "target_data_layout not loaded",
-                        ),
-                        env: Env {
-                            entries: {
-                                "CARGO_PKG_LICENSE": "",
-                                "CARGO_PKG_VERSION_MAJOR": "0",
-                                "CARGO_MANIFEST_DIR": "$ROOT$hello-world",
-                                "CARGO_PKG_VERSION": "0.1.0",
-                                "CARGO_PKG_AUTHORS": "",
-                                "CARGO_CRATE_NAME": "hello_world",
-                                "CARGO_PKG_LICENSE_FILE": "",
-                                "CARGO_PKG_HOMEPAGE": "",
-                                "CARGO_PKG_DESCRIPTION": "",
-                                "CARGO_PKG_NAME": "hello-world",
-                                "CARGO_PKG_VERSION_PATCH": "0",
-                                "CARGO": "cargo",
-                                "CARGO_PKG_REPOSITORY": "",
-                                "CARGO_PKG_VERSION_MINOR": "1",
-                                "CARGO_PKG_VERSION_PRE": "",
-                            },
-                        },
-                        dependencies: [
-                            Dependency {
-                                crate_id: CrateId(
-                                    0,
-                                ),
-                                name: CrateName(
-                                    "hello_world",
-                                ),
-                                prelude: true,
-                            },
-                            Dependency {
-                                crate_id: CrateId(
-                                    4,
+                                    5,
                                 ),
                                 name: CrateName(
                                     "libc",
@@ -1186,7 +1346,7 @@ fn cargo_hello_world_project_model() {
                         3,
                     ): CrateData {
                         root_file_id: FileId(
-                            4,
+                            3,
                         ),
                         edition: Edition2018,
                         version: Some(
@@ -1195,21 +1355,19 @@ fn cargo_hello_world_project_model() {
                         display_name: Some(
                             CrateDisplayName {
                                 crate_name: CrateName(
-                                    "it",
+                                    "an_example",
                                 ),
-                                canonical_name: "it",
+                                canonical_name: "an-example",
                             },
                         ),
                         cfg_options: CfgOptions(
                             [
                                 "debug_assertions",
-                                "test",
                             ],
                         ),
                         potential_cfg_options: CfgOptions(
                             [
                                 "debug_assertions",
-                                "test",
                             ],
                         ),
                         target_layout: Err(
@@ -1246,7 +1404,7 @@ fn cargo_hello_world_project_model() {
                             },
                             Dependency {
                                 crate_id: CrateId(
-                                    4,
+                                    5,
                                 ),
                                 name: CrateName(
                                     "libc",
@@ -1267,6 +1425,87 @@ fn cargo_hello_world_project_model() {
                     },
                     CrateId(
                         4,
+                    ): CrateData {
+                        root_file_id: FileId(
+                            4,
+                        ),
+                        edition: Edition2018,
+                        version: Some(
+                            "0.1.0",
+                        ),
+                        display_name: Some(
+                            CrateDisplayName {
+                                crate_name: CrateName(
+                                    "it",
+                                ),
+                                canonical_name: "it",
+                            },
+                        ),
+                        cfg_options: CfgOptions(
+                            [
+                                "debug_assertions",
+                            ],
+                        ),
+                        potential_cfg_options: CfgOptions(
+                            [
+                                "debug_assertions",
+                            ],
+                        ),
+                        target_layout: Err(
+                            "target_data_layout not loaded",
+                        ),
+                        env: Env {
+                            entries: {
+                                "CARGO_PKG_LICENSE": "",
+                                "CARGO_PKG_VERSION_MAJOR": "0",
+                                "CARGO_MANIFEST_DIR": "$ROOT$hello-world",
+                                "CARGO_PKG_VERSION": "0.1.0",
+                                "CARGO_PKG_AUTHORS": "",
+                                "CARGO_CRATE_NAME": "hello_world",
+                                "CARGO_PKG_LICENSE_FILE": "",
+                                "CARGO_PKG_HOMEPAGE": "",
+                                "CARGO_PKG_DESCRIPTION": "",
+                                "CARGO_PKG_NAME": "hello-world",
+                                "CARGO_PKG_VERSION_PATCH": "0",
+                                "CARGO": "cargo",
+                                "CARGO_PKG_REPOSITORY": "",
+                                "CARGO_PKG_VERSION_MINOR": "1",
+                                "CARGO_PKG_VERSION_PRE": "",
+                            },
+                        },
+                        dependencies: [
+                            Dependency {
+                                crate_id: CrateId(
+                                    0,
+                                ),
+                                name: CrateName(
+                                    "hello_world",
+                                ),
+                                prelude: true,
+                            },
+                            Dependency {
+                                crate_id: CrateId(
+                                    5,
+                                ),
+                                name: CrateName(
+                                    "libc",
+                                ),
+                                prelude: true,
+                            },
+                        ],
+                        proc_macro: Err(
+                            "crate has not (yet) been built",
+                        ),
+                        origin: CratesIo {
+                            repo: None,
+                            name: Some(
+                                "hello-world",
+                            ),
+                        },
+                        is_proc_macro: false,
+                    },
+                    CrateId(
+                        5,
                     ): CrateData {
                         root_file_id: FileId(
                             5,

--- a/crates/project-model/src/workspace.rs
+++ b/crates/project-model/src/workspace.rs
@@ -915,6 +915,16 @@ fn cargo_to_crate_graph(
                         continue;
                     }
 
+                    if dep.kind == DepKind::Dev
+                        && !matches!(
+                            kind,
+                            TargetKind::Test | TargetKind::Example | TargetKind::Bench
+                        )
+                    {
+                        // Only tests, examples and benchmarks may depend on dev dependencies.
+                        continue;
+                    }
+
                     add_dep(&mut crate_graph, from, name.clone(), to)
                 }
             }

--- a/crates/project-model/src/workspace.rs
+++ b/crates/project-model/src/workspace.rs
@@ -926,8 +926,9 @@ fn cargo_to_crate_graph(
             public_deps.add_to_crate_graph(&mut crate_graph, from);
 
             if let Some((to, name)) = lib_tgt.clone() {
-                if to != from && kind != TargetKind::BuildScript {
-                    // (build script can not depend on its library target)
+                if !matches!(kind, TargetKind::BuildScript | TargetKind::Lib) {
+                    // (build script can not depend on its library target, and library target does
+                    // not depend on itself unless manually specified)
 
                     // For root projects with dashes in their name,
                     // cargo metadata does not do any normalization,


### PR DESCRIPTION
Fixes #9574
Fixes #11410

`rust-analyzer` already counts all of the different targets of a crate as different crates, so it was pretty easy to just exclude dev dependencies from the dependency lists of targets other than test, dev and bench when ingesting `cargo metadata`'s output. A similar thing is already done for build dependencies.

It's possible there might be something I'm missing here, since this is quite a long-standing issue which I expected to be much more complicated to solve; but, this seems to work. The circular dependency errors that `rust-analyzer` used to throw on `wasm-bindgen` went away after switching to this patched version.