### PR TITLE
Trait Import completion for Notable Traits

### DIFF
--- a/crates/hir-def/src/attr.rs
+++ b/crates/hir-def/src/attr.rs
@@ -207,6 +207,13 @@ impl Attrs {
         })
     }
 
+    pub fn has_doc_notable_trait(&self) -> bool {
+        self.by_key("doc").tt_values().any(|tt| {
+            tt.delimiter.kind == DelimiterKind::Parenthesis &&
+                matches!(&*tt.token_trees, [tt::TokenTree::Leaf(tt::Leaf::Ident(ident))] if ident.text == "notable_trait")
+        })
+    }
+
     pub fn doc_exprs(&self) -> impl Iterator<Item = DocExpr> + '_ {
         self.by_key("doc").tt_values().map(DocExpr::parse)
     }


### PR DESCRIPTION
cc @Veykril  

`ImportMap` and `ImportInfo` are changed to record information related to `notable_traits`. Does the current implementation look okay? If so I can proceed with actual implementation of the completion.

P.S: sorry if I shouldn't ping