### PR TITLE
fix: Force disable augmentsSyntaxTokens capability on VSCode

### DIFF
--- a/editors/code/src/client.ts
+++ b/editors/code/src/client.ts
@@ -366,6 +366,7 @@ export async function createClient(
 
     // To turn on all proposed features use: client.registerProposedFeatures();
     client.registerFeature(new ExperimentalFeatures());
+    client.registerFeature(new OverrideFeatures());
 
     return client;
 }
@@ -393,6 +394,25 @@ class ExperimentalFeatures implements lc.StaticFeature {
             },
             ...capabilities.experimental,
         };
+    }
+    initialize(
+        _capabilities: lc.ServerCapabilities,
+        _documentSelector: lc.DocumentSelector | undefined
+    ): void {}
+    dispose(): void {}
+}
+
+class OverrideFeatures implements lc.StaticFeature {
+    getState(): lc.FeatureState {
+        return { kind: "static" };
+    }
+    fillClientCapabilities(capabilities: lc.ClientCapabilities): void {
+        // Force disable `augmentsSyntaxTokens`, VSCode's textmate grammar is somewhat incomplete
+        // making the experience generally worse
+        const caps = capabilities.textDocument?.semanticTokens;
+        if (caps) {
+            caps.augmentsSyntaxTokens = false;
+        }
     }
     initialize(
         _capabilities: lc.ServerCapabilities,


### PR DESCRIPTION
The default textmate grammar for rust in VSCode is pretty brittle, quite often coloring things very differently than we'd like to so we force full semantic highlighting by disabling that config.