### PR TITLE
fix: Fix perf regression from symbol index refactor

### DIFF
--- a/crates/ide-db/src/test_data/test_symbol_index_collection.txt
+++ b/crates/ide-db/src/test_data/test_symbol_index_collection.txt
@@ -17,6 +17,20 @@
                         ),
                     },
                 ),
+                loc: DeclarationLocation {
+                    hir_file_id: HirFileId(
+                        0,
+                    ),
+                    ptr: SyntaxNodePtr {
+                        kind: TYPE_ALIAS,
+                        range: 397..417,
+                    },
+                    name_ptr: SyntaxNodePtr {
+                        kind: NAME,
+                        range: 402..407,
+                    },
+                },
+                container_name: None,
             },
             FileSymbol {
                 name: "CONST",
@@ -27,6 +41,20 @@
                         ),
                     },
                 ),
+                loc: DeclarationLocation {
+                    hir_file_id: HirFileId(
+                        0,
+                    ),
+                    ptr: SyntaxNodePtr {
+                        kind: CONST,
+                        range: 340..361,
+                    },
+                    name_ptr: SyntaxNodePtr {
+                        kind: NAME,
+                        range: 346..351,
+                    },
+                },
+                container_name: None,
             },
             FileSymbol {
                 name: "CONST_WITH_INNER",
@@ -37,6 +65,20 @@
                         ),
                     },
                 ),
+                loc: DeclarationLocation {
+                    hir_file_id: HirFileId(
+                        0,
+                    ),
+                    ptr: SyntaxNodePtr {
+                        kind: CONST,
+                        range: 520..592,
+                    },
+                    name_ptr: SyntaxNodePtr {
+                        kind: NAME,
+                        range: 526..542,
+                    },
+                },
+                container_name: None,
             },
             FileSymbol {
                 name: "Enum",
@@ -49,6 +91,20 @@
                         },
                     ),
                 ),
+                loc: DeclarationLocation {
+                    hir_file_id: HirFileId(
+                        0,
+                    ),
+                    ptr: SyntaxNodePtr {
+                        kind: ENUM,
+                        range: 185..207,
+                    },
+                    name_ptr: SyntaxNodePtr {
+                        kind: NAME,
+                        range: 190..194,
+                    },
+                },
+                container_name: None,
             },
             FileSymbol {
                 name: "Macro",
@@ -61,6 +117,20 @@
                         ),
                     },
                 ),
+                loc: DeclarationLocation {
+                    hir_file_id: HirFileId(
+                        0,
+                    ),
+                    ptr: SyntaxNodePtr {
+                        kind: MACRO_DEF,
+                        range: 153..168,
+                    },
+                    name_ptr: SyntaxNodePtr {
+                        kind: NAME,
+                        range: 159..164,
+                    },
+                },
+                container_name: None,
             },
             FileSymbol {
                 name: "STATIC",
@@ -71,6 +141,20 @@
                         ),
                     },
                 ),
+                loc: DeclarationLocation {
+                    hir_file_id: HirFileId(
+                        0,
+                    ),
+                    ptr: SyntaxNodePtr {
+                        kind: STATIC,
+                        range: 362..396,
+                    },
+                    name_ptr: SyntaxNodePtr {
+                        kind: NAME,
+                        range: 369..375,
+                    },
+                },
+                container_name: None,
             },
             FileSymbol {
                 name: "Struct",
@@ -83,6 +167,20 @@
                         },
                     ),
                 ),
+                loc: DeclarationLocation {
+                    hir_file_id: HirFileId(
+                        0,
+                    ),
+                    ptr: SyntaxNodePtr {
+                        kind: STRUCT,
+                        range: 170..184,
+                    },
+                    name_ptr: SyntaxNodePtr {
+                        kind: NAME,
+                        range: 177..183,
+                    },
+                },
+                container_name: None,
             },
             FileSymbol {
                 name: "StructFromMacro",
@@ -95,6 +193,20 @@
                         },
                     ),
                 ),
