### PR TITLE
Give a userful error when rustc cannot be found in explicit sysroot

### DIFF
--- a/crates/project-model/src/sysroot.rs
+++ b/crates/project-model/src/sysroot.rs
@@ -6,7 +6,7 @@
 
 use std::{env, fs, iter, ops, path::PathBuf, process::Command};
 
-use anyhow::{format_err, Result};
+use anyhow::{format_err, Context, Result};
 use base_db::CrateName;
 use la_arena::{Arena, Idx};
 use paths::{AbsPath, AbsPathBuf};
@@ -119,12 +119,15 @@ impl Sysroot {
         get_rustc_src(&self.root)
     }
 
-    pub fn discover_rustc(&self) -> Result<AbsPathBuf, std::io::Error> {
+    pub fn discover_rustc(&self) -> anyhow::Result<AbsPathBuf> {
         let rustc = self.root.join("bin/rustc");
         tracing::debug!(?rustc, "checking for rustc binary at location");
         match fs::metadata(&rustc) {
             Ok(_) => Ok(rustc),
-            Err(e) => Err(e),
+            Err(e) => Err(e).context(format!(
+                "failed to discover rustc in sysroot: {:?}",
+                AsRef::<std::path::Path>::as_ref(&self.root)
+            )),
         }
     }
 


### PR DESCRIPTION
Somehow r-a believed that my sysroot was something weird with no rustc. Probably a me issue, but it was impossible to diagnose since r-a just gave me a plain "No such file or directory". Adding this error makes it clear what happened and allows diagnosing the problem.