### PR TITLE
Properly infer types with type casts

### DIFF
--- a/crates/hir-ty/src/infer/cast.rs
+++ b/crates/hir-ty/src/infer/cast.rs
@@ -1,0 +1,46 @@
+//! Type cast logic. Basically coercion + additional casts.
+
+use crate::{infer::unify::InferenceTable, Interner, Ty, TyExt, TyKind};
+
+#[derive(Clone, Debug)]
+pub(super) struct CastCheck {
+    expr_ty: Ty,
+    cast_ty: Ty,
+}
+
+impl CastCheck {
+    pub(super) fn new(expr_ty: Ty, cast_ty: Ty) -> Self {
+        Self { expr_ty, cast_ty }
+    }
+
+    pub(super) fn check(self, table: &mut InferenceTable<'_>) {
+        // FIXME: This function currently only implements the bits that influence the type
+        // inference. We should return the adjustments on success and report diagnostics on error.
+        let expr_ty = table.resolve_ty_shallow(&self.expr_ty);
+        let cast_ty = table.resolve_ty_shallow(&self.cast_ty);
+
+        if expr_ty.contains_unknown() || cast_ty.contains_unknown() {
+            return;
+        }
+
+        if table.coerce(&expr_ty, &cast_ty).is_ok() {
+            return;
+        }
+
+        if check_ref_to_ptr_cast(expr_ty, cast_ty, table) {
+            // Note that this type of cast is actually split into a coercion to a
+            // pointer type and a cast:
+            // &[T; N] -> *[T; N] -> *T
+            return;
+        }
+
+        // FIXME: Check other kinds of non-coercion casts and report error if any?
+    }
+}
+
+fn check_ref_to_ptr_cast(expr_ty: Ty, cast_ty: Ty, table: &mut InferenceTable<'_>) -> bool {
+    let Some((expr_inner_ty, _, _)) = expr_ty.as_reference() else { return false; };
+    let Some((cast_inner_ty, _)) = cast_ty.as_raw_ptr() else { return false; };
+    let TyKind::Array(expr_elt_ty, _) = expr_inner_ty.kind(Interner) else { return false; };
+    table.coerce(expr_elt_ty, cast_inner_ty).is_ok()
+}

--- a/crates/hir-ty/src/tests/regression.rs
+++ b/crates/hir-ty/src/tests/regression.rs
@@ -1978,3 +1978,23 @@ fn x(a: [i32; 4]) {
         "#,
     );
 }
+
+#[test]
+fn dont_unify_on_casts() {
+    // #15246
+    check_types(
+        r#"
+fn unify(_: [bool; 1]) {}
+fn casted(_: *const bool) {}
+fn default<T>() -> T { loop {} }
+
+fn test() {
+    let foo = default();
+      //^^^ [bool; 1]
+
+    casted(&foo as *const _);
+    unify(foo);
+}
+"#,
+    );
+}

--- a/crates/hir-ty/src/tests/simple.rs
+++ b/crates/hir-ty/src/tests/simple.rs
@@ -3513,7 +3513,6 @@ fn func() {
     );
 }
 
-// FIXME
 #[test]
 fn castable_to() {
     check_infer(
@@ -3538,10 +3537,10 @@ fn func() {
             120..122 '{}': ()
             138..184 '{     ...0]>; }': ()
             148..149 'x': Box<[i32; 0]>
-            152..160 'Box::new': fn new<[{unknown}; 0]>([{unknown}; 0]) -> Box<[{unknown}; 0]>
-            152..164 'Box::new([])': Box<[{unknown}; 0]>
+            152..160 'Box::new': fn new<[i32; 0]>([i32; 0]) -> Box<[i32; 0]>
+            152..164 'Box::new([])': Box<[i32; 0]>
             152..181 'Box::n...2; 0]>': Box<[i32; 0]>
-            161..163 '[]': [{unknown}; 0]
+            161..163 '[]': [i32; 0]
         "#]],
     );
 }
@@ -3574,6 +3573,21 @@ fn f<T>(t: Ark<T>) {
             125..127 '&t': &Ark<T>
             126..127 't': Ark<T>
         "#]],
+    );
+}
+
+#[test]
+fn ref_to_array_to_ptr_cast() {
+    check_types(
+        r#"
+fn default<T>() -> T { loop {} }
+fn foo() {
+    let arr = [default()];
+      //^^^ [i32; 1]
+    let ref_to_arr = &arr;
+    let casted = ref_to_arr as *const i32;
+}
+"#,
     );
 }
 


### PR DESCRIPTION
This PR reenables `Expectation::Castable` (previous attempt at #14104, reverted by #14120) and implements type cast checks, which enable us to infer a bit more.

Castable expectations are relatively weak -- they only influence the inference if we cannot infer the types by other means. Therefore, we need to defer possible type unification with the casted type until we type check all expressions of the body. This PR adds a struct and slots in `InferenceContext` for the deferred cast checks (c.f. [`CastCheck`] in `rustc_hir_typeck`).

I only implemented the bits that affect the inference result. It should be possible to return type adjustments for well-formed casts and report diagnostics for invalid casts, but I'm leaving them for future work for now.

Fixes #11571
Fixes #15246

[`CastCheck`]: https://github.com/rust-lang/rust/blob/da1d099f91ea387a2814a6244dd875a2048b486f/compiler/rustc_hir_typeck/src/cast.rs#L55