### PR TITLE
feat: define problem matcher for panics in VS Code

### DIFF
--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -1512,6 +1512,18 @@
                         "endColumn": 6
                     }
                 ]
+            },
+            {
+                "name": "rust-panic",
+                "patterns": [
+                    {
+                        "regexp": "^thread '.*' panicked at '(.*)', (.*):(\\d*):(\\d*)$",
+                        "message": 1,
+                        "file": 2,
+                        "line": 3,
+                        "column": 4
+                    }
+                ]
             }
         ],
         "languages": [
@@ -1560,6 +1572,16 @@
                     "${workspaceRoot}"
                 ],
                 "pattern": "$rustc-json"
+            },
+            {
+                "name": "rust-panic",
+                "owner": "rust-panic",
+                "source": "panic",
+                "fileLocation": [
+                    "autoDetect",
+                    "${workspaceRoot}"
+                ],
+                "pattern": "$rust-panic"
             },
             {
                 "name": "rustc-watch",

--- a/editors/code/src/tasks.ts
+++ b/editors/code/src/tasks.ts
@@ -128,7 +128,7 @@ export async function buildCargoTask(
         name,
         TASK_SOURCE,
         exec,
-        ["$rustc"]
+        ["$rustc", "$rust-panic"]
     );
 }
 


### PR DESCRIPTION
Now in VS Code "go to next error" (`F8`) will bring you to the source of a panic.