### PR TITLE
Respect $CARGO_HOME when looking up toolchains.

### DIFF
--- a/editors/code/src/toolchain.ts
+++ b/editors/code/src/toolchain.ts
@@ -156,19 +156,10 @@ export const getPathForExecutable = memoizeAsync(
 
         if (await lookupInPath(executableName)) return executableName;
 
-        try {
-            // hmm, `os.homedir()` seems to be infallible
-            // it is not mentioned in docs and cannot be inferred by the type signature...
-            const standardPath = vscode.Uri.joinPath(
-                vscode.Uri.file(os.homedir()),
-                ".cargo",
-                "bin",
-                executableName
-            );
-
+        const cargoHome = getCargoHome();
+        if (cargoHome) {
+            const standardPath = vscode.Uri.joinPath(cargoHome, "bin", executableName);
             if (await isFileAtUri(standardPath)) return standardPath.fsPath;
-        } catch (err) {
-            log.error("Failed to read the fs info", err);
         }
         return executableName;
     }
@@ -188,6 +179,21 @@ async function lookupInPath(exec: string): Promise<boolean> {
         }
     }
     return false;
+}
+
+function getCargoHome(): vscode.Uri | null {
+    const envVar = process.env["CARGO_HOME"];
+    if (envVar) return vscode.Uri.file(envVar);
+
+    try {
+        // hmm, `os.homedir()` seems to be infallible
+        // it is not mentioned in docs and cannot be inferred by the type signature...
+        return vscode.Uri.joinPath(vscode.Uri.file(os.homedir()), ".cargo");
+    } catch (err) {
+        log.error("Failed to read the fs info", err);
+    }
+
+    return null;
 }
 
 async function isFileAtPath(path: string): Promise<boolean> {


### PR DESCRIPTION
Some people set `$CARGO_HOME` to a location other than `~/.cargo` (`$XDG_DATA_DIR/cargo`,  in my case), and I'd be a little nicer if the rust-analyzer extension and server respect that value when looking up toolchains, instead of having us configure all of `$CARGO`, `$RUSTC` ... manually.

The new implementation still defaults to `~/.cargo` if `$CARGO_HOME` is unset, pretty much like cargo itself does (as documented in https://doc.rust-lang.org/cargo/guide/cargo-home.html), so the change is backwards compatible for most people except those who has configured `$CARGO_HOME` explicitly.

I considered using https://crates.io/crates/home as suggested by https://doc.rust-lang.org/cargo/guide/cargo-home.html, but decided to put int on hold because i) we need mirror impl in node, ii) I thought the consistency matters more and iii) the new implementation shouldn't be worse than the current one (i.e. switching to `home` improvement is rather orthogonal and could be done in another PR). If you have any directions on this, please let me know.