### PR TITLE
Draft Callable type matching

### DIFF
--- a/crates/ide-completion/src/render.rs
+++ b/crates/ide-completion/src/render.rs
@@ -519,6 +519,15 @@ fn compute_type_match(
 ) -> Option<CompletionRelevanceTypeMatch> {
     let expected_type = ctx.expected_type.as_ref()?;
 
+    if let (Some(expected), Some(actual)) =
+        (expected_type.as_callable(ctx.db), completion_ty.as_callable(ctx.db))
+    {
+        return if expected.is_unifiable(actual, ctx.db) {
+            Some(CompletionRelevanceTypeMatch::CouldUnify)
+        } else {
+            None
+        };
+    }
     // We don't ever consider unit type to be an exact type match, since
     // nearly always this is not meaningful to the user.
     if expected_type.is_unit() {

--- a/crates/ide-completion/src/render/function.rs
+++ b/crates/ide-completion/src/render/function.rs
@@ -98,11 +98,7 @@ fn render(
         .and_then(|cap| Some((cap, params(ctx.completion, func, &func_kind, has_dot_receiver)?)));
 
     item.set_relevance(CompletionRelevance {
-        type_match: if has_call_parens || complete_call_parens.is_some() {
-            compute_type_match(completion, &ret_type)
-        } else {
-            compute_type_match(completion, &func.ty(db))
-        },
+        type_match: compute_type_match(ctx.completion, &func.ty(db)),
         exact_name_match: compute_exact_name_match(completion, &call),
         is_op_method,
         ..ctx.completion_relevance()


### PR DESCRIPTION
A first attempt at #16053. The type matching is implemented on `Callable` as `Callable::is_unifiable`. We can not import from `ide-completions` and therefore do not have access to `CompletionRelevanceTypeMatch`. `Callable::is_unifiable` therefore returns a `bool` indicating if callables are unifiable or not. The idea is that an exact match is also unifiable. I am not sure what implications this limitation has.

This was what I could get away with, without refactoring too much. It might make sense to go back to the original solution of having a separate function in `render` which differentiates between unifable and exact.

Let me know what you think :)