### PR TITLE
feat: enable excluding refs search results in test

### DIFF
--- a/crates/ide-db/src/search.rs
+++ b/crates/ide-db/src/search.rs
@@ -15,10 +15,7 @@ use memchr::memmem::Finder;
 use nohash_hasher::IntMap;
 use once_cell::unsync::Lazy;
 use parser::SyntaxKind;
-use syntax::{
-    ast::{self, HasAttrs as _},
-    match_ast, AstNode, AstToken, SyntaxElement, TextRange, TextSize,
-};
+use syntax::{ast, match_ast, AstNode, AstToken, SyntaxElement, TextRange, TextSize};
 use triomphe::Arc;
 
 use crate::{
@@ -747,7 +744,7 @@ impl<'a> FindUsages<'a> {
                 let reference = FileReference {
                     range,
                     name: FileReferenceNode::NameRef(name_ref.clone()),
-                    category: ReferenceCategory::new(&def, name_ref),
+                    category: ReferenceCategory::new(self.sema, &def, name_ref),
                 };
                 sink(file_id, reference)
             }
@@ -763,7 +760,7 @@ impl<'a> FindUsages<'a> {
                 let reference = FileReference {
                     range,
                     name: FileReferenceNode::NameRef(name_ref.clone()),
-                    category: ReferenceCategory::new(&def, name_ref),
+                    category: ReferenceCategory::new(self.sema, &def, name_ref),
                 };
                 sink(file_id, reference)
             }
@@ -773,7 +770,7 @@ impl<'a> FindUsages<'a> {
                     let reference = FileReference {
                         range,
                         name: FileReferenceNode::NameRef(name_ref.clone()),
-                        category: ReferenceCategory::new(&def, name_ref),
+                        category: ReferenceCategory::new(self.sema, &def, name_ref),
                     };
                     sink(file_id, reference)
                 } else {
@@ -787,10 +784,10 @@ impl<'a> FindUsages<'a> {
                 let local = Definition::Local(local);
                 let access = match self.def {
                     Definition::Field(_) if field == self.def => {
-                        ReferenceCategory::new(&field, name_ref)
+                        ReferenceCategory::new(self.sema, &field, name_ref)
                     }
                     Definition::Local(_) if local == self.def => {
-                        ReferenceCategory::new(&local, name_ref)
+                        ReferenceCategory::new(self.sema, &local, name_ref)
                     }
                     _ => return false,
                 };
@@ -875,8 +872,12 @@ fn def_to_ty(sema: &Semantics<'_, RootDatabase>, def: &Definition) -> Option<hir
 }
 
 impl ReferenceCategory {
-    fn new(def: &Definition, r: &ast::NameRef) -> Option<ReferenceCategory> {
-        if is_name_ref_in_test(r) {
+    fn new(
+        sema: &Semantics<'_, RootDatabase>,
+        def: &Definition,
+        r: &ast::NameRef,
+    ) -> Option<ReferenceCategory> {
+        if is_name_ref_in_test(sema, r) {
             return Some(ReferenceCategory::Test);
         }
 
@@ -919,29 +920,9 @@ fn is_name_ref_in_import(name_ref: &ast::NameRef) -> bool {
         .map_or(false, |it| it.kind() == SyntaxKind::USE_TREE)
 }
 
-fn is_name_ref_in_test(name_ref: &ast::NameRef) -> bool {
-    let mode = name_ref.syntax().ancestors().find_map(|node| {
-        match_ast! {
-            match node {
-                ast::Fn(f) => {
-                    let attrs = f.attrs();
-                    let mut is_test = false;
-                    for attr in attrs {
-                        if attr.to_string() == "#[test]" {
-                            is_test = true;
-                            break;
-                        }
-                    }
-                    if is_test {
-                        Some(ReferenceCategory::Test)
-                    }
-                    else {
-                        None
-                    }
-                },
-                _ => None
-            }
-        }
-    });
-    mode.is_some()
+fn is_name_ref_in_test(sema: &Semantics<'_, RootDatabase>, name_ref: &ast::NameRef) -> bool {
+    name_ref.syntax().ancestors().any(|node| match ast::Fn::cast(node) {
+        Some(it) => sema.to_def(&it).map_or(false, |func| func.is_test(sema.db)),
+        None => false,
+    })
 }

--- a/crates/ide/src/highlight_related.rs
+++ b/crates/ide/src/highlight_related.rs
@@ -519,6 +519,7 @@ mod tests {
                             ReferenceCategory::Read => "read",
                             ReferenceCategory::Write => "write",
                             ReferenceCategory::Import => "import",
+                            ReferenceCategory::Test => "test",
                         }
                         .to_string()
                     }),

--- a/crates/ide/src/references.rs
+++ b/crates/ide/src/references.rs
@@ -454,6 +454,7 @@ fn main() {
             "#]],
         );
     }
+
     #[test]
     fn test_variant_tuple_before_paren() {
         check(
@@ -1435,7 +1436,7 @@ fn test$0() {
             expect![[r#"
                 test Function FileId(0) 0..33 11..15
 
-                FileId(0) 24..28
+                FileId(0) 24..28 Test
             "#]],
         );
     }

--- a/crates/ide/src/references.rs
+++ b/crates/ide/src/references.rs
@@ -308,6 +308,30 @@ mod tests {
     use crate::{fixture, SearchScope};
 
     #[test]
+    fn exclude_tests() {
+        check(
+            r#"
+fn test_func() {}
+
+fn func() {
+    test_func$0();
+}
+
+#[test]
+fn test() {
+    test_func();
+}
+"#,
+            expect![[r#"
+                test_func Function FileId(0) 0..17 3..12
+
+                FileId(0) 35..44
+                FileId(0) 75..84 Test
+            "#]],
+        );
+    }
+
+    #[test]
     fn test_struct_literal_after_space() {
         check(
             r#"

--- a/crates/ide/src/references.rs
+++ b/crates/ide/src/references.rs
@@ -329,6 +329,27 @@ fn test() {
                 FileId(0) 75..84 Test
             "#]],
         );
+
+        check(
+            r#"
+fn test_func() {}
+
+fn func() {
+    test_func$0();
+}
+
+#[::core::prelude::v1::test]
+fn test() {
+    test_func();
+}
+"#,
+            expect![[r#"
+                test_func Function FileId(0) 0..17 3..12
+
+                FileId(0) 35..44
+                FileId(0) 96..105 Test
+            "#]],
+        );
     }
 
     #[test]

--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -494,6 +494,9 @@ config_data! {
         /// Exclude imports from find-all-references.
         references_excludeImports: bool = "false",
 
+        /// Exclude tests from find-all-references.
+        references_excludeTests: bool = "false",
+
         /// Allow renaming of items not belonging to the loaded workspaces.
         rename_allowExternalItems: bool = "false",
 
@@ -1543,6 +1546,10 @@ impl Config {
 
     pub fn find_all_refs_exclude_imports(&self) -> bool {
         self.data.references_excludeImports
+    }
+
+    pub fn find_all_refs_exclude_tests(&self) -> bool {
+        self.data.references_excludeTests
     }
 
     pub fn snippet_cap(&self) -> bool {

--- a/crates/rust-analyzer/src/handlers/request.rs
+++ b/crates/rust-analyzer/src/handlers/request.rs
@@ -1055,6 +1055,7 @@ pub(crate) fn handle_references(
     let position = from_proto::file_position(&snap, params.text_document_position)?;
 
     let exclude_imports = snap.config.find_all_refs_exclude_imports();
+    let exclude_tests = snap.config.find_all_refs_exclude_tests();
 
     let refs = match snap.analysis.find_all_refs(position, None)? {
         None => return Ok(None),
@@ -1078,7 +1079,8 @@ pub(crate) fn handle_references(
                 .flat_map(|(file_id, refs)| {
                     refs.into_iter()
                         .filter(|&(_, category)| {
-                            !exclude_imports || category != Some(ReferenceCategory::Import)
+                            (!exclude_imports || category != Some(ReferenceCategory::Import))
+                                && (!exclude_tests || category != Some(ReferenceCategory::Test))
                         })
                         .map(move |(range, _)| FileRange { file_id, range })
                 })

--- a/crates/rust-analyzer/src/lsp/to_proto.rs
+++ b/crates/rust-analyzer/src/lsp/to_proto.rs
@@ -92,6 +92,7 @@ pub(crate) fn document_highlight_kind(
         ReferenceCategory::Read => Some(lsp_types::DocumentHighlightKind::READ),
         ReferenceCategory::Write => Some(lsp_types::DocumentHighlightKind::WRITE),
         ReferenceCategory::Import => None,
+        ReferenceCategory::Test => None,
     }
 }
 

--- a/docs/user/generated_config.adoc
+++ b/docs/user/generated_config.adoc
@@ -777,6 +777,11 @@ Internal config, path to proc-macro server executable.
 --
 Exclude imports from find-all-references.
 --
+[[rust-analyzer.references.excludeTests]]rust-analyzer.references.excludeTests (default: `false`)::
++
+--
+Exclude tests from find-all-references.
+--
 [[rust-analyzer.rename.allowExternalItems]]rust-analyzer.rename.allowExternalItems (default: `false`)::
 +
 --

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -1505,6 +1505,11 @@
                     "default": false,
                     "type": "boolean"
                 },
+                "rust-analyzer.references.excludeTests": {
+                    "markdownDescription": "Exclude tests from find-all-references.",
+                    "default": false,
+                    "type": "boolean"
+                },
                 "rust-analyzer.rename.allowExternalItems": {
                     "markdownDescription": "Allow renaming of items not belonging to the loaded workspaces.",
                     "default": false,


### PR DESCRIPTION
## Change

Here I introduce a new `ReferenceCategory::Test` type to indicate whether the function where this reference is located is marked as `#[test]`, and expose an config item (`rust-analyzer.references.excludeTests`) to client.

I also changed the signature of `ReferenceCategory::new`, adding a `sema: &Semantics<'_, RootDatabase>` param to do some hir analysis. Hope the current implementation is good to go.

## Demo

`"rust-analyzer.references.excludeTests": false`

![include](https://github.com/rust-lang/rust-analyzer/assets/71162630/9f1176d4-7b41-4f49-ac79-55d25a42d5d1)

`"rust-analyzer.references.excludeTests": true`

![exclude](https://github.com/rust-lang/rust-analyzer/assets/71162630/2938b44b-9e5b-48de-a049-453f5bbc09d0)

close https://github.com/rust-lang/rust-analyzer/issues/14530