### PR TITLE
fix: use 4 spaces for indentation in macro expansion

### DIFF
--- a/crates/ide-assists/src/handlers/inline_call.rs
+++ b/crates/ide-assists/src/handlers/inline_call.rs
@@ -1348,8 +1348,8 @@ macro_rules! define_foo {
 define_foo!();
 fn bar() -> u32 {
     {
-      let x = 0;
-      x
+        let x = 0;
+        x
     }
 }
 "#,
@@ -1662,7 +1662,7 @@ fn main() {
     let a: A = A{};
     let b = {
         let a = a;
-      a as A
+        a as A
     };
 }
 "#,
@@ -1781,7 +1781,7 @@ fn _hash2(self_: &u64, state: &mut u64) {
     {
         let inner_self_: &u64 = &self_;
         let state: &mut u64 = state;
-      _write_u64(state, *inner_self_)
+        _write_u64(state, *inner_self_)
     };
 }
 "#,

--- a/crates/ide-assists/src/handlers/inline_call.rs
+++ b/crates/ide-assists/src/handlers/inline_call.rs
@@ -417,8 +417,7 @@ fn inline(
         let mut insert_let_stmt = || {
             let param_ty = param_ty.clone().map(|param_ty| {
                 if sema.hir_file_for(param_ty.syntax()).is_macro() {
-                    ast::Type::cast(insert_ws_into(param_ty.syntax().clone()))
-                        .unwrap_or_else(|| param_ty)
+                    ast::Type::cast(insert_ws_into(param_ty.syntax().clone())).unwrap_or(param_ty)
                 } else {
                     param_ty
                 }

--- a/crates/ide-assists/src/handlers/inline_macro.rs
+++ b/crates/ide-assists/src/handlers/inline_macro.rs
@@ -288,11 +288,11 @@ macro_rules! foo {
 }
 fn main() {
     cfg_if!{
-  if #[cfg(test)]{
-    1;
-  }else {
-    1;
-  }
+    if #[cfg(test)]{
+        1;
+    }else {
+        1;
+    }
 };
 }
 "#,

--- a/crates/ide-db/src/syntax_helpers/insert_whitespace_into_node.rs
+++ b/crates/ide-db/src/syntax_helpers/insert_whitespace_into_node.rs
@@ -20,7 +20,7 @@ pub fn insert_ws_into(syn: SyntaxNode) -> SyntaxNode {
     let after = Position::after;
 
     let do_indent = |pos: fn(_) -> Position, token: &SyntaxToken, indent| {
-        (pos(token.clone()), make::tokens::whitespace(&" ".repeat(2 * indent)))
+        (pos(token.clone()), make::tokens::whitespace(&" ".repeat(4 * indent)))
     };
     let do_ws = |pos: fn(_) -> Position, token: &SyntaxToken| {
         (pos(token.clone()), make::tokens::single_space())
@@ -41,7 +41,7 @@ pub fn insert_ws_into(syn: SyntaxNode) -> SyntaxNode {
                 if indent > 0 {
                     mods.push((
                         Position::after(node.clone()),
-                        make::tokens::whitespace(&" ".repeat(2 * indent)),
+                        make::tokens::whitespace(&" ".repeat(4 * indent)),
                     ));
                 }
                 if node.parent().is_some() {
@@ -91,10 +91,7 @@ pub fn insert_ws_into(syn: SyntaxNode) -> SyntaxNode {
             LIFETIME_IDENT if is_next(is_text, true) => {
                 mods.push(do_ws(after, tok));
             }
-            MUT_KW if is_next(|it| it == SELF_KW, false) => {
-                mods.push(do_ws(after, tok));
-            }
-            AS_KW | DYN_KW | IMPL_KW | CONST_KW => {
+            AS_KW | DYN_KW | IMPL_KW | CONST_KW | MUT_KW => {
                 mods.push(do_ws(after, tok));
             }
             T![;] if is_next(|it| it != R_CURLY, true) => {

--- a/crates/ide/src/expand_macro.rs
+++ b/crates/ide/src/expand_macro.rs
@@ -308,8 +308,8 @@ f$0oo!();
             expect![[r#"
                 foo!
                 fn some_thing() -> u32 {
-                  let a = 0;
-                  a+10
+                    let a = 0;
+                    a+10
                 }"#]],
         );
     }
@@ -342,13 +342,13 @@ fn main() {
             expect![[r#"
                 match_ast!
                 {
-                  if let Some(it) = ast::TraitDef::cast(container.clone()){}
-                  else if let Some(it) = ast::ImplDef::cast(container.clone()){}
-                  else {
-                    {
-                      continue
+                    if let Some(it) = ast::TraitDef::cast(container.clone()){}
+                    else if let Some(it) = ast::ImplDef::cast(container.clone()){}
+                    else {
+                        {
+                            continue
+                        }
                     }
-                  }
                 }"#]],
         );
     }
@@ -397,12 +397,12 @@ fn main() {
             expect![[r#"
                 foo!
                 {
-                  macro_rules! bar {
-                    () => {
-                      42
+                    macro_rules! bar {
+                        () => {
+                            42
+                        }
                     }
-                  }
-                  42
+                    42
                 }"#]],
         );
     }
@@ -482,16 +482,16 @@ struct Foo {}
             expect![[r#"
                 Clone
                 impl < >$crate::clone::Clone for Foo< >where {
-                  fn clone(&self) -> Self {
-                    match self {
-                      Foo{}
-                       => Foo{}
-                      ,
+                    fn clone(&self) -> Self {
+                        match self {
+                            Foo{}
+                             => Foo{}
+                            ,
 
-                      }
-                  }
+                            }
+                    }
 
-                  }"#]],
+                    }"#]],
         );
     }
 
@@ -534,16 +534,16 @@ struct Foo {}
             expect![[r#"
                 Clone
                 impl < >$crate::clone::Clone for Foo< >where {
-                  fn clone(&self) -> Self {
-                    match self {
-                      Foo{}
-                       => Foo{}
-                      ,
+                    fn clone(&self) -> Self {
+                        match self {
+                            Foo{}
+                             => Foo{}
+                            ,
 
-                      }
-                  }
+                            }
+                    }
 
-                  }"#]],
+                    }"#]],
         );
     }
 }

--- a/crates/ide/src/hover/tests.rs
+++ b/crates/ide/src/hover/tests.rs
@@ -6341,8 +6341,8 @@ fn main() { $0V; }
 
             ```rust
             pub const V: i8 = {
-              let e = 123;
-              f(e)
+                let e = 123;
+                f(e)
             }
             ```
         "#]],
@@ -6368,7 +6368,7 @@ fn main() { $0V; }
 
             ```rust
             pub static V: i8 = {
-              let e = 123;
+                let e = 123;
             }
             ```
         "#]],


### PR DESCRIPTION
Partial fix for #16471.
 
In the previous code, the indentation produced by macro expansion was set to 2 spaces. This PR modifies it to 4 spaces for the sake of consistency.