### PR TITLE
mark tokio::test as test

### DIFF
--- a/crates/hir-def/src/attr.rs
+++ b/crates/hir-def/src/attr.rs
@@ -202,6 +202,12 @@ impl Attrs {
                 .rev()
                 .zip(["core", "prelude", "v1", "test"].iter().rev())
                 .all(|it| it.0.as_str() == Some(it.1))
+        }) || self.iter().any(|it| {
+            it.path()
+                .segments()
+                .iter()
+                .zip(["tokio", "test"].iter())
+                .all(|it| it.0.as_str() == Some(it.1))
         })
     }
 

--- a/crates/ide/src/references.rs
+++ b/crates/ide/src/references.rs
@@ -319,12 +319,19 @@ fn func() {
 fn test() {
     test_func();
 }
+
+#[tokio::test]
+fn async_test() {
+    test_func();
+}
+
 "#,
             expect![[r#"
                 test_func Function FileId(0) 0..17 3..12
 
                 FileId(0) 35..44
                 FileId(0) 75..84 Test
+                FileId(0) 128..137 Test
             "#]],
         );
 


### PR DESCRIPTION
this is to support the `excludeTests` option to also handle `#[tokio::test]`
