### PR TITLE
Prioritize threads affected by user typing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1518,7 +1518,6 @@ dependencies = [
  "syntax",
  "test-utils",
  "thiserror",
- "threadpool",
  "tikv-jemallocator",
  "toolchain",
  "tracing",
@@ -1712,6 +1711,7 @@ version = "0.0.0"
 dependencies = [
  "always-assert",
  "backtrace",
+ "crossbeam-channel",
  "jod-thread",
  "libc",
  "miow",
@@ -1821,15 +1821,6 @@ checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
 dependencies = [
  "cfg-if",
  "once_cell",
-]
-
-[[package]]
-name = "threadpool"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
-dependencies = [
- "num_cpus",
 ]
 
 [[package]]

--- a/crates/flycheck/src/lib.rs
+++ b/crates/flycheck/src/lib.rs
@@ -90,7 +90,7 @@ impl FlycheckHandle {
     ) -> FlycheckHandle {
         let actor = FlycheckActor::new(id, sender, config, workspace_root);
         let (sender, receiver) = unbounded::<StateChange>();
-        let thread = stdx::thread::Builder::new(stdx::thread::QoSClass::Default)
+        let thread = stdx::thread::Builder::new(stdx::thread::QoSClass::Utility)
             .name("Flycheck".to_owned())
             .spawn(move || actor.run(receiver))
             .expect("failed to spawn thread");
@@ -409,7 +409,7 @@ impl CargoHandle {
 
         let (sender, receiver) = unbounded();
         let actor = CargoActor::new(sender, stdout, stderr);
-        let thread = stdx::thread::Builder::new(stdx::thread::QoSClass::Default)
+        let thread = stdx::thread::Builder::new(stdx::thread::QoSClass::Utility)
             .name("CargoHandle".to_owned())
             .spawn(move || actor.run())
             .expect("failed to spawn thread");

--- a/crates/flycheck/src/lib.rs
+++ b/crates/flycheck/src/lib.rs
@@ -90,7 +90,7 @@ impl FlycheckHandle {
     ) -> FlycheckHandle {
         let actor = FlycheckActor::new(id, sender, config, workspace_root);
         let (sender, receiver) = unbounded::<StateChange>();
-        let thread = stdx::thread::Builder::new(stdx::thread::QoSClass::Utility)
+        let thread = stdx::thread::Builder::new(stdx::thread::QoSClass::Default)
             .name("Flycheck".to_owned())
             .spawn(move || actor.run(receiver))
             .expect("failed to spawn thread");
@@ -409,7 +409,7 @@ impl CargoHandle {
 
         let (sender, receiver) = unbounded();
         let actor = CargoActor::new(sender, stdout, stderr);
-        let thread = stdx::thread::Builder::new(stdx::thread::QoSClass::Utility)
+        let thread = stdx::thread::Builder::new(stdx::thread::QoSClass::Default)
             .name("CargoHandle".to_owned())
             .spawn(move || actor.run())
             .expect("failed to spawn thread");

--- a/crates/flycheck/src/lib.rs
+++ b/crates/flycheck/src/lib.rs
@@ -90,7 +90,7 @@ impl FlycheckHandle {
     ) -> FlycheckHandle {
         let actor = FlycheckActor::new(id, sender, config, workspace_root);
         let (sender, receiver) = unbounded::<StateChange>();
-        let thread = stdx::thread::Builder::new(stdx::thread::QoSClass::Utility)
+        let thread = stdx::thread::Builder::new(stdx::thread::ThreadIntent::Worker)
             .name("Flycheck".to_owned())
             .spawn(move || actor.run(receiver))
             .expect("failed to spawn thread");
@@ -409,7 +409,7 @@ impl CargoHandle {
 
         let (sender, receiver) = unbounded();
         let actor = CargoActor::new(sender, stdout, stderr);
-        let thread = stdx::thread::Builder::new(stdx::thread::QoSClass::Utility)
+        let thread = stdx::thread::Builder::new(stdx::thread::ThreadIntent::Worker)
             .name("CargoHandle".to_owned())
             .spawn(move || actor.run())
             .expect("failed to spawn thread");

--- a/crates/ide/src/prime_caches.rs
+++ b/crates/ide/src/prime_caches.rs
@@ -81,7 +81,7 @@ pub(crate) fn parallel_prime_caches(
             let worker = prime_caches_worker.clone();
             let db = db.snapshot();
 
-            stdx::thread::Builder::new(stdx::thread::QoSClass::Utility)
+            stdx::thread::Builder::new(stdx::thread::ThreadIntent::Worker)
                 .allow_leak(true)
                 .spawn(move || Cancelled::catch(|| worker(db)))
                 .expect("failed to spawn thread");

--- a/crates/ide/src/prime_caches.rs
+++ b/crates/ide/src/prime_caches.rs
@@ -81,7 +81,7 @@ pub(crate) fn parallel_prime_caches(
             let worker = prime_caches_worker.clone();
             let db = db.snapshot();
 
-            stdx::thread::Builder::new(stdx::thread::QoSClass::Default)
+            stdx::thread::Builder::new(stdx::thread::QoSClass::Utility)
                 .allow_leak(true)
                 .spawn(move || Cancelled::catch(|| worker(db)))
                 .expect("failed to spawn thread");

--- a/crates/ide/src/prime_caches.rs
+++ b/crates/ide/src/prime_caches.rs
@@ -81,7 +81,7 @@ pub(crate) fn parallel_prime_caches(
             let worker = prime_caches_worker.clone();
             let db = db.snapshot();
 
-            stdx::thread::Builder::new(stdx::thread::QoSClass::Utility)
+            stdx::thread::Builder::new(stdx::thread::QoSClass::Default)
                 .allow_leak(true)
                 .spawn(move || Cancelled::catch(|| worker(db)))
                 .expect("failed to spawn thread");

--- a/crates/rust-analyzer/Cargo.toml
+++ b/crates/rust-analyzer/Cargo.toml
@@ -31,7 +31,6 @@ oorandom = "11.1.3"
 rustc-hash = "1.1.0"
 serde_json = { workspace = true, features = ["preserve_order"] }
 serde.workspace = true
-threadpool = "1.8.1"
 rayon = "1.6.1"
 num_cpus = "1.15.0"
 mimalloc = { version = "0.1.30", default-features = false, optional = true }

--- a/crates/rust-analyzer/src/bin/main.rs
+++ b/crates/rust-analyzer/src/bin/main.rs
@@ -85,7 +85,7 @@ fn try_main(flags: flags::RustAnalyzer) -> Result<()> {
             // will make actions like hitting enter in the editor slow.
             // rust-analyzer does not block the editor’s render loop,
             // so we don’t use User Interactive.
-            with_extra_thread("LspServer", stdx::thread::QoSClass::Default, run_server)?;
+            with_extra_thread("LspServer", stdx::thread::QoSClass::UserInitiated, run_server)?;
         }
         flags::RustAnalyzerCmd::Parse(cmd) => cmd.run()?,
         flags::RustAnalyzerCmd::Symbols(cmd) => cmd.run()?,

--- a/crates/rust-analyzer/src/bin/main.rs
+++ b/crates/rust-analyzer/src/bin/main.rs
@@ -85,7 +85,7 @@ fn try_main(flags: flags::RustAnalyzer) -> Result<()> {
             // will make actions like hitting enter in the editor slow.
             // rust-analyzer does not block the editor’s render loop,
             // so we don’t use User Interactive.
-            with_extra_thread("LspServer", stdx::thread::QoSClass::UserInitiated, run_server)?;
+            with_extra_thread("LspServer", stdx::thread::QoSClass::Default, run_server)?;
         }
         flags::RustAnalyzerCmd::Parse(cmd) => cmd.run()?,
         flags::RustAnalyzerCmd::Symbols(cmd) => cmd.run()?,

--- a/crates/rust-analyzer/src/bin/main.rs
+++ b/crates/rust-analyzer/src/bin/main.rs
@@ -79,13 +79,15 @@ fn try_main(flags: flags::RustAnalyzer) -> Result<()> {
                 return Ok(());
             }
 
-            // rust-analyzer’s “main thread” is actually a secondary thread
-            // with an increased stack size at the User Initiated QoS class.
-            // We use this QoS class because any delay in the main loop
+            // rust-analyzer’s “main thread” is actually
+            // a secondary latency-sensitive thread with an increased stack size.
+            // We use this thread intent because any delay in the main loop
             // will make actions like hitting enter in the editor slow.
-            // rust-analyzer does not block the editor’s render loop,
-            // so we don’t use User Interactive.
-            with_extra_thread("LspServer", stdx::thread::QoSClass::UserInitiated, run_server)?;
+            with_extra_thread(
+                "LspServer",
+                stdx::thread::ThreadIntent::LatencySensitive,
+                run_server,
+            )?;
         }
         flags::RustAnalyzerCmd::Parse(cmd) => cmd.run()?,
         flags::RustAnalyzerCmd::Symbols(cmd) => cmd.run()?,
@@ -143,10 +145,10 @@ const STACK_SIZE: usize = 1024 * 1024 * 8;
 /// space.
 fn with_extra_thread(
     thread_name: impl Into<String>,
-    qos_class: stdx::thread::QoSClass,
+    thread_intent: stdx::thread::ThreadIntent,
     f: impl FnOnce() -> Result<()> + Send + 'static,
 ) -> Result<()> {
-    let handle = stdx::thread::Builder::new(qos_class)
+    let handle = stdx::thread::Builder::new(thread_intent)
         .name(thread_name.into())
         .stack_size(STACK_SIZE)
         .spawn(f)?;

--- a/crates/rust-analyzer/src/handlers/notification.rs
+++ b/crates/rust-analyzer/src/handlers/notification.rs
@@ -291,7 +291,7 @@ fn run_flycheck(state: &mut GlobalState, vfs_path: VfsPath) -> bool {
             }
             Ok(())
         };
-        state.task_pool.handle.spawn_with_sender(move |_| {
+        state.task_pool.handle.spawn_with_sender(stdx::thread::QoSClass::Default, move |_| {
             if let Err(e) = std::panic::catch_unwind(task) {
                 tracing::error!("flycheck task panicked: {e:?}")
             }

--- a/crates/rust-analyzer/src/handlers/notification.rs
+++ b/crates/rust-analyzer/src/handlers/notification.rs
@@ -291,7 +291,7 @@ fn run_flycheck(state: &mut GlobalState, vfs_path: VfsPath) -> bool {
             }
             Ok(())
         };
-        state.task_pool.handle.spawn_with_sender(stdx::thread::QoSClass::Utility, move |_| {
+        state.task_pool.handle.spawn_with_sender(stdx::thread::ThreadIntent::Worker, move |_| {
             if let Err(e) = std::panic::catch_unwind(task) {
                 tracing::error!("flycheck task panicked: {e:?}")
             }

--- a/crates/rust-analyzer/src/handlers/notification.rs
+++ b/crates/rust-analyzer/src/handlers/notification.rs
@@ -291,7 +291,7 @@ fn run_flycheck(state: &mut GlobalState, vfs_path: VfsPath) -> bool {
             }
             Ok(())
         };
-        state.task_pool.handle.spawn_with_sender(stdx::thread::QoSClass::Default, move |_| {
+        state.task_pool.handle.spawn_with_sender(stdx::thread::QoSClass::Utility, move |_| {
             if let Err(e) = std::panic::catch_unwind(task) {
                 tracing::error!("flycheck task panicked: {e:?}")
             }

--- a/crates/rust-analyzer/src/main_loop.rs
+++ b/crates/rust-analyzer/src/main_loop.rs
@@ -695,6 +695,14 @@ impl GlobalState {
             .on_latency_sensitive::<lsp_types::request::SemanticTokensRangeRequest>(
                 handlers::handle_semantic_tokens_range,
             )
+            // Formatting is not caused by the user typing,
+            // but it does qualify as latency-sensitive
+            // because a delay before formatting is applied
+            // can be confusing for the user.
+            .on_latency_sensitive::<lsp_types::request::Formatting>(handlers::handle_formatting)
+            .on_latency_sensitive::<lsp_types::request::RangeFormatting>(
+                handlers::handle_range_formatting,
+            )
             // All other request handlers
             .on::<lsp_ext::FetchDependencyList>(handlers::fetch_dependency_list)
             .on::<lsp_ext::AnalyzerStatus>(handlers::handle_analyzer_status)
@@ -730,8 +738,6 @@ impl GlobalState {
             .on::<lsp_types::request::PrepareRenameRequest>(handlers::handle_prepare_rename)
             .on::<lsp_types::request::Rename>(handlers::handle_rename)
             .on::<lsp_types::request::References>(handlers::handle_references)
-            .on::<lsp_types::request::Formatting>(handlers::handle_formatting)
-            .on::<lsp_types::request::RangeFormatting>(handlers::handle_range_formatting)
             .on::<lsp_types::request::DocumentHighlightRequest>(handlers::handle_document_highlight)
             .on::<lsp_types::request::CallHierarchyPrepare>(handlers::handle_call_hierarchy_prepare)
             .on::<lsp_types::request::CallHierarchyIncomingCalls>(

--- a/crates/rust-analyzer/src/reload.rs
+++ b/crates/rust-analyzer/src/reload.rs
@@ -185,7 +185,7 @@ impl GlobalState {
     pub(crate) fn fetch_workspaces(&mut self, cause: Cause) {
         tracing::info!(%cause, "will fetch workspaces");
 
-        self.task_pool.handle.spawn_with_sender({
+        self.task_pool.handle.spawn_with_sender(stdx::thread::QoSClass::Default, {
             let linked_projects = self.config.linked_projects();
             let detached_files = self.config.detached_files().to_vec();
             let cargo_config = self.config.cargo();
@@ -260,7 +260,7 @@ impl GlobalState {
         tracing::info!(%cause, "will fetch build data");
         let workspaces = Arc::clone(&self.workspaces);
         let config = self.config.cargo();
-        self.task_pool.handle.spawn_with_sender(move |sender| {
+        self.task_pool.handle.spawn_with_sender(stdx::thread::QoSClass::Default, move |sender| {
             sender.send(Task::FetchBuildData(BuildDataProgress::Begin)).unwrap();
 
             let progress = {
@@ -280,7 +280,7 @@ impl GlobalState {
         let dummy_replacements = self.config.dummy_replacements().clone();
         let proc_macro_clients = self.proc_macro_clients.clone();
 
-        self.task_pool.handle.spawn_with_sender(move |sender| {
+        self.task_pool.handle.spawn_with_sender(stdx::thread::QoSClass::Default, move |sender| {
             sender.send(Task::LoadProcMacros(ProcMacroProgress::Begin)).unwrap();
 
             let dummy_replacements = &dummy_replacements;

--- a/crates/rust-analyzer/src/reload.rs
+++ b/crates/rust-analyzer/src/reload.rs
@@ -27,7 +27,7 @@ use ide_db::{
 use itertools::Itertools;
 use proc_macro_api::{MacroDylib, ProcMacroServer};
 use project_model::{PackageRoot, ProjectWorkspace, WorkspaceBuildScripts};
-use stdx::format_to;
+use stdx::{format_to, thread::ThreadIntent};
 use syntax::SmolStr;
 use triomphe::Arc;
 use vfs::{file_set::FileSetConfig, AbsPath, AbsPathBuf, ChangeKind};
@@ -185,7 +185,7 @@ impl GlobalState {
     pub(crate) fn fetch_workspaces(&mut self, cause: Cause) {
         tracing::info!(%cause, "will fetch workspaces");
 
-        self.task_pool.handle.spawn_with_sender(stdx::thread::QoSClass::Utility, {
+        self.task_pool.handle.spawn_with_sender(ThreadIntent::Worker, {
             let linked_projects = self.config.linked_projects();
             let detached_files = self.config.detached_files().to_vec();
             let cargo_config = self.config.cargo();
@@ -260,7 +260,7 @@ impl GlobalState {
         tracing::info!(%cause, "will fetch build data");
         let workspaces = Arc::clone(&self.workspaces);
         let config = self.config.cargo();
-        self.task_pool.handle.spawn_with_sender(stdx::thread::QoSClass::Utility, move |sender| {
+        self.task_pool.handle.spawn_with_sender(ThreadIntent::Worker, move |sender| {
             sender.send(Task::FetchBuildData(BuildDataProgress::Begin)).unwrap();
 
             let progress = {
@@ -280,7 +280,7 @@ impl GlobalState {
         let dummy_replacements = self.config.dummy_replacements().clone();
         let proc_macro_clients = self.proc_macro_clients.clone();
 
-        self.task_pool.handle.spawn_with_sender(stdx::thread::QoSClass::Utility, move |sender| {
+        self.task_pool.handle.spawn_with_sender(ThreadIntent::Worker, move |sender| {
             sender.send(Task::LoadProcMacros(ProcMacroProgress::Begin)).unwrap();
 
             let dummy_replacements = &dummy_replacements;

--- a/crates/rust-analyzer/src/reload.rs
+++ b/crates/rust-analyzer/src/reload.rs
@@ -185,7 +185,7 @@ impl GlobalState {
     pub(crate) fn fetch_workspaces(&mut self, cause: Cause) {
         tracing::info!(%cause, "will fetch workspaces");
 
-        self.task_pool.handle.spawn_with_sender(stdx::thread::QoSClass::Default, {
+        self.task_pool.handle.spawn_with_sender(stdx::thread::QoSClass::Utility, {
             let linked_projects = self.config.linked_projects();
             let detached_files = self.config.detached_files().to_vec();
             let cargo_config = self.config.cargo();
@@ -260,7 +260,7 @@ impl GlobalState {
         tracing::info!(%cause, "will fetch build data");
         let workspaces = Arc::clone(&self.workspaces);
         let config = self.config.cargo();
-        self.task_pool.handle.spawn_with_sender(stdx::thread::QoSClass::Default, move |sender| {
+        self.task_pool.handle.spawn_with_sender(stdx::thread::QoSClass::Utility, move |sender| {
             sender.send(Task::FetchBuildData(BuildDataProgress::Begin)).unwrap();
 
             let progress = {
@@ -280,7 +280,7 @@ impl GlobalState {
         let dummy_replacements = self.config.dummy_replacements().clone();
         let proc_macro_clients = self.proc_macro_clients.clone();
 
-        self.task_pool.handle.spawn_with_sender(stdx::thread::QoSClass::Default, move |sender| {
+        self.task_pool.handle.spawn_with_sender(stdx::thread::QoSClass::Utility, move |sender| {
             sender.send(Task::LoadProcMacros(ProcMacroProgress::Begin)).unwrap();
 
             let dummy_replacements = &dummy_replacements;

--- a/crates/rust-analyzer/src/task_pool.rs
+++ b/crates/rust-analyzer/src/task_pool.rs
@@ -1,76 +1,42 @@
-//! A thin wrapper around `ThreadPool` to make sure that we join all things
-//! properly.
-use std::sync::{Arc, Barrier};
+//! A thin wrapper around [`stdx::thread::Pool`] which threads a sender through spawned jobs.
+//! It is used in [`crate::global_state::GlobalState`] throughout the main loop.
 
 use crossbeam_channel::Sender;
+use stdx::thread::{Pool, QoSClass};
 
 pub(crate) struct TaskPool<T> {
     sender: Sender<T>,
-    inner: threadpool::ThreadPool,
+    pool: Pool,
 }
 
 impl<T> TaskPool<T> {
     pub(crate) fn new_with_threads(sender: Sender<T>, threads: usize) -> TaskPool<T> {
-        const STACK_SIZE: usize = 8 * 1024 * 1024;
-
-        let inner = threadpool::Builder::new()
-            .thread_name("Worker".into())
-            .thread_stack_size(STACK_SIZE)
-            .num_threads(threads)
-            .build();
-
-        // Set QoS of all threads in threadpool.
-        let barrier = Arc::new(Barrier::new(threads + 1));
-        for _ in 0..threads {
-            let barrier = barrier.clone();
-            inner.execute(move || {
-                stdx::thread::set_current_thread_qos_class(stdx::thread::QoSClass::Utility);
-                barrier.wait();
-            });
-        }
-        barrier.wait();
-
-        TaskPool { sender, inner }
+        TaskPool { sender, pool: Pool::new(threads) }
     }
 
-    pub(crate) fn spawn<F>(&mut self, task: F)
+    pub(crate) fn spawn<F>(&mut self, qos_class: QoSClass, task: F)
     where
         F: FnOnce() -> T + Send + 'static,
         T: Send + 'static,
     {
-        self.inner.execute({
+        self.pool.spawn(qos_class, {
             let sender = self.sender.clone();
-            move || {
-                if stdx::thread::IS_QOS_AVAILABLE {
-                    debug_assert_eq!(
-                        stdx::thread::get_current_thread_qos_class(),
-                        Some(stdx::thread::QoSClass::Utility)
-                    );
-                }
-
-                sender.send(task()).unwrap()
-            }
+            move || sender.send(task()).unwrap()
         })
     }
 
-    pub(crate) fn spawn_with_sender<F>(&mut self, task: F)
+    pub(crate) fn spawn_with_sender<F>(&mut self, qos_class: QoSClass, task: F)
     where
         F: FnOnce(Sender<T>) + Send + 'static,
         T: Send + 'static,
     {
-        self.inner.execute({
+        self.pool.spawn(qos_class, {
             let sender = self.sender.clone();
             move || task(sender)
         })
     }
 
     pub(crate) fn len(&self) -> usize {
-        self.inner.queued_count()
-    }
-}
-
-impl<T> Drop for TaskPool<T> {
-    fn drop(&mut self) {
-        self.inner.join()
+        self.pool.len()
     }
 }

--- a/crates/rust-analyzer/tests/slow-tests/support.rs
+++ b/crates/rust-analyzer/tests/slow-tests/support.rs
@@ -165,7 +165,7 @@ impl Server {
     fn new(dir: TestDir, config: Config) -> Server {
         let (connection, client) = Connection::memory();
 
-        let _thread = stdx::thread::Builder::new(stdx::thread::QoSClass::Utility)
+        let _thread = stdx::thread::Builder::new(stdx::thread::ThreadIntent::Worker)
             .name("test server".to_string())
             .spawn(move || main_loop(config, connection).unwrap())
             .expect("failed to spawn a thread");

--- a/crates/stdx/Cargo.toml
+++ b/crates/stdx/Cargo.toml
@@ -16,6 +16,7 @@ libc = "0.2.135"
 backtrace = { version = "0.3.65", optional = true }
 always-assert = { version = "0.1.2", features = ["log"] }
 jod-thread = "0.1.2"
+crossbeam-channel = "0.5.5"
 # Think twice before adding anything here
 
 [target.'cfg(windows)'.dependencies]

--- a/crates/stdx/src/thread.rs
+++ b/crates/stdx/src/thread.rs
@@ -1,39 +1,46 @@
 //! A utility module for working with threads that automatically joins threads upon drop
-//! and provides functionality for interfacing with operating system quality of service (QoS) APIs.
+//! and abstracts over operating system quality of service (QoS) APIs
+//! through the concept of a “thread intent”.
+//!
+//! The intent of a thread is frozen at thread creation time,
+//! i.e. there is no API to change the intent of a thread once it has been spawned.
 //!
 //! As a system, rust-analyzer should have the property that
 //! old manual scheduling APIs are replaced entirely by QoS.
 //! To maintain this invariant, we panic when it is clear that
 //! old scheduling APIs have been used.
 //!
-//! Moreover, we also want to ensure that every thread has a QoS set explicitly
+//! Moreover, we also want to ensure that every thread has an intent set explicitly
 //! to force a decision about its importance to the system.
-//! Thus, [`QoSClass`] has no default value
-//! and every entry point to creating a thread requires a [`QoSClass`] upfront.
+//! Thus, [`ThreadIntent`] has no default value
+//! and every entry point to creating a thread requires a [`ThreadIntent`] upfront.
 
 use std::fmt;
 
+mod intent;
 mod pool;
+
+pub use intent::ThreadIntent;
 pub use pool::Pool;
 
-pub fn spawn<F, T>(qos_class: QoSClass, f: F) -> JoinHandle<T>
+pub fn spawn<F, T>(intent: ThreadIntent, f: F) -> JoinHandle<T>
 where
     F: FnOnce() -> T,
     F: Send + 'static,
     T: Send + 'static,
 {
-    Builder::new(qos_class).spawn(f).expect("failed to spawn thread")
+    Builder::new(intent).spawn(f).expect("failed to spawn thread")
 }
 
 pub struct Builder {
-    qos_class: QoSClass,
+    intent: ThreadIntent,
     inner: jod_thread::Builder,
     allow_leak: bool,
 }
 
 impl Builder {
-    pub fn new(qos_class: QoSClass) -> Builder {
-        Builder { qos_class, inner: jod_thread::Builder::new(), allow_leak: false }
+    pub fn new(intent: ThreadIntent) -> Builder {
+        Builder { intent, inner: jod_thread::Builder::new(), allow_leak: false }
     }
 
     pub fn name(self, name: String) -> Builder {
@@ -55,7 +62,7 @@ impl Builder {
         T: Send + 'static,
     {
         let inner_handle = self.inner.spawn(move || {
-            set_current_thread_qos_class(self.qos_class);
+            self.intent.apply_to_current_thread();
             f()
         })?;
 
@@ -91,239 +98,5 @@ impl<T> Drop for JoinHandle<T> {
 impl<T> fmt::Debug for JoinHandle<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.pad("JoinHandle { .. }")
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-// Please maintain order from least to most priority for the derived `Ord` impl.
-pub enum QoSClass {
-    // Documentation adapted from https://github.com/apple-oss-distributions/libpthread/blob/67e155c94093be9a204b69637d198eceff2c7c46/include/sys/qos.h#L55
-    //
-    /// TLDR: invisible maintenance tasks
-    ///
-    /// Contract:
-    ///
-    /// * **You do not care about how long it takes for work to finish.**
-    /// * **You do not care about work being deferred temporarily.**
-    ///   (e.g. if the device’s battery is in a critical state)
-    ///
-    /// Examples:
-    ///
-    /// * in a video editor:
-    ///   creating periodic backups of project files
-    /// * in a browser:
-    ///   cleaning up cached sites which have not been accessed in a long time
-    /// * in a collaborative word processor:
-    ///   creating a searchable index of all documents
-    ///
-    /// Use this QoS class for background tasks
-    /// which the user did not initiate themselves
-    /// and which are invisible to the user.
-    /// It is expected that this work will take significant time to complete:
-    /// minutes or even hours.
-    ///
-    /// This QoS class provides the most energy and thermally-efficient execution possible.
-    /// All other work is prioritized over background tasks.
-    Background,
-
-    /// TLDR: tasks that don’t block using your app
-    ///
-    /// Contract:
-    ///
-    /// * **Your app remains useful even as the task is executing.**
-    ///
-    /// Examples:
-    ///
-    /// * in a video editor:
-    ///   exporting a video to disk –
-    ///   the user can still work on the timeline
-    /// * in a browser:
-    ///   automatically extracting a downloaded zip file –
-    ///   the user can still switch tabs
-    /// * in a collaborative word processor:
-    ///   downloading images embedded in a document –
-    ///   the user can still make edits
-    ///
-    /// Use this QoS class for tasks which
-    /// may or may not be initiated by the user,
-    /// but whose result is visible.
-    /// It is expected that this work will take a few seconds to a few minutes.
-    /// Typically your app will include a progress bar
-    /// for tasks using this class.
-    ///
-    /// This QoS class provides a balance between
-    /// performance, responsiveness and efficiency.
-    Utility,
-
-    /// TLDR: tasks that block using your app
-    ///
-    /// Contract:
-    ///
-    /// * **You need this work to complete
-    ///   before the user can keep interacting with your app.**
-    /// * **Your work will not take more than a few seconds to complete.**
-    ///
-    /// Examples:
-    ///
-    /// * in a video editor:
-    ///   opening a saved project
-    /// * in a browser:
-    ///   loading a list of the user’s bookmarks and top sites
-    ///   when a new tab is created
-    /// * in a collaborative word processor:
-    ///   running a search on the document’s content
-    ///
-    /// Use this QoS class for tasks which were initiated by the user
-    /// and block the usage of your app while they are in progress.
-    /// It is expected that this work will take a few seconds or less to complete;
-    /// not long enough to cause the user to switch to something else.
-    /// Your app will likely indicate progress on these tasks
-    /// through the display of placeholder content or modals.
-    ///
-    /// This QoS class is not energy-efficient.
-    /// Rather, it provides responsiveness
-    /// by prioritizing work above other tasks on the system
-    /// except for critical user-interactive work.
-    UserInitiated,
-
-    /// TLDR: render loops and nothing else
-    ///
-    /// Contract:
-    ///
-    /// * **You absolutely need this work to complete immediately
-    ///   or your app will appear to freeze.**
-    /// * **Your work will always complete virtually instantaneously.**
-    ///
-    /// Examples:
-    ///
-    /// * the main thread in a GUI application
-    /// * the update & render loop in a game
-    /// * a secondary thread which progresses an animation
-    ///
-    /// Use this QoS class for any work which, if delayed,
-    /// will make your user interface unresponsive.
-    /// It is expected that this work will be virtually instantaneous.
-    ///
-    /// This QoS class is not energy-efficient.
-    /// Specifying this class is a request to run with
-    /// nearly all available system CPU and I/O bandwidth even under contention.
-    UserInteractive,
-}
-
-pub const IS_QOS_AVAILABLE: bool = imp::IS_QOS_AVAILABLE;
-
-pub fn set_current_thread_qos_class(class: QoSClass) {
-    imp::set_current_thread_qos_class(class)
-}
-
-pub fn get_current_thread_qos_class() -> Option<QoSClass> {
-    imp::get_current_thread_qos_class()
-}
-
-// All Apple platforms use XNU as their kernel
-// and thus have the concept of QoS.
-#[cfg(target_vendor = "apple")]
-mod imp {
-    use super::QoSClass;
-
-    pub(super) const IS_QOS_AVAILABLE: bool = true;
-
-    pub(super) fn set_current_thread_qos_class(class: QoSClass) {
-        let c = match class {
-            QoSClass::UserInteractive => libc::qos_class_t::QOS_CLASS_USER_INTERACTIVE,
-            QoSClass::UserInitiated => libc::qos_class_t::QOS_CLASS_USER_INITIATED,
-            QoSClass::Utility => libc::qos_class_t::QOS_CLASS_UTILITY,
-            QoSClass::Background => libc::qos_class_t::QOS_CLASS_BACKGROUND,
-        };
-
-        let code = unsafe { libc::pthread_set_qos_class_self_np(c, 0) };
-
-        if code == 0 {
-            return;
-        }
-
-        let errno = unsafe { *libc::__error() };
-
-        match errno {
-            libc::EPERM => {
-                // This thread has been excluded from the QoS system
-                // due to a previous call to a function such as `pthread_setschedparam`
-                // which is incompatible with QoS.
-                //
-                // Panic instead of returning an error
-                // to maintain the invariant that we only use QoS APIs.
-                panic!("tried to set QoS of thread which has opted out of QoS (os error {errno})")
-            }
-
-            libc::EINVAL => {
-                // This is returned if we pass something other than a qos_class_t
-                // to `pthread_set_qos_class_self_np`.
-                //
-                // This is impossible, so again panic.
-                unreachable!(
-                    "invalid qos_class_t value was passed to pthread_set_qos_class_self_np"
-                )
-            }
-
-            _ => {
-                // `pthread_set_qos_class_self_np`’s documentation
-                // does not mention any other errors.
-                unreachable!("`pthread_set_qos_class_self_np` returned unexpected error {errno}")
-            }
-        }
-    }
-
-    pub(super) fn get_current_thread_qos_class() -> Option<QoSClass> {
-        let current_thread = unsafe { libc::pthread_self() };
-        let mut qos_class_raw = libc::qos_class_t::QOS_CLASS_UNSPECIFIED;
-        let code = unsafe {
-            libc::pthread_get_qos_class_np(current_thread, &mut qos_class_raw, std::ptr::null_mut())
-        };
-
-        if code != 0 {
-            // `pthread_get_qos_class_np`’s documentation states that
-            // an error value is placed into errno if the return code is not zero.
-            // However, it never states what errors are possible.
-            // Inspecting the source[0] shows that, as of this writing, it always returns zero.
-            //
-            // Whatever errors the function could report in future are likely to be
-            // ones which we cannot handle anyway
-            //
-            // 0: https://github.com/apple-oss-distributions/libpthread/blob/67e155c94093be9a204b69637d198eceff2c7c46/src/qos.c#L171-L177
-            let errno = unsafe { *libc::__error() };
-            unreachable!("`pthread_get_qos_class_np` failed unexpectedly (os error {errno})");
-        }
-
-        match qos_class_raw {
-            libc::qos_class_t::QOS_CLASS_USER_INTERACTIVE => Some(QoSClass::UserInteractive),
-            libc::qos_class_t::QOS_CLASS_USER_INITIATED => Some(QoSClass::UserInitiated),
-            libc::qos_class_t::QOS_CLASS_DEFAULT => None, // QoS has never been set
-            libc::qos_class_t::QOS_CLASS_UTILITY => Some(QoSClass::Utility),
-            libc::qos_class_t::QOS_CLASS_BACKGROUND => Some(QoSClass::Background),
-
-            libc::qos_class_t::QOS_CLASS_UNSPECIFIED => {
-                // Using manual scheduling APIs causes threads to “opt out” of QoS.
-                // At this point they become incompatible with QoS,
-                // and as such have the “unspecified” QoS class.
-                //
-                // Panic instead of returning an error
-                // to maintain the invariant that we only use QoS APIs.
-                panic!("tried to get QoS of thread which has opted out of QoS")
-            }
-        }
-    }
-}
-
-// FIXME: Windows has QoS APIs, we should use them!
-#[cfg(not(target_vendor = "apple"))]
-mod imp {
-    use super::QoSClass;
-
-    pub(super) const IS_QOS_AVAILABLE: bool = false;
-
-    pub(super) fn set_current_thread_qos_class(_: QoSClass) {}
-
-    pub(super) fn get_current_thread_qos_class() -> Option<QoSClass> {
-        None
     }
 }

--- a/crates/stdx/src/thread.rs
+++ b/crates/stdx/src/thread.rs
@@ -13,6 +13,9 @@
 
 use std::fmt;
 
+mod pool;
+pub use pool::Pool;
+
 pub fn spawn<F, T>(qos_class: QoSClass, f: F) -> JoinHandle<T>
 where
     F: FnOnce() -> T,
@@ -152,6 +155,8 @@ pub enum QoSClass {
     /// performance, responsiveness and efficiency.
     Utility,
 
+    Default,
+
     /// TLDR: tasks that block using your app
     ///
     /// Contract:
@@ -229,6 +234,7 @@ mod imp {
         let c = match class {
             QoSClass::UserInteractive => libc::qos_class_t::QOS_CLASS_USER_INTERACTIVE,
             QoSClass::UserInitiated => libc::qos_class_t::QOS_CLASS_USER_INITIATED,
+            QoSClass::Default => libc::qos_class_t::QOS_CLASS_DEFAULT,
             QoSClass::Utility => libc::qos_class_t::QOS_CLASS_UTILITY,
             QoSClass::Background => libc::qos_class_t::QOS_CLASS_BACKGROUND,
         };

--- a/crates/stdx/src/thread.rs
+++ b/crates/stdx/src/thread.rs
@@ -155,8 +155,6 @@ pub enum QoSClass {
     /// performance, responsiveness and efficiency.
     Utility,
 
-    Default,
-
     /// TLDR: tasks that block using your app
     ///
     /// Contract:
@@ -234,7 +232,6 @@ mod imp {
         let c = match class {
             QoSClass::UserInteractive => libc::qos_class_t::QOS_CLASS_USER_INTERACTIVE,
             QoSClass::UserInitiated => libc::qos_class_t::QOS_CLASS_USER_INITIATED,
-            QoSClass::Default => libc::qos_class_t::QOS_CLASS_DEFAULT,
             QoSClass::Utility => libc::qos_class_t::QOS_CLASS_UTILITY,
             QoSClass::Background => libc::qos_class_t::QOS_CLASS_BACKGROUND,
         };

--- a/crates/stdx/src/thread/intent.rs
+++ b/crates/stdx/src/thread/intent.rs
@@ -1,0 +1,287 @@
+//! An opaque façade around platform-specific QoS APIs.
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+// Please maintain order from least to most priority for the derived `Ord` impl.
+pub enum ThreadIntent {
+    /// Any thread which does work that isn’t in the critical path of the user typing
+    /// (e.g. processing Go To Definition).
+    Worker,
+
+    /// Any thread which does work caused by the user typing
+    /// (e.g. processing syntax highlighting).
+    LatencySensitive,
+}
+
+impl ThreadIntent {
+    // These APIs must remain private;
+    // we only want consumers to set thread intent
+    // either during thread creation or using our pool impl.
+
+    pub(super) fn apply_to_current_thread(self) {
+        let class = thread_intent_to_qos_class(self);
+        set_current_thread_qos_class(class);
+    }
+
+    pub(super) fn assert_is_used_on_current_thread(self) {
+        if IS_QOS_AVAILABLE {
+            let class = thread_intent_to_qos_class(self);
+            assert_eq!(get_current_thread_qos_class(), Some(class));
+        }
+    }
+}
+
+use imp::QoSClass;
+
+const IS_QOS_AVAILABLE: bool = imp::IS_QOS_AVAILABLE;
+
+fn set_current_thread_qos_class(class: QoSClass) {
+    imp::set_current_thread_qos_class(class)
+}
+
+fn get_current_thread_qos_class() -> Option<QoSClass> {
+    imp::get_current_thread_qos_class()
+}
+
+fn thread_intent_to_qos_class(intent: ThreadIntent) -> QoSClass {
+    imp::thread_intent_to_qos_class(intent)
+}
+
+// All Apple platforms use XNU as their kernel
+// and thus have the concept of QoS.
+#[cfg(target_vendor = "apple")]
+mod imp {
+    use super::ThreadIntent;
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+    // Please maintain order from least to most priority for the derived `Ord` impl.
+    pub(super) enum QoSClass {
+        // Documentation adapted from https://github.com/apple-oss-distributions/libpthread/blob/67e155c94093be9a204b69637d198eceff2c7c46/include/sys/qos.h#L55
+        //
+        /// TLDR: invisible maintenance tasks
+        ///
+        /// Contract:
+        ///
+        /// * **You do not care about how long it takes for work to finish.**
+        /// * **You do not care about work being deferred temporarily.**
+        ///   (e.g. if the device’s battery is in a critical state)
+        ///
+        /// Examples:
+        ///
+        /// * in a video editor:
+        ///   creating periodic backups of project files
+        /// * in a browser:
+        ///   cleaning up cached sites which have not been accessed in a long time
+        /// * in a collaborative word processor:
+        ///   creating a searchable index of all documents
+        ///
+        /// Use this QoS class for background tasks
+        /// which the user did not initiate themselves
+        /// and which are invisible to the user.
+        /// It is expected that this work will take significant time to complete:
+        /// minutes or even hours.
+        ///
+        /// This QoS class provides the most energy and thermally-efficient execution possible.
+        /// All other work is prioritized over background tasks.
+        Background,
+
+        /// TLDR: tasks that don’t block using your app
+        ///
+        /// Contract:
+        ///
+        /// * **Your app remains useful even as the task is executing.**
+        ///
+        /// Examples:
+        ///
+        /// * in a video editor:
+        ///   exporting a video to disk –
+        ///   the user can still work on the timeline
+        /// * in a browser:
+        ///   automatically extracting a downloaded zip file –
+        ///   the user can still switch tabs
+        /// * in a collaborative word processor:
+        ///   downloading images embedded in a document –
+        ///   the user can still make edits
+        ///
+        /// Use this QoS class for tasks which
+        /// may or may not be initiated by the user,
+        /// but whose result is visible.
+        /// It is expected that this work will take a few seconds to a few minutes.
+        /// Typically your app will include a progress bar
+        /// for tasks using this class.
+        ///
+        /// This QoS class provides a balance between
+        /// performance, responsiveness and efficiency.
+        Utility,
+
+        /// TLDR: tasks that block using your app
+        ///
+        /// Contract:
+        ///
+        /// * **You need this work to complete
+        ///   before the user can keep interacting with your app.**
+        /// * **Your work will not take more than a few seconds to complete.**
+        ///
+        /// Examples:
+        ///
+        /// * in a video editor:
+        ///   opening a saved project
+        /// * in a browser:
+        ///   loading a list of the user’s bookmarks and top sites
+        ///   when a new tab is created
+        /// * in a collaborative word processor:
+        ///   running a search on the document’s content
+        ///
+        /// Use this QoS class for tasks which were initiated by the user
+        /// and block the usage of your app while they are in progress.
+        /// It is expected that this work will take a few seconds or less to complete;
+        /// not long enough to cause the user to switch to something else.
+        /// Your app will likely indicate progress on these tasks
+        /// through the display of placeholder content or modals.
+        ///
+        /// This QoS class is not energy-efficient.
+        /// Rather, it provides responsiveness
+        /// by prioritizing work above other tasks on the system
+        /// except for critical user-interactive work.
+        UserInitiated,
+
+        /// TLDR: render loops and nothing else
+        ///
+        /// Contract:
+        ///
+        /// * **You absolutely need this work to complete immediately
+        ///   or your app will appear to freeze.**
+        /// * **Your work will always complete virtually instantaneously.**
+        ///
+        /// Examples:
+        ///
+        /// * the main thread in a GUI application
+        /// * the update & render loop in a game
+        /// * a secondary thread which progresses an animation
+        ///
+        /// Use this QoS class for any work which, if delayed,
+        /// will make your user interface unresponsive.
+        /// It is expected that this work will be virtually instantaneous.
+        ///
+        /// This QoS class is not energy-efficient.
+        /// Specifying this class is a request to run with
+        /// nearly all available system CPU and I/O bandwidth even under contention.
+        UserInteractive,
+    }
+
+    pub(super) const IS_QOS_AVAILABLE: bool = true;
+
+    pub(super) fn set_current_thread_qos_class(class: QoSClass) {
+        let c = match class {
+            QoSClass::UserInteractive => libc::qos_class_t::QOS_CLASS_USER_INTERACTIVE,
+            QoSClass::UserInitiated => libc::qos_class_t::QOS_CLASS_USER_INITIATED,
+            QoSClass::Utility => libc::qos_class_t::QOS_CLASS_UTILITY,
+            QoSClass::Background => libc::qos_class_t::QOS_CLASS_BACKGROUND,
+        };
+
+        let code = unsafe { libc::pthread_set_qos_class_self_np(c, 0) };
+
+        if code == 0 {
+            return;
+        }
+
+        let errno = unsafe { *libc::__error() };
+
+        match errno {
+            libc::EPERM => {
+                // This thread has been excluded from the QoS system
+                // due to a previous call to a function such as `pthread_setschedparam`
+                // which is incompatible with QoS.
+                //
+                // Panic instead of returning an error
+                // to maintain the invariant that we only use QoS APIs.
+                panic!("tried to set QoS of thread which has opted out of QoS (os error {errno})")
+            }
+
+            libc::EINVAL => {
+                // This is returned if we pass something other than a qos_class_t
+                // to `pthread_set_qos_class_self_np`.
+                //
+                // This is impossible, so again panic.
+                unreachable!(
+                    "invalid qos_class_t value was passed to pthread_set_qos_class_self_np"
+                )
+            }
+
+            _ => {
+                // `pthread_set_qos_class_self_np`’s documentation
+                // does not mention any other errors.
+                unreachable!("`pthread_set_qos_class_self_np` returned unexpected error {errno}")
+            }
+        }
+    }
+
+    pub(super) fn get_current_thread_qos_class() -> Option<QoSClass> {
+        let current_thread = unsafe { libc::pthread_self() };
+        let mut qos_class_raw = libc::qos_class_t::QOS_CLASS_UNSPECIFIED;
+        let code = unsafe {
+            libc::pthread_get_qos_class_np(current_thread, &mut qos_class_raw, std::ptr::null_mut())
+        };
+
+        if code != 0 {
+            // `pthread_get_qos_class_np`’s documentation states that
+            // an error value is placed into errno if the return code is not zero.
+            // However, it never states what errors are possible.
+            // Inspecting the source[0] shows that, as of this writing, it always returns zero.
+            //
+            // Whatever errors the function could report in future are likely to be
+            // ones which we cannot handle anyway
+            //
+            // 0: https://github.com/apple-oss-distributions/libpthread/blob/67e155c94093be9a204b69637d198eceff2c7c46/src/qos.c#L171-L177
+            let errno = unsafe { *libc::__error() };
+            unreachable!("`pthread_get_qos_class_np` failed unexpectedly (os error {errno})");
+        }
+
+        match qos_class_raw {
+            libc::qos_class_t::QOS_CLASS_USER_INTERACTIVE => Some(QoSClass::UserInteractive),
+            libc::qos_class_t::QOS_CLASS_USER_INITIATED => Some(QoSClass::UserInitiated),
+            libc::qos_class_t::QOS_CLASS_DEFAULT => None, // QoS has never been set
+            libc::qos_class_t::QOS_CLASS_UTILITY => Some(QoSClass::Utility),
+            libc::qos_class_t::QOS_CLASS_BACKGROUND => Some(QoSClass::Background),
+
+            libc::qos_class_t::QOS_CLASS_UNSPECIFIED => {
+                // Using manual scheduling APIs causes threads to “opt out” of QoS.
+                // At this point they become incompatible with QoS,
+                // and as such have the “unspecified” QoS class.
+                //
+                // Panic instead of returning an error
+                // to maintain the invariant that we only use QoS APIs.
+                panic!("tried to get QoS of thread which has opted out of QoS")
+            }
+        }
+    }
+
+    pub(super) fn thread_intent_to_qos_class(intent: ThreadIntent) -> QoSClass {
+        match intent {
+            ThreadIntent::Worker => QoSClass::Utility,
+            ThreadIntent::LatencySensitive => QoSClass::UserInitiated,
+        }
+    }
+}
+
+// FIXME: Windows has QoS APIs, we should use them!
+#[cfg(not(target_vendor = "apple"))]
+mod imp {
+    use super::ThreadIntent;
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+    pub(super) enum QoSClass {
+        Default,
+    }
+
+    pub(super) const IS_QOS_AVAILABLE: bool = false;
+
+    pub(super) fn set_current_thread_qos_class(_: QoSClass) {}
+
+    pub(super) fn get_current_thread_qos_class() -> Option<QoSClass> {
+        None
+    }
+
+    pub(super) fn thread_intent_to_qos_class(_: ThreadIntent) -> QoSClass {
+        QoSClass::Default
+    }
+}

--- a/crates/stdx/src/thread/pool.rs
+++ b/crates/stdx/src/thread/pool.rs
@@ -1,0 +1,95 @@
+//! [`Pool`] implements a basic custom thread pool
+//! inspired by the [`threadpool` crate](http://docs.rs/threadpool).
+//! It allows the spawning of tasks under different QoS classes.
+//! rust-analyzer uses this to prioritize work based on latency requirements.
+//!
+//! The thread pool is implemented entirely using
+//! the threading utilities in [`crate::thread`].
+
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    Arc,
+};
+
+use crossbeam_channel::{Receiver, Sender};
+
+use super::{
+    get_current_thread_qos_class, set_current_thread_qos_class, Builder, JoinHandle, QoSClass,
+    IS_QOS_AVAILABLE,
+};
+
+pub struct Pool {
+    // `_handles` is never read: the field is present
+    // only for its `Drop` impl.
+
+    // The worker threads exit once the channel closes;
+    // make sure to keep `job_sender` above `handles`
+    // so that the channel is actually closed
+    // before we join the worker threads!
+    job_sender: Sender<Job>,
+    _handles: Vec<JoinHandle>,
+    extant_tasks: Arc<AtomicUsize>,
+}
+
+struct Job {
+    requested_qos_class: QoSClass,
+    f: Box<dyn FnOnce() + Send + 'static>,
+}
+
+impl Pool {
+    pub fn new(threads: usize) -> Pool {
+        const STACK_SIZE: usize = 8 * 1024 * 1024;
+        const INITIAL_QOS_CLASS: QoSClass = QoSClass::Utility;
+
+        let (job_sender, job_receiver) = crossbeam_channel::unbounded();
+        let extant_tasks = Arc::new(AtomicUsize::new(0));
+
+        let mut handles = Vec::with_capacity(threads);
+        for _ in 0..threads {
+            let handle = Builder::new(INITIAL_QOS_CLASS)
+                .stack_size(STACK_SIZE)
+                .name("Worker".into())
+                .spawn({
+                    let extant_tasks = Arc::clone(&extant_tasks);
+                    let job_receiver: Receiver<Job> = job_receiver.clone();
+                    move || {
+                        let mut current_qos_class = INITIAL_QOS_CLASS;
+                        for job in job_receiver {
+                            if job.requested_qos_class != current_qos_class {
+                                set_current_thread_qos_class(job.requested_qos_class);
+                                current_qos_class = job.requested_qos_class;
+                            }
+                            extant_tasks.fetch_add(1, Ordering::SeqCst);
+                            (job.f)();
+                            extant_tasks.fetch_sub(1, Ordering::SeqCst);
+                        }
+                    }
+                })
+                .expect("failed to spawn thread");
+
+            handles.push(handle);
+        }
+
+        Pool { _handles: handles, extant_tasks, job_sender }
+    }
+
+    pub fn spawn<F>(&self, qos_class: QoSClass, f: F)
+    where
+        F: FnOnce() + Send + 'static,
+    {
+        let f = Box::new(move || {
+            if IS_QOS_AVAILABLE {
+                debug_assert_eq!(get_current_thread_qos_class(), Some(qos_class));
+            }
+
+            f()
+        });
+
+        let job = Job { requested_qos_class: qos_class, f };
+        self.job_sender.send(job).unwrap();
+    }
+
+    pub fn len(&self) -> usize {
+        self.extant_tasks.load(Ordering::SeqCst)
+    }
+}

--- a/crates/vfs-notify/src/lib.rs
+++ b/crates/vfs-notify/src/lib.rs
@@ -34,7 +34,7 @@ impl loader::Handle for NotifyHandle {
     fn spawn(sender: loader::Sender) -> NotifyHandle {
         let actor = NotifyActor::new(sender);
         let (sender, receiver) = unbounded::<Message>();
-        let thread = stdx::thread::Builder::new(stdx::thread::QoSClass::Default)
+        let thread = stdx::thread::Builder::new(stdx::thread::QoSClass::Utility)
             .name("VfsLoader".to_owned())
             .spawn(move || actor.run(receiver))
             .expect("failed to spawn thread");

--- a/crates/vfs-notify/src/lib.rs
+++ b/crates/vfs-notify/src/lib.rs
@@ -34,7 +34,7 @@ impl loader::Handle for NotifyHandle {
     fn spawn(sender: loader::Sender) -> NotifyHandle {
         let actor = NotifyActor::new(sender);
         let (sender, receiver) = unbounded::<Message>();
-        let thread = stdx::thread::Builder::new(stdx::thread::QoSClass::Utility)
+        let thread = stdx::thread::Builder::new(stdx::thread::ThreadIntent::Worker)
             .name("VfsLoader".to_owned())
             .spawn(move || actor.run(receiver))
             .expect("failed to spawn thread");

--- a/crates/vfs-notify/src/lib.rs
+++ b/crates/vfs-notify/src/lib.rs
@@ -34,7 +34,7 @@ impl loader::Handle for NotifyHandle {
     fn spawn(sender: loader::Sender) -> NotifyHandle {
         let actor = NotifyActor::new(sender);
         let (sender, receiver) = unbounded::<Message>();
-        let thread = stdx::thread::Builder::new(stdx::thread::QoSClass::Utility)
+        let thread = stdx::thread::Builder::new(stdx::thread::QoSClass::Default)
             .name("VfsLoader".to_owned())
             .spawn(move || actor.run(receiver))
             .expect("failed to spawn thread");


### PR DESCRIPTION
To this end I’ve introduced a new custom thread pool type which can spawn threads using each QoS class. This way we can run latency-sensitive requests under one QoS class and everything else under another QoS class. The implementation is very similar to that of the `threadpool` crate (which is currently used by rust-analyzer) but with unused functionality stripped out.

I’ll have to rebase on master once #14859 is merged but I think everything else is alright :D