### PR TITLE
feat: enable automatically fix diagnostics 

### DIFF
--- a/crates/ide-assists/src/assist_config.rs
+++ b/crates/ide-assists/src/assist_config.rs
@@ -16,4 +16,6 @@ pub struct AssistConfig {
     pub prefer_no_std: bool,
     pub prefer_prelude: bool,
     pub assist_emit_must_use: bool,
+    // If set to `Some(...)`, we just get the only assist corresponding to this diagnostic code.
+    pub specified_diagnostic_code: Option<String>,
 }

--- a/crates/ide-assists/src/tests.rs
+++ b/crates/ide-assists/src/tests.rs
@@ -33,6 +33,7 @@ pub(crate) const TEST_CONFIG: AssistConfig = AssistConfig {
     prefer_no_std: false,
     prefer_prelude: true,
     assist_emit_must_use: false,
+    specified_diagnostic_code: None,
 };
 
 pub(crate) const TEST_CONFIG_NO_SNIPPET_CAP: AssistConfig = AssistConfig {
@@ -48,6 +49,7 @@ pub(crate) const TEST_CONFIG_NO_SNIPPET_CAP: AssistConfig = AssistConfig {
     prefer_no_std: false,
     prefer_prelude: true,
     assist_emit_must_use: false,
+    specified_diagnostic_code: None,
 };
 
 pub(crate) const TEST_CONFIG_IMPORT_ONE: AssistConfig = AssistConfig {
@@ -63,6 +65,7 @@ pub(crate) const TEST_CONFIG_IMPORT_ONE: AssistConfig = AssistConfig {
     prefer_no_std: false,
     prefer_prelude: true,
     assist_emit_must_use: false,
+    specified_diagnostic_code: None,
 };
 
 pub(crate) fn with_single_file(text: &str) -> (RootDatabase, FileId) {

--- a/crates/ide/src/lib.rs
+++ b/crates/ide/src/lib.rs
@@ -655,7 +655,7 @@ impl Analysis {
                     .into_iter()
                     .filter(|it| {
                         specific_diagnostic_code.map_or(true, |specific_diagnostic_code| {
-                            &it.code.as_str() == specific_diagnostic_code
+                            it.code.as_str() == specific_diagnostic_code
                         })
                     })
                     .flat_map(|it| it.fixes.unwrap_or_default())

--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -1584,6 +1584,7 @@ impl Config {
             prefer_no_std: self.data.imports_preferNoStd,
             prefer_prelude: self.data.imports_preferPrelude,
             assist_emit_must_use: self.data.assist_emitMustUse,
+            specified_diagnostic_code: None,
         }
     }
 

--- a/crates/rust-analyzer/src/handlers/request.rs
+++ b/crates/rust-analyzer/src/handlers/request.rs
@@ -1125,13 +1125,12 @@ pub(crate) fn handle_code_action_for_specified_diagnostic(
     snap: GlobalStateSnapshot,
     params: lsp_types::CodeActionParams,
 ) -> anyhow::Result<Option<Vec<lsp_ext::CodeAction>>> {
-    let _p =
-        tracing::span!(tracing::Level::INFO, "handle_code_action_for_specified_diagnostic")
-            .entered();
+    let _p = tracing::span!(tracing::Level::INFO, "handle_code_action_for_specified_diagnostic")
+        .entered();
 
     let mut assists_config = snap.config.assist();
     assists_config.specified_diagnostic_code =
-        params.context.diagnostics.first().map_or(None, |it| match it.code.clone()? {
+        params.context.diagnostics.first().and_then(|it| match it.code.clone()? {
             NumberOrString::String(code) => Some(code),
             _ => None,
         });

--- a/crates/rust-analyzer/src/lsp/ext.rs
+++ b/crates/rust-analyzer/src/lsp/ext.rs
@@ -413,6 +413,14 @@ impl Request for CodeActionRequest {
     const METHOD: &'static str = "textDocument/codeAction";
 }
 
+pub enum CodeActionForDiagnosticRequest {}
+
+impl Request for CodeActionForDiagnosticRequest {
+    type Params = lsp_types::CodeActionParams;
+    type Result = Option<Vec<CodeAction>>;
+    const METHOD: &'static str = "rust-analyzer/codeActionForDiagnostic";
+}
+
 pub enum CodeActionResolveRequest {}
 
 impl Request for CodeActionResolveRequest {

--- a/crates/rust-analyzer/src/main_loop.rs
+++ b/crates/rust-analyzer/src/main_loop.rs
@@ -848,6 +848,9 @@ impl GlobalState {
             .on::<lsp_ext::Runnables>(handlers::handle_runnables)
             .on::<lsp_ext::RelatedTests>(handlers::handle_related_tests)
             .on::<lsp_ext::CodeActionRequest>(handlers::handle_code_action)
+            .on::<lsp_ext::CodeActionForDiagnosticRequest>(
+                handlers::handle_code_action_for_specified_diagnostic,
+            )
             .on::<lsp_ext::CodeActionResolveRequest>(handlers::handle_code_action_resolve)
             .on::<lsp_ext::HoverRequest>(handlers::handle_hover)
             .on::<lsp_ext::ExternalDocs>(handlers::handle_open_docs)

--- a/docs/dev/lsp-extensions.md
+++ b/docs/dev/lsp-extensions.md
@@ -1,5 +1,5 @@
 <!---
-lsp/ext.rs hash: 8be79cc3b7f10ad7
+lsp/ext.rs hash: 681f7433af4db5c2
 
 If you need to change the above hash to make the test pass, please check if you
 need to adjust this doc as well and ping this issue:

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -318,6 +318,14 @@
             "type": "object",
             "title": "rust-analyzer",
             "properties": {
+                "rust-analyzer.autoFixDiagnostics": {
+                    "type": "array",
+                    "default": [],
+                    "items": {
+                        "type": "string"
+                    },
+                    "description": "List of diagnostic to automatically apply fix."
+                },
                 "rust-analyzer.cargoRunner": {
                     "type": [
                         "null",

--- a/editors/code/src/lsp_ext.ts
+++ b/editors/code/src/lsp_ext.ts
@@ -29,6 +29,11 @@ export type CommandLinkGroup = {
 export const analyzerStatus = new lc.RequestType<AnalyzerStatusParams, string, void>(
     "rust-analyzer/analyzerStatus",
 );
+export const codeActionForDiagnostic = new lc.RequestType<
+    lc.CodeActionParams,
+    (lc.Command | lc.CodeAction)[] | null,
+    void
+>("rust-analyzer/codeActionForDiagnostic");
 export const cancelFlycheck = new lc.NotificationType0("rust-analyzer/cancelFlycheck");
 export const clearFlycheck = new lc.NotificationType0("rust-analyzer/clearFlycheck");
 export const expandMacro = new lc.RequestType<ExpandMacroParams, ExpandedMacro | null, void>(

--- a/editors/code/src/main.ts
+++ b/editors/code/src/main.ts
@@ -7,6 +7,7 @@ import * as diagnostics from "./diagnostics";
 import { activateTaskProvider } from "./tasks";
 import { setContextValue } from "./util";
 import type { JsonProject } from "./rust_project";
+import * as ra from "./lsp_ext";
 
 const RUST_PROJECT_CONTEXT_NAME = "inRustProject";
 
@@ -105,6 +106,15 @@ async function activateServer(ctx: Ctx): Promise<RustAnalyzerExtensionApi> {
         null,
         ctx.subscriptions,
     );
+    vscode.workspace.onWillSaveTextDocument(async (event) => {
+        const client = ctx.client;
+        let document = event.document;
+        if (document.languageId === 'rust' && client) {
+            // get 'rust-analyzer.autoFixDiagnostics' configuration, empty by default
+            const diagnosticsToFix = vscode.workspace.getConfiguration('rust-analyzer').get<string[]>('autoFixDiagnostics') || [];
+            event.waitUntil(autoFixDiagnostics(document, diagnosticsToFix, client));
+        }
+    });
 
     await ctx.start();
     return ctx;
@@ -213,4 +223,53 @@ function checkConflictingExtensions() {
             )
             .then(() => {}, console.error);
     }
+}
+
+async function autoFixDiagnostics(document: vscode.TextDocument, diagnosticsToFix: string[], client: lc.LanguageClient) {
+
+    // get the diagnosis specified by the user for the current document
+    let getDiagnostics = () => {
+        const isInclude = (diagnostic: vscode.Diagnostic) => {
+            const diagnosticCode =
+                typeof diagnostic.code === "string" || typeof diagnostic.code === "number"
+                    ? diagnostic.code
+                    : diagnostic.code?.value || "";
+            return diagnosticsToFix.includes(diagnosticCode.toString());
+        };
+
+        let diagnostics = vscode.languages.getDiagnostics(document.uri);
+        return diagnostics.filter(diagnostic => isInclude(diagnostic))
+    }
+
+    let diagnostics = getDiagnostics();
+
+    while (diagnostics.length != 0) {
+        let currentDiagnostic = diagnostics.at(0);
+        if (!currentDiagnostic) return;
+        let params: lc.CodeActionParams = {
+            textDocument: { uri: document.uri.toString() },
+            range: currentDiagnostic.range,
+            context: {
+                diagnostics: [client.code2ProtocolConverter.asDiagnostic(currentDiagnostic)],
+            }
+        };
+
+        let actions = await client.sendRequest(ra.codeActionForDiagnostic, params);
+        let action = actions?.at(0);
+        if (lc.CodeAction.is(action) && action.edit) {
+            const edit = await client.protocol2CodeConverter.asWorkspaceEdit(action.edit);
+            await vscode.workspace.applyEdit(edit);
+        }
+        else if (action) {
+            let resolvedCodeAction = await client.sendRequest(lc.CodeActionResolveRequest.type, action);
+            if (resolvedCodeAction.edit) {
+                const edit = await client.protocol2CodeConverter.asWorkspaceEdit(resolvedCodeAction.edit);
+                await vscode.workspace.applyEdit(edit);
+            }
+        }
+
+        // after the above `applyEdit(edit)`, source code changed, so we refresh the diagnostics
+        diagnostics = getDiagnostics();
+    }
+
 }


### PR DESCRIPTION
# Change
* server side:  add `specified_diagnostic_code` field into AssistConfig, which use to filter out unreleated fixes to the diagnostic. add `handle_code_action_for_specified_diagnostic` based on the implementation of `handle_code_action`, which use to handle the `rust-analyzer/codeActionForDiagnostic` LSP request, it will return the only code action fix corrsponding to the specified diagnostic
* client side: listen the `onWillSaveTextDocument` event and apply the fix corrsponding to the diagnostics which config by `rust-analyzer.autoFixDiagnostics`

# Demo

![demo-20240229113602-9x1ji67](https://github.com/rust-lang/rust-analyzer/assets/71162630/f9965a1b-1ee3-42d4-a1b8-f45c422e4504)

based on the following config in settings.josn
```json
"rust-analyzer.autoFixDiagnostics": [
    "unused_braces",
    "redundant_field_names",
    "non_snake_case",
],
```

# Todo
* server side: currently we only support native diagnostic fix from rust-analyzer(crates/ide-diagnostics/src/handlers/), ideally we should support fix from cargo check also. we should also add more native diagnostics and fix in rust-analyzer, but it require a lot of work
* client side: expose a config for other event to trigger autoFixDiagnostics, like format file?

close https://github.com/rust-lang/rust-analyzer/issues/12960
