### PR TITLE
feat: using doc aliases to search workspace symbols

### DIFF
--- a/crates/ide-db/src/symbol_index.rs
+++ b/crates/ide-db/src/symbol_index.rs
@@ -434,4 +434,31 @@ struct StructInModB;
 
         expect_file!["./test_data/test_symbol_index_collection.txt"].assert_debug_eq(&symbols);
     }
+
+    #[test]
+    fn test_doc_alias() {
+        let (db, _) = RootDatabase::with_single_file(
+            r#"
+#[doc(alias="s1")]
+#[doc(alias="s2")]
+#[doc(alias("mul1","mul2"))]
+struct Struct;
+
+#[doc(alias="s1")]
+struct Duplicate;
+        "#,
+        );
+
+        let symbols: Vec<_> = Crate::from(db.test_crate())
+            .modules(&db)
+            .into_iter()
+            .map(|module_id| {
+                let mut symbols = SymbolCollector::collect_module(&db, module_id);
+                symbols.sort_by_key(|it| it.name.clone());
+                (module_id, symbols)
+            })
+            .collect();
+
+        expect_file!["./test_data/test_doc_alias.txt"].assert_debug_eq(&symbols);
+    }
 }

--- a/crates/ide-db/src/test_data/test_doc_alias.txt
+++ b/crates/ide-db/src/test_data/test_doc_alias.txt
@@ -1,0 +1,202 @@
+[
+    (
+        Module {
+            id: ModuleId {
+                krate: Idx::<CrateData>(0),
+                block: None,
+                local_id: Idx::<ModuleData>(0),
+            },
+        },
+        [
+            FileSymbol {
+                name: "Duplicate",
+                def: Adt(
+                    Struct(
+                        Struct {
+                            id: StructId(
+                                1,
+                            ),
+                        },
+                    ),
+                ),
+                loc: DeclarationLocation {
+                    hir_file_id: HirFileId(
+                        0,
+                    ),
+                    ptr: SyntaxNodePtr {
+                        kind: STRUCT,
+                        range: 83..119,
+                    },
+                    name_ptr: SyntaxNodePtr {
+                        kind: NAME,
+                        range: 109..118,
+                    },
+                },
+                container_name: None,
+                is_alias: false,
+            },
+            FileSymbol {
+                name: "Struct",
+                def: Adt(
+                    Struct(
+                        Struct {
+                            id: StructId(
+                                0,
+                            ),
+                        },
+                    ),
+                ),
+                loc: DeclarationLocation {
+                    hir_file_id: HirFileId(
+                        0,
+                    ),
+                    ptr: SyntaxNodePtr {
+                        kind: STRUCT,
+                        range: 0..81,
+                    },
+                    name_ptr: SyntaxNodePtr {
+                        kind: NAME,
+                        range: 74..80,
+                    },
+                },
+                container_name: None,
+                is_alias: false,
+            },
+            FileSymbol {
+                name: "mul1",
+                def: Adt(
+                    Struct(
+                        Struct {
+                            id: StructId(
+                                0,
+                            ),
+                        },
+                    ),
+                ),
+                loc: DeclarationLocation {
+                    hir_file_id: HirFileId(
+                        0,
+                    ),
+                    ptr: SyntaxNodePtr {
+                        kind: STRUCT,
+                        range: 0..81,
+                    },
+                    name_ptr: SyntaxNodePtr {
+                        kind: NAME,
+                        range: 74..80,
+                    },
+                },
+                container_name: None,
+                is_alias: true,
+            },
+            FileSymbol {
+                name: "mul2",
+                def: Adt(
+                    Struct(
+                        Struct {
+                            id: StructId(
+                                0,
+                            ),
+                        },
+                    ),
+                ),
+                loc: DeclarationLocation {
+                    hir_file_id: HirFileId(
+                        0,
+                    ),
+                    ptr: SyntaxNodePtr {
+                        kind: STRUCT,
+                        range: 0..81,
+                    },
+                    name_ptr: SyntaxNodePtr {
+                        kind: NAME,
+                        range: 74..80,
+                    },
+                },
+                container_name: None,
+                is_alias: true,
+            },
+            FileSymbol {
+                name: "s1",
+                def: Adt(
+                    Struct(
+                        Struct {
+                            id: StructId(
+                                0,
+                            ),
+                        },
+                    ),
+                ),
+                loc: DeclarationLocation {
+                    hir_file_id: HirFileId(
+                        0,
+                    ),
+                    ptr: SyntaxNodePtr {
+                        kind: STRUCT,
+                        range: 0..81,
+                    },
+                    name_ptr: SyntaxNodePtr {
+                        kind: NAME,
+                        range: 74..80,
+                    },
+                },
+                container_name: None,
+                is_alias: true,
+            },
+            FileSymbol {
+                name: "s1",
+                def: Adt(
+                    Struct(
+                        Struct {
+                            id: StructId(
+                                1,
+                            ),
+                        },
+                    ),
+                ),
+                loc: DeclarationLocation {
+                    hir_file_id: HirFileId(
+                        0,
+                    ),
+                    ptr: SyntaxNodePtr {
+                        kind: STRUCT,
+                        range: 83..119,
+                    },
+                    name_ptr: SyntaxNodePtr {
+                        kind: NAME,
+                        range: 109..118,
+                    },
+                },
+                container_name: None,
+                is_alias: true,
+            },
+            FileSymbol {
+                name: "s2",
+                def: Adt(
+                    Struct(
+                        Struct {
+                            id: StructId(
+                                0,
+                            ),
+                        },
+                    ),
+                ),
+                loc: DeclarationLocation {
+                    hir_file_id: HirFileId(
+                        0,
+                    ),
+                    ptr: SyntaxNodePtr {
+                        kind: STRUCT,
+                        range: 0..81,
+                    },
+                    name_ptr: SyntaxNodePtr {
+                        kind: NAME,
+                        range: 74..80,
+                    },
+                },
+                container_name: None,
+                is_alias: true,
+            },
+        ],
+    ),
+]

