### PR TITLE
Abstract more over ItemTreeLoc-like structs

### DIFF
--- a/crates/hir-def/src/attr.rs
+++ b/crates/hir-def/src/attr.rs
@@ -356,7 +356,6 @@ impl AttrsWithOwner {
             AttrDefId::FieldId(it) => {
                 return db.fields_attrs(it.parent)[it.local_id].clone();
             }
-            // FIXME: DRY this up
             AttrDefId::EnumVariantId(it) => {
                 let id = it.lookup(db).id;
                 let tree = id.item_tree(db);

--- a/crates/hir-def/src/attr.rs
+++ b/crates/hir-def/src/attr.rs
@@ -24,12 +24,11 @@ use triomphe::Arc;
 
 use crate::{
     db::DefDatabase,
-    item_tree::{AttrOwner, Fields, ItemTreeId, ItemTreeModItemNode},
+    item_tree::{AttrOwner, Fields, ItemTreeNode},
     lang_item::LangItem,
     nameres::{ModuleOrigin, ModuleSource},
     src::{HasChildSource, HasSource},
-    AdtId, AssocItemLoc, AttrDefId, GenericParamId, ItemLoc, LocalFieldId, Lookup, MacroId,
-    VariantId,
+    AdtId, AttrDefId, GenericParamId, ItemTreeLoc, LocalFieldId, Lookup, MacroId, VariantId,
 };
 
 /// Desugared attributes of an item post `cfg_attr` expansion.
@@ -356,11 +355,7 @@ impl AttrsWithOwner {
             AttrDefId::FieldId(it) => {
                 return db.fields_attrs(it.parent)[it.local_id].clone();
             }
-            AttrDefId::EnumVariantId(it) => {
-                let id = it.lookup(db).id;
-                let tree = id.item_tree(db);
-                tree.raw_attrs(id.value.into()).clone()
-            }
+            AttrDefId::EnumVariantId(it) => attrs_from_item_tree_loc(db, it),
             AttrDefId::AdtId(it) => match it {
                 AdtId::StructId(it) => attrs_from_item_tree_loc(db, it),
                 AdtId::EnumId(it) => attrs_from_item_tree_loc(db, it),
@@ -369,15 +364,15 @@ impl AttrsWithOwner {
             AttrDefId::TraitId(it) => attrs_from_item_tree_loc(db, it),
             AttrDefId::TraitAliasId(it) => attrs_from_item_tree_loc(db, it),
             AttrDefId::MacroId(it) => match it {
-                MacroId::Macro2Id(it) => attrs_from_item_tree(db, it.lookup(db).id),
-                MacroId::MacroRulesId(it) => attrs_from_item_tree(db, it.lookup(db).id),
-                MacroId::ProcMacroId(it) => attrs_from_item_tree(db, it.lookup(db).id),
+                MacroId::Macro2Id(it) => attrs_from_item_tree_loc(db, it),
+                MacroId::MacroRulesId(it) => attrs_from_item_tree_loc(db, it),
+                MacroId::ProcMacroId(it) => attrs_from_item_tree_loc(db, it),
             },
             AttrDefId::ImplId(it) => attrs_from_item_tree_loc(db, it),
-            AttrDefId::ConstId(it) => attrs_from_item_tree_assoc(db, it),
-            AttrDefId::StaticId(it) => attrs_from_item_tree_assoc(db, it),
-            AttrDefId::FunctionId(it) => attrs_from_item_tree_assoc(db, it),
-            AttrDefId::TypeAliasId(it) => attrs_from_item_tree_assoc(db, it),
+            AttrDefId::ConstId(it) => attrs_from_item_tree_loc(db, it),
+            AttrDefId::StaticId(it) => attrs_from_item_tree_loc(db, it),
+            AttrDefId::FunctionId(it) => attrs_from_item_tree_loc(db, it),
+            AttrDefId::TypeAliasId(it) => attrs_from_item_tree_loc(db, it),
             AttrDefId::GenericParamId(it) => match it {
                 GenericParamId::ConstParamId(it) => {
                     let src = it.parent().child_source(db);
@@ -602,29 +597,14 @@ fn any_has_attrs<'db>(
     id.lookup(db).source(db).map(ast::AnyHasAttrs::new)
 }
 
-fn attrs_from_item_tree<N: ItemTreeModItemNode>(
-    db: &dyn DefDatabase,
-    id: ItemTreeId<N>,
+fn attrs_from_item_tree_loc<'db, N: ItemTreeNode>(
+    db: &(dyn DefDatabase + 'db),
+    lookup: impl Lookup<Database<'db> = dyn DefDatabase + 'db, Data = impl ItemTreeLoc<Id = N>>,
 ) -> RawAttrs {
+    let id = lookup.lookup(db).item_tree_id();
     let tree = id.item_tree(db);
-    let mod_item = N::id_to_mod_item(id.value);
-    tree.raw_attrs(mod_item.into()).clone()
-}
-
-fn attrs_from_item_tree_loc<'db, N: ItemTreeModItemNode>(
-    db: &(dyn DefDatabase + 'db),
-    lookup: impl Lookup<Database<'db> = dyn DefDatabase + 'db, Data = ItemLoc<N>>,
-) -> RawAttrs {
-    let id = lookup.lookup(db).id;
-    attrs_from_item_tree(db, id)
-}
-
-fn attrs_from_item_tree_assoc<'db, N: ItemTreeModItemNode>(
-    db: &(dyn DefDatabase + 'db),
-    lookup: impl Lookup<Database<'db> = dyn DefDatabase + 'db, Data = AssocItemLoc<N>>,
-) -> RawAttrs {
-    let id = lookup.lookup(db).id;
-    attrs_from_item_tree(db, id)
+    let attr_owner = N::attr_owner(id.value);
+    tree.raw_attrs(attr_owner).clone()
 }
 
 pub(crate) fn fields_attrs_source_map(

--- a/crates/hir-def/src/generics.rs
+++ b/crates/hir-def/src/generics.rs
@@ -21,13 +21,13 @@ use crate::{
     db::DefDatabase,
     dyn_map::{keys, DynMap},
     expander::Expander,
-    item_tree::ItemTree,
+    item_tree::{ItemTree, ItemTreeModItemNode},
     lower::LowerCtx,
     nameres::{DefMap, MacroSubNs},
     src::{HasChildSource, HasSource},
     type_ref::{ConstRef, LifetimeRef, TypeBound, TypeRef},
-    AdtId, ConstParamId, GenericDefId, HasModule, LifetimeParamId, LocalLifetimeParamId,
-    LocalTypeOrConstParamId, Lookup, TypeOrConstParamId, TypeParamId,
+    AdtId, AssocItemLoc, ConstParamId, GenericDefId, HasModule, ItemLoc, LifetimeParamId,
+    LocalLifetimeParamId, LocalTypeOrConstParamId, Lookup, TypeOrConstParamId, TypeParamId,
 };
 
 /// Data about a generic type parameter (to a function, struct, impl, ...).
@@ -509,45 +509,34 @@ impl GenericParams {
 }
 
 fn file_id_and_params_of(
-    def: GenericDefId,
     db: &dyn DefDatabase,
+    def: GenericDefId,
 ) -> (HirFileId, Option<ast::GenericParamList>) {
     match def {
-        GenericDefId::FunctionId(it) => {
-            let src = it.lookup(db).source(db);
-            (src.file_id, src.value.generic_param_list())
-        }
-        GenericDefId::AdtId(AdtId::StructId(it)) => {
-            let src = it.lookup(db).source(db);
-            (src.file_id, src.value.generic_param_list())
-        }
-        GenericDefId::AdtId(AdtId::UnionId(it)) => {
-            let src = it.lookup(db).source(db);
-            (src.file_id, src.value.generic_param_list())
-        }
-        GenericDefId::AdtId(AdtId::EnumId(it)) => {
-            let src = it.lookup(db).source(db);
-            (src.file_id, src.value.generic_param_list())
-        }
-        GenericDefId::TraitId(it) => {
-            let src = it.lookup(db).source(db);
-            (src.file_id, src.value.generic_param_list())
-        }
-        GenericDefId::TraitAliasId(it) => {
-            let src = it.lookup(db).source(db);
-            (src.file_id, src.value.generic_param_list())
-        }
-        GenericDefId::TypeAliasId(it) => {
-            let src = it.lookup(db).source(db);
-            (src.file_id, src.value.generic_param_list())
-        }
-        GenericDefId::ImplId(it) => {
-            let src = it.lookup(db).source(db);
-            (src.file_id, src.value.generic_param_list())
-        }
+        GenericDefId::FunctionId(it) => file_id_and_params_of_item_loc(db, it),
+        GenericDefId::TypeAliasId(it) => file_id_and_params_of_item_loc(db, it),
+        GenericDefId::ConstId(_) => (FileId::BOGUS.into(), None),
+        GenericDefId::AdtId(AdtId::StructId(it)) => file_id_and_params_of_item_loc(db, it),
+        GenericDefId::AdtId(AdtId::UnionId(it)) => file_id_and_params_of_item_loc(db, it),
+        GenericDefId::AdtId(AdtId::EnumId(it)) => file_id_and_params_of_item_loc(db, it),
+        GenericDefId::TraitId(it) => file_id_and_params_of_item_loc(db, it),
+        GenericDefId::TraitAliasId(it) => file_id_and_params_of_item_loc(db, it),
+        GenericDefId::ImplId(it) => file_id_and_params_of_item_loc(db, it),
         // We won't be using this ID anyway
-        GenericDefId::EnumVariantId(_) | GenericDefId::ConstId(_) => (FileId::BOGUS.into(), None),
+        GenericDefId::EnumVariantId(_) => (FileId::BOGUS.into(), None),
     }
+}
+
+fn file_id_and_params_of_item_loc<Loc>(
+    db: &dyn DefDatabase,
+    def: impl for<'db> Lookup<Database<'db> = dyn DefDatabase + 'db, Data = Loc>,
+) -> (HirFileId, Option<ast::GenericParamList>)
+where
+    Loc: HasSource,
+    Loc::Value: HasGenericParams,
+{
+    let src = def.lookup(db).source(db);
+    (src.file_id, src.value.generic_param_list())
 }
 
 impl HasChildSource<LocalTypeOrConstParamId> for GenericDefId {
@@ -559,7 +548,7 @@ impl HasChildSource<LocalTypeOrConstParamId> for GenericDefId {
         let generic_params = db.generic_params(*self);
         let mut idx_iter = generic_params.type_or_consts.iter().map(|(idx, _)| idx);
 
-        let (file_id, generic_params_list) = file_id_and_params_of(*self, db);
+        let (file_id, generic_params_list) = file_id_and_params_of(db, *self);
 
         let mut params = ArenaMap::default();
 
@@ -598,7 +587,7 @@ impl HasChildSource<LocalLifetimeParamId> for GenericDefId {
         let generic_params = db.generic_params(*self);
         let idx_iter = generic_params.lifetimes.iter().map(|(idx, _)| idx);
 
-        let (file_id, generic_params_list) = file_id_and_params_of(*self, db);
+        let (file_id, generic_params_list) = file_id_and_params_of(db, *self);
 
         let mut params = ArenaMap::default();
 
@@ -614,7 +603,7 @@ impl HasChildSource<LocalLifetimeParamId> for GenericDefId {
 
 impl ChildBySource for GenericDefId {
     fn child_by_source_to(&self, db: &dyn DefDatabase, res: &mut DynMap, file_id: HirFileId) {
-        let (gfile_id, generic_params_list) = file_id_and_params_of(*self, db);
+        let (gfile_id, generic_params_list) = file_id_and_params_of(db, *self);
         if gfile_id != file_id {
             return;
         }

--- a/crates/hir-def/src/generics.rs
+++ b/crates/hir-def/src/generics.rs
@@ -21,13 +21,13 @@ use crate::{
     db::DefDatabase,
     dyn_map::{keys, DynMap},
     expander::Expander,
-    item_tree::{ItemTree, ItemTreeModItemNode},
+    item_tree::ItemTree,
     lower::LowerCtx,
     nameres::{DefMap, MacroSubNs},
     src::{HasChildSource, HasSource},
     type_ref::{ConstRef, LifetimeRef, TypeBound, TypeRef},
-    AdtId, AssocItemLoc, ConstParamId, GenericDefId, HasModule, ItemLoc, LifetimeParamId,
-    LocalLifetimeParamId, LocalTypeOrConstParamId, Lookup, TypeOrConstParamId, TypeParamId,
+    AdtId, ConstParamId, GenericDefId, HasModule, LifetimeParamId, LocalLifetimeParamId,
+    LocalTypeOrConstParamId, Lookup, TypeOrConstParamId, TypeParamId,
 };
 
 /// Data about a generic type parameter (to a function, struct, impl, ...).

--- a/crates/hir-def/src/item_tree/lower.rs
+++ b/crates/hir-def/src/item_tree/lower.rs
@@ -13,7 +13,7 @@ use crate::{
 
 use super::*;
 
-fn id<N: ItemTreeModItemNode>(index: Idx<N>) -> FileItemTreeId<N> {
+fn id<N: ItemTreeNode>(index: Idx<N>) -> FileItemTreeId<N> {
     FileItemTreeId(index)
 }
 
@@ -267,7 +267,7 @@ impl<'a> Ctx<'a> {
             if let Some(data) = self.lower_variant(&variant) {
                 let idx = self.data().variants.alloc(data);
                 self.add_attrs(
-                    FileItemTreeId(idx).into(),
+                    id(idx).into(),
                     RawAttrs::new(self.db.upcast(), &variant, self.span_map()),
                 );
             }

--- a/crates/hir-def/src/lib.rs
+++ b/crates/hir-def/src/lib.rs
@@ -98,8 +98,8 @@ use crate::{
     data::adt::VariantData,
     db::DefDatabase,
     item_tree::{
-        Const, Enum, ExternCrate, Function, Impl, ItemTreeId, ItemTreeModItemNode, Macro2,
-        MacroRules, Static, Struct, Trait, TraitAlias, TypeAlias, Union, Use, Variant,
+        Const, Enum, ExternCrate, Function, Impl, ItemTreeId, ItemTreeNode, Macro2, MacroRules,
+        Static, Struct, Trait, TraitAlias, TypeAlias, Union, Use, Variant,
     },
 };
 
@@ -212,28 +212,28 @@ impl ModuleId {
 pub type LocalModuleId = Idx<nameres::ModuleData>;
 
 #[derive(Debug)]
-pub struct ItemLoc<N: ItemTreeModItemNode> {
+pub struct ItemLoc<N: ItemTreeNode> {
     pub container: ModuleId,
     pub id: ItemTreeId<N>,
 }
 
-impl<N: ItemTreeModItemNode> Clone for ItemLoc<N> {
+impl<N: ItemTreeNode> Clone for ItemLoc<N> {
     fn clone(&self) -> Self {
         *self
     }
 }
 
-impl<N: ItemTreeModItemNode> Copy for ItemLoc<N> {}
+impl<N: ItemTreeNode> Copy for ItemLoc<N> {}
 
-impl<N: ItemTreeModItemNode> PartialEq for ItemLoc<N> {
+impl<N: ItemTreeNode> PartialEq for ItemLoc<N> {
     fn eq(&self, other: &Self) -> bool {
         self.container == other.container && self.id == other.id
     }
 }
 
-impl<N: ItemTreeModItemNode> Eq for ItemLoc<N> {}
+impl<N: ItemTreeNode> Eq for ItemLoc<N> {}
 
-impl<N: ItemTreeModItemNode> Hash for ItemLoc<N> {
+impl<N: ItemTreeNode> Hash for ItemLoc<N> {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.container.hash(state);
         self.id.hash(state);
@@ -241,32 +241,39 @@ impl<N: ItemTreeModItemNode> Hash for ItemLoc<N> {
 }
 
 #[derive(Debug)]
-pub struct AssocItemLoc<N: ItemTreeModItemNode> {
+pub struct AssocItemLoc<N: ItemTreeNode> {
     pub container: ItemContainerId,
     pub id: ItemTreeId<N>,
 }
 
-impl<N: ItemTreeModItemNode> Clone for AssocItemLoc<N> {
+impl<N: ItemTreeNode> Clone for AssocItemLoc<N> {
     fn clone(&self) -> Self {
         *self
     }
 }
 
-impl<N: ItemTreeModItemNode> Copy for AssocItemLoc<N> {}
+impl<N: ItemTreeNode> Copy for AssocItemLoc<N> {}
 
-impl<N: ItemTreeModItemNode> PartialEq for AssocItemLoc<N> {
+impl<N: ItemTreeNode> PartialEq for AssocItemLoc<N> {
     fn eq(&self, other: &Self) -> bool {
         self.container == other.container && self.id == other.id
     }
 }
 
-impl<N: ItemTreeModItemNode> Eq for AssocItemLoc<N> {}
+impl<N: ItemTreeNode> Eq for AssocItemLoc<N> {}
 
-impl<N: ItemTreeModItemNode> Hash for AssocItemLoc<N> {
+impl<N: ItemTreeNode> Hash for AssocItemLoc<N> {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.container.hash(state);
         self.id.hash(state);
     }
+}
+
+pub trait ItemTreeLoc {
+    type Container;
+    type Id;
+    fn item_tree_id(&self) -> ItemTreeId<Self::Id>;
+    fn container(&self) -> Self::Container;
 }
 
 macro_rules! impl_intern {
@@ -276,25 +283,44 @@ macro_rules! impl_intern {
     };
 }
 
+macro_rules! impl_loc {
+    ($loc:ident, $id:ident: $id_ty:ident, $container:ident: $container_type:ident) => {
+        impl ItemTreeLoc for $loc {
+            type Container = $container_type;
+            type Id = $id_ty;
+            fn item_tree_id(&self) -> ItemTreeId<Self::Id> {
+                self.$id
+            }
+            fn container(&self) -> Self::Container {
+                self.$container
+            }
+        }
+    };
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct FunctionId(salsa::InternId);
 type FunctionLoc = AssocItemLoc<Function>;
 impl_intern!(FunctionId, FunctionLoc, intern_function, lookup_intern_function);
+impl_loc!(FunctionLoc, id: Function, container: ItemContainerId);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct StructId(salsa::InternId);
 type StructLoc = ItemLoc<Struct>;
 impl_intern!(StructId, StructLoc, intern_struct, lookup_intern_struct);
+impl_loc!(StructLoc, id: Struct, container: ModuleId);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct UnionId(salsa::InternId);
 pub type UnionLoc = ItemLoc<Union>;
 impl_intern!(UnionId, UnionLoc, intern_union, lookup_intern_union);
+impl_loc!(UnionLoc, id: Union, container: ModuleId);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct EnumId(salsa::InternId);
 pub type EnumLoc = ItemLoc<Enum>;
 impl_intern!(EnumId, EnumLoc, intern_enum, lookup_intern_enum);
+impl_loc!(EnumLoc, id: Enum, container: ModuleId);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct EnumVariantId(salsa::InternId);
@@ -306,6 +332,7 @@ pub struct EnumVariantLoc {
     pub index: u32,
 }
 impl_intern!(EnumVariantId, EnumVariantLoc, intern_enum_variant, lookup_intern_enum_variant);
+impl_loc!(EnumVariantLoc, id: Variant, parent: EnumId);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct FieldId {
@@ -328,46 +355,55 @@ pub struct TupleFieldId {
 pub struct ConstId(salsa::InternId);
 type ConstLoc = AssocItemLoc<Const>;
 impl_intern!(ConstId, ConstLoc, intern_const, lookup_intern_const);
+impl_loc!(ConstLoc, id: Const, container: ItemContainerId);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct StaticId(salsa::InternId);
 pub type StaticLoc = AssocItemLoc<Static>;
 impl_intern!(StaticId, StaticLoc, intern_static, lookup_intern_static);
+impl_loc!(StaticLoc, id: Static, container: ItemContainerId);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct TraitId(salsa::InternId);
 pub type TraitLoc = ItemLoc<Trait>;
 impl_intern!(TraitId, TraitLoc, intern_trait, lookup_intern_trait);
+impl_loc!(TraitLoc, id: Trait, container: ModuleId);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct TraitAliasId(salsa::InternId);
 pub type TraitAliasLoc = ItemLoc<TraitAlias>;
 impl_intern!(TraitAliasId, TraitAliasLoc, intern_trait_alias, lookup_intern_trait_alias);
+impl_loc!(TraitAliasLoc, id: TraitAlias, container: ModuleId);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct TypeAliasId(salsa::InternId);
 type TypeAliasLoc = AssocItemLoc<TypeAlias>;
 impl_intern!(TypeAliasId, TypeAliasLoc, intern_type_alias, lookup_intern_type_alias);
+impl_loc!(TypeAliasLoc, id: TypeAlias, container: ItemContainerId);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Ord, PartialOrd)]
 pub struct ImplId(salsa::InternId);
 type ImplLoc = ItemLoc<Impl>;
 impl_intern!(ImplId, ImplLoc, intern_impl, lookup_intern_impl);
+impl_loc!(ImplLoc, id: Impl, container: ModuleId);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Ord, PartialOrd)]
 pub struct UseId(salsa::InternId);
 type UseLoc = ItemLoc<Use>;
 impl_intern!(UseId, UseLoc, intern_use, lookup_intern_use);
+impl_loc!(UseLoc, id: Use, container: ModuleId);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Ord, PartialOrd)]
 pub struct ExternCrateId(salsa::InternId);
 type ExternCrateLoc = ItemLoc<ExternCrate>;
 impl_intern!(ExternCrateId, ExternCrateLoc, intern_extern_crate, lookup_intern_extern_crate);
+impl_loc!(ExternCrateLoc, id: ExternCrate, container: ModuleId);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Ord, PartialOrd)]
 pub struct ExternBlockId(salsa::InternId);
 type ExternBlockLoc = ItemLoc<ExternBlock>;
 impl_intern!(ExternBlockId, ExternBlockLoc, intern_extern_block, lookup_intern_extern_block);
+impl_loc!(ExternBlockLoc, id: ExternBlock, container: ModuleId);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum MacroExpander {
@@ -389,6 +425,7 @@ pub struct Macro2Loc {
     pub edition: Edition,
 }
 impl_intern!(Macro2Id, Macro2Loc, intern_macro2, lookup_intern_macro2);
+impl_loc!(Macro2Loc, id: Macro2, container: ModuleId);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Ord, PartialOrd)]
 pub struct MacroRulesId(salsa::InternId);
@@ -401,6 +438,7 @@ pub struct MacroRulesLoc {
     pub edition: Edition,
 }
 impl_intern!(MacroRulesId, MacroRulesLoc, intern_macro_rules, lookup_intern_macro_rules);
+impl_loc!(MacroRulesLoc, id: MacroRules, container: ModuleId);
 
 bitflags::bitflags! {
     #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -421,6 +459,7 @@ pub struct ProcMacroLoc {
     pub edition: Edition,
 }
 impl_intern!(ProcMacroId, ProcMacroLoc, intern_proc_macro, lookup_intern_proc_macro);
+impl_loc!(ProcMacroLoc, id: Function, container: CrateRootModuleId);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Ord, PartialOrd)]
 pub struct BlockId(salsa::InternId);
@@ -996,16 +1035,23 @@ pub trait HasModule {
     }
 }
 
-impl<N: ItemTreeModItemNode> HasModule for AssocItemLoc<N> {
-    #[inline]
-    fn module(&self, db: &dyn DefDatabase) -> ModuleId {
-        self.container.module(db)
-    }
-}
+// In theory this impl should work out for us, but rustc thinks it collides with all the other
+// manual impls that do not have a ModuleId container...
+// impl<N, ItemId, Data> HasModule for ItemId
+// where
+//     N: ItemTreeNode,
+//     ItemId: for<'db> Lookup<Database<'db> = dyn DefDatabase + 'db, Data = Data> + Copy,
+//     Data: ItemTreeLoc<Id = N, Container = ModuleId>,
+// {
+//     #[inline]
+//     fn module(&self, db: &dyn DefDatabase) -> ModuleId {
+//         self.lookup(db).container()
+//     }
+// }
 
 impl<N, ItemId> HasModule for ItemId
 where
-    N: ItemTreeModItemNode,
+    N: ItemTreeNode,
     ItemId: for<'db> Lookup<Database<'db> = dyn DefDatabase + 'db, Data = ItemLoc<N>> + Copy,
 {
     #[inline]
@@ -1031,10 +1077,7 @@ where
 #[inline]
 fn module_for_assoc_item_loc<'db>(
     db: &(dyn 'db + DefDatabase),
-    id: impl Lookup<
-        Database<'db> = dyn DefDatabase + 'db,
-        Data = AssocItemLoc<impl ItemTreeModItemNode>,
-    >,
+    id: impl Lookup<Database<'db> = dyn DefDatabase + 'db, Data = AssocItemLoc<impl ItemTreeNode>>,
 ) -> ModuleId {
     id.lookup(db).container.module(db)
 }

--- a/crates/hir-def/src/nameres/collector.rs
+++ b/crates/hir-def/src/nameres/collector.rs
@@ -33,8 +33,8 @@ use crate::{
     db::DefDatabase,
     item_scope::{ImportId, ImportOrExternCrate, ImportType, PerNsGlobImports},
     item_tree::{
-        self, ExternCrate, Fields, FileItemTreeId, ImportKind, ItemTree, ItemTreeId,
-        ItemTreeModItemNode, Macro2, MacroCall, MacroRules, Mod, ModItem, ModKind, TreeId,
+        self, ExternCrate, Fields, FileItemTreeId, ImportKind, ItemTree, ItemTreeId, ItemTreeNode,
+        Macro2, MacroCall, MacroRules, Mod, ModItem, ModKind, TreeId,
     },
     macro_call_as_call_id, macro_call_as_call_id_with_eager,
     nameres::{

--- a/crates/hir-ty/src/display.rs
+++ b/crates/hir-ty/src/display.rs
@@ -814,9 +814,8 @@ impl HirDisplay for Ty {
 
                             // Don't count Sized but count when it absent
                             // (i.e. when explicit ?Sized bound is set).
-                            let default_sized = SizedByDefault::Sized {
-                                anchor: func.lookup(db.upcast()).module(db.upcast()).krate(),
-                            };
+                            let default_sized =
+                                SizedByDefault::Sized { anchor: func.krate(db.upcast()) };
                             let sized_bounds = bounds
                                 .skip_binders()
                                 .iter()
@@ -1025,7 +1024,7 @@ impl HirDisplay for Ty {
                         let data =
                             (*datas).as_ref().map(|rpit| rpit.impl_traits[idx].bounds.clone());
                         let bounds = data.substitute(Interner, &parameters);
-                        let krate = func.lookup(db.upcast()).module(db.upcast()).krate();
+                        let krate = func.krate(db.upcast());
                         write_bounds_like_dyn_trait_with_prefix(
                             f,
                             "impl",
@@ -1191,7 +1190,7 @@ impl HirDisplay for Ty {
                         let data =
                             (*datas).as_ref().map(|rpit| rpit.impl_traits[idx].bounds.clone());
                         let bounds = data.substitute(Interner, &opaque_ty.substitution);
-                        let krate = func.lookup(db.upcast()).module(db.upcast()).krate();
+                        let krate = func.krate(db.upcast());
                         write_bounds_like_dyn_trait_with_prefix(
                             f,
                             "impl",

--- a/crates/hir-ty/src/lower.rs
+++ b/crates/hir-ty/src/lower.rs
@@ -1225,7 +1225,7 @@ impl<'a> TyLoweringContext<'a> {
                 .collect();
 
             if !ctx.unsized_types.borrow().contains(&self_ty) {
-                let krate = func.lookup(ctx.db.upcast()).module(ctx.db.upcast()).krate();
+                let krate = func.krate(ctx.db.upcast());
                 let sized_trait = ctx
                     .db
                     .lang_item(krate, LangItem::Sized)
@@ -1824,11 +1824,10 @@ impl CallableDefId {
     pub fn krate(self, db: &dyn HirDatabase) -> CrateId {
         let db = db.upcast();
         match self {
-            CallableDefId::FunctionId(f) => f.lookup(db).module(db),
-            CallableDefId::StructId(s) => s.lookup(db).container,
-            CallableDefId::EnumVariantId(e) => e.module(db),
+            CallableDefId::FunctionId(f) => f.krate(db),
+            CallableDefId::StructId(s) => s.krate(db),
+            CallableDefId::EnumVariantId(e) => e.krate(db),
         }
-        .krate()
     }
 }
 

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -1910,7 +1910,7 @@ impl Function {
             return None;
         }
         let loc = self.id.lookup(db.upcast());
-        let def_map = db.crate_def_map(loc.krate(db).into());
+        let def_map = db.crate_def_map(HasModule::krate(&loc, db.upcast()));
         def_map.fn_as_proc_macro(self.id).map(|id| Macro { id: id.into() })
     }
 
@@ -2516,11 +2516,13 @@ pub enum AssocItem {
     Const(Const),
     TypeAlias(TypeAlias),
 }
+
 #[derive(Debug, Clone)]
 pub enum AssocItemContainer {
     Trait(Trait),
     Impl(Impl),
 }
+
 pub trait AsAssocItem {
     fn as_assoc_item(self, db: &dyn HirDatabase) -> Option<AssocItem>;
 }
@@ -2530,16 +2532,19 @@ impl AsAssocItem for Function {
         as_assoc_item(db, AssocItem::Function, self.id)
     }
 }
+
 impl AsAssocItem for Const {
     fn as_assoc_item(self, db: &dyn HirDatabase) -> Option<AssocItem> {
         as_assoc_item(db, AssocItem::Const, self.id)
     }
 }
+
 impl AsAssocItem for TypeAlias {
     fn as_assoc_item(self, db: &dyn HirDatabase) -> Option<AssocItem> {
         as_assoc_item(db, AssocItem::TypeAlias, self.id)
     }
 }
+
 impl AsAssocItem for ModuleDef {
     fn as_assoc_item(self, db: &dyn HirDatabase) -> Option<AssocItem> {
         match self {
@@ -2550,6 +2555,7 @@ impl AsAssocItem for ModuleDef {
         }
     }
 }
+
 impl AsAssocItem for DefWithBody {
     fn as_assoc_item(self, db: &dyn HirDatabase) -> Option<AssocItem> {
         match self {
@@ -2560,15 +2566,14 @@ impl AsAssocItem for DefWithBody {
     }
 }
 
-fn as_assoc_item<'db, ID, DEF, CTOR, AST>(
+fn as_assoc_item<'db, ID, DEF, AST>(
     db: &(dyn HirDatabase + 'db),
-    ctor: CTOR,
+    ctor: impl FnOnce(DEF) -> AssocItem,
     id: ID,
 ) -> Option<AssocItem>
 where
     ID: Lookup<Database<'db> = dyn DefDatabase + 'db, Data = AssocItemLoc<AST>>,
     DEF: From<ID>,
-    CTOR: FnOnce(DEF) -> AssocItem,
     AST: ItemTreeModItemNode,
 {
     match id.lookup(db.upcast()).container {
@@ -2609,24 +2614,31 @@ impl AssocItem {
         }
     }
 
-    pub fn containing_trait(self, db: &dyn HirDatabase) -> Option<Trait> {
+    pub fn container_trait(self, db: &dyn HirDatabase) -> Option<Trait> {
         match self.container(db) {
             AssocItemContainer::Trait(t) => Some(t),
             _ => None,
         }
     }
 
-    pub fn containing_trait_impl(self, db: &dyn HirDatabase) -> Option<Trait> {
+    pub fn implemented_trait(self, db: &dyn HirDatabase) -> Option<Trait> {
         match self.container(db) {
             AssocItemContainer::Impl(i) => i.trait_(db),
             _ => None,
         }
     }
 
-    pub fn containing_trait_or_trait_impl(self, db: &dyn HirDatabase) -> Option<Trait> {
+    pub fn container_or_implemented_trait(self, db: &dyn HirDatabase) -> Option<Trait> {
         match self.container(db) {
             AssocItemContainer::Trait(t) => Some(t),
             AssocItemContainer::Impl(i) => i.trait_(db),
+        }
+    }
+
+    pub fn implementing_ty(self, db: &dyn HirDatabase) -> Option<Type> {
+        match self.container(db) {
+            AssocItemContainer::Impl(i) => Some(i.self_ty(db)),
+            _ => None,
         }
     }
 
@@ -3321,7 +3333,7 @@ impl Impl {
     }
 
     pub fn items(self, db: &dyn HirDatabase) -> Vec<AssocItem> {
-        db.impl_data(self.id).items.iter().map(|it| (*it).into()).collect()
+        db.impl_data(self.id).items.iter().map(|&it| it.into()).collect()
     }
 
     pub fn is_negative(self, db: &dyn HirDatabase) -> bool {
@@ -3677,7 +3689,7 @@ impl Type {
             .and_then(|it| {
                 let into_future_fn = it.as_function()?;
                 let assoc_item = as_assoc_item(db, AssocItem::Function, into_future_fn)?;
-                let into_future_trait = assoc_item.containing_trait_or_trait_impl(db)?;
+                let into_future_trait = assoc_item.container_or_implemented_trait(db)?;
                 Some(into_future_trait.id)
             })
             .or_else(|| {

--- a/crates/ide-assists/src/handlers/convert_bool_then.rs
+++ b/crates/ide-assists/src/handlers/convert_bool_then.rs
@@ -163,9 +163,8 @@ pub(crate) fn convert_bool_then_to_if(acc: &mut Assists, ctx: &AssistContext<'_>
         return None;
     }
     let assoc = func.as_assoc_item(ctx.sema.db)?;
-    match assoc.container(ctx.sema.db) {
-        hir::AssocItemContainer::Impl(impl_) if impl_.self_ty(ctx.sema.db).is_bool() => {}
-        _ => return None,
+    if !assoc.implementing_ty(ctx.sema.db)?.is_bool() {
+        return None;
     }
 
     let target = mcall.syntax().text_range();

--- a/crates/ide-assists/src/handlers/generate_documentation_template.rs
+++ b/crates/ide-assists/src/handlers/generate_documentation_template.rs
@@ -364,7 +364,7 @@ fn is_in_trait_impl(ast_func: &ast::Fn, ctx: &AssistContext<'_>) -> bool {
     ctx.sema
         .to_def(ast_func)
         .and_then(|hir_func| hir_func.as_assoc_item(ctx.db()))
-        .and_then(|assoc_item| assoc_item.containing_trait_impl(ctx.db()))
+        .and_then(|assoc_item| assoc_item.implemented_trait(ctx.db()))
         .is_some()
 }
 
@@ -373,7 +373,7 @@ fn is_in_trait_def(ast_func: &ast::Fn, ctx: &AssistContext<'_>) -> bool {
     ctx.sema
         .to_def(ast_func)
         .and_then(|hir_func| hir_func.as_assoc_item(ctx.db()))
-        .and_then(|assoc_item| assoc_item.containing_trait(ctx.db()))
+        .and_then(|assoc_item| assoc_item.container_trait(ctx.db()))
         .is_some()
 }
 

--- a/crates/ide-assists/src/handlers/into_to_qualified_from.rs
+++ b/crates/ide-assists/src/handlers/into_to_qualified_from.rs
@@ -48,7 +48,7 @@ pub(crate) fn into_to_qualified_from(acc: &mut Assists, ctx: &AssistContext<'_>)
     let fnc = sema.resolve_method_call(&method_call)?;
     let scope = sema.scope(method_call.syntax())?;
     // Check if the method call refers to Into trait.
-    if fnc.as_assoc_item(db)?.containing_trait_impl(db)?
+    if fnc.as_assoc_item(db)?.implemented_trait(db)?
         == FamousDefs(sema, scope.krate()).core_convert_Into()?
     {
         let type_call = sema.type_of_expr(&method_call.clone().into())?;

--- a/crates/ide-assists/src/handlers/qualify_path.rs
+++ b/crates/ide-assists/src/handlers/qualify_path.rs
@@ -203,7 +203,7 @@ fn item_as_trait(db: &RootDatabase, item: hir::ItemInNs) -> Option<hir::Trait> {
 
     match item_module_def {
         hir::ModuleDef::Trait(trait_) => Some(trait_),
-        _ => item_module_def.as_assoc_item(db)?.containing_trait(db),
+        _ => item_module_def.as_assoc_item(db)?.container_trait(db),
     }
 }
 

--- a/crates/ide-completion/src/render.rs
+++ b/crates/ide-completion/src/render.rs
@@ -112,7 +112,7 @@ impl<'a> RenderContext<'a> {
         };
         is_assoc_deprecated
             || assoc
-                .containing_trait_or_trait_impl(db)
+                .container_or_implemented_trait(db)
                 .map(|trait_| self.is_deprecated(trait_))
                 .unwrap_or(false)
     }

--- a/crates/ide-completion/src/render/const_.rs
+++ b/crates/ide-completion/src/render/const_.rs
@@ -23,7 +23,7 @@ fn render(ctx: RenderContext<'_>, const_: hir::Const) -> Option<CompletionItem> 
         .set_relevance(ctx.completion_relevance());
 
     if let Some(actm) = const_.as_assoc_item(db) {
-        if let Some(trt) = actm.containing_trait_or_trait_impl(db) {
+        if let Some(trt) = actm.container_or_implemented_trait(db) {
             item.trait_name(trt.name(db).to_smol_str());
         }
     }

--- a/crates/ide-completion/src/render/function.rs
+++ b/crates/ide-completion/src/render/function.rs
@@ -75,7 +75,7 @@ fn render(
     let ret_type = func.ret_type(db);
     let assoc_item = func.as_assoc_item(db);
 
-    let trait_ = assoc_item.and_then(|trait_| trait_.containing_trait_or_trait_impl(db));
+    let trait_ = assoc_item.and_then(|trait_| trait_.container_or_implemented_trait(db));
     let is_op_method = trait_.map_or(false, |trait_| completion.is_ops_trait(trait_));
 
     let is_item_from_notable_trait =
@@ -145,7 +145,7 @@ fn render(
         }
         None => {
             if let Some(actm) = assoc_item {
-                if let Some(trt) = actm.containing_trait_or_trait_impl(db) {
+                if let Some(trt) = actm.container_or_implemented_trait(db) {
                     item.trait_name(trt.name(db).to_smol_str());
                 }
             }

--- a/crates/ide-completion/src/render/type_alias.rs
+++ b/crates/ide-completion/src/render/type_alias.rs
@@ -47,7 +47,7 @@ fn render(
         .set_relevance(ctx.completion_relevance());
 
     if let Some(actm) = type_alias.as_assoc_item(db) {
-        if let Some(trt) = actm.containing_trait_or_trait_impl(db) {
+        if let Some(trt) = actm.container_or_implemented_trait(db) {
             item.trait_name(trt.name(db).to_smol_str());
         }
     }

--- a/crates/ide-db/src/defs.rs
+++ b/crates/ide-db/src/defs.rs
@@ -206,7 +206,7 @@ impl Definition {
             // docs are missing, for assoc items of trait impls try to fall back to the docs of the
             // original item of the trait
             let assoc = self.as_assoc_item(db)?;
-            let trait_ = assoc.containing_trait_impl(db)?;
+            let trait_ = assoc.implemented_trait(db)?;
             let name = Some(assoc.name(db)?);
             let item = trait_.items(db).into_iter().find(|it| it.name(db) == name)?;
             item.docs(db)

--- a/crates/ide-db/src/imports/import_assets.rs
+++ b/crates/ide-db/src/imports/import_assets.rs
@@ -529,7 +529,7 @@ fn trait_applicable_items(
             return None;
         }
 
-        let assoc_item_trait = assoc.containing_trait(db)?;
+        let assoc_item_trait = assoc.container_trait(db)?;
         if related_traits.contains(&assoc_item_trait) {
             return None;
         }
@@ -550,8 +550,7 @@ fn trait_applicable_items(
             None,
             |assoc| {
                 if required_assoc_items.contains(&assoc) {
-                    let located_trait =
-                        assoc.containing_trait(db).filter(|&it| scope_filter(it))?;
+                    let located_trait = assoc.container_trait(db).filter(|&it| scope_filter(it))?;
                     let trait_item = ItemInNs::from(ModuleDef::from(located_trait));
                     let import_path = trait_import_paths
                         .entry(trait_item)
@@ -576,8 +575,7 @@ fn trait_applicable_items(
             |function| {
                 let assoc = function.as_assoc_item(db)?;
                 if required_assoc_items.contains(&assoc) {
-                    let located_trait =
-                        assoc.containing_trait(db).filter(|&it| scope_filter(it))?;
+                    let located_trait = assoc.container_trait(db).filter(|&it| scope_filter(it))?;
                     let trait_item = ItemInNs::from(ModuleDef::from(located_trait));
                     let import_path = trait_import_paths
                         .entry(trait_item)

--- a/crates/ide-db/src/traits.rs
+++ b/crates/ide-db/src/traits.rs
@@ -75,7 +75,7 @@ pub fn get_missing_assoc_items(
 pub(crate) fn convert_to_def_in_trait(db: &dyn HirDatabase, def: Definition) -> Definition {
     (|| {
         let assoc = def.as_assoc_item(db)?;
-        let trait_ = assoc.containing_trait_impl(db)?;
+        let trait_ = assoc.implemented_trait(db)?;
         assoc_item_of_trait(db, assoc, trait_)
     })()
     .unwrap_or(def)

--- a/crates/ide/src/doc_links.rs
+++ b/crates/ide/src/doc_links.rs
@@ -668,7 +668,7 @@ fn get_assoc_item_fragment(db: &dyn HirDatabase, assoc_item: hir::AssocItem) -> 
     Some(match assoc_item {
         AssocItem::Function(function) => {
             let is_trait_method =
-                function.as_assoc_item(db).and_then(|assoc| assoc.containing_trait(db)).is_some();
+                function.as_assoc_item(db).and_then(|assoc| assoc.container_trait(db)).is_some();
             // This distinction may get more complicated when specialization is available.
             // Rustdoc makes this decision based on whether a method 'has defaultness'.
             // Currently this is only the case for provided trait methods.

--- a/crates/ide/src/goto_declaration.rs
+++ b/crates/ide/src/goto_declaration.rs
@@ -61,7 +61,7 @@ pub(crate) fn goto_declaration(
                 _ => None,
             }?;
 
-            let trait_ = assoc.containing_trait_impl(db)?;
+            let trait_ = assoc.implemented_trait(db)?;
             let name = Some(assoc.name(db)?);
             let item = trait_.items(db).into_iter().find(|it| it.name(db) == name)?;
             item.try_to_nav(db)

--- a/crates/ide/src/goto_definition.rs
+++ b/crates/ide/src/goto_definition.rs
@@ -182,11 +182,7 @@ fn try_filter_trait_item_definition(
     match assoc {
         AssocItem::Function(..) => None,
         AssocItem::Const(..) | AssocItem::TypeAlias(..) => {
-            let imp = match assoc.container(db) {
-                hir::AssocItemContainer::Impl(imp) => imp,
-                _ => return None,
-            };
-            let trait_ = imp.trait_(db)?;
+            let trait_ = assoc.implemented_trait(db)?;
             let name = def.name(db)?;
             let discri_value = discriminant(&assoc);
             trait_

--- a/crates/ide/src/goto_implementation.rs
+++ b/crates/ide/src/goto_implementation.rs
@@ -60,13 +60,13 @@ pub(crate) fn goto_implementation(
                     Definition::Function(f) => {
                         let assoc = f.as_assoc_item(sema.db)?;
                         let name = assoc.name(sema.db)?;
-                        let trait_ = assoc.containing_trait_or_trait_impl(sema.db)?;
+                        let trait_ = assoc.container_or_implemented_trait(sema.db)?;
                         impls_for_trait_item(&sema, trait_, name)
                     }
                     Definition::Const(c) => {
                         let assoc = c.as_assoc_item(sema.db)?;
                         let name = assoc.name(sema.db)?;
-                        let trait_ = assoc.containing_trait_or_trait_impl(sema.db)?;
+                        let trait_ = assoc.container_or_implemented_trait(sema.db)?;
                         impls_for_trait_item(&sema, trait_, name)
                     }
                     _ => return None,

--- a/crates/ide/src/runnables.rs
+++ b/crates/ide/src/runnables.rs
@@ -442,8 +442,7 @@ fn module_def_doctest(db: &RootDatabase, def: Definition) -> Option<Runnable> {
             .for_each(|name| format_to!(path, "{}::", name.display(db)));
         // This probably belongs to canonical_path?
         if let Some(assoc_item) = def.as_assoc_item(db) {
-            if let hir::AssocItemContainer::Impl(imp) = assoc_item.container(db) {
-                let ty = imp.self_ty(db);
+            if let Some(ty) = assoc_item.implementing_ty(db) {
                 if let Some(adt) = ty.as_adt() {
                     let name = adt.name(db);
                     let mut ty_args = ty.generic_parameters(db).peekable();

--- a/crates/ide/src/syntax_highlighting/highlight.rs
+++ b/crates/ide/src/syntax_highlighting/highlight.rs
@@ -559,7 +559,7 @@ fn highlight_method_call(
     }
     if func
         .as_assoc_item(sema.db)
-        .and_then(|it| it.containing_trait_or_trait_impl(sema.db))
+        .and_then(|it| it.container_or_implemented_trait(sema.db))
         .is_some()
     {
         h |= HlMod::Trait;


### PR DESCRIPTION
Allows reducing some code duplication by using functions generic over said structs. The diff isn't negative due to me adding some additional impls for completeness.