### PR TITLE
Fix `preorder_expr` skipping the `else` block of let-else statements

### DIFF
--- a/crates/ide-db/src/syntax_helpers/node_ext.rs
+++ b/crates/ide-db/src/syntax_helpers/node_ext.rs
@@ -52,7 +52,10 @@ pub fn preorder_expr(start: &ast::Expr, cb: &mut dyn FnMut(WalkEvent<ast::Expr>)
             }
         };
         if let Some(let_stmt) = node.parent().and_then(ast::LetStmt::cast) {
-            if Some(node.clone()) != let_stmt.initializer().map(|it| it.syntax().clone()) {
+            let node = Some(node.clone());
+            if node != let_stmt.initializer().map(|it| it.syntax().clone())
+                && node != let_stmt.let_else().map(|it| it.syntax().clone())
+            {
                 // skipping potential const pat expressions in  let statements
                 preorder.skip_subtree();
                 continue;

--- a/crates/ide/src/highlight_related.rs
+++ b/crates/ide/src/highlight_related.rs
@@ -693,6 +693,29 @@ pub async$0 fn foo() {
     }
 
     #[test]
+    fn test_hl_let_else_yield_points() {
+        check(
+            r#"
+pub async fn foo() {
+ // ^^^^^
+    let x = foo()
+        .await$0
+      // ^^^^^
+        .await;
+      // ^^^^^
+    || { 0.await };
+    let Some(_) = None else {
+        foo().await
+           // ^^^^^
+    };
+    (async { 0.await }).await
+                     // ^^^^^
+}
+"#,
+        );
+    }
+
+    #[test]
     fn test_hl_yield_nested_fn() {
         check(
             r#"
@@ -778,6 +801,26 @@ async fn foo() {
         return 0;
      // ^^^^^^
     }
+
+    0?;
+  // ^
+    0xDEAD_BEEF
+ // ^^^^^^^^^^^
+}
+"#,
+        );
+    }
+
+    #[test]
+    fn test_hl_let_else_exit_points() {
+        check(
+            r#"
+  fn$0 foo() -> u32 {
+//^^
+    let Some(bar) = None else {
+        return 0;
+     // ^^^^^^
+    };
 
     0?;
   // ^


### PR DESCRIPTION
Fixes exit/yield points not getting highlighted in such blocks for `highlight_related` (#14813; and possibly other bugs in features that use `preorder_expr`).