### PR TITLE
Add a request for setting response prefix

### DIFF
--- a/crates/proc-macro-api/src/lib.rs
+++ b/crates/proc-macro-api/src/lib.rs
@@ -178,7 +178,9 @@ impl ProcMacro {
             msg::Response::ExpandMacro(it) => {
                 Ok(it.map(|tree| FlatTree::to_subtree_resolved(tree, version, &span_data_table)))
             }
-            msg::Response::ListMacros(..) | msg::Response::ApiVersionCheck(..) => {
+            msg::Response::ListMacros(..)
+            | msg::Response::ApiVersionCheck(..)
+            | msg::Response::SetExpanderSettings { .. } => {
                 Err(ServerError { message: "unexpected response".to_string(), io: None })
             }
         }

--- a/crates/proc-macro-api/src/msg.rs
+++ b/crates/proc-macro-api/src/msg.rs
@@ -17,14 +17,16 @@ pub const NO_VERSION_CHECK_VERSION: u32 = 0;
 pub const VERSION_CHECK_VERSION: u32 = 1;
 pub const ENCODE_CLOSE_SPAN_VERSION: u32 = 2;
 pub const HAS_GLOBAL_SPANS: u32 = 3;
+pub const EXPAND_MACRO_RESPONSE_PREFIX: u32 = 4;
 
-pub const CURRENT_API_VERSION: u32 = HAS_GLOBAL_SPANS;
+pub const CURRENT_API_VERSION: u32 = EXPAND_MACRO_RESPONSE_PREFIX;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub enum Request {
     ListMacros { dylib_path: PathBuf },
     ExpandMacro(ExpandMacro),
     ApiVersionCheck {},
+    SetExpanderSettings { response_prefix: String },
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -32,6 +34,7 @@ pub enum Response {
     ListMacros(Result<Vec<(String, ProcMacroKind)>, String>),
     ExpandMacro(Result<FlatTree, PanicMessage>),
     ApiVersionCheck(u32),
+    SetExpanderSettings {},
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/crates/proc-macro-api/src/process.rs
+++ b/crates/proc-macro-api/src/process.rs
@@ -62,7 +62,9 @@ impl ProcMacroProcessSrv {
 
         match response {
             Response::ApiVersionCheck(version) => Ok(version),
-            Response::ExpandMacro { .. } | Response::ListMacros { .. } => {
+            Response::ExpandMacro { .. }
+            | Response::ListMacros { .. }
+            | Response::SetExpanderSettings { .. } => {
                 Err(ServerError { message: "unexpected response".to_string(), io: None })
             }
         }
@@ -78,7 +80,9 @@ impl ProcMacroProcessSrv {
 
         match response {
             Response::ListMacros(it) => Ok(it),
-            Response::ExpandMacro { .. } | Response::ApiVersionCheck { .. } => {
+            Response::ExpandMacro { .. }
+            | Response::ApiVersionCheck { .. }
+            | Response::SetExpanderSettings { .. } => {
                 Err(ServerError { message: "unexpected response".to_string(), io: None })
             }
         }

--- a/crates/proc-macro-srv-cli/src/main.rs
+++ b/crates/proc-macro-srv-cli/src/main.rs
@@ -26,10 +26,22 @@ fn run() -> io::Result<()> {
 #[cfg(any(feature = "sysroot-abi", rust_analyzer))]
 fn run() -> io::Result<()> {
     use proc_macro_api::msg::{self, Message};
+    use std::cell::RefCell;
+
+    let current_response_prefix = RefCell::new(String::new());
 
     let read_request = |buf: &mut String| msg::Request::read(&mut io::stdin().lock(), buf);
 
-    let write_response = |msg: msg::Response| msg.write(&mut io::stdout().lock());
+    let write_response = |msg: msg::Response| {
+        use std::io::Write;
+
+        let out = &mut io::stdout().lock();
+        let prefix = current_response_prefix.borrow();
+        if !prefix.is_empty() {
+            out.write_all(prefix.as_bytes())?
+        }
+        msg.write(out)
+    };
 
     let mut srv = proc_macro_srv::ProcMacroSrv::default();
     let mut buf = String::new();
@@ -42,6 +54,10 @@ fn run() -> io::Result<()> {
             msg::Request::ExpandMacro(task) => msg::Response::ExpandMacro(srv.expand(task)),
             msg::Request::ApiVersionCheck {} => {
                 msg::Response::ApiVersionCheck(proc_macro_api::msg::CURRENT_API_VERSION)
+            }
+            msg::Request::SetExpanderSettings { response_prefix } => {
+                *current_response_prefix.borrow_mut() = response_prefix;
+                msg::Response::SetExpanderSettings {}
             }
         };
         write_response(res)?

--- a/crates/proc-macro-srv/src/lib.rs
+++ b/crates/proc-macro-srv/src/lib.rs
@@ -14,6 +14,7 @@
 #![feature(proc_macro_internals, proc_macro_diagnostic, proc_macro_span)]
 #![warn(rust_2018_idioms, unused_lifetimes)]
 #![allow(unreachable_pub)]
+#![allow(internal_features)]
 
 extern crate proc_macro;
 


### PR DESCRIPTION
Currently, if a proc macro prints something to the stdout (`println!("stuff {{}}")`) the output mixes with the `proc-macro-srv` protocol messages (`proc-macro-srv` uses stdout to communicate with `rust-analyzer`) and `rust-analyzer` then can't distinguish `proc-macro-srv` JSON messages from the output from the proc macro.

My idea is to prepend `proc-macro-srv` protocol messages with some long string, and then skip the `proc-macro-srv` process output in `rust-analyzer` until that known string (a bit similar to how Ethernet framing works). I.e. the `proc-macro-srv` message should look like "OsdgHOghs895whrhg598{response_fields: {...}}"

I don't want to hardcode some specific string because it could be exploited by some macro, or that string could become a problem if we decide to place that string inside a macro in `rust-analyzer` itself. So I think we should generate a random string.

I added a new requst type `msg::Request::SetExpanderSettings` with `response_prefix` field in order to delegate random string generation to rust-analyzer (and keep the `proc-macro-srv` implementation as simple as possible).

In this PR I just change the `proc-macro-srv` part