### PR TITLE
Canonicalize rust-project.json path for determining the project root

### DIFF
--- a/crates/paths/src/lib.rs
+++ b/crates/paths/src/lib.rs
@@ -179,6 +179,11 @@ impl AbsPath {
         self.0.ends_with(&suffix.0)
     }
 
+    /// Equivalent of [`Path::canonicalize`] for `AbsPath`.
+    pub fn canonicalize(&self) -> Result<AbsPathBuf, std::io::Error> {
+        Ok(self.as_ref().canonicalize()?.try_into().unwrap())
+    }
+
     // region:delegate-methods
 
     // Note that we deliberately don't implement `Deref<Target = Path>` here.

--- a/crates/project-model/src/workspace.rs
+++ b/crates/project-model/src/workspace.rs
@@ -150,13 +150,14 @@ impl ProjectWorkspace {
     ) -> Result<ProjectWorkspace> {
         let res = match manifest {
             ProjectManifest::ProjectJson(project_json) => {
+                let project_json = project_json.canonicalize()?;
                 let file = fs::read_to_string(&project_json).with_context(|| {
                     format!("Failed to read json file {}", project_json.display())
                 })?;
                 let data = serde_json::from_str(&file).with_context(|| {
                     format!("Failed to deserialize json file {}", project_json.display())
                 })?;
-                let project_location = project_json.parent().to_path_buf();
+                let project_location = project_json.parent().unwrap().to_path_buf();
                 let project_json = ProjectJson::new(&project_location, data);
                 ProjectWorkspace::load_inline(
                     project_json,


### PR DESCRIPTION
The meson build system places an autogenerated rust-project.json inside the build directory instead of the source/project root. Using it with rust-analyzer requires additional configuration so that it is found.

Alternatively, by creating a symlink inside the project root to the file in the build directory it can be found automatically. Unfortunately the paths in rust-project.json are relative so rust-analyzer would use the location of the symlink to determine where files are placed and not find any files.

By resolving any symlink before determining it as project root this works correctly.

Only automatically discovered rust-project.json are handled like this. If specified via the configuration file then the configured path is taken as-is.

This also seems to be the behaviour of clangd when loading compile_commands.json, or at least the same approach with a symlink works for clangd.

----

meson PR to write absolute paths: https://github.com/mesonbuild/meson/pull/11467