### PR TITLE
Don't drop rustc crates in the rustc workspace

### DIFF
--- a/crates/project-model/src/workspace.rs
+++ b/crates/project-model/src/workspace.rs
@@ -249,10 +249,6 @@ impl ProjectWorkspace {
                 };
 
                 let rustc = match rustc_dir {
-                    Some(rustc_dir) if rustc_dir == cargo_toml => {
-                        tracing::info!(rustc_dir = %rustc_dir.display(), "Workspace is the rustc workspace itself, not adding the rustc workspace separately");
-                        None
-                    }
                     Some(rustc_dir) => {
                         tracing::info!(workspace = %cargo_toml.display(), rustc_dir = %rustc_dir.display(), "Using rustc source");
                         match CargoWorkspace::fetch_metadata(


### PR DESCRIPTION
Turns out the rustc workspace has tools that rely on the external crates themselves so this check is faulty 