### PR TITLE
SCIP: Report the correct version of rust-analyzer in the metadata

### DIFF
--- a/crates/rust-analyzer/src/cli/scip.rs
+++ b/crates/rust-analyzer/src/cli/scip.rs
@@ -51,7 +51,7 @@ impl flags::Scip {
             version: scip_types::ProtocolVersion::UnspecifiedProtocolVersion.into(),
             tool_info: Some(scip_types::ToolInfo {
                 name: "rust-analyzer".to_owned(),
-                version: "0.1".to_owned(),
+                version: format!("{}", crate::version::version()),
                 arguments: vec![],
                 special_fields: Default::default(),
             })


### PR DESCRIPTION
Previously this was hard coded to "0.1". The SCIP protocol allows this to be an arbitrary string:

```
message ToolInfo {
  // Name of the indexer that produced this index.
  string name = 1;
  // Version of the indexer that produced this index.
  string version = 2;
  // Command-line arguments that were used to invoke this indexer.
  repeated string arguments = 3;
}
```

so use the same string reported by `rust-analyzer --version`.