### PR TITLE
feat: make inlay hints insertable

### DIFF
--- a/crates/hir-ty/src/tests.rs
+++ b/crates/hir-ty/src/tests.rs
@@ -159,7 +159,7 @@ fn check_impl(ra_fixture: &str, allow_none: bool, only_types: bool, display_sour
             let range = node.as_ref().original_file_range(&db);
             if let Some(expected) = types.remove(&range) {
                 let actual = if display_source {
-                    ty.display_source_code(&db, def.module(&db)).unwrap()
+                    ty.display_source_code(&db, def.module(&db), true).unwrap()
                 } else {
                     ty.display_test(&db).to_string()
                 };
@@ -175,7 +175,7 @@ fn check_impl(ra_fixture: &str, allow_none: bool, only_types: bool, display_sour
             let range = node.as_ref().original_file_range(&db);
             if let Some(expected) = types.remove(&range) {
                 let actual = if display_source {
-                    ty.display_source_code(&db, def.module(&db)).unwrap()
+                    ty.display_source_code(&db, def.module(&db), true).unwrap()
                 } else {
                     ty.display_test(&db).to_string()
                 };

--- a/crates/ide-assists/src/handlers/add_explicit_type.rs
+++ b/crates/ide-assists/src/handlers/add_explicit_type.rs
@@ -69,7 +69,7 @@ pub(crate) fn add_explicit_type(acc: &mut Assists, ctx: &AssistContext<'_>) -> O
         return None;
     }
 
-    let inferred_type = ty.display_source_code(ctx.db(), module.into()).ok()?;
+    let inferred_type = ty.display_source_code(ctx.db(), module.into(), false).ok()?;
     acc.add(
         AssistId("add_explicit_type", AssistKind::RefactorRewrite),
         format!("Insert explicit type `{inferred_type}`"),

--- a/crates/ide-assists/src/handlers/add_return_type.rs
+++ b/crates/ide-assists/src/handlers/add_return_type.rs
@@ -22,7 +22,7 @@ pub(crate) fn add_return_type(acc: &mut Assists, ctx: &AssistContext<'_>) -> Opt
     if ty.is_unit() {
         return None;
     }
-    let ty = ty.display_source_code(ctx.db(), module.into()).ok()?;
+    let ty = ty.display_source_code(ctx.db(), module.into(), true).ok()?;
 
     acc.add(
         AssistId("add_return_type", AssistKind::RefactorRewrite),

--- a/crates/ide-assists/src/handlers/extract_function.rs
+++ b/crates/ide-assists/src/handlers/extract_function.rs
@@ -1884,7 +1884,7 @@ fn with_tail_expr(block: ast::BlockExpr, tail_expr: ast::Expr) -> ast::BlockExpr
 }
 
 fn format_type(ty: &hir::Type, ctx: &AssistContext<'_>, module: hir::Module) -> String {
-    ty.display_source_code(ctx.db(), module.into()).ok().unwrap_or_else(|| "_".to_string())
+    ty.display_source_code(ctx.db(), module.into(), true).ok().unwrap_or_else(|| "_".to_string())
 }
 
 fn make_ty(ty: &hir::Type, ctx: &AssistContext<'_>, module: hir::Module) -> ast::Type {

--- a/crates/ide-assists/src/handlers/generate_constant.rs
+++ b/crates/ide-assists/src/handlers/generate_constant.rs
@@ -46,7 +46,8 @@ pub(crate) fn generate_constant(acc: &mut Assists, ctx: &AssistContext<'_>) -> O
     let ty = ctx.sema.type_of_expr(&expr)?;
     let scope = ctx.sema.scope(statement.syntax())?;
     let constant_module = scope.module();
-    let type_name = ty.original().display_source_code(ctx.db(), constant_module.into()).ok()?;
+    let type_name =
+        ty.original().display_source_code(ctx.db(), constant_module.into(), false).ok()?;
     let target = statement.syntax().parent()?.text_range();
     let path = constant_token.syntax().ancestors().find_map(ast::Path::cast)?;
 

--- a/crates/ide-assists/src/handlers/generate_enum_variant.rs
+++ b/crates/ide-assists/src/handlers/generate_enum_variant.rs
@@ -192,7 +192,7 @@ fn expr_ty(
     scope: &hir::SemanticsScope<'_>,
 ) -> Option<ast::Type> {
     let ty = ctx.sema.type_of_expr(&arg).map(|it| it.adjusted())?;
-    let text = ty.display_source_code(ctx.db(), scope.module().into()).ok()?;
+    let text = ty.display_source_code(ctx.db(), scope.module().into(), false).ok()?;
     Some(make::ty(&text))
 }
 

--- a/crates/ide-assists/src/handlers/generate_function.rs
+++ b/crates/ide-assists/src/handlers/generate_function.rs
@@ -438,7 +438,7 @@ fn make_return_type(
             Some(ty) if ty.is_unit() => (None, false),
             Some(ty) => {
                 necessary_generic_params.extend(ty.generic_params(ctx.db()));
-                let rendered = ty.display_source_code(ctx.db(), target_module.into());
+                let rendered = ty.display_source_code(ctx.db(), target_module.into(), true);
                 match rendered {
                     Ok(rendered) => (Some(make::ty(&rendered)), false),
                     Err(_) => (Some(make::ty_placeholder()), true),
@@ -992,9 +992,9 @@ fn fn_arg_type(
             let famous_defs = &FamousDefs(&ctx.sema, ctx.sema.scope(fn_arg.syntax())?.krate());
             convert_reference_type(ty.strip_references(), ctx.db(), famous_defs)
                 .map(|conversion| conversion.convert_type(ctx.db()))
-                .or_else(|| ty.display_source_code(ctx.db(), target_module.into()).ok())
+                .or_else(|| ty.display_source_code(ctx.db(), target_module.into(), true).ok())
         } else {
-            ty.display_source_code(ctx.db(), target_module.into()).ok()
+            ty.display_source_code(ctx.db(), target_module.into(), true).ok()
         }
     }
 

--- a/crates/ide-assists/src/handlers/replace_turbofish_with_explicit_type.rs
+++ b/crates/ide-assists/src/handlers/replace_turbofish_with_explicit_type.rs
@@ -55,7 +55,7 @@ pub(crate) fn replace_turbofish_with_explicit_type(
     let returned_type = match ctx.sema.type_of_expr(&initializer) {
         Some(returned_type) if !returned_type.original.contains_unknown() => {
             let module = ctx.sema.scope(let_stmt.syntax())?.module();
-            returned_type.original.display_source_code(ctx.db(), module.into()).ok()?
+            returned_type.original.display_source_code(ctx.db(), module.into(), false).ok()?
         }
         _ => {
             cov_mark::hit!(fallback_to_turbofish_type_if_type_info_not_available);

--- a/crates/ide-completion/src/completions/fn_param.rs
+++ b/crates/ide-completion/src/completions/fn_param.rs
@@ -127,7 +127,7 @@ fn params_from_stmt_list_scope(
         let module = scope.module().into();
         scope.process_all_names(&mut |name, def| {
             if let hir::ScopeDef::Local(local) = def {
-                if let Ok(ty) = local.ty(ctx.db).display_source_code(ctx.db, module) {
+                if let Ok(ty) = local.ty(ctx.db).display_source_code(ctx.db, module, true) {
                     cb(name, ty);
                 }
             }

--- a/crates/ide-completion/src/completions/type.rs
+++ b/crates/ide-completion/src/completions/type.rs
@@ -242,7 +242,7 @@ pub(crate) fn complete_ascribed_type(
         }
     }?
     .adjusted();
-    let ty_string = x.display_source_code(ctx.db, ctx.module.into()).ok()?;
+    let ty_string = x.display_source_code(ctx.db, ctx.module.into(), true).ok()?;
     acc.add(render_type_inference(ty_string, ctx));
     None
 }

--- a/crates/ide-db/src/path_transform.rs
+++ b/crates/ide-db/src/path_transform.rs
@@ -116,7 +116,9 @@ impl<'a> PathTransform<'a> {
                         Some((
                             k,
                             ast::make::ty(
-                                &default.display_source_code(db, source_module.into()).ok()?,
+                                &default
+                                    .display_source_code(db, source_module.into(), false)
+                                    .ok()?,
                             ),
                         ))
                     }

--- a/crates/ide-diagnostics/src/handlers/missing_fields.rs
+++ b/crates/ide-diagnostics/src/handlers/missing_fields.rs
@@ -176,7 +176,9 @@ fn fixes(ctx: &DiagnosticsContext<'_>, d: &hir::MissingFields) -> Option<Vec<Ass
 fn make_ty(ty: &hir::Type, db: &dyn HirDatabase, module: hir::Module) -> ast::Type {
     let ty_str = match ty.as_adt() {
         Some(adt) => adt.name(db).to_string(),
-        None => ty.display_source_code(db, module.into()).ok().unwrap_or_else(|| "_".to_string()),
+        None => {
+            ty.display_source_code(db, module.into(), false).ok().unwrap_or_else(|| "_".to_string())
+        }
     };
 
     make::ty(&ty_str)

--- a/crates/ide-diagnostics/src/handlers/no_such_field.rs
+++ b/crates/ide-diagnostics/src/handlers/no_such_field.rs
@@ -69,7 +69,7 @@ fn missing_record_expr_field_fixes(
     let new_field = make::record_field(
         None,
         make::name(record_expr_field.field_name()?.ident_token()?.text()),
-        make::ty(&new_field_type.display_source_code(sema.db, module.into()).ok()?),
+        make::ty(&new_field_type.display_source_code(sema.db, module.into(), true).ok()?),
     );
 
     let last_field = record_fields.fields().last()?;

--- a/crates/ide/src/inlay_hints.rs
+++ b/crates/ide/src/inlay_hints.rs
@@ -16,6 +16,7 @@ use syntax::{
     ast::{self, AstNode},
     match_ast, NodeOrToken, SyntaxNode, TextRange,
 };
+use text_edit::TextEdit;
 
 use crate::{navigation_target::TryToNav, FileId};
 
@@ -113,14 +114,26 @@ pub struct InlayHint {
     pub kind: InlayKind,
     /// The actual label to show in the inlay hint.
     pub label: InlayHintLabel,
+    /// Text edit to apply when "accepting" this inlay hint.
+    pub text_edit: Option<TextEdit>,
 }
 
 impl InlayHint {
     fn closing_paren(range: TextRange) -> InlayHint {
-        InlayHint { range, kind: InlayKind::ClosingParenthesis, label: InlayHintLabel::from(")") }
+        InlayHint {
+            range,
+            kind: InlayKind::ClosingParenthesis,
+            label: InlayHintLabel::from(")"),
+            text_edit: None,
+        }
     }
     fn opening_paren(range: TextRange) -> InlayHint {
-        InlayHint { range, kind: InlayKind::OpeningParenthesis, label: InlayHintLabel::from("(") }
+        InlayHint {
+            range,
+            kind: InlayKind::OpeningParenthesis,
+            label: InlayHintLabel::from("("),
+            text_edit: None,
+        }
     }
 }
 

--- a/crates/ide/src/inlay_hints.rs
+++ b/crates/ide/src/inlay_hints.rs
@@ -14,7 +14,7 @@ use smallvec::{smallvec, SmallVec};
 use stdx::never;
 use syntax::{
     ast::{self, AstNode},
-    match_ast, NodeOrToken, SyntaxNode, TextRange,
+    match_ast, NodeOrToken, SyntaxNode, TextRange, TextSize,
 };
 use text_edit::TextEdit;
 
@@ -359,6 +359,23 @@ fn label_of_ty(
     Some(r)
 }
 
+fn ty_to_text_edit(
+    sema: &Semantics<'_, RootDatabase>,
+    node_for_hint: &SyntaxNode,
+    ty: &hir::Type,
+    offset_to_insert: TextSize,
+    prefix: String,
+) -> Option<TextEdit> {
+    let scope = sema.scope(node_for_hint)?;
+    // FIXME: Limit the length and bail out on excess somehow?
+    let rendered = ty.display_source_code(scope.db, scope.module().into(), false).ok()?;
+
+    let mut builder = TextEdit::builder();
+    builder.insert(offset_to_insert, prefix);
+    builder.insert(offset_to_insert, rendered);
+    Some(builder.finish())
+}
+
 // Feature: Inlay Hints
 //
 // rust-analyzer shows additional information inline with the source code.
@@ -564,6 +581,37 @@ mod tests {
         let (analysis, file_id) = fixture::file(ra_fixture);
         let inlay_hints = analysis.inlay_hints(&config, file_id, None).unwrap();
         expect.assert_debug_eq(&inlay_hints)
+    }
+
+    /// Computes inlay hints for the fixture, applies all the provided text edits and then runs
+    /// expect test.
+    #[track_caller]
+    pub(super) fn check_edit(config: InlayHintsConfig, ra_fixture: &str, expect: Expect) {
+        let (analysis, file_id) = fixture::file(ra_fixture);
+        let inlay_hints = analysis.inlay_hints(&config, file_id, None).unwrap();
+
+        let edits = inlay_hints
+            .into_iter()
+            .filter_map(|hint| hint.text_edit)
+            .reduce(|mut acc, next| {
+                acc.union(next).expect("merging text edits failed");
+                acc
+            })
+            .expect("no edit returned");
+
+        let mut actual = analysis.file_text(file_id).unwrap().to_string();
+        edits.apply(&mut actual);
+        expect.assert_eq(&actual);
+    }
+
+    #[track_caller]
+    pub(super) fn check_no_edit(config: InlayHintsConfig, ra_fixture: &str) {
+        let (analysis, file_id) = fixture::file(ra_fixture);
+        let inlay_hints = analysis.inlay_hints(&config, file_id, None).unwrap();
+
+        let edits: Vec<_> = inlay_hints.into_iter().filter_map(|hint| hint.text_edit).collect();
+
+        assert!(edits.is_empty(), "unexpected edits: {edits:?}");
     }
 
     #[test]

--- a/crates/ide/src/inlay_hints/adjustment.rs
+++ b/crates/ide/src/inlay_hints/adjustment.rs
@@ -135,6 +135,7 @@ pub(super) fn hints(
                 ))),
                 None,
             ),
+            text_edit: None,
         });
     }
     if !postfix && needs_inner_parens {

--- a/crates/ide/src/inlay_hints/bind_pat.rs
+++ b/crates/ide/src/inlay_hints/bind_pat.rs
@@ -12,9 +12,10 @@ use syntax::{
     match_ast,
 };
 
-use crate::{inlay_hints::closure_has_block_body, InlayHint, InlayHintsConfig, InlayKind};
-
-use super::label_of_ty;
+use crate::{
+    inlay_hints::{closure_has_block_body, label_of_ty},
+    InlayHint, InlayHintsConfig, InlayKind,
+};
 
 pub(super) fn hints(
     acc: &mut Vec<InlayHint>,
@@ -50,6 +51,7 @@ pub(super) fn hints(
         },
         kind: InlayKind::Type,
         label,
+        text_edit: None,
     });
 
     Some(())

--- a/crates/ide/src/inlay_hints/binding_mode.rs
+++ b/crates/ide/src/inlay_hints/binding_mode.rs
@@ -49,7 +49,12 @@ pub(super) fn hints(
             (true, false) => "&",
             _ => return,
         };
-        acc.push(InlayHint { range, kind: InlayKind::BindingMode, label: r.to_string().into() });
+        acc.push(InlayHint {
+            range,
+            kind: InlayKind::BindingMode,
+            label: r.to_string().into(),
+            text_edit: None,
+        });
     });
     match pat {
         ast::Pat::IdentPat(pat) if pat.ref_token().is_none() && pat.mut_token().is_none() => {
@@ -63,6 +68,7 @@ pub(super) fn hints(
                 range: pat.syntax().text_range(),
                 kind: InlayKind::BindingMode,
                 label: bm.to_string().into(),
+                text_edit: None,
             });
         }
         ast::Pat::OrPat(pat) if !pattern_adjustments.is_empty() && outer_paren_pat.is_none() => {

--- a/crates/ide/src/inlay_hints/chaining.rs
+++ b/crates/ide/src/inlay_hints/chaining.rs
@@ -61,6 +61,7 @@ pub(super) fn hints(
                 range: expr.syntax().text_range(),
                 kind: InlayKind::Chaining,
                 label: label_of_ty(famous_defs, config, ty)?,
+                text_edit: None,
             });
         }
     }
@@ -120,6 +121,7 @@ fn main() {
                             },
                             "",
                         ],
+                        text_edit: None,
                     },
                     InlayHint {
                         range: 147..154,
@@ -140,6 +142,7 @@ fn main() {
                             },
                             "",
                         ],
+                        text_edit: None,
                     },
                 ]
             "#]],
@@ -205,6 +208,7 @@ fn main() {
                             },
                             "",
                         ],
+                        text_edit: None,
                     },
                     InlayHint {
                         range: 143..179,
@@ -225,6 +229,7 @@ fn main() {
                             },
                             "",
                         ],
+                        text_edit: None,
                     },
                 ]
             "#]],