--- a/crates/ide-db/src/test_data/test_symbol_index_collection.txt
+++ b/crates/ide-db/src/test_data/test_symbol_index_collection.txt
@@ -31,6 +31,7 @@
                     },
                 },
                 container_name: None,
+                is_alias: false,
             },
             FileSymbol {
                 name: "CONST",
@@ -55,6 +56,7 @@
                     },
                 },
                 container_name: None,
+                is_alias: false,
             },
             FileSymbol {
                 name: "CONST_WITH_INNER",
@@ -79,6 +81,7 @@
                     },
                 },
                 container_name: None,
+                is_alias: false,
             },
             FileSymbol {
                 name: "Enum",
@@ -105,6 +108,7 @@
                     },
                 },
                 container_name: None,
+                is_alias: false,
             },
             FileSymbol {
                 name: "Macro",
@@ -131,6 +135,7 @@
                     },
                 },
                 container_name: None,
+                is_alias: false,
             },
             FileSymbol {
                 name: "STATIC",
@@ -155,6 +160,7 @@
                     },
                 },
                 container_name: None,
+                is_alias: false,
             },
             FileSymbol {
                 name: "Struct",
@@ -181,6 +187,7 @@
                     },
                 },
                 container_name: None,
+                is_alias: false,
             },
             FileSymbol {
                 name: "StructFromMacro",
@@ -207,6 +214,7 @@
                     },
                 },
                 container_name: None,
+                is_alias: false,
             },
             FileSymbol {
                 name: "StructInFn",
@@ -235,6 +243,7 @@
                 container_name: Some(
                     "main",
                 ),
+                is_alias: false,
             },
             FileSymbol {
                 name: "StructInNamedConst",
@@ -263,6 +272,7 @@
                 container_name: Some(
                     "CONST_WITH_INNER",
                 ),
+                is_alias: false,
             },
             FileSymbol {
                 name: "StructInUnnamedConst",
@@ -289,6 +299,7 @@
                     },
                 },
                 container_name: None,
+                is_alias: false,
             },
             FileSymbol {
                 name: "Trait",
@@ -313,6 +324,7 @@
                     },
                 },
                 container_name: None,
