### PR TITLE
make mir::ProjectionStore-impls pub-accessible

### DIFF
--- a/crates/hir-ty/src/mir.rs
+++ b/crates/hir-ty/src/mir.rs
@@ -243,16 +243,16 @@ impl Default for ProjectionStore {
 }
 
 impl ProjectionStore {
-    fn shrink_to_fit(&mut self) {
+    pub fn shrink_to_fit(&mut self) {
         self.id_to_proj.shrink_to_fit();
         self.proj_to_id.shrink_to_fit();
     }
 
-    fn intern_if_exist(&self, projection: &[PlaceElem]) -> Option<ProjectionId> {
+    pub fn intern_if_exist(&self, projection: &[PlaceElem]) -> Option<ProjectionId> {
         self.proj_to_id.get(projection).copied()
     }
 
-    fn intern(&mut self, projection: Box<[PlaceElem]>) -> ProjectionId {
+    pub fn intern(&mut self, projection: Box<[PlaceElem]>) -> ProjectionId {
         let new_id = ProjectionId(self.proj_to_id.len() as u32);
         match self.proj_to_id.entry(projection) {
             Entry::Occupied(id) => *id.get(),
@@ -267,13 +267,13 @@ impl ProjectionStore {
 }
 
 impl ProjectionId {
-    const EMPTY: ProjectionId = ProjectionId(0);
+    pub const EMPTY: ProjectionId = ProjectionId(0);
 
-    fn lookup(self, store: &ProjectionStore) -> &[PlaceElem] {
+    pub fn lookup(self, store: &ProjectionStore) -> &[PlaceElem] {
         store.id_to_proj.get(&self).unwrap()
     }
 
-    fn project(self, projection: PlaceElem, store: &mut ProjectionStore) -> ProjectionId {
+    pub fn project(self, projection: PlaceElem, store: &mut ProjectionStore) -> ProjectionId {
         let mut current = self.lookup(store).to_vec();
         current.push(projection);
         store.intern(current.into())


### PR DESCRIPTION
When using RA as a crate the `mir::Place` `projection` is accessible, however there is no way to translate the `ProjectionId` to a `&[PlaceElem]`, as the `ProjectionId::lookup` is private.

Personally, I would only need the `ProjectionId::lookup`-fn to be `pub`, but I don't see any reason why the others should be kept private.. am I missing something @HKalbasi ?

Relates to: https://github.com/rust-lang/rust-analyzer/pull/15575