### PR TITLE
Use the warning color when rust-analyzer is stopped

### DIFF
--- a/editors/code/src/ctx.ts
+++ b/editors/code/src/ctx.ts
@@ -442,8 +442,10 @@ export class Ctx {
                 statusBar.tooltip.appendMarkdown(
                     "\n\n[Start server](command:rust-analyzer.startServer)",
                 );
-                statusBar.color = undefined;
-                statusBar.backgroundColor = undefined;
+                statusBar.color = new vscode.ThemeColor("statusBarItem.warningForeground");
+                statusBar.backgroundColor = new vscode.ThemeColor(
+                    "statusBarItem.warningBackground",
+                );
                 statusBar.command = "rust-analyzer.startServer";
                 statusBar.text = `$(stop-circle) rust-analyzer`;
                 return;


### PR DESCRIPTION
If the rust-analyzer server isn't running, we can't do much. Treat this state as a warning color, so it's more obvious.