### PR TITLE
Implement `literal_from_str` for proc macro server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1331,6 +1331,7 @@ dependencies = [
  "proc-macro-test",
  "span",
  "stdx",
+ "syntax",
  "tt",
 ]
 

--- a/crates/proc-macro-srv/Cargo.toml
+++ b/crates/proc-macro-srv/Cargo.toml
@@ -29,6 +29,7 @@ paths.workspace = true
 base-db.workspace = true
 span.workspace = true
 proc-macro-api.workspace = true
+syntax.workspace = true
 
 [dev-dependencies]
 expect-test = "1.4.0"

--- a/crates/proc-macro-srv/src/server.rs
+++ b/crates/proc-macro-srv/src/server.rs
@@ -59,21 +59,21 @@ fn literal_to_external(literal: ast::LiteralKind) -> Option<proc_macro::bridge::
     Some(match lit.kind() {
         ast::LiteralKind::String(data) => {
             if data.is_raw() {
-                bridge::LitKind::StrRaw(raw_delimiter_count(data)?)
+                bridge::LitKind::StrRaw(data.raw_delimiter_count()?)
             } else {
                 bridge::LitKind::Str
             }
         }
         ast::LiteralKind::ByteString(data) => {
             if data.is_raw() {
-                bridge::LitKind::ByteStrRaw(raw_delimiter_count(data)?)
+                bridge::LitKind::ByteStrRaw(data.raw_delimiter_count()?)
             } else {
                 bridge::LitKind::ByteStr
             }
         }
         ast::LiteralKind::CString(data) => {
             if data.is_raw() {
-                bridge::LitKind::CStrRaw(raw_delimiter_count(data)?)
+                bridge::LitKind::CStrRaw(data.raw_delimiter_count()?)
             } else {
                 bridge::LitKind::CStr
             }
@@ -84,13 +84,6 @@ fn literal_to_external(literal: ast::LiteralKind) -> Option<proc_macro::bridge::
         ast::LiteralKind::Byte(_) => bridge::LitKind::Byte,
         ast::LiteralKind::Bool(_) => unreachable!(),
     })
-}
-
-fn raw_delimiter_count<S: IsString>(s: S) -> Option<u8> {
-    let text = s.text();
-    let quote_range = s.text_range_between_quotes()?;
-    let range_start = s.syntax().text_range().start();
-    text[TextRange::up_to((quote_range - range_start).start())].matches('#').count().try_into().ok()
 }
 
 fn str_to_lit_node(input: &str) -> Option<ast::Literal> {

--- a/crates/proc-macro-srv/src/server.rs
+++ b/crates/proc-macro-srv/src/server.rs
@@ -55,8 +55,8 @@ fn spacing_to_external(spacing: Spacing) -> proc_macro::Spacing {
     }
 }
 