@@ -274,6 +279,7 @@ fn main() {
                             },
                             "",
                         ],
+                        text_edit: None,
                     },
                     InlayHint {
                         range: 143..179,
@@ -294,6 +300,7 @@ fn main() {
                             },
                             "",
                         ],
+                        text_edit: None,
                     },
                 ]
             "#]],
@@ -357,6 +364,7 @@ fn main() {
                             },
                             "<i32, bool>>",
                         ],
+                        text_edit: None,
                     },
                     InlayHint {
                         range: 246..265,
@@ -390,6 +398,7 @@ fn main() {
                             },
                             "<i32, bool>>",
                         ],
+                        text_edit: None,
                     },
                 ]
             "#]],
@@ -455,6 +464,7 @@ fn main() {
                             },
                             " = ()>",
                         ],
+                        text_edit: None,
                     },
                     InlayHint {
                         range: 174..224,
@@ -488,6 +498,7 @@ fn main() {
                             },
                             " = ()>",
                         ],
+                        text_edit: None,
                     },
                     InlayHint {
                         range: 174..206,
@@ -521,6 +532,7 @@ fn main() {
                             },
                             " = ()>",
                         ],
+                        text_edit: None,
                     },
                     InlayHint {
                         range: 174..189,
@@ -541,6 +553,7 @@ fn main() {
                             },
                             "",
                         ],
