### PR TITLE
internal: unpin serde

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1000,22 +1000,22 @@ checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
 [[package]]
 name = "lsp-server"
 version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72417faa455bfb4e5bf14b157d8e2ca2ed74b4e89b8cf42ea2d864825ae5c8a2"
 dependencies = [
  "crossbeam-channel",
  "log",
- "lsp-types",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "lsp-server"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72417faa455bfb4e5bf14b157d8e2ca2ed74b4e89b8cf42ea2d864825ae5c8a2"
+version = "0.7.4"
 dependencies = [
  "crossbeam-channel",
  "log",
+ "lsp-types",
  "serde",
  "serde_json",
 ]
@@ -1555,7 +1555,7 @@ dependencies = [
  "ide-ssr",
  "itertools",
  "load-cargo",
- "lsp-server 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lsp-server 0.7.3",
  "lsp-types",
  "mbe",
  "mimalloc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,8 +97,7 @@ smallvec = { version = "1.10.0", features = [
 smol_str = "0.2.0"
 nohash-hasher = "0.2.0"
 text-size = "1.1.0"
-# See https://github.com/serde-rs/serde/issues/2538#issuecomment-1684517372 for why we pin serde
-serde = { version = "1.0.156, < 1.0.172", features = ["derive"] }
+serde = { version = "1.0.156", features = ["derive"] }
 serde_json = "1.0.96"
 triomphe = { version = "0.1.8", default-features = false, features = ["std"] }
 # can't upgrade due to dashmap depending on 0.12.3 currently

--- a/lib/lsp-server/Cargo.toml
+++ b/lib/lsp-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lsp-server"
-version = "0.7.3"
+version = "0.7.4"
 description = "Generic LSP server scaffold."
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/rust-analyzer/tree/master/lib/lsp-server"
@@ -9,8 +9,7 @@ edition = "2021"
 [dependencies]
 log = "0.4.17"
 serde_json = "1.0.96"
-# See https://github.com/serde-rs/serde/issues/2538#issuecomment-1684517372 for why we pin serde
-serde = { version = "1.0.156, < 1.0.172", features = ["derive"] }
+serde = { version = "1.0.156", features = ["derive"] }
 crossbeam-channel = "0.5.6"
 
 [dev-dependencies]


### PR DESCRIPTION
Serde no longer uses blobs as of

https://github.com/serde-rs/serde/pull/2590

As such, there's no longer need for us to pin it.

Note that this doesn't upgrade serde version we use: I am fairly confident that the blobs are already there are fine, and now I am fairly confident that all future versions of serde will be fine as well.