### PR TITLE
feat: add backtick to surrounding and auto-closing pairs

### DIFF
--- a/editors/code/language-configuration.json
+++ b/editors/code/language-configuration.json
@@ -18,7 +18,8 @@
         { "open": "[", "close": "]" },
         { "open": "(", "close": ")" },
         { "open": "\"", "close": "\"", "notIn": ["string"] },
-        { "open": "/*", "close": " */" }
+        { "open": "/*", "close": " */" },
+        { "open": "`", "close": "`", "notIn": ["string"] }
     ],
     "autoCloseBefore": ";:.,=}])> \n\t",
     "surroundingPairs": [
@@ -27,7 +28,8 @@
         ["(", ")"],
         ["<", ">"],
         ["\"", "\""],
-        ["'", "'"]
+        ["'", "'"],
+        ["`", "`"]
     ],
     "indentationRules": {
         "increaseIndentPattern": "^.*\\{[^}\"']*$|^.*\\([^\\)\"']*$",


### PR DESCRIPTION
Makes backticks always complete as a pair and also surround the current selection, similar to double quotes. This is useful primarily in the context of markdown doc comments, but is applied globally for simplicity.

Closes https://github.com/rust-lang/rust-analyzer/issues/11381