### PR TITLE
internal: Set channel override when querying the sysroot metadata

### DIFF
--- a/crates/project-model/src/sysroot.rs
+++ b/crates/project-model/src/sysroot.rs
@@ -254,10 +254,18 @@ impl Sysroot {
                 .ok()?;
                 let current_dir =
                     AbsPathBuf::try_from(&*format!("{sysroot_src_dir}/sysroot")).ok()?;
+
+                let mut cargo_config = CargoConfig::default();
+                // the sysroot uses `public-dependency`, so we make cargo think it's a nightly
+                cargo_config.extra_env.insert(
+                    "__CARGO_TEST_CHANNEL_OVERRIDE_DO_NOT_USE_THIS".to_owned(),
+                    "nightly".to_owned(),
+                );
+
                 let res = CargoWorkspace::fetch_metadata(
                     &sysroot_cargo_toml,
                     &current_dir,
-                    &CargoConfig::default(),
+                    &cargo_config,
                     None,
                     &|_| (),
                 )

--- a/xtask/src/metrics.rs
+++ b/xtask/src/metrics.rs
@@ -117,8 +117,6 @@ impl Metrics {
             sh,
             "./target/release/rust-analyzer -q analysis-stats {path} --query-sysroot-metadata"
         )
-        // the sysroot uses `public-dependency`, so we make cargo think it's a nightly
-        .env("__CARGO_TEST_CHANNEL_OVERRIDE_DO_NOT_USE_THIS", "nightly")
         .read()?;
         for (metric, value, unit) in parse_metrics(&output) {
             self.report(&format!("analysis-stats/{name}/{metric}"), value, unit.into());


### PR DESCRIPTION
This is pretty hard to discover, and makes the setting useless, we should probably enable it for now.

CC #16486