### PR TITLE
Downgrade `unused_variables` to experimental

### DIFF
--- a/crates/ide-diagnostics/src/handlers/unused_variables.rs
+++ b/crates/ide-diagnostics/src/handlers/unused_variables.rs
@@ -14,6 +14,7 @@ pub(crate) fn unused_variables(
         "unused variable",
         ast,
     )
+    .experimental()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
I feel problems like #15679 are common.