### PR TITLE
Replace `doc_comments_and_attrs` with `collect_attrs`

### DIFF
--- a/crates/ide-diagnostics/src/handlers/unresolved_extern_crate.rs
+++ b/crates/ide-diagnostics/src/handlers/unresolved_extern_crate.rs
@@ -47,4 +47,19 @@ use foo::Foo as Bar;
 "#,
         );
     }
+
+    #[test]
+    fn regression_panic_with_inner_attribute_in_presence_of_unresolved_crate() {
+        check_diagnostics(
+            r#"
+//- /lib.rs
+  #[macro_use] extern crate doesnotexist;
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: unresolved extern crate
+    mod _test_inner {
+        #![empty_attr]
+      //^^^^^^^^^^^^^^ error: unresolved macro `empty_attr`
+    }
+"#,
+        );
+    }
 }


### PR DESCRIPTION
fix #16063 

I looked at the other usages of `doc_comments_and_attrs` and it seems all of them are prone to ignoring inner attributes. @Veykril should I replace all of those with `collect_attrs` and remove `doc_comments_and_attrs` (or even `HasDocComments`) entirely?