+                        text_edit: None,
                     },
                 ]
             "#]],
@@ -590,6 +603,7 @@ fn main() {
                             },
                             "",
                         ],
+                        text_edit: None,
                     },
                     InlayHint {
                         range: 145..185,
@@ -610,6 +624,7 @@ fn main() {
                             },
                             "",
                         ],
+                        text_edit: None,
                     },
                     InlayHint {
                         range: 145..168,
@@ -630,6 +645,7 @@ fn main() {
                             },
                             "",
                         ],
+                        text_edit: None,
                     },
                     InlayHint {
                         range: 222..228,
@@ -648,6 +664,7 @@ fn main() {
                                 tooltip: "",
                             },
                         ],
+                        text_edit: None,
                     },
                 ]
             "#]],

--- a/crates/ide/src/inlay_hints/chaining.rs
+++ b/crates/ide/src/inlay_hints/chaining.rs
@@ -603,7 +603,16 @@ fn main() {
                             },
                             "",
                         ],
-                        text_edit: None,
+                        text_edit: Some(
+                            TextEdit {
+                                indels: [
+                                    Indel {
+                                        insert: ": Struct",
+                                        delete: 130..130,
+                                    },
+                                ],
+                            },
+                        ),
                     },
                     InlayHint {
                         range: 145..185,

--- a/crates/ide/src/inlay_hints/closing_brace.rs
+++ b/crates/ide/src/inlay_hints/closing_brace.rs
@@ -112,6 +112,7 @@ pub(super) fn hints(
         range: closing_token.text_range(),
         kind: InlayKind::ClosingBrace,
         label: InlayHintLabel::simple(label, None, linked_location),
+        text_edit: None,
     });
 
     None

