### PR TITLE
Fix incorrectly replacing references in macro invocation in "Convert to named struct" assist

### DIFF
--- a/crates/ide-assists/src/handlers/convert_tuple_struct_to_named_struct.rs
+++ b/crates/ide-assists/src/handlers/convert_tuple_struct_to_named_struct.rs
@@ -216,7 +216,7 @@ fn edit_field_references(
             edit.edit_file(file_id);
             for r in refs {
                 if let Some(name_ref) = r.name.as_name_ref() {
-                    edit.replace(name_ref.syntax().text_range(), name.text());
+                    edit.replace(ctx.sema.original_range(name_ref.syntax()).range, name.text());
                 }
             }
         }


### PR DESCRIPTION
Fixes #15630.

Complements #13647 (same assist but missed this one), #14920 (inverse action assist).