### PR TITLE
Add command for only opening external docs and attempt to fix vscode-remote issue

### DIFF
--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -249,6 +249,11 @@
                 "category": "rust-analyzer"
             },
             {
+                "command": "rust-analyzer.openExternalDocs",
+                "title": "Open External Docs",
+                "category": "rust-analyzer"
+            },
+            {
                 "command": "rust-analyzer.openCargoToml",
                 "title": "Open Cargo.toml",
                 "category": "rust-analyzer"
@@ -260,12 +265,12 @@
             },
             {
                 "command": "rust-analyzer.moveItemUp",
-                "title": "Move item up",
+                "title": "Move Item Up",
                 "category": "rust-analyzer"
             },
             {
                 "command": "rust-analyzer.moveItemDown",
-                "title": "Move item down",
+                "title": "Move Item Down",
                 "category": "rust-analyzer"
             },
             {

--- a/editors/code/src/lsp_ext.ts
+++ b/editors/code/src/lsp_ext.ts
@@ -74,8 +74,8 @@ export interface FetchDependencyListParams {}
 
 export interface FetchDependencyListResult {
     crates: {
-        name: string | undefined;
-        version: string | undefined;
+        name?: string;
+        version?: string;
         path: string;
     }[];
 }
@@ -136,8 +136,8 @@ export const openCargoToml = new lc.RequestType<OpenCargoTomlParams, lc.Location
     "experimental/openCargoToml",
 );
 export interface DocsUrls {
-    local: string | void;
-    web: string | void;
+    local?: string;
+    web?: string;
 }
 export const openDocs = new lc.RequestType<lc.TextDocumentPositionParams, DocsUrls, void>(
     "experimental/externalDocs",

--- a/editors/code/src/main.ts
+++ b/editors/code/src/main.ts
@@ -170,6 +170,7 @@ function createCommands(): Record<string, CommandFactory> {
         debug: { enabled: commands.debug },
         newDebugConfig: { enabled: commands.newDebugConfig },
         openDocs: { enabled: commands.openDocs },
+        openExternalDocs: { enabled: commands.openExternalDocs },
         openCargoToml: { enabled: commands.openCargoToml },
         peekTests: { enabled: commands.peekTests },
         moveItemUp: { enabled: commands.moveItemUp },


### PR DESCRIPTION
opening URI in a remote env causes vscode to ask the OS to handle `vscode-remote` URIs as there is no handler registered for such a scheme. This attempts to instruct vscode to handle those.

This is untested, as I can't figure out how to open a debug session on WSL rn.