### PR TITLE
internal: Switch to `expected.assert_eq` for `ide` tests

### DIFF
--- a/crates/ide/src/rename.rs
+++ b/crates/ide/src/rename.rs
@@ -466,7 +466,7 @@ mod tests {
             .collect::<Vec<_>>();
 
         format!(
-            "source_file_edits: {:#?}\nfile_system_edits: {:#?}",
+            "source_file_edits: {:#?}\nfile_system_edits: {:#?}\n",
             source_file_edits, file_system_edits
         )
     }
@@ -973,7 +973,8 @@ mod foo$0;
                             },
                         },
                     ),
-                ]"#]],
+                ]
+            "#]],
         );
     }
 
@@ -1035,7 +1036,8 @@ use crate::foo$0::FooContent;
                             },
                         },
                     ),
-                ]"#]],
+                ]
+            "#]],
         );
     }
 
@@ -1086,7 +1088,8 @@ mod fo$0o;
                             },
                         },
                     ),
-                ]"#]],
+                ]
+            "#]],
         );
     }
 
@@ -1132,7 +1135,8 @@ mod outer { mod fo$0o; }
                             },
                         },
                     ),
-                ]"#]],
+                ]
+            "#]],
         );
     }
 
@@ -1218,7 +1222,8 @@ pub mod foo$0;
                             },
                         },
                     ),
-                ]"#]],
+                ]
+            "#]],
         );
     }
 
@@ -1299,7 +1304,8 @@ mod quux;
                             },
                         },
                     ),
-                ]"#]],
+                ]
+            "#]],
         )
     }
     #[test]
@@ -1367,7 +1373,8 @@ mod bar$0;
 "#,
             expect![[r#"
                 source_file_edits: []
-                file_system_edits: []"#]],
+                file_system_edits: []
+            "#]],
         )
     }
 
@@ -1444,7 +1451,8 @@ pub fn baz() {}
                             },
                         },
                     ),
-                ]"#]],
+                ]
+            "#]],
         );
     }
 
@@ -1521,7 +1529,8 @@ pub fn baz() {}
                             },
                         },
                     ),
-                ]"#]],
+                ]
+            "#]],
         );
     }
 

