### PR TITLE
Do not send inlay hint refresh requests on file edits

### DIFF
--- a/crates/rust-analyzer/src/global_state.rs
+++ b/crates/rust-analyzer/src/global_state.rs
@@ -66,6 +66,7 @@ pub(crate) struct GlobalState {
 
     // status
     pub(crate) shutdown_requested: bool,
+    pub(crate) send_hint_refresh_query: bool,
     pub(crate) last_reported_status: Option<lsp_ext::ServerStatusParams>,
 
     // proc macros
@@ -177,6 +178,7 @@ impl GlobalState {
             mem_docs: MemDocs::default(),
             semantic_tokens_cache: Arc::new(Default::default()),
             shutdown_requested: false,
+            send_hint_refresh_query: false,
             last_reported_status: None,
             source_root_config: SourceRootConfig::default(),
             config_errors: Default::default(),

--- a/crates/rust-analyzer/src/main_loop.rs
+++ b/crates/rust-analyzer/src/main_loop.rs
@@ -317,8 +317,11 @@ impl GlobalState {
                 }
 
                 // Refresh inlay hints if the client supports it.
-                if self.config.inlay_hints_refresh() {
+                if (self.send_hint_refresh_query || self.proc_macro_changed)
+                    && self.config.inlay_hints_refresh()
+                {
                     self.send_request::<lsp_types::request::InlayHintRefreshRequest>((), |_, _| ());
+                    self.send_hint_refresh_query = false;
                 }
             }
 
@@ -509,6 +512,7 @@ impl GlobalState {
                         }
 
                         self.switch_workspaces("fetched build data".to_string());
+                        self.send_hint_refresh_query = true;
 
                         (Some(Progress::End), None)
                     }
@@ -525,7 +529,7 @@ impl GlobalState {
                     ProcMacroProgress::End(proc_macro_load_result) => {
                         self.fetch_proc_macros_queue.op_completed(true);
                         self.set_proc_macros(proc_macro_load_result);
-
+                        self.send_hint_refresh_query = true;
                         (Some(Progress::End), None)
                     }
                 };


### PR DESCRIPTION
See https://github.com/rust-lang/rust-analyzer/issues/13369#issuecomment-1695306870

Editor itself is able to invalidate hints after edits, and /refresh was sent after editor reports changes to the language server. This forces the editor to either query & invalidate the hints twice after every edit, or wait for /refresh to come before querying the hints.

Both options are rather useless, so instead, send a request on server startup only: client editors do not know when the server actually starts up, this will help to query the initial hints after editor was open and the server was still starting up.