### PR TITLE
Further tuning of the Gentoo installation instructions.

### DIFF
--- a/docs/user/manual.adoc
+++ b/docs/user/manual.adoc
@@ -186,12 +186,13 @@ $ pacman -S rust-analyzer
 
 ==== Gentoo Linux
 
-There are two ways to install `rust-analyzer` under gentoo:
+There are two ways to install `rust-analyzer` under Gentoo:
 
-- When installing dev-lang/rust, or dev-lang/rust-bin, set the `rust-analyzer` USE flag, as well as the `rust-src` USE flag.
-- Use the rustup component to install `rust-analyzer` (see instructions above).
+- when installing `dev-lang/rust` or `dev-lang/rust-bin`, enable the `rust-analyzer` and `rust-src` USE flags
+- use the `rust-analyzer` component in `rustup` (see instructions above)
 
-In both cases, the version installed lags behind the official releases on GitHub. If you need a newer version of `rust-analyzer`, then consider installing from source, or one of the binaries made available on the `rust-analyzer` GitHub page with each release.
+Note that in both cases, the version installed lags for a couple of months behind the official releases on GitHub.
+To obtain a newer one, you can download a binary from GitHub Releases or building from source.
 
 ==== macOS
 

--- a/docs/user/manual.adoc
+++ b/docs/user/manual.adoc
@@ -191,7 +191,7 @@ There are two ways to install `rust-analyzer` under gentoo:
 - When installing dev-lang/rust, or dev-lang/rust-bin, set the `rust-analyzer` USE flag, as well as the `rust-src` USE flag.
 - Use the rustup component to install `rust-analyzer` (see instructions above).
 
-In both cases, the version installed lags behind the official releases on GitHub. If you need a newer version of `rust-analyzer`, then consider installing from source.
+In both cases, the version installed lags behind the official releases on GitHub. If you need a newer version of `rust-analyzer`, then consider installing from source, or one of the binaries made available on the `rust-analyzer` GitHub page with each release.
 
 ==== macOS
 

--- a/docs/user/manual.adoc
+++ b/docs/user/manual.adoc
@@ -186,10 +186,12 @@ $ pacman -S rust-analyzer
 
 ==== Gentoo Linux
 
-`rust-analyzer` is installed when the `rust-analyzer` USE flag is set for `dev-lang/rust` or `dev-lang/rust-bin`.
-You also need to set the `rust-src` USE flag.
+There are two ways to install `rust-analyzer` under gentoo:
 
-This is similar to using the `rustup` component, so it will install a version that lags behind the official releases on GitHub .
+- When installing dev-lang/rust, or dev-lang/rust-bin, set the `rust-analyzer` USE flag, as well as the `rust-src` USE flag.
+- Use the rustup component to install `rust-analyzer` (see instructions above).
+
+In both cases, the version installed lags behind the official releases on GitHub. If you need a newer version of `rust-analyzer`, then consider installing from source.
 
 ==== macOS
 


### PR DESCRIPTION
Based on feedback from the Gentoo repository maintainer, addition of the possibility to install rust-analyzer via rustup.