### PR TITLE
Feature: Add a memory layout viewer

### DIFF
--- a/crates/ide-db/src/helpers.rs
+++ b/crates/ide-db/src/helpers.rs
@@ -9,7 +9,10 @@ use syntax::{
     AstToken, SyntaxKind, SyntaxToken, TokenAtOffset,
 };
 
-use crate::{defs::Definition, generated, RootDatabase};
+use crate::{
+    defs::{Definition, IdentClass},
+    generated, RootDatabase,
+};
 
 pub fn item_name(db: &RootDatabase, item: ItemInNs) -> Option<Name> {
     match item {
@@ -108,4 +111,17 @@ pub fn is_editable_crate(krate: Crate, db: &RootDatabase) -> bool {
     let root_file = krate.root_file(db);
     let source_root_id = db.file_source_root(root_file);
     !db.source_root(source_root_id).is_library
+}
+
+pub fn get_definition(
+    sema: &Semantics<'_, RootDatabase>,
+    token: SyntaxToken,
+) -> Option<Definition> {
+    for token in sema.descend_into_macros(token) {
+        let def = IdentClass::classify_token(sema, &token).map(IdentClass::definitions_no_ops);
+        if let Some(&[x]) = def.as_deref() {
+            return Some(x);
+        }
+    }
+    None
 }

--- a/crates/ide/src/lib.rs
+++ b/crates/ide/src/lib.rs
@@ -60,6 +60,7 @@ mod interpret_function;
 mod view_item_tree;
 mod shuffle_crate_graph;
 mod fetch_crates;
+mod view_memory_layout;
 
 use std::ffi::OsStr;
 
@@ -74,6 +75,7 @@ use ide_db::{
 };
 use syntax::SourceFile;
 use triomphe::Arc;
+use view_memory_layout::{view_memory_layout, RecursiveMemoryLayout};
 
 use crate::navigation_target::{ToNav, TryToNav};
 
@@ -722,6 +724,10 @@ impl Analysis {
         direction: Direction,
     ) -> Cancellable<Option<TextEdit>> {
         self.with_db(|db| move_item::move_item(db, range, direction))
+    }
+
+    pub fn get_recursive_memory_layout(&self, position: FilePosition) -> Cancellable<Option<RecursiveMemoryLayout>> {
+        self.with_db(|db| view_memory_layout(db, position))
     }
 
     /// Performs an operation on the database that may be canceled.

--- a/crates/ide/src/lib.rs
+++ b/crates/ide/src/lib.rs
@@ -726,7 +726,10 @@ impl Analysis {
         self.with_db(|db| move_item::move_item(db, range, direction))
     }
 
-    pub fn get_recursive_memory_layout(&self, position: FilePosition) -> Cancellable<Option<RecursiveMemoryLayout>> {
+    pub fn get_recursive_memory_layout(
+        &self,
+        position: FilePosition,
+    ) -> Cancellable<Option<RecursiveMemoryLayout>> {
         self.with_db(|db| view_memory_layout(db, position))
     }
 

--- a/crates/ide/src/static_index.rs
+++ b/crates/ide/src/static_index.rs
@@ -3,13 +3,14 @@
 
 use std::collections::HashMap;
 
-use hir::{db::HirDatabase, Crate, Module, Semantics};
+use hir::{db::HirDatabase, Crate, Module};
+use ide_db::helpers::get_definition;
 use ide_db::{
     base_db::{FileId, FileRange, SourceDatabaseExt},
-    defs::{Definition, IdentClass},
+    defs::Definition,
     FxHashSet, RootDatabase,
 };
-use syntax::{AstNode, SyntaxKind::*, SyntaxToken, TextRange, T};
+use syntax::{AstNode, SyntaxKind::*, TextRange, T};
 
 use crate::{
     hover::hover_for_definition,
@@ -212,16 +213,6 @@ impl StaticIndex<'_> {
         }
         this
     }
-}
-
-fn get_definition(sema: &Semantics<'_, RootDatabase>, token: SyntaxToken) -> Option<Definition> {
-    for token in sema.descend_into_macros(token) {
-        let def = IdentClass::classify_token(sema, &token).map(IdentClass::definitions_no_ops);
-        if let Some(&[it]) = def.as_deref() {
-            return Some(it);
-        }
-    }
-    None
 }
 
 #[cfg(test)]

--- a/crates/ide/src/view_memory_layout.rs
+++ b/crates/ide/src/view_memory_layout.rs
@@ -1,0 +1,170 @@
+use hir::{Field, HirDisplay, Layout, Semantics, Type};
+use ide_db::{
+    defs::{Definition, IdentClass},
+    helpers::pick_best_token,
+    RootDatabase,
+};
+use syntax::{AstNode, SyntaxKind, SyntaxToken};
+
+use crate::FilePosition;
+
+pub struct MemoryLayoutNode {
+    pub item_name: String,
+    pub typename: String,
+    pub size: u64,
+    pub alignment: u64,
+    pub offset: u64,
+    pub parent_idx: i64,
+    pub children_start: i64,
+    pub children_len: u64,
+}
+
+pub struct RecursiveMemoryLayout {
+    pub nodes: Vec<MemoryLayoutNode>,
+}
+
+fn get_definition(sema: &Semantics<'_, RootDatabase>, token: SyntaxToken) -> Option<Definition> {
+    for token in sema.descend_into_macros(token) {
+        let def = IdentClass::classify_token(sema, &token).map(IdentClass::definitions_no_ops);
+        if let Some(&[x]) = def.as_deref() {
+            return Some(x);
+        }
+    }
+    None
+}
+
+pub(crate) fn view_memory_layout(
+    db: &RootDatabase,
+    position: FilePosition,
+) -> Option<RecursiveMemoryLayout> {
+    let sema = Semantics::new(db);
+    let file = sema.parse(position.file_id);
+    let token =
+        pick_best_token(file.syntax().token_at_offset(position.offset), |kind| match kind {
+            SyntaxKind::IDENT => 3,
+            _ => 0,
+        })?;
+
+    let def = get_definition(&sema, token)?;
+
+    let ty = match def {
+        Definition::Adt(it) => it.ty(db),
+        Definition::TypeAlias(it) => it.ty(db),
+        Definition::BuiltinType(it) => it.ty(db),
+        Definition::SelfType(it) => it.self_ty(db),
+        Definition::Local(it) => it.ty(db),
+        _ => return None,
+    };
+
+    enum FieldOrTupleIdx {
+        Field(Field),
+        TupleIdx(usize),
+    }
+
+    impl FieldOrTupleIdx {
+        fn name(&self, db: &RootDatabase) -> String {
+            match *self {
+                FieldOrTupleIdx::Field(f) => f
+                    .name(db)
+                    .as_str()
+                    .map(|s| s.to_owned())
+                    .unwrap_or_else(|| format!("{:#?}", f.name(db).as_tuple_index().unwrap())),
+                FieldOrTupleIdx::TupleIdx(i) => format!(".{i}").to_owned(),
+            }
+        }
+
+        fn index(&self) -> usize {
+            match *self {
+                FieldOrTupleIdx::Field(f) => f.index(),
+                FieldOrTupleIdx::TupleIdx(i) => i,
+            }
+        }
+    }
+
+    fn read_layout(
+        nodes: &mut Vec<MemoryLayoutNode>,
+        db: &RootDatabase,
+        ty: &Type,
+        layout: &Layout,
+        parent_idx: usize,
+    ) {
+        let mut fields = ty
+            .fields(db)
+            .into_iter()
+            .map(|(f, ty)| (FieldOrTupleIdx::Field(f), ty))
+            .chain(
+                ty.tuple_fields(db)
+                    .into_iter()
+                    .enumerate()
+                    .map(|(i, ty)| (FieldOrTupleIdx::TupleIdx(i), ty)),
+            )
+            .collect::<Vec<_>>();
+
+        fields.sort_by_key(|(f, _)| layout.field_offset(f.index()).unwrap_or(u64::MAX));
+
+        if fields.len() == 0 {
+            return;
+        }
+
+        let children_start = nodes.len();
+        nodes[parent_idx].children_start = children_start as i64;
+        nodes[parent_idx].children_len = fields.len() as u64;
+
+        for (field, child_ty) in fields.iter() {
+            if let Ok(child_layout) = child_ty.layout(db) {
+                nodes.push(MemoryLayoutNode {
+                    item_name: field.name(db),
+                    typename: child_ty.display(db).to_string(),
+                    size: child_layout.size(),
+                    alignment: child_layout.align(),
+                    offset: layout.field_offset(field.index()).unwrap_or(0),
+                    parent_idx: parent_idx as i64,
+                    children_start: -1,
+                    children_len: 0,
+                });
+            } else {
+                nodes.push(MemoryLayoutNode {
+                    item_name: field.name(db)
+                        + format!("(no layout data: {:?})", child_ty.layout(db).unwrap_err())
+                            .as_ref(),
+                    typename: child_ty.display(db).to_string(),
+                    size: 0,
+                    offset: 0,
+                    alignment: 0,
+                    parent_idx: parent_idx as i64,
+                    children_start: -1,
+                    children_len: 0,
+                });
+            }
+        }
+
+        for (i, (_, child_ty)) in fields.iter().enumerate() {
+            if let Ok(child_layout) = child_ty.layout(db) {
+                read_layout(nodes, db, &child_ty, &child_layout, children_start + i);
+            }
+        }
+    }
+
+    ty.layout(db).map(|layout| {
+        let item_name = match def {
+            Definition::Local(l) => l.name(db).as_str().unwrap().to_owned(),
+            _ => "[ROOT]".to_owned(),
+        };
+
+        let typename = ty.display(db).to_string();
+
+        let mut nodes = vec![MemoryLayoutNode {
+            item_name,
+            typename: typename.clone(),
+            size: layout.size(),
+            offset: 0,
+            alignment: layout.align(),
+            parent_idx: -1,
+            children_start: -1,
+            children_len: 0,
+        }];
+        read_layout(&mut nodes, db, &ty, &layout, 0);
+
+        RecursiveMemoryLayout { nodes }
+    })
+}

--- a/crates/ide/src/view_memory_layout.rs
+++ b/crates/ide/src/view_memory_layout.rs
@@ -145,26 +145,28 @@ pub(crate) fn view_memory_layout(
         }
     }
 
