### PR TITLE
Extend `TargetSpec` functionality to rust-project.json

### DIFF
--- a/crates/ide/src/runnables.rs
+++ b/crates/ide/src/runnables.rs
@@ -65,15 +65,13 @@ enum RunnableTestKind {
 
 impl Runnable {
     // test package::module::testname
-    pub fn label(&self, target: Option<String>) -> String {
+    pub fn label(&self, target: String) -> String {
         match &self.kind {
             RunnableKind::Test { test_id, .. } => format!("test {test_id}"),
             RunnableKind::TestMod { path } => format!("test-mod {path}"),
             RunnableKind::Bench { test_id } => format!("bench {test_id}"),
             RunnableKind::DocTest { test_id, .. } => format!("doctest {test_id}"),
-            RunnableKind::Bin => {
-                target.map_or_else(|| "run binary".to_owned(), |t| format!("run {t}"))
-            }
+            RunnableKind::Bin => target,
         }
     }
 

--- a/crates/project-model/src/lib.rs
+++ b/crates/project-model/src/lib.rs
@@ -21,7 +21,7 @@ mod build_scripts;
 mod cargo_workspace;
 mod cfg_flag;
 mod manifest_path;
-mod project_json;
+pub mod project_json;
 mod rustc_cfg;
 mod sysroot;
 pub mod target_data_layout;

--- a/crates/rust-analyzer/src/global_state.rs
+++ b/crates/rust-analyzer/src/global_state.rs
@@ -18,7 +18,7 @@ use parking_lot::{
     RwLockWriteGuard,
 };
 use proc_macro_api::ProcMacroServer;
-use project_model::{CargoWorkspace, ProjectWorkspace, Target, WorkspaceBuildScripts};
+use project_model::{CargoWorkspace, ProjectJson, ProjectWorkspace, Target, WorkspaceBuildScripts};
 use rustc_hash::{FxHashMap, FxHashSet};
 use triomphe::Arc;
 use vfs::{AnchoredPathBuf, ChangedFile, Vfs};
@@ -502,18 +502,20 @@ impl GlobalStateSnapshot {
         self.vfs_read().file_path(file_id).clone()
     }
 
-    pub(crate) fn cargo_target_for_crate_root(
+    pub(crate) fn target_for_crate_root(
         &self,
         crate_id: CrateId,
-    ) -> Option<(&CargoWorkspace, Target)> {
+    ) -> Option<TargetForCrateRoot<'_>> {
         let file_id = self.analysis.crate_root(crate_id).ok()?;
         let path = self.vfs_read().file_path(file_id).clone();
         let path = path.as_path()?;
         self.workspaces.iter().find_map(|ws| match ws {
             ProjectWorkspace::Cargo { cargo, .. } => {
-                cargo.target_by_root(path).map(|it| (cargo, it))
+                cargo.target_by_root(path).map(|it| TargetForCrateRoot::Cargo(cargo, it))
             }
-            ProjectWorkspace::Json { .. } => None,
+            ProjectWorkspace::Json { project, .. } => {
+                project.crate_by_root(path).map(|it| TargetForCrateRoot::JsonProject(project, it))
+            }
             ProjectWorkspace::DetachedFiles { .. } => None,
         })
     }
@@ -521,6 +523,11 @@ impl GlobalStateSnapshot {
     pub(crate) fn file_exists(&self, file_id: FileId) -> bool {
         self.vfs.read().0.exists(file_id)
     }
+}
+
+pub(crate) enum TargetForCrateRoot<'a> {
+    Cargo(&'a CargoWorkspace, Target),
+    JsonProject(&'a ProjectJson, project_model::project_json::Crate),
 }
 
 pub(crate) fn file_id_to_url(vfs: &vfs::Vfs, id: FileId) -> Url {

--- a/crates/rust-analyzer/src/lib.rs
+++ b/crates/rust-analyzer/src/lib.rs
@@ -14,7 +14,6 @@
 pub mod cli;
 
 mod caps;
-mod cargo_target_spec;
 mod diagnostics;
 mod diff;
 mod dispatch;
@@ -25,6 +24,7 @@ mod main_loop;
 mod mem_docs;
 mod op_queue;
 mod reload;
+mod target_spec;
 mod task_pool;
 mod version;
 

--- a/crates/rust-analyzer/src/lsp/ext.rs
+++ b/crates/rust-analyzer/src/lsp/ext.rs
@@ -2,6 +2,7 @@
 
 #![allow(clippy::disallowed_types)]
 
+use std::path::Path;
 use std::path::PathBuf;
 
 use ide_db::line_index::WideEncoding;
@@ -424,13 +425,31 @@ pub struct Runnable {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub location: Option<lsp_types::LocationLink>,
     pub kind: RunnableKind,
-    pub args: CargoRunnable,
+    pub args: RunnableData,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+#[serde(untagged)]
+pub enum RunnableData {
+    Cargo(CargoRunnable),
+    ProjectJson(ProjectJsonRunnable),
+}
+
+impl RunnableData {
+    pub fn workspace_root(&self) -> Option<&Path> {
+        match self {
+            RunnableData::Cargo(cargo) => cargo.workspace_root.as_deref(),
+            RunnableData::ProjectJson(project_json) => Some(&project_json.workspace_root),
+        }
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "lowercase")]
 pub enum RunnableKind {
     Cargo,
+    ProjectJson,
 }
 
 #[derive(Deserialize, Serialize, Debug)]
@@ -448,6 +467,14 @@ pub struct CargoRunnable {
     pub executable_args: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub expect_test: Option<bool>,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct ProjectJsonRunnable {
+    pub build_command: String,
+    pub workspace_root: PathBuf,
+    pub args: Vec<String>,
 }
 
 pub enum RelatedTests {}

--- a/crates/rust-analyzer/src/target_spec.rs
+++ b/crates/rust-analyzer/src/target_spec.rs
@@ -1,35 +1,164 @@
 //! See `CargoTargetSpec`
 
-use std::mem;
-
 use cfg::{CfgAtom, CfgExpr};
 use ide::{Cancellable, CrateId, FileId, RunnableKind, TestId};
 use project_model::{CargoFeatures, ManifestPath, TargetKind};
 use rustc_hash::FxHashSet;
-use vfs::AbsPathBuf;
+use vfs::{AbsPath, AbsPathBuf};
 
-use crate::global_state::GlobalStateSnapshot;
+use crate::global_state::{GlobalStateSnapshot, TargetForCrateRoot};
 
 /// Abstract representation of Cargo target.
 ///
 /// We use it to cook up the set of cli args we need to pass to Cargo to
 /// build/test/run the target.
 #[derive(Clone)]
+pub(crate) enum TargetSpec {
+    Cargo(CargoTargetSpec),
+    ProjectJson(ProjectJsonSpec),
+}
+
+impl TargetSpec {
+    pub(crate) fn for_file(
+        global_state_snapshot: &GlobalStateSnapshot,
+        file_id: FileId,
+    ) -> Cancellable<Option<TargetSpec>> {
+        let crate_id = match &*global_state_snapshot.analysis.crates_for(file_id)? {
+            &[crate_id, ..] => crate_id,
+            _ => return Ok(None),
+        };
+
+        match global_state_snapshot.target_for_crate_root(crate_id) {
+            Some(TargetForCrateRoot::Cargo(cargo_ws, target)) => {
+                let target_data = &cargo_ws[target];
+                let package_data = &cargo_ws[target_data.package];
+                let res = CargoTargetSpec {
+                    workspace_root: cargo_ws.workspace_root().to_path_buf(),
+                    project_manifest: package_data.manifest.clone(),
+                    crate_id,
+                    package: cargo_ws.package_flag(package_data),
+                    target: target_data.name.clone(),
+                    target_kind: target_data.kind,
+                    required_features: target_data.required_features.clone(),
+                    features: package_data.features.keys().cloned().collect(),
+                };
+                Ok(Some(TargetSpec::Cargo(res)))
+            }
+            Some(TargetForCrateRoot::JsonProject(_, krate)) => match krate.target_spec {
+                Some(target) => {
+                    let manifest = ManifestPath::try_from(target.manifest_file).unwrap();
+                    let res = ProjectJsonSpec {
+                        workspace_root: manifest.parent().to_path_buf(),
+                        project_manifest: manifest,
+                        target_kind: target.target_kind,
+                        target_label: target.target_label,
+                        runnables: target.runnables,
+                    };
+                    Ok(Some(TargetSpec::ProjectJson(res)))
+                }
+                None => {
+                    tracing::debug!(?krate, "no target spec");
+                    Ok(None)
+                }
+            },
+            None => {
+                tracing::debug!(?crate_id, "no target found");
+                Ok(None)
+            }
+        }
+    }
+
+    pub(crate) fn project_manifest(&self) -> &AbsPath {
+        match self {
+            TargetSpec::Cargo(cargo) => &cargo.project_manifest,
+            TargetSpec::ProjectJson(project_json) => &project_json.project_manifest,
+        }
+    }
+
+    pub(crate) fn workspace_root(&self) -> &AbsPath {
+        match self {
+            TargetSpec::Cargo(cargo) => &cargo.workspace_root,
+            TargetSpec::ProjectJson(project_json) => &project_json.workspace_root,
+        }
+    }
+
+    pub(crate) fn target_kind(&self) -> TargetKind {
+        match self {
+            TargetSpec::Cargo(cargo) => cargo.target_kind,
+            TargetSpec::ProjectJson(project_json) => project_json.target_kind,
+        }
+    }
+}
+
+#[derive(Clone)]
 pub(crate) struct CargoTargetSpec {
     pub(crate) workspace_root: AbsPathBuf,
-    pub(crate) cargo_toml: ManifestPath,
+    /// [`project_manifest`] corresponds to the file defining a crate. With Cargo,
+    /// this will be a Cargo.toml, but with a non-Cargo build system, this might be
+    /// a `TARGETS` or `BUCK` file. Multiple, distinct crates can share a
+    /// single `project_manifest`.
+    pub(crate) project_manifest: ManifestPath,
+    pub(crate) crate_id: CrateId,
     pub(crate) package: String,
     pub(crate) target: String,
     pub(crate) target_kind: TargetKind,
-    pub(crate) crate_id: CrateId,
     pub(crate) required_features: Vec<String>,
     pub(crate) features: FxHashSet<String>,
+}
+
+#[derive(Clone)]
+pub(crate) struct ProjectJsonSpec {
+    pub(crate) workspace_root: AbsPathBuf,
+    /// [`project_manifest`] corresponds to the file defining a crate. With Cargo,
+    /// this will be a Cargo.toml, but with a non-Cargo build system, this might be
+    /// a `TARGETS` or `BUCK` file. Multiple, distinct crates can share a
+    /// single `project_manifest`.
+    pub(crate) project_manifest: ManifestPath,
+    pub(crate) target_label: String,
+    pub(crate) target_kind: TargetKind,
+    pub(crate) runnables: project_model::project_json::Runnables,
+}
+
+impl ProjectJsonSpec {
+    pub(crate) fn runnable_args(spec: ProjectJsonSpec, kind: &RunnableKind) -> Vec<String> {
+        let mut args = Vec::new();
+
+        match kind {
+            RunnableKind::Test { test_id, attr: _ } | RunnableKind::DocTest { test_id } => {
+                let mut test_runnable = spec.runnables.test;
+                for arg in &mut test_runnable.iter_mut() {
+                    if arg == "{test_id}" {
+                        *arg = test_id.to_string()
+                    }
+                }
+
+                args.append(&mut test_runnable);
+            }
+            RunnableKind::TestMod { path } => {
+                let mut test_runnable = spec.runnables.test;
+                for arg in &mut test_runnable.iter_mut() {
+                    if arg == "{test_id}" {
+                        *arg = path.to_string()
+                    }
+                }
+
+                args.append(&mut test_runnable);
+            }
+            RunnableKind::Bin => {
+                let mut run = spec.runnables.run;
+                args.append(&mut run);
+            }
+            _ => (),
+        };
+
+        args
+    }
 }
 
 impl CargoTargetSpec {
     pub(crate) fn runnable_args(
         snap: &GlobalStateSnapshot,
-        spec: Option<CargoTargetSpec>,
+        spec: CargoTargetSpec,
         kind: &RunnableKind,
         cfg: &Option<CfgExpr>,
     ) -> (Vec<String>, Vec<String>) {
@@ -68,22 +197,18 @@ impl CargoTargetSpec {
                 extra_args.push("--nocapture".to_owned());
             }
             RunnableKind::Bin => {
-                let subcommand = match spec {
-                    Some(CargoTargetSpec { target_kind: TargetKind::Test, .. }) => "test",
+                let subcommand = match spec.target_kind {
+                    TargetKind::Test => "test",
                     _ => "run",
                 };
                 args.push(subcommand.to_owned());
             }
         }
 
-        let (allowed_features, target_required_features) = if let Some(mut spec) = spec {
-            let allowed_features = mem::take(&mut spec.features);
-            let required_features = mem::take(&mut spec.required_features);
-            spec.push_to(&mut args, kind);
-            (allowed_features, required_features)
-        } else {
-            (Default::default(), Default::default())
-        };
+        let allowed_features = spec.features.clone();
+        let target_required_features = spec.required_features.clone();
+
+        spec.clone().push_to(&mut args, kind);
 
         let cargo_config = snap.config.cargo();
 
@@ -120,59 +245,32 @@ impl CargoTargetSpec {
         (args, extra_args)
     }
 
-    pub(crate) fn for_file(
-        global_state_snapshot: &GlobalStateSnapshot,
-        file_id: FileId,
-    ) -> Cancellable<Option<CargoTargetSpec>> {
-        let crate_id = match &*global_state_snapshot.analysis.crates_for(file_id)? {
-            &[crate_id, ..] => crate_id,
-            _ => return Ok(None),
-        };
-        let (cargo_ws, target) = match global_state_snapshot.cargo_target_for_crate_root(crate_id) {
-            Some(it) => it,
-            None => return Ok(None),
-        };
-
-        let target_data = &cargo_ws[target];
-        let package_data = &cargo_ws[target_data.package];
-        let res = CargoTargetSpec {
-            workspace_root: cargo_ws.workspace_root().to_path_buf(),
-            cargo_toml: package_data.manifest.clone(),
-            package: cargo_ws.package_flag(package_data),
-            target: target_data.name.clone(),
-            target_kind: target_data.kind,
-            required_features: target_data.required_features.clone(),
-            features: package_data.features.keys().cloned().collect(),
-            crate_id,
-        };
-
-        Ok(Some(res))
-    }
-
     pub(crate) fn push_to(self, buf: &mut Vec<String>, kind: &RunnableKind) {
+        let (package, target, target_kind) = (self.package, self.target, self.target_kind);
+
         buf.push("--package".to_owned());
-        buf.push(self.package);
+        buf.push(package);
 
         // Can't mix --doc with other target flags
         if let RunnableKind::DocTest { .. } = kind {
             return;
         }
-        match self.target_kind {
+        match target_kind {
             TargetKind::Bin => {
                 buf.push("--bin".to_owned());
-                buf.push(self.target);
+                buf.push(target);
             }
             TargetKind::Test => {
                 buf.push("--test".to_owned());
-                buf.push(self.target);
+                buf.push(target);
             }
             TargetKind::Bench => {
                 buf.push("--bench".to_owned());
-                buf.push(self.target);
+                buf.push(target);
             }
             TargetKind::Example => {
                 buf.push("--example".to_owned());
-                buf.push(self.target);
+                buf.push(target);
             }
             TargetKind::Lib { is_proc_macro: _ } => {
                 buf.push("--lib".to_owned());

--- a/docs/dev/lsp-extensions.md
+++ b/docs/dev/lsp-extensions.md
@@ -1,5 +1,5 @@
 <!---
-lsp/ext.rs hash: 223f48a89a5126a0
+lsp/ext.rs hash: 41b41734670f894a
 
 If you need to change the above hash to make the test pass, please check if you
 need to adjust this doc as well and ping this issue:
@@ -372,7 +372,7 @@ interface Runnable {
 }
 ```
 
-rust-analyzer supports only one `kind`, `"cargo"`. The `args` for `"cargo"` look like this:
+rust-analyzer supports two `kind`s of runnables, `"cargo"` and `"rustproject"`. The `args` for `"cargo"` look like this:
 
 ```typescript
 {
@@ -382,6 +382,16 @@ rust-analyzer supports only one `kind`, `"cargo"`. The `args` for `"cargo"` look
     executableArgs: string[];
     expectTest?: boolean;
     overrideCargo?: string;
+}
+```
+
+The args for `"jsonproject"` look like:
+
+```typescript
+{
+    workspaceRoot: string;
+    args: string[];
+    expectTest?: boolean;
 }
 ```
 

--- a/editors/code/src/commands.ts
+++ b/editors/code/src/commands.ts
@@ -10,7 +10,7 @@ import {
     type SnippetTextDocumentEdit,
 } from "./snippets";
 import { spawnSync } from "child_process";
-import { type RunnableQuickPick, selectRunnable, createTask, createArgs } from "./run";
+import { type RunnableQuickPick, selectRunnable, createTask, createCargoArgs } from "./run";
 import { AstInspector } from "./ast_inspector";
 import {
     isRustDocument,
@@ -19,6 +19,7 @@ import {
     isRustEditor,
     type RustEditor,
     type RustDocument,
+    isCargoRunnable,
 } from "./util";
 import { startDebugSession, makeDebugConfig } from "./debug";
 import type { LanguageClient } from "vscode-languageclient/node";
@@ -1156,8 +1157,8 @@ export function copyRunCommandLine(ctx: CtxInit) {
     let prevRunnable: RunnableQuickPick | undefined;
     return async () => {
         const item = await selectRunnable(ctx, prevRunnable);
-        if (!item) return;
-        const args = createArgs(item.runnable);
+        if (!item || !isCargoRunnable(item.runnable.args)) return;
+        const args = createCargoArgs(item.runnable.args);
         const commandLine = ["cargo", ...args].join(" ");
         await vscode.env.clipboard.writeText(commandLine);
         await vscode.window.showInformationMessage("Cargo invocation copied to the clipboard.");

--- a/editors/code/src/debug.ts
+++ b/editors/code/src/debug.ts
@@ -7,10 +7,12 @@ import { Cargo, type ExecutableInfo, getRustcId, getSysroot } from "./toolchain"
 import type { Ctx } from "./ctx";
 import { prepareEnv } from "./run";
 import { unwrapUndefinable } from "./undefinable";
+import { isCargoRunnable } from "./util";
 
 const debugOutput = vscode.window.createOutputChannel("Debug");
 type DebugConfigProvider = (
-    config: ra.Runnable,
+    label: string,
+    args: ra.CargoRunnable,
     executable: string,
     cargoWorkspace: string,
     env: Record<string, string>,
@@ -77,6 +79,10 @@ async function getDebugConfiguration(
     ctx: Ctx,
     runnable: ra.Runnable,
 ): Promise<vscode.DebugConfiguration | undefined> {
+    if (!isCargoRunnable(runnable.args)) {
+        return;
+    }
+
     const editor = ctx.activeRustEditor;
     if (!editor) return;
 
@@ -134,7 +140,11 @@ async function getDebugConfiguration(
     }
 
     const env = prepareEnv(runnable, ctx.config.runnablesExtraEnv);
-    const { executable, workspace: cargoWorkspace } = await getDebugExecutableInfo(runnable, env);
+    const { executable, workspace: cargoWorkspace } = await getDebugExecutableInfo(
+        runnable.args.workspaceRoot,
+        runnable.args.cargoArgs,
+        env,
+    );
     let sourceFileMap = debugOptions.sourceFileMap;
     if (sourceFileMap === "auto") {
         // let's try to use the default toolchain
@@ -149,7 +159,8 @@ async function getDebugConfiguration(
 
     const provider = unwrapUndefinable(knownEngines[debugEngine.id]);
     const debugConfig = provider(
-        runnable,
+        runnable.label,
+        runnable.args,
         simplifyPath(executable),
         cargoWorkspace,
         env,
@@ -177,18 +188,20 @@ async function getDebugConfiguration(
 }
 
 async function getDebugExecutableInfo(
-    runnable: ra.Runnable,
+    workspaceRoot: string | undefined,
+    cargoArgs: string[],
     env: Record<string, string>,
 ): Promise<ExecutableInfo> {
-    const cargo = new Cargo(runnable.args.workspaceRoot || ".", debugOutput, env);
-    const executableInfo = await cargo.executableInfoFromArgs(runnable.args.cargoArgs);
+    const cargo = new Cargo(workspaceRoot || ".", debugOutput, env);
+    const executableInfo = await cargo.executableInfoFromArgs(cargoArgs);
 
     // if we are here, there were no compilation errors.
     return executableInfo;
 }
 
 function getCCppDebugConfig(
-    runnable: ra.Runnable,
+    label: string,
+    args: ra.CargoRunnable,
     executable: string,
     cargoWorkspace: string,
     env: Record<string, string>,
@@ -197,10 +210,10 @@ function getCCppDebugConfig(
     return {
         type: os.platform() === "win32" ? "cppvsdbg" : "cppdbg",
         request: "launch",
-        name: runnable.label,
+        name: label,
         program: executable,
-        args: runnable.args.executableArgs,
-        cwd: cargoWorkspace || runnable.args.workspaceRoot,
+        args: args.executableArgs,
+        cwd: cargoWorkspace || args.workspaceRoot,
         sourceFileMap,
         env,
         // See https://github.com/rust-lang/rust-analyzer/issues/16901#issuecomment-2024486941
@@ -211,7 +224,8 @@ function getCCppDebugConfig(
 }
 
 function getCodeLldbDebugConfig(
-    runnable: ra.Runnable,
+    label: string,
+    args: ra.CargoRunnable,
     executable: string,
     cargoWorkspace: string,
     env: Record<string, string>,
@@ -220,10 +234,10 @@ function getCodeLldbDebugConfig(
     return {
         type: "lldb",
         request: "launch",
-        name: runnable.label,
+        name: label,
         program: executable,
-        args: runnable.args.executableArgs,
-        cwd: cargoWorkspace || runnable.args.workspaceRoot,
+        args: args.executableArgs,
+        cwd: cargoWorkspace || args.workspaceRoot,
         sourceMap: sourceFileMap,
         sourceLanguages: ["rust"],
         env,

--- a/editors/code/src/lsp_ext.ts
+++ b/editors/code/src/lsp_ext.ts
@@ -223,16 +223,25 @@ export type OpenCargoTomlParams = {
 export type Runnable = {
     label: string;
     location?: lc.LocationLink;
-    kind: "cargo";
-    args: {
-        workspaceRoot?: string;
-        cargoArgs: string[];
-        cargoExtraArgs: string[];
-        executableArgs: string[];
-        expectTest?: boolean;
-        overrideCargo?: string;
-    };
+    kind: "cargo" | "jsonproject";
+    args: CargoRunnable | ProjectJsonRunnable;
 };
+
+export type ProjectJsonRunnable = {
+    workspaceRoot: string;
+    args: string[];
+    expectTest?: boolean;
+};
+
+export type CargoRunnable = {
+    workspaceRoot?: string;
+    cargoArgs: string[];
+    cargoExtraArgs: string[];
+    executableArgs: string[];
+    expectTest?: boolean;
+    overrideCargo?: string;
+};
+
 export type RunnablesParams = {
     textDocument: lc.TextDocumentIdentifier;
     position: lc.Position | null;

--- a/editors/code/src/util.ts
+++ b/editors/code/src/util.ts
@@ -2,6 +2,7 @@ import * as vscode from "vscode";
 import { strict as nativeAssert } from "assert";
 import { exec, type ExecOptions, spawnSync } from "child_process";
 import { inspect } from "util";
+import type { CargoRunnable, ProjectJsonRunnable } from "./lsp_ext";
 import type { Env } from "./client";
 
 export function assert(condition: boolean, explanation: string): asserts condition {
@@ -75,6 +76,10 @@ export function isRustDocument(document: vscode.TextDocument): document is RustD
 export function isCargoTomlDocument(document: vscode.TextDocument): document is RustDocument {
     // ideally `document.languageId` should be 'toml' but user maybe not have toml extension installed
     return document.uri.scheme === "file" && document.fileName.endsWith("Cargo.toml");
+}
+
+export function isCargoRunnable(args: CargoRunnable | ProjectJsonRunnable): args is CargoRunnable {
+    return (args as CargoRunnable).executableArgs !== undefined;
 }
 
 export function isRustEditor(editor: vscode.TextEditor): editor is RustEditor {


### PR DESCRIPTION
Resolves https://github.com/rust-lang/rust-analyzer/issues/15892.

This PR, as structured, adds runnable support to `rust-project.json`-based workspaces, and that works pretty nicely. It's not as polished as I'd like it to be (namely: interpolation of `test_id` feels a bit janky and undocumented, the), but I'm opening this PR as a draft for general direction/feedback.

I think that this approach can also make https://github.com/rust-lang/rust-analyzer/pull/15476 unnecessary by adding a `flycheck_command` to `rust-project.json` _while also_ extending similar functionality to Cargo only build the impacted crate.