### PR TITLE
Try to update parser/event doc

### DIFF
--- a/crates/parser/src/event.rs
+++ b/crates/parser/src/event.rs
@@ -2,11 +2,6 @@
 //! It is intended to be completely decoupled from the
 //! parser, so as to allow to evolve the tree representation
 //! and the parser algorithm independently.
-//!
-//! The `TreeSink` trait is the bridge between the parser and the
-//! tree builder: the parser produces a stream of events like
-//! `start node`, `finish node`, and `FileBuilder` converts
-//! this stream to a real tree.
 use std::mem;
 
 use crate::{


### PR DESCRIPTION
`TokenSource` and `TreeSink` has been refactored as part of #10765, they no longer exist in code repo. This pr tries to remove them from event module level comment to prevent confusion. 