### PR TITLE
fix: panic when inlining callsites inside macros' parameters

### DIFF
--- a/crates/ide-assists/src/handlers/inline_call.rs
+++ b/crates/ide-assists/src/handlers/inline_call.rs
@@ -1817,6 +1817,7 @@ macro_rules! bar {
 fn f() {
     bar!(foo$0());
 }
-"#);
+"#,
+        );
     }
 }

--- a/crates/ide-assists/src/handlers/inline_call.rs
+++ b/crates/ide-assists/src/handlers/inline_call.rs
@@ -1798,4 +1798,25 @@ fn _hash2(self_: &u64, state: &mut u64) {
 "#,
         )
     }
+
+    #[test]
+    fn inline_into_callers_in_macros_not_applicable() {
+        check_assist_not_applicable(
+            inline_into_callers,
+            r#"
+fn foo() -> u32 {
+    42
+}
+
+macro_rules! bar {
+    ($x:expr) => {
+      $x
+    };
+}
+
+fn f() {
+    bar!(foo$0());
+}
+"#);
+    }
 }

--- a/crates/ide-assists/src/handlers/inline_call.rs
+++ b/crates/ide-assists/src/handlers/inline_call.rs
@@ -107,6 +107,9 @@ pub(crate) fn inline_into_callers(acc: &mut Assists, ctx: &AssistContext<'_>) ->
                 let call_infos: Vec<_> = name_refs
                     .into_iter()
                     .filter_map(CallInfo::from_name_ref)
+                    // FIXME: do not handle callsites in macros' parameters, because
+                    // directly inlining into macros may cause errors.
+                    .filter(|call_info| !ctx.sema.hir_file_for(call_info.node.syntax()).is_macro())
                     .map(|call_info| {
                         let mut_node = builder.make_syntax_mut(call_info.node.syntax().clone());
                         (call_info, mut_node)


### PR DESCRIPTION
Close #16660, #12429, #10695.

When `inline_into_callers` encounters callsites in macros parameters, it can lead to panics. Since there is no perfect way to handle macros, this PR directly filters out these cases.