### PR TITLE
assist : generate trait from impl

### DIFF
--- a/crates/ide-assists/src/handlers/generate_trait_from_impl.rs
+++ b/crates/ide-assists/src/handlers/generate_trait_from_impl.rs
@@ -105,8 +105,6 @@ pub(crate) fn generate_trait_from_impl(acc: &mut Assists, ctx: &AssistContext<'_
                 remove_items_visibility(&item);
             });
 
-            ted::replace(assoc_items.clone_for_update().syntax(), impl_items.syntax());
-
             impl_items.assoc_items().for_each(|item| {
                 remove_items_visibility(&item);
             });
@@ -201,7 +199,7 @@ fn strip_body(item: &ast::AssocItem) {
                     }
                 }
 
-                ted::replace(body.syntax(), ast::make::tokens::semicolon());
+                ted::replace(body.syntax(), make::tokens::semicolon());
             }
         }
         _ => (),

--- a/crates/ide-assists/src/handlers/generate_trait_from_impl.rs
+++ b/crates/ide-assists/src/handlers/generate_trait_from_impl.rs
@@ -1,0 +1,343 @@
+use crate::assist_context::{AssistContext, Assists};
+use ide_db::{assists::AssistId, SnippetCap};
+use syntax::{
+    ast::{self, HasGenericParams, HasVisibility},
+    AstNode,
+};
+
+// NOTES :
+// We generate erroneous code if a function is declared const (E0379)
+// This is left to the user to correct as our only option is to remove the
+// function completely which we should not be doing.
+
+// Assist: generate_trait_from_impl
+//
+// Generate trait for an already defined inherent impl and convert impl to a trait impl.
+//
+// ```
+// struct Foo<const N: usize>([i32; N]);
+//
+// macro_rules! const_maker {
+//     ($t:ty, $v:tt) => {
+//         const CONST: $t = $v;
+//     };
+// }
+//
+// impl<const N: usize> Fo$0o<N> {
+//     // Used as an associated constant.
+//     const CONST_ASSOC: usize = N * 4;
+//
+//     fn create() -> Option<()> {
+//         Some(())
+//     }
+//
+//     const_maker! {i32, 7}
+// }
+// ```
+// ->
+// ```
+// struct Foo<const N: usize>([i32; N]);
+//
+// macro_rules! const_maker {
+//     ($t:ty, $v:tt) => {
+//         const CONST: $t = $v;
+//     };
+// }
+//
+// trait NewTrait<const N: usize> {
+//     // Used as an associated constant.
+//     const CONST_ASSOC: usize = N * 4;
+//
+//     fn create() -> Option<()>;
+//
+//     const_maker! {i32, 7}
+// }
+//
+// impl<const N: usize> NewTrait<N> for Foo<N> {
+//     // Used as an associated constant.
+//     const CONST_ASSOC: usize = N * 4;
+//
+//     fn create() -> Option<()> {
+//         Some(())
+//     }
+//
+//     const_maker! {i32, 7}
+// }
+// ```
+pub(crate) fn generate_trait_from_impl(acc: &mut Assists, ctx: &AssistContext<'_>) -> Option<()> {
+    // Get AST Node
+    let impl_ast = ctx.find_node_at_offset::<ast::Impl>()?;
+
+    // If impl is not inherent then we don't really need to go any further.
+    if impl_ast.for_token().is_some() {
+        return None;
+    }
+
+    let assoc_items = impl_ast.assoc_item_list();
+    if assoc_items.is_none() {
+        // Also do not do anything if no assoc item is there.
+        return None;
+    }
+
+    let assoc_items = assoc_items.unwrap();
+    let first_element = assoc_items.assoc_items().next();
+    if first_element.is_none() {
+        // No reason for an assist.
+        return None;
+    }
+
+    acc.add(
+        AssistId("generate_trait_from_impl", ide_db::assists::AssistKind::Generate),
+        "Generate trait from impl".to_owned(),
+        impl_ast.syntax().text_range(),
+        |builder| {
+            let trait_items = assoc_items.clone_for_update();
+            let impl_items = assoc_items.clone_for_update();
+
+            trait_items.assoc_items().for_each(|item| {
+                strip_body(&item);
+                remove_items_visibility(&item);
+            });
+
+            syntax::ted::replace(assoc_items.clone_for_update().syntax(), impl_items.syntax());
+
+            impl_items.assoc_items().for_each(|item| {
+                remove_items_visibility(&item);
+            });
+
+            let trait_ast = ast::make::trait_(
+                false,
+                "NewTrait".to_string(),
+                HasGenericParams::generic_param_list(&impl_ast),
+                HasGenericParams::where_clause(&impl_ast),
+                trait_items,
+            );
+
+            // Change `impl Foo` to `impl NewTrait for Foo`
+            // First find the PATH_TYPE which is what Foo is.
+            let impl_name = impl_ast.self_ty().unwrap();
+            let trait_name = if let Some(genpars) = impl_ast.generic_param_list() {
+                format!("NewTrait{}", genpars.to_generic_args())
+            } else {
+                format!("NewTrait")
+            };
+
+            // // Then replace
+            builder.replace(
+                impl_name.clone().syntax().text_range(),
+                format!("{} for {}", trait_name, impl_name.to_string()),
+            );
+
+            builder.replace(
+                impl_ast.assoc_item_list().unwrap().syntax().text_range(),
+                impl_items.to_string(),
+            );
+
+            // Insert trait before TraitImpl
+            builder.insert_snippet(
+                SnippetCap::new(true).unwrap(),
+                impl_ast.syntax().text_range().start(),
+                format!("{}\n\n", trait_ast.to_string()),
+            );
+        },
+    );
+
+    Some(())
+}
+
+/// `E0449` Trait items always share the visibility of their trait
+fn remove_items_visibility(item: &ast::AssocItem) {
+    match item {
+        ast::AssocItem::Const(c) => {
+            if let Some(vis) = c.visibility() {
+                syntax::ted::remove(vis.syntax());
+            }
+        }
+        ast::AssocItem::Fn(f) => {
+            if let Some(vis) = f.visibility() {
+                syntax::ted::remove(vis.syntax());
+            }
+        }
+        ast::AssocItem::TypeAlias(t) => {
+            if let Some(vis) = t.visibility() {
+                syntax::ted::remove(vis.syntax());
+            }
+        }
+        _ => (),
+    }
+}
+
+fn strip_body(item: &ast::AssocItem) {
+    match item {
+        ast::AssocItem::Fn(f) => {
+            if let Some(body) = f.body() {
+                // In constrast to function bodies, we want to see no ws before a semicolon.
+                // So let's remove them if we see any.
+                if let Some(prev) = body.syntax().prev_sibling_or_token() {
+                    if prev.kind() == syntax::SyntaxKind::WHITESPACE {
+                        syntax::ted::remove(prev);
+                    }
+                }
+
+                syntax::ted::replace(body.syntax(), ast::make::tokens::semicolon());
+            }
+        }
+        _ => (),
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tests::{check_assist, check_assist_not_applicable};
+
+    #[test]
+    fn test_assoc_item_fn() {
+        check_assist(
+            generate_trait_from_impl,
+            r#"
+struct Foo(f64);
+
+impl F$0oo {
+    fn add(&mut self, x: f64) {
+        self.0 += x;
+    }
+}"#,
+            r#"
+struct Foo(f64);
+
+trait NewTrait {
+    fn add(&mut self, x: f64);
+}
+
+impl NewTrait for Foo {
+    fn add(&mut self, x: f64) {
+        self.0 += x;
+    }
+}"#,
+        )
+    }
+
+    #[test]
+    fn test_assoc_item_macro() {
+        check_assist(
+            generate_trait_from_impl,
+            r#"
+struct Foo;
+
+macro_rules! const_maker {
+    ($t:ty, $v:tt) => {
+        const CONST: $t = $v;
+    };
+}
+
+impl F$0oo {
+    const_maker! {i32, 7}
+}"#,
+            r#"
+struct Foo;
+
+macro_rules! const_maker {
+    ($t:ty, $v:tt) => {
+        const CONST: $t = $v;
+    };
+}
+
+trait NewTrait {
+    const_maker! {i32, 7}
+}
+
+impl NewTrait for Foo {
+    const_maker! {i32, 7}
+}"#,
+        )
+    }
+
+    #[test]
+    fn test_assoc_item_const() {
+        check_assist(
+            generate_trait_from_impl,
+            r#"
+struct Foo;
+
+impl F$0oo {
+    const ABC: i32 = 3;
+}"#,
+            r#"
+struct Foo;
+
+trait NewTrait {
+    const ABC: i32 = 3;
+}
+
+impl NewTrait for Foo {
+    const ABC: i32 = 3;
+}"#,
+        )
+    }
+
+    #[test]
+    fn test_impl_with_generics() {
+        check_assist(
+            generate_trait_from_impl,
+            r#"
+struct Foo<const N: usize>([i32; N]);
+
+impl<const N: usize> F$0oo<N> {
+    // Used as an associated constant.
+    const CONST: usize = N * 4;
+}
+            "#,
+            r#"
+struct Foo<const N: usize>([i32; N]);
+
+trait NewTrait<const N: usize> {
+    // Used as an associated constant.
+    const CONST: usize = N * 4;
+}
+
+impl<const N: usize> NewTrait<N> for Foo<N> {
+    // Used as an associated constant.
+    const CONST: usize = N * 4;
+}
+            "#,
+        )
+    }
+
+    #[test]
+    fn test_e0449_avoided() {
+        check_assist(
+            generate_trait_from_impl,
+            r#"
+struct Foo;
+
+impl F$0oo {
+    pub fn a_func() -> Option<()> {
+        Some(())
+    }
+}"#,
+            r#"
+struct Foo;
+
+trait NewTrait {
+     fn a_func() -> Option<()>;
+}
+
+impl NewTrait for Foo {
+     fn a_func() -> Option<()> {
+        Some(())
+    }
+}"#,
+        )
+    }
+
+    #[test]
+    fn test_empty_inherent_impl() {
+        check_assist_not_applicable(
+            generate_trait_from_impl,
+            r#"
+impl Emp$0tyImpl{}
+"#,
+        )
+    }
+}

--- a/crates/ide-assists/src/handlers/generate_trait_from_impl.rs
+++ b/crates/ide-assists/src/handlers/generate_trait_from_impl.rs
@@ -73,13 +73,7 @@ pub(crate) fn generate_trait_from_impl(acc: &mut Assists, ctx: &AssistContext<'_
         return None;
     }
 
-    let assoc_items = impl_ast.assoc_item_list();
-    if assoc_items.is_none() {
-        // Also do not do anything if no assoc item is there.
-        return None;
-    }
-
-    let assoc_items = assoc_items.unwrap();
+    let assoc_items = impl_ast.assoc_item_list()?;
     let first_element = assoc_items.assoc_items().next();
     if first_element.is_none() {
         // No reason for an assist.

--- a/crates/ide-assists/src/lib.rs
+++ b/crates/ide-assists/src/lib.rs
@@ -160,6 +160,7 @@ mod handlers {
     mod generate_new;
     mod generate_setter;
     mod generate_delegate_methods;
+    mod generate_trait_from_impl;
     mod add_return_type;
     mod inline_call;
     mod inline_const_as_literal;
@@ -266,6 +267,7 @@ mod handlers {
             generate_impl::generate_trait_impl,
             generate_is_empty_from_len::generate_is_empty_from_len,
             generate_new::generate_new,
+            generate_trait_from_impl::generate_trait_from_impl,
             inline_call::inline_call,
             inline_call::inline_into_callers,
             inline_const_as_literal::inline_const_as_literal,

--- a/crates/ide-assists/src/tests/generated.rs
+++ b/crates/ide-assists/src/tests/generated.rs
@@ -1533,7 +1533,7 @@ macro_rules! const_maker {
     };
 }
 
-trait NewTrait<const N: usize> {
+trait ${0:TraitName}<const N: usize> {
     // Used as an associated constant.
     const CONST_ASSOC: usize = N * 4;
 
@@ -1542,7 +1542,7 @@ trait NewTrait<const N: usize> {
     const_maker! {i32, 7}
 }
 
-impl<const N: usize> NewTrait<N> for Foo<N> {
+impl<const N: usize> ${0:TraitName}<N> for Foo<N> {
     // Used as an associated constant.
     const CONST_ASSOC: usize = N * 4;
 

--- a/crates/ide-assists/src/tests/generated.rs
+++ b/crates/ide-assists/src/tests/generated.rs
@@ -1501,6 +1501,62 @@ impl Person {
 }
 
 #[test]
+fn doctest_generate_trait_from_impl() {
+    check_doc_test(
+        "generate_trait_from_impl",
+        r#####"
+struct Foo<const N: usize>([i32; N]);
+
+macro_rules! const_maker {
+    ($t:ty, $v:tt) => {
+        const CONST: $t = $v;
+    };
+}
+
+impl<const N: usize> Fo$0o<N> {
+    // Used as an associated constant.
+    const CONST_ASSOC: usize = N * 4;
+
+    fn create() -> Option<()> {
+        Some(())
+    }
+
+    const_maker! {i32, 7}
+}
+"#####,
+        r#####"
+struct Foo<const N: usize>([i32; N]);
+
+macro_rules! const_maker {
+    ($t:ty, $v:tt) => {
+        const CONST: $t = $v;
+    };
+}
+
+trait NewTrait<const N: usize> {
+    // Used as an associated constant.
+    const CONST_ASSOC: usize = N * 4;
+
+    fn create() -> Option<()>;
+
+    const_maker! {i32, 7}
+}
+
+impl<const N: usize> NewTrait<N> for Foo<N> {
+    // Used as an associated constant.
+    const CONST_ASSOC: usize = N * 4;
+
+    fn create() -> Option<()> {
+        Some(())
+    }
+
+    const_maker! {i32, 7}
+}
+"#####,
+    )
+}
+
+#[test]
 fn doctest_generate_trait_impl() {
     check_doc_test(
         "generate_trait_impl",

--- a/crates/syntax/src/ast/make.rs
+++ b/crates/syntax/src/ast/make.rs
@@ -865,7 +865,7 @@ pub fn param_list(
 
 pub fn trait_(
     is_unsafe: bool,
-    ident: String,
+    ident: &str,
     gen_params: Option<ast::GenericParamList>,
     where_clause: Option<ast::WhereClause>,
     assoc_items: ast::AssocItemList,

--- a/crates/syntax/src/ast/make.rs
+++ b/crates/syntax/src/ast/make.rs
@@ -863,6 +863,36 @@ pub fn param_list(
     ast_from_text(&list)
 }
 
+pub fn trait_(
+    is_unsafe: bool,
+    ident: String,
+    gen_params: Option<ast::GenericParamList>,
+    where_clause: Option<ast::WhereClause>,
+    assoc_items: ast::AssocItemList,
+) -> ast::Trait {
+    let mut text = String::new();
+
+    if is_unsafe {
+        format_to!(text, "unsafe ");
+    }
+
+    format_to!(text, "trait {ident}");
+
+    if let Some(gen_params) = gen_params {
+        format_to!(text, "{} ", gen_params.to_string());
+    } else {
+        text.push(' ');
+    }
+
+    if let Some(where_clause) = where_clause {
+        format_to!(text, "{} ", where_clause.to_string());
+    }
+
+    format_to!(text, "{}", assoc_items.to_string());
+
+    ast_from_text(&text)
+}
+
 pub fn type_bound(bound: &str) -> ast::TypeBound {
     ast_from_text(&format!("fn f<T: {bound}>() {{ }}"))
 }
@@ -1036,6 +1066,17 @@ pub mod tokens {
             "const C: <()>::Item = (1 != 1, 2 == 2, 3 < 3, 4 <= 4, 5 > 5, 6 >= 6, !true, *p, &p , &mut p)\n;\n\n",
         )
     });
+
+    pub fn semicolon() -> SyntaxToken {
+        SOURCE_FILE
+            .tree()
+            .syntax()
+            .clone_for_update()
+            .descendants_with_tokens()
+            .filter_map(|it| it.into_token())
+            .find(|it| it.kind() == SEMICOLON)
+            .unwrap()
+    }
 
     pub fn single_space() -> SyntaxToken {
         SOURCE_FILE


### PR DESCRIPTION
fixes #14987 . As the name suggests this assist is used to generate traits from inherent impls while adapting the original impl to fit to the newly generated trait. I made some decisions regarding when the assist should be applicable. These are surely open to discussion. I looking forward to any feedback.

![generate_trait_from_impl_v1](https://github.com/rust-lang/rust-analyzer/assets/20956650/05d4dda5-604a-4108-8b82-9b60bd45894a)
