### PR TITLE
fix: Fix project linking popup appearing for modules that can be linked to a crate

### DIFF
--- a/editors/code/src/client.ts
+++ b/editors/code/src/client.ts
@@ -125,7 +125,11 @@ export async function createClient(
                         typeof diag.code === "string" || typeof diag.code === "number"
                             ? diag.code
                             : diag.code?.value;
-                    if (value === "unlinked-file" && !unlinkedFiles.includes(uri)) {
+                    if (
+                        value === "unlinked-file" &&
+                        !unlinkedFiles.includes(uri) &&
+                        diag.message !== "file not included in module tree"
+                    ) {
                         const config = vscode.workspace.getConfiguration("rust-analyzer");
                         if (config.get("showUnlinkedFileNotification")) {
                             unlinkedFiles.push(uri);


### PR DESCRIPTION

should fix https://github.com/rust-lang/rust-analyzer/issues/14523 