### PR TITLE
internal: add `max_line_length` to `.editorconfig`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,6 +8,7 @@ end_of_line = lf
 insert_final_newline = true
 indent_style = space
 indent_size = 4
+max_line_length = 100
 
 [*.md]
 indent_size = 2


### PR DESCRIPTION
This helps with setting proper visual guides/rulers for the right margin in some editors/IDEs (e.g. CLion)