### PR TITLE
Explicitly depend on serde_derive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -923,6 +923,7 @@ dependencies = [
  "log",
  "lsp-types",
  "serde",
+ "serde_derive",
  "serde_json",
 ]
 
@@ -1223,6 +1224,7 @@ dependencies = [
  "paths",
  "profile",
  "serde",
+ "serde_derive",
  "serde_json",
  "snap",
  "stdx",
@@ -1303,6 +1305,7 @@ dependencies = [
  "rustc-hash",
  "semver",
  "serde",
+ "serde_derive",
  "serde_json",
  "stdx",
  "toolchain",
@@ -1463,6 +1466,7 @@ dependencies = [
  "rustc-hash",
  "scip",
  "serde",
+ "serde_derive",
  "serde_json",
  "serde_repr",
  "sourcegen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,5 +78,6 @@ vfs = { path = "./crates/vfs", version = "0.0.0" }
 # non-local crates
 smallvec = { version = "1.10.0", features = ["const_new", "union", "const_generics"] }
 # the following crates are pinned to prevent us from pulling in syn 2 until all our dependencies have moved
-serde = { version = "=1.0.156", features = ["derive"] }
+serde = { version = "=1.0.156" }
+serde_derive = { version = "=1.0.156" }
 serde_json = "1.0.94"

--- a/crates/proc-macro-api/Cargo.toml
+++ b/crates/proc-macro-api/Cargo.toml
@@ -20,6 +20,7 @@ object = { version = "0.30.2", default-features = false, features = [
     "pe",
 ] }
 serde.workspace = true
+serde_derive.workspace = true
 serde_json = { workspace = true, features = ["unbounded_depth"] }
 tracing = "0.1.37"
 memmap2 = "0.5.4"

--- a/crates/proc-macro-api/src/lib.rs
+++ b/crates/proc-macro-api/src/lib.rs
@@ -18,7 +18,7 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 
 use ::tt::token_id as tt;
 

--- a/crates/proc-macro-api/src/msg.rs
+++ b/crates/proc-macro-api/src/msg.rs
@@ -6,7 +6,11 @@ use std::{
     path::PathBuf,
 };
 
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde::{
+    de::DeserializeOwned,
+    Serialize::{self},
+};
+use serde_derive::{Deserialize, Serialize};
 
 use crate::ProcMacroKind;
 

--- a/crates/proc-macro-api/src/msg/flat.rs
+++ b/crates/proc-macro-api/src/msg/flat.rs
@@ -37,7 +37,7 @@
 
 use std::collections::{HashMap, VecDeque};
 
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 
 use crate::tt::{self, TokenId};
 

--- a/crates/project-model/Cargo.toml
+++ b/crates/project-model/Cargo.toml
@@ -18,6 +18,7 @@ cargo_metadata = "0.15.0"
 semver = "1.0.14"
 serde_json.workspace = true
 serde.workspace = true
+serde_derive.workspace = true
 anyhow = "1.0.62"
 la-arena = { version = "0.3.0", path = "../../lib/la-arena" }
 

--- a/crates/project-model/src/project_json.rs
+++ b/crates/project-model/src/project_json.rs
@@ -54,7 +54,11 @@ use std::path::PathBuf;
 use base_db::{CrateDisplayName, CrateId, CrateName, Dependency, Edition};
 use paths::{AbsPath, AbsPathBuf};
 use rustc_hash::FxHashMap;
-use serde::{de, Deserialize};
+use serde::{
+    de,
+    Deserialize::{self},
+};
+use serde_derive::Deserialize;
 
 use crate::cfg_flag::CfgFlag;
 

--- a/crates/rust-analyzer/Cargo.toml
+++ b/crates/rust-analyzer/Cargo.toml
@@ -31,6 +31,7 @@ oorandom = "11.1.3"
 rustc-hash = "1.1.0"
 serde_json = { workspace = true, features = ["preserve_order"] }
 serde.workspace = true
+serde_derive.workspace = true
 threadpool = "1.8.1"
 rayon = "1.6.1"
 num_cpus = "1.15.0"

--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -26,7 +26,11 @@ use project_model::{
     UnsetTestCrates,
 };
 use rustc_hash::{FxHashMap, FxHashSet};
-use serde::{de::DeserializeOwned, Deserialize};
+use serde::{
+    de::DeserializeOwned,
+    Deserialize::{self},
+};
+use serde_derive::Deserialize;
 use vfs::AbsPathBuf;
 
 use crate::{

--- a/crates/rust-analyzer/src/dispatch.rs
+++ b/crates/rust-analyzer/src/dispatch.rs
@@ -3,7 +3,8 @@ use std::{fmt, panic, thread};
 
 use ide::Cancelled;
 use lsp_server::ExtractError;
-use serde::{de::DeserializeOwned, Serialize};
+use serde::de::DeserializeOwned;
+use serde::Serialize;
 
 use crate::{
     global_state::{GlobalState, GlobalStateSnapshot},

--- a/crates/rust-analyzer/src/lsp_ext.rs
+++ b/crates/rust-analyzer/src/lsp_ext.rs
@@ -9,7 +9,7 @@ use lsp_types::{
     notification::Notification, CodeActionKind, DocumentOnTypeFormattingParams,
     PartialResultParams, Position, Range, TextDocumentIdentifier, WorkDoneProgressParams,
 };
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 
 use crate::line_index::PositionEncoding;
 

--- a/crates/rust-analyzer/tests/slow-tests/main.rs
+++ b/crates/rust-analyzer/tests/slow-tests/main.rs
@@ -508,7 +508,7 @@ fn main() {}
 #[test]
 fn test_missing_module_code_action_in_json_project() {
     if skip_slow_tests() {
-        // return;
+        return;
     }
 
     let tmp_dir = TestDir::new();

--- a/docs/dev/lsp-extensions.md
+++ b/docs/dev/lsp-extensions.md
@@ -1,5 +1,5 @@
 <!---
-lsp_ext.rs hash: 7269e4cfab906e10
+lsp_ext.rs hash: d6e566463284e867
 
 If you need to change the above hash to make the test pass, please check if you
 need to adjust this doc as well and ping this issue:

--- a/lib/lsp-server/Cargo.toml
+++ b/lib/lsp-server/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2021"
 log = "0.4.17"
 serde_json.workspace = true
 serde.workspace = true
+serde_derive.workspace = true
 crossbeam-channel = "0.5.6"
 
 [dev-dependencies]

--- a/lib/lsp-server/src/msg.rs
+++ b/lib/lsp-server/src/msg.rs
@@ -3,7 +3,11 @@ use std::{
     io::{self, BufRead, Write},
 };
 
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde::{
+    de::DeserializeOwned,
+    Serialize::{self},
+};
+use serde_derive::{Deserialize, Serialize};
 
 use crate::error::ExtractError;
 


### PR DESCRIPTION
`serde` depending on `serde_derive` increases our compile times by a good chunk which is unfortunate as that doesn't have to be the case.
![image](https://user-images.githubusercontent.com/3757771/228870318-6f259e27-2b73-455a-975e-3c5a9ed4e622.png)

This PR explicitly changes that for our workspace members, though unfortunately the following dependencies still activate that feature for us:
- camino v1.1.4 
- cargo-platform v0.1.2 
- cargo_metadata v0.15.3 
- lsp-types v0.94.0 
- url v2.3.1 

And I am unsure whether these libraries are open to changing that.