### PR TITLE
fix: Fix method resolution snapshotting receiver_ty too early

### DIFF
--- a/crates/hir-ty/src/infer/unify.rs
+++ b/crates/hir-ty/src/infer/unify.rs
@@ -438,7 +438,6 @@ impl<'a> InferenceTable<'a> {
     where
         T: HasInterner<Interner = Interner> + TypeFoldable<Interner>,
     {
-        // TODO check this vec here
         self.resolve_with_fallback_inner(&mut Vec::new(), t, &fallback)
     }
 


### PR DESCRIPTION
Accidental change in https://github.com/rust-lang/rust-analyzer/pull/16749 presumably caused some type mismatches in webrender