### PR TITLE
fix: Diagnose everything in nested items, not just def diagnostics

### DIFF
--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -1536,9 +1536,7 @@ impl DefWithBody {
         let (body, source_map) = db.body_with_source_map(self.into());
 
         for (_, def_map) in body.blocks(db.upcast()) {
-            for diag in def_map.diagnostics() {
-                emit_def_diagnostic(db, acc, diag);
-            }
+            Module { id: def_map.module_id(DefMap::ROOT) }.diagnostics(db, acc);
         }
 
         for diag in source_map.diagnostics() {

--- a/crates/ide-diagnostics/src/handlers/incorrect_case.rs
+++ b/crates/ide-diagnostics/src/handlers/incorrect_case.rs
@@ -599,12 +599,12 @@ fn main() {
              //^^^ 💡 warn: Static variable `bar` should have UPPER_SNAKE_CASE name, e.g. `BAR`
         fn BAZ() {
          //^^^ 💡 warn: Function `BAZ` should have snake_case name, e.g. `baz`
-            let INNER_INNER = 42;
-              //^^^^^^^^^^^ 💡 warn: Variable `INNER_INNER` should have snake_case name, e.g. `inner_inner`
+            let _INNER_INNER = 42;
+              //^^^^^^^^^^^^ 💡 warn: Variable `_INNER_INNER` should have snake_case name, e.g. `_inner_inner`
         }
 
-        let INNER_LOCAL = 42;
-          //^^^^^^^^^^^ 💡 warn: Variable `INNER_LOCAL` should have snake_case name, e.g. `inner_local`
+        let _INNER_LOCAL = 42;
+          //^^^^^^^^^^^^ 💡 warn: Variable `_INNER_LOCAL` should have snake_case name, e.g. `_inner_local`
     }
 }
 "#,

--- a/crates/ide-diagnostics/src/handlers/type_mismatch.rs
+++ b/crates/ide-diagnostics/src/handlers/type_mismatch.rs
@@ -742,4 +742,19 @@ fn g() { return; }
 "#,
         );
     }
+
+    #[test]
+    fn smoke_test_inner_items() {
+        check_diagnostics(
+            r#"
+fn f() {
+    fn inner() -> i32 {
+        return;
+     // ^^^^^^ error: expected i32, found ()
+        0
+    }
+}
+"#,
+        );
+    }
 }


### PR DESCRIPTION
Turns out we only calculated def diagnostics for these before (was wondering why I wasn't getting any type mismatches)