### PR TITLE
ci: Update GitHub Actions and Node version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -165,9 +165,9 @@ jobs:
         if: needs.changes.outputs.typescript == 'true'
 
       - name: Install Nodejs
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 18
         if: needs.changes.outputs.typescript == 'true'
 
       - name: Install xvfb

--- a/.github/workflows/metrics.yaml
+++ b/.github/workflows/metrics.yaml
@@ -21,7 +21,7 @@ jobs:
           rustup component add rustfmt rust-src
           rustup default stable
       - name: Cache cargo
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/bin/
@@ -39,7 +39,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Restore cargo cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/bin/
@@ -52,7 +52,7 @@ jobs:
         run: cargo xtask metrics build
 
       - name: Cache target
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: target/
           key: ${{ runner.os }}-target-${{ github.sha }}
@@ -76,7 +76,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Restore cargo cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/bin/
@@ -86,7 +86,7 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ github.sha }}
 
       - name: Restore target cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: target/
           key: ${{ runner.os }}-target-${{ github.sha }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -80,7 +80,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 18
 
       - name: Update apt repositories
         if: matrix.target == 'aarch64-unknown-linux-gnu' || matrix.target == 'arm-unknown-linux-gnueabihf'
@@ -188,9 +188,9 @@ jobs:
     needs: ["dist", "dist-x86_64-unknown-linux-musl"]
     steps:
       - name: Install Nodejs
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 18
 
       - run: echo "TAG=$(date --iso -u)" >> $GITHUB_ENV
         if: github.ref == 'refs/heads/release'


### PR DESCRIPTION
Use newer versions of actions; Node 16 -> 18

Fix several warnings in the actions tab regarding usage of the EOL Node 16