+                loc: DeclarationLocation {
+                    hir_file_id: HirFileId(
+                        2147483648,
+                    ),
+                    ptr: SyntaxNodePtr {
+                        kind: STRUCT,
+                        range: 0..22,
+                    },
+                    name_ptr: SyntaxNodePtr {
+                        kind: NAME,
+                        range: 6..21,
+                    },
+                },
+                container_name: None,
             },
             FileSymbol {
                 name: "StructInFn",
@@ -106,6 +218,22 @@
                             ),
                         },
                     ),
+                ),
+                loc: DeclarationLocation {
+                    hir_file_id: HirFileId(
+                        0,
+                    ),
+                    ptr: SyntaxNodePtr {
+                        kind: STRUCT,
+                        range: 318..336,
+                    },
+                    name_ptr: SyntaxNodePtr {
+                        kind: NAME,
+                        range: 325..335,
+                    },
+                },
+                container_name: Some(
+                    "main",
                 ),
             },
             FileSymbol {
@@ -119,6 +247,22 @@
                         },
                     ),
                 ),
+                loc: DeclarationLocation {
+                    hir_file_id: HirFileId(
+                        0,
+                    ),
+                    ptr: SyntaxNodePtr {
+                        kind: STRUCT,
+                        range: 555..581,
+                    },
+                    name_ptr: SyntaxNodePtr {
+                        kind: NAME,
+                        range: 562..580,
+                    },
+                },
+                container_name: Some(
+                    "CONST_WITH_INNER",
+                ),
             },
             FileSymbol {
                 name: "StructInUnnamedConst",
@@ -131,6 +275,20 @@
                         },
                     ),
                 ),
+                loc: DeclarationLocation {
+                    hir_file_id: HirFileId(
+                        0,
+                    ),
+                    ptr: SyntaxNodePtr {
+                        kind: STRUCT,
+                        range: 479..507,
+                    },
+                    name_ptr: SyntaxNodePtr {
+                        kind: NAME,
+                        range: 486..506,
+                    },
+                },
+                container_name: None,
             },
             FileSymbol {
                 name: "Trait",
@@ -141,6 +299,20 @@
                         ),
                     },
                 ),
+                loc: DeclarationLocation {
+                    hir_file_id: HirFileId(
+                        0,
+                    ),
+                    ptr: SyntaxNodePtr {
+                        kind: TRAIT,
+                        range: 261..300,
+                    },
+                    name_ptr: SyntaxNodePtr {
+                        kind: NAME,
+                        range: 267..272,
+                    },
+                },
+                container_name: None,
             },
             FileSymbol {
                 name: "Union",
@@ -153,6 +325,20 @@
                         },
                     ),
                 ),
+                loc: DeclarationLocation {
+                    hir_file_id: HirFileId(
+                        0,
+                    ),
+                    ptr: SyntaxNodePtr {
+                        kind: UNION,
+                        range: 208..222,
+                    },
+                    name_ptr: SyntaxNodePtr {
+                        kind: NAME,
+                        range: 214..219,
+                    },
+                },
+                container_name: None,
             },
             FileSymbol {
                 name: "a_mod",
@@ -165,6 +351,20 @@
                         },
                     },
                 ),
+                loc: DeclarationLocation {
+                    hir_file_id: HirFileId(
+                        0,
+                    ),
+                    ptr: SyntaxNodePtr {
+                        kind: MODULE,
+                        range: 419..457,
+                    },
+                    name_ptr: SyntaxNodePtr {
+                        kind: NAME,
+                        range: 423..428,
+                    },
+                },
+                container_name: None,
             },
             FileSymbol {
                 name: "b_mod",
@@ -177,6 +377,20 @@
                         },
                     },
                 ),
