### PR TITLE
Make rustc_layout_scalar_valid_range attributes work for non-decimal literals

### DIFF
--- a/crates/hir-ty/src/layout/adt.rs
+++ b/crates/hir-ty/src/layout/adt.rs
@@ -119,7 +119,15 @@ fn layout_scalar_valid_range(db: &dyn HirDatabase, def: AdtId) -> (Bound<u128>, 
         let attr = attrs.by_key(name).tt_values();
         for tree in attr {
             if let Some(it) = tree.token_trees.first() {
-                if let Ok(it) = it.to_string().parse() {
+                let text = it.to_string().replace('_', "");
+                let base = match text.as_bytes() {
+                    [b'0', b'x', ..] => 16,
+                    [b'0', b'o', ..] => 8,
+                    [b'0', b'b', ..] => 2,
+                    _ => 10,
+                };
+
+                if let Ok(it) = u128::from_str_radix(&text, base) {
                     return Bound::Included(it);
                 }
             }


### PR DESCRIPTION

Closes https://github.com/rust-lang/rust-analyzer/issues/15687