### PR TITLE
fix: bug in extract_function.rs

### DIFF
--- a/crates/ide-assists/src/handlers/extract_function.rs
+++ b/crates/ide-assists/src/handlers/extract_function.rs
@@ -147,7 +147,12 @@ pub(crate) fn extract_function(acc: &mut Assists, ctx: &AssistContext<'_>) -> Op
                 _ => format_function(ctx, module, &fun, old_indent, new_indent),
             };
 
-            if fn_def.contains("ControlFlow") {
+            // There are external control flows
+            if fun
+                .control_flow
+                .kind
+                .is_some_and(|kind| matches!(kind, FlowKind::Break(_, _) | FlowKind::Continue(_)))
+            {
                 let scope = match scope {
                     ImportScope::File(it) => ImportScope::File(builder.make_mut(it)),
                     ImportScope::Module(it) => ImportScope::Module(builder.make_mut(it)),
@@ -4967,6 +4972,27 @@ pub fn testfn(arg: &mut Foo) {
 
 fn $0fun_name(arg: &mut Foo) {
     arg.field = 8;
+}
+"#,
+        );
+    }
+    #[test]
+    fn does_not_import_control_flow() {
+        check_assist(
+            extract_function,
+            r#"
+//- minicore: try
+fn func() {
+    $0let cf = "I'm ControlFlow";$0
+}
+"#,
+            r#"
+fn func() {
+    fun_name();
+}
+
+fn $0fun_name() {
+    let cf = "I'm ControlFlow";
 }
 "#,
         );


### PR DESCRIPTION
There is a little bug in extract_function: It appends `use path::to::ControlFlow;` if the function created contains string "ControlFlow".

 A case below (also in the test named `does_not_import_control_flow` which will fail in the original code)

<img width="322" alt="image" src="https://github.com/rust-lang/rust-analyzer/assets/53432474/4b80bb58-0cfd-4d56-b64c-d9649eed336e">
<img width="391" alt="image" src="https://github.com/rust-lang/rust-analyzer/assets/53432474/3d7262f4-8a4c-44ea-822d-304b8b23fe28">

Now I have changed the condition determining whether adding import statement. Only when the new function body contains ControlFlow::Break or ControlFlow::Continue can the import statement be added.

Last related PR: https://github.com/rust-lang/rust-analyzer/pull/10309