### PR TITLE
Fix typo in highlight_related.rs

### DIFF
--- a/crates/ide/src/highlight_related.rs
+++ b/crates/ide/src/highlight_related.rs
@@ -43,7 +43,7 @@ pub struct HighlightRelatedConfig {
 //
 // . if on an identifier, highlights all references to that identifier in the current file
 // .. additionally, if the identifier is a trait in a where clause, type parameter trait bound or use item, highlights all references to that trait's assoc items in the corresponding scope
-// . if on an `async` or `await token, highlights all yield points for that async context
+// . if on an `async` or `await` token, highlights all yield points for that async context
 // . if on a `return` or `fn` keyword, `?` character or `->` return type arrow, highlights all exit points for that context
 // . if on a `break`, `loop`, `while` or `for` token, highlights all break points for that loop or block context
 // . if on a `move` or `|` token that belongs to a closure, highlights all captures of the closure.


### PR DESCRIPTION
While reading the user manual, I noticed a random tick, so I went ahead and fixed it. The `await` keyword should be properly rendered as inline code.

![image](https://github.com/rust-lang/rust-analyzer/assets/20878432/f134a4c9-e539-4635-97ac-506790893869)
