### PR TITLE
use `::core` instead of `$crate` in `option_env!`

### DIFF
--- a/crates/hir-def/src/macro_expansion_tests/builtin_fn_macro.rs
+++ b/crates/hir-def/src/macro_expansion_tests/builtin_fn_macro.rs
@@ -97,7 +97,7 @@ fn main() { option_env!("TEST_ENV_VAR"); }
 #[rustc_builtin_macro]
 macro_rules! option_env {() => {}}
 
-fn main() { $crate::option::Option::None:: < &str>; }
+fn main() { ::core::option::Option::None:: < &str>; }
 "#]],
     );
 }

--- a/crates/hir-expand/src/builtin_fn_macro.rs
+++ b/crates/hir-expand/src/builtin_fn_macro.rs
@@ -820,10 +820,10 @@ fn option_env_expand(
             )
         }
     };
-
+    // FIXME: Use `DOLLAR_CRATE` when that works in eager macros.
     let expanded = match get_env_inner(db, arg_id, &key) {
-        None => quote! { #DOLLAR_CRATE::option::Option::None::<&str> },
-        Some(s) => quote! { #DOLLAR_CRATE::option::Option::Some(#s) },
+        None => quote! { ::core::option::Option::None::<&str> },
+        Some(s) => quote! { ::core::option::Option::Some(#s) },
     };
 
     ExpandResult::ok(ExpandedEager::new(expanded))

--- a/crates/hir-ty/src/tests/macros.rs
+++ b/crates/hir-ty/src/tests/macros.rs
@@ -947,7 +947,7 @@ fn infer_builtin_macros_concat_with_lazy() {
 
 #[test]
 fn infer_builtin_macros_env() {
-    check_infer(
+    check_types(
         r#"
         //- /main.rs env:foo=bar
         #[rustc_builtin_macro]
@@ -955,13 +955,26 @@ fn infer_builtin_macros_env() {
 
         fn main() {
             let x = env!("foo");
+              //^ &str
         }
         "#,
-        expect![[r#"
-            !0..22 '"__RA_...TED__"': &str
-            62..90 '{     ...o"); }': ()
-            72..73 'x': &str
-        "#]],
+    );
+}
+
+#[test]
+fn infer_builtin_macros_option_env() {
+    check_types(
+        r#"
+        //- minicore: option
+        //- /main.rs env:foo=bar
+        #[rustc_builtin_macro]
+        macro_rules! option_env {() => {}}
+
+        fn main() {
+            let x = option_env!("foo");
+              //^ Option<&str>
+        }
+        "#,
     );
 }
 


### PR DESCRIPTION
fix #14885 