### PR TITLE
Suggest type completions for type arguments and constant completions for constant arguments

### DIFF
--- a/crates/ide-completion/src/completions.rs
+++ b/crates/ide-completion/src/completions.rs
@@ -703,7 +703,7 @@ pub(super) fn complete_name_ref(
                         TypeLocation::TypeAscription(ascription) => {
                             r#type::complete_ascribed_type(acc, ctx, path_ctx, ascription);
                         }
-                        TypeLocation::GenericArg(_)
+                        TypeLocation::GenericArg { .. }
                         | TypeLocation::AssocConstEq
                         | TypeLocation::AssocTypeEq
                         | TypeLocation::TypeBound

--- a/crates/ide-completion/src/completions.rs
+++ b/crates/ide-completion/src/completions.rs
@@ -703,7 +703,9 @@ pub(super) fn complete_name_ref(
                         TypeLocation::TypeAscription(ascription) => {
                             r#type::complete_ascribed_type(acc, ctx, path_ctx, ascription);
                         }
-                        TypeLocation::GenericArgList(_)
+                        TypeLocation::GenericArg(_)
+                        | TypeLocation::AssocConstEq
+                        | TypeLocation::AssocTypeEq
                         | TypeLocation::TypeBound
                         | TypeLocation::ImplTarget
                         | TypeLocation::ImplTrait

--- a/crates/ide-completion/src/completions/type.rs
+++ b/crates/ide-completion/src/completions/type.rs
@@ -173,7 +173,7 @@ pub(crate) fn complete_type_path(
                     });
                     return;
                 }
