### PR TITLE
minor: Bump rustc deps and chalk

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1502,16 +1502,6 @@ dependencies = [
 
 [[package]]
 name = "ra-ap-rustc_lexer"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90e573bf707e01fe2841dbdedeed42012004274db0edc0314e6e3e58a40598fc"
-dependencies = [
- "unicode-properties",
- "unicode-xid",
-]
-
-[[package]]
-name = "ra-ap-rustc_lexer"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d5e8650195795c4023d8321846466994a975bc457cb8a91c0b3b17a5fc8ba40"
@@ -1527,7 +1517,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a6b325ee1ec90e4dbd4394913adf4ef32e4fcf2b311ec9563a0fa50cd549af6"
 dependencies = [
  "ra-ap-rustc_index 0.20.0",
- "ra-ap-rustc_lexer 0.20.0",
+ "ra-ap-rustc_lexer",
 ]
 
 [[package]]
@@ -1650,7 +1640,7 @@ version = "0.0.0"
 dependencies = [
  "ra-ap-rustc_abi",
  "ra-ap-rustc_index 0.19.0",
- "ra-ap-rustc_lexer 0.19.0",
+ "ra-ap-rustc_lexer",
  "ra-ap-rustc_parse_format",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1458,23 +1458,13 @@ dependencies = [
 
 [[package]]
 name = "ra-ap-rustc_abi"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2ea80a299f04a896000ce17b76f3aa1d2fe59f347fbc99c4b8970316ef5a0d"
+checksum = "b5f38444d48da534b3bb612713fce9b0aeeffb2e0dfa242764f55482acc5b52d"
 dependencies = [
  "bitflags 1.3.2",
- "ra-ap-rustc_index 0.19.0",
+ "ra-ap-rustc_index",
  "tracing",
-]
-
-[[package]]
-name = "ra-ap-rustc_index"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4556489ef652e5eb6cdad6078fff08507badac80bfc1f79085c85a6d8b77ab5c"
-dependencies = [
- "arrayvec",
- "smallvec",
 ]
 
 [[package]]
@@ -1516,7 +1506,7 @@ version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a6b325ee1ec90e4dbd4394913adf4ef32e4fcf2b311ec9563a0fa50cd549af6"
 dependencies = [
- "ra-ap-rustc_index 0.20.0",
+ "ra-ap-rustc_index",
  "ra-ap-rustc_lexer",
 ]
 
@@ -1639,7 +1629,7 @@ name = "rustc-dependencies"
 version = "0.0.0"
 dependencies = [
  "ra-ap-rustc_abi",
- "ra-ap-rustc_index 0.19.0",
+ "ra-ap-rustc_index",
  "ra-ap-rustc_lexer",
  "ra-ap-rustc_parse_format",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1469,16 +1469,6 @@ dependencies = [
 
 [[package]]
 name = "ra-ap-rustc_index"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "643ca3609870b1778d9cd1f2a8e4ccb4af0f48f3637cc257a09494d087bd93dc"
-dependencies = [
- "arrayvec",
- "smallvec",
-]
-
-[[package]]
-name = "ra-ap-rustc_index"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4556489ef652e5eb6cdad6078fff08507badac80bfc1f79085c85a6d8b77ab5c"
@@ -1488,13 +1478,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "ra-ap-rustc_lexer"
-version = "0.14.0"
+name = "ra-ap-rustc_index"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30ffd24f9ba4f1d25ff27ca1469b8d22a3bdfb12cf644fc8bfcb63121fa5da6b"
+checksum = "69fb5da07e1a39222d9c311203123c3b6a86420fa06dc695aa1661b0aecf8d16"
 dependencies = [
- "unicode-properties",
- "unicode-xid",
+ "arrayvec",
+ "ra-ap-rustc_index_macros",
+ "smallvec",
+]
+
+[[package]]
+name = "ra-ap-rustc_index_macros"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d69f9f6af58124f2da0cb8b0c3d8494e0d883a5fe0c6732258bde81ac5a87cc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
+ "synstructure",
 ]
 
 [[package]]
@@ -1508,13 +1511,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "ra-ap-rustc_parse_format"
-version = "0.14.0"
+name = "ra-ap-rustc_lexer"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "207b5ac1a21d4926695e03b605ffb9f63d4968e0488e9197c04c512c37303aa7"
+checksum = "9d5e8650195795c4023d8321846466994a975bc457cb8a91c0b3b17a5fc8ba40"
 dependencies = [
- "ra-ap-rustc_index 0.14.0",
- "ra-ap-rustc_lexer 0.14.0",
+ "unicode-properties",
+ "unicode-xid",
+]
+
+[[package]]
+name = "ra-ap-rustc_parse_format"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6b325ee1ec90e4dbd4394913adf4ef32e4fcf2b311ec9563a0fa50cd549af6"
+dependencies = [
+ "ra-ap-rustc_index 0.20.0",
+ "ra-ap-rustc_lexer 0.20.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,9 +160,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chalk-derive"
-version = "0.94.0"
+version = "0.95.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0322d5289ceba3217a03c9af72aa403d87542822b753daa1da32e4b992a4e80"
+checksum = "329427f28cd2bddaacd47c4dcd3d7082d315c61fb164394c690fe98c1b6ee9d3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -172,20 +172,20 @@ dependencies = [
 
 [[package]]
 name = "chalk-ir"
-version = "0.94.0"
+version = "0.95.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0946cbc6d9136980a24a2dddf1888b5f0aa978dda300a3aa470b55b777b6bf3c"
+checksum = "9e1e1659238bd598d0f7dbc5034cf1ff46010a3d6827704c9ed443c8359cb484"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.1",
  "chalk-derive",
  "lazy_static",
 ]
 
 [[package]]
 name = "chalk-recursive"
-version = "0.94.0"
+version = "0.95.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd93fedbeeadc0cd4d0eb73bd061b621af99f5324a6a518264c8ef5e526e0ec"
+checksum = "b3e0bff0ba1bed11407384fcec0353aeb6888901e63cb47d04505ec47adad847"
 dependencies = [
  "chalk-derive",
  "chalk-ir",
@@ -196,15 +196,15 @@ dependencies = [
 
 [[package]]
 name = "chalk-solve"
-version = "0.94.0"
+version = "0.95.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a254cff72303c58c82df421cfe9465606372b81588923fcf179922b7eaad9a53"
+checksum = "eb9c46d501cf83732a91056c0c846ae7a16d6b3c67a6a6bb5e9cc0a2e91563b6"
 dependencies = [
  "chalk-derive",
  "chalk-ir",
  "ena",
  "indexmap 2.1.0",
- "itertools 0.10.5",
+ "itertools",
  "petgraph",
  "rustc-hash",
  "tracing",
@@ -487,7 +487,7 @@ dependencies = [
  "hir-def",
  "hir-expand",
  "hir-ty",
- "itertools 0.12.0",
+ "itertools",
  "once_cell",
  "profile",
  "rustc-hash",
@@ -516,7 +516,7 @@ dependencies = [
  "hir-expand",
  "indexmap 2.1.0",
  "intern",
- "itertools 0.12.0",
+ "itertools",
  "la-arena 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "limit",
  "mbe",
@@ -544,7 +544,7 @@ dependencies = [
  "expect-test",
  "hashbrown 0.12.3",
  "intern",
- "itertools 0.12.0",
+ "itertools",
  "la-arena 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "limit",
  "mbe",
@@ -576,7 +576,7 @@ dependencies = [
  "hir-def",
  "hir-expand",
  "intern",
- "itertools 0.12.0",
+ "itertools",
  "la-arena 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "limit",
  "nohash-hasher",
@@ -623,7 +623,7 @@ dependencies = [
  "ide-db",
  "ide-diagnostics",
  "ide-ssr",
- "itertools 0.12.0",
+ "itertools",
  "nohash-hasher",
  "oorandom",
  "profile",
@@ -649,7 +649,7 @@ dependencies = [
  "expect-test",
  "hir",
  "ide-db",
- "itertools 0.12.0",
+ "itertools",
  "profile",
  "smallvec",
  "sourcegen",
@@ -668,7 +668,7 @@ dependencies = [
  "expect-test",
  "hir",
  "ide-db",
- "itertools 0.12.0",
+ "itertools",
  "once_cell",
  "profile",
  "smallvec",
@@ -690,7 +690,7 @@ dependencies = [
  "fst",
  "hir",
  "indexmap 2.1.0",
- "itertools 0.12.0",
+ "itertools",
  "limit",
  "line-index 0.1.0-pre.1",
  "memchr",
@@ -721,7 +721,7 @@ dependencies = [
  "expect-test",
  "hir",
  "ide-db",
- "itertools 0.12.0",
+ "itertools",
  "once_cell",
  "profile",
  "serde_json",
@@ -740,7 +740,7 @@ dependencies = [
  "expect-test",
  "hir",
  "ide-db",
- "itertools 0.12.0",
+ "itertools",
  "nohash-hasher",
  "parser",
  "stdx",
@@ -817,15 +817,6 @@ dependencies = [
  "hashbrown 0.12.3",
  "rustc-hash",
  "triomphe",
-]
-
-[[package]]
-name = "itertools"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
 ]
 
 [[package]]
@@ -941,7 +932,7 @@ dependencies = [
  "crossbeam-channel",
  "ide",
  "ide-db",
- "itertools 0.12.0",
+ "itertools",
  "proc-macro-api",
  "project-model",
  "tracing",
@@ -1393,7 +1384,7 @@ dependencies = [
  "cargo_metadata",
  "cfg",
  "expect-test",
- "itertools 0.12.0",
+ "itertools",
  "la-arena 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "paths",
  "profile",
@@ -1578,7 +1569,7 @@ dependencies = [
  "ide",
  "ide-db",
  "ide-ssr",
- "itertools 0.12.0",
+ "itertools",
  "load-cargo",
  "lsp-server 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "lsp-types",
@@ -1855,7 +1846,7 @@ dependencies = [
  "either",
  "expect-test",
  "indexmap 2.1.0",
- "itertools 0.12.0",
+ "itertools",
  "once_cell",
  "parser",
  "proc-macro2",
@@ -1889,7 +1880,7 @@ dependencies = [
 name = "text-edit"
 version = "0.0.0"
 dependencies = [
- "itertools 0.12.0",
+ "itertools",
  "text-size",
 ]
 

--- a/crates/hir-ty/Cargo.toml
+++ b/crates/hir-ty/Cargo.toml
@@ -23,10 +23,10 @@ oorandom = "11.1.3"
 tracing.workspace = true
 rustc-hash = "1.1.0"
 scoped-tls = "1.0.0"
-chalk-solve = { version = "0.94.0", default-features = false }
-chalk-ir = "0.94.0"
-chalk-recursive = { version = "0.94.0", default-features = false }
-chalk-derive = "0.94.0"
+chalk-solve = { version = "0.95.0", default-features = false }
+chalk-ir = "0.95.0"
+chalk-recursive = { version = "0.95.0", default-features = false }
+chalk-derive = "0.95.0"
 la-arena.workspace = true
 once_cell = "1.17.0"
 triomphe.workspace = true

--- a/crates/rustc-dependencies/Cargo.toml
+++ b/crates/rustc-dependencies/Cargo.toml
@@ -12,7 +12,7 @@ authors.workspace = true
 
 [dependencies]
 ra-ap-rustc_lexer = { version = "0.19.0" }
-ra-ap-rustc_parse_format = { version = "0.14.0", default-features = false }
+ra-ap-rustc_parse_format = { version = "0.20.0", default-features = false }
 ra-ap-rustc_index = { version = "0.19.0", default-features = false }
 ra-ap-rustc_abi = { version = "0.19.0", default-features = false }
 

--- a/crates/rustc-dependencies/Cargo.toml
+++ b/crates/rustc-dependencies/Cargo.toml
@@ -11,7 +11,7 @@ authors.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ra-ap-rustc_lexer = { version = "0.19.0" }
+ra-ap-rustc_lexer = { version = "0.20.0" }
 ra-ap-rustc_parse_format = { version = "0.20.0", default-features = false }
 ra-ap-rustc_index = { version = "0.19.0", default-features = false }
 ra-ap-rustc_abi = { version = "0.19.0", default-features = false }

--- a/crates/rustc-dependencies/Cargo.toml
+++ b/crates/rustc-dependencies/Cargo.toml
@@ -13,8 +13,8 @@ authors.workspace = true
 [dependencies]
 ra-ap-rustc_lexer = { version = "0.20.0" }
 ra-ap-rustc_parse_format = { version = "0.20.0", default-features = false }
-ra-ap-rustc_index = { version = "0.19.0", default-features = false }
-ra-ap-rustc_abi = { version = "0.19.0", default-features = false }
+ra-ap-rustc_index = { version = "0.20.0", default-features = false }
+ra-ap-rustc_abi = { version = "0.20.0", default-features = false }
 
 [features]
 in-rust-tree = []


### PR DESCRIPTION
This finally upgrades `ra-ap-rustc_parse_format` (even though it's probably a no-op?).