### PR TITLE
internal: Add more rustc_private declarations

### DIFF
--- a/crates/hir-ty/src/lib.rs
+++ b/crates/hir-ty/src/lib.rs
@@ -1,6 +1,7 @@
 //! The type system. We currently use this to infer types for completion, hover
 //! information and various assists.
 #![warn(rust_2018_idioms, unused_lifetimes, semicolon_in_expressions_from_macros)]
+#![cfg_attr(feature = "in-rust-tree", feature(rustc_private))]
 
 #[allow(unused)]
 macro_rules! eprintln {

--- a/crates/hir/Cargo.toml
+++ b/crates/hir/Cargo.toml
@@ -30,3 +30,6 @@ profile.workspace = true
 stdx.workspace = true
 syntax.workspace = true
 tt.workspace = true
+
+[features]
+in-rust-tree = []

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -18,6 +18,7 @@
 //! <https://www.tedinski.com/2018/02/06/system-boundaries.html>.
 
 #![warn(rust_2018_idioms, unused_lifetimes, semicolon_in_expressions_from_macros)]
+#![cfg_attr(feature = "in-rust-tree", feature(rustc_private))]
 #![recursion_limit = "512"]
 
 mod semantics;

--- a/crates/ide/src/lib.rs
+++ b/crates/ide/src/lib.rs
@@ -8,8 +8,9 @@
 //! in this crate.
 
 // For proving that RootDatabase is RefUnwindSafe.
-#![recursion_limit = "128"]
 #![warn(rust_2018_idioms, unused_lifetimes, semicolon_in_expressions_from_macros)]
+#![cfg_attr(feature = "in-rust-tree", feature(rustc_private))]
+#![recursion_limit = "128"]
 
 #[allow(unused)]
 macro_rules! eprintln {

--- a/crates/rust-analyzer/Cargo.toml
+++ b/crates/rust-analyzer/Cargo.toml
@@ -97,6 +97,7 @@ in-rust-tree = [
     "syntax/in-rust-tree",
     "parser/in-rust-tree",
     "rustc-dependencies/in-rust-tree",
+    "hir/in-rust-tree",
     "hir-def/in-rust-tree",
     "hir-ty/in-rust-tree",
 ]


### PR DESCRIPTION
Lifted off https://github.com/rust-lang/rust/pull/117701, but fails to build:

```bash
$ rustup +nightly add rustc-dev
$ cargo +nightly build --features in-rust-tree
error: crate `rustc_lexer` required to be available in rlib format, but was not found in this form
  |
  = help: try adding `extern crate rustc_driver;` at the top level of this crate

error: crate `unicode_properties` required to be available in rlib format, but was not found in this form

error: crate `unicode_xid` required to be available in rlib format, but was not found in this form

error: crate `rustc_parse_format` required to be available in rlib format, but was not found in this form
  |
  = help: try adding `extern crate rustc_driver;` at the top level of this crate

error: crate `rustc_index` required to be available in rlib format, but was not found in this form
  |
  = help: try adding `extern crate rustc_driver;` at the top level of this crate

error: crate `arrayvec` required to be available in rlib format, but was not found in this form

error: crate `smallvec` required to be available in rlib format, but was not found in this form

error: crate `rustc_serialize` required to be available in rlib format, but was not found in this form
  |
  = help: try adding `extern crate rustc_driver;` at the top level of this crate

error: crate `thin_vec` required to be available in rlib format, but was not found in this form

error: crate `indexmap` required to be available in rlib format, but was not found in this form

error: crate `hashbrown` required to be available in rlib format, but was not found in this form

error: crate `allocator_api2` required to be available in rlib format, but was not found in this form

error: crate `ahash` required to be available in rlib format, but was not found in this form
[snip]
```