### PR TITLE
internal: Reduce memory consumption by not merging trait_impls_in_deps results

### DIFF
--- a/crates/hir-ty/src/db.rs
+++ b/crates/hir-ty/src/db.rs
@@ -134,7 +134,7 @@ pub trait HirDatabase: DefDatabase + Upcast<dyn DefDatabase> {
     fn trait_impls_in_block(&self, block: BlockId) -> Arc<TraitImpls>;
 
     #[salsa::invoke(TraitImpls::trait_impls_in_deps_query)]
-    fn trait_impls_in_deps(&self, krate: CrateId) -> Arc<TraitImpls>;
+    fn trait_impls_in_deps(&self, krate: CrateId) -> Arc<[Arc<TraitImpls>]>;
 
     // Interned IDs for Chalk integration
     #[salsa::interned]


### PR DESCRIPTION
Closes https://github.com/rust-lang/rust-analyzer/issues/9167

We effectively keep a lot of copies of `TraitImpl` results in memory by merging them into the result of this query. This wastes a lot of memory unnecessarily. The change here brings memory usage of self down by 50mb (at a slight cost of trait solving unfortunately, though I'm hopeful it was just noice)