-    ty.layout(db).map(|layout| {
-        let item_name = match def {
-            Definition::Local(l) => l.name(db).as_str().unwrap().to_owned(),
-            _ => "[ROOT]".to_owned(),
-        };
+    ty.layout(db)
+        .map(|layout| {
+            let item_name = match def {
+                Definition::Local(l) => l.name(db).as_str().unwrap().to_owned(),
+                _ => "[ROOT]".to_owned(),
+            };
 
-        let typename = ty.display(db).to_string();
+            let typename = ty.display(db).to_string();
 
-        let mut nodes = vec![MemoryLayoutNode {
-            item_name,
-            typename: typename.clone(),
-            size: layout.size(),
-            offset: 0,
-            alignment: layout.align(),
-            parent_idx: -1,
-            children_start: -1,
-            children_len: 0,
-        }];
-        read_layout(&mut nodes, db, &ty, &layout, 0);
+            let mut nodes = vec![MemoryLayoutNode {
+                item_name,
+                typename: typename.clone(),
+                size: layout.size(),
+                offset: 0,
+                alignment: layout.align(),
+                parent_idx: -1,
+                children_start: -1,
+                children_len: 0,
+            }];
+            read_layout(&mut nodes, db, &ty, &layout, 0);
 
-        RecursiveMemoryLayout { nodes }
-    })
+            RecursiveMemoryLayout { nodes }
+        })
+        .ok()
 }

