### PR TITLE
Specify `--pre-release` when publishing vsce nightly

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -270,7 +270,7 @@ jobs:
       - name: Publish Extension (Code Marketplace, nightly)
         if: github.ref != 'refs/heads/release' && (github.repository == 'rust-analyzer/rust-analyzer' || github.repository == 'rust-lang/rust-analyzer')
         working-directory: ./editors/code
-        run: npx vsce publish --pat ${{ secrets.MARKETPLACE_TOKEN }} --packagePath ../../dist/rust-analyzer-*.vsix
+        run: npx vsce publish --pat ${{ secrets.MARKETPLACE_TOKEN }} --packagePath ../../dist/rust-analyzer-*.vsix --pre-release
 
       - name: Publish Extension (OpenVSX, nightly)
         if: github.ref != 'refs/heads/release' && (github.repository == 'rust-analyzer/rust-analyzer' || github.repository == 'rust-lang/rust-analyzer')


### PR DESCRIPTION
According to https://code.visualstudio.com/api/working-with-extensions/publishing-extension#prerelease-extensions, when publishing pre-release versions, `--pre-release` must also be passed in the publish step.

Currently the behavior with and without the flag seems to be the same, but since it's documented to be required, don't rely on this staying that way.

This flag was previously removed in #13020, so this partially reverts that change.