### PR TITLE
feat: add `Trait` hlmod to `dyn` keyword

### DIFF
--- a/crates/ide/src/syntax_highlighting/highlight.rs
+++ b/crates/ide/src/syntax_highlighting/highlight.rs
@@ -164,6 +164,7 @@ fn keyword(
     let h = match kind {
         T![await] => h | HlMod::Async | HlMod::ControlFlow,
         T![async] => h | HlMod::Async,
+        T![dyn] => h | HlMod::Trait,
         T![break]
         | T![continue]
         | T![else]


### PR DESCRIPTION
I wasn't getting semantic highlighting in Neovim for the `dyn` keyword in the context of trait objects. Adding the `Trait` hlmod to the `dyn` keyword fixed it for me. 