### PR TITLE
VSCode metadata. category:formatters

### DIFF
--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -18,7 +18,6 @@
     ],
     "categories": [
         "Formatters",
-        "Linters",
         "Programming Languages"
     ],
     "capabilities": {

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -17,6 +17,8 @@
         "rust"
     ],
     "categories": [
+        "Formatters",
+        "Linters",
         "Programming Languages"
     ],
     "capabilities": {


### PR DESCRIPTION
If you invoke cmd+p `Format Document` without rust-analyzer installed in the workspace, VSCode suggests you "install a formatter" which triggers a search for `category:formatters rust`. Sadly rust-analyzer extension is not suggested.

Tweak VSCode Extension Metadata so rust-analyzer shows up in 'category:formatters rust' search.

You can see the valid values for categories in the [extension manifest: field reference](https://code.visualstudio.com/api/references/extension-manifest#fields) docs.

<img width="270" alt="search2" src="https://github.com/rust-lang/rust-analyzer/assets/145113/5bd86497-2450-4be4-a073-e134d0616226">
<img width="432" alt="search_1" src="https://github.com/rust-lang/rust-analyzer/assets/145113/1ad1b375-58a1-4b37-b485-78e2a26b8342">

