### PR TITLE
code: expose workspaces to other extensions; remove `addProject` command

### DIFF
--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -210,11 +210,6 @@
                 "category": "rust-analyzer"
             },
             {
-                "command": "rust-analyzer.addProject",
-                "title": "Add current file's crate to workspace",
-                "category": "rust-analyzer"
-            },
-            {
                 "command": "rust-analyzer.restartServer",
                 "title": "Restart server",
                 "category": "rust-analyzer"

--- a/editors/code/src/commands.ts
+++ b/editors/code/src/commands.ts
@@ -870,28 +870,6 @@ export function rebuildProcMacros(ctx: CtxInit): Cmd {
     return async () => ctx.client.sendRequest(ra.rebuildProcMacros);
 }
 
-export function addProject(ctx: CtxInit): Cmd {
-    return async () => {
-        const extensionName = ctx.config.discoverProjectRunner;
-        // this command shouldn't be enabled in the first place if this isn't set.
-        if (!extensionName) {
-            return;
-        }
-
-        const command = `${extensionName}.discoverWorkspaceCommand`;
-        const project: JsonProject = await vscode.commands.executeCommand(command);
-
-        ctx.addToDiscoveredWorkspaces([project]);
-
-        // this is a workaround to avoid needing writing the `rust-project.json` into
-        // a workspace-level VS Code-specific settings folder. We'd like to keep the
-        // `rust-project.json` entirely in-memory.
-        await ctx.client?.sendNotification(lc.DidChangeConfigurationNotification.type, {
-            settings: "",
-        });
-    };
-}
-
 async function showReferencesImpl(
     client: LanguageClient | undefined,
     uri: string,

--- a/editors/code/src/main.ts
+++ b/editors/code/src/main.ts
@@ -9,8 +9,12 @@ import { setContextValue } from "./util";
 
 const RUST_PROJECT_CONTEXT_NAME = "inRustProject";
 
+// This API is not stable and may break in between minor releases.
 export interface RustAnalyzerExtensionApi {
     readonly client?: lc.LanguageClient;
+
+    setWorkspaces(workspaces: JsonProject[]): void;
+    notifyRustAnalyzer(): Promise<void>;
 }
 
 export async function deactivate() {
@@ -152,7 +156,6 @@ function createCommands(): Record<string, CommandFactory> {
         shuffleCrateGraph: { enabled: commands.shuffleCrateGraph },
         reloadWorkspace: { enabled: commands.reloadWorkspace },
         rebuildProcMacros: { enabled: commands.rebuildProcMacros },
-        addProject: { enabled: commands.addProject },
         matchingBrace: { enabled: commands.matchingBrace },
         joinLines: { enabled: commands.joinLines },
         parentModule: { enabled: commands.parentModule },


### PR DESCRIPTION
This (mostly red) PR does three things:
- Exposes two methods to companion extensions (`setWorkspaces` and `notifyRustAnalyzer`). 
    - `setWorkspaces` is needed to update `linkedProjects` _without_ writing workspace/global configuration.
    - `notifyRustAnalyzer` to get the server to pull the new configuration.
- Makes `Ctx` implement `RustAnalyzerExtensionApi` to prevent accidental regressions.
- Remove `rust-analyzer.addProject`, as that will live in a buck2 companion extension. No need for that to be in rust-analyzer!

I can see the utility of combining `notifyRustAnalyzer` and `setWorkspaces` into a single method (`updateWorkspacesAndNotify()`?), but I don't feel strongly about this. My feeling is that this API could be easily changed in the future.