### PR TITLE
internal: scip: update crate to version 0.3.1.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1405,9 +1405,9 @@ dependencies = [
 
 [[package]]
 name = "protobuf"
-version = "3.1.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ee4a7d8b91800c8f167a6268d1a1026607368e1adc84e98fe044aeb905302f7"
+checksum = "b55bad9126f378a853655831eb7363b7b01b81d19f8cb1218861086ca4a1a61e"
 dependencies = [
  "once_cell",
  "protobuf-support",
@@ -1416,9 +1416,9 @@ dependencies = [
 
 [[package]]
 name = "protobuf-support"
-version = "3.1.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ca157fe12fc7ee2e315f2f735e27df41b3d97cdd70ea112824dac1ffb08ee1c"
+checksum = "a5d4d7b8601c814cfb36bcebb79f0e61e45e1e93640cf778837833bbed05c372"
 dependencies = [
  "thiserror",
 ]
@@ -1671,9 +1671,9 @@ dependencies = [
 
 [[package]]
 name = "scip"
-version = "0.1.1"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2bfbb10286f69fad7c78db71004b7839bf957788359fe0c479f029f9849136b"
+checksum = "3e84d21062a3ba08d58870c8c36b0c005b2b2261c6ad1bf7042585427c781883"
 dependencies = [
  "protobuf",
 ]

--- a/crates/rust-analyzer/Cargo.toml
+++ b/crates/rust-analyzer/Cargo.toml
@@ -23,7 +23,7 @@ anyhow = "1.0.62"
 crossbeam-channel = "0.5.5"
 dissimilar = "1.0.4"
 itertools = "0.10.5"
-scip = "0.1.1"
+scip = "0.3.1"
 lsp-types = { version = "=0.94.0", features = ["proposed"] }
 parking_lot = "0.12.1"
 xflags = "0.3.0"

--- a/crates/rust-analyzer/src/cli/scip.rs
+++ b/crates/rust-analyzer/src/cli/scip.rs
@@ -133,6 +133,10 @@ impl flags::Scip {
                             documentation: documentation.unwrap_or_default(),
                             relationships: Vec::new(),
                             special_fields: Default::default(),
+                            kind: Default::default(),
+                            display_name: String::new(),
+                            signature_documentation: Default::default(),
+                            enclosing_symbol: String::new(),
                         };
 
                         symbols.push(symbol_info)
@@ -147,6 +151,7 @@ impl flags::Scip {
                     syntax_kind: Default::default(),
                     diagnostics: Vec::new(),
                     special_fields: Default::default(),
+                    enclosing_range: Vec::new(),
                 });
             });
 
@@ -160,6 +165,7 @@ impl flags::Scip {
                 occurrences,
                 symbols,
                 special_fields: Default::default(),
+                text: String::new(),
             });
         }
 


### PR DESCRIPTION
While the git repo has been updated constantly, crates.io has only now been updated after more than a year of activity.