### PR TITLE
minor: Update notify to 6.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -381,14 +381,14 @@ dependencies = [
 
 [[package]]
 name = "filetime"
-version = "0.2.19"
+version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e884668cd0c7480504233e951174ddc3b382f7c2666e3b7310b5c4e7b0c37f9"
+checksum = "d4029edd3e734da6fe05b6cd7bd2960760a616bd2ddd0d59a0124746d6272af0"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
- "windows-sys 0.42.0",
+ "redox_syscall 0.3.5",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1148,20 +1148,21 @@ checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
 name = "notify"
-version = "5.1.0"
+version = "6.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58ea850aa68a06e48fdb069c0ec44d0d64c8dbffa49bf3b6f7f0a901fdea1ba9"
+checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.3.2",
  "crossbeam-channel",
  "filetime",
  "fsevent-sys",
  "inotify",
  "kqueue",
  "libc",
+ "log",
  "mio",
  "walkdir",
- "windows-sys 0.42.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1250,7 +1251,7 @@ dependencies = [
  "cfg-if",
  "instant",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.2.16",
  "smallvec",
  "winapi",
 ]
@@ -1263,7 +1264,7 @@ checksum = "ba1ef8814b5c993410bb3adfad7a5ed269563e4a2f90c41f5d85be7fb47133bf"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.2.16",
  "smallvec",
  "windows-sys 0.42.0",
 ]
@@ -1522,6 +1523,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
 name = "rowan"
 version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1544,7 +1554,6 @@ dependencies = [
  "crossbeam-channel",
  "dissimilar",
  "expect-test",
- "filetime",
  "flycheck",
  "hir",
  "hir-def",

--- a/crates/rust-analyzer/Cargo.toml
+++ b/crates/rust-analyzer/Cargo.toml
@@ -50,7 +50,6 @@ always-assert = "0.1.2"
 # These 3 deps are not used by r-a directly, but we list them here to lock in their versions
 # in our transitive deps to prevent them from pulling in windows-sys 0.45.0
 mio = "=0.8.5"
-filetime = "=0.2.19"
 parking_lot_core = "=0.9.6"
 
 cfg.workspace = true

--- a/crates/rust-analyzer/tests/slow-tests/tidy.rs
+++ b/crates/rust-analyzer/tests/slow-tests/tidy.rs
@@ -158,7 +158,7 @@ Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT
 Apache-2.0/MIT
 BSD-3-Clause
 BlueOak-1.0.0 OR MIT OR Apache-2.0
-CC0-1.0 OR Artistic-2.0
+CC0-1.0
 ISC
 MIT
 MIT / Apache-2.0

--- a/crates/vfs-notify/Cargo.toml
+++ b/crates/vfs-notify/Cargo.toml
@@ -16,7 +16,7 @@ tracing = "0.1.35"
 walkdir = "2.3.2"
 crossbeam-channel = "0.5.5"
 # We demand 5.1.0 as any higher version pulls in a new windows-sys dupe
-notify = "=5.1.0"
+notify = "6.1.1"
 
 stdx.workspace = true
 vfs.workspace = true


### PR DESCRIPTION
Unlike version 6.0.1, this does not pull windows-sys 0.45.0 as observed in #15077.

```
$ cargo tree --target=x86_64-pc-windows-gnu --charset=ascii | grep windows-sys

|           |   `-- windows-sys v0.42.0
|   |   |   |   |   |       `-- windows-sys v0.42.0 (*)
|       `-- windows-sys v0.48.0
    |   |   `-- windows-sys v0.48.0 (*)
    |   `-- windows-sys v0.48.0 (*)
|   `-- windows-sys v0.48.0 (*)
|   `-- windows-sys v0.42.0 (*)
```