### PR TITLE
Fix release channel detection

### DIFF
--- a/crates/base-db/src/input.rs
+++ b/crates/base-db/src/input.rs
@@ -284,9 +284,9 @@ impl ReleaseChannel {
 
     pub fn from_str(str: &str) -> Option<Self> {
         Some(match str {
-            "stable" => ReleaseChannel::Stable,
-            "beta" => ReleaseChannel::Beta,
+            "" => ReleaseChannel::Stable,
             "nightly" => ReleaseChannel::Nightly,
+            _ if str.starts_with("beta") => ReleaseChannel::Beta,
             _ => return None,
         })
     }

--- a/crates/ide-completion/src/tests/use_tree.rs
+++ b/crates/ide-completion/src/tests/use_tree.rs
@@ -387,7 +387,6 @@ use self::foo::impl$0
 fn use_tree_no_unstable_items_on_stable() {
     check(
         r#"
-//- toolchain:stable
 //- /lib.rs crate:main deps:std
 use std::$0
 //- /std.rs crate:std

--- a/crates/project-model/src/workspace.rs
+++ b/crates/project-model/src/workspace.rs
@@ -779,7 +779,7 @@ fn project_json_to_crate_graph(
                         CrateOrigin::Local { repo: None, name: None }
                     },
                     target_layout.clone(),
-                    None,
+                    channel,
                 );
                 if *is_proc_macro {
                     if let Some(path) = proc_macro_dylib_path.clone() {

--- a/crates/test-utils/src/fixture.rs
+++ b/crates/test-utils/src/fixture.rs
@@ -111,8 +111,9 @@ impl FixtureWithProjectMeta {
     /// //- minicore: sized
     /// ```
     ///
-    /// That will include predefined proc macros and a subset of `libcore` into the fixture, see
-    /// `minicore.rs` for what's available.
+    /// That will set toolchain to nightly and include predefined proc macros and a subset of
+    /// `libcore` into the fixture, see `minicore.rs` for what's available. Note that toolchain
+    /// defaults to stable.
     pub fn parse(ra_fixture: &str) -> Self {
         let fixture = trim_indent(ra_fixture);
         let mut fixture = fixture.as_str();


### PR DESCRIPTION
We detect toolchain's release channel by looking at pre-release identifier of cargo/rustc's version string. It's empty for stable, "beta" or "beta.x" for beta, and "nightly" for nightly.

See rust-lang/rust's [bootstrap code] for how the version string is determined.

[bootstrap code]: https://github.com/rust-lang/rust/blob/e49122fb1ca87a6c3e3c22abb315fc75cfe8daed/src/bootstrap/lib.rs#L1244