### PR TITLE
internal: Report macro definition errors on the definition

### DIFF
--- a/crates/hir-def/src/body.rs
+++ b/crates/hir-def/src/body.rs
@@ -190,8 +190,9 @@ impl Expander {
 
         let file_id = call_id.as_file();
 
-        let raw_node = match db.parse_or_expand(file_id) {
-            Some(it) => it,
+        let raw_node = match db.parse_or_expand_with_err(file_id) {
+            // FIXME: report parse errors
+            Some(it) => it.syntax_node(),
             None => {
                 // Only `None` if the macro expansion produced no usable AST.
                 if err.is_none() {

--- a/crates/hir-def/src/data.rs
+++ b/crates/hir-def/src/data.rs
@@ -641,7 +641,12 @@ impl<'a> AssocItemCollector<'a> {
                     self.items.push((item.name.clone(), def.into()));
                 }
                 AssocItem::MacroCall(call) => {
-                    if let Some(root) = self.db.parse_or_expand(self.expander.current_file_id()) {
+                    if let Some(root) =
+                        self.db.parse_or_expand_with_err(self.expander.current_file_id())
+                    {
+                        // FIXME: report parse errors
+                        let root = root.syntax_node();
+
                         let call = &item_tree[call];
 
                         let ast_id_map = self.db.ast_id_map(self.expander.current_file_id());

--- a/crates/hir-def/src/nameres/collector.rs
+++ b/crates/hir-def/src/nameres/collector.rs
@@ -1374,6 +1374,8 @@ impl DefCollector<'_> {
 
         // Then, fetch and process the item tree. This will reuse the expansion result from above.
         let item_tree = self.db.file_item_tree(file_id);
+        // FIXME: report parse errors for the macro expansion here
+
         let mod_dir = self.mod_dirs[&module_id].clone();
         ModCollector {
             def_collector: &mut *self,

--- a/crates/hir-def/src/nameres/diagnostics.rs
+++ b/crates/hir-def/src/nameres/diagnostics.rs
@@ -34,6 +34,8 @@ pub enum DefDiagnosticKind {
     InvalidDeriveTarget { ast: AstId<ast::Item>, id: usize },
 
     MalformedDerive { ast: AstId<ast::Adt>, id: usize },
+
+    MacroDefError { ast: AstId<ast::Macro>, message: String },
 }
 
 #[derive(Debug, PartialEq, Eq)]

--- a/crates/hir-expand/src/eager.rs
+++ b/crates/hir-expand/src/eager.rs
@@ -187,7 +187,10 @@ fn lazy_expand(
     );
 
     let err = db.macro_expand_error(id);
-    let value = db.parse_or_expand(id.as_file()).map(|node| InFile::new(id.as_file(), node));
+    let value =
+        db.parse_or_expand_with_err(id.as_file()).map(|node| InFile::new(id.as_file(), node));
+    // FIXME: report parse errors
+    let value = value.map(|it| it.map(|it| it.syntax_node()));
 
     ExpandResult { value, err }
 }

--- a/crates/hir/src/diagnostics.rs
+++ b/crates/hir/src/diagnostics.rs
@@ -39,6 +39,7 @@ diagnostics![
     InvalidDeriveTarget,
     IncoherentImpl,
     MacroError,
+    MacroDefError,
     MalformedDerive,
     MismatchedArgCount,
     MissingFields,
@@ -129,6 +130,13 @@ pub struct MacroError {
     pub node: InFile<SyntaxNodePtr>,
     pub precise_location: Option<TextRange>,
     pub message: String,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct MacroDefError {
+    pub node: InFile<AstPtr<ast::Macro>>,
+    pub message: String,
+    pub name: Option<TextRange>,
 }
 
 #[derive(Debug)]

--- a/crates/ide-diagnostics/src/handlers/macro_error.rs
+++ b/crates/ide-diagnostics/src/handlers/macro_error.rs
@@ -9,6 +9,16 @@ pub(crate) fn macro_error(ctx: &DiagnosticsContext<'_>, d: &hir::MacroError) -> 
     Diagnostic::new("macro-error", d.message.clone(), display_range).experimental()
 }
 
+// Diagnostic: macro-error
+//
+// This diagnostic is shown for macro expansion errors.
+pub(crate) fn macro_def_error(ctx: &DiagnosticsContext<'_>, d: &hir::MacroDefError) -> Diagnostic {
+    // Use more accurate position if available.
+    let display_range =
+        ctx.resolve_precise_location(&d.node.clone().map(|it| it.syntax_node_ptr()), d.name);
+    Diagnostic::new("macro-def-error", d.message.clone(), display_range).experimental()
+}
+
 #[cfg(test)]
 mod tests {
     use crate::{
@@ -188,6 +198,7 @@ fn f() {
       "#,
         );
     }
+
     #[test]
     fn dollar_crate_in_builtin_macro() {
         check_diagnostics(
@@ -209,6 +220,24 @@ macro_rules! outer {
 fn f() {
     outer!();
 } //^^^^^^^^ error: leftover tokens
+"#,
+        )
+    }
+
+    #[test]
+    fn def_diagnostic() {
+        check_diagnostics(
+            r#"
+macro_rules! foo {
+           //^^^ error: expected subtree
+    f => {};
+}
+
+fn f() {
+    foo!();
+  //^^^ error: invalid macro definition: expected subtree
+
+}
 "#,
         )
     }

--- a/crates/ide-diagnostics/src/lib.rs
+++ b/crates/ide-diagnostics/src/lib.rs
@@ -249,7 +249,7 @@ pub fn diagnostics(
 
     let mut diags = Vec::new();
     if let Some(m) = module {
-        m.diagnostics(db, &mut diags)
+        m.diagnostics(db, &mut diags);
     }
 
     for diag in diags {
@@ -263,6 +263,7 @@ pub fn diagnostics(
             AnyDiagnostic::IncoherentImpl(d) => handlers::incoherent_impl::incoherent_impl(&ctx, &d),
             AnyDiagnostic::IncorrectCase(d) => handlers::incorrect_case::incorrect_case(&ctx, &d),
             AnyDiagnostic::InvalidDeriveTarget(d) => handlers::invalid_derive_target::invalid_derive_target(&ctx, &d),
+            AnyDiagnostic::MacroDefError(d) => handlers::macro_error::macro_def_error(&ctx, &d),
             AnyDiagnostic::MacroError(d) => handlers::macro_error::macro_error(&ctx, &d),
             AnyDiagnostic::MalformedDerive(d) => handlers::malformed_derive::malformed_derive(&ctx, &d),
             AnyDiagnostic::MismatchedArgCount(d) => handlers::mismatched_arg_count::mismatched_arg_count(&ctx, &d),


### PR DESCRIPTION
We still report them on the call site as well for the time being, and the diagnostic doesn't know where the error in the definition comes from, but that can be done later on