### PR TITLE
minor: correct typos

### DIFF
--- a/crates/hir-def/src/hir/format_args.rs
+++ b/crates/hir-def/src/hir/format_args.rs
@@ -214,7 +214,7 @@ pub(crate) fn parse(
 
     let mut used = vec![false; args.explicit_args().len()];
     let mut invalid_refs = Vec::new();
-    let mut numeric_refences_to_named_arg = Vec::new();
+    let mut numeric_references_to_named_arg = Vec::new();
 
     enum ArgRef<'a> {
         Index(usize),
@@ -231,7 +231,7 @@ pub(crate) fn parse(
                     used[index] = true;
                     if arg.kind.ident().is_some() {
                         // This was a named argument, but it was used as a positional argument.
-                        numeric_refences_to_named_arg.push((index, span, used_as));
+                        numeric_references_to_named_arg.push((index, span, used_as));
                     }
                     Ok(index)
                 } else {

--- a/crates/hir-def/src/lib.rs
+++ b/crates/hir-def/src/lib.rs
@@ -745,7 +745,7 @@ impl InTypeConstId {
     }
 }
 
-/// A constant, which might appears as a const item, an annonymous const block in expressions
+/// A constant, which might appears as a const item, an anonymous const block in expressions
 /// or patterns, or as a constant in types with const generics.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum GeneralConstId {

--- a/crates/hir-def/src/macro_expansion_tests/mbe/regression.rs
+++ b/crates/hir-def/src/macro_expansion_tests/mbe/regression.rs
@@ -72,7 +72,7 @@ fn main() {
 }
 "#]],
     );
