### PR TITLE
Fix rustup installation description

### DIFF
--- a/docs/user/manual.adoc
+++ b/docs/user/manual.adoc
@@ -172,7 +172,7 @@ $ cargo xtask install --server
 If your editor can't find the binary even though the binary is on your `$PATH`, the likely explanation is that it doesn't see the same `$PATH` as the shell, see https://github.com/rust-lang/rust-analyzer/issues/1811[this issue].
 On Unix, running the editor from a shell or changing the `.desktop` file to set the environment should help.
 
-==== `rustup`
+==== rustup
 
 `rust-analyzer` is available in `rustup`:
 

--- a/docs/user/manual.adoc
+++ b/docs/user/manual.adoc
@@ -181,19 +181,6 @@ On Unix, running the editor from a shell or changing the `.desktop` file to set 
 $ rustup component add rust-analyzer
 ----
 
-However, in contrast to `component add clippy` or `component add rustfmt`, this does not actually place a `rust-analyzer` binary in `~/.cargo/bin`, see https://github.com/rust-lang/rustup/issues/2411[this issue]. You can find the path to the binary using:
-[source,bash]
-----
-$ rustup which --toolchain stable rust-analyzer
-----
-You can link to there from `~/.cargo/bin` or configure your editor to use the full path.
-
-Alternatively you might be able to configure your editor to start `rust-analyzer` using the command:
-[source,bash]
-----
-$ rustup run stable rust-analyzer
-----
-
 ==== Arch Linux
 
 The `rust-analyzer` binary can be installed from the repos or AUR (Arch User Repository):


### PR DESCRIPTION
While going through the process of installing rust-analyzer to use with Neovim, I noticed that the instructions for installing with rustup are incorrect now that [issue #2411](https://github.com/rust-lang/rustup/issues/2411) has been closed. Now when rust-analyzer is installed using rustup, it is installed in ~/.cargo/bin and a symlink or some other workaround is no longer needed. I have updated the documentation accordingly.