--- a/crates/rust-analyzer/src/handlers/request.rs
+++ b/crates/rust-analyzer/src/handlers/request.rs
@@ -1691,7 +1691,7 @@ pub(crate) fn handle_move_item(
 
 pub(crate) fn handle_view_recursive_memory_layout(
     snap: GlobalStateSnapshot,
-    params: lsp_ext::ViewRecursiveMemoryLayoutParams,
+    params: lsp_types::TextDocumentPositionParams,
 ) -> anyhow::Result<Option<lsp_ext::RecursiveMemoryLayout>> {
     let _p = profile::span("view_recursive_memory_layout");
     let file_id = from_proto::file_id(&snap, &params.text_document.uri)?;

--- a/crates/rust-analyzer/src/handlers/request.rs
+++ b/crates/rust-analyzer/src/handlers/request.rs
@@ -1692,7 +1692,7 @@ pub(crate) fn handle_move_item(
 pub(crate) fn handle_view_recursive_memory_layout(
     snap: GlobalStateSnapshot,
     params: lsp_ext::ViewRecursiveMemoryLayoutParams,
-) -> Result<Option<lsp_ext::RecursiveMemoryLayout>> {
+) -> anyhow::Result<Option<lsp_ext::RecursiveMemoryLayout>> {
     let _p = profile::span("view_recursive_memory_layout");
     let file_id = from_proto::file_id(&snap, &params.text_document.uri)?;
     let line_index = snap.file_line_index(file_id)?;

--- a/crates/rust-analyzer/src/lsp_ext.rs
+++ b/crates/rust-analyzer/src/lsp_ext.rs
@@ -185,16 +185,9 @@ pub struct ExpandedMacro {
 pub enum ViewRecursiveMemoryLayout {}
 
 impl Request for ViewRecursiveMemoryLayout {
-    type Params = ViewRecursiveMemoryLayoutParams;
+    type Params = lsp_types::TextDocumentPositionParams;
     type Result = Option<RecursiveMemoryLayout>;
     const METHOD: &'static str = "rust-analyzer/viewRecursiveMemoryLayout";
-}
-
-#[derive(Deserialize, Serialize, Debug)]
-#[serde(rename_all = "camelCase")]
-pub struct ViewRecursiveMemoryLayoutParams {
-    pub text_document: TextDocumentIdentifier,
-    pub position: Position,
 }
 
 #[derive(Deserialize, Serialize, Debug)]

--- a/crates/rust-analyzer/src/lsp_ext.rs
+++ b/crates/rust-analyzer/src/lsp_ext.rs
@@ -182,6 +182,40 @@ pub struct ExpandedMacro {
     pub expansion: String,
 }
 
+pub enum ViewRecursiveMemoryLayout {}
+
+impl Request for ViewRecursiveMemoryLayout {
+    type Params = ViewRecursiveMemoryLayoutParams;
+    type Result = Option<RecursiveMemoryLayout>;
+    const METHOD: &'static str = "rust-analyzer/viewRecursiveMemoryLayout";
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct ViewRecursiveMemoryLayoutParams {
+    pub text_document: TextDocumentIdentifier,
+    pub position: Position,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct RecursiveMemoryLayout {
+    pub nodes: Vec<MemoryLayoutNode>,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct MemoryLayoutNode {
+    pub item_name: String,
+    pub typename: String,
+    pub size: u64,
+    pub offset: u64,
+    pub alignment: u64,
+    pub parent_idx: i64,
+    pub children_start: i64,
+    pub children_len: u64,
+}
+
 pub enum CancelFlycheck {}
 
 impl Notification for CancelFlycheck {

--- a/crates/rust-analyzer/src/main_loop.rs
+++ b/crates/rust-analyzer/src/main_loop.rs
@@ -753,6 +753,7 @@ impl GlobalState {
             )
             .on::<lsp_types::request::WillRenameFiles>(handlers::handle_will_rename_files)
             .on::<lsp_ext::Ssr>(handlers::handle_ssr)
+            .on::<lsp_ext::ViewRecursiveMemoryLayout>(handlers::handle_view_recursive_memory_layout)
             .finish();
     }
 

--- a/docs/dev/lsp-extensions.md
+++ b/docs/dev/lsp-extensions.md
@@ -1,5 +1,5 @@
 <!---
-lsp_ext.rs hash: 12bf360ee77cc63d
+lsp_ext.rs hash: 149a5be3c5e469d1
 
 If you need to change the above hash to make the test pass, please check if you
 need to adjust this doc as well and ping this issue:
@@ -889,17 +889,9 @@ Returns all crates from this workspace, so it can be used create a viewTree to h
 
 ## View Recursive Memory Layout
 
-**Method:** `rust-analyzer/fetchDependencyList`
+**Method:** `rust-analyzer/viewRecursiveMemoryLayout`
 
-**Request:**
-
-```typescript
-/// Holds a location in a text document, the location may be a datatype or a variable and it will do its best to locate the desired type.
-export interface ViewRecursiveMemoryLayoutParams {
-  textDocument: TextDocumentIdentifier;
-  position: Position;
-}
-```
+**Request:** `TextDocumentPositionParams`
 
 **Response:**
 

--- a/docs/dev/lsp-extensions.md
+++ b/docs/dev/lsp-extensions.md
@@ -1,5 +1,5 @@
 <!---
-lsp_ext.rs hash: 2d60bbffe70ae198
+lsp_ext.rs hash: 12bf360ee77cc63d
 
 If you need to change the above hash to make the test pass, please check if you
 need to adjust this doc as well and ping this issue:
@@ -886,3 +886,56 @@ export interface FetchDependencyListResult {
 }
 ```
 Returns all crates from this workspace, so it can be used create a viewTree to help navigate the dependency tree.
+
+## View Recursive Memory Layout
+
+**Method:** `rust-analyzer/fetchDependencyList`
+
+**Request:**
+
+```typescript
+/// Holds a location in a text document, the location may be a datatype or a variable and it will do its best to locate the desired type.
+export interface ViewRecursiveMemoryLayoutParams {
+  textDocument: TextDocumentIdentifier;
+  position: Position;
+}
+```
+
+**Response:**
+
+```typescript
+export interface RecursiveMemoryLayoutNode = {
+    /// Name of the item, or [ROOT], `.n` for tuples
+    item_name: string;
+    /// Full name of the type (type aliases are ignored)
+    typename: string;
+    /// Size of the type in bytes
+    size: number;
+    /// Alignment of the type in bytes
+    alignment: number;
+    /// Offset of the type relative to its parent (or 0 if its the root)
+    offset: number;
+    /// Index of the node's parent (or -1 if its the root)
+    parent_idx: number;
+    /// Index of the node's children (or -1 if it does not have children)
+    children_start: number;
+    /// Number of child nodes (unspecified it does not have children)
+    children_len: number;
+};
+
+export interface RecursiveMemoryLayout = {
+    nodes: RecursiveMemoryLayoutNode[];
+};
+```
+
+Returns a vector of nodes representing items in the datatype as a tree, `RecursiveMemoryLayout::nodes[0]` is the root node.
+
+If `RecursiveMemoryLayout::nodes::length == 0` we could not find a suitable type.
+
+Generic Types do not give anything because they are incomplete. Fully specified generic types do not give anything if they are selected directly but do work when a child of other types [this is consistent with other behavior](https://github.com/rust-lang/rust-analyzer/issues/15010).
+
+### Unresolved questions:
+
+- How should enums/unions be represented? currently they do not produce any children because they have multiple distinct sets of children.
+- Should niches be represented? currently they are not reported.
+- A visual representation of the memory layout is not specified, see the provided implementation for an example, however it may not translate well to terminal based editors or other such things.

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -284,6 +284,11 @@
                 "command": "rust-analyzer.revealDependency",
                 "title": "Reveal File",
                 "category": "rust-analyzer"
+            },
+            {
+                "command": "rust-analyzer.viewMemoryLayout",
+                "title": "View Memory Layout",
+                "category": "rust-analyzer"
             }
         ],
         "keybindings": [
@@ -2066,6 +2071,10 @@
                 },
                 {
                     "command": "rust-analyzer.openCargoToml",
+                    "when": "inRustProject"
+                },
+                {
+                    "command": "rust-analyzer.viewMemoryLayout",
                     "when": "inRustProject"
                 }
             ],

--- a/editors/code/src/commands.ts
+++ b/editors/code/src/commands.ts
@@ -1133,7 +1133,7 @@ export function linkToCommand(_: Ctx): Cmd {
 export function viewMemoryLayout(ctx: CtxInit): Cmd {
     return async () => {
         const editor = vscode.window.activeTextEditor;
-        if (!editor) return "";
+        if (!editor) return;
         const client = ctx.client;
 
         const position = editor.selection.active;

--- a/editors/code/src/commands.ts
+++ b/editors/code/src/commands.ts
@@ -1132,27 +1132,24 @@ export function linkToCommand(_: Ctx): Cmd {
 
 export function viewMemoryLayout(ctx: CtxInit): Cmd {
     return async () => {
-
         const editor = vscode.window.activeTextEditor;
         if (!editor) return "";
         const client = ctx.client;
 
         const position = editor.selection.active;
         const expanded = await client.sendRequest(ra.viewRecursiveMemoryLayout, {
-            textDocument: client.code2ProtocolConverter.asTextDocumentIdentifier(
-                editor.document
-            ),
+            textDocument: client.code2ProtocolConverter.asTextDocumentIdentifier(editor.document),
             position,
         });
 
         // if (expanded == null) return "Not available";
 
-
         const document = vscode.window.createWebviewPanel(
             "memory_layout",
             "[Memory Layout]",
             vscode.ViewColumn.Two,
-            { enableScripts: true, });
+            { enableScripts: true }
+        );
 
         document.webview.html = `<!DOCTYPE html>
 <html lang="en">
@@ -1407,7 +1404,7 @@ locate()
 
 })()
 </script>
-</html>`
+</html>`;
 
         ctx.pushExtCleanup(document);
     };

--- a/editors/code/src/commands.ts
+++ b/editors/code/src/commands.ts
@@ -1142,8 +1142,6 @@ export function viewMemoryLayout(ctx: CtxInit): Cmd {
             position,
         });
 
-        // if (expanded == null) return "Not available";
-
         const document = vscode.window.createWebviewPanel(
             "memory_layout",
             "[Memory Layout]",

--- a/editors/code/src/lsp_ext.ts
+++ b/editors/code/src/lsp_ext.ts
@@ -218,7 +218,5 @@ export type RecursiveMemoryLayoutNode = {
     children_len: number;
 };
 export type RecursiveMemoryLayout = {
-    name: string;
-    expansion: string;
     nodes: RecursiveMemoryLayoutNode[];
 };

--- a/editors/code/src/lsp_ext.ts
+++ b/editors/code/src/lsp_ext.ts
@@ -151,7 +151,7 @@ export const serverStatus = new lc.NotificationType<ServerStatusParams>(
 );
 export const ssr = new lc.RequestType<SsrParams, lc.WorkspaceEdit, void>("experimental/ssr");
 export const viewRecursiveMemoryLayout = new lc.RequestType<
-    ViewRecursiveMemoryLayoutParams,
+    lc.TextDocumentPositionParams,
     RecursiveMemoryLayout | null,
     void
 >("rust-analyzer/viewRecursiveMemoryLayout");
@@ -203,10 +203,6 @@ export type SsrParams = {
     selections: readonly lc.Range[];
 };
 
-export type ViewRecursiveMemoryLayoutParams = {
-    textDocument: lc.TextDocumentIdentifier;
-    position: lc.Position;
-};
 export type RecursiveMemoryLayoutNode = {
     item_name: string;
     typename: string;

--- a/editors/code/src/lsp_ext.ts
+++ b/editors/code/src/lsp_ext.ts
@@ -70,7 +70,7 @@ export const viewItemTree = new lc.RequestType<ViewItemTreeParams, string, void>
 
 export type AnalyzerStatusParams = { textDocument?: lc.TextDocumentIdentifier };
 
-export interface FetchDependencyListParams {}
+export interface FetchDependencyListParams { }
 
 export interface FetchDependencyListResult {
     crates: {
@@ -86,7 +86,7 @@ export const fetchDependencyList = new lc.RequestType<
     void
 >("rust-analyzer/fetchDependencyList");
 
-export interface FetchDependencyGraphParams {}
+export interface FetchDependencyGraphParams { }
 
 export interface FetchDependencyGraphResult {
     crates: {
@@ -150,6 +150,9 @@ export const serverStatus = new lc.NotificationType<ServerStatusParams>(
     "experimental/serverStatus"
 );
 export const ssr = new lc.RequestType<SsrParams, lc.WorkspaceEdit, void>("experimental/ssr");
+export const viewRecursiveMemoryLayout = new lc.RequestType<ViewRecursiveMemoryLayoutParams, RecursiveMemoryLayout | null, void>(
+    "rust-analyzer/viewRecursiveMemoryLayout"
+);
 
 export type JoinLinesParams = {
     textDocument: lc.TextDocumentIdentifier;
@@ -196,4 +199,24 @@ export type SsrParams = {
     textDocument: lc.TextDocumentIdentifier;
     position: lc.Position;
     selections: readonly lc.Range[];
+};
+
+export type ViewRecursiveMemoryLayoutParams = {
+    textDocument: lc.TextDocumentIdentifier;
+    position: lc.Position;
+};
+export type RecursiveMemoryLayoutNode = {
+    item_name: string;
+    typename: string;
+    size: number;
+    alignment: number;
+    offset: number;
+    parent_idx: number;
+    children_start: number;
+    children_len: number;
+};
+export type RecursiveMemoryLayout = {
+    name: string;
+    expansion: string;
+    nodes: RecursiveMemoryLayoutNode[];
 };

--- a/editors/code/src/lsp_ext.ts
+++ b/editors/code/src/lsp_ext.ts
@@ -70,7 +70,7 @@ export const viewItemTree = new lc.RequestType<ViewItemTreeParams, string, void>
 
 export type AnalyzerStatusParams = { textDocument?: lc.TextDocumentIdentifier };
 
-export interface FetchDependencyListParams { }
+export interface FetchDependencyListParams {}
 
 export interface FetchDependencyListResult {
     crates: {
@@ -86,7 +86,7 @@ export const fetchDependencyList = new lc.RequestType<
     void
 >("rust-analyzer/fetchDependencyList");
 
-export interface FetchDependencyGraphParams { }
+export interface FetchDependencyGraphParams {}
 
 export interface FetchDependencyGraphResult {
     crates: {
@@ -150,9 +150,11 @@ export const serverStatus = new lc.NotificationType<ServerStatusParams>(
     "experimental/serverStatus"
 );
 export const ssr = new lc.RequestType<SsrParams, lc.WorkspaceEdit, void>("experimental/ssr");
-export const viewRecursiveMemoryLayout = new lc.RequestType<ViewRecursiveMemoryLayoutParams, RecursiveMemoryLayout | null, void>(
-    "rust-analyzer/viewRecursiveMemoryLayout"
-);
+export const viewRecursiveMemoryLayout = new lc.RequestType<
+    ViewRecursiveMemoryLayoutParams,
+    RecursiveMemoryLayout | null,
+    void
+>("rust-analyzer/viewRecursiveMemoryLayout");
 
 export type JoinLinesParams = {
     textDocument: lc.TextDocumentIdentifier;

--- a/editors/code/src/main.ts
+++ b/editors/code/src/main.ts
@@ -24,11 +24,11 @@ export async function activate(
         vscode.window
             .showWarningMessage(
                 `You have both the rust-analyzer (rust-lang.rust-analyzer) and Rust (rust-lang.rust) ` +
-                    "plugins enabled. These are known to conflict and cause various functions of " +
-                    "both plugins to not work correctly. You should disable one of them.",
+                "plugins enabled. These are known to conflict and cause various functions of " +
+                "both plugins to not work correctly. You should disable one of them.",
                 "Got it"
             )
-            .then(() => {}, console.error);
+            .then(() => { }, console.error);
     }
 
     const ctx = new Ctx(context, createCommands(), fetchWorkspace());
@@ -144,7 +144,7 @@ function createCommands(): Record<string, CommandFactory> {
                     health: "stopped",
                 });
             },
-            disabled: (_) => async () => {},
+            disabled: (_) => async () => { },
         },
 
         analyzerStatus: { enabled: commands.analyzerStatus },
@@ -179,6 +179,7 @@ function createCommands(): Record<string, CommandFactory> {
         runFlycheck: { enabled: commands.runFlycheck },
         ssr: { enabled: commands.ssr },
         serverVersion: { enabled: commands.serverVersion },
+        viewMemoryLayout: { enabled: commands.viewMemoryLayout },
         // Internal commands which are invoked by the server.
         applyActionGroup: { enabled: commands.applyActionGroup },
         applySnippetWorkspaceEdit: { enabled: commands.applySnippetWorkspaceEditCommand },

--- a/editors/code/src/main.ts
+++ b/editors/code/src/main.ts
@@ -24,11 +24,11 @@ export async function activate(
         vscode.window
             .showWarningMessage(
                 `You have both the rust-analyzer (rust-lang.rust-analyzer) and Rust (rust-lang.rust) ` +
-                "plugins enabled. These are known to conflict and cause various functions of " +
-                "both plugins to not work correctly. You should disable one of them.",
+                    "plugins enabled. These are known to conflict and cause various functions of " +
+                    "both plugins to not work correctly. You should disable one of them.",
                 "Got it"
             )
-            .then(() => { }, console.error);
+            .then(() => {}, console.error);
     }
 
     const ctx = new Ctx(context, createCommands(), fetchWorkspace());
@@ -144,7 +144,7 @@ function createCommands(): Record<string, CommandFactory> {
                     health: "stopped",
                 });
             },
-            disabled: (_) => async () => { },
+            disabled: (_) => async () => {},
         },
 
         analyzerStatus: { enabled: commands.analyzerStatus },


### PR DESCRIPTION
**Motivation**: rustc by default doesn't enforce a particular memory layout, however it can be useful to see what it is doing under the hood, or if using a particular repr ensure it is behaving how you want it to. This command provides a way to visually explore memory layouts of structures.

**Example**:
this structure:
```rust
struct X {
    x: i32,
    y: u8,
    z: Vec<bool>,
    w: usize,
}
```
produces this output:
<img width="692" alt="image" src="https://github.com/rust-lang/rust-analyzer/assets/22418744/e0312233-18a7-4bb9-ae5b-7b52fcff158a">

**Work yet to be done**:
- tests (see below)
- html is mildly janky (see below)
- enums and unions are viewed flatly, how should they be represented?
- should niches be marked somehow?

This was written for my own use, and the jank is fine for me, but in its current state it is probably not ready to merge mostly because it is missing tests, and also because the code quality is not great. However, before I spend time fixing those things idk if this is even something wanted, if it is I am happy to clean it up, if not that's cool too.