### PR TITLE
Give `readonly` semantic token modifier to non-mutable names

### DIFF
--- a/crates/rust-analyzer/src/semantic_tokens.rs
+++ b/crates/rust-analyzer/src/semantic_tokens.rs
@@ -114,6 +114,7 @@ define_semantic_token_modifiers![
         DECLARATION,
         STATIC,
         DEFAULT_LIBRARY,
+        READONLY,
     }
     custom {
         (ASYNC, "async"),

--- a/crates/rust-analyzer/src/to_proto.rs
+++ b/crates/rust-analyzer/src/to_proto.rs
@@ -631,10 +631,25 @@ fn semantic_token_type_and_modifiers(
             SymbolKind::ConstParam => semantic_tokens::CONST_PARAMETER,
             SymbolKind::LifetimeParam => semantic_tokens::LIFETIME,
             SymbolKind::Label => semantic_tokens::LABEL,
-            SymbolKind::ValueParam => semantic_tokens::PARAMETER,
-            SymbolKind::SelfParam => semantic_tokens::SELF_KEYWORD,
+            SymbolKind::ValueParam => {
+                if !highlight.mods.contains(HlMod::Mutable) {
+                    mods |= semantic_tokens::READONLY;
+                }
+                semantic_tokens::PARAMETER
+            }
+            SymbolKind::SelfParam => {
+                if !highlight.mods.contains(HlMod::Mutable) {
+                    mods |= semantic_tokens::READONLY;
+                }
+                semantic_tokens::SELF_KEYWORD
+            }
             SymbolKind::SelfType => semantic_tokens::SELF_TYPE_KEYWORD,
-            SymbolKind::Local => semantic_tokens::VARIABLE,
+            SymbolKind::Local => {
+                if !highlight.mods.contains(HlMod::Mutable) {
+                    mods |= semantic_tokens::READONLY;
+                }
+                semantic_tokens::VARIABLE
+            }
             SymbolKind::Function => {
                 if highlight.mods.contains(HlMod::Associated) {
                     semantic_tokens::METHOD
@@ -643,12 +658,16 @@ fn semantic_token_type_and_modifiers(
                 }
             }
             SymbolKind::Const => {
+                mods |= semantic_tokens::READONLY;
                 mods |= semantic_tokens::CONSTANT;
                 mods |= semantic_tokens::STATIC;
                 semantic_tokens::VARIABLE
             }
             SymbolKind::Static => {
                 mods |= semantic_tokens::STATIC;
+                if !highlight.mods.contains(HlMod::Mutable) {
+                    mods |= semantic_tokens::READONLY;
+                }
                 semantic_tokens::VARIABLE
             }
             SymbolKind::Struct => semantic_tokens::STRUCT,


### PR DESCRIPTION
This brings rust-analyzer in line with the VS Code convention (i.e. what the builtin TypeScript tooling does).

---

# Default theme considerations

## Possibly remove mutability underlining

The default theme assigns tokens with `readonly` a different shade of blue, which means mutability is now indicated by both a difference in color and a difference in underlining:

<img width="188" alt="Screenshot 2023-03-22 at 11 47 53 pm" src="https://user-images.githubusercontent.com/31783266/226909166-a90d93b1-1452-420f-aed9-53a9995bf856.png">

It might be a good idea to remove the hack currently in place to underline things with the `mutable` modifier so that we don’t have this duplicated differentiation.

https://github.com/rust-lang/rust-analyzer/blob/3321799e8fac622db50fe8c3284062f7d0f1bf53/editors/code/package.json#L1818-L1820

## Is this whole PR a bad idea in the first place?

I think there is an argument to be made that emphasizing immutable things in Rust is unnecessary compared to other traditionally imperative languages. Since Rust is immutable-by-default, immutability is the norm and mutability is the special case. Taking this position, it makes more sense to emphasize mutable things with an underline rather than immutable things a different color. (Gee I wonder why the status quo is what it is? :))

On the other hand, applying `readonly` is more semantically correct, and semantic correctness should take priority over trying to accommodate the whims of the default theme. There is something to be said for highlighting based on semantics and not aesthetics (i.e. the opposite of what the original Vim implementation of Solarized did) so highlighting-based intuition is transferrable across languages.

## Immutable parameter highlighting VS Code bug

One thing to note is that [VS Code’s default semantic-to-TextMate scope mappings](https://github.com/microsoft/vscode/blob/ee036026aa5c8545690f51f8d23e1f1c79a16eff/src/vs/platform/theme/common/tokenClassificationRegistry.ts#L541-L595) have a bug which results in immutable parameters not getting the richer blue color other constants have in the default theme:

<img width="250" alt="Screenshot 2023-03-23 at 12 08 23 am" src="https://user-images.githubusercontent.com/31783266/226914050-1d71255b-872d-4816-8ef2-39365c468d54.png">

We could work around this by adding a special case in `package.json`’s `semanticTokenScopes` for `parameter.readonly` that remaps it to `variable.other.constant.parameter`. This is consistent with VS Code’s default semantic token mappings:

| Semantic token type | No semantic token modifier | With `readonly` modifier |
| -: | :- | :- |
| `variable` | `variable` | `variable.other.constant` |
| `property` | `variable.other.property` | `variable.other.constant.property` |
| `parameter` | `variable.parameter` | `variable.other.constant.parameter` 👈 my proposal |

Something to note here is that a theme which tries to highlight all parameters by applying styles to the `variable.parameter` TextMate scope (such as the built-in Monokai theme) would miss out on highlighting immutable parameters; I think this is mostly fine, since properties already have this problem.

# Implementation notes

I decided to assign the `readonly` modifier in `to_proto` instead of creating an actual `HlMod` and passing that through since

- the places `readonly` has to be applied can be derived purely from which existing `HlMod`s have been applied
- adding `HlMod::ReadOnly` duplicates `HlMod::Mutable`
- the concept of having a modifier which indicates whether something is read-only doesn’t fit with Rust’s semantics: mutability is indicated by adding a syntactic “modifier” (`mut`), not by adding a `readonly` keyword or something of the sort