### PR TITLE
feat: add onBackspace listener

### DIFF
--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -518,7 +518,7 @@
                 "rust-analyzer.enableBackspaceListener": {
                     "markdownDescription": "Enable the automatically remove whilespace functionality when press backspace key",
                     "type": "boolean",
-                    "default": true
+                    "default": false
                 },
                 "$generated-start": {},
                 "rust-analyzer.assist.emitMustUse": {

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -316,7 +316,7 @@
             {
                 "command": "rust-analyzer.onBackspace",
                 "key": "backspace",
-                "when": "editorTextFocus && editorLangId == rust"
+                "when": "config.rust-analyzer.enableBackspaceListener && editorTextFocus && editorLangId == rust"
             }
         ],
         "configuration": {
@@ -953,6 +953,11 @@
                     "items": {
                         "type": "string"
                     }
+                },
+                "rust-analyzer.enableBackspaceListener": {
+                    "markdownDescription": "Enable the automatically remove whilespace functionality when press backspace key",
+                    "type": "boolean",
+                    "default": true
                 },
                 "rust-analyzer.files.excludeDirs": {
                     "markdownDescription": "These directories will be ignored by rust-analyzer. They are\nrelative to the workspace root, and globs are not supported. You may\nalso need to add the folders to Code's `files.watcherExclude`.",

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -312,6 +312,11 @@
                 "command": "rust-analyzer.joinLines",
                 "key": "ctrl+shift+j",
                 "when": "editorTextFocus && editorLangId == rust"
+            },
+            {
+                "command": "rust-analyzer.onBackspace",
+                "key": "backspace",
+                "when": "editorTextFocus && editorLangId == rust"
             }
         ],
         "configuration": {

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -515,6 +515,11 @@
                     "default": true,
                     "type": "boolean"
                 },
+                "rust-analyzer.enableBackspaceListener": {
+                    "markdownDescription": "Enable the automatically remove whilespace functionality when press backspace key",
+                    "type": "boolean",
+                    "default": true
+                },
                 "$generated-start": {},
                 "rust-analyzer.assist.emitMustUse": {
                     "markdownDescription": "Whether to insert #[must_use] when generating `as_` methods\nfor enum variants.",
@@ -953,11 +958,6 @@
                     "items": {
                         "type": "string"
                     }
-                },
-                "rust-analyzer.enableBackspaceListener": {
-                    "markdownDescription": "Enable the automatically remove whilespace functionality when press backspace key",
-                    "type": "boolean",
-                    "default": true
                 },
                 "rust-analyzer.files.excludeDirs": {
                     "markdownDescription": "These directories will be ignored by rust-analyzer. They are\nrelative to the workspace root, and globs are not supported. You may\nalso need to add the folders to Code's `files.watcherExclude`.",

--- a/editors/code/src/commands.ts
+++ b/editors/code/src/commands.ts
@@ -234,14 +234,16 @@ export function onBackspace(): Cmd {
             await editor.edit((editBuilder) => {
                 editBuilder.delete(selection);
             });
-        }
-        else {
+        } else {
             const currentPosition = editor.selection.active;
             const currentLine = editor.document.lineAt(currentPosition.line);
 
             // if current line isn't empty line, we just delete one char(default behavior when press backspace)
             if (!currentLine.isEmptyOrWhitespace) {
-                const previousCharRange = new vscode.Range(currentPosition, currentPosition.translate(0, -1));
+                const previousCharRange = new vscode.Range(
+                    currentPosition,
+                    currentPosition.translate(0, -1),
+                );
                 await editor.edit((editBuilder) => {
                     editBuilder.delete(previousCharRange);
                 });
@@ -251,8 +253,11 @@ export function onBackspace(): Cmd {
                 });
 
                 // go to the end of the previous line
-                let previousLine = currentPosition.with(currentPosition.line - 1);
-                let newPosition = previousLine.with(previousLine.line, editor.document.lineAt(previousLine.line).text.length);
+                const previousLine = currentPosition.with(currentPosition.line - 1);
+                const newPosition = previousLine.with(
+                    previousLine.line,
+                    editor.document.lineAt(previousLine.line).text.length,
+                );
 
                 editor.selection = new vscode.Selection(newPosition, newPosition);
             }
@@ -1053,9 +1058,8 @@ export function resolveCodeAction(ctx: CtxInit): Cmd {
             ...itemEdit,
             documentChanges: itemEdit.documentChanges?.filter((change) => "kind" in change),
         };
-        const fileSystemEdit = await client.protocol2CodeConverter.asWorkspaceEdit(
-            lcFileSystemEdit,
-        );
+        const fileSystemEdit =
+            await client.protocol2CodeConverter.asWorkspaceEdit(lcFileSystemEdit);
         await vscode.workspace.applyEdit(fileSystemEdit);
 
         // replace all text edits so that we can convert snippet text edits into `vscode.SnippetTextEdit`s

--- a/editors/code/src/commands.ts
+++ b/editors/code/src/commands.ts
@@ -1058,8 +1058,9 @@ export function resolveCodeAction(ctx: CtxInit): Cmd {
             ...itemEdit,
             documentChanges: itemEdit.documentChanges?.filter((change) => "kind" in change),
         };
-        const fileSystemEdit =
-            await client.protocol2CodeConverter.asWorkspaceEdit(lcFileSystemEdit);
+        const fileSystemEdit = await client.protocol2CodeConverter.asWorkspaceEdit(
+            lcFileSystemEdit,
+        );
         await vscode.workspace.applyEdit(fileSystemEdit);
 
         // replace all text edits so that we can convert snippet text edits into `vscode.SnippetTextEdit`s

--- a/editors/code/src/main.ts
+++ b/editors/code/src/main.ts
@@ -116,6 +116,9 @@ function createCommands(): Record<string, CommandFactory> {
             enabled: commands.onEnter,
             disabled: (_) => () => vscode.commands.executeCommand("default:type", { text: "\n" }),
         },
+        onBackspace: {
+            enabled: commands.onBackspace,
+        },
         restartServer: {
             enabled: (ctx) => async () => {
                 await ctx.restart();


### PR DESCRIPTION
# Explain

This is one of my favorite IntelliJ detailed feature. When the user is on a line with only characters for indentation (spaces or tabs) , pressing the Backspace key deletes the entire line(and if user select a range and press Backspace, it just delete the selected range) and comes to the end of the previous line, user don't need to press Backspace many times to delete all the indentation, which improve development experience a lot.

# Implementation

It's relatively simple, implemented only in client's TS code, I also expose a config("rust-analyzer.enableBackspaceListener") to turn off it in case someone don't like it.

# Demo

![onBackspace-20240226105423-tm39yns](https://github.com/rust-lang/rust-analyzer/assets/71162630/574981f4-f0c8-4168-b78a-57976c27f1dc)