### PR TITLE
Bump `rustc-perf` checkout for metrics, replace webrender, diesel and ripgrep with newer versions

### DIFF
--- a/.github/workflows/metrics.yaml
+++ b/.github/workflows/metrics.yaml
@@ -67,7 +67,7 @@ jobs:
   other_metrics:
     strategy:
       matrix:
-        names: [self, ripgrep, webrender, diesel]
+        names: [self, ripgrep-13.0.0, webrender-2022, diesel-1.4.8]
     runs-on: ubuntu-latest
     needs: [setup_cargo, build_metrics]
 
@@ -92,7 +92,7 @@ jobs:
           key: ${{ runner.os }}-target-${{ github.sha }}
 
       - name: Collect metrics
-        run: cargo xtask metrics ${{ matrix.names }}
+        run: cargo xtask metrics "${{ matrix.names }}"
 
       - name: Upload metrics
         uses: actions/upload-artifact@v3
@@ -118,25 +118,25 @@ jobs:
         with:
           name: self-${{ github.sha }}
 
-      - name: Download ripgrep metrics
+      - name: Download ripgrep-13.0.0 metrics
         uses: actions/download-artifact@v3
         with:
-          name: ripgrep-${{ github.sha }}
+          name: ripgrep-13.0.0-${{ github.sha }}
 
-      - name: Download webrender metrics
+      - name: Download webrender-2022 metrics
         uses: actions/download-artifact@v3
         with:
-          name: webrender-${{ github.sha }}
+          name: webrender-2022-${{ github.sha }}
 
-      - name: Download diesel metrics
+      - name: Download diesel-1.4.8 metrics
         uses: actions/download-artifact@v3
         with:
-          name: diesel-${{ github.sha }}
+          name: diesel-1.4.8-${{ github.sha }}
 
       - name: Combine json
         run: |
           git clone --depth 1 https://$METRICS_TOKEN@github.com/rust-analyzer/metrics.git
-          jq -s ".[0] * .[1] * .[2] * .[3] * .[4]" build.json self.json ripgrep.json webrender.json diesel.json -c >> metrics/metrics.json
+          jq -s ".[0] * .[1] * .[2] * .[3] * .[4]" build.json self.json ripgrep-13.0.0.json webrender-2022.json diesel-1.4.8.json -c >> metrics/metrics.json
           cd metrics
           git add .
           git -c user.name=Bot -c user.email=dummy@example.com commit --message 📈

--- a/xtask/src/flags.rs
+++ b/xtask/src/flags.rs
@@ -122,10 +122,21 @@ impl FromStr for MeasurementType {
         match s {
             "build" => Ok(Self::Build),
             "self" => Ok(Self::AnalyzeSelf),
-            "ripgrep" => Ok(Self::AnalyzeRipgrep),
-            "webrender" => Ok(Self::AnalyzeWebRender),
-            "diesel" => Ok(Self::AnalyzeDiesel),
+            "ripgrep-13.0.0" => Ok(Self::AnalyzeRipgrep),
+            "webrender-2022" => Ok(Self::AnalyzeWebRender),
+            "diesel-1.4.8" => Ok(Self::AnalyzeDiesel),
             _ => Err("Invalid option".to_string()),
+        }
+    }
+}
+impl AsRef<str> for MeasurementType {
+    fn as_ref(&self) -> &str {
+        match self {
+            Self::Build => "build",
+            Self::AnalyzeSelf => "self",
+            Self::AnalyzeRipgrep => "ripgrep-13.0.0",
+            Self::AnalyzeWebRender => "webrender-2022",
+            Self::AnalyzeDiesel => "diesel-1.4.8",
         }
     }
 }

--- a/xtask/src/metrics.rs
+++ b/xtask/src/metrics.rs
@@ -40,29 +40,24 @@ impl flags::Metrics {
                     "self.json"
                 }
                 MeasurementType::AnalyzeRipgrep => {
-                    metrics.measure_analysis_stats(sh, "ripgrep")?;
-                    "ripgrep.json"
+                    metrics.measure_analysis_stats(sh, "ripgrep-13.0.0")?;
+                    "ripgrep-13.0.0.json"
                 }
                 MeasurementType::AnalyzeWebRender => {
-                    {
-                        // https://github.com/rust-lang/rust-analyzer/issues/9997
-                        let _d = sh.push_dir("target/rustc-perf/collector/benchmarks/webrender");
-                        cmd!(sh, "cargo update -p url --precise 1.6.1").run()?;
-                    }
-                    metrics.measure_analysis_stats(sh, "webrender")?;
-                    "webrender.json"
+                    metrics.measure_analysis_stats(sh, "webrender-2022")?;
+                    "webrender-2022.json"
                 }
                 MeasurementType::AnalyzeDiesel => {
-                    metrics.measure_analysis_stats(sh, "diesel/diesel")?;
-                    "diesel.json"
+                    metrics.measure_analysis_stats(sh, "diesel-1.4.8")?;
+                    "diesel-1.4.8.json"
                 }
             },
             None => {
                 metrics.measure_build(sh)?;
                 metrics.measure_analysis_stats_self(sh)?;
-                metrics.measure_analysis_stats(sh, "ripgrep")?;
-                metrics.measure_analysis_stats(sh, "webrender")?;
-                metrics.measure_analysis_stats(sh, "diesel/diesel")?;
+                metrics.measure_analysis_stats(sh, "ripgrep-13.0.0")?;
+                metrics.measure_analysis_stats(sh, "webrender-2022")?;
+                metrics.measure_analysis_stats(sh, "diesel-1.4.8")?;
                 "all.json"
             }
         };
