### PR TITLE
ide : Disallow renaming of non-local items

### DIFF
--- a/crates/ide-db/src/rename.rs
+++ b/crates/ide-db/src/rename.rs
@@ -93,13 +93,7 @@ impl Definition {
                 bail!("Cannot rename a builtin attr.")
             }
             Definition::SelfType(_) => bail!("Cannot rename `Self`"),
-            Definition::Macro(mac) => {
-                if mac.is_builtin_derive(sema.db) {
-                    bail!("Cannot rename builtin derive")
-                }
-
-                rename_reference(sema, Definition::Macro(mac), new_name)
-            }
+            Definition::Macro(mac) => rename_reference(sema, Definition::Macro(mac), new_name),
             def => rename_reference(sema, def, new_name),
         }
     }

--- a/crates/ide-db/src/rename.rs
+++ b/crates/ide-db/src/rename.rs
@@ -73,6 +73,8 @@ impl Definition {
     ) -> Result<SourceChange> {
         // self.krate() returns None if
         // self is a built-in attr, built-in type or tool module.
+        // it is not allowed for these defs to be renamed.
+        // cases where self.krate() is None is handled below.
         if let Some(krate) = self.krate(sema.db) {
             if !krate.origin(sema.db).is_local() {
                 bail!("Cannot rename a non-local definition.")

--- a/crates/ide/src/rename.rs
+++ b/crates/ide/src/rename.rs
@@ -2639,7 +2639,7 @@ use qux as frob;
 =======
 
     #[test]
-    fn disallow_renaming_for_non_local_struct() {
+    fn disallow_renaming_for_non_local_definition() {
         check(
             "Baz",
             r#"
@@ -2648,7 +2648,7 @@ pub struct S$0;
 //- /main.rs crate:main deps:lib new_source_root:local
 use lib::S;
 "#,
-            "error: Cannot rename a non-local struct.",
+            "error: Cannot rename a non-local definition.",
         );
     }
 >>>>>>> 948d9f274 (Disallow renaming of non-local structs)

--- a/crates/ide/src/rename.rs
+++ b/crates/ide/src/rename.rs
@@ -2529,7 +2529,6 @@ fn main() {
 ",
         )
     }
-<<<<<<< HEAD
 
     #[test]
     fn extern_crate() {
@@ -2635,8 +2634,6 @@ use qux as frob;
         // ",
         //         );
     }
-||||||| parent of 948d9f274 (Disallow renaming of non-local structs)
-=======
 
     #[test]
     fn disallow_renaming_for_non_local_definition() {
@@ -2644,12 +2641,26 @@ use qux as frob;
             "Baz",
             r#"
 //- /lib.rs crate:lib new_source_root:library
-pub struct S$0;
+pub struct S;
 //- /main.rs crate:main deps:lib new_source_root:local
-use lib::S;
+use lib::S$0;
 "#,
             "error: Cannot rename a non-local definition.",
         );
     }
->>>>>>> 948d9f274 (Disallow renaming of non-local structs)
+
+    #[test]
+    fn disallow_renaming_for_builtin_macros() {
+        check(
+            "Baz",
+            r#"
+//- minicore: derive, hash
+//- /main.rs crate:main
+use core::hash::Hash;
+#[derive(H$0ash)]
+struct A;
+            "#,
+            "error: Cannot rename a non-local definition.",
+        )
+    }
 }

--- a/crates/ide/src/rename.rs
+++ b/crates/ide/src/rename.rs
@@ -2529,6 +2529,7 @@ fn main() {
 ",
         )
     }
+<<<<<<< HEAD
 
     #[test]
     fn extern_crate() {
@@ -2634,4 +2635,21 @@ use qux as frob;
         // ",
         //         );
     }
+||||||| parent of 948d9f274 (Disallow renaming of non-local structs)
+=======
+
+    #[test]
+    fn disallow_renaming_for_non_local_struct() {
+        check(
+            "Baz",
+            r#"
+//- /lib.rs crate:lib new_source_root:library
+pub struct S$0;
+//- /main.rs crate:main deps:lib new_source_root:local
+use lib::S;
+"#,
+            "error: Cannot rename a non-local struct.",
+        );
+    }
+>>>>>>> 948d9f274 (Disallow renaming of non-local structs)
 }


### PR DESCRIPTION
fixes #14850 . This makes me wonder , why stop at structs and not do the same for other ADTs? Would be happy to add them too if nothing speaks against it.