### PR TITLE
internal: even more `tracing`

### DIFF
--- a/crates/hir-def/src/find_path.rs
+++ b/crates/hir-def/src/find_path.rs
@@ -171,6 +171,7 @@ fn find_path_inner(ctx: FindPathCtx<'_>, item: ItemInNs, from: ModuleId) -> Opti
     .map(|(item, _)| item)
 }
 
+#[tracing::instrument(skip_all)]
 fn find_path_for_module(
     ctx: FindPathCtx<'_>,
     def_map: &DefMap,
@@ -312,6 +313,7 @@ fn find_self_super(def_map: &DefMap, item: ModuleId, from: ModuleId) -> Option<M
     }
 }
 
+#[tracing::instrument(skip_all)]
 fn calculate_best_path(
     ctx: FindPathCtx<'_>,
     def_map: &DefMap,

--- a/crates/hir-def/src/visibility.rs
+++ b/crates/hir-def/src/visibility.rs
@@ -91,6 +91,7 @@ pub enum Visibility {
 }
 
 impl Visibility {
+    #[tracing::instrument(skip_all)]
     pub fn is_visible_from(self, db: &dyn DefDatabase, from_module: ModuleId) -> bool {
         let to_module = match self {
             Visibility::Module(m, _) => m,

--- a/crates/hir-ty/src/autoderef.rs
+++ b/crates/hir-ty/src/autoderef.rs
@@ -88,6 +88,7 @@ impl<'a, 'db> Autoderef<'a, 'db> {
 impl Iterator for Autoderef<'_, '_> {
     type Item = (Ty, usize);
 
+    #[tracing::instrument(skip_all)]
     fn next(&mut self) -> Option<Self::Item> {
         if self.at_start {
             self.at_start = false;

--- a/crates/hir-ty/src/builder.rs
+++ b/crates/hir-ty/src/builder.rs
@@ -125,6 +125,7 @@ impl<D> TyBuilder<D> {
         this
     }
 
+    #[tracing::instrument(skip_all)]
     pub(crate) fn fill_with_inference_vars(self, table: &mut InferenceTable<'_>) -> Self {
         self.fill(|x| match x {
             ParamKind::Type => table.new_type_var().cast(Interner),
@@ -208,6 +209,7 @@ impl TyBuilder<()> {
         )
     }
 
+    #[tracing::instrument(skip_all)]
     pub fn subst_for_def(
         db: &dyn HirDatabase,
         def: impl Into<GenericDefId>,

--- a/crates/hir-ty/src/infer/unify.rs
+++ b/crates/hir-ty/src/infer/unify.rs
@@ -469,12 +469,14 @@ impl<'a> InferenceTable<'a> {
         }
     }
 
+    #[tracing::instrument(skip_all)]
     pub(crate) fn rollback_to(&mut self, snapshot: InferenceTableSnapshot) {
         self.var_unification_table.rollback_to(snapshot.var_table_snapshot);
         self.type_variable_table = snapshot.type_variable_table_snapshot;
         self.pending_obligations = snapshot.pending_obligations;
     }
 
+    #[tracing::instrument(skip_all)]
     pub(crate) fn run_in_snapshot<T>(&mut self, f: impl FnOnce(&mut InferenceTable<'_>) -> T) -> T {
         let snapshot = self.snapshot();
         let result = f(self);

--- a/crates/hir-ty/src/method_resolution.rs
+++ b/crates/hir-ty/src/method_resolution.rs
@@ -931,6 +931,15 @@ pub fn iterate_method_candidates_dyn(
     mode: LookupMode,
     callback: &mut dyn FnMut(ReceiverAdjustments, AssocItemId, bool) -> ControlFlow<()>,
 ) -> ControlFlow<()> {
+    let _p = tracing::span!(
+        tracing::Level::INFO,
+        "iterate_method_candidates_dyn",
+        ?mode,
+        ?name,
+        traits_in_scope_len = traits_in_scope.len()
+    )
+    .entered();
+
     match mode {
         LookupMode::MethodCall => {
             // For method calls, rust first does any number of autoderef, and
@@ -984,6 +993,7 @@ pub fn iterate_method_candidates_dyn(
     }
 }
 
+#[tracing::instrument(skip_all, fields(name = ?name))]
 fn iterate_method_candidates_with_autoref(
     receiver_ty: &Canonical<Ty>,
     first_adjustment: ReceiverAdjustments,
@@ -1041,6 +1051,7 @@ fn iterate_method_candidates_with_autoref(
     )
 }
 
+#[tracing::instrument(skip_all, fields(name = ?name))]
 fn iterate_method_candidates_by_receiver(
     receiver_ty: &Canonical<Ty>,
     receiver_adjustments: ReceiverAdjustments,
@@ -1088,6 +1099,7 @@ fn iterate_method_candidates_by_receiver(
     ControlFlow::Continue(())
 }
 
+#[tracing::instrument(skip_all, fields(name = ?name))]
 fn iterate_method_candidates_for_self_ty(
     self_ty: &Canonical<Ty>,
     db: &dyn HirDatabase,
@@ -1119,6 +1131,7 @@ fn iterate_method_candidates_for_self_ty(
     )
 }
 
+#[tracing::instrument(skip_all, fields(name = ?name, visible_from_module, receiver_ty))]
 fn iterate_trait_method_candidates(
     self_ty: &Ty,
     table: &mut InferenceTable<'_>,
@@ -1175,6 +1188,7 @@ fn iterate_trait_method_candidates(
     ControlFlow::Continue(())
 }
 
+#[tracing::instrument(skip_all, fields(name = ?name, visible_from_module, receiver_ty))]
 fn iterate_inherent_methods(
     self_ty: &Ty,
     table: &mut InferenceTable<'_>,
@@ -1267,6 +1281,7 @@ fn iterate_inherent_methods(
     }
     return ControlFlow::Continue(());
 
+    #[tracing::instrument(skip_all, fields(name = ?name, visible_from_module, receiver_ty))]
     fn iterate_inherent_trait_methods(
         self_ty: &Ty,
         table: &mut InferenceTable<'_>,
@@ -1293,6 +1308,7 @@ fn iterate_inherent_methods(
         ControlFlow::Continue(())
     }
 
+    #[tracing::instrument(skip_all, fields(name = ?name, visible_from_module, receiver_ty))]
     fn impls_for_self_ty(
         impls: &InherentImpls,
         self_ty: &Ty,
@@ -1356,6 +1372,7 @@ macro_rules! check_that {
     };
 }
 
+#[tracing::instrument(skip_all, fields(name))]
 fn is_valid_candidate(
     table: &mut InferenceTable<'_>,
     name: Option<&Name>,
@@ -1403,6 +1420,7 @@ enum IsValidCandidate {
     NotVisible,
 }
 
+#[tracing::instrument(skip_all, fields(name))]
 fn is_valid_fn_candidate(
     table: &mut InferenceTable<'_>,
     fn_id: FunctionId,
@@ -1540,6 +1558,7 @@ pub fn implements_trait_unique(
 
 /// This creates Substs for a trait with the given Self type and type variables
 /// for all other parameters, to query Chalk with it.
+#[tracing::instrument(skip_all)]
 fn generic_implements_goal(
     db: &dyn HirDatabase,
     env: Arc<TraitEnvironment>,

--- a/crates/hir-ty/src/method_resolution.rs
+++ b/crates/hir-ty/src/method_resolution.rs
@@ -1439,14 +1439,14 @@ fn is_valid_fn_candidate(
             _ => unreachable!(),
         };
 
-        let fn_subst = TyBuilder::subst_for_def(db, fn_id, Some(impl_subst.clone()))
-            .fill_with_inference_vars(table)
-            .build();
-
         check_that!(table.unify(&expect_self_ty, self_ty));
 
         if let Some(receiver_ty) = receiver_ty {
             check_that!(data.has_self_param());
+
+            let fn_subst = TyBuilder::subst_for_def(db, fn_id, Some(impl_subst.clone()))
+                .fill_with_inference_vars(table)
+                .build();
 
             let sig = db.callable_item_signature(fn_id.into());
             let expected_receiver =

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -4101,6 +4101,14 @@ impl Type {
         name: Option<&Name>,
         callback: &mut dyn FnMut(AssocItemId) -> ControlFlow<()>,
     ) {
+        let _p = tracing::span!(
+            tracing::Level::INFO,
+            "iterate_method_candidates_dyn",
+            with_local_impls = traits_in_scope.len(),
+            traits_in_scope = traits_in_scope.len(),
+            ?name,
+        )
+        .entered();
         // There should be no inference vars in types passed here
         let canonical = hir_ty::replace_errors_with_variables(&self.ty);
 
@@ -4122,6 +4130,7 @@ impl Type {
         );
     }
 
+    #[tracing::instrument(skip_all, fields(name = ?name))]
     pub fn iterate_path_candidates<T>(
         &self,
         db: &dyn HirDatabase,
@@ -4150,6 +4159,7 @@ impl Type {
         slot
     }
 
+    #[tracing::instrument(skip_all, fields(name = ?name))]
     fn iterate_path_candidates_dyn(
         &self,
         db: &dyn HirDatabase,

--- a/crates/ide-completion/src/completions/flyimport.rs
+++ b/crates/ide-completion/src/completions/flyimport.rs
@@ -395,6 +395,14 @@ fn import_assets_for_path(
     potential_import_name: &str,
     qualifier: Option<ast::Path>,
 ) -> Option<ImportAssets> {
+    let _p = tracing::span!(
+        tracing::Level::INFO,
+        "import_assets_for_path",
+        ?potential_import_name,
+        ?qualifier
+    )
+    .entered();
+
     let fuzzy_name_length = potential_import_name.len();
     let mut assets_for_path = ImportAssets::for_fuzzy_path(
         ctx.module,

--- a/crates/ide-db/src/imports/import_assets.rs
+++ b/crates/ide-db/src/imports/import_assets.rs
@@ -605,6 +605,7 @@ fn assoc_to_item(assoc: AssocItem) -> ItemInNs {
     }
 }
 
+#[tracing::instrument(skip_all)]
 fn get_mod_path(
     db: &RootDatabase,
     item_to_search: ItemInNs,


### PR DESCRIPTION
As part of profiling completions, I added some additional spans and moved `TyBuilder::subst_for_def` closer to its usage site (the latter had a small impact on completion performance. Thanks for the tip, Lukas!)
