### PR TITLE
config: Add Configuration for Progress Reporting Verbosity

### DIFF
--- a/crates/rust-analyzer/src/main_loop.rs
+++ b/crates/rust-analyzer/src/main_loop.rs
@@ -1,6 +1,6 @@
 //! The main loop of `rust-analyzer` responsible for dispatching LSP
 //! requests/replies and notifications back to the client.
-use crate::lsp::ext;
+use crate::{config::ProgressReportingConfig, lsp::ext};
 use std::{
     fmt,
     time::{Duration, Instant},
@@ -633,14 +633,20 @@ impl GlobalState {
 
                 let mut message = format!("{n_done}/{n_total}");
                 if let Some(dir) = dir {
-                    message += &format!(
-                        ": {}",
-                        match dir.strip_prefix(self.config.root_path()) {
-                            Some(relative_path) => relative_path.as_ref(),
-                            None => dir.as_ref(),
-                        }
-                        .display()
-                    );
+                    if self
+                        .config
+                        .progress_reporting()
+                        .contains(&ProgressReportingConfig::IncludeDirectory)
+                    {
+                        message += &format!(
+                            ": {}",
+                            match dir.strip_prefix(self.config.root_path()) {
+                                Some(relative_path) => relative_path.as_ref(),
+                                None => dir.as_ref(),
+                            }
+                            .display()
+                        );
+                    }
                 }
 
                 self.report_progress(

--- a/docs/user/generated_config.adoc
+++ b/docs/user/generated_config.adoc
@@ -793,6 +793,13 @@ This config takes a map of crate names with the exported proc-macro names to ign
 --
 Internal config, path to proc-macro server executable.
 --
+[[rust-analyzer.progressReporting.verbosity]]rust-analyzer.progressReporting.verbosity (default: `[]`)::
++
+--
+Configures the level of detail rust-analyzer will report while scanning files.
+
+If not set, this will default to including parent directories while scanning.
+--
 [[rust-analyzer.references.excludeImports]]rust-analyzer.references.excludeImports (default: `false`)::
 +
 --

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -1517,6 +1517,17 @@
                         "string"
                     ]
                 },
+                "rust-analyzer.progressReporting.verbosity": {
+                    "markdownDescription": "Configures the level of detail rust-analyzer will report while scanning files.\n\nIf not set, this will default to including parent directories while scanning.",
+                    "default": [],
+                    "type": "string",
+                    "enum": [
+                        "include_directory"
+                    ],
+                    "enumDescriptions": [
+                        "`include_directory`: Include the directory of the files being indexed"
+                    ]
+                },
                 "rust-analyzer.references.excludeImports": {
                     "markdownDescription": "Exclude imports from find-all-references.",
                     "default": false,


### PR DESCRIPTION
At work, some of the indexing would take up the entire status bar because of `buck-out` has some *pretty* long paths. This is an option to make it less chatty/loud.