### PR TITLE
minor: remove `ignore-hidden = false`

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -5,7 +5,6 @@ extend-exclude = [
     "crates/parser/test_data/lexer/err/",
     "crates/project-model/test_data/",
 ]
-ignore-hidden = false
 
 [default]
 extend-ignore-re = [


### PR DESCRIPTION
run `typos` locally and get
```txt
error: `ND` should be `AND`
  --> ./.git/objects/20/a90c507b0c92883b10c29447a56d30bf9e8d57:1:515
  |
1 | xM�{L�a�Cʒ��2�DG$�Q�+1�M.[��9o��z/��<ou�Tn�ICn��˺g�VG�BFmg�j5˵�:2�p�z�����w�ۃ]�V�˼��>>���T$�
                                                                                                Đ��bgJ博3�gzr�ꝛQ�p��x����� u���"Ui"�gw��f�;�>�;���d��0�~�nvx>���+u��;c\��~�T,Ԏ�ԁ��惵���>�[����B�L8R` ��8V� ��~��lrN~��>�s�Y�Z�p"�T�mFA܁�KJ[�b�Ko���>^��Y�
                     c��7�r��0�>{Wl��ꉔ����#��E��L���#�ehm�fiA�h��9#E�������W�(\�h���`���Ca� ��H��� ;qp������:(.i���{*>�"���%���=;4O/ =�:�EZ�gD�)m��������A��ϋ��c�I���e�"��8�[r�%�}CY����=p[F�D,G��d��،��}ms��^��^�.�UC�ND
  |                                                                                                                                          
```
we should ignore `.git`