@@ -93,7 +88,7 @@ impl Metrics {
         self.measure_analysis_stats_path(
             sh,
             bench,
-            &format!("./target/rustc-perf/collector/benchmarks/{bench}"),
+            &format!("./target/rustc-perf/collector/compile-benchmarks/{bench}"),
         )
     }
     fn measure_analysis_stats_path(
@@ -145,7 +140,7 @@ impl Metrics {
         let host = Host::new(sh)?;
         let timestamp = SystemTime::now();
         let revision = cmd!(sh, "git rev-parse HEAD").read()?;
-        let perf_revision = "c52ee623e231e7690a93be88d943016968c1036b".into();
+        let perf_revision = "a584462e145a0c04760fd9391daefb4f6bd13a99".into();
         Ok(Metrics { host, timestamp, revision, perf_revision, metrics: BTreeMap::new() })
     }
 

--- a/xtask/src/metrics.rs
+++ b/xtask/src/metrics.rs
@@ -29,41 +29,40 @@ impl flags::Metrics {
 
         let _env = sh.push_env("RA_METRICS", "1");
 
-        let filename = match self.measurement_type {
-            Some(ms) => match ms {
-                MeasurementType::Build => {
-                    metrics.measure_build(sh)?;
-                    "build.json"
-                }
-                MeasurementType::AnalyzeSelf => {
-                    metrics.measure_analysis_stats_self(sh)?;
-                    "self.json"
-                }
-                MeasurementType::AnalyzeRipgrep => {
-                    metrics.measure_analysis_stats(sh, "ripgrep-13.0.0")?;
-                    "ripgrep-13.0.0.json"
-                }
-                MeasurementType::AnalyzeWebRender => {
-                    metrics.measure_analysis_stats(sh, "webrender-2022")?;
-                    "webrender-2022.json"
-                }
-                MeasurementType::AnalyzeDiesel => {
-                    metrics.measure_analysis_stats(sh, "diesel-1.4.8")?;
-                    "diesel-1.4.8.json"
-                }
-            },
+        let name = match &self.measurement_type {
+            Some(ms) => {
+                let name = ms.as_ref();
+                match ms {
+                    MeasurementType::Build => {
+                        metrics.measure_build(sh)?;
+                    }
+                    MeasurementType::AnalyzeSelf => {
+                        metrics.measure_analysis_stats_self(sh)?;
+                    }
+                    MeasurementType::AnalyzeRipgrep => {
+                        metrics.measure_analysis_stats(sh, name)?;
+                    }
+                    MeasurementType::AnalyzeWebRender => {
+                        metrics.measure_analysis_stats(sh, name)?;
+                    }
+                    MeasurementType::AnalyzeDiesel => {
+                        metrics.measure_analysis_stats(sh, name)?;
+                    }
+                };
+                name
+            }
             None => {
                 metrics.measure_build(sh)?;
                 metrics.measure_analysis_stats_self(sh)?;
-                metrics.measure_analysis_stats(sh, "ripgrep-13.0.0")?;
-                metrics.measure_analysis_stats(sh, "webrender-2022")?;
-                metrics.measure_analysis_stats(sh, "diesel-1.4.8")?;
-                "all.json"
+                metrics.measure_analysis_stats(sh, MeasurementType::AnalyzeRipgrep.as_ref())?;
+                metrics.measure_analysis_stats(sh, MeasurementType::AnalyzeWebRender.as_ref())?;
+                metrics.measure_analysis_stats(sh, MeasurementType::AnalyzeDiesel.as_ref())?;
+                "all"
             }
         };
 
         let mut file =
-            fs::File::options().write(true).create(true).open(format!("target/{}", filename))?;
+            fs::File::options().write(true).create(true).open(format!("target/{}.json", name))?;
         writeln!(file, "{}", metrics.json())?;
         eprintln!("{metrics:#?}");
         Ok(())

--- a/xtask/src/metrics.rs
+++ b/xtask/src/metrics.rs
@@ -97,6 +97,7 @@ impl Metrics {
         name: &str,
         path: &str,
     ) -> anyhow::Result<()> {
+        assert!(Path::new(path).exists(), "unable to find bench in {path}");
         eprintln!("\nMeasuring analysis-stats/{name}");
         let output = cmd!(sh, "./target/release/rust-analyzer -q analysis-stats {path}").read()?;
         for (metric, value, unit) in parse_metrics(&output) {


### PR DESCRIPTION
The previous versions were removed hence the updates. The metric results for the changed ones are disconnected now as to not muddle things up.

I think it's worth it for us to occasionally bump the `rustc-perf` checkout, as it allows us to include more interesting new targets.

Notably, the newer diesel is 3 times as fast to analyze as the one of the current checkout.