### PR TITLE
Disable remove unnecessary braces diagnotics for self imports

### DIFF
--- a/crates/ide-diagnostics/src/handlers/useless_braces.rs
+++ b/crates/ide-diagnostics/src/handlers/useless_braces.rs
@@ -1,6 +1,6 @@
 use ide_db::{base_db::FileId, source_change::SourceChange};
 use itertools::Itertools;
-use syntax::{ast, AstNode, SyntaxKind, SyntaxNode, TextRange};
+use syntax::{ast, AstNode, SyntaxKind, SyntaxNode};
 use text_edit::TextEdit;
 
 use crate::{fix, Diagnostic, DiagnosticCode};

--- a/crates/ide-diagnostics/src/handlers/useless_braces.rs
+++ b/crates/ide-diagnostics/src/handlers/useless_braces.rs
@@ -27,13 +27,11 @@ pub(crate) fn useless_braces(
         }
 
         let use_range = use_tree_list.syntax().text_range();
-        let edit = remove_braces(&single_use_tree).unwrap_or_else(|| {
-            let to_replace = single_use_tree.syntax().text().to_string();
-            let mut edit_builder = TextEdit::builder();
-            edit_builder.delete(use_range);
-            edit_builder.insert(use_range.start(), to_replace);
-            edit_builder.finish()
-        });
+        let to_replace = single_use_tree.syntax().text().to_string();
+        let mut edit_builder = TextEdit::builder();
+        edit_builder.delete(use_range);
+        edit_builder.insert(use_range.start(), to_replace);
+        let edit = edit_builder.finish();
 
         acc.push(
             Diagnostic::new(
@@ -51,16 +49,6 @@ pub(crate) fn useless_braces(
     }
 
     Some(())
-}
-
-fn remove_braces(single_use_tree: &ast::UseTree) -> Option<TextEdit> {
-    let use_tree_list_node = single_use_tree.syntax().parent()?;
-    if single_use_tree.path()?.segment()?.self_token().is_some() {
-        let start = use_tree_list_node.prev_sibling_or_token()?.text_range().start();
-        let end = use_tree_list_node.text_range().end();
-        return Some(TextEdit::delete(TextRange::new(start, end)));
-    }
-    None
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Disable `remove unnecessary braces` diagnostic if the there is a `self` inside the bracketed `use`

Fix #15191