### PR TITLE
add: clean api to get `raw_ptr` type

### DIFF
--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -3190,7 +3190,7 @@ impl Type {
         matches!(self.ty.kind(Interner), TyKind::Raw(..))
     }
 
-    pub fn as_raw_ptr_ty(&self) -> Option<Type> {
+    pub fn remove_raw_ptr(&self) -> Option<Type> {
         if let TyKind::Raw(_, ty) = self.ty.kind(Interner) {
             Some(self.derived(ty.clone()))
         } else {

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -3190,6 +3190,14 @@ impl Type {
         matches!(self.ty.kind(Interner), TyKind::Raw(..))
     }
 
+    pub fn as_raw_ptr_ty(&self) -> Option<Type> {
+        if let TyKind::Raw(_, ty) = self.ty.kind(Interner) {
+            Some(self.derived(ty.clone()))
+        } else {
+            None
+        }
+    }
+
     pub fn contains_unknown(&self) -> bool {
         // FIXME: When we get rid of `ConstScalar::Unknown`, we can just look at precomputed
         // `TypeFlags` in `TyData`.


### PR DESCRIPTION
There doesn't seem to be an API to fetch the type of `raw_ptr`, which is helpful for a project I work on.


Notes:

- I am unsure about the function name, do let me know if I should use something else.
- Also unsure about where to add tests, for hir changes. Will fix it as needed.
