### PR TITLE
Add a stable #visual-studio anchor to the Manual

### DIFF
--- a/docs/user/manual.adoc
+++ b/docs/user/manual.adoc
@@ -512,7 +512,8 @@ https://docs.helix-editor.com/[Helix] supports LSP by default.
 However, it won't install `rust-analyzer` automatically.
 You can follow instructions for installing <<rust-analyzer-language-server-binary,`rust-analyzer` binary>>.
 
-=== Visual Studio 2022
+[#visual-studio]
+=== [[visual-studio-2022]]Visual Studio 2022
 
 There are multiple rust-analyzer extensions for Visual Studio 2022 on Windows:
 


### PR DESCRIPTION
Helpful for https://github.com/rust-lang/www.rust-lang.org/pull/1915 so we have a persistent place to link as "Visual Studio" from the Rust website.

Syntax reference: https://docs.asciidoctor.org/asciidoc/latest/sections/custom-ids/#assign-auxiliary-ids