### PR TITLE
fix: Canonicalize rust-project.json manifest path

### DIFF
--- a/crates/paths/src/lib.rs
+++ b/crates/paths/src/lib.rs
@@ -166,6 +166,11 @@ impl AbsPath {
         AbsPathBuf::try_from(self.0.to_path_buf()).unwrap()
     }
 
+    /// Equivalent of [`Path::canonicalize`] for `AbsPath`.
+    pub fn canonicalize(&self) -> Result<AbsPathBuf, std::io::Error> {
+        Ok(self.as_ref().canonicalize()?.try_into().unwrap())
+    }
+
     /// Equivalent of [`Path::strip_prefix`] for `AbsPath`.
     ///
     /// Returns a relative path.

--- a/crates/project-model/src/manifest_path.rs
+++ b/crates/project-model/src/manifest_path.rs
@@ -34,6 +34,11 @@ impl ManifestPath {
     pub fn parent(&self) -> &AbsPath {
         self.file.parent().unwrap()
     }
+
+    /// Equivalent of [`Path::canonicalize`] for `ManifestPath`.
+    pub fn canonicalize(&self) -> Result<ManifestPath, std::io::Error> {
+        Ok((&**self).canonicalize()?.try_into().unwrap())
+    }
 }
 
 impl ops::Deref for ManifestPath {

--- a/crates/project-model/src/workspace.rs
+++ b/crates/project-model/src/workspace.rs
@@ -4,7 +4,7 @@
 
 use std::{collections::VecDeque, fmt, fs, process::Command, sync::Arc};
 
-use anyhow::{bail, format_err, Context, Result};
+use anyhow::{format_err, Context, Result};
 use base_db::{
     CrateDisplayName, CrateGraph, CrateId, CrateName, CrateOrigin, Dependency, Edition, Env,
     FileId, LangCrateOrigin, ProcMacroPaths, TargetLayoutLoadResult,
@@ -154,12 +154,7 @@ impl ProjectWorkspace {
     ) -> Result<ProjectWorkspace> {
         let res = match manifest {
             ProjectManifest::ProjectJson(project_json) => {
-                let metadata = fs::symlink_metadata(&project_json).with_context(|| {
-                    format!("Failed to read json file {}", project_json.display())
-                })?;
-                if metadata.is_symlink() {
-                    bail!("The project-json may not currently point to a symlink");
-                }
+                let project_json = project_json.canonicalize()?;
                 let file = fs::read_to_string(&project_json).with_context(|| {
                     format!("Failed to read json file {}", project_json.display())
                 })?;


### PR DESCRIPTION
Looked a bit more into this and I think we can do this after all, I don't see any place where this should break things 
cc https://github.com/rust-lang/rust-analyzer/pull/14168 https://github.com/rust-lang/rust-analyzer/pull/14402#issuecomment-1487257246