### PR TITLE
code: remove `rust-analyzer.discoverProjectCommand` in favor of a companion extension

### DIFF
--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -471,16 +471,13 @@
                     "default": false,
                     "type": "boolean"
                 },
-                "rust-analyzer.discoverProjectCommand": {
-                    "markdownDescription": "Sets the command that rust-analyzer uses to generate `rust-project.json` files. This command should only be used\n if a build system like Buck or Bazel is also in use. The command must accept files as arguments and return \n a rust-project.json over stdout.",
+                "rust-analyzer.discoverProjectRunner": {
+                    "markdownDescription": "Sets the extension responsible for determining which extension the rust-analyzer extension uses to generate `rust-project.json` files. This should should only be used\n if a build system like Buck or Bazel is also in use.",
                     "default": null,
                     "type": [
                         "null",
-                        "array"
-                    ],
-                    "items": {
-                        "type": "string"
-                    }
+                        "string"
+                    ]
                 },
                 "rust-analyzer.showUnlinkedFileNotification": {
                     "markdownDescription": "Whether to show a notification for unlinked files asking the user to add the corresponding Cargo.toml to the linked projects setting.",

--- a/editors/code/src/commands.ts
+++ b/editors/code/src/commands.ts
@@ -3,7 +3,7 @@ import * as lc from "vscode-languageclient";
 import * as ra from "./lsp_ext";
 import * as path from "path";
 
-import { type Ctx, type Cmd, type CtxInit } from "./ctx";
+import type { Ctx, Cmd, CtxInit } from "./ctx";
 import { applySnippetWorkspaceEdit, applySnippetTextEdits } from "./snippets";
 import { spawnSync } from "child_process";
 import { type RunnableQuickPick, selectRunnable, createTask, createArgs } from "./run";
@@ -878,7 +878,7 @@ export function addProject(ctx: CtxInit): Cmd {
         }
 
         const command = `${extensionName}.discoverWorkspaceCommand`;
-        const project = (await vscode.commands.executeCommand(command)) as JsonProject;
+        const project = await vscode.commands.executeCommand(command);
 
         ctx.addToDiscoveredWorkspaces([project]);
 

--- a/editors/code/src/commands.ts
+++ b/editors/code/src/commands.ts
@@ -3,7 +3,7 @@ import * as lc from "vscode-languageclient";
 import * as ra from "./lsp_ext";
 import * as path from "path";
 
-import { type Ctx, type Cmd, type CtxInit, discoverWorkspace } from "./ctx";
+import { type Ctx, type Cmd, type CtxInit } from "./ctx";
 import { applySnippetWorkspaceEdit, applySnippetTextEdits } from "./snippets";
 import { spawnSync } from "child_process";
 import { type RunnableQuickPick, selectRunnable, createTask, createArgs } from "./run";
@@ -871,22 +871,16 @@ export function rebuildProcMacros(ctx: CtxInit): Cmd {
 
 export function addProject(ctx: CtxInit): Cmd {
     return async () => {
-        const discoverProjectCommand = ctx.config.discoverProjectCommand;
-        if (!discoverProjectCommand) {
+        const extensionName = ctx.config.discoverProjectRunner;
+        // this command shouldn't be enabled in the first place if this isn't set.
+        if (!extensionName) {
             return;
         }
 
-        const workspaces: JsonProject[] = await Promise.all(
-            vscode.workspace.textDocuments
-                .filter(isRustDocument)
-                .map(async (file): Promise<JsonProject> => {
-                    return discoverWorkspace([file], discoverProjectCommand, {
-                        cwd: path.dirname(file.uri.fsPath),
-                    });
-                }),
-        );
+        const command = `${extensionName}.discoverWorkspaceCommand`;
+        const project = (await vscode.commands.executeCommand(command)) as JsonProject;
 
-        ctx.addToDiscoveredWorkspaces(workspaces);
+        ctx.addToDiscoveredWorkspaces([project]);
 
         // this is a workaround to avoid needing writing the `rust-project.json` into
         // a workspace-level VS Code-specific settings folder. We'd like to keep the

--- a/editors/code/src/commands.ts
+++ b/editors/code/src/commands.ts
@@ -878,7 +878,7 @@ export function addProject(ctx: CtxInit): Cmd {
         }
 
         const command = `${extensionName}.discoverWorkspaceCommand`;
-        const project = await vscode.commands.executeCommand(command);
+        const project: JsonProject = await vscode.commands.executeCommand(command);
 
         ctx.addToDiscoveredWorkspaces([project]);
 

--- a/editors/code/src/config.ts
+++ b/editors/code/src/config.ts
@@ -253,8 +253,8 @@ export class Config {
         return this.get<boolean>("trace.extension");
     }
 
-    get discoverProjectCommand() {
-        return this.get<string[] | undefined>("discoverProjectCommand");
+    get discoverProjectRunner(): string | undefined {
+        return this.get<string | undefined>("discoverProjectRunner");
     }
 
     get problemMatcher(): string[] {

--- a/editors/code/src/ctx.ts
+++ b/editors/code/src/ctx.ts
@@ -30,12 +30,12 @@ import { bootstrap } from "./bootstrap";
 export type Workspace =
     | { kind: "Empty" }
     | {
-          kind: "Workspace Folder";
-      }
+        kind: "Workspace Folder";
+    }
     | {
-          kind: "Detached Files";
-          files: vscode.TextDocument[];
-      };
+        kind: "Detached Files";
+        files: vscode.TextDocument[];
+    };
 
 export function fetchWorkspace(): Workspace {
     const folders = (vscode.workspace.workspaceFolders || []).filter(
@@ -49,9 +49,9 @@ export function fetchWorkspace(): Workspace {
         ? rustDocuments.length === 0
             ? { kind: "Empty" }
             : {
-                  kind: "Detached Files",
-                  files: rustDocuments,
-              }
+                kind: "Detached Files",
+                files: rustDocuments,
+            }
         : { kind: "Workspace Folder" };
 }
 
@@ -189,7 +189,7 @@ export class Ctx {
             if (this.config.discoverProjectRunner) {
                 const command = `${this.config.discoverProjectRunner}.discoverWorkspaceCommand`;
                 log.info(`running command: ${command}`);
-                const project = (await vscode.commands.executeCommand(command)) as JsonProject;
+                const project: JsonProject = await vscode.commands.executeCommand(command);
                 this.addToDiscoveredWorkspaces([project]);
             }
 
@@ -441,8 +441,7 @@ export class Ctx {
         }
         statusBar.tooltip.appendMarkdown("\n\n[Open Logs](command:rust-analyzer.openLogs)");
         statusBar.tooltip.appendMarkdown(
-            `\n\n[${
-                this.config.checkOnSave ? "Disable" : "Enable"
+            `\n\n[${this.config.checkOnSave ? "Disable" : "Enable"
             } Check on Save](command:rust-analyzer.toggleCheckOnSave)`,
         );
         statusBar.tooltip.appendMarkdown(

--- a/editors/code/src/ctx.ts
+++ b/editors/code/src/ctx.ts
@@ -1,12 +1,10 @@
 import * as vscode from "vscode";
 import type * as lc from "vscode-languageclient/node";
 import * as ra from "./lsp_ext";
-import * as path from "path";
 
 import { Config, prepareVSCodeConfig } from "./config";
 import { createClient } from "./client";
 import {
-    executeDiscoverProject,
     isDocumentInWorkspace,
     isRustDocument,
     isRustEditor,
@@ -24,7 +22,6 @@ import {
 import { execRevealDependency } from "./commands";
 import { PersistentState } from "./persistent_state";
 import { bootstrap } from "./bootstrap";
-import type { ExecOptions } from "child_process";
 
 // We only support local folders, not eg. Live Share (`vlsl:` scheme), so don't activate if
 // only those are in use. We use "Empty" to represent these scenarios
@@ -56,17 +53,6 @@ export function fetchWorkspace(): Workspace {
                   files: rustDocuments,
               }
         : { kind: "Workspace Folder" };
-}
-
-export async function discoverWorkspace(
-    files: readonly vscode.TextDocument[],
-    command: string[],
-    options: ExecOptions,
-): Promise<JsonProject> {
-    const paths = files.map((f) => `"${f.uri.fsPath}"`).join(" ");
-    const joinedCommand = command.join(" ");
-    const data = await executeDiscoverProject(`${joinedCommand} ${paths}`, options);
-    return JSON.parse(data) as JsonProject;
 }
 
 export type CommandFactory = {
@@ -200,27 +186,18 @@ export class Ctx {
             };
 
             let rawInitializationOptions = vscode.workspace.getConfiguration("rust-analyzer");
+            if (this.config.discoverProjectRunner) {
+                const command = `${this.config.discoverProjectRunner}.discoverWorkspaceCommand`;
+                log.info(`running command: ${command}`);
+                const project = (await vscode.commands.executeCommand(command)) as JsonProject;
+                this.addToDiscoveredWorkspaces([project]);
+            }
 
             if (this.workspace.kind === "Detached Files") {
                 rawInitializationOptions = {
                     detachedFiles: this.workspace.files.map((file) => file.uri.fsPath),
                     ...rawInitializationOptions,
                 };
-            }
-
-            const discoverProjectCommand = this.config.discoverProjectCommand;
-            if (discoverProjectCommand) {
-                const workspaces: JsonProject[] = await Promise.all(
-                    vscode.workspace.textDocuments
-                        .filter(isRustDocument)
-                        .map(async (file): Promise<JsonProject> => {
-                            return discoverWorkspace([file], discoverProjectCommand, {
-                                cwd: path.dirname(file.uri.fsPath),
-                            });
-                        }),
-                );
-
-                this.addToDiscoveredWorkspaces(workspaces);
             }
 
             const initializationOptions = prepareVSCodeConfig(

--- a/editors/code/src/ctx.ts
+++ b/editors/code/src/ctx.ts
@@ -30,12 +30,12 @@ import { bootstrap } from "./bootstrap";
 export type Workspace =
     | { kind: "Empty" }
     | {
-        kind: "Workspace Folder";
-    }
+          kind: "Workspace Folder";
+      }
     | {
-        kind: "Detached Files";
-        files: vscode.TextDocument[];
-    };
+          kind: "Detached Files";
+          files: vscode.TextDocument[];
+      };
 
 export function fetchWorkspace(): Workspace {
     const folders = (vscode.workspace.workspaceFolders || []).filter(
@@ -49,9 +49,9 @@ export function fetchWorkspace(): Workspace {
         ? rustDocuments.length === 0
             ? { kind: "Empty" }
             : {
-                kind: "Detached Files",
-                files: rustDocuments,
-            }
+                  kind: "Detached Files",
+                  files: rustDocuments,
+              }
         : { kind: "Workspace Folder" };
 }
 
@@ -441,7 +441,8 @@ export class Ctx {
         }
         statusBar.tooltip.appendMarkdown("\n\n[Open Logs](command:rust-analyzer.openLogs)");
         statusBar.tooltip.appendMarkdown(
-            `\n\n[${this.config.checkOnSave ? "Disable" : "Enable"
+            `\n\n[${
+                this.config.checkOnSave ? "Disable" : "Enable"
             } Check on Save](command:rust-analyzer.toggleCheckOnSave)`,
         );
         statusBar.tooltip.appendMarkdown(

--- a/editors/code/src/util.ts
+++ b/editors/code/src/util.ts
@@ -154,22 +154,6 @@ export function execute(command: string, options: ExecOptions): Promise<string> 
     });
 }
 
-export function executeDiscoverProject(command: string, options: ExecOptions): Promise<string> {
-    options = Object.assign({ maxBuffer: 10 * 1024 * 1024 }, options);
-    log.info(`running command: ${command}`);
-    return new Promise((resolve, reject) => {
-        exec(command, options, (err, stdout, _) => {
-            if (err) {
-                log.error(err);
-                reject(err);
-                return;
-            }
-
-            resolve(stdout.trimEnd());
-        });
-    });
-}
-
 export class LazyOutputChannel implements vscode.OutputChannel {
     constructor(name: string) {
         this.name = name;


### PR DESCRIPTION
I think it's time to remove this functionality from the `rust-analyzer` and move it into a dedicated extension responsible for this. Selfishly, this changes makes it tenable to do progress reporting to the editor and potentially do some more complicated things around managing _which_ workspaces are being used.