### PR TITLE
Show type alias layout

### DIFF
--- a/crates/ide/src/hover/render.rs
+++ b/crates/ide/src/hover/render.rs
@@ -473,7 +473,10 @@ pub(super) fn definition(
         }),
         Definition::Trait(it) => label_and_docs(db, it),
         Definition::TraitAlias(it) => label_and_docs(db, it),
-        Definition::TypeAlias(it) => label_and_docs(db, it),
+        Definition::TypeAlias(it) => label_and_layout_info_and_docs(db, it, |&it| {
+            let layout = it.ty(db).layout(db).ok()?;
+            Some(format!("size = {}, align = {}", layout.size.bytes(), layout.align.abi.bytes()))
+        }),
         Definition::BuiltinType(it) => {
             return famous_defs
                 .and_then(|fd| builtin(fd, it))

--- a/crates/ide/src/hover/tests.rs
+++ b/crates/ide/src/hover/tests.rs
@@ -1405,7 +1405,7 @@ fn test_hover_function_pointer_show_identifiers() {
                 ```
 
                 ```rust
-                type foo = fn(a: i32, b: i32) -> i32
+                type foo = fn(a: i32, b: i32) -> i32 // size = 8, align = 8
                 ```
             "#]],
     );
@@ -1423,7 +1423,7 @@ fn test_hover_function_pointer_no_identifier() {
                 ```
 
                 ```rust
-                type foo = fn(i32, i32) -> i32
+                type foo = fn(i32, i32) -> i32 // size = 8, align = 8
                 ```
             "#]],
     );
@@ -3555,7 +3555,7 @@ type Fo$0o2 = Foo<2>;
                 ```
 
                 ```rust
-                type Foo2 = Foo<2>
+                type Foo2 = Foo<2> // size = 0, align = 1
                 ```
             "#]],
     );


### PR DESCRIPTION
This PR expands on #13490 to allow displaying layout data on hover for type aliases.