### PR TITLE
Emit `'_` for lifetime generics in `HirDisplay`

### DIFF
--- a/crates/hir-ty/src/tests/patterns.rs
+++ b/crates/hir-ty/src/tests/patterns.rs
@@ -1109,7 +1109,7 @@ fn var_args() {
 #[lang = "va_list"]
 pub struct VaListImpl<'f>;
 fn my_fn(foo: ...) {}
-       //^^^ VaListImpl
+       //^^^ VaListImpl<'_>
 "#,
     );
 }

--- a/crates/hir-ty/src/tests/regression.rs
+++ b/crates/hir-ty/src/tests/regression.rs
@@ -896,13 +896,13 @@ fn flush(&self) {
 "#,
         expect![[r#"
             123..127 'self': &Mutex<T>
-            150..152 '{}': MutexGuard<T>
+            150..152 '{}': MutexGuard<'_, T>
             234..238 'self': &{unknown}
             240..290 '{     ...()); }': ()
             250..251 'w': &Mutex<BufWriter>
             276..287 '*(w.lock())': BufWriter
             278..279 'w': &Mutex<BufWriter>
-            278..286 'w.lock()': MutexGuard<BufWriter>
+            278..286 'w.lock()': MutexGuard<'_, BufWriter>
         "#]],
     );
 }

--- a/crates/ide-assists/src/handlers/extract_function.rs
+++ b/crates/ide-assists/src/handlers/extract_function.rs
@@ -5479,6 +5479,30 @@ fn $0fun_name<T: Debug>(i: T) {
     }
 
     #[test]
+    fn dont_emit_type_with_hidden_lifetime_parameter() {
+        // FIXME: We should emit a `<T: Debug>` generic argument for the generated function
+        check_assist(
+            extract_function,
+            r#"
+struct Struct<'a, T>(&'a T);
+fn func<T: Debug>(i: Struct<'_, T>) {
+    $0foo(i);$0
+}
+"#,
+            r#"
+struct Struct<'a, T>(&'a T);
+fn func<T: Debug>(i: Struct<'_, T>) {
+    fun_name(i);
+}
+
+fn $0fun_name(i: Struct<'_, T>) {
+    foo(i);
+}
+"#,
+        );
+    }
+
+    #[test]
     fn preserve_generics_from_body() {
         check_assist(
             extract_function,


### PR DESCRIPTION
This makes the generated code not linted by `rust_2018_idioms` lint. But that is an allow by default lint, so should we do this? Maybe we should only do this for `DisplayTarget::SourceCode`?