### PR TITLE
internal: Enable some minor lints that we should tackles (take2)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -168,7 +168,6 @@ new_ret_no_self = "allow"
 useless_asref = "allow"
 
 ## Following lints should be tackled at some point
-borrowed_box = "allow"
 too_many_arguments = "allow"
 type_complexity = "allow"
 wrong_self_convention = "allow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -170,7 +170,6 @@ useless_asref = "allow"
 ## Following lints should be tackled at some point
 borrowed_box = "allow"
 derived_hash_with_manual_eq = "allow"
-forget_non_drop = "allow"
 needless_doctest_main = "allow"
 too_many_arguments = "allow"
 type_complexity = "allow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -169,7 +169,6 @@ useless_asref = "allow"
 
 ## Following lints should be tackled at some point
 borrowed_box = "allow"
-derived_hash_with_manual_eq = "allow"
 too_many_arguments = "allow"
 type_complexity = "allow"
 wrong_self_convention = "allow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -170,7 +170,6 @@ useless_asref = "allow"
 ## Following lints should be tackled at some point
 borrowed_box = "allow"
 derived_hash_with_manual_eq = "allow"
-needless_doctest_main = "allow"
 too_many_arguments = "allow"
 type_complexity = "allow"
 wrong_self_convention = "allow"

--- a/crates/hir-def/src/generics.rs
+++ b/crates/hir-def/src/generics.rs
@@ -264,7 +264,7 @@ impl GenericParamsCollector {
                 self.add_where_predicate_from_bound(
                     lower_ctx,
                     bound,
-                    lifetimes.as_ref(),
+                    lifetimes.as_deref(),
                     target.clone(),
                 );
             }
@@ -275,14 +275,14 @@ impl GenericParamsCollector {
         &mut self,
         lower_ctx: &LowerCtx<'_>,
         bound: ast::TypeBound,
-        hrtb_lifetimes: Option<&Box<[Name]>>,
+        hrtb_lifetimes: Option<&[Name]>,
         target: Either<TypeRef, LifetimeRef>,
     ) {
         let bound = TypeBound::from_ast(lower_ctx, bound);
         let predicate = match (target, bound) {
             (Either::Left(type_ref), bound) => match hrtb_lifetimes {
                 Some(hrtb_lifetimes) => WherePredicate::ForLifetime {
-                    lifetimes: hrtb_lifetimes.clone(),
+                    lifetimes: hrtb_lifetimes.to_vec().into_boxed_slice(),
                     target: WherePredicateTypeTarget::TypeRef(Interned::new(type_ref)),
                     bound: Interned::new(bound),
                 },

--- a/crates/hir-def/src/lib.rs
+++ b/crates/hir-def/src/lib.rs
@@ -721,6 +721,9 @@ impl Clone for Box<dyn OpaqueInternableThing> {
 pub struct InTypeConstId(salsa::InternId);
 impl_intern!(InTypeConstId, InTypeConstLoc, intern_in_type_const, lookup_intern_in_type_const);
 
+// We would like to set `derive(PartialEq)`
+// but the compiler complains about that `.expected_ty` does not implement the `Copy` trait.
+#[allow(clippy::derived_hash_with_manual_eq)]
 #[derive(Debug, Hash, Eq, Clone)]
 pub struct InTypeConstLoc {
     pub id: AstId<ast::ConstArg>,

--- a/crates/hir-ty/src/lib.rs
+++ b/crates/hir-ty/src/lib.rs
@@ -228,7 +228,7 @@ impl MemoryMap {
         &self,
         mut f: impl FnMut(&[u8], usize) -> Result<usize, MirEvalError>,
     ) -> Result<FxHashMap<usize, usize>, MirEvalError> {
-        let mut transform = |(addr, val): (&usize, &Box<[u8]>)| {
+        let mut transform = |(addr, val): (&usize, &[u8])| {
             let addr = *addr;
             let align = if addr == 0 { 64 } else { (addr - (addr & (addr - 1))).min(64) };
             f(val, align).map(|it| (addr, it))
@@ -240,7 +240,9 @@ impl MemoryMap {
                 map.insert(addr, val);
                 map
             }),
-            MemoryMap::Complex(cm) => cm.memory.iter().map(transform).collect(),
+            MemoryMap::Complex(cm) => {
+                cm.memory.iter().map(|(addr, val)| transform((addr, val))).collect()
+            }
         }
     }
 

--- a/crates/hir-ty/src/mir/lower.rs
+++ b/crates/hir-ty/src/mir/lower.rs
@@ -126,6 +126,10 @@ impl DropScopeToken {
     }
 }
 
+impl Drop for DropScopeToken {
+    fn drop(&mut self) {}
+}
+
 // Uncomment this to make `DropScopeToken` a drop bomb. Unfortunately we can't do this in release, since
 // in cases that mir lowering fails, we don't handle (and don't need to handle) drop scopes so it will be
 // actually reached. `pop_drop_scope_assert_finished` will also detect this case, but doesn't show useful

--- a/crates/ide/src/inlay_hints/implicit_drop.rs
+++ b/crates/ide/src/inlay_hints/implicit_drop.rs
@@ -1,10 +1,8 @@
 //! Implementation of "implicit drop" inlay hints:
-//! ```no_run
-//! fn main() {
-//!     let x = vec![2];
-//!     if some_condition() {
-//!         /* drop(x) */return;
-//!     }
+//! ```ignore
+//! let x = vec![2];
+//! if some_condition() {
+//!     /* drop(x) */return;
 //! }
 //! ```
 use hir::{

--- a/crates/ide/src/inlay_hints/range_exclusive.rs
+++ b/crates/ide/src/inlay_hints/range_exclusive.rs
@@ -1,5 +1,5 @@
 //! Implementation of "range exclusive" inlay hints:
-//! ```no_run
+//! ```ignore
 //! for i in 0../* < */10 {}
 //! if let ../* < */100 = 50 {}
 //! ```


### PR DESCRIPTION
This enables these lints:

- borrowed_box
- derived_hash_with_manual_eq
- forget_non_drop
- needless_doctest_main