### PR TITLE
Document nvim 0.10 `inlay_hint`

### DIFF
--- a/docs/user/manual.adoc
+++ b/docs/user/manual.adoc
@@ -378,6 +378,8 @@ lspconfig.rust_analyzer.setup({
 })
 ----
 
+Note that the hints are only visible after `rust-analyzer` has finished loading **and** you have to edit the file to trigger a re-render.
+
 See https://sharksforarms.dev/posts/neovim-rust/ for more tips on getting started.
 
 Check out https://github.com/mrcjkb/rustaceanvim for a batteries included rust-analyzer setup for Neovim.

--- a/docs/user/manual.adoc
+++ b/docs/user/manual.adoc
@@ -337,14 +337,14 @@ You can also pass LSP settings to the server:
 [source,vim]
 ----
 lua << EOF
-local nvim_lsp = require'lspconfig'
+local lspconfig = require'lspconfig'
 
 local on_attach = function(client)
     require'completion'.on_attach(client)
 end
 
-nvim_lsp.rust_analyzer.setup({
-    on_attach=on_attach,
+lspconfig.rust_analyzer.setup({
+    on_attach = on_attach,
     settings = {
         ["rust-analyzer"] = {
             imports = {
@@ -365,6 +365,17 @@ nvim_lsp.rust_analyzer.setup({
     }
 })
 EOF
+----
+
+If you're running Neovim 0.10 or later, you can enable inlay hints via `on_attach`:
+
+[source,vim]
+----
+lspconfig.rust_analyzer.setup({
+    on_attach = function(client, bufnr)
+        vim.lsp.inlay_hint.enable(bufnr)
+    end
+})
 ----
 
 See https://sharksforarms.dev/posts/neovim-rust/ for more tips on getting started.


### PR DESCRIPTION
It took me a few hours to figure out how to enable inlay type hints on Nvim 0.10 with `lspconfig`. `rustaceanvim` has already dropped support for them (https://github.com/mrcjkb/rustaceanvim/discussions/46#discussioncomment-7518669) and most other plugins, like `rust-tools`, are depreciated in favor of `rustaceanvim`.

This PR documents how to enable the inlay hints on Neovim 0.10 and later. I've tested this and changing the `on_attach` function is the only step that is required.