### PR TITLE
project-model: when using `rust-project.json`, prefer the sysroot-defined rustc over discovery in `$PATH`

### DIFF
--- a/crates/project-model/src/rustc_cfg.rs
+++ b/crates/project-model/src/rustc_cfg.rs
@@ -102,6 +102,5 @@ fn get_rust_cfgs(
         cmd.args(["--target", target]);
     }
 
-    let out = utf8_stdout(cmd).context("Unable to run `rustc`")?;
-    Ok(out)
+    utf8_stdout(cmd).context("Unable to run `rustc`")
 }

--- a/crates/project-model/src/rustc_cfg.rs
+++ b/crates/project-model/src/rustc_cfg.rs
@@ -2,15 +2,21 @@
 
 use std::process::Command;
 
+use anyhow::Context;
 use rustc_hash::FxHashMap;
 
 use crate::{cfg_flag::CfgFlag, utf8_stdout, ManifestPath, Sysroot};
 
+pub(crate) enum Config<'a> {
+    Cargo(&'a ManifestPath),
+    Explicit(&'a Sysroot),
+    Discover,
+}
+
 pub(crate) fn get(
-    cargo_toml: Option<&ManifestPath>,
-    sysroot: Option<&Sysroot>,
     target: Option<&str>,
     extra_env: &FxHashMap<String, String>,
+    config: Config<'_>,
 ) -> Vec<CfgFlag> {
     let _p = profile::span("rustc_cfg::get");
     let mut res = Vec::with_capacity(6 * 2 + 1);
@@ -26,64 +32,68 @@ pub(crate) fn get(
     // Add miri cfg, which is useful for mir eval in stdlib
     res.push(CfgFlag::Atom("miri".into()));
 
-    match get_rust_cfgs(cargo_toml, sysroot, target, extra_env) {
-        Ok(rustc_cfgs) => {
-            tracing::debug!(
-                "rustc cfgs found: {:?}",
-                rustc_cfgs
-                    .lines()
-                    .map(|it| it.parse::<CfgFlag>().map(|it| it.to_string()))
-                    .collect::<Vec<_>>()
-            );
-            res.extend(rustc_cfgs.lines().filter_map(|it| it.parse().ok()));
+    let rustc_cfgs = get_rust_cfgs(target, extra_env, config);
+
+    let rustc_cfgs = match rustc_cfgs {
+        Ok(cfgs) => cfgs,
+        Err(e) => {
+            tracing::error!(?e, "failed to get rustc cfgs");
+            return res;
         }
-        Err(e) => tracing::error!("failed to get rustc cfgs: {e:?}"),
+    };
+
+    let rustc_cfgs =
+        rustc_cfgs.lines().map(|it| it.parse::<CfgFlag>()).collect::<Result<Vec<_>, _>>();
+
+    match rustc_cfgs {
+        Ok(rustc_cfgs) => {
+            tracing::debug!(?rustc_cfgs, "rustc cfgs found");
+            res.extend(rustc_cfgs);
+        }
+        Err(e) => {
+            tracing::error!(?e, "failed to get rustc cfgs")
+        }
     }
 
     res
 }
 
 fn get_rust_cfgs(
-    cargo_toml: Option<&ManifestPath>,
-    sysroot: Option<&Sysroot>,
     target: Option<&str>,
     extra_env: &FxHashMap<String, String>,
+    config: Config<'_>,
 ) -> anyhow::Result<String> {
-    if let Some(cargo_toml) = cargo_toml {
-        let mut cargo_config = Command::new(toolchain::cargo());
-        cargo_config.envs(extra_env);
-        cargo_config
-            .current_dir(cargo_toml.parent())
-            .args(["rustc", "-Z", "unstable-options", "--print", "cfg"])
-            .env("RUSTC_BOOTSTRAP", "1");
-        if let Some(target) = target {
-            cargo_config.args(["--target", target]);
-        }
-        match utf8_stdout(cargo_config) {
-            Ok(it) => return Ok(it),
-            Err(e) => tracing::debug!("{e:?}: falling back to querying rustc for cfgs"),
-        }
-    }
+    let mut cmd = match config {
+        Config::Cargo(cargo_toml) => {
+            let mut cmd = Command::new(toolchain::cargo());
+            cmd.envs(extra_env);
+            cmd.current_dir(cargo_toml.parent())
+                .args(["rustc", "-Z", "unstable-options", "--print", "cfg"])
+                .env("RUSTC_BOOTSTRAP", "1");
+            if let Some(target) = target {
+                cmd.args(["--target", target]);
+            }
 
-    let rustc = match sysroot {
-        Some(sysroot) => {
-            let rustc = sysroot.discover_rustc()?.into();
-            tracing::debug!(?rustc, "using rustc from sysroot");
-            rustc
+            return utf8_stdout(cmd).context("Unable to run `cargo rustc`");
         }
-        None => {
+        Config::Explicit(sysroot) => {
+            let rustc: std::path::PathBuf = sysroot.discover_rustc()?.into();
+            tracing::debug!(?rustc, "using explicit rustc from sysroot");
+            Command::new(rustc)
+        }
+        Config::Discover => {
             let rustc = toolchain::rustc();
             tracing::debug!(?rustc, "using rustc from env");
-            rustc
+            Command::new(rustc)
         }
     };
 
-    // using unstable cargo features failed, fall back to using plain rustc
-    let mut cmd = Command::new(rustc);
     cmd.envs(extra_env);
     cmd.args(["--print", "cfg", "-O"]);
     if let Some(target) = target {
         cmd.args(["--target", target]);
     }
-    utf8_stdout(cmd)
+
+    let out = utf8_stdout(cmd).context("Unable to run `rustc`")?;
+    Ok(out)
 }

--- a/crates/project-model/src/rustc_cfg.rs
+++ b/crates/project-model/src/rustc_cfg.rs
@@ -7,6 +7,14 @@ use rustc_hash::FxHashMap;
 
 use crate::{cfg_flag::CfgFlag, utf8_stdout, ManifestPath, Sysroot};
 
+/// Determines how `rustc --print cfg` is discovered and invoked.
+///
+/// There options are supported:
+/// - [`RustcCfgConfig::Cargo`], which relies on `cargo rustc --print cfg`
+///   and `RUSTC_BOOTSTRAP`.
+/// - [`RustcCfgConfig::Explicit`], which uses an explicit path to the `rustc`
+///   binary in the sysroot.
+/// - [`RustcCfgConfig::Discover`], which uses [`toolchain::rustc`].
 pub(crate) enum RustcCfgConfig<'a> {
     Cargo(&'a ManifestPath),
     Explicit(&'a Sysroot),

--- a/crates/project-model/src/sysroot.rs
+++ b/crates/project-model/src/sysroot.rs
@@ -115,8 +115,17 @@ impl Sysroot {
         Ok(Sysroot::load(sysroot_dir, src))
     }
 
-    pub fn discover_rustc(&self) -> Option<ManifestPath> {
+    pub fn discover_rustc_src(&self) -> Option<ManifestPath> {
         get_rustc_src(&self.root)
+    }
+
+    pub fn discover_rustc(&self) -> Result<AbsPathBuf, std::io::Error> {
+        let rustc = self.root.join("bin/rustc");
+        tracing::debug!(?rustc, "checking for rustc binary at location");
+        match fs::metadata(&rustc) {
+            Ok(_) => Ok(rustc),
+            Err(e) => Err(e),
+        }
     }
 
     pub fn with_sysroot_dir(sysroot_dir: AbsPathBuf) -> Result<Sysroot> {

--- a/crates/project-model/src/workspace.rs
+++ b/crates/project-model/src/workspace.rs
@@ -21,7 +21,7 @@ use crate::{
     cargo_workspace::{DepKind, PackageData, RustLibSource},
     cfg_flag::CfgFlag,
     project_json::Crate,
-    rustc_cfg,
+    rustc_cfg::{self, RustcCfgConfig},
     sysroot::SysrootCrate,
     target_data_layout, utf8_stdout, CargoConfig, CargoWorkspace, InvocationStrategy, ManifestPath,
     Package, ProjectJson, ProjectManifest, Sysroot, TargetData, TargetKind, WorkspaceBuildScripts,
@@ -282,7 +282,7 @@ impl ProjectWorkspace {
                 let rustc_cfg = rustc_cfg::get(
                     config.target.as_deref(),
                     &config.extra_env,
-                    rustc_cfg::Config::Cargo(cargo_toml),
+                    RustcCfgConfig::Cargo(cargo_toml),
                 );
 
                 let cfg_overrides = config.cfg_overrides.clone();
@@ -337,11 +337,11 @@ impl ProjectWorkspace {
         let config = match &sysroot {
             Ok(sysroot) => {
                 tracing::debug!(src_root = %sysroot.src_root(), root = %sysroot.root(), "Using sysroot");
-                rustc_cfg::Config::Explicit(sysroot)
+                RustcCfgConfig::Explicit(sysroot)
             }
             Err(_) => {
                 tracing::debug!("discovering sysroot");
-                rustc_cfg::Config::Discover
+                RustcCfgConfig::Discover
             }
         };
 
@@ -370,11 +370,11 @@ impl ProjectWorkspace {
         let rustc_config = match &sysroot {
             Ok(sysroot) => {
                 tracing::info!(src_root = %sysroot.src_root(), root = %sysroot.root(), "Using sysroot");
-                rustc_cfg::Config::Explicit(sysroot)
+                RustcCfgConfig::Explicit(sysroot)
             }
             Err(_) => {
                 tracing::info!("discovering sysroot");
-                rustc_cfg::Config::Discover
+                RustcCfgConfig::Discover
             }
         };
 
@@ -774,8 +774,8 @@ fn project_json_to_crate_graph(
                 let target_cfgs = match target.as_deref() {
                     Some(target) => cfg_cache.entry(target).or_insert_with(|| {
                         let rustc_cfg = match sysroot {
-                            Some(sysroot) => rustc_cfg::Config::Explicit(sysroot),
-                            None => rustc_cfg::Config::Discover,
+                            Some(sysroot) => RustcCfgConfig::Explicit(sysroot),
+                            None => RustcCfgConfig::Discover,
                         };
 
                         rustc_cfg::get(Some(target), extra_env, rustc_cfg)


### PR DESCRIPTION
At the moment, rust-analyzer discovers `rustc` via the `$PATH` even if the `sysroot` field is defined in a `rust-project.json`. However, this does not work for users who do not have rustup installed, resulting in any `cfg`-based inference in rust-analzyer not working correctly. In my (decently naive!) opinion, it makes more sense to rely on the `sysroot` field in the `rust-project.json`.

One might ask "why not add `rustc` to the `$PATH`?" That is a reasonable question, but that doesn't work for my use case:
- The path to the sysroot in my employer's monorepo changes depending on which platform a user is on. For example, if they're on Linux, they'd want to use the sysroot defined at path `a`, whereas if they're on macOS, they'd want to use the sysroot at path `b` (I wrote the sysroot resolution functionality [here](https://github.com/facebook/buck2/blob/765da4ca1e0b97a0de1e82b2fb3af52766fd06f4/integrations/rust-project/src/sysroot.rs#L39), if you're curious).
- The location of the sysroot can (and does!) change, especially as people figure out how to make Rust run successfully on non-Linux platforms (e.g., iOS, Android, etc.) in a monorepo. Updating people's `$PATH` company-wide is hard while updating a config inside a CLI is pretty easy.

## Testing

I've created a `rust-project.json` using [rust-project](https://github.com/facebook/buck2/tree/main/integrations/rust-project) and was able to successfully load a project with and without the `sysroot`/`sysroot_src` fields—without those fields, rust-analyzer fell back to the `$PATH` based approach, as evidenced by `[DEBUG project_model::rustc_cfg] using rustc from env rustc="rustc"` showing up in the logs.