### PR TITLE
finish renaming `rust-analyzer/reloadProcMacros` to `rust-analyzer/rebuildProcMacros`

### DIFF
--- a/editors/code/src/lsp_ext.ts
+++ b/editors/code/src/lsp_ext.ts
@@ -43,7 +43,7 @@ export const relatedTests = new lc.RequestType<lc.TextDocumentPositionParams, Te
     "rust-analyzer/relatedTests"
 );
 export const reloadWorkspace = new lc.RequestType0<null, void>("rust-analyzer/reloadWorkspace");
-export const rebuildProcMacros = new lc.RequestType0<null, void>("rust-analyzer/reloadProcMacros");
+export const rebuildProcMacros = new lc.RequestType0<null, void>("rust-analyzer/rebuildProcMacros");
 
 export const runFlycheck = new lc.NotificationType<{
     textDocument: lc.TextDocumentIdentifier | null;


### PR DESCRIPTION
I was trying out #14409, but noticed that actually _running_ that command resulted in VS Code raising an error. This allows me to successfully run `rust-analyzer/rebuildProcMacros`.