-fn literal_to_external(literal: ast::LiteralKind) -> Option<proc_macro::bridge::LitKind> {
-    Some(match lit.kind() {
+fn literal_to_external(literal_kind: ast::LiteralKind) -> Option<proc_macro::bridge::LitKind> {
+    Some(match literal_kind {
         ast::LiteralKind::String(data) => {
             if data.is_raw() {
                 bridge::LitKind::StrRaw(data.raw_delimiter_count()?)

--- a/crates/proc-macro-srv/src/server.rs
+++ b/crates/proc-macro-srv/src/server.rs
@@ -78,8 +78,8 @@ fn literal_to_external(literal_kind: ast::LiteralKind) -> Option<proc_macro::bri
                 bridge::LitKind::CStr
             }
         }
-        ast::LiteralKind::IntNumber(num) => bridge::LitKind::Integer,
-        ast::LiteralKind::FloatNumber(num) => bridge::LitKind::Float,
+        ast::LiteralKind::IntNumber(_) => bridge::LitKind::Integer,
+        ast::LiteralKind::FloatNumber(_) => bridge::LitKind::Float,
         ast::LiteralKind::Char(_) => bridge::LitKind::Char,
         ast::LiteralKind::Byte(_) => bridge::LitKind::Byte,
         ast::LiteralKind::Bool(_) => unreachable!(),

--- a/crates/proc-macro-srv/src/server/rust_analyzer_span.rs
+++ b/crates/proc-macro-srv/src/server/rust_analyzer_span.rs
@@ -76,6 +76,7 @@ impl server::FreeFunctions for RaSpanServer {
 
         let kind = literal_to_external(literal.kind()).ok_or(Err(()))?;
 
+        // FIXME: handle more than just int and float suffixes
         let suffix = match literal.kind() {
             ast::LiteralKind::FloatNumber(num) | ast::LiteralKind::IntNumber(num) => num.suffix(),
             _ => None,

--- a/crates/proc-macro-srv/src/server/rust_analyzer_span.rs
+++ b/crates/proc-macro-srv/src/server/rust_analyzer_span.rs
@@ -4,7 +4,6 @@
 //! It is an unfortunate result of how the proc-macro API works that we need to look into the
 //! concrete representation of the spans, and as such, RustRover cannot make use of this unless they
 //! change their representation to be compatible with rust-analyzer's.
-use core::num;
 use std::{
     collections::{HashMap, HashSet},
     iter,
@@ -72,13 +71,14 @@ impl server::FreeFunctions for RaSpanServer {
         &mut self,
         s: &str,
     ) -> Result<bridge::Literal<Self::Span, Self::Symbol>, ()> {
-        let literal = str_to_lit_node(s).ok_or(Err(()))?;
+        let literal = str_to_lit_node(s).ok_or(())?;
 
-        let kind = literal_to_external(literal.kind()).ok_or(Err(()))?;
+        let kind = literal_to_external(literal.kind()).ok_or(())?;
 
         // FIXME: handle more than just int and float suffixes
         let suffix = match literal.kind() {
-            ast::LiteralKind::FloatNumber(num) | ast::LiteralKind::IntNumber(num) => num.suffix(),
+            ast::LiteralKind::FloatNumber(num) => num.suffix(),
+            ast::LiteralKind::IntNumber(num) => num.suffix(),
             _ => None,
         }
         .map(|suffix| Symbol::intern(self.interner, suffix));

--- a/crates/proc-macro-srv/src/server/rust_analyzer_span.rs
+++ b/crates/proc-macro-srv/src/server/rust_analyzer_span.rs
@@ -71,7 +71,7 @@ impl server::FreeFunctions for RaSpanServer {
         &mut self,
         s: &str,
     ) -> Result<bridge::Literal<Self::Span, Self::Symbol>, ()> {
-        let literal = ast::Literal::parse(s);
+        let literal = ast::Literal::parse(s).ok_or(())?;
         let literal = literal.tree();
 
         let kind = literal_to_external(literal.kind()).ok_or(())?;

--- a/crates/proc-macro-srv/src/server/rust_analyzer_span.rs
+++ b/crates/proc-macro-srv/src/server/rust_analyzer_span.rs
@@ -77,11 +77,11 @@ impl server::FreeFunctions for RaSpanServer {
 
         // FIXME: handle more than just int and float suffixes
         let suffix = match literal.kind() {
-            ast::LiteralKind::FloatNumber(num) => num.suffix(),
-            ast::LiteralKind::IntNumber(num) => num.suffix(),
+            ast::LiteralKind::FloatNumber(num) => num.suffix().map(ToString::to_string),
+            ast::LiteralKind::IntNumber(num) => num.suffix().map(ToString::to_string),
             _ => None,
         }
-        .map(|suffix| Symbol::intern(self.interner, suffix));
+        .map(|suffix| Symbol::intern(self.interner, &suffix));
 
         Ok(bridge::Literal {
             kind,

--- a/crates/proc-macro-srv/src/server/token_id.rs
+++ b/crates/proc-macro-srv/src/server/token_id.rs
@@ -67,6 +67,7 @@ impl server::FreeFunctions for TokenIdServer {
 
         let kind = literal_to_external(literal.kind()).ok_or(Err(()))?;
 
+        // FIXME: handle more than just int and float suffixes
         let suffix = match literal.kind() {
             ast::LiteralKind::FloatNumber(num) | ast::LiteralKind::IntNumber(num) => num.suffix(),
             _ => None,

--- a/crates/proc-macro-srv/src/server/token_id.rs
+++ b/crates/proc-macro-srv/src/server/token_id.rs
@@ -6,11 +6,11 @@ use std::{
 };
 
 use proc_macro::bridge::{self, server};
-use syntax::ast::{self, HasModuleItem, IsString};
+use syntax::ast;
 
 use crate::server::{
-    delim_to_external, delim_to_internal, token_stream::TokenStreamBuilder, LiteralFormatter,
-    Symbol, SymbolInternerRef, SYMBOL_INTERNER,
+    delim_to_external, delim_to_internal, literal_to_external, str_to_lit_node,
+    token_stream::TokenStreamBuilder, LiteralFormatter, Symbol, SymbolInternerRef, SYMBOL_INTERNER,
 };
 mod tt {
     pub use proc_macro_api::msg::TokenId;
@@ -63,66 +63,15 @@ impl server::FreeFunctions for TokenIdServer {
         &mut self,
         s: &str,
     ) -> Result<bridge::Literal<Self::Span, Self::Symbol>, ()> {
-        let input = s.trim();
-        let source_code = format!("fn f() {{ let _ = {input}; }}");
+        let literal = str_to_lit_node(s).ok_or(Err(()))?;
 
-        let parse = ast::SourceFile::parse(&source_code);
-        let file = parse.tree();
+        let kind = literal_to_external(literal.kind()).ok_or(Err(()))?;
 
-        let Some(ast::Item::Fn(func)) = file.items().next() else { return Err(()) };
-        let Some(ast::Stmt::LetStmt(stmt)) =
-            func.body().ok_or(Err(()))?.stmt_list().ok_or(Err(()))?.statements().next()
-        else {
-            return Err(());
-        };
-        let Some(ast::Expr::Literal(lit)) = stmt.initializer() else { return Err(()) };
-
-        fn raw_delimiter_count<S: IsString>(s: S) -> Option<u8> {
-            let text = s.text();
-            let quote_range = s.text_range_between_quotes()?;
-            let range_start = s.syntax().text_range().start();
-            text[TextRange::up_to((quote_range - range_start).start())]
-                .matches('#')
-                .count()
-                .try_into()
-                .ok()
+        let suffix = match literal.kind() {
+            ast::LiteralKind::FloatNumber(num) | ast::LiteralKind::IntNumber(num) => num.suffix(),
+            _ => None,
         }
-
-        let mut suffix = None;
-        let kind = match lit.kind() {
-            ast::LiteralKind::String(data) => {
-                if data.is_raw() {
-                    bridge::LitKind::StrRaw(raw_delimiter_count(data).ok_or(Err(()))?)
-                } else {
-                    bridge::LitKind::Str
-                }
-            }
-            ast::LiteralKind::ByteString(data) => {
-                if data.is_raw() {
-                    bridge::LitKind::ByteStrRaw(raw_delimiter_count(data).ok_or(Err(()))?)
-                } else {
-                    bridge::LitKind::ByteStr
-                }
-            }
-            ast::LiteralKind::CString(data) => {
-                if data.is_raw() {
-                    bridge::LitKind::CStrRaw(raw_delimiter_count(data).ok_or(Err(()))?)
-                } else {
-                    bridge::LitKind::CStr
-                }
-            }
-            ast::LiteralKind::IntNumber(num) => {
-                suffix = num.suffix();
-                bridge::LitKind::Integer
-            }
-            ast::LiteralKind::FloatNumber(num) => {
-                suffix = num.suffix();
-                bridge::LitKind::Float
-            }
-            ast::LiteralKind::Char(_) => bridge::LitKind::Char,
-            ast::LiteralKind::Byte(_) => bridge::LitKind::Byte,
-            ast::LiteralKind::Bool(_) => unreachable!(),
-        };
+        .map(|suffix| Symbol::intern(self.interner, suffix));
 
         Ok(bridge::Literal {
             kind,

--- a/crates/proc-macro-srv/src/server/token_id.rs
+++ b/crates/proc-macro-srv/src/server/token_id.rs
@@ -63,7 +63,7 @@ impl server::FreeFunctions for TokenIdServer {
         &mut self,
         s: &str,
     ) -> Result<bridge::Literal<Self::Span, Self::Symbol>, ()> {
-        let literal = ast::Literal::parse(s);
+        let literal = ast::Literal::parse(s).ok_or(())?;
         let literal = literal.tree();
 
         let kind = literal_to_external(literal.kind()).ok_or(())?;

--- a/crates/proc-macro-srv/src/server/token_id.rs
+++ b/crates/proc-macro-srv/src/server/token_id.rs
@@ -6,11 +6,11 @@ use std::{
 };
 
 use proc_macro::bridge::{self, server};
-use syntax::ast;
+use syntax::ast::{self, IsString};
 
 use crate::server::{
-    delim_to_external, delim_to_internal, literal_to_external, str_to_lit_node,
-    token_stream::TokenStreamBuilder, LiteralFormatter, Symbol, SymbolInternerRef, SYMBOL_INTERNER,
+    delim_to_external, delim_to_internal, literal_to_external, token_stream::TokenStreamBuilder,
+    LiteralFormatter, Symbol, SymbolInternerRef, SYMBOL_INTERNER,
 };
 mod tt {
     pub use proc_macro_api::msg::TokenId;
@@ -63,7 +63,8 @@ impl server::FreeFunctions for TokenIdServer {
         &mut self,
         s: &str,
     ) -> Result<bridge::Literal<Self::Span, Self::Symbol>, ()> {
-        let literal = str_to_lit_node(s).ok_or(())?;
+        let literal = ast::Literal::parse(s);
+        let literal = literal.tree();
 
         let kind = literal_to_external(literal.kind()).ok_or(())?;
 
@@ -72,12 +73,22 @@ impl server::FreeFunctions for TokenIdServer {
             ast::LiteralKind::FloatNumber(num) => num.suffix().map(ToString::to_string),
             ast::LiteralKind::IntNumber(num) => num.suffix().map(ToString::to_string),
             _ => None,
-        }
-        .map(|suffix| Symbol::intern(self.interner, &suffix));
+        };
+
+        let text = match literal.kind() {
+            ast::LiteralKind::String(data) => data.text_without_quotes().to_string(),
+            ast::LiteralKind::ByteString(data) => data.text_without_quotes().to_string(),
+            ast::LiteralKind::CString(data) => data.text_without_quotes().to_string(),
+            _ => s.to_string(),
+        };
+        let text = if let Some(ref suffix) = suffix { text.strip_suffix(suffix) } else { None }
+            .unwrap_or(&text);
+
+        let suffix = suffix.map(|suffix| Symbol::intern(self.interner, &suffix));
 
         Ok(bridge::Literal {
             kind,
-            symbol: Symbol::intern(self.interner, s),
+            symbol: Symbol::intern(self.interner, text),
             suffix,
             span: self.call_site,
         })

--- a/crates/proc-macro-srv/src/server/token_id.rs
+++ b/crates/proc-macro-srv/src/server/token_id.rs
@@ -63,13 +63,14 @@ impl server::FreeFunctions for TokenIdServer {
         &mut self,
         s: &str,
     ) -> Result<bridge::Literal<Self::Span, Self::Symbol>, ()> {
-        let literal = str_to_lit_node(s).ok_or(Err(()))?;
+        let literal = str_to_lit_node(s).ok_or(())?;
 
-        let kind = literal_to_external(literal.kind()).ok_or(Err(()))?;
+        let kind = literal_to_external(literal.kind()).ok_or(())?;
 
         // FIXME: handle more than just int and float suffixes
         let suffix = match literal.kind() {
-            ast::LiteralKind::FloatNumber(num) | ast::LiteralKind::IntNumber(num) => num.suffix(),
+            ast::LiteralKind::FloatNumber(num) => num.suffix(),
+            ast::LiteralKind::IntNumber(num) => num.suffix(),
             _ => None,
         }
         .map(|suffix| Symbol::intern(self.interner, suffix));

--- a/crates/proc-macro-srv/src/server/token_id.rs
+++ b/crates/proc-macro-srv/src/server/token_id.rs
@@ -6,6 +6,7 @@ use std::{
 };
 
 use proc_macro::bridge::{self, server};
+use syntax::ast::{self, HasModuleItem, IsString};
 
 use crate::server::{
     delim_to_external, delim_to_internal, token_stream::TokenStreamBuilder, LiteralFormatter,
@@ -62,11 +63,71 @@ impl server::FreeFunctions for TokenIdServer {
         &mut self,
         s: &str,
     ) -> Result<bridge::Literal<Self::Span, Self::Symbol>, ()> {
-        // FIXME: keep track of LitKind and Suffix
+        let input = s.trim();
+        let source_code = format!("fn f() {{ let _ = {input}; }}");
+
+        let parse = ast::SourceFile::parse(&source_code);
+        let file = parse.tree();
+
+        let Some(ast::Item::Fn(func)) = file.items().next() else { return Err(()) };
+        let Some(ast::Stmt::LetStmt(stmt)) =
+            func.body().ok_or(Err(()))?.stmt_list().ok_or(Err(()))?.statements().next()
+        else {
+            return Err(());
+        };
+        let Some(ast::Expr::Literal(lit)) = stmt.initializer() else { return Err(()) };
+
+        fn raw_delimiter_count<S: IsString>(s: S) -> Option<u8> {
+            let text = s.text();
+            let quote_range = s.text_range_between_quotes()?;
+            let range_start = s.syntax().text_range().start();
+            text[TextRange::up_to((quote_range - range_start).start())]
+                .matches('#')
+                .count()
+                .try_into()
+                .ok()
+        }
+
+        let mut suffix = None;
+        let kind = match lit.kind() {
+            ast::LiteralKind::String(data) => {
+                if data.is_raw() {
+                    bridge::LitKind::StrRaw(raw_delimiter_count(data).ok_or(Err(()))?)
+                } else {
+                    bridge::LitKind::Str
+                }
+            }
+            ast::LiteralKind::ByteString(data) => {
+                if data.is_raw() {
+                    bridge::LitKind::ByteStrRaw(raw_delimiter_count(data).ok_or(Err(()))?)
+                } else {
+                    bridge::LitKind::ByteStr
+                }
+            }
+            ast::LiteralKind::CString(data) => {
+                if data.is_raw() {
+                    bridge::LitKind::CStrRaw(raw_delimiter_count(data).ok_or(Err(()))?)
+                } else {
+                    bridge::LitKind::CStr
+                }
+            }
+            ast::LiteralKind::IntNumber(num) => {
+                suffix = num.suffix();
+                bridge::LitKind::Integer
+            }
+            ast::LiteralKind::FloatNumber(num) => {
+                suffix = num.suffix();
+                bridge::LitKind::Float
+            }
+            ast::LiteralKind::Char(_) => bridge::LitKind::Char,
+            ast::LiteralKind::Byte(_) => bridge::LitKind::Byte,
+            ast::LiteralKind::Bool(_) => unreachable!(),
+        };
+
         Ok(bridge::Literal {
-            kind: bridge::LitKind::Err,
+            kind,
             symbol: Symbol::intern(self.interner, s),
-            suffix: None,
+            suffix,
             span: self.call_site,
         })
     }

--- a/crates/proc-macro-srv/src/server/token_id.rs
+++ b/crates/proc-macro-srv/src/server/token_id.rs
@@ -69,11 +69,11 @@ impl server::FreeFunctions for TokenIdServer {
 
         // FIXME: handle more than just int and float suffixes
         let suffix = match literal.kind() {
-            ast::LiteralKind::FloatNumber(num) => num.suffix(),
-            ast::LiteralKind::IntNumber(num) => num.suffix(),
+            ast::LiteralKind::FloatNumber(num) => num.suffix().map(ToString::to_string),
+            ast::LiteralKind::IntNumber(num) => num.suffix().map(ToString::to_string),
             _ => None,
         }
-        .map(|suffix| Symbol::intern(self.interner, suffix));
+        .map(|suffix| Symbol::intern(self.interner, &suffix));
 
         Ok(bridge::Literal {
             kind,

--- a/crates/syntax/src/ast/token_ext.rs
+++ b/crates/syntax/src/ast/token_ext.rs
@@ -204,6 +204,16 @@ pub trait IsString: AstToken {
         assert!(TextRange::up_to(contents_range.len()).contains_range(range));
         Some(range + contents_range.start())
     }
+    fn raw_delimiter_count(&self) -> Option<u8> {
+        let text = self.text();
+        let quote_range = self.text_range_between_quotes()?;
+        let range_start = self.syntax().text_range().start();
+        text[TextRange::up_to((quote_range - range_start).start())]
+            .matches('#')
+            .count()
+            .try_into()
+            .ok()
+    }
 }
 
 impl IsString for ast::String {

--- a/crates/syntax/src/lib.rs
+++ b/crates/syntax/src/lib.rs
@@ -188,7 +188,7 @@ impl SourceFile {
 }
 
 impl ast::Literal {
-    pub fn parse(text: &str) -> Parse<ast::Literal> {
+    pub fn parse(text: &str) -> Option<Parse<ast::Literal>> {
         let lexed = parser::LexedStr::new(text);
         let parser_input = lexed.to_input();
         let parser_output = parser::TopEntryPoint::Expr.parse(&parser_input);
@@ -197,11 +197,14 @@ impl ast::Literal {
 
         errors.extend(validation::validate(&root));
 
-        assert_eq!(root.kind(), SyntaxKind::LITERAL);
-        Parse {
-            green,
-            errors: if errors.is_empty() { None } else { Some(errors.into()) },
-            _ty: PhantomData,
+        if root.kind() == SyntaxKind::LITERAL {
+            Some(Parse {
+                green,
+                errors: if errors.is_empty() { None } else { Some(errors.into()) },
+                _ty: PhantomData,
+            })
+        } else {
+            None
         }
     }
 }


### PR DESCRIPTION
Closes #16233

Todos and unanswered questions:

- [x] Is this the correct approach? Can both the legacy and `rust_analyzer_span` servers depend on the `syntax` crate?
- [ ] How should we handle suffixes for string literals? It doesn't seem like `rust-analyzer` preservers suffix information after parsing.
- [x] Why are the `expect` tests failing? Specifically `test_fn_like_macro_clone_literals`