### PR TITLE
Add a few more `db.unwind_if_cancelled()` calls

### DIFF
--- a/crates/hir-ty/src/mir/borrowck.rs
+++ b/crates/hir-ty/src/mir/borrowck.rs
@@ -120,6 +120,7 @@ fn moved_out_of_ref(db: &dyn HirDatabase, body: &MirBody) -> Vec<MovedOutOfRef> 
         Operand::Constant(_) | Operand::Static(_) => (),
     };
     for (_, block) in body.basic_blocks.iter() {
+        db.unwind_if_cancelled();
         for statement in &block.statements {
             match &statement.kind {
                 StatementKind::Assign(_, r) => match r {
@@ -318,6 +319,7 @@ fn ever_initialized_map(
         dfs(db, body, body.start_block, l, &mut result);
     }
     for l in body.locals.iter().map(|it| it.0) {
+        db.unwind_if_cancelled();
         if !result[body.start_block].contains_idx(l) {
             result[body.start_block].insert(l, false);
             dfs(db, body, body.start_block, l, &mut result);

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -1446,6 +1446,7 @@ impl DefWithBody {
     }
 
     pub fn diagnostics(self, db: &dyn HirDatabase, acc: &mut Vec<AnyDiagnostic>) {
+        db.unwind_if_cancelled();
         let krate = self.module(db).id.krate();
 
         let (body, source_map) = db.body_with_source_map(self.into());


### PR DESCRIPTION
Judging from a profile sent by a friend, the borrowck query took up a significant amount of time in their project which might be the cause for some unresponsiveness as nothing in the mir stack currently unwinds on cancellation