### PR TITLE
internal: add `as_slice` to `hir::Type`

### DIFF
--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -3224,6 +3224,13 @@ impl Type {
         }
     }
 
+    pub fn remove_slice(&self) -> Option<Type> {
+        match &self.ty.kind(Interner) {
+            TyKind::Slice(ty) => Some(self.derived(ty.clone())),
+            _ => None,
+        }
+    }
+
     pub fn strip_references(&self) -> Type {
         self.derived(self.ty.strip_references().clone())
     }

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -3224,7 +3224,7 @@ impl Type {
         }
     }
 
-    pub fn remove_slice(&self) -> Option<Type> {
+    pub fn as_slice(&self) -> Option<Type> {
         match &self.ty.kind(Interner) {
             TyKind::Slice(ty) => Some(self.derived(ty.clone())),
             _ => None,


### PR DESCRIPTION
~`remove_slice`~ `as_slice` is same as `remove_ref` but for slices.

Though there is `as_array` which I believe was named such because it also gets the length of the array, maybe. I am still shaky on the names feel free to suggest corrections.