### PR TITLE
add translate button to readme and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+<a href="https://github-com.translate.goog/rust-lang/rust-analyzer/blob/master/README.md?_x_tr_sl=auto&_x_tr_tl=en&_x_tr_hl=en&_x_tr_pto=wapp">![Translate](https://img.shields.io/badge/Translate-blue)</a>
+
 <p align="center">
   <img
     src="https://raw.githubusercontent.com/rust-analyzer/rust-analyzer/master/assets/logo-wide.svg"

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -1,3 +1,5 @@
+<a href="https://github-com.translate.goog/rust-lang/rust-analyzer/blob/master/docs/dev/README.md?_x_tr_sl=auto&_x_tr_tl=en&_x_tr_hl=en&_x_tr_pto=wapp">![Translate](https://img.shields.io/badge/Translate-blue)</a>
+
 # Contributing Quick Start
 
 rust-analyzer is an ordinary Rust project, which is organized as a Cargo workspace, builds on stable and doesn't depend on C libraries.

--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -1,3 +1,5 @@
+<a href="https://github-com.translate.goog/rust-lang/rust-analyzer/blob/master/docs/dev/architecture.md?_x_tr_sl=auto&_x_tr_tl=en&_x_tr_hl=en&_x_tr_pto=wapp">![Translate](https://img.shields.io/badge/Translate-blue)</a>
+
 # Architecture
 
 This document describes the high-level architecture of rust-analyzer.

--- a/docs/dev/debugging.md
+++ b/docs/dev/debugging.md
@@ -1,3 +1,5 @@
+<a href="https://github-com.translate.goog/rust-lang/rust-analyzer/blob/master/docs/dev/debugging.md?_x_tr_sl=auto&_x_tr_tl=en&_x_tr_hl=en&_x_tr_pto=wapp">![Translate](https://img.shields.io/badge/Translate-blue)</a>
+
 # Debugging VSCode plugin and the language server
 
 ## Prerequisites

--- a/docs/dev/guide.md
+++ b/docs/dev/guide.md
@@ -1,3 +1,5 @@
+<a href="https://github-com.translate.goog/rust-lang/rust-analyzer/blob/master/docs/dev/guide.md?_x_tr_sl=auto&_x_tr_tl=en&_x_tr_hl=en&_x_tr_pto=wapp">![Translate](https://img.shields.io/badge/Translate-blue)</a>
+
 # Guide to rust-analyzer
 
 ## About the guide

--- a/docs/dev/lsp-extensions.md
+++ b/docs/dev/lsp-extensions.md
@@ -7,7 +7,7 @@ need to adjust this doc as well and ping this issue:
   https://github.com/rust-lang/rust-analyzer/issues/4604
 
 --->
-
+<a href="https://github-com.translate.goog/rust-lang/rust-analyzer/blob/master/docs/dev/lsp-extensions.md?_x_tr_sl=auto&_x_tr_tl=en&_x_tr_hl=en&_x_tr_pto=wapp">![Translate](https://img.shields.io/badge/Translate-blue)</a>
 # LSP Extensions
 
 This document describes LSP extensions used by rust-analyzer.

--- a/docs/dev/style.md
+++ b/docs/dev/style.md
@@ -1,3 +1,5 @@
+<a href="https://github-com.translate.goog/rust-lang/rust-analyzer/blob/master/docs/dev/style.md?_x_tr_sl=auto&_x_tr_tl=en&_x_tr_hl=en&_x_tr_pto=wapp">![Translate](https://img.shields.io/badge/Translate-blue)</a>
+
 Our approach to "clean code" is two-fold:
 
 * We generally don't block PRs on style changes.

--- a/docs/dev/syntax.md
+++ b/docs/dev/syntax.md
@@ -1,3 +1,5 @@
+<a href="https://github-com.translate.goog/rust-lang/rust-analyzer/blob/master/docs/dev/syntax.md?_x_tr_sl=auto&_x_tr_tl=en&_x_tr_hl=en&_x_tr_pto=wapp">![Translate](https://img.shields.io/badge/Translate-blue)</a>
+
 # Syntax in rust-analyzer
 
 ## About the guide


### PR DESCRIPTION

> add translate button to readme and md files in docs/dev to make it easy for users to just press it and then google translate that docs into whatever language they want

related to discussion following this PR #13270 

for example see the "Translate" badge at top of the README file here : https://github.com/metahris/rust-analyzer/blob/master/README.md



