### PR TITLE
fix: update VSCode rust-panic problem matcher

### DIFF
--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -1689,17 +1689,17 @@
             {
                 "name": "rust-panic",
                 "patterns": [
-					{
-						"regexp": "^thread '.*' panicked at (.*):(\\d*):(\\d*):$",
-						"file": 1,
-						"line": 2,
-						"column": 3
-					},
-					{
-						"regexp": "(.*)",
-						"message": 1
-					}
-				]
+                    {
+                        "regexp": "^thread '.*' panicked at (.*):(\\d*):(\\d*):$",
+                        "file": 1,
+                        "line": 2,
+                        "column": 3
+                    },
+                    {
+                        "regexp": "(.*)",
+                        "message": 1
+                    }
+                ]
             }
         ],
         "languages": [

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -1689,14 +1689,17 @@
             {
                 "name": "rust-panic",
                 "patterns": [
-                    {
-                        "regexp": "^thread '.*' panicked at '(.*)', (.*):(\\d*):(\\d*)$",
-                        "message": 1,
-                        "file": 2,
-                        "line": 3,
-                        "column": 4
-                    }
-                ]
+					{
+						"regexp": "^thread '.*' panicked at (.*):(\\d*):(\\d*):$",
+						"file": 1,
+						"line": 2,
+						"column": 3
+					},
+					{
+						"regexp": "(.*)",
+						"message": 1
+					}
+				]
             }
         ],
         "languages": [


### PR DESCRIPTION
Corrected the `rust-panic` task problem matcher for the VSCode Extension to match the new panic message pattern.

From:
```
thread 'main' panicked at 'PANIC_MESSAGE', src/main.rs:L:C
```
To:
```
thread 'main' panicked at src/main.rs:L:C:
PANIC_MESSAGE
```