### PR TITLE
fix: Add check for extra path segments after a fully qualified one

### DIFF
--- a/crates/hir-def/src/macro_expansion_tests/mbe/regression.rs
+++ b/crates/hir-def/src/macro_expansion_tests/mbe/regression.rs
@@ -827,6 +827,7 @@ macro_rules! rgb_color {
 /* parse error: expected type */
 /* parse error: expected R_PAREN */
 /* parse error: expected R_ANGLE */
+/* parse error: expected `::` */
 /* parse error: expected COMMA */
 /* parse error: expected R_ANGLE */
 /* parse error: expected SEMICOLON */

--- a/crates/parser/src/grammar/paths.rs
+++ b/crates/parser/src/grammar/paths.rs
@@ -77,6 +77,9 @@ fn path_segment(p: &mut Parser<'_>, mode: Mode, first: bool) {
     // type X = <A as B>::Output;
     // fn foo() { <usize as Default>::default(); }
     if first && p.eat(T![<]) {
+        // test_err angled_path_without_qual
+        // type X = <()>;
+        // type Y = <A as B>;
         types::type_(p);
         if p.eat(T![as]) {
             if is_use_path_start(p) {
@@ -86,6 +89,9 @@ fn path_segment(p: &mut Parser<'_>, mode: Mode, first: bool) {
             }
         }
         p.expect(T![>]);
+        if !p.at(T![::]) {
+            p.error("expected `::`");
+        }
     } else {
         let empty = if first {
             p.eat(T![::]);

--- a/crates/parser/test_data/parser/inline/err/0016_angled_path_without_qual.rast
+++ b/crates/parser/test_data/parser/inline/err/0016_angled_path_without_qual.rast
@@ -1,0 +1,49 @@
+SOURCE_FILE
+  TYPE_ALIAS
+    TYPE_KW "type"
+    WHITESPACE " "
+    NAME
+      IDENT "X"
+    WHITESPACE " "
+    EQ "="
+    WHITESPACE " "
+    PATH_TYPE
+      PATH
+        PATH_SEGMENT
+          L_ANGLE "<"
+          TUPLE_TYPE
+            L_PAREN "("
+            R_PAREN ")"
+          R_ANGLE ">"
+    SEMICOLON ";"
+  WHITESPACE "\n"
+  TYPE_ALIAS
+    TYPE_KW "type"
+    WHITESPACE " "
+    NAME
+      IDENT "Y"
+    WHITESPACE " "
+    EQ "="
+    WHITESPACE " "
+    PATH_TYPE
+      PATH
+        PATH_SEGMENT
+          L_ANGLE "<"
+          PATH_TYPE
+            PATH
+              PATH_SEGMENT
+                NAME_REF
+                  IDENT "A"
+          WHITESPACE " "
+          AS_KW "as"
+          WHITESPACE " "
+          PATH_TYPE
+            PATH
+              PATH_SEGMENT
+                NAME_REF
+                  IDENT "B"
+          R_ANGLE ">"
+    SEMICOLON ";"
+  WHITESPACE "\n"
+error 13: expected `::`
+error 32: expected `::`

--- a/crates/parser/test_data/parser/inline/err/0016_angled_path_without_qual.rs
+++ b/crates/parser/test_data/parser/inline/err/0016_angled_path_without_qual.rs
@@ -1,0 +1,2 @@
+type X = <()>;
+type Y = <A as B>;


### PR DESCRIPTION
`type A = <()>;` is parsed just fine by rust-analyzer, but then rejected by rustc:

```
error: expected `::`, found `;`
 --> x.rs:7:14
  |
7 | type A = <()>;
  |              ^ expected `::`

```

Fixed by adding a lookahead for the `::` token after fully-qualified path segments.