### PR TITLE
fix: Don't escape `\` and `$` in "Extract format expressions" assist

### DIFF
--- a/crates/ide-assists/src/handlers/extract_expressions_from_format_string.rs
+++ b/crates/ide-assists/src/handlers/extract_expressions_from_format_string.rs
@@ -274,4 +274,22 @@ fn main() {
 "#,
         );
     }
+
+    #[test]
+    fn escaped_literals() {
+        check_assist(
+            extract_expressions_from_format_string,
+            r#"
+//- minicore: fmt
+fn main() {
+    print!("\n$ {x + 1}$0");
+}
+            "#,
+            r#"
+fn main() {
+    print!("\n$ {}"$0, x + 1);
+}
+            "#,
+        );
+    }
 }

--- a/crates/ide-db/src/syntax_helpers/format_string_exprs.rs
+++ b/crates/ide-db/src/syntax_helpers/format_string_exprs.rs
@@ -79,9 +79,6 @@ pub fn parse_format_exprs(input: &str) -> Result<(String, Vec<Arg>), ()> {
                 state = State::MaybeIncorrect;
             }
             (State::NotArg, _) => {
-                if matches!(chr, '\\' | '$') {
-                    output.push('\\');
-                }
                 output.push(chr);
             }
             (State::MaybeIncorrect, '}') => {
@@ -110,9 +107,6 @@ pub fn parse_format_exprs(input: &str) -> Result<(String, Vec<Arg>), ()> {
                 state = State::FormatOpts;
             }
             (State::MaybeArg, _) => {
-                if matches!(chr, '\\' | '$') {
-                    current_expr.push('\\');
-                }
                 current_expr.push(chr);
 
                 // While Rust uses the unicode sets of XID_start and XID_continue for Identifiers
@@ -172,9 +166,6 @@ pub fn parse_format_exprs(input: &str) -> Result<(String, Vec<Arg>), ()> {
                     state = State::Expr;
                 }
 
-                if matches!(chr, '\\' | '$') {
-                    current_expr.push('\\');
-                }
                 current_expr.push(chr);
             }
             (State::FormatOpts, '}') => {
@@ -182,9 +173,6 @@ pub fn parse_format_exprs(input: &str) -> Result<(String, Vec<Arg>), ()> {
                 state = State::NotArg;
             }
             (State::FormatOpts, _) => {
-                if matches!(chr, '\\' | '$') {
-                    output.push('\\');
-                }
                 output.push(chr);
             }
         }
@@ -217,15 +205,15 @@ mod tests {
     fn format_str_parser() {
         let test_vector = &[
             ("no expressions", expect![["no expressions"]]),
-            (r"no expressions with \$0$1", expect![r"no expressions with \\\$0\$1"]),
+            (r"no expressions with \$0$1", expect![r"no expressions with \$0$1"]),
             ("{expr} is {2 + 2}", expect![["{expr} is {}; 2 + 2"]]),
             ("{expr:?}", expect![["{expr:?}"]]),
-            ("{expr:1$}", expect![[r"{expr:1\$}"]]),
-            ("{:1$}", expect![[r"{:1\$}; $1"]]),
-            ("{:>padding$}", expect![[r"{:>padding\$}; $1"]]),
+            ("{expr:1$}", expect![[r"{expr:1$}"]]),
+            ("{:1$}", expect![[r"{:1$}; $1"]]),
+            ("{:>padding$}", expect![[r"{:>padding$}; $1"]]),
             ("{}, {}, {0}", expect![[r"{}, {}, {0}; $1, $2"]]),
             ("{}, {}, {0:b}", expect![[r"{}, {}, {0:b}; $1, $2"]]),
-            ("{$0}", expect![[r"{}; \$0"]]),
+            ("{$0}", expect![[r"{}; $0"]]),
             ("{malformed", expect![["-"]]),
             ("malformed}", expect![["-"]]),
             ("{{correct", expect![["{{correct"]]),


### PR DESCRIPTION
Fixes #16745