### PR TITLE
fix: Fix item tree lowering pub(self) to pub()

### DIFF
--- a/crates/hir-def/src/item_tree/tests.rs
+++ b/crates/hir-def/src/item_tree/tests.rs
@@ -370,3 +370,15 @@ struct S<#[cfg(never)] T>;
         "#]],
     )
 }
+
+#[test]
+fn pub_self() {
+    check(
+        r#"
+pub(self) struct S;
+        "#,
+        expect![[r#"
+            pub(self) struct S;
+        "#]],
+    )
+}

--- a/crates/hir-def/src/nameres/path_resolution.rs
+++ b/crates/hir-def/src/nameres/path_resolution.rs
@@ -93,11 +93,15 @@ impl DefMap {
                 if remaining.is_some() {
                     return None;
                 }
-                let types = result.take_types()?;
-                match types {
-                    ModuleDefId::ModuleId(m) => Visibility::Module(m),
-                    _ => {
-                        // error: visibility needs to refer to module
+                let types = result.take_types();
+
+                match (types, path.kind) {
+                    (Some(ModuleDefId::ModuleId(m)), _) => Visibility::Module(m),
+                    // resolve_path doesn't find any values for a plan pathkind of a private function
+                    (None, PathKind::Plain | PathKind::Crate) => {
+                        Visibility::Module(self.module_id(original_module))
+                    }
+                    (_, _) => {
                         return None;
                     }
                 }

--- a/crates/hir-def/src/nameres/path_resolution.rs
+++ b/crates/hir-def/src/nameres/path_resolution.rs
@@ -93,15 +93,11 @@ impl DefMap {
                 if remaining.is_some() {
                     return None;
                 }
-                let types = result.take_types();
-
-                match (types, path.kind) {
-                    (Some(ModuleDefId::ModuleId(m)), _) => Visibility::Module(m),
-                    // resolve_path doesn't find any values for a plan pathkind of a private function
-                    (None, PathKind::Plain | PathKind::Crate) => {
-                        Visibility::Module(self.module_id(original_module))
-                    }
-                    (_, _) => {
+                let types = result.take_types()?;
+                match types {
+                    ModuleDefId::ModuleId(m) => Visibility::Module(m),
+                    // error: visibility needs to refer to module
+                    _ => {
                         return None;
                     }
                 }

--- a/crates/hir-def/src/visibility.rs
+++ b/crates/hir-def/src/visibility.rs
@@ -73,7 +73,7 @@ impl RawVisibility {
                 RawVisibility::Module(path)
             }
             ast::VisibilityKind::PubSelf => {
-                let path = ModPath::from_kind(PathKind::Plain);
+                let path = ModPath::from_kind(PathKind::Super(0));
                 RawVisibility::Module(path)
             }
             ast::VisibilityKind::Pub => RawVisibility::Public,

--- a/crates/ide-completion/src/completions/expr.rs
+++ b/crates/ide-completion/src/completions/expr.rs
@@ -1,6 +1,6 @@
 //! Completion of names from the current scope in expression position.
 
-use hir::ScopeDef;
+use hir::{HasVisibility, Module, ScopeDef};
 use syntax::ast;
 
 use crate::{
@@ -8,6 +8,23 @@ use crate::{
     context::{ExprCtx, PathCompletionCtx, Qualified},
     CompletionContext, Completions,
 };
+
+fn scope_def_applicable(
+    def: ScopeDef,
+    ctx: &CompletionContext<'_>,
+    module: Option<&Module>,
+) -> bool {
+    match (def, module) {
+        (ScopeDef::GenericParam(hir::GenericParam::LifetimeParam(_)) | ScopeDef::Label(_), _) => {
+            false
+        }
+        (ScopeDef::ModuleDef(hir::ModuleDef::Macro(mac)), _) => mac.is_fn_like(ctx.db),
+        (ScopeDef::ModuleDef(hir::ModuleDef::Function(f)), Some(m)) => {
+            f.is_visible_from(ctx.db, *m)
+        }
+        _ => true,
+    }
+}
 
 pub(crate) fn complete_expr_path(
     acc: &mut Completions,
@@ -36,12 +53,6 @@ pub(crate) fn complete_expr_path(
 
     let wants_mut_token =
         ref_expr_parent.as_ref().map(|it| it.mut_token().is_none()).unwrap_or(false);
-
-    let scope_def_applicable = |def| match def {
-        ScopeDef::GenericParam(hir::GenericParam::LifetimeParam(_)) | ScopeDef::Label(_) => false,
-        ScopeDef::ModuleDef(hir::ModuleDef::Macro(mac)) => mac.is_fn_like(ctx.db),
-        _ => true,
-    };
 
     let add_assoc_item = |acc: &mut Completions, item| match item {
         hir::AssocItem::Function(func) => acc.add_function(ctx, path_ctx, func, None),
@@ -87,7 +98,7 @@ pub(crate) fn complete_expr_path(
                 hir::PathResolution::Def(hir::ModuleDef::Module(module)) => {
                     let module_scope = module.scope(ctx.db, Some(ctx.module));
                     for (name, def) in module_scope {
-                        if scope_def_applicable(def) {
+                        if scope_def_applicable(def, ctx, Some(module)) {
                             acc.add_path_resolution(
                                 ctx,
                                 path_ctx,
@@ -233,7 +244,7 @@ pub(crate) fn complete_expr_path(
                         [..] => acc.add_path_resolution(ctx, path_ctx, name, def, doc_aliases),
                     }
                 }
-                _ if scope_def_applicable(def) => {
+                _ if scope_def_applicable(def, ctx, None) => {
                     acc.add_path_resolution(ctx, path_ctx, name, def, doc_aliases)
                 }
                 _ => (),

--- a/crates/ide-completion/src/tests/special.rs
+++ b/crates/ide-completion/src/tests/special.rs
@@ -1292,7 +1292,7 @@ fn completes_only_public() {
         r#"
 //- /e.rs
 pub(self) fn i_should_be_hidden() {}
-pub(in crate::krate) fn i_should_also_be_hidden() {}
+pub(in crate::e) fn i_should_also_be_hidden() {}
 pub fn i_am_public () {}
 
 //- /lib.rs crate:krate

--- a/crates/ide-completion/src/tests/special.rs
+++ b/crates/ide-completion/src/tests/special.rs
@@ -1287,6 +1287,30 @@ fn here_we_go() {
 }
 
 #[test]
+fn completes_only_public() {
+    check(
+        r#"
+//- /e.rs
+pub(self) fn i_should_be_hidden() {}
+pub(in crate::krate) fn i_should_also_be_hidden() {}
+pub fn i_am_public () {}
+
+//- /lib.rs crate:krate
+pub mod e;
+
+//- /main.rs deps:krate crate:main
+use krate::e;
+fn main() {
+    e::$0
+}"#,
+        expect![
+            "fn i_am_public() fn()
+"
+        ],
+    )
+}
+
+#[test]
 fn completion_filtering_excludes_non_identifier_doc_aliases() {
     check_edit(
         "PartialOrdcmporder",


### PR DESCRIPTION
Prior to this, the item tree lowered `pub(self)` visibility to `pub()`
Fix #15134 - tested with a unit test and 
a manual end-to-end test of building rust-analyzer from my branch and opening the reproduction repository