### PR TITLE
feature: Add `Replace if let else with Option::map_or_else` assist

### DIFF
--- a/crates/ide-assists/src/assist_context.rs
+++ b/crates/ide-assists/src/assist_context.rs
@@ -150,6 +150,7 @@ impl Assists {
         self.buf
     }
 
+    #[track_caller]
     pub(crate) fn add(
         &mut self,
         id: AssistId,
@@ -173,6 +174,7 @@ impl Assists {
         self.add_impl(Some(group), id, label.into(), target, &mut |it| f.take().unwrap()(it))
     }
 
+    #[track_caller]
     fn add_impl(
         &mut self,
         group: Option<&GroupLabel>,

--- a/crates/ide-assists/src/handlers/extract_function.rs
+++ b/crates/ide-assists/src/handlers/extract_function.rs
@@ -462,7 +462,7 @@ impl Param {
             ParamKind::MutRef => make::ty_ref(ty, true),
         };
 
-        make::param(pat.into(), ty)
+        make::param(pat.into(), Some(ty))
     }
 }
 

--- a/crates/ide-assists/src/handlers/generate_function.rs
+++ b/crates/ide-assists/src/handlers/generate_function.rs
@@ -554,7 +554,7 @@ fn fn_args(
     }
     deduplicate_arg_names(&mut arg_names);
     let params = arg_names.into_iter().zip(arg_types).map(|(name, ty)| {
-        make::param(make::ext::simple_ident_pat(make::name(&name)).into(), make::ty(&ty))
+        make::param(make::ext::simple_ident_pat(make::name(&name)).into(), Some(make::ty(&ty)))
     });
 
     Some(make::param_list(

--- a/crates/ide-assists/src/handlers/replace_if_let_else_option_with_map_or_else.rs
+++ b/crates/ide-assists/src/handlers/replace_if_let_else_option_with_map_or_else.rs
@@ -1,0 +1,101 @@
+use ide_db::{syntax_helpers::node_ext::single_let, ty_filter::TryEnum};
+use syntax::{
+    ast::{self, make},
+    AstNode, TextRange,
+};
+
+use crate::{utils::does_pat_match_variant, AssistContext, AssistId, AssistKind, Assists};
+
+// Assist: replace_if_let_else_option_with_map_or_else
+//
+// Replaces a `if let Some(_) = ... { ... } else { ... }` expression with `Option::map_or_else`.
+//
+// ```
+// fn do_complicated_function() -> i32 { 1 }
+//
+// let optional = Some(1);
+//
+// let _ = $0if let Some(foo) = optional {
+//     foo
+// } else {
+//     let y = do_complicated_function();
+//     y*y
+// };
+// ```
+// ->
+// ```
+// fn do_complicated_function() -> i32 { 1 }
+//
+// let optional = Some(1);
+//
+// let _ = optional.map_or_else(|| {
+//     let y = do_complicated_function();
+//     y*y
+// }, |foo| {
+//     foo
+// });
+// ```
+pub(crate) fn replace_if_let_else_option_with_map_or_else(
+    acc: &mut Assists,
+    ctx: &AssistContext<'_>,
+) -> Option<()> {
+    let if_expr: ast::IfExpr = ctx.find_node_at_offset()?;
+    let available_range = TextRange::new(
+        if_expr.syntax().text_range().start(),
+        if_expr.then_branch()?.syntax().text_range().start(),
+    );
+    let cursor_in_range = available_range.contains_range(ctx.selection_trimmed());
+    if !cursor_in_range {
+        return None;
+    }
+
+    let Some(ast::ElseBranch::Block(else_block)) = if_expr.else_branch() else {
+        return None;
+    };
+
+    let scrutinee_to_be_expr = if_expr.condition()?;
+    let scrutinee_to_be_expr = match single_let(scrutinee_to_be_expr.clone()) {
+        Some(cond) => cond.expr()?,
+        None => scrutinee_to_be_expr,
+    };
+    let expr;
+    let pat;
+    match single_let(if_expr.clone().condition()?) {
+        Some(let_) => {
+            let pat_ = let_.pat()?;
+            expr = let_.expr()?;
+            if !does_pat_match_variant(&pat_, &TryEnum::Option.happy_pattern_wildcard()) {
+                return None;
+            }
+            let ast::Pat::TupleStructPat(tuple_pat) = pat_ else {
+                return None;
+            };
+
+            if scrutinee_to_be_expr.syntax().text() != expr.syntax().text() {
+                return None;
+            }
+            pat = tuple_pat.fields().next()?;
+        }
+        None => return None,
+    };
+    let body = if_expr.then_branch()?;
+
+    acc.add(
+        AssistId("replace_if_let_else_option_with_map_or_else", AssistKind::RefactorRewrite),
+        "Replace if let else with `Option::map_or_else`".to_owned(),
+        available_range,
+        move |edit| {
+            let map_or_else = {
+                let option_map_or_else = make::name_ref("map_or_else");
+                let map_expr = make::expr_closure(Some(make::param(pat, None)), body.into());
+                let else_expr = make::expr_closure(None, else_block.into());
+                make::expr_method_call(
+                    expr,
+                    option_map_or_else,
+                    make::arg_list([else_expr, map_expr]),
+                )
+            };
+            edit.replace_ast(if_expr.into(), map_or_else)
+        },
+    )
+}

--- a/crates/ide-assists/src/lib.rs
+++ b/crates/ide-assists/src/lib.rs
@@ -195,6 +195,7 @@ mod handlers {
     mod reorder_impl_items;
     mod replace_try_expr_with_match;
     mod replace_derive_with_manual_impl;
+    mod replace_if_let_else_option_with_map_or_else;
     mod replace_if_let_with_match;
     mod replace_is_method_with_if_let_method;
     mod replace_method_eager_lazy;
@@ -314,6 +315,7 @@ mod handlers {
             reorder_impl_items::reorder_impl_items,
             replace_try_expr_with_match::replace_try_expr_with_match,
             replace_derive_with_manual_impl::replace_derive_with_manual_impl,
+            replace_if_let_else_option_with_map_or_else::replace_if_let_else_option_with_map_or_else,
             replace_if_let_with_match::replace_if_let_with_match,
             replace_if_let_with_match::replace_match_with_if_let,
             replace_is_method_with_if_let_method::replace_is_method_with_if_let_method,

--- a/crates/ide-assists/src/tests/generated.rs
+++ b/crates/ide-assists/src/tests/generated.rs
@@ -2567,6 +2567,37 @@ impl Debug for S {
 }
 
 #[test]
+fn doctest_replace_if_let_else_option_with_map_or_else() {
+    check_doc_test(
+        "replace_if_let_else_option_with_map_or_else",
+        r#####"
+fn do_complicated_function() -> i32 { 1 }
+
+let optional = Some(1);
+
+let _ = $0if let Some(foo) = optional {
+    foo
+} else {
+    let y = do_complicated_function();
+    y*y
+};
+"#####,
+        r#####"
+fn do_complicated_function() -> i32 { 1 }
+
+let optional = Some(1);
+
+let _ = optional.map_or_else(|| {
+    let y = do_complicated_function();
+    y*y
+}, |foo| {
+    foo
+});
+"#####,
+    )
+}
+
+#[test]
 fn doctest_replace_if_let_with_match() {
     check_doc_test(
         "replace_if_let_with_match",

--- a/crates/ide-db/src/label.rs
+++ b/crates/ide-db/src/label.rs
@@ -29,6 +29,7 @@ impl From<Label> for String {
 }
 
 impl Label {
+    #[track_caller]
     pub fn new(label: String) -> Label {
         assert!(label.starts_with(char::is_uppercase) && !label.ends_with('.'));
         Label(label)

--- a/crates/syntax/src/ast/make.rs
+++ b/crates/syntax/src/ast/make.rs
@@ -844,8 +844,12 @@ pub fn item_const(
     ast_from_text(&format!("{visibility} const {name}: {ty} = {expr};"))
 }
 
-pub fn param(pat: ast::Pat, ty: ast::Type) -> ast::Param {
-    ast_from_text(&format!("fn f({pat}: {ty}) {{ }}"))
+pub fn param(pat: ast::Pat, ty: Option<ast::Type>) -> ast::Param {
+    if let Some(ty) = ty {
+        ast_from_text(&format!("fn f({pat}: {ty}) {{ }}"))
+    } else {
+        ast_from_text(&format!("fn f({pat}) {{ }}"))
+    }
 }
 
 pub fn self_param() -> ast::SelfParam {


### PR DESCRIPTION
Implements the [`option_if_let_else`](https://rust-lang.github.io/rust-clippy/master/index.html#/option_if_let_else) clippy lint.

[](https://github.com/rust-lang/rust-analyzer/assets/1502855/a56624e2-d964-4daa-ac35-6f44fbd71958)
