### PR TITLE
editor/code: Break down CI steps to know what is failing easily

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -161,7 +161,18 @@ jobs:
       #      if: runner.os == 'Linux'
       #      working-directory: ./editors/code
 
+      # If this steps fails, your code's type integrity might be wrong at some places at TypeScript level.
+      - run: npm run typecheck
+        working-directory: ./editors/code
+        if: needs.changes.outputs.typescript == 'true'
+
+      # You may fix the code automatically by running `npm run lint:fix` if this steps fails.
       - run: npm run lint
+        working-directory: ./editors/code
+        if: needs.changes.outputs.typescript == 'true'
+
+      # To fix this steps, please run `npm run format`.
+      - run: npm run format:check
         working-directory: ./editors/code
         if: needs.changes.outputs.typescript == 'true'
 
@@ -178,10 +189,6 @@ jobs:
           VSCODE_CLI: 1
         run: npm test
         working-directory: ./editors/code
-
-      - run: npm run pretest
-        working-directory: ./editors/code
-        if: needs.changes.outputs.typescript == 'true'
 
       - run: npm run package --scripts-prepend-node-path
         working-directory: ./editors/code

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -35,9 +35,12 @@
         "build-base": "esbuild ./src/main.ts --bundle --outfile=out/main.js --external:vscode --format=cjs --platform=node --target=node16",
         "build": "npm run build-base -- --sourcemap",
         "watch": "npm run build-base -- --sourcemap --watch",
-        "lint": "prettier --check . && eslint -c .eslintrc.js --ext ts ./src ./tests",
-        "fix": "prettier --write . && eslint -c .eslintrc.js --ext ts ./src ./tests --fix",
-        "pretest": "tsc && npm run build",
+        "format": "prettier --write .",
+        "format:check": "prettier --check .",
+        "lint": "eslint -c .eslintrc.js --ext ts ./src ./tests",
+        "lint:fix": "npm run lint -- --fix",
+        "typecheck": "tsc",
+        "pretest": "npm run typecheck && npm run build",
         "test": "node ./out/tests/runTests.js"
     },
     "dependencies": {


### PR DESCRIPTION
This do the thing I mentioned in https://github.com/rust-lang/rust-analyzer/pull/15265#issuecomment-1634424385

This aims to improve CI status check more readable.

I tried to use [`jobs.<job_id>.if`](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idif) to make the configuration
more shortly once.

But it could not fire the `end-success` or `end-failure` status if some jobs in the workflow were skipped. This causes an integration problem with bors.

By their reasons, this patch still uses `jobs.<job_id>.steps[*].if`.

---

To do this change, we reorganize npm-script.

| previous           | after                                  |
|--------------------|----------------------------------------|
| `npm run lint`     | `npm run lint && npm run format:check` |
| `npm run fix`      | `npm run lint:fix && npm run format`   |

The previous `npm run fix` sometimes does not complete fix automatically because ESLint's autofix doees not follow prettier's formatting. So we need to run `npm run lint:fix && npm run format` by this order.