### PR TITLE
Disable pattern type mismatches again

### DIFF
--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -1466,6 +1466,9 @@ impl DefWithBody {
         for (pat_or_expr, mismatch) in infer.type_mismatches() {
             let expr_or_pat = match pat_or_expr {
                 ExprOrPatId::ExprId(expr) => source_map.expr_syntax(expr).map(Either::Left),
+                // FIXME: Re-enable these once we have less false positives
+                ExprOrPatId::PatId(_pat) => continue,
+                #[allow(unreachable_patterns)]
                 ExprOrPatId::PatId(pat) => source_map.pat_syntax(pat).map(Either::Right),
             };
             let expr_or_pat = match expr_or_pat {

--- a/crates/ide-diagnostics/src/handlers/missing_match_arms.rs
+++ b/crates/ide-diagnostics/src/handlers/missing_match_arms.rs
@@ -273,20 +273,15 @@ enum Either2 { C, D }
 fn main() {
     match Either::A {
         Either2::C => (),
-     // ^^^^^^^^^^  error: expected Either, found Either2
         Either2::D => (),
-     // ^^^^^^^^^^  error: expected Either, found Either2
     }
     match (true, false) {
         (true, false, true) => (),
-     // ^^^^^^^^^^^^^^^^^^^  error: expected (bool, bool), found (bool, bool, bool)
         (true) => (),
       // ^^^^  error: expected (bool, bool), found bool
     }
     match (true, false) { (true,) => {} }
-                       // ^^^^^^^  error: expected (bool, bool), found (bool,)
     match (0) { () => () }
-             // ^^  error: expected i32, found ()
     match Unresolved::Bar { Unresolved::Baz => () }
 }
         "#,
@@ -300,9 +295,7 @@ fn main() {
             r#"
 fn main() {
     match false { true | () => {} }
-                      // ^^  error: expected bool, found ()
     match (false,) { (true | (),) => {} }
-                          // ^^  error: expected bool, found ()
 }
 "#,
         );
@@ -1050,7 +1043,6 @@ fn main() {
 fn main() {
     match (&false,) {
         (true,) => {}
-     // ^^^^^^^  error: expected (&bool,), found (bool,)
     }
     match (&false,) {
         (&true,) => {}

--- a/crates/ide-diagnostics/src/handlers/type_mismatch.rs
+++ b/crates/ide-diagnostics/src/handlers/type_mismatch.rs
@@ -617,10 +617,8 @@ fn f() -> i32 {
             r#"
 fn f() {
     let &() = &mut ();
-      //^^^ error: expected &mut (), found &()
     match &() {
         &9 => ()
-      //^^ error: expected &(), found &i32
        //^ error: expected (), found i32
     }
 }


### PR DESCRIPTION
We have too many false mismatches at the moment for these to be enabled
cc https://github.com/rust-lang/rust-analyzer/pull/14222