### PR TITLE
Don't provide `generate_default_from_new` when impl self ty is missing

### DIFF
--- a/crates/ide-assists/src/tests/generated.rs
+++ b/crates/ide-assists/src/tests/generated.rs
@@ -952,6 +952,7 @@ fn doctest_generate_default_from_new() {
     check_doc_test(
         "generate_default_from_new",
         r#####"
+//- minicore: default
 struct Example { _inner: () }
 
 impl Example {


### PR DESCRIPTION
Also don't provide the assist when the `Default` trait can't be found.

Part of #15398