-                TypeLocation::GenericArgList(Some((arg_list, generic_param))) => {
+                TypeLocation::GenericArgList(Some((arg_list, _))) => {
                     let in_assoc_type_arg = ctx
                         .original_token
                         .parent_ancestors()

--- a/crates/ide-completion/src/completions/type.rs
+++ b/crates/ide-completion/src/completions/type.rs
@@ -20,7 +20,16 @@ pub(crate) fn complete_type_path(
     let scope_def_applicable = |def| {
         use hir::{GenericParam::*, ModuleDef::*};
         match def {
-            ScopeDef::GenericParam(LifetimeParam(_)) | ScopeDef::Label(_) => false,
+            ScopeDef::GenericParam(LifetimeParam(_)) => {
+                matches!(
+                    location,
+                    TypeLocation::GenericArgList(Some((
+                        _,
+                        Some(ast::GenericParam::LifetimeParam(_))
+                    )))
+                )
+            }
+            ScopeDef::Label(_) => false,
             // no values in type places
             ScopeDef::ModuleDef(Function(_) | Variant(_) | Static(_)) | ScopeDef::Local(_) => false,
             // unless its a constant in a generic arg list position

--- a/crates/ide-completion/src/completions/type.rs
+++ b/crates/ide-completion/src/completions/type.rs
@@ -1,7 +1,7 @@
 //! Completion of names from the current scope in type position.
 
 use hir::{HirDisplay, ScopeDef};
-use syntax::{ast, AstNode, SyntaxKind};
+use syntax::{ast, AstNode};
 
 use crate::{
     context::{PathCompletionCtx, Qualified, TypeAscriptionTarget, TypeLocation},
@@ -20,36 +20,15 @@ pub(crate) fn complete_type_path(
     let scope_def_applicable = |def| {
         use hir::{GenericParam::*, ModuleDef::*};
         match def {
-            ScopeDef::GenericParam(LifetimeParam(_)) => {
-                matches!(
-                    location,
-                    TypeLocation::GenericArgList(Some((
-                        _,
-                        Some(ast::GenericParam::LifetimeParam(_))
-                    )))
-                )
-            }
+            ScopeDef::GenericParam(LifetimeParam(_)) => location.complete_lifetimes(),
             ScopeDef::Label(_) => false,
             // no values in type places
             ScopeDef::ModuleDef(Function(_) | Variant(_) | Static(_)) | ScopeDef::Local(_) => false,
             // unless its a constant in a generic arg list position
-            ScopeDef::ModuleDef(Const(_)) | ScopeDef::GenericParam(ConstParam(_)) => match location
-            {
-                TypeLocation::GenericArgList(location) => match location {
-                    Some((_, Some(generic_param))) => {
-                        matches!(generic_param, ast::GenericParam::ConstParam(_))
-                    }
-                    _ => true,
-                },
-                _ => false,
-            },
-            ScopeDef::ImplSelfType(_) => match location {
-                TypeLocation::ImplTarget | TypeLocation::ImplTrait => false,
-                TypeLocation::GenericArgList(Some((_, Some(generic_param)))) => {
-                    matches!(generic_param, ast::GenericParam::TypeParam(_))
-                }
-                _ => true,
-            },
+            ScopeDef::ModuleDef(Const(_)) | ScopeDef::GenericParam(ConstParam(_)) => {
+                location.complete_consts()
+            }
+            ScopeDef::ImplSelfType(_) => location.complete_self_type(),
             // Don't suggest attribute macros and derives.
             ScopeDef::ModuleDef(Macro(mac)) => mac.is_fn_like(ctx.db),
             // Type things are fine
@@ -58,17 +37,12 @@ pub(crate) fn complete_type_path(
             )
             | ScopeDef::AdtSelfType(_)
             | ScopeDef::Unknown
-            | ScopeDef::GenericParam(TypeParam(_)) => match location {
-                TypeLocation::GenericArgList(Some((_, Some(generic_param)))) => {
-                    matches!(generic_param, ast::GenericParam::TypeParam(_))
-                }
-                _ => true,
-            },
+            | ScopeDef::GenericParam(TypeParam(_)) => location.complete_types(),
         }
     };
 
     let add_assoc_item = |acc: &mut Completions, item| match item {
-        hir::AssocItem::Const(ct) if matches!(location, TypeLocation::GenericArgList(_)) => {
+        hir::AssocItem::Const(ct) if matches!(location, TypeLocation::GenericArg(_)) => {
             acc.add_const(ctx, ct)
         }
         hir::AssocItem::Function(_) | hir::AssocItem::Const(_) => (),
@@ -182,55 +156,32 @@ pub(crate) fn complete_type_path(
                     });
                     return;
                 }
-                TypeLocation::GenericArgList(Some((arg_list, _))) => {
-                    let in_assoc_type_arg = ctx
-                        .original_token
-                        .parent_ancestors()
-                        .any(|node| node.kind() == SyntaxKind::ASSOC_TYPE_ARG);
+                TypeLocation::GenericArg(Some((arg_list, in_trait, _))) => {
+                    if let Some(trait_) = in_trait {
+                        if arg_list.syntax().ancestors().find_map(ast::TypeBound::cast).is_some() {
+                            let arg_idx = arg_list
+                                .generic_args()
+                                .filter(|arg| {
+                                    arg.syntax().text_range().end()
+                                        < ctx.original_token.text_range().start()
+                                })
+                                .count();
 
-                    if !in_assoc_type_arg {
-                        if let Some(path_seg) =
-                            arg_list.syntax().parent().and_then(ast::PathSegment::cast)
-                        {
-                            if path_seg
-                                .syntax()
-                                .ancestors()
-                                .find_map(ast::TypeBound::cast)
-                                .is_some()
-                            {
-                                if let Some(hir::PathResolution::Def(hir::ModuleDef::Trait(
-                                    trait_,
-                                ))) = ctx.sema.resolve_path(&path_seg.parent_path())
-                                {
-                                    let arg_idx = arg_list
-                                        .generic_args()
-                                        .filter(|arg| {
-                                            arg.syntax().text_range().end()
-                                                < ctx.original_token.text_range().start()
-                                        })
-                                        .count();
-
-                                    let n_required_params =
-                                        trait_.type_or_const_param_count(ctx.sema.db, true);
-                                    if arg_idx >= n_required_params {
-                                        trait_
-                                            .items_with_supertraits(ctx.sema.db)
-                                            .into_iter()
-                                            .for_each(|it| {
-                                                if let hir::AssocItem::TypeAlias(alias) = it {
-                                                    cov_mark::hit!(
-                                                        complete_assoc_type_in_generics_list
-                                                    );
-                                                    acc.add_type_alias_with_eq(ctx, alias);
-                                                }
-                                            });
-
-                                        let n_params =
-                                            trait_.type_or_const_param_count(ctx.sema.db, false);
-                                        if arg_idx >= n_params {
-                                            return; // only show assoc types
+                            let n_required_params =
+                                trait_.type_or_const_param_count(ctx.sema.db, true);
+                            if arg_idx >= n_required_params {
+                                trait_.items_with_supertraits(ctx.sema.db).into_iter().for_each(
+                                    |it| {
+                                        if let hir::AssocItem::TypeAlias(alias) = it {
+                                            cov_mark::hit!(complete_assoc_type_in_generics_list);
+                                            acc.add_type_alias_with_eq(ctx, alias);
                                         }
-                                    }
+                                    },
+                                );
+
+                                let n_params = trait_.type_or_const_param_count(ctx.sema.db, false);
+                                if arg_idx >= n_params {
+                                    return; // only show assoc types
                                 }
                             }
                         }

--- a/crates/ide-completion/src/context.rs
+++ b/crates/ide-completion/src/context.rs
@@ -169,19 +169,15 @@ pub(crate) enum TypeLocation {
 
 impl TypeLocation {
     pub(crate) fn complete_lifetimes(&self) -> bool {
-        match self {
-            TypeLocation::GenericArg(Some((_, _, Some(param)))) => {
-                matches!(param, ast::GenericParam::LifetimeParam(_))
-            }
-            _ => false,
-        }
+        matches!(
+            self,
+            TypeLocation::GenericArg(Some((_, _, Some(ast::GenericParam::LifetimeParam(_)))))
+        )
     }
 
     pub(crate) fn complete_consts(&self) -> bool {
         match self {
-            TypeLocation::GenericArg(Some((_, _, Some(param)))) => {
-                matches!(param, ast::GenericParam::ConstParam(_))
-            }
+            TypeLocation::GenericArg(Some((_, _, Some(ast::GenericParam::ConstParam(_))))) => true,
             TypeLocation::AssocConstEq => true,
             _ => false,
         }

--- a/crates/ide-completion/src/context.rs
+++ b/crates/ide-completion/src/context.rs
@@ -155,7 +155,7 @@ pub(crate) struct ExprCtx {
 pub(crate) enum TypeLocation {
     TupleField,
     TypeAscription(TypeAscriptionTarget),
-    GenericArgList(Option<ast::GenericArgList>),
+    GenericArgList(Option<(ast::GenericArgList, Option<ast::GenericParam>)>),
     TypeBound,
     ImplTarget,
     ImplTrait,

--- a/crates/ide-completion/src/context/analysis.rs
+++ b/crates/ide-completion/src/context/analysis.rs
@@ -884,6 +884,16 @@ fn classify_name_ref(
     };
     let make_path_kind_type = |ty: ast::Type| {
         let location = type_location(ty.syntax());
+        if let Some(p) = ty.syntax().parent() {
+            if ast::GenericArg::can_cast(p.kind()) || ast::GenericArgList::can_cast(p.kind()) {
+                if let Some(p) = p.parent().and_then(|p| p.parent()) {
+                    if let Some(segment) = ast::PathSegment::cast(p) {
+                        let path = segment.parent_path().top_path();
+                        dbg!(sema.resolve_path(&path));
+                    }
+                }
+            }
+        }
         PathKind::Type { location: location.unwrap_or(TypeLocation::Other) }
     };
 

--- a/crates/ide-completion/src/context/analysis.rs
+++ b/crates/ide-completion/src/context/analysis.rs
@@ -848,7 +848,6 @@ fn classify_name_ref(
                 ast::TypeBound(_) => TypeLocation::TypeBound,
                 // is this case needed?
                 ast::TypeBoundList(_) => TypeLocation::TypeBound,
-                ast::TypeArg(it) => generic_arg_location(ast::GenericArg::TypeArg(it)),
                 ast::GenericArg(it) => generic_arg_location(it),
                 // is this case needed?
                 ast::GenericArgList(it) => {

--- a/crates/ide-completion/src/context/analysis.rs
+++ b/crates/ide-completion/src/context/analysis.rs
@@ -816,6 +816,9 @@ fn classify_name_ref(
                 // are often omitted, ignore them for the purposes of matching the argument with
                 // its parameter unless a lifetime argument is provided explicitly. That is, for
                 // `struct S<'a, 'b, T>`, match `S::<$0>` to `T` and `S::<'a, $0, _>` to `'b`.
+                // FIXME: This operates on the syntax tree and will produce incorrect results when
+                // generic parameters are disabled by `#[cfg]` directives. It should operate on the
+                // HIR, but the functionality necessary to do so is not exposed at the moment.
                 let mut explicit_lifetime_arg = false;
                 let arg_idx = arg
                     .syntax()

--- a/crates/ide-completion/src/tests/type_pos.rs
+++ b/crates/ide-completion/src/tests/type_pos.rs
@@ -719,3 +719,40 @@ pub struct S;
         "#]],
     )
 }
+
+#[test]
+fn completes_const_and_type_generics_separately() {
+    check(
+        r#"
+struct Foo;
+const X: usize = 0;
+mod foo {
+    fn foo<T>() {}
+}
+fn main() {
+    self::foo::foo::<F$0>();
+}
+"#,
+        expect![[r#"
+            st Foo
+            bt u32
+            kw crate::
+            kw self::
+        "#]],
+    );
+    check(
+        r#"
+struct Foo;
+const X: usize = 0;
+fn foo<const X: usize>() {}
+fn main() {
+    foo::<F$0>();
+}
+"#,
+        expect![[r#"
+            ct X
+            kw crate::
+            kw self::
+        "#]],
+    );
+}

--- a/crates/ide-completion/src/tests/type_pos.rs
+++ b/crates/ide-completion/src/tests/type_pos.rs
@@ -637,6 +637,31 @@ fn f(t: impl MyTrait<Item1 = $0
     check(
         r#"
 trait MyTrait {
+    type Item1;
+    type Item2;
+};
+
+fn f(t: impl MyTrait<Item1 = u8, Item2 = $0
+"#,
+        expect![[r#"
+            en Enum
+            ma makro!(…) macro_rules! makro
+            md module
+            st Record
+            st Tuple
+            st Unit
+            tt MyTrait
+            tt Trait
+            un Union
+            bt u32
+            kw crate::
+            kw self::
+        "#]],
+    );
+
+    check(
+        r#"
+trait MyTrait {
     const C: usize;
 };
 

--- a/crates/ide-completion/src/tests/type_pos.rs
+++ b/crates/ide-completion/src/tests/type_pos.rs
@@ -753,6 +753,9 @@ fn completes_const_and_type_generics_separately() {
                 kw self::
             "#]],
     );
+    // FIXME: This should probably also suggest completions for types, at least those that have
+    // associated constants usable in this position. For example, a user could be typing
+    // `foo::<_, { usize::MAX }>()`, but we currently don't suggest `usize` in constant position.
     check(
         r#"
     struct Foo;

--- a/crates/ide-completion/src/tests/type_pos.rs
+++ b/crates/ide-completion/src/tests/type_pos.rs
@@ -726,15 +726,21 @@ fn completes_const_and_type_generics_separately() {
         r#"
 struct Foo;
 const X: usize = 0;
-mod foo {
-    fn foo<T>() {}
-}
+fn foo<T, const N: usize>() {}
 fn main() {
-    self::foo::foo::<F$0>();
+    foo::<F$0, _>();
 }
 "#,
         expect![[r#"
+            en Enum
+            ma makro!(…) macro_rules! makro
+            md module
             st Foo
+            st Record
+            st Tuple
+            st Unit
+            tt Trait
+            un Union
             bt u32
             kw crate::
             kw self::
@@ -744,13 +750,15 @@ fn main() {
         r#"
 struct Foo;
 const X: usize = 0;
-fn foo<const X: usize>() {}
+fn foo<T, const N: usize>() {}
 fn main() {
-    foo::<F$0>();
+    foo::<_, $0>();
 }
 "#,
         expect![[r#"
+            ct CONST
             ct X
+            ma makro!(…) macro_rules! makro
             kw crate::
             kw self::
         "#]],

--- a/crates/ide-completion/src/tests/type_pos.rs
+++ b/crates/ide-completion/src/tests/type_pos.rs
@@ -402,14 +402,13 @@ fn foo<'lt, T: Trait2<$0>, const CONST_PARAM: usize>(_: T) {}
     );
     check(
         r#"
-trait Trait2 {
+trait Trait2<T> {
     type Foo;
 }
 
 fn foo<'lt, T: Trait2<self::$0>, const CONST_PARAM: usize>(_: T) {}
     "#,
         expect![[r#"
-            ct CONST
             en Enum
             ma makro!(…) macro_rules! makro
             md module
@@ -620,7 +619,6 @@ trait MyTrait {
 fn f(t: impl MyTrait<Item1 = $0
 "#,
         expect![[r#"
-            ct CONST
             en Enum
             ma makro!(…) macro_rules! makro
             md module
@@ -639,24 +637,14 @@ fn f(t: impl MyTrait<Item1 = $0
     check(
         r#"
 trait MyTrait {
-    type Item1;
-    type Item2;
+    const C: usize;
 };
 
-fn f(t: impl MyTrait<Item1 = u8, Item2 = $0
+fn f(t: impl MyTrait<C = $0
 "#,
         expect![[r#"
             ct CONST
-            en Enum
             ma makro!(…) macro_rules! makro
-            md module
-            st Record
-            st Tuple
-            st Unit
-            tt MyTrait
-            tt Trait
-            un Union
-            bt u32
             kw crate::
             kw self::
         "#]],

--- a/crates/ide-completion/src/tests/type_pos.rs
+++ b/crates/ide-completion/src/tests/type_pos.rs
@@ -724,11 +724,70 @@ pub struct S;
 fn completes_const_and_type_generics_separately() {
     check(
         r#"
-struct Foo;
+    struct Foo;
+    const X: usize = 0;
+    fn foo<T, const N: usize>() {}
+    fn main() {
+        foo::<F$0, _>();
+    }
+    "#,
+        expect![[r#"
+                en Enum
+                ma makro!(…) macro_rules! makro
+                md module
+                st Foo
+                st Record
+                st Tuple
+                st Unit
+                tt Trait
+                un Union
+                bt u32
+                kw crate::
+                kw self::
+            "#]],
+    );
+    check(
+        r#"
+    struct Foo;
+    const X: usize = 0;
+    fn foo<T, const N: usize>() {}
+    fn main() {
+        foo::<_, $0>();
+    }
+    "#,
+        expect![[r#"
+                ct CONST
+                ct X
+                ma makro!(…) macro_rules! makro
+                kw crate::
+                kw self::
+            "#]],
+    );
+
+    check(
+        r#"
 const X: usize = 0;
-fn foo<T, const N: usize>() {}
+struct Foo;
+impl Foo { fn bar<const N: usize, T>(self) {} }
 fn main() {
-    foo::<F$0, _>();
+    Foo.bar::<X$0, _>();
+}
+"#,
+        expect![[r#"
+            ct CONST
+            ct X
+            ma makro!(…) macro_rules! makro
+            kw crate::
+            kw self::
+        "#]],
+    );
+    check(
+        r#"
+const X: usize = 0;
+struct Foo;
+impl Foo { fn bar<const N: usize, T>(self) {} }
+fn main() {
+    Foo.bar::<_, $0>();
 }
 "#,
         expect![[r#"
@@ -746,19 +805,46 @@ fn main() {
             kw self::
         "#]],
     );
+
     check(
         r#"
-struct Foo;
 const X: usize = 0;
-fn foo<T, const N: usize>() {}
-fn main() {
-    foo::<_, $0>();
+struct Foo;
+trait Bar {
+    type Baz<T, const X: usize>;
 }
+fn foo<T: Bar<Baz<(), $0> = ()>>() {}
 "#,
         expect![[r#"
             ct CONST
             ct X
             ma makro!(…) macro_rules! makro
+            kw crate::
+            kw self::
+        "#]],
+    );
+    check(
+        r#"
+const X: usize = 0;
+struct Foo;
+trait Bar {
+    type Baz<T, const X: usize>;
+}
+fn foo<T: Bar<Baz<F$0, 0> = ()>>() {}
+"#,
+        expect![[r#"
+            en Enum
+            ma makro!(…) macro_rules! makro
+            md module
+            st Foo
+            st Record
+            st Tuple
+            st Unit
+            tt Bar
+            tt Trait
+            tp T
+            un Union
+            bt u32
             kw crate::
             kw self::
         "#]],

--- a/crates/ide-completion/src/tests/type_pos.rs
+++ b/crates/ide-completion/src/tests/type_pos.rs
@@ -384,10 +384,8 @@ trait Trait2<T>: Trait1 {
 fn foo<'lt, T: Trait2<$0>, const CONST_PARAM: usize>(_: T) {}
 "#,
         expect![[r#"
-            ct CONST
-            cp CONST_PARAM
             en Enum
-            ma makro!(…)   macro_rules! makro
+            ma makro!(…) macro_rules! makro
             md module
             st Record
             st Tuple
@@ -437,7 +435,6 @@ trait Tr<T> {
 impl Tr<$0
     "#,
         expect![[r#"
-            ct CONST
             en Enum
             ma makro!(…) macro_rules! makro
             md module
@@ -485,7 +482,6 @@ trait MyTrait<T, U> {
 fn f(t: impl MyTrait<u$0
 "#,
         expect![[r#"
-            ct CONST
             en Enum
             ma makro!(…) macro_rules! makro
             md module
@@ -511,7 +507,6 @@ trait MyTrait<T, U> {
 fn f(t: impl MyTrait<u8, u$0
 "#,
         expect![[r#"
-            ct CONST
             en Enum
             ma makro!(…) macro_rules! makro
             md module
@@ -555,7 +550,6 @@ trait MyTrait<T, U = u8> {
 fn f(t: impl MyTrait<u$0
 "#,
         expect![[r#"
-            ct CONST
             en Enum
             ma makro!(…) macro_rules! makro
             md module
@@ -581,7 +575,6 @@ trait MyTrait<T, U = u8> {
 fn f(t: impl MyTrait<u8, u$0
 "#,
         expect![[r#"
-            ct CONST
             en Enum
             ma makro!(…)             macro_rules! makro
             md module
@@ -822,7 +815,7 @@ fn foo<T: Bar<Baz<(), $0> = ()>>() {}
 const X: usize = 0;
 struct Foo<T, const N: usize>(T);
 fn main() {
-    let _: Foo::<_, $0> = todo!();
+    let _: Foo::<_, $0> = Foo(());
 }
         "#,
         // Enum variant params
@@ -831,7 +824,7 @@ const X: usize = 0;
 struct Foo<T, const N: usize>(T);
 type Bar<const X: usize, U> = Foo<U, X>;
 fn main() {
-    let _: Bar::<X$0, _> = todo!();
+    let _: Bar::<X$0, _> = Bar(());
 }
         "#,
         r#"

--- a/crates/ide-completion/src/tests/type_pos.rs
+++ b/crates/ide-completion/src/tests/type_pos.rs
@@ -718,216 +718,255 @@ fn completes_const_and_type_generics_separately() {
     // Function generic params
     check(
         r#"
-struct Foo;
-const X: usize = 0;
-fn foo<T, const N: usize>() {}
-fn main() {
-    foo::<F$0, _>();
-}
-        "#,
+    struct Foo;
+    const X: usize = 0;
+    fn foo<T, const N: usize>() {}
+    fn main() {
+        foo::<F$0, _>();
+    }
+            "#,
         expect![[r#"
-            en Enum
-            ma makro!(…) macro_rules! makro
-            md module
-            st Foo
-            st Record
-            st Tuple
-            st Unit
-            tt Trait
-            un Union
-            bt u32
-            kw crate::
-            kw self::
-        "#]],
+                en Enum
+                ma makro!(…) macro_rules! makro
+                md module
+                st Foo
+                st Record
+                st Tuple
+                st Unit
+                tt Trait
+                un Union
+                bt u32
+                kw crate::
+                kw self::
+            "#]],
     );
     check(
         r#"
-struct Foo;
-const X: usize = 0;
-fn foo<T, const N: usize>() {}
-fn main() {
-    foo::<_, $0>();
-}
-        "#,
+    struct Foo;
+    const X: usize = 0;
+    fn foo<T, const N: usize>() {}
+    fn main() {
+        foo::<_, $0>();
+    }
+            "#,
         expect![[r#"
-            ct CONST
-            ct X
-            ma makro!(…) macro_rules! makro
-            kw crate::
-            kw self::
-        "#]],
+                ct CONST
+                ct X
+                ma makro!(…) macro_rules! makro
+                kw crate::
+                kw self::
+            "#]],
     );
 
     // Method generic params
     check(
         r#"
-const X: usize = 0;
-struct Foo;
-impl Foo { fn bar<const N: usize, T>(self) {} }
-fn main() {
-    Foo.bar::<_, $0>();
-}
-        "#,
+    const X: usize = 0;
+    struct Foo;
+    impl Foo { fn bar<const N: usize, T>(self) {} }
+    fn main() {
+        Foo.bar::<_, $0>();
+    }
+            "#,
         expect![[r#"
-            en Enum
-            ma makro!(…) macro_rules! makro
-            md module
-            st Foo
-            st Record
-            st Tuple
-            st Unit
-            tt Trait
-            un Union
-            bt u32
-            kw crate::
-            kw self::
-        "#]],
+                en Enum
+                ma makro!(…) macro_rules! makro
+                md module
+                st Foo
+                st Record
+                st Tuple
+                st Unit
+                tt Trait
+                un Union
+                bt u32
+                kw crate::
+                kw self::
+            "#]],
     );
     check(
         r#"
-const X: usize = 0;
-struct Foo;
-impl Foo { fn bar<const N: usize, T>(self) {} }
-fn main() {
-    Foo.bar::<X$0, _>();
-}
-        "#,
+    const X: usize = 0;
+    struct Foo;
+    impl Foo { fn bar<const N: usize, T>(self) {} }
+    fn main() {
+        Foo.bar::<X$0, _>();
+    }
+            "#,
         expect![[r#"
-            ct CONST
-            ct X
-            ma makro!(…) macro_rules! makro
-            kw crate::
-            kw self::
-        "#]],
+                ct CONST
+                ct X
+                ma makro!(…) macro_rules! makro
+                kw crate::
+                kw self::
+            "#]],
     );
 
     // Associated type generic params
     check(
         r#"
-const X: usize = 0;
-struct Foo;
-trait Bar {
-    type Baz<T, const X: usize>;
-}
-fn foo(_: impl Bar<Baz<F$0, 0> = ()>) {}
-        "#,
+    const X: usize = 0;
+    struct Foo;
+    trait Bar {
+        type Baz<T, const X: usize>;
+    }
+    fn foo(_: impl Bar<Baz<F$0, 0> = ()>) {}
+            "#,
         expect![[r#"
-            en Enum
-            ma makro!(…) macro_rules! makro
-            md module
-            st Foo
-            st Record
-            st Tuple
-            st Unit
-            tt Bar
-            tt Trait
-            un Union
-            bt u32
-            kw crate::
-            kw self::
-        "#]],
+                en Enum
+                ma makro!(…) macro_rules! makro
+                md module
+                st Foo
+                st Record
+                st Tuple
+                st Unit
+                tt Bar
+                tt Trait
+                un Union
+                bt u32
+                kw crate::
+                kw self::
+            "#]],
     );
     check(
         r#"
-const X: usize = 0;
-struct Foo;
-trait Bar {
-    type Baz<T, const X: usize>;
-}
-fn foo<T: Bar<Baz<(), $0> = ()>>() {}
-        "#,
+    const X: usize = 0;
+    struct Foo;
+    trait Bar {
+        type Baz<T, const X: usize>;
+    }
+    fn foo<T: Bar<Baz<(), $0> = ()>>() {}
+            "#,
         expect![[r#"
-            ct CONST
-            ct X
-            ma makro!(…) macro_rules! makro
-            kw crate::
-            kw self::
-        "#]],
+                ct CONST
+                ct X
+                ma makro!(…) macro_rules! makro
+                kw crate::
+                kw self::
+            "#]],
     );
 
     // Type generic params
     check(
         r#"
-const X: usize = 0;
-struct Foo<T, const N: usize>(T);
-fn main() {
-    let _: Foo::<_, $0> = Foo(());
-}
-        "#,
+    const X: usize = 0;
+    struct Foo<T, const N: usize>(T);
+    fn main() {
+        let _: Foo::<_, $0> = Foo(());
+    }
+            "#,
         expect![[r#"
-            ct CONST
-            ct X
-            ma makro!(…) macro_rules! makro
-            kw crate::
-            kw self::
-        "#]],
+                ct CONST
+                ct X
+                ma makro!(…) macro_rules! makro
+                kw crate::
+                kw self::
+            "#]],
     );
 
     // Type alias generic params
     check(
         r#"
-const X: usize = 0;
-struct Foo<T, const N: usize>(T);
-type Bar<const X: usize, U> = Foo<U, X>;
-fn main() {
-    let _: Bar::<X$0, _> = Bar(());
-}
-        "#,
+    const X: usize = 0;
+    struct Foo<T, const N: usize>(T);
+    type Bar<const X: usize, U> = Foo<U, X>;
+    fn main() {
+        let _: Bar::<X$0, _> = Bar(());
+    }
+            "#,
         expect![[r#"
-            ct CONST
-            ct X
-            ma makro!(…) macro_rules! makro
-            kw crate::
-            kw self::
-        "#]],
+                ct CONST
+                ct X
+                ma makro!(…) macro_rules! makro
+                kw crate::
+                kw self::
+            "#]],
     );
 
     // Enum variant params
     check(
         r#"
-const X: usize = 0;
-enum Foo<T, const N: usize> { A(T), B }
-fn main() {
-    Foo::B::<(), $0>;
-}
-        "#,
+    const X: usize = 0;
+    enum Foo<T, const N: usize> { A(T), B }
+    fn main() {
+        Foo::B::<(), $0>;
+    }
+            "#,
         expect![[r#"
-            ct CONST
-            ct X
-            ma makro!(…) macro_rules! makro
-            kw crate::
-            kw self::
-        "#]],
+                ct CONST
+                ct X
+                ma makro!(…) macro_rules! makro
+                kw crate::
+                kw self::
+            "#]],
     );
 
     // Trait params
     check(
         r#"
-const X: usize = 0;
-trait Foo<T, const N: usize> {}
-impl Foo<(), $0> for () {}
-        "#,
+    const X: usize = 0;
+    trait Foo<T, const N: usize> {}
+    impl Foo<(), $0> for () {}
+            "#,
         expect![[r#"
-            ct CONST
-            ct X
-            ma makro!(…) macro_rules! makro
-            kw crate::
-            kw self::
-        "#]],
+                ct CONST
+                ct X
+                ma makro!(…) macro_rules! makro
+                kw crate::
+                kw self::
+            "#]],
     );
 
     // Trait alias params
     check(
         r#"
-#![feature(trait_alias)]
-const X: usize = 0;
-trait Foo<T, const N: usize> {}
-trait Bar<const M: usize, U> = Foo<U, M>;
-fn foo<T: Bar<X$0, ()>>() {}
+    #![feature(trait_alias)]
+    const X: usize = 0;
+    trait Foo<T, const N: usize> {}
+    trait Bar<const M: usize, U> = Foo<U, M>;
+    fn foo<T: Bar<X$0, ()>>() {}
+            "#,
+        expect![[r#"
+                ct CONST
+                ct X
+                ma makro!(…) macro_rules! makro
+                kw crate::
+                kw self::
+            "#]],
+    );
+
+    // Omitted lifetime params
+    check(
+        r#"
+struct S<'a, 'b, const C: usize, T>(core::marker::PhantomData<&'a &'b T>);
+fn foo<'a>() { S::<F$0, _>; }
         "#,
         expect![[r#"
             ct CONST
-            ct X
+            ma makro!(…) macro_rules! makro
+            kw crate::
+            kw self::
+        "#]],
+    );
+    // Explicit lifetime params
+    check(
+        r#"
+struct S<'a, 'b, const C: usize, T>(core::marker::PhantomData<&'a &'b T>);
+fn foo<'a>() { S::<'static, 'static, F$0, _>; }
+        "#,
+        expect![[r#"
+            ct CONST
+            ma makro!(…) macro_rules! makro
+            kw crate::
+            kw self::
+        "#]],
+    );
+    check(
+        r#"
+struct S<'a, 'b, const C: usize, T>(core::marker::PhantomData<&'a &'b T>);
+fn foo<'a>() { S::<'static, F$0, _, _>; }
+        "#,
+        expect![[r#"
+            lt 'a
             ma makro!(…) macro_rules! makro
             kw crate::
             kw self::


### PR DESCRIPTION
When determining completions for generic arguments, suggest only types or only constants if the corresponding generic parameter is a type parameter or constant parameter.

Closes #12568