### PR TITLE
Remove lock on stdout

### DIFF
--- a/lib/lsp-server/src/stdio.rs
+++ b/lib/lsp-server/src/stdio.rs
@@ -13,8 +13,7 @@ use crate::Message;
 pub(crate) fn stdio_transport() -> (Sender<Message>, Receiver<Message>, IoThreads) {
     let (writer_sender, writer_receiver) = bounded::<Message>(0);
     let writer = thread::spawn(move || {
-        let stdout = stdout();
-        let mut stdout = stdout.lock();
+        let mut stdout = stdout();
         writer_receiver.into_iter().try_for_each(|it| it.write(&mut stdout))
     });
     let (reader_sender, reader_receiver) = bounded::<Message>(0);


### PR DESCRIPTION
I've been using the `lsp-server` crate to develop a language server. In my crate I've been using bindgen to link with the [llama.cpp](https://kagi.com/search?q=llama.cpp) and was getting undefined behavior on functions called from llama.cpp when first calling `Connection::stdio()`. For reasons I don't understand, the lock on stdout seems to be causing `llama.cpp` functions to freeze with no returned errors. My code is public and available [here](https://github.com/SilasMarvin/lsp-ai/blob/2f2ff810433f0b3e563eba9d0a0105cff4cd5142/src/main.rs#L43), but I can highlight or expand on specifics if that is helpful.

Removing the lock on stdout does fix the problem. I'm not sure if this is the right way to solve it, but was hoping to understand a little bit more why we are locking stdout. 

Thank you! I love and really appreciate the work you all put into the Rust ecosystem. 