+                loc: DeclarationLocation {
+                    hir_file_id: HirFileId(
+                        0,
+                    ),
+                    ptr: SyntaxNodePtr {
+                        kind: MODULE,
+                        range: 594..604,
+                    },
+                    name_ptr: SyntaxNodePtr {
+                        kind: NAME,
+                        range: 598..603,
+                    },
+                },
+                container_name: None,
             },
             FileSymbol {
                 name: "define_struct",
@@ -189,6 +403,20 @@
                         ),
                     },
                 ),
+                loc: DeclarationLocation {
+                    hir_file_id: HirFileId(
+                        0,
+                    ),
+                    ptr: SyntaxNodePtr {
+                        kind: MACRO_RULES,
+                        range: 51..131,
+                    },
+                    name_ptr: SyntaxNodePtr {
+                        kind: NAME,
+                        range: 64..77,
+                    },
+                },
+                container_name: None,
             },
             FileSymbol {
                 name: "impl_fn",
@@ -199,6 +427,20 @@
                         ),
                     },
                 ),
+                loc: DeclarationLocation {
+                    hir_file_id: HirFileId(
+                        0,
+                    ),
+                    ptr: SyntaxNodePtr {
+                        kind: FN,
+                        range: 242..257,
+                    },
+                    name_ptr: SyntaxNodePtr {
+                        kind: NAME,
+                        range: 245..252,
+                    },
+                },
+                container_name: None,
             },
             FileSymbol {
                 name: "macro_rules_macro",
@@ -211,6 +453,20 @@
                         ),
                     },
                 ),
+                loc: DeclarationLocation {
+                    hir_file_id: HirFileId(
+                        0,
+                    ),
+                    ptr: SyntaxNodePtr {
+                        kind: MACRO_RULES,
+                        range: 1..48,
+                    },
+                    name_ptr: SyntaxNodePtr {
+                        kind: NAME,
+                        range: 14..31,
+                    },
+                },
+                container_name: None,
             },
             FileSymbol {
                 name: "main",
@@ -221,6 +477,20 @@
                         ),
                     },
                 ),
+                loc: DeclarationLocation {
+                    hir_file_id: HirFileId(
+                        0,
+                    ),
+                    ptr: SyntaxNodePtr {
+                        kind: FN,
+                        range: 302..338,
+                    },
+                    name_ptr: SyntaxNodePtr {
+                        kind: NAME,
+                        range: 305..309,
+                    },
+                },
+                container_name: None,
             },
             FileSymbol {
                 name: "trait_fn",
@@ -230,6 +500,22 @@
                             1,
                         ),
                     },
+                ),
+                loc: DeclarationLocation {
+                    hir_file_id: HirFileId(
+                        0,
+                    ),
+                    ptr: SyntaxNodePtr {
+                        kind: FN,
+                        range: 279..298,
+                    },
+                    name_ptr: SyntaxNodePtr {
+                        kind: NAME,
+                        range: 282..290,
+                    },
+                },
+                container_name: Some(
+                    "Trait",
                 ),
             },
         ],
@@ -254,6 +540,20 @@
                         },
                     ),
                 ),
+                loc: DeclarationLocation {
+                    hir_file_id: HirFileId(
+                        0,
+                    ),
+                    ptr: SyntaxNodePtr {
+                        kind: STRUCT,
+                        range: 435..455,
+                    },
+                    name_ptr: SyntaxNodePtr {
+                        kind: NAME,
+                        range: 442..454,
+                    },
+                },
+                container_name: None,
             },
         ],
     ),
@@ -277,6 +577,20 @@
                         },
                     ),
                 ),
+                loc: DeclarationLocation {
+                    hir_file_id: HirFileId(
+                        1,
+                    ),
+                    ptr: SyntaxNodePtr {
+                        kind: STRUCT,
+                        range: 0..20,
+                    },
+                    name_ptr: SyntaxNodePtr {
+                        kind: NAME,
+                        range: 7..19,
+                    },
+                },
+                container_name: None,
             },
         ],
     ),


### PR DESCRIPTION
Should fix the regressions introduced by https://github.com/rust-lang/rust-analyzer/pull/14715 by partially rolling back the PR