### PR TITLE
Load proc-macros for rustc_private crates

### DIFF
--- a/crates/rust-analyzer/src/main_loop.rs
+++ b/crates/rust-analyzer/src/main_loop.rs
@@ -409,12 +409,12 @@ impl GlobalState {
         if self.last_reported_status.as_ref() != Some(&status) {
             self.last_reported_status = Some(status.clone());
 
-            if let (lsp_ext::Health::Error, Some(message)) = (status.health, &status.message) {
-                self.show_message(lsp_types::MessageType::ERROR, message.clone());
-            }
-
             if self.config.server_status_notification() {
                 self.send_notification::<lsp_ext::ServerStatusNotification>(status);
+            } else {
+                if let (lsp_ext::Health::Error, Some(message)) = (status.health, &status.message) {
+                    self.show_message(lsp_types::MessageType::ERROR, message.clone());
+                }
             }
         }
 

--- a/crates/rust-analyzer/src/reload.rs
+++ b/crates/rust-analyzer/src/reload.rs
@@ -202,7 +202,9 @@ impl GlobalState {
         tracing::info!(%cause, "will switch workspaces");
 
         if let Err(error_message) = self.fetch_workspace_error() {
-            self.show_and_log_error(error_message, None);
+            if !self.config.server_status_notification() {
+                self.show_and_log_error(error_message, None);
+            }
             if !self.workspaces.is_empty() {
                 // It only makes sense to switch to a partially broken workspace
                 // if we don't have any workspace at all yet.


### PR DESCRIPTION
If the client support our server status notification there is no need to show the pop up for workspace fetching failures since that's already going to be shown in the status.
cc https://github.com/rust-lang/rust-analyzer/issues/14193