### PR TITLE
editor/code: Use `@tsconfig/strictest` to define type checking rules

### DIFF
--- a/editors/code/package-lock.json
+++ b/editors/code/package-lock.json
@@ -16,6 +16,7 @@
                 "vscode-languageclient": "^8.1.0"
             },
             "devDependencies": {
+                "@tsconfig/strictest": "^2.0.1",
                 "@types/node": "~16.11.7",
                 "@types/vscode": "~1.78.1",
                 "@typescript-eslint/eslint-plugin": "^5.60.1",
@@ -194,6 +195,12 @@
             "engines": {
                 "node": ">= 6"
             }
+        },
+        "node_modules/@tsconfig/strictest": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@tsconfig/strictest/-/strictest-2.0.1.tgz",
+            "integrity": "sha512-7JHHCbyCsGUxLd0pDbp24yz3zjxw2t673W5oAP6HCEdr/UUhaRhYd3SSnUsGCk+VnPVJVA4mXROzbhI+nyIk+w==",
+            "dev": true
         },
         "node_modules/@types/json-schema": {
             "version": "7.0.12",

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -48,6 +48,7 @@
         "vscode-languageclient": "^8.1.0"
     },
     "devDependencies": {
+        "@tsconfig/strictest": "^2.0.1",
         "@types/node": "~16.11.7",
         "@types/vscode": "~1.78.1",
         "@typescript-eslint/eslint-plugin": "^5.60.1",

--- a/editors/code/tsconfig.json
+++ b/editors/code/tsconfig.json
@@ -1,18 +1,21 @@
 {
+    "extends": "@tsconfig/strictest/tsconfig.json",
     "compilerOptions": {
+        "esModuleInterop": false,
         "module": "commonjs",
         "target": "es2021",
         "outDir": "out",
         "lib": ["es2021"],
         "sourceMap": true,
         "rootDir": ".",
-        "strict": true,
+        "newLine": "LF",
+        // These disables some enhancement type checking options
+        // to update typescript version without any code change.
         "useUnknownInCatchVariables": false,
-        "noUnusedLocals": true,
-        "noUnusedParameters": true,
-        "noImplicitReturns": true,
-        "noFallthroughCasesInSwitch": true,
-        "newLine": "LF"
+        "exactOptionalPropertyTypes": false,
+        "noImplicitOverride": false,
+        "noPropertyAccessFromIndexSignature": false,
+        "noUncheckedIndexedAccess": false
     },
     "exclude": ["node_modules", ".vscode-test"],
     "include": ["src", "tests"]


### PR DESCRIPTION
Motivation
-----------

This change aims to make it easier to manage tsconfig by [`@tsconfig/strictest`](https://www.npmjs.com/package/@tsconfig/strictest) and intend to leave to create "ideal" rules about TypeScript's type checking.

Implementation
---------------

This change removes some duplicated rules defined in `@tsconfig/strictest` and add disabing some strict rules that fails with the current codebase.