### PR TITLE
minor: Remove `ffi_returns_twice` references

### DIFF
--- a/crates/hir-def/src/attr/builtin.rs
+++ b/crates/hir-def/src/attr/builtin.rs
@@ -283,9 +283,6 @@ pub const INERT_ATTRIBUTES: &[BuiltinAttribute] = &[
         experimental!(optimize),
     ),
 
-    gated!(
-        ffi_returns_twice, Normal, template!(Word), WarnFollowing, experimental!(ffi_returns_twice)
-    ),
     gated!(ffi_pure, Normal, template!(Word), WarnFollowing, experimental!(ffi_pure)),
     gated!(ffi_const, Normal, template!(Word), WarnFollowing, experimental!(ffi_const)),
     gated!(

--- a/crates/ide-db/src/generated/lints.rs
+++ b/crates/ide-db/src/generated/lints.rs
@@ -5047,17 +5047,6 @@ against are compatible with those of the `#[ffi_pure]`.
 "##,
     },
     Lint {
-        label: "ffi_returns_twice",
-        description: r##"# `ffi_returns_twice`
-
-The tracking issue for this feature is: [#58314]
-
-[#58314]: https://github.com/rust-lang/rust/issues/58314
-
-------------------------
-"##,
-    },
-    Lint {
         label: "float_gamma",
         description: r##"# `float_gamma`
 


### PR DESCRIPTION
This feature has just been [removed](https://github.com/rust-lang/rust/pull/120502)