### PR TITLE
fix: Don't pass feature flags to rustc private crates metadata invocation

### DIFF
--- a/crates/project-model/src/workspace.rs
+++ b/crates/project-model/src/workspace.rs
@@ -254,7 +254,10 @@ impl ProjectWorkspace {
                         match CargoWorkspace::fetch_metadata(
                             &rustc_dir,
                             cargo_toml.parent(),
-                            config,
+                            &CargoConfig {
+                                features: crate::CargoFeatures::default(),
+                                ..config.clone()
+                            },
                             progress,
                         ) {
                             Ok(meta) => {


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust-analyzer/issues/14327

Better error reporting I'll do in a follow up