### PR TITLE
fix: don't make `MissingMatchArms` diagnostic for empty match body

### DIFF
--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -1914,17 +1914,20 @@ impl DefWithBody {
                             if let ast::Expr::MatchExpr(match_expr) =
                                 &source_ptr.value.to_node(&root)
                             {
-                                if let Some(scrut_expr) = match_expr.expr() {
-                                    acc.push(
-                                        MissingMatchArms {
-                                            scrutinee_expr: InFile::new(
-                                                source_ptr.file_id,
-                                                AstPtr::new(&scrut_expr),
-                                            ),
-                                            uncovered_patterns,
-                                        }
-                                        .into(),
-                                    );
+                                match match_expr.expr() {
+                                    Some(scrut_expr) if match_expr.match_arm_list().is_some() => {
+                                        acc.push(
+                                            MissingMatchArms {
+                                                scrutinee_expr: InFile::new(
+                                                    source_ptr.file_id,
+                                                    AstPtr::new(&scrut_expr),
+                                                ),
+                                                uncovered_patterns,
+                                            }
+                                            .into(),
+                                        );
+                                    }
+                                    _ => {}
                                 }
                             }
                         }

--- a/crates/ide-diagnostics/src/handlers/missing_match_arms.rs
+++ b/crates/ide-diagnostics/src/handlers/missing_match_arms.rs
@@ -17,7 +17,10 @@ pub(crate) fn missing_match_arms(
 
 #[cfg(test)]
 mod tests {
-    use crate::tests::check_diagnostics;
+    use crate::{
+        tests::{check_diagnostics, check_diagnostics_with_config},
+        DiagnosticsConfig,
+    };
 
     #[track_caller]
     fn check_diagnostics_no_bails(ra_fixture: &str) {
@@ -27,11 +30,13 @@ mod tests {
 
     #[test]
     fn empty_body() {
-        check_diagnostics_no_bails(
+        let mut config = DiagnosticsConfig::test_sample();
+        config.disabled.insert("syntax-error".to_string());
+        check_diagnostics_with_config(
+            config,
             r#"
 fn main() {
     match 0;
-         //^ error: Syntax Error: expected `{`
 }
 "#,
         );

--- a/crates/ide-diagnostics/src/handlers/missing_match_arms.rs
+++ b/crates/ide-diagnostics/src/handlers/missing_match_arms.rs
@@ -26,6 +26,18 @@ mod tests {
     }
 
     #[test]
+    fn empty_body() {
+        check_diagnostics_no_bails(
+            r#"
+fn main() {
+    match 0;
+         //^ error: Syntax Error: expected `{`
+}
+"#,
+        );
+    }
+
+    #[test]
     fn empty_tuple() {
         check_diagnostics_no_bails(
             r#"


### PR DESCRIPTION
before 
<img width="423" alt="before" src="https://github.com/rust-lang/rust-analyzer/assets/71162630/5c0e46fb-0c03-42f2-96ff-8e5245c25965">

after
<img width="423" alt="after" src="https://github.com/rust-lang/rust-analyzer/assets/71162630/e2479dc5-3634-479b-af29-0b0ec7dc4a4f">


close https://github.com/rust-lang/rust-analyzer/issues/15954