### PR TITLE
Use Cargo's [workspace.lints.*] to config clippy

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,7 +2,7 @@
 xtask = "run --package xtask --bin xtask --"
 tq = "test -- -q"
 qt = "tq"
-lint = "clippy --all-targets -- -Aclippy::collapsible_if -Aclippy::needless_pass_by_value -Aclippy::nonminimal_bool -Aclippy::redundant_pattern_matching --cap-lints warn"
+lint = "clippy --all-targets -- --cap-lints warn"
 
 [target.x86_64-pc-windows-msvc]
 linker = "rust-lld"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["crates/proc-macro-srv/proc-macro-test/"]
 resolver = "2"
 
 [workspace.package]
-rust-version = "1.70"
+rust-version = "1.74"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["rust-analyzer team"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -133,3 +133,9 @@ xshell = "0.2.5"
 
 # We need to freeze the version of the crate, as the raw-api feature is considered unstable
 dashmap = { version = "=5.5.3", features = ["raw-api"] }
+
+[workspace.lints.clippy]
+collapsible_if = "allow"
+needless_pass_by_value = "allow"
+nonminimal_bool = "allow"
+redundant_pattern_matching = "allow"

--- a/crates/base-db/Cargo.toml
+++ b/crates/base-db/Cargo.toml
@@ -25,3 +25,6 @@ stdx.workspace = true
 syntax.workspace = true
 vfs.workspace = true
 span.workspace = true
+
+[lints]
+workspace = true

--- a/crates/cfg/Cargo.toml
+++ b/crates/cfg/Cargo.toml
@@ -29,3 +29,6 @@ derive_arbitrary = "1.3.2"
 # local deps
 mbe.workspace = true
 syntax.workspace = true
+
+[lints]
+workspace = true

--- a/crates/flycheck/Cargo.toml
+++ b/crates/flycheck/Cargo.toml
@@ -24,3 +24,6 @@ command-group.workspace = true
 paths.workspace = true
 stdx.workspace = true
 toolchain.workspace = true
+
+[lints]
+workspace = true

--- a/crates/hir-def/Cargo.toml
+++ b/crates/hir-def/Cargo.toml
@@ -54,3 +54,6 @@ test-fixture.workspace = true
 
 [features]
 in-rust-tree = ["rustc-dependencies/in-rust-tree"]
+
+[lints]
+workspace = true

--- a/crates/hir-expand/Cargo.toml
+++ b/crates/hir-expand/Cargo.toml
@@ -36,3 +36,6 @@ span.workspace = true
 
 [dev-dependencies]
 expect-test = "1.4.0"
+
+[lints]
+workspace = true

--- a/crates/hir-ty/Cargo.toml
+++ b/crates/hir-ty/Cargo.toml
@@ -58,3 +58,6 @@ test-fixture.workspace = true
 
 [features]
 in-rust-tree = ["rustc-dependencies/in-rust-tree"]
+
+[lints]
+workspace = true

--- a/crates/hir/Cargo.toml
+++ b/crates/hir/Cargo.toml
@@ -33,3 +33,6 @@ tt.workspace = true
 
 [features]
 in-rust-tree = []
+
+[lints]
+workspace = true

--- a/crates/ide-assists/Cargo.toml
+++ b/crates/ide-assists/Cargo.toml
@@ -36,3 +36,6 @@ sourcegen.workspace = true
 
 [features]
 in-rust-tree = []
+
+[lints]
+workspace = true

--- a/crates/ide-completion/Cargo.toml
+++ b/crates/ide-completion/Cargo.toml
@@ -36,3 +36,6 @@ expect-test = "1.4.0"
 # local deps
 test-utils.workspace = true
 test-fixture.workspace = true
+
+[lints]
+workspace = true

--- a/crates/ide-db/Cargo.toml
+++ b/crates/ide-db/Cargo.toml
@@ -50,3 +50,6 @@ xshell.workspace = true
 test-utils.workspace = true
 test-fixture.workspace = true
 sourcegen.workspace = true
+
+[lints]
+workspace = true

--- a/crates/ide-diagnostics/Cargo.toml
+++ b/crates/ide-diagnostics/Cargo.toml
@@ -37,3 +37,6 @@ sourcegen.workspace = true
 
 [features]
 in-rust-tree = []
+
+[lints]
+workspace = true

--- a/crates/ide-ssr/Cargo.toml
+++ b/crates/ide-ssr/Cargo.toml
@@ -32,3 +32,6 @@ expect-test = "1.4.0"
 # local deps
 test-utils.workspace = true
 test-fixture.workspace = true
+
+[lints]
+workspace = true

--- a/crates/ide/Cargo.toml
+++ b/crates/ide/Cargo.toml
@@ -54,3 +54,6 @@ test-fixture.workspace = true
 
 [features]
 in-rust-tree = ["ide-assists/in-rust-tree", "ide-diagnostics/in-rust-tree"]
+
+[lints]
+workspace = true

--- a/crates/intern/Cargo.toml
+++ b/crates/intern/Cargo.toml
@@ -18,3 +18,6 @@ dashmap.workspace = true
 hashbrown.workspace = true
 rustc-hash.workspace = true
 triomphe.workspace = true
+
+[lints]
+workspace = true

--- a/crates/limit/Cargo.toml
+++ b/crates/limit/Cargo.toml
@@ -11,3 +11,6 @@ rust-version.workspace = true
 [features]
 tracking = []
 default = ["tracking"]
+
+[lints]
+workspace = true

--- a/crates/load-cargo/Cargo.toml
+++ b/crates/load-cargo/Cargo.toml
@@ -26,3 +26,6 @@ vfs-notify.workspace = true
 span.workspace = true
 
 hir-expand.workspace = true
+
+[lints]
+workspace = true

--- a/crates/mbe/Cargo.toml
+++ b/crates/mbe/Cargo.toml
@@ -26,3 +26,6 @@ span.workspace = true
 
 [dev-dependencies]
 test-utils.workspace = true
+
+[lints]
+workspace = true

--- a/crates/parser/Cargo.toml
+++ b/crates/parser/Cargo.toml
@@ -25,3 +25,6 @@ sourcegen.workspace = true
 
 [features]
 in-rust-tree = ["rustc-dependencies/in-rust-tree"]
+
+[lints]
+workspace = true

--- a/crates/paths/Cargo.toml
+++ b/crates/paths/Cargo.toml
@@ -16,3 +16,6 @@ doctest = false
 # serde-derive crate. Even though we don't activate the derive feature here,
 # someone else in the crate graph certainly does!
 # serde.workspace = true
+
+[lints]
+workspace = true

--- a/crates/proc-macro-api/Cargo.toml
+++ b/crates/proc-macro-api/Cargo.toml
@@ -38,3 +38,6 @@ span.workspace = true
 # InternIds for the syntax context
 base-db.workspace = true
 la-arena.workspace = true
+
+[lints]
+workspace = true

--- a/crates/proc-macro-srv-cli/Cargo.toml
+++ b/crates/proc-macro-srv-cli/Cargo.toml
@@ -18,3 +18,6 @@ sysroot-abi = ["proc-macro-srv/sysroot-abi"]
 [[bin]]
 name = "rust-analyzer-proc-macro-srv"
 path = "src/main.rs"
+
+[lints]
+workspace = true

--- a/crates/proc-macro-srv/Cargo.toml
+++ b/crates/proc-macro-srv/Cargo.toml
@@ -38,3 +38,6 @@ proc-macro-test.path = "./proc-macro-test"
 
 [features]
 sysroot-abi = ["proc-macro-test/sysroot-abi"]
+
+[lints]
+workspace = true

--- a/crates/profile/Cargo.toml
+++ b/crates/profile/Cargo.toml
@@ -31,3 +31,6 @@ jemalloc = ["jemalloc-ctl"]
 
 # Uncomment to enable for the whole crate graph
 # default = [ "cpu_profiler" ]
+
+[lints]
+workspace = true

--- a/crates/project-model/Cargo.toml
+++ b/crates/project-model/Cargo.toml
@@ -33,3 +33,6 @@ toolchain.workspace = true
 
 [dev-dependencies]
 expect-test = "1.4.0"
+
+[lints]
+workspace = true

--- a/crates/rust-analyzer/Cargo.toml
+++ b/crates/rust-analyzer/Cargo.toml
@@ -94,3 +94,6 @@ in-rust-tree = [
     "hir-def/in-rust-tree",
     "hir-ty/in-rust-tree",
 ]
+
+[lints]
+workspace = true

--- a/crates/rustc-dependencies/Cargo.toml
+++ b/crates/rustc-dependencies/Cargo.toml
@@ -18,3 +18,6 @@ ra-ap-rustc_abi = { version = "0.21.0", default-features = false }
 
 [features]
 in-rust-tree = []
+
+[lints]
+workspace = true

--- a/crates/sourcegen/Cargo.toml
+++ b/crates/sourcegen/Cargo.toml
@@ -14,3 +14,6 @@ doctest = false
 
 [dependencies]
 xshell.workspace = true
+
+[lints]
+workspace = true

--- a/crates/span/Cargo.toml
+++ b/crates/span/Cargo.toml
@@ -16,3 +16,6 @@ rust-analyzer-salsa.workspace = true
 vfs.workspace = true
 syntax.workspace = true
 stdx.workspace = true
+
+[lints]
+workspace = true

--- a/crates/stdx/Cargo.toml
+++ b/crates/stdx/Cargo.toml
@@ -27,3 +27,6 @@ winapi = { version = "0.3.9", features = ["winerror"] }
 [features]
 # Uncomment to enable for the whole crate graph
 # default = [ "backtrace" ]
+
+[lints]
+workspace = true

--- a/crates/syntax/Cargo.toml
+++ b/crates/syntax/Cargo.toml
@@ -42,3 +42,6 @@ sourcegen.workspace = true
 
 [features]
 in-rust-tree = ["rustc-dependencies/in-rust-tree"]
+
+[lints]
+workspace = true

--- a/crates/syntax/fuzz/Cargo.toml
+++ b/crates/syntax/fuzz/Cargo.toml
@@ -24,3 +24,6 @@ path = "fuzz_targets/parser.rs"
 [[bin]]
 name = "reparse"
 path = "fuzz_targets/reparse.rs"
+
+[lints]
+workspace = true

--- a/crates/test-fixture/Cargo.toml
+++ b/crates/test-fixture/Cargo.toml
@@ -16,3 +16,6 @@ base-db.workspace = true
 rustc-hash.workspace = true
 span.workspace = true
 stdx.workspace = true
+
+[lints]
+workspace = true

--- a/crates/test-utils/Cargo.toml
+++ b/crates/test-utils/Cargo.toml
@@ -19,3 +19,6 @@ rustc-hash.workspace = true
 
 stdx.workspace = true
 profile.workspace = true
+
+[lints]
+workspace = true

--- a/crates/text-edit/Cargo.toml
+++ b/crates/text-edit/Cargo.toml
@@ -14,3 +14,6 @@ doctest = false
 [dependencies]
 itertools.workspace = true
 text-size.workspace = true
+
+[lints]
+workspace = true

--- a/crates/toolchain/Cargo.toml
+++ b/crates/toolchain/Cargo.toml
@@ -13,3 +13,6 @@ doctest = false
 
 [dependencies]
 home = "0.5.4"
+
+[lints]
+workspace = true

--- a/crates/tt/Cargo.toml
+++ b/crates/tt/Cargo.toml
@@ -19,3 +19,6 @@ stdx.workspace = true
 
 # FIXME: Remove this dependency once the `Span` trait is gone (that is once Span::DUMMY has been removed)
 span.workspace = true
+
+[lints]
+workspace = true

--- a/crates/vfs-notify/Cargo.toml
+++ b/crates/vfs-notify/Cargo.toml
@@ -20,3 +20,6 @@ notify = "6.1.1"
 stdx.workspace = true
 vfs.workspace = true
 paths.workspace = true
+
+[lints]
+workspace = true

--- a/crates/vfs/Cargo.toml
+++ b/crates/vfs/Cargo.toml
@@ -19,3 +19,6 @@ nohash-hasher.workspace = true
 
 paths.workspace = true
 stdx.workspace = true
+
+[lints]
+workspace = true

--- a/lib/la-arena/Cargo.toml
+++ b/lib/la-arena/Cargo.toml
@@ -8,3 +8,6 @@ documentation = "https://docs.rs/la-arena"
 categories = ["data-structures", "memory-management", "rust-patterns"]
 edition = "2021"
 rust-version = "1.56"
+
+[lints]
+workspace = true

--- a/lib/line-index/Cargo.toml
+++ b/lib/line-index/Cargo.toml
@@ -9,3 +9,6 @@ edition = "2021"
 [dependencies]
 text-size = "1.1.1"
 nohash-hasher = "0.2.0"
+
+[lints]
+workspace = true

--- a/lib/lsp-server/Cargo.toml
+++ b/lib/lsp-server/Cargo.toml
@@ -15,3 +15,6 @@ crossbeam-channel = "0.5.6"
 [dev-dependencies]
 lsp-types = "=0.95"
 ctrlc = "3.4.1"
+
+[lints]
+workspace = true

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -15,3 +15,6 @@ xflags = "0.3.0"
 time = { version = "0.3", default-features = false }
 zip = { version = "0.6", default-features = false, features = ["deflate", "time"] }
 # Avoid adding more dependencies to this crate
+
+[lints]
+workspace = true


### PR DESCRIPTION
This change begin to use [`[workspace.lints.*]`](https://doc.rust-lang.org/cargo/reference/workspaces.html#the-lints-table) that is stabilized since [Rust 1.74](https://blog.rust-lang.org/2023/11/16/Rust-1.74.0.html).

By this change, we make the configure more readable and simplify `xargo lint` more.