### PR TITLE
Add a new config to allow renaming of non-local defs

### DIFF
--- a/crates/ide-db/src/rename.rs
+++ b/crates/ide-db/src/rename.rs
@@ -71,14 +71,17 @@ impl Definition {
         &self,
         sema: &Semantics<'_, RootDatabase>,
         new_name: &str,
+        rename_external: bool,
     ) -> Result<SourceChange> {
         // self.krate() returns None if
         // self is a built-in attr, built-in type or tool module.
         // it is not allowed for these defs to be renamed.
         // cases where self.krate() is None is handled below.
         if let Some(krate) = self.krate(sema.db) {
-            if !krate.origin(sema.db).is_local() {
-                bail!("Cannot rename a non-local definition.")
+            // Can we not rename non-local items?
+            // Then bail if non-local
+            if !rename_external && !krate.origin(sema.db).is_local() {
+                bail!("Cannot rename a non-local definition. Set `renameExternalItems` to `true` to allow renaming for this item.")
             }
         }
 

--- a/crates/ide-diagnostics/src/handlers/incorrect_case.rs
+++ b/crates/ide-diagnostics/src/handlers/incorrect_case.rs
@@ -43,7 +43,7 @@ fn fixes(ctx: &DiagnosticsContext<'_>, d: &hir::IncorrectCase) -> Option<Vec<Ass
     let label = format!("Rename to {}", d.suggested_text);
     let mut res = unresolved_fix("change_case", &label, frange.range);
     if ctx.resolve.should_resolve(&res.id) {
-        let source_change = def.rename(&ctx.sema, &d.suggested_text);
+        let source_change = def.rename(&ctx.sema, &d.suggested_text, true);
         res.source_change = Some(source_change.ok().unwrap_or_default());
     }
 

--- a/crates/ide/src/lib.rs
+++ b/crates/ide/src/lib.rs
@@ -680,8 +680,9 @@ impl Analysis {
         &self,
         position: FilePosition,
         new_name: &str,
+        rename_external: bool,
     ) -> Cancellable<Result<SourceChange, RenameError>> {
-        self.with_db(|db| rename::rename(db, position, new_name))
+        self.with_db(|db| rename::rename(db, position, new_name, rename_external))
     }
 
     pub fn prepare_rename(

--- a/crates/ide/src/rename.rs
+++ b/crates/ide/src/rename.rs
@@ -84,6 +84,7 @@ pub(crate) fn rename(
     db: &RootDatabase,
     position: FilePosition,
     new_name: &str,
+    rename_external: bool,
 ) -> RenameResult<SourceChange> {
     let sema = Semantics::new(db);
     let source_file = sema.parse(position.file_id);
@@ -103,7 +104,7 @@ pub(crate) fn rename(
                     return rename_to_self(&sema, local);
                 }
             }
-            def.rename(&sema, new_name)
+            def.rename(&sema, new_name, rename_external)
         })
         .collect();
 
@@ -122,9 +123,9 @@ pub(crate) fn will_rename_file(
     let module = sema.to_module_def(file_id)?;
     let def = Definition::Module(module);
     let mut change = if is_raw_identifier(new_name_stem) {
-        def.rename(&sema, &SmolStr::from_iter(["r#", new_name_stem])).ok()?
+        def.rename(&sema, &SmolStr::from_iter(["r#", new_name_stem]), true).ok()?
     } else {
-        def.rename(&sema, new_name_stem).ok()?
+        def.rename(&sema, new_name_stem, true).ok()?
     };
     change.file_system_edits.clear();
     Some(change)
@@ -375,8 +376,17 @@ mod tests {
 
     use super::{RangeInfo, RenameError};
 
-    #[track_caller]
     fn check(new_name: &str, ra_fixture_before: &str, ra_fixture_after: &str) {
+        check_with_rename_config(new_name, ra_fixture_before, ra_fixture_after, true);
+    }
+
+    #[track_caller]
+    fn check_with_rename_config(
+        new_name: &str,
+        ra_fixture_before: &str,
+        ra_fixture_after: &str,
+        rename_external: bool,
+    ) {
         let ra_fixture_after = &trim_indent(ra_fixture_after);
         let (analysis, position) = fixture::position(ra_fixture_before);
         if !ra_fixture_after.starts_with("error: ") {
@@ -385,7 +395,7 @@ mod tests {
             }
         }
         let rename_result = analysis
-            .rename(position, new_name)
+            .rename(position, new_name, rename_external)
             .unwrap_or_else(|err| panic!("Rename to '{new_name}' was cancelled: {err}"));
         match rename_result {
             Ok(source_change) => {
@@ -417,8 +427,10 @@ mod tests {
 
     fn check_expect(new_name: &str, ra_fixture: &str, expect: Expect) {
         let (analysis, position) = fixture::position(ra_fixture);
-        let source_change =
-            analysis.rename(position, new_name).unwrap().expect("Expect returned a RenameError");
+        let source_change = analysis
+            .rename(position, new_name, true)
+            .unwrap()
+            .expect("Expect returned a RenameError");
         expect.assert_eq(&filter_expect(source_change))
     }
 
@@ -2617,6 +2629,18 @@ use qux as frob;
 
     #[test]
     fn disallow_renaming_for_non_local_definition() {
+        check_with_rename_config(
+            "Baz",
+            r#"
+//- /lib.rs crate:lib new_source_root:library
+pub struct S;
+//- /main.rs crate:main deps:lib new_source_root:local
+use lib::S$0;
+"#,
+            "error: Cannot rename a non-local definition. Set `renameExternalItems` to `true` to allow renaming for this item.",
+            false,
+        );
+
         check(
             "Baz",
             r#"
@@ -2625,13 +2649,13 @@ pub struct S;
 //- /main.rs crate:main deps:lib new_source_root:local
 use lib::S$0;
 "#,
-            "error: Cannot rename a non-local definition.",
+            "use lib::Baz;",
         );
     }
 
     #[test]
     fn disallow_renaming_for_builtin_macros() {
-        check(
+        check_with_rename_config(
             "Baz",
             r#"
 //- minicore: derive, hash
@@ -2640,8 +2664,9 @@ use core::hash::Hash;
 #[derive(H$0ash)]
 struct A;
             "#,
-            "error: Cannot rename a non-local definition.",
-        )
+            "error: Cannot rename a non-local definition. Set `renameExternalItems` to `true` to allow renaming for this item.",
+            false,
+        );
     }
 
     #[test]

--- a/crates/ide/src/rename.rs
+++ b/crates/ide/src/rename.rs
@@ -372,7 +372,7 @@ mod tests {
     use test_utils::assert_eq_text;
     use text_edit::TextEdit;
 
-    use crate::{fixture, FileId};
+    use crate::fixture;
 
     use super::{RangeInfo, RenameError};
 
@@ -400,18 +400,17 @@ mod tests {
         match rename_result {
             Ok(source_change) => {
                 let mut text_edit_builder = TextEdit::builder();
-                let mut file_id: Option<FileId> = None;
-                for edit in source_change.source_file_edits {
-                    file_id = Some(edit.0);
-                    for indel in edit.1 .0.into_iter() {
-                        text_edit_builder.replace(indel.delete, indel.insert);
-                    }
+                let (&file_id, edit) = match source_change.source_file_edits.len() {
+                    0 => return,
+                    1 => source_change.source_file_edits.iter().next().unwrap(),
+                    _ => (&position.file_id, &source_change.source_file_edits[&position.file_id]),
+                };
+                for indel in edit.0.iter() {
+                    text_edit_builder.replace(indel.delete, indel.insert.clone());
                 }
-                if let Some(file_id) = file_id {
-                    let mut result = analysis.file_text(file_id).unwrap().to_string();
-                    text_edit_builder.finish().apply(&mut result);
-                    assert_eq_text!(ra_fixture_after, &*result);
-                }
+                let mut result = analysis.file_text(file_id).unwrap().to_string();
+                text_edit_builder.finish().apply(&mut result);
+                assert_eq_text!(ra_fixture_after, &*result);
             }
             Err(err) => {
                 if ra_fixture_after.starts_with("error:") {
@@ -2649,7 +2648,7 @@ pub struct S;
 //- /main.rs crate:main deps:lib new_source_root:local
 use lib::S$0;
 "#,
-            "use lib::Baz;",
+            "use lib::Baz;\n",
         );
     }
 

--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -494,6 +494,9 @@ config_data! {
         /// Exclude imports from find-all-references.
         references_excludeImports: bool = "false",
 
+        /// Allow renaming of items not belonging to any workspace crates.
+        renameExternalItems_enable : bool = "false",
+
         /// Command to be executed instead of 'cargo' for runnables.
         runnables_command: Option<String> = "null",
         /// Additional arguments to be passed to cargo for runnables such as
@@ -1737,6 +1740,10 @@ impl Config {
 
     pub fn typing_autoclose_angle(&self) -> bool {
         self.data.typing_autoClosingAngleBrackets_enable
+    }
+
+    pub fn rename(&self) -> bool {
+        self.data.renameExternalItems_enable
     }
 
     // FIXME: VSCode seems to work wrong sometimes, see https://github.com/microsoft/vscode/issues/193124

--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -494,8 +494,9 @@ config_data! {
         /// Exclude imports from find-all-references.
         references_excludeImports: bool = "false",
 
-        /// Allow renaming of items not belonging to any workspace crates.
-        renameExternalItems_enable : bool = "false",
+        /// Allow renaming of items not belonging to the loaded workspaces.
+        rename_allowExternalItems: bool = "false",
+
 
         /// Command to be executed instead of 'cargo' for runnables.
         runnables_command: Option<String> = "null",
@@ -1743,7 +1744,7 @@ impl Config {
     }
 
     pub fn rename(&self) -> bool {
-        self.data.renameExternalItems_enable
+        self.data.rename_allowExternalItems
     }
 
     // FIXME: VSCode seems to work wrong sometimes, see https://github.com/microsoft/vscode/issues/193124

--- a/crates/rust-analyzer/src/handlers/request.rs
+++ b/crates/rust-analyzer/src/handlers/request.rs
@@ -1017,8 +1017,10 @@ pub(crate) fn handle_rename(
     let _p = profile::span("handle_rename");
     let position = from_proto::file_position(&snap, params.text_document_position)?;
 
-    let mut change =
-        snap.analysis.rename(position, &params.new_name)?.map_err(to_proto::rename_error)?;
+    let mut change = snap
+        .analysis
+        .rename(position, &params.new_name, snap.config.rename())?
+        .map_err(to_proto::rename_error)?;
 
     // this is kind of a hack to prevent double edits from happening when moving files
     // When a module gets renamed by renaming the mod declaration this causes the file to move

--- a/docs/user/generated_config.adoc
+++ b/docs/user/generated_config.adoc
@@ -777,6 +777,11 @@ Internal config, path to proc-macro server executable.
 --
 Exclude imports from find-all-references.
 --
+[[rust-analyzer.renameExternalItems.enable]]rust-analyzer.renameExternalItems.enable (default: `false`)::
++
+--
+Allow renaming of items not belonging to any workspace crates.
+--
 [[rust-analyzer.runnables.command]]rust-analyzer.runnables.command (default: `null`)::
 +
 --

--- a/docs/user/generated_config.adoc
+++ b/docs/user/generated_config.adoc
@@ -777,10 +777,10 @@ Internal config, path to proc-macro server executable.
 --
 Exclude imports from find-all-references.
 --
-[[rust-analyzer.renameExternalItems.enable]]rust-analyzer.renameExternalItems.enable (default: `false`)::
+[[rust-analyzer.rename.allowExternalItems]]rust-analyzer.rename.allowExternalItems (default: `false`)::
 +
 --
-Allow renaming of items not belonging to any workspace crates.
+Allow renaming of items not belonging to the loaded workspaces.
 --
 [[rust-analyzer.runnables.command]]rust-analyzer.runnables.command (default: `null`)::
 +

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -1503,6 +1503,11 @@
                     "default": false,
                     "type": "boolean"
                 },
+                "rust-analyzer.renameExternalItems.enable": {
+                    "markdownDescription": "Allow renaming of items not belonging to any workspace crates.",
+                    "default": false,
+                    "type": "boolean"
+                },
                 "rust-analyzer.runnables.command": {
                     "markdownDescription": "Command to be executed instead of 'cargo' for runnables.",
                     "default": null,

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -1503,8 +1503,8 @@
                     "default": false,
                     "type": "boolean"
                 },
-                "rust-analyzer.renameExternalItems.enable": {
-                    "markdownDescription": "Allow renaming of items not belonging to any workspace crates.",
+                "rust-analyzer.rename.allowExternalItems": {
+                    "markdownDescription": "Allow renaming of items not belonging to the loaded workspaces.",
                     "default": false,
                     "type": "boolean"
                 },


### PR DESCRIPTION
With #15656 we started disallowing renaming of non-local items. Although this makes sense there are some false positives that impacted users' workflows. So this config aims to mitigate this by giving users the liberty to disable this feature.

The reason why this is a draft is that I saw one of the tests fail and I am not sure if the "got" result even syntactically makes sense 

Test case is :

```rust
check(
            "Baz",
            r#"
//- /lib.rs crate:lib new_source_root:library
pub struct S;
//- /main.rs crate:main deps:lib new_source_root:local
use lib::S$0;
"#,
            "use lib::Baz;"
);
```

```
Left:
use lib::Baz;

Right:
use lib::Baz;Baz

Diff:
use lib::Baz;Baz
```
