### PR TITLE
internal: Follow rustfmt's algorithm for ordering imports when ordering and merging use trees

### DIFF
--- a/crates/ide-assists/src/handlers/bool_to_enum.rs
+++ b/crates/ide-assists/src/handlers/bool_to_enum.rs
@@ -986,7 +986,7 @@ fn foo() {
 }
 
 //- /main.rs
-use foo::{Foo, Bool};
+use foo::{Bool, Foo};
 
 mod foo;
 
@@ -1662,7 +1662,7 @@ impl Foo {
 }
 
 //- /foo.rs
-use crate::{Foo, Bool};
+use crate::{Bool, Foo};
 
 fn foo() -> bool {
     Foo::BOOL == Bool::True

--- a/crates/ide-assists/src/handlers/merge_imports.rs
+++ b/crates/ide-assists/src/handlers/merge_imports.rs
@@ -179,7 +179,7 @@ use std::fmt::Debug;
 use std::fmt$0::Display;
 ",
             r"
-use std::fmt::{Display, Debug};
+use std::fmt::{Debug, Display};
 ",
         );
     }
@@ -206,7 +206,7 @@ use std::fmt::{self, Display};
 use std::{fmt, $0fmt::Display};
 ",
             r"
-use std::{fmt::{Display, self}};
+use std::{fmt::{self, Display}};
 ",
         );
     }
@@ -318,7 +318,7 @@ use std::{fmt::{Debug, Display}};
 use std::{fmt::Debug, fmt$0::Display};
 ",
             r"
-use std::{fmt::{Display, Debug}};
+use std::{fmt::{Debug, Display}};
 ",
         );
     }
@@ -332,7 +332,7 @@ use std$0::{fmt::{Write, Display}};
 use std::{fmt::{self, Debug}};
 ",
             r"
-use std::{fmt::{Write, Display, self, Debug}};
+use std::{fmt::{self, Debug, Display, Write}};
 ",
         );
     }
@@ -346,7 +346,7 @@ use std$0::{fmt::{self, Debug}};
 use std::{fmt::{Write, Display}};
 ",
             r"
-use std::{fmt::{self, Debug, Write, Display}};
+use std::{fmt::{self, Debug, Display, Write}};
 ",
         );
     }
@@ -359,7 +359,7 @@ use std::{fmt::{self, Debug, Write, Display}};
 use std::{fmt$0::{self, Debug}, fmt::{Write, Display}};
 ",
             r"
-use std::{fmt::{self, Debug, Write, Display}};
+use std::{fmt::{self, Debug, Display, Write}};
 ",
         );
     }
@@ -401,7 +401,7 @@ use std$0::{fmt::*};
 use std::{fmt::{self, Display}};
 ",
             r"
-use std::{fmt::{*, self, Display}};
+use std::{fmt::{self, Display, *}};
 ",
         )
     }
@@ -496,7 +496,7 @@ use foo::$0{
 ",
             r"
 use foo::{
-    FooBar, bar::baz,
+    bar::baz, FooBar
 };
 ",
         )
@@ -521,7 +521,7 @@ use foo::$0*;
 use foo::bar::Baz;
 ",
             r"
-use foo::{*, bar::Baz};
+use foo::{bar::Baz, *};
 ",
         );
     }
@@ -539,7 +539,7 @@ $0use std::fmt::Result;
 ",
             r"
 use std::fmt::Error;
-use std::fmt::{Display, Debug, Write};
+use std::fmt::{Debug, Display, Write};
 use std::fmt::Result;
 ",
         );
@@ -560,7 +560,7 @@ use std::{
             r"
 use std::{
     fmt::Error,
-    fmt::{Display, Debug, Write},
+    fmt::{Debug, Display, Write},
     fmt::Result,
 };",
         );
@@ -568,7 +568,7 @@ use std::{
         check_assist(
             merge_imports,
             r"use std::$0{fmt::Display, fmt::Debug}$0;",
-            r"use std::{fmt::{Display, Debug}};",
+            r"use std::{fmt::{Debug, Display}};",
         );
     }
 }

