### PR TITLE
Disable chaining inlay hints by default

### DIFF
--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -329,7 +329,7 @@ config_data! {
         /// Whether to show inlay type hints for binding modes.
         inlayHints_bindingModeHints_enable: bool                   = "false",
         /// Whether to show inlay type hints for method chains.
-        inlayHints_chainingHints_enable: bool                      = "true",
+        inlayHints_chainingHints_enable: bool                      = "false",
         /// Whether to show inlay hints after a closing `}` to indicate what item it belongs to.
         inlayHints_closingBraceHints_enable: bool                  = "true",
         /// Minimum number of lines required before the `}` until the hint is shown (set to 0 or 1

--- a/docs/user/generated_config.adoc
+++ b/docs/user/generated_config.adoc
@@ -448,7 +448,7 @@ The path structure for newly inserted paths to use.
 --
 Whether to show inlay type hints for binding modes.
 --
-[[rust-analyzer.inlayHints.chainingHints.enable]]rust-analyzer.inlayHints.chainingHints.enable (default: `true`)::
+[[rust-analyzer.inlayHints.chainingHints.enable]]rust-analyzer.inlayHints.chainingHints.enable (default: `false`)::
 +
 --
 Whether to show inlay type hints for method chains.

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -965,7 +965,7 @@
                 },
                 "rust-analyzer.inlayHints.chainingHints.enable": {
                     "markdownDescription": "Whether to show inlay type hints for method chains.",
-                    "default": true,
+                    "default": false,
                     "type": "boolean"
                 },
                 "rust-analyzer.inlayHints.closingBraceHints.enable": {


### PR DESCRIPTION
People tend to complain about inlay hints being to noisy, some also get confused by some of them as they aren't valid rust (chaining hints and param name hints) especially for newcomes to the language. I feel like chaining hints are not valuable enough to be enabled by default given these complaints (they are in fact the only hints I have disabled myself as I find them just unnecessary, while having pretty much every other hint enabled explicitly). Chaining in rust does not always span multiple lines and in those cases we already don't show them either (for obvious reasons).

So I'd be inclined to say we should switch the default to disabled.