### PR TITLE
Stop eagerly resolving inlay hint text edits for VSCode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1597,6 +1597,7 @@ dependencies = [
  "rayon",
  "rustc-hash",
  "scip",
+ "semver",
  "serde",
  "serde_json",
  "sourcegen",

--- a/crates/rust-analyzer/Cargo.toml
+++ b/crates/rust-analyzer/Cargo.toml
@@ -42,6 +42,7 @@ triomphe.workspace = true
 nohash-hasher.workspace = true
 always-assert = "0.2.0"
 walkdir = "2.3.2"
+semver.workspace = true
 
 cfg.workspace = true
 flycheck.workspace = true

--- a/crates/rust-analyzer/src/cli/scip.rs
+++ b/crates/rust-analyzer/src/cli/scip.rs
@@ -32,8 +32,8 @@ impl flags::Scip {
         let mut config = crate::config::Config::new(
             root.clone(),
             lsp_types::ClientCapabilities::default(),
-            /* workspace_roots = */ vec![],
-            /* is_visual_studio_code = */ false,
+            vec![],
+            None,
         );
 
         if let Some(p) = self.config_path {

--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -31,6 +31,7 @@ use project_model::{
     CargoConfig, CargoFeatures, ProjectJson, ProjectJsonData, ProjectManifest, RustLibSource,
 };
 use rustc_hash::{FxHashMap, FxHashSet};
+use semver::Version;
 use serde::{de::DeserializeOwned, Deserialize};
 use stdx::format_to_acc;
 use vfs::{AbsPath, AbsPathBuf};
@@ -624,7 +625,7 @@ pub struct Config {
     data: ConfigData,
     detached_files: Vec<AbsPathBuf>,
     snippets: Vec<Snippet>,
-    is_visual_studio_code: bool,
+    visual_studio_code_version: Option<Version>,
 }
 
 type ParallelCachePrimingNumThreads = u8;
@@ -823,7 +824,7 @@ impl Config {
         root_path: AbsPathBuf,
         caps: ClientCapabilities,
         workspace_roots: Vec<AbsPathBuf>,
-        is_visual_studio_code: bool,
+        visual_studio_code_version: Option<Version>,
     ) -> Self {
         Config {
             caps,
@@ -833,7 +834,7 @@ impl Config {
             root_path,
             snippets: Default::default(),
             workspace_roots,
-            is_visual_studio_code,
+            visual_studio_code_version,
         }
     }
 
@@ -1778,10 +1779,10 @@ impl Config {
         self.data.typing_autoClosingAngleBrackets_enable
     }
 
-    // FIXME: VSCode seems to work wrong sometimes, see https://github.com/microsoft/vscode/issues/193124
-    // hence, distinguish it for now.
-    pub fn is_visual_studio_code(&self) -> bool {
-        self.is_visual_studio_code
+    // VSCode is our reference implementation, so we allow ourselves to work around issues by
+    // special casing certain versions
+    pub fn visual_studio_code_version(&self) -> Option<&Version> {
+        self.visual_studio_code_version.as_ref()
     }
 }
 // Deserialization definitions
@@ -2694,7 +2695,7 @@ mod tests {
             AbsPathBuf::try_from(project_root()).unwrap(),
             Default::default(),
             vec![],
-            false,
+            None,
         );
         config
             .update(serde_json::json!({
@@ -2710,7 +2711,7 @@ mod tests {
             AbsPathBuf::try_from(project_root()).unwrap(),
             Default::default(),
             vec![],
-            false,
+            None,
         );
         config
             .update(serde_json::json!({
@@ -2726,7 +2727,7 @@ mod tests {
             AbsPathBuf::try_from(project_root()).unwrap(),
             Default::default(),
             vec![],
-            false,
+            None,
         );
         config
             .update(serde_json::json!({
@@ -2745,7 +2746,7 @@ mod tests {
             AbsPathBuf::try_from(project_root()).unwrap(),
             Default::default(),
             vec![],
-            false,
+            None,
         );
         config
             .update(serde_json::json!({
@@ -2764,7 +2765,7 @@ mod tests {
             AbsPathBuf::try_from(project_root()).unwrap(),
             Default::default(),
             vec![],
-            false,
+            None,
         );
         config
             .update(serde_json::json!({
@@ -2783,7 +2784,7 @@ mod tests {
             AbsPathBuf::try_from(project_root()).unwrap(),
             Default::default(),
             vec![],
-            false,
+            None,
         );
         config
             .update(serde_json::json!({

--- a/crates/rust-analyzer/src/diagnostics/to_proto.rs
+++ b/crates/rust-analyzer/src/diagnostics/to_proto.rs
@@ -542,7 +542,7 @@ mod tests {
                 workspace_root.to_path_buf(),
                 ClientCapabilities::default(),
                 Vec::new(),
-                false,
+                None,
             ),
         );
         let snap = state.snapshot();

--- a/crates/rust-analyzer/src/lsp/to_proto.rs
+++ b/crates/rust-analyzer/src/lsp/to_proto.rs
@@ -443,17 +443,16 @@ pub(crate) fn inlay_hint(
     file_id: FileId,
     inlay_hint: InlayHint,
 ) -> Cancellable<lsp_types::InlayHint> {
-    let is_visual_studio_code = snap.config.is_visual_studio_code();
     let needs_resolve = inlay_hint.needs_resolve;
     let (label, tooltip, mut something_to_resolve) =
         inlay_hint_label(snap, fields_to_resolve, needs_resolve, inlay_hint.label)?;
-    let text_edits =
-        if !is_visual_studio_code && needs_resolve && fields_to_resolve.resolve_text_edits {
-            something_to_resolve |= inlay_hint.text_edit.is_some();
-            None
-        } else {
-            inlay_hint.text_edit.map(|it| text_edit_vec(line_index, it))
-        };
+    let text_edits = if needs_resolve && fields_to_resolve.resolve_text_edits {
+        something_to_resolve |= inlay_hint.text_edit.is_some();
+        None
+    } else {
+        inlay_hint.text_edit.map(|it| text_edit_vec(line_index, it))
+    };
+
     let data = if needs_resolve && something_to_resolve {
         Some(to_value(lsp_ext::InlayHintResolveData { file_id: file_id.index() }).unwrap())
     } else {

--- a/crates/rust-analyzer/tests/slow-tests/support.rs
+++ b/crates/rust-analyzer/tests/slow-tests/support.rs
@@ -171,7 +171,7 @@ impl Project<'_> {
                 ..Default::default()
             },
             roots,
-            false,
+            None,
         );
         config.update(self.config).expect("invalid config");
         config.rediscover_workspaces();


### PR DESCRIPTION
Send less json over the wire.
After https://github.com/microsoft/vscode/issues/193124 was fixed, this change is not needed anymore.

VSCode 1.86.0 now supports double click for unresolved hint data too.