### PR TITLE
fix: place type inlay hints after the item and without left-padding

### DIFF
--- a/crates/ide/src/inlay_hints/bind_pat.rs
+++ b/crates/ide/src/inlay_hints/bind_pat.rs
@@ -106,8 +106,8 @@ pub(super) fn hints(
         kind: InlayKind::Type,
         label,
         text_edit,
-        position: InlayHintPosition::Before,
-        pad_left: !has_colon,
+        position: InlayHintPosition::After,
+        pad_left: false,
         pad_right: false,
     });
 

--- a/crates/ide/src/inlay_hints/chaining.rs
+++ b/crates/ide/src/inlay_hints/chaining.rs
@@ -625,8 +625,8 @@ fn main() {
                 [
                     InlayHint {
                         range: 124..130,
-                        position: Before,
-                        pad_left: true,
+                        position: After,
+                        pad_left: false,
                         pad_right: false,
                         kind: Type,
                         label: [


### PR DESCRIPTION
**Before**:

![Type hints were placed before the item and there was left-padding that accentuaded the issue](https://github.com/rust-lang/rust-analyzer/assets/7951708/006a28e9-ed7b-4d49-a7e7-3c6da8efca79)

**After**:

![Type hints are now placed after the item and without padding since there already is `: ` in front of the type](https://github.com/rust-lang/rust-analyzer/assets/7951708/330a847f-8c59-40c7-877f-bf1aaced30e2)
