### PR TITLE
Only run tests on linux in pull requests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -84,6 +84,7 @@ jobs:
         run: cargo build --quiet ${{ env.USE_SYSROOT_ABI }}
 
       - name: Test
+        if: matrix.os == 'ubuntu-latest' || github.event_name == 'push'
         run: cargo test ${{ env.USE_SYSROOT_ABI }} -- --nocapture --quiet
 
       - name: Switch to stable toolchain


### PR DESCRIPTION
There is little gain from running them on all platforms, they should almost never fail if the linux one pass and if they do, bors will catch it still.