### PR TITLE
internal: simplify the removal of dulicate workspaces.

### DIFF
--- a/crates/rust-analyzer/src/reload.rs
+++ b/crates/rust-analyzer/src/reload.rs
@@ -22,6 +22,7 @@ use ide_db::{
     base_db::{salsa::Durability, CrateGraph, ProcMacroPaths, ProcMacros},
     FxHashMap,
 };
+use itertools::Itertools;
 use load_cargo::{load_proc_macro, ProjectFolders};
 use proc_macro_api::ProcMacroServer;
 use project_model::{ProjectWorkspace, WorkspaceBuildScripts};
@@ -227,16 +228,12 @@ impl GlobalState {
                 let mut i = 0;
                 while i < workspaces.len() {
                     if let Ok(w) = &workspaces[i] {
-                        let dupes: Vec<_> = workspaces
+                        let dupes: Vec<_> = workspaces[i + 1..]
                             .iter()
-                            .enumerate()
-                            .skip(i + 1)
-                            .filter_map(|(i, it)| {
-                                it.as_ref().ok().filter(|ws| ws.eq_ignore_build_data(w)).map(|_| i)
-                            })
+                            .positions(|it| it.as_ref().is_ok_and(|ws| ws.eq_ignore_build_data(w)))
                             .collect();
                         dupes.into_iter().rev().for_each(|d| {
-                            _ = workspaces.remove(d);
+                            _ = workspaces.remove(d + i + 1);
                         });
                     }
                     i += 1;


### PR DESCRIPTION
### Summary:
Refactoring the duplicate removal process for `workspaces` in `fetch_workspaces`.

### Changes Made:

Replaced `[].iter().enumerate().skip(...).filter_map(...)` with a more concise `[i+1..].positions(...)` provided by `itertools`, which enhances clarity without changing functionality

### Impact:

This change aims to enhance the duplicate removal process for `workspaces`. This change has been tested on my machine.

Please review and provide feedback. Thanks!