+                is_alias: false,
             },
             FileSymbol {
                 name: "Union",
@@ -339,6 +351,7 @@
                     },
                 },
                 container_name: None,
+                is_alias: false,
             },
             FileSymbol {
                 name: "a_mod",
@@ -365,6 +378,7 @@
                     },
                 },
                 container_name: None,
+                is_alias: false,
             },
             FileSymbol {
                 name: "b_mod",
@@ -391,6 +405,7 @@
                     },
                 },
                 container_name: None,
+                is_alias: false,
             },
             FileSymbol {
                 name: "define_struct",
@@ -417,6 +432,7 @@
                     },
                 },
                 container_name: None,
+                is_alias: false,
             },
             FileSymbol {
                 name: "impl_fn",
@@ -441,6 +457,7 @@
                     },
                 },
                 container_name: None,
+                is_alias: false,
             },
             FileSymbol {
                 name: "macro_rules_macro",
@@ -467,6 +484,7 @@
                     },
                 },
                 container_name: None,
+                is_alias: false,
             },
             FileSymbol {
                 name: "main",
@@ -491,6 +509,7 @@
                     },
                 },
                 container_name: None,
+                is_alias: false,
             },
             FileSymbol {
                 name: "trait_fn",
@@ -517,6 +536,7 @@
                 container_name: Some(
                     "Trait",
                 ),
+                is_alias: false,
             },
         ],
     ),
@@ -554,6 +574,7 @@
                     },
                 },
                 container_name: None,
+                is_alias: false,
             },
         ],
     ),
@@ -591,6 +612,7 @@
                     },
                 },
                 container_name: None,
+                is_alias: false,
             },
         ],
     ),

