### PR TITLE
fix: restrict applicable range of `reorder-impl-trait-items`

### DIFF
--- a/crates/ide-assists/src/handlers/reorder_impl_items.rs
+++ b/crates/ide-assists/src/handlers/reorder_impl_items.rs
@@ -21,7 +21,7 @@ use crate::{AssistContext, AssistId, AssistKind, Assists};
 // }
 //
 // struct Bar;
-// $0impl Foo for Bar {
+// $0impl Foo for Bar$0 {
 //     const B: u8 = 17;
 //     fn c() {}
 //     type A = String;
@@ -45,6 +45,16 @@ use crate::{AssistContext, AssistId, AssistKind, Assists};
 pub(crate) fn reorder_impl_items(acc: &mut Assists, ctx: &AssistContext<'_>) -> Option<()> {
     let impl_ast = ctx.find_node_at_offset::<ast::Impl>()?;
     let items = impl_ast.assoc_item_list()?;
+
+    // restrict the range
+    // if cursor is in assoc_items, abort
+    let assoc_range = items.syntax().text_range();
+    let cursor_position = ctx.offset();
+    if assoc_range.contains_inclusive(cursor_position) {
+        cov_mark::hit!(not_applicable_editing_assoc_items);
+        return None;
+    }
+
     let assoc_items = items.assoc_items().collect::<Vec<_>>();
 
     let path = impl_ast
@@ -264,9 +274,9 @@ trait Bar {
 }
 
 struct Foo;
-impl Bar for Foo {
+$0impl Bar for Foo {
     type Fooo = ();
-    type Foo = ();$0
+    type Foo = ();
 }"#,
             r#"
 trait Bar {
@@ -279,6 +289,31 @@ impl Bar for Foo {
     type Foo = ();
     type Fooo = ();
 }"#,
+        )
+    }
+
+    #[test]
+    fn not_applicable_editing_assoc_items() {
+        cov_mark::check!(not_applicable_editing_assoc_items);
+        check_assist_not_applicable(
+            reorder_impl_items,
+            r#"
+trait Bar {
+    type T;
+    const C: ();
+    fn a() {}
+    fn z() {}
+    fn b() {}
+}
+struct Foo;
+impl Bar for Foo {
+    type T = ();$0
+    const C: () = ();
+    fn a() {}
+    fn z() {}
+    fn b() {}
+}
+        "#,
         )
     }
 }

--- a/crates/ide-assists/src/handlers/reorder_impl_items.rs
+++ b/crates/ide-assists/src/handlers/reorder_impl_items.rs
@@ -309,8 +309,8 @@ struct Foo;
 impl Bar for Foo {
     type T = ();$0
     const C: () = ();
-    fn a() {}
     fn z() {}
+    fn a() {}
     fn b() {}
 }
         "#,

--- a/crates/ide-assists/src/tests/generated.rs
+++ b/crates/ide-assists/src/tests/generated.rs
@@ -2141,7 +2141,7 @@ trait Foo {
 }
 
 struct Bar;
-$0impl Foo for Bar {
+$0impl Foo for Bar$0 {
     const B: u8 = 17;
     fn c() {}
     type A = String;


### PR DESCRIPTION
This PR should complete the need for restricting the applicable range of `reorder-impl-trait-items`.

When the cursor is in the associated items of the `impl` range, the assist will be disabled.

Fix: #14515 

## Showcases
Note: If there is any available `code-action` (`ide-assist`) available, a lightbulb icon from `lspsaga` will show in the left.

- cursor in `impl` headers
![code action available](https://user-images.githubusercontent.com/44747719/230756854-7b236018-cfa8-4005-b589-2996ec42917f.png)
Code action is available. And it is reordering impl items.
![code action detail](https://user-images.githubusercontent.com/44747719/230756971-341c7fbc-f2ba-4715-a1e5-b1add984d4dd.png)


- cursor in `impl` associated items
![code action unavailable](
https://user-images.githubusercontent.com/44747719/230756906-bee7784e-bd9d-49b2-801b-743c94b4af54.png)
