### PR TITLE
feat: vscode: Support opening local documentation if available

### DIFF
--- a/editors/code/src/client.ts
+++ b/editors/code/src/client.ts
@@ -389,6 +389,7 @@ class ExperimentalFeatures implements lc.StaticFeature {
             serverStatusNotification: true,
             colorDiagnosticOutput: true,
             openServerLogs: true,
+            localDocs: true,
             commands: {
                 commands: [
                     "rust-analyzer.runSingle",

--- a/editors/code/src/commands.ts
+++ b/editors/code/src/commands.ts
@@ -950,7 +950,7 @@ export function openDocs(ctx: CtxInit): Cmd {
         const doclink = await client.sendRequest(ra.openDocs, { position, textDocument });
 
         if (doclink != null) {
-            await vscode.commands.executeCommand("vscode.open", vscode.Uri.parse(doclink));
+            await vscode.env.openExternal(vscode.Uri.parse(doclink));
         }
     };
 }

--- a/editors/code/src/lsp_ext.ts
+++ b/editors/code/src/lsp_ext.ts
@@ -135,7 +135,11 @@ export const onEnter = new lc.RequestType<lc.TextDocumentPositionParams, lc.Text
 export const openCargoToml = new lc.RequestType<OpenCargoTomlParams, lc.Location, void>(
     "experimental/openCargoToml",
 );
-export const openDocs = new lc.RequestType<lc.TextDocumentPositionParams, string | void, void>(
+export interface DocsUrls {
+    local: string | void;
+    web: string | void;
+}
+export const openDocs = new lc.RequestType<lc.TextDocumentPositionParams, DocsUrls, void>(
     "experimental/externalDocs",
 );
 export const parentModule = new lc.RequestType<


### PR DESCRIPTION
This PR implements the VS code support for opening local documentation (server side support was already implemented in #14662).

[local_docs.webm](https://github.com/rust-lang/rust-analyzer/assets/9659253/715b84dd-4f14-4ba0-a904-749b847eb3d5)

Displaying local instead of web docs can have many benefits:
- the web version may have different features enabled than locally selected
- the standard library may be a different version than is available online
- the user may not be online and therefore cannot access the web documentation
- the documentation may not be available online at all, for example because it is for a new feature in a library the user is currently developing

If the documentation is not available locally, the extension still falls back to the web version.

Closes #12867.

-----

If my implementation isn't really idiomatic TypeScript: Sorry, I'm not much of a TypeScript developer. I am open to feedback, however.