### PR TITLE
fix panic with reference in macro

### DIFF
--- a/crates/ide-assists/src/handlers/extract_struct_from_enum_variant.rs
+++ b/crates/ide-assists/src/handlers/extract_struct_from_enum_variant.rs
@@ -414,9 +414,8 @@ fn reference_to_node(
         reference.name.as_name_ref()?.syntax().parent().and_then(ast::PathSegment::cast)?;
 
     // filter out the reference in marco
-    let s_range = segment.syntax().text_range();
-    let origin_range = sema.original_range(segment.syntax()).range;
-    if s_range != origin_range {
+    let segment_range = segment.syntax().text_range();
+    if segment_range != reference.range {
         return None;
     }
 

--- a/crates/ide-assists/src/handlers/extract_struct_from_enum_variant.rs
+++ b/crates/ide-assists/src/handlers/extract_struct_from_enum_variant.rs
@@ -412,6 +412,14 @@ fn reference_to_node(
 ) -> Option<(ast::PathSegment, SyntaxNode, hir::Module)> {
     let segment =
         reference.name.as_name_ref()?.syntax().parent().and_then(ast::PathSegment::cast)?;
+
+    // filter out the reference in marco
+    let s_range = segment.syntax().text_range();
+    let origin_range = sema.original_range(segment.syntax()).range;
+    if s_range != origin_range {
+        return None;
+    }
+
     let parent = segment.parent_path().syntax().parent()?;
     let expr_or_pat = match_ast! {
         match parent {

--- a/crates/ide-assists/src/handlers/extract_struct_from_enum_variant.rs
+++ b/crates/ide-assists/src/handlers/extract_struct_from_enum_variant.rs
@@ -441,6 +441,45 @@ mod tests {
     use super::*;
 
     #[test]
+    fn test_with_marco() {
+        check_assist(
+            extract_struct_from_enum_variant,
+            r#"
+macro_rules! foo {
+    ($x:expr) => {
+        $x
+    };
+}
+
+enum TheEnum {
+    TheVariant$0 { the_field: u8 },
+}
+
+fn main() {
+    foo![TheEnum::TheVariant { the_field: 42 }];
+}
+"#,
+            r#"
+macro_rules! foo {
+    ($x:expr) => {
+        $x
+    };
+}
+
+struct TheVariant{ the_field: u8 }
+
+enum TheEnum {
+    TheVariant(TheVariant),
+}
+
+fn main() {
+    foo![TheEnum::TheVariant { the_field: 42 }];
+}
+"#,
+        );
+    }
+
+    #[test]
     fn issue_16197() {
         check_assist(
             extract_struct_from_enum_variant,


### PR DESCRIPTION
it panic at `builder.make_mut(segment)`, where segment is from macro expand. And the usage reference in orginal macro call isn't a `PathSegment` so we can't update it in `apply_references`, I can't find a way to deal with it properly so here just filter out the reference in macro. LMK if there are better way to fix this

try to close https://github.com/rust-lang/rust-analyzer/issues/16328