### PR TITLE
Fix explicit deref problems in closure capture

### DIFF
--- a/crates/hir-ty/src/layout/tests/closure.rs
+++ b/crates/hir-ty/src/layout/tests/closure.rs
@@ -41,6 +41,15 @@ fn ref_simple() {
         }
     }
     size_and_align_expr! {
+        minicore: copy, deref_mut;
+        stmts: [
+            let y: &mut i32 = &mut 5;
+        ]
+        |x: i32| {
+            *y += x;
+        }
+    }
+    size_and_align_expr! {
         minicore: copy;
         stmts: [
             struct X(i32, i64);
@@ -48,6 +57,16 @@ fn ref_simple() {
         ]
         || {
             x
+        }
+    }
+    size_and_align_expr! {
+        minicore: copy, deref_mut;
+        stmts: [
+            struct X(i32, i64);
+            let x: &mut X = &mut X(2, 6);
+        ]
+        || {
+            (*x).0 as i64 + x.1
         }
     }
 }

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -1564,7 +1564,10 @@ impl DefWithBody {
                         }
                         (mir::MutabilityReason::Not, true) => {
                             if !infer.mutated_bindings_in_closure.contains(&binding_id) {
-                                acc.push(UnusedMut { local }.into())
+                                let should_ignore = matches!(body[binding_id].name.as_str(), Some(x) if x.starts_with("_"));
+                                if !should_ignore {
+                                    acc.push(UnusedMut { local }.into())
+                                }
                             }
                         }
                     }

--- a/crates/ide-diagnostics/src/handlers/mutability_errors.rs
+++ b/crates/ide-diagnostics/src/handlers/mutability_errors.rs
@@ -851,6 +851,43 @@ fn f() {
 }
             "#,
         );
+        check_diagnostics(
+            r#"
+        //- minicore: copy, fn, deref_mut
+        struct X(i32, i64);
+
+        fn f() {
+            let mut x = &mut 5;
+              //^^^^^ 💡 weak: variable does not need to be mutable
+            let closure1 = || { *x = 2; };
+            let _ = closure1();
+                  //^^^^^^^^ 💡 error: cannot mutate immutable variable `closure1`
+            let mut x = &mut 5;
+              //^^^^^ 💡 weak: variable does not need to be mutable
+            let closure1 = move || { *x = 2; };
+            let _ = closure1();
+                  //^^^^^^^^ 💡 error: cannot mutate immutable variable `closure1`
+            let mut x = &mut X(1, 2);
+              //^^^^^ 💡 weak: variable does not need to be mutable
+            let closure1 = || { x.0 = 2; };
+            let _ = closure1();
+                  //^^^^^^^^ 💡 error: cannot mutate immutable variable `closure1`
+        }
+                    "#,
+        );
+    }
+
+    #[test]
+    fn allow_unused_mut_for_identifiers_starting_with_underline() {
+        check_diagnostics(
+            r#"
+fn f(_: i32) {}
+fn main() {
+    let mut _x = 2;
+    f(_x);
+}
+"#,
+        );
     }
 
     #[test]


### PR DESCRIPTION
fix the `need-mut` part of #14562

Perhaps surprisingly, it wasn't unique immutable borrow. The code still doesn't emit any of them, and I think those won't happen in edition 2021 (which is currently the only thing implemented), since we always capture `&mut *x` instead of `&mut x`. But I'm not very sure about it.