### PR TITLE
Fix rust-analzyer ssr help message

### DIFF
--- a/crates/rust-analyzer/src/cli/flags.rs
+++ b/crates/rust-analyzer/src/cli/flags.rs
@@ -113,7 +113,7 @@ xflags::xflags! {
         }
 
         cmd ssr {
-            /// A structured search replace rule (`$a.foo($b) ==> bar($a, $b)`)
+            /// A structured search replace rule (`$a.foo($b) ==>> bar($a, $b)`)
             repeated rule: SsrRule
         }
 


### PR DESCRIPTION
It's missing a `>`, so

```
> rust-analyzer ssr '''$a.foo($b) ==> bar($a, $b)'''
can't parse `rule`, Parse error: Cannot find delimiter `==>>`
```

happens.