### PR TITLE
Set the default status bar action to openLogs

### DIFF
--- a/editors/code/src/ctx.ts
+++ b/editors/code/src/ctx.ts
@@ -414,7 +414,7 @@ export class Ctx {
                 statusBar.tooltip.appendText(status.message ?? "Ready");
                 statusBar.color = undefined;
                 statusBar.backgroundColor = undefined;
-                statusBar.command = "rust-analyzer.stopServer";
+                statusBar.command = "rust-analyzer.openLogs";
                 this.dependencies?.refresh();
                 break;
             case "warning":


### PR DESCRIPTION
Previously, clicking 'rust-analyzer' would stop the server entirely. This was easy to do accidentally, and then the user has to wait for the server to start up again.