### PR TITLE
internal: skip associated items and call `generic_implements_goal` earlier in method resolution

### DIFF
--- a/crates/hir-ty/src/infer/unify.rs
+++ b/crates/hir-ty/src/infer/unify.rs
@@ -422,6 +422,7 @@ impl<'a> InferenceTable<'a> {
     }
 
     /// Unify two relatable values (e.g. `Ty`) and register new trait goals that arise from that.
+    #[tracing::instrument(skip_all)]
     pub(crate) fn unify<T: ?Sized + Zip<Interner>>(&mut self, ty1: &T, ty2: &T) -> bool {
         let result = match self.try_unify(ty1, ty2) {
             Ok(r) => r,

--- a/crates/hir-ty/src/traits.rs
+++ b/crates/hir-ty/src/traits.rs
@@ -139,6 +139,7 @@ fn solve(
     block: Option<BlockId>,
     goal: &chalk_ir::UCanonical<chalk_ir::InEnvironment<chalk_ir::Goal<Interner>>>,
 ) -> Option<chalk_solve::Solution<Interner>> {
+    let _p = tracing::span!(tracing::Level::INFO, "solve", ?krate, ?block).entered();
     let context = ChalkContext { db, krate, block };
     tracing::debug!("solve goal: {:?}", goal);
     let mut solver = create_chalk_solver();


### PR DESCRIPTION
This is a small change whose correctness I'm not entirely convinced of, but based on the discussion in https://github.com/rust-lang/rust-analyzer/issues/6432 and my testing in https://github.com/oxidecomputer/omicron, this _seems_ to provide faster completions, especially when it comes to flyimport-based ones.

_Without_ these changes, I'm seeing completions take roughly 808ms cold and 570ms warm. _With_ these changes, I'm seeing completions take 473ms cold and 55-90ms warm.
