### PR TITLE
internal: Only intern blocks that declare items

### DIFF
--- a/crates/hir-def/src/body/scope.rs
+++ b/crates/hir-def/src/body/scope.rs
@@ -115,15 +115,10 @@ impl ExprScopes {
     fn new_block_scope(
         &mut self,
         parent: ScopeId,
-        block: BlockId,
+        block: Option<BlockId>,
         label: Option<(LabelId, Name)>,
     ) -> ScopeId {
-        self.scopes.alloc(ScopeData {
-            parent: Some(parent),
-            block: Some(block),
-            label,
-            entries: vec![],
-        })
+        self.scopes.alloc(ScopeData { parent: Some(parent), block, label, entries: vec![] })
     }
 
     fn add_bindings(&mut self, body: &Body, scope: ScopeId, binding: BindingId) {

--- a/crates/hir-def/src/expr.rs
+++ b/crates/hir-def/src/expr.rs
@@ -117,23 +117,23 @@ pub enum Expr {
         expr: ExprId,
     },
     Block {
-        id: BlockId,
+        id: Option<BlockId>,
         statements: Box<[Statement]>,
         tail: Option<ExprId>,
         label: Option<LabelId>,
     },
     Async {
-        id: BlockId,
+        id: Option<BlockId>,
         statements: Box<[Statement]>,
         tail: Option<ExprId>,
     },
     Const {
-        id: BlockId,
+        id: Option<BlockId>,
         statements: Box<[Statement]>,
         tail: Option<ExprId>,
     },
     Unsafe {
-        id: BlockId,
+        id: Option<BlockId>,
         statements: Box<[Statement]>,
         tail: Option<ExprId>,
     },

--- a/crates/hir-def/src/item_tree.rs
+++ b/crates/hir-def/src/item_tree.rs
@@ -152,6 +152,14 @@ impl ItemTree {
         &self.top_level
     }
 
+    pub fn block_has_items(
+        db: &dyn DefDatabase,
+        file_id: HirFileId,
+        block: &ast::BlockExpr,
+    ) -> bool {
+        lower::Ctx::new(db, file_id).block_has_items(block)
+    }
+
     /// Returns the inner attributes of the source file.
     pub fn top_level_attrs(&self, db: &dyn DefDatabase, krate: CrateId) -> Attrs {
         Attrs::filter(


### PR DESCRIPTION
We only used `BlockId` for the block defmap, so this is wasted memory. Lowering for non item declaring blocks is also cheaper now as we no longer have to fully lower a block that defines not items.