### PR TITLE
fix: Deduplicate passed workspaces by top level cargo workspace they belong to

### DIFF
--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -535,7 +535,7 @@ impl Default for ConfigData {
 
 #[derive(Debug, Clone)]
 pub struct Config {
-    discovered_projects: Option<Vec<ProjectManifest>>,
+    discovered_projects: Vec<ProjectManifest>,
     /// The workspace roots as registered by the LSP client
     workspace_roots: Vec<AbsPathBuf>,
     caps: lsp_types::ClientCapabilities,
@@ -743,7 +743,7 @@ impl Config {
             caps,
             data: ConfigData::default(),
             detached_files: Vec::new(),
-            discovered_projects: None,
+            discovered_projects: Vec::new(),
             root_path,
             snippets: Default::default(),
             workspace_roots,
@@ -756,7 +756,7 @@ impl Config {
         if discovered.is_empty() {
             tracing::error!("failed to find any projects in {:?}", &self.workspace_roots);
         }
-        self.discovered_projects = Some(discovered);
+        self.discovered_projects = discovered;
     }
 
     pub fn remove_workspace(&mut self, path: &AbsPath) {
@@ -871,25 +871,19 @@ impl Config {
     pub fn linked_projects(&self) -> Vec<LinkedProject> {
         match self.data.linkedProjects.as_slice() {
             [] => {
-                match self.discovered_projects.as_ref() {
-                    Some(discovered_projects) => {
-                        let exclude_dirs: Vec<_> = self
-                            .data
-                            .files_excludeDirs
-                            .iter()
-                            .map(|p| self.root_path.join(p))
-                            .collect();
-                        discovered_projects
-                        .iter()
-                        .filter(|(ProjectManifest::ProjectJson(path) | ProjectManifest::CargoToml(path))| {
+                let exclude_dirs: Vec<_> =
+                    self.data.files_excludeDirs.iter().map(|p| self.root_path.join(p)).collect();
+                self.discovered_projects
+                    .iter()
+                    .filter(
+                        |(ProjectManifest::ProjectJson(path)
+                         | ProjectManifest::CargoToml(path))| {
                             !exclude_dirs.iter().any(|p| path.starts_with(p))
-                        })
-                        .cloned()
-                        .map(LinkedProject::from)
-                        .collect()
-                    }
-                    None => Vec::new(),
-                }
+                        },
+                    )
+                    .cloned()
+                    .map(LinkedProject::from)
+                    .collect()
             }
             linked_projects => linked_projects
                 .iter()

--- a/crates/rust-analyzer/src/handlers.rs
+++ b/crates/rust-analyzer/src/handlers.rs
@@ -777,14 +777,7 @@ pub(crate) fn handle_runnables(
             }
         }
         None => {
-            if !snap.config.linked_projects().is_empty()
-                || !snap
-                    .config
-                    .discovered_projects
-                    .as_ref()
-                    .map(|projects| projects.is_empty())
-                    .unwrap_or(true)
-            {
+            if !snap.config.linked_projects().is_empty() {
                 res.push(lsp_ext::Runnable {
                     label: "cargo check --workspace".to_string(),
                     location: None,

--- a/crates/rust-analyzer/src/reload.rs
+++ b/crates/rust-analyzer/src/reload.rs
@@ -212,6 +212,20 @@ impl GlobalState {
                     })
                     .collect::<Vec<_>>();
 
+                let mut i = 0;
+                while i < workspaces.len() {
+                    if let Ok(w) = &workspaces[i] {
+                        if let Some(dupe) = workspaces[i + 1..]
+                            .iter()
+                            .filter_map(|it| it.as_ref().ok())
+                            .position(|ws| ws.eq_ignore_build_data(w))
+                        {
+                            _ = workspaces.remove(dupe);
+                        }
+                    }
+                    i += 1;
+                }
+
                 if !detached_files.is_empty() {
                     workspaces.push(project_model::ProjectWorkspace::load_detached_files(
                         detached_files,

--- a/crates/rust-analyzer/tests/slow-tests/support.rs
+++ b/crates/rust-analyzer/tests/slow-tests/support.rs
@@ -9,7 +9,6 @@ use std::{
 use crossbeam_channel::{after, select, Receiver};
 use lsp_server::{Connection, Message, Notification, Request};
 use lsp_types::{notification::Exit, request::Shutdown, TextDocumentIdentifier, Url};
-use project_model::ProjectManifest;
 use rust_analyzer::{config::Config, lsp_ext, main_loop};
 use serde::Serialize;
 use serde_json::{json, to_string_pretty, Value};

--- a/crates/rust-analyzer/tests/slow-tests/support.rs
+++ b/crates/rust-analyzer/tests/slow-tests/support.rs
@@ -101,10 +101,6 @@ impl<'a> Project<'a> {
         if roots.is_empty() {
             roots.push(tmp_dir_path.clone());
         }
-        let discovered_projects = roots
-            .into_iter()
-            .map(|it| ProjectManifest::discover_single(&it).unwrap())
-            .collect::<Vec<_>>();
 
         let mut config = Config::new(
             tmp_dir_path,
@@ -144,10 +140,10 @@ impl<'a> Project<'a> {
                 })),
                 ..Default::default()
             },
-            Vec::new(),
+            roots,
         );
-        config.discovered_projects = Some(discovered_projects);
         config.update(self.config).expect("invalid config");
+        config.rediscover_workspaces();
 
         Server::new(tmp_dir, config)
     }


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust-analyzer/issues/14571

With this we should be supporting vscode workspaces properly