### PR TITLE
Expand Macro Recursively: don't append "!" to non-bang macro name

### DIFF
--- a/crates/ide/src/expand_macro.rs
+++ b/crates/ide/src/expand_macro.rs
@@ -83,8 +83,10 @@ pub(crate) fn expand_macro(db: &RootDatabase, position: FilePosition) -> Option<
             }
         }
         if let Some(mac) = ast::MacroCall::cast(node) {
+            let mut name = mac.path()?.segment()?.name_ref()?.to_string();
+            name.push('!');
             break (
-                mac.path()?.segment()?.name_ref()?.to_string(),
+                name,
                 expand_macro_recur(&sema, &mac)?,
                 mac.syntax().parent().map(|it| it.kind()).unwrap_or(SyntaxKind::MACRO_ITEMS),
             );
@@ -235,7 +237,7 @@ fn main() {
 }
 "#,
             expect![[r#"
-                bar
+                bar!
                 5i64 as _"#]],
         );
     }
@@ -252,7 +254,7 @@ fn main() {
 }
 "#,
             expect![[r#"
-                bar
+                bar!
                 for _ in 0..42{}"#]],
         );
     }
@@ -273,7 +275,7 @@ macro_rules! baz {
 f$0oo!();
 "#,
             expect![[r#"
-                foo
+                foo!
                 fn b(){}
             "#]],
         );
@@ -294,7 +296,7 @@ macro_rules! foo {
 f$0oo!();
         "#,
             expect![[r#"
-                foo
+                foo!
                 fn some_thing() -> u32 {
                   let a = 0;
                   a+10
@@ -328,16 +330,16 @@ fn main() {
 }
 "#,
             expect![[r#"
-       match_ast
-       {
-         if let Some(it) = ast::TraitDef::cast(container.clone()){}
-         else if let Some(it) = ast::ImplDef::cast(container.clone()){}
-         else {
-           {
-             continue
-           }
-         }
-       }"#]],
+                match_ast!
+                {
+                  if let Some(it) = ast::TraitDef::cast(container.clone()){}
+                  else if let Some(it) = ast::ImplDef::cast(container.clone()){}
+                  else {
+                    {
+                      continue
+                    }
+                  }
+                }"#]],
         );
     }
 
@@ -358,7 +360,7 @@ fn main() {
 }
 "#,
             expect![[r#"
-                match_ast
+                match_ast!
                 {}"#]],
         );
     }
@@ -383,7 +385,7 @@ fn main() {
 }
             "#,
             expect![[r#"
-                foo
+                foo!
                 {
                   macro_rules! bar {
                     () => {
@@ -411,7 +413,7 @@ fn main() {
 }
 "#,
             expect![[r#"
-                foo
+                foo!
             "#]],
         );
     }
@@ -433,7 +435,7 @@ fn main() {
 }
 "#,
             expect![[r#"
-                foo
+                foo!
                 0"#]],
         );
     }
@@ -451,7 +453,7 @@ fn main() {
 }
 "#,
             expect![[r#"
-                foo
+                foo!
                 fn f<T>(_: &dyn ::std::marker::Copy){}"#]],
         );
     }

--- a/editors/code/src/commands.ts
+++ b/editors/code/src/commands.ts
@@ -699,7 +699,7 @@ export function viewFullCrateGraph(ctx: CtxInit): Cmd {
 // The contents of the file come from the `TextDocumentContentProvider`
 export function expandMacro(ctx: CtxInit): Cmd {
     function codeFormat(expanded: ra.ExpandedMacro): string {
-        let result = `// Recursive expansion of ${expanded.name}! macro\n`;
+        let result = `// Recursive expansion of ${expanded.name} macro\n`;
         result += "// " + "=".repeat(result.length - 3);
         result += "\n\n";
         result += expanded.expansion;


### PR DESCRIPTION
When we run `Expand Macro Recursively`, we prepend a comment "Recursive expansion of foo! macro" to the expansion result. I've noticed we unconditionally render the macro name with "!" and, while super subtle, I feel a bit awkward when the macro is either a derive or attribute macro.