### PR TITLE
Add regression test for #10989

### DIFF
--- a/crates/hir-ty/src/tests/regression.rs
+++ b/crates/hir-ty/src/tests/regression.rs
@@ -1802,3 +1802,21 @@ where
 "#,
     );
 }
+
+#[test]
+fn match_ergonomics_with_binding_modes_interaction() {
+    check_types(
+        r"
+enum E { A }
+fn foo() {
+    match &E::A {
+        b @ (x @ E::A | x) => {
+            b;
+          //^ &E
+            x;
+          //^ &E
+        }
+    }
+}",
+    );
+}


### PR DESCRIPTION
#10989 seems to have been fixed. This patch merely adds a regression test.

Closes #10989