### PR TITLE
Runnable env per platform

### DIFF
--- a/docs/user/manual.adoc
+++ b/docs/user/manual.adoc
@@ -952,6 +952,29 @@ Or it is possible to specify vars more granularly:
 You can use any valid regular expression as a mask.
 Also note that a full runnable name is something like *run bin_or_example_name*, *test some::mod::test_name* or *test-mod some::mod*, so it is possible to distinguish binaries, single tests, and test modules with this masks: `"^run"`, `"^test "` (the trailing space matters!), and `"^test-mod"` respectively.
 
+If needed, you can set different values for different platforms:
+```jsonc
+"rust-analyzer.runnables.extraEnv": [
+    {
+        "platform": "win32", // windows only
+        env: {
+             "APP_DATA": "windows specific data"
+        }
+    },
+    {
+        "platform": ["linux"],
+        "env": {
+             "APP_DATA": "linux data",
+        }
+    },
+    { // for all platforms
+        "env": {
+             "APP_COMMON_DATA": "xxx",
+        }
+    }
+]
+```
+
 ==== Compiler feedback from external commands
 
 Instead of relying on the built-in `cargo check`, you can configure Code to run a command in the background and use the `$rustc-watch` problem matcher to generate inline error markers from its output.

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -325,6 +325,15 @@
                             "items": {
                                 "type": "object",
                                 "properties": {
+                                    "platform": {
+                                        "type": [
+                                            "null",
+                                            "string",
+                                            "array"
+                                        ],
+                                        "default": null,
+                                        "markdownDescription": "Platform(s) filter like \"win32\" or [\"linux\", \"win32\"]. See [process.platform](https://nodejs.org/api/process.html#processplatform) values."
+                                    },
                                     "mask": {
                                         "type": "string",
                                         "description": "Runnable name mask"

--- a/editors/code/src/config.ts
+++ b/editors/code/src/config.ts
@@ -6,10 +6,12 @@ import type { Env } from "./client";
 import { log } from "./util";
 import { expectNotUndefined, unwrapUndefinable } from "./undefinable";
 
-export type RunnableEnvCfg =
-    | undefined
-    | Record<string, string>
-    | { mask?: string; env: Record<string, string> }[];
+export type RunnableEnvCfgItem = {
+    mask?: string;
+    env: Record<string, string>;
+    platform?: string | string[];
+};
+export type RunnableEnvCfg = undefined | Record<string, string> | RunnableEnvCfgItem[];
 
 export class Config {
     readonly extensionId = "rust-lang.rust-analyzer";

--- a/editors/code/src/run.ts
+++ b/editors/code/src/run.ts
@@ -7,7 +7,6 @@ import type { CtxInit } from "./ctx";
 import { makeDebugConfig } from "./debug";
 import type { Config, RunnableEnvCfg, RunnableEnvCfgItem } from "./config";
 import { unwrapUndefinable } from "./undefinable";
-import { string } from "vscode-languageclient/lib/common/utils/is";
 
 const quickPickButtons = [
     { iconPath: new vscode.ThemeIcon("save"), tooltip: "Save as a launch.json configuration." },

--- a/editors/code/src/run.ts
+++ b/editors/code/src/run.ts
@@ -5,8 +5,9 @@ import * as tasks from "./tasks";
 
 import type { CtxInit } from "./ctx";
 import { makeDebugConfig } from "./debug";
-import type { Config, RunnableEnvCfg } from "./config";
+import type { Config, RunnableEnvCfg, RunnableEnvCfgItem } from "./config";
 import { unwrapUndefinable } from "./undefinable";
+import { string } from "vscode-languageclient/lib/common/utils/is";
 
 const quickPickButtons = [
     { iconPath: new vscode.ThemeIcon("save"), tooltip: "Save as a launch.json configuration." },
@@ -112,11 +113,21 @@ export function prepareEnv(
     }
 
     Object.assign(env, process.env as { [key: string]: string });
+    const platform = process.platform;
+
+    const checkPlatform = (it: RunnableEnvCfgItem) => {
+        if (it.platform) {
+            const platforms = Array.isArray(it.platform) ? it.platform : [it.platform];
+            return platforms.indexOf(platform) >= 0;
+        }
+        return true;
+    };
 
     if (runnableEnvCfg) {
         if (Array.isArray(runnableEnvCfg)) {
             for (const it of runnableEnvCfg) {
-                if (!it.mask || new RegExp(it.mask).test(runnable.label)) {
+                const masked = !it.mask || new RegExp(it.mask).test(runnable.label);
+                if (masked && checkPlatform(it)) {
                     Object.assign(env, it.env);
                 }
             }


### PR DESCRIPTION
This PR adds an option to specify runnables `env` per platform (win32, linux, etc.):
```
{
    "rust-analyzer.runnables.extraEnv": [
            {
                "platform": "win32",
                "env": {
                    "SCITER_BIN_FOLDER": "C:\\Projects\\3rd\\sciter-js-sdk\\bin\\windows\\x64",
                }
            },
            {
                "platform":["linux","darwin"],
                "env": {
                    "SCITER_BIN_FOLDER": "/home/vit/Projects/sciter/sciter-js-sdk/bin/linux/x64",
                }
            }
        ]
}
```