### PR TITLE
Expand more single ident macro calls upon item collection

### DIFF
--- a/crates/hir-def/src/nameres/path_resolution.rs
+++ b/crates/hir-def/src/nameres/path_resolution.rs
@@ -59,7 +59,11 @@ impl ResolvePathResult {
 }
 
 impl PerNs {
-    fn filter_macro(mut self, db: &dyn DefDatabase, expected: Option<MacroSubNs>) -> Self {
+    pub(super) fn filter_macro(
+        mut self,
+        db: &dyn DefDatabase,
+        expected: Option<MacroSubNs>,
+    ) -> Self {
         self.macros = self.macros.filter(|&(id, _)| {
             let this = MacroSubNs::from_id(db, id);
             sub_namespace_match(Some(this), expected)


### PR DESCRIPTION
Addresses https://github.com/rust-lang/rust-analyzer/pull/14781#issuecomment-1546201022

I believe this (almost) brings the number of unresolved names back to pre-#14781:

|r-a version|`analysis-stats compiler/rustc` (rust-lang/rust@69fef92ab2f287f072b66fb7b4f62c8bb4acba43) |
|---|---|
|pre-#14781 (b069eb720bec6ce40ab224f57d271687b19b5a07) | exprs: 2747778, ??ty: 122236 (4%), ?ty: 107826 (3%), !ty: 728 |
| #14781 (a7944a93a1520b96f079bbbcd841d6aec9e4ba5d) | exprs: 2713080, ??ty: 139651 (5%), ?ty: 114444 (4%), !ty: 730 |
| with this fix | exprs: 2747871, ??ty: 122237 (4%), ?ty: 108171 (3%), !ty: 676 |

(I haven't investigated on the increase in some numbers but hopefully not too much of a problem)

This is only a temporary solution. The core problem is that we haven't fully implemented the textual scope of legacy macros. For example, we *have been* failing to resolve `foo` in the following snippet, even before #14781 or after this patch. As noted in a FIXME, we need a way to resolve names in textual scope without eager expansion during item collection.

```rust
//- /main.rs crate:main deps:lib
lib::mk_foo!();
const A: i32 = foo!();
             //^^^^^^ unresolved-macro-call

//- /lib.rs crate:lib
#[macro_export]
macro_rules! mk_foo {
    () => {
        macro_rules! foo { () => { 42 } }
    }
}
```