### PR TITLE
fix: Don't emit "missing items" diagnostic for negative impls

### DIFF
--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -671,7 +671,8 @@ impl Module {
                 _ => (),
             };
 
-            if let Some(trait_) = trait_ {
+            // Negative impls can't have items, don't emit missing items diagnostic for them
+            if let (false, Some(trait_)) = (impl_is_negative, trait_) {
                 let items = &db.trait_data(trait_.into()).items;
                 let required_items = items.iter().filter(|&(_, assoc)| match *assoc {
                     AssocItemId::FunctionId(it) => !db.function_data(it).has_body(),

--- a/crates/ide-diagnostics/src/handlers/trait_impl_missing_assoc_item.rs
+++ b/crates/ide-diagnostics/src/handlers/trait_impl_missing_assoc_item.rs
@@ -112,4 +112,18 @@ impl Trait for () {
 "#,
         );
     }
+
+    #[test]
+    fn negative_impl() {
+        check_diagnostics(
+            r#"
+trait Trait {
+    fn item();
+}
+
+// Negative impls don't require any items (in fact, the forbid providing any)
+impl !Trait for () {}
+"#,
+        )
+    }
 }


### PR DESCRIPTION
Negative impls can't have items, so there is no reason for this diagnostic.

LMK if I should add a test somewhere. Also LMK if that's not how we usually check multiple things in an if in r-a.