### PR TITLE
fix: add a toggle to disable the dependency explorer

### DIFF
--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -465,6 +465,11 @@
                     "default": true,
                     "type": "boolean"
                 },
+                "rust-analyzer.showDependenciesExplorer": {
+                    "markdownDescription": "Whether to show the dependencies view.",
+                    "default": true,
+                    "type": "boolean"
+                },
                 "$generated-start": {},
                 "rust-analyzer.assist.emitMustUse": {
                     "markdownDescription": "Whether to insert #[must_use] when generating `as_` methods\nfor enum variants.",
@@ -2013,7 +2018,7 @@
                 {
                     "id": "rustDependencies",
                     "name": "Rust Dependencies",
-                    "when": "inRustProject"
+                    "when": "inRustProject && config.rust-analyzer.showDependenciesExplorer"
                 }
             ]
         },

--- a/editors/code/src/config.ts
+++ b/editors/code/src/config.ts
@@ -284,6 +284,10 @@ export class Config {
     get useRustcErrorCode() {
         return this.get<boolean>("diagnostics.useRustcErrorCode");
     }
+
+    get showDependenciesExplorer() {
+        return this.get<boolean>("showDependenciesExplorer");
+    }
 }
 
 // the optional `cb?` parameter is meant to be used to add additional

--- a/editors/code/src/ctx.ts
+++ b/editors/code/src/ctx.ts
@@ -263,7 +263,10 @@ export class Ctx {
         }
         await client.start();
         this.updateCommands();
-        this.prepareTreeDependenciesView(client);
+
+        if (this.config.showDependenciesExplorer) {
+            this.prepareTreeDependenciesView(client);
+        }
     }
 
     private prepareTreeDependenciesView(client: lc.LanguageClient) {


### PR DESCRIPTION
For common uses of non-Cargo build systems with rust-analyzer, the dependency view isn't particularly helpful because there isn't a Cargo.toml present for dependencies or the dependencies are part of the current workspace.

Speaking from the perspective of a user of `rust-project.json`, I'd prefer to have this feature disabled until I can add a field to `Crate` that defines the location of a build file (e.g., a `BUCK`) file, which would allow for removing the "search for a Cargo.toml in parent directories of a crate root" behavior that exists in a few places (I've opened [an issue](https://github.com/rust-lang/cargo/issues/12187) on Cargo to request this data from `cargo-metadata`).