### PR TITLE
Add unstable cargo lint tables and make use of clippy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,3 +92,25 @@ serde_json = "1.0.94"
 triomphe = { version = "0.1.8", default-features = false, features = ["std"] }
 
 rustc_lexer = { version = "0.1.0", package = "ra-ap-rustc_lexer" }
+
+[workspace.lints.rust]
+rust_2018_idioms = "warn"
+unused_lifetimes = "warn"
+semicolon_in_expressions_from_macros = "warn"
+
+[workspace.lints.clippy]
+all = { level = "warn", priority = -1 }
+# () makes a fine error in most cases
+result_unit_err = "allow"
+# We don't expose public APIs that matter like this
+len_without_is_empty = "allow"
+# Should be tackled at some point
+too_many_arguments = "allow"
+# Should be tackled at some point
+type_complexity = "allow"
+# we currently prefer explicit control flow return over `...?;` statements whose result is unused
+question_mark = "allow"
+# We have macros that rely on this currently
+enum_variant_names = "allow"
+# Builder pattern disagrees
+new_ret_no_self = "allow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,18 +99,41 @@ unused_lifetimes = "warn"
 semicolon_in_expressions_from_macros = "warn"
 
 [workspace.lints.clippy]
-all = { level = "warn", priority = -1 }
+# complexity lints
+complexity = { level = "warn", priority = -1 }
+# Should be tackled at some point where relevant
+too_many_arguments = "allow"
+# Should be tackled at some point
+type_complexity = "allow"
+
+# correctness lints
+correctness = { level = "deny", priority = -1 }
+
+# perf lints
+perf = { level = "deny", priority = -1 }
+
+# style lints
+style = { level = "warn", priority = -1 }
 # () makes a fine error in most cases
 result_unit_err = "allow"
 # We don't expose public APIs that matter like this
 len_without_is_empty = "allow"
-# Should be tackled at some point
-too_many_arguments = "allow"
-# Should be tackled at some point
-type_complexity = "allow"
 # we currently prefer explicit control flow return over `...?;` statements whose result is unused
 question_mark = "allow"
 # We have macros that rely on this currently
 enum_variant_names = "allow"
 # Builder pattern disagrees
 new_ret_no_self = "allow"
+
+# suspicious lints
+suspicious = { level = "warn", priority = -1 }
+
+# suspicious lints
+restriction = { level = "allow", priority = -1 }
+# Remove the tidy test once the lint table is stable
+dbg_macro = "warn"
+todo = "warn"
+unimplemented = "warn"
+rc_buffer = "warn"
+# FIXME enable this, we use this pattern a lot so its annoying work ...
+# str_to_string = "warn"

--- a/crates/base-db/Cargo.toml
+++ b/crates/base-db/Cargo.toml
@@ -27,3 +27,6 @@ syntax.workspace = true
 test-utils.workspace = true
 tt.workspace = true
 vfs.workspace = true
+
+[lints]
+workspace = true

