### PR TITLE
fix(analysis-stats): divided by zero error

### DIFF
--- a/crates/rust-analyzer/src/cli/analysis_stats.rs
+++ b/crates/rust-analyzer/src/cli/analysis_stats.rs
@@ -227,7 +227,7 @@ impl flags::AnalysisStats {
             fail += 1;
         }
         eprintln!("{:<20} {}", "Data layouts:", sw.elapsed());
-        eprintln!("Failed data layouts: {fail} ({}%)", fail * 100 / all);
+        eprintln!("Failed data layouts: {fail} ({}%)", percentage(fail, all));
         report_metric("failed data layouts", fail, "#");
     }
 
@@ -254,7 +254,7 @@ impl flags::AnalysisStats {
             fail += 1;
         }
         eprintln!("{:<20} {}", "Const evaluation:", sw.elapsed());
-        eprintln!("Failed const evals: {fail} ({}%)", fail * 100 / all);
+        eprintln!("Failed const evals: {fail} ({}%)", percentage(fail, all));
         report_metric("failed const evals", fail, "#");
     }
 
@@ -280,7 +280,7 @@ impl flags::AnalysisStats {
             fail += 1;
         }
         eprintln!("{:<20} {}", "MIR lowering:", sw.elapsed());
-        eprintln!("Mir failed bodies: {fail} ({}%)", fail * 100 / all);
+        eprintln!("Mir failed bodies: {fail} ({}%)", percentage(fail, all));
         report_metric("mir failed bodies", fail, "#");
     }
 


### PR DESCRIPTION
## What does this PR try to resolve?

2023-05-15 rust-analyzer suffers from

```
 thread 'main' panicked at 'attempt to divide by zero', crates/rust-analyzer/src/cli/analysis_stats.rs:230:56 
```

This commit <https://github.com/rust-lang/rust-analyzer/pull/14808/commits/51e8b8ff14de3507d5e21d80b750577da52b6fdd> might be the culprit.

This PR uses `percentage` function to avoid the classic “division by zero” bug.

## Reproducer

```console
cargo new ra-test
pushd ra-test
echo "pub type Foo = u32;" >> src/lib.rs
rust-analyzer analysis-stats .
```
