### PR TITLE
fix: Fix docs path for derive macros

### DIFF
--- a/crates/ide/src/doc_links.rs
+++ b/crates/ide/src/doc_links.rs
@@ -602,7 +602,17 @@ fn filename_and_frag_for_def(
         }
         Definition::Const(c) => format!("const.{}.html", c.name(db)?.display(db.upcast())),
         Definition::Static(s) => format!("static.{}.html", s.name(db).display(db.upcast())),
-        Definition::Macro(mac) => format!("macro.{}.html", mac.name(db).display(db.upcast())),
+        Definition::Macro(mac) => match mac.kind(db) {
+            hir::MacroKind::Declarative
+            | hir::MacroKind::BuiltIn
+            | hir::MacroKind::Attr
+            | hir::MacroKind::ProcMacro => {
+                format!("macro.{}.html", mac.name(db).display(db.upcast()))
+            }
+            hir::MacroKind::Derive => {
+                format!("derive.{}.html", mac.name(db).display(db.upcast()))
+            }
+        },
         Definition::Field(field) => {
             let def = match field.parent_def(db) {
                 hir::VariantDef::Struct(it) => Definition::Adt(it.into()),


### PR DESCRIPTION
Fixes #15831.

Not sure about `attr`, I don't think those are documented anyway. And many macros don't work because we pick the wrong path.