### PR TITLE
fix: insert whitespace between text and pound

### DIFF
--- a/crates/ide-assists/src/handlers/inline_macro.rs
+++ b/crates/ide-assists/src/handlers/inline_macro.rs
@@ -254,4 +254,49 @@ fn f() { if true{}; }
 "#,
         )
     }
+
+    #[test]
+    fn whitespace_between_text_and_pound() {
+        check_assist(
+            inline_macro,
+            r#"
+macro_rules! foo {
+    () => {
+        cfg_if! {
+            if #[cfg(test)] {
+                1;
+            } else {
+                1;
+            }
+        }
+    }
+}
+fn main() {
+    $0foo!();
+}
+"#,
+            r#"
+macro_rules! foo {
+    () => {
+        cfg_if! {
+            if #[cfg(test)] {
+                1;
+            } else {
+                1;
+            }
+        }
+    }
+}
+fn main() {
+    cfg_if!{
+  if #[cfg(test)]{
+    1;
+  }else {
+    1;
+  }
+};
+}
+"#,
+        );
+    }
 }

--- a/crates/ide-db/src/syntax_helpers/insert_whitespace_into_node.rs
+++ b/crates/ide-db/src/syntax_helpers/insert_whitespace_into_node.rs
@@ -60,7 +60,9 @@ pub fn insert_ws_into(syn: SyntaxNode) -> SyntaxNode {
             |f: fn(SyntaxKind) -> bool, default| -> bool { last.map(f).unwrap_or(default) };
 
         match tok.kind() {
-            k if is_text(k) && is_next(|it| !it.is_punct() || it == UNDERSCORE, false) => {
+            k if is_text(k)
+                && is_next(|it| !it.is_punct() || matches!(it, T![_] | T![#]), false) =>
+            {
                 mods.push(do_ws(after, tok));
             }
             L_CURLY if is_next(|it| it != R_CURLY, true) => {


### PR DESCRIPTION
Because `text#`, `text"..."`, and `text'...'` are [reserved syntax since Rust 2021][guide]. Note that the latter two are already handled correctly.

Fixes #14487

[guide]: https://doc.rust-lang.org/edition-guide/rust-2021/reserving-syntax.html