### PR TITLE
fix: add error recovery for use_tree_list parsing

### DIFF
--- a/crates/parser/src/grammar/items/use_item.rs
+++ b/crates/parser/src/grammar/items/use_item.rs
@@ -11,7 +11,7 @@ pub(super) fn use_(p: &mut Parser<'_>, m: Marker) {
 
 // test use_tree
 // use outer::tree::{inner::tree};
-fn use_tree(p: &mut Parser<'_>, top_level: bool) {
+fn use_tree(p: &mut Parser<'_>, top_level: bool) -> bool {
     let m = p.start();
     match p.current() {
         // test use_tree_star
@@ -70,24 +70,25 @@ fn use_tree(p: &mut Parser<'_>, top_level: bool) {
                 // main balanced `{}`
                 p.err_and_bump(msg);
             }
-            return;
+            return false;
         }
     }
     m.complete(p, USE_TREE);
+    true
 }
+
+pub(super) const USE_TREE_LIST_RECOVERY_SET: TokenSet =
+    TokenSet::new(&[T![;], T![,], T![.], T![ident]]);
 
 // test use_tree_list
 // use {a, b, c};
 pub(crate) fn use_tree_list(p: &mut Parser<'_>) {
     assert!(p.at(T!['{']));
     let m = p.start();
-    p.bump(T!['{']);
-    while !p.at(EOF) && !p.at(T!['}']) {
-        use_tree(p, false);
-        if !p.at(T!['}']) {
-            p.expect(T![,]);
-        }
-    }
-    p.expect(T!['}']);
+
+    delimited(p, T!['{'], T!['}'], T![,], USE_TREE_LIST_RECOVERY_SET, |p: &mut Parser<'_>| {
+        use_tree(p, false) || p.at_ts(USE_TREE_LIST_RECOVERY_SET)
+    });
+
     m.complete(p, USE_TREE_LIST);
 }

--- a/crates/parser/src/grammar/items/use_item.rs
+++ b/crates/parser/src/grammar/items/use_item.rs
@@ -86,6 +86,11 @@ pub(crate) fn use_tree_list(p: &mut Parser<'_>) {
     assert!(p.at(T!['{']));
     let m = p.start();
 
+    // test_err use_tree_list_err_recovery
+    // use {a;
+    // use b;
+    // struct T;
+    // fn test() {}
     delimited(p, T!['{'], T!['}'], T![,], USE_TREE_LIST_RECOVERY_SET, |p: &mut Parser<'_>| {
         use_tree(p, false) || p.at_ts(USE_TREE_LIST_RECOVERY_SET)
     });

--- a/crates/parser/test_data/parser/err/0036_partial_use.rast
+++ b/crates/parser/test_data/parser/err/0036_partial_use.rast
@@ -22,30 +22,23 @@ SOURCE_FILE
                 IDENT "Error"
         ERROR
           SEMICOLON ";"
-        WHITESPACE "\n"
-        ERROR
-          USE_KW "use"
-        WHITESPACE " "
-        USE_TREE
-          PATH
-            PATH
-              PATH_SEGMENT
-                NAME_REF
-                  IDENT "std"
-            COLON2 "::"
-            PATH_SEGMENT
-              NAME_REF
-                IDENT "io"
-        ERROR
-          SEMICOLON ";"
+  WHITESPACE "\n"
+  USE
+    USE_KW "use"
+    WHITESPACE " "
+    USE_TREE
+      PATH
+        PATH
+          PATH_SEGMENT
+            NAME_REF
+              IDENT "std"
+        COLON2 "::"
+        PATH_SEGMENT
+          NAME_REF
+            IDENT "io"
+    SEMICOLON ";"
   WHITESPACE "\n"
 error 22: expected COMMA
 error 22: expected one of `*`, `::`, `{`, `self`, `super` or an identifier
-error 23: expected COMMA
-error 24: expected one of `*`, `::`, `{`, `self`, `super` or an identifier
-error 27: expected COMMA
-error 35: expected COMMA
-error 35: expected one of `*`, `::`, `{`, `self`, `super` or an identifier
-error 36: expected COMMA
-error 36: expected R_CURLY
-error 36: expected SEMICOLON
+error 23: expected R_CURLY
+error 23: expected SEMICOLON

--- a/crates/parser/test_data/parser/inline/err/0026_use_tree_list_err_recovery.rast
+++ b/crates/parser/test_data/parser/inline/err/0026_use_tree_list_err_recovery.rast
@@ -1,0 +1,50 @@
+SOURCE_FILE
+  USE
+    USE_KW "use"
+    WHITESPACE " "
+    USE_TREE
+      USE_TREE_LIST
+        L_CURLY "{"
+        USE_TREE
+          PATH
+            PATH_SEGMENT
+              NAME_REF
+                IDENT "a"
+        ERROR
+          SEMICOLON ";"
+  WHITESPACE "\n"
+  USE
+    USE_KW "use"
+    WHITESPACE " "
+    USE_TREE
+      PATH
+        PATH_SEGMENT
+          NAME_REF
+            IDENT "b"
+    SEMICOLON ";"
+  WHITESPACE "\n"
+  STRUCT
+    STRUCT_KW "struct"
+    WHITESPACE " "
+    NAME
+      IDENT "T"
+    SEMICOLON ";"
+  WHITESPACE "\n"
+  FN
+    FN_KW "fn"
+    WHITESPACE " "
+    NAME
+      IDENT "test"
+    PARAM_LIST
+      L_PAREN "("
+      R_PAREN ")"
+    WHITESPACE " "
+    BLOCK_EXPR
+      STMT_LIST
+        L_CURLY "{"
+        R_CURLY "}"
+  WHITESPACE "\n"
+error 6: expected COMMA
+error 6: expected one of `*`, `::`, `{`, `self`, `super` or an identifier
+error 7: expected R_CURLY
+error 7: expected SEMICOLON

--- a/crates/parser/test_data/parser/inline/err/0026_use_tree_list_err_recovery.rs
+++ b/crates/parser/test_data/parser/inline/err/0026_use_tree_list_err_recovery.rs
@@ -1,0 +1,4 @@
+use {a;
+use b;
+struct T;
+fn test() {}


### PR DESCRIPTION
This PR adds error recovery for USE_TREE_LIST parsing, avoid the wrong USE_TREE_LIST making the rest parsing incorrectly.

before

![before](https://github.com/rust-lang/rust-analyzer/assets/71162630/c6643690-f25c-4ad9-93d9-e661ba5b1dc3)

after

![after](https://github.com/rust-lang/rust-analyzer/assets/71162630/30a58c40-2711-48d2-b2e5-fb208fc8636c)

close https://github.com/rust-lang/rust-analyzer/issues/16227