### PR TITLE
fix: Fix `ast::Path::segments` implementation

### DIFF
--- a/crates/ide-db/src/imports/import_assets.rs
+++ b/crates/ide-db/src/imports/import_assets.rs
@@ -681,11 +681,10 @@ fn path_import_candidate(
         Some(qualifier) => match sema.resolve_path(&qualifier) {
             None => {
                 if qualifier.first_qualifier().map_or(true, |it| sema.resolve_path(&it).is_none()) {
-                    let mut qualifier = qualifier
-                        .segments_of_this_path_only_rev()
+                    let qualifier = qualifier
+                        .segments()
                         .map(|seg| seg.name_ref().map(|name| SmolStr::new(name.text())))
                         .collect::<Option<Vec<_>>>()?;
-                    qualifier.reverse();
                     ImportCandidate::Path(PathImportCandidate { qualifier: Some(qualifier), name })
                 } else {
                     return None;

--- a/crates/syntax/src/ast/node_ext.rs
+++ b/crates/syntax/src/ast/node_ext.rs
@@ -283,11 +283,6 @@ impl ast::Path {
         self.first_qualifier_or_self().segment()
     }
 
-    // FIXME: Check usages of Self::segments, they might be wrong because of the logic of the bloew function
-    pub fn segments_of_this_path_only_rev(&self) -> impl Iterator<Item = ast::PathSegment> + Clone {
-        self.qualifiers_and_self().filter_map(|it| it.segment())
-    }
-
     pub fn segments(&self) -> impl Iterator<Item = ast::PathSegment> + Clone {
         let path_range = self.syntax().text_range();
         successors(self.first_segment(), move |p| {
@@ -303,10 +298,6 @@ impl ast::Path {
 
     pub fn qualifiers(&self) -> impl Iterator<Item = ast::Path> + Clone {
         successors(self.qualifier(), |p| p.qualifier())
-    }
-
-    pub fn qualifiers_and_self(&self) -> impl Iterator<Item = ast::Path> + Clone {
-        successors(Some(self.clone()), |p| p.qualifier())
     }
 
     pub fn top_path(&self) -> ast::Path {

--- a/crates/syntax/src/ast/node_ext.rs
+++ b/crates/syntax/src/ast/node_ext.rs
@@ -289,8 +289,15 @@ impl ast::Path {
     }
 
     pub fn segments(&self) -> impl Iterator<Item = ast::PathSegment> + Clone {
-        successors(self.first_segment(), |p| {
-            p.parent_path().parent_path().and_then(|p| p.segment())
+        let path_range = self.syntax().text_range();
+        successors(self.first_segment(), move |p| {
+            p.parent_path().parent_path().and_then(|p| {
+                if path_range.contains_range(p.syntax().text_range()) {
+                    p.segment()
+                } else {
+                    None
+                }
+            })
         })
     }
 


### PR DESCRIPTION
calling `ast::Path::segments` on a qualifier currently returns all the segments of the top path instead of just the segments of the qualifier.

The issue can be summarized by the simple failing test below:
```rust
#[test]
fn path_segments() {
    //use ra_ap_syntax::ast;
    let path: ast::Path = ...; // e.g. `ast::Path` for "foo::bar::item".

    let path_segments: Vec<_> = path.segments().collect();
    let qualifier_segments: Vec<_> = path.qualifier().unwrap().segments().collect();
    assert_eq!(path_segments.len(), qualifier_segments.len() + 1); // Fails because `LHS = RHS`.
}
```

This PR:
- Fixes the implementation of `ast::Path::segments`
- Fixes `ast::Path::segments` callers that either implicitly relied on behavior of previous implementation or exhibited other "wrong" behavior directly related to the result of `ast::Path::segments` (all callers have been reviewed, only one required modification)
- Removes unnecessary (and now unused) `ast::Path::segments` alternatives