### PR TITLE
fix: Fix view mir, hir and eval function not working when cursor is inside macros

### DIFF
--- a/crates/ide/src/view_hir.rs
+++ b/crates/ide/src/view_hir.rs
@@ -20,7 +20,7 @@ fn body_hir(db: &RootDatabase, position: FilePosition) -> Option<String> {
     let source_file = sema.parse(position.file_id);
 
     let item = ancestors_at_offset(source_file.syntax(), position.offset)
-        .filter(|it| ast::MacroCall::can_cast(it.kind()))
+        .filter(|it| !ast::MacroCall::can_cast(it.kind()))
         .find_map(ast::Item::cast)?;
     let def: DefWithBody = match item {
         ast::Item::Fn(it) => sema.to_def(&it)?.into(),

--- a/crates/ide/src/view_mir.rs
+++ b/crates/ide/src/view_mir.rs
@@ -19,7 +19,7 @@ fn body_mir(db: &RootDatabase, position: FilePosition) -> Option<String> {
     let source_file = sema.parse(position.file_id);
 
     let item = ancestors_at_offset(source_file.syntax(), position.offset)
-        .filter(|it| ast::MacroCall::can_cast(it.kind()))
+        .filter(|it| !ast::MacroCall::can_cast(it.kind()))
         .find_map(ast::Item::cast)?;
     let def: DefWithBody = match item {
         ast::Item::Fn(it) => sema.to_def(&it)?.into(),


### PR DESCRIPTION
I broke the view ones completely by inverting the macro check by accident a few days ago but we don't talk about that.