### PR TITLE
lsp-server: add license files

### DIFF
--- a/lib/lsp-server/LICENSE-APACHE
+++ b/lib/lsp-server/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../../LICENSE-APACHE

--- a/lib/lsp-server/LICENSE-MIT
+++ b/lib/lsp-server/LICENSE-MIT
@@ -1,0 +1,1 @@
+../../LICENSE-MIT


### PR DESCRIPTION
The `lsp-server` crate is currently published without license files, which is needed when packaging in Linux distributions.

Symlink the files from the repository root so they are kept in sync.

Test showing the files get picked up by `cargo package`:
```
michel in rust-analyzer/lib/lsp-server on  add-lsp-server-license [+] is 📦 v0.7.6 via 🐍 v3.12.1 (.venv311) via 🦀 v1.76.0
⬢ [fedora:39] ❯ cargo package --allow-dirty --no-verify
    Updating crates.io index
   Packaging lsp-server v0.7.6 (/home/michel/src/github/rust-lang/rust-analyzer/lib/lsp-server)
    Updating crates.io index
    Packaged 12 files, 59.6KiB (16.3KiB compressed)

michel in rust-analyzer/lib/lsp-server on  add-lsp-server-license [+] is 📦 v0.7.6 via 🐍 v3.12.1 (.venv311) via 🦀 v1.76.0
⬢ [fedora:39] ❯ tar tf ../../target/package/lsp-server-0.7.6.crate | grep LICENSE
lsp-server-0.7.6/LICENSE-APACHE
lsp-server-0.7.6/LICENSE-MIT
```