### PR TITLE
internal: Undo special bracket classification for attributes in vscode config

### DIFF
--- a/editors/code/language-configuration.json
+++ b/editors/code/language-configuration.json
@@ -6,9 +6,7 @@
     "brackets": [
         ["{", "}"],
         ["[", "]"],
-        ["(", ")"],
-        ["#[", "]"],
-        ["#![", "]"]
+        ["(", ")"]
     ],
     "colorizedBracketPairs": [
         ["{", "}"],
@@ -19,8 +17,6 @@
         { "open": "{", "close": "}" },
         { "open": "[", "close": "]" },
         { "open": "(", "close": ")" },
-        { "open": "#[", "close": "]" },
-        { "open": "#![", "close": "]" },
         { "open": "\"", "close": "\"", "notIn": ["string"] },
         { "open": "/*", "close": " */" },
         { "open": "`", "close": "`", "notIn": ["string"] }


### PR DESCRIPTION

I changed this thinking the `#` could be considered part of the bracket but on second though I don't think that's quite right in general.

Fixes https://github.com/rust-lang/rust-analyzer/issues/16449