### PR TITLE
Missing runnable env on debug target

### DIFF
--- a/editors/code/src/debug.ts
+++ b/editors/code/src/debug.ts
@@ -118,8 +118,8 @@ async function getDebugConfiguration(
         return path.normalize(p).replace(wsFolder, "${workspaceFolder" + workspaceQualifier + "}");
     }
 
-    const executable = await getDebugExecutable(runnable);
     const env = prepareEnv(runnable, ctx.config.runnableEnv);
+    const executable = await getDebugExecutable(runnable, env);
     let sourceFileMap = debugOptions.sourceFileMap;
     if (sourceFileMap === "auto") {
         // let's try to use the default toolchain
@@ -156,8 +156,11 @@ async function getDebugConfiguration(
     return debugConfig;
 }
 
-async function getDebugExecutable(runnable: ra.Runnable): Promise<string> {
-    const cargo = new Cargo(runnable.args.workspaceRoot || ".", debugOutput);
+async function getDebugExecutable(
+    runnable: ra.Runnable,
+    env: Record<string, string>
+): Promise<string> {
+    const cargo = new Cargo(runnable.args.workspaceRoot || ".", debugOutput, env);
     const executable = await cargo.executableFromArgs(runnable.args.cargoArgs);
 
     // if we are here, there were no compilation errors.

--- a/editors/code/src/toolchain.ts
+++ b/editors/code/src/toolchain.ts
@@ -18,7 +18,11 @@ export interface ArtifactSpec {
 }
 
 export class Cargo {
-    constructor(readonly rootFolder: string, readonly output: vscode.OutputChannel) {}
+    constructor(
+        readonly rootFolder: string,
+        readonly output: vscode.OutputChannel,
+        readonly env: Record<string, string>
+    ) {}
 
     // Made public for testing purposes
     static artifactSpec(args: readonly string[]): ArtifactSpec {
@@ -102,6 +106,7 @@ export class Cargo {
             const cargo = cp.spawn(path, cargoArgs, {
                 stdio: ["ignore", "pipe", "pipe"],
                 cwd: this.rootFolder,
+                env: this.env,
             });
 
             cargo.on("error", (err) => reject(new Error(`could not launch cargo: ${err}`)));


### PR DESCRIPTION
Fix bug in Rust Analyzer VSCode where runnable debugging did not pass
environment variable from configuration to child process of Cargo on binary build stage

There is a missing env passing along to `cargo` in debug target which give an in-consistent result from debug and run target

For example
```json
{
    "rust-analyzer.runnableEnv": {
        "OUT_DIR": "/test/path2"
    }
}
```

## run
![image](https://user-images.githubusercontent.com/4373581/228749503-fa55f62c-13d3-4d3c-bee6-1cfbe042bdd0.png)
## debug
compiling binary is failed. Missing env
![image](https://user-images.githubusercontent.com/4373581/228749688-3fe42efb-b5ca-41be-862d-f2d97ecab7be.png)

## debug (after fix)
![image](https://user-images.githubusercontent.com/4373581/228750057-1db60051-3465-47db-8b18-4159ec58cfdb.png)

