### PR TITLE
internal: tool discovery prefers sysroot tools

### DIFF
--- a/crates/hir-ty/src/layout/tests.rs
+++ b/crates/hir-ty/src/layout/tests.rs
@@ -1,6 +1,7 @@
 use chalk_ir::{AdtId, TyKind};
 use either::Either;
 use hir_def::db::DefDatabase;
+use project_model::target_data_layout::RustcDataLayoutConfig;
 use rustc_hash::FxHashMap;
 use test_fixture::WithFixture;
 use triomphe::Arc;
@@ -15,7 +16,12 @@ use crate::{
 mod closure;
 
 fn current_machine_data_layout() -> String {
-    project_model::target_data_layout::get(None, None, &FxHashMap::default()).unwrap()
+    project_model::target_data_layout::get(
+        RustcDataLayoutConfig::Rustc(None),
+        None,
+        &FxHashMap::default(),
+    )
+    .unwrap()
 }
 
 fn eval_goal(ra_fixture: &str, minicore: &str) -> Result<Arc<Layout>, LayoutError> {

--- a/crates/project-model/src/sysroot.rs
+++ b/crates/project-model/src/sysroot.rs
@@ -4,7 +4,7 @@
 //! but we can't process `.rlib` and need source code instead. The source code
 //! is typically installed with `rustup component add rust-src` command.
 
-use std::{env, fs, iter, ops, path::PathBuf, process::Command};
+use std::{env, fs, iter, ops, path::PathBuf, process::Command, sync::Arc};
 
 use anyhow::{format_err, Context, Result};
 use base_db::CrateName;
@@ -12,14 +12,28 @@ use itertools::Itertools;
 use la_arena::{Arena, Idx};
 use paths::{AbsPath, AbsPathBuf};
 use rustc_hash::FxHashMap;
+use toolchain::{probe_for_binary, Tool};
 
 use crate::{utf8_stdout, CargoConfig, CargoWorkspace, ManifestPath};
 
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone)]
 pub struct Sysroot {
     root: AbsPathBuf,
-    src_root: AbsPathBuf,
+    src_root: Option<Result<AbsPathBuf, Arc<anyhow::Error>>>,
     mode: SysrootMode,
+}
+
+impl Eq for Sysroot {}
+impl PartialEq for Sysroot {
+    fn eq(&self, other: &Self) -> bool {
+        self.root == other.root
+            && self.mode == other.mode
+            && match (&self.src_root, &other.src_root) {
+                (Some(Ok(this)), Some(Ok(other))) => this == other,
+                (None, None) | (Some(Err(_)), Some(Err(_))) => true,
+                _ => false,
+            }
+    }
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -86,8 +100,8 @@ impl Sysroot {
 
     /// Returns the sysroot "source" directory, where stdlib sources are located, like:
     /// `$HOME/.rustup/toolchains/nightly-2022-07-23-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library`
-    pub fn src_root(&self) -> &AbsPath {
-        &self.src_root
+    pub fn src_root(&self) -> Option<&AbsPath> {
+        self.src_root.as_ref()?.as_deref().ok()
     }
 
     pub fn is_empty(&self) -> bool {
@@ -98,6 +112,11 @@ impl Sysroot {
     }
 
     pub fn loading_warning(&self) -> Option<String> {
+        let src_root = match &self.src_root {
+            None => return Some(format!("sysroot at `{}` has no library sources", self.root)),
+            Some(Ok(src_root)) => src_root,
+            Some(Err(e)) => return Some(e.to_string()),
+        };
         let has_core = match &self.mode {
             SysrootMode::Workspace(ws) => ws.packages().any(|p| ws[p].name == "core"),
             SysrootMode::Stitched(stitched) => stitched.by_name("core").is_some(),
@@ -108,10 +127,7 @@ impl Sysroot {
             } else {
                 " try running `rustup component add rust-src` to possible fix this"
             };
-            Some(format!(
-                "could not find libcore in loaded sysroot at `{}`{var_note}",
-                self.src_root.as_path(),
-            ))
+            Some(format!("could not find libcore in loaded sysroot at `{}`{var_note}", src_root,))
         } else {
             None
         }
@@ -140,8 +156,19 @@ impl Sysroot {
         tracing::debug!("discovering sysroot for {dir}");
         let sysroot_dir = discover_sysroot_dir(dir, extra_env)?;
         let sysroot_src_dir =
-            discover_sysroot_src_dir_or_add_component(&sysroot_dir, dir, extra_env)?;
-        Ok(Sysroot::load(sysroot_dir, sysroot_src_dir, metadata))
+            discover_sysroot_src_dir_or_add_component(&sysroot_dir, dir, extra_env);
+        Ok(Sysroot::load(sysroot_dir, Some(sysroot_src_dir), metadata))
+    }
+
+    pub fn discover_no_source(
+        dir: &AbsPath,
+        extra_env: &FxHashMap<String, String>,
+    ) -> Result<Sysroot> {
+        tracing::debug!("discovering sysroot for {dir}");
+        let sysroot_dir = discover_sysroot_dir(dir, extra_env)?;
+        let sysroot_src_dir =
+            discover_sysroot_src_dir_or_add_component(&sysroot_dir, dir, extra_env);
+        Ok(Sysroot::load(sysroot_dir, Some(sysroot_src_dir), false))
     }
 
     pub fn discover_with_src_override(
@@ -152,33 +179,73 @@ impl Sysroot {
     ) -> Result<Sysroot> {
         tracing::debug!("discovering sysroot for {current_dir}");
         let sysroot_dir = discover_sysroot_dir(current_dir, extra_env)?;
-        Ok(Sysroot::load(sysroot_dir, src, metadata))
+        Ok(Sysroot::load(sysroot_dir, Some(Ok(src)), metadata))
     }
 
     pub fn discover_rustc_src(&self) -> Option<ManifestPath> {
         get_rustc_src(&self.root)
     }
 
-    pub fn discover_rustc(&self) -> anyhow::Result<AbsPathBuf> {
-        let rustc = self.root.join("bin/rustc");
-        tracing::debug!(?rustc, "checking for rustc binary at location");
-        match fs::metadata(&rustc) {
-            Ok(_) => Ok(rustc),
-            Err(e) => Err(e).context(format!(
-                "failed to discover rustc in sysroot: {:?}",
-                AsRef::<std::path::Path>::as_ref(&self.root)
-            )),
-        }
-    }
-
     pub fn with_sysroot_dir(sysroot_dir: AbsPathBuf, metadata: bool) -> Result<Sysroot> {
         let sysroot_src_dir = discover_sysroot_src_dir(&sysroot_dir).ok_or_else(|| {
             format_err!("can't load standard library from sysroot path {sysroot_dir}")
-        })?;
-        Ok(Sysroot::load(sysroot_dir, sysroot_src_dir, metadata))
+        });
+        Ok(Sysroot::load(sysroot_dir, Some(sysroot_src_dir), metadata))
     }
 
-    pub fn load(sysroot_dir: AbsPathBuf, sysroot_src_dir: AbsPathBuf, metadata: bool) -> Sysroot {
+    pub fn discover_binary(&self, binary: &str) -> anyhow::Result<AbsPathBuf> {
+        toolchain::probe_for_binary(self.root.join("bin").join(binary).into())
+            .ok_or_else(|| anyhow::anyhow!("no rustc binary found in {}", self.root.join("bin")))
+            .and_then(|rustc| {
+                fs::metadata(&rustc).map(|_| AbsPathBuf::assert(rustc)).with_context(|| {
+                    format!(
+                        "failed to discover rustc in sysroot: {:?}",
+                        AsRef::<std::path::Path>::as_ref(&self.root)
+                    )
+                })
+            })
+    }
+
+    pub fn discover_tool(sysroot: Option<&Self>, tool: Tool) -> anyhow::Result<PathBuf> {
+        match sysroot {
+            Some(sysroot) => sysroot.discover_binary(tool.name()).map(Into::into),
+            None => Ok(tool.path()),
+        }
+    }
+
+    pub fn discover_proc_macro_srv(&self) -> anyhow::Result<AbsPathBuf> {
+        ["libexec", "lib"]
+            .into_iter()
+            .map(|segment| self.root().join(segment).join("rust-analyzer-proc-macro-srv"))
+            .find_map(|server_path| probe_for_binary(server_path.into()))
+            .map(AbsPathBuf::assert)
+            .ok_or_else(|| {
+                anyhow::format_err!("cannot find proc-macro server in sysroot `{}`", self.root())
+            })
+    }
+
+    pub fn load(
+        sysroot_dir: AbsPathBuf,
+        sysroot_src_dir: Option<Result<AbsPathBuf, anyhow::Error>>,
+        metadata: bool,
+    ) -> Sysroot {
+        let sysroot_src_dir = match sysroot_src_dir {
+            Some(Ok(sysroot_src_dir)) => sysroot_src_dir,
+            Some(Err(e)) => {
+                return Sysroot {
+                    root: sysroot_dir,
+                    src_root: Some(Err(Arc::new(e))),
+                    mode: SysrootMode::Stitched(Stitched { crates: Arena::default() }),
+                }
+            }
+            None => {
+                return Sysroot {
+                    root: sysroot_dir,
+                    src_root: None,
+                    mode: SysrootMode::Stitched(Stitched { crates: Arena::default() }),
+                }
+            }
+        };
         if metadata {
             let sysroot: Option<_> = (|| {
                 let sysroot_cargo_toml = ManifestPath::try_from(
@@ -191,6 +258,7 @@ impl Sysroot {
                     &sysroot_cargo_toml,
                     &current_dir,
                     &CargoConfig::default(),
+                    None,
                     &|_| (),
                 )
                 .map_err(|e| {
@@ -274,7 +342,7 @@ impl Sysroot {
                 let cargo_workspace = CargoWorkspace::new(res);
                 Some(Sysroot {
                     root: sysroot_dir.clone(),
-                    src_root: sysroot_src_dir.clone(),
+                    src_root: Some(Ok(sysroot_src_dir.clone())),
                     mode: SysrootMode::Workspace(cargo_workspace),
                 })
             })();
@@ -326,7 +394,7 @@ impl Sysroot {
         }
         Sysroot {
             root: sysroot_dir,
-            src_root: sysroot_src_dir,
+            src_root: Some(Ok(sysroot_src_dir)),
             mode: SysrootMode::Stitched(stitched),
         }
     }

--- a/crates/project-model/src/target_data_layout.rs
+++ b/crates/project-model/src/target_data_layout.rs
@@ -3,16 +3,27 @@ use std::process::Command;
 
 use rustc_hash::FxHashMap;
 
-use crate::{utf8_stdout, ManifestPath};
+use crate::{utf8_stdout, ManifestPath, Sysroot};
+
+/// Determines how `rustc --print target-spec-json` is discovered and invoked.
+pub enum RustcDataLayoutConfig<'a> {
+    /// Use `rustc --print target-spec-json`, either from with the binary from the sysroot or by discovering via
+    /// [`toolchain::rustc`].
+    Rustc(Option<&'a Sysroot>),
+    /// Use `cargo --print target-spec-json`, either from with the binary from the sysroot or by discovering via
+    /// [`toolchain::cargo`].
+    Cargo(Option<&'a Sysroot>, &'a ManifestPath),
+}
 
 pub fn get(
-    cargo_toml: Option<&ManifestPath>,
+    config: RustcDataLayoutConfig<'_>,
     target: Option<&str>,
     extra_env: &FxHashMap<String, String>,
 ) -> anyhow::Result<String> {
-    let output = (|| {
-        if let Some(cargo_toml) = cargo_toml {
-            let mut cmd = Command::new(toolchain::rustc());
+    let output = match config {
+        RustcDataLayoutConfig::Cargo(sysroot, cargo_toml) => {
+            let cargo = Sysroot::discover_tool(sysroot, toolchain::Tool::Cargo)?;
+            let mut cmd = Command::new(cargo);
             cmd.envs(extra_env);
             cmd.current_dir(cargo_toml.parent())
                 .args(["-Z", "unstable-options", "--print", "target-spec-json"])
@@ -20,21 +31,20 @@ pub fn get(
             if let Some(target) = target {
                 cmd.args(["--target", target]);
             }
-            match utf8_stdout(cmd) {
-                Ok(it) => return Ok(it),
-                Err(e) => tracing::debug!("{e:?}: falling back to querying rustc for cfgs"),
+            utf8_stdout(cmd)
+        }
+        RustcDataLayoutConfig::Rustc(sysroot) => {
+            let rustc = Sysroot::discover_tool(sysroot, toolchain::Tool::Rustc)?;
+            let mut cmd = Command::new(rustc);
+            cmd.envs(extra_env)
+                .args(["-Z", "unstable-options", "--print", "target-spec-json"])
+                .env("RUSTC_BOOTSTRAP", "1");
+            if let Some(target) = target {
+                cmd.args(["--target", target]);
             }
+            utf8_stdout(cmd)
         }
-        // using unstable cargo features failed, fall back to using plain rustc
-        let mut cmd = Command::new(toolchain::rustc());
-        cmd.envs(extra_env)
-            .args(["-Z", "unstable-options", "--print", "target-spec-json"])
-            .env("RUSTC_BOOTSTRAP", "1");
-        if let Some(target) = target {
-            cmd.args(["--target", target]);
-        }
-        utf8_stdout(cmd)
-    })()?;
+    }?;
     (|| Some(output.split_once(r#""data-layout": ""#)?.1.split_once('"')?.0.to_owned()))()
         .ok_or_else(|| anyhow::format_err!("could not fetch target-spec-json from command output"))
 }

--- a/crates/project-model/src/tests.rs
+++ b/crates/project-model/src/tests.rs
@@ -69,8 +69,13 @@ fn load_rust_project(file: &str) -> (CrateGraph, ProcMacroPaths) {
     let data = get_test_json_file(file);
     let project = rooted_project_json(data);
     let sysroot = Ok(get_fake_sysroot());
-    let project_workspace =
-        ProjectWorkspace::Json { project, sysroot, rustc_cfg: Vec::new(), toolchain: None };
+    let project_workspace = ProjectWorkspace::Json {
+        project,
+        sysroot,
+        rustc_cfg: Vec::new(),
+        toolchain: None,
+        target_layout: Err("test has no data layout".to_owned()),
+    };
     to_crate_graph(project_workspace)
 }
 
@@ -125,7 +130,7 @@ fn get_fake_sysroot() -> Sysroot {
     // fake sysroot, so we give them both the same path:
     let sysroot_dir = AbsPathBuf::assert(sysroot_path);
     let sysroot_src_dir = sysroot_dir.clone();
-    Sysroot::load(sysroot_dir, sysroot_src_dir, false)
+    Sysroot::load(sysroot_dir, Some(Ok(sysroot_src_dir)), false)
 }
 
 fn rooted_project_json(data: ProjectJsonData) -> ProjectJson {

--- a/crates/project-model/test_data/output/rust_project_hello_world_project_model.txt
+++ b/crates/project-model/test_data/output/rust_project_hello_world_project_model.txt
@@ -37,7 +37,7 @@
         ),
         is_proc_macro: false,
         target_layout: Err(
-            "rust-project.json projects have no target layout set",
+            "test has no data layout",
         ),
         toolchain: None,
     },
@@ -70,7 +70,7 @@
         ),
         is_proc_macro: false,
         target_layout: Err(
-            "rust-project.json projects have no target layout set",
+            "test has no data layout",
         ),
         toolchain: None,
     },
@@ -103,7 +103,7 @@
         ),
         is_proc_macro: false,
         target_layout: Err(
-            "rust-project.json projects have no target layout set",
+            "test has no data layout",
         ),
         toolchain: None,
     },
@@ -136,7 +136,7 @@
         ),
         is_proc_macro: false,
         target_layout: Err(
-            "rust-project.json projects have no target layout set",
+            "test has no data layout",
         ),
         toolchain: None,
     },
@@ -186,7 +186,7 @@
         ),
         is_proc_macro: false,
         target_layout: Err(
-            "rust-project.json projects have no target layout set",
+            "test has no data layout",
         ),
         toolchain: None,
     },
@@ -219,7 +219,7 @@
         ),
         is_proc_macro: false,
         target_layout: Err(
-            "rust-project.json projects have no target layout set",
+            "test has no data layout",
         ),
         toolchain: None,
     },
@@ -317,7 +317,7 @@
         ),
         is_proc_macro: false,
         target_layout: Err(
-            "rust-project.json projects have no target layout set",
+            "test has no data layout",
         ),
         toolchain: None,
     },
@@ -350,7 +350,7 @@
         ),
         is_proc_macro: false,
         target_layout: Err(
-            "rust-project.json projects have no target layout set",
+            "test has no data layout",
         ),
         toolchain: None,
     },
@@ -383,7 +383,7 @@
         ),
         is_proc_macro: false,
         target_layout: Err(
-            "rust-project.json projects have no target layout set",
+            "test has no data layout",
         ),
         toolchain: None,
     },
