### PR TITLE
fix: Fix auto-import (and completions) importing `#[doc(hidden)]` items

### DIFF
--- a/crates/hir-def/src/item_scope.rs
+++ b/crates/hir-def/src/item_scope.rs
@@ -66,7 +66,8 @@ pub struct ItemScope {
     _c: Count<Self>,
 
     /// Defs visible in this scope. This includes `declarations`, but also
-    /// imports.
+    /// imports. The imports belong to this module and can be resolved by using them on
+    /// the `use_imports_*` fields.
     types: FxHashMap<Name, (ModuleDefId, Visibility, Option<ImportOrExternCrate>)>,
     values: FxHashMap<Name, (ModuleDefId, Visibility, Option<ImportId>)>,
     macros: FxHashMap<Name, (MacroId, Visibility, Option<ImportId>)>,
@@ -375,8 +376,8 @@ impl ItemScope {
                         None | Some(ImportType::Glob(_)) => None,
                     };
                     let prev = std::mem::replace(&mut fld.2, import);
-                    if let Some(ImportOrExternCrate::Import(import)) = import {
-                        self.use_imports_values.insert(
+                    if let Some(import) = import {
+                        self.use_imports_types.insert(
                             import,
                             match prev {
                                 Some(ImportOrExternCrate::Import(import)) => {
@@ -404,8 +405,8 @@ impl ItemScope {
                             None | Some(ImportType::Glob(_)) => None,
                         };
                         let prev = std::mem::replace(&mut fld.2, import);
-                        if let Some(ImportOrExternCrate::Import(import)) = import {
-                            self.use_imports_values.insert(
+                        if let Some(import) = import {
+                            self.use_imports_types.insert(
                                 import,
                                 match prev {
                                     Some(ImportOrExternCrate::Import(import)) => {

--- a/crates/hir-def/src/lib.rs
+++ b/crates/hir-def/src/lib.rs
@@ -870,7 +870,8 @@ impl_from!(
     MacroId(Macro2Id, MacroRulesId, ProcMacroId),
     ImplId,
     GenericParamId,
-    ExternCrateId
+    ExternCrateId,
+    UseId
     for AttrDefId
 );
 
@@ -901,6 +902,15 @@ impl From<ItemContainerId> for AttrDefId {
             ItemContainerId::ImplId(iid) => AttrDefId::ImplId(iid),
             ItemContainerId::TraitId(tid) => AttrDefId::TraitId(tid),
             ItemContainerId::ExternBlockId(id) => AttrDefId::ExternBlockId(id),
+        }
+    }
+}
+impl From<AssocItemId> for AttrDefId {
+    fn from(assoc: AssocItemId) -> Self {
+        match assoc {
+            AssocItemId::FunctionId(it) => AttrDefId::FunctionId(it),
+            AssocItemId::ConstId(it) => AttrDefId::ConstId(it),
+            AssocItemId::TypeAliasId(it) => AttrDefId::TypeAliasId(it),
         }
     }
 }

--- a/crates/hir-def/src/per_ns.rs
+++ b/crates/hir-def/src/per_ns.rs
@@ -117,12 +117,20 @@ impl PerNs {
         }
     }
 
-    pub fn iter_items(self) -> impl Iterator<Item = ItemInNs> {
+    pub fn iter_items(self) -> impl Iterator<Item = (ItemInNs, Option<ImportOrExternCrate>)> {
         let _p = profile::span("PerNs::iter_items");
         self.types
-            .map(|it| ItemInNs::Types(it.0))
+            .map(|it| (ItemInNs::Types(it.0), it.2))
             .into_iter()
-            .chain(self.values.map(|it| ItemInNs::Values(it.0)).into_iter())
-            .chain(self.macros.map(|it| ItemInNs::Macros(it.0)).into_iter())
+            .chain(
+                self.values
+                    .map(|it| (ItemInNs::Values(it.0), it.2.map(ImportOrExternCrate::Import)))
+                    .into_iter(),
+            )
+            .chain(
+                self.macros
+                    .map(|it| (ItemInNs::Macros(it.0), it.2.map(ImportOrExternCrate::Import)))
+                    .into_iter(),
+            )
     }
 }

--- a/crates/hir/src/attrs.rs
+++ b/crates/hir/src/attrs.rs
@@ -212,7 +212,7 @@ fn resolve_doc_path(
             Some(Namespace::Types) => resolved.take_types(),
             Some(Namespace::Values) => resolved.take_values(),
             Some(Namespace::Macros) => resolved.take_macros().map(ModuleDefId::MacroId),
-            None => resolved.iter_items().next().map(|it| match it {
+            None => resolved.iter_items().next().map(|(it, _)| match it {
                 ItemInNs::Types(it) => it,
                 ItemInNs::Values(it) => it,
                 ItemInNs::Macros(it) => ModuleDefId::MacroId(it),


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust-analyzer/issues/9197 and https://github.com/rust-lang/rust-analyzer/issues/9911

Turns out while https://github.com/rust-lang/rust-analyzer/pull/15472 didn't give access to the import stuff to the IDE layer, these can be fixed already since they use the import map which works in the hir-def crate 🎉 