--- a/crates/ide/src/inlay_hints/closure_ret.rs
+++ b/crates/ide/src/inlay_hints/closure_ret.rs
@@ -1,13 +1,13 @@
 //! Implementation of "closure return type" inlay hints.
+//!
+//! Tests live in [`bind_pat`][super::bind_pat] module.
 use ide_db::{base_db::FileId, famous_defs::FamousDefs};
 use syntax::ast::{self, AstNode};
 
 use crate::{
-    inlay_hints::closure_has_block_body, ClosureReturnTypeHints, InlayHint, InlayHintsConfig,
-    InlayKind,
+    inlay_hints::{closure_has_block_body, label_of_ty, ty_to_text_edit},
+    ClosureReturnTypeHints, InlayHint, InlayHintsConfig, InlayKind,
 };
-
-use super::label_of_ty;
 
 pub(super) fn hints(
     acc: &mut Vec<InlayHint>,
@@ -24,26 +24,39 @@ pub(super) fn hints(
         return None;
     }
 
-    if !closure_has_block_body(&closure)
-        && config.closure_return_type_hints == ClosureReturnTypeHints::WithBlock
-    {
+    let has_block_body = closure_has_block_body(&closure);
+    if !has_block_body && config.closure_return_type_hints == ClosureReturnTypeHints::WithBlock {
         return None;
     }
 
     let param_list = closure.param_list()?;
 
     let closure = sema.descend_node_into_attributes(closure).pop()?;
-    let ty = sema.type_of_expr(&ast::Expr::ClosureExpr(closure))?.adjusted();
+    let ty = sema.type_of_expr(&ast::Expr::ClosureExpr(closure.clone()))?.adjusted();
     let callable = ty.as_callable(sema.db)?;
     let ty = callable.return_type();
     if ty.is_unit() {
         return None;
     }
+
+    // FIXME?: We could provide text edit to insert braces for closures with non-block body.
+    let text_edit = if has_block_body {
+        ty_to_text_edit(
+            sema,
+            closure.syntax(),
+            &ty,
+            param_list.syntax().text_range().end(),
+            String::from(" -> "),
+        )
+    } else {
+        None
+    };
+
     acc.push(InlayHint {
         range: param_list.syntax().text_range(),
         kind: InlayKind::ClosureReturnType,
         label: label_of_ty(famous_defs, config, ty)?,
-        text_edit: None,
+        text_edit,
     });
     Some(())
 }

--- a/crates/ide/src/inlay_hints/closure_ret.rs
+++ b/crates/ide/src/inlay_hints/closure_ret.rs
@@ -43,6 +43,7 @@ pub(super) fn hints(
         range: param_list.syntax().text_range(),
         kind: InlayKind::ClosureReturnType,
         label: label_of_ty(famous_defs, config, ty)?,
+        text_edit: None,
     });
     Some(())
 }

