### PR TITLE
Add a clear diagnostics command to flycheck.

### DIFF
--- a/crates/rust-analyzer/src/main_loop.rs
+++ b/crates/rust-analyzer/src/main_loop.rs
@@ -556,6 +556,7 @@ impl GlobalState {
 
     fn handle_flycheck_msg(&mut self, message: flycheck::Message) {
         match message {
+            flycheck::Message::ClearDiagnostics { id } => self.diagnostics.clear_check(id),
             flycheck::Message::AddDiagnostic { id, workspace_root, diagnostic } => {
                 let snap = self.snapshot();
                 let diagnostics = crate::diagnostics::to_proto::map_rust_diagnostic_to_lsp(


### PR DESCRIPTION
This will allow for watcher-style flychecks. Currently, we can only run flychecks on every save. This allows for a long-running flycheck that can update diagnostics between file saves (eg. update on every build).

Rationale:
I'm trying to improve the experience developing using bazel + rust (see [issue](https://github.com/bazelbuild/rules_rust/pull/1657)). The developer experience I'm looking at is:

1. Dev invokes "ibazel build //:my_crate //:my_crate_test". This ensures that whenever the source code changes, it rebuilds. both the crate and the test for the crate.
2. The discover project command is automatically invoked when you open main.rs, which generates a file listing the `.rustc-output` files mentioned below.
3. Dev modifies `my_crate/src/main.rs` and saves in vscode.
4. bazel is automatically invoked on save, and under the hood invokes rustc, which generates `bazel-out/k8-fastbuild/bin/my_crate/my_crate.rustc-output` and `bazel-out/k8-fastbuild/bin/my_crate_test/my_crate_test.rustc_output` for the original crate and the test crate respectively.
5. The non-test crate finishes building
6. A watcher script would see that `my_crate.rustc-output` has been updated, and update the rust-analyzer result for the file.
7. The test crate finishes building
8. The watcher script would see that `my_crate_test.rustc-output` has been updated, and update the rust-analyzer result for the file.