### PR TITLE
Revert "fix: when running the "discoverProjectCommand", use the Rust file's parent directory instead of the workspace folder"

### DIFF
--- a/editors/code/src/commands.ts
+++ b/editors/code/src/commands.ts
@@ -766,13 +766,12 @@ export function addProject(ctx: CtxInit): Cmd {
         }
 
         const workspaces: JsonProject[] = await Promise.all(
-            vscode.workspace.textDocuments
-                .filter(isRustDocument)
-                .map(async (file): Promise<JsonProject> => {
-                    return discoverWorkspace([file], discoverProjectCommand, {
-                        cwd: path.dirname(file.uri.fsPath),
-                    });
-                })
+            vscode.workspace.workspaceFolders!.map(async (folder): Promise<JsonProject> => {
+                const rustDocuments = vscode.workspace.textDocuments.filter(isRustDocument);
+                return discoverWorkspace(rustDocuments, discoverProjectCommand, {
+                    cwd: folder.uri.fsPath,
+                });
+            })
         );
 
         ctx.addToDiscoveredWorkspaces(workspaces);

--- a/editors/code/src/ctx.ts
+++ b/editors/code/src/ctx.ts
@@ -1,7 +1,6 @@
 import * as vscode from "vscode";
 import * as lc from "vscode-languageclient/node";
 import * as ra from "./lsp_ext";
-import * as path from "path";
 
 import { Config, prepareVSCodeConfig } from "./config";
 import { createClient } from "./client";
@@ -193,13 +192,12 @@ export class Ctx {
             const discoverProjectCommand = this.config.discoverProjectCommand;
             if (discoverProjectCommand) {
                 const workspaces: JsonProject[] = await Promise.all(
-                    vscode.workspace.textDocuments
-                        .filter(isRustDocument)
-                        .map(async (file): Promise<JsonProject> => {
-                            return discoverWorkspace([file], discoverProjectCommand, {
-                                cwd: path.dirname(file.uri.fsPath),
-                            });
-                        })
+                    vscode.workspace.workspaceFolders!.map(async (folder): Promise<JsonProject> => {
+                        const rustDocuments = vscode.workspace.textDocuments.filter(isRustDocument);
+                        return discoverWorkspace(rustDocuments, discoverProjectCommand, {
+                            cwd: folder.uri.fsPath,
+                        });
+                    })
                 );
 
                 this.addToDiscoveredWorkspaces(workspaces);


### PR DESCRIPTION
Reverts rust-lang/rust-analyzer#14535

This is a breaking change, as it completely changes how r-a workspaces work. While previously, it was one r-a workspace per vscode workspace, this changes it to be one r-a workspace per open file.

I'm not opposed to the idea of having an option for doing it this way, but since it's a breaking change, something like that should be locked behind a setting, IMO.