--- a/crates/ide/src/inlay_hints/discriminant.rs
+++ b/crates/ide/src/inlay_hints/discriminant.rs
@@ -75,6 +75,7 @@ fn variant_hints(
             })),
             None,
         ),
+        text_edit: None,
     });
 
     Some(())

--- a/crates/ide/src/inlay_hints/fn_lifetime_fn.rs
+++ b/crates/ide/src/inlay_hints/fn_lifetime_fn.rs
@@ -25,6 +25,7 @@ pub(super) fn hints(
         range: t.text_range(),
         kind: InlayKind::Lifetime,
         label: label.into(),
+        text_edit: None,
     };
 
     let param_list = func.param_list()?;
@@ -189,12 +190,14 @@ pub(super) fn hints(
                     if is_empty { "" } else { ", " }
                 )
                 .into(),
+                text_edit: None,
             });
         }
         (None, allocated_lifetimes) => acc.push(InlayHint {
             range: func.name()?.syntax().text_range(),
             kind: InlayKind::GenericParamList,
             label: format!("<{}>", allocated_lifetimes.iter().format(", "),).into(),
+            text_edit: None,
         }),
     }
     Some(())

--- a/crates/ide/src/inlay_hints/implicit_static.rs
+++ b/crates/ide/src/inlay_hints/implicit_static.rs
@@ -34,6 +34,7 @@ pub(super) fn hints(
                 range: t.text_range(),
                 kind: InlayKind::Lifetime,
                 label: "'static".to_owned().into(),
+                text_edit: None,
             });
         }
     }

