### PR TITLE
scip: Allow customizing cargo config.

### DIFF
--- a/crates/rust-analyzer/src/cli/flags.rs
+++ b/crates/rust-analyzer/src/cli/flags.rs
@@ -131,6 +131,9 @@ xflags::xflags! {
 
             /// The output path where the SCIP file will be written to. Defaults to `index.scip`.
             optional --output path: PathBuf
+
+            /// A path to an json configuration file that can be used to customize cargo behavior.
+            optional --config-path config_path: PathBuf
         }
     }
 }
@@ -239,6 +242,7 @@ pub struct Scip {
     pub path: PathBuf,
 
     pub output: Option<PathBuf>,
+    pub config_path: Option<PathBuf>,
 }
 
 impl RustAnalyzer {

--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -766,6 +766,8 @@ impl fmt::Display for ConfigError {
     }
 }
 
+impl std::error::Error for ConfigError {}
+
 impl Config {
     pub fn new(
         root_path: AbsPathBuf,


### PR DESCRIPTION
Re-use the LSP config json for simplicity.