### PR TITLE
Add a workspace state command.

### DIFF
--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -206,6 +206,11 @@
                 "category": "rust-analyzer"
             },
             {
+                "command": "rust-analyzer.workspaceStateJson",
+                "title": "Returns the current state of the workspace, encoded as JSON.",
+                "category": "rust-analyzer"
+            },
+            {
                 "command": "rust-analyzer.addProject",
                 "title": "Add current file's crate to workspace",
                 "category": "rust-analyzer"

--- a/editors/code/src/commands.ts
+++ b/editors/code/src/commands.ts
@@ -758,6 +758,15 @@ export function rebuildProcMacros(ctx: CtxInit): Cmd {
     return async () => ctx.client.sendRequest(ra.rebuildProcMacros);
 }
 
+export function workspaceStateJson(): Cmd {
+    return async () => {
+        const openFiles = vscode.workspace.textDocuments
+            .filter(isRustDocument)
+            .map((f) => f.fileName);
+        return JSON.stringify({ openFiles: openFiles });
+    };
+}
+
 export function addProject(ctx: CtxInit): Cmd {
     return async () => {
         const discoverProjectCommand = ctx.config.discoverProjectCommand;

--- a/editors/code/src/main.ts
+++ b/editors/code/src/main.ts
@@ -154,6 +154,7 @@ function createCommands(): Record<string, CommandFactory> {
         shuffleCrateGraph: { enabled: commands.shuffleCrateGraph },
         reloadWorkspace: { enabled: commands.reloadWorkspace },
         rebuildProcMacros: { enabled: commands.rebuildProcMacros },
+        workspaceStateJson: { enabled: commands.workspaceStateJson },
         addProject: { enabled: commands.addProject },
         matchingBrace: { enabled: commands.matchingBrace },
         joinLines: { enabled: commands.joinLines },


### PR DESCRIPTION
The current rules_rust [recommended configuration](https://bazelbuild.github.io/rules_rust/rust_analyzer.html#vscode) is to add a task that generates a rust-project.json that covers every single rust file in your workspace. This obviously doesn't work on very large projects. This workspace state adds a mechanism through which we can query the currently open files. Unfortunately, in order for commands to be used in tasks, they must return a string, so we return the json format.

This will allow us to instead write `["run", "@rules_rust//tools/rust_analyzer:gen_rust_project", "--", "${command:rust-analyzer.workspaceStateJson}"]`. This would then expand to '{"open_files":["/path/to/src/main.rs"]}'.

Note that I tried using the "discoverProjectCommand" setting, but it wasn't viable because:
* It was very non-obvious when gen-rust-project failed (which it does frequently, since doing so requires building your code).
* gen-rust-project is expensive, so I wanted it to be manually run.