### PR TITLE
minor: Bump `@vscode/test-electron`

### DIFF
--- a/editors/code/package-lock.json
+++ b/editors/code/package-lock.json
@@ -21,7 +21,7 @@
                 "@types/vscode": "~1.78.1",
                 "@typescript-eslint/eslint-plugin": "^6.0.0",
                 "@typescript-eslint/parser": "^6.0.0",
-                "@vscode/test-electron": "^2.3.3",
+                "@vscode/test-electron": "^2.3.8",
                 "@vscode/vsce": "^2.19.0",
                 "esbuild": "^0.18.12",
                 "eslint": "^8.44.0",
@@ -763,15 +763,15 @@
             }
         },
         "node_modules/@vscode/test-electron": {
-            "version": "2.3.3",
-            "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.3.3.tgz",
-            "integrity": "sha512-hgXCkDP0ibboF1K6seqQYyHAzCURgTwHS/6QU7slhwznDLwsRwg9bhfw1CZdyUEw8vvCmlrKWnd7BlQnI0BC4w==",
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.3.8.tgz",
+            "integrity": "sha512-b4aZZsBKtMGdDljAsOPObnAi7+VWIaYl3ylCz1jTs+oV6BZ4TNHcVNC3xUn0azPeszBmwSBDQYfFESIaUQnrOg==",
             "dev": true,
             "dependencies": {
                 "http-proxy-agent": "^4.0.1",
                 "https-proxy-agent": "^5.0.0",
                 "jszip": "^3.10.1",
-                "semver": "^7.3.8"
+                "semver": "^7.5.2"
             },
             "engines": {
                 "node": ">=16"

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -57,7 +57,7 @@
         "@types/vscode": "~1.78.1",
         "@typescript-eslint/eslint-plugin": "^6.0.0",
         "@typescript-eslint/parser": "^6.0.0",
-        "@vscode/test-electron": "^2.3.3",
+        "@vscode/test-electron": "^2.3.8",
         "@vscode/vsce": "^2.19.0",
         "esbuild": "^0.18.12",
         "eslint": "^8.44.0",


### PR DESCRIPTION
Fixes this failure in #16162:

![image](https://github.com/rust-lang/rust-analyzer/assets/308347/d52e9b51-ce35-4145-bb43-20af82cc4e26)
