### PR TITLE
fix: exclude Markdown injection grammar from .vscodeignore.

### DIFF
--- a/editors/code/.vscodeignore
+++ b/editors/code/.vscodeignore
@@ -10,5 +10,6 @@
 !package-lock.json
 !package.json
 !ra_syntax_tree.tmGrammar.json
+!rustdoc.markdown.injection.tmGrammar.json
 !server
 !README.md


### PR DESCRIPTION
Enables Markdown injection introduced in #14866 but wasn't included in release due to the grammar file being ignored by `.vscodeignore`. I verified the fix by doing `vsce package` and installing it manually:

<img width="779" alt="image" src="https://github.com/rust-lang/rust-analyzer/assets/1593486/bb3da211-a017-45bf-ba7b-4122335aa6e8">

<img width="780" alt="image" src="https://github.com/rust-lang/rust-analyzer/assets/1593486/aa0c4025-e72c-4b0c-9d40-44c33e7d45e6">
