### PR TITLE
fix: Don't duplicate sysroot crates in rustc workspace

### DIFF
--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -2703,8 +2703,8 @@ impl LocalSource {
         self.source.file_id
     }
 
-    pub fn name(&self) -> Option<ast::Name> {
-        self.source.value.name()
+    pub fn name(&self) -> Option<InFile<ast::Name>> {
+        self.source.as_ref().map(|it| it.name()).transpose()
     }
 
     pub fn syntax(&self) -> &SyntaxNode {

--- a/crates/ide-diagnostics/src/handlers/mutability_errors.rs
+++ b/crates/ide-diagnostics/src/handlers/mutability_errors.rs
@@ -18,7 +18,8 @@ pub(crate) fn need_mut(ctx: &DiagnosticsContext<'_>, d: &hir::NeedMut) -> Diagno
         let use_range = d.span.value.text_range();
         for source in d.local.sources(ctx.sema.db) {
             let Some(ast) = source.name() else { continue };
-            edit_builder.insert(ast.syntax().text_range().start(), "mut ".to_string());
+            // FIXME: macros
+            edit_builder.insert(ast.value.syntax().text_range().start(), "mut ".to_string());
         }
         let edit = edit_builder.finish();
         Some(vec![fix(

--- a/crates/ide/src/inlay_hints/closure_captures.rs
+++ b/crates/ide/src/inlay_hints/closure_captures.rs
@@ -74,7 +74,7 @@ pub(super) fn hints(
                     capture.display_place(sema.db)
                 ),
                 None,
-                source.name().and_then(|name| sema.original_range_opt(name.syntax())),
+                source.name().and_then(|name| name.syntax().original_file_range_opt(sema.db)),
             ),
             text_edit: None,
             position: InlayHintPosition::After,


### PR DESCRIPTION
Since we handle `library` as the sysroot source directly in the rustc workspace, we now duplicate the crates there, once as sysroot and once as just plain workspace crate. This causes a variety of issues for `vec!` macros and similar that emit `$crate` tokens across crates.