--- a/crates/ide/src/goto_definition.rs
+++ b/crates/ide/src/goto_definition.rs
@@ -113,6 +113,7 @@ fn try_lookup_include_path(
         file_id,
         full_range: TextRange::new(0.into(), size),
         name: path.into(),
+        alias: None,
         focus_range: None,
         kind: None,
         container_name: None,

--- a/crates/ide/src/lib.rs
+++ b/crates/ide/src/lib.rs
@@ -405,7 +405,7 @@ impl Analysis {
         self.with_db(|db| {
             symbol_index::world_symbols(db, query)
                 .into_iter() // xx: should we make this a par iter?
-                .filter_map(|s| s.def.try_to_nav(db))
+                .filter_map(|s| s.try_to_nav(db))
                 .collect::<Vec<_>>()
         })
     }

--- a/crates/ide/src/navigation_target.rs
+++ b/crates/ide/src/navigation_target.rs
@@ -169,7 +169,7 @@ impl TryToNav for FileSymbol {
 
         Some(NavigationTarget {
             file_id: full_range.file_id,
-            name: self.def.name(db)?.to_smol_str(),
+            name: if self.is_alias { self.def.name(db)?.to_smol_str() } else { self.name.clone() },
             alias: if self.is_alias { Some(self.name.clone()) } else { None },
             kind: Some(hir::ModuleDefId::from(self.def).into()),
             full_range: full_range.range,

--- a/crates/ide/src/navigation_target.rs
+++ b/crates/ide/src/navigation_target.rs
@@ -45,6 +45,9 @@ pub struct NavigationTarget {
     pub container_name: Option<SmolStr>,
     pub description: Option<String>,
     pub docs: Option<Documentation>,
+    /// In addition to a `name` field, a `NavigationTarget` may also be aliased
+    /// In such cases we want a `NavigationTarget` to be accessible by its alias
+    pub alias: Option<SmolStr>,
 }
 
 impl fmt::Debug for NavigationTarget {
@@ -154,6 +157,7 @@ impl NavigationTarget {
             container_name: None,
             description: None,
             docs: None,
+            alias: None,
         }
     }
 }
@@ -165,7 +169,8 @@ impl TryToNav for FileSymbol {
 
         Some(NavigationTarget {
             file_id: full_range.file_id,
-            name: self.name.clone(),
+            name: self.def.name(db)?.to_smol_str(),
+            alias: if self.is_alias { Some(self.name.clone()) } else { None },
             kind: Some(hir::ModuleDefId::from(self.def).into()),
             full_range: full_range.range,
             focus_range: Some(name_range.range),
@@ -466,6 +471,7 @@ impl ToNav for LocalSource {
         NavigationTarget {
             file_id,
             name,
+            alias: None,
             kind: Some(kind),
             full_range,
             focus_range,
@@ -494,6 +500,7 @@ impl ToNav for hir::Label {
         NavigationTarget {
             file_id,
             name,
+            alias: None,
             kind: Some(SymbolKind::Label),
             full_range,
             focus_range,
@@ -534,6 +541,7 @@ impl TryToNav for hir::TypeParam {
         Some(NavigationTarget {
             file_id,
             name,
+            alias: None,
             kind: Some(SymbolKind::TypeParam),
             full_range,
             focus_range,
@@ -560,6 +568,7 @@ impl TryToNav for hir::LifetimeParam {
         Some(NavigationTarget {
             file_id,
             name,
+            alias: None,
             kind: Some(SymbolKind::LifetimeParam),
             full_range,
             focus_range: Some(full_range),
@@ -589,6 +598,7 @@ impl TryToNav for hir::ConstParam {
         Some(NavigationTarget {
             file_id,
             name,
+            alias: None,
             kind: Some(SymbolKind::ConstParam),
             full_range,
             focus_range,
@@ -643,6 +653,7 @@ fn foo() { enum FooInner { } }
                     focus_range: 34..42,
                     name: "FooInner",
                     kind: Enum,
+                    container_name: "foo",
                     description: "enum FooInner",
                 },
             ]

--- a/crates/ide/src/runnables.rs
+++ b/crates/ide/src/runnables.rs
@@ -2232,14 +2232,14 @@ mod tests {
                             file_id: FileId(
                                 0,
                             ),
-                            full_range: 52..115,
-                            focus_range: 67..75,
-                            name: "foo_test",
+                            full_range: 121..185,
+                            focus_range: 136..145,
+                            name: "foo2_test",
                             kind: Function,
                         },
                         kind: Test {
                             test_id: Path(
-                                "tests::foo_test",
+                                "tests::foo2_test",
                             ),
                             attr: TestAttr {
                                 ignore: false,
@@ -2253,14 +2253,14 @@ mod tests {
                             file_id: FileId(
                                 0,
                             ),
-                            full_range: 121..185,
-                            focus_range: 136..145,
-                            name: "foo2_test",
+                            full_range: 52..115,
+                            focus_range: 67..75,
+                            name: "foo_test",
                             kind: Function,
                         },
                         kind: Test {
                             test_id: Path(
-                                "tests::foo2_test",
+                                "tests::foo_test",
                             ),
                             attr: TestAttr {
                                 ignore: false,

--- a/crates/rust-analyzer/src/handlers/request.rs
+++ b/crates/rust-analyzer/src/handlers/request.rs
@@ -520,7 +520,10 @@ pub(crate) fn handle_workspace_symbol(
 
             #[allow(deprecated)]
             let info = SymbolInformation {
-                name: nav.name.to_string(),
+                name: match nav.alias {
+                    Some(ref alias) => format!("{} (alias {})", alias, nav.name),
+                    None => format!("{}", nav.name),
+                },
                 kind: nav
                     .kind
                     .map(to_proto::symbol_kind)

--- a/crates/rust-analyzer/src/handlers/request.rs
+++ b/crates/rust-analyzer/src/handlers/request.rs
@@ -520,8 +520,8 @@ pub(crate) fn handle_workspace_symbol(
 
             #[allow(deprecated)]
             let info = SymbolInformation {
-                name: match nav.alias {
-                    Some(ref alias) => format!("{} (alias {})", alias, nav.name),
+                name: match &nav.alias {
+                    Some(alias) => format!("{} (alias for {})", alias, nav.name),
                     None => format!("{}", nav.name),
                 },
                 kind: nav


### PR DESCRIPTION
Doc aliases are now visible among symbols and can be used for searching. 

 fixes #14557