### PR TITLE
internal: convert unwrap to except and add a debug log 

### DIFF
--- a/lib/lsp-server/src/stdio.rs
+++ b/lib/lsp-server/src/stdio.rs
@@ -3,6 +3,8 @@ use std::{
     thread,
 };
 
+use log::debug;
+
 use crossbeam_channel::{bounded, Receiver, Sender};
 
 use crate::Message;
@@ -23,7 +25,8 @@ pub(crate) fn stdio_transport() -> (Sender<Message>, Receiver<Message>, IoThread
         while let Some(msg) = Message::read(&mut stdin)? {
             let is_exit = matches!(&msg, Message::Notification(n) if n.is_exit());
 
-            reader_sender.send(msg).unwrap();
+            debug!("sending message {:#?}", msg);
+            reader_sender.send(msg).expect("receiver was dropped, failed to send a message");
 
             if is_exit {
                 break;


### PR DESCRIPTION
Remove an unsafe unwrap that can cause crashes if the value is a `SendError`.

This is my first PR on this repo, please let me know if there is anything I can improve or details I can provide.