### PR TITLE
fix: Fix some typos in `StructFlags`

### DIFF
--- a/crates/hir-def/src/data/adt.rs
+++ b/crates/hir-def/src/data/adt.rs
@@ -60,7 +60,7 @@ bitflags! {
         /// Indicates whether this struct is `ManuallyDrop`.
         const IS_MANUALLY_DROP = 1 << 6;
         /// Indicates whether this struct is `UnsafeCell`.
-        const IS_UNSAFE_CELL   = 1 << 6;
+        const IS_UNSAFE_CELL   = 1 << 7;
     }
 }
 

--- a/crates/hir-ty/src/lang_items.rs
+++ b/crates/hir-ty/src/lang_items.rs
@@ -7,7 +7,7 @@ use crate::db::HirDatabase;
 
 pub fn is_box(db: &dyn HirDatabase, adt: AdtId) -> bool {
     let AdtId::StructId(id) = adt else { return false };
-    db.struct_data(id).flags.contains(StructFlags::IS_UNSAFE_CELL)
+    db.struct_data(id).flags.contains(StructFlags::IS_BOX)
 }
 
 pub fn is_unsafe_cell(db: &dyn HirDatabase, adt: AdtId) -> bool {

--- a/crates/test-utils/src/minicore.rs
+++ b/crates/test-utils/src/minicore.rs
@@ -31,6 +31,7 @@
 //!     infallible:
 //!     iterator: option
 //!     iterators: iterator, fn
+//!     manually_drop: drop
 //!     non_zero:
 //!     option: panic
 //!     ord: eq, option
@@ -194,6 +195,30 @@ pub mod convert {
 
 // region:drop
 pub mod mem {
+    // region:manually_drop
+    #[lang = "manually_drop"]
+    #[repr(transparent)]
+    pub struct ManuallyDrop<T: ?Sized> {
+        value: T,
+    }
+
+    impl<T> ManuallyDrop<T> {
+        pub const fn new(value: T) -> ManuallyDrop<T> {
+            ManuallyDrop { value }
+        }
+    }
+
+    // region:deref
+    impl<T: ?Sized> crate::ops::Deref for ManuallyDrop<T> {
+        type Target = T;
+        fn deref(&self) -> &T {
+            &self.value
+        }
+    }
+    // endregion:deref
+
+    // endregion:manually_drop
+
     pub fn drop<T>(_x: T) {}
 }
 // endregion:drop


### PR DESCRIPTION
And a question: what is the benefit of storing things like `IS_BOX` in struct flags over using `lang_attr`?