--- a/crates/ide/src/rename.rs
+++ b/crates/ide/src/rename.rs
@@ -430,22 +430,24 @@ mod tests {
         //     file_system_edits:
         //         MoveFile AnchoredPathBuf { anchor: FileId(2), path: "foo2.rs", }
 
-        let mut source_file_edits = HashMap::new();
-        for (id, (text_edit, _)) in source_change.source_file_edits {
-            let indels = text_edit.into_iter().collect::<Vec<_>>();
-            source_file_edits.insert(id, indels);
-        }
+        let source_file_edits = source_change
+            .source_file_edits
+            .into_iter()
+            .map(|(a, (b, _))| (a, b.into_iter().collect::<Vec<_>>()))
+            .collect::<HashMap<_, _>>();
 
-        let mut file_system_edits = HashMap::new();
-        for a in source_change.file_system_edits {
-            let id = match &a {
-                FileSystemEdit::CreateFile { dst, initial_contents } => unreachable!(),
-                FileSystemEdit::MoveFile { src, dst } => src,
-                FileSystemEdit::MoveDir { src, src_id, dst } => src_id,
-            }
-            .clone();
-            file_system_edits.insert(id, a);
-        }
+        let file_system_edits = source_change
+            .file_system_edits
+            .into_iter()
+            .map(|a| {
+                let id = match &a {
+                    FileSystemEdit::CreateFile { .. } => unreachable!(),
+                    FileSystemEdit::MoveFile { src, .. } => src,
+                    FileSystemEdit::MoveDir { src_id, .. } => src_id,
+                };
+                (id.clone(), a)
+            })
+            .collect::<HashMap<_, _>>();
 
         let b = format!(
             "source_file_edits: {:#?}\nfile_system_edits: {:#?}",

--- a/crates/ide/src/rename.rs
+++ b/crates/ide/src/rename.rs
@@ -365,8 +365,6 @@ fn text_edit_from_self_param(self_param: &ast::SelfParam, new_name: &str) -> Opt
 
 #[cfg(test)]
 mod tests {
-    use std::collections::BTreeMap;
-
     use expect_test::{expect, Expect};
     use ide_db::source_change::{FileSystemEdit, SourceChange};
     use stdx::trim_indent;
@@ -452,7 +450,7 @@ mod tests {
             .source_file_edits
             .into_iter()
             .map(|(id, (text_edit, _))| (id, text_edit.into_iter().collect::<Vec<_>>()))
-            .collect::<BTreeMap<_, _>>();
+            .collect::<Vec<_>>();
 
         let file_system_edits = source_change
             .file_system_edits
@@ -465,7 +463,7 @@ mod tests {
                 };
                 (id.clone(), file_system_edit)
             })
-            .collect::<BTreeMap<_, _>>();
+            .collect::<Vec<_>>();
 
         format!(
             "source_file_edits: {:#?}\nfile_system_edits: {:#?}",
@@ -945,31 +943,37 @@ mod foo$0;
 // empty
 "#,
             expect![[r#"
-                source_file_edits: {
-                    FileId(
-                        1,
-                    ): [
-                        Indel {
-                            insert: "foo2",
-                            delete: 4..7,
-                        },
-                    ],
-                }
-                file_system_edits: {
-                    FileId(
-                        2,
-                    ): MoveFile {
-                        src: FileId(
+                source_file_edits: [
+                    (
+                        FileId(
+                            1,
+                        ),
+                        [
+                            Indel {
+                                insert: "foo2",
+                                delete: 4..7,
+                            },
+                        ],
+                    ),
+                ]
+                file_system_edits: [
+                    (
+                        FileId(
                             2,
                         ),
-                        dst: AnchoredPathBuf {
-                            anchor: FileId(
+                        MoveFile {
+                            src: FileId(
                                 2,
                             ),
-                            path: "foo2.rs",
+                            dst: AnchoredPathBuf {
+                                anchor: FileId(
+                                    2,
+                                ),
+                                path: "foo2.rs",
+                            },
                         },
-                    },
-                }"#]],
+                    ),
+                ]"#]],
         );
     }
 
@@ -990,39 +994,48 @@ pub struct FooContent;
 use crate::foo$0::FooContent;
 "#,
             expect![[r#"
-                source_file_edits: {
-                    FileId(
-                        0,
-                    ): [
-                        Indel {
-                            insert: "quux",
-                            delete: 8..11,
-                        },
-                    ],
-                    FileId(
-                        2,
-                    ): [
-                        Indel {
-                            insert: "quux",
-                            delete: 11..14,
-                        },
-                    ],
-                }
-                file_system_edits: {
-                    FileId(
-                        1,
-                    ): MoveFile {
-                        src: FileId(
+                source_file_edits: [
+                    (
+                        FileId(
+                            0,
+                        ),
+                        [
+                            Indel {
+                                insert: "quux",
+                                delete: 8..11,
+                            },
+                        ],
+                    ),
+                    (
+                        FileId(
+                            2,
+                        ),
+                        [
+                            Indel {
+                                insert: "quux",
+                                delete: 11..14,
+                            },
+                        ],
+                    ),
+                ]
+                file_system_edits: [
+                    (
+                        FileId(
                             1,
                         ),
-                        dst: AnchoredPathBuf {
-                            anchor: FileId(
+                        MoveFile {
+                            src: FileId(
                                 1,
                             ),
-                            path: "quux.rs",
+                            dst: AnchoredPathBuf {
+                                anchor: FileId(
+                                    1,
+                                ),
+                                path: "quux.rs",
+                            },
                         },
-                    },
-                }"#]],
+                    ),
+                ]"#]],
         );
     }
 
@@ -1037,37 +1050,43 @@ mod fo$0o;
 // empty
 "#,
             expect![[r#"
-                source_file_edits: {
-                    FileId(
-                        0,
-                    ): [
-                        Indel {
-                            insert: "foo2",
-                            delete: 4..7,
-                        },
-                    ],
-                }
-                file_system_edits: {
-                    FileId(
-                        1,
-                    ): MoveDir {
-                        src: AnchoredPathBuf {
-                            anchor: FileId(
-                                1,
-                            ),
-                            path: "../foo",
-                        },
-                        src_id: FileId(
+                source_file_edits: [
+                    (
+                        FileId(
+                            0,
+                        ),
+                        [
+                            Indel {
+                                insert: "foo2",
+                                delete: 4..7,
+                            },
+                        ],
+                    ),
+                ]
+                file_system_edits: [
+                    (
+                        FileId(
                             1,
                         ),
-                        dst: AnchoredPathBuf {
-                            anchor: FileId(
+                        MoveDir {
+                            src: AnchoredPathBuf {
+                                anchor: FileId(
+                                    1,
+                                ),
+                                path: "../foo",
+                            },
+                            src_id: FileId(
                                 1,
                             ),
-                            path: "../foo2",
+                            dst: AnchoredPathBuf {
+                                anchor: FileId(
+                                    1,
+                                ),
+                                path: "../foo2",
+                            },
                         },
-                    },
-                }"#]],
+                    ),
+                ]"#]],
         );
     }
 
@@ -1083,31 +1102,37 @@ mod outer { mod fo$0o; }
 // empty
 "#,
             expect![[r#"
-                source_file_edits: {
-                    FileId(
-                        0,
-                    ): [
-                        Indel {
-                            insert: "bar",
-                            delete: 16..19,
-                        },
-                    ],
-                }
-                file_system_edits: {
-                    FileId(
-                        1,
-                    ): MoveFile {
-                        src: FileId(
+                source_file_edits: [
+                    (
+                        FileId(
+                            0,
+                        ),
+                        [
+                            Indel {
+                                insert: "bar",
+                                delete: 16..19,
+                            },
+                        ],
+                    ),
+                ]
+                file_system_edits: [
+                    (
+                        FileId(
                             1,
                         ),
-                        dst: AnchoredPathBuf {
-                            anchor: FileId(
+                        MoveFile {
+                            src: FileId(
                                 1,
                             ),
-                            path: "bar.rs",
+                            dst: AnchoredPathBuf {
+                                anchor: FileId(
+                                    1,
+                                ),
+                                path: "bar.rs",
+                            },
                         },
-                    },
-                }"#]],
+                    ),
+                ]"#]],
         );
     }
 
@@ -1152,39 +1177,48 @@ pub mod foo$0;
 // pub fn fun() {}
 "#,
             expect![[r#"
-                source_file_edits: {
-                    FileId(
-                        0,
-                    ): [
-                        Indel {
-                            insert: "foo2",
-                            delete: 27..30,
-                        },
-                    ],
-                    FileId(
-                        1,
-                    ): [
-                        Indel {
-                            insert: "foo2",
-                            delete: 8..11,
-                        },
-                    ],
-                }
-                file_system_edits: {
-                    FileId(
-                        2,
-                    ): MoveFile {
-                        src: FileId(
+                source_file_edits: [
+                    (
+                        FileId(
+                            0,
+                        ),
+                        [
+                            Indel {
+                                insert: "foo2",
+                                delete: 27..30,
+                            },
+                        ],
+                    ),
+                    (
+                        FileId(
+                            1,
+                        ),
+                        [
+                            Indel {
+                                insert: "foo2",
+                                delete: 8..11,
+                            },
+                        ],
+                    ),
+                ]
+                file_system_edits: [
+                    (
+                        FileId(
                             2,
                         ),
-                        dst: AnchoredPathBuf {
-                            anchor: FileId(
+                        MoveFile {
+                            src: FileId(
                                 2,
                             ),
-                            path: "foo2.rs",
+                            dst: AnchoredPathBuf {
+                                anchor: FileId(
+                                    2,
+                                ),
+                                path: "foo2.rs",
+                            },
                         },
-                    },
-                }"#]],
+                    ),
+                ]"#]],
         );
     }
 
@@ -1213,37 +1247,59 @@ mod quux;
 // empty
 "#,
             expect![[r#"
-                source_file_edits: {
-                    FileId(
-                        0,
-                    ): [
-                        Indel {
-                            insert: "foo2",
-                            delete: 4..7,
-                        },
-                    ],
-                }
-                file_system_edits: {
-                    FileId(
-                        1,
-                    ): MoveDir {
-                        src: AnchoredPathBuf {
-                            anchor: FileId(
-                                1,
-                            ),
-                            path: "foo",
-                        },
-                        src_id: FileId(
+                source_file_edits: [
+                    (
+                        FileId(
+                            0,
+                        ),
+                        [
+                            Indel {
+                                insert: "foo2",
+                                delete: 4..7,
+                            },
+                        ],
+                    ),
+                ]
+                file_system_edits: [
+                    (
+                        FileId(
                             1,
                         ),
-                        dst: AnchoredPathBuf {
-                            anchor: FileId(
+                        MoveFile {
+                            src: FileId(
                                 1,
                             ),
-                            path: "foo2",
+                            dst: AnchoredPathBuf {
+                                anchor: FileId(
+                                    1,
+                                ),
+                                path: "foo2.rs",
+                            },
                         },
-                    },
-                }"#]],
+                    ),
+                    (
+                        FileId(
+                            1,
+                        ),
+                        MoveDir {
+                            src: AnchoredPathBuf {
+                                anchor: FileId(
+                                    1,
+                                ),
+                                path: "foo",
+                            },
+                            src_id: FileId(
+                                1,
+                            ),
+                            dst: AnchoredPathBuf {
+                                anchor: FileId(
+                                    1,
+                                ),
+                                path: "foo2",
+                            },
+                        },
+                    ),
+                ]"#]],
         )
     }
     #[test]
@@ -1310,8 +1366,8 @@ fn foo() {}
 mod bar$0;
 "#,
             expect![[r#"
-                source_file_edits: {}
-                file_system_edits: {}"#]],
+                source_file_edits: []
+                file_system_edits: []"#]],
         )
     }
 
@@ -1332,41 +1388,63 @@ pub mod bar;
 pub fn baz() {}
 "#,
             expect![[r#"
-                source_file_edits: {
-                    FileId(
-                        0,
-                    ): [
-                        Indel {
-                            insert: "r#fn",
-                            delete: 4..7,
-                        },
-                        Indel {
-                            insert: "r#fn",
-                            delete: 22..25,
-                        },
-                    ],
-                }
-                file_system_edits: {
-                    FileId(
-                        1,
-                    ): MoveDir {
-                        src: AnchoredPathBuf {
-                            anchor: FileId(
-                                1,
-                            ),
-                            path: "foo",
-                        },
-                        src_id: FileId(
+                source_file_edits: [
+                    (
+                        FileId(
+                            0,
+                        ),
+                        [
+                            Indel {
+                                insert: "r#fn",
+                                delete: 4..7,
+                            },
+                            Indel {
+                                insert: "r#fn",
+                                delete: 22..25,
+                            },
+                        ],
+                    ),
+                ]
+                file_system_edits: [
+                    (
+                        FileId(
                             1,
                         ),
-                        dst: AnchoredPathBuf {
-                            anchor: FileId(
+                        MoveFile {
+                            src: FileId(
                                 1,
                             ),
-                            path: "fn",
+                            dst: AnchoredPathBuf {
+                                anchor: FileId(
+                                    1,
+                                ),
+                                path: "fn.rs",
+                            },
                         },
-                    },
-                }"#]],
+                    ),
+                    (
+                        FileId(
+                            1,
+                        ),
+                        MoveDir {
+                            src: AnchoredPathBuf {
+                                anchor: FileId(
+                                    1,
+                                ),
+                                path: "foo",
+                            },
+                            src_id: FileId(
+                                1,
+                            ),
+                            dst: AnchoredPathBuf {
+                                anchor: FileId(
+                                    1,
+                                ),
+                                path: "fn",
+                            },
+                        },
+                    ),
+                ]"#]],
         );
     }
 
@@ -1387,41 +1465,63 @@ pub mod bar;
 pub fn baz() {}
 "#,
             expect![[r#"
-                source_file_edits: {
-                    FileId(
-                        0,
-                    ): [
-                        Indel {
-                            insert: "foo",
-                            delete: 4..8,
-                        },
-                        Indel {
-                            insert: "foo",
-                            delete: 23..27,
-                        },
-                    ],
-                }
-                file_system_edits: {
-                    FileId(
-                        1,
-                    ): MoveDir {
-                        src: AnchoredPathBuf {
-                            anchor: FileId(
-                                1,
-                            ),
-                            path: "fn",
-                        },
-                        src_id: FileId(
+                source_file_edits: [
+                    (
+                        FileId(
+                            0,
+                        ),
+                        [
+                            Indel {
+                                insert: "foo",
+                                delete: 4..8,
+                            },
+                            Indel {
+                                insert: "foo",
+                                delete: 23..27,
+                            },
+                        ],
+                    ),
+                ]
+                file_system_edits: [
+                    (
+                        FileId(
                             1,
                         ),
-                        dst: AnchoredPathBuf {
-                            anchor: FileId(
+                        MoveFile {
+                            src: FileId(
                                 1,
                             ),
-                            path: "foo",
+                            dst: AnchoredPathBuf {
+                                anchor: FileId(
+                                    1,
+                                ),
+                                path: "foo.rs",
+                            },
                         },
-                    },
-                }"#]],
+                    ),
+                    (
+                        FileId(
+                            1,
+                        ),
+                        MoveDir {
+                            src: AnchoredPathBuf {
+                                anchor: FileId(
+                                    1,
+                                ),
+                                path: "fn",
+                            },
+                            src_id: FileId(
+                                1,
+                            ),
+                            dst: AnchoredPathBuf {
+                                anchor: FileId(
+                                    1,
+                                ),
+                                path: "foo",
+                            },
+                        },
+                    ),
+                ]"#]],
         );
     }
 

--- a/crates/ide/src/rename.rs
+++ b/crates/ide/src/rename.rs
@@ -365,7 +365,7 @@ fn text_edit_from_self_param(self_param: &ast::SelfParam, new_name: &str) -> Opt
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
+    use std::collections::BTreeMap;
 
     use expect_test::{expect, Expect};
     use ide_db::source_change::{FileSystemEdit, SourceChange};
@@ -452,7 +452,7 @@ mod tests {
             .source_file_edits
             .into_iter()
             .map(|(id, (text_edit, _))| (id, text_edit.into_iter().collect::<Vec<_>>()))
-            .collect::<HashMap<_, _>>();
+            .collect::<BTreeMap<_, _>>();
 
         let file_system_edits = source_change
             .file_system_edits
@@ -465,7 +465,7 @@ mod tests {
                 };
                 (id.clone(), file_system_edit)
             })
-            .collect::<HashMap<_, _>>();
+            .collect::<BTreeMap<_, _>>();
 
         format!(
             "source_file_edits: {:#?}\nfile_system_edits: {:#?}",
@@ -1310,12 +1310,8 @@ fn foo() {}
 mod bar$0;
 "#,
             expect![[r#"
-                SourceChange {
-                    source_file_edits: {},
-                    file_system_edits: [],
-                    is_snippet: false,
-                }
-                "#]],
+                source_file_edits: {}
+                file_system_edits: {}"#]],
         )
     }
 


### PR DESCRIPTION
This PR switches from `assert_debug_eq` to `assert_eq` and only compares parts of the result and not the whole. The aim is to only compare parts which are relevant to the test and also make it more readable.

Part of #14268.

## Questions
- [x] Can I use `Vec`? If not, what is the alternative?
    I assume I cannot because of: https://github.com/rust-lang/rust-analyzer/blob/c3a00b5468576de4e39adc8fa5ceae35a0024e49/docs/dev/architecture.md?plain=1#L413
- [x] Should I group it by file, as proposed by Lukas?
    ```
    file_id 1:
        source_file_edits: 
            - Indel { insert: "foo2", delete: 4..7 }

    file_id 2:
        file_system_edits:
            MoveFile AnchoredPathBuf { anchor: FileId(2), path: "foo2.rs", }
    ```
- [x] Is it okay to ignore `CreateFile` events? They do not have a FileId, which would be problematic, but they do not occur in the existing tests, so I marked them as `unreachable!()` so far.