### PR TITLE
vscode: change minimum VS Code version to 1.75 from 1.78

### DIFF
--- a/editors/code/package-lock.json
+++ b/editors/code/package-lock.json
@@ -18,7 +18,7 @@
             "devDependencies": {
                 "@tsconfig/strictest": "^2.0.1",
                 "@types/node": "~16.11.7",
-                "@types/vscode": "~1.78.1",
+                "@types/vscode": "~1.75",
                 "@typescript-eslint/eslint-plugin": "^6.0.0",
                 "@typescript-eslint/parser": "^6.0.0",
                 "@vscode/test-electron": "^2.3.3",
@@ -32,7 +32,7 @@
                 "typescript": "^5.1.6"
             },
             "engines": {
-                "vscode": "^1.78.0"
+                "vscode": "^1.75.0"
             }
         },
         "node_modules/@aashutoshrathi/word-wrap": {
@@ -565,9 +565,9 @@
             "dev": true
         },
         "node_modules/@types/vscode": {
-            "version": "1.78.1",
-            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.78.1.tgz",
-            "integrity": "sha512-wEA+54axejHu7DhcUfnFBan1IqFD1gBDxAFz8LoX06NbNDMRJv/T6OGthOs52yZccasKfN588EyffHWABkR0fg==",
+            "version": "1.75.1",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.75.1.tgz",
+            "integrity": "sha512-emg7wdsTFzdi+elvoyoA+Q8keEautdQHyY5LNmHVM4PTpY8JgOTVADrGVyXGepJ6dVW2OS5/xnLUWh+nZxvdiA==",
             "dev": true
         },
         "node_modules/@typescript-eslint/eslint-plugin": {

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -26,7 +26,7 @@
         }
     },
     "engines": {
-        "vscode": "^1.78.0"
+        "vscode": "^1.75.0"
     },
     "enabledApiProposals": [],
     "scripts": {
@@ -53,7 +53,7 @@
     "devDependencies": {
         "@tsconfig/strictest": "^2.0.1",
         "@types/node": "~16.11.7",
-        "@types/vscode": "~1.78.1",
+        "@types/vscode": "~1.75",
         "@typescript-eslint/eslint-plugin": "^6.0.0",
         "@typescript-eslint/parser": "^6.0.0",
         "@vscode/test-electron": "^2.3.3",


### PR DESCRIPTION
I previously mentioned [in a comment](https://github.com/rust-lang/rust-analyzer/pull/15265#issuecomment-1633240290) that folks at my employer are on 1.78, but I was incorrect: people are on 1.75. I know this is outside the standard version support policy, but I haven't seen any of the new features in VS Code be used in rust-analyzer. The most applicable feature in those three versions of VS Code that I can find [is lazily resolving code actions](https://code.visualstudio.com/updates/v1_78#_resolve-code-action-commands-in-resolvecodeaction), but it doesn't seem like rust-analyzer is making use of that feature.

(I'll be posting a PR that adds support for `$saved_file` within the next day, so feel free to bump the minimum VS Code version back to 1.78 if/when that PR lands. This just makes vendoring the _actual_ change I'm interested in a little bit easier.)
