### PR TITLE
Add short flag -V for consistency with other rust tooling

### DIFF
--- a/crates/rust-analyzer/src/cli/flags.rs
+++ b/crates/rust-analyzer/src/cli/flags.rs
@@ -30,7 +30,7 @@ xflags::xflags! {
 
         default cmd lsp-server {
             /// Print version.
-            optional --version
+            optional -V, --version
 
             /// Dump a LSP config JSON schema.
             optional --print-config-schema


### PR DESCRIPTION
Minor change to add the `-V` short flag to `rust-analyzer` to bring it in-line with other rust tooling such as:

> rustc -V
```bash
rustc 1.76.0 (07dca489a 2024-02-04)
```

> rustup -V
```bash
rustup 1.26.0 (5af9b9484 2023-04-05)
info: This is the version for the rustup toolchain manager, not the rustc compiler.
info: The currently active `rustc` version is `rustc 1.76.0 (07dca489a 2024-02-04)`
```

> cargo -V
```bash
cargo 1.76.0 (c84b36747 2024-01-18)
```