### PR TITLE
internal: clean and enhance readability for `generate_delegate_trait`

### DIFF
--- a/crates/ide-assists/src/handlers/generate_delegate_trait.rs
+++ b/crates/ide-assists/src/handlers/generate_delegate_trait.rs
@@ -351,11 +351,7 @@ fn generate_impl(
                 transform_impl(ctx, ast_strukt, &old_impl, &transform_args, &trait_args.syntax())?;
             }
 
-            let mut type_gen_args = strukt_params.clone().map(|params| params.to_generic_args());
-            if let Some(type_args) = &mut type_gen_args {
-                *type_args = type_args.clone_for_update();
-                transform_impl(ctx, ast_strukt, &old_impl, &transform_args, &type_args.syntax())?;
-            }
+            let type_gen_args = strukt_params.clone().map(|params| params.to_generic_args());
 
             let path_type = make::ty(&trait_.name(db).to_smol_str()).clone_for_update();
             transform_impl(ctx, ast_strukt, &old_impl, &transform_args, &path_type.syntax())?;

--- a/crates/syntax/src/ast/edit_in_place.rs
+++ b/crates/syntax/src/ast/edit_in_place.rs
@@ -293,13 +293,12 @@ impl ast::GenericParamList {
     }
 
     /// Removes the corresponding generic arg
-    pub fn remove_generic_arg(&self, generic_arg: &ast::GenericArg) -> Option<GenericParam> {
+    pub fn remove_generic_arg(&self, generic_arg: &ast::GenericArg) {
         let param_to_remove = self.find_generic_arg(generic_arg);
 
         if let Some(param) = &param_to_remove {
             self.remove_generic_param(param.clone());
         }
-        param_to_remove
     }
 
     /// Constructs a matching [`ast::GenericArgList`]

--- a/crates/syntax/src/ast/make.rs
+++ b/crates/syntax/src/ast/make.rs
@@ -263,9 +263,6 @@ pub fn impl_(
     ast_from_text(&format!("impl{gen_params} {path_type}{tr_gen_args}{where_clause}{{{}}}", body))
 }
 
-// FIXME : We must make *_gen_args' type ast::GenericArgList but in order to do so we must implement in `edit_in_place.rs`
-// `add_generic_arg()` just like `add_generic_param()`
-// is implemented for `ast::GenericParamList`
 pub fn impl_trait(
     is_unsafe: bool,
     trait_gen_params: Option<ast::GenericParamList>,


### PR DESCRIPTION
Continue from #16112

This PR primarily involves some cleanup and simple refactoring work, including:

- Adding numerous comments to layer the code and explain the behavior of each step.
- Renaming some variables to make them more sensible.
- Simplify certain operations using a more elegant approach.

The goal is to make this intricate implementation clearer and facilitate future maintenance.

In addition to this, the PR also removes redundant `path_transform` operations for `type_gen_args`.
Taking the example of `impl Trait<T1> for S<S1>`, where `S1` is considered. The struct `S` must be in the file where the user triggers code actions, so there's no need for the `path_transform`. Furthermore, before performing the transform, we've already renamed `S1`, ensuring it won't clash with existing generics parameters. Therefore, there's no need to transform it.