### PR TITLE
Remove unncessary check for macro call

### DIFF
--- a/crates/parser/src/grammar/items.rs
+++ b/crates/parser/src/grammar/items.rs
@@ -70,8 +70,7 @@ pub(super) fn item_or_macro(p: &mut Parser<'_>, stop_on_r_curly: bool) {
     // macro_rules! {};
     // macro_rules! ()
     // macro_rules! []
-    let no_ident = p.at_contextual_kw(T![macro_rules]) && p.nth_at(1, BANG) && !p.nth_at(2, IDENT);
-    if paths::is_use_path_start(p) || no_ident {
+    if paths::is_use_path_start(p) {
         macro_call(p, m);
         return;
     }


### PR DESCRIPTION
Since `macro_rules` is a contextual keyword, it is an `IDENT` token and thus `is_path_start` already identifies it correctly. You can tell the previous check is unnecessary because the relevant tests still pass.
