### PR TITLE
fix: Evaluate consts in `path_to_const`

### DIFF
--- a/crates/hir-ty/src/consteval.rs
+++ b/crates/hir-ty/src/consteval.rs
@@ -100,6 +100,7 @@ pub(crate) fn path_to_const(
             };
             Some(ConstData { ty, value }.intern(Interner))
         }
+        Some(ValueNs::ConstId(c)) => db.const_eval(c).ok(),
         _ => None,
     }
 }

--- a/crates/hir-ty/src/tests/simple.rs
+++ b/crates/hir-ty/src/tests/simple.rs
@@ -3274,3 +3274,17 @@ fn func() {
         "#]],
     );
 }
+
+#[test]
+fn issue_14275() {
+    check_types(
+        r#"
+struct Foo<const T: bool>;
+fn main() {
+    const B: bool = false;
+    let foo = Foo::<B>;
+      //^^^ Foo<false>
+}
+"#,
+    );
+}


### PR DESCRIPTION
fix #14275 