### PR TITLE
Increase the buffer size for discover project command

### DIFF
--- a/editors/code/src/util.ts
+++ b/editors/code/src/util.ts
@@ -151,6 +151,7 @@ export function execute(command: string, options: ExecOptions): Promise<string> 
 }
 
 export function executeDiscoverProject(command: string, options: ExecOptions): Promise<string> {
+    options = Object.assign({ maxBuffer: 10 * 1024 * 1024 }, options);
     log.info(`running command: ${command}`);
     return new Promise((resolve, reject) => {
         exec(command, options, (err, stdout, _) => {


### PR DESCRIPTION
The default value for maxBuffer is 1 MiB[1]. If the discover project command returns stdout or stderr that is greater than 1 MiB, the extension would error with "RangeError: stderr maxBuffer length exceeded".

Set the default value for maxBuffer to 10 MiB for project discovery.

[1] https://nodejs.org/api/child_process.html#child_processexeccommand-options-callback