### PR TITLE
editor/code: add option to suppress internal error notifications

### DIFF
--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -503,7 +503,7 @@
                     "type": "boolean"
                 },
                 "rust-analyzer.showRequestFailedErrorNotification": {
-                    "markdownDescription": "Whether to show panic error notifications.",
+                    "markdownDescription": "Whether to show error notifications for failing requests.",
                     "default": true,
                     "type": "boolean"
                 },

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -502,6 +502,11 @@
                     "default": true,
                     "type": "boolean"
                 },
+                "rust-analyzer.showRequestFailedErrorNotification": {
+                    "markdownDescription": "Whether to show panic error notifications.",
+                    "default": true,
+                    "type": "boolean"
+                },
                 "rust-analyzer.showDependenciesExplorer": {
                     "markdownDescription": "Whether to show the dependencies view.",
                     "default": true,

--- a/editors/code/src/base_client.ts
+++ b/editors/code/src/base_client.ts
@@ -1,0 +1,12 @@
+import * as lc from "vscode-languageclient/node";
+
+export class RaLanguageClient extends lc.LanguageClient {
+    override error(message: string, data?: any, showNotification?: boolean | "force"): void {
+        // ignore `Request TYPE failed.` errors
+        if (message.startsWith("Request") && message.endsWith("failed.")) {
+            return;
+        }
+
+        super.error(message, data, showNotification);
+    }
+}

--- a/editors/code/src/client.ts
+++ b/editors/code/src/client.ts
@@ -10,7 +10,7 @@ import { type Config, prepareVSCodeConfig } from "./config";
 import { randomUUID } from "crypto";
 import { sep as pathSeparator } from "path";
 import { unwrapUndefinable } from "./undefinable";
-import { RaLanguageClient } from "./base_client";
+import { RaLanguageClient } from "./lang_client";
 
 export interface Env {
     [name: string]: string;

--- a/editors/code/src/client.ts
+++ b/editors/code/src/client.ts
@@ -10,6 +10,7 @@ import { type Config, prepareVSCodeConfig } from "./config";
 import { randomUUID } from "crypto";
 import { sep as pathSeparator } from "path";
 import { unwrapUndefinable } from "./undefinable";
+import { RaLanguageClient } from "./base_client";
 
 export interface Env {
     [name: string]: string;
@@ -363,7 +364,7 @@ export async function createClient(
         },
     };
 
-    const client = new lc.LanguageClient(
+    const client = new RaLanguageClient(
         "rust-analyzer",
         "Rust Analyzer Language Server",
         serverOptions,

--- a/editors/code/src/lang_client.ts
+++ b/editors/code/src/lang_client.ts
@@ -1,9 +1,13 @@
 import * as lc from "vscode-languageclient/node";
+import * as vscode from "vscode";
 
 export class RaLanguageClient extends lc.LanguageClient {
     override error(message: string, data?: any, showNotification?: boolean | "force"): void {
         // ignore `Request TYPE failed.` errors
-        if (message.startsWith("Request") && message.endsWith("failed.")) {
+        const showError = vscode.workspace
+            .getConfiguration("rust-analyzer")
+            .get("showRequestFailedErrorNotification");
+        if (!showError && message.startsWith("Request") && message.endsWith("failed.")) {
             return;
         }
 


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust-analyzer/issues/14193

- Added the `rust-analyzer.showRequestFailedErrorNotification` configuration option, which defaults to `true`
- If `rust-analyzer.showRequestFailedErrorNotification` is set to `true`, the current behavior is preserved.
- If `rust-analyzer.showRequestFailedErrorNotification` is set to `false`, no error toasts will be displayed for any of the failed requests caused by panics in r-a. This _only_ applies to events that are triggered "implicitly", such as `textDocument/hover`.

To test this, you can manually introduce a panic in one of the language server LSP handlers for non-command events. I added an explicit `panic!()` in the `textDocument/hover` event handler:

#### `rust-analyzer.showRequestFailedErrorNotification` set to `true` (default)

[2023-11-07 17-17-48.webm](https://github.com/rust-lang/rust-analyzer/assets/1665677/d0408ab8-79d1-42cf-a4e7-94e99d9783ec)

#### `rust-analyzer.showRequestFailedErrorNotification` set to `false`

[2023-11-07 17-16-49.webm](https://github.com/rust-lang/rust-analyzer/assets/1665677/0496d8d0-fb53-4bc6-a279-1a47f412dbdb)
