### PR TITLE
fix: Don't auto-close block comments in strings

### DIFF
--- a/editors/code/language-configuration.json
+++ b/editors/code/language-configuration.json
@@ -18,7 +18,7 @@
         { "open": "[", "close": "]" },
         { "open": "(", "close": ")" },
         { "open": "\"", "close": "\"", "notIn": ["string"] },
-        { "open": "/*", "close": " */" },
+        { "open": "/*", "close": " */", "notIn": ["string"] },
         { "open": "`", "close": "`", "notIn": ["string"] }
     ],
     "autoCloseBefore": ";:.,=}])> \n\t",


### PR DESCRIPTION
Fixes #16815