### PR TITLE
fix: remove wrong comma after remove unnecessary braces

### DIFF
--- a/crates/ide-assists/src/handlers/remove_unused_imports.rs
+++ b/crates/ide-assists/src/handlers/remove_unused_imports.rs
@@ -610,6 +610,111 @@ mod b {
     }
 
     #[test]
+    fn remove_comma_after_auto_remove_brace() {
+        check_assist(
+            remove_unused_imports,
+            r#"
+mod m {
+    pub mod x {
+        pub struct A;
+        pub struct B;
+    }
+    pub mod y {
+        pub struct C;
+    }
+}
+
+$0use m::{
+    x::{A, B},
+    y::C,
+};$0
+
+fn main() {
+    B;
+}
+"#,
+            r#"
+mod m {
+    pub mod x {
+        pub struct A;
+        pub struct B;
+    }
+    pub mod y {
+        pub struct C;
+    }
+}
+
+use m::
+    x::B
+;
+
+fn main() {
+    B;
+}
+"#,
+        );
+        check_assist(
+            remove_unused_imports,
+            r#"
+mod m {
+    pub mod x {
+        pub struct A;
+        pub struct B;
+    }
+    pub mod y {
+        pub struct C;
+        pub struct D;
+    }
+    pub mod z {
+        pub struct E;
+        pub struct F;
+    }
+}
+
+$0use m::{
+    x::{A, B},
+    y::{C, D,},
+    z::{E, F},
+};$0
+
+fn main() {
+    B;
+    C;
+    F;
+}
+"#,
+            r#"
+mod m {
+    pub mod x {
+        pub struct A;
+        pub struct B;
+    }
+    pub mod y {
+        pub struct C;
+        pub struct D;
+    }
+    pub mod z {
+        pub struct E;
+        pub struct F;
+    }
+}
+
+use m::{
+    x::B,
+    y::C,
+    z::F,
+};
+
+fn main() {
+    B;
+    C;
+    F;
+}
+"#,
+        );
+    }
+
+    #[test]
     fn remove_nested_all_unused() {
         check_assist(
             remove_unused_imports,

--- a/crates/syntax/src/ast/node_ext.rs
+++ b/crates/syntax/src/ast/node_ext.rs
@@ -345,6 +345,12 @@ impl ast::UseTreeList {
             .is_some()
     }
 
+    pub fn comma(&self) -> impl Iterator<Item = SyntaxToken> {
+        self.syntax()
+            .children_with_tokens()
+            .filter_map(|it| it.into_token().filter(|it| it.kind() == T![,]))
+    }
+
     /// Remove the unnecessary braces in current `UseTreeList`
     pub fn remove_unnecessary_braces(mut self) {
         let remove_brace_in_use_tree_list = |u: &ast::UseTreeList| {
@@ -352,6 +358,7 @@ impl ast::UseTreeList {
             if use_tree_count == 1 {
                 u.l_curly_token().map(ted::remove);
                 u.r_curly_token().map(ted::remove);
+                u.comma().for_each(ted::remove);
             }
         };
 


### PR DESCRIPTION
![remove_comma](https://github.com/rust-lang/rust-analyzer/assets/71162630/56ef8cfc-a024-4c4a-82de-a8cca513b32e)

follow up https://github.com/rust-lang/rust-analyzer/pull/16066, close https://github.com/rust-lang/rust-analyzer/issues/16181