### PR TITLE
RFC: Hide size/layout information by default

### DIFF
--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -370,7 +370,7 @@ config_data! {
         /// How to render the align information in a memory layout hover.
         hover_memoryLayout_alignment: Option<MemoryLayoutHoverRenderKindDef> = "\"hexadecimal\"",
         /// Whether to show memory layout data on hover.
-        hover_memoryLayout_enable: bool = "true",
+        hover_memoryLayout_enable: bool = "false",
         /// How to render the niche information in a memory layout hover.
         hover_memoryLayout_niches: Option<bool> = "false",
         /// How to render the offset information in a memory layout hover.

--- a/docs/user/generated_config.adoc
+++ b/docs/user/generated_config.adoc
@@ -500,7 +500,7 @@ Use markdown syntax for links on hover.
 --
 How to render the align information in a memory layout hover.
 --
-[[rust-analyzer.hover.memoryLayout.enable]]rust-analyzer.hover.memoryLayout.enable (default: `true`)::
+[[rust-analyzer.hover.memoryLayout.enable]]rust-analyzer.hover.memoryLayout.enable (default: `false`)::
 +
 --
 Whether to show memory layout data on hover.

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -1089,7 +1089,7 @@
                 },
                 "rust-analyzer.hover.memoryLayout.enable": {
                     "markdownDescription": "Whether to show memory layout data on hover.",
-                    "default": true,
+                    "default": false,
                     "type": "boolean"
                 },
                 "rust-analyzer.hover.memoryLayout.niches": {


### PR DESCRIPTION
Most of the time, I'm not interested in the exact layout of types. However, rust-analyzer shows the information very prominently, even before the doc comment.

<img width="317" alt="Screenshot 2024-03-12 at 12 38 03" src="https://github.com/rust-lang/rust-analyzer/assets/70800/0832c958-d307-4875-8583-19f4060f5102">

I've fixed the whitespace in #16824, but I feel like opt-in is a better default for layout information. I know that this has been the behaviour for a while, but the layout information is much more visible after cf905cff7613fc2425244facb4849b7f23208ef5.

What do you think?