### PR TITLE
Remove root component from patched Windows UNC path prefix

### DIFF
--- a/crates/rust-analyzer/src/bin/main.rs
+++ b/crates/rust-analyzer/src/bin/main.rs
@@ -246,7 +246,7 @@ fn patch_path_prefix(path: PathBuf) -> PathBuf {
                         format!("{}:", d.to_ascii_uppercase() as char)
                     }
                     Prefix::VerbatimDisk(d) => {
-                        format!(r"\\?\{}:\", d.to_ascii_uppercase() as char)
+                        format!(r"\\?\{}:", d.to_ascii_uppercase() as char)
                     }
                     _ => return path,
                 };


### PR DESCRIPTION
As it shouldn't be there to begin with (per discussion in #14689).