### PR TITLE
feat: add hover display for trait assoc items

### DIFF
--- a/crates/hir-ty/src/display.rs
+++ b/crates/hir-ty/src/display.rs
@@ -62,7 +62,7 @@ pub struct HirFormatter<'a> {
     fmt: &'a mut dyn HirWrite,
     buf: String,
     curr_size: usize,
-    pub(crate) max_size: Option<usize>,
+    pub max_size: Option<usize>,
     omit_verbose_types: bool,
     closure_style: ClosureStyle,
     display_target: DisplayTarget,

--- a/crates/hir/src/display.rs
+++ b/crates/hir/src/display.rs
@@ -598,7 +598,7 @@ impl HirDisplay for Trait {
 
         let assoc_items = self.items(f.db);
         let assoc_items_size = assoc_items.len();
-        let max_display_size = f.max_size.unwrap_or(assoc_items_size);
+        let limited_size = f.limited_size.unwrap_or(assoc_items_size);
         if assoc_items.is_empty() {
             f.write_str(" {}")?;
         } else {
@@ -617,7 +617,7 @@ impl HirDisplay for Trait {
                     }
                 };
                 f.write_str(",\n")?;
-                if index + 1 == max_display_size && index + 1 != assoc_items_size {
+                if index + 1 == limited_size && index + 1 != assoc_items_size {
                     f.write_str("    ...\n")?;
                     break;
                 }

--- a/crates/hir/src/display.rs
+++ b/crates/hir/src/display.rs
@@ -17,10 +17,7 @@ use hir_ty::{
 };
 
 use crate::{
-    Adt, AsAssocItem, AssocItemContainer, Const, ConstParam, Enum, ExternCrateDecl, Field,
-    Function, GenericParam, HasCrate, HasVisibility, LifetimeParam, Macro, Module, SelfParam,
-    Static, Struct, Trait, TraitAlias, TupleField, TyBuilder, Type, TypeAlias, TypeOrConstParam,
-    TypeParam, Union, Variant,
+    Adt, AsAssocItem, AssocItem, AssocItemContainer, Const, ConstParam, Enum, ExternCrateDecl, Field, Function, GenericParam, HasCrate, HasVisibility, LifetimeParam, Macro, Module, SelfParam, Static, Struct, Trait, TraitAlias, TupleField, TyBuilder, Type, TypeAlias, TypeOrConstParam, TypeParam, Union, Variant
 };
 
 impl HirDisplay for Function {

--- a/crates/hir/src/display.rs
+++ b/crates/hir/src/display.rs
@@ -595,6 +595,30 @@ impl HirDisplay for Trait {
         let def_id = GenericDefId::TraitId(self.id);
         write_generic_params(def_id, f)?;
         write_where_clause(def_id, f)?;
+
+        let assoc_items = self.items(f.db);
+        if assoc_items.is_empty() {
+            f.write_str(" {}")?;
+        } else {
+            f.write_str(" {\n")?;
+            for item in assoc_items {
+                f.write_str("    ")?;
+                match item {
+                    AssocItem::Function(func) => {
+                        func.hir_fmt(f)?;
+                    }
+                    AssocItem::Const(cst) => {
+                        cst.hir_fmt(f)?;
+                    }
+                    AssocItem::TypeAlias(type_alias) => {
+                        type_alias.hir_fmt(f)?;
+                    }
+                };
+                f.write_str(",\n")?;
+            }
+            f.write_str("}")?;
+        }
+
         Ok(())
     }
 }

--- a/crates/hir/src/display.rs
+++ b/crates/hir/src/display.rs
@@ -593,12 +593,14 @@ impl HirDisplay for Trait {
         write_generic_params(def_id, f)?;
         write_where_clause(def_id, f)?;
 
+        let mut display_size = 0;
+        let max_display_size = f.max_size.unwrap_or(7);
         let assoc_items = self.items(f.db);
         if assoc_items.is_empty() {
             f.write_str(" {}")?;
         } else {
             f.write_str(" {\n")?;
-            for item in assoc_items {
+            for (index, item) in assoc_items.iter().enumerate() {
                 f.write_str("    ")?;
                 match item {
                     AssocItem::Function(func) => {
@@ -612,6 +614,11 @@ impl HirDisplay for Trait {
                     }
                 };
                 f.write_str(",\n")?;
+                display_size += 1;
+                if display_size == max_display_size && index != assoc_items.len() - 1{
+                    f.write_str("    ...\n")?;
+                    break;
+                }
             }
             f.write_str("}")?;
         }

--- a/crates/hir/src/display.rs
+++ b/crates/hir/src/display.rs
@@ -17,7 +17,10 @@ use hir_ty::{
 };
 
 use crate::{
-    Adt, AsAssocItem, AssocItem, AssocItemContainer, Const, ConstParam, Enum, ExternCrateDecl, Field, Function, GenericParam, HasCrate, HasVisibility, LifetimeParam, Macro, Module, SelfParam, Static, Struct, Trait, TraitAlias, TupleField, TyBuilder, Type, TypeAlias, TypeOrConstParam, TypeParam, Union, Variant
+    Adt, AsAssocItem, AssocItem, AssocItemContainer, Const, ConstParam, Enum, ExternCrateDecl,
+    Field, Function, GenericParam, HasCrate, HasVisibility, LifetimeParam, Macro, Module,
+    SelfParam, Static, Struct, Trait, TraitAlias, TupleField, TyBuilder, Type, TypeAlias,
+    TypeOrConstParam, TypeParam, Union, Variant,
 };
 
 impl HirDisplay for Function {
@@ -593,9 +596,9 @@ impl HirDisplay for Trait {
         write_generic_params(def_id, f)?;
         write_where_clause(def_id, f)?;
 
-        let mut display_size = 0;
-        let max_display_size = f.max_size.unwrap_or(7);
         let assoc_items = self.items(f.db);
+        let assoc_items_size = assoc_items.len();
+        let max_display_size = f.max_size.unwrap_or(assoc_items_size);
         if assoc_items.is_empty() {
             f.write_str(" {}")?;
         } else {
@@ -614,8 +617,7 @@ impl HirDisplay for Trait {
                     }
                 };
                 f.write_str(",\n")?;
-                display_size += 1;
-                if display_size == max_display_size && index != assoc_items.len() - 1{
+                if index + 1 == max_display_size && index + 1 != assoc_items_size {
                     f.write_str("    ...\n")?;
                     break;
                 }

--- a/crates/ide-db/src/defs.rs
+++ b/crates/ide-db/src/defs.rs
@@ -24,12 +24,6 @@ use crate::documentation::{Documentation, HasDocs};
 use crate::famous_defs::FamousDefs;
 use crate::RootDatabase;
 
-#[derive(Default)]
-pub struct HoverDisplayConfig {
-    pub trait_item_display_num: Option<usize>,
-    // todo: add config for struct & enum
-}
-
 // FIXME: a more precise name would probably be `Symbol`?
 #[derive(Debug, PartialEq, Eq, Copy, Clone, Hash)]
 pub enum Definition {
@@ -219,7 +213,7 @@ impl Definition {
         })
     }
 
-    pub fn label(&self, db: &RootDatabase, hover_display_config: HoverDisplayConfig) -> String {
+    pub fn label(&self, db: &RootDatabase) -> String {
         match *self {
             Definition::Macro(it) => it.display(db).to_string(),
             Definition::Field(it) => it.display(db).to_string(),
@@ -230,9 +224,7 @@ impl Definition {
             Definition::Variant(it) => it.display(db).to_string(),
             Definition::Const(it) => it.display(db).to_string(),
             Definition::Static(it) => it.display(db).to_string(),
-            Definition::Trait(it) => {
-                it.display_truncated(db, hover_display_config.trait_item_display_num).to_string()
-            }
+            Definition::Trait(it) => it.display(db).to_string(),
             Definition::TraitAlias(it) => it.display(db).to_string(),
             Definition::TypeAlias(it) => it.display(db).to_string(),
             Definition::BuiltinType(it) => it.name().display(db).to_string(),

--- a/crates/ide-db/src/defs.rs
+++ b/crates/ide-db/src/defs.rs
@@ -213,7 +213,7 @@ impl Definition {
         })
     }
 
-    pub fn label(&self, db: &RootDatabase) -> String {
+    pub fn label(&self, db: &RootDatabase, max_size: Option<usize>) -> String {
         match *self {
             Definition::Macro(it) => it.display(db).to_string(),
             Definition::Field(it) => it.display(db).to_string(),
@@ -224,7 +224,7 @@ impl Definition {
             Definition::Variant(it) => it.display(db).to_string(),
             Definition::Const(it) => it.display(db).to_string(),
             Definition::Static(it) => it.display(db).to_string(),
-            Definition::Trait(it) => it.display(db).to_string(),
+            Definition::Trait(it) => it.display_truncated(db, max_size).to_string(),
             Definition::TraitAlias(it) => it.display(db).to_string(),
             Definition::TypeAlias(it) => it.display(db).to_string(),
             Definition::BuiltinType(it) => it.name().display(db).to_string(),

--- a/crates/ide-db/src/defs.rs
+++ b/crates/ide-db/src/defs.rs
@@ -24,6 +24,12 @@ use crate::documentation::{Documentation, HasDocs};
 use crate::famous_defs::FamousDefs;
 use crate::RootDatabase;
 
+#[derive(Default)]
+pub struct HoverDisplayConfig {
+    pub trait_item_display_num: Option<usize>,
+    // todo: add config for struct & enum
+}
+
 // FIXME: a more precise name would probably be `Symbol`?
 #[derive(Debug, PartialEq, Eq, Copy, Clone, Hash)]
 pub enum Definition {
@@ -213,7 +219,7 @@ impl Definition {
         })
     }
 
-    pub fn label(&self, db: &RootDatabase, max_size: Option<usize>) -> String {
+    pub fn label(&self, db: &RootDatabase, hover_display_config: HoverDisplayConfig) -> String {
         match *self {
             Definition::Macro(it) => it.display(db).to_string(),
             Definition::Field(it) => it.display(db).to_string(),
@@ -224,7 +230,9 @@ impl Definition {
             Definition::Variant(it) => it.display(db).to_string(),
             Definition::Const(it) => it.display(db).to_string(),
             Definition::Static(it) => it.display(db).to_string(),
-            Definition::Trait(it) => it.display_truncated(db, max_size).to_string(),
+            Definition::Trait(it) => {
+                it.display_truncated(db, hover_display_config.trait_item_display_num).to_string()
+            }
             Definition::TraitAlias(it) => it.display(db).to_string(),
             Definition::TypeAlias(it) => it.display(db).to_string(),
             Definition::BuiltinType(it) => it.name().display(db).to_string(),

--- a/crates/ide/src/hover.rs
+++ b/crates/ide/src/hover.rs
@@ -32,7 +32,7 @@ pub struct HoverConfig {
     pub documentation: bool,
     pub keywords: bool,
     pub format: HoverDocFormat,
-    pub trait_item_display_num: Option<usize>,
+    pub trait_assoc_items_size: Option<usize>,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]

--- a/crates/ide/src/hover.rs
+++ b/crates/ide/src/hover.rs
@@ -32,6 +32,7 @@ pub struct HoverConfig {
     pub documentation: bool,
     pub keywords: bool,
     pub format: HoverDocFormat,
+    pub trait_item_display_on_hover: Option<usize>,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]

--- a/crates/ide/src/hover.rs
+++ b/crates/ide/src/hover.rs
@@ -32,7 +32,7 @@ pub struct HoverConfig {
     pub documentation: bool,
     pub keywords: bool,
     pub format: HoverDocFormat,
-    pub trait_item_display_on_hover: Option<usize>,
+    pub trait_item_display_num: Option<usize>,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]

--- a/crates/ide/src/hover/render.rs
+++ b/crates/ide/src/hover/render.rs
@@ -8,7 +8,7 @@ use hir::{
 };
 use ide_db::{
     base_db::SourceDatabase,
-    defs::{Definition, HoverDisplayConfig},
+    defs::Definition,
     documentation::HasDocs,
     famous_defs::FamousDefs,
     generated::lints::{CLIPPY_LINTS, DEFAULT_LINTS, FEATURES},
@@ -406,8 +406,12 @@ pub(super) fn definition(
     config: &HoverConfig,
 ) -> Markup {
     let mod_path = definition_mod_path(db, &def);
-    let hover_config = HoverDisplayConfig { trait_item_display_num: config.trait_item_display_num };
-    let label = def.label(db, hover_config);
+    let label = match def {
+        Definition::Trait(trait_) => {
+            trait_.display_limited(db, config.trait_assoc_items_size).to_string()
+        }
+        _ => def.label(db),
+    };
     let docs = def.docs(db, famous_defs);
     let value = (|| match def {
         Definition::Variant(it) => {

--- a/crates/ide/src/hover/render.rs
+++ b/crates/ide/src/hover/render.rs
@@ -8,7 +8,7 @@ use hir::{
 };
 use ide_db::{
     base_db::SourceDatabase,
-    defs::Definition,
+    defs::{Definition, HoverDisplayConfig},
     documentation::HasDocs,
     famous_defs::FamousDefs,
     generated::lints::{CLIPPY_LINTS, DEFAULT_LINTS, FEATURES},
@@ -406,7 +406,8 @@ pub(super) fn definition(
     config: &HoverConfig,
 ) -> Markup {
     let mod_path = definition_mod_path(db, &def);
-    let label = def.label(db, config.trait_item_display_on_hover);
+    let hover_config = HoverDisplayConfig { trait_item_display_num: config.trait_item_display_num };
+    let label = def.label(db, hover_config);
     let docs = def.docs(db, famous_defs);
     let value = (|| match def {
         Definition::Variant(it) => {

--- a/crates/ide/src/hover/render.rs
+++ b/crates/ide/src/hover/render.rs
@@ -406,7 +406,7 @@ pub(super) fn definition(
     config: &HoverConfig,
 ) -> Markup {
     let mod_path = definition_mod_path(db, &def);
-    let label = def.label(db);
+    let label = def.label(db, config.trait_item_display_on_hover);
     let docs = def.docs(db, famous_defs);
     let value = (|| match def {
         Definition::Variant(it) => {

--- a/crates/ide/src/hover/tests.rs
+++ b/crates/ide/src/hover/tests.rs
@@ -17,7 +17,7 @@ const HOVER_BASE_CONFIG: HoverConfig = HoverConfig {
     documentation: true,
     format: HoverDocFormat::Markdown,
     keywords: true,
-    trait_item_display_num: Some(7),
+    trait_assoc_items_size: None,
 };
 
 fn check_hover_no_result(ra_fixture: &str) {

--- a/crates/ide/src/hover/tests.rs
+++ b/crates/ide/src/hover/tests.rs
@@ -17,7 +17,7 @@ const HOVER_BASE_CONFIG: HoverConfig = HoverConfig {
     documentation: true,
     format: HoverDocFormat::Markdown,
     keywords: true,
-    trait_item_display_on_hover: Some(7),
+    trait_item_display_num: Some(7),
 };
 
 fn check_hover_no_result(ra_fixture: &str) {

--- a/crates/ide/src/hover/tests.rs
+++ b/crates/ide/src/hover/tests.rs
@@ -2685,7 +2685,7 @@ fn main() { let s$0t = foo(); }
                                     focus_range: 6..9,
                                     name: "Foo",
                                     kind: Trait,
-                                    description: "trait Foo",
+                                    description: "trait Foo {}",
                                 },
                             },
                         ],
@@ -2719,7 +2719,7 @@ fn main() { let s$0t = foo(); }
                                     focus_range: 6..9,
                                     name: "Foo",
                                     kind: Trait,
-                                    description: "trait Foo<T>",
+                                    description: "trait Foo<T> {}",
                                 },
                             },
                             HoverGotoTypeData {
@@ -2886,7 +2886,7 @@ fn foo(ar$0g: &impl Foo) {}
                                     focus_range: 6..9,
                                     name: "Foo",
                                     kind: Trait,
-                                    description: "trait Foo",
+                                    description: "trait Foo {}",
                                 },
                             },
                         ],
@@ -2988,7 +2988,7 @@ pub mod future {
                                 name: "Future",
                                 kind: Trait,
                                 container_name: "future",
-                                description: "pub trait Future",
+                                description: "pub trait Future {}",
                             },
                         },
                         HoverGotoTypeData {
@@ -3033,7 +3033,7 @@ fn foo(ar$0g: &impl Foo<S>) {}
                                     focus_range: 6..9,
                                     name: "Foo",
                                     kind: Trait,
-                                    description: "trait Foo<T>",
+                                    description: "trait Foo<T> {}",
                                 },
                             },
                             HoverGotoTypeData {
@@ -3096,7 +3096,7 @@ fn main() { let s$0t = foo(); }
                                     focus_range: 6..9,
                                     name: "Foo",
                                     kind: Trait,
-                                    description: "trait Foo",
+                                    description: "trait Foo {}",
                                 },
                             },
                         ],
@@ -3127,7 +3127,7 @@ fn foo(ar$0g: &dyn Foo) {}
                                     focus_range: 6..9,
                                     name: "Foo",
                                     kind: Trait,
-                                    description: "trait Foo",
+                                    description: "trait Foo {}",
                                 },
                             },
                         ],
@@ -3159,7 +3159,7 @@ fn foo(ar$0g: &dyn Foo<S>) {}
                                     focus_range: 6..9,
                                     name: "Foo",
                                     kind: Trait,
-                                    description: "trait Foo<T>",
+                                    description: "trait Foo<T> {}",
                                 },
                             },
                             HoverGotoTypeData {
@@ -3288,7 +3288,7 @@ fn main() { let s$0t = test().get(); }
                                     focus_range: 6..9,
                                     name: "Foo",
                                     kind: Trait,
-                                    description: "trait Foo",
+                                    description: "trait Foo {\n    type Item,\n    fn get(self) -> Self::Item,\n}",
                                 },
                             },
                         ],
@@ -3353,7 +3353,7 @@ fn foo<T: Foo>(t: T$0){}
                                     focus_range: 6..9,
                                     name: "Foo",
                                     kind: Trait,
-                                    description: "trait Foo",
+                                    description: "trait Foo {}",
                                 },
                             },
                         ],
@@ -6248,6 +6248,99 @@ impl T for () {
             ---
 
             Trait docs
+        "#]],
+    );
+}
+
+#[test]
+fn hover_trait_show_assoc_items() {
+    check(
+        r#"
+trait T {}
+impl T$0 for () {}
+"#,
+        expect![[r#"
+        *T*
+
+        ```rust
+        test
+        ```
+
+        ```rust
+        trait T {}
+        ```
+        "#]],
+    );
+
+    check(
+        r#"
+trait T {
+    fn func() {}
+}
+impl T$0 for () {}
+"#,
+        expect![[r#"
+        *T*
+
+        ```rust
+        test
+        ```
+
+        ```rust
+        trait T {
+            fn func(),
+        }
+        ```
+        "#]],
+    );
+
+    check(
+        r#"
+trait T {
+    fn func() {}
+    const FLAG: i32 = 34;
+}
+impl T$0 for () {}
+"#,
+        expect![[r#"
+        *T*
+
+        ```rust
+        test
+        ```
+
+        ```rust
+        trait T {
+            fn func(),
+            const FLAG: i32,
+        }
+        ```
+        "#]],
+    );
+
+    check(
+        r#"
+trait T {
+    fn func() {}
+    const FLAG: i32 = 34;
+    type Bar;
+}
+impl T$0 for () {}
+"#,
+        expect![[r#"
+        *T*
+
+        ```rust
+        test
+        ```
+
+        ```rust
+        trait T {
+            fn func(),
+            const FLAG: i32,
+            type Bar,
+        }
+        ```
         "#]],
     );
 }

--- a/crates/ide/src/hover/tests.rs
+++ b/crates/ide/src/hover/tests.rs
@@ -411,7 +411,7 @@ fn main() {
                                 name: "FnOnce",
                                 kind: Trait,
                                 container_name: "function",
-                                description: "pub trait FnOnce<Args>\nwhere\n    Args: Tuple,",
+                                description: "pub trait FnOnce<Args>\nwhere\n    Args: Tuple, {\n    pub type Output,\n    pub extern \"rust-call\" fn call_once(self, args: Args) -> Self::Output,\n}",
                             },
                         },
                     ],
@@ -2766,7 +2766,7 @@ fn main() { let s$0t = foo(); }
                                 focus_range: 19..22,
                                 name: "Bar",
                                 kind: Trait,
-                                description: "trait Bar",
+                                description: "trait Bar {}",
                             },
                         },
                         HoverGotoTypeData {
@@ -2779,7 +2779,7 @@ fn main() { let s$0t = foo(); }
                                 focus_range: 6..9,
                                 name: "Foo",
                                 kind: Trait,
-                                description: "trait Foo",
+                                description: "trait Foo {}",
                             },
                         },
                     ],
@@ -2816,7 +2816,7 @@ fn main() { let s$0t = foo(); }
                                 focus_range: 22..25,
                                 name: "Bar",
                                 kind: Trait,
-                                description: "trait Bar<T>",
+                                description: "trait Bar<T> {}",
                             },
                         },
                         HoverGotoTypeData {
@@ -2829,7 +2829,7 @@ fn main() { let s$0t = foo(); }
                                 focus_range: 6..9,
                                 name: "Foo",
                                 kind: Trait,
-                                description: "trait Foo<T>",
+                                description: "trait Foo<T> {}",
                             },
                         },
                         HoverGotoTypeData {
@@ -2920,7 +2920,7 @@ fn foo(ar$0g: &impl Foo + Bar<S>) {}
                                 focus_range: 19..22,
                                 name: "Bar",
                                 kind: Trait,
-                                description: "trait Bar<T>",
+                                description: "trait Bar<T> {}",
                             },
                         },
                         HoverGotoTypeData {
@@ -2933,7 +2933,7 @@ fn foo(ar$0g: &impl Foo + Bar<S>) {}
                                 focus_range: 6..9,
                                 name: "Foo",
                                 kind: Trait,
-                                description: "trait Foo",
+                                description: "trait Foo {}",
                             },
                         },
                         HoverGotoTypeData {
@@ -3220,7 +3220,7 @@ fn foo(a$0rg: &impl ImplTrait<B<dyn DynTrait<B<S>>>>) {}
                                 focus_range: 28..36,
                                 name: "DynTrait",
                                 kind: Trait,
-                                description: "trait DynTrait<T>",
+                                description: "trait DynTrait<T> {}",
                             },
                         },
                         HoverGotoTypeData {
@@ -3233,7 +3233,7 @@ fn foo(a$0rg: &impl ImplTrait<B<dyn DynTrait<B<S>>>>) {}
                                 focus_range: 6..15,
                                 name: "ImplTrait",
                                 kind: Trait,
-                                description: "trait ImplTrait<T>",
+                                description: "trait ImplTrait<T> {}",
                             },
                         },
                         HoverGotoTypeData {
@@ -7456,7 +7456,7 @@ impl Iterator for S {
                                 name: "Future",
                                 kind: Trait,
                                 container_name: "future",
-                                description: "pub trait Future",
+                                description: "pub trait Future {\n    pub type Output,\n    pub fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output>,\n}",
                             },
                         },
                         HoverGotoTypeData {
@@ -7470,7 +7470,7 @@ impl Iterator for S {
                                 name: "Iterator",
                                 kind: Trait,
                                 container_name: "iterator",
-                                description: "pub trait Iterator",
+                                description: "pub trait Iterator {\n    pub type Item,\n    pub fn next(&mut self) -> Option<Self::Item>,\n    pub fn nth(&mut self, n: usize) -> Option<Self::Item>,\n    pub fn by_ref(&mut self) -> &mut Self\nwhere\n    Self: Sized,,\n}",
                             },
                         },
                         HoverGotoTypeData {
@@ -7483,7 +7483,7 @@ impl Iterator for S {
                                 focus_range: 49..56,
                                 name: "Notable",
                                 kind: Trait,
-                                description: "trait Notable",
+                                description: "trait Notable {}",
                             },
                         },
                         HoverGotoTypeData {

--- a/crates/ide/src/hover/tests.rs
+++ b/crates/ide/src/hover/tests.rs
@@ -17,6 +17,7 @@ const HOVER_BASE_CONFIG: HoverConfig = HoverConfig {
     documentation: true,
     format: HoverDocFormat::Markdown,
     keywords: true,
+    trait_item_display_on_hover: Some(7),
 };
 
 fn check_hover_no_result(ra_fixture: &str) {

--- a/crates/ide/src/static_index.rs
+++ b/crates/ide/src/static_index.rs
@@ -4,7 +4,7 @@
 use hir::{db::HirDatabase, Crate, HirFileIdExt, Module, Semantics};
 use ide_db::{
     base_db::{FileId, FileRange, SourceDatabaseExt},
-    defs::{Definition, HoverDisplayConfig},
+    defs::Definition,
     documentation::Documentation,
     famous_defs::FamousDefs,
     helpers::get_definition,
@@ -166,7 +166,7 @@ impl StaticIndex<'_> {
             documentation: true,
             keywords: true,
             format: crate::HoverDocFormat::Markdown,
-            trait_item_display_num: None,
+            trait_assoc_items_size: None,
         };
         let tokens = tokens.filter(|token| {
             matches!(
@@ -197,7 +197,7 @@ impl StaticIndex<'_> {
                     enclosing_moniker: current_crate
                         .zip(def.enclosing_definition(self.db))
                         .and_then(|(cc, enclosing_def)| def_to_moniker(self.db, enclosing_def, cc)),
-                    signature: Some(def.label(self.db, HoverDisplayConfig::default())),
+                    signature: Some(def.label(self.db)),
                     kind: def_to_kind(self.db, def),
                 });
                 self.def_map.insert(def, it);

--- a/crates/ide/src/static_index.rs
+++ b/crates/ide/src/static_index.rs
@@ -4,7 +4,7 @@
 use hir::{db::HirDatabase, Crate, HirFileIdExt, Module, Semantics};
 use ide_db::{
     base_db::{FileId, FileRange, SourceDatabaseExt},
-    defs::Definition,
+    defs::{Definition, HoverDisplayConfig},
     documentation::Documentation,
     famous_defs::FamousDefs,
     helpers::get_definition,
@@ -166,7 +166,7 @@ impl StaticIndex<'_> {
             documentation: true,
             keywords: true,
             format: crate::HoverDocFormat::Markdown,
-            trait_item_display_on_hover: Some(7)
+            trait_item_display_num: None,
         };
         let tokens = tokens.filter(|token| {
             matches!(
@@ -197,7 +197,7 @@ impl StaticIndex<'_> {
                     enclosing_moniker: current_crate
                         .zip(def.enclosing_definition(self.db))
                         .and_then(|(cc, enclosing_def)| def_to_moniker(self.db, enclosing_def, cc)),
-                    signature: Some(def.label(self.db, hover_config.trait_item_display_on_hover)),
+                    signature: Some(def.label(self.db, HoverDisplayConfig::default())),
                     kind: def_to_kind(self.db, def),
                 });
                 self.def_map.insert(def, it);

--- a/crates/ide/src/static_index.rs
+++ b/crates/ide/src/static_index.rs
@@ -166,6 +166,7 @@ impl StaticIndex<'_> {
             documentation: true,
             keywords: true,
             format: crate::HoverDocFormat::Markdown,
+            trait_item_display_on_hover: Some(7)
         };
         let tokens = tokens.filter(|token| {
             matches!(
@@ -196,7 +197,7 @@ impl StaticIndex<'_> {
                     enclosing_moniker: current_crate
                         .zip(def.enclosing_definition(self.db))
                         .and_then(|(cc, enclosing_def)| def_to_moniker(self.db, enclosing_def, cc)),
-                    signature: Some(def.label(self.db)),
+                    signature: Some(def.label(self.db, hover_config.trait_item_display_on_hover)),
                     kind: def_to_kind(self.db, def),
                 });
                 self.def_map.insert(def, it);

--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -368,6 +368,9 @@ config_data! {
         /// How to render the size information in a memory layout hover.
         hover_memoryLayout_size: Option<MemoryLayoutHoverRenderKindDef> = "\"both\"",
 
+        /// How many associated items of a trait to display when hovering a trait.
+        hover_show_traitAssocItems: Option<usize> = "null",
+
         /// Whether to enforce the import granularity setting for all files. If set to false rust-analyzer will try to keep import styles consistent per file.
         imports_granularity_enforce: bool              = "false",
         /// How imports should be grouped into use statements.
@@ -589,9 +592,6 @@ config_data! {
         signatureInfo_detail: SignatureDetail                           = "\"full\"",
         /// Show documentation.
         signatureInfo_documentation_enable: bool                       = "true",
-
-        /// How many trait item display on hover.
-        traitItemDisplayNum: Option<usize> = "7",
 
         /// Whether to insert closing angle brackets when typing an opening angle bracket of a generic argument list.
         typing_autoClosingAngleBrackets_enable: bool = "false",
@@ -1685,7 +1685,7 @@ impl Config {
                 }
             },
             keywords: self.data.hover_documentation_keywords_enable,
-            trait_item_display_num: self.data.traitItemDisplayNum,
+            trait_assoc_items_size: self.data.hover_show_traitAssocItems,
         }
     }
 

--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -511,7 +511,6 @@ config_data! {
         /// Exclude tests from find-all-references.
         references_excludeTests: bool = "false",
 
-
         /// Command to be executed instead of 'cargo' for runnables.
         runnables_command: Option<String> = "null",
         /// Additional arguments to be passed to cargo for runnables such as
@@ -590,6 +589,9 @@ config_data! {
         signatureInfo_detail: SignatureDetail                           = "\"full\"",
         /// Show documentation.
         signatureInfo_documentation_enable: bool                       = "true",
+
+        /// How many trait item display on hover.
+        trait_item_display_on_hover: Option<usize> = "7",
 
         /// Whether to insert closing angle brackets when typing an opening angle bracket of a generic argument list.
         typing_autoClosingAngleBrackets_enable: bool = "false",
@@ -1683,6 +1685,7 @@ impl Config {
                 }
             },
             keywords: self.data.hover_documentation_keywords_enable,
+            trait_item_display_on_hover: self.data.trait_item_display_on_hover,
         }
     }
 

--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -591,7 +591,7 @@ config_data! {
         signatureInfo_documentation_enable: bool                       = "true",
 
         /// How many trait item display on hover.
-        trait_item_display_on_hover: Option<usize> = "7",
+        traitItemDisplayNum: Option<usize> = "7",
 
         /// Whether to insert closing angle brackets when typing an opening angle bracket of a generic argument list.
         typing_autoClosingAngleBrackets_enable: bool = "false",
@@ -1685,7 +1685,7 @@ impl Config {
                 }
             },
             keywords: self.data.hover_documentation_keywords_enable,
-            trait_item_display_on_hover: self.data.trait_item_display_on_hover,
+            trait_item_display_num: self.data.traitItemDisplayNum,
         }
     }
 

--- a/docs/user/generated_config.adoc
+++ b/docs/user/generated_config.adoc
@@ -505,6 +505,11 @@ How to render the offset information in a memory layout hover.
 --
 How to render the size information in a memory layout hover.
 --
+[[rust-analyzer.hover.show.traitAssocItems]]rust-analyzer.hover.show.traitAssocItems (default: `null`)::
++
+--
+How many associated items of a trait to display when hovering a trait.
+--
 [[rust-analyzer.imports.granularity.enforce]]rust-analyzer.imports.granularity.enforce (default: `false`)::
 +
 --
@@ -926,11 +931,6 @@ Show full signature of the callable. Only shows parameters if disabled.
 +
 --
 Show documentation.
---
-[[rust-analyzer.traitItemDisplayNum]]rust-analyzer.traitItemDisplayNum (default: `7`)::
-+
---
-How many trait item display on hover.
 --
 [[rust-analyzer.typing.autoClosingAngleBrackets.enable]]rust-analyzer.typing.autoClosingAngleBrackets.enable (default: `false`)::
 +

--- a/docs/user/generated_config.adoc
+++ b/docs/user/generated_config.adoc
@@ -927,7 +927,7 @@ Show full signature of the callable. Only shows parameters if disabled.
 --
 Show documentation.
 --
-[[rust-analyzer.trait.item.display.on.hover]]rust-analyzer.trait.item.display.on.hover (default: `7`)::
+[[rust-analyzer.traitItemDisplayNum]]rust-analyzer.traitItemDisplayNum (default: `7`)::
 +
 --
 How many trait item display on hover.

--- a/docs/user/generated_config.adoc
+++ b/docs/user/generated_config.adoc
@@ -927,6 +927,11 @@ Show full signature of the callable. Only shows parameters if disabled.
 --
 Show documentation.
 --
+[[rust-analyzer.trait.item.display.on.hover]]rust-analyzer.trait.item.display.on.hover (default: `7`)::
++
+--
+How many trait item display on hover.
+--
 [[rust-analyzer.typing.autoClosingAngleBrackets.enable]]rust-analyzer.typing.autoClosingAngleBrackets.enable (default: `false`)::
 +
 --

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -1119,6 +1119,15 @@
                         }
                     ]
                 },
+                "rust-analyzer.hover.show.traitAssocItems": {
+                    "markdownDescription": "How many associated items of a trait to display when hovering a trait.",
+                    "default": null,
+                    "type": [
+                        "null",
+                        "integer"
+                    ],
+                    "minimum": 0
+                },
                 "rust-analyzer.imports.granularity.enforce": {
                     "markdownDescription": "Whether to enforce the import granularity setting for all files. If set to false rust-analyzer will try to keep import styles consistent per file.",
                     "default": false,
@@ -1647,15 +1656,6 @@
                     "markdownDescription": "Show documentation.",
                     "default": true,
                     "type": "boolean"
-                },
-                "rust-analyzer.traitItemDisplayNum": {
-                    "markdownDescription": "How many trait item display on hover.",
-                    "default": 7,
-                    "type": [
-                        "null",
-                        "integer"
-                    ],
-                    "minimum": 0
                 },
                 "rust-analyzer.typing.autoClosingAngleBrackets.enable": {
                     "markdownDescription": "Whether to insert closing angle brackets when typing an opening angle bracket of a generic argument list.",

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -1648,7 +1648,7 @@
                     "default": true,
                     "type": "boolean"
                 },
-                "rust-analyzer.trait.item.display.on.hover": {
+                "rust-analyzer.traitItemDisplayNum": {
                     "markdownDescription": "How many trait item display on hover.",
                     "default": 7,
                     "type": [

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -1648,6 +1648,15 @@
                     "default": true,
                     "type": "boolean"
                 },
+                "rust-analyzer.trait.item.display.on.hover": {
+                    "markdownDescription": "How many trait item display on hover.",
+                    "default": 7,
+                    "type": [
+                        "null",
+                        "integer"
+                    ],
+                    "minimum": 0
+                },
                 "rust-analyzer.typing.autoClosingAngleBrackets.enable": {
                     "markdownDescription": "Whether to insert closing angle brackets when typing an opening angle bracket of a generic argument list.",
                     "default": false,


### PR DESCRIPTION
This PR enable preview assoc items when hover on `trait`

![image](https://github.com/rust-lang/rust-analyzer/assets/71162630/d9c3949c-33cf-4a32-aa97-3af46b28033a)

inspired by https://github.com/rust-lang/rust-analyzer/pull/15847
