### PR TITLE
SCIP: Qualify parameters by the containing function

### DIFF
--- a/crates/ide/src/moniker.rs
+++ b/crates/ide/src/moniker.rs
@@ -177,6 +177,17 @@ pub(crate) fn def_to_moniker(
         });
     }
 
+    // Qualify locals/parameters by their parent definition name.
+    if let Definition::Local(it) = def {
+        let parent_name = it.parent(db).name(db);
+        if let Some(name) = parent_name {
+            description.push(MonikerDescriptor {
+                name: name.display(db).to_string(),
+                desc: MonikerDescriptorKind::Method,
+            });
+        }
+    }
+
     let name_desc = match def {
         // These are handled by top-level guard (for performance).
         Definition::GenericParam(_)

--- a/crates/rust-analyzer/src/cli/scip.rs
+++ b/crates/rust-analyzer/src/cli/scip.rs
@@ -417,6 +417,44 @@ pub mod module {
     }
 
     #[test]
+    fn symbol_for_param() {
+        check_symbol(
+            r#"
+//- /lib.rs crate:main deps:foo
+use foo::example_mod::func;
+fn main() {
+    func(42);
+}
+//- /foo/lib.rs crate:foo@0.1.0,https://a.b/foo.git library
+pub mod example_mod {
+    pub fn func(x$0: usize) {}
+}
+"#,
+            "rust-analyzer cargo foo 0.1.0 example_mod/func().(x)",
+        );
+    }
+
+    #[test]
+    fn symbol_for_closure_param() {
+        check_symbol(
+            r#"
+//- /lib.rs crate:main deps:foo
+use foo::example_mod::func;
+fn main() {
+    func();
+}
+//- /foo/lib.rs crate:foo@0.1.0,https://a.b/foo.git library
+pub mod example_mod {
+    pub fn func() {
+        let f = |x$0: usize| {};
+    }
+}
+"#,
+            "rust-analyzer cargo foo 0.1.0 example_mod/func().(x)",
+        );
+    }
+
+    #[test]
     fn local_symbol_for_local() {
         check_symbol(
             r#"


### PR DESCRIPTION
SCIP requires symbols to be unique, but multiple functions may have a parameter with the same name. Qualify parameters according to the containing function.