### PR TITLE
fix: remove extra argument "rustc"

### DIFF
--- a/crates/project-model/src/target_data_layout.rs
+++ b/crates/project-model/src/target_data_layout.rs
@@ -16,7 +16,7 @@ pub fn get(
             let mut cmd = Command::new(toolchain::rustc());
             cmd.envs(extra_env);
             cmd.current_dir(cargo_toml.parent())
-                .args(["-Z", "unstable-options", "rustc", "--print", "target-spec-json"])
+                .args(["-Z", "unstable-options", "--print", "target-spec-json"])
                 .env("RUSTC_BOOTSTRAP", "1");
             if let Some(target) = target {
                 cmd.args(["--target", target]);


### PR DESCRIPTION
Two extra "rustc"s were accidentally introduced [here](https://github.com/rust-lang/rust-analyzer/commit/33591cd3f47b14961ed07a99ac23deece704243c#diff-53e4b6b2c1ff2465d8abd50db160753199426fd788ddcad925752e0838e28de2R156-R169). (I guess because `cmd` is sometimes initialized with a `cargo` under the hood, sometimes `rustc`, thus error-prone?)

One of them has been fixed [here](https://github.com/rust-lang/rust-analyzer/commit/384fa4b84ae881f402933e105c5c92b8b471036a#diff-35c78d76dfccbcece2c917b1e5b9a8e0951d5e340cf579e5ce4951142e2077d3R32). This patch fixes the other.