### PR TITLE
internal: Only compare relevant parts in  `ide::{runnables,inlay_hints}` tests

### DIFF
--- a/crates/ide/src/inlay_hints.rs
+++ b/crates/ide/src/inlay_hints.rs
@@ -593,7 +593,6 @@ mod tests {
     use hir::ClosureStyle;
     use itertools::Itertools;
     use test_utils::extract_annotations;
-    use text_edit::{TextRange, TextSize};
 
     use crate::inlay_hints::{AdjustmentHints, AdjustmentHintsMode};
     use crate::DiscriminantHints;
@@ -652,33 +651,6 @@ mod tests {
         expected.sort_by_key(|(range, _)| range.start());
 
         assert_eq!(expected, actual, "\nExpected:\n{expected:#?}\n\nActual:\n{actual:#?}");
-    }
-
-    #[track_caller]
-    pub(super) fn check_expect(config: InlayHintsConfig, ra_fixture: &str, expect: Expect) {
-        let (analysis, file_id) = fixture::file(ra_fixture);
-        let inlay_hints = analysis.inlay_hints(&config, file_id, None).unwrap();
-        let filtered =
-            inlay_hints.into_iter().map(|hint| (hint.range, hint.label)).collect::<Vec<_>>();
-        expect.assert_debug_eq(&filtered)
-    }
-
-    #[track_caller]
-    pub(super) fn check_expect_clear_loc(
-        config: InlayHintsConfig,
-        ra_fixture: &str,
-        expect: Expect,
-    ) {
-        let (analysis, file_id) = fixture::file(ra_fixture);
-        let mut inlay_hints = analysis.inlay_hints(&config, file_id, None).unwrap();
-        inlay_hints.iter_mut().flat_map(|hint| &mut hint.label.parts).for_each(|hint| {
-            if let Some(loc) = &mut hint.linked_location {
-                loc.range = TextRange::empty(TextSize::from(0));
-            }
-        });
-        let filtered =
-            inlay_hints.into_iter().map(|hint| (hint.range, hint.label)).collect::<Vec<_>>();
-        expect.assert_debug_eq(&filtered)
     }
 
     /// Computes inlay hints for the fixture, applies all the provided text edits and then runs

--- a/crates/ide/src/inlay_hints.rs
+++ b/crates/ide/src/inlay_hints.rs
@@ -658,7 +658,9 @@ mod tests {
     pub(super) fn check_expect(config: InlayHintsConfig, ra_fixture: &str, expect: Expect) {
         let (analysis, file_id) = fixture::file(ra_fixture);
         let inlay_hints = analysis.inlay_hints(&config, file_id, None).unwrap();
-        expect.assert_debug_eq(&inlay_hints)
+        let filtered =
+            inlay_hints.into_iter().map(|hint| (hint.range, hint.label)).collect::<Vec<_>>();
+        expect.assert_debug_eq(&filtered)
     }
 
     #[track_caller]
@@ -674,7 +676,9 @@ mod tests {
                 loc.range = TextRange::empty(TextSize::from(0));
             }
         });
-        expect.assert_debug_eq(&inlay_hints)
+        let filtered =
+            inlay_hints.into_iter().map(|hint| (hint.range, hint.label)).collect::<Vec<_>>();
+        expect.assert_debug_eq(&filtered)
     }
 
     /// Computes inlay hints for the fixture, applies all the provided text edits and then runs