--- a/crates/ide/src/inlay_hints/param_name.rs
+++ b/crates/ide/src/inlay_hints/param_name.rs
@@ -57,6 +57,7 @@ pub(super) fn hints(
                 range,
                 kind: InlayKind::Parameter,
                 label: InlayHintLabel::simple(param_name, None, linked_location),
+                text_edit: None,
             }
         });
 

--- a/crates/rust-analyzer/src/to_proto.rs
+++ b/crates/rust-analyzer/src/to_proto.rs
@@ -510,7 +510,7 @@ pub(crate) fn inlay_hint(
             | InlayKind::AdjustmentPostfix
             | InlayKind::ClosingBrace => None,
         },
-        text_edits: None,
+        text_edits: inlay_hint.text_edit.map(|it| text_edit_vec(line_index, it)),
         data: None,
         tooltip,
         label,


### PR DESCRIPTION
Part of #13812

This PR implements text edit for inlay hints. When an inlay hint contain text edit, user can "accept" it (e.g. by double-clicking in VS Code) to make the hint actual code (effectively deprecating the hint itself).

This PR does not implement auto import despite the original request; text edits only insert qualified types along with necessary punctuation. I feel there are some missing pieces to implement efficient auto import (in particular, type traversal function with early exit) so left it for future work. Even without it, user can use `replace_qualified_name_with_use` assist after accepting the edit to achieve the same result.

I implemented for the following inlay hints:
- top-level identifier pattern in let statements
- top-level identifier pattern in closure parameters
- closure return type when its has block body

One somewhat strange interaction can be observed when top-level identifier pattern has subpattern: text edit inserts type annotation in different place than the inlay hint. Do we want to allow it or should we not provide text edits for these cases at all?

```rust
let a /* inlay hint shown here */ @ (b, c) = foo();
let a @ (b, c) /* text edit inserts types here */ = foo();
```