### PR TITLE
internal: Remove `abi_amdgpu_kernel` references

### DIFF
--- a/crates/hir-ty/src/lib.rs
+++ b/crates/hir-ty/src/lib.rs
@@ -363,7 +363,6 @@ has_interner!(CallableSig);
 pub enum FnAbi {
     Aapcs,
     AapcsUnwind,
-    AmdgpuKernel,
     AvrInterrupt,
     AvrNonBlockingInterrupt,
     C,
@@ -422,7 +421,6 @@ impl FnAbi {
         match s {
             "aapcs-unwind" => FnAbi::AapcsUnwind,
             "aapcs" => FnAbi::Aapcs,
-            "amdgpu-kernel" => FnAbi::AmdgpuKernel,
             "avr-interrupt" => FnAbi::AvrInterrupt,
             "avr-non-blocking-interrupt" => FnAbi::AvrNonBlockingInterrupt,
             "C-cmse-nonsecure-call" => FnAbi::CCmseNonsecureCall,
@@ -465,7 +463,6 @@ impl FnAbi {
         match self {
             FnAbi::Aapcs => "aapcs",
             FnAbi::AapcsUnwind => "aapcs-unwind",
-            FnAbi::AmdgpuKernel => "amdgpu-kernel",
             FnAbi::AvrInterrupt => "avr-interrupt",
             FnAbi::AvrNonBlockingInterrupt => "avr-non-blocking-interrupt",
             FnAbi::C => "C",

--- a/crates/ide-completion/src/completions/extern_abi.rs
+++ b/crates/ide-completion/src/completions/extern_abi.rs
@@ -26,7 +26,6 @@ const SUPPORTED_CALLING_CONVENTIONS: &[&str] = &[
     "ptx-kernel",
     "msp430-interrupt",
     "x86-interrupt",
-    "amdgpu-kernel",
     "efiapi",
     "avr-interrupt",
     "avr-non-blocking-interrupt",

--- a/crates/ide-db/src/generated/lints.rs
+++ b/crates/ide-db/src/generated/lints.rs
@@ -967,17 +967,6 @@ The tracking issue for this feature is: [#44839]
 "##,
     },
     Lint {
-        label: "abi_amdgpu_kernel",
-        description: r##"# `abi_amdgpu_kernel`
-
-The tracking issue for this feature is: [#51575]
-
-[#51575]: https://github.com/rust-lang/rust/issues/51575
-
-------------------------
-"##,
-    },
-    Lint {
         label: "abi_avr_interrupt",
         description: r##"# `abi_avr_interrupt`
 


### PR DESCRIPTION
This feature was removed in https://github.com/rust-lang/rust/pull/120495