### PR TITLE
editor/code: Allow to apply static analysis for codes opened in webview

### DIFF
--- a/editors/code/.prettierrc.js
+++ b/editors/code/.prettierrc.js
@@ -2,4 +2,5 @@ module.exports = {
     // use 100 because it's Rustfmt's default
     // https://rust-lang.github.io/rustfmt/?version=v1.4.38&search=#max_width
     printWidth: 100,
+    tabWidth: 4,
 };

--- a/editors/code/.vscodeignore
+++ b/editors/code/.vscodeignore
@@ -7,6 +7,7 @@
 !node_modules/d3-graphviz/build/d3-graphviz.min.js
 !node_modules/d3/dist/d3.min.js
 !out/main.js
+!out/webview/
 !package-lock.json
 !package.json
 !ra_syntax_tree.tmGrammar.json

--- a/editors/code/README.md
+++ b/editors/code/README.md
@@ -5,15 +5,15 @@ It is recommended over and replaces `rust-lang.rust`.
 
 ## Features
 
-- [code completion] with [imports insertion]
-- go to [definition], [implementation], [type definition]
-- [find all references], [workspace symbol search], [symbol renaming]
-- [types and documentation on hover]
-- [inlay hints] for types and parameter names
-- [semantic syntax highlighting]
-- a lot of [assists (code actions)]
-- apply suggestions from errors
-- ... and many more, check out the [manual] to see them all
+-   [code completion] with [imports insertion]
+-   go to [definition], [implementation], [type definition]
+-   [find all references], [workspace symbol search], [symbol renaming]
+-   [types and documentation on hover]
+-   [inlay hints] for types and parameter names
+-   [semantic syntax highlighting]
+-   a lot of [assists (code actions)]
+-   apply suggestions from errors
+-   ... and many more, check out the [manual] to see them all
 
 [code completion]: https://rust-analyzer.github.io/manual.html#magic-completions
 [imports insertion]: https://rust-analyzer.github.io/manual.html#completion-with-autoimport

--- a/editors/code/build.mjs
+++ b/editors/code/build.mjs
@@ -1,0 +1,60 @@
+import * as path from "node:path";
+import { parseArgs } from "node:util";
+import * as esbuild from "esbuild";
+
+function parseCliOptions() {
+    const { values } = parseArgs({
+        options: {
+            minify: {
+                type: "boolean",
+                default: false,
+            },
+            sourcemap: {
+                type: "boolean",
+                default: false,
+            },
+            watch: {
+                type: "boolean",
+                default: false,
+            },
+        },
+        strict: true,
+    });
+    return {
+        shouldMinify: !!values.minify,
+        shouldEmitSourceMap: !!values.sourcemap,
+        isWatchMode: !!values.watch,
+    };
+}
+
+const { shouldMinify, shouldEmitSourceMap, isWatchMode } = parseCliOptions();
+
+const OUT_DIR = "./out";
+
+function createBuildOption(entryPoints) {
+    /** @type {esbuild.BuildOptions} */
+    const options = {
+        entryPoints,
+        minify: shouldMinify,
+        sourcemap: shouldEmitSourceMap ? "external" : false,
+        bundle: true,
+        external: ["vscode"],
+        format: "cjs",
+        platform: "node",
+        target: "node16",
+        outdir: OUT_DIR,
+    };
+    return options;
+}
+
+async function bundleSource(options) {
+    if (!isWatchMode) {
+        return esbuild.build(options);
+    }
+
+    const ctx = await esbuild.context(options);
+    return ctx.watch();
+}
+
+const extensionMain = bundleSource(createBuildOption(["src/main.ts"]));
+await Promise.all([extensionMain]);

