### PR TITLE
fix: Insert fn call parens only if the parens inserted around field name

### DIFF
--- a/crates/ide-completion/src/completions/record.rs
+++ b/crates/ide-completion/src/completions/record.rs
@@ -430,4 +430,29 @@ fn foo() {
 "#,
         );
     }
+
+    #[test]
+    fn callable_field_struct_init() {
+        check_edit(
+            "field",
+            r#"
+struct S {
+    field: fn(),
+}
+
+fn main() {
+    S {fi$0
+}
+"#,
+            r#"
+struct S {
+    field: fn(),
+}
+
+fn main() {
+    S {field
+}
+"#,
+        );
+    }
 }

--- a/crates/ide-completion/src/render.rs
+++ b/crates/ide-completion/src/render.rs
@@ -169,14 +169,14 @@ pub(crate) fn render_field(
                 if let Some(receiver) = ctx.completion.sema.original_ast_node(receiver.clone()) {
                     builder.insert(receiver.syntax().text_range().start(), "(".to_string());
                     builder.insert(ctx.source_range().end(), ")".to_string());
+
+                    let is_parens_needed =
+                        !matches!(dot_access.kind, DotAccessKind::Method { has_parens: true });
+
+                    if is_parens_needed {
+                        builder.insert(ctx.source_range().end(), "()".to_string());
+                    }
                 }
-            }
-
-            let is_parens_needed =
-                !matches!(dot_access.kind, DotAccessKind::Method { has_parens: true });
-
-            if is_parens_needed {
-                builder.insert(ctx.source_range().end(), "()".to_string());
             }
         }
 


### PR DESCRIPTION
Fixes #16014.

Sorry I missed it in previous PR. I've added a test as level to prevent regressions again. 
Give any suggestions to improve the test if anything.