### PR TITLE
Add the comment why `HasSource::source()` returns `Option`

### DIFF
--- a/crates/hir/src/has_source.rs
+++ b/crates/hir/src/has_source.rs
@@ -21,6 +21,10 @@ pub trait HasSource {
     /// Fetches the definition's source node.
     /// Using [`crate::Semantics::source`] is preferred when working with [`crate::Semantics`],
     /// as that caches the parsed file in the semantics' cache.
+    ///
+    /// The current some implementations can return `InFile` instead of `Option<InFile>`.
+    /// But we made this method `Option` to support rlib in the future
+    /// by https://github.com/rust-lang/rust-analyzer/issues/6913
     fn source(self, db: &dyn HirDatabase) -> Option<InFile<Self::Ast>>;
 }
 


### PR DESCRIPTION
Fix https://github.com/rust-lang/rust-analyzer/issues/15088