### PR TITLE
feat: completion list suggests constructor like & builder methods first

### DIFF
--- a/crates/ide-completion/src/item.rs
+++ b/crates/ide-completion/src/item.rs
@@ -211,8 +211,8 @@ pub enum CompletionRelevancePostfixMatch {
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub struct CompletionRelevanceFn {
-    pub has_args: bool,
-    pub has_self_arg: bool,
+    pub has_params: bool,
+    pub has_self_param: bool,
     pub return_type: CompletionRelevanceReturnType,
 }
 
@@ -310,10 +310,10 @@ impl CompletionRelevance {
                 // Bump Constructor or Builder methods with no arguments,
                 // over them tha with self arguments
                 if fn_score > 0 {
-                    if !asf.has_args {
+                    if !asf.has_params {
                         // bump associated functions
                         fn_score += 1;
-                    } else if asf.has_self_arg {
+                    } else if asf.has_self_param {
                         // downgrade methods (below Constructor)
                         fn_score = 1;
                     }

--- a/crates/ide-completion/src/item.rs
+++ b/crates/ide-completion/src/item.rs
@@ -166,6 +166,8 @@ pub struct CompletionRelevance {
     pub postfix_match: Option<CompletionRelevancePostfixMatch>,
     /// This is set for type inference results
     pub is_definite: bool,
+    /// This is set for items that are function (associated or method)
+    pub function: Option<CompletionRelevanceFn>,
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
@@ -207,6 +209,24 @@ pub enum CompletionRelevancePostfixMatch {
     Exact,
 }
 
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub struct CompletionRelevanceFn {
+    pub has_args: bool,
+    pub has_self_arg: bool,
+    pub return_type: CompletionRelevanceReturnType,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum CompletionRelevanceReturnType {
+    Other,
+    /// Returns the Self type of the impl/trait
+    DirectConstructor,
+    /// Returns something that indirectly constructs the `Self` type of the impl/trait e.g. `Result<Self, ()>`, `Option<Self>`
+    Constructor,
+    /// Returns a possible builder for the type
+    Builder,
+}
+
 impl CompletionRelevance {
     /// Provides a relevance score. Higher values are more relevant.
     ///
@@ -231,6 +251,7 @@ impl CompletionRelevance {
             postfix_match,
             is_definite,
             is_item_from_notable_trait,
+            function,
         } = self;
 
         // lower rank private things
@@ -275,6 +296,33 @@ impl CompletionRelevance {
         if is_definite {
             score += 10;
         }
+
+        score += function
+            .map(|asf| {
+                let mut fn_score = match asf.return_type {
+                    CompletionRelevanceReturnType::DirectConstructor => 15,
+                    CompletionRelevanceReturnType::Builder => 10,
+                    CompletionRelevanceReturnType::Constructor => 5,
+                    CompletionRelevanceReturnType::Other => 0,
+                };
+
+                // When a fn is bumped due to return type:
+                // Bump Constructor or Builder methods with no arguments,
+                // over them tha with self arguments
+                if fn_score > 0 {
+                    if !asf.has_args {
+                        // bump associated functions
+                        fn_score += 1;
+                    } else if asf.has_self_arg {
+                        // downgrade methods (below Constructor)
+                        fn_score = 1;
+                    }
+                }
+
+                fn_score
+            })
+            .unwrap_or_default();
+
         score
     }
 

--- a/crates/ide-completion/src/render.rs
+++ b/crates/ide-completion/src/render.rs
@@ -1420,8 +1420,8 @@ impl S {
                             is_definite: false,
                             function: Some(
                                 CompletionRelevanceFn {
-                                    has_args: true,
-                                    has_self_arg: true,
+                                    has_params: true,
+                                    has_self_param: true,
                                     return_type: Other,
                                 },
                             ),
@@ -1545,8 +1545,8 @@ fn foo(s: S) { s.$0 }
                             is_definite: false,
                             function: Some(
                                 CompletionRelevanceFn {
-                                    has_args: true,
-                                    has_self_arg: true,
+                                    has_params: true,
+                                    has_self_param: true,
                                     return_type: Other,
                                 },
                             ),
@@ -2207,8 +2207,8 @@ fn test() {
                         "fn(&self, u32) -> Bar",
                         Some(
                             CompletionRelevanceFn {
-                                has_args: true,
-                                has_self_arg: true,
+                                has_params: true,
+                                has_self_param: true,
                                 return_type: Other,
                             },
                         ),
@@ -2217,8 +2217,8 @@ fn test() {
                         "fn(&self)",
                         Some(
                             CompletionRelevanceFn {
-                                has_args: true,
-                                has_self_arg: true,
+                                has_params: true,
+                                has_self_param: true,
                                 return_type: Other,
                             },
                         ),
@@ -2227,8 +2227,8 @@ fn test() {
                         "fn(&self) -> Foo",
                         Some(
                             CompletionRelevanceFn {
-                                has_args: true,
-                                has_self_arg: true,
+                                has_params: true,
+                                has_self_param: true,
                                 return_type: DirectConstructor,
                             },
                         ),
@@ -2237,8 +2237,8 @@ fn test() {
                         "fn(&self, u32) -> Foo",
                         Some(
                             CompletionRelevanceFn {
-                                has_args: true,
-                                has_self_arg: true,
+                                has_params: true,
+                                has_self_param: true,
                                 return_type: DirectConstructor,
                             },
                         ),
@@ -2247,8 +2247,8 @@ fn test() {
                         "fn(&self) -> Option<Foo>",
                         Some(
                             CompletionRelevanceFn {
-                                has_args: true,
-                                has_self_arg: true,
+                                has_params: true,
+                                has_self_param: true,
                                 return_type: Constructor,
                             },
                         ),
@@ -2257,8 +2257,8 @@ fn test() {
                         "fn(&self) -> Result<Foo, Bar>",
                         Some(
                             CompletionRelevanceFn {
-                                has_args: true,
-                                has_self_arg: true,
+                                has_params: true,
+                                has_self_param: true,
                                 return_type: Constructor,
                             },
                         ),
@@ -2267,8 +2267,8 @@ fn test() {
                         "fn(&self) -> Result<Bar, Foo>",
                         Some(
                             CompletionRelevanceFn {
-                                has_args: true,
-                                has_self_arg: true,
+                                has_params: true,
+                                has_self_param: true,
                                 return_type: Constructor,
                             },
                         ),
@@ -2277,8 +2277,8 @@ fn test() {
                         "fn(&self, u32) -> Option<Foo>",
                         Some(
                             CompletionRelevanceFn {
-                                has_args: true,
-                                has_self_arg: true,
+                                has_params: true,
+                                has_self_param: true,
                                 return_type: Constructor,
                             },
                         ),
@@ -2433,8 +2433,8 @@ fn foo(f: Foo) { let _: &u32 = f.b$0 }
                             is_definite: false,
                             function: Some(
                                 CompletionRelevanceFn {
-                                    has_args: true,
-                                    has_self_arg: true,
+                                    has_params: true,
+                                    has_self_param: true,
                                     return_type: Other,
                                 },
                             ),
@@ -2565,8 +2565,8 @@ fn main() {
                             is_definite: false,
                             function: Some(
                                 CompletionRelevanceFn {
-                                    has_args: false,
-                                    has_self_arg: false,
+                                    has_params: false,
+                                    has_self_param: false,
                                     return_type: Other,
                                 },
                             ),
@@ -2932,13 +2932,7 @@ fn main() {
                             is_private_editable: false,
                             postfix_match: None,
                             is_definite: false,
-                            function: Some(
-                                CompletionRelevanceFn {
-                                    has_args: true,
-                                    has_self_arg: true,
-                                    return_type: Other,
-                                },
-                            ),
+                            function: None,
                         },
                     },
                     CompletionItem {
@@ -2961,13 +2955,7 @@ fn main() {
                             is_private_editable: false,
                             postfix_match: None,
                             is_definite: false,
-                            function: Some(
-                                CompletionRelevanceFn {
-                                    has_args: true,
-                                    has_self_arg: true,
-                                    return_type: Other,
-                                },
-                            ),
+                            function: None,
                         },
                     },
                 ]

--- a/crates/ide-completion/src/render/function.rs
+++ b/crates/ide-completion/src/render/function.rs
@@ -177,7 +177,7 @@ fn compute_return_type_match(
     self_type: hir::Type,
     ret_type: &hir::Type,
 ) -> CompletionRelevanceReturnType {
-    if match_types(ctx.completion, &self_type, &ret_type).is_some() {
+    if match_types(ctx.completion, &self_type, ret_type).is_some() {
         // fn([..]) -> Self
         CompletionRelevanceReturnType::DirectConstructor
     } else if ret_type


### PR DESCRIPTION
When typing `MyType::` the completion items' order could be re-ordered based on how likely we want to select those:
* Constructors: `new` like functions to be able to create the type,
* Constructors that take args: Any other function that creates `Self`,
* Builder Methods: any builder methods available,
* Regular methods & associated functions (no change there)

![image](https://github.com/rust-lang/rust-analyzer/assets/1546896/54593b91-07b3-455a-8a71-8d203d4eaf4a)

In this photo, the order is:
* `new` constructor is first
* `new_builder` second is a builder method
* `aaaanew` is a constructor that takes arguments, is third  and is irrespective of its alphabetical order among names.

---

Another Example using actix `HttpServer` shows preferring constructor without `self` arg first (the `new` method)

![image](https://github.com/rust-lang/rust-analyzer/assets/1546896/938d3fb0-3d7a-4427-ae2f-ec02a834ccbe)

![image](https://github.com/rust-lang/rust-analyzer/assets/1546896/2c13860c-efd1-459d-b25e-df8adb61bbd0)


I've dropped my previous idea of highlighting these functions in the rustdoc (https://github.com/rust-lang/rust/pull/107926)