### PR TITLE
Properly intern names / symbols

### DIFF
--- a/crates/hir-def/src/attr.rs
+++ b/crates/hir-def/src/attr.rs
@@ -234,7 +234,7 @@ impl Attrs {
                 .iter()
                 .rev()
                 .zip(["core", "prelude", "v1", "test"].iter().rev())
-                .all(|it| it.0.as_str() == Some(it.1))
+                .all(|(name, path_segment)| name.as_str() == *path_segment)
         })
     }
 
@@ -604,7 +604,7 @@ impl<'attr> AttrQuery<'attr> {
         let key = self.key;
         self.attrs
             .iter()
-            .filter(move |attr| attr.path.as_ident().map_or(false, |s| s.to_smol_str() == key))
+            .filter(move |attr| attr.path.as_ident().map_or(false, |s| s.as_str() == key))
     }
 
     /// Find string value for a specific key inside token tree

--- a/crates/hir-def/src/body/scope.rs
+++ b/crates/hir-def/src/body/scope.rs
@@ -316,7 +316,7 @@ mod tests {
         let actual = scopes
             .scope_chain(scope)
             .flat_map(|scope| scopes.entries(scope))
-            .map(|it| it.name().to_smol_str())
+            .map(|it| it.name().as_str())
             .collect::<Vec<_>>()
             .join("\n");
         let expected = expected.join("\n");

--- a/crates/hir-def/src/data.rs
+++ b/crates/hir-def/src/data.rs
@@ -502,6 +502,7 @@ impl ExternCrateDeclData {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ConstData {
     /// `None` for `const _: () = ();`
+    // FIXME: Consider making this required, using interned `_` as the name
     pub name: Option<Name>,
     pub type_ref: Interned<TypeRef>,
     pub visibility: RawVisibility,

--- a/crates/hir-def/src/db.rs
+++ b/crates/hir-def/src/db.rs
@@ -276,9 +276,9 @@ fn crate_supports_no_std(db: &dyn DefDatabase, crate_id: CrateId) -> bool {
     let item_tree = db.file_item_tree(file.into());
     let attrs = item_tree.raw_attrs(AttrOwner::TopLevel);
     for attr in &**attrs {
-        match attr.path().as_ident().and_then(|id| id.as_text()) {
-            Some(ident) if ident == "no_std" => return true,
-            Some(ident) if ident == "cfg_attr" => {}
+        match attr.path().as_ident().map(|id| id.as_str()) {
+            Some("no_std") => return true,
+            Some("cfg_attr") => {}
             _ => continue,
         }
 

--- a/crates/hir-def/src/import_map.rs
+++ b/crates/hir-def/src/import_map.rs
@@ -64,7 +64,7 @@ impl ImportMap {
         let mut importables: Vec<_> = map
             .iter()
             // We've only collected items, whose name cannot be tuple field.
-            .map(|(&item, info)| (item, info.name.as_str().unwrap().to_ascii_lowercase()))
+            .map(|(&item, info)| (item, info.name.as_str().to_ascii_lowercase()))
             .collect();
         importables.sort_by(|(_, lhs_name), (_, rhs_name)| lhs_name.cmp(rhs_name));
 
@@ -410,8 +410,7 @@ pub fn search_dependencies(
             }
 
             // Name shared by the importable items in this group.
-            let common_importable_name =
-                common_importable_data.name.to_smol_str().to_ascii_lowercase();
+            let common_importable_name = common_importable_data.name.as_str().to_ascii_lowercase();
             // Add the items from this name group. Those are all subsequent items in
             // `importables` whose name match `common_importable_name`.
             let iter = importables
@@ -419,7 +418,7 @@ pub fn search_dependencies(
                 .copied()
                 .take_while(|item| {
                     common_importable_name
-                        == import_map.map[item].name.to_smol_str().to_ascii_lowercase()
+                        == import_map.map[item].name.as_str().to_ascii_lowercase()
                 })
                 .filter(|item| {
                     !query.case_sensitive // we've already checked the common importables name case-insensitively

--- a/crates/hir-def/src/lang_item.rs
+++ b/crates/hir-def/src/lang_item.rs
@@ -234,7 +234,7 @@ macro_rules! language_item_table {
 impl LangItem {
     /// Opposite of [`LangItem::name`]
     pub fn from_name(name: &hir_expand::name::Name) -> Option<Self> {
-        Self::from_str(name.as_str()?)
+        Self::from_str(name.as_str())
     }
 
     pub fn path(&self, db: &dyn DefDatabase, start_crate: CrateId) -> Option<Path> {

--- a/crates/hir-def/src/lib.rs
+++ b/crates/hir-def/src/lib.rs
@@ -745,7 +745,7 @@ impl GeneralConstId {
                 .const_data(const_id)
                 .name
                 .as_ref()
-                .and_then(|it| it.as_str())
+                .map(|it| it.as_str())
                 .unwrap_or("_")
                 .to_owned(),
             GeneralConstId::ConstBlockId(id) => format!("{{anonymous const {id:?}}}"),

--- a/crates/hir-def/src/nameres/attr_resolution.rs
+++ b/crates/hir-def/src/nameres/attr_resolution.rs
@@ -75,8 +75,8 @@ impl DefMap {
         let segments = path.segments();
 
         if let Some(name) = segments.first() {
-            let name = name.to_smol_str();
-            let pred = |n: &_| *n == name;
+            let name = name.as_str();
+            let pred = |n: &_| n == name;
 
             let registered = self.data.registered_tools.iter().map(SmolStr::as_str);
             let is_tool = TOOL_MODULES.iter().copied().chain(registered).any(pred);

--- a/crates/hir-def/src/nameres/collector.rs
+++ b/crates/hir-def/src/nameres/collector.rs
@@ -309,7 +309,7 @@ impl DefCollector<'_> {
                 continue;
             }
 
-            if attr_name.as_text().as_deref() == Some("rustc_coherence_is_core") {
+            if attr_name.as_str() == "rustc_coherence_is_core" {
                 crate_data.rustc_coherence_is_core = true;
                 continue;
             }

--- a/crates/hir-def/src/path.rs
+++ b/crates/hir-def/src/path.rs
@@ -29,7 +29,7 @@ impl Display for ImportAlias {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             ImportAlias::Underscore => f.write_str("_"),
-            ImportAlias::Alias(name) => f.write_str(&name.to_smol_str()),
+            ImportAlias::Alias(name) => f.write_str(name.as_str()),
         }
     }
 }

--- a/crates/hir-ty/src/infer/closure.rs
+++ b/crates/hir-ty/src/infer/closure.rs
@@ -192,11 +192,7 @@ impl CapturedItem {
                     }
                     let variant_data = f.parent.variant_data(db.upcast());
                     let field = match &*variant_data {
-                        VariantData::Record(fields) => fields[f.local_id]
-                            .name
-                            .as_str()
-                            .unwrap_or("[missing field]")
-                            .to_string(),
+                        VariantData::Record(fields) => fields[f.local_id].name.as_str().to_string(),
                         VariantData::Tuple(fields) => fields
                             .iter()
                             .position(|it| it.0 == f.local_id)

--- a/crates/hir-ty/src/mir/eval.rs
+++ b/crates/hir-ty/src/mir/eval.rs
@@ -2475,10 +2475,7 @@ impl Evaluator<'_> {
         let static_data = self.db.static_data(st);
         let result = if !static_data.is_extern {
             let konst = self.db.const_eval_static(st).map_err(|e| {
-                MirEvalError::ConstEvalError(
-                    static_data.name.as_str().unwrap_or("_").to_owned(),
-                    Box::new(e),
-                )
+                MirEvalError::ConstEvalError(static_data.name.as_str().to_owned(), Box::new(e))
             })?;
             self.allocate_const_in_heap(locals, &konst)?
         } else {

--- a/crates/hir-ty/src/mir/eval/shim.rs
+++ b/crates/hir-ty/src/mir/eval/shim.rs
@@ -56,7 +56,7 @@ impl Evaluator<'_> {
         };
         if is_intrinsic {
             self.exec_intrinsic(
-                function_data.name.as_text().unwrap_or_default().as_str(),
+                function_data.name.as_str(),
                 args,
                 generic_args,
                 destination,
@@ -78,7 +78,7 @@ impl Evaluator<'_> {
         };
         if is_platform_intrinsic {
             self.exec_platform_intrinsic(
-                function_data.name.as_text().unwrap_or_default().as_str(),
+                function_data.name.as_str(),
                 args,
                 generic_args,
                 destination,
@@ -96,7 +96,7 @@ impl Evaluator<'_> {
         };
         if is_extern_c {
             self.exec_extern_c(
-                function_data.name.as_text().unwrap_or_default().as_str(),
+                function_data.name.as_str(),
                 args,
                 generic_args,
                 destination,
@@ -109,7 +109,7 @@ impl Evaluator<'_> {
             .attrs
             .iter()
             .filter_map(|it| it.path().as_ident())
-            .filter_map(|it| it.as_str())
+            .map(|it| it.as_str())
             .find(|it| {
                 [
                     "rustc_allocator",

--- a/crates/hir-ty/src/mir/lower.rs
+++ b/crates/hir-ty/src/mir/lower.rs
@@ -1099,9 +1099,9 @@ impl<'ctx> MirLowerCtx<'ctx> {
                             .iter()
                             .map(|it| {
                                 let o = match it.1.name.as_str() {
-                                    Some("start") => lp.take(),
-                                    Some("end") => rp.take(),
-                                    Some("exhausted") => {
+                                    "start" => lp.take(),
+                                    "end" => rp.take(),
+                                    "exhausted" => {
                                         Some(Operand::from_bytes(vec![0], TyBuilder::bool()))
                                     }
                                     _ => None,

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -1723,7 +1723,7 @@ impl DefWithBody {
                         }
                         (mir::MutabilityReason::Not, true) => {
                             if !infer.mutated_bindings_in_closure.contains(&binding_id) {
-                                let should_ignore = matches!(body[binding_id].name.as_str(), Some(it) if it.starts_with("_"));
+                                let should_ignore = body[binding_id].name.as_str().starts_with("_");
                                 if !should_ignore {
                                     acc.push(UnusedMut { local }.into())
                                 }

--- a/crates/hir/src/symbols.rs
+++ b/crates/hir/src/symbols.rs
@@ -244,7 +244,7 @@ impl<'a> SymbolCollector<'a> {
 
     fn collect_from_trait(&mut self, trait_id: TraitId) {
         let trait_data = self.db.trait_data(trait_id);
-        self.with_container_name(trait_data.name.as_text(), |s| {
+        self.with_container_name(Some(trait_data.name.to_smol_str()), |s| {
             for &(_, assoc_item_id) in &trait_data.items {
                 s.push_assoc_item(assoc_item_id);
             }

--- a/crates/ide-assists/src/handlers/replace_method_eager_lazy.rs
+++ b/crates/ide-assists/src/handlers/replace_method_eager_lazy.rs
@@ -47,7 +47,7 @@ pub(crate) fn replace_with_lazy_method(acc: &mut Assists, ctx: &AssistContext<'_
         None,
         None,
         |func| {
-            let valid = func.name(ctx.sema.db).as_str() == Some(&*method_name_lazy)
+            let valid = func.name(ctx.sema.db).as_str() == &*method_name_lazy
                 && func.num_params(ctx.sema.db) == n_params
                 && {
                     let params = func.params_without_self(ctx.sema.db);
@@ -133,7 +133,7 @@ pub(crate) fn replace_with_eager_method(acc: &mut Assists, ctx: &AssistContext<'
         None,
         None,
         |func| {
-            let valid = func.name(ctx.sema.db).as_str() == Some(&*method_name_eager)
+            let valid = func.name(ctx.sema.db).as_str() == &*method_name_eager
                 && func.num_params(ctx.sema.db) == n_params;
             valid.then_some(func)
         },

--- a/crates/ide-completion/src/completions/use_.rs
+++ b/crates/ide-completion/src/completions/use_.rs
@@ -48,16 +48,15 @@ pub(crate) fn complete_use_path(
                     let unknown_is_current = |name: &hir::Name| {
                         matches!(
                             name_ref,
-                            Some(name_ref) if name_ref.syntax().text() == name.to_smol_str().as_str()
+                            Some(name_ref) if name_ref.syntax().text() == name.as_str()
                         )
                     };
                     for (name, def) in module_scope {
                         if !ctx.check_stability(def.attrs(ctx.db).as_deref()) {
                             continue;
                         }
-                        let is_name_already_imported = name
-                            .as_text()
-                            .map_or(false, |text| already_imported_names.contains(text.as_str()));
+                        let is_name_already_imported =
+                            already_imported_names.contains(name.as_str());
 
                         let add_resolution = match def {
                             ScopeDef::Unknown if unknown_is_current(&name) => {

--- a/crates/ide-completion/src/context/analysis.rs
+++ b/crates/ide-completion/src/context/analysis.rs
@@ -755,13 +755,13 @@ fn classify_name_ref(
                                             for item in trait_.items_with_supertraits(sema.db) {
                                                 match item {
                                                     hir::AssocItem::TypeAlias(assoc_ty) => {
-                                                        if assoc_ty.name(sema.db).as_str()? == arg_name {
+                                                        if assoc_ty.name(sema.db).as_str() == arg_name {
                                                             override_location = Some(TypeLocation::AssocTypeEq);
                                                             return None;
                                                         }
                                                     },
                                                     hir::AssocItem::Const(const_) => {
-                                                        if const_.name(sema.db)?.as_str()? == arg_name {
+                                                        if const_.name(sema.db)?.as_str() == arg_name {
                                                             override_location =  Some(TypeLocation::AssocConstEq);
                                                             return None;
                                                         }
@@ -800,7 +800,7 @@ fn classify_name_ref(
                                         let trait_items = trait_.items_with_supertraits(sema.db);
                                         let assoc_ty = trait_items.iter().find_map(|item| match item {
                                             hir::AssocItem::TypeAlias(assoc_ty) => {
-                                                (assoc_ty.name(sema.db).as_str()? == arg_name)
+                                                (assoc_ty.name(sema.db).as_str() == arg_name)
                                                     .then_some(assoc_ty)
                                             },
                                             _ => None,

--- a/crates/ide-completion/src/render/function.rs
+++ b/crates/ide-completion/src/render/function.rs
@@ -186,11 +186,9 @@ pub(super) fn add_call_parens<'b>(
                         None => {
                             let name = match param.ty().as_adt() {
                                 None => "_".to_string(),
-                                Some(adt) => adt
-                                    .name(ctx.db)
-                                    .as_text()
-                                    .map(|s| to_lower_snake_case(s.as_str()))
-                                    .unwrap_or_else(|| "_".to_string()),
+                                Some(adt) => {
+                                    to_lower_snake_case(adt.name(ctx.db).to_smol_str().as_str())
+                                }
                             };
                             f(&format_args!("${{{}:{name}}}", index + offset))
                         }
@@ -223,7 +221,7 @@ pub(super) fn add_call_parens<'b>(
 fn ref_of_param(ctx: &CompletionContext<'_>, arg: &str, ty: &hir::Type) -> &'static str {
     if let Some(derefed_ty) = ty.remove_ref() {
         for (name, local) in ctx.locals.iter() {
-            if name.as_text().as_deref() == Some(arg) {
+            if name.as_str() == arg {
                 return if local.ty(ctx.db) == derefed_ty {
                     if ty.is_mutable_reference() {
                         "&mut "

--- a/crates/ide-db/src/path_transform.rs
+++ b/crates/ide-db/src/path_transform.rs
@@ -389,7 +389,7 @@ fn find_trait_for_assoc_item(
         });
 
         for name in names {
-            if assoc_item_name.as_str() == name.as_text()?.as_str() {
+            if assoc_item_name.as_str() == name.as_str() {
                 // It is fine to return the first match because in case of
                 // multiple possibilities, the exact trait must be disambiguated
                 // in the definition of trait being implemented, so this search

--- a/crates/ide/src/view_memory_layout.rs
+++ b/crates/ide/src/view_memory_layout.rs
@@ -63,11 +63,7 @@ enum FieldOrTupleIdx {
 impl FieldOrTupleIdx {
     fn name(&self, db: &RootDatabase) -> String {
         match *self {
-            FieldOrTupleIdx::Field(f) => f
-                .name(db)
-                .as_str()
-                .map(|s| s.to_owned())
-                .unwrap_or_else(|| format!(".{}", f.name(db).as_tuple_index().unwrap())),
+            FieldOrTupleIdx::Field(f) => f.name(db).as_str().to_owned(),
             FieldOrTupleIdx::TupleIdx(i) => format!(".{i}").to_owned(),
         }
     }
@@ -189,14 +185,7 @@ pub(crate) fn view_memory_layout(
                 | Definition::SelfType(_) => "[ROOT]".to_owned(),
 
                 // def is an item
-                def => def
-                    .name(db)
-                    .map(|n| {
-                        n.as_str()
-                            .map(|s| s.to_owned())
-                            .unwrap_or_else(|| format!(".{}", n.as_tuple_index().unwrap()))
-                    })
-                    .unwrap_or("[ROOT]".to_owned()),
+                def => def.name(db).map(|n| n.as_str().to_owned()).unwrap_or("[ROOT]".to_owned()),
             };
 
             let typename = ty.display(db).to_string();


### PR DESCRIPTION
Rough idea will be to do arc based interning, storing the interner in salsa for deduplication as well as pre-allocating the known symbols, Then maybe use pointer tagging for a bit of perf improvements for handling known symbols better, though probably not worth it.

cc https://github.com/rust-lang/rust-analyzer/issues/15590