### PR TITLE
Clean up `activationEvents` field in vscode extension's package.json

### DIFF
--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -64,11 +64,6 @@
         "vsce": "^2.9.2"
     },
     "activationEvents": [
-        "onLanguage:rust",
-        "onCommand:rust-analyzer.analyzerStatus",
-        "onCommand:rust-analyzer.memoryUsage",
-        "onCommand:rust-analyzer.reloadWorkspace",
-        "onCommand:rust-analyzer.startServer",
         "workspaceContains:*/Cargo.toml",
         "workspaceContains:*/rust-project.json"
     ],


### PR DESCRIPTION
By documents, VSCode v1.74 or later activates the extension automatically according to other configurations.

See:
- https://code.visualstudio.com/api/references/activation-events#onLanguage
    - https://code.visualstudio.com/docs/languages/identifiers
- https://code.visualstudio.com/api/references/activation-events#onCommand
    - https://code.visualstudio.com/api/references/contribution-points#contributes.commands