### PR TITLE
fix: filter out cfg disabled filed when lowering `RecordPat`

### DIFF
--- a/crates/hir-def/src/body/lower.rs
+++ b/crates/hir-def/src/body/lower.rs
@@ -1335,6 +1335,7 @@ impl ExprCollector<'_> {
                 let args = record_pat_field_list
                     .fields()
                     .filter_map(|f| {
+                        self.check_cfg(&f)?;
                         let ast_pat = f.pat()?;
                         let pat = self.collect_pat(ast_pat, binding_list);
                         let name = f.field_name()?.as_name();

--- a/crates/ide-diagnostics/src/handlers/no_such_field.rs
+++ b/crates/ide-diagnostics/src/handlers/no_such_field.rs
@@ -129,6 +129,36 @@ mod tests {
     use crate::tests::{check_diagnostics, check_fix, check_no_fix};
 
     #[test]
+    fn dont_work_for_field_with_disabled_cfg() {
+        check_diagnostics(
+            r#"
+struct Test {
+    #[cfg(feature = "hello")]
+    test: u32,
+    other: u32
+}
+
+fn main() {
+    let a = Test {
+        #[cfg(feature = "hello")]
+        test: 1,
+        other: 1
+    };
+
+    let Test {
+        #[cfg(feature = "hello")]
+        test,
+        mut other,
+        ..
+    } = a;
+
+    other += 1;
+}
+"#,
+        );
+    }
+
+    #[test]
     fn no_such_field_diagnostics() {
         check_diagnostics(
             r#"


### PR DESCRIPTION
we should filter out field with disabled cfg when lowering ast `RecordPat` to hir.

close https://github.com/rust-lang/rust-analyzer/issues/16169