### PR TITLE
bugfix :  skip doc(hidden) default members

### DIFF
--- a/crates/ide-assists/src/handlers/add_missing_impl_members.rs
+++ b/crates/ide-assists/src/handlers/add_missing_impl_members.rs
@@ -46,7 +46,7 @@ pub(crate) fn add_missing_impl_members(acc: &mut Assists, ctx: &AssistContext<'_
         acc,
         ctx,
         DefaultMethods::No,
-        IgnoreAssocItems::HiddenDocAttrPresent,
+        IgnoreAssocItems::DocHiddenAttrPresent,
         "add_impl_missing_members",
         "Implement missing members",
     )
@@ -91,7 +91,7 @@ pub(crate) fn add_missing_default_members(
         acc,
         ctx,
         DefaultMethods::Only,
-        IgnoreAssocItems::HiddenDocAttrPresent,
+        IgnoreAssocItems::DocHiddenAttrPresent,
         "add_impl_default_members",
         "Implement default members",
     )
@@ -123,7 +123,7 @@ fn add_missing_impl_members_inner(
 
     let mut ign_item = ignore_items;
 
-    if let IgnoreAssocItems::HiddenDocAttrPresent = ignore_items {
+    if let IgnoreAssocItems::DocHiddenAttrPresent = ignore_items {
         // Relax condition for local crates.
         let db = ctx.db();
         if trait_.module(db).krate().origin(db).is_local() {

--- a/crates/ide-assists/src/handlers/replace_derive_with_manual_impl.rs
+++ b/crates/ide-assists/src/handlers/replace_derive_with_manual_impl.rs
@@ -172,7 +172,7 @@ fn impl_def_from_trait(
 ) -> Option<(ast::Impl, ast::AssocItem)> {
     let trait_ = trait_?;
     let target_scope = sema.scope(annotated_name.syntax())?;
-    let trait_items = filter_assoc_items(sema, &trait_.items(sema.db), DefaultMethods::No);
+    let trait_items = filter_assoc_items(sema, &trait_.items(sema.db), DefaultMethods::No, true);
     if trait_items.is_empty() {
         return None;
     }

--- a/crates/ide-assists/src/handlers/replace_derive_with_manual_impl.rs
+++ b/crates/ide-assists/src/handlers/replace_derive_with_manual_impl.rs
@@ -177,7 +177,7 @@ fn impl_def_from_trait(
     let ignore_items = if trait_.module(sema.db).krate().origin(sema.db).is_local() {
         IgnoreAssocItems::No
     } else {
-        IgnoreAssocItems::HiddenDocAttrPresent
+        IgnoreAssocItems::DocHiddenAttrPresent
     };
 
     let trait_items =

--- a/crates/ide-assists/src/handlers/replace_derive_with_manual_impl.rs
+++ b/crates/ide-assists/src/handlers/replace_derive_with_manual_impl.rs
@@ -10,7 +10,7 @@ use crate::{
     assist_context::{AssistContext, Assists, SourceChangeBuilder},
     utils::{
         add_trait_assoc_items_to_impl, filter_assoc_items, gen_trait_fn_body,
-        generate_trait_impl_text, render_snippet, Cursor, DefaultMethods,
+        generate_trait_impl_text, render_snippet, Cursor, DefaultMethods, IgnoreAssocItems,
     },
     AssistId, AssistKind,
 };
@@ -172,7 +172,17 @@ fn impl_def_from_trait(
 ) -> Option<(ast::Impl, ast::AssocItem)> {
     let trait_ = trait_?;
     let target_scope = sema.scope(annotated_name.syntax())?;
-    let trait_items = filter_assoc_items(sema, &trait_.items(sema.db), DefaultMethods::No, true);
+
+    // Keep assoc items of local crates even if they have #[doc(hidden)] attr.
+    let ignore_items = if trait_.module(sema.db).krate().origin(sema.db).is_local() {
+        IgnoreAssocItems::No
+    } else {
+        IgnoreAssocItems::HiddenDocAttrPresent
+    };
+
+    let trait_items =
+        filter_assoc_items(sema, &trait_.items(sema.db), DefaultMethods::No, ignore_items);
+
     if trait_items.is_empty() {
         return None;
     }

--- a/crates/ide-assists/src/utils.rs
+++ b/crates/ide-assists/src/utils.rs
@@ -86,7 +86,7 @@ pub fn test_related_attribute(fn_def: &ast::Fn) -> Option<ast::Attr> {
 
 #[derive(Clone, Copy, PartialEq)]
 pub enum IgnoreAssocItems {
-    HiddenDocAttrPresent,
+    DocHiddenAttrPresent,
     No,
 }
 
@@ -106,7 +106,7 @@ pub fn filter_assoc_items(
         .iter()
         .copied()
         .filter(|assoc_item| {
-            !(ignore_items == IgnoreAssocItems::HiddenDocAttrPresent
+            !(ignore_items == IgnoreAssocItems::DocHiddenAttrPresent
                 && assoc_item.attrs(sema.db).has_doc_hidden())
         })
         // Note: This throws away items with no source.

--- a/crates/ide-assists/src/utils.rs
+++ b/crates/ide-assists/src/utils.rs
@@ -109,6 +109,7 @@ pub fn filter_assoc_items(
             !(ignore_items == IgnoreAssocItems::HiddenDocAttrPresent
                 && assoc_item.attrs(sema.db).has_doc_hidden())
         })
+        // Note: This throws away items with no source.
         .filter_map(|assoc_item| {
             let item = match assoc_item {
                 hir::AssocItem::Function(it) => sema.source(it)?.map(ast::AssocItem::Fn),
@@ -118,7 +119,6 @@ pub fn filter_assoc_items(
             Some(item)
         })
         .filter(has_def_name)
-        // Note: This throws away items with no source.
         .filter(|it| match &it.value {
             ast::AssocItem::Fn(def) => matches!(
                 (default_methods, def.body()),


### PR DESCRIPTION
fixes  #14957 . I have two questions :

1.  I am definitely looking for a more idiomatic way for the things I added in `crates/ide-assists/src/utils.rs`. See `FIXME` in that file.
2. Would it be actually better to change `DefaultMethods` to something like

```rust
enum DefaultMethods {
     Only( IgnoreHidden ( bool ) ) ,
     None
}
```

instead of adding a boolean to every function that calls `crates/ide-assists/src/utils.rs::filter_assoc_items`