### PR TITLE
Fix runnable detection for `#[tokio::test]`

### DIFF
--- a/crates/hir-def/src/attr.rs
+++ b/crates/hir-def/src/attr.rs
@@ -273,7 +273,14 @@ impl Attrs {
     }
 
     pub fn is_test(&self) -> bool {
-        self.by_key("test").exists()
+        self.iter().any(|x| {
+            x.path()
+                .segments()
+                .iter()
+                .rev()
+                .zip(["core", "prelude", "v1", "test"].iter().rev())
+                .all(|x| x.0.as_str() == Some(x.1))
+        })
     }
 
     pub fn is_ignore(&self) -> bool {

--- a/crates/ide/src/runnables.rs
+++ b/crates/ide/src/runnables.rs
@@ -589,6 +589,9 @@ fn main() {}
 #[test]
 fn test_foo() {}
 
+#[::core::prelude::v1::test]
+fn test_full_path() {}
+
 #[test]
 #[ignore]
 fn test_foo() {}
@@ -600,7 +603,7 @@ mod not_a_root {
     fn main() {}
 }
 "#,
-            &[TestMod, Bin, Test, Test, Bench],
+            &[TestMod, Bin, Test, Test, Test, Bench],
             expect![[r#"
                 [
                     Runnable {
@@ -609,7 +612,7 @@ mod not_a_root {
                             file_id: FileId(
                                 0,
                             ),
-                            full_range: 0..137,
+                            full_range: 0..190,
                             name: "",
                             kind: Module,
                         },
@@ -659,8 +662,29 @@ mod not_a_root {
                             file_id: FileId(
                                 0,
                             ),
-                            full_range: 41..75,
-                            focus_range: 62..70,
+                            full_range: 41..92,
+                            focus_range: 73..87,
+                            name: "test_full_path",
+                            kind: Function,
+                        },
+                        kind: Test {
+                            test_id: Path(
+                                "test_full_path",
+                            ),
+                            attr: TestAttr {
+                                ignore: false,
+                            },
+                        },
+                        cfg: None,
+                    },
+                    Runnable {
+                        use_name_in_title: false,
+                        nav: NavigationTarget {
+                            file_id: FileId(
+                                0,
+                            ),
+                            full_range: 94..128,
+                            focus_range: 115..123,
                             name: "test_foo",
                             kind: Function,
                         },
@@ -680,8 +704,8 @@ mod not_a_root {
                             file_id: FileId(
                                 0,
                             ),
-                            full_range: 77..99,
-                            focus_range: 89..94,
+                            full_range: 130..152,
+                            focus_range: 142..147,
                             name: "bench",
                             kind: Function,
                         },


### PR DESCRIPTION
fix #15141

It is hacky, and it wouldn't work for e.g. this case:
```Rust
use ::core::prelude;

#[prelude::v1::test]
fn foo() {
}
```
But it works for the tokio case. We should use the name resolution here somehow, and after that we should probably also get rid of the ast based `test_related_attribute` function.