### PR TITLE
Activate on top level `Cargo.toml` and `rust-project.json` files

### DIFF
--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -68,7 +68,9 @@
         "typescript": "^5.1.6"
     },
     "activationEvents": [
+        "workspaceContains:Cargo.toml",
         "workspaceContains:*/Cargo.toml",
+        "workspaceContains:rust-project.json",
         "workspaceContains:*/rust-project.json"
     ],
     "main": "./out/main",


### PR DESCRIPTION
I believe there is an issue with how rust-analyzer is activated from within a VS Code project.

IIUC, the intent is that when you open a rust project with a top level `Cargo.toml`, then rust-analyzer should just start right up due to a VS Code activation event. This is not currently the case. i.e. run something like `cargo new ~/Desktop/hithere`, then open that folder in VS Code:

https://github.com/rust-lang/rust-analyzer/assets/19150088/1608b985-fd88-4174-a22a-5b3dd0fad84b

It is not until you actually open a Rust file that the extension starts up.

It looks like this was introduced in https://github.com/rust-lang/rust-analyzer/pull/10442. I do agree that recursive searching with `**/` is likely overkill, but I'm not sure `*/Cargo.toml` is working as expected in this comment (https://github.com/rust-lang/rust-analyzer/pull/10442#issuecomment-932967421):

> For some reason, */Cargo.toml works for both Cargo.toml in the project root and in a subdirectory (but not two levels deep).

That does not seem to be the case for me. I even went into VS Code itself and added some fake tests for `glob.match()` (which is eventually what gets used for this) and `*/Cargo.toml` doesn't seem to match a top level `Cargo.toml` (and I think that makes sense).

<img width="1087" alt="Screenshot 2024-02-12 at 6 07 08 PM" src="https://github.com/rust-lang/rust-analyzer/assets/19150088/510b0aaa-ac66-48b1-a9e2-a3bdfc237c48">

Lastly, the VS Code search filtering uses the same glob patterns, and it also doesn't match with `*/Cargo.toml`:


https://github.com/rust-lang/rust-analyzer/assets/19150088/4973f5e7-270d-489a-8db4-37469ffe12df

---

If you want both top level `Cargo.toml`s and 1-level-deep `Cargo.toml`s to be detected by VS Code's activation events, then I think we need to lay both of those conditions out explicitly, which I've done in this PR. That does fix the problem for me.

https://github.com/rust-lang/rust-analyzer/assets/19150088/bfcb1223-c45c-479a-9ea4-4be3f36e6838


