### PR TITLE
Replace `x` with `it`

### DIFF
--- a/crates/base-db/src/fixture.rs
+++ b/crates/base-db/src/fixture.rs
@@ -224,7 +224,7 @@ impl ChangeFixture {
                 false,
                 CrateOrigin::Local { repo: None, name: None },
                 default_target_data_layout
-                    .map(|x| x.into())
+                    .map(|it| it.into())
                     .ok_or_else(|| "target_data_layout unset".into()),
                 Some(toolchain),
             );

--- a/crates/cfg/src/lib.rs
+++ b/crates/cfg/src/lib.rs
@@ -69,7 +69,7 @@ impl CfgOptions {
     }
 
     pub fn get_cfg_keys(&self) -> impl Iterator<Item = &SmolStr> {
-        self.enabled.iter().map(|x| match x {
+        self.enabled.iter().map(|it| match it {
             CfgAtom::Flag(key) => key,
             CfgAtom::KeyValue { key, .. } => key,
         })
@@ -79,7 +79,7 @@ impl CfgOptions {
         &'a self,
         cfg_key: &'a str,
     ) -> impl Iterator<Item = &'a SmolStr> + 'a {
-        self.enabled.iter().filter_map(move |x| match x {
+        self.enabled.iter().filter_map(move |it| match it {
             CfgAtom::KeyValue { key, value } if cfg_key == key => Some(value),
             _ => None,
         })

--- a/crates/hir-def/src/attr.rs
+++ b/crates/hir-def/src/attr.rs
@@ -276,13 +276,13 @@ impl Attrs {
     }
 
     pub fn is_test(&self) -> bool {
-        self.iter().any(|x| {
-            x.path()
+        self.iter().any(|it| {
+            it.path()
                 .segments()
                 .iter()
                 .rev()
                 .zip(["core", "prelude", "v1", "test"].iter().rev())
-                .all(|x| x.0.as_str() == Some(x.1))
+                .all(|it| it.0.as_str() == Some(it.1))
         })
     }
 
@@ -304,7 +304,7 @@ use std::slice::Iter as SliceIter;
 pub enum DocAtom {
     /// eg. `#[doc(hidden)]`
     Flag(SmolStr),
-    /// eg. `#[doc(alias = "x")]`
+    /// eg. `#[doc(alias = "it")]`
     ///
     /// Note that a key can have multiple values that are all considered "active" at the same time.
     /// For example, `#[doc(alias = "x")]` and `#[doc(alias = "y")]`.

--- a/crates/hir-def/src/body.rs
+++ b/crates/hir-def/src/body.rs
@@ -273,10 +273,10 @@ impl Body {
 
     pub fn is_binding_upvar(&self, binding: BindingId, relative_to: ExprId) -> bool {
         match self.binding_owners.get(&binding) {
-            Some(x) => {
+            Some(it) => {
                 // We assign expression ids in a way that outer closures will receive
                 // a lower id
-                x.into_raw() < relative_to.into_raw()
+                it.into_raw() < relative_to.into_raw()
             }
             None => true,
         }

--- a/crates/hir-def/src/body/lower.rs
+++ b/crates/hir-def/src/body/lower.rs
@@ -297,11 +297,11 @@ impl ExprCollector<'_> {
                         let (result_expr_id, prev_binding_owner) =
                             this.initialize_binding_owner(syntax_ptr);
                         let inner_expr = this.collect_block(e);
-                        let x = this.db.intern_anonymous_const(ConstBlockLoc {
+                        let it = this.db.intern_anonymous_const(ConstBlockLoc {
                             parent: this.owner,
                             root: inner_expr,
                         });
-                        this.body.exprs[result_expr_id] = Expr::Const(x);
+                        this.body.exprs[result_expr_id] = Expr::Const(it);
                         this.current_binding_owner = prev_binding_owner;
                         result_expr_id
                     })
@@ -324,10 +324,10 @@ impl ExprCollector<'_> {
             ast::Expr::CallExpr(e) => {
                 let is_rustc_box = {
                     let attrs = e.attrs();
-                    attrs.filter_map(|x| x.as_simple_atom()).any(|x| x == "rustc_box")
+                    attrs.filter_map(|it| it.as_simple_atom()).any(|it| it == "rustc_box")
                 };
                 if is_rustc_box {
-                    let expr = self.collect_expr_opt(e.arg_list().and_then(|x| x.args().next()));
+                    let expr = self.collect_expr_opt(e.arg_list().and_then(|it| it.args().next()));
                     self.alloc_expr(Expr::Box { expr }, syntax_ptr)
                 } else {
                     let callee = self.collect_expr_opt(e.expr());
@@ -781,7 +781,7 @@ impl ExprCollector<'_> {
             pat: self.alloc_pat_desugared(some_pat),
             guard: None,
             expr: self.with_opt_labeled_rib(label, |this| {
-                this.collect_expr_opt(e.loop_body().map(|x| x.into()))
+                this.collect_expr_opt(e.loop_body().map(|it| it.into()))
             }),
         };
         let iter_name = Name::generate_new_name();
@@ -874,10 +874,10 @@ impl ExprCollector<'_> {
             }),
             guard: None,
             expr: {
-                let x = self.alloc_expr(Expr::Path(Path::from(break_name)), syntax_ptr.clone());
+                let it = self.alloc_expr(Expr::Path(Path::from(break_name)), syntax_ptr.clone());
                 let callee = self.alloc_expr(Expr::Path(try_from_residual), syntax_ptr.clone());
                 let result = self.alloc_expr(
-                    Expr::Call { callee, args: Box::new([x]), is_assignee_expr: false },
+                    Expr::Call { callee, args: Box::new([it]), is_assignee_expr: false },
                     syntax_ptr.clone(),
                 );
                 self.alloc_expr(
@@ -1240,12 +1240,12 @@ impl ExprCollector<'_> {
                 pats.push(self.collect_pat(first, binding_list));
                 binding_list.reject_new = true;
                 for rest in it {
-                    for (_, x) in binding_list.is_used.iter_mut() {
-                        *x = false;
+                    for (_, it) in binding_list.is_used.iter_mut() {
+                        *it = false;
                     }
                     pats.push(self.collect_pat(rest, binding_list));
-                    for (&id, &x) in binding_list.is_used.iter() {
-                        if !x {
+                    for (&id, &is_used) in binding_list.is_used.iter() {
+                        if !is_used {
                             self.body.bindings[id].problems =
                                 Some(BindingProblems::NotBoundAcrossAll);
                         }
@@ -1352,9 +1352,9 @@ impl ExprCollector<'_> {
             // FIXME: implement in a way that also builds source map and calculates assoc resolutions in type inference.
             ast::Pat::RangePat(p) => {
                 let mut range_part_lower = |p: Option<ast::Pat>| {
-                    p.and_then(|x| match &x {
-                        ast::Pat::LiteralPat(x) => {
-                            Some(Box::new(LiteralOrConst::Literal(pat_literal_to_hir(x)?.0)))
+                    p.and_then(|it| match &it {
+                        ast::Pat::LiteralPat(it) => {
+                            Some(Box::new(LiteralOrConst::Literal(pat_literal_to_hir(it)?.0)))
                         }
                         ast::Pat::IdentPat(p) => {
                             let name =

--- a/crates/hir-def/src/generics.rs
+++ b/crates/hir-def/src/generics.rs
@@ -67,21 +67,21 @@ pub enum TypeOrConstParamData {
 impl TypeOrConstParamData {
     pub fn name(&self) -> Option<&Name> {
         match self {
-            TypeOrConstParamData::TypeParamData(x) => x.name.as_ref(),
-            TypeOrConstParamData::ConstParamData(x) => Some(&x.name),
+            TypeOrConstParamData::TypeParamData(it) => it.name.as_ref(),
+            TypeOrConstParamData::ConstParamData(it) => Some(&it.name),
         }
     }
 
     pub fn has_default(&self) -> bool {
         match self {
-            TypeOrConstParamData::TypeParamData(x) => x.default.is_some(),
-            TypeOrConstParamData::ConstParamData(x) => x.has_default,
+            TypeOrConstParamData::TypeParamData(it) => it.default.is_some(),
+            TypeOrConstParamData::ConstParamData(it) => it.has_default,
         }
     }
 
     pub fn type_param(&self) -> Option<&TypeParamData> {
         match self {
-            TypeOrConstParamData::TypeParamData(x) => Some(x),
+            TypeOrConstParamData::TypeParamData(it) => Some(it),
             TypeOrConstParamData::ConstParamData(_) => None,
         }
     }
@@ -89,14 +89,14 @@ impl TypeOrConstParamData {
     pub fn const_param(&self) -> Option<&ConstParamData> {
         match self {
             TypeOrConstParamData::TypeParamData(_) => None,
-            TypeOrConstParamData::ConstParamData(x) => Some(x),
+            TypeOrConstParamData::ConstParamData(it) => Some(it),
         }
     }
 
     pub fn is_trait_self(&self) -> bool {
         match self {
-            TypeOrConstParamData::TypeParamData(x) => {
-                x.provenance == TypeParamProvenance::TraitSelf
+            TypeOrConstParamData::TypeParamData(it) => {
+                it.provenance == TypeParamProvenance::TraitSelf
             }
             TypeOrConstParamData::ConstParamData(_) => false,
         }

--- a/crates/hir-def/src/hir/type_ref.rs
+++ b/crates/hir-def/src/hir/type_ref.rs
@@ -425,8 +425,8 @@ impl ConstRef {
         }
         match expr {
             ast::Expr::PathExpr(p) if is_path_ident(&p) => {
-                match p.path().and_then(|x| x.segment()).and_then(|x| x.name_ref()) {
-                    Some(x) => Self::Path(x.as_name()),
+                match p.path().and_then(|it| it.segment()).and_then(|it| it.name_ref()) {
+                    Some(it) => Self::Path(it.as_name()),
                     None => Self::Scalar(LiteralConstRef::Unknown),
                 }
             }

--- a/crates/hir-def/src/lib.rs
+++ b/crates/hir-def/src/lib.rs
@@ -406,14 +406,14 @@ impl TypeParamId {
 
 impl TypeParamId {
     /// Caller should check if this toc id really belongs to a type
-    pub fn from_unchecked(x: TypeOrConstParamId) -> Self {
-        Self(x)
+    pub fn from_unchecked(it: TypeOrConstParamId) -> Self {
+        Self(it)
     }
 }
 
 impl From<TypeParamId> for TypeOrConstParamId {
-    fn from(x: TypeParamId) -> Self {
-        x.0
+    fn from(it: TypeParamId) -> Self {
+        it.0
     }
 }
 
@@ -432,14 +432,14 @@ impl ConstParamId {
 
 impl ConstParamId {
     /// Caller should check if this toc id really belongs to a const
-    pub fn from_unchecked(x: TypeOrConstParamId) -> Self {
-        Self(x)
+    pub fn from_unchecked(it: TypeOrConstParamId) -> Self {
+        Self(it)
     }
 }
 
 impl From<ConstParamId> for TypeOrConstParamId {
-    fn from(x: ConstParamId) -> Self {
-        x.0
+    fn from(it: ConstParamId) -> Self {
+        it.0
     }
 }
 
@@ -562,14 +562,14 @@ pub enum TypeOwnerId {
 impl TypeOwnerId {
     fn as_generic_def_id(self) -> Option<GenericDefId> {
         Some(match self {
-            TypeOwnerId::FunctionId(x) => GenericDefId::FunctionId(x),
-            TypeOwnerId::ConstId(x) => GenericDefId::ConstId(x),
-            TypeOwnerId::AdtId(x) => GenericDefId::AdtId(x),
-            TypeOwnerId::TraitId(x) => GenericDefId::TraitId(x),
-            TypeOwnerId::TraitAliasId(x) => GenericDefId::TraitAliasId(x),
-            TypeOwnerId::TypeAliasId(x) => GenericDefId::TypeAliasId(x),
-            TypeOwnerId::ImplId(x) => GenericDefId::ImplId(x),
-            TypeOwnerId::EnumVariantId(x) => GenericDefId::EnumVariantId(x),
+            TypeOwnerId::FunctionId(it) => GenericDefId::FunctionId(it),
+            TypeOwnerId::ConstId(it) => GenericDefId::ConstId(it),
+            TypeOwnerId::AdtId(it) => GenericDefId::AdtId(it),
+            TypeOwnerId::TraitId(it) => GenericDefId::TraitId(it),
+            TypeOwnerId::TraitAliasId(it) => GenericDefId::TraitAliasId(it),
+            TypeOwnerId::TypeAliasId(it) => GenericDefId::TypeAliasId(it),
+            TypeOwnerId::ImplId(it) => GenericDefId::ImplId(it),
+            TypeOwnerId::EnumVariantId(it) => GenericDefId::EnumVariantId(it),
             TypeOwnerId::InTypeConstId(_) | TypeOwnerId::ModuleId(_) | TypeOwnerId::StaticId(_) => {
                 return None
             }
@@ -592,15 +592,15 @@ impl_from!(
     for TypeOwnerId
 );
 
-// Every `DefWithBodyId` is a type owner, since bodies can contain type (e.g. `{ let x: Type = _; }`)
+// Every `DefWithBodyId` is a type owner, since bodies can contain type (e.g. `{ let it: Type = _; }`)
 impl From<DefWithBodyId> for TypeOwnerId {
     fn from(value: DefWithBodyId) -> Self {
         match value {
-            DefWithBodyId::FunctionId(x) => x.into(),
-            DefWithBodyId::StaticId(x) => x.into(),
-            DefWithBodyId::ConstId(x) => x.into(),
-            DefWithBodyId::InTypeConstId(x) => x.into(),
-            DefWithBodyId::VariantId(x) => x.into(),
+            DefWithBodyId::FunctionId(it) => it.into(),
+            DefWithBodyId::StaticId(it) => it.into(),
+            DefWithBodyId::ConstId(it) => it.into(),
+            DefWithBodyId::InTypeConstId(it) => it.into(),
+            DefWithBodyId::VariantId(it) => it.into(),
         }
     }
 }
@@ -608,14 +608,14 @@ impl From<DefWithBodyId> for TypeOwnerId {
 impl From<GenericDefId> for TypeOwnerId {
     fn from(value: GenericDefId) -> Self {
         match value {
-            GenericDefId::FunctionId(x) => x.into(),
-            GenericDefId::AdtId(x) => x.into(),
-            GenericDefId::TraitId(x) => x.into(),
-            GenericDefId::TraitAliasId(x) => x.into(),
-            GenericDefId::TypeAliasId(x) => x.into(),
-            GenericDefId::ImplId(x) => x.into(),
-            GenericDefId::EnumVariantId(x) => x.into(),
-            GenericDefId::ConstId(x) => x.into(),
+            GenericDefId::FunctionId(it) => it.into(),
+            GenericDefId::AdtId(it) => it.into(),
+            GenericDefId::TraitId(it) => it.into(),
+            GenericDefId::TraitAliasId(it) => it.into(),
+            GenericDefId::TypeAliasId(it) => it.into(),
+            GenericDefId::ImplId(it) => it.into(),
+            GenericDefId::EnumVariantId(it) => it.into(),
+            GenericDefId::ConstId(it) => it.into(),
         }
     }
 }
@@ -730,7 +730,7 @@ impl GeneralConstId {
                 .const_data(const_id)
                 .name
                 .as_ref()
-                .and_then(|x| x.as_str())
+                .and_then(|it| it.as_str())
                 .unwrap_or("_")
                 .to_owned(),
             GeneralConstId::ConstBlockId(id) => format!("{{anonymous const {id:?}}}"),
@@ -972,17 +972,17 @@ impl HasModule for MacroId {
 impl HasModule for TypeOwnerId {
     fn module(&self, db: &dyn db::DefDatabase) -> ModuleId {
         match self {
-            TypeOwnerId::FunctionId(x) => x.lookup(db).module(db),
-            TypeOwnerId::StaticId(x) => x.lookup(db).module(db),
-            TypeOwnerId::ConstId(x) => x.lookup(db).module(db),
-            TypeOwnerId::InTypeConstId(x) => x.lookup(db).owner.module(db),
-            TypeOwnerId::AdtId(x) => x.module(db),
-            TypeOwnerId::TraitId(x) => x.lookup(db).container,
-            TypeOwnerId::TraitAliasId(x) => x.lookup(db).container,
-            TypeOwnerId::TypeAliasId(x) => x.lookup(db).module(db),
-            TypeOwnerId::ImplId(x) => x.lookup(db).container,
-            TypeOwnerId::EnumVariantId(x) => x.parent.lookup(db).container,
-            TypeOwnerId::ModuleId(x) => *x,
+            TypeOwnerId::FunctionId(it) => it.lookup(db).module(db),
+            TypeOwnerId::StaticId(it) => it.lookup(db).module(db),
+            TypeOwnerId::ConstId(it) => it.lookup(db).module(db),
+            TypeOwnerId::InTypeConstId(it) => it.lookup(db).owner.module(db),
+            TypeOwnerId::AdtId(it) => it.module(db),
+            TypeOwnerId::TraitId(it) => it.lookup(db).container,
+            TypeOwnerId::TraitAliasId(it) => it.lookup(db).container,
+            TypeOwnerId::TypeAliasId(it) => it.lookup(db).module(db),
+            TypeOwnerId::ImplId(it) => it.lookup(db).container,
+            TypeOwnerId::EnumVariantId(it) => it.parent.lookup(db).container,
+            TypeOwnerId::ModuleId(it) => *it,
         }
     }
 }

--- a/crates/hir-def/src/path.rs
+++ b/crates/hir-def/src/path.rs
@@ -45,7 +45,7 @@ pub enum Path {
         /// Invariant: the same len as `self.mod_path.segments` or `None` if all segments are `None`.
         generic_args: Option<Box<[Option<Interned<GenericArgs>>]>>,
     },
-    /// A link to a lang item. It is used in desugaring of things like `x?`. We can show these
+    /// A link to a lang item. It is used in desugaring of things like `it?`. We can show these
     /// links via a normal path since they might be private and not accessible in the usage place.
     LangItem(LangItemTarget),
 }

--- a/crates/hir-def/src/pretty.rs
+++ b/crates/hir-def/src/pretty.rs
@@ -12,8 +12,8 @@ use crate::{
 };
 
 pub(crate) fn print_path(db: &dyn ExpandDatabase, path: &Path, buf: &mut dyn Write) -> fmt::Result {
-    if let Path::LangItem(x) = path {
-        return write!(buf, "$lang_item::{x:?}");
+    if let Path::LangItem(it) = path {
+        return write!(buf, "$lang_item::{it:?}");
     }
     match path.type_anchor() {
         Some(anchor) => {

--- a/crates/hir-def/src/resolver.rs
+++ b/crates/hir-def/src/resolver.rs
@@ -186,12 +186,12 @@ impl Resolver {
             Path::LangItem(l) => {
                 return Some((
                     match *l {
-                        LangItemTarget::Union(x) => TypeNs::AdtId(x.into()),
-                        LangItemTarget::TypeAlias(x) => TypeNs::TypeAliasId(x),
-                        LangItemTarget::Struct(x) => TypeNs::AdtId(x.into()),
-                        LangItemTarget::EnumVariant(x) => TypeNs::EnumVariantId(x),
-                        LangItemTarget::EnumId(x) => TypeNs::AdtId(x.into()),
-                        LangItemTarget::Trait(x) => TypeNs::TraitId(x),
+                        LangItemTarget::Union(it) => TypeNs::AdtId(it.into()),
+                        LangItemTarget::TypeAlias(it) => TypeNs::TypeAliasId(it),
+                        LangItemTarget::Struct(it) => TypeNs::AdtId(it.into()),
+                        LangItemTarget::EnumVariant(it) => TypeNs::EnumVariantId(it),
+                        LangItemTarget::EnumId(it) => TypeNs::AdtId(it.into()),
+                        LangItemTarget::Trait(it) => TypeNs::TraitId(it),
                         LangItemTarget::Function(_)
                         | LangItemTarget::ImplDef(_)
                         | LangItemTarget::Static(_) => return None,
@@ -273,10 +273,10 @@ impl Resolver {
             Path::Normal { mod_path, .. } => mod_path,
             Path::LangItem(l) => {
                 return Some(ResolveValueResult::ValueNs(match *l {
-                    LangItemTarget::Function(x) => ValueNs::FunctionId(x),
-                    LangItemTarget::Static(x) => ValueNs::StaticId(x),
-                    LangItemTarget::Struct(x) => ValueNs::StructId(x),
-                    LangItemTarget::EnumVariant(x) => ValueNs::EnumVariantId(x),
+                    LangItemTarget::Function(it) => ValueNs::FunctionId(it),
+                    LangItemTarget::Static(it) => ValueNs::StaticId(it),
+                    LangItemTarget::Struct(it) => ValueNs::StructId(it),
+                    LangItemTarget::EnumVariant(it) => ValueNs::EnumVariantId(it),
                     LangItemTarget::Union(_)
                     | LangItemTarget::ImplDef(_)
                     | LangItemTarget::TypeAlias(_)
@@ -425,14 +425,14 @@ impl Resolver {
     /// The shadowing is accounted for: in
     ///
     /// ```
-    /// let x = 92;
+    /// let it = 92;
     /// {
-    ///     let x = 92;
+    ///     let it = 92;
     ///     $0
     /// }
     /// ```
     ///
-    /// there will be only one entry for `x` in the result.
+    /// there will be only one entry for `it` in the result.
     ///
     /// The result is ordered *roughly* from the innermost scope to the
     /// outermost: when the name is introduced in two namespaces in two scopes,
@@ -1027,17 +1027,17 @@ impl HasResolver for ExternCrateId {
 impl HasResolver for TypeOwnerId {
     fn resolver(self, db: &dyn DefDatabase) -> Resolver {
         match self {
-            TypeOwnerId::FunctionId(x) => x.resolver(db),
-            TypeOwnerId::StaticId(x) => x.resolver(db),
-            TypeOwnerId::ConstId(x) => x.resolver(db),
-            TypeOwnerId::InTypeConstId(x) => x.lookup(db).owner.resolver(db),
-            TypeOwnerId::AdtId(x) => x.resolver(db),
-            TypeOwnerId::TraitId(x) => x.resolver(db),
-            TypeOwnerId::TraitAliasId(x) => x.resolver(db),
-            TypeOwnerId::TypeAliasId(x) => x.resolver(db),
-            TypeOwnerId::ImplId(x) => x.resolver(db),
-            TypeOwnerId::EnumVariantId(x) => x.resolver(db),
-            TypeOwnerId::ModuleId(x) => x.resolver(db),
+            TypeOwnerId::FunctionId(it) => it.resolver(db),
+            TypeOwnerId::StaticId(it) => it.resolver(db),
+            TypeOwnerId::ConstId(it) => it.resolver(db),
+            TypeOwnerId::InTypeConstId(it) => it.lookup(db).owner.resolver(db),
+            TypeOwnerId::AdtId(it) => it.resolver(db),
+            TypeOwnerId::TraitId(it) => it.resolver(db),
+            TypeOwnerId::TraitAliasId(it) => it.resolver(db),
+            TypeOwnerId::TypeAliasId(it) => it.resolver(db),
+            TypeOwnerId::ImplId(it) => it.resolver(db),
+            TypeOwnerId::EnumVariantId(it) => it.resolver(db),
+            TypeOwnerId::ModuleId(it) => it.resolver(db),
         }
     }
 }

--- a/crates/hir-expand/src/builtin_fn_macro.rs
+++ b/crates/hir-expand/src/builtin_fn_macro.rs
@@ -339,7 +339,7 @@ fn format_args_expand_general(
                 parts.push(mem::take(&mut last_part));
                 let arg_tree = if argument.is_empty() {
                     match args.next() {
-                        Some(x) => x,
+                        Some(it) => it,
                         None => {
                             err = Some(mbe::ExpandError::NoMatchingRule.into());
                             tt::Subtree::empty()
@@ -378,11 +378,11 @@ fn format_args_expand_general(
     if !last_part.is_empty() {
         parts.push(last_part);
     }
-    let part_tts = parts.into_iter().map(|x| {
+    let part_tts = parts.into_iter().map(|it| {
         let text = if let Some(raw) = &raw_sharps {
-            format!("r{raw}\"{}\"{raw}", x).into()
+            format!("r{raw}\"{}\"{raw}", it).into()
         } else {
-            format!("\"{}\"", x).into()
+            format!("\"{}\"", it).into()
         };
         let l = tt::Literal { span: tt::TokenId::unspecified(), text };
         quote!(#l ,)
@@ -574,7 +574,7 @@ fn concat_bytes_expand(
                     syntax::SyntaxKind::BYTE => bytes.push(token.text().to_string()),
                     syntax::SyntaxKind::BYTE_STRING => {
                         let components = unquote_byte_string(lit).unwrap_or_default();
-                        components.into_iter().for_each(|x| bytes.push(x.to_string()));
+                        components.into_iter().for_each(|it| bytes.push(it.to_string()));
                     }
                     _ => {
                         err.get_or_insert(mbe::ExpandError::UnexpectedToken.into());

--- a/crates/hir-expand/src/fixup.rs
+++ b/crates/hir-expand/src/fixup.rs
@@ -472,13 +472,13 @@ fn foo () {match __ra_fixup {}}
         check(
             r#"
 fn foo() {
-    match x {
+    match it {
 
     }
 }
 "#,
             expect![[r#"
-fn foo () {match x {}}
+fn foo () {match it {}}
 "#]],
         )
     }
@@ -547,11 +547,11 @@ fn foo () {a . __ra_fixup ; bar () ;}
         check(
             r#"
 fn foo() {
-    let x = a
+    let it = a
 }
 "#,
             expect![[r#"
-fn foo () {let x = a ;}
+fn foo () {let it = a ;}
 "#]],
         )
     }
@@ -561,11 +561,11 @@ fn foo () {let x = a ;}
         check(
             r#"
 fn foo() {
-    let x = a.
+    let it = a.
 }
 "#,
             expect![[r#"
-fn foo () {let x = a . __ra_fixup ;}
+fn foo () {let it = a . __ra_fixup ;}
 "#]],
         )
     }

--- a/crates/hir-ty/src/chalk_ext.rs
+++ b/crates/hir-ty/src/chalk_ext.rs
@@ -343,7 +343,7 @@ impl TyExt for Ty {
 
     fn is_copy(self, db: &dyn HirDatabase, owner: DefWithBodyId) -> bool {
         let crate_id = owner.module(db.upcast()).krate();
-        let Some(copy_trait) = db.lang_item(crate_id, LangItem::Copy).and_then(|x| x.as_trait())
+        let Some(copy_trait) = db.lang_item(crate_id, LangItem::Copy).and_then(|it| it.as_trait())
         else {
             return false;
         };

--- a/crates/hir-ty/src/consteval.rs
+++ b/crates/hir-ty/src/consteval.rs
@@ -88,7 +88,7 @@ pub(crate) fn path_to_const(
                     ConstValue::Placeholder(to_placeholder_idx(db, p.into()))
                 }
                 ParamLoweringMode::Variable => match args.param_idx(p.into()) {
-                    Some(x) => ConstValue::BoundVar(BoundVar::new(debruijn, x)),
+                    Some(it) => ConstValue::BoundVar(BoundVar::new(debruijn, it)),
                     None => {
                         never!(
                             "Generic list doesn't contain this param: {:?}, {:?}, {:?}",
@@ -139,11 +139,11 @@ pub fn intern_const_ref(
     let bytes = match value {
         LiteralConstRef::Int(i) => {
             // FIXME: We should handle failure of layout better.
-            let size = layout.map(|x| x.size.bytes_usize()).unwrap_or(16);
+            let size = layout.map(|it| it.size.bytes_usize()).unwrap_or(16);
             ConstScalar::Bytes(i.to_le_bytes()[0..size].to_vec(), MemoryMap::default())
         }
         LiteralConstRef::UInt(i) => {
-            let size = layout.map(|x| x.size.bytes_usize()).unwrap_or(16);
+            let size = layout.map(|it| it.size.bytes_usize()).unwrap_or(16);
             ConstScalar::Bytes(i.to_le_bytes()[0..size].to_vec(), MemoryMap::default())
         }
         LiteralConstRef::Bool(b) => ConstScalar::Bytes(vec![*b as u8], MemoryMap::default()),
@@ -171,7 +171,7 @@ pub fn try_const_usize(db: &dyn HirDatabase, c: &Const) -> Option<u128> {
         chalk_ir::ConstValue::InferenceVar(_) => None,
         chalk_ir::ConstValue::Placeholder(_) => None,
         chalk_ir::ConstValue::Concrete(c) => match &c.interned {
-            ConstScalar::Bytes(x, _) => Some(u128::from_le_bytes(pad16(&x, false))),
+            ConstScalar::Bytes(it, _) => Some(u128::from_le_bytes(pad16(&it, false))),
             ConstScalar::UnevaluatedConst(c, subst) => {
                 let ec = db.const_eval(*c, subst.clone()).ok()?;
                 try_const_usize(db, &ec)

--- a/crates/hir-ty/src/consteval/tests/intrinsics.rs
+++ b/crates/hir-ty/src/consteval/tests/intrinsics.rs
@@ -37,8 +37,8 @@ fn size_of_val() {
         }
 
         const GOAL: usize = {
-            let x: &[i32] = &[1, 2, 3];
-            size_of_val(x)
+            let it: &[i32] = &[1, 2, 3];
+            size_of_val(it)
         };
         "#,
         12,

--- a/crates/hir-ty/src/display.rs
+++ b/crates/hir-ty/src/display.rs
@@ -481,28 +481,28 @@ fn render_const_scalar(
         TyKind::Scalar(s) => match s {
             Scalar::Bool => write!(f, "{}", if b[0] == 0 { false } else { true }),
             Scalar::Char => {
-                let x = u128::from_le_bytes(pad16(b, false)) as u32;
-                let Ok(c) = char::try_from(x) else {
+                let it = u128::from_le_bytes(pad16(b, false)) as u32;
+                let Ok(c) = char::try_from(it) else {
                     return f.write_str("<unicode-error>");
                 };
                 write!(f, "{c:?}")
             }
             Scalar::Int(_) => {
-                let x = i128::from_le_bytes(pad16(b, true));
-                write!(f, "{x}")
+                let it = i128::from_le_bytes(pad16(b, true));
+                write!(f, "{it}")
             }
             Scalar::Uint(_) => {
-                let x = u128::from_le_bytes(pad16(b, false));
-                write!(f, "{x}")
+                let it = u128::from_le_bytes(pad16(b, false));
+                write!(f, "{it}")
             }
             Scalar::Float(fl) => match fl {
                 chalk_ir::FloatTy::F32 => {
-                    let x = f32::from_le_bytes(b.try_into().unwrap());
-                    write!(f, "{x:?}")
+                    let it = f32::from_le_bytes(b.try_into().unwrap());
+                    write!(f, "{it:?}")
                 }
                 chalk_ir::FloatTy::F64 => {
-                    let x = f64::from_le_bytes(b.try_into().unwrap());
-                    write!(f, "{x:?}")
+                    let it = f64::from_le_bytes(b.try_into().unwrap());
+                    write!(f, "{it:?}")
                 }
             },
         },
@@ -659,8 +659,8 @@ fn render_const_scalar(
         }
         TyKind::FnDef(..) => ty.hir_fmt(f),
         TyKind::Function(_) | TyKind::Raw(_, _) => {
-            let x = u128::from_le_bytes(pad16(b, false));
-            write!(f, "{:#X} as ", x)?;
+            let it = u128::from_le_bytes(pad16(b, false));
+            write!(f, "{:#X} as ", it)?;
             ty.hir_fmt(f)
         }
         TyKind::Array(ty, len) => {
@@ -736,7 +736,7 @@ fn render_variant_after_name(
                 }
                 write!(f, " }}")?;
             } else {
-                let mut it = it.map(|x| x.0);
+                let mut it = it.map(|it| it.0);
                 write!(f, "(")?;
                 if let Some(id) = it.next() {
                     render_field(f, id)?;
@@ -1278,19 +1278,20 @@ fn hir_fmt_generics(
                         i: usize,
                         parameters: &Substitution,
                     ) -> bool {
-                        if parameter.ty(Interner).map(|x| x.kind(Interner)) == Some(&TyKind::Error)
+                        if parameter.ty(Interner).map(|it| it.kind(Interner))
+                            == Some(&TyKind::Error)
                         {
                             return true;
                         }
                         if let Some(ConstValue::Concrete(c)) =
-                            parameter.constant(Interner).map(|x| &x.data(Interner).value)
+                            parameter.constant(Interner).map(|it| &it.data(Interner).value)
                         {
                             if c.interned == ConstScalar::Unknown {
                                 return true;
                             }
                         }
                         let default_parameter = match default_parameters.get(i) {
-                            Some(x) => x,
+                            Some(it) => it,
                             None => return true,
                         };
                         let actual_default =

--- a/crates/hir-ty/src/infer.rs
+++ b/crates/hir-ty/src/infer.rs
@@ -290,7 +290,7 @@ impl Default for InternedStandardTypes {
 ///    ```
 ///
 ///    Note that for a struct, the 'deep' unsizing of the struct is not recorded.
-///    E.g., `struct Foo<T> { x: T }` we can coerce &Foo<[i32; 4]> to &Foo<[i32]>
+///    E.g., `struct Foo<T> { it: T }` we can coerce &Foo<[i32; 4]> to &Foo<[i32]>
 ///    The autoderef and -ref are the same as in the above example, but the type
 ///    stored in `unsize` is `Foo<[i32]>`, we don't store any further detail about
 ///    the underlying conversions from `[i32; 4]` to `[i32]`.
@@ -1172,7 +1172,7 @@ impl<'a> InferenceContext<'a> {
         unresolved: Option<usize>,
         path: &ModPath,
     ) -> (Ty, Option<VariantId>) {
-        let remaining = unresolved.map(|x| path.segments()[x..].len()).filter(|x| x > &0);
+        let remaining = unresolved.map(|it| path.segments()[it..].len()).filter(|it| it > &0);
         match remaining {
             None => {
                 let variant = ty.as_adt().and_then(|(adt_id, _)| match adt_id {
@@ -1324,7 +1324,7 @@ impl Expectation {
     /// The primary use case is where the expected type is a fat pointer,
     /// like `&[isize]`. For example, consider the following statement:
     ///
-    ///     let x: &[isize] = &[1, 2, 3];
+    ///     let it: &[isize] = &[1, 2, 3];
     ///
     /// In this case, the expected type for the `&[1, 2, 3]` expression is
     /// `&[isize]`. If however we were to say that `[1, 2, 3]` has the

--- a/crates/hir-ty/src/infer/closure.rs
+++ b/crates/hir-ty/src/infer/closure.rs
@@ -139,7 +139,7 @@ impl HirPlace {
     ) -> CaptureKind {
         match current_capture {
             CaptureKind::ByRef(BorrowKind::Mut { .. }) => {
-                if self.projections[len..].iter().any(|x| *x == ProjectionElem::Deref) {
+                if self.projections[len..].iter().any(|it| *it == ProjectionElem::Deref) {
                     current_capture = CaptureKind::ByRef(BorrowKind::Unique);
                 }
             }
@@ -199,7 +199,7 @@ impl CapturedItem {
                             .to_string(),
                         VariantData::Tuple(fields) => fields
                             .iter()
-                            .position(|x| x.0 == f.local_id)
+                            .position(|it| it.0 == f.local_id)
                             .unwrap_or_default()
                             .to_string(),
                         VariantData::Unit => "[missing field]".to_string(),
@@ -439,10 +439,10 @@ impl InferenceContext<'_> {
     }
 
     fn walk_expr(&mut self, tgt_expr: ExprId) {
-        if let Some(x) = self.result.expr_adjustments.get_mut(&tgt_expr) {
+        if let Some(it) = self.result.expr_adjustments.get_mut(&tgt_expr) {
             // FIXME: this take is completely unneeded, and just is here to make borrow checker
             // happy. Remove it if you can.
-            let x_taken = mem::take(x);
+            let x_taken = mem::take(it);
             self.walk_expr_with_adjust(tgt_expr, &x_taken);
             *self.result.expr_adjustments.get_mut(&tgt_expr).unwrap() = x_taken;
         } else {
@@ -536,7 +536,7 @@ impl InferenceContext<'_> {
                 if let &Some(expr) = spread {
                     self.consume_expr(expr);
                 }
-                self.consume_exprs(fields.iter().map(|x| x.expr));
+                self.consume_exprs(fields.iter().map(|it| it.expr));
             }
             Expr::Field { expr, name: _ } => self.select_from_expr(*expr),
             Expr::UnaryOp { expr, op: UnaryOp::Deref } => {
@@ -548,7 +548,7 @@ impl InferenceContext<'_> {
                 } else if let Some((f, _)) = self.result.method_resolution(tgt_expr) {
                     let mutability = 'b: {
                         if let Some(deref_trait) =
-                            self.resolve_lang_item(LangItem::DerefMut).and_then(|x| x.as_trait())
+                            self.resolve_lang_item(LangItem::DerefMut).and_then(|it| it.as_trait())
                         {
                             if let Some(deref_fn) =
                                 self.db.trait_data(deref_trait).method_by_name(&name![deref_mut])
@@ -615,8 +615,8 @@ impl InferenceContext<'_> {
                         "We sort closures, so we should always have data for inner closures",
                     );
                 let mut cc = mem::take(&mut self.current_captures);
-                cc.extend(captures.iter().filter(|x| self.is_upvar(&x.place)).map(|x| {
-                    CapturedItemWithoutTy { place: x.place.clone(), kind: x.kind, span: x.span }
+                cc.extend(captures.iter().filter(|it| self.is_upvar(&it.place)).map(|it| {
+                    CapturedItemWithoutTy { place: it.place.clone(), kind: it.kind, span: it.span }
                 }));
                 self.current_captures = cc;
             }
@@ -694,7 +694,7 @@ impl InferenceContext<'_> {
                 },
             },
         }
-        if self.result.pat_adjustments.get(&p).map_or(false, |x| !x.is_empty()) {
+        if self.result.pat_adjustments.get(&p).map_or(false, |it| !it.is_empty()) {
             for_mut = BorrowKind::Unique;
         }
         self.body.walk_pats_shallow(p, |p| self.walk_pat_inner(p, update_result, for_mut));
@@ -706,9 +706,9 @@ impl InferenceContext<'_> {
 
     fn expr_ty_after_adjustments(&self, e: ExprId) -> Ty {
         let mut ty = None;
-        if let Some(x) = self.result.expr_adjustments.get(&e) {
-            if let Some(x) = x.last() {
-                ty = Some(x.target.clone());
+        if let Some(it) = self.result.expr_adjustments.get(&e) {
+            if let Some(it) = it.last() {
+                ty = Some(it.target.clone());
             }
         }
         ty.unwrap_or_else(|| self.expr_ty(e))
@@ -727,7 +727,7 @@ impl InferenceContext<'_> {
             // FIXME: We handle closure as a special case, since chalk consider every closure as copy. We
             // should probably let chalk know which closures are copy, but I don't know how doing it
             // without creating query cycles.
-            return self.result.closure_info.get(id).map(|x| x.1 == FnTrait::Fn).unwrap_or(true);
+            return self.result.closure_info.get(id).map(|it| it.1 == FnTrait::Fn).unwrap_or(true);
         }
         self.table.resolve_completely(ty).is_copy(self.db, self.owner)
     }
@@ -748,7 +748,7 @@ impl InferenceContext<'_> {
     }
 
     fn minimize_captures(&mut self) {
-        self.current_captures.sort_by_key(|x| x.place.projections.len());
+        self.current_captures.sort_by_key(|it| it.place.projections.len());
         let mut hash_map = HashMap::<HirPlace, usize>::new();
         let result = mem::take(&mut self.current_captures);
         for item in result {
@@ -759,7 +759,7 @@ impl InferenceContext<'_> {
                     break Some(*k);
                 }
                 match it.next() {
-                    Some(x) => lookup_place.projections.push(x.clone()),
+                    Some(it) => lookup_place.projections.push(it.clone()),
                     None => break None,
                 }
             };
@@ -780,7 +780,7 @@ impl InferenceContext<'_> {
     }
 
     fn consume_with_pat(&mut self, mut place: HirPlace, pat: PatId) {
-        let cnt = self.result.pat_adjustments.get(&pat).map(|x| x.len()).unwrap_or_default();
+        let cnt = self.result.pat_adjustments.get(&pat).map(|it| it.len()).unwrap_or_default();
         place.projections = place
             .projections
             .iter()
@@ -894,10 +894,10 @@ impl InferenceContext<'_> {
 
     fn closure_kind(&self) -> FnTrait {
         let mut r = FnTrait::Fn;
-        for x in &self.current_captures {
+        for it in &self.current_captures {
             r = cmp::min(
                 r,
-                match &x.kind {
+                match &it.kind {
                     CaptureKind::ByRef(BorrowKind::Unique | BorrowKind::Mut { .. }) => {
                         FnTrait::FnMut
                     }
@@ -933,7 +933,7 @@ impl InferenceContext<'_> {
         }
         self.minimize_captures();
         let result = mem::take(&mut self.current_captures);
-        let captures = result.into_iter().map(|x| x.with_ty(self)).collect::<Vec<_>>();
+        let captures = result.into_iter().map(|it| it.with_ty(self)).collect::<Vec<_>>();
         self.result.closure_info.insert(closure, (captures, closure_kind));
         closure_kind
     }
@@ -973,20 +973,20 @@ impl InferenceContext<'_> {
     fn sort_closures(&mut self) -> Vec<(ClosureId, Vec<(Ty, Ty, Vec<Ty>, ExprId)>)> {
         let mut deferred_closures = mem::take(&mut self.deferred_closures);
         let mut dependents_count: FxHashMap<ClosureId, usize> =
-            deferred_closures.keys().map(|x| (*x, 0)).collect();
+            deferred_closures.keys().map(|it| (*it, 0)).collect();
         for (_, deps) in &self.closure_dependencies {
             for dep in deps {
                 *dependents_count.entry(*dep).or_default() += 1;
             }
         }
         let mut queue: Vec<_> =
-            deferred_closures.keys().copied().filter(|x| dependents_count[x] == 0).collect();
+            deferred_closures.keys().copied().filter(|it| dependents_count[it] == 0).collect();
         let mut result = vec![];
-        while let Some(x) = queue.pop() {
-            if let Some(d) = deferred_closures.remove(&x) {
-                result.push((x, d));
+        while let Some(it) = queue.pop() {
+            if let Some(d) = deferred_closures.remove(&it) {
+                result.push((it, d));
             }
-            for dep in self.closure_dependencies.get(&x).into_iter().flat_map(|x| x.iter()) {
+            for dep in self.closure_dependencies.get(&it).into_iter().flat_map(|it| it.iter()) {
                 let cnt = dependents_count.get_mut(dep).unwrap();
                 *cnt -= 1;
                 if *cnt == 0 {

--- a/crates/hir-ty/src/infer/expr.rs
+++ b/crates/hir-ty/src/infer/expr.rs
@@ -928,7 +928,7 @@ impl InferenceContext<'_> {
                 if let TyKind::Ref(Mutability::Mut, _, inner) = derefed_callee.kind(Interner) {
                     if adjustments
                         .last()
-                        .map(|x| matches!(x.kind, Adjust::Borrow(_)))
+                        .map(|it| matches!(it.kind, Adjust::Borrow(_)))
                         .unwrap_or(true)
                     {
                         // prefer reborrow to move

--- a/crates/hir-ty/src/infer/mutability.rs
+++ b/crates/hir-ty/src/infer/mutability.rs
@@ -73,12 +73,12 @@ impl InferenceContext<'_> {
                 self.infer_mut_expr(c, Mutability::Not);
                 self.infer_mut_expr(body, Mutability::Not);
             }
-            Expr::MethodCall { receiver: x, method_name: _, args, generic_args: _ }
-            | Expr::Call { callee: x, args, is_assignee_expr: _ } => {
-                self.infer_mut_not_expr_iter(args.iter().copied().chain(Some(*x)));
+            Expr::MethodCall { receiver: it, method_name: _, args, generic_args: _ }
+            | Expr::Call { callee: it, args, is_assignee_expr: _ } => {
+                self.infer_mut_not_expr_iter(args.iter().copied().chain(Some(*it)));
             }
             Expr::Match { expr, arms } => {
-                let m = self.pat_iter_bound_mutability(arms.iter().map(|x| x.pat));
+                let m = self.pat_iter_bound_mutability(arms.iter().map(|it| it.pat));
                 self.infer_mut_expr(*expr, m);
                 for arm in arms.iter() {
                     self.infer_mut_expr(arm.expr, Mutability::Not);
@@ -96,7 +96,7 @@ impl InferenceContext<'_> {
                 }
             }
             Expr::RecordLit { path: _, fields, spread, ellipsis: _, is_assignee_expr: _ } => {
-                self.infer_mut_not_expr_iter(fields.iter().map(|x| x.expr).chain(*spread))
+                self.infer_mut_not_expr_iter(fields.iter().map(|it| it.expr).chain(*spread))
             }
             &Expr::Index { base, index } => {
                 if mutability == Mutability::Mut {
@@ -204,8 +204,8 @@ impl InferenceContext<'_> {
     }
 
     /// Checks if the pat contains a `ref mut` binding. Such paths makes the context of bounded expressions
-    /// mutable. For example in `let (ref mut x0, ref x1) = *x;` we need to use `DerefMut` for `*x` but in
-    /// `let (ref x0, ref x1) = *x;` we should use `Deref`.
+    /// mutable. For example in `let (ref mut x0, ref x1) = *it;` we need to use `DerefMut` for `*it` but in
+    /// `let (ref x0, ref x1) = *it;` we should use `Deref`.
     fn pat_bound_mutability(&self, pat: PatId) -> Mutability {
         let mut r = Mutability::Not;
         self.body.walk_bindings_in_pat(pat, |b| {

--- a/crates/hir-ty/src/infer/pat.rs
+++ b/crates/hir-ty/src/infer/pat.rs
@@ -306,7 +306,7 @@ impl InferenceContext<'_> {
         self.result
             .pat_adjustments
             .get(&pat)
-            .and_then(|x| x.first())
+            .and_then(|it| it.first())
             .unwrap_or(&self.result.type_of_pat[pat])
             .clone()
     }

--- a/crates/hir-ty/src/infer/unify.rs
+++ b/crates/hir-ty/src/infer/unify.rs
@@ -91,7 +91,7 @@ pub(crate) fn unify(
     let mut table = InferenceTable::new(db, env);
     let vars = Substitution::from_iter(
         Interner,
-        tys.binders.iter(Interner).map(|x| match &x.kind {
+        tys.binders.iter(Interner).map(|it| match &it.kind {
             chalk_ir::VariableKind::Ty(_) => {
                 GenericArgData::Ty(table.new_type_var()).intern(Interner)
             }
@@ -686,8 +686,8 @@ impl<'a> InferenceTable<'a> {
 
         let mut arg_tys = vec![];
         let arg_ty = TyBuilder::tuple(num_args)
-            .fill(|x| {
-                let arg = match x {
+            .fill(|it| {
+                let arg = match it {
                     ParamKind::Type => self.new_type_var(),
                     ParamKind::Const(ty) => {
                         never!("Tuple with const parameter");
@@ -753,7 +753,7 @@ impl<'a> InferenceTable<'a> {
     {
         fold_tys_and_consts(
             ty,
-            |x, _| match x {
+            |it, _| match it {
                 Either::Left(ty) => Either::Left(self.insert_type_vars_shallow(ty)),
                 Either::Right(c) => Either::Right(self.insert_const_vars_shallow(c)),
             },

--- a/crates/hir-ty/src/layout.rs
+++ b/crates/hir-ty/src/layout.rs
@@ -24,8 +24,8 @@ pub use self::{
 };
 
 macro_rules! user_error {
-    ($x: expr) => {
-        return Err(LayoutError::UserError(format!($x)))
+    ($it: expr) => {
+        return Err(LayoutError::UserError(format!($it)))
     };
 }
 
@@ -90,13 +90,13 @@ fn layout_of_simd_ty(
     // Supported SIMD vectors are homogeneous ADTs with at least one field:
     //
     // * #[repr(simd)] struct S(T, T, T, T);
-    // * #[repr(simd)] struct S { x: T, y: T, z: T, w: T }
+    // * #[repr(simd)] struct S { it: T, y: T, z: T, w: T }
     // * #[repr(simd)] struct S([T; 4])
     //
     // where T is a primitive scalar (integer/float/pointer).
 
     let f0_ty = match fields.iter().next() {
-        Some(x) => x.1.clone().substitute(Interner, subst),
+        Some(it) => it.1.clone().substitute(Interner, subst),
         None => {
             user_error!("simd type with zero fields");
         }
@@ -230,7 +230,7 @@ pub fn layout_of_ty_query(
                 .iter(Interner)
                 .map(|k| db.layout_of_ty(k.assert_ty_ref(Interner).clone(), krate))
                 .collect::<Result<Vec<_>, _>>()?;
-            let fields = fields.iter().map(|x| &**x).collect::<Vec<_>>();
+            let fields = fields.iter().map(|it| &**it).collect::<Vec<_>>();
             let fields = fields.iter().collect::<Vec<_>>();
             cx.univariant(dl, &fields, &ReprOptions::default(), kind).ok_or(LayoutError::Unknown)?
         }
@@ -348,14 +348,14 @@ pub fn layout_of_ty_query(
             let (captures, _) = infer.closure_info(c);
             let fields = captures
                 .iter()
-                .map(|x| {
+                .map(|it| {
                     db.layout_of_ty(
-                        x.ty.clone().substitute(Interner, ClosureSubst(subst).parent_subst()),
+                        it.ty.clone().substitute(Interner, ClosureSubst(subst).parent_subst()),
                         krate,
                     )
                 })
                 .collect::<Result<Vec<_>, _>>()?;
-            let fields = fields.iter().map(|x| &**x).collect::<Vec<_>>();
+            let fields = fields.iter().map(|it| &**it).collect::<Vec<_>>();
             let fields = fields.iter().collect::<Vec<_>>();
             cx.univariant(dl, &fields, &ReprOptions::default(), StructKind::AlwaysSized)
                 .ok_or(LayoutError::Unknown)?

--- a/crates/hir-ty/src/layout/adt.rs
+++ b/crates/hir-ty/src/layout/adt.rs
@@ -72,9 +72,9 @@ pub fn layout_of_adt_query(
     };
     let variants = variants
         .iter()
-        .map(|x| x.iter().map(|x| &**x).collect::<Vec<_>>())
+        .map(|it| it.iter().map(|it| &**it).collect::<Vec<_>>())
         .collect::<SmallVec<[_; 1]>>();
-    let variants = variants.iter().map(|x| x.iter().collect()).collect();
+    let variants = variants.iter().map(|it| it.iter().collect()).collect();
     let result = if matches!(def, AdtId::UnionId(..)) {
         cx.layout_of_union(&repr, &variants).ok_or(LayoutError::Unknown)?
     } else {
@@ -105,7 +105,7 @@ pub fn layout_of_adt_query(
                 && variants
                     .iter()
                     .next()
-                    .and_then(|x| x.last().map(|x| !x.is_unsized()))
+                    .and_then(|it| it.last().map(|it| !it.is_unsized()))
                     .unwrap_or(true),
         )
         .ok_or(LayoutError::SizeOverflow)?
@@ -118,9 +118,9 @@ fn layout_scalar_valid_range(db: &dyn HirDatabase, def: AdtId) -> (Bound<u128>, 
     let get = |name| {
         let attr = attrs.by_key(name).tt_values();
         for tree in attr {
-            if let Some(x) = tree.token_trees.first() {
-                if let Ok(x) = x.to_string().parse() {
-                    return Bound::Included(x);
+            if let Some(it) = tree.token_trees.first() {
+                if let Ok(it) = it.to_string().parse() {
+                    return Bound::Included(it);
                 }
             }
         }

--- a/crates/hir-ty/src/method_resolution.rs
+++ b/crates/hir-ty/src/method_resolution.rs
@@ -559,10 +559,10 @@ impl ReceiverAdjustments {
             adjust.push(a);
         }
         if self.unsize_array {
-            ty = 'x: {
+            ty = 'it: {
                 if let TyKind::Ref(m, l, inner) = ty.kind(Interner) {
                     if let TyKind::Array(inner, _) = inner.kind(Interner) {
-                        break 'x TyKind::Ref(
+                        break 'it TyKind::Ref(
                             m.clone(),
                             l.clone(),
                             TyKind::Slice(inner.clone()).intern(Interner),
@@ -666,7 +666,7 @@ pub fn is_dyn_method(
     let self_ty = trait_ref.self_type_parameter(Interner);
     if let TyKind::Dyn(d) = self_ty.kind(Interner) {
         let is_my_trait_in_bounds =
-            d.bounds.skip_binders().as_slice(Interner).iter().any(|x| match x.skip_binders() {
+            d.bounds.skip_binders().as_slice(Interner).iter().any(|it| match it.skip_binders() {
                 // rustc doesn't accept `impl Foo<2> for dyn Foo<5>`, so if the trait id is equal, no matter
                 // what the generics are, we are sure that the method is come from the vtable.
                 WhereClause::Implemented(tr) => tr.trait_id == trait_ref.trait_id,
@@ -731,7 +731,7 @@ fn lookup_impl_assoc_item_for_trait_ref(
     let impls = db.trait_impls_in_deps(env.krate);
     let self_impls = match self_ty.kind(Interner) {
         TyKind::Adt(id, _) => {
-            id.0.module(db.upcast()).containing_block().map(|x| db.trait_impls_in_block(x))
+            id.0.module(db.upcast()).containing_block().map(|it| db.trait_impls_in_block(it))
         }
         _ => None,
     };
@@ -895,8 +895,8 @@ pub fn iterate_method_candidates_dyn(
             // (just as rustc does an autoderef and then autoref again).
 
             // We have to be careful about the order we're looking at candidates
-            // in here. Consider the case where we're resolving `x.clone()`
-            // where `x: &Vec<_>`. This resolves to the clone method with self
+            // in here. Consider the case where we're resolving `it.clone()`
+            // where `it: &Vec<_>`. This resolves to the clone method with self
             // type `Vec<_>`, *not* `&_`. I.e. we need to consider methods where
             // the receiver type exactly matches before cases where we have to
             // do autoref. But in the autoderef steps, the `&_` self type comes
@@ -1480,8 +1480,8 @@ fn generic_implements_goal(
         .push(self_ty.value.clone())
         .fill_with_bound_vars(DebruijnIndex::INNERMOST, kinds.len())
         .build();
-    kinds.extend(trait_ref.substitution.iter(Interner).skip(1).map(|x| {
-        let vk = match x.data(Interner) {
+    kinds.extend(trait_ref.substitution.iter(Interner).skip(1).map(|it| {
+        let vk = match it.data(Interner) {
             chalk_ir::GenericArgData::Ty(_) => {
                 chalk_ir::VariableKind::Ty(chalk_ir::TyVariableKind::General)
             }

--- a/crates/hir-ty/src/mir/borrowck.rs
+++ b/crates/hir-ty/src/mir/borrowck.rs
@@ -52,7 +52,7 @@ fn all_mir_bodies(
                 let closures = body.closures.clone();
                 Box::new(
                     iter::once(Ok(body))
-                        .chain(closures.into_iter().flat_map(|x| for_closure(db, x))),
+                        .chain(closures.into_iter().flat_map(|it| for_closure(db, it))),
                 )
             }
             Err(e) => Box::new(iter::once(Err(e))),
@@ -62,7 +62,7 @@ fn all_mir_bodies(
         Ok(body) => {
             let closures = body.closures.clone();
             Box::new(
-                iter::once(Ok(body)).chain(closures.into_iter().flat_map(|x| for_closure(db, x))),
+                iter::once(Ok(body)).chain(closures.into_iter().flat_map(|it| for_closure(db, it))),
             )
         }
         Err(e) => Box::new(iter::once(Err(e))),
@@ -171,7 +171,7 @@ fn moved_out_of_ref(db: &dyn HirDatabase, body: &MirBody) -> Vec<MovedOutOfRef> 
                 }
                 TerminatorKind::Call { func, args, .. } => {
                     for_operand(func, terminator.span);
-                    args.iter().for_each(|x| for_operand(x, terminator.span));
+                    args.iter().for_each(|it| for_operand(it, terminator.span));
                 }
                 TerminatorKind::Assert { cond, .. } => {
                     for_operand(cond, terminator.span);
@@ -245,7 +245,7 @@ fn ever_initialized_map(
     body: &MirBody,
 ) -> ArenaMap<BasicBlockId, ArenaMap<LocalId, bool>> {
     let mut result: ArenaMap<BasicBlockId, ArenaMap<LocalId, bool>> =
-        body.basic_blocks.iter().map(|x| (x.0, ArenaMap::default())).collect();
+        body.basic_blocks.iter().map(|it| (it.0, ArenaMap::default())).collect();
     fn dfs(
         db: &dyn HirDatabase,
         body: &MirBody,
@@ -314,7 +314,7 @@ fn ever_initialized_map(
         result[body.start_block].insert(l, true);
         dfs(db, body, body.start_block, l, &mut result);
     }
-    for l in body.locals.iter().map(|x| x.0) {
+    for l in body.locals.iter().map(|it| it.0) {
         if !result[body.start_block].contains_idx(l) {
             result[body.start_block].insert(l, false);
             dfs(db, body, body.start_block, l, &mut result);
@@ -328,10 +328,10 @@ fn mutability_of_locals(
     body: &MirBody,
 ) -> ArenaMap<LocalId, MutabilityReason> {
     let mut result: ArenaMap<LocalId, MutabilityReason> =
-        body.locals.iter().map(|x| (x.0, MutabilityReason::Not)).collect();
+        body.locals.iter().map(|it| (it.0, MutabilityReason::Not)).collect();
     let mut push_mut_span = |local, span| match &mut result[local] {
         MutabilityReason::Mut { spans } => spans.push(span),
-        x @ MutabilityReason::Not => *x = MutabilityReason::Mut { spans: vec![span] },
+        it @ MutabilityReason::Not => *it = MutabilityReason::Mut { spans: vec![span] },
     };
     let ever_init_maps = ever_initialized_map(db, body);
     for (block_id, mut ever_init_map) in ever_init_maps.into_iter() {

--- a/crates/hir-ty/src/mir/lower/as_place.rs
+++ b/crates/hir-ty/src/mir/lower/as_place.rs
@@ -5,8 +5,8 @@ use hir_def::{lang_item::lang_attr, FunctionId};
 use hir_expand::name;
 
 macro_rules! not_supported {
-    ($x: expr) => {
-        return Err(MirLowerError::NotSupported(format!($x)))
+    ($it: expr) => {
+        return Err(MirLowerError::NotSupported(format!($it)))
     };
 }
 
@@ -34,7 +34,7 @@ impl MirLowerCtx<'_> {
     ) -> Result<Option<(Place, BasicBlockId)>> {
         let ty = adjustments
             .last()
-            .map(|x| x.target.clone())
+            .map(|it| it.target.clone())
             .unwrap_or_else(|| self.expr_ty_without_adjust(expr_id));
         let place = self.temp(ty, prev_block, expr_id.into())?;
         let Some(current) =
@@ -61,7 +61,7 @@ impl MirLowerCtx<'_> {
         if let Some((last, rest)) = adjustments.split_last() {
             match last.kind {
                 Adjust::Deref(None) => {
-                    let Some(mut x) = self.lower_expr_as_place_with_adjust(
+                    let Some(mut it) = self.lower_expr_as_place_with_adjust(
                         current,
                         expr_id,
                         upgrade_rvalue,
@@ -70,8 +70,8 @@ impl MirLowerCtx<'_> {
                     else {
                         return Ok(None);
                     };
-                    x.0 = x.0.project(ProjectionElem::Deref);
-                    Ok(Some(x))
+                    it.0 = it.0.project(ProjectionElem::Deref);
+                    Ok(Some(it))
                 }
                 Adjust::Deref(Some(od)) => {
                     let Some((r, current)) = self.lower_expr_as_place_with_adjust(
@@ -87,7 +87,7 @@ impl MirLowerCtx<'_> {
                         current,
                         r,
                         rest.last()
-                            .map(|x| x.target.clone())
+                            .map(|it| it.target.clone())
                             .unwrap_or_else(|| self.expr_ty_without_adjust(expr_id)),
                         last.target.clone(),
                         expr_id.into(),
@@ -253,8 +253,8 @@ impl MirLowerCtx<'_> {
                     .infer
                     .expr_adjustments
                     .get(base)
-                    .and_then(|x| x.split_last())
-                    .map(|x| x.1)
+                    .and_then(|it| it.split_last())
+                    .map(|it| it.1)
                     .unwrap_or(&[]);
                 let Some((mut p_base, current)) =
                     self.lower_expr_as_place_with_adjust(current, *base, true, adjusts)?

--- a/crates/hir-ty/src/mir/monomorphization.rs
+++ b/crates/hir-ty/src/mir/monomorphization.rs
@@ -29,8 +29,8 @@ use crate::{
 use super::{MirBody, MirLowerError, Operand, Rvalue, StatementKind, TerminatorKind};
 
 macro_rules! not_supported {
-    ($x: expr) => {
-        return Err(MirLowerError::NotSupported(format!($x)))
+    ($it: expr) => {
+        return Err(MirLowerError::NotSupported(format!($it)))
     };
 }
 
@@ -97,16 +97,16 @@ impl FallibleTypeFolder<Interner> for Filler<'_> {
         idx: chalk_ir::PlaceholderIndex,
         _outer_binder: DebruijnIndex,
     ) -> std::result::Result<chalk_ir::Const<Interner>, Self::Error> {
-        let x = from_placeholder_idx(self.db, idx);
-        let Some(idx) = self.generics.as_ref().and_then(|g| g.param_idx(x)) else {
+        let it = from_placeholder_idx(self.db, idx);
+        let Some(idx) = self.generics.as_ref().and_then(|g| g.param_idx(it)) else {
             not_supported!("missing idx in generics");
         };
         Ok(self
             .subst
             .as_slice(Interner)
             .get(idx)
-            .and_then(|x| x.constant(Interner))
-            .ok_or_else(|| MirLowerError::GenericArgNotProvided(x, self.subst.clone()))?
+            .and_then(|it| it.constant(Interner))
+            .ok_or_else(|| MirLowerError::GenericArgNotProvided(it, self.subst.clone()))?
             .clone())
     }
 
@@ -115,16 +115,16 @@ impl FallibleTypeFolder<Interner> for Filler<'_> {
         idx: chalk_ir::PlaceholderIndex,
         _outer_binder: DebruijnIndex,
     ) -> std::result::Result<Ty, Self::Error> {
-        let x = from_placeholder_idx(self.db, idx);
-        let Some(idx) = self.generics.as_ref().and_then(|g| g.param_idx(x)) else {
+        let it = from_placeholder_idx(self.db, idx);
+        let Some(idx) = self.generics.as_ref().and_then(|g| g.param_idx(it)) else {
             not_supported!("missing idx in generics");
         };
         Ok(self
             .subst
             .as_slice(Interner)
             .get(idx)
-            .and_then(|x| x.ty(Interner))
-            .ok_or_else(|| MirLowerError::GenericArgNotProvided(x, self.subst.clone()))?
+            .and_then(|it| it.ty(Interner))
+            .ok_or_else(|| MirLowerError::GenericArgNotProvided(it, self.subst.clone()))?
             .clone())
     }
 
@@ -180,7 +180,7 @@ impl Filler<'_> {
                                 MirLowerError::GenericArgNotProvided(
                                     self.generics
                                         .as_ref()
-                                        .and_then(|x| x.iter().nth(b.index))
+                                        .and_then(|it| it.iter().nth(b.index))
                                         .unwrap()
                                         .0,
                                     self.subst.clone(),

--- a/crates/hir-ty/src/mir/pretty.rs
+++ b/crates/hir-ty/src/mir/pretty.rs
@@ -135,7 +135,7 @@ impl<'a> MirPrettyCtx<'a> {
 
     fn for_closure(&mut self, closure: ClosureId) {
         let body = match self.db.mir_body_for_closure(closure) {
-            Ok(x) => x,
+            Ok(it) => it,
             Err(e) => {
                 wln!(self, "// error in {closure:?}: {e:?}");
                 return;
@@ -145,7 +145,7 @@ impl<'a> MirPrettyCtx<'a> {
         let indent = mem::take(&mut self.indent);
         let mut ctx = MirPrettyCtx {
             body: &body,
-            local_to_binding: body.binding_locals.iter().map(|(x, y)| (*y, x)).collect(),
+            local_to_binding: body.binding_locals.iter().map(|(it, y)| (*y, it)).collect(),
             result,
             indent,
             ..*self
@@ -167,7 +167,7 @@ impl<'a> MirPrettyCtx<'a> {
     }
 
     fn new(body: &'a MirBody, hir_body: &'a Body, db: &'a dyn HirDatabase) -> Self {
-        let local_to_binding = body.binding_locals.iter().map(|(x, y)| (*y, x)).collect();
+        let local_to_binding = body.binding_locals.iter().map(|(it, y)| (*y, it)).collect();
         MirPrettyCtx {
             body,
             db,
@@ -315,17 +315,17 @@ impl<'a> MirPrettyCtx<'a> {
                         }
                     }
                 }
-                ProjectionElem::TupleOrClosureField(x) => {
+                ProjectionElem::TupleOrClosureField(it) => {
                     f(this, local, head);
-                    w!(this, ".{}", x);
+                    w!(this, ".{}", it);
                 }
                 ProjectionElem::Index(l) => {
                     f(this, local, head);
                     w!(this, "[{}]", this.local_name(*l).display(this.db));
                 }
-                x => {
+                it => {
                     f(this, local, head);
-                    w!(this, ".{:?}", x);
+                    w!(this, ".{:?}", it);
                 }
             }
         }
@@ -356,14 +356,14 @@ impl<'a> MirPrettyCtx<'a> {
                 }
                 self.place(p);
             }
-            Rvalue::Aggregate(AggregateKind::Tuple(_), x) => {
+            Rvalue::Aggregate(AggregateKind::Tuple(_), it) => {
                 w!(self, "(");
-                self.operand_list(x);
+                self.operand_list(it);
                 w!(self, ")");
             }
-            Rvalue::Aggregate(AggregateKind::Array(_), x) => {
+            Rvalue::Aggregate(AggregateKind::Array(_), it) => {
                 w!(self, "[");
-                self.operand_list(x);
+                self.operand_list(it);
                 w!(self, "]");
             }
             Rvalue::Repeat(op, len) => {
@@ -371,19 +371,19 @@ impl<'a> MirPrettyCtx<'a> {
                 self.operand(op);
                 w!(self, "; {}]", len.display(self.db));
             }
-            Rvalue::Aggregate(AggregateKind::Adt(_, _), x) => {
+            Rvalue::Aggregate(AggregateKind::Adt(_, _), it) => {
                 w!(self, "Adt(");
-                self.operand_list(x);
+                self.operand_list(it);
                 w!(self, ")");
             }
-            Rvalue::Aggregate(AggregateKind::Closure(_), x) => {
+            Rvalue::Aggregate(AggregateKind::Closure(_), it) => {
                 w!(self, "Closure(");
-                self.operand_list(x);
+                self.operand_list(it);
                 w!(self, ")");
             }
-            Rvalue::Aggregate(AggregateKind::Union(_, _), x) => {
+            Rvalue::Aggregate(AggregateKind::Union(_, _), it) => {
                 w!(self, "Union(");
-                self.operand_list(x);
+                self.operand_list(it);
                 w!(self, ")");
             }
             Rvalue::Len(p) => {
@@ -428,8 +428,8 @@ impl<'a> MirPrettyCtx<'a> {
         }
     }
 
-    fn operand_list(&mut self, x: &[Operand]) {
-        let mut it = x.iter();
+    fn operand_list(&mut self, it: &[Operand]) {
+        let mut it = it.iter();
         if let Some(first) = it.next() {
             self.operand(first);
             for op in it {

--- a/crates/hir/src/display.rs
+++ b/crates/hir/src/display.rs
@@ -251,8 +251,8 @@ impl HirDisplay for GenericParam {
 impl HirDisplay for TypeOrConstParam {
     fn hir_fmt(&self, f: &mut HirFormatter<'_>) -> Result<(), HirDisplayError> {
         match self.split(f.db) {
-            either::Either::Left(x) => x.hir_fmt(f),
-            either::Either::Right(x) => x.hir_fmt(f),
+            either::Either::Left(it) => it.hir_fmt(f),
+            either::Either::Right(it) => it.hir_fmt(f),
         }
     }
 }
@@ -303,11 +303,11 @@ fn write_generic_params(
 ) -> Result<(), HirDisplayError> {
     let params = f.db.generic_params(def);
     if params.lifetimes.is_empty()
-        && params.type_or_consts.iter().all(|x| x.1.const_param().is_none())
+        && params.type_or_consts.iter().all(|it| it.1.const_param().is_none())
         && params
             .type_or_consts
             .iter()
-            .filter_map(|x| x.1.type_param())
+            .filter_map(|it| it.1.type_param())
             .all(|param| !matches!(param.provenance, TypeParamProvenance::TypeParamList))
     {
         return Ok(());

--- a/crates/hir/src/semantics/source_to_def.rs
+++ b/crates/hir/src/semantics/source_to_def.rs
@@ -298,7 +298,7 @@ impl SourceToDefCtx<'_, '_> {
     pub(super) fn type_param_to_def(&mut self, src: InFile<ast::TypeParam>) -> Option<TypeParamId> {
         let container: ChildContainer = self.find_generic_param_container(src.syntax())?.into();
         let dyn_map = self.cache_for(container, src.file_id);
-        dyn_map[keys::TYPE_PARAM].get(&src.value).copied().map(|x| TypeParamId::from_unchecked(x))
+        dyn_map[keys::TYPE_PARAM].get(&src.value).copied().map(|it| TypeParamId::from_unchecked(it))
     }
 
     pub(super) fn lifetime_param_to_def(
@@ -316,7 +316,10 @@ impl SourceToDefCtx<'_, '_> {
     ) -> Option<ConstParamId> {
         let container: ChildContainer = self.find_generic_param_container(src.syntax())?.into();
         let dyn_map = self.cache_for(container, src.file_id);
-        dyn_map[keys::CONST_PARAM].get(&src.value).copied().map(|x| ConstParamId::from_unchecked(x))
+        dyn_map[keys::CONST_PARAM]
+            .get(&src.value)
+            .copied()
+            .map(|it| ConstParamId::from_unchecked(it))
     }
 
     pub(super) fn generic_param_to_def(

--- a/crates/ide-completion/src/context/analysis.rs
+++ b/crates/ide-completion/src/context/analysis.rs
@@ -733,7 +733,7 @@ fn classify_name_ref(
                         return None;
                     }
                     let parent = match ast::Fn::cast(parent.parent()?) {
-                        Some(x) => x.param_list(),
+                        Some(it) => it.param_list(),
                         None => ast::ClosureExpr::cast(parent.parent()?)?.param_list(),
                     };
 

--- a/crates/ide/src/hover/render.rs
+++ b/crates/ide/src/hover/render.rs
@@ -422,10 +422,10 @@ pub(super) fn definition(
             |&it| {
                 if !it.parent_enum(db).is_data_carrying(db) {
                     match it.eval(db) {
-                        Ok(x) => {
-                            Some(if x >= 10 { format!("{x} ({x:#X})") } else { format!("{x}") })
+                        Ok(it) => {
+                            Some(if it >= 10 { format!("{it} ({it:#X})") } else { format!("{it}") })
                         }
-                        Err(_) => it.value(db).map(|x| format!("{x:?}")),
+                        Err(_) => it.value(db).map(|it| format!("{it:?}")),
                     }
                 } else {
                     None
@@ -437,7 +437,7 @@ pub(super) fn definition(
         Definition::Const(it) => label_value_and_docs(db, it, |it| {
             let body = it.render_eval(db);
             match body {
-                Ok(x) => Some(x),
+                Ok(it) => Some(it),
                 Err(_) => {
                     let source = it.source(db)?;
                     let mut body = source.value.body()?.syntax().clone();

--- a/crates/rust-analyzer/src/cli/lsif.rs
+++ b/crates/rust-analyzer/src/cli/lsif.rs
@@ -48,8 +48,8 @@ struct LsifManager<'a> {
 struct Id(i32);
 
 impl From<Id> for lsp_types::NumberOrString {
-    fn from(Id(x): Id) -> Self {
-        lsp_types::NumberOrString::Number(x)
+    fn from(Id(it): Id) -> Self {
+        lsp_types::NumberOrString::Number(it)
     }
 }
 
@@ -88,8 +88,8 @@ impl LsifManager<'_> {
     }
 
     fn get_token_id(&mut self, id: TokenId) -> Id {
-        if let Some(x) = self.token_map.get(&id) {
-            return *x;
+        if let Some(it) = self.token_map.get(&id) {
+            return *it;
         }
         let result_set_id = self.add_vertex(lsif::Vertex::ResultSet(lsif::ResultSet { key: None }));
         self.token_map.insert(id, result_set_id);
@@ -97,8 +97,8 @@ impl LsifManager<'_> {
     }
 
     fn get_package_id(&mut self, package_information: PackageInformation) -> Id {
-        if let Some(x) = self.package_map.get(&package_information) {
-            return *x;
+        if let Some(it) = self.package_map.get(&package_information) {
+            return *it;
         }
         let pi = package_information.clone();
         let result_set_id =
@@ -119,8 +119,8 @@ impl LsifManager<'_> {
     }
 
     fn get_range_id(&mut self, id: FileRange) -> Id {
-        if let Some(x) = self.range_map.get(&id) {
-            return *x;
+        if let Some(it) = self.range_map.get(&id) {
+            return *it;
         }
         let file_id = id.file_id;
         let doc_id = self.get_file_id(file_id);
@@ -142,8 +142,8 @@ impl LsifManager<'_> {
     }
 
     fn get_file_id(&mut self, id: FileId) -> Id {
-        if let Some(x) = self.file_map.get(&id) {
-            return *x;
+        if let Some(it) = self.file_map.get(&id) {
+            return *it;
         }
         let path = self.vfs.file_path(id);
         let path = path.as_path().unwrap();
@@ -216,18 +216,18 @@ impl LsifManager<'_> {
             }));
             let mut edges = token.references.iter().fold(
                 HashMap::<_, Vec<lsp_types::NumberOrString>>::new(),
-                |mut edges, x| {
+                |mut edges, it| {
                     let entry =
-                        edges.entry((x.range.file_id, x.is_definition)).or_insert_with(Vec::new);
-                    entry.push((*self.range_map.get(&x.range).unwrap()).into());
+                        edges.entry((it.range.file_id, it.is_definition)).or_insert_with(Vec::new);
+                    entry.push((*self.range_map.get(&it.range).unwrap()).into());
                     edges
                 },
             );
-            for x in token.references {
-                if let Some(vertices) = edges.remove(&(x.range.file_id, x.is_definition)) {
+            for it in token.references {
+                if let Some(vertices) = edges.remove(&(it.range.file_id, it.is_definition)) {
                     self.add_edge(lsif::Edge::Item(lsif::Item {
-                        document: (*self.file_map.get(&x.range.file_id).unwrap()).into(),
-                        property: Some(if x.is_definition {
+                        document: (*self.file_map.get(&it.range.file_id).unwrap()).into(),
+                        property: Some(if it.is_definition {
                             lsif::ItemKind::Definitions
                         } else {
                             lsif::ItemKind::References


### PR DESCRIPTION
I kept some usages of `x`:
* `x`s that are used together with `y`, `z`, ...
* `x` that shadow `it`. I use `it` for iterators out of r-a, so there were some cases that I used `it` and `x` together.
* `x` in test fixtures. Many of those `x` usages was not me so I thought it's better to keep them as is.

I tried to remove the rest, but since there was too many `x` I might missed some of them or changed some of them that I didn't want to change.