### PR TITLE
internal: Forbid canonicalization of paths and normalize all rust-project.json paths

### DIFF
--- a/crates/paths/src/lib.rs
+++ b/crates/paths/src/lib.rs
@@ -166,9 +166,8 @@ impl AbsPath {
         AbsPathBuf::try_from(self.0.to_path_buf()).unwrap()
     }
 
-    /// Equivalent of [`Path::canonicalize`] for `AbsPath`.
-    pub fn canonicalize(&self) -> Result<AbsPathBuf, std::io::Error> {
-        Ok(self.as_ref().canonicalize()?.try_into().unwrap())
+    pub fn canonicalize(&self) -> ! {
+        panic!("We explicitly do not provide canonicalization API, as that is almost always a wrong solution, see #14430")
     }
 
     /// Equivalent of [`Path::strip_prefix`] for `AbsPath`.

--- a/crates/paths/src/lib.rs
+++ b/crates/paths/src/lib.rs
@@ -140,6 +140,11 @@ impl AbsPath {
         self.0.parent().map(AbsPath::assert)
     }
 
+    /// Equivalent of [`Path::join`] for `AbsPath` with an additional normalize step afterwards.
+    pub fn absolutize(&self, path: impl AsRef<Path>) -> AbsPathBuf {
+        self.join(path).normalize()
+    }
+
     /// Equivalent of [`Path::join`] for `AbsPath`.
     pub fn join(&self, path: impl AsRef<Path>) -> AbsPathBuf {
         self.as_ref().join(path).try_into().unwrap()

--- a/crates/project-model/src/manifest_path.rs
+++ b/crates/project-model/src/manifest_path.rs
@@ -35,9 +35,8 @@ impl ManifestPath {
         self.file.parent().unwrap()
     }
 
-    /// Equivalent of [`Path::canonicalize`] for `ManifestPath`.
-    pub fn canonicalize(&self) -> Result<ManifestPath, std::io::Error> {
-        Ok((&**self).canonicalize()?.try_into().unwrap())
+    pub fn canonicalize(&self) -> ! {
+        (&**self).canonicalize()
     }
 }
 

--- a/crates/project-model/src/workspace.rs
+++ b/crates/project-model/src/workspace.rs
@@ -179,7 +179,6 @@ impl ProjectWorkspace {
         };
         let res = match manifest {
             ProjectManifest::ProjectJson(project_json) => {
-                let project_json = project_json.canonicalize()?;
                 let file = fs::read_to_string(&project_json).with_context(|| {
                     format!("Failed to read json file {}", project_json.display())
                 })?;


### PR DESCRIPTION
Closes https://github.com/rust-lang/rust-analyzer/issues/14728
cc https://github.com/rust-lang/rust-analyzer/pull/14430

- Removes canonicalization (and forbids it from being used in a sense, clippy could help here again with its lint in the future)
- Normalizes all paths in rust-project.json which we weren't doing in some cases