### PR TITLE
Add `fn index()` and `fn parent_fn()` accessors for `hir::Param`/`hir::SelfParam`

### DIFF
--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -2112,6 +2112,10 @@ impl Param {
         self.func
     }
 
+    pub fn index(&self) -> usize {
+        self.idx
+    }
+
     pub fn ty(&self) -> &Type {
         &self.ty
     }

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -2108,6 +2108,10 @@ pub struct Param {
 }
 
 impl Param {
+    pub fn parent_fn(&self) -> Function {
+        self.func
+    }
+
     pub fn ty(&self) -> &Type {
         &self.ty
     }
@@ -2170,6 +2174,10 @@ impl SelfParam {
             .param_list()
             .and_then(|params| params.self_param())
             .map(|value| InFile { file_id, value })
+    }
+
+    pub fn parent_fn(&self) -> Function {
+        Function::from(self.func)
     }
 
     pub fn ty(&self, db: &dyn HirDatabase) -> Type {


### PR DESCRIPTION
(the PR is motivated by an outside use of the `ra_ap_hir` crate that would benefit from being able to access a `hir::Param`'s/`hir::SelfParam`'s index and parent function)