### PR TITLE
fix: waker_getters tracking issue from 87021 for 96992.

### DIFF
--- a/crates/ide-db/src/generated/lints.rs
+++ b/crates/ide-db/src/generated/lints.rs
@@ -9630,9 +9630,9 @@ The tracking issue for this feature is: [#81944]
         label: "waker_getters",
         description: r##"# `waker_getters`
 
-The tracking issue for this feature is: [#87021]
+The tracking issue for this feature is: [#96992]
 
-[#87021]: https://github.com/rust-lang/rust/issues/87021
+[#96992]: https://github.com/rust-lang/rust/issues/96992
 
 ------------------------
 "##,


### PR DESCRIPTION
I was directed to make the fix here by this comment https://github.com/rust-lang/rust/pull/118960#issuecomment-1857888974.