### PR TITLE
Expand Emacs documentation

### DIFF
--- a/docs/user/manual.adoc
+++ b/docs/user/manual.adoc
@@ -237,13 +237,22 @@ To use `rust-analyzer`, you need to install and enable one of the two popular LS
 
 ==== Eglot
 
-Eglot is the more minimalistic and lightweight LSP client for Emacs, integrates well with existing Emacs functionality and will be built into Emacs starting from release 29.
+Eglot is the more minimalistic and lightweight LSP client for Emacs, integrates well with existing Emacs functionality and is built into Emacs starting from release 29.
 
 After installing Eglot, e.g. via `M-x package-install` (not needed from Emacs 29), you can enable it via the `M-x eglot` command or load it automatically in `rust-mode` via
 
 [source,emacs-lisp]
 ----
 (add-hook 'rust-mode-hook 'eglot-ensure)
+----
+
+To enable clippy, you will need to configure the initialization options to pass the `check.command` setting.
+
+[source,emacs-lisp]
+----
+(add-to-list 'eglot-server-programs
+             '((rust-ts-mode rust-mode) .
+               ("rust-analyzer" :initializationOptions (:check (:command "clippy")))))
 ----
 
 For more detailed instructions and options see the https://joaotavora.github.io/eglot[Eglot manual] (also available from Emacs via `M-x info`) and the


### PR DESCRIPTION
Emacs 29 is now released, and include an example of enabling clippy.