### PR TITLE
Skip mutable diagnostics on synthetic bindings

### DIFF
--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -1661,6 +1661,14 @@ impl DefWithBody {
                     let Some(&local) = mir_body.binding_locals.get(binding_id) else {
                         continue;
                     };
+                    if body[binding_id]
+                        .definitions
+                        .iter()
+                        .any(|&pat| source_map.pat_syntax(pat).is_err())
+                    {
+                        // Skip synthetic bindings
+                        continue;
+                    }
                     let need_mut = &mol[local];
                     let local = Local { parent: self.into(), binding_id };
                     match (need_mut, local.is_mut(db)) {

--- a/crates/ide-diagnostics/src/handlers/mutability_errors.rs
+++ b/crates/ide-diagnostics/src/handlers/mutability_errors.rs
@@ -1094,4 +1094,17 @@ fn main() {
 "#,
         );
     }
+
+    #[test]
+    fn regression_15099() {
+        check_diagnostics(
+            r#"
+//- minicore: iterator, range
+fn f() {
+    loop {}
+    for _ in 0..2 {}
+}
+"#,
+        );
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust-analyzer/issues/15099

We probabnly need to look into this in a more general manner in the future now that we desugar more things