### PR TITLE
Use build scripts from rustc source workspace

### DIFF
--- a/crates/load-cargo/src/lib.rs
+++ b/crates/load-cargo/src/lib.rs
@@ -40,7 +40,7 @@ pub fn load_workspace_at(
 ) -> anyhow::Result<(AnalysisHost, vfs::Vfs, Option<ProcMacroServer>)> {
     let root = AbsPathBuf::assert(std::env::current_dir()?.join(root));
     let root = ProjectManifest::discover_single(&root)?;
-    let mut workspace = ProjectWorkspace::load(root, cargo_config, progress)?;
+    let mut workspace = ProjectWorkspace::load(root, cargo_config, progress, false)?;
 
     if load_config.load_out_dirs_from_check {
         let build_scripts = workspace.run_build_scripts(cargo_config, progress)?;
@@ -81,6 +81,7 @@ pub fn load_workspace(
             vfs.file_id(&path)
         },
         extra_env,
+        None,
     );
     let proc_macros = {
         let proc_macro_server = match &proc_macro_server {

--- a/crates/project-model/src/lib.rs
+++ b/crates/project-model/src/lib.rs
@@ -50,7 +50,7 @@ pub use crate::{
     manifest_path::ManifestPath,
     project_json::{ProjectJson, ProjectJsonData},
     sysroot::Sysroot,
-    workspace::{CfgOverrides, PackageRoot, ProjectWorkspace},
+    workspace::{CfgOverrides, PackageRoot, ProjectWorkspace, RustcWorkspace},
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Ord, PartialOrd)]

--- a/crates/project-model/src/tests.rs
+++ b/crates/project-model/src/tests.rs
@@ -11,8 +11,8 @@ use rustc_hash::FxHashMap;
 use serde::de::DeserializeOwned;
 
 use crate::{
-    CargoWorkspace, CfgOverrides, ProjectJson, ProjectJsonData, ProjectWorkspace, Sysroot,
-    WorkspaceBuildScripts,
+    CargoWorkspace, CfgOverrides, ProjectJson, ProjectJsonData, ProjectWorkspace, RustcWorkspace,
+    Sysroot, WorkspaceBuildScripts,
 };
 
 fn load_cargo(file: &str) -> (CrateGraph, ProcMacroPaths) {
@@ -29,7 +29,7 @@ fn load_cargo_with_overrides(
         cargo: cargo_workspace,
         build_scripts: WorkspaceBuildScripts::default(),
         sysroot: Err(None),
-        rustc: Err(None),
+        rustc: RustcWorkspace::Loaded(Err(None)),
         rustc_cfg: Vec::new(),
         cfg_overrides,
         toolchain: None,
@@ -48,7 +48,7 @@ fn load_cargo_with_sysroot(
         cargo: cargo_workspace,
         build_scripts: WorkspaceBuildScripts::default(),
         sysroot: Ok(get_fake_sysroot()),
-        rustc: Err(None),
+        rustc: RustcWorkspace::Loaded(Err(None)),
         rustc_cfg: Vec::new(),
         cfg_overrides: Default::default(),
         toolchain: None,
@@ -62,6 +62,7 @@ fn load_cargo_with_sysroot(
             }
         },
         &Default::default(),
+        None,
     )
 }
 
@@ -146,6 +147,7 @@ fn to_crate_graph(project_workspace: ProjectWorkspace) -> (CrateGraph, ProcMacro
             }
         },
         &Default::default(),
+        None,
     )
 }
 

--- a/crates/rust-analyzer/src/cli/analysis_stats.rs
+++ b/crates/rust-analyzer/src/cli/analysis_stats.rs
@@ -70,7 +70,7 @@ impl flags::AnalysisStats {
         let path = AbsPathBuf::assert(env::current_dir()?.join(&self.path));
         let manifest = ProjectManifest::discover_single(&path)?;
 
-        let mut workspace = ProjectWorkspace::load(manifest, &cargo_config, no_progress)?;
+        let mut workspace = ProjectWorkspace::load(manifest, &cargo_config, no_progress, false)?;
         let metadata_time = db_load_sw.elapsed();
         let load_cargo_config = LoadCargoConfig {
             load_out_dirs_from_check: !self.disable_build_scripts,

--- a/crates/rust-analyzer/src/cli/lsif.rs
+++ b/crates/rust-analyzer/src/cli/lsif.rs
@@ -299,7 +299,7 @@ impl flags::Lsif {
         let path = AbsPathBuf::assert(env::current_dir()?.join(&self.path));
         let manifest = ProjectManifest::discover_single(&path)?;
 
-        let workspace = ProjectWorkspace::load(manifest, &cargo_config, no_progress)?;
+        let workspace = ProjectWorkspace::load(manifest, &cargo_config, no_progress, false)?;
 
         let (host, vfs, _proc_macro) =
             load_workspace(workspace, &cargo_config.extra_env, &load_cargo_config)?;


### PR DESCRIPTION
The status quo ante (since #14348)  is that, if a workspace has one or more packages with `package.metadata.rust-analyzer.rustc_private = true`, build scripts for those `rustc_private` crates are located either from building the workspace itself (if the workspace is the rustc source root) or else from the toolchain's `target-libdir` (as determined from invoking `rustc --print target-libdir`).

The problem with this approach is that, when working on rustc, there are such workspaces that are not themselves the rustc source root—and the toolchain `target-libdir` in such situations is not the appropriate one for use by the stage0 proc-macro server.  For example, `rustc_codegen_cranelift` is opened as a workspace, it is not the rustc source root, and (owing to its `rust-toolchain` override file) its `target-libdir` is that of a specific nightly compiler; attempting to use the proc-macro dylibs therein gives rise to an ABI mismatch error.

The correct build scripts are instead located from building the opened rustc source root workspace, but finding these when building another workspace's crate graph requires the rustc source root workspace already to have been identified (and built).  This PR therefore ensures that any such workspace is processed first, and that a reference thereto is passed into the crate graph construction functions for each workspace.

Incidentally, while working on debugging this issue, I noticed that such arising `CrateOrigin::Rustc` crates end up as duplicates of the `CrateOrigin::Local` crates from the opened rustc source root workspace—I already have a little deduplication tweak to the `CrateGraph::extend` function which I will open as a separate PR (and this pretty much halves the number of crates indexed by RA when working on rustc).