### PR TITLE
minor: Make "Expand macro" command title more explicit

### DIFF
--- a/crates/ide/src/expand_macro.rs
+++ b/crates/ide/src/expand_macro.rs
@@ -14,12 +14,12 @@ pub struct ExpandedMacro {
 
 // Feature: Expand Macro Recursively
 //
-// Shows the full macro expansion of the macro at current cursor.
+// Shows the full macro expansion of the macro at the current caret position.
 //
 // |===
 // | Editor  | Action Name
 //
-// | VS Code | **rust-analyzer: Expand macro recursively**
+// | VS Code | **rust-analyzer: Expand macro recursively at caret**
 // |===
 //
 // image::https://user-images.githubusercontent.com/48062697/113020648-b3973180-917a-11eb-84a9-ecb921293dc5.gif[]

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -156,7 +156,7 @@
             },
             {
                 "command": "rust-analyzer.expandMacro",
-                "title": "Expand macro recursively",
+                "title": "Expand macro recursively at caret",
                 "category": "rust-analyzer"
             },
             {


### PR DESCRIPTION
Closes [#15856](https://github.com/rust-lang/rust-analyzer/issues/15856).

I opted for "caret", since it's the better term (cursor is the mouse), but I'm not sure how popular it is these days.