### PR TITLE
internal: use current folder's `rustfmt.toml` with all rustfmt configurations

### DIFF
--- a/crates/rust-analyzer/src/lsp/from_proto.rs
+++ b/crates/rust-analyzer/src/lsp/from_proto.rs
@@ -72,7 +72,7 @@ pub(crate) fn file_position(
 
 pub(crate) fn file_range(
     snap: &GlobalStateSnapshot,
-    text_document_identifier: lsp_types::TextDocumentIdentifier,
+    text_document_identifier: &lsp_types::TextDocumentIdentifier,
     range: lsp_types::Range,
 ) -> anyhow::Result<FileRange> {
     file_range_uri(snap, &text_document_identifier.uri, range)


### PR DESCRIPTION
## Introduction

Resolves https://github.com/rust-lang/rust-analyzer/issues/15540. I moved the `chdir` functionality outside of the `match` to ensure that this functionality wouldn’t fall through again. As part of this PR, I also changed `from_proto::file_range` to accept a `TextDocumentIdentifier` by reference instead of by value, but I can undo this change if desired.

## Testing

I added a `rustfmt.toml` will the contents below at `crates/rust-analyzer/rustfmt.toml`: 

```toml
reorder_modules = false
use_small_heuristics = "Max"
# this is the only difference from the `rustfmt.toml` at the root of the repo
tab_spaces = 8
```

In addition, I've also added `"rust-analyzer.rustfmt.overrideCommand": ["rustfmt"]` to my VS Code configuration.

With the above changes, saving `crates/rust-analyzer/src/handlers/request.rs` results in 8-space indentation. Meanwhile, saving `crates/toolchain/src/lib.rs` _does not_ result in any formatting changes.