### PR TITLE
fix: `editor.parameterHints.enabled` not always being respected

### DIFF
--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -1455,6 +1455,11 @@
                         "Search in current workspace and dependencies."
                     ]
                 },
+                "rust-analyzer.autoTriggerParameterHints": {
+                    "type": "boolean",
+                    "default": true,
+                    "markdownDescription": "Enable or disable automatic triggering of parameter hints when accepting suggestions."
+                },
                 "$generated-end": {}
             }
         },

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -1455,11 +1455,6 @@
                         "Search in current workspace and dependencies."
                     ]
                 },
-                "rust-analyzer.autoTriggerParameterHints": {
-                    "type": "boolean",
-                    "default": true,
-                    "markdownDescription": "Enable or disable automatic triggering of parameter hints when accepting suggestions."
-                },
                 "$generated-end": {}
             }
         },

--- a/editors/code/src/commands.ts
+++ b/editors/code/src/commands.ts
@@ -89,7 +89,13 @@ export function shuffleCrateGraph(ctx: CtxInit): Cmd {
 
 export function triggerParameterHints(_: CtxInit): Cmd {
     return async () => {
-        await vscode.commands.executeCommand("editor.action.triggerParameterHints");
+        const autoTriggerParameterHints = vscode.workspace
+            .getConfiguration("rust-analyzer")
+            .get<boolean>("autoTriggerParameterHints");
+
+        if (autoTriggerParameterHints) {
+            await vscode.commands.executeCommand("editor.action.triggerParameterHints");
+        }
     };
 }
 

--- a/editors/code/src/commands.ts
+++ b/editors/code/src/commands.ts
@@ -89,11 +89,11 @@ export function shuffleCrateGraph(ctx: CtxInit): Cmd {
 
 export function triggerParameterHints(_: CtxInit): Cmd {
     return async () => {
-        const autoTriggerParameterHints = vscode.workspace
-            .getConfiguration("rust-analyzer")
-            .get<boolean>("autoTriggerParameterHints");
+        const parameterHintsEnabled = vscode.workspace
+            .getConfiguration("editor")
+            .get<boolean>("parameterHints.enabled");
 
-        if (autoTriggerParameterHints) {
+        if (parameterHintsEnabled) {
             await vscode.commands.executeCommand("editor.action.triggerParameterHints");
         }
     };


### PR DESCRIPTION
#13472

When accepting a suggestion, the parameter hints would always trigger automatically. This PR provides the ability for users to toggle this functionality off by specifying the new "rust-analyzer.autoTriggerParameterHints" option in `settings.json`. Possible options are `true` and `false`. It's `true` by default.