### PR TITLE
Sort rust dependencies in vscode tree view

### DIFF
--- a/editors/code/src/dependencies_provider.ts
+++ b/editors/code/src/dependencies_provider.ts
@@ -89,6 +89,8 @@ export class RustDependenciesProvider
             const dep = this.toDep(crate.name || "unknown", crate.version || "", crate.path);
             this.dependenciesMap[dep.dependencyPath.toLowerCase()] = dep;
             return dep;
+        }).sort((a, b) => {
+            return a.label.localeCompare(b.label)
         });
     }
 

--- a/editors/code/src/dependencies_provider.ts
+++ b/editors/code/src/dependencies_provider.ts
@@ -85,13 +85,15 @@ export class RustDependenciesProvider
         );
         const crates = dependenciesResult.crates;
 
-        return crates.map((crate) => {
-            const dep = this.toDep(crate.name || "unknown", crate.version || "", crate.path);
-            this.dependenciesMap[dep.dependencyPath.toLowerCase()] = dep;
-            return dep;
-        }).sort((a, b) => {
-            return a.label.localeCompare(b.label)
-        });
+        return crates
+            .map((crate) => {
+                const dep = this.toDep(crate.name || "unknown", crate.version || "", crate.path);
+                this.dependenciesMap[dep.dependencyPath.toLowerCase()] = dep;
+                return dep;
+            })
+            .sort((a, b) => {
+                return a.label.localeCompare(b.label);
+            });
     }
 
     private toDep(moduleName: string, version: string, path: string): Dependency {


### PR DESCRIPTION
Sorts alphabetically based on dependency name. Fixes #14729