### PR TITLE
internal: Add analysis-stats flag to trigger some IDE features

### DIFF
--- a/crates/ide-diagnostics/src/lib.rs
+++ b/crates/ide-diagnostics/src/lib.rs
@@ -155,6 +155,8 @@ impl Default for ExprFillDefaultMode {
 
 #[derive(Debug, Clone)]
 pub struct DiagnosticsConfig {
+    /// Whether native diagnostics are enabled.
+    pub enabled: bool,
     pub proc_macros_enabled: bool,
     pub proc_attr_macros_enabled: bool,
     pub disable_experimental: bool,
@@ -171,6 +173,7 @@ impl DiagnosticsConfig {
         use ide_db::imports::insert_use::ImportGranularity;
 
         Self {
+            enabled: true,
             proc_macros_enabled: Default::default(),
             proc_attr_macros_enabled: Default::default(),
             disable_experimental: Default::default(),

--- a/crates/ide/src/lib.rs
+++ b/crates/ide/src/lib.rs
@@ -642,7 +642,7 @@ impl Analysis {
         };
 
         self.with_db(|db| {
-            let diagnostic_assists = if include_fixes {
+            let diagnostic_assists = if diagnostics_config.enabled && include_fixes {
                 ide_diagnostics::diagnostics(db, diagnostics_config, &resolve, frange.file_id)
                     .into_iter()
                     .flat_map(|it| it.fixes.unwrap_or_default())

--- a/crates/rust-analyzer/src/cli/flags.rs
+++ b/crates/rust-analyzer/src/cli/flags.rs
@@ -88,6 +88,10 @@ xflags::xflags! {
             optional --skip-data-layout
             /// Skip const evaluation
             optional --skip-const-eval
+            /// Runs several IDE features after analysis, including semantics highlighting, diagnostics
+            /// and annotations. This is useful for benchmarking the memory usage on a project that has
+            /// been worked on for a bit in a longer running session.
+            optional --run-all-ide-things
         }
 
         /// Run unit tests of the project using mir interpreter
@@ -199,6 +203,7 @@ pub struct AnalysisStats {
     pub skip_mir_stats: bool,
     pub skip_data_layout: bool,
     pub skip_const_eval: bool,
+    pub run_all_ide_things: bool,
 }
 
 #[derive(Debug)]

--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -1079,6 +1079,7 @@ impl Config {
 
     pub fn diagnostics(&self) -> DiagnosticsConfig {
         DiagnosticsConfig {
+            enabled: self.data.diagnostics_enable,
             proc_attr_macros_enabled: self.expand_proc_attr_macros(),
             proc_macros_enabled: self.data.procMacro_enable,
             disable_experimental: !self.data.diagnostics_experimental_enable,


### PR DESCRIPTION
Closes https://github.com/rust-lang/rust-analyzer/issues/15131

Running this on r-a showed an 86mb memory increase, but that was without running it on the deps, will try that later when I don't need to use my pc.