### PR TITLE
fix: allow new, subsequent `rust-project.json`-based workspaces to get proc macro expansion

### DIFF
--- a/crates/base-db/src/input.rs
+++ b/crates/base-db/src/input.rs
@@ -17,7 +17,7 @@ use vfs::{file_set::FileSet, AbsPathBuf, AnchoredPath, FileId, VfsPath};
 
 // Map from crate id to the name of the crate and path of the proc-macro. If the value is `None`,
 // then the crate for the proc-macro hasn't been build yet as the build data is missing.
-pub type ProcMacroPaths = FxHashMap<CrateId, Option<(Option<String>, AbsPathBuf)>>;
+pub type ProcMacroPaths = FxHashMap<CrateId, Result<(Option<String>, AbsPathBuf), String>>;
 pub type ProcMacros = FxHashMap<CrateId, ProcMacroLoadResult>;
 
 /// Files are grouped into source roots. A source root is a directory on the

--- a/crates/project-model/src/workspace.rs
+++ b/crates/project-model/src/workspace.rs
@@ -672,6 +672,14 @@ impl ProjectWorkspace {
             _ => false,
         }
     }
+
+    /// Returns `true` if the project workspace is [`Json`].
+    ///
+    /// [`Json`]: ProjectWorkspace::Json
+    #[must_use]
+    pub fn is_json(&self) -> bool {
+        matches!(self, Self::Json { .. })
+    }
 }
 
 fn project_json_to_crate_graph(

--- a/crates/rust-analyzer/src/cli/load_cargo.rs
+++ b/crates/rust-analyzer/src/cli/load_cargo.rs
@@ -102,7 +102,7 @@ pub fn load_workspace(
                 (
                     crate_id,
                     path.map_or_else(
-                        || Err("proc macro crate is missing dylib".to_owned()),
+                        |_| Err("proc macro crate is missing dylib".to_owned()),
                         |(_, path)| load_proc_macro(proc_macro_server, &path, &[]),
                     ),
                 )

--- a/crates/rust-analyzer/src/reload.rs
+++ b/crates/rust-analyzer/src/reload.rs
@@ -296,11 +296,25 @@ impl GlobalState {
         let workspaces =
             workspaces.iter().filter_map(|res| res.as_ref().ok().cloned()).collect::<Vec<_>>();
 
-        let same_workspaces = workspaces.len() == self.workspaces.len()
-            && workspaces
-                .iter()
-                .zip(self.workspaces.iter())
-                .all(|(l, r)| l.eq_ignore_build_data(r));
+        // `different_workspaces` is used to spawn a new proc macro server for a newly-added
+        // rust workspace (most commonly sourced from a `rust-project.json`). While the algorithm
+        // to find the new workspaces is quadratic, we generally expect that the number of total
+        // workspaces to remain in the low single digits. the `cloned_workspace` is needed for borrowck
+        // reasons.
+        let cloned_workspaces = workspaces.clone();
+        let different_workspaces = cloned_workspaces
+            .iter()
+            .filter(|ws| {
+                !self
+                    .workspaces
+                    .iter()
+                    .find(|existing_ws| ws.eq_ignore_build_data(&existing_ws))
+                    .is_some()
+            })
+            .collect::<Vec<_>>();
+        let same_workspaces = different_workspaces.is_empty();
+
+        tracing::debug!(current_workspaces = ?self.workspaces, new_workspaces = ?workspaces, ?same_workspaces, "comparing workspaces");
 
         if same_workspaces {
             let (workspaces, build_scripts) = self.fetch_build_data_queue.last_op_result();
@@ -370,11 +384,10 @@ impl GlobalState {
         let files_config = self.config.files();
         let project_folders = ProjectFolders::new(&self.workspaces, &files_config.exclude);
 
-        if self.proc_macro_clients.is_empty() {
+        if self.proc_macro_clients.is_empty() || !different_workspaces.is_empty() {
             if let Some((path, path_manually_set)) = self.config.proc_macro_srv() {
                 tracing::info!("Spawning proc-macro servers");
-                self.proc_macro_clients = self
-                    .workspaces
+                self.proc_macro_clients = different_workspaces
                     .iter()
                     .map(|ws| {
                         let (path, args): (_, &[_]) = if path_manually_set {
@@ -448,7 +461,19 @@ impl GlobalState {
         };
         let mut change = Change::new();
 
-        if same_workspaces {
+        // `self.fetch_proc_macros_queue.request_op(cause, proc_macro_paths)` is only called in
+        // when `switch_workspaces` is called _without_ changing workspaces. This typically occurs
+        // when build scripts have finishing building, but when rust-analyzer is used with a
+        // rust-project.json, the build scripts have already been built by the external build system
+        // that generated the `rust-project.json`.
+
+        // Therefore, in order to allow _new_ workspaces added via rust-project.json (e.g., after
+        // a workspace was already added), we check whether this is the same workspace _or_
+        // if any of the new workspaces is a `rust-project.json`.
+        //
+        // The else branch is used to provide better diagnostics to users while procedural macros
+        // are still being built.
+        if same_workspaces || different_workspaces.iter().any(|ws| ws.is_json()) {
             if self.config.expand_proc_macros() {
                 self.fetch_proc_macros_queue.request_op(cause, proc_macro_paths);
             }

--- a/crates/rust-analyzer/src/reload.rs
+++ b/crates/rust-analyzer/src/reload.rs
@@ -296,9 +296,9 @@ impl GlobalState {
         let workspaces =
             workspaces.iter().filter_map(|res| res.as_ref().ok().cloned()).collect::<Vec<_>>();
 
-        // `different_workspaces` is used to spawn a new proc macro server for a newly-added
-        // rust workspace (most commonly sourced from a `rust-project.json`). While the algorithm
-        // to find the new workspaces is quadratic, we generally expect that the number of total
+        // `different_workspaces` is used to determine whether to spawn a a new proc macro server for
+        // a newly-added rust workspace (most commonly sourced from a `rust-project.json`). While the
+        // algorithm to find the new workspaces is quadratic, we generally expect that the number of total
         // workspaces to remain in the low single digits. the `cloned_workspace` is needed for borrowck
         // reasons.
         let cloned_workspaces = workspaces.clone();
@@ -387,7 +387,8 @@ impl GlobalState {
         if self.proc_macro_clients.is_empty() || !different_workspaces.is_empty() {
             if let Some((path, path_manually_set)) = self.config.proc_macro_srv() {
                 tracing::info!("Spawning proc-macro servers");
-                self.proc_macro_clients = different_workspaces
+                self.proc_macro_clients = self
+                    .workspaces
                     .iter()
                     .map(|ws| {
                         let (path, args): (_, &[_]) = if path_manually_set {


### PR DESCRIPTION
As detailed in https://github.com/rust-lang/rust-analyzer/issues/14417#issuecomment-1485336174, `rust-project.json` workspaces added after the initial `rust-project.json`-based workspace was already indexed by rust-analyzer would not receive procedural macro expansion despite `config.expand_proc_macros` returning true. To fix this issue:
1. I changed `reload.rs` to check which workspaces are newly added.
2. Spawned new procedural macro expansion servers based on the _new_ workspaces.
    1. This is to prevent spawning duplicate procedural macro expansion servers for already existing workspaces. While the overall memory usage of duplicate procedural macro servers is minimal, this is more about the _principle_ of not leaking processes 😅.
3. Launched procedural macro expansion if any workspaces are `rust-project.json`-based _or_ `same_workspaces` is true. `same_workspaces` being true (and reachable) indicates that that build scripts have finished building (in Cargo-based projects), while the build scripts in `rust-project.json`-based projects have _already been built_ by the build system that produced the `rust-project.json`.

I couldn't really think of structuring this code in a better way without engaging with https://github.com/rust-lang/rust-analyzer/issues/7444.