### PR TITLE
expand: Change how `#![cfg(FALSE)]` behaves on crate root

### DIFF
--- a/crates/hir-def/src/attr.rs
+++ b/crates/hir-def/src/attr.rs
@@ -202,6 +202,7 @@ impl Attrs {
             None => Some(first),
         }
     }
+
     pub(crate) fn is_cfg_enabled(&self, cfg_options: &CfgOptions) -> bool {
         match self.cfg() {
             None => true,

--- a/crates/hir-def/src/nameres/collector.rs
+++ b/crates/hir-def/src/nameres/collector.rs
@@ -290,16 +290,16 @@ impl DefCollector<'_> {
         let module_id = self.def_map.root;
 
         let attrs = item_tree.top_level_attrs(self.db, self.def_map.krate);
-        if let Some(cfg) = attrs.cfg() {
-            if self.cfg_options.check(&cfg) == Some(false) {
-                return;
-            }
-        }
 
         self.inject_prelude(&attrs);
 
         // Process other crate-level attributes.
         for attr in &*attrs {
+            if let Some(cfg) = attr.cfg() {
+                if self.cfg_options.check(&cfg) == Some(false) {
+                    return;
+                }
+            }
             let attr_name = match attr.path.as_ident() {
                 Some(name) => name,
                 None => continue,

--- a/crates/hir-expand/src/attrs.rs
+++ b/crates/hir-expand/src/attrs.rs
@@ -309,6 +309,14 @@ impl Attr {
 
         Some(paths)
     }
+
+    pub fn cfg(&self) -> Option<CfgExpr> {
+        if *self.path.as_ident()? == crate::name![cfg] {
+            self.token_tree_value().map(CfgExpr::parse)
+        } else {
+            None
+        }
+    }
 }
 
 pub fn collect_attrs(


### PR DESCRIPTION
Closes https://github.com/rust-lang/rust-analyzer/issues/14769