### PR TITLE
MIR episode 4

### DIFF
--- a/crates/base-db/src/change.rs
+++ b/crates/base-db/src/change.rs
@@ -34,7 +34,7 @@ impl fmt::Debug for Change {
 }
 
 impl Change {
-    pub fn new() -> Change {
+    pub fn new() -> Self {
         Change::default()
     }
 

--- a/crates/hir-ty/src/chalk_db.rs
+++ b/crates/hir-ty/src/chalk_db.rs
@@ -24,7 +24,7 @@ use crate::{
     method_resolution::{TraitImpls, TyFingerprint, ALL_FLOAT_FPS, ALL_INT_FPS},
     to_assoc_type_id, to_chalk_trait_id,
     traits::ChalkContext,
-    utils::generics,
+    utils::{generics, ClosureSubst},
     wrap_empty_binders, AliasEq, AliasTy, BoundVar, CallableDefId, DebruijnIndex, FnDefId,
     Interner, ProjectionTy, ProjectionTyExt, QuantifiedWhereClause, Substitution, TraitRef,
     TraitRefExt, Ty, TyBuilder, TyExt, TyKind, WhereClause,
@@ -337,7 +337,7 @@ impl<'a> chalk_solve::RustIrDatabase<Interner> for ChalkContext<'a> {
         _closure_id: chalk_ir::ClosureId<Interner>,
         substs: &chalk_ir::Substitution<Interner>,
     ) -> chalk_ir::Binders<rust_ir::FnDefInputsAndOutputDatum<Interner>> {
-        let sig_ty = substs.at(Interner, 0).assert_ty_ref(Interner).clone();
+        let sig_ty = ClosureSubst(substs).sig_ty();
         let sig = &sig_ty.callable_sig(self.db).expect("first closure param should be fn ptr");
         let io = rust_ir::FnDefInputsAndOutputDatum {
             argument_types: sig.params().to_vec(),

--- a/crates/hir-ty/src/consteval.rs
+++ b/crates/hir-ty/src/consteval.rs
@@ -7,7 +7,7 @@ use hir_def::{
     path::Path,
     resolver::{Resolver, ValueNs},
     type_ref::ConstRef,
-    ConstId, EnumVariantId,
+    DefWithBodyId, EnumVariantId,
 };
 use la_arena::{Idx, RawIdx};
 use stdx::never;
@@ -57,7 +57,7 @@ pub enum ConstEvalError {
 impl From<MirLowerError> for ConstEvalError {
     fn from(value: MirLowerError) -> Self {
         match value {
-            MirLowerError::ConstEvalError(e) => *e,
+            MirLowerError::ConstEvalError(_, e) => *e,
             _ => ConstEvalError::MirLowerError(value),
         }
     }
@@ -168,7 +168,7 @@ pub fn try_const_usize(c: &Const) -> Option<u128> {
 pub(crate) fn const_eval_recover(
     _: &dyn HirDatabase,
     _: &[String],
-    _: &ConstId,
+    _: &DefWithBodyId,
     _: &Substitution,
 ) -> Result<Const, ConstEvalError> {
     Err(ConstEvalError::MirLowerError(MirLowerError::Loop))
@@ -184,10 +184,9 @@ pub(crate) fn const_eval_discriminant_recover(
 
 pub(crate) fn const_eval_query(
     db: &dyn HirDatabase,
-    const_id: ConstId,
+    def: DefWithBodyId,
     subst: Substitution,
 ) -> Result<Const, ConstEvalError> {
-    let def = const_id.into();
     let body = db.mir_body(def)?;
     let c = interpret_mir(db, &body, subst, false)?;
     Ok(c)

--- a/crates/hir-ty/src/consteval/tests/intrinsics.rs
+++ b/crates/hir-ty/src/consteval/tests/intrinsics.rs
@@ -68,6 +68,135 @@ fn wrapping_add() {
 }
 
 #[test]
+fn allocator() {
+    check_number(
+        r#"
+        extern "Rust" {
+            #[rustc_allocator]
+            fn __rust_alloc(size: usize, align: usize) -> *mut u8;
+            #[rustc_deallocator]
+            fn __rust_dealloc(ptr: *mut u8, size: usize, align: usize);
+            #[rustc_reallocator]
+            fn __rust_realloc(ptr: *mut u8, old_size: usize, align: usize, new_size: usize) -> *mut u8;
+            #[rustc_allocator_zeroed]
+            fn __rust_alloc_zeroed(size: usize, align: usize) -> *mut u8;
+        }
+
+        const GOAL: u8 = unsafe {
+            let ptr = __rust_alloc(4, 1);
+            let ptr2 = ((ptr as usize) + 1) as *mut u8;
+            *ptr = 23;
+            *ptr2 = 32;
+            let ptr = __rust_realloc(ptr, 4, 1, 8);
+            let ptr2 = ((ptr as usize) + 1) as *mut u8;
+            *ptr + *ptr2
+        };
+        "#,
+        55,
+    );
+}
+
+#[test]
+fn overflowing_add() {
+    check_number(
+        r#"
+        extern "rust-intrinsic" {
+            pub fn add_with_overflow<T>(x: T, y: T) -> (T, bool);
+        }
+
+        const GOAL: u8 = add_with_overflow(1, 2).0;
+        "#,
+        3,
+    );
+    check_number(
+        r#"
+        extern "rust-intrinsic" {
+            pub fn add_with_overflow<T>(x: T, y: T) -> (T, bool);
+        }
+
+        const GOAL: u8 = add_with_overflow(1, 2).1 as u8;
+        "#,
+        0,
+    );
+}
+
+#[test]
+fn needs_drop() {
+    check_number(
+        r#"
+        //- minicore: copy, sized
+        extern "rust-intrinsic" {
+            pub fn needs_drop<T: ?Sized>() -> bool;
+        }
+        struct X;
+        const GOAL: bool = !needs_drop::<i32>() && needs_drop::<X>();
+        "#,
+        1,
+    );
+}
+
+#[test]
+fn likely() {
+    check_number(
+        r#"
+        extern "rust-intrinsic" {
+            pub fn likely(b: bool) -> bool;
+            pub fn unlikely(b: bool) -> bool;
+        }
+
+        const GOAL: bool = likely(true) && unlikely(true) && !likely(false) && !unlikely(false);
+        "#,
+        1,
+    );
+}
+
+#[test]
+fn atomic() {
+    check_number(
+        r#"
+        //- minicore: copy
+        extern "rust-intrinsic" {
+            pub fn atomic_load_seqcst<T: Copy>(src: *const T) -> T;
+            pub fn atomic_xchg_acquire<T: Copy>(dst: *mut T, src: T) -> T;
+            pub fn atomic_cxchg_release_seqcst<T: Copy>(dst: *mut T, old: T, src: T) -> (T, bool);
+            pub fn atomic_cxchgweak_acquire_acquire<T: Copy>(dst: *mut T, old: T, src: T) -> (T, bool);
+            pub fn atomic_store_release<T: Copy>(dst: *mut T, val: T);
+            pub fn atomic_xadd_acqrel<T: Copy>(dst: *mut T, src: T) -> T;
+            pub fn atomic_xsub_seqcst<T: Copy>(dst: *mut T, src: T) -> T;
+            pub fn atomic_and_acquire<T: Copy>(dst: *mut T, src: T) -> T;
+            pub fn atomic_nand_seqcst<T: Copy>(dst: *mut T, src: T) -> T;
+            pub fn atomic_or_release<T: Copy>(dst: *mut T, src: T) -> T;
+            pub fn atomic_xor_seqcst<T: Copy>(dst: *mut T, src: T) -> T;
+        }
+
+        fn should_not_reach() {
+            _ // fails the test if executed
+        }
+
+        const GOAL: i32 = {
+            let mut x = 5;
+            atomic_store_release(&mut x, 10);
+            let mut y = atomic_xchg_acquire(&mut x, 100);
+            atomic_xadd_acqrel(&mut y, 20);
+            if (30, true) != atomic_cxchg_release_seqcst(&mut y, 30, 40) {
+                should_not_reach();
+            }
+            if (40, false) != atomic_cxchg_release_seqcst(&mut y, 30, 50) {
+                should_not_reach();
+            }
+            if (40, true) != atomic_cxchgweak_acquire_acquire(&mut y, 40, 30) {
+                should_not_reach();
+            }
+            let mut z = atomic_xsub_seqcst(&mut x, -200);
+            atomic_xor_seqcst(&mut x, 1024);
+            atomic_load_seqcst(&x) + z * 3 + atomic_load_seqcst(&y) * 2
+        };
+        "#,
+        660 + 1024,
+    );
+}
+
+#[test]
 fn offset() {
     check_number(
         r#"

--- a/crates/hir-ty/src/db.rs
+++ b/crates/hir-ty/src/db.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 
 use base_db::{impl_intern_key, salsa, CrateId, Upcast};
 use hir_def::{
-    db::DefDatabase, hir::ExprId, layout::TargetDataLayout, AdtId, BlockId, ConstId, ConstParamId,
+    db::DefDatabase, hir::ExprId, layout::TargetDataLayout, AdtId, BlockId, ConstParamId,
     DefWithBodyId, EnumVariantId, FunctionId, GenericDefId, ImplId, LifetimeParamId, LocalFieldId,
     TypeOrConstParamId, VariantId,
 };
@@ -59,7 +59,7 @@ pub trait HirDatabase: DefDatabase + Upcast<dyn DefDatabase> {
 
     #[salsa::invoke(crate::consteval::const_eval_query)]
     #[salsa::cycle(crate::consteval::const_eval_recover)]
-    fn const_eval(&self, def: ConstId, subst: Substitution) -> Result<Const, ConstEvalError>;
+    fn const_eval(&self, def: DefWithBodyId, subst: Substitution) -> Result<Const, ConstEvalError>;
 
     #[salsa::invoke(crate::consteval::const_eval_discriminant_variant)]
     #[salsa::cycle(crate::consteval::const_eval_discriminant_recover)]

--- a/crates/hir-ty/src/diagnostics/match_check/deconstruct_pat.rs
+++ b/crates/hir-ty/src/diagnostics/match_check/deconstruct_pat.rs
@@ -772,7 +772,7 @@ impl<'p> Fields<'p> {
 
         (0..fields_len).map(|idx| LocalFieldId::from_raw(idx.into())).filter_map(move |fid| {
             let ty = field_ty[fid].clone().substitute(Interner, substs);
-            let ty = normalize(cx.db, cx.body, ty);
+            let ty = normalize(cx.db, cx.db.trait_environment_for_body(cx.body), ty);
             let is_visible = matches!(adt, hir_def::AdtId::EnumId(..))
                 || visibility[fid].is_visible_from(cx.db.upcast(), cx.module);
             let is_uninhabited = cx.is_uninhabited(&ty);

--- a/crates/hir-ty/src/infer.rs
+++ b/crates/hir-ty/src/infer.rs
@@ -44,7 +44,7 @@ use crate::{
     db::HirDatabase, fold_tys, infer::coerce::CoerceMany, lower::ImplTraitLoweringMode,
     static_lifetime, to_assoc_type_id, traits::FnTrait, AliasEq, AliasTy, ClosureId, DomainGoal,
     GenericArg, Goal, ImplTraitId, InEnvironment, Interner, ProjectionTy, RpitId, Substitution,
-    TraitRef, Ty, TyBuilder, TyExt, TyKind,
+    TraitEnvironment, TraitRef, Ty, TyBuilder, TyExt, TyKind,
 };
 
 // This lint has a false positive here. See the link below for details.
@@ -117,11 +117,10 @@ pub(crate) fn infer_query(db: &dyn HirDatabase, def: DefWithBodyId) -> Arc<Infer
 ///
 /// This is appropriate to use only after type-check: it assumes
 /// that normalization will succeed, for example.
-pub(crate) fn normalize(db: &dyn HirDatabase, owner: DefWithBodyId, ty: Ty) -> Ty {
+pub(crate) fn normalize(db: &dyn HirDatabase, trait_env: Arc<TraitEnvironment>, ty: Ty) -> Ty {
     if !ty.data(Interner).flags.intersects(TypeFlags::HAS_PROJECTION) {
         return ty;
     }
-    let trait_env = db.trait_environment_for_body(owner);
     let mut table = unify::InferenceTable::new(db, trait_env);
 
     let ty_with_vars = table.normalize_associated_types_in(ty);

--- a/crates/hir-ty/src/infer/coerce.rs
+++ b/crates/hir-ty/src/infer/coerce.rs
@@ -21,8 +21,10 @@ use crate::{
         Adjust, Adjustment, AutoBorrow, InferOk, InferenceContext, OverloadedDeref, PointerCast,
         TypeError, TypeMismatch,
     },
-    static_lifetime, Canonical, DomainGoal, FnPointer, FnSig, Guidance, InEnvironment, Interner,
-    Solution, Substitution, TraitEnvironment, Ty, TyBuilder, TyExt,
+    static_lifetime,
+    utils::ClosureSubst,
+    Canonical, DomainGoal, FnPointer, FnSig, Guidance, InEnvironment, Interner, Solution,
+    Substitution, TraitEnvironment, Ty, TyBuilder, TyExt,
 };
 
 use super::unify::InferenceTable;
@@ -670,7 +672,7 @@ impl<'a> InferenceTable<'a> {
 }
 
 fn coerce_closure_fn_ty(closure_substs: &Substitution, safety: chalk_ir::Safety) -> Ty {
-    let closure_sig = closure_substs.at(Interner, 0).assert_ty_ref(Interner).clone();
+    let closure_sig = ClosureSubst(closure_substs).sig_ty().clone();
     match closure_sig.kind(Interner) {
         TyKind::Function(fn_ty) => TyKind::Function(FnPointer {
             num_binders: fn_ty.num_binders,

--- a/crates/hir-ty/src/infer/expr.rs
+++ b/crates/hir-ty/src/infer/expr.rs
@@ -282,7 +282,7 @@ impl<'a> InferenceContext<'a> {
                         let closure_id = self.db.intern_closure((self.owner, tgt_expr)).into();
                         let closure_ty = TyKind::Closure(
                             closure_id,
-                            Substitution::from1(Interner, sig_ty.clone()),
+                            TyBuilder::subst_for_closure(self.db, self.owner, sig_ty.clone()),
                         )
                         .intern(Interner);
                         self.deferred_closures.entry(closure_id).or_default();

--- a/crates/hir-ty/src/layout/tests.rs
+++ b/crates/hir-ty/src/layout/tests.rs
@@ -219,6 +219,22 @@ fn generic() {
 }
 
 #[test]
+fn associated_types() {
+    size_and_align! {
+        trait Tr {
+            type Ty;
+        }
+
+        impl Tr for i32 {
+            type Ty = i64;
+        }
+
+        struct Foo<A: Tr>(<A as Tr>::Ty);
+        struct Goal(Foo<i32>);
+    }
+}
+
+#[test]
 fn return_position_impl_trait() {
     size_and_align_expr! {
         trait T {}

--- a/crates/hir-ty/src/mir/borrowck.rs
+++ b/crates/hir-ty/src/mir/borrowck.rs
@@ -13,7 +13,7 @@ use crate::{db::HirDatabase, ClosureId};
 
 use super::{
     BasicBlockId, BorrowKind, LocalId, MirBody, MirLowerError, MirSpan, Place, ProjectionElem,
-    Rvalue, StatementKind, Terminator,
+    Rvalue, StatementKind, TerminatorKind,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -141,26 +141,26 @@ fn ever_initialized_map(body: &MirBody) -> ArenaMap<BasicBlockId, ArenaMap<Local
             never!("Terminator should be none only in construction");
             return;
         };
-        let targets = match terminator {
-            Terminator::Goto { target } => vec![*target],
-            Terminator::SwitchInt { targets, .. } => targets.all_targets().to_vec(),
-            Terminator::Resume
-            | Terminator::Abort
-            | Terminator::Return
-            | Terminator::Unreachable => vec![],
-            Terminator::Call { target, cleanup, destination, .. } => {
+        let targets = match &terminator.kind {
+            TerminatorKind::Goto { target } => vec![*target],
+            TerminatorKind::SwitchInt { targets, .. } => targets.all_targets().to_vec(),
+            TerminatorKind::Resume
+            | TerminatorKind::Abort
+            | TerminatorKind::Return
+            | TerminatorKind::Unreachable => vec![],
+            TerminatorKind::Call { target, cleanup, destination, .. } => {
                 if destination.projection.len() == 0 && destination.local == l {
                     is_ever_initialized = true;
                 }
                 target.into_iter().chain(cleanup.into_iter()).copied().collect()
             }
-            Terminator::Drop { .. }
-            | Terminator::DropAndReplace { .. }
-            | Terminator::Assert { .. }
-            | Terminator::Yield { .. }
-            | Terminator::GeneratorDrop
-            | Terminator::FalseEdge { .. }
-            | Terminator::FalseUnwind { .. } => {
+            TerminatorKind::Drop { .. }
+            | TerminatorKind::DropAndReplace { .. }
+            | TerminatorKind::Assert { .. }
+            | TerminatorKind::Yield { .. }
+            | TerminatorKind::GeneratorDrop
+            | TerminatorKind::FalseEdge { .. }
+            | TerminatorKind::FalseUnwind { .. } => {
                 never!("We don't emit these MIR terminators yet");
                 vec![]
             }
@@ -228,21 +228,21 @@ fn mutability_of_locals(body: &MirBody) -> ArenaMap<LocalId, MutabilityReason> {
             never!("Terminator should be none only in construction");
             continue;
         };
-        match terminator {
-            Terminator::Goto { .. }
-            | Terminator::Resume
-            | Terminator::Abort
-            | Terminator::Return
-            | Terminator::Unreachable
-            | Terminator::FalseEdge { .. }
-            | Terminator::FalseUnwind { .. }
-            | Terminator::GeneratorDrop
-            | Terminator::SwitchInt { .. }
-            | Terminator::Drop { .. }
-            | Terminator::DropAndReplace { .. }
-            | Terminator::Assert { .. }
-            | Terminator::Yield { .. } => (),
-            Terminator::Call { destination, .. } => {
+        match &terminator.kind {
+            TerminatorKind::Goto { .. }
+            | TerminatorKind::Resume
+            | TerminatorKind::Abort
+            | TerminatorKind::Return
+            | TerminatorKind::Unreachable
+            | TerminatorKind::FalseEdge { .. }
+            | TerminatorKind::FalseUnwind { .. }
+            | TerminatorKind::GeneratorDrop
+            | TerminatorKind::SwitchInt { .. }
+            | TerminatorKind::Drop { .. }
+            | TerminatorKind::DropAndReplace { .. }
+            | TerminatorKind::Assert { .. }
+            | TerminatorKind::Yield { .. } => (),
+            TerminatorKind::Call { destination, .. } => {
                 if destination.projection.len() == 0 {
                     if ever_init_map.get(destination.local).copied().unwrap_or_default() {
                         push_mut_span(destination.local, MirSpan::Unknown);

--- a/crates/hir-ty/src/mir/eval/shim.rs
+++ b/crates/hir-ty/src/mir/eval/shim.rs
@@ -1,0 +1,396 @@
+//! Interpret intrinsics, lang items and `extern "C"` wellknown functions which their implementation
+//! is not available.
+
+use super::*;
+
+macro_rules! from_bytes {
+    ($ty:tt, $value:expr) => {
+        ($ty::from_le_bytes(match ($value).try_into() {
+            Ok(x) => x,
+            Err(_) => return Err(MirEvalError::TypeError("mismatched size")),
+        }))
+    };
+}
+
+macro_rules! not_supported {
+    ($x: expr) => {
+        return Err(MirEvalError::NotSupported(format!($x)))
+    };
+}
+
+impl Evaluator<'_> {
+    pub(super) fn detect_and_exec_special_function(
+        &mut self,
+        def: FunctionId,
+        args: &[IntervalAndTy],
+        generic_args: &Substitution,
+        locals: &Locals<'_>,
+        destination: Interval,
+        span: MirSpan,
+    ) -> Result<bool> {
+        let function_data = self.db.function_data(def);
+        let is_intrinsic = match &function_data.abi {
+            Some(abi) => *abi == Interned::new_str("rust-intrinsic"),
+            None => match def.lookup(self.db.upcast()).container {
+                hir_def::ItemContainerId::ExternBlockId(block) => {
+                    let id = block.lookup(self.db.upcast()).id;
+                    id.item_tree(self.db.upcast())[id.value].abi.as_deref()
+                        == Some("rust-intrinsic")
+                }
+                _ => false,
+            },
+        };
+        if is_intrinsic {
+            self.exec_intrinsic(
+                function_data.name.as_text().unwrap_or_default().as_str(),
+                args,
+                generic_args,
+                destination,
+                &locals,
+                span,
+            )?;
+            return Ok(true);
+        }
+        let alloc_fn = function_data
+            .attrs
+            .iter()
+            .filter_map(|x| x.path().as_ident())
+            .filter_map(|x| x.as_str())
+            .find(|x| {
+                [
+                    "rustc_allocator",
+                    "rustc_deallocator",
+                    "rustc_reallocator",
+                    "rustc_allocator_zeroed",
+                ]
+                .contains(x)
+            });
+        if let Some(alloc_fn) = alloc_fn {
+            self.exec_alloc_fn(alloc_fn, args, destination)?;
+            return Ok(true);
+        }
+        if let Some(x) = self.detect_lang_function(def) {
+            let arg_bytes =
+                args.iter().map(|x| Ok(x.get(&self)?.to_owned())).collect::<Result<Vec<_>>>()?;
+            let result = self.exec_lang_item(x, &arg_bytes)?;
+            destination.write_from_bytes(self, &result)?;
+            return Ok(true);
+        }
+        Ok(false)
+    }
+
+    fn exec_alloc_fn(
+        &mut self,
+        alloc_fn: &str,
+        args: &[IntervalAndTy],
+        destination: Interval,
+    ) -> Result<()> {
+        match alloc_fn {
+            "rustc_allocator_zeroed" | "rustc_allocator" => {
+                let [size, align] = args else {
+                    return Err(MirEvalError::TypeError("rustc_allocator args are not provided"));
+                };
+                let size = from_bytes!(usize, size.get(self)?);
+                let align = from_bytes!(usize, align.get(self)?);
+                let result = self.heap_allocate(size, align);
+                destination.write_from_bytes(self, &result.to_bytes())?;
+            }
+            "rustc_deallocator" => { /* no-op for now */ }
+            "rustc_reallocator" => {
+                let [ptr, old_size, align, new_size] = args else {
+                    return Err(MirEvalError::TypeError("rustc_allocator args are not provided"));
+                };
+                let ptr = Address::from_bytes(ptr.get(self)?)?;
+                let old_size = from_bytes!(usize, old_size.get(self)?);
+                let new_size = from_bytes!(usize, new_size.get(self)?);
+                let align = from_bytes!(usize, align.get(self)?);
+                let result = self.heap_allocate(new_size, align);
+                Interval { addr: result, size: old_size }
+                    .write_from_interval(self, Interval { addr: ptr, size: old_size })?;
+                destination.write_from_bytes(self, &result.to_bytes())?;
+            }
+            _ => not_supported!("unknown alloc function"),
+        }
+        Ok(())
+    }
+
+    fn detect_lang_function(&self, def: FunctionId) -> Option<LangItem> {
+        use LangItem::*;
+        let candidate = lang_attr(self.db.upcast(), def)?;
+        // We want to execute these functions with special logic
+        if [PanicFmt, BeginPanic, SliceLen].contains(&candidate) {
+            return Some(candidate);
+        }
+        None
+    }
+
+    fn exec_lang_item(&self, x: LangItem, args: &[Vec<u8>]) -> Result<Vec<u8>> {
+        use LangItem::*;
+        let mut args = args.iter();
+        match x {
+            // FIXME: we want to find the panic message from arguments, but it wouldn't work
+            // currently even if we do that, since macro expansion of panic related macros
+            // is dummy.
+            PanicFmt | BeginPanic => Err(MirEvalError::Panic("<format-args>".to_string())),
+            SliceLen => {
+                let arg = args
+                    .next()
+                    .ok_or(MirEvalError::TypeError("argument of <[T]>::len() is not provided"))?;
+                let ptr_size = arg.len() / 2;
+                Ok(arg[ptr_size..].into())
+            }
+            x => not_supported!("Executing lang item {x:?}"),
+        }
+    }
+
+    fn exec_intrinsic(
+        &mut self,
+        as_str: &str,
+        args: &[IntervalAndTy],
+        generic_args: &Substitution,
+        destination: Interval,
+        locals: &Locals<'_>,
+        span: MirSpan,
+    ) -> Result<()> {
+        // We are a single threaded runtime with no UB checking and no optimization, so
+        // we can implement these as normal functions.
+        if let Some(name) = as_str.strip_prefix("atomic_") {
+            let Some(ty) = generic_args.as_slice(Interner).get(0).and_then(|x| x.ty(Interner)) else {
+                return Err(MirEvalError::TypeError("atomic intrinsic generic arg is not provided"));
+            };
+            let Some(arg0) = args.get(0) else {
+                return Err(MirEvalError::TypeError("atomic intrinsic arg0 is not provided"));
+            };
+            let arg0_addr = Address::from_bytes(arg0.get(self)?)?;
+            let arg0_interval = Interval::new(
+                arg0_addr,
+                self.size_of_sized(ty, locals, "atomic intrinsic type arg")?,
+            );
+            if name.starts_with("load_") {
+                return destination.write_from_interval(self, arg0_interval);
+            }
+            let Some(arg1) = args.get(1) else {
+                return Err(MirEvalError::TypeError("atomic intrinsic arg1 is not provided"));
+            };
+            if name.starts_with("store_") {
+                return arg0_interval.write_from_interval(self, arg1.interval);
+            }
+            if name.starts_with("xchg_") {
+                destination.write_from_interval(self, arg0_interval)?;
+                return arg0_interval.write_from_interval(self, arg1.interval);
+            }
+            if name.starts_with("xadd_") {
+                destination.write_from_interval(self, arg0_interval)?;
+                let lhs = u128::from_le_bytes(pad16(arg0_interval.get(self)?, false));
+                let rhs = u128::from_le_bytes(pad16(arg1.get(self)?, false));
+                let ans = lhs.wrapping_add(rhs);
+                return arg0_interval
+                    .write_from_bytes(self, &ans.to_le_bytes()[0..destination.size]);
+            }
+            if name.starts_with("xsub_") {
+                destination.write_from_interval(self, arg0_interval)?;
+                let lhs = u128::from_le_bytes(pad16(arg0_interval.get(self)?, false));
+                let rhs = u128::from_le_bytes(pad16(arg1.get(self)?, false));
+                let ans = lhs.wrapping_sub(rhs);
+                return arg0_interval
+                    .write_from_bytes(self, &ans.to_le_bytes()[0..destination.size]);
+            }
+            if name.starts_with("and_") {
+                destination.write_from_interval(self, arg0_interval)?;
+                let lhs = u128::from_le_bytes(pad16(arg0_interval.get(self)?, false));
+                let rhs = u128::from_le_bytes(pad16(arg1.get(self)?, false));
+                let ans = lhs & rhs;
+                return arg0_interval
+                    .write_from_bytes(self, &ans.to_le_bytes()[0..destination.size]);
+            }
+            if name.starts_with("or_") {
+                destination.write_from_interval(self, arg0_interval)?;
+                let lhs = u128::from_le_bytes(pad16(arg0_interval.get(self)?, false));
+                let rhs = u128::from_le_bytes(pad16(arg1.get(self)?, false));
+                let ans = lhs | rhs;
+                return arg0_interval
+                    .write_from_bytes(self, &ans.to_le_bytes()[0..destination.size]);
+            }
+            if name.starts_with("xor_") {
+                destination.write_from_interval(self, arg0_interval)?;
+                let lhs = u128::from_le_bytes(pad16(arg0_interval.get(self)?, false));
+                let rhs = u128::from_le_bytes(pad16(arg1.get(self)?, false));
+                let ans = lhs ^ rhs;
+                return arg0_interval
+                    .write_from_bytes(self, &ans.to_le_bytes()[0..destination.size]);
+            }
+            if name.starts_with("nand_") {
+                destination.write_from_interval(self, arg0_interval)?;
+                let lhs = u128::from_le_bytes(pad16(arg0_interval.get(self)?, false));
+                let rhs = u128::from_le_bytes(pad16(arg1.get(self)?, false));
+                let ans = !(lhs & rhs);
+                return arg0_interval
+                    .write_from_bytes(self, &ans.to_le_bytes()[0..destination.size]);
+            }
+            let Some(arg2) = args.get(2) else {
+                return Err(MirEvalError::TypeError("atomic intrinsic arg2 is not provided"));
+            };
+            if name.starts_with("cxchg_") || name.starts_with("cxchgweak_") {
+                let dest = if arg1.get(self)? == arg0_interval.get(self)? {
+                    arg0_interval.write_from_interval(self, arg2.interval)?;
+                    (arg1.interval, true)
+                } else {
+                    (arg0_interval, false)
+                };
+                let result_ty = TyKind::Tuple(
+                    2,
+                    Substitution::from_iter(Interner, [ty.clone(), TyBuilder::bool()]),
+                )
+                .intern(Interner);
+                let layout = self.layout(&result_ty)?;
+                let result = self.make_by_layout(
+                    layout.size.bytes_usize(),
+                    &layout,
+                    None,
+                    [
+                        IntervalOrOwned::Borrowed(dest.0),
+                        IntervalOrOwned::Owned(vec![u8::from(dest.1)]),
+                    ]
+                    .into_iter(),
+                )?;
+                return destination.write_from_bytes(self, &result);
+            }
+            not_supported!("unknown atomic intrinsic {name}");
+        }
+        match as_str {
+            "size_of" => {
+                let Some(ty) = generic_args.as_slice(Interner).get(0).and_then(|x| x.ty(Interner)) else {
+                    return Err(MirEvalError::TypeError("size_of generic arg is not provided"));
+                };
+                let size = self.size_of_sized(ty, locals, "size_of arg")?;
+                destination.write_from_bytes(self, &size.to_le_bytes()[0..destination.size])
+            }
+            "min_align_of" | "pref_align_of" => {
+                let Some(ty) = generic_args.as_slice(Interner).get(0).and_then(|x| x.ty(Interner)) else {
+                    return Err(MirEvalError::TypeError("align_of generic arg is not provided"));
+                };
+                let align = self.layout_filled(ty, locals)?.align.abi.bytes();
+                destination.write_from_bytes(self, &align.to_le_bytes()[0..destination.size])
+            }
+            "needs_drop" => {
+                let Some(ty) = generic_args.as_slice(Interner).get(0).and_then(|x| x.ty(Interner)) else {
+                    return Err(MirEvalError::TypeError("size_of generic arg is not provided"));
+                };
+                let result = !ty.clone().is_copy(self.db, locals.body.owner);
+                destination.write_from_bytes(self, &[u8::from(result)])
+            }
+            "ptr_guaranteed_cmp" => {
+                // FIXME: this is wrong for const eval, it should return 2 in some
+                // cases.
+                let [lhs, rhs] = args else {
+                    return Err(MirEvalError::TypeError("wrapping_add args are not provided"));
+                };
+                let ans = lhs.get(self)? == rhs.get(self)?;
+                destination.write_from_bytes(self, &[u8::from(ans)])
+            }
+            "wrapping_add" => {
+                let [lhs, rhs] = args else {
+                    return Err(MirEvalError::TypeError("wrapping_add args are not provided"));
+                };
+                let lhs = u128::from_le_bytes(pad16(lhs.get(self)?, false));
+                let rhs = u128::from_le_bytes(pad16(rhs.get(self)?, false));
+                let ans = lhs.wrapping_add(rhs);
+                destination.write_from_bytes(self, &ans.to_le_bytes()[0..destination.size])
+            }
+            "add_with_overflow" => {
+                let [lhs, rhs] = args else {
+                    return Err(MirEvalError::TypeError("const_eval_select args are not provided"));
+                };
+                let result_ty = TyKind::Tuple(
+                    2,
+                    Substitution::from_iter(Interner, [lhs.ty.clone(), TyBuilder::bool()]),
+                )
+                .intern(Interner);
+                let op_size =
+                    self.size_of_sized(&lhs.ty, locals, "operand of add_with_overflow")?;
+                let lhs = u128::from_le_bytes(pad16(lhs.get(self)?, false));
+                let rhs = u128::from_le_bytes(pad16(rhs.get(self)?, false));
+                let ans = lhs.wrapping_add(rhs);
+                let is_overflow = false;
+                let is_overflow = vec![u8::from(is_overflow)];
+                let layout = self.layout(&result_ty)?;
+                let result = self.make_by_layout(
+                    layout.size.bytes_usize(),
+                    &layout,
+                    None,
+                    [ans.to_le_bytes()[0..op_size].to_vec(), is_overflow]
+                        .into_iter()
+                        .map(IntervalOrOwned::Owned),
+                )?;
+                destination.write_from_bytes(self, &result)
+            }
+            "copy" | "copy_nonoverlapping" => {
+                let [src, dst, offset] = args else {
+                    return Err(MirEvalError::TypeError("copy_nonoverlapping args are not provided"));
+                };
+                let Some(ty) = generic_args.as_slice(Interner).get(0).and_then(|x| x.ty(Interner)) else {
+                    return Err(MirEvalError::TypeError("copy_nonoverlapping generic arg is not provided"));
+                };
+                let src = Address::from_bytes(src.get(self)?)?;
+                let dst = Address::from_bytes(dst.get(self)?)?;
+                let offset = from_bytes!(usize, offset.get(self)?);
+                let size = self.size_of_sized(ty, locals, "copy_nonoverlapping ptr type")?;
+                let size = offset * size;
+                let src = Interval { addr: src, size };
+                let dst = Interval { addr: dst, size };
+                dst.write_from_interval(self, src)
+            }
+            "offset" | "arith_offset" => {
+                let [ptr, offset] = args else {
+                    return Err(MirEvalError::TypeError("offset args are not provided"));
+                };
+                let Some(ty) = generic_args.as_slice(Interner).get(0).and_then(|x| x.ty(Interner)) else {
+                    return Err(MirEvalError::TypeError("offset generic arg is not provided"));
+                };
+                let ptr = u128::from_le_bytes(pad16(ptr.get(self)?, false));
+                let offset = u128::from_le_bytes(pad16(offset.get(self)?, false));
+                let size = self.size_of_sized(ty, locals, "offset ptr type")? as u128;
+                let ans = ptr + offset * size;
+                destination.write_from_bytes(self, &ans.to_le_bytes()[0..destination.size])
+            }
+            "assert_inhabited" | "assert_zero_valid" | "assert_uninit_valid" | "assume" => {
+                // FIXME: We should actually implement these checks
+                Ok(())
+            }
+            "forget" => {
+                // We don't call any drop glue yet, so there is nothing here
+                Ok(())
+            }
+            "transmute" => {
+                let [arg] = args else {
+                    return Err(MirEvalError::TypeError("trasmute arg is not provided"));
+                };
+                destination.write_from_interval(self, arg.interval)
+            }
+            "likely" | "unlikely" => {
+                let [arg] = args else {
+                    return Err(MirEvalError::TypeError("likely arg is not provided"));
+                };
+                destination.write_from_interval(self, arg.interval)
+            }
+            "const_eval_select" => {
+                let [tuple, const_fn, _] = args else {
+                    return Err(MirEvalError::TypeError("const_eval_select args are not provided"));
+                };
+                let mut args = vec![const_fn.clone()];
+                let TyKind::Tuple(_, fields) = tuple.ty.kind(Interner) else {
+                    return Err(MirEvalError::TypeError("const_eval_select arg[0] is not a tuple"));
+                };
+                let layout = self.layout(&tuple.ty)?;
+                for (i, field) in fields.iter(Interner).enumerate() {
+                    let field = field.assert_ty_ref(Interner).clone();
+                    let offset = layout.fields.offset(i).bytes_usize();
+                    let addr = tuple.interval.addr.offset(offset);
+                    args.push(IntervalAndTy::new(addr, field, self, locals)?);
+                }
+                self.exec_fn_trait(&args, destination, locals, span)
+            }
+            _ => not_supported!("unknown intrinsic {as_str}"),
+        }
+    }
+}

--- a/crates/ide/src/hover.rs
+++ b/crates/ide/src/hover.rs
@@ -30,7 +30,6 @@ pub struct HoverConfig {
     pub documentation: bool,
     pub keywords: bool,
     pub format: HoverDocFormat,
-    pub interpret_tests: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/crates/ide/src/hover/render.rs
+++ b/crates/ide/src/hover/render.rs
@@ -3,8 +3,7 @@ use std::fmt::Display;
 
 use either::Either;
 use hir::{
-    db::DefDatabase, Adt, AsAssocItem, AttributeTemplate, HasAttrs, HasSource, HirDisplay,
-    MirEvalError, Semantics, TypeInfo,
+    Adt, AsAssocItem, AttributeTemplate, HasAttrs, HasSource, HirDisplay, Semantics, TypeInfo,
 };
 use ide_db::{
     base_db::SourceDatabase,
@@ -435,19 +434,7 @@ pub(super) fn definition(
             ))
         }),
         Definition::Module(it) => label_and_docs(db, it),
-        Definition::Function(it) => label_and_layout_info_and_docs(db, it, |_| {
-            if !config.interpret_tests {
-                return None;
-            }
-            match it.eval(db) {
-                Ok(()) => Some("pass".into()),
-                Err(MirEvalError::MirLowerError(f, e)) => {
-                    let name = &db.function_data(f).name;
-                    Some(format!("error: fail to lower {name} due {e:?}"))
-                }
-                Err(e) => Some(format!("error: {e:?}")),
-            }
-        }),
+        Definition::Function(it) => label_and_docs(db, it),
         Definition::Adt(it) => label_and_layout_info_and_docs(db, it, |&it| {
             let layout = it.layout(db).ok()?;
             Some(format!("size = {}, align = {}", layout.size.bytes(), layout.align.abi.bytes()))

--- a/crates/ide/src/hover/tests.rs
+++ b/crates/ide/src/hover/tests.rs
@@ -9,7 +9,6 @@ const HOVER_BASE_CONFIG: HoverConfig = HoverConfig {
     documentation: true,
     format: HoverDocFormat::Markdown,
     keywords: true,
-    interpret_tests: false,
 };
 
 fn check_hover_no_result(ra_fixture: &str) {

--- a/crates/ide/src/inlay_hints/chaining.rs
+++ b/crates/ide/src/inlay_hints/chaining.rs
@@ -444,7 +444,7 @@ fn main() {
                                         file_id: FileId(
                                             1,
                                         ),
-                                        range: 5768..5776,
+                                        range: 5769..5777,
                                     },
                                 ),
                                 tooltip: "",
@@ -457,7 +457,7 @@ fn main() {
                                         file_id: FileId(
                                             1,
                                         ),
-                                        range: 5800..5804,
+                                        range: 5801..5805,
                                     },
                                 ),
                                 tooltip: "",
@@ -478,7 +478,7 @@ fn main() {
                                         file_id: FileId(
                                             1,
                                         ),
-                                        range: 5768..5776,
+                                        range: 5769..5777,
                                     },
                                 ),
                                 tooltip: "",
@@ -491,7 +491,7 @@ fn main() {
                                         file_id: FileId(
                                             1,
                                         ),
-                                        range: 5800..5804,
+                                        range: 5801..5805,
                                     },
                                 ),
                                 tooltip: "",
@@ -512,7 +512,7 @@ fn main() {
                                         file_id: FileId(
                                             1,
                                         ),
-                                        range: 5768..5776,
+                                        range: 5769..5777,
                                     },
                                 ),
                                 tooltip: "",
@@ -525,7 +525,7 @@ fn main() {
                                         file_id: FileId(
                                             1,
                                         ),
-                                        range: 5800..5804,
+                                        range: 5801..5805,
                                     },
                                 ),
                                 tooltip: "",

--- a/crates/ide/src/interpret_function.rs
+++ b/crates/ide/src/interpret_function.rs
@@ -1,0 +1,49 @@
+use hir::Semantics;
+use ide_db::base_db::SourceDatabaseExt;
+use ide_db::RootDatabase;
+use ide_db::{base_db::FilePosition, LineIndexDatabase};
+use std::{fmt::Write, time::Instant};
+use syntax::TextRange;
+use syntax::{algo::find_node_at_offset, ast, AstNode};
+
+// Feature: Interpret Function
+//
+// |===
+// | Editor  | Action Name
+//
+// | VS Code | **rust-analyzer: Interpret Function**
+// |===
+pub(crate) fn interpret_function(db: &RootDatabase, position: FilePosition) -> String {
+    let start_time = Instant::now();
+    let mut result = find_and_interpret(db, position)
+        .unwrap_or_else(|| "Not inside a function body".to_string());
+    let duration = Instant::now() - start_time;
+    writeln!(result, "").unwrap();
+    writeln!(result, "----------------------").unwrap();
+    writeln!(result, "  Finished in {}s", duration.as_secs_f32()).unwrap();
+    result
+}
+
+fn find_and_interpret(db: &RootDatabase, position: FilePosition) -> Option<String> {
+    let sema = Semantics::new(db);
+    let source_file = sema.parse(position.file_id);
+
+    let item = find_node_at_offset::<ast::Item>(source_file.syntax(), position.offset)?;
+    let def = match item {
+        ast::Item::Fn(it) => sema.to_def(&it)?,
+        _ => return None,
+    };
+    let span_formatter = |file_id, text_range: TextRange| {
+        let line_col = db.line_index(file_id).line_col(text_range.start());
+        let path = &db
+            .source_root(db.file_source_root(file_id))
+            .path_for_file(&file_id)
+            .map(|x| x.to_string());
+        let path = path.as_deref().unwrap_or("<unknown file>");
+        format!("file://{path}#{}:{}", line_col.line + 1, line_col.col)
+    };
+    match def.eval(db, span_formatter) {
+        Ok(_) => Some("pass".to_string()),
+        Err(e) => Some(e),
+    }
+}

--- a/crates/ide/src/lib.rs
+++ b/crates/ide/src/lib.rs
@@ -56,6 +56,7 @@ mod typing;
 mod view_crate_graph;
 mod view_hir;
 mod view_mir;
+mod interpret_function;
 mod view_item_tree;
 mod shuffle_crate_graph;
 
@@ -315,6 +316,10 @@ impl Analysis {
 
     pub fn view_mir(&self, position: FilePosition) -> Cancellable<String> {
         self.with_db(|db| view_mir::view_mir(db, position))
+    }
+
+    pub fn interpret_function(&self, position: FilePosition) -> Cancellable<String> {
+        self.with_db(|db| interpret_function::interpret_function(db, position))
     }
 
     pub fn view_item_tree(&self, file_id: FileId) -> Cancellable<String> {

--- a/crates/ide/src/static_index.rs
+++ b/crates/ide/src/static_index.rs
@@ -140,7 +140,6 @@ impl StaticIndex<'_> {
             documentation: true,
             keywords: true,
             format: crate::HoverDocFormat::Markdown,
-            interpret_tests: false,
         };
         let tokens = tokens.filter(|token| {
             matches!(

--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -574,6 +574,7 @@ pub struct LensConfig {
     // runnables
     pub run: bool,
     pub debug: bool,
+    pub interpret: bool,
 
     // implementations
     pub implementations: bool,
@@ -1423,6 +1424,9 @@ impl Config {
         LensConfig {
             run: self.data.lens_enable && self.data.lens_run_enable,
             debug: self.data.lens_enable && self.data.lens_debug_enable,
+            interpret: self.data.lens_enable
+                && self.data.lens_run_enable
+                && self.data.interpret_tests,
             implementations: self.data.lens_enable && self.data.lens_implementations_enable,
             method_refs: self.data.lens_enable && self.data.lens_references_method_enable,
             refs_adt: self.data.lens_enable && self.data.lens_references_adt_enable,
@@ -1481,7 +1485,6 @@ impl Config {
                 }
             },
             keywords: self.data.hover_documentation_keywords_enable,
-            interpret_tests: self.data.interpret_tests,
         }
     }
 

--- a/crates/rust-analyzer/src/handlers.rs
+++ b/crates/rust-analyzer/src/handlers.rs
@@ -163,6 +163,16 @@ pub(crate) fn handle_view_mir(
     Ok(res)
 }
 
+pub(crate) fn handle_interpret_function(
+    snap: GlobalStateSnapshot,
+    params: lsp_types::TextDocumentPositionParams,
+) -> Result<String> {
+    let _p = profile::span("handle_interpret_function");
+    let position = from_proto::file_position(&snap, params)?;
+    let res = snap.analysis.interpret_function(position)?;
+    Ok(res)
+}
+
 pub(crate) fn handle_view_file_text(
     snap: GlobalStateSnapshot,
     params: lsp_types::TextDocumentIdentifier,

--- a/crates/rust-analyzer/src/lsp_ext.rs
+++ b/crates/rust-analyzer/src/lsp_ext.rs
@@ -90,6 +90,14 @@ impl Request for ViewMir {
     const METHOD: &'static str = "rust-analyzer/viewMir";
 }
 
+pub enum InterpretFunction {}
+
+impl Request for InterpretFunction {
+    type Params = lsp_types::TextDocumentPositionParams;
+    type Result = String;
+    const METHOD: &'static str = "rust-analyzer/interpretFunction";
+}
+
 pub enum ViewFileText {}
 
 impl Request for ViewFileText {

--- a/crates/rust-analyzer/src/main_loop.rs
+++ b/crates/rust-analyzer/src/main_loop.rs
@@ -665,6 +665,7 @@ impl GlobalState {
             .on::<lsp_ext::SyntaxTree>(handlers::handle_syntax_tree)
             .on::<lsp_ext::ViewHir>(handlers::handle_view_hir)
             .on::<lsp_ext::ViewMir>(handlers::handle_view_mir)
+            .on::<lsp_ext::InterpretFunction>(handlers::handle_interpret_function)
             .on::<lsp_ext::ViewFileText>(handlers::handle_view_file_text)
             .on::<lsp_ext::ViewCrateGraph>(handlers::handle_view_crate_graph)
             .on::<lsp_ext::ViewItemTree>(handlers::handle_view_item_tree)

--- a/crates/rust-analyzer/src/to_proto.rs
+++ b/crates/rust-analyzer/src/to_proto.rs
@@ -1215,6 +1215,14 @@ pub(crate) fn code_lens(
                     data: None,
                 })
             }
+            if lens_config.interpret {
+                let command = command::interpret_single(&r);
+                acc.push(lsp_types::CodeLens {
+                    range: annotation_range,
+                    command: Some(command),
+                    data: None,
+                })
+            }
         }
         AnnotationKind::HasImpls { pos: file_range, data } => {
             if !client_commands_config.show_reference {
@@ -1356,6 +1364,15 @@ pub(crate) mod command {
             title: "Debug".into(),
             command: "rust-analyzer.debugSingle".into(),
             arguments: Some(vec![to_value(runnable).unwrap()]),
+        }
+    }
+
+    pub(crate) fn interpret_single(_runnable: &lsp_ext::Runnable) -> lsp_types::Command {
+        lsp_types::Command {
+            title: "Interpret".into(),
+            command: "rust-analyzer.interpretFunction".into(),
+            // FIXME: use the `_runnable` here.
+            arguments: Some(vec![]),
         }
     }
 

--- a/docs/dev/lsp-extensions.md
+++ b/docs/dev/lsp-extensions.md
@@ -1,5 +1,5 @@
 <!---
-lsp_ext.rs hash: be2f663a78beb7bd
+lsp_ext.rs hash: 37ac44a0f507e05a
 
 If you need to change the above hash to make the test pass, please check if you
 need to adjust this doc as well and ping this issue:
@@ -547,6 +547,18 @@ For debugging or when working on rust-analyzer itself.
 
 Returns a textual representation of the MIR of the function containing the cursor.
 For debugging or when working on rust-analyzer itself.
+
+## Interpret Function
+
+**Method:** `rust-analyzer/interpretFunction`
+
+**Request:** `TextDocumentPositionParams`
+
+**Response:** `string`
+
+Tries to evaluate the function using internal rust analyzer knowledge, without compiling
+the code. Currently evaluates the function under cursor, but will give a runnable in
+future. Highly experimental.
 
 ## View File Text
 

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -121,6 +121,11 @@
                 "category": "rust-analyzer (debug command)"
             },
             {
+                "command": "rust-analyzer.interpretFunction",
+                "title": "Interpret Function",
+                "category": "rust-analyzer (debug command)"
+            },
+            {
                 "command": "rust-analyzer.viewFileText",
                 "title": "View File Text (as seen by the server)",
                 "category": "rust-analyzer (debug command)"

--- a/editors/code/src/lsp_ext.ts
+++ b/editors/code/src/lsp_ext.ts
@@ -64,6 +64,9 @@ export const viewHir = new lc.RequestType<lc.TextDocumentPositionParams, string,
 export const viewMir = new lc.RequestType<lc.TextDocumentPositionParams, string, void>(
     "rust-analyzer/viewMir"
 );
+export const interpretFunction = new lc.RequestType<lc.TextDocumentPositionParams, string, void>(
+    "rust-analyzer/interpretFunction"
+);
 export const viewItemTree = new lc.RequestType<ViewItemTreeParams, string, void>(
     "rust-analyzer/viewItemTree"
 );

--- a/editors/code/src/main.ts
+++ b/editors/code/src/main.ts
@@ -159,6 +159,7 @@ function createCommands(): Record<string, CommandFactory> {
         syntaxTree: { enabled: commands.syntaxTree },
         viewHir: { enabled: commands.viewHir },
         viewMir: { enabled: commands.viewMir },
+        interpretFunction: { enabled: commands.interpretFunction },
         viewFileText: { enabled: commands.viewFileText },
         viewItemTree: { enabled: commands.viewItemTree },
         viewCrateGraph: { enabled: commands.viewCrateGraph },


### PR DESCRIPTION
In lowering, it now supports overloaded and arith assignment binary operators, statics. and constants in patterns. There is now 252 functions that we fail to emit mir for them, and the majority of them are due type mismatches or other deep and unrelated issues (but it isn't done yet, for example slice patterns and destructing assignment is not implemented yet).

In evaluating, it now can evaluate associated constants in traits (so now typenum's `U5::ToConst` should work), allocator functions, atomic intrinsics, and some more things. It also provides a (hacky) basis for making progress in #14275. I also added a `Interpret` code lens to `Run` and `Debug` when the experimental `interpret tests` is enabled (previously it showed result in hover, which was unusable even for debugging)

Changes in unrelated files are:
* Changes substitutions of closures, now it includes parent substs ~~before~~ after `sig_ty`.
* ~~A salsa input for retrieving the path of a file id, used in emitting stack trace for interpret result.~~
* Normalizing associated types in layout computing