### PR TITLE
add test case for negative impl

### DIFF
--- a/crates/ide-diagnostics/src/handlers/trait_impl_redundant_assoc_item.rs
+++ b/crates/ide-diagnostics/src/handlers/trait_impl_redundant_assoc_item.rs
@@ -76,4 +76,24 @@ impl Marker for Foo {
             "#,
         )
     }
+
+    #[test]
+    fn dont_work_for_negative_impl() {
+        check_diagnostics(
+            r#"
+trait Marker {
+    const FLAG: bool = false;
+    fn boo();
+    fn foo () {}
+}
+struct Foo;
+impl !Marker for Foo {
+    type T = i32;
+    const FLAG: bool = true;
+    fn bar() {}
+    fn boo() {}
+}
+            "#,
+        )
+    }
 }


### PR DESCRIPTION
add a small test case to ensure that we don't emit `trait_impl_redundant_assoc_item` diagnostic for negative impl trait