### PR TITLE
fix: Indent after pressing enter on a blank line

### DIFF
--- a/editors/code/src/config.ts
+++ b/editors/code/src/config.ts
@@ -99,7 +99,8 @@ export class Config {
         let onEnterRules: vscode.OnEnterRule[] = [
             {
                 // Carry indentation from the previous line
-                beforeText: /^\s*$/,
+                // if it's only whitespace
+                beforeText: /^\s+$/,
                 action: { indentAction: vscode.IndentAction.None },
             },
             {


### PR DESCRIPTION
Regressed after https://github.com/rust-lang/rust-analyzer/pull/13975 (whoops).