### PR TITLE
fix: ensure `rustfmt` runs when configured with `./`

### DIFF
--- a/crates/rust-analyzer/src/handlers/request.rs
+++ b/crates/rust-analyzer/src/handlers/request.rs
@@ -1997,41 +1997,13 @@ fn run_rustfmt(
         }
         RustfmtConfig::CustomCommand { command, args } => {
             let cmd = PathBuf::from(&command);
-            let mut components = cmd.components();
-
-            // to support rustc's suggested, default configuration
-            let mut cmd = match components.next() {
-                Some(std::path::Component::CurDir) => {
-                    let rest = components.as_path();
-
-                    let roots = snap
-                        .workspaces
-                        .iter()
-                        .flat_map(|ws| ws.workspace_definition_path())
-                        .collect::<Vec<&AbsPath>>();
-
-                    let abs: Option<AbsPathBuf> = roots.into_iter().find_map(|base| {
-                        let abs = base.join(rest);
-                        std::fs::metadata(&abs).ok().map(|_| abs)
-                    });
-
-                    let command = match abs {
-                        Some(cmd) => cmd,
-                        None => {
-                            tracing::error!(
-                                rustfmt = ?command,
-                                "Unable to make the format command an absolute path"
-                            );
-                            anyhow::bail!(
-                                "Unable to make the format command an absolute path: {}",
-                                command
-                            );
-                        }
-                    };
-
-                    process::Command::new(&command.as_os_str())
+            let workspace = CargoTargetSpec::for_file(&snap, file_id)?;
+            let mut cmd = match workspace {
+                Some(spec) => {
+                    let cmd = spec.workspace_root.join(cmd);
+                    process::Command::new(cmd.as_os_str())
                 }
-                _ => process::Command::new(command),
+                None => process::Command::new(cmd),
             };
 
             cmd.envs(snap.config.extra_env());


### PR DESCRIPTION
(Hopefully) resolves https://github.com/rust-lang/rust-analyzer/issues/15595. This change kinda approaches canonicalization—which I am not a fan of—but only in service of making `./`-configured commands run correctly.

Longer-term, I feel like this code should be removed once `rustfmt` supports recursive searches of configuration files or interpolation of values like `${workspace_folder}` lands in rust-analyzer.

## Testing

I cloned `rustc`, setup rust-analyzer as suggested in the [`rustc` dev guide](https://rustc-dev-guide.rust-lang.org/building/suggested.html#configuring-rust-analyzer-for-rustc), saved and formatted files in `src/tools/miri` and `compiler`, and saw `rustfmt` (seemingly) correctly.