### PR TITLE
minor: hover_simple refactor

### DIFF
--- a/crates/base-db/src/input.rs
+++ b/crates/base-db/src/input.rs
@@ -257,6 +257,7 @@ pub trait ProcMacroExpander: fmt::Debug + Send + Sync + RefUnwindSafe {
     ) -> Result<Subtree, ProcMacroExpansionError>;
 }
 
+#[derive(Debug)]
 pub enum ProcMacroExpansionError {
     Panic(String),
     /// Things like "proc macro server was killed by OOM".

--- a/crates/ide-db/src/defs.rs
+++ b/crates/ide-db/src/defs.rs
@@ -161,8 +161,8 @@ impl IdentClass {
                 ast::AwaitExpr(await_expr) => OperatorClass::classify_await(sema, &await_expr).map(IdentClass::Operator),
                 ast::BinExpr(bin_expr) => OperatorClass::classify_bin(sema, &bin_expr).map(IdentClass::Operator),
                 ast::IndexExpr(index_expr) => OperatorClass::classify_index(sema, &index_expr).map(IdentClass::Operator),
-                ast::PrefixExpr(prefix_expr) => OperatorClass::classify_prefix(sema,&prefix_expr).map(IdentClass::Operator),
-                ast::TryExpr(try_expr) => OperatorClass::classify_try(sema,&try_expr).map(IdentClass::Operator),
+                ast::PrefixExpr(prefix_expr) => OperatorClass::classify_prefix(sema, &prefix_expr).map(IdentClass::Operator),
+                ast::TryExpr(try_expr) => OperatorClass::classify_try(sema, &try_expr).map(IdentClass::Operator),
                 _ => None,
             }
         }


### PR DESCRIPTION
A minor refactor of `hover_simple` opportunity I noticed while skimming through the code.

- `if let`s -> `match`
- `iter::once(x).cycle` -> `iter::repeat`
- `classify_token` -> `classify_node`