### PR TITLE
Update rustc dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1454,12 +1454,12 @@ dependencies = [
 
 [[package]]
 name = "ra-ap-rustc_abi"
-version = "0.14.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a51b7a02377b3246ec5c095b852b5cf1678bd9ed6b572b2a79efbf7ad711c292"
+checksum = "7082716cb2bbcd8b5f062fe950cbbc87f3aba022d6da4168db35af6732a7f15d"
 dependencies = [
  "bitflags 1.3.2",
- "ra-ap-rustc_index",
+ "ra-ap-rustc_index 0.18.0",
  "tracing",
 ]
 
@@ -1468,6 +1468,16 @@ name = "ra-ap-rustc_index"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "643ca3609870b1778d9cd1f2a8e4ccb4af0f48f3637cc257a09494d087bd93dc"
+dependencies = [
+ "arrayvec",
+ "smallvec",
+]
+
+[[package]]
+name = "ra-ap-rustc_index"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19e14b1fc835d6992b128a03a3f3a8365ba9f03e1c656a1670305f63f30d786d"
 dependencies = [
  "arrayvec",
  "smallvec",
@@ -1484,13 +1494,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "ra-ap-rustc_lexer"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1762abb25eb1e37c1823f62b5da0821bbcd870812318db084c9516c2f78d2dcd"
+dependencies = [
+ "unicode-properties",
+ "unicode-xid",
+]
+
+[[package]]
 name = "ra-ap-rustc_parse_format"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "207b5ac1a21d4926695e03b605ffb9f63d4968e0488e9197c04c512c37303aa7"
 dependencies = [
- "ra-ap-rustc_index",
- "ra-ap-rustc_lexer",
+ "ra-ap-rustc_index 0.14.0",
+ "ra-ap-rustc_lexer 0.14.0",
 ]
 
 [[package]]
@@ -1614,8 +1634,8 @@ name = "rustc-dependencies"
 version = "0.0.0"
 dependencies = [
  "ra-ap-rustc_abi",
- "ra-ap-rustc_index",
- "ra-ap-rustc_lexer",
+ "ra-ap-rustc_index 0.18.0",
+ "ra-ap-rustc_lexer 0.18.0",
  "ra-ap-rustc_parse_format",
 ]
 

--- a/crates/hir-def/src/data/adt.rs
+++ b/crates/hir-def/src/data/adt.rs
@@ -178,7 +178,7 @@ fn parse_repr_tt(tt: &Subtree) -> Option<ReprOptions> {
         }
     }
 
-    Some(ReprOptions { int, align: max_align, pack: min_pack, flags })
+    Some(ReprOptions { int, align: max_align, pack: min_pack, flags, field_shuffle_seed: 0 })
 }
 
 impl StructData {

--- a/crates/rustc-dependencies/Cargo.toml
+++ b/crates/rustc-dependencies/Cargo.toml
@@ -11,10 +11,10 @@ authors.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ra-ap-rustc_lexer = { version = "0.14.0" }
+ra-ap-rustc_lexer = { version = "0.18.0" }
 ra-ap-rustc_parse_format = { version = "0.14.0", default-features = false }
-ra-ap-rustc_index = { version = "0.14.0", default-features = false }
-ra-ap-rustc_abi = { version = "0.14.0", default-features = false }
+ra-ap-rustc_index = { version = "0.18.0", default-features = false }
+ra-ap-rustc_abi = { version = "0.18.0", default-features = false }
 
 [features]
 in-rust-tree = []


### PR DESCRIPTION
Except `rustc_parse_format` that was broken by upstream.