### PR TITLE
internal: Warn when loading sysroot fails to find the core library

### DIFF
--- a/crates/rust-analyzer/src/reload.rs
+++ b/crates/rust-analyzer/src/reload.rs
@@ -138,10 +138,20 @@ impl GlobalState {
             let (ProjectWorkspace::Cargo { sysroot, .. }
             | ProjectWorkspace::Json { sysroot, .. }
             | ProjectWorkspace::DetachedFiles { sysroot, .. }) = ws;
-            if let Err(Some(e)) = sysroot {
-                status.health = lsp_ext::Health::Warning;
-                message.push_str(e);
-                message.push_str("\n\n");
+            match sysroot {
+                Err(None) => (),
+                Err(Some(e)) => {
+                    status.health = lsp_ext::Health::Warning;
+                    message.push_str(e);
+                    message.push_str("\n\n");
+                }
+                Ok(s) => {
+                    if let Some(e) = s.loading_warning() {
+                        status.health = lsp_ext::Health::Warning;
+                        message.push_str(&e);
+                        message.push_str("\n\n");
+                    }
+                }
             }
             if let ProjectWorkspace::Cargo { rustc: Err(Some(e)), .. } = ws {
                 status.health = lsp_ext::Health::Warning;


### PR DESCRIPTION
Should help a bit more with user experience, before we only logged this now we show it in the status
Closes https://github.com/rust-lang/rust-analyzer/issues/11606