### PR TITLE
Add `ManifestPath` to `CrateData`; update dependency view to use ManifestPath

### DIFF
--- a/crates/base-db/src/input.rs
+++ b/crates/base-db/src/input.rs
@@ -296,6 +296,7 @@ impl ReleaseChannel {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CrateData {
     pub root_file_id: FileId,
+    pub manifest_path_id: Option<FileId>,
     pub edition: Edition,
     pub version: Option<String>,
     /// A name used in the package's project declaration: for Cargo projects,
@@ -359,6 +360,7 @@ impl CrateGraph {
     pub fn add_crate_root(
         &mut self,
         root_file_id: FileId,
+        manifest_path_id: Option<FileId>,
         edition: Edition,
         display_name: Option<CrateDisplayName>,
         version: Option<String>,
@@ -372,6 +374,7 @@ impl CrateGraph {
     ) -> CrateId {
         let data = CrateData {
             root_file_id,
+            manifest_path_id,
             edition,
             version,
             display_name,
@@ -738,6 +741,7 @@ mod tests {
         let mut graph = CrateGraph::default();
         let crate1 = graph.add_crate_root(
             FileId(1u32),
+            Some(FileId(2u32)),
             Edition2018,
             None,
             None,
@@ -750,7 +754,8 @@ mod tests {
             None,
         );
         let crate2 = graph.add_crate_root(
-            FileId(2u32),
+            FileId(3u32),
+            Some(FileId(4u32)),
             Edition2018,
             None,
             None,
@@ -763,7 +768,8 @@ mod tests {
             None,
         );
         let crate3 = graph.add_crate_root(
-            FileId(3u32),
+            FileId(5u32),
+            Some(FileId(6u32)),
             Edition2018,
             None,
             None,
@@ -791,6 +797,7 @@ mod tests {
         let mut graph = CrateGraph::default();
         let crate1 = graph.add_crate_root(
             FileId(1u32),
+            Some(FileId(2u32)),
             Edition2018,
             None,
             None,
@@ -803,7 +810,8 @@ mod tests {
             None,
         );
         let crate2 = graph.add_crate_root(
-            FileId(2u32),
+            FileId(3u32),
+            Some(FileId(4u32)),
             Edition2018,
             None,
             None,
@@ -828,6 +836,7 @@ mod tests {
         let mut graph = CrateGraph::default();
         let crate1 = graph.add_crate_root(
             FileId(1u32),
+            Some(FileId(2u32)),
             Edition2018,
             None,
             None,
@@ -840,7 +849,8 @@ mod tests {
             None,
         );
         let crate2 = graph.add_crate_root(
-            FileId(2u32),
+            FileId(3u32),
+            Some(FileId(4u32)),
             Edition2018,
             None,
             None,
@@ -853,7 +863,8 @@ mod tests {
             None,
         );
         let crate3 = graph.add_crate_root(
-            FileId(3u32),
+            FileId(5u32),
+            Some(FileId(6u32)),
             Edition2018,
             None,
             None,
@@ -878,6 +889,7 @@ mod tests {
         let mut graph = CrateGraph::default();
         let crate1 = graph.add_crate_root(
             FileId(1u32),
+            Some(FileId(1u32)),
             Edition2018,
             None,
             None,
@@ -890,7 +902,8 @@ mod tests {
             None,
         );
         let crate2 = graph.add_crate_root(
-            FileId(2u32),
+            FileId(3u32),
+            Some(FileId(4u32)),
             Edition2018,
             None,
             None,

--- a/crates/ide/src/fetch_crates.rs
+++ b/crates/ide/src/fetch_crates.rs
@@ -8,6 +8,7 @@ pub struct CrateInfo {
     pub name: Option<String>,
     pub version: Option<String>,
     pub root_file_id: FileId,
+    pub manifest_path_id: Option<FileId>,
 }
 
 // Feature: Show Dependency Tree
@@ -32,11 +33,12 @@ pub(crate) fn fetch_crates(db: &RootDatabase) -> FxIndexSet<CrateInfo> {
 }
 
 fn crate_info(data: &ide_db::base_db::CrateData) -> CrateInfo {
-    let crate_name = crate_name(data);
-    let version = data.version.clone();
-    CrateInfo { name: crate_name, version, root_file_id: data.root_file_id }
-}
+    let name = data.display_name.as_ref().map(|it| it.canonical_name().to_owned());
 
-fn crate_name(data: &ide_db::base_db::CrateData) -> Option<String> {
-    data.display_name.as_ref().map(|it| it.canonical_name().to_owned())
+    CrateInfo {
+        name,
+        version: data.version.clone(),
+        root_file_id: data.root_file_id,
+        manifest_path_id: data.manifest_path_id,
+    }
 }

--- a/crates/ide/src/lib.rs
+++ b/crates/ide/src/lib.rs
@@ -237,6 +237,7 @@ impl Analysis {
         cfg_options.insert_atom("test".into());
         crate_graph.add_crate_root(
             file_id,
+            None,
             Edition::CURRENT,
             None,
             None,

--- a/crates/ide/src/shuffle_crate_graph.rs
+++ b/crates/ide/src/shuffle_crate_graph.rs
@@ -30,6 +30,7 @@ pub(crate) fn shuffle_crate_graph(db: &mut RootDatabase) {
         let data = &crate_graph[old_id];
         let new_id = new_graph.add_crate_root(
             data.root_file_id,
+            data.manifest_path_id,
             data.edition,
             data.display_name.clone(),
             data.version.clone(),

--- a/crates/project-model/src/workspace.rs
+++ b/crates/project-model/src/workspace.rs
@@ -897,6 +897,8 @@ fn cargo_to_crate_graph(
             cfg_options
         });
 
+        let manifest_id = load(&cargo[pkg].manifest);
+
         let mut lib_tgt = None;
         for &tgt in cargo[pkg].targets.iter() {
             if cargo[tgt].kind != TargetKind::Lib && !cargo[pkg].is_member {
@@ -916,7 +918,7 @@ fn cargo_to_crate_graph(
                 build_scripts.get_output(pkg),
                 cfg_options.clone(),
                 file_id,
-                None,
+                manifest_id,
                 &cargo[tgt].name,
                 cargo[tgt].is_proc_macro,
                 target_layout.clone(),

--- a/crates/project-model/src/workspace.rs
+++ b/crates/project-model/src/workspace.rs
@@ -1319,7 +1319,7 @@ fn sysroot_to_crate_graph(
                     CrateDisplayName::from_canonical_name(sysroot[krate].name.clone());
                 let crate_id = crate_graph.add_crate_root(
                     file_id,
-                    None, // TODO: are all sysroot crates build with Cargo?
+                    None, // FIXME: are all sysroot crates build with Cargo?
                     Edition::CURRENT,
                     Some(display_name),
                     None,

--- a/crates/project-model/test_data/output/cargo_hello_world_project_model.txt
+++ b/crates/project-model/test_data/output/cargo_hello_world_project_model.txt
@@ -1,7 +1,12 @@
 {
     0: CrateData {
         root_file_id: FileId(
-            1,
+            2,
+        ),
+        manifest_path_id: Some(
+            FileId(
+                1,
+            ),
         ),
         edition: Edition2018,
         version: Some(
@@ -64,7 +69,12 @@
     },
     1: CrateData {
         root_file_id: FileId(
-            2,
+            3,
+        ),
+        manifest_path_id: Some(
+            FileId(
+                1,
+            ),
         ),
         edition: Edition2018,
         version: Some(
@@ -134,7 +144,12 @@
     },
     2: CrateData {
         root_file_id: FileId(
-            3,
+            4,
+        ),
+        manifest_path_id: Some(
+            FileId(
+                1,
+            ),
         ),
         edition: Edition2018,
         version: Some(
@@ -204,7 +219,12 @@
     },
     3: CrateData {
         root_file_id: FileId(
-            4,
+            5,
+        ),
+        manifest_path_id: Some(
+            FileId(
+                1,
+            ),
         ),
         edition: Edition2018,
         version: Some(
@@ -274,7 +294,12 @@
     },
     4: CrateData {
         root_file_id: FileId(
-            5,
+            7,
+        ),
+        manifest_path_id: Some(
+            FileId(
+                6,
+            ),
         ),
         edition: Edition2015,
         version: Some(

--- a/crates/project-model/test_data/output/cargo_hello_world_project_model_with_selective_overrides.txt
+++ b/crates/project-model/test_data/output/cargo_hello_world_project_model_with_selective_overrides.txt
@@ -1,7 +1,12 @@
 {
     0: CrateData {
         root_file_id: FileId(
-            1,
+            2,
+        ),
+        manifest_path_id: Some(
+            FileId(
+                1,
+            ),
         ),
         edition: Edition2018,
         version: Some(
@@ -64,7 +69,12 @@
     },
     1: CrateData {
         root_file_id: FileId(
-            2,
+            3,
+        ),
+        manifest_path_id: Some(
+            FileId(
+                1,
+            ),
         ),
         edition: Edition2018,
         version: Some(
@@ -134,7 +144,12 @@
     },
     2: CrateData {
         root_file_id: FileId(
-            3,
+            4,
+        ),
+        manifest_path_id: Some(
+            FileId(
+                1,
+            ),
         ),
         edition: Edition2018,
         version: Some(
@@ -204,7 +219,12 @@
     },
     3: CrateData {
         root_file_id: FileId(
-            4,
+            5,
+        ),
+        manifest_path_id: Some(
+            FileId(
+                1,
+            ),
         ),
         edition: Edition2018,
         version: Some(
@@ -274,7 +294,12 @@
     },
     4: CrateData {
         root_file_id: FileId(
-            5,
+            7,
+        ),
+        manifest_path_id: Some(
+            FileId(
+                6,
+            ),
         ),
         edition: Edition2015,
         version: Some(

--- a/crates/project-model/test_data/output/cargo_hello_world_project_model_with_wildcard_overrides.txt
+++ b/crates/project-model/test_data/output/cargo_hello_world_project_model_with_wildcard_overrides.txt
@@ -1,7 +1,12 @@
 {
     0: CrateData {
         root_file_id: FileId(
-            1,
+            2,
+        ),
+        manifest_path_id: Some(
+            FileId(
+                1,
+            ),
         ),
         edition: Edition2018,
         version: Some(
@@ -63,7 +68,12 @@
     },
     1: CrateData {
         root_file_id: FileId(
-            2,
+            3,
+        ),
+        manifest_path_id: Some(
+            FileId(
+                1,
+            ),
         ),
         edition: Edition2018,
         version: Some(
@@ -132,7 +142,12 @@
     },
     2: CrateData {
         root_file_id: FileId(
-            3,
+            4,
+        ),
+        manifest_path_id: Some(
+            FileId(
+                1,
+            ),
         ),
         edition: Edition2018,
         version: Some(
@@ -201,7 +216,12 @@
     },
     3: CrateData {
         root_file_id: FileId(
-            4,
+            5,
+        ),
+        manifest_path_id: Some(
+            FileId(
+                1,
+            ),
         ),
         edition: Edition2018,
         version: Some(
@@ -270,7 +290,12 @@
     },
     4: CrateData {
         root_file_id: FileId(
-            5,
+            7,
+        ),
+        manifest_path_id: Some(
+            FileId(
+                6,
+            ),
         ),
         edition: Edition2015,
         version: Some(

--- a/crates/project-model/test_data/output/rust_project_hello_world_project_model.txt
+++ b/crates/project-model/test_data/output/rust_project_hello_world_project_model.txt
@@ -3,6 +3,7 @@
         root_file_id: FileId(
             1,
         ),
+        manifest_path_id: None,
         edition: Edition2021,
         version: None,
         display_name: Some(
@@ -42,6 +43,7 @@
         root_file_id: FileId(
             2,
         ),
+        manifest_path_id: None,
         edition: Edition2021,
         version: None,
         display_name: Some(
@@ -73,6 +75,7 @@
         root_file_id: FileId(
             3,
         ),
+        manifest_path_id: None,
         edition: Edition2021,
         version: None,
         display_name: Some(
@@ -104,6 +107,7 @@
         root_file_id: FileId(
             4,
         ),
+        manifest_path_id: None,
         edition: Edition2021,
         version: None,
         display_name: Some(
@@ -135,6 +139,7 @@
         root_file_id: FileId(
             5,
         ),
+        manifest_path_id: None,
         edition: Edition2021,
         version: None,
         display_name: Some(
@@ -181,6 +186,7 @@
         root_file_id: FileId(
             6,
         ),
+        manifest_path_id: None,
         edition: Edition2021,
         version: None,
         display_name: Some(
@@ -212,6 +218,7 @@
         root_file_id: FileId(
             7,
         ),
+        manifest_path_id: None,
         edition: Edition2021,
         version: None,
         display_name: Some(
@@ -300,6 +307,7 @@
         root_file_id: FileId(
             8,
         ),
+        manifest_path_id: None,
         edition: Edition2021,
         version: None,
         display_name: Some(
@@ -331,6 +339,7 @@
         root_file_id: FileId(
             9,
         ),
+        manifest_path_id: None,
         edition: Edition2021,
         version: None,
         display_name: Some(
@@ -362,6 +371,7 @@
         root_file_id: FileId(
             10,
         ),
+        manifest_path_id: None,
         edition: Edition2021,
         version: None,
         display_name: Some(
@@ -393,6 +403,7 @@
         root_file_id: FileId(
             11,
         ),
+        manifest_path_id: None,
         edition: Edition2018,
         version: None,
         display_name: Some(

--- a/crates/rust-analyzer/src/handlers/request.rs
+++ b/crates/rust-analyzer/src/handlers/request.rs
@@ -2,7 +2,6 @@
 //! Protocol. This module specifically handles requests.
 
 use std::{
-    fs,
     io::Write as _,
     process::{self, Stdio},
 };
@@ -30,7 +29,7 @@ use serde_json::json;
 use stdx::{format_to, never};
 use syntax::{algo, ast, AstNode, TextRange, TextSize};
 use triomphe::Arc;
-use vfs::{AbsPath, AbsPathBuf, VfsPath};
+use vfs::{AbsPath, AbsPathBuf};
 
 use crate::{
     cargo_target_spec::CargoTargetSpec,
@@ -1947,43 +1946,11 @@ pub(crate) fn fetch_dependency_list(
     let crate_infos = crates
         .into_iter()
         .filter_map(|it| {
-            let root_file_path = state.file_id_to_file_path(it.root_file_id);
-            crate_path(root_file_path).and_then(to_url).map(|path| CrateInfoResult {
-                name: it.name,
-                version: it.version,
-                path,
-            })
+            dbg!(&it);
+            let path = state.file_id_to_file_path(it.manifest_path_id?);
+            let path = Url::from_file_path(path.as_path()?).ok()?;
+            Some(CrateInfoResult { name: it.name, version: it.version, path })
         })
         .collect();
     Ok(FetchDependencyListResult { crates: crate_infos })
-}
-
-/// Searches for the directory of a Rust crate given this crate's root file path.
-///
-/// # Arguments
-///
-/// * `root_file_path`: The path to the root file of the crate.
-///
-/// # Returns
-///
-/// An `Option` value representing the path to the directory of the crate with the given
-/// name, if such a crate is found. If no crate with the given name is found, this function
-/// returns `None`.
-fn crate_path(root_file_path: VfsPath) -> Option<VfsPath> {
-    let mut current_dir = root_file_path.parent();
-    while let Some(path) = current_dir {
-        let cargo_toml_path = path.join("../Cargo.toml")?;
-        if fs::metadata(cargo_toml_path.as_path()?).is_ok() {
-            let crate_path = cargo_toml_path.parent()?;
-            return Some(crate_path);
-        }
-        current_dir = path.parent();
-    }
-    None
-}
-
-fn to_url(path: VfsPath) -> Option<Url> {
-    let path = path.as_path()?;
-    let str_path = path.as_os_str().to_str()?;
-    Url::from_file_path(str_path).ok()
 }

--- a/crates/rust-analyzer/src/handlers/request.rs
+++ b/crates/rust-analyzer/src/handlers/request.rs
@@ -1946,7 +1946,6 @@ pub(crate) fn fetch_dependency_list(
     let crate_infos = crates
         .into_iter()
         .filter_map(|it| {
-            dbg!(&it);
             let path = state.file_id_to_file_path(it.manifest_path_id?);
             let path = Url::from_file_path(path.as_path()?).ok()?;
             Some(CrateInfoResult { name: it.name, version: it.version, path })


### PR DESCRIPTION
Hi! I've got a few changes:
- I've added an optional `ManifestPath` to `CrateGraph` and `project_json.rs`'s `Crate`/`CrateData` structs. `ManifestPath` is optional inside of `CrateGraph` because single file workspaces don't have a manifest file by definition. I've made `ManifestPath` optional inside of `project_json.rs` for backwards compatibility reasons, but I'd be happy to make it non-optional after a period of time.
- I've also made the dependency explorer to use the manifest path from the crate graph instead of trying to figure out the location of the the crate root by searching for a `Cargo.toml`. Since this is is sourced from `Cargo` itself, I think this is an overall improvement. It also allows for non-Cargo build systems to make use of this feature.

If you're okay with these changes, please let me know before landing it! I'd like to update the documentation for `rust-project.json` with these details (as well as update the `rust-project` definition in the VS Code extension).
