### PR TITLE
fix: consider outer binders when folding captured items' type

### DIFF
--- a/crates/hir-ty/src/infer.rs
+++ b/crates/hir-ty/src/infer.rs
@@ -367,6 +367,10 @@ pub enum PointerCast {
 }
 
 /// The result of type inference: A mapping from expressions and patterns to types.
+///
+/// When you add a field that stores types (including `Substitution` and the like), don't forget
+/// `resolve_completely()`'ing  them in `InferenceContext::resolve_all()`. Inference variables must
+/// not appear in the final inference result.
 #[derive(Clone, PartialEq, Eq, Debug, Default)]
 pub struct InferenceResult {
     /// For each method call expr, records the function it resolves to.
@@ -575,6 +579,8 @@ impl<'a> InferenceContext<'a> {
     // used this function for another workaround, mention it here. If you really need this function and believe that
     // there is no problem in it being `pub(crate)`, remove this comment.
     pub(crate) fn resolve_all(self) -> InferenceResult {
+        // NOTE: `InferenceResult::closure_info` is `resolve_completely()`'d during
+        // `InferenceContext::infer_closures()` (in `HirPlace::ty()` specifically).
         let InferenceContext { mut table, mut result, .. } = self;
 
         table.fallback_if_possible();

--- a/crates/hir-ty/src/mir/eval/tests.rs
+++ b/crates/hir-ty/src/mir/eval/tests.rs
@@ -640,3 +640,37 @@ fn main() {
         "#,
     );
 }
+
+#[test]
+fn regression_14966() {
+    check_pass(
+        r#"
+//- minicore: fn, copy, coerce_unsized
+trait A<T> {
+    fn a(&self) {}
+}
+impl A<()> for () {}
+
+struct B;
+impl B {
+    pub fn b<T>(s: &dyn A<T>) -> Self {
+        B
+    }
+}
+struct C;
+impl C {
+    fn c<T>(a: &dyn A<T>) -> Self {
+        let mut c = C;
+        let b = B::b(a);
+        c.d(|| a.a());
+        c
+    }
+    fn d(&mut self, f: impl FnOnce()) {}
+}
+
+fn main() {
+    C::c(&());
+}
+"#,
+    );
+}

--- a/crates/hir-ty/src/mir/monomorphization.rs
+++ b/crates/hir-ty/src/mir/monomorphization.rs
@@ -303,13 +303,7 @@ pub fn monomorphized_mir_body_query(
     subst: Substitution,
     trait_env: Arc<crate::TraitEnvironment>,
 ) -> Result<Arc<MirBody>, MirLowerError> {
-    let g_def = match owner {
-        DefWithBodyId::FunctionId(f) => Some(f.into()),
-        DefWithBodyId::StaticId(_) => None,
-        DefWithBodyId::ConstId(f) => Some(f.into()),
-        DefWithBodyId::VariantId(f) => Some(f.into()),
-    };
-    let generics = g_def.map(|g_def| generics(db.upcast(), g_def));
+    let generics = owner.as_generic_def_id().map(|g_def| generics(db.upcast(), g_def));
     let filler = &mut Filler { db, subst: &subst, trait_env, generics, owner };
     let body = db.mir_body(owner)?;
     let mut body = (*body).clone();
@@ -334,13 +328,7 @@ pub fn monomorphized_mir_body_for_closure_query(
     trait_env: Arc<crate::TraitEnvironment>,
 ) -> Result<Arc<MirBody>, MirLowerError> {
     let (owner, _) = db.lookup_intern_closure(closure.into());
-    let g_def = match owner {
-        DefWithBodyId::FunctionId(f) => Some(f.into()),
-        DefWithBodyId::StaticId(_) => None,
-        DefWithBodyId::ConstId(f) => Some(f.into()),
-        DefWithBodyId::VariantId(f) => Some(f.into()),
-    };
-    let generics = g_def.map(|g_def| generics(db.upcast(), g_def));
+    let generics = owner.as_generic_def_id().map(|g_def| generics(db.upcast(), g_def));
     let filler = &mut Filler { db, subst: &subst, trait_env, generics, owner };
     let body = db.mir_body_for_closure(closure)?;
     let mut body = (*body).clone();
@@ -356,13 +344,7 @@ pub fn monomorphize_mir_body_bad(
     trait_env: Arc<crate::TraitEnvironment>,
 ) -> Result<MirBody, MirLowerError> {
     let owner = body.owner;
-    let g_def = match owner {
-        DefWithBodyId::FunctionId(f) => Some(f.into()),
-        DefWithBodyId::StaticId(_) => None,
-        DefWithBodyId::ConstId(f) => Some(f.into()),
-        DefWithBodyId::VariantId(f) => Some(f.into()),
-    };
-    let generics = g_def.map(|g_def| generics(db.upcast(), g_def));
+    let generics = owner.as_generic_def_id().map(|g_def| generics(db.upcast(), g_def));
     let filler = &mut Filler { db, subst: &subst, trait_env, generics, owner };
     filler.fill_body(&mut body)?;
     Ok(body)


### PR DESCRIPTION
Fixes #14966

Basically, the crash is caused by us producing a broken type and passing it to chalk: `&dyn for<type> [for<> Implemented(^1.0: A<^0.0>)]` (notice the innermost bound var `^0.0` has no corresponding binder). It's created in `CapturedItemWithoutTy::with_ty()`, which didn't consider outer binders when folding types to replace placeholders with bound variables.

The fix is one-liner, but I've also refactored the surrounding code a little.