### PR TITLE
feat: don't add panics to error jump list by default

### DIFF
--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -339,6 +339,16 @@
                     "default": null,
                     "markdownDescription": "Environment variables passed to the runnable launched using `Test` or `Debug` lens or `rust-analyzer.run` command."
                 },
+                "rust-analyzer.runnables.problemMatcher": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "default": [
+                        "$rustc"
+                    ],
+                    "markdownDescription": "Problem matchers to use for `rust-analyzer.run` command, eg `[\"$rustc\", \"$rust-panic\"]`."
+                },
                 "rust-analyzer.server.path": {
                     "type": [
                         "null",

--- a/editors/code/src/config.ts
+++ b/editors/code/src/config.ts
@@ -220,6 +220,10 @@ export class Config {
         return this.get<string[] | undefined>("discoverProjectCommand");
     }
 
+    get problemMatcher(): string[] {
+        return this.get<string[]>("runnables.problemMatcher") || [];
+    }
+
     get cargoRunner() {
         return this.get<string | undefined>("cargoRunner");
     }

--- a/editors/code/src/run.ts
+++ b/editors/code/src/run.ts
@@ -151,6 +151,7 @@ export async function createTask(runnable: ra.Runnable, config: Config): Promise
         definition,
         runnable.label,
         args,
+        config.problemMatcher,
         config.cargoRunner,
         true
     );

--- a/editors/code/src/tasks.ts
+++ b/editors/code/src/tasks.ts
@@ -46,6 +46,7 @@ class CargoTaskProvider implements vscode.TaskProvider {
                     { type: TASK_TYPE, command: def.command },
                     `cargo ${def.command}`,
                     [def.command],
+                    this.config.problemMatcher,
                     this.config.cargoRunner
                 );
                 vscodeTask.group = def.group;
@@ -70,6 +71,7 @@ class CargoTaskProvider implements vscode.TaskProvider {
                 definition,
                 task.name,
                 args,
+                this.config.problemMatcher,
                 this.config.cargoRunner
             );
         }
@@ -83,6 +85,7 @@ export async function buildCargoTask(
     definition: CargoTaskDefinition,
     name: string,
     args: string[],
+    problemMatcher: string[],
     customRunner?: string,
     throwOnError: boolean = false
 ): Promise<vscode.Task> {
@@ -128,7 +131,7 @@ export async function buildCargoTask(
         name,
         TASK_SOURCE,
         exec,
-        ["$rustc", "$rust-panic"]
+        problemMatcher
     );
 }
 


### PR DESCRIPTION
To re-enable this, use

    "rust-analyzer.runnables.problemMatcher": [
        "$rustc",
        "$rust-panic"
    ],

setting.

closes: #14977