### PR TITLE
proc-macro-test: Pass target to cargo invocation

### DIFF
--- a/crates/proc-macro-test/build.rs
+++ b/crates/proc-macro-test/build.rs
@@ -71,6 +71,10 @@ fn main() {
         .arg("--target-dir")
         .arg(&target_dir);
 
+    if let Ok(target) = std::env::var("TARGET") {
+        cmd.args(["--target", &target]);
+    }
+
     println!("Running {cmd:?}");
 
     let output = cmd.output().unwrap();


### PR DESCRIPTION
When cross compiling macos → dragonfly the dist build fails in the proc-maro-test-impl crate with the following error:

`ld: unknown option: -z\nclang: error: linker command failed with exit code 1 (use -v to see invocation)`

This appears to be a wart stemming from using an Apple host for cross compiling.  Passing the target along to cargo allows it to pick up a linker that it understands and DTRT.