--- a/crates/base-db/src/fixture.rs
+++ b/crates/base-db/src/fixture.rs
@@ -116,7 +116,7 @@ impl ChangeFixture {
         let toolchain = toolchain
             .map(|it| {
                 ReleaseChannel::from_str(&it)
-                    .unwrap_or_else(|| panic!("unknown release channel found: {it}"))
+                    .unwrap_or_else(|()| panic!("unknown release channel found: {it}"))
             })
             .unwrap_or(ReleaseChannel::Stable);
         let mut change = Change::new();

--- a/crates/base-db/src/fixture.rs
+++ b/crates/base-db/src/fixture.rs
@@ -131,7 +131,7 @@ impl ChangeFixture {
 
         let mut file_set = FileSet::default();
         let mut current_source_root_kind = SourceRootKind::Local;
-        let source_root_prefix = "/".to_string();
+        let source_root_prefix = "/".to_owned();
         let mut file_id = FileId(0);
         let mut roots = Vec::new();
 
@@ -245,7 +245,7 @@ impl ChangeFixture {
             file_id.0 += 1;
 
             let mut fs = FileSet::default();
-            fs.insert(core_file, VfsPath::new_virtual_path("/sysroot/core/lib.rs".to_string()));
+            fs.insert(core_file, VfsPath::new_virtual_path("/sysroot/core/lib.rs".to_owned()));
             roots.push(SourceRoot::new_library(fs));
 
             change.change_file(core_file, Some(Arc::from(mini_core.source_code())));
@@ -255,7 +255,7 @@ impl ChangeFixture {
             let core_crate = crate_graph.add_crate_root(
                 core_file,
                 Edition::Edition2021,
-                Some(CrateDisplayName::from_canonical_name("core".to_string())),
+                Some(CrateDisplayName::from_canonical_name("core".to_owned())),
                 None,
                 Default::default(),
                 Default::default(),
@@ -283,7 +283,7 @@ impl ChangeFixture {
             let mut fs = FileSet::default();
             fs.insert(
                 proc_lib_file,
-                VfsPath::new_virtual_path("/sysroot/proc_macros/lib.rs".to_string()),
+                VfsPath::new_virtual_path("/sysroot/proc_macros/lib.rs".to_owned()),
             );
             roots.push(SourceRoot::new_library(fs));
 
@@ -294,7 +294,7 @@ impl ChangeFixture {
             let proc_macros_crate = crate_graph.add_crate_root(
                 proc_lib_file,
                 Edition::Edition2021,
-                Some(CrateDisplayName::from_canonical_name("proc_macros".to_string())),
+                Some(CrateDisplayName::from_canonical_name("proc_macros".to_owned())),
                 None,
                 Default::default(),
                 Default::default(),
@@ -453,7 +453,7 @@ fn parse_crate(crate_str: String) -> (String, CrateOrigin, Option<String>) {
             },
             _ => panic!("Bad string for crate origin: {b}"),
         };
-        (a.to_owned(), origin, Some(version.to_string()))
+        (a.to_owned(), origin, Some(version.to_owned()))
     } else {
         let crate_origin = match LangCrateOrigin::from(&*crate_str) {
             LangCrateOrigin::Other => CrateOrigin::Local { repo: None, name: None },

--- a/crates/base-db/src/input.rs
+++ b/crates/base-db/src/input.rs
@@ -282,13 +282,17 @@ impl ReleaseChannel {
             ReleaseChannel::Nightly => "nightly",
         }
     }
+}
 
-    pub fn from_str(str: &str) -> Option<Self> {
-        Some(match str {
+impl FromStr for ReleaseChannel {
+    type Err = ();
+
+    fn from_str(str: &str) -> Result<Self, Self::Err> {
+        Ok(match str {
             "" => ReleaseChannel::Stable,
             "nightly" => ReleaseChannel::Nightly,
             _ if str.starts_with("beta") => ReleaseChannel::Beta,
-            _ => return None,
+            _ => return Err(()),
         })
     }
 }

--- a/crates/cfg/Cargo.toml
+++ b/crates/cfg/Cargo.toml
@@ -29,3 +29,6 @@ derive_arbitrary = "1.2.2"
 # local deps
 mbe.workspace = true
 syntax.workspace = true
+
+[lints]
+workspace = true

--- a/crates/flycheck/Cargo.toml
+++ b/crates/flycheck/Cargo.toml
@@ -24,3 +24,6 @@ command-group = "2.0.1"
 paths.workspace = true
 stdx.workspace = true
 toolchain.workspace = true
+
+[lints]
+workspace = true

--- a/crates/flycheck/src/lib.rs
+++ b/crates/flycheck/src/lib.rs
@@ -513,6 +513,7 @@ impl CargoActor {
     }
 }
 
+#[allow(clippy::large_enum_variant)]
 enum CargoMessage {
     CompilerArtifact(cargo_metadata::Artifact),
     Diagnostic(Diagnostic),

--- a/crates/hir-def/Cargo.toml
+++ b/crates/hir-def/Cargo.toml
@@ -51,3 +51,6 @@ expect-test = "1.4.0"
 
 # local deps
 test-utils.workspace = true
+
+[lints]
+workspace = true

--- a/crates/hir-def/src/attr.rs
+++ b/crates/hir-def/src/attr.rs
@@ -379,7 +379,7 @@ fn parse_comma_sep<S>(subtree: &tt::Subtree<S>) -> Vec<SmolStr> {
 }
 
 impl AttrsWithOwner {
-    pub(crate) fn attrs_with_owner(db: &dyn DefDatabase, owner: AttrDefId) -> Self {
+    pub(crate) fn attrs_with_owner_query(db: &dyn DefDatabase, owner: AttrDefId) -> Self {
         Self { attrs: db.attrs(owner), owner }
     }
 

--- a/crates/hir-def/src/body.rs
+++ b/crates/hir-def/src/body.rs
@@ -242,12 +242,12 @@ impl Body {
                 }
             }
             Pat::Or(args) | Pat::Tuple { args, .. } | Pat::TupleStruct { args, .. } => {
-                args.iter().copied().for_each(|p| f(p));
+                args.iter().copied().for_each(&mut f);
             }
             Pat::Ref { pat, .. } => f(*pat),
             Pat::Slice { prefix, slice, suffix } => {
                 let total_iter = prefix.iter().chain(slice.iter()).chain(suffix.iter());
-                total_iter.copied().for_each(|p| f(p));
+                total_iter.copied().for_each(&mut f);
             }
             Pat::Record { args, .. } => {
                 args.iter().for_each(|RecordFieldPat { pat, .. }| f(*pat));

--- a/crates/hir-def/src/body/lower.rs
+++ b/crates/hir-def/src/body/lower.rs
@@ -811,7 +811,7 @@ impl ExprCollector<'_> {
                 expr: iterator,
                 arms: Box::new([MatchArm { pat: iter_pat, guard: None, expr: loop_outer }]),
             },
-            syntax_ptr.clone(),
+            syntax_ptr,
         )
     }
 

--- a/crates/hir-def/src/body/pretty.rs
+++ b/crates/hir-def/src/body/pretty.rs
@@ -36,7 +36,7 @@ pub(super) fn print_body_hir(db: &dyn DefDatabase, body: &Body, owner: DefWithBo
             let item_tree_id = it.lookup(db).id;
             let name = match &item_tree_id.item_tree(db)[item_tree_id.value].name {
                 Some(name) => name.display(db.upcast()).to_string(),
-                None => "_".to_string(),
+                None => "_".to_owned(),
             };
             format!("const {name} = ")
         }
@@ -45,7 +45,7 @@ pub(super) fn print_body_hir(db: &dyn DefDatabase, body: &Body, owner: DefWithBo
             let variant = &src.value[it.local_id];
             match &variant.name() {
                 Some(name) => name.to_string(),
-                None => "_".to_string(),
+                None => "_".to_owned(),
             }
         }
     };

--- a/crates/hir-def/src/data.rs
+++ b/crates/hir-def/src/data.rs
@@ -739,7 +739,7 @@ impl<'a> AssocItemCollector<'a> {
             self.diagnostics.push(DefDiagnostic::macro_expansion_parse_error(
                 self.module_id.local_id,
                 error_call_kind(),
-                errors.into(),
+                errors,
             ));
         }
 

--- a/crates/hir-def/src/data/adt.rs
+++ b/crates/hir-def/src/data/adt.rs
@@ -473,7 +473,7 @@ fn lower_struct(
     trace: &mut Trace<FieldData, Either<ast::TupleField, ast::RecordField>>,
     ast: &InFile<ast::StructKind>,
 ) -> StructKind {
-    let ctx = LowerCtx::new(db, &expander.hygiene(), ast.file_id);
+    let ctx = LowerCtx::new(db, expander.hygiene(), ast.file_id);
 
     match &ast.value {
         ast::StructKind::Tuple(fl) => {

--- a/crates/hir-def/src/db.rs
+++ b/crates/hir-def/src/db.rs
@@ -193,7 +193,7 @@ pub trait DefDatabase: InternDatabase + ExpandDatabase + Upcast<dyn ExpandDataba
     fn attrs(&self, def: AttrDefId) -> Attrs;
 
     #[salsa::transparent]
-    #[salsa::invoke(AttrsWithOwner::attrs_with_owner)]
+    #[salsa::invoke(AttrsWithOwner::attrs_with_owner_query)]
     fn attrs_with_owner(&self, def: AttrDefId) -> AttrsWithOwner;
 
     // endregion:attrs
@@ -271,10 +271,8 @@ fn crate_supports_no_std(db: &dyn DefDatabase, crate_id: CrateId) -> bool {
             None => continue,
         };
 
-        let segments = tt.split(|tt| match tt {
-            tt::TokenTree::Leaf(tt::Leaf::Punct(p)) if p.char == ',' => true,
-            _ => false,
-        });
+        let segments =
+            tt.split(|tt| matches!(tt, tt::TokenTree::Leaf(tt::Leaf::Punct(p)) if p.char == ','));
         for output in segments.skip(1) {
             match output {
                 [tt::TokenTree::Leaf(tt::Leaf::Ident(ident))] if ident.text == "no_std" => {

--- a/crates/hir-def/src/dyn_map.rs
+++ b/crates/hir-def/src/dyn_map.rs
@@ -14,7 +14,7 @@
 //! let mut map = DynMap::new();
 //!
 //! // To access a specific map, index the `DynMap` by `Key`:
-//! map[STRING_TO_U32].insert("hello".to_string(), 92);
+//! map[STRING_TO_U32].insert("hello".to_owned(), 92);
 //! let value = map[U32_TO_VEC].get(92);
 //! assert!(value.is_none());
 //! ```

--- a/crates/hir-def/src/find_path.rs
+++ b/crates/hir-def/src/find_path.rs
@@ -206,7 +206,7 @@ fn find_path_for_module(
     }
 
     if let value @ Some(_) =
-        find_in_prelude(db, &root_def_map, &def_map, ItemInNs::Types(module_id.into()), from)
+        find_in_prelude(db, &root_def_map, def_map, ItemInNs::Types(module_id.into()), from)
     {
         return value;
     }

--- a/crates/hir-def/src/generics.rs
+++ b/crates/hir-def/src/generics.rs
@@ -300,6 +300,7 @@ impl GenericParams {
         }
     }
 
+    #[allow(clippy::borrowed_box)]
     fn add_where_predicate_from_bound(
         &mut self,
         lower_ctx: &LowerCtx<'_>,

--- a/crates/hir-def/src/import_map.rs
+++ b/crates/hir-def/src/import_map.rs
@@ -872,7 +872,7 @@ mod tests {
         check_search(
             ra_fixture,
             "main",
-            Query::new("fmt".to_string()).search_mode(SearchMode::Fuzzy),
+            Query::new("fmt".to_owned()).search_mode(SearchMode::Fuzzy),
             expect![[r#"
                 dep::fmt (t)
                 dep::fmt::Display (t)
@@ -902,7 +902,7 @@ mod tests {
         check_search(
             ra_fixture,
             "main",
-            Query::new("fmt".to_string()).search_mode(SearchMode::Fuzzy).assoc_items_only(),
+            Query::new("fmt".to_owned()).search_mode(SearchMode::Fuzzy).assoc_items_only(),
             expect![[r#"
                 dep::fmt::Display::FMT_CONST (a)
                 dep::fmt::Display::format_function (a)
@@ -913,7 +913,7 @@ mod tests {
         check_search(
             ra_fixture,
             "main",
-            Query::new("fmt".to_string())
+            Query::new("fmt".to_owned())
                 .search_mode(SearchMode::Fuzzy)
                 .exclude_import_kind(ImportKind::AssociatedItem),
             expect![[r#"
@@ -925,7 +925,7 @@ mod tests {
         check_search(
             ra_fixture,
             "main",
-            Query::new("fmt".to_string())
+            Query::new("fmt".to_owned())
                 .search_mode(SearchMode::Fuzzy)
                 .assoc_items_only()
                 .exclude_import_kind(ImportKind::AssociatedItem),
@@ -962,7 +962,7 @@ mod tests {
         check_search(
             ra_fixture,
             "main",
-            Query::new("fmt".to_string()).search_mode(SearchMode::Fuzzy),
+            Query::new("fmt".to_owned()).search_mode(SearchMode::Fuzzy),
             expect![[r#"
                 dep::Fmt (m)
                 dep::Fmt (t)
@@ -977,7 +977,7 @@ mod tests {
         check_search(
             ra_fixture,
             "main",
-            Query::new("fmt".to_string()).search_mode(SearchMode::Equals),
+            Query::new("fmt".to_owned()).search_mode(SearchMode::Equals),
             expect![[r#"
                 dep::Fmt (m)
                 dep::Fmt (t)
@@ -990,7 +990,7 @@ mod tests {
         check_search(
             ra_fixture,
             "main",
-            Query::new("fmt".to_string()).search_mode(SearchMode::Contains),
+            Query::new("fmt".to_owned()).search_mode(SearchMode::Contains),
             expect![[r#"
                 dep::Fmt (m)
                 dep::Fmt (t)
@@ -1031,7 +1031,7 @@ mod tests {
         check_search(
             ra_fixture,
             "main",
-            Query::new("fmt".to_string()),
+            Query::new("fmt".to_owned()),
             expect![[r#"
                 dep::Fmt (m)
                 dep::Fmt (t)
@@ -1045,7 +1045,7 @@ mod tests {
         check_search(
             ra_fixture,
             "main",
-            Query::new("fmt".to_string()).name_only(),
+            Query::new("fmt".to_owned()).name_only(),
             expect![[r#"
                 dep::Fmt (m)
                 dep::Fmt (t)
@@ -1069,7 +1069,7 @@ mod tests {
         check_search(
             ra_fixture,
             "main",
-            Query::new("FMT".to_string()),
+            Query::new("FMT".to_owned()),
             expect![[r#"
                 dep::FMT (t)
                 dep::FMT (v)
@@ -1081,7 +1081,7 @@ mod tests {
         check_search(
             ra_fixture,
             "main",
-            Query::new("FMT".to_string()).case_sensitive(),
+            Query::new("FMT".to_owned()).case_sensitive(),
             expect![[r#"
                 dep::FMT (t)
                 dep::FMT (v)
@@ -1110,7 +1110,7 @@ mod tests {
         pub fn no() {}
     "#,
             "main",
-            Query::new("".to_string()).limit(2),
+            Query::new("".to_owned()).limit(2),
             expect![[r#"
                 dep::Fmt (m)
                 dep::Fmt (t)
@@ -1133,7 +1133,7 @@ mod tests {
         check_search(
             ra_fixture,
             "main",
-            Query::new("FMT".to_string()),
+            Query::new("FMT".to_owned()),
             expect![[r#"
                 dep::FMT (t)
                 dep::FMT (v)
@@ -1145,7 +1145,7 @@ mod tests {
         check_search(
             ra_fixture,
             "main",
-            Query::new("FMT".to_string()).exclude_import_kind(ImportKind::Adt),
+            Query::new("FMT".to_owned()).exclude_import_kind(ImportKind::Adt),
             expect![[r#""#]],
         );
     }

--- a/crates/hir-def/src/item_scope.rs
+++ b/crates/hir-def/src/item_scope.rs
@@ -366,7 +366,7 @@ impl ItemScope {
             format_to!(
                 buf,
                 "{}:",
-                name.map_or("_".to_string(), |name| name.display(db).to_string())
+                name.map_or("_".to_owned(), |name| name.display(db).to_string())
             );
 
             if def.types.is_some() {

--- a/crates/hir-def/src/lang_item.rs
+++ b/crates/hir-def/src/lang_item.rs
@@ -219,6 +219,7 @@ macro_rules! language_item_table {
                 }
             }
 
+            #[allow(clippy::should_implement_trait)]
             /// Opposite of [`LangItem::name`]
             pub fn from_str(name: &str) -> Option<Self> {
                 match name {

--- a/crates/hir-def/src/macro_expansion_tests/mod.rs
+++ b/crates/hir-def/src/macro_expansion_tests/mod.rs
@@ -108,7 +108,7 @@ pub fn identity_when_valid(_attr: TokenStream, item: TokenStream) -> TokenStream
         if let TokenExpander::DeclarativeMacro { mac, def_site_token_map } = &*macro_def {
             let tt = match &macro_ {
                 ast::Macro::MacroRules(mac) => mac.token_tree().unwrap(),
-                ast::Macro::MacroDef(_) => unimplemented!(""),
+                ast::Macro::MacroDef(m) => m.body().unwrap(),
             };
 
             let tt_start = tt.syntax().text_range().start();

--- a/crates/hir-def/src/nameres/path_resolution.rs
+++ b/crates/hir-def/src/nameres/path_resolution.rs
@@ -454,7 +454,7 @@ impl DefMap {
         let macro_use_prelude = || {
             self.macro_use_prelude
                 .get(name)
-                .map_or(PerNs::none(), |&it| PerNs::macros(it.into(), Visibility::Public))
+                .map_or(PerNs::none(), |&it| PerNs::macros(it, Visibility::Public))
         };
         let prelude = || self.resolve_in_prelude(db, name);
 

--- a/crates/hir-def/src/nameres/tests/macros.rs
+++ b/crates/hir-def/src/nameres/tests/macros.rs
@@ -1294,8 +1294,8 @@ fn proc_attr(a: TokenStream, b: TokenStream) -> TokenStream { a }
 
     let actual = def_map
         .macro_use_prelude
-        .iter()
-        .map(|(name, _)| name.display(&db).to_string())
+        .keys()
+        .map(|name| name.display(&db).to_string())
         .sorted()
         .join("\n");
 

--- a/crates/hir-def/src/path.rs
+++ b/crates/hir-def/src/path.rs
@@ -150,7 +150,7 @@ impl Path {
 
     pub fn mod_path(&self) -> Option<&ModPath> {
         match self {
-            Path::Normal { mod_path, .. } => Some(&mod_path),
+            Path::Normal { mod_path, .. } => Some(mod_path),
             Path::LangItem(_) => None,
         }
     }
@@ -215,13 +215,13 @@ impl<'a> PathSegments<'a> {
     }
     pub fn skip(&self, len: usize) -> PathSegments<'a> {
         PathSegments {
-            segments: &self.segments.get(len..).unwrap_or(&[]),
+            segments: self.segments.get(len..).unwrap_or(&[]),
             generic_args: self.generic_args.and_then(|it| it.get(len..)),
         }
     }
     pub fn take(&self, len: usize) -> PathSegments<'a> {
         PathSegments {
-            segments: &self.segments.get(..len).unwrap_or(&self.segments),
+            segments: self.segments.get(..len).unwrap_or(self.segments),
             generic_args: self.generic_args.map(|it| it.get(..len).unwrap_or(it)),
         }
     }

--- a/crates/hir-def/src/path/lower.rs
+++ b/crates/hir-def/src/path/lower.rs
@@ -45,7 +45,7 @@ pub(super) fn lower_path(mut path: ast::Path, ctx: &LowerCtx<'_>) -> Option<Path
                                 )
                             })
                             .map(Interned::new);
-                        if let Some(_) = args {
+                        if args.is_some() {
                             generic_args.resize(segments.len(), None);
                             generic_args.push(args);
                         }

--- a/crates/hir-def/src/per_ns.rs
+++ b/crates/hir-def/src/per_ns.rs
@@ -5,17 +5,11 @@
 
 use crate::{item_scope::ItemInNs, visibility::Visibility, MacroId, ModuleDefId};
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Default, Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct PerNs {
     pub types: Option<(ModuleDefId, Visibility)>,
     pub values: Option<(ModuleDefId, Visibility)>,
     pub macros: Option<(MacroId, Visibility)>,
-}
-
-impl Default for PerNs {
-    fn default() -> Self {
-        PerNs { types: None, values: None, macros: None }
-    }
 }
 
 impl PerNs {

--- a/crates/hir-def/src/test_db.rs
+++ b/crates/hir-def/src/test_db.rs
@@ -39,12 +39,14 @@ impl Default for TestDB {
     }
 }
 
+#[allow(clippy::borrow_deref_ref)] // false positive
 impl Upcast<dyn ExpandDatabase> for TestDB {
     fn upcast(&self) -> &(dyn ExpandDatabase + 'static) {
         &*self
     }
 }
 
+#[allow(clippy::borrow_deref_ref)] // false positive
 impl Upcast<dyn DefDatabase> for TestDB {
     fn upcast(&self) -> &(dyn DefDatabase + 'static) {
         &*self

--- a/crates/hir-expand/Cargo.toml
+++ b/crates/hir-expand/Cargo.toml
@@ -37,3 +37,6 @@ limit.workspace = true
 
 [dev-dependencies]
 expect-test = "1.4.0"
+
+[lints]
+workspace = true

--- a/crates/hir-expand/src/attrs.rs
+++ b/crates/hir-expand/src/attrs.rs
@@ -30,7 +30,7 @@ impl ops::Deref for RawAttrs {
 
     fn deref(&self) -> &[Attr] {
         match &self.entries {
-            Some(it) => &*it,
+            Some(it) => it,
             None => &[],
         }
     }
@@ -76,7 +76,7 @@ impl RawAttrs {
                             .cloned()
                             .chain(b.iter().map(|it| {
                                 let mut it = it.clone();
-                                it.id.id = it.id.ast_index() as u32 + last_ast_index
+                                it.id.id = (it.id.ast_index() as u32 + last_ast_index)
                                     | (it.id.cfg_attr_index().unwrap_or(0) as u32)
                                         << AttrId::AST_INDEX_BITS;
                                 it
@@ -293,7 +293,7 @@ impl Attr {
                 // FIXME: This is necessarily a hack. It'd be nice if we could avoid allocation here.
                 let subtree = tt::Subtree {
                     delimiter: tt::Delimiter::unspecified(),
-                    token_trees: tts.into_iter().cloned().collect(),
+                    token_trees: tts.to_vec(),
                 };
                 let (parse, _) =
                     mbe::token_tree_to_syntax_node(&subtree, mbe::TopEntryPoint::MetaItem);

--- a/crates/hir-expand/src/builtin_fn_macro.rs
+++ b/crates/hir-expand/src/builtin_fn_macro.rs
@@ -326,7 +326,7 @@ fn format_args_expand_general(
                     '}' => "".to_owned(),
                     ':' => {
                         let mut s = String::new();
-                        while let Some(c) = format_iter.next() {
+                        for c in format_iter.by_ref() {
                             if c == '}' {
                                 break;
                             }

--- a/crates/hir-expand/src/builtin_fn_macro.rs
+++ b/crates/hir-expand/src/builtin_fn_macro.rs
@@ -777,7 +777,7 @@ fn env_expand(
         // We cannot use an empty string here, because for
         // `include!(concat!(env!("OUT_DIR"), "/foo.rs"))` will become
         // `include!("foo.rs"), which might go to infinite loop
-        "UNRESOLVED_ENV_VAR".to_string()
+        "UNRESOLVED_ENV_VAR".to_owned()
     });
     let expanded = quote! { #s };
 

--- a/crates/hir-expand/src/quote.rs
+++ b/crates/hir-expand/src/quote.rs
@@ -9,17 +9,17 @@
 #[macro_export]
 macro_rules! __quote {
     () => {
-        Vec::<crate::tt::TokenTree>::new()
+        Vec::<$crate::tt::TokenTree>::new()
     };
 
     ( @SUBTREE $delim:ident $($tt:tt)* ) => {
         {
             let children = $crate::__quote!($($tt)*);
-            crate::tt::Subtree {
-                delimiter: crate::tt::Delimiter {
-                    kind: crate::tt::DelimiterKind::$delim,
-                    open: crate::tt::TokenId::unspecified(),
-                    close: crate::tt::TokenId::unspecified(),
+            $crate::tt::Subtree {
+                delimiter: $crate::tt::Delimiter {
+                    kind: $crate::tt::DelimiterKind::$delim,
+                    open: $crate::tt::TokenId::unspecified(),
+                    close: $crate::tt::TokenId::unspecified(),
                 },
                 token_trees: $crate::quote::IntoTt::to_tokens(children),
             }
@@ -29,10 +29,10 @@ macro_rules! __quote {
     ( @PUNCT $first:literal ) => {
         {
             vec![
-                crate::tt::Leaf::Punct(crate::tt::Punct {
+                $crate::tt::Leaf::Punct($crate::tt::Punct {
                     char: $first,
-                    spacing: crate::tt::Spacing::Alone,
-                    span: crate::tt::TokenId::unspecified(),
+                    spacing: $crate::tt::Spacing::Alone,
+                    span: $crate::tt::TokenId::unspecified(),
                 }).into()
             ]
         }
@@ -41,15 +41,15 @@ macro_rules! __quote {
     ( @PUNCT $first:literal, $sec:literal ) => {
         {
             vec![
-                crate::tt::Leaf::Punct(crate::tt::Punct {
+                $crate::tt::Leaf::Punct($crate::tt::Punct {
                     char: $first,
-                    spacing: crate::tt::Spacing::Joint,
-                    span: crate::tt::TokenId::unspecified(),
+                    spacing: $crate::tt::Spacing::Joint,
+                    span: $crate::tt::TokenId::unspecified(),
                 }).into(),
-                crate::tt::Leaf::Punct(crate::tt::Punct {
+                $crate::tt::Leaf::Punct($crate::tt::Punct {
                     char: $sec,
-                    spacing: crate::tt::Spacing::Alone,
-                    span: crate::tt::TokenId::unspecified(),
+                    spacing: $crate::tt::Spacing::Alone,
+                    span: $crate::tt::TokenId::unspecified(),
                 }).into()
             ]
         }
@@ -68,7 +68,7 @@ macro_rules! __quote {
 
     ( ## $first:ident $($tail:tt)* ) => {
         {
-            let mut tokens = $first.into_iter().map($crate::quote::ToTokenTree::to_token).collect::<Vec<crate::tt::TokenTree>>();
+            let mut tokens = $first.into_iter().map($crate::quote::ToTokenTree::to_token).collect::<Vec<$crate::tt::TokenTree>>();
             let mut tail_tokens = $crate::quote::IntoTt::to_tokens($crate::__quote!($($tail)*));
             tokens.append(&mut tail_tokens);
             tokens
@@ -87,9 +87,9 @@ macro_rules! __quote {
     // Ident
     ( $tt:ident ) => {
         vec![ {
-            crate::tt::Leaf::Ident(crate::tt::Ident {
+            $crate::tt::Leaf::Ident($crate::tt::Ident {
                 text: stringify!($tt).into(),
-                span: crate::tt::TokenId::unspecified(),
+                span: $crate::tt::TokenId::unspecified(),
             }).into()
         }]
     };

--- a/crates/hir-ty/Cargo.toml
+++ b/crates/hir-ty/Cargo.toml
@@ -55,3 +55,6 @@ project-model = { path = "../project-model" }
 
 # local deps
 test-utils.workspace = true
+
+[lints]
+workspace = true

--- a/crates/hir-ty/src/chalk_db.rs
+++ b/crates/hir-ty/src/chalk_db.rs
@@ -200,7 +200,7 @@ impl<'a> chalk_solve::RustIrDatabase<Interner> for ChalkContext<'a> {
         well_known_trait: rust_ir::WellKnownTrait,
     ) -> Option<chalk_ir::TraitId<Interner>> {
         let lang_attr = lang_item_from_well_known_trait(well_known_trait);
-        let trait_ = match self.db.lang_item(self.krate, lang_attr.into()) {
+        let trait_ = match self.db.lang_item(self.krate, lang_attr) {
             Some(LangItemTarget::Trait(trait_)) => trait_,
             _ => return None,
         };

--- a/crates/hir-ty/src/chalk_db.rs
+++ b/crates/hir-ty/src/chalk_db.rs
@@ -188,6 +188,7 @@ impl<'a> chalk_solve::RustIrDatabase<Interner> for ChalkContext<'a> {
     fn custom_clauses(&self) -> Vec<chalk_ir::ProgramClause<Interner>> {
         vec![]
     }
+    #[allow(clippy::unimplemented)]
     fn local_impls_to_coherence_check(&self, _trait_id: TraitId) -> Vec<ImplId> {
         // We don't do coherence checking (yet)
         unimplemented!()

--- a/crates/hir-ty/src/chalk_ext.rs
+++ b/crates/hir-ty/src/chalk_ext.rs
@@ -50,7 +50,7 @@ pub trait TyExt {
 
     fn impl_trait_bounds(&self, db: &dyn HirDatabase) -> Option<Vec<QuantifiedWhereClause>>;
     fn associated_type_parent_trait(&self, db: &dyn HirDatabase) -> Option<TraitId>;
-    fn is_copy(self, db: &dyn HirDatabase, owner: DefWithBodyId) -> bool;
+    fn implements_copy(self, db: &dyn HirDatabase, owner: DefWithBodyId) -> bool;
 
     /// FIXME: Get rid of this, it's not a good abstraction
     fn equals_ctor(&self, other: &Ty) -> bool;
@@ -341,7 +341,7 @@ impl TyExt for Ty {
         }
     }
 
-    fn is_copy(self, db: &dyn HirDatabase, owner: DefWithBodyId) -> bool {
+    fn implements_copy(self, db: &dyn HirDatabase, owner: DefWithBodyId) -> bool {
         let crate_id = owner.module(db.upcast()).krate();
         let Some(copy_trait) = db.lang_item(crate_id, LangItem::Copy).and_then(|x| x.as_trait()) else {
             return false;

--- a/crates/hir-ty/src/consteval.rs
+++ b/crates/hir-ty/src/consteval.rs
@@ -166,7 +166,7 @@ pub fn try_const_usize(db: &dyn HirDatabase, c: &Const) -> Option<u128> {
         chalk_ir::ConstValue::InferenceVar(_) => None,
         chalk_ir::ConstValue::Placeholder(_) => None,
         chalk_ir::ConstValue::Concrete(c) => match &c.interned {
-            ConstScalar::Bytes(x, _) => Some(u128::from_le_bytes(pad16(&x, false))),
+            ConstScalar::Bytes(x, _) => Some(u128::from_le_bytes(pad16(x, false))),
             ConstScalar::UnevaluatedConst(c, subst) => {
                 let ec = db.const_eval(*c, subst.clone()).ok()?;
                 try_const_usize(db, &ec)
@@ -286,7 +286,7 @@ pub(crate) fn eval_to_const(
         }
     }
     let infer = ctx.clone().resolve_all();
-    if let Ok(mir_body) = lower_to_mir(ctx.db, ctx.owner, &ctx.body, &infer, expr) {
+    if let Ok(mir_body) = lower_to_mir(ctx.db, ctx.owner, ctx.body, &infer, expr) {
         if let Ok(result) = interpret_mir(db, &mir_body, true).0 {
             return result;
         }

--- a/crates/hir-ty/src/consteval/tests.rs
+++ b/crates/hir-ty/src/consteval/tests.rs
@@ -106,7 +106,7 @@ fn bit_op() {
     check_number(r#"const GOAL: i8 = 1 << 7"#, (1i8 << 7) as i128);
     check_number(r#"const GOAL: i8 = -1 << 2"#, (-1i8 << 2) as i128);
     check_fail(r#"const GOAL: i8 = 1 << 8"#, |e| {
-        e == ConstEvalError::MirEvalError(MirEvalError::Panic("Overflow in Shl".to_string()))
+        e == ConstEvalError::MirEvalError(MirEvalError::Panic("Overflow in Shl".to_owned()))
     });
 }
 
@@ -2309,7 +2309,7 @@ fn panic_messages() {
         panic!("hello");
     };
     "#,
-        |e| e == ConstEvalError::MirEvalError(MirEvalError::Panic("hello".to_string())),
+        |e| e == ConstEvalError::MirEvalError(MirEvalError::Panic("hello".to_owned())),
     );
 }
 

--- a/crates/hir-ty/src/diagnostics/decl_check.rs
+++ b/crates/hir-ty/src/diagnostics/decl_check.rs
@@ -55,6 +55,7 @@ pub fn incorrect_case(
     validator.sink
 }
 
+#[allow(clippy::enum_variant_names)]
 #[derive(Debug)]
 pub enum CaseType {
     // `some_var`

--- a/crates/hir-ty/src/diagnostics/expr.rs
+++ b/crates/hir-ty/src/diagnostics/expr.rs
@@ -120,29 +120,24 @@ impl ExprValidator {
             return;
         }
 
-        match expr {
-            Expr::MethodCall { receiver, .. } => {
-                let (callee, _) = match self.infer.method_resolution(call_id) {
-                    Some(it) => it,
-                    None => return,
-                };
+        if let Expr::MethodCall { receiver, .. } = expr {
+            let (callee, _) = match self.infer.method_resolution(call_id) {
+                Some(it) => it,
+                None => return,
+            };
 
-                if filter_map_next_checker
-                    .get_or_insert_with(|| {
-                        FilterMapNextChecker::new(&self.owner.resolver(db.upcast()), db)
-                    })
-                    .check(call_id, receiver, &callee)
-                    .is_some()
-                {
-                    self.diagnostics.push(
-                        BodyValidationDiagnostic::ReplaceFilterMapNextWithFindMap {
-                            method_call_expr: call_id,
-                        },
-                    );
-                }
+            if filter_map_next_checker
+                .get_or_insert_with(|| {
+                    FilterMapNextChecker::new(&self.owner.resolver(db.upcast()), db)
+                })
+                .check(call_id, receiver, &callee)
+                .is_some()
+            {
+                self.diagnostics.push(BodyValidationDiagnostic::ReplaceFilterMapNextWithFindMap {
+                    method_call_expr: call_id,
+                });
             }
-            _ => return,
-        };
+        }
     }
 
     fn validate_match(

--- a/crates/hir-ty/src/diagnostics/match_check/deconstruct_pat.rs
+++ b/crates/hir-ty/src/diagnostics/match_check/deconstruct_pat.rs
@@ -129,7 +129,7 @@ impl IntRange {
     fn from_range(lo: u128, hi: u128, scalar_ty: Scalar) -> IntRange {
         match scalar_ty {
             Scalar::Bool => IntRange { range: lo..=hi },
-            _ => unimplemented!(),
+            s => panic!("unexpected scalar {s:?}"),
         }
     }
 
@@ -161,7 +161,7 @@ impl IntRange {
                 };
                 Pat { ty, kind: kind.into() }
             }
-            _ => unimplemented!(),
+            t => panic!("unexpected type {t:?}"),
         }
     }
 

--- a/crates/hir-ty/src/display.rs
+++ b/crates/hir-ty/src/display.rs
@@ -561,9 +561,7 @@ fn render_const_scalar(
                     write!(f, "&{}", data.name.display(f.db.upcast()))?;
                     Ok(())
                 }
-                _ => {
-                    return f.write_str("<unsized-enum-or-union>");
-                }
+                _ => f.write_str("<unsized-enum-or-union>"),
             },
             _ => {
                 let addr = usize::from_le_bytes(match b.try_into() {

--- a/crates/hir-ty/src/infer.rs
+++ b/crates/hir-ty/src/infer.rs
@@ -136,8 +136,9 @@ pub(crate) fn normalize(db: &dyn HirDatabase, trait_env: Arc<TraitEnvironment>, 
 
 /// Binding modes inferred for patterns.
 /// <https://doc.rust-lang.org/reference/patterns.html#binding-modes>
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Default)]
 pub enum BindingMode {
+    #[default]
     Move,
     Ref(Mutability),
 }
@@ -149,12 +150,6 @@ impl BindingMode {
             BindingAnnotation::Ref => BindingMode::Ref(Mutability::Not),
             BindingAnnotation::RefMut => BindingMode::Ref(Mutability::Mut),
         }
-    }
-}
-
-impl Default for BindingMode {
-    fn default() -> Self {
-        BindingMode::Move
     }
 }
 
@@ -522,10 +517,10 @@ enum BreakableKind {
     Border,
 }
 
-fn find_breakable<'c>(
-    ctxs: &'c mut [BreakableContext],
+fn find_breakable(
+    ctxs: &mut [BreakableContext],
     label: Option<LabelId>,
-) -> Option<&'c mut BreakableContext> {
+) -> Option<&mut BreakableContext> {
     let mut ctxs = ctxs
         .iter_mut()
         .rev()
@@ -536,10 +531,10 @@ fn find_breakable<'c>(
     }
 }
 
-fn find_continuable<'c>(
-    ctxs: &'c mut [BreakableContext],
+fn find_continuable(
+    ctxs: &mut [BreakableContext],
     label: Option<LabelId>,
-) -> Option<&'c mut BreakableContext> {
+) -> Option<&mut BreakableContext> {
     match label {
         Some(_) => find_breakable(ctxs, label).filter(|it| matches!(it.kind, BreakableKind::Loop)),
         None => find_breakable(ctxs, label),
@@ -754,8 +749,8 @@ impl<'a> InferenceContext<'a> {
                     ImplTraitId::ReturnTypeImplTrait(_, idx) => idx,
                     _ => unreachable!(),
                 };
-                let bounds = (*rpits)
-                    .map_ref(|rpits| rpits.impl_traits[idx].bounds.map_ref(|it| it.into_iter()));
+                let bounds =
+                    (*rpits).map_ref(|rpits| rpits.impl_traits[idx].bounds.map_ref(|it| it.iter()));
                 let var = self.table.new_type_var();
                 let var_subst = Substitution::from1(Interner, var.clone());
                 for bound in bounds {

--- a/crates/hir-ty/src/infer/closure.rs
+++ b/crates/hir-ty/src/infer/closure.rs
@@ -199,7 +199,7 @@ impl CapturedItem {
                             .position(|x| x.0 == f.local_id)
                             .unwrap_or_default()
                             .to_string(),
-                        VariantData::Unit => "[missing field]".to_string(),
+                        VariantData::Unit => "[missing field]".to_owned(),
                     };
                     result = format!("{result}.{field}");
                     field_need_paren = false;

--- a/crates/hir-ty/src/infer/expr.rs
+++ b/crates/hir-ty/src/infer/expr.rs
@@ -576,6 +576,7 @@ impl<'a> InferenceContext<'a> {
                 let cast_ty = self.make_ty(type_ref);
                 // FIXME: propagate the "castable to" expectation
                 let inner_ty = self.infer_expr_no_expect(*expr);
+                #[allow(clippy::single_match)]
                 match (inner_ty.kind(Interner), cast_ty.kind(Interner)) {
                     (TyKind::Ref(_, _, inner), TyKind::Raw(_, cast)) => {
                         // FIXME: record invalid cast diagnostic in case of mismatch

--- a/crates/hir-ty/src/infer/pat.rs
+++ b/crates/hir-ty/src/infer/pat.rs
@@ -149,13 +149,13 @@ impl<'a> InferenceContext<'a> {
     ) -> Ty {
         let expected = self.resolve_ty_shallow(expected);
         let expectations = match expected.as_tuple() {
-            Some(parameters) => &*parameters.as_slice(Interner),
+            Some(parameters) => parameters.as_slice(Interner),
             _ => &[],
         };
 
         let ((pre, post), n_uncovered_patterns) = match ellipsis {
             Some(idx) => (subs.split_at(idx), expectations.len().saturating_sub(subs.len())),
-            None => ((&subs[..], &[][..]), 0),
+            None => ((subs, &[][..]), 0),
         };
         let mut expectations_iter = expectations
             .iter()
@@ -262,7 +262,7 @@ impl<'a> InferenceContext<'a> {
             &Pat::Lit(expr) => {
                 // Don't emit type mismatches again, the expression lowering already did that.
                 let ty = self.infer_lit_pat(expr, &expected);
-                self.write_pat_ty(pat, ty.clone());
+                self.write_pat_ty(pat, ty);
                 return self.pat_ty_after_adjustment(pat);
             }
             Pat::Box { inner } => match self.resolve_boxed_box() {
@@ -350,7 +350,7 @@ impl<'a> InferenceContext<'a> {
         self.result.binding_modes.insert(binding, mode);
 
         let inner_ty = match subpat {
-            Some(subpat) => self.infer_pat(subpat, &expected, default_bm),
+            Some(subpat) => self.infer_pat(subpat, expected, default_bm),
             None => expected.clone(),
         };
         let inner_ty = self.insert_type_vars_shallow(inner_ty);
@@ -363,7 +363,7 @@ impl<'a> InferenceContext<'a> {
         };
         self.write_pat_ty(pat, inner_ty.clone());
         self.write_binding_ty(binding, bound_ty);
-        return inner_ty;
+        inner_ty
     }
 
     fn infer_slice_pat(

--- a/crates/hir-ty/src/infer/path.rs
+++ b/crates/hir-ty/src/infer/path.rs
@@ -351,7 +351,7 @@ impl InferenceContext<'_> {
         name: &Name,
         id: ExprOrPatId,
     ) -> Option<(ValueNs, Substitution)> {
-        let ty = self.resolve_ty_shallow(&ty);
+        let ty = self.resolve_ty_shallow(ty);
         let (enum_id, subst) = match ty.as_adt() {
             Some((AdtId::EnumId(e), subst)) => (e, subst),
             _ => return None,

--- a/crates/hir-ty/src/infer/unify.rs
+++ b/crates/hir-ty/src/infer/unify.rs
@@ -252,8 +252,7 @@ impl<'a> InferenceTable<'a> {
                             // and registering an obligation. But it needs chalk support, so we handle the most basic
                             // case (a non associated const without generic parameters) manually.
                             if subst.len(Interner) == 0 {
-                                if let Ok(eval) = self.db.const_eval((*c_id).into(), subst.clone())
-                                {
+                                if let Ok(eval) = self.db.const_eval(*c_id, subst.clone()) {
                                     eval
                                 } else {
                                     unknown_const(c.data(Interner).ty.clone())
@@ -491,9 +490,8 @@ impl<'a> InferenceTable<'a> {
     pub(crate) fn try_obligation(&mut self, goal: Goal) -> Option<Solution> {
         let in_env = InEnvironment::new(&self.trait_env.env, goal);
         let canonicalized = self.canonicalize(in_env);
-        let solution =
-            self.db.trait_solve(self.trait_env.krate, self.trait_env.block, canonicalized.value);
-        solution
+
+        self.db.trait_solve(self.trait_env.krate, self.trait_env.block, canonicalized.value)
     }
 
     pub(crate) fn register_obligation(&mut self, goal: Goal) {

--- a/crates/hir-ty/src/inhabitedness.rs
+++ b/crates/hir-ty/src/inhabitedness.rs
@@ -86,8 +86,7 @@ impl TypeVisitor<Interner> for UninhabitedFrom<'_> {
                 Some(0) | None => CONTINUE_OPAQUELY_INHABITED,
                 Some(1..) => item_ty.super_visit_with(self, outer_binder),
             },
-
-            TyKind::Ref(..) | _ => CONTINUE_OPAQUELY_INHABITED,
+            _ => CONTINUE_OPAQUELY_INHABITED,
         };
         self.recursive_ty.remove(ty);
         self.max_depth += 1;

--- a/crates/hir-ty/src/interner.rs
+++ b/crates/hir-ty/src/interner.rs
@@ -415,7 +415,7 @@ impl chalk_ir::interner::HasInterner for Interner {
 macro_rules! has_interner {
     ($t:ty) => {
         impl HasInterner for $t {
-            type Interner = crate::Interner;
+            type Interner = $crate::Interner;
         }
     };
 }

--- a/crates/hir-ty/src/layout.rs
+++ b/crates/hir-ty/src/layout.rs
@@ -153,7 +153,7 @@ pub fn layout_of_ty_query(
         }
         TyKind::Array(element, count) => {
             let count = try_const_usize(db, count).ok_or(LayoutError::UserError(
-                "unevaluated or mistyped const generic parameter".to_string(),
+                "unevaluated or mistyped const generic parameter".to_owned(),
             ))? as u64;
             let element = db.layout_of_ty(element.clone(), krate)?;
             let size = element.size.checked_mul(count, dl).ok_or(LayoutError::SizeOverflow)?;

--- a/crates/hir-ty/src/layout/adt.rs
+++ b/crates/hir-ty/src/layout/adt.rs
@@ -82,7 +82,7 @@ pub fn layout_of_adt_query(
             matches!(def, AdtId::EnumId(..)),
             is_unsafe_cell(db, def),
             layout_scalar_valid_range(db, def),
-            |min, max| repr_discr(&dl, &repr, min, max).unwrap_or((Integer::I8, false)),
+            |min, max| repr_discr(dl, &repr, min, max).unwrap_or((Integer::I8, false)),
             variants.iter_enumerated().filter_map(|(id, _)| {
                 let AdtId::EnumId(e) = def else { return None };
                 let d =

--- a/crates/hir-ty/src/layout/adt.rs
+++ b/crates/hir-ty/src/layout/adt.rs
@@ -161,7 +161,7 @@ fn repr_discr(
             return Err(LayoutError::UserError(
                 "Integer::repr_discr: `#[repr]` hint too small for \
                       discriminant range of enum "
-                    .to_string(),
+                    .to_owned(),
             ));
         }
         return Ok((discr, ity.is_signed()));

--- a/crates/hir-ty/src/layout/target.rs
+++ b/crates/hir-ty/src/layout/target.rs
@@ -12,7 +12,7 @@ pub fn target_data_layout_query(
 ) -> Option<Arc<TargetDataLayout>> {
     let crate_graph = db.crate_graph();
     let target_layout = crate_graph[krate].target_layout.as_ref().ok()?;
-    let res = TargetDataLayout::parse_from_llvm_datalayout_string(&target_layout);
+    let res = TargetDataLayout::parse_from_llvm_datalayout_string(target_layout);
     if let Err(_e) = &res {
         // FIXME: Print the error here once it implements debug/display
         // also logging here is somewhat wrong, but unfortunately this is the earliest place we can

--- a/crates/hir-ty/src/layout/tests.rs
+++ b/crates/hir-ty/src/layout/tests.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::useless_attribute)]
+
 use std::collections::HashMap;
 
 use base_db::fixture::WithFixture;
@@ -307,11 +309,11 @@ fn return_position_impl_trait() {
             }
             let waker = Arc::new(EmptyWaker).into();
             let mut context = Context::from_waker(&waker);
-            let x = pinned.poll(&mut context);
-            x
+
+            pinned.poll(&mut context)
         }
-        let x = unwrap_fut(f());
-        x
+
+        unwrap_fut(f())
     }
     size_and_align_expr! {
         struct Foo<T>(T, T, (T, T));

--- a/crates/hir-ty/src/layout/tests.rs
+++ b/crates/hir-ty/src/layout/tests.rs
@@ -196,14 +196,14 @@ fn recursive() {
     }
     check_fail(
         r#"struct Goal(Goal);"#,
-        LayoutError::UserError("infinite sized recursive type".to_string()),
+        LayoutError::UserError("infinite sized recursive type".to_owned()),
     );
     check_fail(
         r#"
         struct Foo<T>(Foo<T>);
         struct Goal(Foo<i32>);
         "#,
-        LayoutError::UserError("infinite sized recursive type".to_string()),
+        LayoutError::UserError("infinite sized recursive type".to_owned()),
     );
 }
 

--- a/crates/hir-ty/src/layout/tests/closure.rs
+++ b/crates/hir-ty/src/layout/tests/closure.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::all)]
 use crate::size_and_align_expr;
 
 #[test]

--- a/crates/hir-ty/src/lib.rs
+++ b/crates/hir-ty/src/lib.rs
@@ -185,7 +185,7 @@ impl MemoryMap {
         self.memory.iter().map(|x| Ok((*x.0, f(x.1)?))).collect()
     }
 
-    fn get<'a>(&'a self, addr: usize, size: usize) -> Option<&'a [u8]> {
+    fn get(&self, addr: usize, size: usize) -> Option<&[u8]> {
         if size == 0 {
             Some(&[])
         } else {

--- a/crates/hir-ty/src/lower.rs
+++ b/crates/hir-ty/src/lower.rs
@@ -1316,7 +1316,7 @@ fn named_associated_type_shorthand_candidates<R>(
                 ),
                 _ => None,
             });
-            if let Some(_) = res {
+            if res.is_some() {
                 return res;
             }
             // Handle `Self::Type` referring to own associated type in trait definitions

--- a/crates/hir-ty/src/method_resolution.rs
+++ b/crates/hir-ty/src/method_resolution.rs
@@ -563,7 +563,7 @@ impl ReceiverAdjustments {
                 if let TyKind::Ref(m, l, inner) = ty.kind(Interner) {
                     if let TyKind::Array(inner, _) = inner.kind(Interner) {
                         break 'x TyKind::Ref(
-                            m.clone(),
+                            *m,
                             l.clone(),
                             TyKind::Slice(inner.clone()).intern(Interner),
                         )
@@ -911,7 +911,7 @@ pub fn iterate_method_candidates_dyn(
             let ty = table.instantiate_canonical(ty.clone());
             let deref_chain = autoderef_method_receiver(&mut table, ty);
 
-            let result = deref_chain.into_iter().try_for_each(|(receiver_ty, adj)| {
+            deref_chain.into_iter().try_for_each(|(receiver_ty, adj)| {
                 iterate_method_candidates_with_autoref(
                     &receiver_ty,
                     adj,
@@ -922,8 +922,7 @@ pub fn iterate_method_candidates_dyn(
                     name,
                     callback,
                 )
-            });
-            result
+            })
         }
         LookupMode::Path => {
             // No autoderef for path lookups
@@ -1288,7 +1287,7 @@ pub(crate) fn resolve_indexing_op(
     ty: Canonical<Ty>,
     index_trait: TraitId,
 ) -> Option<ReceiverAdjustments> {
-    let mut table = InferenceTable::new(db, env.clone());
+    let mut table = InferenceTable::new(db, env);
     let ty = table.instantiate_canonical(ty);
     let deref_chain = autoderef_method_receiver(&mut table, ty);
     for (ty, adj) in deref_chain {

--- a/crates/hir-ty/src/mir.rs
+++ b/crates/hir-ty/src/mir.rs
@@ -142,7 +142,7 @@ impl<V, T> ProjectionElem<V, T> {
                 }
                 _ => {
                     never!("Overloaded deref on type {} is not a projection", base.display(db));
-                    return TyKind::Error.intern(Interner);
+                    TyKind::Error.intern(Interner)
                 }
             },
             ProjectionElem::Field(f) => match &base.data(Interner).kind {
@@ -151,7 +151,7 @@ impl<V, T> ProjectionElem<V, T> {
                 }
                 _ => {
                     never!("Only adt has field");
-                    return TyKind::Error.intern(Interner);
+                    TyKind::Error.intern(Interner)
                 }
             },
             ProjectionElem::TupleOrClosureField(f) => match &base.data(Interner).kind {
@@ -167,7 +167,7 @@ impl<V, T> ProjectionElem<V, T> {
                 TyKind::Closure(id, subst) => closure_field(*id, subst, *f),
                 _ => {
                     never!("Only tuple or closure has tuple or closure field");
-                    return TyKind::Error.intern(Interner);
+                    TyKind::Error.intern(Interner)
                 }
             },
             ProjectionElem::ConstantIndex { .. } | ProjectionElem::Index(_) => {
@@ -175,7 +175,7 @@ impl<V, T> ProjectionElem<V, T> {
                     TyKind::Array(inner, _) | TyKind::Slice(inner) => inner.clone(),
                     _ => {
                         never!("Overloaded index is not a projection");
-                        return TyKind::Error.intern(Interner);
+                        TyKind::Error.intern(Interner)
                     }
                 }
             }
@@ -194,12 +194,12 @@ impl<V, T> ProjectionElem<V, T> {
                 TyKind::Slice(_) => base.clone(),
                 _ => {
                     never!("Subslice projection should only happen on slice and array");
-                    return TyKind::Error.intern(Interner);
+                    TyKind::Error.intern(Interner)
                 }
             },
             ProjectionElem::OpaqueCast(_) => {
                 never!("We don't emit these yet");
-                return TyKind::Error.intern(Interner);
+                TyKind::Error.intern(Interner)
             }
         }
     }

--- a/crates/hir-ty/src/mir/borrowck.rs
+++ b/crates/hir-ty/src/mir/borrowck.rs
@@ -116,7 +116,7 @@ fn moved_out_of_ref(db: &dyn HirDatabase, body: &MirBody) -> Vec<MovedOutOfRef> 
                 );
             }
             if is_dereference_of_ref
-                && !ty.clone().is_copy(db, body.owner)
+                && !ty.clone().implements_copy(db, body.owner)
                 && !ty.data(Interner).flags.intersects(TypeFlags::HAS_ERROR)
             {
                 result.push(MovedOutOfRef { span, ty });
@@ -281,10 +281,10 @@ fn ever_initialized_map(body: &MirBody) -> ArenaMap<BasicBlockId, ArenaMap<Local
                 if destination.projection.len() == 0 && destination.local == l {
                     is_ever_initialized = true;
                 }
-                target.into_iter().chain(cleanup.into_iter()).copied().collect()
+                target.iter().chain(cleanup.iter()).copied().collect()
             }
             TerminatorKind::Drop { target, unwind, place: _ } => {
-                Some(target).into_iter().chain(unwind.into_iter()).copied().collect()
+                Some(target).into_iter().chain(unwind.iter()).copied().collect()
             }
             TerminatorKind::DropAndReplace { .. }
             | TerminatorKind::Assert { .. }

--- a/crates/hir-ty/src/mir/eval.rs
+++ b/crates/hir-ty/src/mir/eval.rs
@@ -1463,7 +1463,7 @@ impl Evaluator<'_> {
             }
         };
         mem.get(pos..pos + size)
-            .ok_or_else(|| MirEvalError::UndefinedBehavior("out of bound memory read".to_string()))
+            .ok_or_else(|| MirEvalError::UndefinedBehavior("out of bound memory read".to_owned()))
     }
 
     fn write_memory(&mut self, addr: Address, r: &[u8]) -> Result<()> {
@@ -1480,9 +1480,7 @@ impl Evaluator<'_> {
             }
         };
         mem.get_mut(pos..pos + r.len())
-            .ok_or_else(|| {
-                MirEvalError::UndefinedBehavior("out of bound memory write".to_string())
-            })?
+            .ok_or_else(|| MirEvalError::UndefinedBehavior("out of bound memory write".to_owned()))?
             .copy_from_slice(r);
         Ok(())
     }
@@ -1584,7 +1582,7 @@ impl Evaluator<'_> {
                             if let Some(ty) = check_inner {
                                 for i in 0..count {
                                     let offset = element_size * i;
-                                    rec(this, &b[offset..offset + element_size], &ty, locals, mm)?;
+                                    rec(this, &b[offset..offset + element_size], ty, locals, mm)?;
                                 }
                             }
                         }

--- a/crates/hir-ty/src/mir/eval/shim.rs
+++ b/crates/hir-ty/src/mir/eval/shim.rs
@@ -48,7 +48,7 @@ impl Evaluator<'_> {
                 args,
                 generic_args,
                 destination,
-                &locals,
+                locals,
                 span,
             )?;
             return Ok(true);
@@ -66,7 +66,7 @@ impl Evaluator<'_> {
                 args,
                 generic_args,
                 destination,
-                &locals,
+                locals,
                 span,
             )?;
             return Ok(true);
@@ -91,7 +91,7 @@ impl Evaluator<'_> {
         }
         if let Some(x) = self.detect_lang_function(def) {
             let arg_bytes =
-                args.iter().map(|x| Ok(x.get(&self)?.to_owned())).collect::<Result<Vec<_>>>()?;
+                args.iter().map(|x| Ok(x.get(self)?.to_owned())).collect::<Result<Vec<_>>>()?;
             let result = self.exec_lang_item(x, generic_args, &arg_bytes, locals, span)?;
             destination.write_from_bytes(self, &result)?;
             return Ok(true);
@@ -489,7 +489,7 @@ impl Evaluator<'_> {
                 let Some(ty) = generic_args.as_slice(Interner).get(0).and_then(|x| x.ty(Interner)) else {
                     return Err(MirEvalError::TypeError("size_of generic arg is not provided"));
                 };
-                let result = !ty.clone().is_copy(self.db, locals.body.owner);
+                let result = !ty.clone().implements_copy(self.db, locals.body.owner);
                 destination.write_from_bytes(self, &[u8::from(result)])
             }
             "ptr_guaranteed_cmp" => {

--- a/crates/hir-ty/src/mir/eval/shim.rs
+++ b/crates/hir-ty/src/mir/eval/shim.rs
@@ -155,7 +155,7 @@ impl Evaluator<'_> {
         use LangItem::*;
         let mut args = args.iter();
         match x {
-            BeginPanic => Err(MirEvalError::Panic("<unknown-panic-payload>".to_string())),
+            BeginPanic => Err(MirEvalError::Panic("<unknown-panic-payload>".to_owned())),
             PanicFmt => {
                 let message = (|| {
                     let arguments_struct =
@@ -178,7 +178,7 @@ impl Evaluator<'_> {
                             .try_into()
                             .ok()?,
                     );
-                    let mut message = "".to_string();
+                    let mut message = "".to_owned();
                     for i in 0..pieces_array_len {
                         let piece_ptr_addr = pieces_array_addr.offset(2 * i * ptr_size);
                         let piece_addr =
@@ -195,7 +195,7 @@ impl Evaluator<'_> {
                     }
                     Some(message)
                 })()
-                .unwrap_or_else(|| "<format-args-evaluation-failed>".to_string());
+                .unwrap_or_else(|| "<format-args-evaluation-failed>".to_owned());
                 Err(MirEvalError::Panic(message))
             }
             SliceLen => {

--- a/crates/hir-ty/src/mir/eval/tests.rs
+++ b/crates/hir-ty/src/mir/eval/tests.rs
@@ -29,7 +29,7 @@ fn eval_main(db: &TestDB, file_id: FileId) -> Result<(String, String), MirEvalEr
             Substitution::empty(Interner),
             db.trait_environment(func_id.into()),
         )
-        .map_err(|e| MirEvalError::MirLowerError(func_id.into(), e))?;
+        .map_err(|e| MirEvalError::MirLowerError(func_id, e))?;
     let (result, stdout, stderr) = interpret_mir(db, &body, false);
     result?;
     Ok((stdout, stderr))
@@ -48,8 +48,8 @@ fn check_pass_and_stdio(ra_fixture: &str, expected_stdout: &str, expected_stderr
             let mut err = String::new();
             let line_index = |size: TextSize| {
                 let mut size = u32::from(size) as usize;
-                let mut lines = ra_fixture.lines().enumerate();
-                while let Some((i, l)) = lines.next() {
+                let lines = ra_fixture.lines().enumerate();
+                for (i, l) in lines {
                     if let Some(x) = size.checked_sub(l.len()) {
                         size = x;
                     } else {

--- a/crates/hir-ty/src/mir/lower.rs
+++ b/crates/hir-ty/src/mir/lower.rs
@@ -1435,7 +1435,7 @@ impl<'ctx> MirLowerCtx<'ctx> {
         self.set_goto(prev_block, begin, span);
         f(self, begin)?;
         let my = mem::replace(&mut self.current_loop_blocks, prev).ok_or(
-            MirLowerError::ImplementationError("current_loop_blocks is corrupt".to_string()),
+            MirLowerError::ImplementationError("current_loop_blocks is corrupt".to_owned()),
         )?;
         if let Some(prev) = prev_label {
             self.labeled_loop_blocks.insert(label.unwrap(), prev);
@@ -1470,7 +1470,7 @@ impl<'ctx> MirLowerCtx<'ctx> {
             .current_loop_blocks
             .as_mut()
             .ok_or(MirLowerError::ImplementationError(
-                "Current loop access out of loop".to_string(),
+                "Current loop access out of loop".to_owned(),
             ))?
             .end
         {
@@ -1480,7 +1480,7 @@ impl<'ctx> MirLowerCtx<'ctx> {
                 self.current_loop_blocks
                     .as_mut()
                     .ok_or(MirLowerError::ImplementationError(
-                        "Current loop access out of loop".to_string(),
+                        "Current loop access out of loop".to_owned(),
                     ))?
                     .end = Some(s);
                 s

--- a/crates/hir-ty/src/mir/lower/as_place.rs
+++ b/crates/hir-ty/src/mir/lower/as_place.rs
@@ -215,7 +215,7 @@ impl MirLowerCtx<'_> {
                     )
                 {
                     let Some(index_fn) = self.infer.method_resolution(expr_id) else {
-                        return Err(MirLowerError::UnresolvedMethod("[overloaded index]".to_string()));
+                        return Err(MirLowerError::UnresolvedMethod("[overloaded index]".to_owned()));
                     };
                     let Some((base_place, current)) = self.lower_expr_as_place(current, *base, true)? else {
                         return Ok(None);

--- a/crates/hir-ty/src/mir/monomorphization.rs
+++ b/crates/hir-ty/src/mir/monomorphization.rs
@@ -206,11 +206,10 @@ impl Filler<'_> {
                                 const_id = GeneralConstId::ConstId(c);
                                 subst = s;
                             }
-                            let result =
-                                self.db.const_eval(const_id.into(), subst).map_err(|e| {
-                                    let name = const_id.name(self.db.upcast());
-                                    MirLowerError::ConstEvalError(name, Box::new(e))
-                                })?;
+                            let result = self.db.const_eval(const_id, subst).map_err(|e| {
+                                let name = const_id.name(self.db.upcast());
+                                MirLowerError::ConstEvalError(name, Box::new(e))
+                            })?;
                             *c = result;
                         }
                         crate::ConstScalar::Bytes(_, _) | crate::ConstScalar::Unknown => (),
@@ -318,7 +317,7 @@ pub fn monomorphized_mir_body_recover(
     _: &Substitution,
     _: &Arc<crate::TraitEnvironment>,
 ) -> Result<Arc<MirBody>, MirLowerError> {
-    return Err(MirLowerError::Loop);
+    Err(MirLowerError::Loop)
 }
 
 pub fn monomorphized_mir_body_for_closure_query(

--- a/crates/hir-ty/src/test_db.rs
+++ b/crates/hir-ty/src/test_db.rs
@@ -43,13 +43,13 @@ impl fmt::Debug for TestDB {
 
 impl Upcast<dyn ExpandDatabase> for TestDB {
     fn upcast(&self) -> &(dyn ExpandDatabase + 'static) {
-        &*self
+        self
     }
 }
 
 impl Upcast<dyn DefDatabase> for TestDB {
     fn upcast(&self) -> &(dyn DefDatabase + 'static) {
-        &*self
+        self
     }
 }
 

--- a/crates/hir-ty/src/tests.rs
+++ b/crates/hir-ty/src/tests.rs
@@ -107,7 +107,7 @@ fn check_impl(ra_fixture: &str, allow_none: bool, only_types: bool, display_sour
                         .trim_start_matches("adjustments:")
                         .trim()
                         .split(',')
-                        .map(|it| it.trim().to_string())
+                        .map(|it| it.trim().to_owned())
                         .filter(|it| !it.is_empty())
                         .collect(),
                 );
@@ -335,7 +335,7 @@ fn infer_with_mismatches(content: &str, include_mismatches: bool) -> String {
         });
         for (node, ty) in &types {
             let (range, text) = if let Some(self_param) = ast::SelfParam::cast(node.value.clone()) {
-                (self_param.name().unwrap().syntax().text_range(), "self".to_string())
+                (self_param.name().unwrap().syntax().text_range(), "self".to_owned())
             } else {
                 (node.value.text_range(), node.value.text().to_string().replace('\n', " "))
             };

--- a/crates/hir-ty/src/traits.rs
+++ b/crates/hir-ty/src/traits.rs
@@ -90,8 +90,8 @@ pub(crate) fn trait_solve_query(
         GoalData::DomainGoal(DomainGoal::Holds(WhereClause::Implemented(it))) => {
             db.trait_data(it.hir_trait_id()).name.display(db.upcast()).to_string()
         }
-        GoalData::DomainGoal(DomainGoal::Holds(WhereClause::AliasEq(_))) => "alias_eq".to_string(),
-        _ => "??".to_string(),
+        GoalData::DomainGoal(DomainGoal::Holds(WhereClause::AliasEq(_))) => "alias_eq".to_owned(),
+        _ => "??".to_owned(),
     });
     tracing::info!("trait_solve_query({:?})", goal.value.goal);
 

--- a/crates/hir-ty/src/utils.rs
+++ b/crates/hir-ty/src/utils.rs
@@ -435,7 +435,7 @@ pub(crate) fn detect_variant_from_bytes<'a>(
     e: EnumId,
 ) -> Option<(LocalEnumVariantId, &'a Layout)> {
     let (var_id, var_layout) = match &layout.variants {
-        hir_def::layout::Variants::Single { index } => (index.0, &*layout),
+        hir_def::layout::Variants::Single { index } => (index.0, layout),
         hir_def::layout::Variants::Multiple { tag, tag_encoding, variants, .. } => {
             let target_data_layout = db.target_data_layout(krate)?;
             let size = tag.size(&*target_data_layout).bytes_usize();

--- a/crates/hir/Cargo.toml
+++ b/crates/hir/Cargo.toml
@@ -30,3 +30,6 @@ profile.workspace = true
 stdx.workspace = true
 syntax.workspace = true
 tt.workspace = true
+
+[lints]
+workspace = true

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -1946,7 +1946,7 @@ impl Function {
         };
         let (result, stdout, stderr) = interpret_mir(db, &body, false);
         let mut text = match result {
-            Ok(_) => "pass".to_string(),
+            Ok(_) => "pass".to_owned(),
             Err(e) => {
                 let mut r = String::new();
                 _ = e.pretty_print(&mut r, db, &span_formatter);

--- a/crates/hir/src/semantics.rs
+++ b/crates/hir/src/semantics.rs
@@ -758,7 +758,7 @@ impl<'db> SemanticsImpl<'db> {
                 res = Some(value);
                 true
             } else {
-                if let None = res {
+                if res.is_none() {
                     res = Some(value)
                 }
                 false
@@ -1126,9 +1126,7 @@ impl<'db> SemanticsImpl<'db> {
                     // Update `source_ty` for the next adjustment
                     let source = mem::replace(&mut source_ty, target.clone());
 
-                    let adjustment = Adjustment { source, target, kind };
-
-                    adjustment
+                    Adjustment { source, target, kind }
                 })
                 .collect()
         })
@@ -1375,7 +1373,7 @@ impl<'db> SemanticsImpl<'db> {
         assert!(root_node.parent().is_none());
         let mut cache = self.cache.borrow_mut();
         let prev = cache.insert(root_node, file_id);
-        assert!(prev == None || prev == Some(file_id))
+        assert!(prev.is_none() || prev == Some(file_id))
     }
 
     fn assert_contains_node(&self, node: &SyntaxNode) {

--- a/crates/hir/src/semantics/source_to_def.rs
+++ b/crates/hir/src/semantics/source_to_def.rs
@@ -275,6 +275,7 @@ impl SourceToDefCtx<'_, '_> {
         self.dyn_map(adt).as_ref().map_or(false, |map| !map[keys::DERIVE_MACRO_CALL].is_empty())
     }
 
+    #[allow(clippy::wrong_self_convention)]
     fn to_def<Ast: AstNode + 'static, ID: Copy + 'static>(
         &mut self,
         src: InFile<Ast>,
@@ -298,7 +299,7 @@ impl SourceToDefCtx<'_, '_> {
     pub(super) fn type_param_to_def(&mut self, src: InFile<ast::TypeParam>) -> Option<TypeParamId> {
         let container: ChildContainer = self.find_generic_param_container(src.syntax())?.into();
         let dyn_map = self.cache_for(container, src.file_id);
-        dyn_map[keys::TYPE_PARAM].get(&src.value).copied().map(|x| TypeParamId::from_unchecked(x))
+        dyn_map[keys::TYPE_PARAM].get(&src.value).copied().map(TypeParamId::from_unchecked)
     }
 
     pub(super) fn lifetime_param_to_def(
@@ -316,7 +317,7 @@ impl SourceToDefCtx<'_, '_> {
     ) -> Option<ConstParamId> {
         let container: ChildContainer = self.find_generic_param_container(src.syntax())?.into();
         let dyn_map = self.cache_for(container, src.file_id);
-        dyn_map[keys::CONST_PARAM].get(&src.value).copied().map(|x| ConstParamId::from_unchecked(x))
+        dyn_map[keys::CONST_PARAM].get(&src.value).copied().map(ConstParamId::from_unchecked)
     }
 
     pub(super) fn generic_param_to_def(

--- a/crates/hir/src/source_analyzer.rs
+++ b/crates/hir/src/source_analyzer.rs
@@ -199,10 +199,8 @@ impl SourceAnalyzer {
     ) -> Option<(Type, Option<Type>)> {
         let pat_id = self.pat_id(pat)?;
         let infer = self.infer.as_ref()?;
-        let coerced = infer
-            .pat_adjustments
-            .get(&pat_id)
-            .and_then(|adjusts| adjusts.last().map(|adjust| adjust.clone()));
+        let coerced =
+            infer.pat_adjustments.get(&pat_id).and_then(|adjusts| adjusts.last().cloned());
         let ty = infer[pat_id].clone();
         let mk_ty = |ty| Type::new_with_resolver(db, &self.resolver, ty);
         Some((mk_ty(ty), coerced.map(mk_ty)))
@@ -591,7 +589,7 @@ impl SourceAnalyzer {
             }
             None
         })();
-        if let Some(_) = resolved {
+        if resolved.is_some() {
             return resolved;
         }
 
@@ -637,7 +635,7 @@ impl SourceAnalyzer {
             if let Some(name_ref) = path.as_single_name_ref() {
                 let builtin =
                     BuiltinAttr::by_name(db, self.resolver.krate().into(), &name_ref.text());
-                if let Some(_) = builtin {
+                if builtin.is_some() {
                     return builtin.map(PathResolution::BuiltinAttr);
                 }
 
@@ -1093,7 +1091,7 @@ fn resolve_hir_path_qualifier(
     path: &Path,
 ) -> Option<PathResolution> {
     resolver
-        .resolve_path_in_type_ns_fully(db.upcast(), &path)
+        .resolve_path_in_type_ns_fully(db.upcast(), path)
         .map(|ty| match ty {
             TypeNs::SelfType(it) => PathResolution::SelfType(it.into()),
             TypeNs::GenericParam(id) => PathResolution::TypeParam(id.into()),

--- a/crates/ide-assists/Cargo.toml
+++ b/crates/ide-assists/Cargo.toml
@@ -35,3 +35,6 @@ sourcegen.workspace = true
 
 [features]
 in-rust-tree = []
+
+[lints]
+workspace = true

--- a/crates/ide-assists/src/handlers/add_missing_match_arms.rs
+++ b/crates/ide-assists/src/handlers/add_missing_match_arms.rs
@@ -42,7 +42,7 @@ pub(crate) fn add_missing_match_arms(acc: &mut Assists, ctx: &AssistContext<'_>)
     let match_arm_list = match_expr.match_arm_list()?;
     let target_range = ctx.sema.original_range(match_expr.syntax()).range;
 
-    if let None = cursor_at_trivial_match_arm_list(ctx, &match_expr, &match_arm_list) {
+    if cursor_at_trivial_match_arm_list(ctx, &match_expr, &match_arm_list).is_none() {
         let arm_list_range = ctx.sema.original_range(match_arm_list.syntax()).range;
         let cursor_in_range = arm_list_range.contains_range(ctx.selection_trimmed());
         if cursor_in_range {
@@ -159,7 +159,7 @@ pub(crate) fn add_missing_match_arms(acc: &mut Assists, ctx: &AssistContext<'_>)
                     .iter()
                     .any(|variant| variant.should_be_hidden(ctx.db(), module.krate()));
                 let patterns = variants.into_iter().filter_map(|variant| {
-                    build_pat(ctx.db(), module, variant.clone(), ctx.config.prefer_no_std)
+                    build_pat(ctx.db(), module, variant, ctx.config.prefer_no_std)
                 });
                 (ast::Pat::from(make::slice_pat(patterns)), is_hidden)
             })
@@ -253,7 +253,7 @@ fn cursor_at_trivial_match_arm_list(
     match_arm_list: &MatchArmList,
 ) -> Option<()> {
     // match x { $0 }
-    if match_arm_list.arms().next() == None {
+    if match_arm_list.arms().next().is_none() {
         cov_mark::hit!(add_missing_match_arms_empty_body);
         return Some(());
     }

--- a/crates/ide-assists/src/handlers/auto_import.rs
+++ b/crates/ide-assists/src/handlers/auto_import.rs
@@ -158,7 +158,7 @@ pub(super) fn find_importable_node(
     {
         ImportAssets::for_method_call(&method_under_caret, &ctx.sema)
             .zip(Some(method_under_caret.syntax().clone().into()))
-    } else if let Some(_) = ctx.find_node_at_offset_with_descend::<ast::Param>() {
+    } else if ctx.find_node_at_offset_with_descend::<ast::Param>().is_some() {
         None
     } else if let Some(pat) = ctx
         .find_node_at_offset_with_descend::<ast::IdentPat>()

--- a/crates/ide-assists/src/handlers/convert_match_to_let_else.rs
+++ b/crates/ide-assists/src/handlers/convert_match_to_let_else.rs
@@ -113,7 +113,7 @@ fn find_extracted_variable(ctx: &AssistContext<'_>, arm: &ast::MatchArm) -> Opti
         }
         _ => {
             cov_mark::hit!(extracting_arm_is_not_an_identity_expr);
-            return None;
+            None
         }
     }
 }

--- a/crates/ide-assists/src/handlers/convert_nested_function_to_closure.rs
+++ b/crates/ide-assists/src/handlers/convert_nested_function_to_closure.rs
@@ -49,8 +49,8 @@ pub(crate) fn convert_nested_function_to_closure(
         target,
         |edit| {
             let params = &param_list.syntax().text().to_string();
-            let params = params.strip_prefix("(").unwrap_or(params);
-            let params = params.strip_suffix(")").unwrap_or(params);
+            let params = params.strip_prefix('(').unwrap_or(params);
+            let params = params.strip_suffix(')').unwrap_or(params);
 
             let mut body = body.to_string();
             if !has_semicolon(&function) {

--- a/crates/ide-assists/src/handlers/convert_two_arm_bool_match_to_matches_macro.rs
+++ b/crates/ide-assists/src/handlers/convert_two_arm_bool_match_to_matches_macro.rs
@@ -80,7 +80,7 @@ fn is_bool_literal_expr(expr: &Option<ast::Expr>, expect_bool: bool) -> bool {
         }
     }
 
-    return false;
+    false
 }
 
 #[cfg(test)]

--- a/crates/ide-assists/src/handlers/extract_expressions_from_format_string.rs
+++ b/crates/ide-assists/src/handlers/extract_expressions_from_format_string.rs
@@ -158,7 +158,7 @@ mod tests {
     use super::*;
     use crate::tests::check_assist;
 
-    const MACRO_DECL: &'static str = r#"
+    const MACRO_DECL: &str = r#"
 macro_rules! format_args {
     ($lit:literal $(tt:tt)*) => { 0 },
 }

--- a/crates/ide-assists/src/handlers/extract_function.rs
+++ b/crates/ide-assists/src/handlers/extract_function.rs
@@ -1884,7 +1884,7 @@ fn with_tail_expr(block: ast::BlockExpr, tail_expr: ast::Expr) -> ast::BlockExpr
 }
 
 fn format_type(ty: &hir::Type, ctx: &AssistContext<'_>, module: hir::Module) -> String {
-    ty.display_source_code(ctx.db(), module.into(), true).ok().unwrap_or_else(|| "_".to_string())
+    ty.display_source_code(ctx.db(), module.into(), true).ok().unwrap_or_else(|| "_".to_owned())
 }
 
 fn make_ty(ty: &hir::Type, ctx: &AssistContext<'_>, module: hir::Module) -> ast::Type {

--- a/crates/ide-assists/src/handlers/extract_module.rs
+++ b/crates/ide-assists/src/handlers/extract_module.rs
@@ -668,7 +668,7 @@ fn check_intersection_and_push(
     // check for intersection between all current members
     // and combine all such ranges into one.
     let s: SmallVec<[_; 2]> = import_paths_to_be_removed
-        .into_iter()
+        .iter_mut()
         .positions(|it| it.intersect(import_path).is_some())
         .collect();
     for pos in s.into_iter().rev() {
@@ -704,12 +704,9 @@ fn does_source_exists_outside_sel_in_same_mod(
             }
 
             if have_same_parent {
-                match source.value {
-                    ModuleSource::Module(module_) => {
-                        source_exists_outside_sel_in_same_mod =
-                            !selection_range.contains_range(module_.syntax().text_range());
-                    }
-                    _ => {}
+                if let ModuleSource::Module(module_) = source.value {
+                    source_exists_outside_sel_in_same_mod =
+                        !selection_range.contains_range(module_.syntax().text_range());
                 }
             }
         }

--- a/crates/ide-assists/src/handlers/extract_type_alias.rs
+++ b/crates/ide-assists/src/handlers/extract_type_alias.rs
@@ -185,7 +185,7 @@ fn collect_used_generics<'gp>(
         ast::GenericParam::TypeParam(_) => 1,
     });
 
-    Some(generics).filter(|it| it.len() > 0)
+    Some(generics).filter(|it| !it.is_empty())
 }
 
 #[cfg(test)]

--- a/crates/ide-assists/src/handlers/generate_constant.rs
+++ b/crates/ide-assists/src/handlers/generate_constant.rs
@@ -103,10 +103,10 @@ fn get_text_for_generate_constant(
     type_name: String,
 ) -> Option<String> {
     let constant_token = not_exist_name_ref.pop()?;
-    let vis = if not_exist_name_ref.len() == 0 && !outer_exists { "" } else { "\npub " };
+    let vis = if not_exist_name_ref.is_empty() && !outer_exists { "" } else { "\npub " };
     let mut text = format!("{vis}const {constant_token}: {type_name} = $0;");
     while let Some(name_ref) = not_exist_name_ref.pop() {
-        let vis = if not_exist_name_ref.len() == 0 && !outer_exists { "" } else { "\npub " };
+        let vis = if not_exist_name_ref.is_empty() && !outer_exists { "" } else { "\npub " };
         text = text.replace('\n', "\n    ");
         text = format!("{vis}mod {name_ref} {{{text}\n}}");
     }
@@ -132,8 +132,7 @@ fn target_data_for_generate_constant(
 
             let siblings_has_newline = l_curly_token
                 .siblings_with_tokens(Direction::Next)
-                .find(|it| it.kind() == SyntaxKind::WHITESPACE && it.to_string().contains('\n'))
-                .is_some();
+                .any(|it| it.kind() == SyntaxKind::WHITESPACE && it.to_string().contains('\n'));
             let post_string =
                 if siblings_has_newline { format!("{indent}") } else { format!("\n{indent}") };
             Some((offset, indent + 1, Some(file_id), post_string))

--- a/crates/ide-assists/src/handlers/generate_delegate_methods.rs
+++ b/crates/ide-assists/src/handlers/generate_delegate_methods.rs
@@ -168,7 +168,7 @@ pub(crate) fn generate_delegate_methods(acc: &mut Assists, ctx: &AssistContext<'
                         // Attach the function to the impl block
                         let name = &strukt_name.to_string();
                         let params = strukt.generic_param_list();
-                        let ty_params = params.clone();
+                        let ty_params = params;
                         let where_clause = strukt.where_clause();
 
                         let impl_def = make::impl_(

--- a/crates/ide-assists/src/handlers/generate_documentation_template.rs
+++ b/crates/ide-assists/src/handlers/generate_documentation_template.rs
@@ -148,7 +148,7 @@ fn make_example_for_fn(ast_func: &ast::Fn, ctx: &AssistContext<'_>) -> Option<St
     format_to!(example, "use {use_path};\n\n");
     if let Some(self_name) = &self_name {
         if let Some(mut_) = is_ref_mut_self(ast_func) {
-            let mut_ = if mut_ == true { "mut " } else { "" };
+            let mut_ = if mut_ { "mut " } else { "" };
             format_to!(example, "let {mut_}{self_name} = ;\n");
         }
     }

--- a/crates/ide-assists/src/handlers/generate_documentation_template.rs
+++ b/crates/ide-assists/src/handlers/generate_documentation_template.rs
@@ -416,9 +416,9 @@ fn arguments_from_params(param_list: &ast::ParamList) -> String {
                 true => format!("&mut {name}"),
                 false => name.to_string(),
             },
-            None => "_".to_string(),
+            None => "_".to_owned(),
         },
-        _ => "_".to_string(),
+        _ => "_".to_owned(),
     });
     args_iter.format(", ").to_string()
 }

--- a/crates/ide-assists/src/handlers/generate_enum_variant.rs
+++ b/crates/ide-assists/src/handlers/generate_enum_variant.rs
@@ -162,7 +162,7 @@ fn make_record_field_list(
 fn name_from_field(field: &ast::RecordExprField) -> ast::Name {
     let text = match field.name_ref() {
         Some(it) => it.to_string(),
-        None => name_from_field_shorthand(field).unwrap_or("unknown".to_string()),
+        None => name_from_field_shorthand(field).unwrap_or("unknown".to_owned()),
     };
     make::name(&text)
 }

--- a/crates/ide-assists/src/handlers/generate_enum_variant.rs
+++ b/crates/ide-assists/src/handlers/generate_enum_variant.rs
@@ -124,7 +124,9 @@ fn add_variant_to_accumulator(
             builder.edit_file(file_id.original_file(db));
             let node = builder.make_mut(enum_node);
             let variant = make_variant(ctx, name_ref, parent);
-            node.variant_list().map(|it| it.add_variant(variant.clone_for_update()));
+            if let Some(it) = node.variant_list() {
+                it.add_variant(variant.clone_for_update())
+            }
         },
     )
 }

--- a/crates/ide-assists/src/handlers/generate_function.rs
+++ b/crates/ide-assists/src/handlers/generate_function.rs
@@ -961,7 +961,7 @@ fn fn_arg_name(sema: &Semantics<'_, RootDatabase>, arg_expr: &ast::Expr) -> Stri
             name
         }
         Some(name) => name,
-        None => "arg".to_string(),
+        None => "arg".to_owned(),
     }
 }
 

--- a/crates/ide-assists/src/handlers/generate_getter.rs
+++ b/crates/ide-assists/src/handlers/generate_getter.rs
@@ -129,7 +129,7 @@ pub(crate) fn generate_getter_impl(
     };
 
     // No record fields to do work on :(
-    if info_of_record_fields.len() == 0 {
+    if info_of_record_fields.is_empty() {
         return None;
     }
 
@@ -179,10 +179,8 @@ pub(crate) fn generate_getter_impl(
                     generate_getter_from_info(ctx, &getter_info, record_field_info);
 
                 // Insert `$0` only for last getter we generate
-                if i == record_fields_count - 1 {
-                    if ctx.config.snippet_cap.is_some() {
-                        getter_buf = getter_buf.replacen("fn ", "fn $0", 1);
-                    }
+                if i == record_fields_count - 1 && ctx.config.snippet_cap.is_some() {
+                    getter_buf = getter_buf.replacen("fn ", "fn $0", 1);
                 }
 
                 // For first element we do not merge with '\n', as
@@ -209,7 +207,7 @@ pub(crate) fn generate_getter_impl(
                 // getter and end of impl ( i.e. `}` ) with an
                 // extra line for no reason
                 if i < record_fields_count - 1 {
-                    buf = buf + "\n";
+                    buf += "\n";
                 }
             }
 
@@ -304,15 +302,13 @@ fn extract_and_parse_record_fields(
                 })
                 .collect::<Vec<RecordFieldInfo>>();
 
-            if info_of_record_fields_in_selection.len() == 0 {
+            if info_of_record_fields_in_selection.is_empty() {
                 return None;
             }
 
             Some((info_of_record_fields_in_selection, field_names))
         }
-        ast::FieldList::TupleFieldList(_) => {
-            return None;
-        }
+        ast::FieldList::TupleFieldList(_) => None,
     }
 }
 

--- a/crates/ide-assists/src/handlers/generate_impl.rs
+++ b/crates/ide-assists/src/handlers/generate_impl.rs
@@ -29,7 +29,7 @@ pub(crate) fn generate_impl(acc: &mut Assists, ctx: &AssistContext<'_>) -> Optio
     let name = nominal.name()?;
     let target = nominal.syntax().text_range();
 
-    if let Some(_) = ctx.find_node_at_offset::<ast::RecordFieldList>() {
+    if ctx.find_node_at_offset::<ast::RecordFieldList>().is_some() {
         return None;
     }
 
@@ -77,7 +77,7 @@ pub(crate) fn generate_trait_impl(acc: &mut Assists, ctx: &AssistContext<'_>) ->
     let name = nominal.name()?;
     let target = nominal.syntax().text_range();
 
-    if let Some(_) = ctx.find_node_at_offset::<ast::RecordFieldList>() {
+    if ctx.find_node_at_offset::<ast::RecordFieldList>().is_some() {
         return None;
     }
 

--- a/crates/ide-assists/src/handlers/generate_is_empty_from_len.rs
+++ b/crates/ide-assists/src/handlers/generate_is_empty_from_len.rs
@@ -95,7 +95,7 @@ fn get_impl_method(
 
     let scope = ctx.sema.scope(impl_.syntax())?;
     let ty = impl_def.self_ty(db);
-    ty.iterate_method_candidates(db, &scope, None, Some(fn_name), |func| Some(func))
+    ty.iterate_method_candidates(db, &scope, None, Some(fn_name), Some)
 }
 
 #[cfg(test)]

--- a/crates/ide-assists/src/handlers/inline_const_as_literal.rs
+++ b/crates/ide-assists/src/handlers/inline_const_as_literal.rs
@@ -60,7 +60,7 @@ pub(crate) fn inline_const_as_literal(acc: &mut Assists, ctx: &AssistContext<'_>
 
         let id = AssistId("inline_const_as_literal", AssistKind::RefactorInline);
 
-        let label = "Inline const as literal".to_string();
+        let label = "Inline const as literal".to_owned();
         let target = variable.syntax().text_range();
 
         return acc.add(id, label, target, |edit| {

--- a/crates/ide-assists/src/handlers/inline_const_as_literal.rs
+++ b/crates/ide-assists/src/handlers/inline_const_as_literal.rs
@@ -60,7 +60,7 @@ pub(crate) fn inline_const_as_literal(acc: &mut Assists, ctx: &AssistContext<'_>
 
         let id = AssistId("inline_const_as_literal", AssistKind::RefactorInline);
 
-        let label = format!("Inline const as literal");
+        let label = "Inline const as literal".to_string();
         let target = variable.syntax().text_range();
 
         return acc.add(id, label, target, |edit| {
@@ -100,7 +100,7 @@ fn validate_type_recursively(
         }
         (_, Some(ty)) => match ty.as_builtin() {
             // `const A: str` is not correct, but `const A: &builtin` is.
-            Some(builtin) if refed || (!refed && !builtin.is_str()) => Some(()),
+            Some(builtin) if refed || !builtin.is_str() => Some(()),
             _ => None,
         },
         _ => None,
@@ -138,7 +138,7 @@ mod tests {
     // -----------Not supported-----------
     #[test]
     fn inline_const_as_literal_const_fn_call_slice() {
-        TEST_PAIRS.into_iter().for_each(|(ty, val, _)| {
+        TEST_PAIRS.iter().for_each(|(ty, val, _)| {
             check_assist_not_applicable(
                 inline_const_as_literal,
                 &format!(
@@ -240,7 +240,7 @@ mod tests {
 
     #[test]
     fn inline_const_as_literal_const_expr() {
-        TEST_PAIRS.into_iter().for_each(|(ty, val, _)| {
+        TEST_PAIRS.iter().for_each(|(ty, val, _)| {
             check_assist(
                 inline_const_as_literal,
                 &format!(
@@ -261,7 +261,7 @@ mod tests {
 
     #[test]
     fn inline_const_as_literal_const_block_expr() {
-        TEST_PAIRS.into_iter().for_each(|(ty, val, _)| {
+        TEST_PAIRS.iter().for_each(|(ty, val, _)| {
             check_assist(
                 inline_const_as_literal,
                 &format!(
@@ -282,7 +282,7 @@ mod tests {
 
     #[test]
     fn inline_const_as_literal_const_block_eval_expr() {
-        TEST_PAIRS.into_iter().for_each(|(ty, val, _)| {
+        TEST_PAIRS.iter().for_each(|(ty, val, _)| {
             check_assist(
                 inline_const_as_literal,
                 &format!(
@@ -303,7 +303,7 @@ mod tests {
 
     #[test]
     fn inline_const_as_literal_const_block_eval_block_expr() {
-        TEST_PAIRS.into_iter().for_each(|(ty, val, _)| {
+        TEST_PAIRS.iter().for_each(|(ty, val, _)| {
             check_assist(
                 inline_const_as_literal,
                 &format!(
@@ -324,7 +324,7 @@ mod tests {
 
     #[test]
     fn inline_const_as_literal_const_fn_call_block_nested_builtin() {
-        TEST_PAIRS.into_iter().for_each(|(ty, val, _)| {
+        TEST_PAIRS.iter().for_each(|(ty, val, _)| {
             check_assist(
                 inline_const_as_literal,
                 &format!(
@@ -347,7 +347,7 @@ mod tests {
 
     #[test]
     fn inline_const_as_literal_const_fn_call_tuple() {
-        TEST_PAIRS.into_iter().for_each(|(ty, val, _)| {
+        TEST_PAIRS.iter().for_each(|(ty, val, _)| {
             check_assist(
                 inline_const_as_literal,
                 &format!(
@@ -370,7 +370,7 @@ mod tests {
 
     #[test]
     fn inline_const_as_literal_const_fn_call_builtin() {
-        TEST_PAIRS.into_iter().for_each(|(ty, val, _)| {
+        TEST_PAIRS.iter().for_each(|(ty, val, _)| {
             check_assist(
                 inline_const_as_literal,
                 &format!(

--- a/crates/ide-assists/src/handlers/inline_macro.rs
+++ b/crates/ide-assists/src/handlers/inline_macro.rs
@@ -42,7 +42,7 @@ pub(crate) fn inline_macro(acc: &mut Assists, ctx: &AssistContext<'_>) -> Option
 
     acc.add(
         AssistId("inline_macro", AssistKind::RefactorRewrite),
-        format!("Inline macro"),
+        "Inline macro".to_string(),
         text_range,
         |builder| builder.replace(text_range, expanded.to_string()),
     )

--- a/crates/ide-assists/src/handlers/inline_macro.rs
+++ b/crates/ide-assists/src/handlers/inline_macro.rs
@@ -42,7 +42,7 @@ pub(crate) fn inline_macro(acc: &mut Assists, ctx: &AssistContext<'_>) -> Option
 
     acc.add(
         AssistId("inline_macro", AssistKind::RefactorRewrite),
-        "Inline macro".to_string(),
+        "Inline macro".to_owned(),
         text_range,
         |builder| builder.replace(text_range, expanded.to_string()),
     )

--- a/crates/ide-assists/src/handlers/introduce_named_lifetime.rs
+++ b/crates/ide-assists/src/handlers/introduce_named_lifetime.rs
@@ -129,7 +129,7 @@ fn generate_unique_lifetime_param_name(
                 type_params.lifetime_params().map(|p| p.syntax().text().to_string()).collect();
             ('a'..='z').map(|it| format!("'{it}")).find(|it| !used_lifetime_params.contains(it))
         }
-        None => Some("'a".to_string()),
+        None => Some("'a".to_owned()),
     }
     .map(|it| make::lifetime(&it))
 }

--- a/crates/ide-assists/src/handlers/introduce_named_lifetime.rs
+++ b/crates/ide-assists/src/handlers/introduce_named_lifetime.rs
@@ -87,7 +87,7 @@ fn generate_fn_def_assist(
         let fn_def = builder.make_mut(fn_def);
         let lifetime = builder.make_mut(lifetime);
         let loc_needing_lifetime =
-            loc_needing_lifetime.and_then(|it| it.make_mut(builder).to_position());
+            loc_needing_lifetime.and_then(|it| it.make_mut(builder).into_position());
 
         fn_def.get_or_create_generic_param_list().add_generic_param(
             make::lifetime_param(new_lifetime_param.clone()).clone_for_update().into(),
@@ -147,7 +147,7 @@ impl NeedsLifetime {
         }
     }
 
-    fn to_position(self) -> Option<Position> {
+    fn into_position(self) -> Option<Position> {
         match self {
             Self::SelfParam(it) => Some(Position::after(it.amp_token()?)),
             Self::RefType(it) => Some(Position::after(it.amp_token()?)),

--- a/crates/ide-assists/src/handlers/replace_if_let_with_match.rs
+++ b/crates/ide-assists/src/handlers/replace_if_let_with_match.rs
@@ -279,7 +279,7 @@ pub(crate) fn replace_match_with_if_let(acc: &mut Assists, ctx: &AssistContext<'
             let then_block = make_block_expr(then_expr.reset_indent());
             let else_expr = if is_empty_expr(&else_expr) { None } else { Some(else_expr) };
             let if_let_expr = make::expr_if(
-                condition.into(),
+                condition,
                 then_block,
                 else_expr.map(make_block_expr).map(ast::ElseBranch::Block),
             )

--- a/crates/ide-assists/src/handlers/replace_method_eager_lazy.rs
+++ b/crates/ide-assists/src/handlers/replace_method_eager_lazy.rs
@@ -133,7 +133,7 @@ pub(crate) fn replace_with_eager_method(acc: &mut Assists, ctx: &AssistContext<'
         None,
         None,
         |func| {
-            let valid = func.name(ctx.sema.db).as_str() == Some(&*method_name_eager)
+            let valid = func.name(ctx.sema.db).as_str() == Some(method_name_eager)
                 && func.num_params(ctx.sema.db) == n_params;
             valid.then_some(func)
         },

--- a/crates/ide-assists/src/handlers/replace_turbofish_with_explicit_type.rs
+++ b/crates/ide-assists/src/handlers/replace_turbofish_with_explicit_type.rs
@@ -69,7 +69,7 @@ pub(crate) fn replace_turbofish_with_explicit_type(
         return None;
     }
 
-    if let None = let_stmt.colon_token() {
+    if let_stmt.colon_token().is_none() {
         // If there's no colon in a let statement, then there is no explicit type.
         // let x = fn::<...>();
         let ident_range = let_stmt.pat()?.syntax().text_range();
@@ -111,7 +111,7 @@ fn generic_arg_list(expr: &Expr) -> Option<GenericArgList> {
                 pe.path()?.segment()?.generic_arg_list()
             } else {
                 cov_mark::hit!(not_applicable_if_non_path_function_call);
-                return None;
+                None
             }
         }
         Expr::AwaitExpr(expr) => generic_arg_list(&expr.expr()?),

--- a/crates/ide-assists/src/handlers/unnecessary_async.rs
+++ b/crates/ide-assists/src/handlers/unnecessary_async.rs
@@ -37,7 +37,7 @@ pub(crate) fn unnecessary_async(acc: &mut Assists, ctx: &AssistContext<'_>) -> O
         return None;
     }
     // Do nothing if the function isn't async.
-    if let None = function.async_token() {
+    if function.async_token().is_none() {
         return None;
     }
     // Do nothing if the function has an `await` expression in its body.
@@ -46,7 +46,7 @@ pub(crate) fn unnecessary_async(acc: &mut Assists, ctx: &AssistContext<'_>) -> O
     }
     // Do nothing if the method is a member of trait.
     if let Some(impl_) = function.syntax().ancestors().nth(2).and_then(ast::Impl::cast) {
-        if let Some(_) = impl_.trait_() {
+        if impl_.trait_().is_some() {
             return None;
         }
     }

--- a/crates/ide-assists/src/handlers/unwrap_block.rs
+++ b/crates/ide-assists/src/handlers/unwrap_block.rs
@@ -53,7 +53,7 @@ pub(crate) fn unwrap_block(acc: &mut Assists, ctx: &AssistContext<'_>) -> Option
                 let stmts: Vec<ast::Stmt> = list.statements().collect();
                 let initializer = ast::Expr::cast(last)?;
                 let let_stmt = make::let_stmt(pattern, ty, Some(initializer));
-                if stmts.len() > 0 {
+                if !stmts.is_empty() {
                     let block = make::block_expr(stmts, None);
                     format!("{}\n    {}", update_expr_string(block.to_string()), let_stmt)
                 } else {

--- a/crates/ide-assists/src/tests.rs
+++ b/crates/ide-assists/src/tests.rs
@@ -188,7 +188,7 @@ fn check_with_config(
                 .filter(|it| !it.source_file_edits.is_empty() || !it.file_system_edits.is_empty())
                 .expect("Assist did not contain any source changes");
             let skip_header = source_change.source_file_edits.len() == 1
-                && source_change.file_system_edits.len() == 0;
+                && source_change.file_system_edits.is_empty();
 
             let mut buf = String::new();
             for (file_id, edit) in source_change.source_file_edits {

--- a/crates/ide-assists/src/tests.rs
+++ b/crates/ide-assists/src/tests.rs
@@ -416,7 +416,7 @@ pub fn test_some_range(a: int) -> bool {
             &db,
             &cfg,
             AssistResolveStrategy::Single(SingleResolve {
-                assist_id: "SOMETHING_MISMATCHING".to_string(),
+                assist_id: "SOMETHING_MISMATCHING".to_owned(),
                 assist_kind: AssistKind::RefactorExtract,
             }),
             frange,
@@ -462,7 +462,7 @@ pub fn test_some_range(a: int) -> bool {
             &db,
             &cfg,
             AssistResolveStrategy::Single(SingleResolve {
-                assist_id: "extract_variable".to_string(),
+                assist_id: "extract_variable".to_owned(),
                 assist_kind: AssistKind::RefactorExtract,
             }),
             frange,

--- a/crates/ide-assists/src/tests/sourcegen.rs
+++ b/crates/ide-assists/src/tests/sourcegen.rs
@@ -103,7 +103,7 @@ impl Assist {
                     let doc = take_until(lines.by_ref(), "```").trim().to_string();
                     assert!(
                         (doc.chars().next().unwrap().is_ascii_uppercase() && doc.ends_with('.'))
-                            || assist.sections.len() > 0,
+                            || !assist.sections.is_empty(),
                         "\n\n{}: assist docs should be proper sentences, with capitalization and a full stop at the end.\n\n{}\n\n",
                         &assist.id,
                         doc,

--- a/crates/ide-assists/src/utils.rs
+++ b/crates/ide-assists/src/utils.rs
@@ -578,7 +578,7 @@ impl ReferenceConversion {
     pub(crate) fn convert_type(&self, db: &dyn HirDatabase) -> String {
         match self.conversion {
             ReferenceConversionType::Copy => self.ty.display(db).to_string(),
-            ReferenceConversionType::AsRefStr => "&str".to_string(),
+            ReferenceConversionType::AsRefStr => "&str".to_owned(),
             ReferenceConversionType::AsRefSlice => {
                 let type_argument_name =
                     self.ty.type_arguments().next().unwrap().display(db).to_string();

--- a/crates/ide-assists/src/utils/suggest_name.rs
+++ b/crates/ide-assists/src/utils/suggest_name.rs
@@ -137,10 +137,10 @@ fn normalize(name: &str) -> Option<String> {
 }
 
 fn is_valid_name(name: &str) -> bool {
-    match ide_db::syntax_helpers::LexedStr::single_token(name) {
-        Some((syntax::SyntaxKind::IDENT, _error)) => true,
-        _ => false,
-    }
+    matches!(
+        ide_db::syntax_helpers::LexedStr::single_token(name),
+        Some((syntax::SyntaxKind::IDENT, _error))
+    )
 }
 
 fn is_useless_method(method: &ast::MethodCallExpr) -> bool {

--- a/crates/ide-assists/src/utils/suggest_name.rs
+++ b/crates/ide-assists/src/utils/suggest_name.rs
@@ -119,7 +119,7 @@ pub(crate) fn for_variable(expr: &ast::Expr, sema: &Semantics<'_, RootDatabase>)
         }
     }
 
-    "var_name".to_string()
+    "var_name".to_owned()
 }
 
 fn normalize(name: &str) -> Option<String> {

--- a/crates/ide-completion/Cargo.toml
+++ b/crates/ide-completion/Cargo.toml
@@ -35,3 +35,6 @@ expect-test = "1.4.0"
 
 # local deps
 test-utils.workspace = true
+
+[lints]
+workspace = true

--- a/crates/ide-completion/src/completions/env_vars.rs
+++ b/crates/ide-completion/src/completions/env_vars.rs
@@ -37,7 +37,7 @@ pub(crate) fn complete_cargo_env_vars(
     guard_env_macro(expanded, &ctx.sema)?;
     let range = expanded.text_range_between_quotes()?;
 
-    CARGO_DEFINED_VARS.into_iter().for_each(|&(var, detail)| {
+    CARGO_DEFINED_VARS.iter().for_each(|&(var, detail)| {
         let mut item = CompletionItem::new(CompletionItemKind::Keyword, range, var);
         item.detail(detail);
         item.add_to(acc, ctx.db);

--- a/crates/ide-completion/src/completions/field.rs
+++ b/crates/ide-completion/src/completions/field.rs
@@ -13,20 +13,18 @@ pub(crate) fn complete_field_list_tuple_variant(
     if ctx.qualifier_ctx.vis_node.is_some() {
         return;
     }
-    match path_ctx {
-        PathCompletionCtx {
-            has_macro_bang: false,
-            qualified: Qualified::No,
-            parent: None,
-            has_type_args: false,
-            ..
-        } => {
-            let mut add_keyword = |kw, snippet| acc.add_keyword_snippet(ctx, kw, snippet);
-            add_keyword("pub(crate)", "pub(crate)");
-            add_keyword("pub(super)", "pub(super)");
-            add_keyword("pub", "pub");
-        }
-        _ => (),
+    if let PathCompletionCtx {
+        has_macro_bang: false,
+        qualified: Qualified::No,
+        parent: None,
+        has_type_args: false,
+        ..
+    } = path_ctx
+    {
+        let mut add_keyword = |kw, snippet| acc.add_keyword_snippet(ctx, kw, snippet);
+        add_keyword("pub(crate)", "pub(crate)");
+        add_keyword("pub(super)", "pub(super)");
+        add_keyword("pub", "pub");
     }
 }
 

--- a/crates/ide-completion/src/completions/flyimport.rs
+++ b/crates/ide-completion/src/completions/flyimport.rs
@@ -346,11 +346,10 @@ fn import_on_the_fly_method(
         .sorted_by_key(|located_import| {
             compute_fuzzy_completion_order_key(&located_import.import_path, &user_input_lowercased)
         })
-        .for_each(|import| match import.original_item {
-            ItemInNs::Values(hir::ModuleDef::Function(f)) => {
+        .for_each(|import| {
+            if let ItemInNs::Values(hir::ModuleDef::Function(f)) = import.original_item {
                 acc.add_method_with_import(ctx, dot_access, f, import);
             }
-            _ => (),
         });
     Some(())
 }

--- a/crates/ide-completion/src/completions/fn_param.rs
+++ b/crates/ide-completion/src/completions/fn_param.rs
@@ -108,7 +108,7 @@ fn fill_fn_params(
     remove_duplicated(&mut file_params, param_list.params());
     let self_completion_items = ["self", "&self", "mut self", "&mut self"];
     if should_add_self_completions(ctx.token.text_range().start(), param_list, impl_) {
-        self_completion_items.into_iter().for_each(|self_item| add_new_item_to_acc(self_item));
+        self_completion_items.into_iter().for_each(&mut add_new_item_to_acc);
     }
 
     file_params.keys().for_each(|whole_param| add_new_item_to_acc(whole_param));

--- a/crates/ide-completion/src/completions/item_list.rs
+++ b/crates/ide-completion/src/completions/item_list.rs
@@ -80,7 +80,7 @@ fn add_keywords(acc: &mut Completions, ctx: &CompletionContext<'_>, kind: Option
     let in_trait_impl = matches!(kind, Some(ItemListKind::TraitImpl(_)));
     let in_inherent_impl = matches!(kind, Some(ItemListKind::Impl));
     let no_qualifiers = ctx.qualifier_ctx.vis_node.is_none();
-    let in_block = matches!(kind, None);
+    let in_block = kind.is_none();
 
     if !in_trait_impl {
         if ctx.qualifier_ctx.unsafe_tok.is_some() {

--- a/crates/ide-completion/src/item.rs
+++ b/crates/ide-completion/src/item.rs
@@ -516,7 +516,7 @@ impl Builder {
         self.detail = detail.map(Into::into);
         if let Some(detail) = &self.detail {
             if never!(detail.contains('\n'), "multiline detail:\n{}", detail) {
-                self.detail = Some(detail.splitn(2, '\n').next().unwrap().to_string());
+                self.detail = Some(detail.split('\n').next().unwrap().to_string());
             }
         }
         self

--- a/crates/ide-completion/src/render.rs
+++ b/crates/ide-completion/src/render.rs
@@ -256,12 +256,9 @@ fn render_resolution_pat(
     let _p = profile::span("render_resolution");
     use hir::ModuleDef::*;
 
-    match resolution {
-        ScopeDef::ModuleDef(Macro(mac)) => {
-            let ctx = ctx.import_to_add(import_to_add);
-            return render_macro_pat(ctx, pattern_ctx, local_name, mac);
-        }
-        _ => (),
+    if let ScopeDef::ModuleDef(Macro(mac)) = resolution {
+        let ctx = ctx.import_to_add(import_to_add);
+        return render_macro_pat(ctx, pattern_ctx, local_name, mac);
     }
 
     render_resolution_simple_(ctx, &local_name, import_to_add, resolution)

--- a/crates/ide-completion/src/render/function.rs
+++ b/crates/ide-completion/src/render/function.rs
@@ -173,12 +173,12 @@ pub(super) fn add_call_parens<'b>(
                         }
                         None => {
                             let name = match param.ty().as_adt() {
-                                None => "_".to_string(),
+                                None => "_".to_owned(),
                                 Some(adt) => adt
                                     .name(ctx.db)
                                     .as_text()
                                     .map(|s| to_lower_snake_case(s.as_str()))
-                                    .unwrap_or_else(|| "_".to_string()),
+                                    .unwrap_or_else(|| "_".to_owned()),
                             };
                             f(&format_args!("${{{}:{name}}}", index + offset))
                         }

--- a/crates/ide-completion/src/render/literal.rs
+++ b/crates/ide-completion/src/render/literal.rs
@@ -54,11 +54,11 @@ fn render(
 ) -> Option<Builder> {
     let db = completion.db;
     let mut kind = thing.kind(db);
-    let should_add_parens = match &path_ctx {
-        PathCompletionCtx { has_call_parens: true, .. } => false,
-        PathCompletionCtx { kind: PathKind::Use | PathKind::Type { .. }, .. } => false,
-        _ => true,
-    };
+    let should_add_parens = !matches!(
+        path_ctx,
+        PathCompletionCtx { has_call_parens: true, .. }
+            | PathCompletionCtx { kind: PathKind::Use | PathKind::Type { .. }, .. }
+    );
 
     let fields = thing.fields(completion)?;
     let (qualified_name, short_qualified_name, qualified) = match path {

--- a/crates/ide-completion/src/render/macro_.rs
+++ b/crates/ide-completion/src/render/macro_.rs
@@ -94,7 +94,7 @@ fn label(
 ) -> SmolStr {
     if needs_bang {
         if ctx.snippet_cap().is_some() {
-            SmolStr::from_iter([&*name, "!", bra, "…", ket])
+            SmolStr::from_iter([name, "!", bra, "…", ket])
         } else {
             banged_name(name)
         }

--- a/crates/ide-completion/src/tests.rs
+++ b/crates/ide-completion/src/tests.rs
@@ -202,7 +202,7 @@ pub(crate) fn check_edit_with_config(
             .import_to_add
             .iter()
             .cloned()
-            .filter_map(|(import_path, import_name)| Some((import_path, import_name))),
+            .map(|(import_path, import_name)| (import_path, import_name)),
     )
     .into_iter()
     .flatten()

--- a/crates/ide-db/Cargo.toml
+++ b/crates/ide-db/Cargo.toml
@@ -48,3 +48,6 @@ xshell = "0.2.2"
 # local deps
 test-utils.workspace = true
 sourcegen.workspace = true
+
+[lints]
+workspace = true

--- a/crates/ide-db/src/generated/lints.rs
+++ b/crates/ide-db/src/generated/lints.rs
@@ -2056,7 +2056,7 @@ A simple example is:
 fn foo<T: ?Sized>(_f: impl AsRef<T>) {}
 
 fn main() {
-    foo::<str>("".to_string());
+    foo::<str>("".to_owned());
 }
 ```
 
@@ -2066,7 +2066,7 @@ This is currently rejected:
 error[E0632]: cannot provide explicit generic arguments when `impl Trait` is used in argument position
  --> src/main.rs:6:11
   |
-6 |     foo::<str>("".to_string());
+6 |     foo::<str>("".to_owned());
   |           ^^^ explicit generic argument not allowed
 
 ```
@@ -2083,11 +2083,11 @@ fn foo<T: ?Sized>(_f: impl AsRef<T>) {}
 fn bar<T: ?Sized, F: AsRef<T>>(_f: F) {}
 
 fn main() {
-    bar::<str, _>("".to_string()); // Okay
-    bar::<str, String>("".to_string()); // Okay
+    bar::<str, _>("".to_owned()); // Okay
+    bar::<str, String>("".to_owned()); // Okay
 
-    foo::<str>("".to_string()); // Okay
-    foo::<str, String>("".to_string()); // Error, you cannot specify `impl Trait` explicitly
+    foo::<str>("".to_owned()); // Okay
+    foo::<str, String>("".to_owned()); // Error, you cannot specify `impl Trait` explicitly
 }
 ```
 "##,

--- a/crates/ide-db/src/items_locator.rs
+++ b/crates/ide-db/src/items_locator.rs
@@ -112,9 +112,9 @@ fn find_items<'a>(
     let local_results = local_query
         .search(&symbol_index::crate_symbols(db, krate))
         .into_iter()
-        .filter_map(|local_candidate| match local_candidate.def {
-            hir::ModuleDef::Macro(macro_def) => Some(ItemInNs::Macros(macro_def)),
-            def => Some(ItemInNs::from(def)),
+        .map(|local_candidate| match local_candidate.def {
+            hir::ModuleDef::Macro(macro_def) => ItemInNs::Macros(macro_def),
+            def => ItemInNs::from(def),
         });
 
     external_importables.chain(local_results).filter(move |&item| match assoc_item_search {

--- a/crates/ide-db/src/lib.rs
+++ b/crates/ide-db/src/lib.rs
@@ -95,19 +95,19 @@ impl fmt::Debug for RootDatabase {
 
 impl Upcast<dyn ExpandDatabase> for RootDatabase {
     fn upcast(&self) -> &(dyn ExpandDatabase + 'static) {
-        &*self
+        self
     }
 }
 
 impl Upcast<dyn DefDatabase> for RootDatabase {
     fn upcast(&self) -> &(dyn DefDatabase + 'static) {
-        &*self
+        self
     }
 }
 
 impl Upcast<dyn HirDatabase> for RootDatabase {
     fn upcast(&self) -> &(dyn HirDatabase + 'static) {
-        &*self
+        self
     }
 }
 

--- a/crates/ide-db/src/syntax_helpers/format_string_exprs.rs
+++ b/crates/ide-db/src/syntax_helpers/format_string_exprs.rs
@@ -203,7 +203,7 @@ mod tests {
     use expect_test::{expect, Expect};
 
     fn check(input: &str, expect: &Expect) {
-        let (output, exprs) = parse_format_exprs(input).unwrap_or(("-".to_string(), vec![]));
+        let (output, exprs) = parse_format_exprs(input).unwrap_or(("-".to_owned(), vec![]));
         let outcome_repr = if !exprs.is_empty() {
             format!("{output}; {}", with_placeholders(exprs).join(", "))
         } else {

--- a/crates/ide-diagnostics/Cargo.toml
+++ b/crates/ide-diagnostics/Cargo.toml
@@ -35,3 +35,6 @@ sourcegen.workspace = true
 
 [features]
 in-rust-tree = []
+
+[lints]
+workspace = true

--- a/crates/ide-diagnostics/src/handlers/inactive_code.rs
+++ b/crates/ide-diagnostics/src/handlers/inactive_code.rs
@@ -16,7 +16,7 @@ pub(crate) fn inactive_code(
     }
 
     let inactive = DnfExpr::new(d.cfg.clone()).why_inactive(&d.opts);
-    let mut message = "code is inactive due to #[cfg] directives".to_string();
+    let mut message = "code is inactive due to #[cfg] directives".to_owned();
 
     if let Some(inactive) = inactive {
         let inactive_reasons = inactive.to_string();

--- a/crates/ide-diagnostics/src/handlers/incoherent_impl.rs
+++ b/crates/ide-diagnostics/src/handlers/incoherent_impl.rs
@@ -8,7 +8,7 @@ use crate::{Diagnostic, DiagnosticsContext, Severity};
 pub(crate) fn incoherent_impl(ctx: &DiagnosticsContext<'_>, d: &hir::IncoherentImpl) -> Diagnostic {
     Diagnostic::new(
         "incoherent-impl",
-        format!("cannot define inherent `impl` for foreign type"),
+        "cannot define inherent `impl` for foreign type".to_string(),
         ctx.sema.diagnostics_display_range(InFile::new(d.file_id, d.impl_.clone().into())).range,
     )
     .severity(Severity::Error)

--- a/crates/ide-diagnostics/src/handlers/incoherent_impl.rs
+++ b/crates/ide-diagnostics/src/handlers/incoherent_impl.rs
@@ -8,7 +8,7 @@ use crate::{Diagnostic, DiagnosticsContext, Severity};
 pub(crate) fn incoherent_impl(ctx: &DiagnosticsContext<'_>, d: &hir::IncoherentImpl) -> Diagnostic {
     Diagnostic::new(
         "incoherent-impl",
-        "cannot define inherent `impl` for foreign type".to_string(),
+        "cannot define inherent `impl` for foreign type".to_owned(),
         ctx.sema.diagnostics_display_range(InFile::new(d.file_id, d.impl_.clone().into())).range,
     )
     .severity(Severity::Error)

--- a/crates/ide-diagnostics/src/handlers/json_is_not_rust.rs
+++ b/crates/ide-diagnostics/src/handlers/json_is_not_rust.rs
@@ -42,12 +42,12 @@ impl State {
             v.push("Deserialize");
         }
         match v.as_slice() {
-            [] => "".to_string(),
+            [] => "".to_owned(),
             [x] => format!("#[derive({x})]\n"),
             [x, y] => format!("#[derive({x}, {y})]\n"),
             _ => {
                 never!();
-                "".to_string()
+                "".to_owned()
             }
         }
     }
@@ -175,7 +175,7 @@ mod tests {
     #[test]
     fn diagnostic_for_simple_case() {
         let mut config = DiagnosticsConfig::test_sample();
-        config.disabled.insert("syntax-error".to_string());
+        config.disabled.insert("syntax-error".to_owned());
         check_diagnostics_with_config(
             config,
             r#"

--- a/crates/ide-diagnostics/src/handlers/macro_error.rs
+++ b/crates/ide-diagnostics/src/handlers/macro_error.rs
@@ -90,7 +90,7 @@ pub macro panic {
 
         // FIXME: This is a false-positive, the file is actually linked in via
         // `include!` macro
-        config.disabled.insert("unlinked-file".to_string());
+        config.disabled.insert("unlinked-file".to_owned());
 
         check_diagnostics_with_config(
             config,

--- a/crates/ide-diagnostics/src/handlers/missing_fields.rs
+++ b/crates/ide-diagnostics/src/handlers/missing_fields.rs
@@ -102,7 +102,7 @@ fn fixes(ctx: &DiagnosticsContext<'_>, d: &hir::MissingFields) -> Option<Vec<Ass
             let generate_fill_expr = |ty: &Type| match ctx.config.expr_fill_default {
                 crate::ExprFillDefaultMode::Todo => make::ext::expr_todo(),
                 crate::ExprFillDefaultMode::Default => {
-                    get_default_constructor(ctx, d, ty).unwrap_or_else(|| make::ext::expr_todo())
+                    get_default_constructor(ctx, d, ty).unwrap_or_else(make::ext::expr_todo)
                 }
             };
 

--- a/crates/ide-diagnostics/src/handlers/missing_fields.rs
+++ b/crates/ide-diagnostics/src/handlers/missing_fields.rs
@@ -177,7 +177,7 @@ fn make_ty(ty: &hir::Type, db: &dyn HirDatabase, module: hir::Module) -> ast::Ty
     let ty_str = match ty.as_adt() {
         Some(adt) => adt.name(db).display(db.upcast()).to_string(),
         None => {
-            ty.display_source_code(db, module.into(), false).ok().unwrap_or_else(|| "_".to_string())
+            ty.display_source_code(db, module.into(), false).ok().unwrap_or_else(|| "_".to_owned())
         }
     };
 

--- a/crates/ide-diagnostics/src/handlers/missing_unsafe.rs
+++ b/crates/ide-diagnostics/src/handlers/missing_unsafe.rs
@@ -312,7 +312,7 @@ fn main() {
         check_fix(
             r#"
 unsafe fn foo() -> String {
-    "string".to_string()
+    "string".to_owned()
 }
 
 fn main() {
@@ -321,7 +321,7 @@ fn main() {
 "#,
             r#"
 unsafe fn foo() -> String {
-    "string".to_string()
+    "string".to_owned()
 }
 
 fn main() {

--- a/crates/ide-diagnostics/src/handlers/mutability_errors.rs
+++ b/crates/ide-diagnostics/src/handlers/mutability_errors.rs
@@ -19,7 +19,7 @@ pub(crate) fn need_mut(ctx: &DiagnosticsContext<'_>, d: &hir::NeedMut) -> Diagno
         for source in d.local.sources(ctx.sema.db) {
             let Some(ast) = source.name() else { continue };
             // FIXME: macros
-            edit_builder.insert(ast.value.syntax().text_range().start(), "mut ".to_string());
+            edit_builder.insert(ast.value.syntax().text_range().start(), "mut ".to_owned());
         }
         let edit = edit_builder.finish();
         Some(vec![fix(

--- a/crates/ide-diagnostics/src/handlers/replace_filter_map_next_with_find_map.rs
+++ b/crates/ide-diagnostics/src/handlers/replace_filter_map_next_with_find_map.rs
@@ -63,8 +63,8 @@ mod tests {
     #[track_caller]
     pub(crate) fn check_diagnostics(ra_fixture: &str) {
         let mut config = DiagnosticsConfig::test_sample();
-        config.disabled.insert("inactive-code".to_string());
-        config.disabled.insert("unresolved-method".to_string());
+        config.disabled.insert("inactive-code".to_owned());
+        config.disabled.insert("unresolved-method".to_owned());
         check_diagnostics_with_config(config, ra_fixture)
     }
 

--- a/crates/ide-diagnostics/src/handlers/type_mismatch.rs
+++ b/crates/ide-diagnostics/src/handlers/type_mismatch.rs
@@ -183,7 +183,7 @@ fn str_ref_to_owned(
     let expr = expr_ptr.value.to_node(&root);
     let expr_range = expr.syntax().text_range();
 
-    let to_owned = format!(".to_owned()");
+    let to_owned = ".to_owned()".to_string();
 
     let edit = TextEdit::insert(expr.syntax().text_range().end(), to_owned);
     let source_change =

--- a/crates/ide-diagnostics/src/handlers/type_mismatch.rs
+++ b/crates/ide-diagnostics/src/handlers/type_mismatch.rs
@@ -129,7 +129,7 @@ fn add_missing_ok_or_some(
 
     let mut builder = TextEdit::builder();
     builder.insert(expr.syntax().text_range().start(), format!("{variant_name}("));
-    builder.insert(expr.syntax().text_range().end(), ")".to_string());
+    builder.insert(expr.syntax().text_range().end(), ")".to_owned());
     let source_change =
         SourceChange::from_text_edit(expr_ptr.file_id.original_file(ctx.sema.db), builder.finish());
     let name = format!("Wrap in {variant_name}");
@@ -183,7 +183,7 @@ fn str_ref_to_owned(
     let expr = expr_ptr.value.to_node(&root);
     let expr_range = expr.syntax().text_range();
 
-    let to_owned = ".to_owned()".to_string();
+    let to_owned = ".to_owned()".to_owned();
 
     let edit = TextEdit::insert(expr.syntax().text_range().end(), to_owned);
     let source_change =

--- a/crates/ide-diagnostics/src/handlers/unimplemented_builtin_macro.rs
+++ b/crates/ide-diagnostics/src/handlers/unimplemented_builtin_macro.rs
@@ -9,7 +9,7 @@ pub(crate) fn unimplemented_builtin_macro(
 ) -> Diagnostic {
     Diagnostic::new(
         "unimplemented-builtin-macro",
-        "unimplemented built-in macro".to_string(),
+        "unimplemented built-in macro".to_owned(),
         ctx.sema.diagnostics_display_range(d.node.clone()).range,
     )
     .severity(Severity::WeakWarning)

--- a/crates/ide-diagnostics/src/handlers/unresolved_field.rs
+++ b/crates/ide-diagnostics/src/handlers/unresolved_field.rs
@@ -55,7 +55,7 @@ fn method_fix(
     let FileRange { range, file_id } = ctx.sema.original_range_opt(expr.syntax())?;
     Some(vec![Assist {
         id: AssistId("expected-field-found-method-call-fix", AssistKind::QuickFix),
-        label: Label::new("Use parentheses to call the method".to_string()),
+        label: Label::new("Use parentheses to call the method".to_owned()),
         group: None,
         target: range,
         source_change: Some(SourceChange::from_text_edit(

--- a/crates/ide-diagnostics/src/handlers/unresolved_method.rs
+++ b/crates/ide-diagnostics/src/handlers/unresolved_method.rs
@@ -70,7 +70,7 @@ fn field_fix(
     };
     Some(vec![Assist {
         id: AssistId("expected-method-found-field-fix", AssistKind::QuickFix),
-        label: Label::new("Use parentheses to call the value of the field".to_string()),
+        label: Label::new("Use parentheses to call the value of the field".to_owned()),
         group: None,
         target: range,
         source_change: Some(SourceChange::from_iter([

--- a/crates/ide-diagnostics/src/handlers/unresolved_module.rs
+++ b/crates/ide-diagnostics/src/handlers/unresolved_module.rs
@@ -15,7 +15,7 @@ pub(crate) fn unresolved_module(
     Diagnostic::new(
         "unresolved-module",
         match &*d.candidates {
-            [] => "unresolved module".to_string(),
+            [] => "unresolved module".to_owned(),
             [candidate] => format!("unresolved module, can't find module file: {candidate}"),
             [candidates @ .., last] => {
                 format!(
@@ -45,7 +45,7 @@ fn fixes(ctx: &DiagnosticsContext<'_>, d: &hir::UnresolvedModule) -> Option<Vec<
                             anchor: d.decl.file_id.original_file(ctx.sema.db),
                             path: candidate.clone(),
                         },
-                        initial_contents: "".to_string(),
+                        initial_contents: "".to_owned(),
                     }
                     .into(),
                     unresolved_module.syntax().text_range(),

--- a/crates/ide-diagnostics/src/handlers/unresolved_proc_macro.rs
+++ b/crates/ide-diagnostics/src/handlers/unresolved_proc_macro.rs
@@ -27,7 +27,7 @@ pub(crate) fn unresolved_proc_macro(
 
     let not_expanded_message = match &d.macro_name {
         Some(name) => format!("proc macro `{name}` not expanded"),
-        None => "proc macro not expanded".to_string(),
+        None => "proc macro not expanded".to_owned(),
     };
     let severity = if config_enabled { Severity::Error } else { Severity::WeakWarning };
     let def_map = ctx.sema.db.crate_def_map(d.krate);

--- a/crates/ide-diagnostics/src/handlers/useless_braces.rs
+++ b/crates/ide-diagnostics/src/handlers/useless_braces.rs
@@ -33,7 +33,7 @@ pub(crate) fn useless_braces(
         acc.push(
             Diagnostic::new(
                 "unnecessary-braces",
-                "Unnecessary braces in use statement".to_string(),
+                "Unnecessary braces in use statement".to_owned(),
                 use_range,
             )
             .severity(Severity::WeakWarning)

--- a/crates/ide-diagnostics/src/lib.rs
+++ b/crates/ide-diagnostics/src/lib.rs
@@ -310,8 +310,8 @@ pub fn diagnostics(
     }
 
     res.retain(|d| {
-        !ctx.config.disabled.contains(d.code.as_str())
-            && !(ctx.config.disable_experimental && d.experimental)
+        !(ctx.config.disabled.contains(d.code.as_str())
+            || ctx.config.disable_experimental && d.experimental)
     });
 
     res

--- a/crates/ide-diagnostics/src/tests.rs
+++ b/crates/ide-diagnostics/src/tests.rs
@@ -92,7 +92,7 @@ pub(crate) fn check_expect(ra_fixture: &str, expect: Expect) {
 #[track_caller]
 pub(crate) fn check_diagnostics(ra_fixture: &str) {
     let mut config = DiagnosticsConfig::test_sample();
-    config.disabled.insert("inactive-code".to_string());
+    config.disabled.insert("inactive-code".to_owned());
     check_diagnostics_with_config(config, ra_fixture)
 }
 
@@ -159,7 +159,7 @@ fn minicore_smoke_test() {
         let source = minicore.source_code();
         let mut config = DiagnosticsConfig::test_sample();
         // This should be ignored since we conditionaly remove code which creates single item use with braces
-        config.disabled.insert("unnecessary-braces".to_string());
+        config.disabled.insert("unnecessary-braces".to_owned());
         check_diagnostics_with_config(config, &source);
     }
 

--- a/crates/ide-ssr/Cargo.toml
+++ b/crates/ide-ssr/Cargo.toml
@@ -31,3 +31,6 @@ expect-test = "1.4.0"
 
 # local deps
 test-utils.workspace = true
+
+[lints]
+workspace = true

--- a/crates/ide-ssr/src/fragments.rs
+++ b/crates/ide-ssr/src/fragments.rs
@@ -35,7 +35,9 @@ pub(crate) fn stmt(s: &str) -> Result<SyntaxNode, ()> {
         parse.tree().syntax().descendants().skip(2).find_map(ast::Stmt::cast).ok_or(())?;
     if !s.ends_with(';') && node.to_string().ends_with(';') {
         node = node.clone_for_update();
-        node.syntax().last_token().map(|it| it.detach());
+        if let Some(it) = node.syntax().last_token() {
+            it.detach()
+        }
     }
     if node.to_string() != s {
         return Err(());

--- a/crates/ide-ssr/src/matching.rs
+++ b/crates/ide-ssr/src/matching.rs
@@ -310,6 +310,7 @@ impl<'db, 'sema> Matcher<'db, 'sema> {
         Ok(())
     }
 
+    #[allow(clippy::only_used_in_recursion)]
     fn check_constraint(
         &self,
         constraint: &Constraint,
@@ -320,7 +321,7 @@ impl<'db, 'sema> Matcher<'db, 'sema> {
                 kind.matches(code)?;
             }
             Constraint::Not(sub) => {
-                if self.check_constraint(&*sub, code).is_ok() {
+                if self.check_constraint(sub, code).is_ok() {
                     fail_match!("Constraint {:?} failed for '{}'", constraint, code.text());
                 }
             }
@@ -762,12 +763,7 @@ impl Iterator for PatternIterator {
     type Item = SyntaxElement;
 
     fn next(&mut self) -> Option<SyntaxElement> {
-        for element in &mut self.iter {
-            if !element.kind().is_trivia() {
-                return Some(element);
-            }
-        }
-        None
+        self.iter.by_ref().find(|element| !element.kind().is_trivia())
     }
 }
 

--- a/crates/ide/Cargo.toml
+++ b/crates/ide/Cargo.toml
@@ -52,3 +52,6 @@ test-utils.workspace = true
 
 [features]
 in-rust-tree = ["ide-assists/in-rust-tree", "ide-diagnostics/in-rust-tree"]
+
+[lints]
+workspace = true

--- a/crates/ide/src/annotations.rs
+++ b/crates/ide/src/annotations.rs
@@ -94,10 +94,9 @@ pub(crate) fn annotations(
                         enum_
                             .variants(db)
                             .into_iter()
-                            .map(|variant| {
+                            .filter_map(|variant| {
                                 variant.source(db).and_then(|node| name_range(db, node, file_id))
                             })
-                            .flatten()
                             .for_each(|range| {
                                 let (annotation_range, target_position) = mk_ranges(range);
                                 annotations.push(Annotation {

--- a/crates/ide/src/annotations/fn_references.rs
+++ b/crates/ide/src/annotations/fn_references.rs
@@ -14,7 +14,7 @@ pub(super) fn find_all_methods(
 ) -> Vec<(TextRange, Option<TextRange>)> {
     let sema = Semantics::new(db);
     let source_file = sema.parse(file_id);
-    source_file.syntax().descendants().filter_map(|it| method_range(it)).collect()
+    source_file.syntax().descendants().filter_map(method_range).collect()
 }
 
 fn method_range(item: SyntaxNode) -> Option<(TextRange, Option<TextRange>)> {

--- a/crates/ide/src/doc_links.rs
+++ b/crates/ide/src/doc_links.rs
@@ -342,8 +342,12 @@ fn get_doc_links(
     web_url = join_url(web_url, &file);
     local_url = join_url(local_url, &file);
 
-    web_url.as_mut().map(|url| url.set_fragment(frag.as_deref()));
-    local_url.as_mut().map(|url| url.set_fragment(frag.as_deref()));
+    if let Some(url) = web_url.as_mut() {
+        url.set_fragment(frag.as_deref());
+    }
+    if let Some(url) = local_url.as_mut() {
+        url.set_fragment(frag.as_deref());
+    }
 
     DocumentationLinks {
         web_url: web_url.map(|it| it.into()),

--- a/crates/ide/src/doc_links/tests.rs
+++ b/crates/ide/src/doc_links/tests.rs
@@ -28,9 +28,6 @@ fn check_external_docs(
     let web_url = links.web_url;
     let local_url = links.local_url;
 
-    println!("web_url: {:?}", web_url);
-    println!("local_url: {:?}", local_url);
-
     match (expect_web_url, web_url) {
         (Some(expect), Some(url)) => expect.assert_eq(&url),
         (None, None) => (),
@@ -127,10 +124,10 @@ fn external_docs_doc_builtin_type() {
 //- /main.rs crate:foo
 let x: u3$02 = 0;
 "#,
-        Some(&OsStr::new("/home/user/project")),
+        Some(OsStr::new("/home/user/project")),
         Some(expect![[r#"https://doc.rust-lang.org/nightly/core/primitive.u32.html"#]]),
         Some(expect![[r#"file:///sysroot/share/doc/rust/html/core/primitive.u32.html"#]]),
-        Some(&OsStr::new("/sysroot")),
+        Some(OsStr::new("/sysroot")),
     );
 }
 
@@ -143,10 +140,10 @@ use foo$0::Foo;
 //- /lib.rs crate:foo
 pub struct Foo;
 "#,
-        Some(&OsStr::new("/home/user/project")),
+        Some(OsStr::new("/home/user/project")),
         Some(expect![[r#"https://docs.rs/foo/*/foo/index.html"#]]),
         Some(expect![[r#"file:///home/user/project/doc/foo/index.html"#]]),
-        Some(&OsStr::new("/sysroot")),
+        Some(OsStr::new("/sysroot")),
     );
 }
 
@@ -157,10 +154,10 @@ fn external_docs_doc_url_std_crate() {
 //- /main.rs crate:std
 use self$0;
 "#,
-        Some(&OsStr::new("/home/user/project")),
+        Some(OsStr::new("/home/user/project")),
         Some(expect!["https://doc.rust-lang.org/stable/std/index.html"]),
         Some(expect!["file:///sysroot/share/doc/rust/html/std/index.html"]),
-        Some(&OsStr::new("/sysroot")),
+        Some(OsStr::new("/sysroot")),
     );
 }
 
@@ -171,10 +168,10 @@ fn external_docs_doc_url_struct() {
 //- /main.rs crate:foo
 pub struct Fo$0o;
 "#,
-        Some(&OsStr::new("/home/user/project")),
+        Some(OsStr::new("/home/user/project")),
         Some(expect![[r#"https://docs.rs/foo/*/foo/struct.Foo.html"#]]),
         Some(expect![[r#"file:///home/user/project/doc/foo/struct.Foo.html"#]]),
-        Some(&OsStr::new("/sysroot")),
+        Some(OsStr::new("/sysroot")),
     );
 }
 
@@ -185,10 +182,10 @@ fn external_docs_doc_url_windows_backslash_path() {
 //- /main.rs crate:foo
 pub struct Fo$0o;
 "#,
-        Some(&OsStr::new(r"C:\Users\user\project")),
+        Some(OsStr::new(r"C:\Users\user\project")),
         Some(expect![[r#"https://docs.rs/foo/*/foo/struct.Foo.html"#]]),
         Some(expect![[r#"file:///C:/Users/user/project/doc/foo/struct.Foo.html"#]]),
-        Some(&OsStr::new("/sysroot")),
+        Some(OsStr::new("/sysroot")),
     );
 }
 
@@ -199,10 +196,10 @@ fn external_docs_doc_url_windows_slash_path() {
 //- /main.rs crate:foo
 pub struct Fo$0o;
 "#,
-        Some(&OsStr::new(r"C:/Users/user/project")),
+        Some(OsStr::new(r"C:/Users/user/project")),
         Some(expect![[r#"https://docs.rs/foo/*/foo/struct.Foo.html"#]]),
         Some(expect![[r#"file:///C:/Users/user/project/doc/foo/struct.Foo.html"#]]),
-        Some(&OsStr::new("/sysroot")),
+        Some(OsStr::new("/sysroot")),
     );
 }
 

--- a/crates/ide/src/fetch_crates.rs
+++ b/crates/ide/src/fetch_crates.rs
@@ -27,7 +27,7 @@ pub(crate) fn fetch_crates(db: &RootDatabase) -> FxIndexSet<CrateInfo> {
         .iter()
         .map(|crate_id| &crate_graph[crate_id])
         .filter(|&data| !matches!(data.origin, CrateOrigin::Local { .. }))
-        .map(|data| crate_info(data))
+        .map(crate_info)
         .collect()
 }
 

--- a/crates/ide/src/folding_ranges.rs
+++ b/crates/ide/src/folding_ranges.rs
@@ -220,6 +220,7 @@ fn contiguous_range_for_comment(
         return None;
     }
 
+    #[allow(clippy::redundant_clone)] // false positive
     let mut last = first.clone();
     for element in first.syntax().siblings_with_tokens(Direction::Next) {
         match element {
@@ -271,7 +272,7 @@ fn fold_range_for_where_clause(where_clause: ast::WhereClause) -> Option<TextRan
 }
 
 fn fold_range_for_multiline_match_arm(match_arm: ast::MatchArm) -> Option<TextRange> {
-    if let Some(_) = fold_kind(match_arm.expr()?.syntax().kind()) {
+    if fold_kind(match_arm.expr()?.syntax().kind()).is_some() {
         return None;
     }
     if match_arm.expr()?.syntax().text().contains_char('\n') {

--- a/crates/ide/src/highlight_related.rs
+++ b/crates/ide/src/highlight_related.rs
@@ -462,8 +462,7 @@ fn find_defs(sema: &Semantics<'_, RootDatabase>, token: SyntaxToken) -> FxHashSe
     sema.descend_into_macros(token)
         .into_iter()
         .filter_map(|token| IdentClass::classify_token(sema, &token))
-        .map(IdentClass::definitions_no_ops)
-        .flatten()
+        .flat_map(IdentClass::definitions_no_ops)
         .collect()
 }
 

--- a/crates/ide/src/hover/render.rs
+++ b/crates/ide/src/hover/render.rs
@@ -127,7 +127,7 @@ pub(super) fn try_expr(
     let l = "Propagated as: ".len() - " Type: ".len();
     let static_text_len_diff = l as isize - s.len() as isize;
     let tpad = static_text_len_diff.max(0) as usize;
-    let ppad = static_text_len_diff.min(0).abs() as usize;
+    let ppad = static_text_len_diff.min(0).unsigned_abs();
 
     res.markup = format!(
         "```text\n{} Type: {:>pad0$}\nPropagated as: {:>pad1$}\n```\n",
@@ -337,7 +337,7 @@ pub(super) fn try_for_lint(attr: &ast::Attr, token: &SyntaxToken) -> Option<Hove
         tmp = format!("clippy::{}", token.text());
         &tmp
     } else {
-        &*token.text()
+        token.text()
     };
 
     let lint =
@@ -527,7 +527,7 @@ fn type_info(
         )
         .into()
     } else {
-        Markup::fenced_block(&original.display(sema.db))
+        Markup::fenced_block(original.display(sema.db))
     };
     res.actions.push(HoverAction::goto_type_from_targets(sema.db, targets));
     Some(res)
@@ -566,7 +566,7 @@ fn closure_ty(
     });
 
     let adjusted = if let Some(adjusted_ty) = adjusted {
-        walk_and_push_ty(sema.db, &adjusted_ty, &mut push_new_def);
+        walk_and_push_ty(sema.db, adjusted_ty, &mut push_new_def);
         format!(
             "\nCoerced to: {}",
             adjusted_ty.display(sema.db).with_closure_style(hir::ClosureStyle::ImplFn)

--- a/crates/ide/src/hover/render.rs
+++ b/crates/ide/src/hover/render.rs
@@ -552,7 +552,7 @@ fn closure_ty(
         })
         .join("\n");
     if captures_rendered.trim().is_empty() {
-        captures_rendered = "This closure captures nothing".to_string();
+        captures_rendered = "This closure captures nothing".to_owned();
     }
     let mut targets: Vec<hir::ModuleDef> = Vec::new();
     let mut push_new_def = |item: hir::ModuleDef| {

--- a/crates/ide/src/inlay_hints.rs
+++ b/crates/ide/src/inlay_hints.rs
@@ -321,7 +321,7 @@ fn label_of_ty(
         label_builder: &mut InlayHintLabelBuilder<'_>,
         config: &InlayHintsConfig,
     ) -> Result<(), HirDisplayError> {
-        let iter_item_type = hint_iterator(sema, famous_defs, &ty);
+        let iter_item_type = hint_iterator(sema, famous_defs, ty);
         match iter_item_type {
             Some((iter_trait, item, ty)) => {
                 const LABEL_START: &str = "impl ";

--- a/crates/ide/src/inlay_hints/discriminant.rs
+++ b/crates/ide/src/inlay_hints/discriminant.rs
@@ -74,7 +74,7 @@ fn variant_hints(
         },
         Some(InlayTooltip::String(match &d {
             Ok(_) => "enum variant discriminant".into(),
-            Err(e) => format!("{e:?}").into(),
+            Err(e) => format!("{e:?}"),
         })),
         None,
     );

--- a/crates/ide/src/inlay_hints/fn_lifetime_fn.rs
+++ b/crates/ide/src/inlay_hints/fn_lifetime_fn.rs
@@ -97,15 +97,13 @@ pub(super) fn hints(
         };
     {
         let mut potential_lt_refs = potential_lt_refs.iter().filter(|&&(.., is_elided)| is_elided);
-        if let Some(_) = &self_param {
-            if let Some(_) = potential_lt_refs.next() {
-                allocated_lifetimes.push(if config.param_names_for_lifetime_elision_hints {
-                    // self can't be used as a lifetime, so no need to check for collisions
-                    "'self".into()
-                } else {
-                    gen_idx_name()
-                });
-            }
+        if self_param.is_some() && potential_lt_refs.next().is_some() {
+            allocated_lifetimes.push(if config.param_names_for_lifetime_elision_hints {
+                // self can't be used as a lifetime, so no need to check for collisions
+                "'self".into()
+            } else {
+                gen_idx_name()
+            });
         }
         potential_lt_refs.for_each(|(name, ..)| {
             let name = match name {

--- a/crates/ide/src/inlay_hints/param_name.rs
+++ b/crates/ide/src/inlay_hints/param_name.rs
@@ -47,7 +47,7 @@ pub(super) fn hints(
             if let Some(name) = param {
                 if let hir::CallableKind::Function(f) = callable.kind() {
                     // assert the file is cached so we can map out of macros
-                    if let Some(_) = sema.source(f) {
+                    if sema.source(f).is_some() {
                         linked_location = sema.original_range_opt(name.syntax());
                     }
                 }

--- a/crates/ide/src/interpret_function.rs
+++ b/crates/ide/src/interpret_function.rs
@@ -18,7 +18,7 @@ pub(crate) fn interpret_function(db: &RootDatabase, position: FilePosition) -> S
     let mut result = find_and_interpret(db, position)
         .unwrap_or_else(|| "Not inside a function body".to_string());
     let duration = Instant::now() - start_time;
-    writeln!(result, "").unwrap();
+    writeln!(result).unwrap();
     writeln!(result, "----------------------").unwrap();
     writeln!(result, "  Finished in {}s", duration.as_secs_f32()).unwrap();
     result

--- a/crates/ide/src/interpret_function.rs
+++ b/crates/ide/src/interpret_function.rs
@@ -15,8 +15,8 @@ use syntax::{algo::find_node_at_offset, ast, AstNode};
 // |===
 pub(crate) fn interpret_function(db: &RootDatabase, position: FilePosition) -> String {
     let start_time = Instant::now();
-    let mut result = find_and_interpret(db, position)
-        .unwrap_or_else(|| "Not inside a function body".to_string());
+    let mut result =
+        find_and_interpret(db, position).unwrap_or_else(|| "Not inside a function body".to_owned());
     let duration = Instant::now() - start_time;
     writeln!(result).unwrap();
     writeln!(result, "----------------------").unwrap();

--- a/crates/ide/src/join_lines.rs
+++ b/crates/ide/src/join_lines.rs
@@ -154,7 +154,7 @@ fn remove_newline(
                 Some(_) => cov_mark::hit!(join_two_ifs_with_existing_else),
                 None => {
                     cov_mark::hit!(join_two_ifs);
-                    edit.replace(token.text_range(), " else ".to_string());
+                    edit.replace(token.text_range(), " else ".to_owned());
                     return;
                 }
             }

--- a/crates/ide/src/lib.rs
+++ b/crates/ide/src/lib.rs
@@ -259,7 +259,7 @@ impl Analysis {
 
     /// Debug info about the current state of the analysis.
     pub fn status(&self, file_id: Option<FileId>) -> Cancellable<String> {
-        self.with_db(|db| status::status(&*db, file_id))
+        self.with_db(|db| status::status(db, file_id))
     }
 
     pub fn parallel_prime_caches<F>(&self, num_worker_threads: u8, cb: F) -> Cancellable<()>
@@ -338,7 +338,7 @@ impl Analysis {
     }
 
     pub fn fetch_crates(&self) -> Cancellable<FxIndexSet<CrateInfo>> {
-        self.with_db(|db| fetch_crates::fetch_crates(db))
+        self.with_db(fetch_crates::fetch_crates)
     }
 
     pub fn expand_macro(&self, position: FilePosition) -> Cancellable<Option<ExpandedMacro>> {

--- a/crates/ide/src/lib.rs
+++ b/crates/ide/src/lib.rs
@@ -228,7 +228,7 @@ impl Analysis {
         let mut host = AnalysisHost::default();
         let file_id = FileId(0);
         let mut file_set = FileSet::default();
-        file_set.insert(file_id, VfsPath::new_virtual_path("/main.rs".to_string()));
+        file_set.insert(file_id, VfsPath::new_virtual_path("/main.rs".to_owned()));
         let source_root = SourceRoot::new_local(file_set);
 
         let mut change = Change::new();

--- a/crates/ide/src/markdown_remove.rs
+++ b/crates/ide/src/markdown_remove.rs
@@ -59,7 +59,7 @@ fn standalone_function() {
 
 pub fn public_thing(argument: bool) -> String {
     // code
-    # "".to_string()
+    # "".to_owned()
 }
 
 struct Thing {
@@ -120,7 +120,7 @@ book] or the [Reference].
 
             pub fn public_thing(argument: bool) -> String {
                 // code
-                # "".to_string()
+                # "".to_owned()
             }
 
             struct Thing {

--- a/crates/ide/src/moniker.rs
+++ b/crates/ide/src/moniker.rs
@@ -39,11 +39,8 @@ pub struct MonikerIdentifier {
 
 impl ToString for MonikerIdentifier {
     fn to_string(&self) -> String {
-        match self {
-            MonikerIdentifier { description, crate_name } => {
-                format!("{}::{}", crate_name, description.iter().map(|x| &x.name).join("::"))
-            }
-        }
+        let MonikerIdentifier { description, crate_name } = self;
+        format!("{}::{}", crate_name, description.iter().map(|x| &x.name).join("::"))
     }
 }
 

--- a/crates/ide/src/moniker.rs
+++ b/crates/ide/src/moniker.rs
@@ -264,12 +264,12 @@ pub(crate) fn def_to_moniker(
                 ),
                 CrateOrigin::Rustc { name } => (
                     name.clone(),
-                    Some("https://github.com/rust-lang/rust/".to_string()),
+                    Some("https://github.com/rust-lang/rust/".to_owned()),
                     Some(format!("https://github.com/rust-lang/rust/compiler/{name}",)),
                 ),
                 CrateOrigin::Lang(lang) => (
                     krate.display_name(db)?.canonical_name().to_string(),
-                    Some("https://github.com/rust-lang/rust/".to_string()),
+                    Some("https://github.com/rust-lang/rust/".to_owned()),
                     Some(match lang {
                         LangCrateOrigin::Other => {
                             "https://github.com/rust-lang/rust/library/".into()

--- a/crates/ide/src/navigation_target.rs
+++ b/crates/ide/src/navigation_target.rs
@@ -630,7 +630,7 @@ fn foo() { enum FooInner { } }
 "#,
         );
 
-        let navs = analysis.symbol_search(Query::new("FooInner".to_string())).unwrap();
+        let navs = analysis.symbol_search(Query::new("FooInner".to_owned())).unwrap();
         expect![[r#"
             [
                 NavigationTarget {
@@ -668,7 +668,7 @@ struct Foo;
 "#,
         );
 
-        let navs = analysis.symbol_search(Query::new("foo".to_string())).unwrap();
+        let navs = analysis.symbol_search(Query::new("foo".to_owned())).unwrap();
         assert_eq!(navs.len(), 2)
     }
 }

--- a/crates/ide/src/runnables.rs
+++ b/crates/ide/src/runnables.rs
@@ -71,7 +71,7 @@ impl Runnable {
             RunnableKind::Bench { test_id } => format!("bench {test_id}"),
             RunnableKind::DocTest { test_id, .. } => format!("doctest {test_id}"),
             RunnableKind::Bin => {
-                target.map_or_else(|| "run binary".to_string(), |t| format!("run {t}"))
+                target.map_or_else(|| "run binary".to_owned(), |t| format!("run {t}"))
             }
         }
     }

--- a/crates/ide/src/signature_help.rs
+++ b/crates/ide/src/signature_help.rs
@@ -633,7 +633,7 @@ fn signature_help_for_tuple_pat_ish(
         res.push_call_param(&buf);
         buf.clear();
     }
-    res.signature.push_str(")");
+    res.signature.push(')');
     res
 }
 #[cfg(test)]

--- a/crates/ide/src/syntax_highlighting.rs
+++ b/crates/ide/src/syntax_highlighting.rs
@@ -275,8 +275,8 @@ fn traverse(
                 inside_attribute = false
             }
 
-            Enter(NodeOrToken::Node(node)) => match ast::Item::cast(node.clone()) {
-                Some(item) => {
+            Enter(NodeOrToken::Node(node)) => {
+                if let Some(item) = ast::Item::cast(node.clone()) {
                     match item {
                         ast::Item::MacroRules(mac) => {
                             macro_highlighter.init();
@@ -317,8 +317,7 @@ fn traverse(
                         }
                     }
                 }
-                _ => (),
-            },
+            }
             Leave(NodeOrToken::Node(node)) if ast::Item::can_cast(node.kind()) => {
                 match ast::Item::cast(node.clone()) {
                     Some(ast::Item::MacroRules(mac)) => {

--- a/crates/ide/src/typing.rs
+++ b/crates/ide/src/typing.rs
@@ -342,12 +342,9 @@ fn on_left_angle_typed(file: &SourceFile, offset: TextSize) -> Option<ExtendedTe
         }
     }
 
-    if ancestors_at_offset(file.syntax(), offset)
-        .find(|n| {
-            ast::GenericParamList::can_cast(n.kind()) || ast::GenericArgList::can_cast(n.kind())
-        })
-        .is_some()
-    {
+    if ancestors_at_offset(file.syntax(), offset).any(|n| {
+        ast::GenericParamList::can_cast(n.kind()) || ast::GenericArgList::can_cast(n.kind())
+    }) {
         return Some(ExtendedTextEdit {
             edit: TextEdit::replace(range, "<$0>".to_string()),
             is_snippet: true,

--- a/crates/ide/src/typing.rs
+++ b/crates/ide/src/typing.rs
@@ -137,10 +137,7 @@ fn on_opening_brace_typed(file: &Parse<SourceFile>, offset: TextSize) -> Option<
 
         let tree: ast::UseTree = find_node_at_offset(file.syntax(), offset)?;
 
-        Some(TextEdit::insert(
-            tree.syntax().text_range().end() + TextSize::of("{"),
-            "}".to_string(),
-        ))
+        Some(TextEdit::insert(tree.syntax().text_range().end() + TextSize::of("{"), "}".to_owned()))
     }
 
     fn brace_expr(file: &SourceFile, offset: TextSize) -> Option<TextEdit> {
@@ -167,10 +164,7 @@ fn on_opening_brace_typed(file: &Parse<SourceFile>, offset: TextSize) -> Option<
         }
 
         // Insert `}` right after the expression.
-        Some(TextEdit::insert(
-            expr.syntax().text_range().end() + TextSize::of("{"),
-            "}".to_string(),
-        ))
+        Some(TextEdit::insert(expr.syntax().text_range().end() + TextSize::of("{"), "}".to_owned()))
     }
 }
 
@@ -218,7 +212,7 @@ fn on_eq_typed(file: &SourceFile, offset: TextSize) -> Option<TextEdit> {
             return None;
         }
         let offset = expr.syntax().text_range().end();
-        Some(TextEdit::insert(offset, ";".to_string()))
+        Some(TextEdit::insert(offset, ";".to_owned()))
     }
 
     /// `a =$0 b;` removes the semicolon if an expression is valid in this context.
@@ -258,7 +252,7 @@ fn on_eq_typed(file: &SourceFile, offset: TextSize) -> Option<TextEdit> {
             return None;
         }
         let offset = let_stmt.syntax().text_range().end();
-        Some(TextEdit::insert(offset, ";".to_string()))
+        Some(TextEdit::insert(offset, ";".to_owned()))
     }
 }
 
@@ -336,7 +330,7 @@ fn on_left_angle_typed(file: &SourceFile, offset: TextSize) -> Option<ExtendedTe
     if let Some(t) = file.syntax().token_at_offset(offset).left_biased() {
         if T![impl] == t.kind() {
             return Some(ExtendedTextEdit {
-                edit: TextEdit::replace(range, "<$0>".to_string()),
+                edit: TextEdit::replace(range, "<$0>".to_owned()),
                 is_snippet: true,
             });
         }
@@ -346,7 +340,7 @@ fn on_left_angle_typed(file: &SourceFile, offset: TextSize) -> Option<ExtendedTe
         ast::GenericParamList::can_cast(n.kind()) || ast::GenericArgList::can_cast(n.kind())
     }) {
         return Some(ExtendedTextEdit {
-            edit: TextEdit::replace(range, "<$0>".to_string()),
+            edit: TextEdit::replace(range, "<$0>".to_owned()),
             is_snippet: true,
         });
     }
@@ -368,7 +362,7 @@ fn on_right_angle_typed(file: &SourceFile, offset: TextSize) -> Option<TextEdit>
         return None;
     }
 
-    Some(TextEdit::insert(after_arrow, " ".to_string()))
+    Some(TextEdit::insert(after_arrow, " ".to_owned()))
 }
 
 #[cfg(test)]

--- a/crates/ide/src/view_crate_graph.rs
+++ b/crates/ide/src/view_crate_graph.rs
@@ -86,7 +86,7 @@ impl<'a> dot::Labeller<'a, CrateId, Edge<'a>> for DotCrateGraph {
     }
 
     fn node_label(&'a self, n: &CrateId) -> LabelText<'a> {
-        let name = self.graph[*n].display_name.as_ref().map_or("(unnamed crate)", |name| &*name);
+        let name = self.graph[*n].display_name.as_ref().map_or("(unnamed crate)", |name| name);
         LabelText::LabelStr(name.into())
     }
 }

--- a/crates/ide/src/view_hir.rs
+++ b/crates/ide/src/view_hir.rs
@@ -12,7 +12,7 @@ use syntax::{algo::find_node_at_offset, ast, AstNode};
 // |===
 // image::https://user-images.githubusercontent.com/48062697/113065588-068bdb80-91b1-11eb-9a78-0b4ef1e972fb.gif[]
 pub(crate) fn view_hir(db: &RootDatabase, position: FilePosition) -> String {
-    body_hir(db, position).unwrap_or_else(|| "Not inside a function body".to_string())
+    body_hir(db, position).unwrap_or_else(|| "Not inside a function body".to_owned())
 }
 
 fn body_hir(db: &RootDatabase, position: FilePosition) -> Option<String> {

--- a/crates/ide/src/view_mir.rs
+++ b/crates/ide/src/view_mir.rs
@@ -11,7 +11,7 @@ use syntax::{algo::find_node_at_offset, ast, AstNode};
 // | VS Code | **rust-analyzer: View Mir**
 // |===
 pub(crate) fn view_mir(db: &RootDatabase, position: FilePosition) -> String {
-    body_mir(db, position).unwrap_or_else(|| "Not inside a function body".to_string())
+    body_mir(db, position).unwrap_or_else(|| "Not inside a function body".to_owned())
 }
 
 fn body_mir(db: &RootDatabase, position: FilePosition) -> Option<String> {

--- a/crates/intern/Cargo.toml
+++ b/crates/intern/Cargo.toml
@@ -19,3 +19,6 @@ hashbrown = { version = "0.12.1", default-features = false }
 once_cell = "1.17.0"
 rustc-hash = "1.1.0"
 triomphe.workspace = true
+
+[lints]
+workspace = true

--- a/crates/intern/src/lib.rs
+++ b/crates/intern/src/lib.rs
@@ -33,13 +33,10 @@ impl<T: Internable> Interned<T> {
         //   - if not, box it up, insert it, and return a clone
         // This needs to be atomic (locking the shard) to avoid races with other thread, which could
         // insert the same object between us looking it up and inserting it.
-        match shard.raw_entry_mut().from_key_hashed_nocheck(hash as u64, &obj) {
+        match shard.raw_entry_mut().from_key_hashed_nocheck(hash, &obj) {
             RawEntryMut::Occupied(occ) => Self { arc: occ.key().clone() },
             RawEntryMut::Vacant(vac) => Self {
-                arc: vac
-                    .insert_hashed_nocheck(hash as u64, Arc::new(obj), SharedValue::new(()))
-                    .0
-                    .clone(),
+                arc: vac.insert_hashed_nocheck(hash, Arc::new(obj), SharedValue::new(())).0.clone(),
             },
         }
     }
@@ -54,13 +51,10 @@ impl Interned<str> {
         //   - if not, box it up, insert it, and return a clone
         // This needs to be atomic (locking the shard) to avoid races with other thread, which could
         // insert the same object between us looking it up and inserting it.
-        match shard.raw_entry_mut().from_key_hashed_nocheck(hash as u64, s) {
+        match shard.raw_entry_mut().from_key_hashed_nocheck(hash, s) {
             RawEntryMut::Occupied(occ) => Self { arc: occ.key().clone() },
             RawEntryMut::Vacant(vac) => Self {
-                arc: vac
-                    .insert_hashed_nocheck(hash as u64, Arc::from(s), SharedValue::new(()))
-                    .0
-                    .clone(),
+                arc: vac.insert_hashed_nocheck(hash, Arc::from(s), SharedValue::new(())).0.clone(),
             },
         }
     }

--- a/crates/limit/Cargo.toml
+++ b/crates/limit/Cargo.toml
@@ -11,3 +11,6 @@ rust-version.workspace = true
 [features]
 tracking = []
 default = ["tracking"]
+
+[lints]
+workspace = true

--- a/crates/mbe/Cargo.toml
+++ b/crates/mbe/Cargo.toml
@@ -25,3 +25,6 @@ stdx.workspace = true
 
 [dev-dependencies]
 test-utils.workspace = true
+
+[lints]
+workspace = true

--- a/crates/mbe/src/expander/transcriber.rs
+++ b/crates/mbe/src/expander/transcriber.rs
@@ -414,16 +414,16 @@ fn push_subtree(buf: &mut Vec<tt::TokenTree>, tt: tt::Subtree) {
 /// Handles `${count(t, depth)}`. `our_depth` is the recursion depth and `count_depth` is the depth
 /// defined by the metavar expression.
 fn count(
-    ctx: &ExpandCtx<'_>,
+    _ctx: &ExpandCtx<'_>,
     binding: &Binding,
     our_depth: usize,
     count_depth: Option<usize>,
 ) -> Result<usize, CountError> {
     match binding {
         Binding::Nested(bs) => match count_depth {
-            None => bs.iter().map(|b| count(ctx, b, our_depth + 1, None)).sum(),
+            None => bs.iter().map(|b| count(_ctx, b, our_depth + 1, None)).sum(),
             Some(0) => Ok(bs.len()),
-            Some(d) => bs.iter().map(|b| count(ctx, b, our_depth + 1, Some(d - 1))).sum(),
+            Some(d) => bs.iter().map(|b| count(_ctx, b, our_depth + 1, Some(d - 1))).sum(),
         },
         Binding::Empty => Ok(0),
         Binding::Fragment(_) | Binding::Missing(_) => {

--- a/crates/mbe/src/syntax_bridge.rs
+++ b/crates/mbe/src/syntax_bridge.rs
@@ -619,9 +619,8 @@ impl Converter {
                     return (None, v);
                 }
             }
-            match ele {
-                SyntaxElement::Token(t) => return (Some(t), Vec::new()),
-                _ => {}
+            if let SyntaxElement::Token(t) = ele {
+                return (Some(t), Vec::new());
             }
         }
         (None, Vec::new())

--- a/crates/parser/Cargo.toml
+++ b/crates/parser/Cargo.toml
@@ -22,3 +22,6 @@ expect-test = "1.4.0"
 
 stdx.workspace = true
 sourcegen.workspace = true
+
+[lints]
+workspace = true

--- a/crates/paths/Cargo.toml
+++ b/crates/paths/Cargo.toml
@@ -16,3 +16,6 @@ doctest = false
 # serde-derive crate. Even though we don't activate the derive feature here,
 # someone else in the crate graph certainly does!
 # serde.workspace = true
+
+[lints]
+workspace = true

--- a/crates/proc-macro-api/Cargo.toml
+++ b/crates/proc-macro-api/Cargo.toml
@@ -33,3 +33,6 @@ stdx.workspace = true
 profile.workspace = true
 # Intentionally *not* depend on anything salsa-related
 # base-db.workspace = true
+
+[lints]
+workspace = true

--- a/crates/proc-macro-api/src/lib.rs
+++ b/crates/proc-macro-api/src/lib.rs
@@ -162,7 +162,7 @@ impl ProcMacro {
                 Ok(it.map(|tree| FlatTree::to_subtree(tree, version)))
             }
             msg::Response::ListMacros(..) | msg::Response::ApiVersionCheck(..) => {
-                Err(ServerError { message: "unexpected response".to_string(), io: None })
+                Err(ServerError { message: "unexpected response".to_owned(), io: None })
             }
         }
     }

--- a/crates/proc-macro-api/src/msg.rs
+++ b/crates/proc-macro-api/src/msg.rs
@@ -19,6 +19,7 @@ pub const ENCODE_CLOSE_SPAN_VERSION: u32 = 2;
 
 pub const CURRENT_API_VERSION: u32 = ENCODE_CLOSE_SPAN_VERSION;
 
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, Serialize, Deserialize)]
 pub enum Request {
     ListMacros { dylib_path: PathBuf },

--- a/crates/proc-macro-api/src/process.rs
+++ b/crates/proc-macro-api/src/process.rs
@@ -63,7 +63,7 @@ impl ProcMacroProcessSrv {
         match response {
             Response::ApiVersionCheck(version) => Ok(version),
             Response::ExpandMacro { .. } | Response::ListMacros { .. } => {
-                Err(ServerError { message: "unexpected response".to_string(), io: None })
+                Err(ServerError { message: "unexpected response".to_owned(), io: None })
             }
         }
     }
@@ -79,7 +79,7 @@ impl ProcMacroProcessSrv {
         match response {
             Response::ListMacros(it) => Ok(it),
             Response::ExpandMacro { .. } | Response::ApiVersionCheck { .. } => {
-                Err(ServerError { message: "unexpected response".to_string(), io: None })
+                Err(ServerError { message: "unexpected response".to_owned(), io: None })
             }
         }
     }

--- a/crates/proc-macro-srv-cli/Cargo.toml
+++ b/crates/proc-macro-srv-cli/Cargo.toml
@@ -18,3 +18,6 @@ sysroot-abi = ["proc-macro-srv/sysroot-abi"]
 [[bin]]
 name = "rust-analyzer-proc-macro-srv"
 path = "src/main.rs"
+
+[lints]
+workspace = true

--- a/crates/proc-macro-srv/Cargo.toml
+++ b/crates/proc-macro-srv/Cargo.toml
@@ -36,3 +36,6 @@ proc-macro-test.workspace = true
 
 [features]
 sysroot-abi = []
+
+[lints]
+workspace = true

--- a/crates/proc-macro-srv/src/dylib.rs
+++ b/crates/proc-macro-srv/src/dylib.rs
@@ -154,7 +154,7 @@ impl Expander {
         attributes: Option<&crate::tt::Subtree>,
     ) -> Result<crate::tt::Subtree, String> {
         let result = self.inner.proc_macros.expand(macro_name, macro_body, attributes);
-        result.map_err(|e| e.as_str().unwrap_or_else(|| "<unknown error>".to_string()))
+        result.map_err(|e| e.as_str().unwrap_or_else(|| "<unknown error>".to_owned()))
     }
 
     pub fn list_macros(&self) -> Vec<(String, ProcMacroKind)> {

--- a/crates/proc-macro-srv/src/proc_macros.rs
+++ b/crates/proc-macro-srv/src/proc_macros.rs
@@ -92,7 +92,7 @@ impl ProcMacros {
             }
         }
 
-        Err(proc_macro::bridge::PanicMessage::String("Nothing to expand".to_string()).into())
+        Err(proc_macro::bridge::PanicMessage::String("Nothing to expand".to_owned()).into())
     }
 
     pub(crate) fn list_macros(&self) -> Vec<(String, ProcMacroKind)> {

--- a/crates/proc-macro-test/Cargo.toml
+++ b/crates/proc-macro-test/Cargo.toml
@@ -18,3 +18,6 @@ proc-macro-test-impl = { path = "imp", version = "0.0.0" }
 
 # local deps
 toolchain.workspace = true
+
+[lints]
+workspace = true

--- a/crates/proc-macro-test/build.rs
+++ b/crates/proc-macro-test/build.rs
@@ -86,7 +86,7 @@ fn main() {
     let mut artifact_path = None;
     for message in Message::parse_stream(output.stdout.as_slice()) {
         if let Message::CompilerArtifact(artifact) = message.unwrap() {
-            if artifact.target.kind.contains(&"proc-macro".to_string()) {
+            if artifact.target.kind.contains(&"proc-macro".to_owned()) {
                 let repr = format!("{name} {version}");
                 if artifact.package_id.repr.starts_with(&repr) {
                     artifact_path = Some(PathBuf::from(&artifact.filenames[0]));

--- a/crates/proc-macro-test/imp/src/lib.rs
+++ b/crates/proc-macro-test/imp/src/lib.rs
@@ -1,6 +1,7 @@
 //! Exports a few trivial procedural macros for testing.
 
 #![warn(rust_2018_idioms, unused_lifetimes, semicolon_in_expressions_from_macros)]
+#![allow(clippy::all)]
 
 use proc_macro::{Group, Ident, Literal, Punct, Span, TokenStream, TokenTree};
 

--- a/crates/profile/Cargo.toml
+++ b/crates/profile/Cargo.toml
@@ -31,3 +31,6 @@ jemalloc = ["jemalloc-ctl"]
 
 # Uncomment to enable for the whole crate graph
 # default = [ "cpu_profiler" ]
+
+[lints]
+workspace = true

--- a/crates/project-model/Cargo.toml
+++ b/crates/project-model/Cargo.toml
@@ -33,3 +33,6 @@ toolchain.workspace = true
 
 [dev-dependencies]
 expect-test = "1.4.0"
+
+[lints]
+workspace = true

--- a/crates/project-model/src/build_scripts.rs
+++ b/crates/project-model/src/build_scripts.rs
@@ -341,7 +341,7 @@ impl WorkspaceBuildScripts {
                                 if let Some(out_dir) =
                                     out_dir.as_os_str().to_str().map(|s| s.to_owned())
                                 {
-                                    data.envs.push(("OUT_DIR".to_string(), out_dir));
+                                    data.envs.push(("OUT_DIR".to_owned(), out_dir));
                                 }
                                 data.out_dir = Some(out_dir);
                                 data.cfgs = cfgs;
@@ -381,7 +381,7 @@ impl WorkspaceBuildScripts {
 
         let errors = if !output.status.success() {
             let errors = errors.into_inner();
-            Some(if errors.is_empty() { "cargo check failed".to_string() } else { errors })
+            Some(if errors.is_empty() { "cargo check failed".to_owned() } else { errors })
         } else {
             None
         };

--- a/crates/project-model/src/cargo_workspace.rs
+++ b/crates/project-model/src/cargo_workspace.rs
@@ -275,7 +275,7 @@ impl CargoWorkspace {
             other_options.append(
                 &mut targets
                     .into_iter()
-                    .flat_map(|target| ["--filter-platform".to_owned().to_string(), target])
+                    .flat_map(|target| ["--filter-platform".to_owned(), target])
                     .collect(),
             );
         }
@@ -366,7 +366,7 @@ impl CargoWorkspace {
                     name,
                     root: AbsPathBuf::assert(src_path.into()),
                     kind: TargetKind::new(&kind),
-                    is_proc_macro: &*kind == ["proc-macro"],
+                    is_proc_macro: *kind == ["proc-macro"],
                     required_features,
                 });
                 pkg_data.targets.push(tgt);
@@ -439,7 +439,7 @@ impl CargoWorkspace {
             .collect::<Vec<ManifestPath>>();
 
         // some packages has this pkg as dep. return their manifests
-        if parent_manifests.len() > 0 {
+        if !parent_manifests.is_empty() {
             return Some(parent_manifests);
         }
 

--- a/crates/project-model/src/cargo_workspace.rs
+++ b/crates/project-model/src/cargo_workspace.rs
@@ -284,7 +284,7 @@ impl CargoWorkspace {
         // FIXME: Fetching metadata is a slow process, as it might require
         // calling crates.io. We should be reporting progress here, but it's
         // unclear whether cargo itself supports it.
-        progress("metadata".to_string());
+        progress("metadata".to_owned());
 
         (|| -> Result<cargo_metadata::Metadata, cargo_metadata::Error> {
             let mut command = meta.cargo_command();

--- a/crates/project-model/src/manifest_path.rs
+++ b/crates/project-model/src/manifest_path.rs
@@ -36,7 +36,7 @@ impl ManifestPath {
     }
 
     pub fn canonicalize(&self) -> ! {
-        (&**self).canonicalize()
+        (**self).canonicalize()
     }
 }
 

--- a/crates/project-model/src/tests.rs
+++ b/crates/project-model/src/tests.rs
@@ -129,7 +129,7 @@ fn get_fake_sysroot() -> Sysroot {
 }
 
 fn rooted_project_json(data: ProjectJsonData) -> ProjectJson {
-    let mut root = "$ROOT$".to_string();
+    let mut root = "$ROOT$".to_owned();
     replace_root(&mut root, true);
     let path = Path::new(&root);
     let base = AbsPath::assert(path);

--- a/crates/project-model/src/tests.rs
+++ b/crates/project-model/src/tests.rs
@@ -106,7 +106,7 @@ fn replace_fake_sys_root(s: &mut String) {
     let fake_sysroot_path = get_test_path("fake-sysroot");
     let fake_sysroot_path = if cfg!(windows) {
         let normalized_path =
-            fake_sysroot_path.to_str().expect("expected str").replace(r#"\"#, r#"\\"#);
+            fake_sysroot_path.to_str().expect("expected str").replace('\\', r#"\\"#);
         format!(r#"{}\\"#, normalized_path)
     } else {
         format!("{}/", fake_sysroot_path.to_str().expect("expected str"))

--- a/crates/rust-analyzer/Cargo.toml
+++ b/crates/rust-analyzer/Cargo.toml
@@ -96,3 +96,6 @@ jemalloc = ["jemallocator", "profile/jemalloc"]
 force-always-assert = ["always-assert/force"]
 sysroot-abi = []
 in-rust-tree = ["sysroot-abi", "ide/in-rust-tree", "syntax/in-rust-tree"]
+
+[lints]
+workspace = true

--- a/crates/rust-analyzer/src/bin/main.rs
+++ b/crates/rust-analyzer/src/bin/main.rs
@@ -17,7 +17,7 @@ use lsp_server::Connection;
 use rust_analyzer::{cli::flags, config::Config, from_json, Result};
 use vfs::AbsPathBuf;
 
-#[cfg(all(feature = "mimalloc"))]
+#[cfg(feature = "mimalloc")]
 #[global_allocator]
 static ALLOC: mimalloc::MiMalloc = mimalloc::MiMalloc;
 

--- a/crates/rust-analyzer/src/caps.rs
+++ b/crates/rust-analyzer/src/caps.rs
@@ -42,17 +42,17 @@ pub fn server_capabilities(config: &Config) -> ServerCapabilities {
         completion_provider: Some(CompletionOptions {
             resolve_provider: completions_resolve_provider(config.caps()),
             trigger_characters: Some(vec![
-                ":".to_string(),
-                ".".to_string(),
-                "'".to_string(),
-                "(".to_string(),
+                ":".to_owned(),
+                ".".to_owned(),
+                "'".to_owned(),
+                "(".to_owned(),
             ]),
             all_commit_characters: None,
             completion_item: completion_item(config),
             work_done_progress_options: WorkDoneProgressOptions { work_done_progress: None },
         }),
         signature_help_provider: Some(SignatureHelpOptions {
-            trigger_characters: Some(vec!["(".to_string(), ",".to_string(), "<".to_string()]),
+            trigger_characters: Some(vec!["(".to_owned(), ",".to_owned(), "<".to_owned()]),
             retrigger_characters: None,
             work_done_progress_options: WorkDoneProgressOptions { work_done_progress: None },
         }),
@@ -72,7 +72,7 @@ pub fn server_capabilities(config: &Config) -> ServerCapabilities {
             _ => Some(OneOf::Left(false)),
         },
         document_on_type_formatting_provider: Some(DocumentOnTypeFormattingOptions {
-            first_trigger_character: "=".to_string(),
+            first_trigger_character: "=".to_owned(),
             more_trigger_character: Some(more_trigger_character(config)),
         }),
         selection_range_provider: Some(SelectionRangeProviderCapability::Simple(true)),
@@ -218,9 +218,9 @@ fn code_action_capabilities(client_caps: &ClientCapabilities) -> CodeActionProvi
 }
 
 fn more_trigger_character(config: &Config) -> Vec<String> {
-    let mut res = vec![".".to_string(), ">".to_string(), "{".to_string()];
+    let mut res = vec![".".to_owned(), ">".to_owned(), "{".to_owned()];
     if config.snippet_cap() {
-        res.push("<".to_string());
+        res.push("<".to_owned());
     }
     res
 }

--- a/crates/rust-analyzer/src/cli/analysis_stats.rs
+++ b/crates/rust-analyzer/src/cli/analysis_stats.rs
@@ -54,10 +54,12 @@ impl flags::AnalysisStats {
             Rand32::new(seed)
         };
 
-        let mut cargo_config = CargoConfig::default();
-        cargo_config.sysroot = match self.no_sysroot {
-            true => None,
-            false => Some(RustLibSource::Discover),
+        let cargo_config = CargoConfig {
+            sysroot: match self.no_sysroot {
+                true => None,
+                false => Some(RustLibSource::Discover),
+            },
+            ..Default::default()
         };
         let no_progress = &|_| ();
 
@@ -210,7 +212,7 @@ impl flags::AnalysisStats {
                 continue;
             }
             all += 1;
-            let Err(e) = db.layout_of_adt(hir_def::AdtId::from(a).into(), Substitution::empty(Interner), a.krate(db).into()) else {
+            let Err(e) = db.layout_of_adt(hir_def::AdtId::from(a), Substitution::empty(Interner), a.krate(db).into()) else {
                 continue;
             };
             if verbosity.is_spammy() {

--- a/crates/rust-analyzer/src/cli/analysis_stats.rs
+++ b/crates/rust-analyzer/src/cli/analysis_stats.rs
@@ -609,7 +609,7 @@ fn location_csv_expr(
 ) -> String {
     let src = match sm.expr_syntax(expr_id) {
         Ok(s) => s,
-        Err(SyntheticSyntax) => return "synthetic,,".to_string(),
+        Err(SyntheticSyntax) => return "synthetic,,".to_owned(),
     };
     let root = db.parse_or_expand(src.file_id);
     let node = src.map(|e| e.to_node(&root).syntax().clone());
@@ -631,7 +631,7 @@ fn location_csv_pat(
 ) -> String {
     let src = match sm.pat_syntax(pat_id) {
         Ok(s) => s,
-        Err(SyntheticSyntax) => return "synthetic,,".to_string(),
+        Err(SyntheticSyntax) => return "synthetic,,".to_owned(),
     };
     let root = db.parse_or_expand(src.file_id);
     let node = src.map(|e| {

--- a/crates/rust-analyzer/src/cli/diagnostics.rs
+++ b/crates/rust-analyzer/src/cli/diagnostics.rs
@@ -15,8 +15,8 @@ use crate::cli::{
 
 impl flags::Diagnostics {
     pub fn run(self) -> anyhow::Result<()> {
-        let mut cargo_config = CargoConfig::default();
-        cargo_config.sysroot = Some(RustLibSource::Discover);
+        let cargo_config =
+            CargoConfig { sysroot: Some(RustLibSource::Discover), ..Default::default() };
         let load_cargo_config = LoadCargoConfig {
             load_out_dirs_from_check: !self.disable_build_scripts,
             with_proc_macro_server: ProcMacroServerChoice::Sysroot,

--- a/crates/rust-analyzer/src/cli/lsif.rs
+++ b/crates/rust-analyzer/src/cli/lsif.rs
@@ -289,8 +289,8 @@ impl flags::Lsif {
     pub fn run(self) -> Result<()> {
         eprintln!("Generating LSIF started...");
         let now = Instant::now();
-        let mut cargo_config = CargoConfig::default();
-        cargo_config.sysroot = Some(RustLibSource::Discover);
+        let cargo_config =
+            CargoConfig { sysroot: Some(RustLibSource::Discover), ..Default::default() };
         let no_progress = &|_| ();
         let load_cargo_config = LoadCargoConfig {
             load_out_dirs_from_check: true,

--- a/crates/rust-analyzer/src/cli/lsif.rs
+++ b/crates/rust-analyzer/src/cli/lsif.rs
@@ -105,12 +105,12 @@ impl LsifManager<'_> {
         let result_set_id =
             self.add_vertex(lsif::Vertex::PackageInformation(lsif::PackageInformation {
                 name: pi.name,
-                manager: "cargo".to_string(),
+                manager: "cargo".to_owned(),
                 uri: None,
                 content: None,
                 repository: pi.repo.map(|url| lsif::Repository {
                     url,
-                    r#type: "git".to_string(),
+                    r#type: "git".to_owned(),
                     commit_id: None,
                 }),
                 version: pi.version,
@@ -149,7 +149,7 @@ impl LsifManager<'_> {
         let path = self.vfs.file_path(id);
         let path = path.as_path().unwrap();
         let doc_id = self.add_vertex(lsif::Vertex::Document(lsif::Document {
-            language_id: "rust".to_string(),
+            language_id: "rust".to_owned(),
             uri: lsp_types::Url::from_file_path(path).unwrap(),
         }));
         self.file_map.insert(id, doc_id);
@@ -176,7 +176,7 @@ impl LsifManager<'_> {
         if let Some(moniker) = token.moniker {
             let package_id = self.get_package_id(moniker.package_information);
             let moniker_id = self.add_vertex(lsif::Vertex::Moniker(lsp_types::Moniker {
-                scheme: "rust-analyzer".to_string(),
+                scheme: "rust-analyzer".to_owned(),
                 identifier: moniker.identifier.to_string(),
                 unique: lsp_types::UniquenessLevel::Scheme,
                 kind: Some(match moniker.kind {
@@ -315,7 +315,7 @@ impl flags::Lsif {
             project_root: lsp_types::Url::from_file_path(path).unwrap(),
             position_encoding: lsif::Encoding::Utf16,
             tool_info: Some(lsp_types::lsif::ToolInfo {
-                name: "rust-analyzer".to_string(),
+                name: "rust-analyzer".to_owned(),
                 args: vec![],
                 version: Some(version().to_string()),
             }),

--- a/crates/rust-analyzer/src/cli/scip.rs
+++ b/crates/rust-analyzer/src/cli/scip.rs
@@ -29,8 +29,8 @@ impl flags::Scip {
     pub fn run(self) -> Result<()> {
         eprintln!("Generating SCIP start...");
         let now = Instant::now();
-        let mut cargo_config = CargoConfig::default();
-        cargo_config.sysroot = Some(RustLibSource::Discover);
+        let cargo_config =
+            CargoConfig { sysroot: Some(RustLibSource::Discover), ..Default::default() };
 
         let no_progress = &|s| (eprintln!("rust-analyzer: Loading {s}"));
         let load_cargo_config = LoadCargoConfig {
@@ -214,7 +214,7 @@ fn new_descriptor(name: &str, suffix: scip_types::descriptor::Suffix) -> scip_ty
     if name.contains('\'') {
         new_descriptor_str(&format!("`{name}`"), suffix)
     } else {
-        new_descriptor_str(&name, suffix)
+        new_descriptor_str(name, suffix)
     }
 }
 
@@ -305,7 +305,7 @@ mod test {
             }
         }
 
-        if expected == "" {
+        if expected.is_empty() {
             assert!(found_symbol.is_none(), "must have no symbols {found_symbol:?}");
             return;
         }

--- a/crates/rust-analyzer/src/cli/scip.rs
+++ b/crates/rust-analyzer/src/cli/scip.rs
@@ -152,7 +152,7 @@ impl flags::Scip {
 
             documents.push(scip_types::Document {
                 relative_path,
-                language: "rust".to_string(),
+                language: "rust".to_owned(),
                 occurrences,
                 symbols,
                 special_fields: Default::default(),
@@ -204,7 +204,7 @@ fn new_descriptor_str(
 ) -> scip_types::Descriptor {
     scip_types::Descriptor {
         name: name.to_string(),
-        disambiguator: "".to_string(),
+        disambiguator: "".to_owned(),
         suffix: suffix.into(),
         special_fields: Default::default(),
     }
@@ -253,9 +253,9 @@ fn token_to_symbol(token: &TokenStaticData) -> Option<scip_types::Symbol> {
     Some(scip_types::Symbol {
         scheme: "rust-analyzer".into(),
         package: Some(scip_types::Package {
-            manager: "cargo".to_string(),
+            manager: "cargo".to_owned(),
             name: package_name,
-            version: version.unwrap_or_else(|| ".".to_string()),
+            version: version.unwrap_or_else(|| ".".to_owned()),
             special_fields: Default::default(),
         })
         .into(),

--- a/crates/rust-analyzer/src/cli/ssr.rs
+++ b/crates/rust-analyzer/src/cli/ssr.rs
@@ -12,8 +12,8 @@ use crate::cli::{
 impl flags::Ssr {
     pub fn run(self) -> Result<()> {
         use ide_db::base_db::SourceDatabaseExt;
-        let mut cargo_config = CargoConfig::default();
-        cargo_config.sysroot = Some(RustLibSource::Discover);
+        let cargo_config =
+            CargoConfig { sysroot: Some(RustLibSource::Discover), ..Default::default() };
         let load_cargo_config = LoadCargoConfig {
             load_out_dirs_from_check: true,
             with_proc_macro_server: ProcMacroServerChoice::Sysroot,

--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -1125,12 +1125,12 @@ impl Config {
     }
 
     pub fn lru_query_capacities(&self) -> Option<&FxHashMap<Box<str>, usize>> {
-        self.data.lru_query_capacities.is_empty().not().then(|| &self.data.lru_query_capacities)
+        self.data.lru_query_capacities.is_empty().not().then_some(&self.data.lru_query_capacities)
     }
 
     pub fn proc_macro_srv(&self) -> Option<AbsPathBuf> {
         let path = self.data.procMacro_server.clone()?;
-        Some(AbsPathBuf::try_from(path).unwrap_or_else(|path| self.root_path.join(&path)))
+        Some(AbsPathBuf::try_from(path).unwrap_or_else(|path| self.root_path.join(path)))
     }
 
     pub fn dummy_replacements(&self) -> &FxHashMap<Box<str>, Box<[Box<str>]>> {
@@ -1635,7 +1635,7 @@ impl Config {
     }
 
     pub fn main_loop_num_threads(&self) -> usize {
-        self.data.numThreads.unwrap_or(num_cpus::get_physical().try_into().unwrap_or(1))
+        self.data.numThreads.unwrap_or(num_cpus::get_physical())
     }
 
     pub fn typing_autoclose_angle(&self) -> bool {
@@ -1751,16 +1751,12 @@ mod de_unit_v {
 
 #[derive(Deserialize, Debug, Clone, Copy)]
 #[serde(rename_all = "snake_case")]
+#[derive(Default)]
 enum SnippetScopeDef {
+    #[default]
     Expr,
     Item,
     Type,
-}
-
-impl Default for SnippetScopeDef {
-    fn default() -> Self {
-        SnippetScopeDef::Expr
-    }
 }
 
 #[derive(Deserialize, Debug, Clone, Default)]

--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -841,7 +841,7 @@ impl Config {
         use serde::de::Error;
         if self.data.check_command.is_empty() {
             error_sink.push((
-                "/check/command".to_string(),
+                "/check/command".to_owned(),
                 serde_json::Error::custom("expected a non-empty string"),
             ));
         }

--- a/crates/rust-analyzer/src/diagnostics/to_proto.rs
+++ b/crates/rust-analyzer/src/diagnostics/to_proto.rs
@@ -396,16 +396,16 @@ pub(crate) fn map_rust_diagnostic_to_lsp(
                 related_info_macro_calls.push(lsp_types::DiagnosticRelatedInformation {
                     location: secondary_location.clone(),
                     message: if is_in_macro_call {
-                        "Error originated from macro call here".to_string()
+                        "Error originated from macro call here".to_owned()
                     } else {
-                        "Actual error occurred here".to_string()
+                        "Actual error occurred here".to_owned()
                     },
                 });
                 // For the additional in-macro diagnostic we add the inverse message pointing to the error location in code.
                 let information_for_additional_diagnostic =
                     vec![lsp_types::DiagnosticRelatedInformation {
                         location: primary_location.clone(),
-                        message: "Exact error occurred here".to_string(),
+                        message: "Exact error occurred here".to_owned(),
                     }];
 
                 let diagnostic = lsp_types::Diagnostic {
@@ -460,7 +460,7 @@ pub(crate) fn map_rust_diagnostic_to_lsp(
             // `related_information`, which just produces hard-to-read links, at least in VS Code.
             let back_ref = lsp_types::DiagnosticRelatedInformation {
                 location: primary_location,
-                message: "original diagnostic".to_string(),
+                message: "original diagnostic".to_owned(),
             };
             for sub in &subdiagnostics {
                 diagnostics.push(MappedRustDiagnostic {
@@ -673,7 +673,7 @@ mod tests {
     fn rustc_unused_variable_as_info() {
         check_with_config(
             DiagnosticsMapConfig {
-                warnings_as_info: vec!["unused_variables".to_string()],
+                warnings_as_info: vec!["unused_variables".to_owned()],
                 ..DiagnosticsMapConfig::default()
             },
             r##"{
@@ -757,7 +757,7 @@ mod tests {
     fn rustc_unused_variable_as_hint() {
         check_with_config(
             DiagnosticsMapConfig {
-                warnings_as_hint: vec!["unused_variables".to_string()],
+                warnings_as_hint: vec!["unused_variables".to_owned()],
                 ..DiagnosticsMapConfig::default()
             },
             r##"{

--- a/crates/rust-analyzer/src/dispatch.rs
+++ b/crates/rust-analyzer/src/dispatch.rs
@@ -116,7 +116,7 @@ impl<'a> RequestDispatcher<'a> {
                     Err(_) => Task::Response(lsp_server::Response::new_err(
                         req.id,
                         lsp_server::ErrorCode::ContentModified as i32,
-                        "content modified".to_string(),
+                        "content modified".to_owned(),
                     )),
                 }
             }
@@ -157,7 +157,7 @@ impl<'a> RequestDispatcher<'a> {
             let response = lsp_server::Response::new_err(
                 req.id,
                 lsp_server::ErrorCode::MethodNotFound as i32,
-                "unknown request".to_string(),
+                "unknown request".to_owned(),
             );
             self.global_state.respond(response);
         }
@@ -242,7 +242,7 @@ where
                 .map(String::as_str)
                 .or_else(|| panic.downcast_ref::<&str>().copied());
 
-            let mut message = "request handler panicked".to_string();
+            let mut message = "request handler panicked".to_owned();
             if let Some(panic_message) = panic_message {
                 message.push_str(": ");
                 message.push_str(panic_message)

--- a/crates/rust-analyzer/src/from_proto.rs
+++ b/crates/rust-analyzer/src/from_proto.rs
@@ -103,7 +103,7 @@ pub(crate) fn annotation(
     code_lens: lsp_types::CodeLens,
 ) -> Result<Option<Annotation>> {
     let data =
-        code_lens.data.ok_or_else(|| invalid_params_error("code lens without data".to_string()))?;
+        code_lens.data.ok_or_else(|| invalid_params_error("code lens without data".to_owned()))?;
     let resolve = from_json::<lsp_ext::CodeLensResolveData>("CodeLensResolveData", &data)?;
 
     match resolve.kind {

--- a/crates/rust-analyzer/src/global_state.rs
+++ b/crates/rust-analyzer/src/global_state.rs
@@ -280,10 +280,10 @@ impl GlobalState {
 
                 let text = if file.exists() {
                     let bytes = vfs.file_contents(file.file_id).to_vec();
-                    String::from_utf8(bytes).ok().and_then(|text| {
+                    String::from_utf8(bytes).ok().map(|text| {
                         let (text, line_endings) = LineEndings::normalize(text);
                         line_endings_map.insert(file.file_id, line_endings);
-                        Some(Arc::from(text))
+                        Arc::from(text)
                     })
                 } else {
                     None

--- a/crates/rust-analyzer/src/handlers/notification.rs
+++ b/crates/rust-analyzer/src/handlers/notification.rs
@@ -32,7 +32,7 @@ pub(crate) fn handle_work_done_progress_cancel(
 ) -> Result<()> {
     if let lsp_types::NumberOrString::String(s) = &params.token {
         if let Some(id) = s.strip_prefix("rust-analyzer/flycheck/") {
-            if let Ok(id) = u32::from_str_radix(id, 10) {
+            if let Ok(id) = id.parse::<u32>() {
                 if let Some(flycheck) = state.flycheck.get(id as usize) {
                     flycheck.cancel();
                 }

--- a/crates/rust-analyzer/src/handlers/notification.rs
+++ b/crates/rust-analyzer/src/handlers/notification.rs
@@ -153,7 +153,7 @@ pub(crate) fn handle_did_change_configuration(
         lsp_types::ConfigurationParams {
             items: vec![lsp_types::ConfigurationItem {
                 scope_uri: None,
-                section: Some("rust-analyzer".to_string()),
+                section: Some("rust-analyzer".to_owned()),
             }],
         },
         |this, resp| {
@@ -205,7 +205,7 @@ pub(crate) fn handle_did_change_workspace_folders(
 
     if !config.has_linked_projects() && config.detached_files().is_empty() {
         config.rediscover_workspaces();
-        state.fetch_workspaces_queue.request_op("client workspaces changed".to_string(), ())
+        state.fetch_workspaces_queue.request_op("client workspaces changed".to_owned(), ())
     }
 
     Ok(())

--- a/crates/rust-analyzer/src/handlers/request.rs
+++ b/crates/rust-analyzer/src/handlers/request.rs
@@ -52,7 +52,7 @@ pub(crate) fn handle_workspace_reload(state: &mut GlobalState, _: ()) -> Result<
     state.proc_macro_clients = Arc::from(Vec::new());
     state.proc_macro_changed = false;
 
-    state.fetch_workspaces_queue.request_op("reload workspace request".to_string(), ());
+    state.fetch_workspaces_queue.request_op("reload workspace request".to_owned(), ());
     Ok(())
 }
 
@@ -61,7 +61,7 @@ pub(crate) fn handle_proc_macros_rebuild(state: &mut GlobalState, _: ()) -> Resu
     state.proc_macro_clients = Arc::from(Vec::new());
     state.proc_macro_changed = false;
 
-    state.fetch_build_data_queue.request_op("rebuild proc macros request".to_string(), ());
+    state.fetch_build_data_queue.request_op("rebuild proc macros request".to_owned(), ());
     Ok(())
 }
 
@@ -798,13 +798,13 @@ pub(crate) fn handle_runnables(
         None => {
             if !snap.config.linked_projects().is_empty() {
                 res.push(lsp_ext::Runnable {
-                    label: "cargo check --workspace".to_string(),
+                    label: "cargo check --workspace".to_owned(),
                     location: None,
                     kind: lsp_ext::RunnableKind::Cargo,
                     args: lsp_ext::CargoRunnable {
                         workspace_root: None,
                         override_cargo: config.override_cargo,
-                        cargo_args: vec!["check".to_string(), "--workspace".to_string()],
+                        cargo_args: vec!["check".to_owned(), "--workspace".to_owned()],
                         cargo_extra_args: config.cargo_extra_args,
                         executable_args: Vec::new(),
                         expect_test: None,
@@ -878,7 +878,7 @@ pub(crate) fn handle_completion_resolve(
 
     if !all_edits_are_disjoint(&original_completion, &[]) {
         return Err(invalid_params_error(
-            "Received a completion with overlapping edits, this is not LSP-compliant".to_string(),
+            "Received a completion with overlapping edits, this is not LSP-compliant".to_owned(),
         )
         .into());
     }
@@ -1163,7 +1163,7 @@ pub(crate) fn handle_code_action_resolve(
     let _p = profile::span("handle_code_action_resolve");
     let params = match code_action.data.take() {
         Some(it) => it,
-        None => return Err(invalid_params_error("code action without data".to_string()).into()),
+        None => return Err(invalid_params_error("code action without data".to_owned()).into()),
     };
 
     let file_id = from_proto::file_id(&snap, &params.code_action_params.text_document.uri)?;
@@ -1231,7 +1231,7 @@ fn parse_action_id(action_id: &str) -> Result<(usize, SingleResolve), String> {
             };
             Ok((index, SingleResolve { assist_id: assist_id_string.to_string(), assist_kind }))
         }
-        _ => Err("Action id contains incorrect number of segments".to_string()),
+        _ => Err("Action id contains incorrect number of segments".to_owned()),
     }
 }
 

--- a/crates/rust-analyzer/src/lsp_utils.rs
+++ b/crates/rust-analyzer/src/lsp_utils.rs
@@ -287,7 +287,7 @@ mod tests {
         }
 
         let encoding = PositionEncoding::Wide(WideEncoding::Utf16);
-        let text = apply_document_changes(encoding, || String::new(), vec![]);
+        let text = apply_document_changes(encoding, String::new, vec![]);
         assert_eq!(text, "");
         let text = apply_document_changes(
             encoding,

--- a/crates/rust-analyzer/src/lsp_utils.rs
+++ b/crates/rust-analyzer/src/lsp_utils.rs
@@ -347,21 +347,20 @@ mod tests {
 
     #[test]
     fn empty_completion_disjoint_tests() {
-        let empty_completion =
-            CompletionItem::new_simple("label".to_string(), "detail".to_string());
+        let empty_completion = CompletionItem::new_simple("label".to_owned(), "detail".to_owned());
 
         let disjoint_edit_1 = lsp_types::TextEdit::new(
             Range::new(Position::new(2, 2), Position::new(3, 3)),
-            "new_text".to_string(),
+            "new_text".to_owned(),
         );
         let disjoint_edit_2 = lsp_types::TextEdit::new(
             Range::new(Position::new(3, 3), Position::new(4, 4)),
-            "new_text".to_string(),
+            "new_text".to_owned(),
         );
 
         let joint_edit = lsp_types::TextEdit::new(
             Range::new(Position::new(1, 1), Position::new(5, 5)),
-            "new_text".to_string(),
+            "new_text".to_owned(),
         );
 
         assert!(
@@ -389,19 +388,19 @@ mod tests {
     fn completion_with_joint_edits_disjoint_tests() {
         let disjoint_edit = lsp_types::TextEdit::new(
             Range::new(Position::new(1, 1), Position::new(2, 2)),
-            "new_text".to_string(),
+            "new_text".to_owned(),
         );
         let disjoint_edit_2 = lsp_types::TextEdit::new(
             Range::new(Position::new(2, 2), Position::new(3, 3)),
-            "new_text".to_string(),
+            "new_text".to_owned(),
         );
         let joint_edit = lsp_types::TextEdit::new(
             Range::new(Position::new(1, 1), Position::new(5, 5)),
-            "new_text".to_string(),
+            "new_text".to_owned(),
         );
 
         let mut completion_with_joint_edits =
-            CompletionItem::new_simple("label".to_string(), "detail".to_string());
+            CompletionItem::new_simple("label".to_owned(), "detail".to_owned());
         completion_with_joint_edits.additional_text_edits =
             Some(vec![disjoint_edit.clone(), joint_edit.clone()]);
         assert!(
@@ -419,7 +418,7 @@ mod tests {
 
         completion_with_joint_edits.text_edit =
             Some(CompletionTextEdit::InsertAndReplace(InsertReplaceEdit {
-                new_text: "new_text".to_string(),
+                new_text: "new_text".to_owned(),
                 insert: disjoint_edit.range,
                 replace: disjoint_edit_2.range,
             }));
@@ -434,19 +433,19 @@ mod tests {
     fn completion_with_disjoint_edits_disjoint_tests() {
         let disjoint_edit = lsp_types::TextEdit::new(
             Range::new(Position::new(1, 1), Position::new(2, 2)),
-            "new_text".to_string(),
+            "new_text".to_owned(),
         );
         let disjoint_edit_2 = lsp_types::TextEdit::new(
             Range::new(Position::new(2, 2), Position::new(3, 3)),
-            "new_text".to_string(),
+            "new_text".to_owned(),
         );
         let joint_edit = lsp_types::TextEdit::new(
             Range::new(Position::new(1, 1), Position::new(5, 5)),
-            "new_text".to_string(),
+            "new_text".to_owned(),
         );
 
         let mut completion_with_disjoint_edits =
-            CompletionItem::new_simple("label".to_string(), "detail".to_string());
+            CompletionItem::new_simple("label".to_owned(), "detail".to_owned());
         completion_with_disjoint_edits.text_edit = Some(CompletionTextEdit::Edit(disjoint_edit));
         let completion_with_disjoint_edits = completion_with_disjoint_edits;
 

--- a/crates/rust-analyzer/src/main_loop.rs
+++ b/crates/rust-analyzer/src/main_loop.rs
@@ -480,7 +480,7 @@ impl GlobalState {
 
                         if self.config.run_build_scripts() && workspaces_updated {
                             self.fetch_build_data_queue
-                                .request_op(format!("workspace updated"), ());
+                                .request_op("workspace updated".to_string(), ());
                         }
 
                         (Progress::End, None)

--- a/crates/rust-analyzer/src/main_loop.rs
+++ b/crates/rust-analyzer/src/main_loop.rs
@@ -115,7 +115,7 @@ impl GlobalState {
             self.register_did_save_capability();
         }
 
-        self.fetch_workspaces_queue.request_op("startup".to_string(), ());
+        self.fetch_workspaces_queue.request_op("startup".to_owned(), ());
         if let Some((cause, ())) = self.fetch_workspaces_queue.should_start_op() {
             self.fetch_workspaces(cause);
         }
@@ -159,8 +159,8 @@ impl GlobalState {
         };
 
         let registration = lsp_types::Registration {
-            id: "textDocument/didSave".to_string(),
-            method: "textDocument/didSave".to_string(),
+            id: "textDocument/didSave".to_owned(),
+            method: "textDocument/didSave".to_owned(),
             register_options: Some(serde_json::to_value(save_registration_options).unwrap()),
         };
         self.send_request::<lsp_types::request::RegisterCapability>(
@@ -252,7 +252,7 @@ impl GlobalState {
                             self.prime_caches_queue.op_completed(());
                             if cancelled {
                                 self.prime_caches_queue
-                                    .request_op("restart after cancellation".to_string(), ());
+                                    .request_op("restart after cancellation".to_owned(), ());
                             }
                         }
                     };
@@ -293,7 +293,7 @@ impl GlobalState {
                     self.flycheck.iter().for_each(FlycheckHandle::restart);
                 }
                 if self.config.prefill_caches() {
-                    self.prime_caches_queue.request_op("became quiescent".to_string(), ());
+                    self.prime_caches_queue.request_op("became quiescent".to_owned(), ());
                 }
             }
 
@@ -340,7 +340,7 @@ impl GlobalState {
                 // See https://github.com/rust-lang/rust-analyzer/issues/13130
                 let patch_empty = |message: &mut String| {
                     if message.is_empty() {
-                        *message = " ".to_string();
+                        *message = " ".to_owned();
                     }
                 };
 
@@ -475,12 +475,12 @@ impl GlobalState {
                         }
 
                         let old = Arc::clone(&self.workspaces);
-                        self.switch_workspaces("fetched workspace".to_string());
+                        self.switch_workspaces("fetched workspace".to_owned());
                         let workspaces_updated = !Arc::ptr_eq(&old, &self.workspaces);
 
                         if self.config.run_build_scripts() && workspaces_updated {
                             self.fetch_build_data_queue
-                                .request_op("workspace updated".to_string(), ());
+                                .request_op("workspace updated".to_owned(), ());
                         }
 
                         (Progress::End, None)
@@ -499,7 +499,7 @@ impl GlobalState {
                             tracing::error!("FetchBuildDataError:\n{e}");
                         }
 
-                        self.switch_workspaces("fetched build data".to_string());
+                        self.switch_workspaces("fetched build data".to_owned());
 
                         (Some(Progress::End), None)
                     }
@@ -833,7 +833,7 @@ impl GlobalState {
                                     ))
                                     .unwrap(),
                                 }),
-                                source: Some("rust-analyzer".to_string()),
+                                source: Some("rust-analyzer".to_owned()),
                                 message: d.message,
                                 related_information: None,
                                 tags: if d.unused {

--- a/crates/rust-analyzer/src/reload.rs
+++ b/crates/rust-analyzer/src/reload.rs
@@ -85,7 +85,7 @@ impl GlobalState {
             );
         }
         if self.config.linked_projects() != old_config.linked_projects() {
-            self.fetch_workspaces_queue.request_op("linked projects changed".to_string(), ())
+            self.fetch_workspaces_queue.request_op("linked projects changed".to_owned(), ())
         } else if self.config.flycheck() != old_config.flycheck() {
             self.reload_flycheck();
         }
@@ -407,8 +407,8 @@ impl GlobalState {
                     .collect(),
             };
             let registration = lsp_types::Registration {
-                id: "workspace/didChangeWatchedFiles".to_string(),
-                method: "workspace/didChangeWatchedFiles".to_string(),
+                id: "workspace/didChangeWatchedFiles".to_owned(),
+                method: "workspace/didChangeWatchedFiles".to_owned(),
                 register_options: Some(serde_json::to_value(registration_options).unwrap()),
             };
             self.send_request::<lsp_types::request::RegisterCapability>(
@@ -753,7 +753,7 @@ pub(crate) fn load_proc_macro(
         let dylib = MacroDylib::new(path.to_path_buf());
         let vec = server.load_dylib(dylib).map_err(|e| format!("{e}"))?;
         if vec.is_empty() {
-            return Err("proc macro library returned no proc macros".to_string());
+            return Err("proc macro library returned no proc macros".to_owned());
         }
         Ok(vec
             .into_iter()

--- a/crates/rust-analyzer/src/semantic_tokens.rs
+++ b/crates/rust-analyzer/src/semantic_tokens.rs
@@ -156,7 +156,7 @@ pub(crate) struct ModifierSet(pub(crate) u32);
 impl ModifierSet {
     pub(crate) fn standard_fallback(&mut self) {
         // Remove all non standard modifiers
-        self.0 = self.0 & !(!0u32 << LAST_STANDARD_MOD)
+        self.0 &= !(!0u32 << LAST_STANDARD_MOD)
     }
 }
 

--- a/crates/rust-analyzer/src/to_proto.rs
+++ b/crates/rust-analyzer/src/to_proto.rs
@@ -301,22 +301,18 @@ fn completion_item(
 
     set_score(&mut lsp_item, max_relevance, item.relevance);
 
-    if config.completion().enable_imports_on_the_fly {
-        if !item.import_to_add.is_empty() {
-            let imports: Vec<_> = item
-                .import_to_add
-                .into_iter()
-                .filter_map(|(import_path, import_name)| {
-                    Some(lsp_ext::CompletionImport {
-                        full_import_path: import_path,
-                        imported_name: import_name,
-                    })
-                })
-                .collect();
-            if !imports.is_empty() {
-                let data = lsp_ext::CompletionResolveData { position: tdpp.clone(), imports };
-                lsp_item.data = Some(to_value(data).unwrap());
-            }
+    if config.completion().enable_imports_on_the_fly && !item.import_to_add.is_empty() {
+        let imports: Vec<_> = item
+            .import_to_add
+            .into_iter()
+            .map(|(import_path, import_name)| lsp_ext::CompletionImport {
+                full_import_path: import_path,
+                imported_name: import_name,
+            })
+            .collect();
+        if !imports.is_empty() {
+            let data = lsp_ext::CompletionResolveData { position: tdpp.clone(), imports };
+            lsp_item.data = Some(to_value(data).unwrap());
         }
     }
 

--- a/crates/rust-analyzer/tests/slow-tests/main.rs
+++ b/crates/rust-analyzer/tests/slow-tests/main.rs
@@ -621,9 +621,9 @@ fn main() {{}}
         server.notification::<DidOpenTextDocument>(DidOpenTextDocumentParams {
             text_document: TextDocumentItem {
                 uri: server.doc_id(&format!("src/m{i}.rs")).uri,
-                language_id: "rust".to_string(),
+                language_id: "rust".to_owned(),
                 version: 0,
-                text: "/// Docs\nfn foo() {}".to_string(),
+                text: "/// Docs\nfn foo() {}".to_owned(),
             },
         });
     }

--- a/crates/rust-analyzer/tests/slow-tests/support.rs
+++ b/crates/rust-analyzer/tests/slow-tests/support.rs
@@ -217,6 +217,7 @@ impl Server {
         self.send_request_(r)
     }
     fn send_request_(&self, r: Request) -> Value {
+        #[allow(clippy::redundant_clone)] // false positive
         let id = r.id.clone();
         self.client.sender.send(r.clone().into()).unwrap();
         while let Some(msg) = self.recv().unwrap_or_else(|Timeout| panic!("timeout: {r:?}")) {

--- a/crates/rust-analyzer/tests/slow-tests/support.rs
+++ b/crates/rust-analyzer/tests/slow-tests/support.rs
@@ -166,7 +166,7 @@ impl Server {
         let (connection, client) = Connection::memory();
 
         let _thread = stdx::thread::Builder::new(stdx::thread::ThreadIntent::Worker)
-            .name("test server".to_string())
+            .name("test server".to_owned())
             .spawn(move || main_loop(config, connection).unwrap())
             .expect("failed to spawn a thread");
 

--- a/crates/sourcegen/Cargo.toml
+++ b/crates/sourcegen/Cargo.toml
@@ -13,3 +13,6 @@ doctest = false
 
 [dependencies]
 xshell = "0.2.2"
+
+[lints]
+workspace = true

--- a/crates/sourcegen/src/lib.rs
+++ b/crates/sourcegen/src/lib.rs
@@ -67,7 +67,7 @@ impl CommentBlock {
                 panic!("Use plain (non-doc) comments with tags like {tag}:\n    {first}");
             }
 
-            block.id = id.trim().to_string();
+            block.id = id.trim().to_owned();
             true
         });
         blocks
@@ -91,7 +91,7 @@ impl CommentBlock {
                     if let Some(' ') = contents.chars().next() {
                         contents = &contents[1..];
                     }
-                    block.contents.push(contents.to_string());
+                    block.contents.push(contents.to_owned());
                 }
                 None => {
                     if !block.contents.is_empty() {

--- a/crates/stdx/Cargo.toml
+++ b/crates/stdx/Cargo.toml
@@ -26,3 +26,6 @@ winapi = { version = "0.3.9", features = ["winerror"] }
 [features]
 # Uncomment to enable for the whole crate graph
 # default = [ "backtrace" ]
+
+[lints]
+workspace = true

--- a/crates/syntax/Cargo.toml
+++ b/crates/syntax/Cargo.toml
@@ -42,3 +42,6 @@ sourcegen.workspace = true
 
 [features]
 in-rust-tree = []
+
+[lints]
+workspace = true

--- a/crates/syntax/src/ast/edit_in_place.rs
+++ b/crates/syntax/src/ast/edit_in_place.rs
@@ -391,7 +391,9 @@ impl ast::UseTree {
         if &path == prefix && self.use_tree_list().is_none() {
             if self.star_token().is_some() {
                 // path$0::* -> *
-                self.coloncolon_token().map(ted::remove);
+                if let Some(a) = self.coloncolon_token() {
+                    ted::remove(a);
+                }
                 ted::remove(prefix.syntax());
             } else {
                 // path$0 -> self
@@ -418,7 +420,9 @@ impl ast::UseTree {
             for p in successors(parent.parent_path(), |it| it.parent_path()) {
                 p.segment()?;
             }
-            prefix.parent_path().and_then(|p| p.coloncolon_token()).map(ted::remove);
+            if let Some(a) = prefix.parent_path().and_then(|p| p.coloncolon_token()) {
+                ted::remove(a)
+            }
             ted::remove(prefix.syntax());
             Some(())
         }
@@ -903,7 +907,9 @@ enum Foo {
 
     fn check_add_variant(before: &str, expected: &str, variant: ast::Variant) {
         let enum_ = ast_mut_from_text::<ast::Enum>(before);
-        enum_.variant_list().map(|it| it.add_variant(variant));
+        if let Some(it) = enum_.variant_list() {
+            it.add_variant(variant);
+        }
         let after = enum_.to_string();
         assert_eq_text!(&trim_indent(expected.trim()), &trim_indent(after.trim()));
     }

--- a/crates/syntax/src/ast/make.rs
+++ b/crates/syntax/src/ast/make.rs
@@ -279,14 +279,14 @@ pub fn impl_trait(
 
     let where_clause = match (ty_where_clause, trait_where_clause) {
         (None, None) => " ".to_string(),
-        (None, Some(tr)) => format!("\n{}\n", tr).to_string(),
-        (Some(ty), None) => format!("\n{}\n", ty).to_string(),
+        (None, Some(tr)) => format!("\n{}\n", tr),
+        (Some(ty), None) => format!("\n{}\n", ty),
         (Some(ty), Some(tr)) => {
             let updated = ty.clone_for_update();
             tr.predicates().for_each(|p| {
                 ty.add_predicate(p);
             });
-            format!("\n{}\n", updated).to_string()
+            format!("\n{}\n", updated)
         }
     };
 

--- a/crates/syntax/src/ast/make.rs
+++ b/crates/syntax/src/ast/make.rs
@@ -232,7 +232,7 @@ pub fn impl_(
 
     let where_clause = match where_clause {
         Some(pr) => pr.to_string(),
-        None => " ".to_string(),
+        None => " ".to_owned(),
     };
 
     let body = match body {
@@ -278,7 +278,7 @@ pub fn impl_trait(
     let is_negative = if is_negative { "! " } else { "" };
 
     let where_clause = match (ty_where_clause, trait_where_clause) {
-        (None, None) => " ".to_string(),
+        (None, None) => " ".to_owned(),
         (None, Some(tr)) => format!("\n{}\n", tr),
         (Some(ty), None) => format!("\n{}\n", ty),
         (Some(ty), Some(tr)) => {
@@ -369,7 +369,7 @@ pub fn use_tree(
     alias: Option<ast::Rename>,
     add_star: bool,
 ) -> ast::UseTree {
-    let mut buf = "use ".to_string();
+    let mut buf = "use ".to_owned();
     buf += &path.syntax().to_string();
     if let Some(use_tree_list) = use_tree_list {
         format_to!(buf, "::{use_tree_list}");
@@ -436,7 +436,7 @@ pub fn block_expr(
     stmts: impl IntoIterator<Item = ast::Stmt>,
     tail_expr: Option<ast::Expr>,
 ) -> ast::BlockExpr {
-    let mut buf = "{\n".to_string();
+    let mut buf = "{\n".to_owned();
     for stmt in stmts.into_iter() {
         format_to!(buf, "    {stmt}\n");
     }
@@ -459,7 +459,7 @@ pub fn hacky_block_expr(
     elements: impl IntoIterator<Item = crate::SyntaxElement>,
     tail_expr: Option<ast::Expr>,
 ) -> ast::BlockExpr {
-    let mut buf = "{\n".to_string();
+    let mut buf = "{\n".to_owned();
     for node_or_token in elements.into_iter() {
         match node_or_token {
             rowan::NodeOrToken::Node(n) => format_to!(buf, "    {n}\n"),

--- a/crates/test-utils/Cargo.toml
+++ b/crates/test-utils/Cargo.toml
@@ -19,3 +19,6 @@ rustc-hash = "1.1.0"
 
 stdx.workspace = true
 profile.workspace = true
+
+[lints]
+workspace = true

--- a/crates/test-utils/src/bench_fixture.rs
+++ b/crates/test-utils/src/bench_fixture.rs
@@ -12,7 +12,7 @@ pub fn big_struct() -> String {
 }
 
 pub fn big_struct_n(n: u32) -> String {
-    let mut buf = "pub struct RegisterBlock {".to_string();
+    let mut buf = "pub struct RegisterBlock {".to_owned();
     for i in 0..n {
         format_to!(buf, "  /// Doc comment for {}.\n", i);
         format_to!(buf, "  pub s{}: S{},\n", i, i);

--- a/crates/test-utils/src/fixture.rs
+++ b/crates/test-utils/src/fixture.rs
@@ -192,7 +192,7 @@ impl FixtureWithProjectMeta {
         let mut env = FxHashMap::default();
         let mut introduce_new_source_root = None;
         let mut target_data_layout = Some(
-            "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128".to_string(),
+            "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128".to_owned(),
         );
         for component in components[1..].iter() {
             let (key, value) =
@@ -423,9 +423,9 @@ fn parse_fixture_gets_full_meta() {
 mod m;
 "#,
         );
-    assert_eq!(toolchain, Some("nightly".to_string()));
-    assert_eq!(proc_macro_names, vec!["identity".to_string()]);
-    assert_eq!(mini_core.unwrap().activated_flags, vec!["coerce_unsized".to_string()]);
+    assert_eq!(toolchain, Some("nightly".to_owned()));
+    assert_eq!(proc_macro_names, vec!["identity".to_owned()]);
+    assert_eq!(mini_core.unwrap().activated_flags, vec!["coerce_unsized".to_owned()]);
     assert_eq!(1, parsed.len());
 
     let meta = &parsed[0];

--- a/crates/text-edit/Cargo.toml
+++ b/crates/text-edit/Cargo.toml
@@ -14,3 +14,6 @@ doctest = false
 [dependencies]
 itertools = "0.10.5"
 text-size.workspace = true
+
+[lints]
+workspace = true

--- a/crates/text-edit/src/lib.rs
+++ b/crates/text-edit/src/lib.rs
@@ -231,11 +231,11 @@ mod tests {
 
     #[test]
     fn test_apply() {
-        let mut text = "_11h1_2222_xx3333_4444_6666".to_string();
+        let mut text = "_11h1_2222_xx3333_4444_6666".to_owned();
         let mut builder = TextEditBuilder::default();
-        builder.replace(range(3, 4), "1".to_string());
+        builder.replace(range(3, 4), "1".to_owned());
         builder.delete(range(11, 13));
-        builder.insert(22.into(), "_5555".to_string());
+        builder.insert(22.into(), "_5555".to_owned());
 
         let text_edit = builder.finish();
         text_edit.apply(&mut text);

--- a/crates/toolchain/Cargo.toml
+++ b/crates/toolchain/Cargo.toml
@@ -13,3 +13,6 @@ doctest = false
 
 [dependencies]
 home = "0.5.4"
+
+[lints]
+workspace = true

--- a/crates/tt/Cargo.toml
+++ b/crates/tt/Cargo.toml
@@ -15,3 +15,6 @@ doctest = false
 smol_str.workspace = true
 
 stdx.workspace = true
+
+[lints]
+workspace = true

--- a/crates/tt/src/buffer.rs
+++ b/crates/tt/src/buffer.rs
@@ -33,6 +33,7 @@ pub struct TokenBuffer<'t, Span> {
     buffers: Vec<Box<[Entry<'t, Span>]>>,
 }
 
+#[allow(clippy::type_complexity)]
 trait TokenList<'a, Span> {
     fn entries(
         &self,

--- a/crates/tt/src/lib.rs
+++ b/crates/tt/src/lib.rs
@@ -327,11 +327,11 @@ impl<Span> Subtree<Span> {
                     };
                     match (it, last) {
                         (Leaf::Ident(_), Some(&TokenTree::Leaf(Leaf::Ident(_)))) => {
-                            " ".to_string() + &s
+                            " ".to_owned() + &s
                         }
                         (Leaf::Punct(_), Some(TokenTree::Leaf(Leaf::Punct(punct)))) => {
                             if punct.spacing == Spacing::Alone {
-                                " ".to_string() + &s
+                                " ".to_owned() + &s
                             } else {
                                 s
                             }

--- a/crates/vfs-notify/Cargo.toml
+++ b/crates/vfs-notify/Cargo.toml
@@ -20,3 +20,6 @@ notify = "5.0"
 stdx.workspace = true
 vfs.workspace = true
 paths.workspace = true
+
+[lints]
+workspace = true

--- a/crates/vfs/Cargo.toml
+++ b/crates/vfs/Cargo.toml
@@ -19,3 +19,6 @@ nohash-hasher.workspace = true
 
 paths.workspace = true
 stdx.workspace = true
+
+[lints]
+workspace = true

--- a/crates/vfs/src/file_set.rs
+++ b/crates/vfs/src/file_set.rs
@@ -71,12 +71,12 @@ impl fmt::Debug for FileSet {
 /// ```rust
 /// # use vfs::{file_set::FileSetConfigBuilder, VfsPath, Vfs};
 /// let mut builder = FileSetConfigBuilder::default();
-/// builder.add_file_set(vec![VfsPath::new_virtual_path("/src".to_string())]);
+/// builder.add_file_set(vec![VfsPath::new_virtual_path("/src".to_owned())]);
 /// let config = builder.build();
 /// let mut file_system = Vfs::default();
-/// file_system.set_file_contents(VfsPath::new_virtual_path("/src/main.rs".to_string()), Some(vec![]));
-/// file_system.set_file_contents(VfsPath::new_virtual_path("/src/lib.rs".to_string()), Some(vec![]));
-/// file_system.set_file_contents(VfsPath::new_virtual_path("/build.rs".to_string()), Some(vec![]));
+/// file_system.set_file_contents(VfsPath::new_virtual_path("/src/main.rs".to_owned()), Some(vec![]));
+/// file_system.set_file_contents(VfsPath::new_virtual_path("/src/lib.rs".to_owned()), Some(vec![]));
+/// file_system.set_file_contents(VfsPath::new_virtual_path("/build.rs".to_owned()), Some(vec![]));
 /// // contains the sets :
 /// // { "/src/main.rs", "/src/lib.rs" }
 /// // { "build.rs" }

--- a/crates/vfs/src/loader.rs
+++ b/crates/vfs/src/loader.rs
@@ -190,7 +190,7 @@ impl Directories {
 /// ```
 fn dirs(base: AbsPathBuf, exclude: &[&str]) -> Directories {
     let exclude = exclude.iter().map(|it| base.join(it)).collect::<Vec<_>>();
-    Directories { extensions: vec!["rs".to_string()], include: vec![base], exclude }
+    Directories { extensions: vec!["rs".to_owned()], include: vec![base], exclude }
 }
 
 impl fmt::Debug for Message {

--- a/crates/vfs/src/vfs_path.rs
+++ b/crates/vfs/src/vfs_path.rs
@@ -342,7 +342,7 @@ impl VirtualPath {
     /// # Example
     ///
     /// ```rust,ignore
-    /// let mut path = VirtualPath("/foo/bar".to_string());
+    /// let mut path = VirtualPath("/foo/bar".to_owned());
     /// path.pop();
     /// assert_eq!(path.0, "/foo");
     /// path.pop();

--- a/crates/vfs/src/vfs_path/tests.rs
+++ b/crates/vfs/src/vfs_path/tests.rs
@@ -2,29 +2,29 @@ use super::*;
 
 #[test]
 fn virtual_path_extensions() {
-    assert_eq!(VirtualPath("/".to_string()).name_and_extension(), None);
+    assert_eq!(VirtualPath("/".to_owned()).name_and_extension(), None);
     assert_eq!(
-        VirtualPath("/directory".to_string()).name_and_extension(),
+        VirtualPath("/directory".to_owned()).name_and_extension(),
         Some(("directory", None))
     );
     assert_eq!(
-        VirtualPath("/directory/".to_string()).name_and_extension(),
+        VirtualPath("/directory/".to_owned()).name_and_extension(),
         Some(("directory", None))
     );
     assert_eq!(
-        VirtualPath("/directory/file".to_string()).name_and_extension(),
+        VirtualPath("/directory/file".to_owned()).name_and_extension(),
         Some(("file", None))
     );
     assert_eq!(
-        VirtualPath("/directory/.file".to_string()).name_and_extension(),
+        VirtualPath("/directory/.file".to_owned()).name_and_extension(),
         Some((".file", None))
     );
     assert_eq!(
-        VirtualPath("/directory/.file.rs".to_string()).name_and_extension(),
+        VirtualPath("/directory/.file.rs".to_owned()).name_and_extension(),
         Some((".file", Some("rs")))
     );
     assert_eq!(
-        VirtualPath("/directory/file.rs".to_string()).name_and_extension(),
+        VirtualPath("/directory/file.rs".to_owned()).name_and_extension(),
         Some(("file", Some("rs")))
     );
 }

--- a/lib/line-index/tests/it.rs
+++ b/lib/line-index/tests/it.rs
@@ -1,15 +1,16 @@
 use line_index::{LineCol, LineIndex, TextRange};
 
 #[test]
+#[rustfmt::skip]
 fn test_line_index() {
     let text = "hello\nworld";
     let table = [
-        (00, 0, 0),
-        (01, 0, 1),
-        (05, 0, 5),
-        (06, 1, 0),
-        (07, 1, 1),
-        (08, 1, 2),
+        ( 0, 0, 0),
+        ( 1, 0, 1),
+        ( 5, 0, 5),
+        ( 6, 1, 0),
+        ( 7, 1, 1),
+        ( 8, 1, 2),
         (10, 1, 4),
         (11, 1, 5),
     ];


### PR DESCRIPTION
Figured we can allow all lints and then selectively disable the ones we don't want. The nice thing is this doesn't break stable builds, although it does spam a bit for each cargo toml ...