### PR TITLE
Add `to_path_buf()` method for `RelPath`

### DIFF
--- a/crates/paths/src/lib.rs
+++ b/crates/paths/src/lib.rs
@@ -305,6 +305,11 @@ impl RelPath {
     pub fn new_unchecked(path: &Path) -> &RelPath {
         unsafe { &*(path as *const Path as *const RelPath) }
     }
+
+    /// Equivalent of [`Path::to_path_buf`] for `RelPath`.
+    pub fn to_path_buf(&self) -> RelPathBuf {
+        RelPathBuf::try_from(self.0.to_path_buf()).unwrap()
+    }
 }
 
 /// Taken from <https://github.com/rust-lang/cargo/blob/79c769c3d7b4c2cf6a93781575b7f592ef974255/src/cargo/util/paths.rs#L60-L85>


### PR DESCRIPTION
There seems to be no ergonomic way to obtain a `RelPathBuf` from a corresponding `&RelPath` at the moment, making the latter sort of a dead end.

The `AbsPath` type provides the following:

```rust
impl AbsPath {
    // ...

    /// Equivalent of [`Path::to_path_buf`] for `AbsPath`.
    pub fn to_path_buf(&self) -> AbsPathBuf {
        AbsPathBuf::try_from(self.0.to_path_buf()).unwrap()
    }

    // ...
}
```

So I took the liberty of adding a corresponding equivalent for `RelPath:

```rust
impl RelPath {
    // ...

    /// Equivalent of [`Path::to_path_buf`] for `RelPath`.
    pub fn to_path_buf(&self) -> RelPathBuf {
        RelPathBuf::try_from(self.0.to_path_buf()).unwrap()
    }

    // ...
}
```

(the change is motivated by an outside use of the `ra_ap_paths` crate that would benefit from being able to use `RelPath` and `AbsPath` over `Path`)