### PR TITLE
Enable `rust_analyzer` for cfgs when code is being analyzed by rust-analyzer

### DIFF
--- a/crates/base-db/src/fixture.rs
+++ b/crates/base-db/src/fixture.rs
@@ -179,8 +179,8 @@ impl ChangeFixture {
                     meta.edition,
                     Some(crate_name.clone().into()),
                     version,
-                    meta.cfg,
-                    Default::default(),
+                    meta.cfg.clone(),
+                    Some(meta.cfg),
                     meta.env,
                     false,
                     origin,
@@ -200,7 +200,7 @@ impl ChangeFixture {
             } else if meta.path == "/main.rs" || meta.path == "/lib.rs" {
                 assert!(default_crate_root.is_none());
                 default_crate_root = Some(file_id);
-                default_cfg = meta.cfg;
+                default_cfg.extend(meta.cfg.into_iter());
                 default_env.extend(meta.env.iter().map(|(x, y)| (x.to_owned(), y.to_owned())));
                 default_target_data_layout = meta.target_data_layout;
             }
@@ -220,8 +220,8 @@ impl ChangeFixture {
                 Edition::CURRENT,
                 Some(CrateName::new("test").unwrap().into()),
                 None,
-                default_cfg,
-                Default::default(),
+                default_cfg.clone(),
+                Some(default_cfg),
                 default_env,
                 false,
                 CrateOrigin::Local { repo: None, name: None },

--- a/crates/cfg/src/lib.rs
+++ b/crates/cfg/src/lib.rs
@@ -86,6 +86,32 @@ impl CfgOptions {
     }
 }
 
+impl Extend<CfgAtom> for CfgOptions {
+    fn extend<T: IntoIterator<Item = CfgAtom>>(&mut self, iter: T) {
+        iter.into_iter().for_each(|cfg_flag| _ = self.enabled.insert(cfg_flag));
+    }
+}
+
+impl IntoIterator for CfgOptions {
+    type Item = <FxHashSet<CfgAtom> as IntoIterator>::Item;
+
+    type IntoIter = <FxHashSet<CfgAtom> as IntoIterator>::IntoIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        <FxHashSet<CfgAtom> as IntoIterator>::into_iter(self.enabled)
+    }
+}
+
+impl<'a> IntoIterator for &'a CfgOptions {
+    type Item = <&'a FxHashSet<CfgAtom> as IntoIterator>::Item;
+
+    type IntoIter = <&'a FxHashSet<CfgAtom> as IntoIterator>::IntoIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        <&FxHashSet<CfgAtom> as IntoIterator>::into_iter(&self.enabled)
+    }
+}
+
 #[derive(Default, Clone, Debug, PartialEq, Eq)]
 pub struct CfgDiff {
     // Invariants: No duplicates, no atom that's both in `enable` and `disable`.

--- a/crates/ide-completion/src/completions/attribute/cfg.rs
+++ b/crates/ide-completion/src/completions/attribute/cfg.rs
@@ -1,10 +1,8 @@
 //! Completion for cfg
 
-use std::iter;
-
 use ide_db::SymbolKind;
 use itertools::Itertools;
-use syntax::SyntaxKind;
+use syntax::{algo, ast::Ident, AstToken, Direction, NodeOrToken, SyntaxKind};
 
 use crate::{completions::Completions, context::CompletionContext, CompletionItem};
 
@@ -15,31 +13,44 @@ pub(crate) fn complete_cfg(acc: &mut Completions, ctx: &CompletionContext<'_>) {
         acc.add(completion.build(ctx.db));
     };
 
-    let previous = iter::successors(ctx.original_token.prev_token(), |t| {
-        (matches!(t.kind(), SyntaxKind::EQ) || t.kind().is_trivia())
-            .then(|| t.prev_token())
-            .flatten()
-    })
-    .find(|t| matches!(t.kind(), SyntaxKind::IDENT));
+    // FIXME: Move this into context/analysis.rs
+    let previous = ctx
+        .original_token
+        .prev_token()
+        .and_then(|it| {
+            if matches!(it.kind(), SyntaxKind::EQ) {
+                Some(it.into())
+            } else {
+                algo::non_trivia_sibling(it.into(), Direction::Prev)
+            }
+        })
+        .filter(|t| matches!(t.kind(), SyntaxKind::EQ))
+        .and_then(|it| algo::non_trivia_sibling(it.prev_sibling_or_token()?, Direction::Prev))
+        .map(|it| match it {
+            NodeOrToken::Node(_) => None,
+            NodeOrToken::Token(t) => Ident::cast(t),
+        });
+    match previous {
+        Some(None) => (),
+        Some(Some(p)) => match p.text() {
+            "target_arch" => KNOWN_ARCH.iter().copied().for_each(add_completion),
+            "target_env" => KNOWN_ENV.iter().copied().for_each(add_completion),
+            "target_os" => KNOWN_OS.iter().copied().for_each(add_completion),
+            "target_vendor" => KNOWN_VENDOR.iter().copied().for_each(add_completion),
+            "target_endian" => ["little", "big"].into_iter().for_each(add_completion),
+            name => ctx.krate.potential_cfg(ctx.db).get_cfg_values(name).cloned().for_each(|s| {
+                let insert_text = format!(r#""{s}""#);
+                let mut item = CompletionItem::new(SymbolKind::BuiltinAttr, ctx.source_range(), s);
+                item.insert_text(insert_text);
 
-    match previous.as_ref().map(|p| p.text()) {
-        Some("target_arch") => KNOWN_ARCH.iter().copied().for_each(add_completion),
-        Some("target_env") => KNOWN_ENV.iter().copied().for_each(add_completion),
-        Some("target_os") => KNOWN_OS.iter().copied().for_each(add_completion),
-        Some("target_vendor") => KNOWN_VENDOR.iter().copied().for_each(add_completion),
-        Some("target_endian") => ["little", "big"].into_iter().for_each(add_completion),
-        Some(name) => ctx.krate.potential_cfg(ctx.db).get_cfg_values(name).cloned().for_each(|s| {
-            let insert_text = format!(r#""{s}""#);
-            let mut item = CompletionItem::new(SymbolKind::BuiltinAttr, ctx.source_range(), s);
-            item.insert_text(insert_text);
-
-            acc.add(item.build(ctx.db));
-        }),
+                acc.add(item.build(ctx.db));
+            }),
+        },
         None => ctx.krate.potential_cfg(ctx.db).get_cfg_keys().cloned().unique().for_each(|s| {
             let item = CompletionItem::new(SymbolKind::BuiltinAttr, ctx.source_range(), s);
             acc.add(item.build(ctx.db));
         }),
-    };
+    }
 }
 
 const KNOWN_ARCH: [&str; 20] = [

--- a/crates/ide-completion/src/tests/attribute.rs
+++ b/crates/ide-completion/src/tests/attribute.rs
@@ -67,11 +67,6 @@ struct Foo;
 }
 
 #[test]
-fn inside_nested_attr() {
-    check(r#"#[cfg($0)]"#, expect![[]])
-}
-
-#[test]
 fn with_existing_attr() {
     check(
         r#"#[no_mangle] #[$0] mcall!();"#,
@@ -636,9 +631,42 @@ mod cfg {
     use super::*;
 
     #[test]
+    fn inside_cfg() {
+        check(
+            r#"
+//- /main.rs cfg:test,dbg=false,opt_level=2
+#[cfg($0)]
+"#,
+            expect![[r#"
+                ba dbg
+                ba opt_level
+                ba test
+            "#]],
+        );
+        check(
+            r#"
+//- /main.rs cfg:test,dbg=false,opt_level=2
+#[cfg(b$0)]
+"#,
+            expect![[r#"
+                ba dbg
+                ba opt_level
+                ba test
+            "#]],
+        );
+    }
+
+    #[test]
     fn cfg_target_endian() {
         check(
             r#"#[cfg(target_endian = $0"#,
+            expect![[r#"
+                ba big
+                ba little
+            "#]],
+        );
+        check(
+            r#"#[cfg(target_endian = b$0"#,
             expect![[r#"
                 ba big
                 ba little

--- a/crates/ide-db/src/search.rs
+++ b/crates/ide-db/src/search.rs
@@ -221,7 +221,6 @@ impl Definition {
         }
 
         // def is crate root
-        // FIXME: We don't do searches for crates currently, as a crate does not actually have a single name
         if let &Definition::Module(module) = self {
             if module.is_crate_root() {
                 return SearchScope::reverse_dependencies(db, module.krate());
@@ -393,7 +392,10 @@ impl<'a> FindUsages<'a> {
         let name = match self.def {
             // special case crate modules as these do not have a proper name
             Definition::Module(module) if module.is_crate_root() => {
-                // FIXME: This assumes the crate name is always equal to its display name when it really isn't
+                // FIXME: This assumes the crate name is always equal to its display name when it
+                // really isn't
+                // we should instead look at the dependency edge name and recursively search our way
+                // up the ancestors
                 module
                     .krate()
                     .display_name(self.sema.db)

--- a/crates/project-model/src/workspace.rs
+++ b/crates/project-model/src/workspace.rs
@@ -867,6 +867,9 @@ fn cargo_to_crate_graph(
             if cargo[pkg].is_local {
                 cfg_options.insert_atom("test".into());
             }
+            if cargo[pkg].is_member {
+                cfg_options.insert_atom("rust_analyzer".into());
+            }
 
             if !override_cfg.global.is_empty() {
                 cfg_options.apply_diff(override_cfg.global.clone());
@@ -1030,7 +1033,8 @@ fn detached_files_to_crate_graph(
         None => (SysrootPublicDeps::default(), None),
     };
 
-    let cfg_options = create_cfg_options(rustc_cfg);
+    let mut cfg_options = create_cfg_options(rustc_cfg);
+    cfg_options.insert_atom("rust_analyzer".into());
 
     for detached_file in detached_files {
         let file_id = match load(detached_file) {
@@ -1479,6 +1483,5 @@ fn create_cfg_options(rustc_cfg: Vec<CfgFlag>) -> CfgOptions {
     let mut cfg_options = CfgOptions::default();
     cfg_options.extend(rustc_cfg);
     cfg_options.insert_atom("debug_assertions".into());
-    cfg_options.insert_atom("rust_analyzer".into());
     cfg_options
 }

--- a/crates/project-model/test_data/output/cargo_hello_world_project_model.txt
+++ b/crates/project-model/test_data/output/cargo_hello_world_project_model.txt
@@ -18,6 +18,7 @@
         cfg_options: CfgOptions(
             [
                 "debug_assertions",
+                "rust_analyzer",
                 "test",
             ],
         ),
@@ -81,6 +82,7 @@
         cfg_options: CfgOptions(
             [
                 "debug_assertions",
+                "rust_analyzer",
                 "test",
             ],
         ),
@@ -151,6 +153,7 @@
         cfg_options: CfgOptions(
             [
                 "debug_assertions",
+                "rust_analyzer",
                 "test",
             ],
         ),
@@ -221,6 +224,7 @@
         cfg_options: CfgOptions(
             [
                 "debug_assertions",
+                "rust_analyzer",
                 "test",
             ],
         ),
@@ -293,6 +297,7 @@
                 "debug_assertions",
                 "feature=default",
                 "feature=std",
+                "rust_analyzer",
             ],
         ),
         potential_cfg_options: Some(
@@ -306,6 +311,7 @@
                     "feature=rustc-dep-of-std",
                     "feature=std",
                     "feature=use_std",
+                    "rust_analyzer",
                 ],
             ),
         ),

--- a/crates/project-model/test_data/output/cargo_hello_world_project_model.txt
+++ b/crates/project-model/test_data/output/cargo_hello_world_project_model.txt
@@ -297,7 +297,6 @@
                 "debug_assertions",
                 "feature=default",
                 "feature=std",
-                "rust_analyzer",
             ],
         ),
         potential_cfg_options: Some(
@@ -311,7 +310,6 @@
                     "feature=rustc-dep-of-std",
                     "feature=std",
                     "feature=use_std",
-                    "rust_analyzer",
                 ],
             ),
         ),

--- a/crates/project-model/test_data/output/cargo_hello_world_project_model_with_selective_overrides.txt
+++ b/crates/project-model/test_data/output/cargo_hello_world_project_model_with_selective_overrides.txt
@@ -18,6 +18,7 @@
         cfg_options: CfgOptions(
             [
                 "debug_assertions",
+                "rust_analyzer",
                 "test",
             ],
         ),
@@ -81,6 +82,7 @@
         cfg_options: CfgOptions(
             [
                 "debug_assertions",
+                "rust_analyzer",
                 "test",
             ],
         ),
@@ -151,6 +153,7 @@
         cfg_options: CfgOptions(
             [
                 "debug_assertions",
+                "rust_analyzer",
                 "test",
             ],
         ),
@@ -221,6 +224,7 @@
         cfg_options: CfgOptions(
             [
                 "debug_assertions",
+                "rust_analyzer",
                 "test",
             ],
         ),
@@ -293,6 +297,7 @@
                 "debug_assertions",
                 "feature=default",
                 "feature=std",
+                "rust_analyzer",
             ],
         ),
         potential_cfg_options: Some(
@@ -306,6 +311,7 @@
                     "feature=rustc-dep-of-std",
                     "feature=std",
                     "feature=use_std",
+                    "rust_analyzer",
                 ],
             ),
         ),

--- a/crates/project-model/test_data/output/cargo_hello_world_project_model_with_selective_overrides.txt
+++ b/crates/project-model/test_data/output/cargo_hello_world_project_model_with_selective_overrides.txt
@@ -297,7 +297,6 @@
                 "debug_assertions",
                 "feature=default",
                 "feature=std",
-                "rust_analyzer",
             ],
         ),
         potential_cfg_options: Some(
@@ -311,7 +310,6 @@
                     "feature=rustc-dep-of-std",
                     "feature=std",
                     "feature=use_std",
-                    "rust_analyzer",
                 ],
             ),
         ),

--- a/crates/project-model/test_data/output/cargo_hello_world_project_model_with_wildcard_overrides.txt
+++ b/crates/project-model/test_data/output/cargo_hello_world_project_model_with_wildcard_overrides.txt
@@ -293,7 +293,6 @@
                 "debug_assertions",
                 "feature=default",
                 "feature=std",
-                "rust_analyzer",
             ],
         ),
         potential_cfg_options: Some(
@@ -307,7 +306,6 @@
                     "feature=rustc-dep-of-std",
                     "feature=std",
                     "feature=use_std",
-                    "rust_analyzer",
                 ],
             ),
         ),

--- a/crates/project-model/test_data/output/cargo_hello_world_project_model_with_wildcard_overrides.txt
+++ b/crates/project-model/test_data/output/cargo_hello_world_project_model_with_wildcard_overrides.txt
@@ -18,6 +18,7 @@
         cfg_options: CfgOptions(
             [
                 "debug_assertions",
+                "rust_analyzer",
             ],
         ),
         potential_cfg_options: None,
@@ -80,6 +81,7 @@
         cfg_options: CfgOptions(
             [
                 "debug_assertions",
+                "rust_analyzer",
             ],
         ),
         potential_cfg_options: None,
@@ -149,6 +151,7 @@
         cfg_options: CfgOptions(
             [
                 "debug_assertions",
+                "rust_analyzer",
             ],
         ),
         potential_cfg_options: None,
@@ -218,6 +221,7 @@
         cfg_options: CfgOptions(
             [
                 "debug_assertions",
+                "rust_analyzer",
             ],
         ),
         potential_cfg_options: None,
@@ -289,6 +293,7 @@
                 "debug_assertions",
                 "feature=default",
                 "feature=std",
+                "rust_analyzer",
             ],
         ),
         potential_cfg_options: Some(
@@ -302,6 +307,7 @@
                     "feature=rustc-dep-of-std",
                     "feature=std",
                     "feature=use_std",
+                    "rust_analyzer",
                 ],
             ),
         ),

--- a/crates/project-model/test_data/output/rust_project_hello_world_project_model.txt
+++ b/crates/project-model/test_data/output/rust_project_hello_world_project_model.txt
@@ -16,7 +16,6 @@
         cfg_options: CfgOptions(
             [
                 "debug_assertions",
-                "rust_analyzer",
             ],
         ),
         potential_cfg_options: None,
@@ -58,7 +57,6 @@
         cfg_options: CfgOptions(
             [
                 "debug_assertions",
-                "rust_analyzer",
             ],
         ),
         potential_cfg_options: None,
@@ -92,7 +90,6 @@
         cfg_options: CfgOptions(
             [
                 "debug_assertions",
-                "rust_analyzer",
             ],
         ),
         potential_cfg_options: None,
@@ -126,7 +123,6 @@
         cfg_options: CfgOptions(
             [
                 "debug_assertions",
-                "rust_analyzer",
             ],
         ),
         potential_cfg_options: None,
@@ -160,7 +156,6 @@
         cfg_options: CfgOptions(
             [
                 "debug_assertions",
-                "rust_analyzer",
             ],
         ),
         potential_cfg_options: None,
@@ -209,7 +204,6 @@
         cfg_options: CfgOptions(
             [
                 "debug_assertions",
-                "rust_analyzer",
             ],
         ),
         potential_cfg_options: None,
@@ -243,7 +237,6 @@
         cfg_options: CfgOptions(
             [
                 "debug_assertions",
-                "rust_analyzer",
             ],
         ),
         potential_cfg_options: None,
@@ -334,7 +327,6 @@
         cfg_options: CfgOptions(
             [
                 "debug_assertions",
-                "rust_analyzer",
             ],
         ),
         potential_cfg_options: None,
@@ -368,7 +360,6 @@
         cfg_options: CfgOptions(
             [
                 "debug_assertions",
-                "rust_analyzer",
             ],
         ),
         potential_cfg_options: None,
@@ -402,7 +393,6 @@
         cfg_options: CfgOptions(
             [
                 "debug_assertions",
-                "rust_analyzer",
             ],
         ),
         potential_cfg_options: None,

--- a/crates/project-model/test_data/output/rust_project_hello_world_project_model.txt
+++ b/crates/project-model/test_data/output/rust_project_hello_world_project_model.txt
@@ -14,7 +14,10 @@
             },
         ),
         cfg_options: CfgOptions(
-            [],
+            [
+                "debug_assertions",
+                "rust_analyzer",
+            ],
         ),
         potential_cfg_options: None,
         env: Env {
@@ -53,7 +56,10 @@
             },
         ),
         cfg_options: CfgOptions(
-            [],
+            [
+                "debug_assertions",
+                "rust_analyzer",
+            ],
         ),
         potential_cfg_options: None,
         env: Env {
@@ -84,7 +90,10 @@
             },
         ),
         cfg_options: CfgOptions(
-            [],
+            [
+                "debug_assertions",
+                "rust_analyzer",
+            ],
         ),
         potential_cfg_options: None,
         env: Env {
@@ -115,7 +124,10 @@
             },
         ),
         cfg_options: CfgOptions(
-            [],
+            [
+                "debug_assertions",
+                "rust_analyzer",
+            ],
         ),
         potential_cfg_options: None,
         env: Env {
@@ -146,7 +158,10 @@
             },
         ),
         cfg_options: CfgOptions(
-            [],
+            [
+                "debug_assertions",
+                "rust_analyzer",
+            ],
         ),
         potential_cfg_options: None,
         env: Env {
@@ -192,7 +207,10 @@
             },
         ),
         cfg_options: CfgOptions(
-            [],
+            [
+                "debug_assertions",
+                "rust_analyzer",
+            ],
         ),
         potential_cfg_options: None,
         env: Env {
@@ -223,7 +241,10 @@
             },
         ),
         cfg_options: CfgOptions(
-            [],
+            [
+                "debug_assertions",
+                "rust_analyzer",
+            ],
         ),
         potential_cfg_options: None,
         env: Env {
@@ -311,7 +332,10 @@
             },
         ),
         cfg_options: CfgOptions(
-            [],
+            [
+                "debug_assertions",
+                "rust_analyzer",
+            ],
         ),
         potential_cfg_options: None,
         env: Env {
@@ -342,7 +366,10 @@
             },
         ),
         cfg_options: CfgOptions(
-            [],
+            [
+                "debug_assertions",
+                "rust_analyzer",
+            ],
         ),
         potential_cfg_options: None,
         env: Env {
@@ -373,7 +400,10 @@
             },
         ),
         cfg_options: CfgOptions(
-            [],
+            [
+                "debug_assertions",
+                "rust_analyzer",
+            ],
         ),
         potential_cfg_options: None,
         env: Env {
@@ -404,7 +434,9 @@
             },
         ),
         cfg_options: CfgOptions(
-            [],
+            [
+                "rust_analyzer",
+            ],
         ),
         potential_cfg_options: None,
         env: Env {


### PR DESCRIPTION
This allows one to have r-a skip analysis/replace macros that work not well with r-a at all by gating them behind this cfg (an example being the `quote` macro which r-a struggles with in terms of performance).