### PR TITLE
fix: add fallback for completion label details

### DIFF
--- a/crates/ide-completion/src/item.rs
+++ b/crates/ide-completion/src/item.rs
@@ -26,7 +26,7 @@ use crate::{
 pub struct CompletionItem {
     /// Label in the completion pop up which identifies completion.
     pub label: SmolStr,
-    /// Addition label details in the completion pop up that are
+    /// Additional label details in the completion pop up that are
     /// displayed and aligned on the right side after the label.
     pub label_detail: Option<SmolStr>,
 

--- a/crates/rust-analyzer/src/lsp/to_proto.rs
+++ b/crates/rust-analyzer/src/lsp/to_proto.rs
@@ -304,6 +304,8 @@ fn completion_item(
             detail: item.label_detail.as_ref().map(ToString::to_string),
             description: lsp_item.detail.clone(),
         });
+    } else if let Some(label_detail) = item.label_detail {
+        lsp_item.label.push_str(label_detail.as_str());
     }
 
     set_score(&mut lsp_item, max_relevance, item.relevance);


### PR DESCRIPTION
This PR adds a fallback to a previous implementation in a case when the label detail field isn't supported by LSP client and the support isn't reported by the LSP initialize request. In this case additional info about trait and aliases would be merged into the label field as it was before the #15956 PR.