### PR TITLE
Update bail message referencing config

### DIFF
--- a/crates/ide-db/src/rename.rs
+++ b/crates/ide-db/src/rename.rs
@@ -81,7 +81,7 @@ impl Definition {
             // Can we not rename non-local items?
             // Then bail if non-local
             if !rename_external && !krate.origin(sema.db).is_local() {
-                bail!("Cannot rename a non-local definition. Set `renameExternalItems` to `true` to allow renaming for this item.")
+                bail!("Cannot rename a non-local definition. Set `rename_allowExternalItems` to `true` to allow renaming for this item.")
             }
         }
 

--- a/crates/ide-db/src/rename.rs
+++ b/crates/ide-db/src/rename.rs
@@ -81,7 +81,7 @@ impl Definition {
             // Can we not rename non-local items?
             // Then bail if non-local
             if !rename_external && !krate.origin(sema.db).is_local() {
-                bail!("Cannot rename a non-local definition. Set `rename_allowExternalItems` to `true` to allow renaming for this item.")
+                bail!("Cannot rename a non-local definition as the config for it is disabled")
             }
         }
 

--- a/crates/ide/src/rename.rs
+++ b/crates/ide/src/rename.rs
@@ -2636,7 +2636,7 @@ pub struct S;
 //- /main.rs crate:main deps:lib new_source_root:local
 use lib::S$0;
 "#,
-            "error: Cannot rename a non-local definition. Set `renameExternalItems` to `true` to allow renaming for this item.",
+            "error: Cannot rename a non-local definition as the config for it is disabled",
             false,
         );
 
@@ -2663,7 +2663,7 @@ use core::hash::Hash;
 #[derive(H$0ash)]
 struct A;
             "#,
-            "error: Cannot rename a non-local definition. Set `renameExternalItems` to `true` to allow renaming for this item.",
+            "error: Cannot rename a non-local definition as the config for it is disabled",
             false,
         );
     }


### PR DESCRIPTION
Even though we changed the name of the config I forgot to update the warning message that referenced it.