### PR TITLE
make ParamLoweringMode accessible

### DIFF
--- a/crates/hir-ty/src/lib.rs
+++ b/crates/hir-ty/src/lib.rs
@@ -73,8 +73,8 @@ pub use infer::{
 };
 pub use interner::Interner;
 pub use lower::{
-    associated_type_shorthand_candidates, CallableDefId, ImplTraitLoweringMode, TyDefId,
-    TyLoweringContext, ValueTyDefId,
+    associated_type_shorthand_candidates, CallableDefId, ImplTraitLoweringMode, ParamLoweringMode,
+    TyDefId, TyLoweringContext, ValueTyDefId,
 };
 pub use mapping::{
     from_assoc_type_id, from_chalk_trait_id, from_foreign_def_id, from_placeholder_idx,


### PR DESCRIPTION
In `hir-ty`, the `TyLoweringContext` has functions `pub fn with_impl_trait_mode` and `pub fn with_type_param_mode`, which can be used to fine-tune certain lowering properties.
Each of these takes one enum (either `pub enum ImplTraitLoweringMode`, or `pub enum ParamLoweringMode`), which encodes the possible configuration options.

To then make this usable for other crates, `TyLoweringContext` and `ImplTraitLoweringMode` are exported. Unfortuntely, `ParamLoweringMode` is not. This means that while the method can be called, there are no useful values to call it with.

Presumably this is an oversight. It would be great if this was made actually public.