### PR TITLE
fix: Goto definition for `deref_mut`

### DIFF
--- a/crates/hir/src/source_analyzer.rs
+++ b/crates/hir/src/source_analyzer.rs
@@ -42,7 +42,7 @@ use hir_ty::{
 use itertools::Itertools;
 use smallvec::SmallVec;
 use syntax::{
-    ast::{self, AstNode, BinExpr, Expr, IdentPat, PathExpr},
+    ast::{self, AstNode},
     SyntaxKind, SyntaxNode, TextRange, TextSize,
 };
 use triomphe::Arc;

--- a/crates/ide/src/goto_definition.rs
+++ b/crates/ide/src/goto_definition.rs
@@ -1978,6 +1978,33 @@ fn f() {
     }
 
     #[test]
+    fn goto_deref_mut() {
+        check(
+            r#"
+//- minicore: deref, deref_mut
+
+struct Foo;
+struct Bar;
+
+impl core::ops::Deref for Foo {
+    type Target = Bar;
+    fn deref(&self) -> &Self::Target {}
+}
+
+impl core::ops::DerefMut for Foo {
+    fn deref_mut(&mut self) -> &mut Self::Target {}
+     //^^^^^^^^^
+}
+
+fn f() {
+    let a = Foo;
+    $0*a = Bar;
+}
+"#,
+        );
+    }
+
+    #[test]
     fn goto_bin_op() {
         check(
             r#"


### PR DESCRIPTION
Fixes #16520

https://github.com/rust-lang/rust-analyzer/blob/a3236be9d7a8179ac4a997858138a4d6c260a451/crates/hir/src/source_analyzer.rs#L375-L393

As we can see from the above, current implementation routes all dereferencing prefix operations to `Deref::deref` implementation, not regarding mutabilities.

https://github.com/rust-lang/rust-analyzer/blob/a3236be9d7a8179ac4a997858138a4d6c260a451/crates/hir-ty/src/infer/mutability.rs#L134-L151

Since we are resolving them already in mutability inferences, we can use those results for proper `deref` / `deref_mut` routing.