### PR TITLE
Change comparsion for checking if number is negative to include 128

### DIFF
--- a/crates/hir-ty/src/consteval/tests.rs
+++ b/crates/hir-ty/src/consteval/tests.rs
@@ -2018,6 +2018,57 @@ fn consts() {
     "#,
         6,
     );
+
+    check_number(
+        r#"
+    const F1: i32 = 2147483647;
+    const F2: i32 = F1 - 25;
+    const GOAL: i32 = F2;
+    "#,
+        2147483622,
+    );
+
+    check_number(
+        r#"
+    const F1: i32 = -2147483648;
+    const F2: i32 = F1 + 18;
+    const GOAL: i32 = F2;
+    "#,
+        -2147483630,
+    );
+
+    check_number(
+        r#"
+    const F1: i32 = 10;
+    const F2: i32 = F1 - 20;
+    const GOAL: i32 = F2;
+    "#,
+        -10,
+    );
+
+    check_number(
+        r#"
+    const F1: i32 = 25;
+    const F2: i32 = F1 - 25;
+    const GOAL: i32 = F2;
+    "#,
+        0,
+    );
+
+    check_number(
+        r#"
+    const A: i32 = -2147483648;
+    const GOAL: bool = A > 0;
+    "#,
+        0,
+    );
+
+    check_number(
+        r#"
+    const GOAL: i64 = (-2147483648_i32) as i64;
+    "#,
+        -2147483648,
+    );
 }
 
 #[test]

--- a/crates/hir-ty/src/mir/eval.rs
+++ b/crates/hir-ty/src/mir/eval.rs
@@ -2122,7 +2122,7 @@ impl Evaluator<'_> {
 }
 
 pub fn pad16(x: &[u8], is_signed: bool) -> [u8; 16] {
-    let is_negative = is_signed && x.last().unwrap_or(&0) > &128;
+    let is_negative = is_signed && x.last().unwrap_or(&0) > &127;
     let fill_with = if is_negative { 255 } else { 0 };
     x.iter()
         .copied()

--- a/crates/ide/src/hover/tests.rs
+++ b/crates/ide/src/hover/tests.rs
@@ -779,6 +779,39 @@ const foo$0: u32 = {
             ```
         "#]],
     );
+
+    check(
+        r#"const FOO$0: i32 = -2147483648;"#,
+        expect![[r#"
+            *FOO*
+
+            ```rust
+            test
+            ```
+
+            ```rust
+            const FOO: i32 = -2147483648 (0x80000000)
+            ```
+        "#]],
+    );
+
+    check(
+        r#"
+        const FOO: i32 = -2147483648;
+        const BAR$0: bool = FOO > 0;
+        "#,
+        expect![[r#"
+            *BAR*
+
+            ```rust
+            test
+            ```
+
+            ```rust
+            const BAR: bool = false
+            ```
+        "#]],
+    );
 }
 
 #[test]


### PR DESCRIPTION
The last byte in Little-Endian representation of negative integers start at 128 (Ox80) till 255 (OxFF). The comparison before the fix didn't check for 128 which made is_negative variable as false.

Potentially fixes #15096 