### PR TITLE
fix: make cursor select at _tmp

### DIFF
--- a/crates/ide-assists/src/handlers/replace_is_method_with_if_let_method.rs
+++ b/crates/ide-assists/src/handlers/replace_is_method_with_if_let_method.rs
@@ -16,7 +16,7 @@ use crate::{AssistContext, AssistId, AssistKind, Assists};
 // ```
 // fn main() {
 //     let x = Some(1);
-//     if let Some(_tmp) = x {}
+//     if let Some(${0:_tmp}) = x {}
 // }
 // ```
 pub(crate) fn replace_is_method_with_if_let_method(
@@ -44,7 +44,7 @@ pub(crate) fn replace_is_method_with_if_let_method(
             };
 
             acc.add(AssistId(assist_id, AssistKind::RefactorRewrite), message, target, |edit| {
-                let replacement = format!("let {}(_tmp) = {}", text, receiver);
+                let replacement = format!("let {}({}) = {}", text, "${0:_tmp}", receiver);
                 edit.replace(target, replacement);
             })
         }
@@ -71,7 +71,7 @@ fn main() {
             r#"
 fn main() {
     let x = Some(1);
-    if let Some(_tmp) = x {}
+    if let Some(${0:_tmp}) = x {}
 }
 "#,
         );
@@ -103,7 +103,7 @@ fn main() {
             r#"
 fn main() {
     let x = Ok(1);
-    if let Ok(_tmp) = x {}
+    if let Ok(${0:_tmp}) = x {}
 }
 "#,
         );

--- a/crates/ide-assists/src/tests/generated.rs
+++ b/crates/ide-assists/src/tests/generated.rs
@@ -2571,7 +2571,7 @@ fn main() {
         r#####"
 fn main() {
     let x = Some(1);
-    if let Some(_tmp) = x {}
+    if let Some(${0:_tmp}) = x {}
 }
 "#####,
     )


### PR DESCRIPTION
Here make cursor select at `_tmp` atuomatically after the assist apply. Refer to [vscode snippet placeholder](https://code.visualstudio.com/docs/editor/userdefinedsnippets#_placeholders).

![cursor_selection](https://github.com/rust-lang/rust-analyzer/assets/71162630/a7866efe-2d54-488b-903e-9df039f34a7e)

following https://github.com/rust-lang/rust-analyzer/pull/15752