### PR TITLE
fix: Differentiate between vfs config load and file changed events

### DIFF
--- a/crates/load-cargo/src/lib.rs
+++ b/crates/load-cargo/src/lib.rs
@@ -322,7 +322,7 @@ fn load_crate_graph(
                     break;
                 }
             }
-            vfs::loader::Message::Loaded { files } => {
+            vfs::loader::Message::Loaded { files } | vfs::loader::Message::Changed { files } => {
                 for (path, contents) in files {
                     vfs.set_file_contents(path.into(), contents);
                 }

--- a/crates/project-model/src/workspace.rs
+++ b/crates/project-model/src/workspace.rs
@@ -1398,7 +1398,7 @@ fn sysroot_to_crate_graph(
     let public_deps = SysrootPublicDeps {
         deps: sysroot
             .public_deps()
-            .map(|(name, idx, prelude)| (name, sysroot_crates[&idx], prelude))
+            .filter_map(|(name, idx, prelude)| Some((name, *sysroot_crates.get(&idx)?, prelude)))
             .collect::<Vec<_>>(),
     };
 

--- a/crates/rust-analyzer/src/handlers/notification.rs
+++ b/crates/rust-analyzer/src/handlers/notification.rs
@@ -101,8 +101,10 @@ pub(crate) fn handle_did_change_text_document(
             params.content_changes,
         )
         .into_bytes();
-        *data = new_contents.clone();
-        state.vfs.write().0.set_file_contents(path, Some(new_contents));
+        if *data != new_contents {
+            *data = new_contents.clone();
+            state.vfs.write().0.set_file_contents(path, Some(new_contents));
+        }
     }
     Ok(())
 }

--- a/crates/rust-analyzer/src/main_loop.rs
+++ b/crates/rust-analyzer/src/main_loop.rs
@@ -571,15 +571,18 @@ impl GlobalState {
     }
 
     fn handle_vfs_msg(&mut self, message: vfs::loader::Message) {
+        let is_changed = matches!(message, vfs::loader::Message::Changed { .. });
         match message {
-            vfs::loader::Message::Loaded { files } => {
+            vfs::loader::Message::Changed { files } | vfs::loader::Message::Loaded { files } => {
                 let vfs = &mut self.vfs.write().0;
                 for (path, contents) in files {
                     let path = VfsPath::from(path);
                     // if the file is in mem docs, it's managed by the client via notifications
                     // so only set it if its not in there
                     if !self.mem_docs.contains(&path) {
-                        vfs.set_file_contents(path, contents);
+                        if is_changed || vfs.file_id(&path).is_none() {
+                            vfs.set_file_contents(path, contents);
+                        }
                     }
                 }
             }

--- a/crates/rust-analyzer/tests/slow-tests/main.rs
+++ b/crates/rust-analyzer/tests/slow-tests/main.rs
@@ -835,7 +835,7 @@ fn main() {
 #[cfg(any(feature = "sysroot-abi", rust_analyzer))]
 fn resolve_proc_macro() {
     use expect_test::expect;
-    if skip_slow_tests() || true {
+    if skip_slow_tests() {
         return;
     }
 

--- a/crates/vfs-notify/src/lib.rs
+++ b/crates/vfs-notify/src/lib.rs
@@ -160,7 +160,7 @@ impl NotifyActor {
                                 Some((path, contents))
                             })
                             .collect();
-                        self.send(loader::Message::Loaded { files });
+                        self.send(loader::Message::Changed { files });
                     }
                 }
             }

--- a/crates/vfs/src/loader.rs
+++ b/crates/vfs/src/loader.rs
@@ -51,6 +51,8 @@ pub enum Message {
     Progress { n_total: usize, n_done: usize, config_version: u32 },
     /// The handle loaded the following files' content.
     Loaded { files: Vec<(AbsPathBuf, Option<Vec<u8>>)> },
+    /// The handle loaded the following files' content.
+    Changed { files: Vec<(AbsPathBuf, Option<Vec<u8>>)> },
 }
 
 /// Type that will receive [`Messages`](Message) from a [`Handle`].
@@ -198,6 +200,9 @@ impl fmt::Debug for Message {
         match self {
             Message::Loaded { files } => {
                 f.debug_struct("Loaded").field("n_files", &files.len()).finish()
+            }
+            Message::Changed { files } => {
+                f.debug_struct("Changed").field("n_files", &files.len()).finish()
             }
             Message::Progress { n_total, n_done, config_version } => f
                 .debug_struct("Progress")


### PR DESCRIPTION
Kind of fixes https://github.com/rust-lang/rust-analyzer/issues/14730 in a pretty bad way. We need to rethink the vfs-notify layer entirely. For a decent fix.