### PR TITLE
fix: introduce new type var when expectation for ref pat is not ref

### DIFF
--- a/crates/hir-ty/src/tests/patterns.rs
+++ b/crates/hir-ty/src/tests/patterns.rs
@@ -1,6 +1,6 @@
 use expect_test::expect;
 
-use super::{check, check_infer, check_infer_with_mismatches, check_types};
+use super::{check, check_infer, check_infer_with_mismatches, check_no_mismatches, check_types};
 
 #[test]
 fn infer_pattern() {
@@ -237,6 +237,21 @@ fn infer_pattern_match_ergonomics_ref() {
             47..48 'w': i32
             52..53 'v': &(i32, &i32)
         "#]],
+    );
+}
+
+#[test]
+fn ref_pat_with_inference_variable() {
+    check_no_mismatches(
+        r#"
+enum E { A }
+fn test() {
+    let f = |e| match e {
+        &E::A => {}
+    };
+    f(&E::A);
+}
+"#,
     );
 }
 


### PR DESCRIPTION
Fixes #14840

When we infer the type of ref patterns, its expected type may not be reference type: 1) expected type is an unresolved inference variable, or 2) expected type is erroneously other kind of type. In either case, we should produce a reference type with a new type variable rather than an error type so that we can continue inferring the inner patterns without further errors because of the (possible) type mismatch of this pattern.