### PR TITLE
MIR episode 6

### DIFF
--- a/crates/hir-def/src/body/scope.rs
+++ b/crates/hir-def/src/body/scope.rs
@@ -228,12 +228,6 @@ fn compute_expr_scopes(expr: ExprId, body: &Body, scopes: &mut ExprScopes, scope
             scopes.set_scope(expr, scope);
             compute_block_scopes(statements, *tail, body, scopes, &mut scope);
         }
-        Expr::For { iterable, pat, body: body_expr, label } => {
-            compute_expr_scopes(*iterable, body, scopes, scope);
-            let mut scope = scopes.new_labeled_scope(*scope, make_label(label));
-            scopes.add_pat_bindings(body, scope, *pat);
-            compute_expr_scopes(*body_expr, body, scopes, &mut scope);
-        }
         Expr::While { condition, body: body_expr, label } => {
             let mut scope = scopes.new_labeled_scope(*scope, make_label(label));
             compute_expr_scopes(*condition, body, scopes, &mut scope);

--- a/crates/hir-def/src/hir.rs
+++ b/crates/hir-def/src/hir.rs
@@ -96,6 +96,13 @@ pub enum Literal {
     Float(FloatTypeWrapper, Option<BuiltinFloat>),
 }
 
+#[derive(Debug, Clone, Eq, PartialEq)]
+/// Used in range patterns.
+pub enum LiteralOrConst {
+    Literal(Literal),
+    Const(Path),
+}
+
 impl Literal {
     pub fn negate(self) -> Option<Self> {
         if let Literal::Int(i, k) = self {
@@ -186,12 +193,6 @@ pub enum Expr {
     },
     While {
         condition: ExprId,
-        body: ExprId,
-        label: Option<LabelId>,
-    },
-    For {
-        iterable: ExprId,
-        pat: PatId,
         body: ExprId,
         label: Option<LabelId>,
     },
@@ -382,10 +383,6 @@ impl Expr {
                 f(*condition);
                 f(*body);
             }
-            Expr::For { iterable, body, .. } => {
-                f(*iterable);
-                f(*body);
-            }
             Expr::Call { callee, args, .. } => {
                 f(*callee);
                 args.iter().copied().for_each(f);
@@ -526,7 +523,7 @@ pub enum Pat {
     Tuple { args: Box<[PatId]>, ellipsis: Option<usize> },
     Or(Box<[PatId]>),
     Record { path: Option<Box<Path>>, args: Box<[RecordFieldPat]>, ellipsis: bool },
-    Range { start: ExprId, end: ExprId },
+    Range { start: Option<Box<LiteralOrConst>>, end: Option<Box<LiteralOrConst>> },
     Slice { prefix: Box<[PatId]>, slice: Option<PatId>, suffix: Box<[PatId]> },
     Path(Box<Path>),
     Lit(ExprId),

--- a/crates/hir-ty/src/consteval.rs
+++ b/crates/hir-ty/src/consteval.rs
@@ -14,9 +14,9 @@ use stdx::never;
 use triomphe::Arc;
 
 use crate::{
-    db::HirDatabase, infer::InferenceContext, layout::layout_of_ty, lower::ParamLoweringMode,
-    to_placeholder_idx, utils::Generics, Const, ConstData, ConstScalar, ConstValue, GenericArg,
-    Interner, MemoryMap, Substitution, Ty, TyBuilder,
+    db::HirDatabase, infer::InferenceContext, lower::ParamLoweringMode,
+    mir::monomorphize_mir_body_bad, to_placeholder_idx, utils::Generics, Const, ConstData,
+    ConstScalar, ConstValue, GenericArg, Interner, MemoryMap, Substitution, Ty, TyBuilder,
 };
 
 use super::mir::{interpret_mir, lower_to_mir, pad16, MirEvalError, MirLowerError};
@@ -130,14 +130,15 @@ pub fn intern_const_scalar(value: ConstScalar, ty: Ty) -> Const {
 
 /// Interns a constant scalar with the given type
 pub fn intern_const_ref(db: &dyn HirDatabase, value: &ConstRef, ty: Ty, krate: CrateId) -> Const {
+    let layout = db.layout_of_ty(ty.clone(), krate);
     let bytes = match value {
         ConstRef::Int(i) => {
             // FIXME: We should handle failure of layout better.
-            let size = layout_of_ty(db, &ty, krate).map(|x| x.size.bytes_usize()).unwrap_or(16);
+            let size = layout.map(|x| x.size.bytes_usize()).unwrap_or(16);
             ConstScalar::Bytes(i.to_le_bytes()[0..size].to_vec(), MemoryMap::default())
         }
         ConstRef::UInt(i) => {
-            let size = layout_of_ty(db, &ty, krate).map(|x| x.size.bytes_usize()).unwrap_or(16);
+            let size = layout.map(|x| x.size.bytes_usize()).unwrap_or(16);
             ConstScalar::Bytes(i.to_le_bytes()[0..size].to_vec(), MemoryMap::default())
         }
         ConstRef::Bool(b) => ConstScalar::Bytes(vec![*b as u8], MemoryMap::default()),
@@ -206,15 +207,22 @@ pub(crate) fn const_eval_query(
     subst: Substitution,
 ) -> Result<Const, ConstEvalError> {
     let body = match def {
-        GeneralConstId::ConstId(c) => db.mir_body(c.into())?,
+        GeneralConstId::ConstId(c) => {
+            db.monomorphized_mir_body(c.into(), subst, db.trait_environment(c.into()))?
+        }
         GeneralConstId::AnonymousConstId(c) => {
             let (def, root) = db.lookup_intern_anonymous_const(c);
             let body = db.body(def);
             let infer = db.infer(def);
-            Arc::new(lower_to_mir(db, def, &body, &infer, root)?)
+            Arc::new(monomorphize_mir_body_bad(
+                db,
+                lower_to_mir(db, def, &body, &infer, root)?,
+                subst,
+                db.trait_environment_for_body(def),
+            )?)
         }
     };
-    let c = interpret_mir(db, &body, subst, false).0?;
+    let c = interpret_mir(db, &body, false).0?;
     Ok(c)
 }
 
@@ -222,8 +230,12 @@ pub(crate) fn const_eval_static_query(
     db: &dyn HirDatabase,
     def: StaticId,
 ) -> Result<Const, ConstEvalError> {
-    let body = db.mir_body(def.into())?;
-    let c = interpret_mir(db, &body, Substitution::empty(Interner), false).0?;
+    let body = db.monomorphized_mir_body(
+        def.into(),
+        Substitution::empty(Interner),
+        db.trait_environment_for_body(def.into()),
+    )?;
+    let c = interpret_mir(db, &body, false).0?;
     Ok(c)
 }
 
@@ -245,8 +257,12 @@ pub(crate) fn const_eval_discriminant_variant(
         };
         return Ok(value);
     }
-    let mir_body = db.mir_body(def)?;
-    let c = interpret_mir(db, &mir_body, Substitution::empty(Interner), false).0?;
+    let mir_body = db.monomorphized_mir_body(
+        def,
+        Substitution::empty(Interner),
+        db.trait_environment_for_body(def),
+    )?;
+    let c = interpret_mir(db, &mir_body, false).0?;
     let c = try_const_usize(db, &c).unwrap() as i128;
     Ok(c)
 }
@@ -271,7 +287,7 @@ pub(crate) fn eval_to_const(
     }
     let infer = ctx.clone().resolve_all();
     if let Ok(mir_body) = lower_to_mir(ctx.db, ctx.owner, &ctx.body, &infer, expr) {
-        if let Ok(result) = interpret_mir(db, &mir_body, Substitution::empty(Interner), true).0 {
+        if let Ok(result) = interpret_mir(db, &mir_body, true).0 {
             return result;
         }
     }

--- a/crates/hir-ty/src/consteval/tests/intrinsics.rs
+++ b/crates/hir-ty/src/consteval/tests/intrinsics.rs
@@ -68,6 +68,30 @@ fn wrapping_add() {
 }
 
 #[test]
+fn saturating_add() {
+    check_number(
+        r#"
+        extern "rust-intrinsic" {
+            pub fn saturating_add<T>(a: T, b: T) -> T;
+        }
+
+        const GOAL: u8 = saturating_add(10, 250);
+        "#,
+        255,
+    );
+    check_number(
+        r#"
+        extern "rust-intrinsic" {
+            pub fn saturating_add<T>(a: T, b: T) -> T;
+        }
+
+        const GOAL: i8 = saturating_add(5, 8);
+        "#,
+        13,
+    );
+}
+
+#[test]
 fn allocator() {
     check_number(
         r#"

--- a/crates/hir-ty/src/db.rs
+++ b/crates/hir-ty/src/db.rs
@@ -41,6 +41,23 @@ pub trait HirDatabase: DefDatabase + Upcast<dyn DefDatabase> {
     #[salsa::invoke(crate::mir::mir_body_for_closure_query)]
     fn mir_body_for_closure(&self, def: ClosureId) -> Result<Arc<MirBody>, MirLowerError>;
 
+    #[salsa::invoke(crate::mir::monomorphized_mir_body_query)]
+    #[salsa::cycle(crate::mir::monomorphized_mir_body_recover)]
+    fn monomorphized_mir_body(
+        &self,
+        def: DefWithBodyId,
+        subst: Substitution,
+        env: Arc<crate::TraitEnvironment>,
+    ) -> Result<Arc<MirBody>, MirLowerError>;
+
+    #[salsa::invoke(crate::mir::monomorphized_mir_body_for_closure_query)]
+    fn monomorphized_mir_body_for_closure(
+        &self,
+        def: ClosureId,
+        subst: Substitution,
+        env: Arc<crate::TraitEnvironment>,
+    ) -> Result<Arc<MirBody>, MirLowerError>;
+
     #[salsa::invoke(crate::mir::borrowck_query)]
     fn borrowck(&self, def: DefWithBodyId) -> Result<Arc<[BorrowckResult]>, MirLowerError>;
 
@@ -84,7 +101,11 @@ pub trait HirDatabase: DefDatabase + Upcast<dyn DefDatabase> {
         def: AdtId,
         subst: Substitution,
         krate: CrateId,
-    ) -> Result<Layout, LayoutError>;
+    ) -> Result<Arc<Layout>, LayoutError>;
+
+    #[salsa::invoke(crate::layout::layout_of_ty_query)]
+    #[salsa::cycle(crate::layout::layout_of_ty_recover)]
+    fn layout_of_ty(&self, ty: Ty, krate: CrateId) -> Result<Arc<Layout>, LayoutError>;
 
     #[salsa::invoke(crate::layout::target_data_layout_query)]
     fn target_data_layout(&self, krate: CrateId) -> Option<Arc<TargetDataLayout>>;

--- a/crates/hir-ty/src/infer.rs
+++ b/crates/hir-ty/src/infer.rs
@@ -1153,22 +1153,6 @@ impl<'a> InferenceContext<'a> {
         self.db.lang_item(krate, item)
     }
 
-    fn resolve_into_iter_item(&self) -> Option<TypeAliasId> {
-        let ItemContainerId::TraitId(trait_) = self.resolve_lang_item(LangItem::IntoIterIntoIter)?
-            .as_function()?
-            .lookup(self.db.upcast()).container
-        else { return None };
-        self.db.trait_data(trait_).associated_type_by_name(&name![IntoIter])
-    }
-
-    fn resolve_iterator_item(&self) -> Option<TypeAliasId> {
-        let ItemContainerId::TraitId(trait_) = self.resolve_lang_item(LangItem::IteratorNext)?
-            .as_function()?
-            .lookup(self.db.upcast()).container
-        else { return None };
-        self.db.trait_data(trait_).associated_type_by_name(&name![Item])
-    }
-
     fn resolve_output_on(&self, trait_: TraitId) -> Option<TypeAliasId> {
         self.db.trait_data(trait_).associated_type_by_name(&name![Output])
     }

--- a/crates/hir-ty/src/infer/expr.rs
+++ b/crates/hir-ty/src/infer/expr.rs
@@ -211,24 +211,6 @@ impl<'a> InferenceContext<'a> {
                 self.diverges = Diverges::Maybe;
                 TyBuilder::unit()
             }
-            &Expr::For { iterable, body, pat, label } => {
-                let iterable_ty = self.infer_expr(iterable, &Expectation::none());
-                let into_iter_ty =
-                    self.resolve_associated_type(iterable_ty, self.resolve_into_iter_item());
-                let pat_ty = self
-                    .resolve_associated_type(into_iter_ty.clone(), self.resolve_iterator_item());
-
-                self.result.type_of_for_iterator.insert(tgt_expr, into_iter_ty);
-
-                self.infer_top_pat(pat, &pat_ty);
-                self.with_breakable_ctx(BreakableKind::Loop, None, label, |this| {
-                    this.infer_expr(body, &Expectation::HasType(TyBuilder::unit()));
-                });
-
-                // the body may not run, so it diverging doesn't mean we diverge
-                self.diverges = Diverges::Maybe;
-                TyBuilder::unit()
-            }
             Expr::Closure { body, args, ret_type, arg_types, closure_kind, capture_by: _ } => {
                 assert_eq!(args.len(), arg_types.len());
 

--- a/crates/hir-ty/src/infer/mutability.rs
+++ b/crates/hir-ty/src/infer/mutability.rs
@@ -69,8 +69,7 @@ impl<'a> InferenceContext<'a> {
                     self.infer_mut_expr(*tail, Mutability::Not);
                 }
             }
-            &Expr::For { iterable: c, pat: _, body, label: _ }
-            | &Expr::While { condition: c, body, label: _ } => {
+            &Expr::While { condition: c, body, label: _ } => {
                 self.infer_mut_expr(c, Mutability::Not);
                 self.infer_mut_expr(body, Mutability::Not);
             }

--- a/crates/hir-ty/src/infer/pat.rs
+++ b/crates/hir-ty/src/infer/pat.rs
@@ -255,9 +255,9 @@ impl<'a> InferenceContext<'a> {
                 self.infer_slice_pat(&expected, prefix, slice, suffix, default_bm)
             }
             Pat::Wild => expected.clone(),
-            Pat::Range { start, end } => {
-                let start_ty = self.infer_expr(*start, &Expectation::has_type(expected.clone()));
-                self.infer_expr(*end, &Expectation::has_type(start_ty))
+            Pat::Range { .. } => {
+                // FIXME: do some checks here.
+                expected.clone()
             }
             &Pat::Lit(expr) => {
                 // Don't emit type mismatches again, the expression lowering already did that.

--- a/crates/hir-ty/src/method_resolution.rs
+++ b/crates/hir-ty/src/method_resolution.rs
@@ -782,7 +782,9 @@ fn find_matching_impl(
                 .into_iter()
                 .map(|b| b.cast(Interner));
             let goal = crate::Goal::all(Interner, wcs);
-            table.try_obligation(goal).map(|_| (impl_data, table.resolve_completely(impl_substs)))
+            table.try_obligation(goal.clone())?;
+            table.register_obligation(goal);
+            Some((impl_data, table.resolve_completely(impl_substs)))
         })
     })
 }

--- a/crates/hir-ty/src/mir/eval.rs
+++ b/crates/hir-ty/src/mir/eval.rs
@@ -3,20 +3,17 @@
 use std::{borrow::Cow, collections::HashMap, fmt::Write, iter, ops::Range};
 
 use base_db::{CrateId, FileId};
-use chalk_ir::{
-    fold::{FallibleTypeFolder, TypeFoldable, TypeSuperFoldable},
-    DebruijnIndex, Mutability, ProjectionTy,
-};
+use chalk_ir::Mutability;
 use either::Either;
 use hir_def::{
     builtin_type::BuiltinType,
     data::adt::{StructFlags, VariantData},
     lang_item::{lang_attr, LangItem},
     layout::{TagEncoding, Variants},
-    AdtId, DefWithBodyId, EnumVariantId, FunctionId, GeneralConstId, HasModule, ItemContainerId,
-    Lookup, StaticId, TypeOrConstParamId, VariantId,
+    AdtId, DefWithBodyId, EnumVariantId, FunctionId, HasModule, ItemContainerId, Lookup, StaticId,
+    VariantId,
 };
-use hir_expand::{name::Name, InFile};
+use hir_expand::InFile;
 use intern::Interned;
 use la_arena::ArenaMap;
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -27,14 +24,13 @@ use crate::{
     consteval::{intern_const_scalar, try_const_usize, ConstEvalError},
     db::HirDatabase,
     display::{ClosureStyle, HirDisplay},
-    from_placeholder_idx,
-    infer::{normalize, PointerCast},
-    layout::{layout_of_ty, Layout, LayoutError, RustcEnumVariantIdx},
+    infer::PointerCast,
+    layout::{Layout, LayoutError, RustcEnumVariantIdx},
     mapping::from_chalk,
-    method_resolution::{is_dyn_method, lookup_impl_const, lookup_impl_method},
+    method_resolution::{is_dyn_method, lookup_impl_method},
     name, static_lifetime,
     traits::FnTrait,
-    utils::{generics, ClosureSubst, Generics},
+    utils::ClosureSubst,
     CallableDefId, ClosureId, Const, ConstScalar, FnDefId, GenericArgData, Interner, MemoryMap,
     Substitution, TraitEnvironment, Ty, TyBuilder, TyExt, TyKind,
 };
@@ -279,7 +275,6 @@ pub enum MirEvalError {
     /// Means that code had undefined behavior. We don't try to actively detect UB, but if it was detected
     /// then use this type of error.
     UndefinedBehavior(String),
-    GenericArgNotProvided(TypeOrConstParamId, Substitution),
     Panic(String),
     MirLowerError(FunctionId, MirLowerError),
     MirLowerErrorForClosure(ClosureId, MirLowerError),
@@ -348,20 +343,6 @@ impl MirEvalError {
                     ty.display(db).with_closure_style(ClosureStyle::ClosureWithId).to_string()
                 )?;
             }
-            MirEvalError::GenericArgNotProvided(id, subst) => {
-                let parent = id.parent;
-                let param = &db.generic_params(parent).type_or_consts[id.local_id];
-                writeln!(
-                    f,
-                    "Generic arg not provided for {}",
-                    param.name().unwrap_or(&Name::missing()).display(db.upcast())
-                )?;
-                writeln!(f, "Provided args: [")?;
-                for g in subst.iter(Interner) {
-                    write!(f, "    {},", g.display(db).to_string())?;
-                }
-                writeln!(f, "]")?;
-            }
             MirEvalError::MirLowerError(func, err) => {
                 let function_name = db.function_data(*func);
                 writeln!(
@@ -416,7 +397,6 @@ impl std::fmt::Debug for MirEvalError {
             Self::TypeIsUnsized(ty, it) => write!(f, "{ty:?} is unsized. {it} should be sized."),
             Self::ExecutionLimitExceeded => write!(f, "execution limit exceeded"),
             Self::StackOverflow => write!(f, "stack overflow"),
-            Self::GenericArgNotProvided(..) => f.debug_tuple("GenericArgNotProvided").finish(),
             Self::MirLowerError(arg0, arg1) => {
                 f.debug_tuple("MirLowerError").field(arg0).field(arg1).finish()
             }
@@ -471,14 +451,12 @@ impl DropFlags {
 struct Locals<'a> {
     ptr: &'a ArenaMap<LocalId, Interval>,
     body: &'a MirBody,
-    subst: &'a Substitution,
     drop_flags: DropFlags,
 }
 
 pub fn interpret_mir(
     db: &dyn HirDatabase,
     body: &MirBody,
-    subst: Substitution,
     // FIXME: This is workaround. Ideally, const generics should have a separate body (issue #7434), but now
     // they share their body with their parent, so in MIR lowering we have locals of the parent body, which
     // might have placeholders. With this argument, we (wrongly) assume that every placeholder type has
@@ -489,17 +467,11 @@ pub fn interpret_mir(
     let ty = body.locals[return_slot()].ty.clone();
     let mut evaluator = Evaluator::new(db, body, assert_placeholder_ty_is_unused);
     let x: Result<Const> = (|| {
-        let ty = evaluator.ty_filler(&ty, &subst, body.owner)?;
-        let bytes = evaluator.interpret_mir(&body, None.into_iter(), subst.clone())?;
+        let bytes = evaluator.interpret_mir(&body, None.into_iter())?;
         let mut memory_map = evaluator.create_memory_map(
             &bytes,
             &ty,
-            &Locals {
-                ptr: &ArenaMap::new(),
-                body: &body,
-                subst: &subst,
-                drop_flags: DropFlags::default(),
-            },
+            &Locals { ptr: &ArenaMap::new(), body: &body, drop_flags: DropFlags::default() },
         )?;
         memory_map.vtable = evaluator.vtable_map.clone();
         return Ok(intern_const_scalar(ConstScalar::Bytes(bytes, memory_map), ty));
@@ -565,8 +537,7 @@ impl Evaluator<'_> {
         locals: &'a Locals<'a>,
     ) -> Result<(Address, Ty, Option<IntervalOrOwned>)> {
         let mut addr = locals.ptr[p.local].addr;
-        let mut ty: Ty =
-            self.ty_filler(&locals.body.locals[p.local].ty, locals.subst, locals.body.owner)?;
+        let mut ty: Ty = locals.body.locals[p.local].ty.clone();
         let mut metadata: Option<IntervalOrOwned> = None; // locals are always sized
         for proj in &*p.projection {
             let prev_ty = ty.clone();
@@ -689,17 +660,13 @@ impl Evaluator<'_> {
         Ok((addr, ty, metadata))
     }
 
-    fn layout(&self, ty: &Ty) -> Result<Layout> {
-        layout_of_ty(self.db, ty, self.crate_id)
+    fn layout(&self, ty: &Ty) -> Result<Arc<Layout>> {
+        self.db
+            .layout_of_ty(ty.clone(), self.crate_id)
             .map_err(|e| MirEvalError::LayoutError(e, ty.clone()))
     }
 
-    fn layout_filled(&self, ty: &Ty, locals: &Locals<'_>) -> Result<Layout> {
-        let ty = &self.ty_filler(ty, locals.subst, locals.body.owner)?;
-        self.layout(ty)
-    }
-
-    fn layout_adt(&self, adt: AdtId, subst: Substitution) -> Result<Layout> {
+    fn layout_adt(&self, adt: AdtId, subst: Substitution) -> Result<Arc<Layout>> {
         self.db.layout_of_adt(adt, subst.clone(), self.crate_id).map_err(|e| {
             MirEvalError::LayoutError(e, TyKind::Adt(chalk_ir::AdtId(adt), subst).intern(Interner))
         })
@@ -735,7 +702,6 @@ impl Evaluator<'_> {
         &mut self,
         body: &MirBody,
         args: impl Iterator<Item = Vec<u8>>,
-        subst: Substitution,
     ) -> Result<Vec<u8>> {
         if let Some(x) = self.stack_depth_limit.checked_sub(1) {
             self.stack_depth_limit = x;
@@ -743,12 +709,8 @@ impl Evaluator<'_> {
             return Err(MirEvalError::StackOverflow);
         }
         let mut current_block_idx = body.start_block;
-        let mut locals = Locals {
-            ptr: &ArenaMap::new(),
-            body: &body,
-            subst: &subst,
-            drop_flags: DropFlags::default(),
-        };
+        let mut locals =
+            Locals { ptr: &ArenaMap::new(), body: &body, drop_flags: DropFlags::default() };
         let (locals_ptr, stack_size) = {
             let mut stack_ptr = self.stack.len();
             let addr = body
@@ -882,7 +844,17 @@ impl Evaluator<'_> {
                 }
                 Owned(r)
             }
-            Rvalue::Len(_) => not_supported!("rvalue len"),
+            Rvalue::Len(p) => {
+                let (_, _, metadata) = self.place_addr_and_ty_and_metadata(p, locals)?;
+                match metadata {
+                    Some(m) => m,
+                    None => {
+                        return Err(MirEvalError::TypeError(
+                            "type without metadata is used for Rvalue::Len",
+                        ));
+                    }
+                }
+            }
             Rvalue::UnaryOp(op, val) => {
                 let mut c = self.eval_operand(val, locals)?.get(&self)?;
                 let mut ty = self.operand_ty(val, locals)?;
@@ -1080,7 +1052,7 @@ impl Evaluator<'_> {
                     }
                     return Ok(Owned(0u128.to_le_bytes().to_vec()));
                 };
-                match layout.variants {
+                match &layout.variants {
                     Variants::Single { index } => {
                         let r = self.const_eval_discriminant(EnumVariantId {
                             parent: enum_id,
@@ -1102,14 +1074,14 @@ impl Evaluator<'_> {
                             TagEncoding::Niche { untagged_variant, niche_start, .. } => {
                                 let tag = &bytes[offset..offset + size];
                                 let candidate_tag = i128::from_le_bytes(pad16(tag, false))
-                                    .wrapping_sub(niche_start as i128)
+                                    .wrapping_sub(*niche_start as i128)
                                     as usize;
                                 let variant = variants
                                     .iter_enumerated()
                                     .map(|(x, _)| x)
-                                    .filter(|x| *x != untagged_variant)
+                                    .filter(|x| x != untagged_variant)
                                     .nth(candidate_tag)
-                                    .unwrap_or(untagged_variant)
+                                    .unwrap_or(*untagged_variant)
                                     .0;
                                 let result = self.const_eval_discriminant(EnumVariantId {
                                     parent: enum_id,
@@ -1122,7 +1094,7 @@ impl Evaluator<'_> {
                 }
             }
             Rvalue::Repeat(x, len) => {
-                let len = match try_const_usize(self.db, len) {
+                let len = match try_const_usize(self.db, &len) {
                     Some(x) => x as usize,
                     None => not_supported!("non evaluatable array len in repeat Rvalue"),
                 };
@@ -1154,7 +1126,7 @@ impl Evaluator<'_> {
                         Owned(r)
                     }
                     AggregateKind::Tuple(ty) => {
-                        let layout = self.layout_filled(&ty, locals)?;
+                        let layout = self.layout(&ty)?;
                         Owned(self.make_by_layout(
                             layout.size.bytes_usize(),
                             &layout,
@@ -1174,9 +1146,8 @@ impl Evaluator<'_> {
                         Owned(result)
                     }
                     AggregateKind::Adt(x, subst) => {
-                        let subst = self.subst_filler(subst, locals);
                         let (size, variant_layout, tag) =
-                            self.layout_of_variant(*x, subst, locals)?;
+                            self.layout_of_variant(*x, subst.clone(), locals)?;
                         Owned(self.make_by_layout(
                             size,
                             &variant_layout,
@@ -1185,7 +1156,7 @@ impl Evaluator<'_> {
                         )?)
                     }
                     AggregateKind::Closure(ty) => {
-                        let layout = self.layout_filled(&ty, locals)?;
+                        let layout = self.layout(&ty)?;
                         Owned(self.make_by_layout(
                             layout.size.bytes_usize(),
                             &layout,
@@ -1220,7 +1191,10 @@ impl Evaluator<'_> {
                         // This is no-op
                         Borrowed(self.eval_operand(operand, locals)?)
                     }
-                    x => not_supported!("pointer cast {x:?}"),
+                    PointerCast::ArrayToPointer => {
+                        // We should remove the metadata part if the current type is slice
+                        Borrowed(self.eval_operand(operand, locals)?.slice(0..self.ptr_size()))
+                    }
                 },
                 CastKind::DynStar => not_supported!("dyn star cast"),
                 CastKind::IntToInt
@@ -1235,12 +1209,6 @@ impl Evaluator<'_> {
                 CastKind::FloatToInt => not_supported!("float to int cast"),
                 CastKind::FloatToFloat => not_supported!("float to float cast"),
                 CastKind::IntToFloat => not_supported!("float to int cast"),
-                CastKind::PtrToPtr => {
-                    let current = pad16(self.eval_operand(operand, locals)?.get(&self)?, false);
-                    let dest_size =
-                        self.size_of_sized(target_ty, locals, "destination of ptr to ptr cast")?;
-                    Owned(current[0..dest_size].to_vec())
-                }
                 CastKind::FnPtrToPtr => not_supported!("fn ptr to ptr cast"),
             },
         })
@@ -1300,8 +1268,8 @@ impl Evaluator<'_> {
                                 r.extend(len.to_le_bytes().into_iter());
                                 Owned(r)
                             }
-                            _ => {
-                                not_supported!("slice unsizing from non arrays")
+                            t => {
+                                not_supported!("slice unsizing from non array type {t:?}")
                             }
                         },
                     }
@@ -1327,7 +1295,7 @@ impl Evaluator<'_> {
         x: VariantId,
         subst: Substitution,
         locals: &Locals<'_>,
-    ) -> Result<(usize, Layout, Option<(usize, usize, i128)>)> {
+    ) -> Result<(usize, Arc<Layout>, Option<(usize, usize, i128)>)> {
         let adt = x.adt_id();
         if let DefWithBodyId::VariantId(f) = locals.body.owner {
             if let VariantId::EnumVariantId(x) = x {
@@ -1340,7 +1308,7 @@ impl Evaluator<'_> {
             }
         }
         let layout = self.layout_adt(adt, subst)?;
-        Ok(match layout.variants {
+        Ok(match &layout.variants {
             Variants::Single { .. } => (layout.size.bytes_usize(), layout, None),
             Variants::Multiple { variants, tag, tag_encoding, .. } => {
                 let cx = self
@@ -1357,22 +1325,22 @@ impl Evaluator<'_> {
                 let have_tag = match tag_encoding {
                     TagEncoding::Direct => true,
                     TagEncoding::Niche { untagged_variant, niche_variants: _, niche_start } => {
-                        if untagged_variant == rustc_enum_variant_idx {
+                        if *untagged_variant == rustc_enum_variant_idx {
                             false
                         } else {
                             discriminant = (variants
                                 .iter_enumerated()
-                                .filter(|(x, _)| *x != untagged_variant)
+                                .filter(|(x, _)| x != untagged_variant)
                                 .position(|(x, _)| x == rustc_enum_variant_idx)
                                 .unwrap() as i128)
-                                .wrapping_add(niche_start as i128);
+                                .wrapping_add(*niche_start as i128);
                             true
                         }
                     }
                 };
                 (
                     layout.size.bytes_usize(),
-                    variant_layout,
+                    Arc::new(variant_layout),
                     if have_tag {
                         Some((
                             layout.fields.offset(0).bytes_usize(),
@@ -1419,15 +1387,7 @@ impl Evaluator<'_> {
             Operand::Constant(konst) => {
                 let data = &konst.data(Interner);
                 match &data.value {
-                    chalk_ir::ConstValue::BoundVar(b) => {
-                        let c = locals
-                            .subst
-                            .as_slice(Interner)
-                            .get(b.index)
-                            .ok_or(MirEvalError::TypeError("missing generic arg"))?
-                            .assert_const_ref(Interner);
-                        self.eval_operand(&Operand::Constant(c.clone()), locals)?
-                    }
+                    chalk_ir::ConstValue::BoundVar(_) => not_supported!("bound var constant"),
                     chalk_ir::ConstValue::InferenceVar(_) => {
                         not_supported!("inference var constant")
                     }
@@ -1471,29 +1431,8 @@ impl Evaluator<'_> {
                 self.patch_addresses(&patch_map, &memory_map.vtable, addr, ty, locals)?;
                 Interval::new(addr, size)
             }
-            ConstScalar::UnevaluatedConst(const_id, subst) => {
-                let mut const_id = *const_id;
-                let mut subst = self.subst_filler(subst, locals);
-                if let GeneralConstId::ConstId(c) = const_id {
-                    let (c, s) = lookup_impl_const(
-                        self.db,
-                        self.db.trait_environment_for_body(locals.body.owner),
-                        c,
-                        subst,
-                    );
-                    const_id = GeneralConstId::ConstId(c);
-                    subst = s;
-                }
-                let c = self.db.const_eval(const_id.into(), subst).map_err(|e| {
-                    let name = const_id.name(self.db.upcast());
-                    MirEvalError::ConstEvalError(name, Box::new(e))
-                })?;
-                if let chalk_ir::ConstValue::Concrete(c) = &c.data(Interner).value {
-                    if let ConstScalar::Bytes(_, _) = &c.interned {
-                        return self.allocate_const_in_heap(&c, ty, locals, konst);
-                    }
-                }
-                not_supported!("failing at evaluating unevaluated const");
+            ConstScalar::UnevaluatedConst(..) => {
+                not_supported!("unevaluated const present in monomorphized mir");
             }
             ConstScalar::Unknown => not_supported!("evaluating unknown const"),
         })
@@ -1555,7 +1494,7 @@ impl Evaluator<'_> {
                 }
             }
         }
-        let layout = self.layout_filled(ty, locals);
+        let layout = self.layout(ty);
         if self.assert_placeholder_ty_is_unused {
             if matches!(layout, Err(MirEvalError::LayoutError(LayoutError::HasPlaceholder, _))) {
                 return Ok(Some((0, 1)));
@@ -1576,120 +1515,10 @@ impl Evaluator<'_> {
         }
     }
 
-    /// Uses `ty_filler` to fill an entire subst
-    fn subst_filler(&self, subst: &Substitution, locals: &Locals<'_>) -> Substitution {
-        Substitution::from_iter(
-            Interner,
-            subst.iter(Interner).map(|x| match x.data(Interner) {
-                chalk_ir::GenericArgData::Ty(ty) => {
-                    let Ok(ty) = self.ty_filler(ty, locals.subst, locals.body.owner) else {
-                        return x.clone();
-                    };
-                    chalk_ir::GenericArgData::Ty(ty).intern(Interner)
-                }
-                _ => x.clone(),
-            }),
-        )
-    }
-
-    /// This function substitutes placeholders of the body with the provided subst, effectively plays
-    /// the rule of monomorphization. In addition to placeholders, it substitutes opaque types (return
-    /// position impl traits) with their underlying type.
-    fn ty_filler(&self, ty: &Ty, subst: &Substitution, owner: DefWithBodyId) -> Result<Ty> {
-        struct Filler<'a> {
-            db: &'a dyn HirDatabase,
-            subst: &'a Substitution,
-            generics: Option<Generics>,
-        }
-        impl FallibleTypeFolder<Interner> for Filler<'_> {
-            type Error = MirEvalError;
-
-            fn as_dyn(&mut self) -> &mut dyn FallibleTypeFolder<Interner, Error = Self::Error> {
-                self
-            }
-
-            fn interner(&self) -> Interner {
-                Interner
-            }
-
-            fn try_fold_ty(
-                &mut self,
-                ty: Ty,
-                outer_binder: DebruijnIndex,
-            ) -> std::result::Result<Ty, Self::Error> {
-                match ty.kind(Interner) {
-                    TyKind::AssociatedType(id, subst) => {
-                        // I don't know exactly if and why this is needed, but it looks like `normalize_ty` likes
-                        // this kind of associated types.
-                        Ok(TyKind::Alias(chalk_ir::AliasTy::Projection(ProjectionTy {
-                            associated_ty_id: *id,
-                            substitution: subst.clone().try_fold_with(self, outer_binder)?,
-                        }))
-                        .intern(Interner))
-                    }
-                    TyKind::OpaqueType(id, subst) => {
-                        let impl_trait_id = self.db.lookup_intern_impl_trait_id((*id).into());
-                        let subst = subst.clone().try_fold_with(self.as_dyn(), outer_binder)?;
-                        match impl_trait_id {
-                            crate::ImplTraitId::ReturnTypeImplTrait(func, idx) => {
-                                let infer = self.db.infer(func.into());
-                                let filler = &mut Filler {
-                                    db: self.db,
-                                    subst: &subst,
-                                    generics: Some(generics(self.db.upcast(), func.into())),
-                                };
-                                filler.try_fold_ty(infer.type_of_rpit[idx].clone(), outer_binder)
-                            }
-                            crate::ImplTraitId::AsyncBlockTypeImplTrait(_, _) => {
-                                not_supported!("async block impl trait");
-                            }
-                        }
-                    }
-                    _ => ty.try_super_fold_with(self.as_dyn(), outer_binder),
-                }
-            }
-
-            fn try_fold_free_placeholder_ty(
-                &mut self,
-                idx: chalk_ir::PlaceholderIndex,
-                _outer_binder: DebruijnIndex,
-            ) -> std::result::Result<Ty, Self::Error> {
-                let x = from_placeholder_idx(self.db, idx);
-                let Some(idx) = self.generics.as_ref().and_then(|g| g.param_idx(x)) else {
-                    not_supported!("missing idx in generics");
-                };
-                Ok(self
-                    .subst
-                    .as_slice(Interner)
-                    .get(idx)
-                    .and_then(|x| x.ty(Interner))
-                    .ok_or_else(|| MirEvalError::GenericArgNotProvided(x, self.subst.clone()))?
-                    .clone())
-            }
-        }
-        let g_def = match owner {
-            DefWithBodyId::FunctionId(f) => Some(f.into()),
-            DefWithBodyId::StaticId(_) => None,
-            DefWithBodyId::ConstId(f) => Some(f.into()),
-            DefWithBodyId::VariantId(f) => Some(f.into()),
-        };
-        let generics = g_def.map(|g_def| generics(self.db.upcast(), g_def));
-        let filler = &mut Filler { db: self.db, subst, generics };
-        Ok(normalize(
-            self.db,
-            self.trait_env.clone(),
-            ty.clone().try_fold_with(filler, DebruijnIndex::INNERMOST)?,
-        ))
-    }
-
     fn heap_allocate(&mut self, size: usize, _align: usize) -> Address {
         let pos = self.heap.len();
         self.heap.extend(iter::repeat(0).take(size));
         Address::Heap(pos)
-    }
-
-    pub fn interpret_mir_with_no_arg(&mut self, body: &MirBody) -> Result<Vec<u8>> {
-        self.interpret_mir(&body, vec![].into_iter(), Substitution::empty(Interner))
     }
 
     fn detect_fn_trait(&self, def: FunctionId) -> Option<FnTrait> {
@@ -1849,21 +1678,24 @@ impl Evaluator<'_> {
     ) -> Result<()> {
         let mir_body = self
             .db
-            .mir_body_for_closure(closure)
+            .monomorphized_mir_body_for_closure(
+                closure,
+                generic_args.clone(),
+                self.trait_env.clone(),
+            )
             .map_err(|x| MirEvalError::MirLowerErrorForClosure(closure, x))?;
-        let arg_bytes = iter::once(Ok(closure_data.get(self)?.to_owned()))
+        let closure_data = if mir_body.locals[mir_body.param_locals[0]].ty.as_reference().is_some()
+        {
+            closure_data.addr.to_bytes()
+        } else {
+            closure_data.get(self)?.to_owned()
+        };
+        let arg_bytes = iter::once(Ok(closure_data))
             .chain(args.iter().map(|x| Ok(x.get(&self)?.to_owned())))
             .collect::<Result<Vec<_>>>()?;
-        let bytes = self
-            .interpret_mir(&mir_body, arg_bytes.into_iter(), generic_args.clone())
-            .map_err(|e| {
-                MirEvalError::InFunction(
-                    Either::Right(closure),
-                    Box::new(e),
-                    span,
-                    locals.body.owner,
-                )
-            })?;
+        let bytes = self.interpret_mir(&mir_body, arg_bytes.into_iter()).map_err(|e| {
+            MirEvalError::InFunction(Either::Right(closure), Box::new(e), span, locals.body.owner)
+        })?;
         destination.write_from_bytes(self, &bytes)
     }
 
@@ -1877,7 +1709,7 @@ impl Evaluator<'_> {
         span: MirSpan,
     ) -> Result<()> {
         let def: CallableDefId = from_chalk(self.db, def);
-        let generic_args = self.subst_filler(generic_args, &locals);
+        let generic_args = generic_args.clone();
         match def {
             CallableDefId::FunctionId(def) => {
                 if let Some(_) = self.detect_fn_trait(def) {
@@ -1982,14 +1814,14 @@ impl Evaluator<'_> {
         span: MirSpan,
         destination: Interval,
     ) -> Result<()> {
-        let generic_args = self.subst_filler(&generic_args, &locals);
         let def = imp.into();
-        let mir_body = self.db.mir_body(def).map_err(|e| MirEvalError::MirLowerError(imp, e))?;
-        let result = self
-            .interpret_mir(&mir_body, arg_bytes.iter().cloned(), generic_args)
-            .map_err(|e| {
-                MirEvalError::InFunction(Either::Left(imp), Box::new(e), span, locals.body.owner)
-            })?;
+        let mir_body = self
+            .db
+            .monomorphized_mir_body(def, generic_args, self.trait_env.clone())
+            .map_err(|e| MirEvalError::MirLowerError(imp, e))?;
+        let result = self.interpret_mir(&mir_body, arg_bytes.iter().cloned()).map_err(|e| {
+            MirEvalError::InFunction(Either::Left(imp), Box::new(e), span, locals.body.owner)
+        })?;
         destination.write_from_bytes(self, &result)?;
         Ok(())
     }

--- a/crates/hir-ty/src/mir/monomorphization.rs
+++ b/crates/hir-ty/src/mir/monomorphization.rs
@@ -1,0 +1,369 @@
+//! Monomorphization of mir, which is used in mir interpreter and const eval.
+//!
+//! The job of monomorphization is:
+//! * Monomorphization. That is, replacing `Option<T>` with `Option<i32>` where `T:=i32` substitution
+//!   is provided
+//! * Normalizing types, for example replacing RPIT of other functions called in this body.
+//!
+//! So the monomorphization should be called even if the substitution is empty.
+
+use std::mem;
+
+use chalk_ir::{
+    fold::{FallibleTypeFolder, TypeFoldable, TypeSuperFoldable},
+    ConstData, DebruijnIndex,
+};
+use hir_def::{DefWithBodyId, GeneralConstId};
+use triomphe::Arc;
+
+use crate::{
+    consteval::unknown_const,
+    db::HirDatabase,
+    from_placeholder_idx,
+    infer::normalize,
+    method_resolution::lookup_impl_const,
+    utils::{generics, Generics},
+    ClosureId, Const, Interner, ProjectionTy, Substitution, TraitEnvironment, Ty, TyKind,
+};
+
+use super::{MirBody, MirLowerError, Operand, Rvalue, StatementKind, TerminatorKind};
+
+macro_rules! not_supported {
+    ($x: expr) => {
+        return Err(MirLowerError::NotSupported(format!($x)))
+    };
+}
+
+struct Filler<'a> {
+    db: &'a dyn HirDatabase,
+    trait_env: Arc<TraitEnvironment>,
+    subst: &'a Substitution,
+    generics: Option<Generics>,
+    owner: DefWithBodyId,
+}
+impl FallibleTypeFolder<Interner> for Filler<'_> {
+    type Error = MirLowerError;
+
+    fn as_dyn(&mut self) -> &mut dyn FallibleTypeFolder<Interner, Error = Self::Error> {
+        self
+    }
+
+    fn interner(&self) -> Interner {
+        Interner
+    }
+
+    fn try_fold_ty(
+        &mut self,
+        ty: Ty,
+        outer_binder: DebruijnIndex,
+    ) -> std::result::Result<Ty, Self::Error> {
+        match ty.kind(Interner) {
+            TyKind::AssociatedType(id, subst) => {
+                // I don't know exactly if and why this is needed, but it looks like `normalize_ty` likes
+                // this kind of associated types.
+                Ok(TyKind::Alias(chalk_ir::AliasTy::Projection(ProjectionTy {
+                    associated_ty_id: *id,
+                    substitution: subst.clone().try_fold_with(self, outer_binder)?,
+                }))
+                .intern(Interner))
+            }
+            TyKind::OpaqueType(id, subst) => {
+                let impl_trait_id = self.db.lookup_intern_impl_trait_id((*id).into());
+                let subst = subst.clone().try_fold_with(self.as_dyn(), outer_binder)?;
+                match impl_trait_id {
+                    crate::ImplTraitId::ReturnTypeImplTrait(func, idx) => {
+                        let infer = self.db.infer(func.into());
+                        let filler = &mut Filler {
+                            db: self.db,
+                            owner: self.owner,
+                            trait_env: self.trait_env.clone(),
+                            subst: &subst,
+                            generics: Some(generics(self.db.upcast(), func.into())),
+                        };
+                        filler.try_fold_ty(infer.type_of_rpit[idx].clone(), outer_binder)
+                    }
+                    crate::ImplTraitId::AsyncBlockTypeImplTrait(_, _) => {
+                        not_supported!("async block impl trait");
+                    }
+                }
+            }
+            _ => ty.try_super_fold_with(self.as_dyn(), outer_binder),
+        }
+    }
+
+    fn try_fold_free_placeholder_const(
+        &mut self,
+        _ty: chalk_ir::Ty<Interner>,
+        idx: chalk_ir::PlaceholderIndex,
+        _outer_binder: DebruijnIndex,
+    ) -> std::result::Result<chalk_ir::Const<Interner>, Self::Error> {
+        let x = from_placeholder_idx(self.db, idx);
+        let Some(idx) = self.generics.as_ref().and_then(|g| g.param_idx(x)) else {
+            not_supported!("missing idx in generics");
+        };
+        Ok(self
+            .subst
+            .as_slice(Interner)
+            .get(idx)
+            .and_then(|x| x.constant(Interner))
+            .ok_or_else(|| MirLowerError::GenericArgNotProvided(x, self.subst.clone()))?
+            .clone())
+    }
+
+    fn try_fold_free_placeholder_ty(
+        &mut self,
+        idx: chalk_ir::PlaceholderIndex,
+        _outer_binder: DebruijnIndex,
+    ) -> std::result::Result<Ty, Self::Error> {
+        let x = from_placeholder_idx(self.db, idx);
+        let Some(idx) = self.generics.as_ref().and_then(|g| g.param_idx(x)) else {
+            not_supported!("missing idx in generics");
+        };
+        Ok(self
+            .subst
+            .as_slice(Interner)
+            .get(idx)
+            .and_then(|x| x.ty(Interner))
+            .ok_or_else(|| MirLowerError::GenericArgNotProvided(x, self.subst.clone()))?
+            .clone())
+    }
+
+    fn try_fold_const(
+        &mut self,
+        constant: chalk_ir::Const<Interner>,
+        outer_binder: DebruijnIndex,
+    ) -> Result<chalk_ir::Const<Interner>, Self::Error> {
+        let next_ty = normalize(
+            self.db,
+            self.trait_env.clone(),
+            constant.data(Interner).ty.clone().try_fold_with(self, outer_binder)?,
+        );
+        ConstData { ty: next_ty, value: constant.data(Interner).value.clone() }
+            .intern(Interner)
+            .try_super_fold_with(self, outer_binder)
+    }
+}
+
+impl Filler<'_> {
+    fn fill_ty(&mut self, ty: &mut Ty) -> Result<(), MirLowerError> {
+        let tmp = mem::replace(ty, TyKind::Error.intern(Interner));
+        *ty = normalize(
+            self.db,
+            self.trait_env.clone(),
+            tmp.try_fold_with(self, DebruijnIndex::INNERMOST)?,
+        );
+        Ok(())
+    }
+
+    fn fill_const(&mut self, c: &mut Const) -> Result<(), MirLowerError> {
+        let tmp = mem::replace(c, unknown_const(c.data(Interner).ty.clone()));
+        *c = tmp.try_fold_with(self, DebruijnIndex::INNERMOST)?;
+        Ok(())
+    }
+
+    fn fill_subst(&mut self, ty: &mut Substitution) -> Result<(), MirLowerError> {
+        let tmp = mem::replace(ty, Substitution::empty(Interner));
+        *ty = tmp.try_fold_with(self, DebruijnIndex::INNERMOST)?;
+        Ok(())
+    }
+
+    fn fill_operand(&mut self, op: &mut Operand) -> Result<(), MirLowerError> {
+        match op {
+            Operand::Constant(c) => {
+                match &c.data(Interner).value {
+                    chalk_ir::ConstValue::BoundVar(b) => {
+                        let resolved = self
+                            .subst
+                            .as_slice(Interner)
+                            .get(b.index)
+                            .ok_or_else(|| {
+                                MirLowerError::GenericArgNotProvided(
+                                    self.generics
+                                        .as_ref()
+                                        .and_then(|x| x.iter().nth(b.index))
+                                        .unwrap()
+                                        .0,
+                                    self.subst.clone(),
+                                )
+                            })?
+                            .assert_const_ref(Interner);
+                        *c = resolved.clone();
+                    }
+                    chalk_ir::ConstValue::InferenceVar(_)
+                    | chalk_ir::ConstValue::Placeholder(_) => {}
+                    chalk_ir::ConstValue::Concrete(cc) => match &cc.interned {
+                        crate::ConstScalar::UnevaluatedConst(const_id, subst) => {
+                            let mut const_id = *const_id;
+                            let mut subst = subst.clone();
+                            self.fill_subst(&mut subst)?;
+                            if let GeneralConstId::ConstId(c) = const_id {
+                                let (c, s) = lookup_impl_const(
+                                    self.db,
+                                    self.db.trait_environment_for_body(self.owner),
+                                    c,
+                                    subst,
+                                );
+                                const_id = GeneralConstId::ConstId(c);
+                                subst = s;
+                            }
+                            let result =
+                                self.db.const_eval(const_id.into(), subst).map_err(|e| {
+                                    let name = const_id.name(self.db.upcast());
+                                    MirLowerError::ConstEvalError(name, Box::new(e))
+                                })?;
+                            *c = result;
+                        }
+                        crate::ConstScalar::Bytes(_, _) | crate::ConstScalar::Unknown => (),
+                    },
+                }
+                self.fill_const(c)?;
+            }
+            Operand::Copy(_) | Operand::Move(_) | Operand::Static(_) => (),
+        }
+        Ok(())
+    }
+
+    fn fill_body(&mut self, body: &mut MirBody) -> Result<(), MirLowerError> {
+        for (_, l) in body.locals.iter_mut() {
+            self.fill_ty(&mut l.ty)?;
+        }
+        for (_, bb) in body.basic_blocks.iter_mut() {
+            for statement in &mut bb.statements {
+                match &mut statement.kind {
+                    StatementKind::Assign(_, r) => match r {
+                        Rvalue::Aggregate(ak, ops) => {
+                            for op in &mut **ops {
+                                self.fill_operand(op)?;
+                            }
+                            match ak {
+                                super::AggregateKind::Array(ty)
+                                | super::AggregateKind::Tuple(ty)
+                                | super::AggregateKind::Closure(ty) => self.fill_ty(ty)?,
+                                super::AggregateKind::Adt(_, subst) => self.fill_subst(subst)?,
+                                super::AggregateKind::Union(_, _) => (),
+                            }
+                        }
+                        Rvalue::ShallowInitBox(_, ty) | Rvalue::ShallowInitBoxWithAlloc(ty) => {
+                            self.fill_ty(ty)?;
+                        }
+                        Rvalue::Use(op) => {
+                            self.fill_operand(op)?;
+                        }
+                        Rvalue::Repeat(op, len) => {
+                            self.fill_operand(op)?;
+                            self.fill_const(len)?;
+                        }
+                        Rvalue::Ref(_, _)
+                        | Rvalue::Len(_)
+                        | Rvalue::Cast(_, _, _)
+                        | Rvalue::CheckedBinaryOp(_, _, _)
+                        | Rvalue::UnaryOp(_, _)
+                        | Rvalue::Discriminant(_)
+                        | Rvalue::CopyForDeref(_) => (),
+                    },
+                    StatementKind::Deinit(_)
+                    | StatementKind::StorageLive(_)
+                    | StatementKind::StorageDead(_)
+                    | StatementKind::Nop => (),
+                }
+            }
+            if let Some(terminator) = &mut bb.terminator {
+                match &mut terminator.kind {
+                    TerminatorKind::Call { func, args, .. } => {
+                        self.fill_operand(func)?;
+                        for op in &mut **args {
+                            self.fill_operand(op)?;
+                        }
+                    }
+                    TerminatorKind::SwitchInt { discr, .. } => {
+                        self.fill_operand(discr)?;
+                    }
+                    TerminatorKind::Goto { .. }
+                    | TerminatorKind::Resume
+                    | TerminatorKind::Abort
+                    | TerminatorKind::Return
+                    | TerminatorKind::Unreachable
+                    | TerminatorKind::Drop { .. }
+                    | TerminatorKind::DropAndReplace { .. }
+                    | TerminatorKind::Assert { .. }
+                    | TerminatorKind::Yield { .. }
+                    | TerminatorKind::GeneratorDrop
+                    | TerminatorKind::FalseEdge { .. }
+                    | TerminatorKind::FalseUnwind { .. } => (),
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+pub fn monomorphized_mir_body_query(
+    db: &dyn HirDatabase,
+    owner: DefWithBodyId,
+    subst: Substitution,
+    trait_env: Arc<crate::TraitEnvironment>,
+) -> Result<Arc<MirBody>, MirLowerError> {
+    let g_def = match owner {
+        DefWithBodyId::FunctionId(f) => Some(f.into()),
+        DefWithBodyId::StaticId(_) => None,
+        DefWithBodyId::ConstId(f) => Some(f.into()),
+        DefWithBodyId::VariantId(f) => Some(f.into()),
+    };
+    let generics = g_def.map(|g_def| generics(db.upcast(), g_def));
+    let filler = &mut Filler { db, subst: &subst, trait_env, generics, owner };
+    let body = db.mir_body(owner)?;
+    let mut body = (*body).clone();
+    filler.fill_body(&mut body)?;
+    Ok(Arc::new(body))
+}
+
+pub fn monomorphized_mir_body_recover(
+    _: &dyn HirDatabase,
+    _: &[String],
+    _: &DefWithBodyId,
+    _: &Substitution,
+    _: &Arc<crate::TraitEnvironment>,
+) -> Result<Arc<MirBody>, MirLowerError> {
+    return Err(MirLowerError::Loop);
+}
+
+pub fn monomorphized_mir_body_for_closure_query(
+    db: &dyn HirDatabase,
+    closure: ClosureId,
+    subst: Substitution,
+    trait_env: Arc<crate::TraitEnvironment>,
+) -> Result<Arc<MirBody>, MirLowerError> {
+    let (owner, _) = db.lookup_intern_closure(closure.into());
+    let g_def = match owner {
+        DefWithBodyId::FunctionId(f) => Some(f.into()),
+        DefWithBodyId::StaticId(_) => None,
+        DefWithBodyId::ConstId(f) => Some(f.into()),
+        DefWithBodyId::VariantId(f) => Some(f.into()),
+    };
+    let generics = g_def.map(|g_def| generics(db.upcast(), g_def));
+    let filler = &mut Filler { db, subst: &subst, trait_env, generics, owner };
+    let body = db.mir_body_for_closure(closure)?;
+    let mut body = (*body).clone();
+    filler.fill_body(&mut body)?;
+    Ok(Arc::new(body))
+}
+
+// FIXME: remove this function. Monomorphization is a time consuming job and should always be a query.
+pub fn monomorphize_mir_body_bad(
+    db: &dyn HirDatabase,
+    mut body: MirBody,
+    subst: Substitution,
+    trait_env: Arc<crate::TraitEnvironment>,
+) -> Result<MirBody, MirLowerError> {
+    let owner = body.owner;
+    let g_def = match owner {
+        DefWithBodyId::FunctionId(f) => Some(f.into()),
+        DefWithBodyId::StaticId(_) => None,
+        DefWithBodyId::ConstId(f) => Some(f.into()),
+        DefWithBodyId::VariantId(f) => Some(f.into()),
+    };
+    let generics = g_def.map(|g_def| generics(db.upcast(), g_def));
+    let filler = &mut Filler { db, subst: &subst, trait_env, generics, owner };
+    filler.fill_body(&mut body)?;
+    Ok(body)
+}

--- a/crates/hir-ty/src/mir/pretty.rs
+++ b/crates/hir-ty/src/mir/pretty.rs
@@ -437,6 +437,6 @@ impl<'a> MirPrettyCtx<'a> {
     }
 
     fn hir_display<T: HirDisplay>(&self, ty: &'a T) -> impl Display + 'a {
-        ty.display(self.db).with_closure_style(ClosureStyle::ClosureWithId)
+        ty.display(self.db).with_closure_style(ClosureStyle::ClosureWithSubst)
     }
 }

--- a/crates/hir-ty/src/tests/macros.rs
+++ b/crates/hir-ty/src/tests/macros.rs
@@ -140,6 +140,7 @@ fn infer_path_qualified_macros_expanded() {
 fn expr_macro_def_expanded_in_various_places() {
     check_infer(
         r#"
+        //- minicore: iterator
         macro spam() {
             1isize
         }
@@ -195,8 +196,17 @@ fn expr_macro_def_expanded_in_various_places() {
             !0..6 '1isize': isize
             39..442 '{     ...!(); }': ()
             73..94 'spam!(...am!())': {unknown}
+            100..119 'for _ ...!() {}': fn into_iter<isize>(isize) -> <isize as IntoIterator>::IntoIter
+            100..119 'for _ ...!() {}': IntoIterator::IntoIter<isize>
+            100..119 'for _ ...!() {}': !
+            100..119 'for _ ...!() {}': IntoIterator::IntoIter<isize>
+            100..119 'for _ ...!() {}': &mut IntoIterator::IntoIter<isize>
+            100..119 'for _ ...!() {}': fn next<IntoIterator::IntoIter<isize>>(&mut IntoIterator::IntoIter<isize>) -> Option<<IntoIterator::IntoIter<isize> as Iterator>::Item>
+            100..119 'for _ ...!() {}': Option<Iterator::Item<IntoIterator::IntoIter<isize>>>
             100..119 'for _ ...!() {}': ()
-            104..105 '_': {unknown}
+            100..119 'for _ ...!() {}': ()
+            100..119 'for _ ...!() {}': ()
+            104..105 '_': Iterator::Item<IntoIterator::IntoIter<isize>>
             117..119 '{}': ()
             124..134 '|| spam!()': impl Fn() -> isize
             140..156 'while ...!() {}': ()
@@ -221,6 +231,7 @@ fn expr_macro_def_expanded_in_various_places() {
 fn expr_macro_rules_expanded_in_various_places() {
     check_infer(
         r#"
+        //- minicore: iterator
         macro_rules! spam {
             () => (1isize);
         }
@@ -276,8 +287,17 @@ fn expr_macro_rules_expanded_in_various_places() {
             !0..6 '1isize': isize
             53..456 '{     ...!(); }': ()
             87..108 'spam!(...am!())': {unknown}
+            114..133 'for _ ...!() {}': fn into_iter<isize>(isize) -> <isize as IntoIterator>::IntoIter
+            114..133 'for _ ...!() {}': IntoIterator::IntoIter<isize>
+            114..133 'for _ ...!() {}': !
+            114..133 'for _ ...!() {}': IntoIterator::IntoIter<isize>
+            114..133 'for _ ...!() {}': &mut IntoIterator::IntoIter<isize>
+            114..133 'for _ ...!() {}': fn next<IntoIterator::IntoIter<isize>>(&mut IntoIterator::IntoIter<isize>) -> Option<<IntoIterator::IntoIter<isize> as Iterator>::Item>
+            114..133 'for _ ...!() {}': Option<Iterator::Item<IntoIterator::IntoIter<isize>>>
             114..133 'for _ ...!() {}': ()
-            118..119 '_': {unknown}
+            114..133 'for _ ...!() {}': ()
+            114..133 'for _ ...!() {}': ()
+            118..119 '_': Iterator::Item<IntoIterator::IntoIter<isize>>
             131..133 '{}': ()
             138..148 '|| spam!()': impl Fn() -> isize
             154..170 'while ...!() {}': ()

--- a/crates/hir-ty/src/tests/never_type.rs
+++ b/crates/hir-ty/src/tests/never_type.rs
@@ -327,6 +327,7 @@ fn diverging_expression_2() {
 fn diverging_expression_3_break() {
     check_infer_with_mismatches(
         r"
+        //- minicore: iterator
         //- /main.rs
         fn test1() {
             // should give type mismatch
@@ -360,6 +361,15 @@ fn diverging_expression_3_break() {
             97..343 '{     ...; }; }': ()
             140..141 'x': u32
             149..175 '{ for ...; }; }': u32
+            151..172 'for a ...eak; }': fn into_iter<{unknown}>({unknown}) -> <{unknown} as IntoIterator>::IntoIter
+            151..172 'for a ...eak; }': {unknown}
+            151..172 'for a ...eak; }': !
+            151..172 'for a ...eak; }': {unknown}
+            151..172 'for a ...eak; }': &mut {unknown}
+            151..172 'for a ...eak; }': fn next<{unknown}>(&mut {unknown}) -> Option<<{unknown} as Iterator>::Item>
+            151..172 'for a ...eak; }': Option<{unknown}>
+            151..172 'for a ...eak; }': ()
+            151..172 'for a ...eak; }': ()
             151..172 'for a ...eak; }': ()
             155..156 'a': {unknown}
             160..161 'b': {unknown}
@@ -367,12 +377,30 @@ fn diverging_expression_3_break() {
             164..169 'break': !
             226..227 'x': u32
             235..253 '{ for ... {}; }': u32
+            237..250 'for a in b {}': fn into_iter<{unknown}>({unknown}) -> <{unknown} as IntoIterator>::IntoIter
+            237..250 'for a in b {}': {unknown}
+            237..250 'for a in b {}': !
+            237..250 'for a in b {}': {unknown}
+            237..250 'for a in b {}': &mut {unknown}
+            237..250 'for a in b {}': fn next<{unknown}>(&mut {unknown}) -> Option<<{unknown} as Iterator>::Item>
+            237..250 'for a in b {}': Option<{unknown}>
+            237..250 'for a in b {}': ()
+            237..250 'for a in b {}': ()
             237..250 'for a in b {}': ()
             241..242 'a': {unknown}
             246..247 'b': {unknown}
             248..250 '{}': ()
             304..305 'x': u32
             313..340 '{ for ...; }; }': u32
+            315..337 'for a ...urn; }': fn into_iter<{unknown}>({unknown}) -> <{unknown} as IntoIterator>::IntoIter
+            315..337 'for a ...urn; }': {unknown}
+            315..337 'for a ...urn; }': !
+            315..337 'for a ...urn; }': {unknown}
+            315..337 'for a ...urn; }': &mut {unknown}
+            315..337 'for a ...urn; }': fn next<{unknown}>(&mut {unknown}) -> Option<<{unknown} as Iterator>::Item>
+            315..337 'for a ...urn; }': Option<{unknown}>
+            315..337 'for a ...urn; }': ()
+            315..337 'for a ...urn; }': ()
             315..337 'for a ...urn; }': ()
             319..320 'a': {unknown}
             324..325 'b': {unknown}

--- a/crates/hir-ty/src/tests/patterns.rs
+++ b/crates/hir-ty/src/tests/patterns.rs
@@ -6,6 +6,7 @@ use super::{check, check_infer, check_infer_with_mismatches, check_no_mismatches
 fn infer_pattern() {
     check_infer(
         r#"
+        //- minicore: iterator
         fn test(x: &i32) {
             let y = x;
             let &z = x;
@@ -46,6 +47,15 @@ fn infer_pattern() {
             82..94 '(1, "hello")': (i32, &str)
             83..84 '1': i32
             86..93 '"hello"': &str
+            101..151 'for (e...     }': fn into_iter<{unknown}>({unknown}) -> <{unknown} as IntoIterator>::IntoIter
+            101..151 'for (e...     }': {unknown}
+            101..151 'for (e...     }': !
+            101..151 'for (e...     }': {unknown}
+            101..151 'for (e...     }': &mut {unknown}
+            101..151 'for (e...     }': fn next<{unknown}>(&mut {unknown}) -> Option<<{unknown} as Iterator>::Item>
+            101..151 'for (e...     }': Option<({unknown}, {unknown})>
+            101..151 'for (e...     }': ()
+            101..151 'for (e...     }': ()
             101..151 'for (e...     }': ()
             105..111 '(e, f)': ({unknown}, {unknown})
             106..107 'e': {unknown}

--- a/crates/hir-ty/src/tests/regression.rs
+++ b/crates/hir-ty/src/tests/regression.rs
@@ -246,6 +246,7 @@ fn infer_std_crash_5() {
     // taken from rustc
     check_infer(
         r#"
+        //- minicore: iterator
         fn extra_compiler_flags() {
             for content in doesnt_matter {
                 let name = if doesnt_matter {
@@ -264,6 +265,15 @@ fn infer_std_crash_5() {
         "#,
         expect![[r#"
             26..322 '{     ...   } }': ()
+            32..320 'for co...     }': fn into_iter<{unknown}>({unknown}) -> <{unknown} as IntoIterator>::IntoIter
+            32..320 'for co...     }': {unknown}
+            32..320 'for co...     }': !
+            32..320 'for co...     }': {unknown}
+            32..320 'for co...     }': &mut {unknown}
+            32..320 'for co...     }': fn next<{unknown}>(&mut {unknown}) -> Option<<{unknown} as Iterator>::Item>
+            32..320 'for co...     }': Option<{unknown}>
+            32..320 'for co...     }': ()
+            32..320 'for co...     }': ()
             32..320 'for co...     }': ()
             36..43 'content': {unknown}
             47..60 'doesnt_matter': {unknown}
@@ -1215,6 +1225,7 @@ fn mamba(a: U32!(), p: u32) -> u32 {
 fn for_loop_block_expr_iterable() {
     check_infer(
         r#"
+//- minicore: iterator
 fn test() {
     for _ in { let x = 0; } {
         let y = 0;
@@ -1223,8 +1234,17 @@ fn test() {
         "#,
         expect![[r#"
             10..68 '{     ...   } }': ()
+            16..66 'for _ ...     }': fn into_iter<()>(()) -> <() as IntoIterator>::IntoIter
+            16..66 'for _ ...     }': IntoIterator::IntoIter<()>
+            16..66 'for _ ...     }': !
+            16..66 'for _ ...     }': IntoIterator::IntoIter<()>
+            16..66 'for _ ...     }': &mut IntoIterator::IntoIter<()>
+            16..66 'for _ ...     }': fn next<IntoIterator::IntoIter<()>>(&mut IntoIterator::IntoIter<()>) -> Option<<IntoIterator::IntoIter<()> as Iterator>::Item>
+            16..66 'for _ ...     }': Option<Iterator::Item<IntoIterator::IntoIter<()>>>
             16..66 'for _ ...     }': ()
-            20..21 '_': {unknown}
+            16..66 'for _ ...     }': ()
+            16..66 'for _ ...     }': ()
+            20..21 '_': Iterator::Item<IntoIterator::IntoIter<()>>
             25..39 '{ let x = 0; }': ()
             31..32 'x': i32
             35..36 '0': i32

--- a/crates/ide-assists/src/handlers/extract_function.rs
+++ b/crates/ide-assists/src/handlers/extract_function.rs
@@ -4728,6 +4728,7 @@ const fn $0fun_name() {
         check_assist(
             extract_function,
             r#"
+//- minicore: iterator
 fn foo() {
     let mut x = 5;
     for _ in 0..10 {
@@ -4751,6 +4752,7 @@ fn $0fun_name(x: &mut i32) {
         check_assist(
             extract_function,
             r#"
+//- minicore: iterator
 fn foo() {
     for _ in 0..10 {
         let mut x = 5;
@@ -4774,6 +4776,7 @@ fn $0fun_name(mut x: i32) {
         check_assist(
             extract_function,
             r#"
+//- minicore: iterator
 fn foo() {
     loop {
         let mut x = 5;

--- a/crates/ide-completion/src/completions/lifetime.rs
+++ b/crates/ide-completion/src/completions/lifetime.rs
@@ -329,6 +329,7 @@ fn foo() {
     fn complete_label_in_for_iterable() {
         check(
             r#"
+//- minicore: iterator
 fn foo() {
     'outer: for _ in [{ 'inner: loop { break '$0 } }] {}
 }

--- a/crates/ide-diagnostics/src/handlers/break_outside_of_loop.rs
+++ b/crates/ide-diagnostics/src/handlers/break_outside_of_loop.rs
@@ -124,12 +124,14 @@ fn foo() {
 
     #[test]
     fn value_break_in_for_loop() {
+        // FIXME: the error is correct, but the message is terrible
         check_diagnostics(
             r#"
+//- minicore: iterator
 fn test() {
     for _ in [()] {
         break 3;
-     // ^^^^^^^ error: can't break with a value in this position
+           // ^ error: expected (), found i32
     }
 }
 "#,

--- a/crates/ide/src/syntax_highlighting/tests.rs
+++ b/crates/ide/src/syntax_highlighting/tests.rs
@@ -1137,5 +1137,5 @@ fn benchmark_syntax_highlighting_parser() {
             .filter(|it| it.highlight.tag == HlTag::Symbol(SymbolKind::Function))
             .count()
     };
-    assert_eq!(hash, 1170);
+    assert_eq!(hash, 1169);
 }


### PR DESCRIPTION
This PR separates monomorphization from interpreting, and add a monomorphization query to cache the results. Together with making layout queries returning `Arc<Layout>` instead of `Layout` (did you know that `Layout` is a 312 byte struct with a couple of vectors, so it is very costly to clone? I thought it should be very small and cheap) it makes mir interpreting an order of magnitude faster in warmed calls.

It still can't evaluate no test in the r-a repo, but all tests that I tried are hitting #7434 so I hope after that it will become able to interpret some real world test.