### PR TITLE
Enable Syntax Highlighting for no_test Code Blocks

### DIFF
--- a/crates/ide-db/src/rust_doc.rs
+++ b/crates/ide-db/src/rust_doc.rs
@@ -15,7 +15,7 @@ pub fn is_rust_fence(s: &str) -> bool {
 
     for token in tokens {
         match token {
-            "should_panic" | "no_run" | "ignore" | "allow_fail" => {
+            "should_panic" | "no_run" | "ignore" | "allow_fail" | "no_test" => {
                 seen_rust_tags = !seen_other_tags
             }
             "rust" => seen_rust_tags = true,
@@ -199,5 +199,11 @@ let s = "foo
 ## A second-level heading
 ```"#;
         assert_eq!(format_docs_(comment), "```markdown\n## A second-level heading\n```");
+    }
+
+    #[test]
+    fn test_format_docs_handles_no_test() {
+        let comment = "```no_test\nlet x = 1;\n```";
+        assert_eq!(format_docs_(comment), "```rust\nlet x = 1;\n```");
     }
 }


### PR DESCRIPTION
Syntax highlighting is now enabled for code blocks annotated with `no_test`.

currently:
![image](https://github.com/rust-lang/rust-analyzer/assets/60851042/591e390b-8f94-4fbf-a623-a985e0dc8cc9)

after:
![image](https://github.com/rust-lang/rust-analyzer/assets/60851042/b16bdb4b-f498-4bfb-87e3-606b7c2ab95f)

might address https://github.com/rust-lang/rust/issues/63193 where there are comments about missing code syntax while also not being picked up by doc tests.
