### PR TITLE
Set `IS_RUST_ANALYZER=1` for build commands

### DIFF
--- a/crates/project-model/src/build_scripts.rs
+++ b/crates/project-model/src/build_scripts.rs
@@ -106,6 +106,7 @@ impl WorkspaceBuildScripts {
             }
         };
 
+        cmd.env("IS_RUST_ANALYZER", "1");
         cmd.envs(&config.extra_env);
         if config.wrap_rustc_in_build_scripts {
             // Setup RUSTC_WRAPPER to point to `rust-analyzer` binary itself. We use


### PR DESCRIPTION
We have some builds scripts that do heavy work (e.g., running `wasm-pack`) that isn't necessary for RA's analysis, but nonetheless slows down IDE startup because RA runs the build script on server restart^1. We want to add something essentially like this to our build script:

```rust
// build.rs
if !is_rust_analyzer() {
    // do slow stuff that RA doesn't need
}
```

But right now there isn't a great way to detect RA in a build script. Based on [current main](https://github.com/rust-lang/rust-analyzer/blob/85493dfdb045ce78db78c6d50e8015bdb442cc62/crates/project-model/src/build_scripts.rs#L109C1-L117), our build script actually looks like this:

```rust
let is_rust_analyzer = option_env!("RA_RUSTC_WRAPPER").is_some() || option_env!("IS_RUST_ANALYZER").is_some();
if !is_rust_analyzer {
    do_wasm_pack();
}
```

Where `RA_RUSTC_WRAPPER` is set for *some* invocations, but for full coverage you need to manually add `IS_RUST_ANALYZER` to `cargoExtraEnv` in your editor's rust-analyzer config. This PR simply unconditionally sets that environment variable.

Bikeshedding welcome on the variable name, I just picked what seemed reasonable. There's also the question of documentation, tests, etc.—this is my first RA PR so (if people want to see this merged), I'd appreciate guidance on how to do that.

^1 : We do emit the appropriate `cargo:rerun-if-changed` directives, but that doesn't help when switching branches causes genuine changes in those directories.