### PR TITLE
feat: add #[doc(alias(..))]-based method completions

### DIFF
--- a/crates/ide-completion/src/completions.rs
+++ b/crates/ide-completion/src/completions.rs
@@ -295,9 +295,12 @@ impl Completions {
             Visible::Editable => true,
             Visible::No => return,
         };
+        let doc_aliases = ctx.doc_aliases(&func);
         self.add(
             render_fn(
-                RenderContext::new(ctx).private_editable(is_private_editable),
+                RenderContext::new(ctx)
+                    .private_editable(is_private_editable)
+                    .doc_aliases(doc_aliases),
                 path_ctx,
                 local_name,
                 func,
@@ -322,9 +325,12 @@ impl Completions {
             Visible::Editable => true,
             Visible::No => return,
         };
+        let doc_aliases = ctx.doc_aliases(&func);
         self.add(
             render_method(
-                RenderContext::new(ctx).private_editable(is_private_editable),
+                RenderContext::new(ctx)
+                    .private_editable(is_private_editable)
+                    .doc_aliases(doc_aliases),
                 dot_access,
                 receiver,
                 local_name,
@@ -349,10 +355,12 @@ impl Completions {
             Visible::Editable => true,
             Visible::No => return,
         };
+        let doc_aliases = ctx.doc_aliases(&func);
         self.add(
             render_method(
                 RenderContext::new(ctx)
                     .private_editable(is_private_editable)
+                    .doc_aliases(doc_aliases)
                     .import_to_add(Some(import)),
                 dot_access,
                 None,

--- a/crates/ide-completion/src/tests/special.rs
+++ b/crates/ide-completion/src/tests/special.rs
@@ -1107,6 +1107,62 @@ fn here_we_go() {
 }
 
 #[test]
+fn completes_struct_fn_name_via_doc_alias_in_fn_body() {
+    check(
+        r#"
+struct Foo;
+impl Foo {
+    #[doc(alias = "qux")]
+    fn bar() -> u8 { 1 }
+}
+
+fn here_we_go() {
+    Foo::q$0
+}
+"#,
+        expect![[r#"
+            fn bar() (alias qux) fn() -> u8
+        "#]],
+    );
+}
+
+#[test]
+fn completes_method_name_via_doc_alias_in_fn_body() {
+    check(
+        r#"
+struct Foo {
+    bar: u8
+}
+impl Foo {
+    #[doc(alias = "qux")]
+    fn baz(&self) -> u8 {
+        self.bar
+    }
+}
+
+fn here_we_go() {
+    let foo = Foo { field: 42 };
+    foo.q$0
+}
+"#,
+        expect![[r#"
+            fd bar               u8
+            me baz() (alias qux) fn(&self) -> u8
+            sn box               Box::new(expr)
+            sn call              function(expr)
+            sn dbg               dbg!(expr)
+            sn dbgr              dbg!(&expr)
+            sn let               let
+            sn letm              let mut
+            sn match             match expr {}
+            sn ref               &expr
+            sn refm              &mut expr
+            sn unsafe            unsafe {}
+        "#]],
+    );
+}
+
+#[test]
 fn completes_fn_name_via_doc_alias_in_fn_body() {
     check(
         r#"

--- a/crates/rust-analyzer/tests/slow-tests/tidy.rs
+++ b/crates/rust-analyzer/tests/slow-tests/tidy.rs
@@ -257,6 +257,8 @@ fn check_dbg(path: &Path, text: &str) {
         "ide-db/src/generated/lints.rs",
         // test for doc test for remove_dbg
         "src/tests/generated.rs",
+        // `expect!` string can contain `dbg!` (due to .dbg postfix)
+        "ide-completion/src/tests/special.rs",
     ];
     if need_dbg.iter().any(|p| path.ends_with(p)) {
         return;


### PR DESCRIPTION
![Screenshot showing a completion when you type a doc alias instead of a real name](https://github.com/rust-lang/rust-analyzer/assets/108802164/e7c69bb9-3da6-4d8f-a09b-fece1bdd1c0e)
