### PR TITLE
Add config option to use `rust-analyzer` specific target dir

### DIFF
--- a/crates/flycheck/src/lib.rs
+++ b/crates/flycheck/src/lib.rs
@@ -50,6 +50,7 @@ pub enum FlycheckConfig {
         extra_args: Vec<String>,
         extra_env: FxHashMap<String, String>,
         ansi_color_output: bool,
+        target_dir: Option<PathBuf>,
     },
     CustomCommand {
         command: String,
@@ -308,6 +309,7 @@ impl FlycheckActor {
                 features,
                 extra_env,
                 ansi_color_output,
+                target_dir,
             } => {
                 let mut cmd = Command::new(toolchain::cargo());
                 cmd.arg(command);
@@ -339,6 +341,9 @@ impl FlycheckActor {
                         cmd.arg("--features");
                         cmd.arg(features.join(" "));
                     }
+                }
+                if let Some(target_dir) = target_dir {
+                    cmd.arg("--target-dir").arg(target_dir);
                 }
                 cmd.envs(extra_env);
                 (cmd, extra_args)

--- a/crates/flycheck/src/lib.rs
+++ b/crates/flycheck/src/lib.rs
@@ -58,6 +58,7 @@ pub enum FlycheckConfig {
         extra_env: FxHashMap<String, String>,
         invocation_strategy: InvocationStrategy,
         invocation_location: InvocationLocation,
+        target_dir: Option<PathBuf>,
     },
 }
 
