### PR TITLE
Revert "Support `#[rustc_coinductive]`"

### DIFF
--- a/crates/hir-ty/src/chalk_db.rs
+++ b/crates/hir-ty/src/chalk_db.rs
@@ -550,10 +550,6 @@ pub(crate) fn trait_datum_query(
     debug!("trait_datum {:?}", trait_id);
     let trait_ = from_chalk_trait_id(trait_id);
     let trait_data = db.trait_data(trait_);
-
-    let coinductive =
-        trait_data.is_auto || db.attrs(trait_.into()).by_key("rustc_coinductive").exists();
-
     debug!("trait {:?} = {:?}", trait_id, trait_data.name);
     let generic_params = generics(db.upcast(), trait_.into());
     let bound_vars = generic_params.bound_vars_subst(db, DebruijnIndex::INNERMOST);
@@ -561,7 +557,7 @@ pub(crate) fn trait_datum_query(
         auto: trait_data.is_auto,
         upstream: trait_.lookup(db.upcast()).container.krate() != krate,
         non_enumerable: true,
-        coinductive,
+        coinductive: false, // only relevant for Chalk testing
         // FIXME: set these flags correctly
         marker: false,
         fundamental: false,
@@ -643,7 +639,7 @@ pub(crate) fn struct_datum_query(
         fundamental: false,
         phantom_data: false,
     };
-    // FIXME provide enum variants properly (for auto traits and `Sized`)
+    // FIXME provide enum variants properly (for auto traits)
     let variant = rust_ir::AdtVariantDatum {
         fields: Vec::new(), // FIXME add fields (only relevant for auto traits),
     };

--- a/crates/hir-ty/src/tests/traits.rs
+++ b/crates/hir-ty/src/tests/traits.rs
@@ -4410,35 +4410,3 @@ fn test(v: S<i32>) {
 "#,
     );
 }
-
-#[test]
-fn rustc_coinductive() {
-    // Taken from rust-lang/rust#108033 with modification.
-    check_types(
-        r#"
-#[rustc_coinductive]
-trait Trait { type Assoc; }
-
-impl<T, U> Trait for (T, U)
-where
-    (U, T): Trait,
-    (): ConstrainToU32<T>,
-{
-    type Assoc = i32;
-}
-
-trait ConstrainToU32<T> {}
-impl ConstrainToU32<u32> for () {}
-
-fn impls_trait<T, U, R>() -> R
-where
-    (T, U): Trait<Assoc = R>,
-{ loop {} }
-
-fn main() {
-    let _ = impls_trait::<_, _, _>();
-      //^ i32
-}
-"#,
-    );
-}

--- a/crates/ide/src/inlay_hints/chaining.rs
+++ b/crates/ide/src/inlay_hints/chaining.rs
@@ -474,7 +474,7 @@ fn main() {
                                         file_id: FileId(
                                             1,
                                         ),
-                                        range: 9313..9321,
+                                        range: 9288..9296,
                                     },
                                 ),
                                 tooltip: "",
@@ -487,7 +487,7 @@ fn main() {
                                         file_id: FileId(
                                             1,
                                         ),
-                                        range: 9345..9349,
+                                        range: 9320..9324,
                                     },
                                 ),
                                 tooltip: "",
@@ -511,7 +511,7 @@ fn main() {
                                         file_id: FileId(
                                             1,
                                         ),
-                                        range: 9313..9321,
+                                        range: 9288..9296,
                                     },
                                 ),
                                 tooltip: "",
@@ -524,7 +524,7 @@ fn main() {
                                         file_id: FileId(
                                             1,
                                         ),
-                                        range: 9345..9349,
+                                        range: 9320..9324,
                                     },
                                 ),
                                 tooltip: "",
@@ -548,7 +548,7 @@ fn main() {
                                         file_id: FileId(
                                             1,
                                         ),
-                                        range: 9313..9321,
+                                        range: 9288..9296,
                                     },
                                 ),
                                 tooltip: "",
@@ -561,7 +561,7 @@ fn main() {
                                         file_id: FileId(
                                             1,
                                         ),
-                                        range: 9345..9349,
+                                        range: 9320..9324,
                                     },
                                 ),
                                 tooltip: "",

--- a/crates/test-utils/src/minicore.rs
+++ b/crates/test-utils/src/minicore.rs
@@ -63,7 +63,6 @@ pub mod marker {
     #[lang = "sized"]
     #[fundamental]
     #[rustc_specialization_trait]
-    #[rustc_coinductive]
     pub trait Sized {}
     // endregion:sized
 


### PR DESCRIPTION
Reverts #15125, addresses https://github.com/rust-lang/rust-analyzer/pull/15125#issuecomment-1615517893

I'll add the support again once I figure out the problem.