@@ -416,7 +416,7 @@
         ),
         is_proc_macro: false,
         target_layout: Err(
-            "rust-project.json projects have no target layout set",
+            "test has no data layout",
         ),
         toolchain: None,
     },
@@ -493,7 +493,7 @@
         },
         is_proc_macro: false,
         target_layout: Err(
-            "rust-project.json projects have no target layout set",
+            "test has no data layout",
         ),
         toolchain: None,
     },

--- a/crates/rust-analyzer/src/handlers/request.rs
+++ b/crates/rust-analyzer/src/handlers/request.rs
@@ -1937,6 +1937,7 @@ fn run_rustfmt(
 
     let mut command = match snap.config.rustfmt() {
         RustfmtConfig::Rustfmt { extra_args, enable_range_formatting } => {
+            // FIXME: This should use the sysroot's rustfmt if its loaded
             let mut cmd = process::Command::new(toolchain::rustfmt());
             cmd.envs(snap.config.extra_env());
             cmd.args(extra_args);


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust-analyzer/issues/15927, Fixes https://github.com/rust-lang/rust-analyzer/issues/16523

After this PR we will look for `cargo` and `rustc` in the sysroot if it was succesfully loaded instead of using the current lookup scheme. This should be more correct than the current approach as that relies on the working directory of the server binary or loade workspace, meaning it can behave a bit odd wrt overrides. 