### PR TITLE
internal: Use MacOS 12 runners for releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,10 +43,10 @@ jobs:
           - os: ubuntu-20.04
             target: arm-unknown-linux-gnueabihf
             code-target: linux-armhf
-          - os: macos-11
+          - os: macos-12
             target: x86_64-apple-darwin
             code-target: darwin-x64
-          - os: macos-11
+          - os: macos-12
             target: aarch64-apple-darwin
             code-target: darwin-arm64
 


### PR DESCRIPTION
CC #16457