### PR TITLE
Allocate ast ids for parameters

### DIFF
--- a/crates/hir-def/src/data.rs
+++ b/crates/hir-def/src/data.rs
@@ -15,9 +15,7 @@ use crate::{
     attr::Attrs,
     db::DefDatabase,
     expander::{Expander, Mark},
-    item_tree::{
-        self, AssocItem, FnFlags, ItemTree, ItemTreeId, MacroCall, ModItem, Param, TreeId,
-    },
+    item_tree::{self, AssocItem, FnFlags, ItemTree, ItemTreeId, MacroCall, ModItem, TreeId},
     macro_call_as_call_id, macro_id_to_def_id,
     nameres::{
         attr_resolution::ResolvedAttr,
@@ -69,7 +67,7 @@ impl FunctionData {
         let is_varargs = enabled_params
             .clone()
             .next_back()
-            .map_or(false, |param| matches!(item_tree[param], Param::Varargs));
+            .map_or(false, |param| item_tree[param].type_ref.is_none());
 
         let mut flags = func.flags;
         if is_varargs {
@@ -105,10 +103,7 @@ impl FunctionData {
             name: func.name.clone(),
             params: enabled_params
                 .clone()
-                .filter_map(|id| match &item_tree[id] {
-                    Param::Normal(ty) => Some(ty.clone()),
-                    Param::Varargs => None,
-                })
+                .filter_map(|id| item_tree[id].type_ref.clone())
                 .collect(),
             ret_type: func.ret_type.clone(),
             attrs: item_tree.attrs(db, krate, ModItem::from(loc.id.value).into()),

--- a/crates/hir-def/src/item_tree.rs
+++ b/crates/hir-def/src/item_tree.rs
@@ -613,10 +613,17 @@ pub struct Function {
     pub(crate) flags: FnFlags,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq)]
-pub enum Param {
-    Normal(Interned<TypeRef>),
-    Varargs,
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Param {
+    /// This is [`None`] for varargs
+    pub type_ref: Option<Interned<TypeRef>>,
+    pub ast_id: ParamAstId,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ParamAstId {
+    Param(FileAstId<ast::Param>),
+    SelfParam(FileAstId<ast::SelfParam>),
 }
 
 bitflags::bitflags! {

--- a/crates/hir-def/src/item_tree/pretty.rs
+++ b/crates/hir-def/src/item_tree/pretty.rs
@@ -261,15 +261,15 @@ impl Printer<'_> {
                     self.indented(|this| {
                         for param in params.clone() {
                             this.print_attrs_of(param, "\n");
-                            match &this.tree[param] {
-                                Param::Normal(ty) => {
+                            match &this.tree[param].type_ref {
+                                Some(ty) => {
                                     if flags.contains(FnFlags::HAS_SELF_PARAM) {
                                         w!(this, "self: ");
                                     }
                                     this.print_type_ref(ty);
                                     wln!(this, ",");
                                 }
-                                Param::Varargs => {
+                                None => {
                                     wln!(this, "...");
                                 }
                             };

--- a/crates/hir-expand/src/ast_id_map.rs
+++ b/crates/hir-expand/src/ast_id_map.rs
@@ -99,7 +99,7 @@ register_ast_id_node! {
         TraitAlias,
         TypeAlias,
         Use,
-    AssocItem, BlockExpr, Variant, RecordField, TupleField, ConstArg
+    AssocItem, BlockExpr, Variant, RecordField, TupleField, ConstArg, Param, SelfParam
 }
 
 /// Maps items' `SyntaxNode`s to `ErasedFileAstId`s and back.


### PR DESCRIPTION
Since these can have attributes attached to them, we'll need this sooner or later (sooner being me tinkering with the token map right now)