### PR TITLE
internal: fix crash inside `filter_unnecessary_bounds` for a missing generic param

### DIFF
--- a/crates/ide-assists/src/handlers/generate_function.rs
+++ b/crates/ide-assists/src/handlers/generate_function.rs
@@ -908,7 +908,7 @@ fn filter_unnecessary_bounds(
         }
     }
 
-    let starting_nodes = necessary_params.iter().map(|param| param_map[param]);
+    let starting_nodes = necessary_params.iter().flat_map(|param| param_map.get(param).copied());
     let reachable = graph.compute_reachable_nodes(starting_nodes);
 
     // Not pretty, but effective. If only there were `Vec::retain_index()`...


### PR DESCRIPTION
@Wilfred reported a crash here shortly after reporting https://github.com/rust-lang/rust-analyzer/issues/16516, which makes us think that the blast radius of ambiguities in Chalk can be larger than expected. This PR tries to be a bit more defensive as a result.

(The 20th frame is the salient frame in the backtrace below.)

<details>
<summary>Backtrace of the crash</summary>

```
request handler panicked: no entry found for key
backtrace:
   0: stdx::panic_context::PanicContext::init::{{closure}}::{{closure}}::{{closure}}
             at /data/sandcastle/boxes/eden-trunk-hg-fbcode-fbsource/third-party/rust-analyzer/master/crates/stdx/src/panic_context.rs:32:43
   1: stdx::panic_context::with_backtrace::{{closure}}
             at /data/sandcastle/boxes/eden-trunk-hg-fbcode-fbsource/third-party/rust-analyzer/master/crates/stdx/src/panic_context.rs:61:32
   2: std::thread::local::LocalKey<T>::try_with
             at /rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/std/src/thread/local.rs:270:16
   3: std::thread::local::LocalKey<T>::with
             at /rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/std/src/thread/local.rs:246:9
   4: stdx::panic_context::with_backtrace
             at /data/sandcastle/boxes/eden-trunk-hg-fbcode-fbsource/third-party/rust-analyzer/master/crates/stdx/src/panic_context.rs:61:5
   5: stdx::panic_context::PanicContext::init::{{closure}}::{{closure}}
             at /data/sandcastle/boxes/eden-trunk-hg-fbcode-fbsource/third-party/rust-analyzer/master/crates/stdx/src/panic_context.rs:31:21
   6: stdx::panic_context::with_ctx::{{closure}}
             at /data/sandcastle/boxes/eden-trunk-hg-fbcode-fbsource/third-party/rust-analyzer/master/crates/stdx/src/panic_context.rs:53:20
   7: std::thread::local::LocalKey<T>::try_with
             at /rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/std/src/thread/local.rs:270:16
   8: std::thread::local::LocalKey<T>::with
             at /rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/std/src/thread/local.rs:246:9
   9: <alloc::boxed::Box<F,A> as core::ops::function::Fn<Args>>::call
             at /rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/alloc/src/boxed.rs:2021:9
  10: std::panicking::rust_panic_with_hook
             at /rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/std/src/panicking.rs:783:13
  11: std::panicking::begin_panic_handler::{{closure}}
             at /rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/std/src/panicking.rs:657:13
  12: std::sys_common::backtrace::__rust_end_short_backtrace
             at /rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/std/src/sys_common/backtrace.rs:170:18
  13: rust_begin_unwind
             at /rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/std/src/panicking.rs:645:5
  14: core::panicking::panic_fmt
             at /rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/core/src/panicking.rs:72:14
  15: core::panicking::panic_display
             at /rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/core/src/panicking.rs:178:5
  16: core::panicking::panic_str
             at /rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/core/src/panicking.rs:152:5
  17: core::option::expect_failed
             at /rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/core/src/option.rs:1985:5
  18: core::option::Option<T>::expect
             at /rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/core/src/option.rs:894:21
  19: <std::collections::hash::map::HashMap<K,V,S> as core::ops::index::Index<&Q>>::index
             at /rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/std/src/collections/hash/map.rs:1341:23
  20: ide_assists::handlers::generate_function::filter_unnecessary_bounds::{{closure}}
             at /data/sandcastle/boxes/eden-trunk-hg-fbcode-fbsource/third-party/rust-analyzer/master/crates/ide-assists/src/handlers/generate_function.rs:911:71
  21: core::ops::function::impls::<impl core::ops::function::FnOnce<A> for &mut F>::call_once
             at /rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/core/src/ops/function.rs:305:13
  22: core::option::Option<T>::map
             at /rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/core/src/option.rs:1072:29
  23: <core::iter::adapters::map::Map<I,F> as core::iter::traits::iterator::Iterator>::next
             at /rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/core/src/iter/adapters/map.rs:103:26
  24: ide_assists::handlers::generate_function::Graph::compute_reachable_nodes
             at /data/sandcastle/boxes/eden-trunk-hg-fbcode-fbsource/third-party/rust-analyzer/master/crates/ide-assists/src/handlers/generate_function.rs:1158:20
  25: ide_assists::handlers::generate_function::filter_unnecessary_bounds
             at /data/sandcastle/boxes/eden-trunk-hg-fbcode-fbsource/third-party/rust-analyzer/master/crates/ide-assists/src/handlers/generate_function.rs:912:21
  26: ide_assists::handlers::generate_function::fn_generic_params
             at /data/sandcastle/boxes/eden-trunk-hg-fbcode-fbsource/third-party/rust-analyzer/master/crates/ide-assists/src/handlers/generate_function.rs:640:5
  27: ide_assists::handlers::generate_function::FunctionBuilder::from_call
             at /data/sandcastle/boxes/eden-trunk-hg-fbcode-fbsource/third-party/rust-analyzer/master/crates/ide-assists/src/handlers/generate_function.rs:283:13
  28: ide_assists::handlers::generate_function::gen_fn
             at /data/sandcastle/boxes/eden-trunk-hg-fbcode-fbsource/third-party/rust-analyzer/master/crates/ide-assists/src/handlers/generate_function.rs:78:28
  29: ide_assists::handlers::generate_function::generate_function
             at /data/sandcastle/boxes/eden-trunk-hg-fbcode-fbsource/third-party/rust-analyzer/master/crates/ide-assists/src/handlers/generate_function.rs:55:5
  30: ide_assists::assists::{{closure}}
             at /data/sandcastle/boxes/eden-trunk-hg-fbcode-fbsource/third-party/rust-analyzer/master/crates/ide-assists/src/lib.rs:99:9
  31: <core::slice::iter::Iter<T> as core::iter::traits::iterator::Iterator>::for_each
             at /rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/core/src/slice/iter/macros.rs:254:21
  32: ide_assists::assists
             at /data/sandcastle/boxes/eden-trunk-hg-fbcode-fbsource/third-party/rust-analyzer/master/crates/ide-assists/src/lib.rs:98:5
  33: ide::Analysis::assists_with_fixes::{{closure}}
             at /data/sandcastle/boxes/eden-trunk-hg-fbcode-fbsource/third-party/rust-analyzer/master/crates/ide/src/lib.rs:667:27
  34: ide::Analysis::with_db::{{closure}}
             at /data/sandcastle/boxes/eden-trunk-hg-fbcode-fbsource/third-party/rust-analyzer/master/crates/ide/src/lib.rs:764:29
  35: std::panicking::try::do_call
             at /rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/std/src/panicking.rs:552:40
  36: std::panicking::try
             at /rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/std/src/panicking.rs:516:19
  37: std::panic::catch_unwind
             at /rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/std/src/panic.rs:142:14
  38: salsa::Cancelled::catch
             at /var/twsvcscm/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rust-analyzer-salsa-0.17.0-pre.5/src/lib.rs:631:15
  39: ide::Analysis::with_db
             at /data/sandcastle/boxes/eden-trunk-hg-fbcode-fbsource/third-party/rust-analyzer/master/crates/ide/src/lib.rs:764:9
  40: ide::Analysis::assists_with_fixes
             at /data/sandcastle/boxes/eden-trunk-hg-fbcode-fbsource/third-party/rust-analyzer/master/crates/ide/src/lib.rs:656:9
  41: rust_analyzer::handlers::request::handle_code_action
             at /data/sandcastle/boxes/eden-trunk-hg-fbcode-fbsource/third-party/rust-analyzer/master/crates/rust-analyzer/src/handlers/request.rs:1149:19
  42: rust_analyzer::dispatch::RequestDispatcher::on_with_thread_intent::{{closure}}::{{closure}}
             at /data/sandcastle/boxes/eden-trunk-hg-fbcode-fbsource/third-party/rust-analyzer/master/crates/rust-analyzer/src/dispatch.rs:198:54
  43: std::panicking::try::do_call
             at /rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/std/src/panicking.rs:552:40
  44: std::panicking::try
             at /rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/std/src/panicking.rs:516:19
  45: std::panic::catch_unwind
             at /rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/std/src/panic.rs:142:14
  46: rust_analyzer::dispatch::RequestDispatcher::on_with_thread_intent::{{closure}}
             at /data/sandcastle/boxes/eden-trunk-hg-fbcode-fbsource/third-party/rust-analyzer/master/crates/rust-analyzer/src/dispatch.rs:198:26
  47: rust_analyzer::task_pool::TaskPool<T>::spawn::{{closure}}
             at /data/sandcastle/boxes/eden-trunk-hg-fbcode-fbsource/third-party/rust-analyzer/master/crates/rust-analyzer/src/task_pool.rs:26:33
  48: stdx::thread::pool::Pool::spawn::{{closure}}
             at /data/sandcastle/boxes/eden-trunk-hg-fbcode-fbsource/third-party/rust-analyzer/master/crates/stdx/src/thread/pool.rs:82:13
  49: core::ops::function::FnOnce::call_once{{vtable.shim}}
             at /rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/core/src/ops/function.rs:250:5
  50: <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once
             at /rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/alloc/src/boxed.rs:2007:9
  51: stdx::thread::pool::Pool::new::{{closure}}
             at /data/sandcastle/boxes/eden-trunk-hg-fbcode-fbsource/third-party/rust-analyzer/master/crates/stdx/src/thread/pool.rs:61:29
  52: stdx::thread::Builder::spawn::{{closure}}
             at /data/sandcastle/boxes/eden-trunk-hg-fbcode-fbsource/third-party/rust-analyzer/master/crates/stdx/src/thread.rs:66:13
  53: std::sys_common::backtrace::__rust_begin_short_backtrace
             at /rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/std/src/sys_common/backtrace.rs:154:18
  54: std::thread::Builder::spawn_unchecked_::{{closure}}::{{closure}}
             at /rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/std/src/thread/mod.rs:529:17
  55: <core::panic::unwind_safe::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once
             at /rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/core/src/panic/unwind_safe.rs:272:9
  56: std::panicking::try::do_call
             at /rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/std/src/panicking.rs:552:40
  57: std::panicking::try
             at /rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/std/src/panicking.rs:516:19
  58: std::panic::catch_unwind
             at /rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/std/src/panic.rs:142:14
  59: std::thread::Builder::spawn_unchecked_::{{closure}}
             at /rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/std/src/thread/mod.rs:528:30
  60: core::ops::function::FnOnce::call_once{{vtable.shim}}
             at /rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/core/src/ops/function.rs:250:5
  61: <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once
             at /rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/alloc/src/boxed.rs:2007:9
  62: <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once
             at /rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/alloc/src/boxed.rs:2007:9
  63: std::sys::unix::thread::Thread::new::thread_start
             at /rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/std/src/sys/unix/thread.rs:108:17
  64: start_thread
  65: clone3
  ```
  </details>