### PR TITLE
More APIs for `la_arena::IdxRange`

### DIFF
--- a/lib/la-arena/src/lib.rs
+++ b/lib/la-arena/src/lib.rs
@@ -184,6 +184,24 @@ impl<T> Iterator for IdxRange<T> {
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.range.size_hint()
     }
+
+    fn count(self) -> usize
+    where
+        Self: Sized,
+    {
+        self.range.count()
+    }
+
+    fn last(self) -> Option<Self::Item>
+    where
+        Self: Sized,
+    {
+        self.range.last().map(|raw| Idx::from_raw(raw.into()))
+    }
+
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        self.range.nth(n).map(|raw| Idx::from_raw(raw.into()))
+    }
 }
 
 impl<T> DoubleEndedIterator for IdxRange<T> {

--- a/lib/la-arena/src/lib.rs
+++ b/lib/la-arena/src/lib.rs
@@ -312,6 +312,21 @@ impl<T> Arena<T> {
         idx
     }
 
+    /// Densely allocates multiple values, returning the values’ index range.
+    ///
+    /// ```
+    /// let mut arena = la_arena::Arena::new();
+    /// let range = arena.alloc_many(0..4);
+    ///
+    /// assert_eq!(arena[range], [0, 1, 2, 3]);
+    /// ```
+    pub fn alloc_many<II: IntoIterator<Item = T>>(&mut self, iter: II) -> IdxRange<T> {
+        let start = self.next_idx();
+        self.extend(iter);
+        let end = self.next_idx();
+        IdxRange::new(start..end)
+    }
+
     /// Returns an iterator over the arena’s elements.
     ///
     /// ```

--- a/lib/la-arena/src/lib.rs
+++ b/lib/la-arena/src/lib.rs
@@ -176,8 +176,13 @@ impl<T> IdxRange<T> {
 
 impl<T> Iterator for IdxRange<T> {
     type Item = Idx<T>;
+
     fn next(&mut self) -> Option<Self::Item> {
         self.range.next().map(|raw| Idx::from_raw(raw.into()))
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.range.size_hint()
     }
 }
 
@@ -186,6 +191,8 @@ impl<T> DoubleEndedIterator for IdxRange<T> {
         self.range.next_back().map(|raw| Idx::from_raw(raw.into()))
     }
 }
+
+impl<T> ExactSizeIterator for IdxRange<T> {}
 
 impl<T> fmt::Debug for IdxRange<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/lib/la-arena/src/lib.rs
+++ b/lib/la-arena/src/lib.rs
@@ -6,7 +6,7 @@
 use std::{
     cmp, fmt,
     hash::{Hash, Hasher},
-    iter::Enumerate,
+    iter::{Enumerate, FusedIterator},
     marker::PhantomData,
     ops::{Index, IndexMut, Range, RangeInclusive},
 };
@@ -211,6 +211,8 @@ impl<T> DoubleEndedIterator for IdxRange<T> {
 }
 
 impl<T> ExactSizeIterator for IdxRange<T> {}
+
+impl<T> FusedIterator for IdxRange<T> {}
 
 impl<T> fmt::Debug for IdxRange<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/lib/la-arena/src/lib.rs
+++ b/lib/la-arena/src/lib.rs
@@ -168,7 +168,7 @@ impl<T> IdxRange<T> {
         Idx::from_raw(RawIdx::from(self.range.start))
     }
 
-    /// Returns the start of the index range.
+    /// Returns the end of the index range.
     pub fn end(&self) -> Idx<T> {
         Idx::from_raw(RawIdx::from(self.range.end))
     }


### PR DESCRIPTION
```rust
impl<T> ExactSizeIterator for IdxRange<T>;

impl<T> Arena<T> {
    pub fn alloc_many<II: IntoIterator<Item = T>>(&mut self, iter: II) -> IdxRange<T>;
}
```

1. There are no currently ways to get `IdxRange` without manually offseting `Idx`. Providing a method for multiple-allocation simplifies this process and makes it less error-prone.
2. `IdxRange: ExactSizeIterator` makes `iter.zip(range).rev()` possible. Since `Zip: DoubleEndedIterator` requires all its arguments to be `ExactSizeIterator`. It also ease the usage for, eg. `len()`.
3. Fixed a typo.

I noticed that `IdxRange::end` may be invalid. Is it good to return `Idx` instead of `RawIdx`?