### PR TITLE
Add syntax::make::ty_alias

### DIFF
--- a/crates/syntax/src/ast/make.rs
+++ b/crates/syntax/src/ast/make.rs
@@ -159,14 +159,12 @@ fn ty_from_text(text: &str) -> ast::Type {
 }
 
 /// Related goto [link](https://doc.rust-lang.org/reference/items/type-aliases.html)
-///     Type Alias syntax is
-///
-///     ```
-///     TypeAlias :
-///        type IDENTIFIER GenericParams? ( : TypeParamBounds )? WhereClause? ( = Type WhereClause?)? ;
-///     ```
-///
-///     FIXME : ident should be of type ast::Ident
+/// Type Alias syntax is
+/// ```
+/// TypeAlias :
+/// type IDENTIFIER GenericParams? ( : TypeParamBounds )? WhereClause? ( = Type WhereClause?)? ;
+/// ```
+/// FIXME : ident should be of type ast::Ident
 pub fn ty_alias(
     ident: &str,
     generic_param_list: Option<ast::GenericParamList>,
@@ -182,7 +180,7 @@ pub fn ty_alias(
     }
 
     if let Some(list) = type_param_bounds {
-        s.push_str(&format!(" : {}", &list.to_string()));
+        s.push_str(&format!(" : {}", &list));
     }
 
     if let Some(cl) = where_clause {

--- a/crates/syntax/src/ast/make.rs
+++ b/crates/syntax/src/ast/make.rs
@@ -14,8 +14,6 @@ use stdx::{format_to, never};
 
 use crate::{ast, utils::is_raw_identifier, AstNode, SourceFile, SyntaxKind, SyntaxToken};
 
-use super::WhereClause;
-
 /// While the parent module defines basic atomic "constructors", the `ext`
 /// module defines shortcuts for common things.
 ///
@@ -160,50 +158,47 @@ fn ty_from_text(text: &str) -> ast::Type {
     ast_from_text(&format!("type _T = {text};"))
 }
 
-/** Related goto [link](https://doc.rust-lang.org/reference/items/type-aliases.html)
-    Type Alias syntax is
-
-    ```
-    TypeAlias :
-       type IDENTIFIER GenericParams? ( : TypeParamBounds )? WhereClause? ( = Type WhereClause?)? ;
-    ```
-
-    FIXME : ident should be of type ast::Ident
-*/
+/// Related goto [link](https://doc.rust-lang.org/reference/items/type-aliases.html)
+///     Type Alias syntax is
+///
+///     ```
+///     TypeAlias :
+///        type IDENTIFIER GenericParams? ( : TypeParamBounds )? WhereClause? ( = Type WhereClause?)? ;
+///     ```
+///
+///     FIXME : ident should be of type ast::Ident
 pub fn ty_alias(
-    ident: String,
+    ident: &str,
     generic_param_list: Option<ast::GenericParamList>,
     type_param_bounds: Option<ast::TypeParam>,
-    where_clause: Option<WhereClause>,
+    where_clause: Option<ast::WhereClause>,
     assignment: Option<(ast::Type, Option<ast::WhereClause>)>,
 ) -> ast::TypeAlias {
     let mut s = String::new();
-    s.push_str(format!("type {}", ident.as_str()).as_str());
+    s.push_str(&format!("type {}", ident));
 
     if let Some(list) = generic_param_list {
-        s.push_str(list.to_string().as_str());
+        s.push_str(&list.to_string());
     }
 
     if let Some(list) = type_param_bounds {
-        s.push_str(format!(" : {}", list.to_string().as_str()).as_str());
+        s.push_str(&format!(" : {}", &list.to_string()));
     }
 
     if let Some(cl) = where_clause {
-        s.push_str(format!(" {}", cl.to_string().as_str()).as_str());
+        s.push_str(&format!(" {}", &cl.to_string()));
     }
 
     if let Some(exp) = assignment {
         if let Some(cl) = exp.1 {
-            s.push_str(
-                format!("= {} {}", exp.0.to_string().as_str(), cl.to_string().as_str()).as_str(),
-            );
+            s.push_str(&format!("= {} {}", &exp.0.to_string(), &cl.to_string()));
         } else {
-            s.push_str(format!("= {}", exp.0.to_string().as_str()).as_str());
+            s.push_str(&format!("= {}", &exp.0.to_string()));
         }
     }
 
     s.push_str(";");
-    ast_from_text(s.as_str())
+    ast_from_text(&s)
 }
 
 pub fn assoc_item_list() -> ast::AssocItemList {


### PR DESCRIPTION
There was until now no function that returns TypeAlias. This commit introduces a func that is fully compliant with the Rust Reference. I had problems working with Ident so for now the function uses simple string manipulation until ast_from_text function is called. I am however open to any ideas that could replace ident param in such a way that it accepts syntax::ast::Ident