### PR TITLE
fix: Diagnose non-value return and break type mismatches

### DIFF
--- a/crates/ide-diagnostics/src/handlers/type_mismatch.rs
+++ b/crates/ide-diagnostics/src/handlers/type_mismatch.rs
@@ -681,4 +681,18 @@ struct Bar {
 "#,
         );
     }
+
+    #[test]
+    fn return_no_value() {
+        check_diagnostics(
+            r#"
+fn f() -> i32 {
+    return;
+ // ^^^^^^ error: expected i32, found ()
+    0
+}
+fn g() { return; }
+"#,
+        );
+    }
 }


### PR DESCRIPTION
Could definitely deserve more polished diagnostics, but this at least brings the message across for now.