### PR TITLE
 Provide links to locally built documentation for `experimental/externalDocs`

### DIFF
--- a/crates/ide/src/doc_links.rs
+++ b/crates/ide/src/doc_links.rs
@@ -535,13 +535,11 @@ fn get_doc_base_urls(
 
     return (web_base, local_base);
 
-    // On Windows, cargo metadata returns paths without leading slashes, but
-    // Url::from_directory_path requires them.
-    // In unix adding another "/" will not make any difference.
     fn create_url_from_os_str(path: &OsStr) -> Option<Url> {
-        let mut with_leading_slash = OsStr::new("/").to_os_string();
-        with_leading_slash.push(path);
-        Url::from_directory_path(with_leading_slash.as_os_str()).ok()
+        let mut with_prefix = OsStr::new("file:///").to_os_string();
+        with_prefix.push(path);
+        with_prefix.push("/");
+        with_prefix.to_str().and_then(|s| Url::parse(s).ok())
     }
 }
 

--- a/crates/ide/src/doc_links.rs
+++ b/crates/ide/src/doc_links.rs
@@ -35,10 +35,10 @@ use crate::{
 #[derive(Default, Debug, Clone, PartialEq, Eq)]
 pub struct DocumentationLinks {
     /// The URL to the documentation on docs.rs.
-    /// Could be invalid.
+    /// May not lead anywhere.
     pub web_url: Option<String>,
     /// The URL to the documentation in the local file system.
-    /// Could be invalid.
+    /// May not lead anywhere.
     pub local_url: Option<String>,
 }
 
@@ -119,7 +119,7 @@ pub(crate) fn remove_links(markdown: &str) -> String {
 
 // Feature: Open Docs
 //
-// Retrieve a link to documentation for the given symbol.
+// Retrieve a links to documentation for the given symbol.
 //
 // The simplest way to use this feature is via the context menu. Right-click on
 // the selected item. The context menu opens. Select **Open Docs**.
@@ -459,6 +459,8 @@ fn map_links<'e>(
 /// ```ignore
 /// https://doc.rust-lang.org/std/iter/trait.Iterator.html#tymethod.next
 /// ^^^^^^^^^^^^^^^^^^^^^^^^^^
+/// file:///project/root/target/doc/std/iter/trait.Iterator.html#tymethod.next
+/// ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 /// ```
 fn get_doc_base_urls(
     db: &RootDatabase,

--- a/crates/ide/src/doc_links.rs
+++ b/crates/ide/src/doc_links.rs
@@ -473,7 +473,7 @@ fn get_doc_base_urls(
     // https://github.com/rust-lang/rust-analyzer/issues/12250
     if let Definition::BuiltinType(..) = def {
         let weblink = Url::parse("https://doc.rust-lang.org/nightly/core/").ok();
-        return (weblink, local_doc_path);
+        return (weblink, None);
     };
 
     let Some(krate) = def.krate(db) else { return Default::default() };

--- a/crates/ide/src/doc_links.rs
+++ b/crates/ide/src/doc_links.rs
@@ -481,6 +481,8 @@ fn get_doc_base_urls(
     let Some(display_name) = krate.display_name(db) else { return Default::default() };
     let crate_data = &db.crate_graph()[krate.into()];
     let channel = crate_data.channel.map_or("nightly", ReleaseChannel::as_str);
+    let sysroot = "/home/ddystopia/.rustup/toolchains/stable-x86_64-unknown-linux-gnu";
+
     let (web_base, local_base) = match &crate_data.origin {
         // std and co do not specify `html_root_url` any longer so we gotta handwrite this ourself.
         // FIXME: Use the toolchains channel instead of nightly
@@ -490,7 +492,14 @@ fn get_doc_base_urls(
             | LangCrateOrigin::ProcMacro
             | LangCrateOrigin::Std
             | LangCrateOrigin::Test),
-        ) => (Some(format!("https://doc.rust-lang.org/{channel}/{origin}")), None),
+        ) => {
+            let local_url = format!("file:///{sysroot}/share/doc/rust/html/{origin}/index.html");
+            let local_url = Url::parse(&local_url).ok();
+            let web_url = format!("https://doc.rust-lang.org/{channel}/{origin}");
+            println!("local_url: {:?}", local_url.unwrap().to_string());
+            panic!();
+            (Some(web_url), local_url)
+        },
         CrateOrigin::Lang(_) => return (None, None),
         CrateOrigin::Rustc { name: _ } => {
             (Some(format!("https://doc.rust-lang.org/{channel}/nightly-rustc/")), None)

--- a/crates/ide/src/doc_links.rs
+++ b/crates/ide/src/doc_links.rs
@@ -164,7 +164,7 @@ pub(crate) fn external_docs(
         }
     };
 
-    return get_doc_links(db, definition, target_dir);
+    get_doc_links(db, definition, target_dir)
 }
 
 /// Extracts all links from a given markdown text returning the definition text range, link-text

--- a/crates/ide/src/doc_links.rs
+++ b/crates/ide/src/doc_links.rs
@@ -148,17 +148,15 @@ pub(crate) fn external_docs(
     let node = token.parent()?;
     let definition = match_ast! {
         match node {
-            ast::NameRef(name_ref) => match NameRefClass::classify(sema, &name_ref) {
-                Some(NameRefClass::Definition(def)) => def,
-                Some(NameRefClass::FieldShorthand { local_ref: _, field_ref }) => {
+            ast::NameRef(name_ref) => match NameRefClass::classify(sema, &name_ref)? {
+                NameRefClass::Definition(def) => def,
+                NameRefClass::FieldShorthand { local_ref: _, field_ref } => {
                     Definition::Field(field_ref)
                 }
-                None => return None,
             },
-            ast::Name(name) => match NameClass::classify(sema, &name) {
-                Some(NameClass::Definition(it) | NameClass::ConstReference(it)) => it,
-                Some(NameClass::PatFieldShorthand { local_def: _, field_ref }) => Definition::Field(field_ref),
-                None => return None,
+            ast::Name(name) => match NameClass::classify(sema, &name)? {
+                NameClass::Definition(it) | NameClass::ConstReference(it) => it,
+                NameClass::PatFieldShorthand { local_def: _, field_ref } => Definition::Field(field_ref),
             },
             _ => return None
         }
@@ -347,10 +345,10 @@ fn get_doc_links(
     web_url.as_mut().map(|url| url.set_fragment(frag.as_deref()));
     local_url.as_mut().map(|url| url.set_fragment(frag.as_deref()));
 
-    return DocumentationLinks {
+    DocumentationLinks {
         web_url: web_url.map(|it| it.into()),
         local_url: local_url.map(|it| it.into()),
-    };
+    }
 }
 
 fn rewrite_intra_doc_link(

--- a/crates/ide/src/doc_links/tests.rs
+++ b/crates/ide/src/doc_links/tests.rs
@@ -120,6 +120,19 @@ fn node_to_def(
 }
 
 #[test]
+fn external_docs_doc_builtin_type() {
+    check_external_docs(
+        r#"
+//- /main.rs crate:foo
+let x: u3$02 = 0;
+"#,
+        Some(&OsStr::new("/home/user/project")),
+        Some(expect![[r#"https://doc.rust-lang.org/nightly/core/primitive.u32.html"#]]),
+        None,
+    );
+}
+
+#[test]
 fn external_docs_doc_url_crate() {
     check_external_docs(
         r#"

--- a/crates/ide/src/doc_links/tests.rs
+++ b/crates/ide/src/doc_links/tests.rs
@@ -128,7 +128,7 @@ use foo$0::Foo;
 //- /lib.rs crate:foo
 pub struct Foo;
 "#,
-        Some(&OsStr::new("/home/user/project/")),
+        Some(&OsStr::new("/home/user/project")),
         Some(expect![[r#"https://docs.rs/foo/*/foo/index.html"#]]),
         Some(expect![[r#"file:///home/user/project/doc/foo/index.html"#]]),
     );
@@ -141,7 +141,7 @@ fn external_docs_doc_url_std_crate() {
 //- /main.rs crate:std
 use self$0;
 "#,
-        Some(&OsStr::new("/home/user/project/")),
+        Some(&OsStr::new("/home/user/project")),
         Some(expect!["https://doc.rust-lang.org/stable/std/index.html"]),
         None,
     );
@@ -154,7 +154,7 @@ fn external_docs_doc_url_struct() {
 //- /main.rs crate:foo
 pub struct Fo$0o;
 "#,
-        Some(&OsStr::new("/home/user/project/")),
+        Some(&OsStr::new("/home/user/project")),
         Some(expect![[r#"https://docs.rs/foo/*/foo/struct.Foo.html"#]]),
         Some(expect![[r#"file:///home/user/project/doc/foo/struct.Foo.html"#]]),
     );
@@ -169,7 +169,7 @@ pub struct Fo$0o;
 "#,
         Some(&OsStr::new(r"C:\Users\user\project")),
         Some(expect![[r#"https://docs.rs/foo/*/foo/struct.Foo.html"#]]),
-        Some(expect![[r#"file:///C:\Users\user\project/doc/foo/struct.Foo.html"#]]),
+        Some(expect![[r#"file:///C:/Users/user/project/doc/foo/struct.Foo.html"#]]),
     );
 }
 

--- a/crates/ide/src/doc_links/tests.rs
+++ b/crates/ide/src/doc_links/tests.rs
@@ -20,9 +20,10 @@ fn check_external_docs(
     target_dir: Option<&OsStr>,
     expect_web_url: Option<Expect>,
     expect_local_url: Option<Expect>,
+    sysroot: Option<&OsStr>,
 ) {
     let (analysis, position) = fixture::position(ra_fixture);
-    let links = analysis.external_docs(position, target_dir).unwrap();
+    let links = analysis.external_docs(position, target_dir, sysroot).unwrap();
 
     let web_url = links.web_url;
     let local_url = links.local_url;
@@ -128,7 +129,8 @@ let x: u3$02 = 0;
 "#,
         Some(&OsStr::new("/home/user/project")),
         Some(expect![[r#"https://doc.rust-lang.org/nightly/core/primitive.u32.html"#]]),
-        None,
+        Some(expect![[r#"file:///sysroot/share/doc/rust/html/core/primitive.u32.html"#]]),
+        Some(&OsStr::new("/sysroot")),
     );
 }
 
@@ -144,6 +146,7 @@ pub struct Foo;
         Some(&OsStr::new("/home/user/project")),
         Some(expect![[r#"https://docs.rs/foo/*/foo/index.html"#]]),
         Some(expect![[r#"file:///home/user/project/doc/foo/index.html"#]]),
+        Some(&OsStr::new("/sysroot")),
     );
 }
 
@@ -156,7 +159,8 @@ use self$0;
 "#,
         Some(&OsStr::new("/home/user/project")),
         Some(expect!["https://doc.rust-lang.org/stable/std/index.html"]),
-        None,
+        Some(expect!["file:///sysroot/share/doc/rust/html/std/index.html"]),
+        Some(&OsStr::new("/sysroot")),
     );
 }
 
@@ -170,6 +174,7 @@ pub struct Fo$0o;
         Some(&OsStr::new("/home/user/project")),
         Some(expect![[r#"https://docs.rs/foo/*/foo/struct.Foo.html"#]]),
         Some(expect![[r#"file:///home/user/project/doc/foo/struct.Foo.html"#]]),
+        Some(&OsStr::new("/sysroot")),
     );
 }
 
@@ -183,6 +188,7 @@ pub struct Fo$0o;
         Some(&OsStr::new(r"C:\Users\user\project")),
         Some(expect![[r#"https://docs.rs/foo/*/foo/struct.Foo.html"#]]),
         Some(expect![[r#"file:///C:/Users/user/project/doc/foo/struct.Foo.html"#]]),
+        Some(&OsStr::new("/sysroot")),
     );
 }
 
@@ -196,6 +202,7 @@ pub struct Fo$0o;
         Some(&OsStr::new(r"C:/Users/user/project")),
         Some(expect![[r#"https://docs.rs/foo/*/foo/struct.Foo.html"#]]),
         Some(expect![[r#"file:///C:/Users/user/project/doc/foo/struct.Foo.html"#]]),
+        Some(&OsStr::new("/sysroot")),
     );
 }
 
@@ -211,6 +218,7 @@ pub struct Foo {
         None,
         Some(expect![[r##"https://docs.rs/foo/*/foo/struct.Foo.html#structfield.field"##]]),
         None,
+        None,
     );
 }
 
@@ -223,6 +231,7 @@ pub fn fo$0o() {}
 "#,
         None,
         Some(expect![[r#"https://docs.rs/foo/*/foo/fn.foo.html"#]]),
+        None,
         None,
     );
 }
@@ -240,6 +249,7 @@ impl Foo {
         None,
         Some(expect![[r##"https://docs.rs/foo/*/foo/struct.Foo.html#method.method"##]]),
         None,
+        None,
     );
     check_external_docs(
         r#"
@@ -251,6 +261,7 @@ impl Foo {
 "#,
         None,
         Some(expect![[r##"https://docs.rs/foo/*/foo/struct.Foo.html#associatedconstant.CONST"##]]),
+        None,
         None,
     );
 }
@@ -271,6 +282,7 @@ impl Trait for Foo {
         None,
         Some(expect![[r##"https://docs.rs/foo/*/foo/struct.Foo.html#method.method"##]]),
         None,
+        None,
     );
     check_external_docs(
         r#"
@@ -285,6 +297,7 @@ impl Trait for Foo {
 "#,
         None,
         Some(expect![[r##"https://docs.rs/foo/*/foo/struct.Foo.html#associatedconstant.CONST"##]]),
+        None,
         None,
     );
     check_external_docs(
@@ -301,6 +314,7 @@ impl Trait for Foo {
         None,
         Some(expect![[r##"https://docs.rs/foo/*/foo/struct.Foo.html#associatedtype.Type"##]]),
         None,
+        None,
     );
 }
 
@@ -316,6 +330,7 @@ pub trait Foo {
         None,
         Some(expect![[r##"https://docs.rs/foo/*/foo/trait.Foo.html#tymethod.method"##]]),
         None,
+        None,
     );
     check_external_docs(
         r#"
@@ -327,6 +342,7 @@ pub trait Foo {
         None,
         Some(expect![[r##"https://docs.rs/foo/*/foo/trait.Foo.html#associatedconstant.CONST"##]]),
         None,
+        None,
     );
     check_external_docs(
         r#"
@@ -337,6 +353,7 @@ pub trait Foo {
 "#,
         None,
         Some(expect![[r##"https://docs.rs/foo/*/foo/trait.Foo.html#associatedtype.Type"##]]),
+        None,
         None,
     );
 }
@@ -350,6 +367,7 @@ trait Trait$0 {}
 "#,
         None,
         Some(expect![[r#"https://docs.rs/foo/*/foo/trait.Trait.html"#]]),
+        None,
         None,
     )
 }
@@ -365,6 +383,7 @@ pub mod foo {
 "#,
         None,
         Some(expect![[r#"https://docs.rs/foo/*/foo/foo/bar/index.html"#]]),
+        None,
         None,
     )
 }
@@ -388,6 +407,7 @@ fn foo() {
         "#,
         None,
         Some(expect![[r#"https://docs.rs/foo/*/foo/wrapper/module/struct.Item.html"#]]),
+        None,
         None,
     )
 }

--- a/crates/ide/src/lib.rs
+++ b/crates/ide/src/lib.rs
@@ -476,7 +476,7 @@ impl Analysis {
         position: FilePosition,
         target_dir: Option<&OsStr>,
     ) -> Cancellable<doc_links::DocumentationLinks> {
-        self.with_db(|db| doc_links::external_docs(db, &position, target_dir))
+        self.with_db(|db| doc_links::external_docs(db, &position, target_dir).unwrap_or_default())
     }
 
     /// Computes parameter information at the given position.

--- a/crates/ide/src/lib.rs
+++ b/crates/ide/src/lib.rs
@@ -475,8 +475,11 @@ impl Analysis {
         &self,
         position: FilePosition,
         target_dir: Option<&OsStr>,
+        sysroot: Option<&OsStr>,
     ) -> Cancellable<doc_links::DocumentationLinks> {
-        self.with_db(|db| doc_links::external_docs(db, &position, target_dir).unwrap_or_default())
+        self.with_db(|db| {
+            doc_links::external_docs(db, &position, target_dir, sysroot).unwrap_or_default()
+        })
     }
 
     /// Computes parameter information at the given position.

--- a/crates/ide/src/lib.rs
+++ b/crates/ide/src/lib.rs
@@ -467,7 +467,10 @@ impl Analysis {
         self.with_db(|db| moniker::moniker(db, position))
     }
 
-    /// Return URL(s) for the documentation of the symbol under the cursor.
+    /// Returns URL(s) for the documentation of the symbol under the cursor.
+    /// # Arguments
+    /// * `position` - Position in the file.
+    /// * `target_dir` - Directory where the build output is storeda.
     pub fn external_docs(
         &self,
         position: FilePosition,

--- a/crates/ide/src/lib.rs
+++ b/crates/ide/src/lib.rs
@@ -61,7 +61,7 @@ mod view_item_tree;
 mod shuffle_crate_graph;
 mod fetch_crates;
 
-use std::sync::Arc;
+use std::{ffi::OsStr, sync::Arc};
 
 use cfg::CfgOptions;
 use fetch_crates::CrateInfo;
@@ -471,8 +471,9 @@ impl Analysis {
     pub fn external_docs(
         &self,
         position: FilePosition,
+        target_dir: Option<&OsStr>,
     ) -> Cancellable<doc_links::DocumentationLinks> {
-        self.with_db(|db| doc_links::external_docs(db, &position))
+        self.with_db(|db| doc_links::external_docs(db, &position, target_dir))
     }
 
     /// Computes parameter information at the given position.

--- a/crates/ide/src/lib.rs
+++ b/crates/ide/src/lib.rs
@@ -471,7 +471,7 @@ impl Analysis {
     pub fn external_docs(
         &self,
         position: FilePosition,
-    ) -> Cancellable<Option<doc_links::DocumentationLink>> {
+    ) -> Cancellable<doc_links::DocumentationLinks> {
         self.with_db(|db| doc_links::external_docs(db, &position))
     }
 

--- a/crates/project-model/src/cargo_workspace.rs
+++ b/crates/project-model/src/cargo_workspace.rs
@@ -32,6 +32,7 @@ pub struct CargoWorkspace {
     packages: Arena<PackageData>,
     targets: Arena<TargetData>,
     workspace_root: AbsPathBuf,
+    target_directory: AbsPathBuf,
 }
 
 impl ops::Index<Package> for CargoWorkspace {
@@ -414,7 +415,10 @@ impl CargoWorkspace {
         let workspace_root =
             AbsPathBuf::assert(PathBuf::from(meta.workspace_root.into_os_string()));
 
-        CargoWorkspace { packages, targets, workspace_root }
+        let target_directory =
+            AbsPathBuf::assert(PathBuf::from(meta.target_directory.into_os_string()));
+
+        CargoWorkspace { packages, targets, workspace_root, target_directory }
     }
 
     pub fn packages(&self) -> impl Iterator<Item = Package> + ExactSizeIterator + '_ {
@@ -430,6 +434,10 @@ impl CargoWorkspace {
 
     pub fn workspace_root(&self) -> &AbsPath {
         &self.workspace_root
+    }
+
+    pub fn target_directory(&self) -> &AbsPath {
+        &self.target_directory
     }
 
     pub fn package_flag(&self, package: &PackageData) -> String {

--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -1036,6 +1036,10 @@ impl Config {
         self.experimental("codeActionGroup")
     }
 
+    pub fn local_docs(&self) -> bool {
+        self.experimental("localDocs")
+    }
+
     pub fn open_server_logs(&self) -> bool {
         self.experimental("openServerLogs")
     }

--- a/crates/rust-analyzer/src/handlers/request.rs
+++ b/crates/rust-analyzer/src/handlers/request.rs
@@ -1537,14 +1537,16 @@ pub(crate) fn handle_open_docs(
     params: lsp_types::TextDocumentPositionParams,
 ) -> Result<(Option<lsp_types::Url>, Option<lsp_types::Url>)> {
     let _p = profile::span("handle_open_docs");
+    let file_uri = &params.text_document.uri;
+    let file_id = from_proto::file_id(&snap, file_uri)?;
     let position = from_proto::file_position(&snap, params)?;
 
-    let cargo = match snap.workspaces.get(0) {
-        Some(ProjectWorkspace::Cargo { cargo, .. }) => Some(cargo),
+    let cargo = match &*snap.analysis.crates_for(file_id)? {
+        &[crate_id, ..] => snap.cargo_target_for_crate_root(crate_id).map(|(it, _)| it),
         _ => None,
     };
-    let target_dir =
-        cargo.and_then(|cargo| Some(cargo.target_directory())).and_then(|p| Some(p.as_os_str()));
+
+    let target_dir = cargo.map(|cargo| cargo.target_directory()).map(|p| p.as_os_str());
     let Ok(remote_urls) = snap.analysis.external_docs(position, target_dir) else { return Ok((None, None)); };
 
     let web_url = remote_urls.web_url.and_then(|it| Url::parse(&it).ok());

--- a/crates/rust-analyzer/src/handlers/request.rs
+++ b/crates/rust-analyzer/src/handlers/request.rs
@@ -1539,7 +1539,13 @@ pub(crate) fn handle_open_docs(
     let _p = profile::span("handle_open_docs");
     let position = from_proto::file_position(&snap, params)?;
 
-    let Ok(remote_urls) = snap.analysis.external_docs(position) else { return Ok((None, None)); };
+    let cargo = match snap.workspaces.get(0) {
+        Some(ProjectWorkspace::Cargo { cargo, .. }) => Some(cargo),
+        _ => None,
+    };
+    let target_dir =
+        cargo.and_then(|cargo| Some(cargo.target_directory())).and_then(|p| Some(p.as_os_str()));
+    let Ok(remote_urls) = snap.analysis.external_docs(position, target_dir) else { return Ok((None, None)); };
 
     let web_url = remote_urls.web_url.and_then(|it| Url::parse(&it).ok());
     let local_url = remote_urls.local_url.and_then(|it| Url::parse(&it).ok());

--- a/crates/rust-analyzer/src/handlers/request.rs
+++ b/crates/rust-analyzer/src/handlers/request.rs
@@ -1546,7 +1546,7 @@ pub(crate) fn handle_open_docs(
     });
 
     let (cargo, sysroot) = match ws_and_sysroot {
-        Some((ws, Some(sysroot))) => (Some(ws), Some(sysroot)),
+        Some((ws, sysroot)) => (Some(ws), sysroot),
         _ => (None, None),
     };
 

--- a/crates/rust-analyzer/src/lsp_ext.rs
+++ b/crates/rust-analyzer/src/lsp_ext.rs
@@ -508,7 +508,7 @@ pub enum ExternalDocs {}
 
 impl Request for ExternalDocs {
     type Params = lsp_types::TextDocumentPositionParams;
-    type Result = Option<lsp_types::Url>;
+    type Result = (Option<lsp_types::Url>, Option<lsp_types::Url>);
     const METHOD: &'static str = "experimental/externalDocs";
 }
 

--- a/crates/rust-analyzer/src/lsp_ext.rs
+++ b/crates/rust-analyzer/src/lsp_ext.rs
@@ -508,8 +508,22 @@ pub enum ExternalDocs {}
 
 impl Request for ExternalDocs {
     type Params = lsp_types::TextDocumentPositionParams;
-    type Result = (Option<lsp_types::Url>, Option<lsp_types::Url>);
+    type Result = ExternalDocsResponse;
     const METHOD: &'static str = "experimental/externalDocs";
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
+#[serde(untagged)]
+pub enum ExternalDocsResponse {
+    Simple(Option<lsp_types::Url>),
+    WithLocal(ExternalDocsPair),
+}
+
+#[derive(Debug, Default, PartialEq, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct ExternalDocsPair {
+    pub web: Option<lsp_types::Url>,
+    pub local: Option<lsp_types::Url>,
 }
 
 pub enum OpenCargoToml {}

--- a/docs/dev/lsp-extensions.md
+++ b/docs/dev/lsp-extensions.md
@@ -386,13 +386,13 @@ rust-analyzer supports only one `kind`, `"cargo"`. The `args` for `"cargo"` look
 
 ## Open External Documentation
 
-This request is sent from client to server to get a URL to documentation for the symbol under the cursor, if available.
+This request is sent from client to server to get a web and local URL(s) to documentation for the symbol under the cursor, if available.
 
 **Method** `experimental/externalDocs`
 
 **Request:**: `TextDocumentPositionParams`
 
-**Response** `string | null`
+**Response** `[string | null, string | null]`
 
 
 ## Analyzer Status

--- a/docs/dev/lsp-extensions.md
+++ b/docs/dev/lsp-extensions.md
@@ -1,5 +1,5 @@
 <!---
-lsp_ext.rs hash: fdf1afd34548abbc
+lsp_ext.rs hash: 4e825bd8f3921c87
 
 If you need to change the above hash to make the test pass, please check if you
 need to adjust this doc as well and ping this issue:
@@ -863,7 +863,7 @@ export interface Diagnostic {
 export interface FetchDependencyListParams {}
 ```
 
-**Response:** 
+**Response:**
 ```typescript
 export interface FetchDependencyListResult {
     crates: {

--- a/docs/dev/lsp-extensions.md
+++ b/docs/dev/lsp-extensions.md
@@ -1,5 +1,5 @@
 <!---
-lsp_ext.rs hash: 4e825bd8f3921c87
+lsp_ext.rs hash: 2d60bbffe70ae198
 
 If you need to change the above hash to make the test pass, please check if you
 need to adjust this doc as well and ping this issue:
@@ -386,14 +386,26 @@ rust-analyzer supports only one `kind`, `"cargo"`. The `args` for `"cargo"` look
 
 ## Open External Documentation
 
-This request is sent from client to server to get a web and local URL(s) to documentation for the symbol under the cursor, if available.
+This request is sent from the client to the server to obtain web and local URL(s) for documentation related to the symbol under the cursor, if available.
 
-**Method** `experimental/externalDocs`
+**Method:** `experimental/externalDocs`
 
-**Request:**: `TextDocumentPositionParams`
+**Request:** `TextDocumentPositionParams`
 
-**Response** `[string | null, string | null]`
+**Response:** `string | null`
 
+## Local Documentation
+
+**Experimental Client Capability:** `{ "localDocs": boolean }`
+
+If this capability is set, the `Open External Documentation` request returned from the server will have the following structure:
+
+```typescript
+interface ExternalDocsResponse {
+    web?: string;
+    local?: string;
+}
+```
 
 ## Analyzer Status
 


### PR DESCRIPTION
This pull request addresses issue #12867, which requested the ability to provide links to locally built documentation when using the "Open docs for symbol" feature. Previously, rust-analyzer always used docs.rs for this purpose. With these changes, the feature will provide both web (docs.rs) and local documentation links without verifying their existence.

Changes in this PR:

   - Added support for local documentation links alongside web documentation links.
   - Added `target_dir` path argument for external_docs and other related methods.
   - Added `sysroot` argument for external_docs.
   - Added `target_directory` path to `CargoWorkspace`.

API Changes:
   
   - Added an experimental client capability `{ "localDocs": boolean }`. If this capability is set, the `Open External Documentation` request returned from the server will include both web and local documentation links in the `ExternalDocsResponse` object.

Here's the `ExternalDocsResponse` interface:

```typescript
interface ExternalDocsResponse {
    web?: string;
    local?: string;
}
```


By providing links to both web-based and locally built documentation, this update improves the developer experience for those using different versions of crates, git dependencies, or local crates not available on docs.rs. Rust-analyzer will now provide both web (docs.rs) and local documentation links, leaving it to the client to open the desired link. Please note that this update does not perform any checks to ensure the validity of the provided links.