### PR TITLE
fix: Recompiles due to RUSTC_BOOTSTRAP

### DIFF
--- a/crates/project-model/src/build_scripts.rs
+++ b/crates/project-model/src/build_scripts.rs
@@ -138,7 +138,7 @@ impl WorkspaceBuildScripts {
         toolchain: &Option<Version>,
         sysroot: Option<&Sysroot>,
     ) -> io::Result<WorkspaceBuildScripts> {
-        const RUST_1_62: Version = Version::new(1, 62, 0);
+        const RUST_1_75: Version = Version::new(1, 75, 0);
 
         let current_dir = match &config.invocation_location {
             InvocationLocation::Root(root) if config.run_build_script_command.is_some() => {
@@ -162,7 +162,7 @@ impl WorkspaceBuildScripts {
             progress,
         ) {
             Ok(WorkspaceBuildScripts { error: Some(error), .. })
-                if toolchain.as_ref().map_or(false, |it| *it >= RUST_1_62) =>
+                if toolchain.as_ref().map_or(false, |it| *it >= RUST_1_75) =>
             {
                 // building build scripts failed, attempt to build with --keep-going so
                 // that we potentially get more build data
@@ -172,7 +172,8 @@ impl WorkspaceBuildScripts {
                     &workspace.workspace_root().to_path_buf(),
                     sysroot,
                 )?;
-                cmd.args(["-Z", "unstable-options", "--keep-going"]).env("RUSTC_BOOTSTRAP", "1");
+
+                cmd.args(["--keep-going"]);
                 let mut res = Self::run_per_ws(cmd, workspace, current_dir, progress)?;
                 res.error = Some(error);
                 Ok(res)

--- a/crates/project-model/src/target_data_layout.rs
+++ b/crates/project-model/src/target_data_layout.rs
@@ -32,7 +32,16 @@ pub fn get(
             Sysroot::set_rustup_toolchain_env(&mut cmd, sysroot);
             cmd.envs(extra_env);
             cmd.current_dir(cargo_toml.parent())
-                .args(["rustc", "--", "-Z", "unstable-options", "--print", "target-spec-json"])
+                .args([
+                    "rustc",
+                    "-Z",
+                    "unstable-options",
+                    "--print",
+                    "target-spec-json",
+                    "--",
+                    "-Z",
+                    "unstable-options",
+                ])
                 .env("RUSTC_BOOTSTRAP", "1");
             if let Some(target) = target {
                 cmd.args(["--target", target]);


### PR DESCRIPTION
Some packages (e.g. thiserror) force a recompile if the value of the `RUSTC_BOOTSTRAP` env var changes. RA sets the variable to 1 in order to enable rustc / cargo unstable options. This causes flapping recompiles when building outside of RA.

Fixes #15057