@@ -354,9 +355,14 @@ impl FlycheckActor {
                 extra_env,
                 invocation_strategy,
                 invocation_location,
+                target_dir,
             } => {
                 let mut cmd = Command::new(command);
                 cmd.envs(extra_env);
+
+                if let Some(target_dir) = target_dir {
+                    cmd.env("CARGO_TARGET_DIR", target_dir);
+                }
 
                 match invocation_location {
                     InvocationLocation::Workspace => {

--- a/crates/flycheck/src/lib.rs
+++ b/crates/flycheck/src/lib.rs
@@ -360,10 +360,6 @@ impl FlycheckActor {
                 let mut cmd = Command::new(command);
                 cmd.envs(extra_env);
 
-                if let Some(target_dir) = target_dir {
-                    cmd.env("CARGO_TARGET_DIR", target_dir);
-                }
-
                 match invocation_location {
                     InvocationLocation::Workspace => {
                         match invocation_strategy {
@@ -379,6 +375,10 @@ impl FlycheckActor {
                     InvocationLocation::Root(root) => {
                         cmd.current_dir(root);
                     }
+                }
+
+                if let Some(target_dir) = target_dir {
+                    cmd.arg("--target-dir").arg(target_dir);
                 }
 
                 (cmd, args)

--- a/crates/flycheck/src/lib.rs
+++ b/crates/flycheck/src/lib.rs
@@ -58,7 +58,6 @@ pub enum FlycheckConfig {
         extra_env: FxHashMap<String, String>,
         invocation_strategy: InvocationStrategy,
         invocation_location: InvocationLocation,
-        target_dir: Option<PathBuf>,
     },
 }
 
@@ -355,7 +354,6 @@ impl FlycheckActor {
                 extra_env,
                 invocation_strategy,
                 invocation_location,
-                target_dir,
             } => {
                 let mut cmd = Command::new(command);
                 cmd.envs(extra_env);
@@ -375,10 +373,6 @@ impl FlycheckActor {
                     InvocationLocation::Root(root) => {
                         cmd.current_dir(root);
                     }
-                }
-
-                if let Some(target_dir) = target_dir {
-                    cmd.arg("--target-dir").arg(target_dir);
                 }
 
                 (cmd, args)

--- a/crates/project-model/src/build_scripts.rs
+++ b/crates/project-model/src/build_scripts.rs
@@ -73,6 +73,10 @@ impl WorkspaceBuildScripts {
                 cmd.args(["check", "--quiet", "--workspace", "--message-format=json"]);
                 cmd.args(&config.extra_args);
 
+                if let Some(target_dir) = &config.target_dir {
+                    cmd.arg("--target-dir").arg(target_dir);
+                }
+
                 // --all-targets includes tests, benches and examples in addition to the
                 // default lib and bins. This is an independent concept from the --target
                 // flag below.

--- a/crates/project-model/src/cargo_workspace.rs
+++ b/crates/project-model/src/cargo_workspace.rs
@@ -96,6 +96,8 @@ pub struct CargoConfig {
     pub extra_env: FxHashMap<String, String>,
     pub invocation_strategy: InvocationStrategy,
     pub invocation_location: InvocationLocation,
+    /// Optional path to use instead of `target` when building
+    pub target_dir: Option<PathBuf>,
 }
 
 pub type Package = Idx<PackageData>;

--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -1289,6 +1289,7 @@ impl Config {
     }
 
     pub fn flycheck(&self) -> FlycheckConfig {
+        let target_dir = self.target_dir_from_config();
         match &self.data.check_overrideCommand {
             Some(args) if !args.is_empty() => {
                 let mut args = args.clone();
@@ -1309,6 +1310,7 @@ impl Config {
                         }
                         InvocationLocation::Workspace => flycheck::InvocationLocation::Workspace,
                     },
+                    target_dir,
                 }
             }
             Some(_) | None => FlycheckConfig::CargoCommand {
@@ -1343,7 +1345,7 @@ impl Config {
                 extra_args: self.check_extra_args(),
                 extra_env: self.check_extra_env(),
                 ansi_color_output: self.color_diagnostic_output(),
-                target_dir: self.target_dir_from_config(),
+                target_dir,
             },
         }
     }

--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -1289,7 +1289,6 @@ impl Config {
     }
 
     pub fn flycheck(&self) -> FlycheckConfig {
-        let target_dir = self.target_dir_from_config();
         match &self.data.check_overrideCommand {
             Some(args) if !args.is_empty() => {
                 let mut args = args.clone();
@@ -1310,7 +1309,6 @@ impl Config {
                         }
                         InvocationLocation::Workspace => flycheck::InvocationLocation::Workspace,
                     },
-                    target_dir,
                 }
             }
             Some(_) | None => FlycheckConfig::CargoCommand {
@@ -1345,7 +1343,7 @@ impl Config {
                 extra_args: self.check_extra_args(),
                 extra_env: self.check_extra_env(),
                 ansi_color_output: self.color_diagnostic_output(),
-                target_dir,
+                target_dir: self.target_dir_from_config(),
             },
         }
     }

--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -484,7 +484,7 @@ config_data! {
         /// This is useful to prevent rust-analyzer's `cargo check` from blocking builds.
         ///
         /// Set to `true` to use a subdirectory of the existing target directory or
-        /// set to a path to use that path.
+        /// set to a path relative to the workspace to use that path.
         rust_analyzerTargetDir: Option<TargetDirectory> = "null",
 
         /// Path to the Cargo.toml of the rust compiler workspace, for usage in rustc_private

--- a/docs/user/generated_config.adoc
+++ b/docs/user/generated_config.adoc
@@ -757,6 +757,15 @@ Command to be executed instead of 'cargo' for runnables.
 Additional arguments to be passed to cargo for runnables such as
 tests or binaries. For example, it may be `--release`.
 --
+[[rust-analyzer.rust.analyzerTargetDir]]rust-analyzer.rust.analyzerTargetDir (default: `null`)::
++
+--
+Optional path to a rust-analyzer specific target directory.
+This is useful to prevent rust-analyzer's `cargo check` from blocking builds.
+
+Set to `true` to use a subdirectory of the existing target directory or
+set to a path to use that path.
+--
 [[rust-analyzer.rustc.source]]rust-analyzer.rustc.source (default: `null`)::
 +
 --

--- a/docs/user/generated_config.adoc
+++ b/docs/user/generated_config.adoc
@@ -761,7 +761,8 @@ tests or binaries. For example, it may be `--release`.
 +
 --
 Optional path to a rust-analyzer specific target directory.
-This is useful to prevent rust-analyzer's `cargo check` from blocking builds.
+This prevents rust-analyzer's `cargo check` from locking the `Cargo.lock`
+at the expense of duplicating build artifacts.
 
 Set to `true` to use a subdirectory of the existing target directory or
 set to a path relative to the workspace to use that path.

--- a/docs/user/generated_config.adoc
+++ b/docs/user/generated_config.adoc
@@ -764,7 +764,7 @@ Optional path to a rust-analyzer specific target directory.
 This is useful to prevent rust-analyzer's `cargo check` from blocking builds.
 
 Set to `true` to use a subdirectory of the existing target directory or
-set to a path to use that path.
+set to a path relative to the workspace to use that path.
 --
 [[rust-analyzer.rustc.source]]rust-analyzer.rustc.source (default: `null`)::
 +

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -1488,6 +1488,21 @@
                         "type": "string"
                     }
                 },
+                "rust-analyzer.rust.analyzerTargetDir": {
+                    "markdownDescription": "Optional path to a rust-analyzer specific target directory.\nThis is useful to prevent rust-analyzer's `cargo check` from blocking builds.\n\nSet to `true` to use a subdirectory of the existing target directory or\nset to a path to use that path.",
+                    "default": null,
+                    "anyOf": [
+                        {
+                            "type": "null"
+                        },
+                        {
+                            "type": "boolean"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ]
+                },
                 "rust-analyzer.rustc.source": {
                     "markdownDescription": "Path to the Cargo.toml of the rust compiler workspace, for usage in rustc_private\nprojects, or \"discover\" to try to automatically find it if the `rustc-dev` component\nis installed.\n\nAny project which uses rust-analyzer with the rustcPrivate\ncrates must set `[package.metadata.rust-analyzer] rustc_private=true` to use it.\n\nThis option does not take effect until rust-analyzer is restarted.",
                     "default": null,

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -1489,7 +1489,7 @@
                     }
                 },
                 "rust-analyzer.rust.analyzerTargetDir": {
-                    "markdownDescription": "Optional path to a rust-analyzer specific target directory.\nThis is useful to prevent rust-analyzer's `cargo check` from blocking builds.\n\nSet to `true` to use a subdirectory of the existing target directory or\nset to a path relative to the workspace to use that path.",
+                    "markdownDescription": "Optional path to a rust-analyzer specific target directory.\nThis prevents rust-analyzer's `cargo check` from locking the `Cargo.lock`\nat the expense of duplicating build artifacts.\n\nSet to `true` to use a subdirectory of the existing target directory or\nset to a path relative to the workspace to use that path.",
                     "default": null,
                     "anyOf": [
                         {

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -1489,7 +1489,7 @@
                     }
                 },
                 "rust-analyzer.rust.analyzerTargetDir": {
-                    "markdownDescription": "Optional path to a rust-analyzer specific target directory.\nThis is useful to prevent rust-analyzer's `cargo check` from blocking builds.\n\nSet to `true` to use a subdirectory of the existing target directory or\nset to a path to use that path.",
+                    "markdownDescription": "Optional path to a rust-analyzer specific target directory.\nThis is useful to prevent rust-analyzer's `cargo check` from blocking builds.\n\nSet to `true` to use a subdirectory of the existing target directory or\nset to a path relative to the workspace to use that path.",
                     "default": null,
                     "anyOf": [
                         {


### PR DESCRIPTION
Adds a Rust Analyzer configuration option to set a custom target directory for builds. This is a workaround for Rust Analyzer blocking debug builds while running `cargo check`. This change should close #6007.

This is my first time contributing to this project, so any feedback regarding best practices that I'm not aware of are greatly appreciated! Thanks to all the maintainers for their hard work on this project and reviewing contributions.