--- a/crates/ide-assists/src/handlers/replace_qualified_name_with_use.rs
+++ b/crates/ide-assists/src/handlers/replace_qualified_name_with_use.rs
@@ -313,7 +313,7 @@ fn main() {
     ",
             r"
 mod std { pub mod fmt { pub trait Display {} } }
-use std::fmt::{Display, self};
+use std::fmt::{self, Display};
 
 fn main() {
     fmt;

--- a/crates/ide-db/src/imports/insert_use.rs
+++ b/crates/ide-db/src/imports/insert_use.rs
@@ -382,9 +382,7 @@ fn insert_use_(
         // find the element that would come directly after our new import
         let post_insert: Option<(_, _, SyntaxNode)> = group_iter
             .inspect(|(.., node)| last = Some(node.clone()))
-            .find(|&(_, ref use_tree, _)| {
-                use_tree_cmp(&insert_use_tree, use_tree) != Ordering::Greater
-            });
+            .find(|(_, use_tree, _)| use_tree_cmp(&insert_use_tree, use_tree) != Ordering::Greater);
 
         if let Some((.., node)) = post_insert {
             cov_mark::hit!(insert_group);

--- a/crates/ide-db/src/imports/insert_use.rs
+++ b/crates/ide-db/src/imports/insert_use.rs
@@ -16,7 +16,7 @@ use syntax::{
 
 use crate::{
     imports::merge_imports::{
-        common_prefix, eq_attrs, eq_visibility, try_merge_imports, use_tree_path_cmp, MergeBehavior,
+        common_prefix, eq_attrs, eq_visibility, try_merge_imports, use_tree_cmp, MergeBehavior,
     },
     RootDatabase,
 };
@@ -357,6 +357,8 @@ fn insert_use_(
     use_item: ast::Use,
 ) {
     let scope_syntax = scope.as_syntax_node();
+    let insert_use_tree =
+        use_item.use_tree().expect("`use_item` should have a use tree for `insert_path`");
     let group = ImportGroup::new(insert_path);
     let path_node_iter = scope_syntax
         .children()
@@ -364,8 +366,7 @@ fn insert_use_(
         .flat_map(|(use_, node)| {
             let tree = use_.use_tree()?;
             let path = tree.path()?;
-            let has_tl = tree.use_tree_list().is_some();
-            Some((path, has_tl, node))
+            Some((path, tree, node))
         });
 
     if group_imports {
@@ -381,8 +382,8 @@ fn insert_use_(
         // find the element that would come directly after our new import
         let post_insert: Option<(_, _, SyntaxNode)> = group_iter
             .inspect(|(.., node)| last = Some(node.clone()))
-            .find(|&(ref path, has_tl, _)| {
-                use_tree_path_cmp(insert_path, false, path, has_tl) != Ordering::Greater
+            .find(|&(_, ref use_tree, _)| {
+                use_tree_cmp(&insert_use_tree, use_tree) != Ordering::Greater
             });
 
         if let Some((.., node)) = post_insert {

--- a/crates/ide-db/src/imports/insert_use/tests.rs
+++ b/crates/ide-db/src/imports/insert_use/tests.rs
@@ -596,7 +596,7 @@ fn merge_groups_full() {
 
 #[test]
 fn merge_groups_long_full() {
-    check_crate("std::foo::bar::Baz", r"use std::foo::bar::Qux;", r"use std::foo::bar::{Qux, Baz};")
+    check_crate("std::foo::bar::Baz", r"use std::foo::bar::Qux;", r"use std::foo::bar::{Baz, Qux};")
 }
 
 #[test]
@@ -604,7 +604,7 @@ fn merge_groups_long_last() {
     check_module(
         "std::foo::bar::Baz",
         r"use std::foo::bar::Qux;",
-        r"use std::foo::bar::{Qux, Baz};",
+        r"use std::foo::bar::{Baz, Qux};",
     )
 }
 
@@ -613,7 +613,7 @@ fn merge_groups_long_full_list() {
     check_crate(
         "std::foo::bar::Baz",
         r"use std::foo::bar::{Qux, Quux};",
-        r"use std::foo::bar::{Qux, Quux, Baz};",
+        r"use std::foo::bar::{Baz, Quux, Qux};",
     )
 }
 
@@ -622,7 +622,7 @@ fn merge_groups_long_last_list() {
     check_module(
         "std::foo::bar::Baz",
         r"use std::foo::bar::{Qux, Quux};",
-        r"use std::foo::bar::{Qux, Quux, Baz};",
+        r"use std::foo::bar::{Baz, Quux, Qux};",
     )
 }
 
@@ -631,7 +631,7 @@ fn merge_groups_long_full_nested() {
     check_crate(
         "std::foo::bar::Baz",
         r"use std::foo::bar::{Qux, quux::{Fez, Fizz}};",
-        r"use std::foo::bar::{Qux, quux::{Fez, Fizz}, Baz};",
+        r"use std::foo::bar::{quux::{Fez, Fizz}, Baz, Qux};",
     )
 }
 
@@ -650,7 +650,7 @@ fn merge_groups_full_nested_deep() {
     check_crate(
         "std::foo::bar::quux::Baz",
         r"use std::foo::bar::{Qux, quux::{Fez, Fizz}};",
-        r"use std::foo::bar::{Qux, quux::{Fez, Fizz, Baz}};",
+        r"use std::foo::bar::{Qux, quux::{Baz, Fez, Fizz}};",
     )
 }
 
@@ -659,7 +659,7 @@ fn merge_groups_full_nested_long() {
     check_crate(
         "std::foo::bar::Baz",
         r"use std::{foo::bar::Qux};",
-        r"use std::{foo::bar::{Qux, Baz}};",
+        r"use std::{foo::bar::{Baz, Qux}};",
     );
 }
 
@@ -668,7 +668,7 @@ fn merge_groups_last_nested_long() {
     check_crate(
         "std::foo::bar::Baz",
         r"use std::{foo::bar::Qux};",
-        r"use std::{foo::bar::{Qux, Baz}};",
+        r"use std::{foo::bar::{Baz, Qux}};",
     );
 }
 
@@ -733,7 +733,7 @@ fn merge_mod_into_glob() {
     check_with_config(
         "token::TokenKind",
         r"use token::TokenKind::*;",
-        r"use token::TokenKind::{*, self};",
+        r"use token::TokenKind::{self, *};",
         &InsertUseConfig {
             granularity: ImportGranularity::Crate,
             enforce_granularity: true,
@@ -742,7 +742,6 @@ fn merge_mod_into_glob() {
             skip_glob_imports: false,
         },
     )
-    // FIXME: have it emit `use token::TokenKind::{self, *}`?
 }
 
 #[test]
@@ -750,7 +749,7 @@ fn merge_self_glob() {
     check_with_config(
         "self",
         r"use self::*;",
-        r"use self::{*, self};",
+        r"use self::{self, *};",
         &InsertUseConfig {
             granularity: ImportGranularity::Crate,
             enforce_granularity: true,
@@ -759,7 +758,6 @@ fn merge_self_glob() {
             skip_glob_imports: false,
         },
     )
-    // FIXME: have it emit `use {self, *}`?
 }
 
 #[test]
@@ -769,7 +767,7 @@ fn merge_glob() {
         r"
 use syntax::{SyntaxKind::*};",
         r"
-use syntax::{SyntaxKind::{*, self}};",
+use syntax::{SyntaxKind::{self, *}};",
     )
 }
 
@@ -778,7 +776,7 @@ fn merge_glob_nested() {
     check_crate(
         "foo::bar::quux::Fez",
         r"use foo::bar::{Baz, quux::*};",
-        r"use foo::bar::{Baz, quux::{*, Fez}};",
+        r"use foo::bar::{Baz, quux::{Fez, *}};",
     )
 }
 
@@ -787,7 +785,7 @@ fn merge_nested_considers_first_segments() {
     check_crate(
         "hir_ty::display::write_bounds_like_dyn_trait",
         r"use hir_ty::{autoderef, display::{HirDisplayError, HirFormatter}, method_resolution};",
-        r"use hir_ty::{autoderef, display::{HirDisplayError, HirFormatter, write_bounds_like_dyn_trait}, method_resolution};",
+        r"use hir_ty::{autoderef, display::{write_bounds_like_dyn_trait, HirDisplayError, HirFormatter}, method_resolution};",
     );
 }
 

--- a/crates/ide-db/src/imports/merge_imports.rs
+++ b/crates/ide-db/src/imports/merge_imports.rs
@@ -263,7 +263,7 @@ fn use_tree_cmp_bin_search(lhs: &ast::UseTree, rhs: &ast::UseTree) -> Ordering {
         (Some(_), None) => Ordering::Greater,
         (None, Some(_)) if !lhs_is_simple_path => Ordering::Greater,
         (None, Some(_)) => Ordering::Less,
-        (Some(ref a), Some(ref b)) => path_segment_cmp(a, b),
+        (Some(a), Some(b)) => path_segment_cmp(&a, &b),
     }
 }
 
@@ -287,15 +287,15 @@ pub(super) fn use_tree_cmp(a: &ast::UseTree, b: &ast::UseTree) -> Ordering {
         (Some(_), None) => Ordering::Greater,
         (None, Some(_)) if !a_is_simple_path => Ordering::Greater,
         (None, Some(_)) => Ordering::Less,
-        (Some(ref a_path), Some(ref b_path)) => {
+        (Some(a_path), Some(b_path)) => {
             // cmp_by would be useful for us here but that is currently unstable
             // cmp doesn't work due the lifetimes on text's return type
             a_path
                 .segments()
                 .zip_longest(b_path.segments())
                 .find_map(|zipped| match zipped {
-                    EitherOrBoth::Both(ref a_segment, ref b_segment) => {
-                        match path_segment_cmp(a_segment, b_segment) {
+                    EitherOrBoth::Both(a_segment, b_segment) => {
+                        match path_segment_cmp(&a_segment, &b_segment) {
                             Ordering::Equal => None,
                             ord => Some(ord),
                         }
@@ -409,7 +409,7 @@ fn use_tree_cmp_by_tree_list_glob_or_alias(
             .use_trees()
             .zip_longest(b_list.use_trees())
             .find_map(|zipped| match zipped {
-                EitherOrBoth::Both(ref a_tree, ref b_tree) => match use_tree_cmp(a_tree, b_tree) {
+                EitherOrBoth::Both(a_tree, b_tree) => match use_tree_cmp(&a_tree, &b_tree) {
                     Ordering::Equal => None,
                     ord => Some(ord),
                 },

--- a/crates/ide-db/src/imports/merge_imports.rs
+++ b/crates/ide-db/src/imports/merge_imports.rs
@@ -4,6 +4,7 @@ use std::iter::empty;
 
 use itertools::{EitherOrBoth, Itertools};
 use parser::T;
+use stdx::is_upper_snake_case;
 use syntax::{
     algo,
     ast::{self, make, AstNode, HasAttrs, HasName, HasVisibility, PathSegmentKind},
@@ -340,9 +341,6 @@ fn path_segment_cmp(a: &ast::PathSegment, b: &ast::PathSegment) -> Ordering {
                     // snake_case < CamelCase < UPPER_SNAKE_CASE
                     let a_text = a_name.as_str();
                     let b_text = b_name.as_str();
-                    fn is_upper_snake_case(s: &str) -> bool {
-                        s.chars().all(|c| c.is_uppercase() || c == '_' || c.is_numeric())
-                    }
                     if a_text.starts_with(char::is_lowercase)
                         && b_text.starts_with(char::is_uppercase)
                     {

--- a/crates/stdx/src/lib.rs
+++ b/crates/stdx/src/lib.rs
@@ -171,6 +171,10 @@ pub fn char_has_case(c: char) -> bool {
     c.is_lowercase() || c.is_uppercase()
 }
 
+pub fn is_upper_snake_case(s: &str) -> bool {
+    s.chars().all(|c| c.is_uppercase() || c == '_' || c.is_numeric())
+}
+
 pub fn replace(buf: &mut String, from: char, to: &str) {
     if !buf.contains(from) {
         return;


### PR DESCRIPTION
Updates use tree ordering and merging utilities to follow rustfmt's algorithm for ordering imports.
The [rustfmt implementation](https://github.com/rust-lang/rustfmt/blob/6356fca675bd756d71f5c123cd053d17b16c573e/src/imports.rs) was used as reference.