### PR TITLE
docs: fix VS Code setting samples

### DIFF
--- a/docs/user/manual.adoc
+++ b/docs/user/manual.adoc
@@ -946,7 +946,7 @@ Or it is possible to specify vars more granularly:
 "rust-analyzer.runnables.extraEnv": [
     {
         // "mask": null, // null mask means that this rule will be applied for all runnables
-        env: {
+        "env": {
              "APP_ID": "1",
              "APP_DATA": "asdf"
         }
@@ -968,7 +968,7 @@ If needed, you can set different values for different platforms:
 "rust-analyzer.runnables.extraEnv": [
     {
         "platform": "win32", // windows only
-        env: {
+        "env": {
              "APP_DATA": "windows specific data"
         }
     },


### PR DESCRIPTION
Fix invalid JSONC examples (missing double quotes) in VS Code's `settings.json` .
Thank you.