### PR TITLE
Fix libs publish branch filter

### DIFF
--- a/.github/workflows/publish-libs.yaml
+++ b/.github/workflows/publish-libs.yaml
@@ -3,9 +3,9 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - main
+      - master
     paths:
-      - 'lib/**'
+      - "lib/**"
 
 jobs:
   publish-libs:

--- a/lib/README.md
+++ b/lib/README.md
@@ -1,2 +1,5 @@
-Crates in this directory are published to crates.io and obey semver.
-They *could* live in a separate repo, but we want to experiment with a monorepo setup.
+# lib
+
+Crates in this directory are published to [crates.io](https://crates.io) and obey semver.
+
+They _could_ live in a separate repo, but we want to experiment with a monorepo setup.


### PR DESCRIPTION
line-index didn't actually get published from #14733, probably because the branch filter was for main but the main branch is called master here. This fixes the workflow file.

I also tweaked the libs readme mostly just so the paths filter would pick up the changes.