--- a/editors/code/build.mjs
+++ b/editors/code/build.mjs
@@ -81,6 +81,12 @@ await Promise.all([
     bundleSource(createBuildOption(["src/main.ts"])),
     bundleSource(
         createBuildOptionForWebView([
+            "src/webview/show_crate_graph.ts",
+            "src/webview/show_crate_graph.css",
+        ]),
+    ),
+    bundleSource(
+        createBuildOptionForWebView([
             "src/webview/view_memory_layout.ts",
             "src/webview/view_memory_layout.css",
         ]),

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -32,7 +32,7 @@
     "scripts": {
         "vscode:prepublish": "npm run build-base -- --minify",
         "package": "vsce package -o rust-analyzer.vsix",
-        "build-base": "esbuild ./src/main.ts --bundle --outfile=out/main.js --external:vscode --format=cjs --platform=node --target=node16",
+        "build-base": "node ./build.mjs",
         "build": "npm run build-base -- --sourcemap",
         "watch": "npm run build-base -- --sourcemap --watch",
         "format": "prettier --write .",

--- a/editors/code/src/commands.ts
+++ b/editors/code/src/commands.ts
@@ -21,6 +21,7 @@ import type { LanguageClient } from "vscode-languageclient/node";
 import { LINKED_COMMANDS } from "./client";
 import type { DependencyId } from "./dependencies_provider";
 import { unwrapUndefinable } from "./undefinable";
+import { getWebViewModulePath } from "./uri";
 
 export * from "./ast_inspector";
 export * from "./run";
@@ -1142,12 +1143,17 @@ export function viewMemoryLayout(ctx: CtxInit): Cmd {
             position,
         });
 
+        const webviewModulePath = getWebViewModulePath(ctx);
+
         const document = vscode.window.createWebviewPanel(
             "memory_layout",
             "[Memory Layout]",
             vscode.ViewColumn.Two,
             { enableScripts: true },
+            { enableScripts: true, localResourceRoots: [webviewModulePath] },
         );
+
+        const uri = document.webview.asWebviewUri(webviewModulePath);
 
         document.webview.html = `<!DOCTYPE html>
 <html lang="en">
@@ -1155,252 +1161,16 @@ export function viewMemoryLayout(ctx: CtxInit): Cmd {
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Document</title>
-    <style>
-        * {
-            box-sizing: border-box;
-        }
-
-        body {
-            margin: 0;
-            overflow: hidden;
-            min-height: 100%;
-            height: 100vh;
-            padding: 32px;
-            position: relative;
-            display: block;
-
-            background-color: var(--vscode-editor-background);
-            font-family: var(--vscode-editor-font-family);
-            font-size: var(--vscode-editor-font-size);
-            color: var(--vscode-editor-foreground);
-        }
-
-        .container {
-            position: relative;
-        }
-
-        .trans {
-            transition: all 0.2s ease-in-out;
-        }
-
-        .grid {
-            height: 100%;
-            position: relative;
-            color: var(--vscode-commandCenter-activeBorder);
-            pointer-events: none;
-        }
-
-        .grid-line {
-            position: absolute;
-            width: 100%;
-            height: 1px;
-            background-color: var(--vscode-commandCenter-activeBorder);
-        }
-
-        #tooltip {
-            position: fixed;
-            display: none;
-            z-index: 1;
-            pointer-events: none;
-            padding: 4px 8px;
-            z-index: 2;
-
-            color: var(--vscode-editorHoverWidget-foreground);
-            background-color: var(--vscode-editorHoverWidget-background);
-            border: 1px solid var(--vscode-editorHoverWidget-border);
-        }
-
-        #tooltip b {
-            color: var(--vscode-editorInlayHint-typeForeground);
-        }
-
-        #tooltip ul {
-            margin-left: 0;
-            padding-left: 20px;
-        }
-
-        table {
-            position: absolute;
-            transform: rotateZ(90deg) rotateX(180deg);
-            transform-origin: top left;
-            border-collapse: collapse;
-            table-layout: fixed;
-            left: 48px;
-            top: 0;
-            max-height: calc(100vw - 64px - 48px);
-            z-index: 1;
-        }
-
-        td {
-            border: 1px solid var(--vscode-focusBorder);
-            writing-mode: vertical-rl;
-            text-orientation: sideways-right;
-
-            height: 80px;
-        }
-
-        td p {
-            height: calc(100% - 16px);
-            width: calc(100% - 8px);
-            margin: 8px 4px;
-            display: inline-block;
-            transform: rotateY(180deg);
-            pointer-events: none;
-            overflow: hidden;
-        }
-
-        td p * {
-            overflow: hidden;
-            white-space: nowrap;
-            text-overflow: ellipsis;
-            display: inline-block;
-            height: 100%;
-        }
-
-        td p b {
-            color: var(--vscode-editorInlayHint-typeForeground);
-        }
-
-        td:hover {
-            background-color: var(--vscode-editor-hoverHighlightBackground);
-        }
-
-        td:empty {
-            visibility: hidden;
-            border: 0;
-        }
-    </style>
+    <link href="${uri}/view_memory_layout.css" rel="stylesheet" media="screen"/>
 </head>
 <body>
     <div id="tooltip"></div>
 </body>
-<script>(function() {
+<script type="module">
+import { showMemoryLayout } from '${uri}/view_memory_layout.js';
 
 const data = ${JSON.stringify(expanded)}
-
-if (!(data && data.nodes.length)) {
-    document.body.innerText = "Not Available"
-    return
-}
-
-data.nodes.map(n => {
-    n.typename = n.typename.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;').replaceAll('"', ' & quot; ').replaceAll("'", '&#039;')
-    return n
-})
-
-let height = window.innerHeight - 64
-
-addEventListener("resize", e => {
-    const new_height = window.innerHeight - 64
-    height = new_height
-    container.classList.remove("trans")
-    table.classList.remove("trans")
-    locate()
-    setTimeout(() => { // give delay to redraw, annoying but needed
-        container.classList.add("trans")
-        table.classList.add("trans")
-    }, 0)
-})
-
-const container = document.createElement("div")
-container.classList.add("container")
-container.classList.add("trans")
-document.body.appendChild(container)
-
-const tooltip = document.getElementById("tooltip")
-
-let y = 0
-let zoom = 1.0
-
-const table = document.createElement("table")
-table.classList.add("trans")
-container.appendChild(table)
-const rows = []
-
-function node_t(idx, depth, offset) {
-    if (!rows[depth]) {
-        rows[depth] = { el: document.createElement("tr"), offset: 0 }
-    }
-
-    if (rows[depth].offset < offset) {
-        const pad = document.createElement("td")
-        pad.colSpan = offset - rows[depth].offset
-        rows[depth].el.appendChild(pad)
-        rows[depth].offset += offset - rows[depth].offset
-    }
-
-    const td = document.createElement("td")
-    td.innerHTML = '<p><span>' + data.nodes[idx].itemName + ':</span> <b>' + data.nodes[idx].typename + '</b></p>'
-
-    td.colSpan = data.nodes[idx].size
-
-    td.addEventListener("mouseover", e => {
-        const node = data.nodes[idx]
-        tooltip.innerHTML = node.itemName + ": <b>" + node.typename + "</b><br/>"
-            + "<ul>"
-            + "<li>size = " + node.size + "</li>"
-            + "<li>align = " + node.alignment + "</li>"
-            + "<li>field offset = " + node.offset + "</li>"
-            + "</ul>"
-            + "<i>double click to focus</i>"
-
-        tooltip.style.display = "block"
-    })
-    td.addEventListener("mouseleave", _ => tooltip.style.display = "none")
-    const total_offset = rows[depth].offset
-    td.addEventListener("dblclick", e => {
-        const node = data.nodes[idx]
-        zoom = data.nodes[0].size / node.size
-        y = -(total_offset) / data.nodes[0].size * zoom
-        x = 0
-        locate()
-    })
-
-    rows[depth].el.appendChild(td)
-    rows[depth].offset += data.nodes[idx].size
-
-
-    if (data.nodes[idx].childrenStart != -1) {
-        for (let i = 0; i < data.nodes[idx].childrenLen; i++) {
-            if (data.nodes[data.nodes[idx].childrenStart + i].size) {
-                node_t(data.nodes[idx].childrenStart + i, depth + 1, offset + data.nodes[data.nodes[idx].childrenStart + i].offset)
-            }
-        }
-    }
-}
-
-node_t(0, 0, 0)
-
-for (const row of rows) table.appendChild(row.el)
-
-const grid = document.createElement("div")
-grid.classList.add("grid")
-container.appendChild(grid)
-
-for (let i = 0; i < data.nodes[0].size / 8 + 1; i++) {
-    const el = document.createElement("div")
-    el.classList.add("grid-line")
-    el.style.top = (i / (data.nodes[0].size / 8) * 100) + "%"
-    el.innerText = i * 8
-    grid.appendChild(el)
-}
-
-addEventListener("mousemove", e => {
-    tooltip.style.top = e.clientY + 10 + "px"
-    tooltip.style.left = e.clientX + 10 + "px"
-})
-
-function locate() {
-    container.style.top = height * y + "px"
-    container.style.height = (height * zoom) + "px"
-
-    table.style.width = container.style.height
-}
-
-locate()
-
-})()
+showMemoryLayout(data);
 </script>
 </html>`;
 

--- a/editors/code/src/commands.ts
+++ b/editors/code/src/commands.ts
@@ -1149,7 +1149,6 @@ export function viewMemoryLayout(ctx: CtxInit): Cmd {
             "memory_layout",
             "[Memory Layout]",
             vscode.ViewColumn.Two,
-            { enableScripts: true },
             { enableScripts: true, localResourceRoots: [webviewModulePath] },
         );
 

--- a/editors/code/src/commands.ts
+++ b/editors/code/src/commands.ts
@@ -1158,7 +1158,6 @@ export function viewMemoryLayout(ctx: CtxInit): Cmd {
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link href="${uri}/view_memory_layout.css" rel="stylesheet" media="screen"/>
 </head>

--- a/editors/code/src/uri.ts
+++ b/editors/code/src/uri.ts
@@ -10,3 +10,7 @@ function getBundledAssetsUri(ctx: CtxInit, pathname: string): Uri {
 export function getWebViewModulePath(ctx: CtxInit) {
     return getBundledAssetsUri(ctx, "out/webview");
 }
+
+export function getNodeModulePath(ctx: CtxInit) {
+    return getBundledAssetsUri(ctx, "node_modules");
+}

--- a/editors/code/src/uri.ts
+++ b/editors/code/src/uri.ts
@@ -1,0 +1,12 @@
+import * as path from "node:path";
+import { Uri } from "vscode";
+import type { CtxInit } from "./ctx";
+
+function getBundledAssetsUri(ctx: CtxInit, pathname: string): Uri {
+    const resolved = path.join(ctx.extensionPath, pathname);
+    return Uri.file(resolved);
+}
+
+export function getWebViewModulePath(ctx: CtxInit) {
+    return getBundledAssetsUri(ctx, "out/webview");
+}

--- a/editors/code/src/webview/show_crate_graph.css
+++ b/editors/code/src/webview/show_crate_graph.css
@@ -1,0 +1,27 @@
+/* Fill the entire view */
+html,
+body {
+    margin: 0;
+    padding: 0;
+    overflow: hidden;
+}
+svg {
+    position: fixed;
+    top: 0;
+    left: 0;
+    height: 100%;
+    width: 100%;
+}
+
+/* Disable the graphviz background and fill the polygons */
+.graph > polygon {
+    display: none;
+}
+:is(.node, .edge) polygon {
+    fill: white;
+}
+
+/* Invert the line colours for dark themes */
+body:not(.vscode-light) .edge path {
+    stroke: white;
+}

--- a/editors/code/src/webview/show_crate_graph.ts
+++ b/editors/code/src/webview/show_crate_graph.ts
@@ -1,0 +1,19 @@
+// @ts-nocheck
+export function showCrateDependencyGraph(dot): void {
+    const graph = d3
+        .select("#graph")
+        .graphviz({ useWorker: false, useSharedWorker: false })
+        .fit(true)
+        .zoomScaleExtent([0.1, Infinity])
+        .renderDot(dot);
+
+    d3.select(window).on("click", (event) => {
+        if (event.ctrlKey) {
+            graph.resetZoom(d3.transition().duration(100));
+        }
+    });
+    d3.select(window).on("copy", (event) => {
+        event.clipboardData.setData("text/plain", dot);
+        event.preventDefault();
+    });
+}

--- a/editors/code/src/webview/view_memory_layout.css
+++ b/editors/code/src/webview/view_memory_layout.css
@@ -1,0 +1,113 @@
+* {
+    box-sizing: border-box;
+}
+
+body {
+    margin: 0;
+    overflow: hidden;
+    min-height: 100%;
+    height: 100vh;
+    padding: 32px;
+    position: relative;
+    display: block;
+
+    background-color: var(--vscode-editor-background);
+    font-family: var(--vscode-editor-font-family);
+    font-size: var(--vscode-editor-font-size);
+    color: var(--vscode-editor-foreground);
+}
+
+.container {
+    position: relative;
+}
+
+.trans {
+    transition: all 0.2s ease-in-out;
+}
+
+.grid {
+    height: 100%;
+    position: relative;
+    color: var(--vscode-commandCenter-activeBorder);
+    pointer-events: none;
+}
+
+.grid-line {
+    position: absolute;
+    width: 100%;
+    height: 1px;
+    background-color: var(--vscode-commandCenter-activeBorder);
+}
+
+#tooltip {
+    position: fixed;
+    display: none;
+    z-index: 1;
+    pointer-events: none;
+    padding: 4px 8px;
+    z-index: 2;
+
+    color: var(--vscode-editorHoverWidget-foreground);
+    background-color: var(--vscode-editorHoverWidget-background);
+    border: 1px solid var(--vscode-editorHoverWidget-border);
+}
+
+#tooltip b {
+    color: var(--vscode-editorInlayHint-typeForeground);
+}
+
+#tooltip ul {
+    margin-left: 0;
+    padding-left: 20px;
+}
+
+table {
+    position: absolute;
+    transform: rotateZ(90deg) rotateX(180deg);
+    transform-origin: top left;
+    border-collapse: collapse;
+    table-layout: fixed;
+    left: 48px;
+    top: 0;
+    max-height: calc(100vw - 64px - 48px);
+    z-index: 1;
+}
+
+td {
+    border: 1px solid var(--vscode-focusBorder);
+    writing-mode: vertical-rl;
+    text-orientation: sideways-right;
+
+    height: 80px;
+}
+
+td p {
+    height: calc(100% - 16px);
+    width: calc(100% - 8px);
+    margin: 8px 4px;
+    display: inline-block;
+    transform: rotateY(180deg);
+    pointer-events: none;
+    overflow: hidden;
+}
+
+td p * {
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    display: inline-block;
+    height: 100%;
+}
+
+td p b {
+    color: var(--vscode-editorInlayHint-typeForeground);
+}
+
+td:hover {
+    background-color: var(--vscode-editor-hoverHighlightBackground);
+}
+
+td:empty {
+    visibility: hidden;
+    border: 0;
+}

--- a/editors/code/src/webview/view_memory_layout.ts
+++ b/editors/code/src/webview/view_memory_layout.ts
@@ -1,0 +1,152 @@
+// @ts-nocheck
+
+export function showMemoryLayout(data): void {
+    if (!(data && data.nodes.length)) {
+        document.body.innerText = "Not Available";
+        return;
+    }
+
+    data.nodes.map((n) => {
+        n.typename = n.typename
+            .replaceAll("&", "&amp;")
+            .replaceAll("<", "&lt;")
+            .replaceAll(">", "&gt;")
+            .replaceAll('"', " & quot; ")
+            .replaceAll("'", "&#039;");
+        return n;
+    });
+
+    let height = window.innerHeight - 64;
+
+    window.addEventListener("resize", (e) => {
+        const newHeight = window.innerHeight - 64;
+        height = newHeight;
+        container.classList.remove("trans");
+        table.classList.remove("trans");
+        locate();
+        setTimeout(() => {
+            // give delay to redraw, annoying but needed
+            container.classList.add("trans");
+            table.classList.add("trans");
+        }, 0);
+    });
+
+    const container = document.createElement("div");
+    container.classList.add("container");
+    container.classList.add("trans");
+    document.body.appendChild(container);
+
+    const tooltip = document.getElementById("tooltip");
+
+    let y = 0;
+    let zoom = 1.0;
+
+    const table = document.createElement("table");
+    table.classList.add("trans");
+    container.appendChild(table);
+    const rows = [];
+
+    // eslint-disable-next-line camelcase
+    function node_t(idx, depth, offset) {
+        if (!rows[depth]) {
+            rows[depth] = { el: document.createElement("tr"), offset: 0 };
+        }
+
+        if (rows[depth].offset < offset) {
+            const pad = document.createElement("td");
+            pad.colSpan = offset - rows[depth].offset;
+            rows[depth].el.appendChild(pad);
+            rows[depth].offset += offset - rows[depth].offset;
+        }
+
+        const td = document.createElement("td");
+        td.innerHTML =
+            "<p><span>" +
+            data.nodes[idx].itemName +
+            ":</span> <b>" +
+            data.nodes[idx].typename +
+            "</b></p>";
+
+        td.colSpan = data.nodes[idx].size;
+
+        td.addEventListener("mouseover", (e) => {
+            const node = data.nodes[idx];
+            tooltip.innerHTML =
+                node.itemName +
+                ": <b>" +
+                node.typename +
+                "</b><br/>" +
+                "<ul>" +
+                "<li>size = " +
+                node.size +
+                "</li>" +
+                "<li>align = " +
+                node.alignment +
+                "</li>" +
+                "<li>field offset = " +
+                node.offset +
+                "</li>" +
+                "</ul>" +
+                "<i>double click to focus</i>";
+
+            tooltip.style.display = "block";
+        });
+        td.addEventListener("mouseleave", (_) => (tooltip.style.display = "none"));
+        // eslint-disable-next-line camelcase
+        const total_offset = rows[depth].offset;
+        td.addEventListener("dblclick", (e) => {
+            const node = data.nodes[idx];
+            zoom = data.nodes[0].size / node.size;
+            // eslint-disable-next-line camelcase
+            y = (-total_offset / data.nodes[0].size) * zoom;
+            x = 0;
+            locate();
+        });
+
+        rows[depth].el.appendChild(td);
+        rows[depth].offset += data.nodes[idx].size;
+
+        // eslint-disable-next-line eqeqeq
+        if (data.nodes[idx].childrenStart != -1) {
+            for (let i = 0; i < data.nodes[idx].childrenLen; i++) {
+                if (data.nodes[data.nodes[idx].childrenStart + i].size) {
+                    node_t(
+                        data.nodes[idx].childrenStart + i,
+                        depth + 1,
+                        offset + data.nodes[data.nodes[idx].childrenStart + i].offset,
+                    );
+                }
+            }
+        }
+    }
+
+    node_t(0, 0, 0);
+
+    for (const row of rows) table.appendChild(row.el);
+
+    const grid = document.createElement("div");
+    grid.classList.add("grid");
+    container.appendChild(grid);
+
+    for (let i = 0; i < data.nodes[0].size / 8 + 1; i++) {
+        const el = document.createElement("div");
+        el.classList.add("grid-line");
+        el.style.top = (i / (data.nodes[0].size / 8)) * 100 + "%";
+        el.innerText = i * 8;
+        grid.appendChild(el);
+    }
+
+    window.addEventListener("mousemove", (e) => {
+        tooltip.style.top = e.clientY + 10 + "px";
+        tooltip.style.left = e.clientX + 10 + "px";
+    });
+
+    function locate() {
+        container.style.top = height * y + "px";
+        container.style.height = height * zoom + "px";
+
+        table.style.width = container.style.height;
+    }
+
+    locate();
+}

--- a/editors/code/src/webview/view_memory_layout.ts
+++ b/editors/code/src/webview/view_memory_layout.ts
@@ -46,8 +46,7 @@ export function showMemoryLayout(data): void {
     container.appendChild(table);
     const rows = [];
 
-    // eslint-disable-next-line camelcase
-    function node_t(idx, depth, offset) {
+    function nodeT(idx, depth, offset) {
         if (!rows[depth]) {
             rows[depth] = { el: document.createElement("tr"), offset: 0 };
         }
@@ -92,13 +91,12 @@ export function showMemoryLayout(data): void {
             tooltip.style.display = "block";
         });
         td.addEventListener("mouseleave", (_) => (tooltip.style.display = "none"));
-        // eslint-disable-next-line camelcase
-        const total_offset = rows[depth].offset;
+
+        const totalOffset = rows[depth].offset;
         td.addEventListener("dblclick", (e) => {
             const node = data.nodes[idx];
             zoom = data.nodes[0].size / node.size;
-            // eslint-disable-next-line camelcase
-            y = (-total_offset / data.nodes[0].size) * zoom;
+            y = (-totalOffset / data.nodes[0].size) * zoom;
             x = 0;
             locate();
         });
@@ -106,11 +104,10 @@ export function showMemoryLayout(data): void {
         rows[depth].el.appendChild(td);
         rows[depth].offset += data.nodes[idx].size;
 
-        // eslint-disable-next-line eqeqeq
-        if (data.nodes[idx].childrenStart != -1) {
+        if (data.nodes[idx].childrenStart !== -1) {
             for (let i = 0; i < data.nodes[idx].childrenLen; i++) {
                 if (data.nodes[data.nodes[idx].childrenStart + i].size) {
-                    node_t(
+                    nodeT(
                         data.nodes[idx].childrenStart + i,
                         depth + 1,
                         offset + data.nodes[data.nodes[idx].childrenStart + i].offset,
@@ -120,7 +117,7 @@ export function showMemoryLayout(data): void {
         }
     }
 
-    node_t(0, 0, 0);
+    nodeT(0, 0, 0);
 
     for (const row of rows) table.appendChild(row.el);
 

--- a/editors/code/tsconfig.eslint.json
+++ b/editors/code/tsconfig.eslint.json
@@ -6,6 +6,7 @@
         "src",
         "tests",
         // these are the eslint-only inclusions
-        ".eslintrc.js"
+        ".eslintrc.js",
+        "./build.mjs"
     ]
 }

--- a/editors/code/tsconfig.json
+++ b/editors/code/tsconfig.json
@@ -6,7 +6,6 @@
         "moduleResolution": "node16",
         "target": "es2021",
         "outDir": "out",
-        "lib": ["es2021"],
         "sourceMap": true,
         "rootDir": ".",
         "newLine": "LF",


### PR DESCRIPTION
This pull request introduces build phase to bundle a code opened in a webview by esbuild.

By this change, we are able to apply a static analysis for codes that are opened in webview.

As a caveat, we might confuse the execution context between vscode extension and webview after this change. For example, you may be able to touch DOM that is not actually in the vscode extension context but TypeScript does not warn it. I think this would not be a problem in a almost case by pushing codes into `src/webview/` directly.

To prevents this problem, we need introduce a separated npm workspace to use an another tsconfig.json. But I think we don't have to do it in this moment. We should postpone it to the future.