### PR TITLE
minor: Allow multiple snippet edits in a `TextDocumentEdit`

### DIFF
--- a/docs/dev/lsp-extensions.md
+++ b/docs/dev/lsp-extensions.md
@@ -57,8 +57,9 @@ export interface TextDocumentEdit {
 }
 ```
 
-When applying such code action or text edit, the editor should insert snippet, with tab stops and placeholder.
-At the moment, rust-analyzer guarantees that only a single edit will have `InsertTextFormat.Snippet`.
+When applying such code action or text edit, the editor should insert snippet, with tab stops and placeholders.
+At the moment, rust-analyzer guarantees that only a single `TextDocumentEdit` will have edits which can be `InsertTextFormat.Snippet`.
+Any additional `TextDocumentEdit`s will only have edits which are `InsertTextFormat.PlainText`.
 
 ### Example
 


### PR DESCRIPTION
Explicitly[^1] allow a single `TextDocumentEdit` to have multiple `SnippetTextEdit`s. This allows things like renaming extracted variables and functions without having to go through a separate rename step. For an example of what this looks like, see the video in [this comment](https://github.com/microsoft/vscode/issues/145374#issuecomment-1177341711).

The behavior described here lines up with [what VSCode does](https://github.com/microsoft/vscode/blob/bdc113ffe148a92d0e1a8ec34b12c44ea0b73f29/src/vscode-dts/vscode.d.ts#L3728-L3731), and presumably what the eventual LSP behavior will be.

[^1]: This was technically the case before #15269, a single `TextDocumentEdit` always had multiple edits which were `InsertTextFormat.Snippet` as all of the edits were marked as being snippets, even if there weren't any tab stops or placeholders.