### PR TITLE
Allow users to override the .scip output file path

### DIFF
--- a/crates/rust-analyzer/src/cli/flags.rs
+++ b/crates/rust-analyzer/src/cli/flags.rs
@@ -112,6 +112,9 @@ xflags::xflags! {
 
         cmd scip {
             required path: PathBuf
+
+            /// The output path where the SCIP file will be written to. Defaults to `index.scip`.
+            optional --output path: PathBuf
         }
     }
 }
@@ -208,6 +211,7 @@ pub struct Lsif {
 #[derive(Debug)]
 pub struct Scip {
     pub path: PathBuf,
+    pub output: Option<PathBuf>,
 }
 
 impl RustAnalyzer {

--- a/crates/rust-analyzer/src/cli/scip.rs
+++ b/crates/rust-analyzer/src/cli/scip.rs
@@ -2,6 +2,7 @@
 
 use std::{
     collections::{HashMap, HashSet},
+    path::PathBuf,
     time::Instant,
 };
 
@@ -165,7 +166,8 @@ impl flags::Scip {
             special_fields: Default::default(),
         };
 
-        scip::write_message_to_file("index.scip", index)
+        let out_path = self.output.unwrap_or_else(|| PathBuf::from(r"index.scip"));
+        scip::write_message_to_file(out_path, index)
             .map_err(|err| anyhow::anyhow!("Failed to write scip to file: {}", err))?;
 
         eprintln!("Generating SCIP finished {:?}", now.elapsed());


### PR DESCRIPTION
Previously, rust-analyzer would write to the file index.scip unconditionally.