--- a/crates/ide/src/inlay_hints/chaining.rs
+++ b/crates/ide/src/inlay_hints/chaining.rs
@@ -109,13 +109,9 @@ fn main() {
 "#,
             expect![[r#"
                 [
-                    InlayHint {
-                        range: 147..172,
-                        position: After,
-                        pad_left: true,
-                        pad_right: false,
-                        kind: Chaining,
-                        label: [
+                    (
+                        147..172,
+                        [
                             "",
                             InlayHintLabelPart {
                                 text: "B",
@@ -131,16 +127,10 @@ fn main() {
                             },
                             "",
                         ],
-                        text_edit: None,
-                        needs_resolve: true,
-                    },
-                    InlayHint {
-                        range: 147..154,
-                        position: After,
-                        pad_left: true,
-                        pad_right: false,
-                        kind: Chaining,
-                        label: [
+                    ),
+                    (
+                        147..154,
+                        [
                             "",
                             InlayHintLabelPart {
                                 text: "A",
@@ -156,9 +146,7 @@ fn main() {
                             },
                             "",
                         ],
-                        text_edit: None,
-                        needs_resolve: true,
-                    },
+                    ),
                 ]
             "#]],
         );
@@ -204,13 +192,9 @@ fn main() {
     }"#,
             expect![[r#"
                 [
-                    InlayHint {
-                        range: 143..190,
-                        position: After,
-                        pad_left: true,
-                        pad_right: false,
-                        kind: Chaining,
-                        label: [
+                    (
+                        143..190,
+                        [
                             "",
                             InlayHintLabelPart {
                                 text: "C",
@@ -226,16 +210,10 @@ fn main() {
                             },
                             "",
                         ],
-                        text_edit: None,
-                        needs_resolve: true,
-                    },
-                    InlayHint {
-                        range: 143..179,
-                        position: After,
-                        pad_left: true,
-                        pad_right: false,
-                        kind: Chaining,
-                        label: [
+                    ),
+                    (
+                        143..179,
+                        [
                             "",
                             InlayHintLabelPart {
                                 text: "B",
@@ -251,9 +229,7 @@ fn main() {
                             },
                             "",
                         ],
-                        text_edit: None,
-                        needs_resolve: true,
-                    },
+                    ),
                 ]
             "#]],
         );
@@ -283,13 +259,9 @@ fn main() {
 }"#,
             expect![[r#"
                 [
-                    InlayHint {
-                        range: 143..190,
-                        position: After,
-                        pad_left: true,
-                        pad_right: false,
-                        kind: Chaining,
-                        label: [
+                    (
+                        143..190,
+                        [
                             "",
                             InlayHintLabelPart {
                                 text: "C",
@@ -305,16 +277,10 @@ fn main() {
                             },
                             "",
                         ],
-                        text_edit: None,
-                        needs_resolve: true,
-                    },
-                    InlayHint {
-                        range: 143..179,
-                        position: After,
-                        pad_left: true,
-                        pad_right: false,
-                        kind: Chaining,
-                        label: [
+                    ),
+                    (
+                        143..179,
+                        [
                             "",
                             InlayHintLabelPart {
                                 text: "B",
@@ -330,9 +296,7 @@ fn main() {
                             },
                             "",
                         ],
-                        text_edit: None,
-                        needs_resolve: true,
-                    },
+                    ),
                 ]
             "#]],
         );
@@ -363,13 +327,9 @@ fn main() {
 "#,
             expect![[r#"
                 [
-                    InlayHint {
-                        range: 246..283,
-                        position: After,
-                        pad_left: true,
-                        pad_right: false,
-                        kind: Chaining,
-                        label: [
+                    (
+                        246..283,
+                        [
                             "",
                             InlayHintLabelPart {
                                 text: "B",
@@ -398,16 +358,10 @@ fn main() {
                             },
                             "<i32, bool>>",
                         ],
-                        text_edit: None,
-                        needs_resolve: true,
-                    },
-                    InlayHint {
-                        range: 246..265,
-                        position: After,
-                        pad_left: true,
-                        pad_right: false,
-                        kind: Chaining,
-                        label: [
+                    ),
+                    (
+                        246..265,
+                        [
                             "",
                             InlayHintLabelPart {
                                 text: "A",
@@ -436,9 +390,7 @@ fn main() {
                             },
                             "<i32, bool>>",
                         ],
-                        text_edit: None,
-                        needs_resolve: true,
-                    },
+                    ),
                 ]
             "#]],
         );
@@ -471,13 +423,9 @@ fn main() {
 "#,
             expect![[r#"
                 [
-                    InlayHint {
-                        range: 174..241,
-                        position: After,
-                        pad_left: true,
-                        pad_right: false,
-                        kind: Chaining,
-                        label: [
+                    (
+                        174..241,
+                        [
                             "impl ",
                             InlayHintLabelPart {
                                 text: "Iterator",
@@ -506,16 +454,10 @@ fn main() {
                             },
                             " = ()>",
                         ],
-                        text_edit: None,
-                        needs_resolve: true,
-                    },
-                    InlayHint {
-                        range: 174..224,
-                        position: After,
-                        pad_left: true,
-                        pad_right: false,
-                        kind: Chaining,
-                        label: [
+                    ),
+                    (
+                        174..224,
+                        [
                             "impl ",
                             InlayHintLabelPart {
                                 text: "Iterator",
@@ -544,16 +486,10 @@ fn main() {
                             },
                             " = ()>",
                         ],
-                        text_edit: None,
-                        needs_resolve: true,
-                    },
-                    InlayHint {
-                        range: 174..206,
-                        position: After,
-                        pad_left: true,
-                        pad_right: false,
-                        kind: Chaining,
-                        label: [
+                    ),
+                    (
+                        174..206,
+                        [
                             "impl ",
                             InlayHintLabelPart {
                                 text: "Iterator",
@@ -582,16 +518,10 @@ fn main() {
                             },
                             " = ()>",
                         ],
-                        text_edit: None,
-                        needs_resolve: true,
-                    },
-                    InlayHint {
-                        range: 174..189,
-                        position: After,
-                        pad_left: true,
-                        pad_right: false,
-                        kind: Chaining,
-                        label: [
+                    ),
+                    (
+                        174..189,
+                        [
                             "&mut ",
                             InlayHintLabelPart {
                                 text: "MyIter",
@@ -607,9 +537,7 @@ fn main() {
                             },
                             "",
                         ],
-                        text_edit: None,
-                        needs_resolve: true,
-                    },
+                    ),
                 ]
             "#]],
         );
@@ -639,13 +567,9 @@ fn main() {
 "#,
             expect![[r#"
                 [
-                    InlayHint {
-                        range: 124..130,
-                        position: After,
-                        pad_left: true,
-                        pad_right: false,
-                        kind: Type,
-                        label: [
+                    (
+                        124..130,
+                        [
                             "",
                             InlayHintLabelPart {
                                 text: "Struct",
@@ -661,25 +585,10 @@ fn main() {
                             },
                             "",
                         ],
-                        text_edit: Some(
-                            TextEdit {
-                                indels: [
-                                    Indel {
-                                        insert: ": Struct",
-                                        delete: 130..130,
-                                    },
-                                ],
-                            },
-                        ),
-                        needs_resolve: true,
-                    },
-                    InlayHint {
-                        range: 145..185,
-                        position: After,
-                        pad_left: true,
-                        pad_right: false,
-                        kind: Chaining,
-                        label: [
+                    ),
+                    (
+                        145..185,
+                        [
                             "",
                             InlayHintLabelPart {
                                 text: "Struct",
@@ -695,16 +604,10 @@ fn main() {
                             },
                             "",
                         ],
-                        text_edit: None,
-                        needs_resolve: true,
-                    },
-                    InlayHint {
-                        range: 145..168,
-                        position: After,
-                        pad_left: true,
-                        pad_right: false,
-                        kind: Chaining,
-                        label: [
+                    ),
+                    (
+                        145..168,
+                        [
                             "",
                             InlayHintLabelPart {
                                 text: "Struct",
@@ -720,16 +623,10 @@ fn main() {
                             },
                             "",
                         ],
-                        text_edit: None,
-                        needs_resolve: true,
-                    },
-                    InlayHint {
-                        range: 222..228,
-                        position: Before,
-                        pad_left: false,
-                        pad_right: true,
-                        kind: Parameter,
-                        label: [
+                    ),
+                    (
+                        222..228,
+                        [
                             InlayHintLabelPart {
                                 text: "self",
                                 linked_location: Some(
@@ -743,9 +640,7 @@ fn main() {
                                 tooltip: "",
                             },
                         ],
-                        text_edit: None,
-                        needs_resolve: true,
-                    },
+                    ),
                 ]
             "#]],
         );

--- a/crates/ide/src/runnables.rs
+++ b/crates/ide/src/runnables.rs
@@ -576,8 +576,14 @@ mod tests {
     fn check_tests(ra_fixture: &str, expect: Expect) {
         let (analysis, position) = fixture::position(ra_fixture);
         let tests = analysis.related_tests(position, None).unwrap();
-        let test_names = tests.into_iter().map(|a| a.nav.name).collect::<Vec<_>>();
-        expect.assert_debug_eq(&test_names);
+        let test_ids = tests
+            .into_iter()
+            .map(|runnable| match runnable.kind {
+                RunnableKind::Test { test_id, .. } => test_id,
+                _ => unreachable!(),
+            })
+            .collect::<Vec<_>>();
+        expect.assert_debug_eq(&test_ids);
     }
 
     #[test]
@@ -2144,7 +2150,9 @@ mod tests {
 "#,
             expect![[r#"
                 [
-                    "foo_test",
+                    Path(
+                        "tests::foo_test",
+                    ),
                 ]
             "#]],
         );
@@ -2169,7 +2177,9 @@ mod tests {
 "#,
             expect![[r#"
                 [
-                    "foo_test",
+                    Path(
+                        "tests::foo_test",
+                    ),
                 ]
             "#]],
         );
@@ -2201,7 +2211,9 @@ mod tests {
 "#,
             expect![[r#"
                 [
-                    "foo_test",
+                    Path(
+                        "tests::foo_test",
+                    ),
                 ]
             "#]],
         );
@@ -2233,8 +2245,12 @@ mod tests {
 "#,
             expect![[r#"
                 [
-                    "foo2_test",
-                    "foo_test",
+                    Path(
+                        "tests::foo2_test",
+                    ),
+                    Path(
+                        "tests::foo_test",
+                    ),
                 ]
             "#]],
         );

--- a/crates/ide/src/runnables.rs
+++ b/crates/ide/src/runnables.rs
@@ -566,7 +566,10 @@ mod tests {
         let (analysis, position) = fixture::position(ra_fixture);
         let mut runnables = analysis.runnables(position.file_id).unwrap();
         runnables.sort_by_key(|it| (it.nav.full_range.start(), it.nav.name.clone()));
-        expect.assert_debug_eq(&runnables);
+
+        let navigation_targets = runnables.iter().map(|a| a.nav.clone()).collect::<Vec<_>>();
+        expect.assert_debug_eq(&navigation_targets);
+
         assert_eq!(
             actions,
             runnables.into_iter().map(|it| it.test_kind()).collect::<Vec<_>>().as_slice()
@@ -617,129 +620,67 @@ mod not_a_root {
             &[TestMod, Bin, Bin, Test, Test, Test, Bench],
             expect![[r#"
                 [
-                    Runnable {
-                        use_name_in_title: false,
-                        nav: NavigationTarget {
-                            file_id: FileId(
-                                0,
-                            ),
-                            full_range: 0..253,
-                            name: "",
-                            kind: Module,
-                        },
-                        kind: TestMod {
-                            path: "",
-                        },
-                        cfg: None,
+                    NavigationTarget {
+                        file_id: FileId(
+                            0,
+                        ),
+                        full_range: 0..253,
+                        name: "",
+                        kind: Module,
                     },
-                    Runnable {
-                        use_name_in_title: false,
-                        nav: NavigationTarget {
-                            file_id: FileId(
-                                0,
-                            ),
-                            full_range: 1..13,
-                            focus_range: 4..8,
-                            name: "main",
-                            kind: Function,
-                        },
-                        kind: Bin,
-                        cfg: None,
+                    NavigationTarget {
+                        file_id: FileId(
+                            0,
+                        ),
+                        full_range: 1..13,
+                        focus_range: 4..8,
+                        name: "main",
+                        kind: Function,
                     },
-                    Runnable {
-                        use_name_in_title: false,
-                        nav: NavigationTarget {
-                            file_id: FileId(
-                                0,
-                            ),
-                            full_range: 15..76,
-                            focus_range: 42..71,
-                            name: "__cortex_m_rt_main_trampoline",
-                            kind: Function,
-                        },
-                        kind: Bin,
-                        cfg: None,
+                    NavigationTarget {
+                        file_id: FileId(
+                            0,
+                        ),
+                        full_range: 15..76,
+                        focus_range: 42..71,
+                        name: "__cortex_m_rt_main_trampoline",
+                        kind: Function,
                     },
-                    Runnable {
-                        use_name_in_title: false,
-                        nav: NavigationTarget {
-                            file_id: FileId(
-                                0,
-                            ),
-                            full_range: 78..102,
-                            focus_range: 89..97,
-                            name: "test_foo",
-                            kind: Function,
-                        },
-                        kind: Test {
-                            test_id: Path(
-                                "test_foo",
-                            ),
-                            attr: TestAttr {
-                                ignore: false,
-                            },
-                        },
-                        cfg: None,
+                    NavigationTarget {
+                        file_id: FileId(
+                            0,
+                        ),
+                        full_range: 78..102,
+                        focus_range: 89..97,
+                        name: "test_foo",
+                        kind: Function,
                     },
-                    Runnable {
-                        use_name_in_title: false,
-                        nav: NavigationTarget {
-                            file_id: FileId(
-                                0,
-                            ),
-                            full_range: 104..155,
-                            focus_range: 136..150,
-                            name: "test_full_path",
-                            kind: Function,
-                        },
-                        kind: Test {
-                            test_id: Path(
-                                "test_full_path",
-                            ),
-                            attr: TestAttr {
-                                ignore: false,
-                            },
-                        },
-                        cfg: None,
+                    NavigationTarget {
+                        file_id: FileId(
+                            0,
+                        ),
+                        full_range: 104..155,
+                        focus_range: 136..150,
+                        name: "test_full_path",
+                        kind: Function,
                     },
-                    Runnable {
-                        use_name_in_title: false,
-                        nav: NavigationTarget {
-                            file_id: FileId(
-                                0,
-                            ),
-                            full_range: 157..191,
-                            focus_range: 178..186,
-                            name: "test_foo",
-                            kind: Function,
-                        },
-                        kind: Test {
-                            test_id: Path(
-                                "test_foo",
-                            ),
-                            attr: TestAttr {
-                                ignore: true,
-                            },
-                        },
-                        cfg: None,
+                    NavigationTarget {
+                        file_id: FileId(
+                            0,
+                        ),
+                        full_range: 157..191,
+                        focus_range: 178..186,
+                        name: "test_foo",
+                        kind: Function,
                     },
-                    Runnable {
-                        use_name_in_title: false,
-                        nav: NavigationTarget {
-                            file_id: FileId(
-                                0,
-                            ),
-                            full_range: 193..215,
-                            focus_range: 205..210,
-                            name: "bench",
-                            kind: Function,
-                        },
-                        kind: Bench {
-                            test_id: Path(
-                                "bench",
-                            ),
-                        },
-                        cfg: None,
+                    NavigationTarget {
+                        file_id: FileId(
+                            0,
+                        ),
+                        full_range: 193..215,
+                        focus_range: 205..210,
+                        name: "bench",
+                        kind: Function,
                     },
                 ]
             "#]],
@@ -845,151 +786,74 @@ impl Test for StructWithRunnable {}
             &[Bin, DocTest, DocTest, DocTest, DocTest, DocTest, DocTest, DocTest, DocTest],
             expect![[r#"
                 [
-                    Runnable {
-                        use_name_in_title: false,
-                        nav: NavigationTarget {
-                            file_id: FileId(
-                                0,
-                            ),
-                            full_range: 1..13,
-                            focus_range: 4..8,
-                            name: "main",
-                            kind: Function,
-                        },
-                        kind: Bin,
-                        cfg: None,
+                    NavigationTarget {
+                        file_id: FileId(
+                            0,
+                        ),
+                        full_range: 1..13,
+                        focus_range: 4..8,
+                        name: "main",
+                        kind: Function,
                     },
-                    Runnable {
-                        use_name_in_title: false,
-                        nav: NavigationTarget {
-                            file_id: FileId(
-                                0,
-                            ),
-                            full_range: 15..74,
-                            name: "should_have_runnable",
-                        },
-                        kind: DocTest {
-                            test_id: Path(
-                                "should_have_runnable",
-                            ),
-                        },
-                        cfg: None,
+                    NavigationTarget {
+                        file_id: FileId(
+                            0,
+                        ),
+                        full_range: 15..74,
+                        name: "should_have_runnable",
                     },
-                    Runnable {
-                        use_name_in_title: false,
-                        nav: NavigationTarget {
-                            file_id: FileId(
-                                0,
-                            ),
-                            full_range: 76..148,
-                            name: "should_have_runnable_1",
-                        },
-                        kind: DocTest {
-                            test_id: Path(
-                                "should_have_runnable_1",
-                            ),
-                        },
-                        cfg: None,
+                    NavigationTarget {
+                        file_id: FileId(
+                            0,
+                        ),
+                        full_range: 76..148,
+                        name: "should_have_runnable_1",
                     },
-                    Runnable {
-                        use_name_in_title: false,
-                        nav: NavigationTarget {
-                            file_id: FileId(
-                                0,
-                            ),
-                            full_range: 150..254,
-                            name: "should_have_runnable_2",
-                        },
-                        kind: DocTest {
-                            test_id: Path(
-                                "should_have_runnable_2",
-                            ),
-                        },
-                        cfg: None,
+                    NavigationTarget {
+                        file_id: FileId(
+                            0,
+                        ),
+                        full_range: 150..254,
+                        name: "should_have_runnable_2",
                     },
-                    Runnable {
-                        use_name_in_title: false,
-                        nav: NavigationTarget {
-                            file_id: FileId(
-                                0,
-                            ),
-                            full_range: 256..320,
-                            name: "should_have_no_runnable_3",
-                        },
-                        kind: DocTest {
-                            test_id: Path(
-                                "should_have_no_runnable_3",
-                            ),
-                        },
-                        cfg: None,
+                    NavigationTarget {
+                        file_id: FileId(
+                            0,
+                        ),
+                        full_range: 256..320,
+                        name: "should_have_no_runnable_3",
                     },
-                    Runnable {
-                        use_name_in_title: false,
-                        nav: NavigationTarget {
-                            file_id: FileId(
-                                0,
-                            ),
-                            full_range: 322..398,
-                            name: "should_have_no_runnable_4",
-                        },
-                        kind: DocTest {
-                            test_id: Path(
-                                "should_have_no_runnable_4",
-                            ),
-                        },
-                        cfg: None,
+                    NavigationTarget {
+                        file_id: FileId(
+                            0,
+                        ),
+                        full_range: 322..398,
+                        name: "should_have_no_runnable_4",
                     },
-                    Runnable {
-                        use_name_in_title: false,
-                        nav: NavigationTarget {
-                            file_id: FileId(
-                                0,
-                            ),
-                            full_range: 900..965,
-                            name: "StructWithRunnable",
-                        },
-                        kind: DocTest {
-                            test_id: Path(
-                                "StructWithRunnable",
-                            ),
-                        },
-                        cfg: None,
+                    NavigationTarget {
+                        file_id: FileId(
+                            0,
+                        ),
+                        full_range: 900..965,
+                        name: "StructWithRunnable",
                     },
-                    Runnable {
-                        use_name_in_title: false,
-                        nav: NavigationTarget {
-                            file_id: FileId(
-                                0,
-                            ),
-                            full_range: 967..1024,
-                            focus_range: 1003..1021,
-                            name: "impl",
-                            kind: Impl,
-                        },
-                        kind: DocTest {
-                            test_id: Path(
-                                "StructWithRunnable",
-                            ),
-                        },
-                        cfg: None,
+                    NavigationTarget {
+                        file_id: FileId(
+                            0,
+                        ),
+                        full_range: 967..1024,
+                        focus_range: 1003..1021,
+                        name: "impl",
+                        kind: Impl,
                     },
-                    Runnable {
-                        use_name_in_title: false,
-                        nav: NavigationTarget {
-                            file_id: FileId(
-                                0,
-                            ),
-                            full_range: 1088..1154,
-                            focus_range: 1133..1151,
-                            name: "impl",
-                            kind: Impl,
-                        },
-                        kind: DocTest {
-                            test_id: Path(
-                                "StructWithRunnable",
-                            ),
-                        },
-                        cfg: None,
+                    NavigationTarget {
+                        file_id: FileId(
+                            0,
+                        ),
+                        full_range: 1088..1154,
+                        focus_range: 1133..1151,
+                        name: "impl",
+                        kind: Impl,
                     },
                 ]
             "#]],
@@ -1015,35 +879,21 @@ impl Data {
             &[Bin, DocTest],
             expect![[r#"
                 [
-                    Runnable {
-                        use_name_in_title: false,
-                        nav: NavigationTarget {
-                            file_id: FileId(
-                                0,
-                            ),
-                            full_range: 1..13,
-                            focus_range: 4..8,
-                            name: "main",
-                            kind: Function,
-                        },
-                        kind: Bin,
-                        cfg: None,
+                    NavigationTarget {
+                        file_id: FileId(
+                            0,
+                        ),
+                        full_range: 1..13,
+                        focus_range: 4..8,
+                        name: "main",
+                        kind: Function,
                     },
-                    Runnable {
-                        use_name_in_title: false,
-                        nav: NavigationTarget {
-                            file_id: FileId(
-                                0,
-                            ),
-                            full_range: 44..98,
-                            name: "foo",
-                        },
-                        kind: DocTest {
-                            test_id: Path(
-                                "Data::foo",
-                            ),
-                        },
-                        cfg: None,
+                    NavigationTarget {
+                        file_id: FileId(
+                            0,
+                        ),
+                        full_range: 44..98,
+                        name: "foo",
                     },
                 ]
             "#]],
@@ -1069,35 +919,21 @@ impl Data<'a> {
             &[Bin, DocTest],
             expect![[r#"
                 [
-                    Runnable {
-                        use_name_in_title: false,
-                        nav: NavigationTarget {
-                            file_id: FileId(
-                                0,
-                            ),
-                            full_range: 1..13,
-                            focus_range: 4..8,
-                            name: "main",
-                            kind: Function,
-                        },
-                        kind: Bin,
-                        cfg: None,
+                    NavigationTarget {
+                        file_id: FileId(
+                            0,
+                        ),
+                        full_range: 1..13,
+                        focus_range: 4..8,
+                        name: "main",
+                        kind: Function,
                     },
-                    Runnable {
-                        use_name_in_title: false,
-                        nav: NavigationTarget {
-                            file_id: FileId(
-                                0,
-                            ),
-                            full_range: 52..106,
-                            name: "foo",
-                        },
-                        kind: DocTest {
-                            test_id: Path(
-                                "Data<'a>::foo",
-                            ),
-                        },
-                        cfg: None,
+                    NavigationTarget {
+                        file_id: FileId(
+                            0,
+                        ),
+                        full_range: 52..106,
+                        name: "foo",
                     },
                 ]
             "#]],
@@ -1123,35 +959,21 @@ impl<T, U> Data<'a, T, U> {
             &[Bin, DocTest],
             expect![[r#"
                 [
-                    Runnable {
-                        use_name_in_title: false,
-                        nav: NavigationTarget {
-                            file_id: FileId(
-                                0,
-                            ),
-                            full_range: 1..13,
-                            focus_range: 4..8,
-                            name: "main",
-                            kind: Function,
-                        },
-                        kind: Bin,
-                        cfg: None,
+                    NavigationTarget {
+                        file_id: FileId(
+                            0,
+                        ),
+                        full_range: 1..13,
+                        focus_range: 4..8,
+                        name: "main",
+                        kind: Function,
                     },
-                    Runnable {
-                        use_name_in_title: false,
-                        nav: NavigationTarget {
-                            file_id: FileId(
-                                0,
-                            ),
-                            full_range: 70..124,
-                            name: "foo",
-                        },
-                        kind: DocTest {
-                            test_id: Path(
-                                "Data<'a,T,U>::foo",
-                            ),
-                        },
-                        cfg: None,
+                    NavigationTarget {
+                        file_id: FileId(
+                            0,
+                        ),
+                        full_range: 70..124,
+                        name: "foo",
                     },
                 ]
             "#]],
@@ -1177,35 +999,21 @@ impl<const N: usize> Data<N> {
             &[Bin, DocTest],
             expect![[r#"
                 [
-                    Runnable {
-                        use_name_in_title: false,
-                        nav: NavigationTarget {
-                            file_id: FileId(
-                                0,
-                            ),
-                            full_range: 1..13,
-                            focus_range: 4..8,
-                            name: "main",
-                            kind: Function,
-                        },
-                        kind: Bin,
-                        cfg: None,
+                    NavigationTarget {
+                        file_id: FileId(
+                            0,
+                        ),
+                        full_range: 1..13,
+                        focus_range: 4..8,
+                        name: "main",
+                        kind: Function,
                     },
-                    Runnable {
-                        use_name_in_title: false,
-                        nav: NavigationTarget {
-                            file_id: FileId(
-                                0,
-                            ),
-                            full_range: 79..133,
-                            name: "foo",
-                        },
-                        kind: DocTest {
-                            test_id: Path(
-                                "Data<N>::foo",
-                            ),
-                        },
-                        cfg: None,
+                    NavigationTarget {
+                        file_id: FileId(
+                            0,
+                        ),
+                        full_range: 79..133,
+                        name: "foo",
                     },
                 ]
             "#]],
@@ -1231,35 +1039,21 @@ impl<'a, T, const N: usize> Data<'a, T, N> {
             &[Bin, DocTest],
             expect![[r#"
                 [
-                    Runnable {
-                        use_name_in_title: false,
-                        nav: NavigationTarget {
-                            file_id: FileId(
-                                0,
-                            ),
-                            full_range: 1..13,
-                            focus_range: 4..8,
-                            name: "main",
-                            kind: Function,
-                        },
-                        kind: Bin,
-                        cfg: None,
+                    NavigationTarget {
+                        file_id: FileId(
+                            0,
+                        ),
+                        full_range: 1..13,
+                        focus_range: 4..8,
+                        name: "main",
+                        kind: Function,
                     },
-                    Runnable {
-                        use_name_in_title: false,
-                        nav: NavigationTarget {
-                            file_id: FileId(
-                                0,
-                            ),
-                            full_range: 100..154,
-                            name: "foo",
-                        },
-                        kind: DocTest {
-                            test_id: Path(
-                                "Data<'a,T,N>::foo",
-                            ),
-                        },
-                        cfg: None,
+                    NavigationTarget {
+                        file_id: FileId(
+                            0,
+                        ),
+                        full_range: 100..154,
+                        name: "foo",
                     },
                 ]
             "#]],
@@ -1279,43 +1073,24 @@ mod test_mod {
             &[TestMod, Test],
             expect![[r#"
                 [
-                    Runnable {
-                        use_name_in_title: false,
-                        nav: NavigationTarget {
-                            file_id: FileId(
-                                0,
-                            ),
-                            full_range: 1..51,
-                            focus_range: 5..13,
-                            name: "test_mod",
-                            kind: Module,
-                            description: "mod test_mod",
-                        },
-                        kind: TestMod {
-                            path: "test_mod",
-                        },
-                        cfg: None,
+                    NavigationTarget {
+                        file_id: FileId(
+                            0,
+                        ),
+                        full_range: 1..51,
+                        focus_range: 5..13,
+                        name: "test_mod",
+                        kind: Module,
+                        description: "mod test_mod",
                     },
-                    Runnable {
-                        use_name_in_title: false,
-                        nav: NavigationTarget {
-                            file_id: FileId(
-                                0,
-                            ),
-                            full_range: 20..49,
-                            focus_range: 35..44,
-                            name: "test_foo1",
-                            kind: Function,
-                        },
-                        kind: Test {
-                            test_id: Path(
-                                "test_mod::test_foo1",
-                            ),
-                            attr: TestAttr {
-                                ignore: false,
-                            },
-                        },
-                        cfg: None,
+                    NavigationTarget {
+                        file_id: FileId(
+                            0,
+                        ),
+                        full_range: 20..49,
+                        focus_range: 35..44,
+                        name: "test_foo1",
+                        kind: Function,
                     },
                 ]
             "#]],
@@ -1352,119 +1127,62 @@ mod root_tests {
             &[TestMod, TestMod, Test, Test, TestMod, Test],
             expect![[r#"
                 [
-                    Runnable {
-                        use_name_in_title: false,
-                        nav: NavigationTarget {
-                            file_id: FileId(
-                                0,
-                            ),
-                            full_range: 22..323,
-                            focus_range: 26..40,
-                            name: "nested_tests_0",
-                            kind: Module,
-                            description: "mod nested_tests_0",
-                        },
-                        kind: TestMod {
-                            path: "root_tests::nested_tests_0",
-                        },
-                        cfg: None,
+                    NavigationTarget {
+                        file_id: FileId(
+                            0,
+                        ),
+                        full_range: 22..323,
+                        focus_range: 26..40,
+                        name: "nested_tests_0",
+                        kind: Module,
+                        description: "mod nested_tests_0",
                     },
-                    Runnable {
-                        use_name_in_title: false,
-                        nav: NavigationTarget {
-                            file_id: FileId(
-                                0,
-                            ),
-                            full_range: 51..192,
-                            focus_range: 55..69,
-                            name: "nested_tests_1",
-                            kind: Module,
-                            description: "mod nested_tests_1",
-                        },
-                        kind: TestMod {
-                            path: "root_tests::nested_tests_0::nested_tests_1",
-                        },
-                        cfg: None,
+                    NavigationTarget {
+                        file_id: FileId(
+                            0,
+                        ),
+                        full_range: 51..192,
+                        focus_range: 55..69,
+                        name: "nested_tests_1",
+                        kind: Module,
+                        description: "mod nested_tests_1",
                     },
-                    Runnable {
-                        use_name_in_title: false,
-                        nav: NavigationTarget {
-                            file_id: FileId(
-                                0,
-                            ),
-                            full_range: 84..126,
-                            focus_range: 107..121,
-                            name: "nested_test_11",
-                            kind: Function,
-                        },
-                        kind: Test {
-                            test_id: Path(
-                                "root_tests::nested_tests_0::nested_tests_1::nested_test_11",
-                            ),
-                            attr: TestAttr {
-                                ignore: false,
-                            },
-                        },
-                        cfg: None,
+                    NavigationTarget {
+                        file_id: FileId(
+                            0,
+                        ),
+                        full_range: 84..126,
+                        focus_range: 107..121,
+                        name: "nested_test_11",
+                        kind: Function,
                     },
-                    Runnable {
-                        use_name_in_title: false,
-                        nav: NavigationTarget {
-                            file_id: FileId(
-                                0,
-                            ),
-                            full_range: 140..182,
-                            focus_range: 163..177,
-                            name: "nested_test_12",
-                            kind: Function,
-                        },
-                        kind: Test {
-                            test_id: Path(
-                                "root_tests::nested_tests_0::nested_tests_1::nested_test_12",
-                            ),
-                            attr: TestAttr {
-                                ignore: false,
-                            },
-                        },
-                        cfg: None,
+                    NavigationTarget {
+                        file_id: FileId(
+                            0,
+                        ),
+                        full_range: 140..182,
+                        focus_range: 163..177,
+                        name: "nested_test_12",
+                        kind: Function,
                     },
-                    Runnable {
-                        use_name_in_title: false,
-                        nav: NavigationTarget {
-                            file_id: FileId(
-                                0,
-                            ),
-                            full_range: 202..286,
-                            focus_range: 206..220,
-                            name: "nested_tests_2",
-                            kind: Module,
-                            description: "mod nested_tests_2",
-                        },
-                        kind: TestMod {
-                            path: "root_tests::nested_tests_0::nested_tests_2",
-                        },
-                        cfg: None,
+                    NavigationTarget {
+                        file_id: FileId(
+                            0,
+                        ),
+                        full_range: 202..286,
+                        focus_range: 206..220,
+                        name: "nested_tests_2",
+                        kind: Module,
+                        description: "mod nested_tests_2",
                     },
-                    Runnable {
-                        use_name_in_title: false,
-                        nav: NavigationTarget {
-                            file_id: FileId(
-                                0,
-                            ),
-                            full_range: 235..276,
-                            focus_range: 258..271,
-                            name: "nested_test_2",
-                            kind: Function,
-                        },
-                        kind: Test {
-                            test_id: Path(
-                                "root_tests::nested_tests_0::nested_tests_2::nested_test_2",
-                            ),
-                            attr: TestAttr {
-                                ignore: false,
-                            },
-                        },
-                        cfg: None,
+                    NavigationTarget {
+                        file_id: FileId(
+                            0,
+                        ),
+                        full_range: 235..276,
+                        focus_range: 258..271,
+                        name: "nested_test_2",
+                        kind: Function,
                     },
                 ]
             "#]],
@@ -1484,48 +1202,22 @@ fn test_foo1() {}
             &[TestMod, Test],
             expect![[r#"
                 [
-                    Runnable {
-                        use_name_in_title: false,
-                        nav: NavigationTarget {
-                            file_id: FileId(
-                                0,
-                            ),
-                            full_range: 0..51,
-                            name: "",
-                            kind: Module,
-                        },
-                        kind: TestMod {
-                            path: "",
-                        },
-                        cfg: None,
-                    },
-                    Runnable {
-                        use_name_in_title: false,
-                        nav: NavigationTarget {
-                            file_id: FileId(
-                                0,
-                            ),
-                            full_range: 1..50,
-                            focus_range: 36..45,
-                            name: "test_foo1",
-                            kind: Function,
-                        },
-                        kind: Test {
-                            test_id: Path(
-                                "test_foo1",
-                            ),
-                            attr: TestAttr {
-                                ignore: false,
-                            },
-                        },
-                        cfg: Some(
-                            Atom(
-                                KeyValue {
-                                    key: "feature",
-                                    value: "foo",
-                                },
-                            ),
+                    NavigationTarget {
+                        file_id: FileId(
+                            0,
                         ),
+                        full_range: 0..51,
+                        name: "",
+                        kind: Module,
+                    },
+                    NavigationTarget {
+                        file_id: FileId(
+                            0,
+                        ),
+                        full_range: 1..50,
+                        focus_range: 36..45,
+                        name: "test_foo1",
+                        kind: Function,
                     },
                 ]
             "#]],
@@ -1545,58 +1237,22 @@ fn test_foo1() {}
             &[TestMod, Test],
             expect![[r#"
                 [
-                    Runnable {
-                        use_name_in_title: false,
-                        nav: NavigationTarget {
-                            file_id: FileId(
-                                0,
-                            ),
-                            full_range: 0..73,
-                            name: "",
-                            kind: Module,
-                        },
-                        kind: TestMod {
-                            path: "",
-                        },
-                        cfg: None,
-                    },
-                    Runnable {
-                        use_name_in_title: false,
-                        nav: NavigationTarget {
-                            file_id: FileId(
-                                0,
-                            ),
-                            full_range: 1..72,
-                            focus_range: 58..67,
-                            name: "test_foo1",
-                            kind: Function,
-                        },
-                        kind: Test {
-                            test_id: Path(
-                                "test_foo1",
-                            ),
-                            attr: TestAttr {
-                                ignore: false,
-                            },
-                        },
-                        cfg: Some(
-                            All(
-                                [
-                                    Atom(
-                                        KeyValue {
-                                            key: "feature",
-                                            value: "foo",
-                                        },
-                                    ),
-                                    Atom(
-                                        KeyValue {
-                                            key: "feature",
-                                            value: "bar",
-                                        },
-                                    ),
-                                ],
-                            ),
+                    NavigationTarget {
+                        file_id: FileId(
+                            0,
                         ),
+                        full_range: 0..73,
+                        name: "",
+                        kind: Module,
+                    },
+                    NavigationTarget {
+                        file_id: FileId(
+                            0,
+                        ),
+                        full_range: 1..72,
+                        focus_range: 58..67,
+                        name: "test_foo1",
+                        kind: Function,
                     },
                 ]
             "#]],
@@ -1638,21 +1294,12 @@ impl Foo {
             &[DocTest],
             expect![[r#"
                 [
-                    Runnable {
-                        use_name_in_title: false,
-                        nav: NavigationTarget {
-                            file_id: FileId(
-                                1,
-                            ),
-                            full_range: 27..81,
-                            name: "foo",
-                        },
-                        kind: DocTest {
-                            test_id: Path(
-                                "foo::Foo::foo",
-                            ),
-                        },
-                        cfg: None,
+                    NavigationTarget {
+                        file_id: FileId(
+                            1,
+                        ),
+                        full_range: 27..81,
+                        name: "foo",
                     },
                 ]
             "#]],
@@ -1693,106 +1340,56 @@ gen_main!();
             &[TestMod, TestMod, Test, Test, TestMod, Bin],
             expect![[r#"
                 [
-                    Runnable {
-                        use_name_in_title: false,
-                        nav: NavigationTarget {
-                            file_id: FileId(
-                                0,
-                            ),
-                            full_range: 0..315,
-                            name: "",
-                            kind: Module,
-                        },
-                        kind: TestMod {
-                            path: "",
-                        },
-                        cfg: None,
+                    NavigationTarget {
+                        file_id: FileId(
+                            0,
+                        ),
+                        full_range: 0..315,
+                        name: "",
+                        kind: Module,
                     },
-                    Runnable {
-                        use_name_in_title: false,
-                        nav: NavigationTarget {
-                            file_id: FileId(
-                                0,
-                            ),
-                            full_range: 267..292,
-                            focus_range: 271..276,
-                            name: "tests",
-                            kind: Module,
-                            description: "mod tests",
-                        },
-                        kind: TestMod {
-                            path: "tests",
-                        },
-                        cfg: None,
+                    NavigationTarget {
+                        file_id: FileId(
+                            0,
+                        ),
+                        full_range: 267..292,
+                        focus_range: 271..276,
+                        name: "tests",
+                        kind: Module,
+                        description: "mod tests",
                     },
-                    Runnable {
-                        use_name_in_title: false,
-                        nav: NavigationTarget {
-                            file_id: FileId(
-                                0,
-                            ),
-                            full_range: 283..290,
-                            name: "foo_test",
-                            kind: Function,
-                        },
-                        kind: Test {
-                            test_id: Path(
-                                "tests::foo_test",
-                            ),
-                            attr: TestAttr {
-                                ignore: false,
-                            },
-                        },
-                        cfg: None,
+                    NavigationTarget {
+                        file_id: FileId(
+                            0,
+                        ),
+                        full_range: 283..290,
+                        name: "foo_test",
+                        kind: Function,
                     },
-                    Runnable {
-                        use_name_in_title: true,
-                        nav: NavigationTarget {
-                            file_id: FileId(
-                                0,
-                            ),
-                            full_range: 293..301,
-                            name: "foo_test2",
-                            kind: Function,
-                        },
-                        kind: Test {
-                            test_id: Path(
-                                "tests2::foo_test2",
-                            ),
-                            attr: TestAttr {
-                                ignore: false,
-                            },
-                        },
-                        cfg: None,
+                    NavigationTarget {
+                        file_id: FileId(
+                            0,
+                        ),
+                        full_range: 293..301,
+                        name: "foo_test2",
+                        kind: Function,
                     },
-                    Runnable {
-                        use_name_in_title: true,
-                        nav: NavigationTarget {
-                            file_id: FileId(
-                                0,
-                            ),
-                            full_range: 293..301,
-                            name: "tests2",
-                            kind: Module,
-                            description: "mod tests2",
-                        },
-                        kind: TestMod {
-                            path: "tests2",
-                        },
-                        cfg: None,
+                    NavigationTarget {
+                        file_id: FileId(
+                            0,
+                        ),
+                        full_range: 293..301,
+                        name: "tests2",
+                        kind: Module,
+                        description: "mod tests2",
                     },
-                    Runnable {
-                        use_name_in_title: false,
-                        nav: NavigationTarget {
-                            file_id: FileId(
-                                0,
-                            ),
-                            full_range: 302..314,
-                            name: "main",
-                            kind: Function,
-                        },
-                        kind: Bin,
-                        cfg: None,
+                    NavigationTarget {
+                        file_id: FileId(
+                            0,
+                        ),
+                        full_range: 302..314,
+                        name: "main",
+                        kind: Function,
                     },
                 ]
             "#]],
@@ -1822,81 +1419,38 @@ foo!();
             &[Test, Test, Test, TestMod],
             expect![[r#"
                 [
-                    Runnable {
-                        use_name_in_title: true,
-                        nav: NavigationTarget {
-                            file_id: FileId(
-                                0,
-                            ),
-                            full_range: 210..217,
-                            name: "foo0",
-                            kind: Function,
-                        },
-                        kind: Test {
-                            test_id: Path(
-                                "foo_tests::foo0",
-                            ),
-                            attr: TestAttr {
-                                ignore: false,
-                            },
-                        },
-                        cfg: None,
+                    NavigationTarget {
+                        file_id: FileId(
+                            0,
+                        ),
+                        full_range: 210..217,
+                        name: "foo0",
+                        kind: Function,
                     },
-                    Runnable {
-                        use_name_in_title: true,
-                        nav: NavigationTarget {
-                            file_id: FileId(
-                                0,
-                            ),
-                            full_range: 210..217,
-                            name: "foo1",
-                            kind: Function,
-                        },
-                        kind: Test {
-                            test_id: Path(
-                                "foo_tests::foo1",
-                            ),
-                            attr: TestAttr {
-                                ignore: false,
-                            },
-                        },
-                        cfg: None,
+                    NavigationTarget {
+                        file_id: FileId(
+                            0,
+                        ),
+                        full_range: 210..217,
+                        name: "foo1",
+                        kind: Function,
                     },
-                    Runnable {
-                        use_name_in_title: true,
-                        nav: NavigationTarget {
-                            file_id: FileId(
-                                0,
-                            ),
-                            full_range: 210..217,
-                            name: "foo2",
-                            kind: Function,
-                        },
-                        kind: Test {
-                            test_id: Path(
-                                "foo_tests::foo2",
-                            ),
-                            attr: TestAttr {
-                                ignore: false,
-                            },
-                        },
-                        cfg: None,
+                    NavigationTarget {
+                        file_id: FileId(
+                            0,
+                        ),
+                        full_range: 210..217,
+                        name: "foo2",
+                        kind: Function,
                     },
-                    Runnable {
-                        use_name_in_title: true,
-                        nav: NavigationTarget {
-                            file_id: FileId(
-                                0,
-                            ),
-                            full_range: 210..217,
-                            name: "foo_tests",
-                            kind: Module,
-                            description: "mod foo_tests",
-                        },
-                        kind: TestMod {
-                            path: "foo_tests",
-                        },
-                        cfg: None,
+                    NavigationTarget {
+                        file_id: FileId(
+                            0,
+                        ),
+                        full_range: 210..217,
+                        name: "foo_tests",
+                        kind: Module,
+                        description: "mod foo_tests",
                     },
                 ]
             "#]],
@@ -1939,22 +1493,15 @@ fn t1() {}
             &[TestMod],
             expect![[r#"
                 [
-                    Runnable {
-                        use_name_in_title: false,
-                        nav: NavigationTarget {
-                            file_id: FileId(
-                                0,
-                            ),
-                            full_range: 1..7,
-                            focus_range: 5..6,
-                            name: "m",
-                            kind: Module,
-                            description: "mod m",
-                        },
-                        kind: TestMod {
-                            path: "m",
-                        },
-                        cfg: None,
+                    NavigationTarget {
+                        file_id: FileId(
+                            0,
+                        ),
+                        full_range: 1..7,
+                        focus_range: 5..6,
+                        name: "m",
+                        kind: Module,
+                        description: "mod m",
                     },
                 ]
             "#]],
@@ -1977,62 +1524,31 @@ fn t1() {}
             &[TestMod, Test, Test],
             expect![[r#"
                 [
-                    Runnable {
-                        use_name_in_title: false,
-                        nav: NavigationTarget {
-                            file_id: FileId(
-                                1,
-                            ),
-                            full_range: 0..39,
-                            name: "m",
-                            kind: Module,
-                        },
-                        kind: TestMod {
-                            path: "m",
-                        },
-                        cfg: None,
+                    NavigationTarget {
+                        file_id: FileId(
+                            1,
+                        ),
+                        full_range: 0..39,
+                        name: "m",
+                        kind: Module,
                     },
-                    Runnable {
-                        use_name_in_title: false,
-                        nav: NavigationTarget {
-                            file_id: FileId(
-                                1,
-                            ),
-                            full_range: 1..19,
-                            focus_range: 12..14,
-                            name: "t0",
-                            kind: Function,
-                        },
-                        kind: Test {
-                            test_id: Path(
-                                "m::t0",
-                            ),
-                            attr: TestAttr {
-                                ignore: false,
-                            },
-                        },
-                        cfg: None,
+                    NavigationTarget {
+                        file_id: FileId(
+                            1,
+                        ),
+                        full_range: 1..19,
+                        focus_range: 12..14,
+                        name: "t0",
+                        kind: Function,
                     },
-                    Runnable {
-                        use_name_in_title: false,
-                        nav: NavigationTarget {
-                            file_id: FileId(
-                                1,
-                            ),
-                            full_range: 20..38,
-                            focus_range: 31..33,
-                            name: "t1",
-                            kind: Function,
-                        },
-                        kind: Test {
-                            test_id: Path(
-                                "m::t1",
-                            ),
-                            attr: TestAttr {
-                                ignore: false,
-                            },
-                        },
-                        cfg: None,
+                    NavigationTarget {
+                        file_id: FileId(
+                            1,
+                        ),
+                        full_range: 20..38,
+                        focus_range: 31..33,
+                        name: "t1",
+                        kind: Function,
                     },
                 ]
             "#]],
@@ -2057,64 +1573,33 @@ mod module {
             &[TestMod, Test, Test],
             expect![[r#"
                 [
-                    Runnable {
-                        use_name_in_title: true,
-                        nav: NavigationTarget {
-                            file_id: FileId(
-                                0,
-                            ),
-                            full_range: 26..94,
-                            focus_range: 30..36,
-                            name: "module",
-                            kind: Module,
-                            description: "mod module",
-                        },
-                        kind: TestMod {
-                            path: "module",
-                        },
-                        cfg: None,
+                    NavigationTarget {
+                        file_id: FileId(
+                            0,
+                        ),
+                        full_range: 26..94,
+                        focus_range: 30..36,
+                        name: "module",
+                        kind: Module,
+                        description: "mod module",
                     },
-                    Runnable {
-                        use_name_in_title: true,
-                        nav: NavigationTarget {
-                            file_id: FileId(
-                                0,
-                            ),
-                            full_range: 43..65,
-                            focus_range: 58..60,
-                            name: "t0",
-                            kind: Function,
-                        },
-                        kind: Test {
-                            test_id: Path(
-                                "module::t0",
-                            ),
-                            attr: TestAttr {
-                                ignore: false,
-                            },
-                        },
-                        cfg: None,
+                    NavigationTarget {
+                        file_id: FileId(
+                            0,
+                        ),
+                        full_range: 43..65,
+                        focus_range: 58..60,
+                        name: "t0",
+                        kind: Function,
                     },
-                    Runnable {
-                        use_name_in_title: true,
-                        nav: NavigationTarget {
-                            file_id: FileId(
-                                0,
-                            ),
-                            full_range: 70..92,
-                            focus_range: 85..87,
-                            name: "t1",
-                            kind: Function,
-                        },
-                        kind: Test {
-                            test_id: Path(
-                                "module::t1",
-                            ),
-                            attr: TestAttr {
-                                ignore: false,
-                            },
-                        },
-                        cfg: None,
+                    NavigationTarget {
+                        file_id: FileId(
+                            0,
+                        ),
+                        full_range: 70..92,
+                        focus_range: 85..87,
+                        name: "t1",
+                        kind: Function,
                     },
                 ]
             "#]],
@@ -2274,35 +1759,21 @@ impl<A, C, const D: u32> Data<'a, A, 12, C, D> {
             &[Bin, DocTest],
             expect![[r#"
                 [
-                    Runnable {
-                        use_name_in_title: false,
-                        nav: NavigationTarget {
-                            file_id: FileId(
-                                0,
-                            ),
-                            full_range: 1..13,
-                            focus_range: 4..8,
-                            name: "main",
-                            kind: Function,
-                        },
-                        kind: Bin,
-                        cfg: None,
+                    NavigationTarget {
+                        file_id: FileId(
+                            0,
+                        ),
+                        full_range: 1..13,
+                        focus_range: 4..8,
+                        name: "main",
+                        kind: Function,
                     },
-                    Runnable {
-                        use_name_in_title: false,
-                        nav: NavigationTarget {
-                            file_id: FileId(
-                                0,
-                            ),
-                            full_range: 121..156,
-                            name: "foo",
-                        },
-                        kind: DocTest {
-                            test_id: Path(
-                                "Data<'a,A,12,C,D>::foo",
-                            ),
-                        },
-                        cfg: None,
+                    NavigationTarget {
+                        file_id: FileId(
+                            0,
+                        ),
+                        full_range: 121..156,
+                        name: "foo",
                     },
                 ]
             "#]],
@@ -2336,73 +1807,37 @@ impl Foo<Foo<(), ()>, ()> {
             &[DocTest, DocTest, DocTest, DocTest],
             expect![[r#"
                 [
-                    Runnable {
-                        use_name_in_title: false,
-                        nav: NavigationTarget {
-                            file_id: FileId(
-                                0,
-                            ),
-                            full_range: 20..103,
-                            focus_range: 47..56,
-                            name: "impl",
-                            kind: Impl,
-                        },
-                        kind: DocTest {
-                            test_id: Path(
-                                "Foo<T,U>",
-                            ),
-                        },
-                        cfg: None,
+                    NavigationTarget {
+                        file_id: FileId(
+                            0,
+                        ),
+                        full_range: 20..103,
+                        focus_range: 47..56,
+                        name: "impl",
+                        kind: Impl,
                     },
-                    Runnable {
-                        use_name_in_title: false,
-                        nav: NavigationTarget {
-                            file_id: FileId(
-                                0,
-                            ),
-                            full_range: 63..101,
-                            name: "t",
-                        },
-                        kind: DocTest {
-                            test_id: Path(
-                                "Foo<T,U>::t",
-                            ),
-                        },
-                        cfg: None,
+                    NavigationTarget {
+                        file_id: FileId(
+                            0,
+                        ),
+                        full_range: 63..101,
+                        name: "t",
                     },
-                    Runnable {
-                        use_name_in_title: false,
-                        nav: NavigationTarget {
-                            file_id: FileId(
-                                0,
-                            ),
-                            full_range: 105..188,
-                            focus_range: 126..146,
-                            name: "impl",
-                            kind: Impl,
-                        },
-                        kind: DocTest {
-                            test_id: Path(
-                                "Foo<Foo<(),()>,()>",
-                            ),
-                        },
-                        cfg: None,
+                    NavigationTarget {
+                        file_id: FileId(
+                            0,
+                        ),
+                        full_range: 105..188,
+                        focus_range: 126..146,
+                        name: "impl",
+                        kind: Impl,
                     },
-                    Runnable {
-                        use_name_in_title: false,
-                        nav: NavigationTarget {
-                            file_id: FileId(
-                                0,
-                            ),
-                            full_range: 153..186,
-                            name: "t",
-                        },
-                        kind: DocTest {
-                            test_id: Path(
-                                "Foo<Foo<(),()>,()>::t",
-                            ),
-                        },
-                        cfg: None,
+                    NavigationTarget {
+                        file_id: FileId(
+                            0,
+                        ),
+                        full_range: 153..186,
+                        name: "t",
                     },
                 ]
             "#]],
@@ -2452,21 +1887,12 @@ macro_rules! foo {
             &[DocTest],
             expect![[r#"
                 [
-                    Runnable {
-                        use_name_in_title: false,
-                        nav: NavigationTarget {
-                            file_id: FileId(
-                                0,
-                            ),
-                            full_range: 1..94,
-                            name: "foo",
-                        },
-                        kind: DocTest {
-                            test_id: Path(
-                                "foo",
-                            ),
-                        },
-                        cfg: None,
+                    NavigationTarget {
+                        file_id: FileId(
+                            0,
+                        ),
+                        full_range: 1..94,
+                        name: "foo",
                     },
                 ]
             "#]],
@@ -2516,145 +1942,72 @@ mod r#mod {
             &[TestMod, Test, DocTest, DocTest, DocTest, DocTest, DocTest, DocTest],
             expect![[r#"
                 [
-                    Runnable {
-                        use_name_in_title: false,
-                        nav: NavigationTarget {
-                            file_id: FileId(
-                                0,
-                            ),
-                            full_range: 1..461,
-                            focus_range: 5..10,
-                            name: "r#mod",
-                            kind: Module,
-                            description: "mod r#mod",
-                        },
-                        kind: TestMod {
-                            path: "r#mod",
-                        },
-                        cfg: None,
+                    NavigationTarget {
+                        file_id: FileId(
+                            0,
+                        ),
+                        full_range: 1..461,
+                        focus_range: 5..10,
+                        name: "r#mod",
+                        kind: Module,
+                        description: "mod r#mod",
                     },
-                    Runnable {
-                        use_name_in_title: false,
-                        nav: NavigationTarget {
-                            file_id: FileId(
-                                0,
-                            ),
-                            full_range: 17..41,
-                            focus_range: 32..36,
-                            name: "r#fn",
-                            kind: Function,
-                        },
-                        kind: Test {
-                            test_id: Path(
-                                "r#mod::r#fn",
-                            ),
-                            attr: TestAttr {
-                                ignore: false,
-                            },
-                        },
-                        cfg: None,
+                    NavigationTarget {
+                        file_id: FileId(
+                            0,
+                        ),
+                        full_range: 17..41,
+                        focus_range: 32..36,
+                        name: "r#fn",
+                        kind: Function,
                     },
-                    Runnable {
-                        use_name_in_title: false,
-                        nav: NavigationTarget {
-                            file_id: FileId(
-                                0,
-                            ),
-                            full_range: 47..84,
-                            name: "r#for",
-                            container_name: "r#mod",
-                        },
-                        kind: DocTest {
-                            test_id: Path(
-                                "r#mod::r#for",
-                            ),
-                        },
-                        cfg: None,
+                    NavigationTarget {
+                        file_id: FileId(
+                            0,
+                        ),
+                        full_range: 47..84,
+                        name: "r#for",
+                        container_name: "r#mod",
                     },
-                    Runnable {
-                        use_name_in_title: false,
-                        nav: NavigationTarget {
-                            file_id: FileId(
-                                0,
-                            ),
-                            full_range: 90..146,
-                            name: "r#struct",
-                            container_name: "r#mod",
-                        },
-                        kind: DocTest {
-                            test_id: Path(
-                                "r#mod::r#struct",
-                            ),
-                        },
-                        cfg: None,
+                    NavigationTarget {
+                        file_id: FileId(
+                            0,
+                        ),
+                        full_range: 90..146,
+                        name: "r#struct",
+                        container_name: "r#mod",
                     },
-                    Runnable {
-                        use_name_in_title: false,
-                        nav: NavigationTarget {
-                            file_id: FileId(
-                                0,
-                            ),
-                            full_range: 152..266,
-                            focus_range: 189..205,
-                            name: "impl",
-                            kind: Impl,
-                        },
-                        kind: DocTest {
-                            test_id: Path(
-                                "r#struct<r#type>",
-                            ),
-                        },
-                        cfg: None,
+                    NavigationTarget {
+                        file_id: FileId(
+                            0,
+                        ),
+                        full_range: 152..266,
+                        focus_range: 189..205,
+                        name: "impl",
+                        kind: Impl,
                     },
-                    Runnable {
-                        use_name_in_title: false,
-                        nav: NavigationTarget {
-                            file_id: FileId(
-                                0,
-                            ),
-                            full_range: 216..260,
-                            name: "r#fn",
-                        },
-                        kind: DocTest {
-                            test_id: Path(
-                                "r#mod::r#struct<r#type>::r#fn",
-                            ),
-                        },
-                        cfg: None,
+                    NavigationTarget {
+                        file_id: FileId(
+                            0,
+                        ),
+                        full_range: 216..260,
+                        name: "r#fn",
                     },
-                    Runnable {
-                        use_name_in_title: false,
-                        nav: NavigationTarget {
-                            file_id: FileId(
-                                0,
-                            ),
-                            full_range: 323..367,
-                            name: "r#fn",
-                        },
-                        kind: DocTest {
-                            test_id: Path(
-                                "r#mod::r#struct<r#enum>::r#fn",
-                            ),
-                        },
-                        cfg: None,
+                    NavigationTarget {
+                        file_id: FileId(
+                            0,
+                        ),
+                        full_range: 323..367,
+                        name: "r#fn",
                     },
-                    Runnable {
-                        use_name_in_title: false,
-                        nav: NavigationTarget {
-                            file_id: FileId(
-                                0,
-                            ),
-                            full_range: 401..459,
-                            focus_range: 445..456,
-                            name: "impl",
-                            kind: Impl,
-                        },
-                        kind: DocTest {
-                            test_id: Path(
-                                "r#struct<T>",
-                            ),
-                        },
-                        cfg: None,
+                    NavigationTarget {
+                        file_id: FileId(
+                            0,
+                        ),
+                        full_range: 401..459,
+                        focus_range: 445..456,
+                        name: "impl",
+                        kind: Impl,
                     },
                 ]
             "#]],

--- a/crates/ide/src/runnables.rs
+++ b/crates/ide/src/runnables.rs
@@ -581,14 +581,8 @@ mod tests {
     fn check_tests(ra_fixture: &str, expect: Expect) {
         let (analysis, position) = fixture::position(ra_fixture);
         let tests = analysis.related_tests(position, None).unwrap();
-        let test_ids = tests
-            .into_iter()
-            .map(|runnable| match runnable.kind {
-                RunnableKind::Test { test_id, .. } => test_id,
-                _ => unreachable!(),
-            })
-            .collect::<Vec<_>>();
-        expect.assert_debug_eq(&test_ids);
+        let navigation_targets = tests.into_iter().map(|runnable| runnable.nav).collect::<Vec<_>>();
+        expect.assert_debug_eq(&navigation_targets);
     }
 
     #[test]
@@ -1637,9 +1631,15 @@ mod tests {
 "#,
             expect![[r#"
                 [
-                    Path(
-                        "tests::foo_test",
-                    ),
+                    NavigationTarget {
+                        file_id: FileId(
+                            0,
+                        ),
+                        full_range: 31..85,
+                        focus_range: 46..54,
+                        name: "foo_test",
+                        kind: Function,
+                    },
                 ]
             "#]],
         );
@@ -1664,9 +1664,15 @@ mod tests {
 "#,
             expect![[r#"
                 [
-                    Path(
-                        "tests::foo_test",
-                    ),
+                    NavigationTarget {
+                        file_id: FileId(
+                            0,
+                        ),
+                        full_range: 71..122,
+                        focus_range: 86..94,
+                        name: "foo_test",
+                        kind: Function,
+                    },
                 ]
             "#]],
         );
@@ -1698,9 +1704,15 @@ mod tests {
 "#,
             expect![[r#"
                 [
-                    Path(
-                        "tests::foo_test",
-                    ),
+                    NavigationTarget {
+                        file_id: FileId(
+                            0,
+                        ),
+                        full_range: 133..183,
+                        focus_range: 148..156,
+                        name: "foo_test",
+                        kind: Function,
+                    },
                 ]
             "#]],
         );
@@ -1732,12 +1744,24 @@ mod tests {
 "#,
             expect![[r#"
                 [
-                    Path(
-                        "tests::foo2_test",
-                    ),
-                    Path(
-                        "tests::foo_test",
-                    ),
+                    NavigationTarget {
+                        file_id: FileId(
+                            0,
+                        ),
+                        full_range: 121..185,
+                        focus_range: 136..145,
+                        name: "foo2_test",
+                        kind: Function,
+                    },
+                    NavigationTarget {
+                        file_id: FileId(
+                            0,
+                        ),
+                        full_range: 52..115,
+                        focus_range: 67..75,
+                        name: "foo_test",
+                        kind: Function,
+                    },
                 ]
             "#]],
         );

--- a/crates/ide/src/runnables.rs
+++ b/crates/ide/src/runnables.rs
@@ -567,13 +567,15 @@ mod tests {
         let mut runnables = analysis.runnables(position.file_id).unwrap();
         runnables.sort_by_key(|it| (it.nav.full_range.start(), it.nav.name.clone()));
 
-        let navigation_targets = runnables.iter().map(|a| a.nav.clone()).collect::<Vec<_>>();
-        expect.assert_debug_eq(&navigation_targets);
+        let mut navigation_targets = Vec::with_capacity(runnables.len());
+        let mut test_kinds = Vec::with_capacity(runnables.len());
+        for runnable in runnables {
+            test_kinds.push(runnable.test_kind());
+            navigation_targets.push(runnable.nav);
+        }
 
-        assert_eq!(
-            actions,
-            runnables.into_iter().map(|it| it.test_kind()).collect::<Vec<_>>().as_slice()
-        );
+        expect.assert_debug_eq(&navigation_targets);
+        assert_eq!(actions, test_kinds.as_slice());
     }
 
     fn check_tests(ra_fixture: &str, expect: Expect) {

--- a/crates/ide/src/runnables.rs
+++ b/crates/ide/src/runnables.rs
@@ -576,7 +576,8 @@ mod tests {
     fn check_tests(ra_fixture: &str, expect: Expect) {
         let (analysis, position) = fixture::position(ra_fixture);
         let tests = analysis.related_tests(position, None).unwrap();
-        expect.assert_debug_eq(&tests);
+        let test_names = tests.into_iter().map(|a| a.nav.name).collect::<Vec<_>>();
+        expect.assert_debug_eq(&test_names);
     }
 
     #[test]
@@ -2143,27 +2144,7 @@ mod tests {
 "#,
             expect![[r#"
                 [
-                    Runnable {
-                        use_name_in_title: false,
-                        nav: NavigationTarget {
-                            file_id: FileId(
-                                0,
-                            ),
-                            full_range: 31..85,
-                            focus_range: 46..54,
-                            name: "foo_test",
-                            kind: Function,
-                        },
-                        kind: Test {
-                            test_id: Path(
-                                "tests::foo_test",
-                            ),
-                            attr: TestAttr {
-                                ignore: false,
-                            },
-                        },
-                        cfg: None,
-                    },
+                    "foo_test",
                 ]
             "#]],
         );
@@ -2188,27 +2169,7 @@ mod tests {
 "#,
             expect![[r#"
                 [
-                    Runnable {
-                        use_name_in_title: false,
-                        nav: NavigationTarget {
-                            file_id: FileId(
-                                0,
-                            ),
-                            full_range: 71..122,
-                            focus_range: 86..94,
-                            name: "foo_test",
-                            kind: Function,
-                        },
-                        kind: Test {
-                            test_id: Path(
-                                "tests::foo_test",
-                            ),
-                            attr: TestAttr {
-                                ignore: false,
-                            },
-                        },
-                        cfg: None,
-                    },
+                    "foo_test",
                 ]
             "#]],
         );
@@ -2240,27 +2201,7 @@ mod tests {
 "#,
             expect![[r#"
                 [
-                    Runnable {
-                        use_name_in_title: false,
-                        nav: NavigationTarget {
-                            file_id: FileId(
-                                0,
-                            ),
-                            full_range: 133..183,
-                            focus_range: 148..156,
-                            name: "foo_test",
-                            kind: Function,
-                        },
-                        kind: Test {
-                            test_id: Path(
-                                "tests::foo_test",
-                            ),
-                            attr: TestAttr {
-                                ignore: false,
-                            },
-                        },
-                        cfg: None,
-                    },
+                    "foo_test",
                 ]
             "#]],
         );
@@ -2292,48 +2233,8 @@ mod tests {
 "#,
             expect![[r#"
                 [
-                    Runnable {
-                        use_name_in_title: false,
-                        nav: NavigationTarget {
-                            file_id: FileId(
-                                0,
-                            ),
-                            full_range: 121..185,
-                            focus_range: 136..145,
-                            name: "foo2_test",
-                            kind: Function,
-                        },
-                        kind: Test {
-                            test_id: Path(
-                                "tests::foo2_test",
-                            ),
-                            attr: TestAttr {
-                                ignore: false,
-                            },
-                        },
-                        cfg: None,
-                    },
-                    Runnable {
-                        use_name_in_title: false,
-                        nav: NavigationTarget {
-                            file_id: FileId(
-                                0,
-                            ),
-                            full_range: 52..115,
-                            focus_range: 67..75,
-                            name: "foo_test",
-                            kind: Function,
-                        },
-                        kind: Test {
-                            test_id: Path(
-                                "tests::foo_test",
-                            ),
-                            attr: TestAttr {
-                                ignore: false,
-                            },
-                        },
-                        cfg: None,
-                    },
+                    "foo2_test",
+                    "foo_test",
                 ]
             "#]],
         );

--- a/crates/ide/src/runnables.rs
+++ b/crates/ide/src/runnables.rs
@@ -555,27 +555,16 @@ mod tests {
 
     use crate::fixture;
 
-    use super::{RunnableTestKind::*, *};
-
-    fn check(
-        ra_fixture: &str,
-        // FIXME: fold this into `expect` as well
-        actions: &[RunnableTestKind],
-        expect: Expect,
-    ) {
+    fn check(ra_fixture: &str, expect: Expect) {
         let (analysis, position) = fixture::position(ra_fixture);
-        let mut runnables = analysis.runnables(position.file_id).unwrap();
-        runnables.sort_by_key(|it| (it.nav.full_range.start(), it.nav.name.clone()));
-
-        let mut navigation_targets = Vec::with_capacity(runnables.len());
-        let mut test_kinds = Vec::with_capacity(runnables.len());
-        for runnable in runnables {
-            test_kinds.push(runnable.test_kind());
-            navigation_targets.push(runnable.nav);
-        }
-
-        expect.assert_debug_eq(&navigation_targets);
-        assert_eq!(actions, test_kinds.as_slice());
+        let mut result = analysis
+            .runnables(position.file_id)
+            .unwrap()
+            .into_iter()
+            .map(|runnable| (runnable.test_kind(), runnable.nav))
+            .collect::<Vec<_>>();
+        result.sort_by_key(|(_, nav)| (nav.full_range.start(), nav.name.clone()));
+        expect.assert_debug_eq(&result);
     }
 
     fn check_tests(ra_fixture: &str, expect: Expect) {
@@ -613,71 +602,91 @@ mod not_a_root {
     fn main() {}
 }
 "#,
-            &[TestMod, Bin, Bin, Test, Test, Test, Bench],
             expect![[r#"
                 [
-                    NavigationTarget {
-                        file_id: FileId(
-                            0,
-                        ),
-                        full_range: 0..253,
-                        name: "",
-                        kind: Module,
-                    },
-                    NavigationTarget {
-                        file_id: FileId(
-                            0,
-                        ),
-                        full_range: 1..13,
-                        focus_range: 4..8,
-                        name: "main",
-                        kind: Function,
-                    },
-                    NavigationTarget {
-                        file_id: FileId(
-                            0,
-                        ),
-                        full_range: 15..76,
-                        focus_range: 42..71,
-                        name: "__cortex_m_rt_main_trampoline",
-                        kind: Function,
-                    },
-                    NavigationTarget {
-                        file_id: FileId(
-                            0,
-                        ),
-                        full_range: 78..102,
-                        focus_range: 89..97,
-                        name: "test_foo",
-                        kind: Function,
-                    },
-                    NavigationTarget {
-                        file_id: FileId(
-                            0,
-                        ),
-                        full_range: 104..155,
-                        focus_range: 136..150,
-                        name: "test_full_path",
-                        kind: Function,
-                    },
-                    NavigationTarget {
-                        file_id: FileId(
-                            0,
-                        ),
-                        full_range: 157..191,
-                        focus_range: 178..186,
-                        name: "test_foo",
-                        kind: Function,
-                    },
-                    NavigationTarget {
-                        file_id: FileId(
-                            0,
-                        ),
-                        full_range: 193..215,
-                        focus_range: 205..210,
-                        name: "bench",
-                        kind: Function,
-                    },
+                    (
+                        TestMod,
+                        NavigationTarget {
+                            file_id: FileId(
+                                0,
+                            ),
+                            full_range: 0..253,
+                            name: "",
+                            kind: Module,
+                        },
+                    ),
+                    (
+                        Bin,
+                        NavigationTarget {
+                            file_id: FileId(
+                                0,
+                            ),
+                            full_range: 1..13,
+                            focus_range: 4..8,
+                            name: "main",
+                            kind: Function,
+                        },
+                    ),
+                    (
+                        Bin,
+                        NavigationTarget {
+                            file_id: FileId(
+                                0,
+                            ),
+                            full_range: 15..76,
+                            focus_range: 42..71,
+                            name: "__cortex_m_rt_main_trampoline",
+                            kind: Function,
+                        },
+                    ),
+                    (
+                        Test,
+                        NavigationTarget {
+                            file_id: FileId(
+                                0,
+                            ),
+                            full_range: 78..102,
+                            focus_range: 89..97,
+                            name: "test_foo",
+                            kind: Function,
+                        },
+                    ),
+                    (
+                        Test,
+                        NavigationTarget {
+                            file_id: FileId(
+                                0,
+                            ),
+                            full_range: 104..155,
+                            focus_range: 136..150,
+                            name: "test_full_path",
+                            kind: Function,
+                        },
+                    ),
+                    (
+                        Test,
+                        NavigationTarget {
+                            file_id: FileId(
+                                0,
+                            ),
+                            full_range: 157..191,
+                            focus_range: 178..186,
+                            name: "test_foo",
+                            kind: Function,
+                        },
+                    ),
+                    (
+                        Bench,
+                        NavigationTarget {
+                            file_id: FileId(
+                                0,
+                            ),
+                            full_range: 193..215,
+                            focus_range: 205..210,
+                            name: "bench",
+                            kind: Function,
+                        },
+                    ),
                 ]
             "#]],
         );
@@ -779,78 +788,104 @@ trait Test {
 /// ```
 impl Test for StructWithRunnable {}
 "#,
-            &[Bin, DocTest, DocTest, DocTest, DocTest, DocTest, DocTest, DocTest, DocTest],
             expect![[r#"
                 [
-                    NavigationTarget {
-                        file_id: FileId(
-                            0,
-                        ),
-                        full_range: 1..13,
-                        focus_range: 4..8,
-                        name: "main",
-                        kind: Function,
-                    },
-                    NavigationTarget {
-                        file_id: FileId(
-                            0,
-                        ),
-                        full_range: 15..74,
-                        name: "should_have_runnable",
-                    },
-                    NavigationTarget {
-                        file_id: FileId(
-                            0,
-                        ),
-                        full_range: 76..148,
-                        name: "should_have_runnable_1",
-                    },
-                    NavigationTarget {
-                        file_id: FileId(
-                            0,
-                        ),
-                        full_range: 150..254,
-                        name: "should_have_runnable_2",
-                    },
-                    NavigationTarget {
-                        file_id: FileId(
-                            0,
-                        ),
-                        full_range: 256..320,
-                        name: "should_have_no_runnable_3",
-                    },
-                    NavigationTarget {
-                        file_id: FileId(
-                            0,
-                        ),
-                        full_range: 322..398,
-                        name: "should_have_no_runnable_4",
-                    },
-                    NavigationTarget {
-                        file_id: FileId(
-                            0,
-                        ),
-                        full_range: 900..965,
-                        name: "StructWithRunnable",
-                    },
-                    NavigationTarget {
-                        file_id: FileId(
-                            0,
-                        ),
-                        full_range: 967..1024,
-                        focus_range: 1003..1021,
-                        name: "impl",
-                        kind: Impl,
-                    },
-                    NavigationTarget {
-                        file_id: FileId(
-                            0,
-                        ),
-                        full_range: 1088..1154,
-                        focus_range: 1133..1151,
-                        name: "impl",
-                        kind: Impl,
-                    },
+                    (
+                        Bin,
+                        NavigationTarget {
+                            file_id: FileId(
+                                0,
+                            ),
+                            full_range: 1..13,
+                            focus_range: 4..8,
+                            name: "main",
+                            kind: Function,
+                        },
+                    ),
+                    (
+                        DocTest,
+                        NavigationTarget {
+                            file_id: FileId(
+                                0,
+                            ),
+                            full_range: 15..74,
+                            name: "should_have_runnable",
+                        },
+                    ),
+                    (
+                        DocTest,
+                        NavigationTarget {
+                            file_id: FileId(
+                                0,
+                            ),
+                            full_range: 76..148,
+                            name: "should_have_runnable_1",
+                        },
+                    ),
+                    (
+                        DocTest,
+                        NavigationTarget {
+                            file_id: FileId(
+                                0,
+                            ),
+                            full_range: 150..254,
+                            name: "should_have_runnable_2",
+                        },
+                    ),
+                    (
+                        DocTest,
+                        NavigationTarget {
+                            file_id: FileId(
+                                0,
+                            ),
+                            full_range: 256..320,
+                            name: "should_have_no_runnable_3",
+                        },
+                    ),
+                    (
+                        DocTest,
+                        NavigationTarget {
+                            file_id: FileId(
+                                0,
+                            ),
+                            full_range: 322..398,
+                            name: "should_have_no_runnable_4",
+                        },
+                    ),
+                    (
+                        DocTest,
+                        NavigationTarget {
+                            file_id: FileId(
+                                0,
+                            ),
+                            full_range: 900..965,
+                            name: "StructWithRunnable",
+                        },
+                    ),
+                    (
+                        DocTest,
+                        NavigationTarget {
+                            file_id: FileId(
+                                0,
+                            ),
+                            full_range: 967..1024,
+                            focus_range: 1003..1021,
+                            name: "impl",
+                            kind: Impl,
+                        },
+                    ),
+                    (
+                        DocTest,
+                        NavigationTarget {
+                            file_id: FileId(
+                                0,
+                            ),
+                            full_range: 1088..1154,
+                            focus_range: 1133..1151,
+                            name: "impl",
+                            kind: Impl,
+                        },
+                    ),
                 ]
             "#]],
         );
@@ -872,25 +907,30 @@ impl Data {
     fn foo() {}
 }
 "#,
-            &[Bin, DocTest],
             expect![[r#"
                 [
-                    NavigationTarget {
-                        file_id: FileId(
-                            0,
-                        ),
-                        full_range: 1..13,
-                        focus_range: 4..8,
-                        name: "main",
-                        kind: Function,
-                    },
-                    NavigationTarget {
-                        file_id: FileId(
-                            0,
-                        ),
-                        full_range: 44..98,
-                        name: "foo",
-                    },
+                    (
+                        Bin,
+                        NavigationTarget {
+                            file_id: FileId(
+                                0,
+                            ),
+                            full_range: 1..13,
+                            focus_range: 4..8,
+                            name: "main",
+                            kind: Function,
+                        },
+                    ),
+                    (
+                        DocTest,
+                        NavigationTarget {
+                            file_id: FileId(
+                                0,
+                            ),
+                            full_range: 44..98,
+                            name: "foo",
+                        },
+                    ),
                 ]
             "#]],
         );
@@ -912,25 +952,30 @@ impl Data<'a> {
     fn foo() {}
 }
 "#,
-            &[Bin, DocTest],
             expect![[r#"
                 [
-                    NavigationTarget {
-                        file_id: FileId(
-                            0,
-                        ),
-                        full_range: 1..13,
-                        focus_range: 4..8,
-                        name: "main",
-                        kind: Function,
-                    },
-                    NavigationTarget {
-                        file_id: FileId(
-                            0,
-                        ),
-                        full_range: 52..106,
-                        name: "foo",
-                    },
+                    (
+                        Bin,
+                        NavigationTarget {
+                            file_id: FileId(
+                                0,
+                            ),
+                            full_range: 1..13,
+                            focus_range: 4..8,
+                            name: "main",
+                            kind: Function,
+                        },
+                    ),
+                    (
+                        DocTest,
+                        NavigationTarget {
+                            file_id: FileId(
+                                0,
+                            ),
+                            full_range: 52..106,
+                            name: "foo",
+                        },
+                    ),
                 ]
             "#]],
         );
@@ -952,25 +997,30 @@ impl<T, U> Data<'a, T, U> {
     fn foo() {}
 }
 "#,
-            &[Bin, DocTest],
             expect![[r#"
                 [
-                    NavigationTarget {
-                        file_id: FileId(
-                            0,
-                        ),
-                        full_range: 1..13,
-                        focus_range: 4..8,
-                        name: "main",
-                        kind: Function,
-                    },
-                    NavigationTarget {
-                        file_id: FileId(
-                            0,
-                        ),
-                        full_range: 70..124,
-                        name: "foo",
-                    },
+                    (
+                        Bin,
+                        NavigationTarget {
+                            file_id: FileId(
+                                0,
+                            ),
+                            full_range: 1..13,
+                            focus_range: 4..8,
+                            name: "main",
+                            kind: Function,
+                        },
+                    ),
+                    (
+                        DocTest,
+                        NavigationTarget {
+                            file_id: FileId(
+                                0,
+                            ),
+                            full_range: 70..124,
+                            name: "foo",
+                        },
+                    ),
                 ]
             "#]],
         );
@@ -992,25 +1042,30 @@ impl<const N: usize> Data<N> {
     fn foo() {}
 }
 "#,
-            &[Bin, DocTest],
             expect![[r#"
                 [
-                    NavigationTarget {
-                        file_id: FileId(
-                            0,
-                        ),
-                        full_range: 1..13,
-                        focus_range: 4..8,
-                        name: "main",
-                        kind: Function,
-                    },
-                    NavigationTarget {
-                        file_id: FileId(
-                            0,
-                        ),
-                        full_range: 79..133,
-                        name: "foo",
-                    },
+                    (
+                        Bin,
+                        NavigationTarget {
+                            file_id: FileId(
+                                0,
+                            ),
+                            full_range: 1..13,
+                            focus_range: 4..8,
+                            name: "main",
+                            kind: Function,
+                        },
+                    ),
+                    (
+                        DocTest,
+                        NavigationTarget {
+                            file_id: FileId(
+                                0,
+                            ),
+                            full_range: 79..133,
+                            name: "foo",
+                        },
+                    ),
                 ]
             "#]],
         );
@@ -1032,25 +1087,30 @@ impl<'a, T, const N: usize> Data<'a, T, N> {
     fn foo() {}
 }
 "#,
-            &[Bin, DocTest],
             expect![[r#"
                 [
-                    NavigationTarget {
-                        file_id: FileId(
-                            0,
-                        ),
-                        full_range: 1..13,
-                        focus_range: 4..8,
-                        name: "main",
-                        kind: Function,
-                    },
-                    NavigationTarget {
-                        file_id: FileId(
-                            0,
-                        ),
-                        full_range: 100..154,
-                        name: "foo",
-                    },
+                    (
+                        Bin,
+                        NavigationTarget {
+                            file_id: FileId(
+                                0,
+                            ),
+                            full_range: 1..13,
+                            focus_range: 4..8,
+                            name: "main",
+                            kind: Function,
+                        },
+                    ),
+                    (
+                        DocTest,
+                        NavigationTarget {
+                            file_id: FileId(
+                                0,
+                            ),
+                            full_range: 100..154,
+                            name: "foo",
+                        },
+                    ),
                 ]
             "#]],
         );
@@ -1066,28 +1126,33 @@ mod test_mod {
     fn test_foo1() {}
 }
 "#,
-            &[TestMod, Test],
             expect![[r#"
                 [
-                    NavigationTarget {
-                        file_id: FileId(
-                            0,
-                        ),
-                        full_range: 1..51,
-                        focus_range: 5..13,
-                        name: "test_mod",
-                        kind: Module,
-                        description: "mod test_mod",
-                    },
-                    NavigationTarget {
-                        file_id: FileId(
-                            0,
-                        ),
-                        full_range: 20..49,
-                        focus_range: 35..44,
-                        name: "test_foo1",
-                        kind: Function,
-                    },
+                    (
+                        TestMod,
+                        NavigationTarget {
+                            file_id: FileId(
+                                0,
+                            ),
+                            full_range: 1..51,
+                            focus_range: 5..13,
+                            name: "test_mod",
+                            kind: Module,
+                            description: "mod test_mod",
+                        },
+                    ),
+                    (
+                        Test,
+                        NavigationTarget {
+                            file_id: FileId(
+                                0,
+                            ),
+                            full_range: 20..49,
+                            focus_range: 35..44,
+                            name: "test_foo1",
+                            kind: Function,
+                        },
+                    ),
                 ]
             "#]],
         );
@@ -1120,66 +1185,83 @@ mod root_tests {
     mod nested_tests_4 {}
 }
 "#,
-            &[TestMod, TestMod, Test, Test, TestMod, Test],
             expect![[r#"
                 [
-                    NavigationTarget {
-                        file_id: FileId(
-                            0,
-                        ),
-                        full_range: 22..323,
-                        focus_range: 26..40,
-                        name: "nested_tests_0",
-                        kind: Module,
-                        description: "mod nested_tests_0",
-                    },
-                    NavigationTarget {
-                        file_id: FileId(
-                            0,
-                        ),
-                        full_range: 51..192,
-                        focus_range: 55..69,
-                        name: "nested_tests_1",
-                        kind: Module,
-                        description: "mod nested_tests_1",
-                    },
-                    NavigationTarget {
-                        file_id: FileId(
-                            0,
-                        ),
-                        full_range: 84..126,
-                        focus_range: 107..121,
-                        name: "nested_test_11",
-                        kind: Function,
-                    },
-                    NavigationTarget {
-                        file_id: FileId(
-                            0,
-                        ),
-                        full_range: 140..182,
-                        focus_range: 163..177,
-                        name: "nested_test_12",
-                        kind: Function,
-                    },
-                    NavigationTarget {
-                        file_id: FileId(
-                            0,
-                        ),
-                        full_range: 202..286,
-                        focus_range: 206..220,
-                        name: "nested_tests_2",
-                        kind: Module,
-                        description: "mod nested_tests_2",
-                    },
-                    NavigationTarget {
-                        file_id: FileId(
-                            0,
-                        ),
-                        full_range: 235..276,
-                        focus_range: 258..271,
-                        name: "nested_test_2",
-                        kind: Function,
-                    },
+                    (
+                        TestMod,
+                        NavigationTarget {
+                            file_id: FileId(
+                                0,
+                            ),
+                            full_range: 22..323,
+                            focus_range: 26..40,
+                            name: "nested_tests_0",
+                            kind: Module,
+                            description: "mod nested_tests_0",
+                        },
+                    ),
+                    (
+                        TestMod,
+                        NavigationTarget {
+                            file_id: FileId(
+                                0,
+                            ),
+                            full_range: 51..192,
+                            focus_range: 55..69,
+                            name: "nested_tests_1",
+                            kind: Module,
+                            description: "mod nested_tests_1",
+                        },
+                    ),
+                    (
+                        Test,
+                        NavigationTarget {
+                            file_id: FileId(
+                                0,
+                            ),
+                            full_range: 84..126,
+                            focus_range: 107..121,
+                            name: "nested_test_11",
+                            kind: Function,
+                        },
+                    ),
+                    (
+                        Test,
+                        NavigationTarget {
+                            file_id: FileId(
+                                0,
+                            ),
+                            full_range: 140..182,
+                            focus_range: 163..177,
+                            name: "nested_test_12",
+                            kind: Function,
+                        },
+                    ),
+                    (
+                        TestMod,
+                        NavigationTarget {
+                            file_id: FileId(
+                                0,
+                            ),
+                            full_range: 202..286,
+                            focus_range: 206..220,
+                            name: "nested_tests_2",
+                            kind: Module,
+                            description: "mod nested_tests_2",
+                        },
+                    ),
+                    (
+                        Test,
+                        NavigationTarget {
+                            file_id: FileId(
+                                0,
+                            ),
+                            full_range: 235..276,
+                            focus_range: 258..271,
+                            name: "nested_test_2",
+                            kind: Function,
+                        },
+                    ),
                 ]
             "#]],
         );
@@ -1195,26 +1277,31 @@ $0
 #[cfg(feature = "foo")]
 fn test_foo1() {}
 "#,
-            &[TestMod, Test],
             expect![[r#"
                 [
-                    NavigationTarget {
-                        file_id: FileId(
-                            0,
-                        ),
-                        full_range: 0..51,
-                        name: "",
-                        kind: Module,
-                    },
-                    NavigationTarget {
-                        file_id: FileId(
-                            0,
-                        ),
-                        full_range: 1..50,
-                        focus_range: 36..45,
-                        name: "test_foo1",
-                        kind: Function,
-                    },
+                    (
+                        TestMod,
+                        NavigationTarget {
+                            file_id: FileId(
+                                0,
+                            ),
+                            full_range: 0..51,
+                            name: "",
+                            kind: Module,
+                        },
+                    ),
+                    (
+                        Test,
+                        NavigationTarget {
+                            file_id: FileId(
+                                0,
+                            ),
+                            full_range: 1..50,
+                            focus_range: 36..45,
+                            name: "test_foo1",
+                            kind: Function,
+                        },
+                    ),
                 ]
             "#]],
         );
@@ -1230,26 +1317,31 @@ $0
 #[cfg(all(feature = "foo", feature = "bar"))]
 fn test_foo1() {}
 "#,
-            &[TestMod, Test],
             expect![[r#"
                 [
-                    NavigationTarget {
-                        file_id: FileId(
-                            0,
-                        ),
-                        full_range: 0..73,
-                        name: "",
-                        kind: Module,
-                    },
-                    NavigationTarget {
-                        file_id: FileId(
-                            0,
-                        ),
-                        full_range: 1..72,
-                        focus_range: 58..67,
-                        name: "test_foo1",
-                        kind: Function,
-                    },
+                    (
+                        TestMod,
+                        NavigationTarget {
+                            file_id: FileId(
+                                0,
+                            ),
+                            full_range: 0..73,
+                            name: "",
+                            kind: Module,
+                        },
+                    ),
+                    (
+                        Test,
+                        NavigationTarget {
+                            file_id: FileId(
+                                0,
+                            ),
+                            full_range: 1..72,
+                            focus_range: 58..67,
+                            name: "test_foo1",
+                            kind: Function,
+                        },
+                    ),
                 ]
             "#]],
         );
@@ -1265,7 +1357,6 @@ mod test_mod {
     fn foo1() {}
 }
 "#,
-            &[],
             expect![[r#"
                 []
             "#]],
@@ -1287,16 +1378,18 @@ impl Foo {
     fn foo() {}
 }
         "#,
-            &[DocTest],
             expect![[r#"
                 [
-                    NavigationTarget {
-                        file_id: FileId(
-                            1,
-                        ),
-                        full_range: 27..81,
-                        name: "foo",
-                    },
+                    (
+                        DocTest,
+                        NavigationTarget {
+                            file_id: FileId(
+                                1,
+                            ),
+                            full_range: 27..81,
+                            name: "foo",
+                        },
+                    ),
                 ]
             "#]],
         );
@@ -1333,60 +1426,77 @@ mod tests {
 gen2!();
 gen_main!();
 "#,
-            &[TestMod, TestMod, Test, Test, TestMod, Bin],
             expect![[r#"
                 [
-                    NavigationTarget {
-                        file_id: FileId(
-                            0,
-                        ),
-                        full_range: 0..315,
-                        name: "",
-                        kind: Module,
-                    },
-                    NavigationTarget {
-                        file_id: FileId(
-                            0,
-                        ),
-                        full_range: 267..292,
-                        focus_range: 271..276,
-                        name: "tests",
-                        kind: Module,
-                        description: "mod tests",
-                    },
-                    NavigationTarget {
-                        file_id: FileId(
-                            0,
-                        ),
-                        full_range: 283..290,
-                        name: "foo_test",
-                        kind: Function,
-                    },
-                    NavigationTarget {
-                        file_id: FileId(
-                            0,
-                        ),
-                        full_range: 293..301,
-                        name: "foo_test2",
-                        kind: Function,
-                    },
-                    NavigationTarget {
-                        file_id: FileId(
-                            0,
-                        ),
-                        full_range: 293..301,
-                        name: "tests2",
-                        kind: Module,
-                        description: "mod tests2",
-                    },
-                    NavigationTarget {
-                        file_id: FileId(
-                            0,
-                        ),
-                        full_range: 302..314,
-                        name: "main",
-                        kind: Function,
-                    },
+                    (
+                        TestMod,
+                        NavigationTarget {
+                            file_id: FileId(
+                                0,
+                            ),
+                            full_range: 0..315,
+                            name: "",
+                            kind: Module,
+                        },
+                    ),
+                    (
+                        TestMod,
+                        NavigationTarget {
+                            file_id: FileId(
+                                0,
+                            ),
+                            full_range: 267..292,
+                            focus_range: 271..276,
+                            name: "tests",
+                            kind: Module,
+                            description: "mod tests",
+                        },
+                    ),
+                    (
+                        Test,
+                        NavigationTarget {
+                            file_id: FileId(
+                                0,
+                            ),
+                            full_range: 283..290,
+                            name: "foo_test",
+                            kind: Function,
+                        },
+                    ),
+                    (
+                        Test,
+                        NavigationTarget {
+                            file_id: FileId(
+                                0,
+                            ),
+                            full_range: 293..301,
+                            name: "foo_test2",
+                            kind: Function,
+                        },
+                    ),
+                    (
+                        TestMod,
+                        NavigationTarget {
+                            file_id: FileId(
+                                0,
+                            ),
+                            full_range: 293..301,
+                            name: "tests2",
+                            kind: Module,
+                            description: "mod tests2",
+                        },
+                    ),
+                    (
+                        Bin,
+                        NavigationTarget {
+                            file_id: FileId(
+                                0,
+                            ),
+                            full_range: 302..314,
+                            name: "main",
+                            kind: Function,
+                        },
+                    ),
                 ]
             "#]],
         );
@@ -1412,42 +1522,53 @@ macro_rules! foo {
 }
 foo!();
 "#,
-            &[Test, Test, Test, TestMod],
             expect![[r#"
                 [
-                    NavigationTarget {
-                        file_id: FileId(
-                            0,
-                        ),
-                        full_range: 210..217,
-                        name: "foo0",
-                        kind: Function,
-                    },
-                    NavigationTarget {
-                        file_id: FileId(
-                            0,
-                        ),
-                        full_range: 210..217,
-                        name: "foo1",
-                        kind: Function,
-                    },
-                    NavigationTarget {
-                        file_id: FileId(
-                            0,
-                        ),
-                        full_range: 210..217,
-                        name: "foo2",
-                        kind: Function,
-                    },
-                    NavigationTarget {
-                        file_id: FileId(
-                            0,
-                        ),
-                        full_range: 210..217,
-                        name: "foo_tests",
-                        kind: Module,
-                        description: "mod foo_tests",
-                    },
+                    (
+                        Test,
+                        NavigationTarget {
+                            file_id: FileId(
+                                0,
+                            ),
+                            full_range: 210..217,
+                            name: "foo0",
+                            kind: Function,
+                        },
+                    ),
+                    (
+                        Test,
+                        NavigationTarget {
+                            file_id: FileId(
+                                0,
+                            ),
+                            full_range: 210..217,
+                            name: "foo1",
+                            kind: Function,
+                        },
+                    ),
+                    (
+                        Test,
+                        NavigationTarget {
+                            file_id: FileId(
+                                0,
+                            ),
+                            full_range: 210..217,
+                            name: "foo2",
+                            kind: Function,
+                        },
+                    ),
+                    (
+                        TestMod,
+                        NavigationTarget {
+                            file_id: FileId(
+                                0,
+                            ),
+                            full_range: 210..217,
+                            name: "foo_tests",
+                            kind: Module,
+                            description: "mod foo_tests",
+                        },
+                    ),
                 ]
             "#]],
         );
@@ -1466,7 +1587,6 @@ mod tests {
     fn t() {}
 }
 "#,
-            &[],
             expect![[r#"
                 []
             "#]],
@@ -1486,19 +1606,21 @@ fn t0() {}
 #[test]
 fn t1() {}
 "#,
-            &[TestMod],
             expect![[r#"
                 [
-                    NavigationTarget {
-                        file_id: FileId(
-                            0,
-                        ),
-                        full_range: 1..7,
-                        focus_range: 5..6,
-                        name: "m",
-                        kind: Module,
-                        description: "mod m",
-                    },
+                    (
+                        TestMod,
+                        NavigationTarget {
+                            file_id: FileId(
+                                0,
+                            ),
+                            full_range: 1..7,
+                            focus_range: 5..6,
+                            name: "m",
+                            kind: Module,
+                            description: "mod m",
+                        },
+                    ),
                 ]
             "#]],
         );
@@ -1517,35 +1639,43 @@ fn t0() {}
 #[test]
 fn t1() {}
 "#,
-            &[TestMod, Test, Test],
             expect![[r#"
                 [
-                    NavigationTarget {
-                        file_id: FileId(
-                            1,
-                        ),
-                        full_range: 0..39,
-                        name: "m",
-                        kind: Module,
-                    },
-                    NavigationTarget {
-                        file_id: FileId(
-                            1,
-                        ),
-                        full_range: 1..19,
-                        focus_range: 12..14,
-                        name: "t0",
-                        kind: Function,
-                    },
-                    NavigationTarget {
-                        file_id: FileId(
-                            1,
-                        ),
-                        full_range: 20..38,
-                        focus_range: 31..33,
-                        name: "t1",
-                        kind: Function,
-                    },
+                    (
+                        TestMod,
+                        NavigationTarget {
+                            file_id: FileId(
+                                1,
+                            ),
+                            full_range: 0..39,
+                            name: "m",
+                            kind: Module,
+                        },
+                    ),
+                    (
+                        Test,
+                        NavigationTarget {
+                            file_id: FileId(
+                                1,
+                            ),
+                            full_range: 1..19,
+                            focus_range: 12..14,
+                            name: "t0",
+                            kind: Function,
+                        },
+                    ),
+                    (
+                        Test,
+                        NavigationTarget {
+                            file_id: FileId(
+                                1,
+                            ),
+                            full_range: 20..38,
+                            focus_range: 31..33,
+                            name: "t1",
+                            kind: Function,
+                        },
+                    ),
                 ]
             "#]],
         );
@@ -1566,37 +1696,45 @@ mod module {
     fn t1() {}
 }
 "#,
-            &[TestMod, Test, Test],
             expect![[r#"
                 [
-                    NavigationTarget {
-                        file_id: FileId(
-                            0,
-                        ),
-                        full_range: 26..94,
-                        focus_range: 30..36,
-                        name: "module",
-                        kind: Module,
-                        description: "mod module",
-                    },
-                    NavigationTarget {
-                        file_id: FileId(
-                            0,
-                        ),
-                        full_range: 43..65,
-                        focus_range: 58..60,
-                        name: "t0",
-                        kind: Function,
-                    },
-                    NavigationTarget {
-                        file_id: FileId(
-                            0,
-                        ),
-                        full_range: 70..92,
-                        focus_range: 85..87,
-                        name: "t1",
-                        kind: Function,
-                    },
+                    (
+                        TestMod,
+                        NavigationTarget {
+                            file_id: FileId(
+                                0,
+                            ),
+                            full_range: 26..94,
+                            focus_range: 30..36,
+                            name: "module",
+                            kind: Module,
+                            description: "mod module",
+                        },
+                    ),
+                    (
+                        Test,
+                        NavigationTarget {
+                            file_id: FileId(
+                                0,
+                            ),
+                            full_range: 43..65,
+                            focus_range: 58..60,
+                            name: "t0",
+                            kind: Function,
+                        },
+                    ),
+                    (
+                        Test,
+                        NavigationTarget {
+                            file_id: FileId(
+                                0,
+                            ),
+                            full_range: 70..92,
+                            focus_range: 85..87,
+                            name: "t1",
+                            kind: Function,
+                        },
+                    ),
                 ]
             "#]],
         );
@@ -1782,25 +1920,30 @@ impl<A, C, const D: u32> Data<'a, A, 12, C, D> {
     fn foo() {}
 }
 "#,
-            &[Bin, DocTest],
             expect![[r#"
                 [
-                    NavigationTarget {
-                        file_id: FileId(
-                            0,
-                        ),
-                        full_range: 1..13,
-                        focus_range: 4..8,
-                        name: "main",
-                        kind: Function,
-                    },
-                    NavigationTarget {
-                        file_id: FileId(
-                            0,
-                        ),
-                        full_range: 121..156,
-                        name: "foo",
-                    },
+                    (
+                        Bin,
+                        NavigationTarget {
+                            file_id: FileId(
+                                0,
+                            ),
+                            full_range: 1..13,
+                            focus_range: 4..8,
+                            name: "main",
+                            kind: Function,
+                        },
+                    ),
+                    (
+                        DocTest,
+                        NavigationTarget {
+                            file_id: FileId(
+                                0,
+                            ),
+                            full_range: 121..156,
+                            name: "foo",
+                        },
+                    ),
                 ]
             "#]],
         );
@@ -1830,41 +1973,52 @@ impl Foo<Foo<(), ()>, ()> {
     fn t() {}
 }
 "#,
-            &[DocTest, DocTest, DocTest, DocTest],
             expect![[r#"
                 [
-                    NavigationTarget {
-                        file_id: FileId(
-                            0,
-                        ),
-                        full_range: 20..103,
-                        focus_range: 47..56,
-                        name: "impl",
-                        kind: Impl,
-                    },
-                    NavigationTarget {
-                        file_id: FileId(
-                            0,
-                        ),
-                        full_range: 63..101,
-                        name: "t",
-                    },
-                    NavigationTarget {
-                        file_id: FileId(
-                            0,
-                        ),
-                        full_range: 105..188,
-                        focus_range: 126..146,
-                        name: "impl",
-                        kind: Impl,
-                    },
-                    NavigationTarget {
-                        file_id: FileId(
-                            0,
-                        ),
-                        full_range: 153..186,
-                        name: "t",
-                    },
+                    (
+                        DocTest,
+                        NavigationTarget {
+                            file_id: FileId(
+                                0,
+                            ),
+                            full_range: 20..103,
+                            focus_range: 47..56,
+                            name: "impl",
+                            kind: Impl,
+                        },
+                    ),
+                    (
+                        DocTest,
+                        NavigationTarget {
+                            file_id: FileId(
+                                0,
+                            ),
+                            full_range: 63..101,
+                            name: "t",
+                        },
+                    ),
+                    (
+                        DocTest,
+                        NavigationTarget {
+                            file_id: FileId(
+                                0,
+                            ),
+                            full_range: 105..188,
+                            focus_range: 126..146,
+                            name: "impl",
+                            kind: Impl,
+                        },
+                    ),
+                    (
+                        DocTest,
+                        NavigationTarget {
+                            file_id: FileId(
+                                0,
+                            ),
+                            full_range: 153..186,
+                            name: "t",
+                        },
+                    ),
                 ]
             "#]],
         );
@@ -1890,7 +2044,6 @@ macro_rules! foo {
     };
 }
 "#,
-            &[],
             expect![[r#"
                 []
             "#]],
@@ -1910,16 +2063,18 @@ macro_rules! foo {
     };
 }
 "#,
-            &[DocTest],
             expect![[r#"
                 [
-                    NavigationTarget {
-                        file_id: FileId(
-                            0,
-                        ),
-                        full_range: 1..94,
-                        name: "foo",
-                    },
+                    (
+                        DocTest,
+                        NavigationTarget {
+                            file_id: FileId(
+                                0,
+                            ),
+                            full_range: 1..94,
+                            name: "foo",
+                        },
+                    ),
                 ]
             "#]],
         );
@@ -1965,76 +2120,99 @@ mod r#mod {
     impl<T> r#trait for r#struct<T> {}
 }
 "#,
-            &[TestMod, Test, DocTest, DocTest, DocTest, DocTest, DocTest, DocTest],
             expect![[r#"
                 [
-                    NavigationTarget {
-                        file_id: FileId(
-                            0,
-                        ),
-                        full_range: 1..461,
-                        focus_range: 5..10,
-                        name: "r#mod",
-                        kind: Module,
-                        description: "mod r#mod",
-                    },
-                    NavigationTarget {
-                        file_id: FileId(
-                            0,
-                        ),
-                        full_range: 17..41,
-                        focus_range: 32..36,
-                        name: "r#fn",
-                        kind: Function,
-                    },
-                    NavigationTarget {
-                        file_id: FileId(
-                            0,
-                        ),
-                        full_range: 47..84,
-                        name: "r#for",
-                        container_name: "r#mod",
-                    },
-                    NavigationTarget {
-                        file_id: FileId(
-                            0,
-                        ),
-                        full_range: 90..146,
-                        name: "r#struct",
-                        container_name: "r#mod",
-                    },
-                    NavigationTarget {
-                        file_id: FileId(
-                            0,
-                        ),
-                        full_range: 152..266,
-                        focus_range: 189..205,
-                        name: "impl",
-                        kind: Impl,
-                    },
-                    NavigationTarget {
-                        file_id: FileId(
-                            0,
-                        ),
-                        full_range: 216..260,
-                        name: "r#fn",
-                    },
-                    NavigationTarget {
-                        file_id: FileId(
-                            0,
-                        ),
-                        full_range: 323..367,
-                        name: "r#fn",
-                    },
-                    NavigationTarget {
-                        file_id: FileId(
-                            0,
-                        ),
-                        full_range: 401..459,
-                        focus_range: 445..456,
-                        name: "impl",
-                        kind: Impl,
-                    },
+                    (
+                        TestMod,
+                        NavigationTarget {
+                            file_id: FileId(
+                                0,
+                            ),
+                            full_range: 1..461,
+                            focus_range: 5..10,
+                            name: "r#mod",
+                            kind: Module,
+                            description: "mod r#mod",
+                        },
+                    ),
+                    (
+                        Test,
+                        NavigationTarget {
+                            file_id: FileId(
+                                0,
+                            ),
+                            full_range: 17..41,
+                            focus_range: 32..36,
+                            name: "r#fn",
+                            kind: Function,
+                        },
+                    ),
+                    (
+                        DocTest,
+                        NavigationTarget {
+                            file_id: FileId(
+                                0,
+                            ),
+                            full_range: 47..84,
+                            name: "r#for",
+                            container_name: "r#mod",
+                        },
+                    ),
+                    (
+                        DocTest,
+                        NavigationTarget {
+                            file_id: FileId(
+                                0,
+                            ),
+                            full_range: 90..146,
+                            name: "r#struct",
+                            container_name: "r#mod",
+                        },
+                    ),
+                    (
+                        DocTest,
+                        NavigationTarget {
+                            file_id: FileId(
+                                0,
+                            ),
+                            full_range: 152..266,
+                            focus_range: 189..205,
+                            name: "impl",
+                            kind: Impl,
+                        },
+                    ),
+                    (
+                        DocTest,
+                        NavigationTarget {
+                            file_id: FileId(
+                                0,
+                            ),
+                            full_range: 216..260,
+                            name: "r#fn",
+                        },
+                    ),
+                    (
+                        DocTest,
+                        NavigationTarget {
+                            file_id: FileId(
+                                0,
+                            ),
+                            full_range: 323..367,
+                            name: "r#fn",
+                        },
+                    ),
+                    (
+                        DocTest,
+                        NavigationTarget {
+                            file_id: FileId(
+                                0,
+                            ),
+                            full_range: 401..459,
+                            focus_range: 445..456,
+                            name: "impl",
+                            kind: Impl,
+                        },
+                    ),
                 ]
             "#]],
         )


### PR DESCRIPTION
This PR limits the data being compared. Therefore the tests should be more readable, as well as being more robust to changes to the data structure.

Part of https://github.com/rust-lang/rust-analyzer/issues/14268.