### PR TITLE
Remove markdown injection for block comments

### DIFF
--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -1648,7 +1648,7 @@
                 "path": "ra_syntax_tree.tmGrammar.json"
             },
             {
-                "scopeName": "rustdoc.markdown.injection",
+                "scopeName": "source.rustdoc.markdown.injection",
                 "path": "rustdoc.markdown.injection.tmGrammar.json",
                 "injectTo": [
                     "source.rust"

--- a/editors/code/rustdoc.markdown.injection.tmGrammar.json
+++ b/editors/code/rustdoc.markdown.injection.tmGrammar.json
@@ -1,30 +1,17 @@
 {
-    "scopeName": "rustdoc.markdown.injection",
+    "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+    "scopeName": "source.rustdoc.markdown.injection",
     "injectionSelector": "L:source.rust",
     "patterns": [
         {
             "include": "#doc-comment-line"
-        },
-        {
-            "include": "#doc-comment-block"
         }
     ],
     "repository": {
         "doc-comment-line": {
             "name": "comment.line.documentation.rust",
             "begin": "^\\s*//(/|!)",
-            "while": "^\\s*//(/|!)",
-            "contentName": "meta.embedded.block.markdown",
-            "patterns": [
-                {
-                    "include": "text.html.markdown"
-                }
-            ]
-        },
-        "doc-comment-block": {
-            "name": "comment.block.documentation.rust",
-            "begin": "/\\*(\\*|!)",
-            "end": "\\s*\\*/",
+            "end": "$",
             "contentName": "meta.embedded.block.markdown",
             "patterns": [
                 {


### PR DESCRIPTION
Closes https://github.com/rust-lang/rust-analyzer/issues/15091

I tried making it work but it doesn't seem possible, as the `*` of the closing `*/` sequence gets eaten by the markdown grammar no matter what.