### PR TITLE
Fix drop scopes problems in mir

### DIFF
--- a/crates/hir-ty/src/mir/eval.rs
+++ b/crates/hir-ty/src/mir/eval.rs
@@ -1896,7 +1896,14 @@ impl Evaluator<'_> {
         let mir_body = self
             .db
             .monomorphized_mir_body(def, generic_args, self.trait_env.clone())
-            .map_err(|e| MirEvalError::MirLowerError(imp, e))?;
+            .map_err(|e| {
+                MirEvalError::InFunction(
+                    Either::Left(imp),
+                    Box::new(MirEvalError::MirLowerError(imp, e)),
+                    span,
+                    locals.body.owner,
+                )
+            })?;
         let result = self.interpret_mir(&mir_body, arg_bytes.iter().cloned()).map_err(|e| {
             MirEvalError::InFunction(Either::Left(imp), Box::new(e), span, locals.body.owner)
         })?;

--- a/crates/test-utils/src/minicore.rs
+++ b/crates/test-utils/src/minicore.rs
@@ -726,6 +726,19 @@ pub mod ops {
     pub trait AddAssign<Rhs = Self> {
         fn add_assign(&mut self, rhs: Rhs);
     }
+
+    // region:builtin_impls
+    macro_rules! add_impl {
+        ($($t:ty)*) => ($(
+            impl const Add for $t {
+                type Output = $t;
+                fn add(self, other: $t) -> $t { self + other }
+            }
+        )*)
+    }
+
+    add_impl! { usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 f32 f64 }
+    // endregion:builtin_impls
     // endregion:add
 
     // region:generator


### PR DESCRIPTION
Fix false positives of `need-mut` emerged from #14955 

There are still 5 `need-mut` false positives on self, all related to `izip!` macro hygenic issue. I will try to do something about that before monday release.