### PR TITLE
Show which roots are being scanned in progress messages

### DIFF
--- a/crates/load-cargo/src/lib.rs
+++ b/crates/load-cargo/src/lib.rs
@@ -317,7 +317,7 @@ fn load_crate_graph(
     // wait until Vfs has loaded all roots
     for task in receiver {
         match task {
-            vfs::loader::Message::Progress { n_done, n_total, config_version: _ } => {
+            vfs::loader::Message::Progress { n_done, n_total, .. } => {
                 if n_done == n_total {
                     break;
                 }

--- a/crates/rust-analyzer/src/main_loop.rs
+++ b/crates/rust-analyzer/src/main_loop.rs
@@ -586,7 +586,7 @@ impl GlobalState {
                     }
                 }
             }
-            vfs::loader::Message::Progress { n_total, n_done, config_version } => {
+            vfs::loader::Message::Progress { n_total, n_done, file, config_version } => {
                 always!(config_version <= self.vfs_config_version);
 
                 self.vfs_progress_config_version = config_version;
@@ -601,10 +601,23 @@ impl GlobalState {
                     assert_eq!(n_done, n_total);
                     Progress::End
                 };
+
+                let mut message = format!("{n_done}/{n_total}");
+                if let Some(file) = file {
+                    message += &format!(
+                        ": {}",
+                        match file.strip_prefix(&self.config.root_path()) {
+                            Some(relative_path) => relative_path.as_ref(),
+                            None => file.as_ref(),
+                        }
+                        .display()
+                    );
+                }
+
                 self.report_progress(
                     "Roots Scanned",
                     state,
-                    Some(format!("{n_done}/{n_total}")),
+                    Some(message),
                     Some(Progress::fraction(n_done, n_total)),
                     None,
                 );

--- a/crates/rust-analyzer/src/main_loop.rs
+++ b/crates/rust-analyzer/src/main_loop.rs
@@ -586,7 +586,7 @@ impl GlobalState {
                     }
                 }
             }
-            vfs::loader::Message::Progress { n_total, n_done, file, config_version } => {
+            vfs::loader::Message::Progress { n_total, n_done, dir, config_version } => {
                 always!(config_version <= self.vfs_config_version);
 
                 self.vfs_progress_config_version = config_version;
@@ -603,12 +603,12 @@ impl GlobalState {
                 };
 
                 let mut message = format!("{n_done}/{n_total}");
-                if let Some(file) = file {
+                if let Some(dir) = dir {
                     message += &format!(
                         ": {}",
-                        match file.strip_prefix(&self.config.root_path()) {
+                        match dir.strip_prefix(&self.config.root_path()) {
                             Some(relative_path) => relative_path.as_ref(),
-                            None => file.as_ref(),
+                            None => dir.as_ref(),
                         }
                         .display()
                     );

--- a/crates/vfs-notify/src/lib.rs
+++ b/crates/vfs-notify/src/lib.rs
@@ -107,18 +107,12 @@ impl NotifyActor {
                             n_total,
                             n_done: 0,
                             config_version,
-                            file: None,
+                            dir: None,
                         });
 
                         self.watched_entries.clear();
 
                         for (i, entry) in config.load.into_iter().enumerate() {
-                            self.send(loader::Message::Progress {
-                                n_total,
-                                n_done: i,
-                                config_version,
-                                file: None,
-                            });
                             let watch = config.watch.contains(&i);
                             if watch {
                                 self.watched_entries.push(entry.clone());
@@ -127,7 +121,7 @@ impl NotifyActor {
                                 self.load_entry(entry, watch, |file| loader::Message::Progress {
                                     n_total,
                                     n_done: i,
-                                    file: Some(file),
+                                    dir: Some(file),
                                     config_version,
                                 });
                             self.send(loader::Message::Loaded { files });
@@ -135,7 +129,7 @@ impl NotifyActor {
                                 n_total,
                                 n_done: i + 1,
                                 config_version,
-                                file: None,
+                                dir: None,
                             });
                         }
                     }

--- a/crates/vfs/src/loader.rs
+++ b/crates/vfs/src/loader.rs
@@ -53,8 +53,8 @@ pub enum Message {
         n_total: usize,
         /// The files that have been loaded successfully.
         n_done: usize,
-        /// The file being loaded, if any.
-        file: Option<AbsPathBuf>,
+        /// The dir being loaded, `None` if its for a file.
+        dir: Option<AbsPathBuf>,
         /// The [`Config`] version.
         config_version: u32,
     },
@@ -213,11 +213,11 @@ impl fmt::Debug for Message {
             Message::Changed { files } => {
                 f.debug_struct("Changed").field("n_files", &files.len()).finish()
             }
-            Message::Progress { n_total, n_done, file, config_version } => f
+            Message::Progress { n_total, n_done, dir, config_version } => f
                 .debug_struct("Progress")
                 .field("n_total", n_total)
                 .field("n_done", n_done)
-                .field("file", file)
+                .field("dir", dir)
                 .field("config_version", config_version)
                 .finish(),
         }

--- a/crates/vfs/src/loader.rs
+++ b/crates/vfs/src/loader.rs
@@ -48,7 +48,16 @@ pub enum Message {
     /// Indicate a gradual progress.
     ///
     /// This is supposed to be the number of loaded files.
-    Progress { n_total: usize, n_done: usize, config_version: u32 },
+    Progress {
+        /// The total files to be loaded.
+        n_total: usize,
+        /// The files that have been loaded successfully.
+        n_done: usize,
+        /// The file being loaded, if any.
+        file: Option<AbsPathBuf>,
+        /// The [`Config`] version.
+        config_version: u32,
+    },
     /// The handle loaded the following files' content.
     Loaded { files: Vec<(AbsPathBuf, Option<Vec<u8>>)> },
     /// The handle loaded the following files' content.
@@ -204,10 +213,11 @@ impl fmt::Debug for Message {
             Message::Changed { files } => {
                 f.debug_struct("Changed").field("n_files", &files.len()).finish()
             }
-            Message::Progress { n_total, n_done, config_version } => f
+            Message::Progress { n_total, n_done, file, config_version } => f
                 .debug_struct("Progress")
                 .field("n_total", n_total)
                 .field("n_done", n_done)
+                .field("file", file)
                 .field("config_version", config_version)
                 .finish(),
         }


### PR DESCRIPTION
This changes the `Roots Scanned` message to include the directory being scanned.

Before: `Roots Scanned 206/210 (98%)`
After: `Roots Scanned 206/210: .direnv (98%)`

This makes it a lot easier to tell that `rust-analyzer` isn't crashed, it's just trying to scan a huge directory.

See: #12613