-    // FIXME we should ahev testing infra for multi level expansion tests
+    // FIXME we should have testing infra for multi level expansion tests
     check(
         r#"
 macro_rules! __rust_force_expr {

--- a/crates/hir-def/src/nameres/path_resolution.rs
+++ b/crates/hir-def/src/nameres/path_resolution.rs
@@ -269,7 +269,7 @@ impl DefMap {
                 stdx::never!(module.is_block_module());
 
                 if self.block != def_map.block {
-                    // If we have a different `DefMap` from `self` (the orignal `DefMap` we started
+                    // If we have a different `DefMap` from `self` (the original `DefMap` we started
                     // with), resolve the remaining path segments in that `DefMap`.
                     let path =
                         ModPath::from_segments(PathKind::Super(0), path.segments().iter().cloned());
@@ -540,7 +540,7 @@ impl DefMap {
     }
 }
 
-/// Given a block module, returns its nearest non-block module and the `DefMap` it blongs to.
+/// Given a block module, returns its nearest non-block module and the `DefMap` it belongs to.
 fn adjust_to_nearest_non_block_module(
     db: &dyn DefDatabase,
     def_map: &DefMap,

--- a/crates/hir-ty/src/mir/eval.rs
+++ b/crates/hir-ty/src/mir/eval.rs
@@ -359,8 +359,8 @@ impl MirEvalError {
                             func
                         )?;
                     }
-                    Either::Right(clos) => {
-                        writeln!(f, "In {:?}", clos)?;
+                    Either::Right(close) => {
+                        writeln!(f, "In {:?}", close)?;
                     }
                 }
                 let source_map = db.body_with_source_map(*def).1;

--- a/crates/hir-ty/src/mir/eval.rs
+++ b/crates/hir-ty/src/mir/eval.rs
@@ -359,8 +359,8 @@ impl MirEvalError {
                             func
                         )?;
                     }
-                    Either::Right(close) => {
-                        writeln!(f, "In {:?}", close)?;
+                    Either::Right(closure) => {
+                        writeln!(f, "In {:?}", closure)?;
                     }
                 }
                 let source_map = db.body_with_source_map(*def).1;

--- a/crates/hir-ty/src/utils.rs
+++ b/crates/hir-ty/src/utils.rs
@@ -192,7 +192,7 @@ pub(crate) fn generics(db: &dyn DefDatabase, def: GenericDefId) -> Generics {
 /// and it doesn't store the closure types and fields.
 ///
 /// Codes should not assume this ordering, and should always use methods available
-/// on this struct for retriving, and `TyBuilder::substs_for_closure` for creating.
+/// on this struct for retrieving, and `TyBuilder::substs_for_closure` for creating.
 pub(crate) struct ClosureSubst<'a>(pub(crate) &'a Substitution);
 
 impl<'a> ClosureSubst<'a> {

--- a/crates/ide-assists/src/handlers/add_missing_impl_members.rs
+++ b/crates/ide-assists/src/handlers/add_missing_impl_members.rs
@@ -370,17 +370,17 @@ impl<U> Foo<U> for S {
             add_missing_impl_members,
             r#"
 pub trait Trait<'a, 'b, A, B, C> {
-    fn foo(&self, one: &'a A, anoter: &'b B) -> &'a C;
+    fn foo(&self, one: &'a A, another: &'b B) -> &'a C;
 }
 
 impl<'x, 'y, T, V, U> Trait<'x, 'y, T, V, U> for () {$0}"#,
             r#"
 pub trait Trait<'a, 'b, A, B, C> {
-    fn foo(&self, one: &'a A, anoter: &'b B) -> &'a C;
+    fn foo(&self, one: &'a A, another: &'b B) -> &'a C;
 }
 
 impl<'x, 'y, T, V, U> Trait<'x, 'y, T, V, U> for () {
-    fn foo(&self, one: &'x T, anoter: &'y V) -> &'x U {
+    fn foo(&self, one: &'x T, another: &'y V) -> &'x U {
         ${0:todo!()}
     }
 }"#,
@@ -393,7 +393,7 @@ impl<'x, 'y, T, V, U> Trait<'x, 'y, T, V, U> for () {
             add_missing_default_members,
             r#"
 pub trait Trait<'a, 'b, A, B, C: Default> {
-    fn foo(&self, _one: &'a A, _anoter: &'b B) -> (C, &'a i32) {
+    fn foo(&self, _one: &'a A, _another: &'b B) -> (C, &'a i32) {
         let value: &'a i32 = &0;
         (C::default(), value)
     }
@@ -402,14 +402,14 @@ pub trait Trait<'a, 'b, A, B, C: Default> {
 impl<'x, 'y, T, V, U: Default> Trait<'x, 'y, T, V, U> for () {$0}"#,
             r#"
 pub trait Trait<'a, 'b, A, B, C: Default> {
-    fn foo(&self, _one: &'a A, _anoter: &'b B) -> (C, &'a i32) {
+    fn foo(&self, _one: &'a A, _another: &'b B) -> (C, &'a i32) {
         let value: &'a i32 = &0;
         (C::default(), value)
     }
 }
 
 impl<'x, 'y, T, V, U: Default> Trait<'x, 'y, T, V, U> for () {
-    $0fn foo(&self, _one: &'x T, _anoter: &'y V) -> (U, &'x i32) {
+    $0fn foo(&self, _one: &'x T, _another: &'y V) -> (U, &'x i32) {
         let value: &'x i32 = &0;
         (<U>::default(), value)
     }

--- a/crates/ide-assists/src/handlers/extract_variable.rs
+++ b/crates/ide-assists/src/handlers/extract_variable.rs
@@ -163,7 +163,7 @@ pub(crate) fn extract_variable(acc: &mut Assists, ctx: &AssistContext<'_>) -> Op
                         block
                     } else {
                         // `expr_replace` is a descendant of `to_wrap`, so both steps need to be
-                        // handled seperately, otherwise we wrap the wrong expression
+                        // handled separately, otherwise we wrap the wrong expression
                         let to_wrap = edit.make_mut(to_wrap);
 
                         // Replace the target expr first so that we don't need to find where

--- a/crates/ide-assists/src/handlers/generate_delegate_trait.rs
+++ b/crates/ide-assists/src/handlers/generate_delegate_trait.rs
@@ -491,7 +491,7 @@ fn remove_useless_where_clauses(trait_ty: &ast::Type, self_ty: &ast::Type, wc: a
 
 // Generate generic args that should be apply to current impl.
 //
-// For exmaple, say we have implementation `impl<A, B, C> Trait for B<A>`,
+// For example, say we have implementation `impl<A, B, C> Trait for B<A>`,
 // and `b: B<T>` in struct `S<T>`. Then the `A` should be instantiated to `T`.
 // While the last two generic args `B` and `C` doesn't change, it remains
 // `<B, C>`. So we apply `<T, B, C>` as generic arguments to impl.
@@ -637,7 +637,7 @@ fn const_assoc_item(item: syntax::ast::Const, qual_path_ty: ast::Path) -> Option
     let path_expr_segment = make::path_from_text(item.name()?.to_string().as_str());
 
     // We want rhs of the const assignment to be a qualified path
-    // The general case for const assigment can be found [here](`https://doc.rust-lang.org/reference/items/constant-items.html`)
+    // The general case for const assignment can be found [here](`https://doc.rust-lang.org/reference/items/constant-items.html`)
     // The qualified will have the following generic syntax :
     // <Base as Trait<GenArgs>>::ConstName;
     // FIXME : We can't rely on `make::path_qualified` for now but it would be nice to replace the following with it.
@@ -779,7 +779,7 @@ impl Trait for Base {}
 
     #[test]
     fn test_self_ty() {
-        // trait whith `Self` type cannot be delegated
+        // trait with `Self` type cannot be delegated
         //
         // See the function `fn f() -> Self`.
         // It should be `fn f() -> Base` in `Base`, and `fn f() -> S` in `S`

--- a/crates/ide-assists/src/handlers/generate_mut_trait_impl.rs
+++ b/crates/ide-assists/src/handlers/generate_mut_trait_impl.rs
@@ -6,7 +6,7 @@ use syntax::{
 
 use crate::{AssistContext, AssistId, AssistKind, Assists};
 
-// FIXME: Generate proper `index_mut` method body refer to `index` method body may impossible due to the unpredicable case [#15581].
+// FIXME: Generate proper `index_mut` method body refer to `index` method body may impossible due to the unpredictable case [#15581].
 // Here just leave the `index_mut` method body be same as `index` method body, user can modify it manually to meet their need.
 
 // Assist: generate_mut_trait_impl

--- a/crates/ide-assists/src/handlers/generate_trait_from_impl.rs
+++ b/crates/ide-assists/src/handlers/generate_trait_from_impl.rs
@@ -183,7 +183,7 @@ fn remove_items_visibility(item: &ast::AssocItem) {
 fn strip_body(item: &ast::AssocItem) {
     if let ast::AssocItem::Fn(f) = item {
         if let Some(body) = f.body() {
-            // In constrast to function bodies, we want to see no ws before a semicolon.
+            // In contrast to function bodies, we want to see no ws before a semicolon.
             // So let's remove them if we see any.
             if let Some(prev) = body.syntax().prev_sibling_or_token() {
                 if prev.kind() == SyntaxKind::WHITESPACE {

--- a/crates/ide-completion/src/completions/dot.rs
+++ b/crates/ide-completion/src/completions/dot.rs
@@ -31,7 +31,7 @@ pub(crate) fn complete_dot(
     }
 
     let is_field_access = matches!(dot_access.kind, DotAccessKind::Field { .. });
-    let is_method_acces_with_parens =
+    let is_method_access_with_parens =
         matches!(dot_access.kind, DotAccessKind::Method { has_parens: true });
 
     complete_fields(
@@ -41,7 +41,7 @@ pub(crate) fn complete_dot(
         |acc, field, ty| acc.add_field(ctx, dot_access, None, field, &ty),
         |acc, field, ty| acc.add_tuple_field(ctx, None, field, &ty),
         is_field_access,
-        is_method_acces_with_parens,
+        is_method_access_with_parens,
     );
 
     complete_methods(ctx, receiver_ty, |func| acc.add_method(ctx, dot_access, func, None, None));
@@ -114,14 +114,14 @@ fn complete_fields(
     mut named_field: impl FnMut(&mut Completions, hir::Field, hir::Type),
     mut tuple_index: impl FnMut(&mut Completions, usize, hir::Type),
     is_field_access: bool,
-    is_method_acess_with_parens: bool,
+    is_method_access_with_parens: bool,
 ) {
     let mut seen_names = FxHashSet::default();
     for receiver in receiver.autoderef(ctx.db) {
         for (field, ty) in receiver.fields(ctx.db) {
             if seen_names.insert(field.name(ctx.db))
                 && (is_field_access
-                    || (is_method_acess_with_parens && (ty.is_fn() || ty.is_closure())))
+                    || (is_method_access_with_parens && (ty.is_fn() || ty.is_closure())))
             {
                 named_field(acc, field, ty);
             }
@@ -131,7 +131,7 @@ fn complete_fields(
             // already seen without inserting into the hashset.
             if !seen_names.contains(&hir::Name::new_tuple_field(i))
                 && (is_field_access
-                    || (is_method_acess_with_parens && (ty.is_fn() || ty.is_closure())))
+                    || (is_method_access_with_parens && (ty.is_fn() || ty.is_closure())))
             {
                 // Tuple fields are always public (tuple struct fields are handled above).
                 tuple_index(acc, i, ty);

--- a/crates/ide-completion/src/tests/expression.rs
+++ b/crates/ide-completion/src/tests/expression.rs
@@ -105,7 +105,7 @@ fn func(param0 @ (param1, param2): (i32, i32)) {
 fn completes_all_the_things_in_fn_body() {
     check(
         r#"
-use non_existant::Unresolved;
+use non_existent::Unresolved;
 mod qualified { pub enum Enum { Variant } }
 
 impl Unit {
@@ -170,7 +170,7 @@ impl Unit {
     );
     check(
         r#"
-use non_existant::Unresolved;
+use non_existent::Unresolved;
 mod qualified { pub enum Enum { Variant } }
 
 impl Unit {

--- a/crates/ide-db/src/documentation.rs
+++ b/crates/ide-db/src/documentation.rs
@@ -1,4 +1,4 @@
-//! Documentation attribute related utilties.
+//! Documentation attribute related utilities.
 use either::Either;
 use hir::{
     db::{DefDatabase, HirDatabase},

--- a/crates/ide-diagnostics/src/tests.rs
+++ b/crates/ide-diagnostics/src/tests.rs
@@ -173,7 +173,7 @@ fn minicore_smoke_test() {
     fn check(minicore: MiniCore) {
         let source = minicore.source_code();
         let mut config = DiagnosticsConfig::test_sample();
-        // This should be ignored since we conditionaly remove code which creates single item use with braces
+        // This should be ignored since we conditionally remove code which creates single item use with braces
         config.disabled.insert("unused_braces".to_string());
         check_diagnostics_with_config(config, &source);
     }

--- a/crates/ide/src/inlay_hints/implicit_drop.rs
+++ b/crates/ide/src/inlay_hints/implicit_drop.rs
@@ -177,7 +177,7 @@ mod tests {
 
     #[test]
     fn try_operator() {
-        // We currently show drop inlay hint for every `?` operator that may potentialy drop something. We probably need to
+        // We currently show drop inlay hint for every `?` operator that may potentially drop something. We probably need to
         // make it configurable as it doesn't seem very useful.
         check_with_config(
             ONLY_DROP_CONFIG,

--- a/crates/mbe/src/expander/transcriber.rs
+++ b/crates/mbe/src/expander/transcriber.rs
@@ -292,7 +292,7 @@ fn expand_subtree<S: Span>(
                     Err(e) => {
                         // XXX: It *might* make sense to emit a dummy integer value like `0` here.
                         // That would type inference a bit more robust in cases like
-                        // `v[${count(t)}]` where index doesn't matter, but also coult also lead to
+                        // `v[${count(t)}]` where index doesn't matter, but also could lead to
                         // wrong infefrence for cases like `tup.${count(t)}` where index itself
                         // does matter.
                         if err.is_none() {

--- a/crates/proc-macro-srv/src/server/rust_analyzer_span.rs
+++ b/crates/proc-macro-srv/src/server/rust_analyzer_span.rs
@@ -1,4 +1,4 @@
-//! proc-macro server backend based on rust-analyzer's internal span represention
+//! proc-macro server backend based on rust-analyzer's internal span representation
 //! This backend is used solely by rust-analyzer as it ties into rust-analyzer internals.
 //!
 //! It is an unfortunate result of how the proc-macro API works that we need to look into the

--- a/crates/rust-analyzer/src/cli/flags.rs
+++ b/crates/rust-analyzer/src/cli/flags.rs
@@ -71,7 +71,7 @@ xflags::xflags! {
             optional --with-deps
             /// Don't load sysroot crates (`std`, `core` & friends).
             optional --no-sysroot
-            /// Run cargo metadata on the sysroot to analyze its third-pary dependencies.
+            /// Run cargo metadata on the sysroot to analyze its third-party dependencies.
             /// Requires --no-sysroot to not be set.
             optional --query-sysroot-metadata
 

--- a/crates/syntax/src/ast/edit_in_place.rs
+++ b/crates/syntax/src/ast/edit_in_place.rs
@@ -960,10 +960,10 @@ impl ast::IdentPat {
 }
 
 pub trait HasVisibilityEdit: ast::HasVisibility {
-    fn set_visibility(&self, visbility: ast::Visibility) {
+    fn set_visibility(&self, visibility: ast::Visibility) {
         match self.visibility() {
             Some(current_visibility) => {
-                ted::replace(current_visibility.syntax(), visbility.syntax())
+                ted::replace(current_visibility.syntax(), visibility.syntax())
             }
             None => {
                 let vis_before = self
@@ -972,7 +972,7 @@ pub trait HasVisibilityEdit: ast::HasVisibility {
                     .find(|it| !matches!(it.kind(), WHITESPACE | COMMENT | ATTR))
                     .unwrap_or_else(|| self.syntax().first_child_or_token().unwrap());
 
-                ted::insert(ted::Position::before(vis_before), visbility.syntax());
+                ted::insert(ted::Position::before(vis_before), visibility.syntax());
             }
         }
     }

--- a/crates/syntax/src/ast/node_ext.rs
+++ b/crates/syntax/src/ast/node_ext.rs
@@ -384,7 +384,7 @@ impl ast::UseTreeList {
         // the below remove the innermost {}, got `use crate::{{{A}}}`
         remove_brace_in_use_tree_list(&self);
 
-        // the below remove othe unnecessary {}, got `use crate::A`
+        // the below remove other unnecessary {}, got `use crate::A`
         while let Some(parent_use_tree_list) = self.parent_use_tree().parent_use_tree_list() {
             remove_brace_in_use_tree_list(&parent_use_tree_list);
             self = parent_use_tree_list;

--- a/docs/dev/syntax.md
+++ b/docs/dev/syntax.md
@@ -128,7 +128,7 @@ Interior nodes are shared as well (for example in `(1 + 1) * (1 + 1)`).
 Note that, the result of the interning is an `Arc<Node>`.
 That is, it's not an index into interning table, so you don't have to have the table around to do anything with the tree.
 Each tree is fully self-contained (although different trees might share parts).
-Currently, the interner is created per-file, but it will be easy to use a per-thread or per-some-contex one.
+Currently, the interner is created per-file, but it will be easy to use a per-thread or per-some-context one.
 
 We use a `TextSize`, a newtyped `u32`, to store the length of the text.
 

--- a/lib/lsp-server/src/error.rs
+++ b/lib/lsp-server/src/error.rs
@@ -14,7 +14,7 @@ impl ProtocolError {
         ProtocolError("disconnected channel".into(), true)
     }
 
-    /// Whether this error occured due to a disconnected channel.
+    /// Whether this error occurred due to a disconnected channel.
     pub fn channel_is_disconnected(&self) -> bool {
         self.1
     }


### PR DESCRIPTION
I use [crate-ci/typos](https://github.com/crate-ci/typos) to check typos in codebase, if it's ok with you, I'd like to add a typo check CI using [typos](https://github.com/crate-ci/typos) (with Apache-2.0, MIT licenses).

BTW, we can add a [_typos.toml](https://github.com/crate-ci/typos/blob/master/docs/reference.md) as white list for some intentional typos