### PR TITLE
add option to show full function signatures in completion docs

### DIFF
--- a/crates/ide-completion/src/config.rs
+++ b/crates/ide-completion/src/config.rs
@@ -14,6 +14,7 @@ pub struct CompletionConfig {
     pub enable_imports_on_the_fly: bool,
     pub enable_self_on_the_fly: bool,
     pub enable_private_editable: bool,
+    pub full_function_signatures: bool,
     pub callable: Option<CallableSnippets>,
     pub snippet_cap: Option<SnippetCap>,
     pub insert_use: InsertUseConfig,

--- a/crates/ide-completion/src/render/function.rs
+++ b/crates/ide-completion/src/render/function.rs
@@ -98,9 +98,14 @@ fn render(
         _ => (),
     }
 
+    let detail = if ctx.completion.config.full_function_signatures {
+        detail_full(db, func)
+    } else {
+        detail(db, func)
+    };
     item.set_documentation(ctx.docs(func))
         .set_deprecated(ctx.is_deprecated(func) || ctx.is_deprecated_assoc_item(func))
-        .detail(detail(db, func, ctx.completion.config.full_function_signatures))
+        .detail(detail)
         .lookup_by(name.unescaped().to_smol_str());
 
     match ctx.completion.config.snippet_cap {
@@ -239,22 +244,7 @@ fn ref_of_param(ctx: &CompletionContext<'_>, arg: &str, ty: &hir::Type) -> &'sta
     ""
 }
 
-fn detail(db: &dyn HirDatabase, func: hir::Function, full_function_signature: bool) -> String {
-    if full_function_signature {
-        let signature = format!("{}", func.display(db));
-        let mut singleline = String::with_capacity(signature.len());
-
-        for segment in signature.split_whitespace() {
-            if !singleline.is_empty() {
-                singleline.push(' ');
-            }
-
-            singleline.push_str(segment);
-        }
-
-        return singleline;
-    }
-
+fn detail(db: &dyn HirDatabase, func: hir::Function) -> String {
     let mut ret_ty = func.ret_type(db);
     let mut detail = String::new();
 
@@ -275,6 +265,21 @@ fn detail(db: &dyn HirDatabase, func: hir::Function, full_function_signature: bo
     if !ret_ty.is_unit() {
         format_to!(detail, " -> {}", ret_ty.display(db));
     }
+    detail
+}
+
+fn detail_full(db: &dyn HirDatabase, func: hir::Function) -> String {
+    let signature = format!("{}", func.display(db));
+    let mut detail = String::with_capacity(signature.len());
+
+    for segment in signature.split_whitespace() {
+        if !detail.is_empty() {
+            detail.push(' ');
+        }
+
+        detail.push_str(segment);
+    }
+
     detail
 }
 

--- a/crates/ide-completion/src/render/function.rs
+++ b/crates/ide-completion/src/render/function.rs
@@ -241,7 +241,18 @@ fn ref_of_param(ctx: &CompletionContext<'_>, arg: &str, ty: &hir::Type) -> &'sta
 
 fn detail(db: &dyn HirDatabase, func: hir::Function, full_function_signature: bool) -> String {
     if full_function_signature {
-        return format!("{}", func.display(db)).replace("\n", " ");
+        let signature = format!("{}", func.display(db));
+        let mut singleline = String::with_capacity(signature.len());
+
+        for segment in signature.split_whitespace() {
+            if !singleline.is_empty() {
+                singleline.push(' ');
+            }
+
+            singleline.push_str(segment);
+        }
+
+        return singleline;
     }
 
     let mut ret_ty = func.ret_type(db);

--- a/crates/ide-completion/src/render/function.rs
+++ b/crates/ide-completion/src/render/function.rs
@@ -100,7 +100,7 @@ fn render(
 
     item.set_documentation(ctx.docs(func))
         .set_deprecated(ctx.is_deprecated(func) || ctx.is_deprecated_assoc_item(func))
-        .detail(detail(db, func))
+        .detail(detail(db, func, ctx.completion.config.full_function_signatures))
         .lookup_by(name.unescaped().to_smol_str());
 
     match ctx.completion.config.snippet_cap {
@@ -239,7 +239,11 @@ fn ref_of_param(ctx: &CompletionContext<'_>, arg: &str, ty: &hir::Type) -> &'sta
     ""
 }
 
-fn detail(db: &dyn HirDatabase, func: hir::Function) -> String {
+fn detail(db: &dyn HirDatabase, func: hir::Function, full_function_signature: bool) -> String {
+    if full_function_signature {
+        return format!("{}", func.display(db)).replace("\n", " ");
+    }
+
     let mut ret_ty = func.ret_type(db);
     let mut detail = String::new();
 

--- a/crates/ide-completion/src/tests.rs
+++ b/crates/ide-completion/src/tests.rs
@@ -64,6 +64,7 @@ pub(crate) const TEST_CONFIG: CompletionConfig = CompletionConfig {
     enable_imports_on_the_fly: true,
     enable_self_on_the_fly: true,
     enable_private_editable: false,
+    full_function_signatures: false,
     callable: Some(CallableSnippets::FillArguments),
     snippet_cap: SnippetCap::new(true),
     prefer_no_std: false,

--- a/crates/ide-completion/src/tests/special.rs
+++ b/crates/ide-completion/src/tests/special.rs
@@ -2,9 +2,14 @@
 
 use expect_test::{expect, Expect};
 
-use crate::tests::{
-    check_edit, completion_list, completion_list_no_kw, completion_list_with_trigger_character,
+use crate::{
+    tests::{
+        check_edit, completion_list, completion_list_no_kw, completion_list_with_trigger_character,
+    },
+    CompletionItemKind,
 };
+
+use super::{do_completion_with_config, TEST_CONFIG};
 
 fn check_no_kw(ra_fixture: &str, expect: Expect) {
     let actual = completion_list_no_kw(ra_fixture);
@@ -1301,5 +1306,69 @@ trait PartialOrd {}
 
 struct Foo<T: PartialOrd
 "#,
+    );
+}
+
+fn check_signatures(src: &str, kind: CompletionItemKind, reduced: Expect, full: Expect) {
+    const FULL_SIGNATURES_CONFIG: crate::CompletionConfig = {
+        let mut x = TEST_CONFIG;
+        x.full_function_signatures = true;
+        x
+    };
+
+    // reduced signature
+    let completion = do_completion_with_config(TEST_CONFIG, src, kind);
+    assert!(completion[0].detail.is_some());
+    reduced.assert_eq(completion[0].detail.as_ref().unwrap());
+
+    // full signature
+    let completion = do_completion_with_config(FULL_SIGNATURES_CONFIG, src, kind);
+    assert!(completion[0].detail.is_some());
+    full.assert_eq(completion[0].detail.as_ref().unwrap());
+}
+
+#[test]
+fn respects_full_function_signatures() {
+    check_signatures(
+        r#"
+pub fn foo<'x, T>(x: &'x mut T) -> u8 where T: Clone, { 0u8 }
+fn main() { fo$0 }
+"#,
+        CompletionItemKind::SymbolKind(ide_db::SymbolKind::Function),
+        expect!("fn(&mut T) -> u8"),
+        expect!("pub fn foo<'x, T>(x: &'x mut T) -> u8 where T: Clone,"),
+    );
+
+    check_signatures(
+        r#"
+struct Foo;
+struct Bar;
+impl Bar {
+    pub const fn baz(x: Foo) -> ! { loop {} };
+}
+
+fn main() { Bar::b$0 }
+"#,
+        CompletionItemKind::SymbolKind(ide_db::SymbolKind::Function),
+        expect!("const fn(Foo) -> !"),
+        expect!("pub const fn baz(x: Foo) -> !"),
+    );
+
+    check_signatures(
+        r#"
+struct Foo;
+struct Bar;
+impl Bar {
+    pub const fn baz<'foo>(&'foo mut self, x: &'foo Foo) -> ! { loop {} };
+}
+
+fn main() {
+    let mut bar = Bar;
+    bar.b$0
+}
+"#,
+        CompletionItemKind::Method,
+        expect!("const fn(&'foo mut self, &Foo) -> !"),
+        expect!("pub const fn baz<'foo>(&'foo mut self, x: &'foo Foo) -> !"),
     );
 }

--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -209,14 +209,14 @@ config_data! {
         completion_autoself_enable: bool        = "true",
         /// Whether to add parenthesis and argument snippets when completing function.
         completion_callable_snippets: CallableCompletionDef  = "\"fill_arguments\"",
+        /// Whether to show full function/method signatures in completion docs.
+        completion_fullFunctionSignatures_enable: bool = "false",
         /// Maximum number of completions to return. If `None`, the limit is infinite.
         completion_limit: Option<usize> = "null",
         /// Whether to show postfix snippets like `dbg`, `if`, `not`, etc.
         completion_postfix_enable: bool         = "true",
         /// Enables completions of private items and fields that are defined in the current workspace even if they are not visible at the current position.
         completion_privateEditable_enable: bool = "false",
-        /// Whether to show full function/method signatures in completion docs.
-        completion_fullFunctionSignatures_enable: bool = "false",
         /// Custom completion snippets.
         // NOTE: Keep this list in sync with the feature docs of user snippets.
         completion_snippets_custom: FxHashMap<String, SnippetDef> = r#"{

--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -215,6 +215,8 @@ config_data! {
         completion_postfix_enable: bool         = "true",
         /// Enables completions of private items and fields that are defined in the current workspace even if they are not visible at the current position.
         completion_privateEditable_enable: bool = "false",
+        /// Whether to show full function/method signatures in completion docs.
+        completion_fullFunctionSignatures_enable: bool = "false",
         /// Custom completion snippets.
         // NOTE: Keep this list in sync with the feature docs of user snippets.
         completion_snippets_custom: FxHashMap<String, SnippetDef> = r#"{
@@ -1444,6 +1446,7 @@ impl Config {
                 && completion_item_edit_resolve(&self.caps),
             enable_self_on_the_fly: self.data.completion_autoself_enable,
             enable_private_editable: self.data.completion_privateEditable_enable,
+            full_function_signatures: self.data.completion_fullFunctionSignatures_enable,
             callable: match self.data.completion_callable_snippets {
                 CallableCompletionDef::FillArguments => Some(CallableSnippets::FillArguments),
                 CallableCompletionDef::AddParentheses => Some(CallableSnippets::AddParentheses),

--- a/crates/rust-analyzer/src/integrated_benchmarks.rs
+++ b/crates/rust-analyzer/src/integrated_benchmarks.rs
@@ -134,6 +134,7 @@ fn integrated_completion_benchmark() {
             enable_imports_on_the_fly: true,
             enable_self_on_the_fly: true,
             enable_private_editable: true,
+            full_function_signatures: false,
             callable: Some(CallableSnippets::FillArguments),
             snippet_cap: SnippetCap::new(true),
             insert_use: InsertUseConfig {
@@ -173,6 +174,7 @@ fn integrated_completion_benchmark() {
             enable_imports_on_the_fly: true,
             enable_self_on_the_fly: true,
             enable_private_editable: true,
+            full_function_signatures: false,
             callable: Some(CallableSnippets::FillArguments),
             snippet_cap: SnippetCap::new(true),
             insert_use: InsertUseConfig {

--- a/docs/user/generated_config.adoc
+++ b/docs/user/generated_config.adoc
@@ -244,6 +244,11 @@ with `self` prefixed to them when inside a method.
 --
 Whether to add parenthesis and argument snippets when completing function.
 --
+[[rust-analyzer.completion.fullFunctionSignatures.enable]]rust-analyzer.completion.fullFunctionSignatures.enable (default: `false`)::
++
+--
+Whether to show full function/method signatures in completion docs.
+--
 [[rust-analyzer.completion.limit]]rust-analyzer.completion.limit (default: `null`)::
 +
 --

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -799,6 +799,11 @@
                         "Do no snippet completions for callables."
                     ]
                 },
+                "rust-analyzer.completion.fullFunctionSignatures.enable": {
+                    "markdownDescription": "Whether to show full function/method signatures in completion docs.",
+                    "default": false,
+                    "type": "boolean"
+                },
                 "rust-analyzer.completion.limit": {
                     "markdownDescription": "Maximum number of completions to return. If `None`, the limit is infinite.",
                     "default": null,


### PR DESCRIPTION
implements #15538 

with `"rust-analyzer.completion.fullFunctionSignatures.enable": false`:
![image](https://github.com/rust-lang/rust-analyzer/assets/59714841/ff739ad1-9975-461f-a62d-22c7823e7b71)

with `"rust-analyzer.completion.fullFunctionSignatures.enable": true`:
![image](https://github.com/rust-lang/rust-analyzer/assets/59714841/9bc98300-cef6-44ef-a353-dcf35cd36fce)
