### PR TITLE
Have Derive Attribute share a token tree with it's proc macros.

### DIFF
--- a/crates/hir-def/src/nameres/attr_resolution.rs
+++ b/crates/hir-def/src/nameres/attr_resolution.rs
@@ -136,6 +136,7 @@ pub(super) fn derive_macro_as_call_id(
     call_site: SyntaxContextId,
     krate: CrateId,
     resolver: impl Fn(path::ModPath) -> Option<(MacroId, MacroDefId)>,
+    derive_macro_id: MacroCallId,
 ) -> Result<(MacroId, MacroDefId, MacroCallId), UnresolvedMacro> {
     let (macro_id, def_id) = resolver(item_attr.path.clone())
         .filter(|(_, def_id)| def_id.is_derive())
@@ -147,6 +148,7 @@ pub(super) fn derive_macro_as_call_id(
             ast_id: item_attr.ast_id,
             derive_index: derive_pos,
             derive_attr_index,
+            derive_macro_id,
         },
         call_site,
     );

--- a/crates/hir-def/src/nameres/attr_resolution.rs
+++ b/crates/hir-def/src/nameres/attr_resolution.rs
@@ -3,7 +3,7 @@
 use base_db::CrateId;
 use hir_expand::{
     attrs::{Attr, AttrId, AttrInput},
-    MacroCallId, MacroCallKind, MacroDefId,
+    AstId, MacroCallId, MacroCallKind, MacroDefId,
 };
 use span::SyntaxContextId;
 use syntax::{ast, SmolStr};
@@ -98,7 +98,20 @@ impl DefMap {
         false
     }
 }
-
+pub(super) fn derive_attr_macro_as_call_id(
+    db: &dyn DefDatabase,
+    item_attr: &AstId<ast::Adt>,
+    macro_attr: &Attr,
+    krate: CrateId,
+    def: MacroDefId,
+) -> MacroCallId {
+    def.make_call(
+        db.upcast(),
+        krate,
+        MacroCallKind::DeriveAttr { ast_id: *item_attr, invoc_attr_index: macro_attr.id },
+        macro_attr.ctxt,
+    )
+}
 pub(super) fn attr_macro_as_call_id(
     db: &dyn DefDatabase,
     item_attr: &AstIdWithPath<ast::Item>,

--- a/crates/hir-def/src/nameres/attr_resolution.rs
+++ b/crates/hir-def/src/nameres/attr_resolution.rs
@@ -3,7 +3,7 @@
 use base_db::CrateId;
 use hir_expand::{
     attrs::{Attr, AttrId, AttrInput},
-    AstId, MacroCallId, MacroCallKind, MacroDefId,
+    MacroCallId, MacroCallKind, MacroDefId,
 };
 use span::SyntaxContextId;
 use syntax::{ast, SmolStr};
@@ -98,20 +98,7 @@ impl DefMap {
         false
     }
 }
-pub(super) fn derive_attr_macro_as_call_id(
-    db: &dyn DefDatabase,
-    item_attr: &AstId<ast::Adt>,
-    macro_attr: &Attr,
-    krate: CrateId,
-    def: MacroDefId,
-) -> MacroCallId {
-    def.make_call(
-        db.upcast(),
-        krate,
-        MacroCallKind::DeriveAttr { ast_id: *item_attr, invoc_attr_index: macro_attr.id },
-        macro_attr.ctxt,
-    )
-}
+
 pub(super) fn attr_macro_as_call_id(
     db: &dyn DefDatabase,
     item_attr: &AstIdWithPath<ast::Item>,

--- a/crates/hir-def/src/nameres/collector.rs
+++ b/crates/hir-def/src/nameres/collector.rs
@@ -14,6 +14,7 @@ use crate::item_tree::Mod;
 use crate::item_tree::ModKind;
 use crate::macro_call_as_call_id_with_eager;
 
+use crate::nameres::attr_resolution::derive_attr_macro_as_call_id;
 use crate::nameres::mod_resolution::ModDir;
 
 use crate::item_tree::ItemTree;
@@ -1258,9 +1259,7 @@ impl DefCollector<'_> {
                         Some(def) if def.is_attribute() => def,
                         _ => return Resolved::No,
                     };
-                    // We will treat derive macros as an attribute as a reference for the input to derives
-                    let call_id =
-                        attr_macro_as_call_id(self.db, file_ast_id, attr, self.def_map.krate, def);
+
                     if let MacroDefId {
                         kind:
                             MacroDefKind::BuiltInAttr(
@@ -1289,8 +1288,16 @@ impl DefCollector<'_> {
                                 return recollect_without(self);
                             }
                         };
-                        let ast_id = ast_id.with_value(ast_adt_id);
 
+                        let ast_id = ast_id.with_value(ast_adt_id);
+                        // the call_id for the actual derive macro. This is used so all the derive proc macros can share a token tree
+                        let call_id = derive_attr_macro_as_call_id(
+                            self.db,
+                            &ast_id,
+                            attr,
+                            self.def_map.krate,
+                            def,
+                        );
                         match attr.parse_path_comma_token_tree(self.db.upcast()) {
                             Some(derive_macros) => {
                                 let mut len = 0;
@@ -1338,7 +1345,8 @@ impl DefCollector<'_> {
 
                         return recollect_without(self);
                     }
-
+                    let call_id =
+                        attr_macro_as_call_id(self.db, file_ast_id, attr, self.def_map.krate, def);
                     // Skip #[test]/#[bench] expansion, which would merely result in more memory usage
                     // due to duplicating functions into macro expansions
                     if matches!(

--- a/crates/hir-def/src/nameres/collector.rs
+++ b/crates/hir-def/src/nameres/collector.rs
@@ -17,8 +17,6 @@ use crate::macro_call_as_call_id_with_eager;
 use crate::nameres::mod_resolution::ModDir;
 
 use crate::item_tree::ItemTree;
-use base_db::{CrateId, Dependency, FileId};
-use cfg::{CfgExpr, CfgOptions};
 
 use crate::item_tree::TreeId;
 

--- a/crates/hir-def/src/nameres/collector.rs
+++ b/crates/hir-def/src/nameres/collector.rs
@@ -1232,6 +1232,7 @@ impl DefCollector<'_> {
                         Some(def) if def.is_attribute() => def,
                         _ => return Resolved::No,
                     };
+
                     let call_id =
                         attr_macro_as_call_id(self.db, file_ast_id, attr, self.def_map.krate, def);
                     if let MacroDefId {
@@ -1264,7 +1265,6 @@ impl DefCollector<'_> {
                         };
 
                         let ast_id = ast_id.with_value(ast_adt_id);
-                        // the call_id for the actual derive macro. This is used so all the derive proc macros can share a token tree
 
                         match attr.parse_path_comma_token_tree(self.db.upcast()) {
                             Some(derive_macros) => {
@@ -2305,7 +2305,7 @@ impl ModCollector<'_, '_> {
 
     fn collect_macro_call(
         &mut self,
-        &MacroCall { ref path, ast_id, expand_to, ctxt, .. }: &MacroCall,
+        &MacroCall { ref path, ast_id, expand_to, ctxt }: &MacroCall,
         container: ItemContainerId,
     ) {
         let ast_id = AstIdWithPath::new(self.file_id(), ast_id, ModPath::clone(path));
@@ -2444,10 +2444,7 @@ mod tests {
     use base_db::SourceDatabase;
     use test_fixture::WithFixture;
 
-    use crate::{
-        nameres::{DefMapCrateData, ModuleData, ModuleOrigin},
-        test_db::TestDB,
-    };
+    use crate::{nameres::DefMapCrateData, test_db::TestDB};
 
     use super::*;
 

--- a/crates/hir-expand/src/cfg_process.rs
+++ b/crates/hir-expand/src/cfg_process.rs
@@ -180,7 +180,7 @@ pub(crate) fn process_cfg_attrs(
     db: &dyn ExpandDatabase,
 ) -> Option<FxHashSet<SyntaxElement>> {
     // FIXME: #[cfg_eval] is not implemented. But it is not stable yet
-    if !matches!(loc.kind, MacroCallKind::Derive { .. }) {
+    if !matches!(loc.kind, MacroCallKind::Derive { .. } | MacroCallKind::DeriveAttr { .. }) {
         return None;
     }
     let mut remove = FxHashSet::default();

--- a/crates/hir-expand/src/cfg_process.rs
+++ b/crates/hir-expand/src/cfg_process.rs
@@ -10,7 +10,7 @@ use syntax::{
 use tracing::{debug, warn};
 use tt::SmolStr;
 
-use crate::{db::ExpandDatabase, MacroCallKind, MacroCallLoc};
+use crate::{db::ExpandDatabase, proc_macro::ProcMacroKind, MacroCallLoc, MacroDefKind};
 
 fn check_cfg_attr(attr: &Attr, loc: &MacroCallLoc, db: &dyn ExpandDatabase) -> Option<bool> {
     if !attr.simple_name().as_deref().map(|v| v == "cfg")? {
@@ -180,7 +180,13 @@ pub(crate) fn process_cfg_attrs(
     db: &dyn ExpandDatabase,
 ) -> Option<FxHashSet<SyntaxElement>> {
     // FIXME: #[cfg_eval] is not implemented. But it is not stable yet
-    if !matches!(loc.kind, MacroCallKind::Derive { .. } | MacroCallKind::DeriveAttr { .. }) {
+    let is_derive = match loc.def.kind {
+        MacroDefKind::BuiltInDerive(..)
+        | MacroDefKind::ProcMacro(_, ProcMacroKind::CustomDerive, _) => true,
+        MacroDefKind::BuiltInAttr(expander, _) => expander.is_derive(),
+        _ => false,
+    };
+    if !is_derive {
         return None;
     }
     let mut remove = FxHashSet::default();

--- a/crates/hir-expand/src/db.rs
+++ b/crates/hir-expand/src/db.rs
@@ -7,6 +7,7 @@ use mbe::syntax_node_to_token_tree;
 use rustc_hash::FxHashSet;
 use span::{AstIdMap, Span, SyntaxContextData, SyntaxContextId};
 use syntax::{ast, AstNode, Parse, SyntaxElement, SyntaxError, SyntaxNode, SyntaxToken, T};
+use tracing::debug;
 use triomphe::Arc;
 
 use crate::{
@@ -353,7 +354,13 @@ fn smart_macro_arg(db: &dyn ExpandDatabase, id: MacroCallId) -> MacroArgResult {
     // FIXME: We called lookup_intern_macro_call twice.
     match loc.kind {
         // Get the macro arg for the derive macro
-        MacroCallKind::Derive { derive_macro_id, .. } => db.macro_arg(derive_macro_id),
+        MacroCallKind::Derive { derive_macro_id, .. } => {
+            debug!(
+                ?loc,
+                "{id:?} is a derive macro. Using the derive macro, id: {derive_macro_id:?}, attribute as the macro arg."
+            );
+            db.macro_arg(derive_macro_id)
+        }
         // Normal macro arg
         _ => db.macro_arg(id),
     }

--- a/crates/hir-expand/src/db.rs
+++ b/crates/hir-expand/src/db.rs
@@ -340,7 +340,7 @@ pub(crate) fn parse_with_map(
     }
 }
 /// This is just to ensure the types of smart_macro_arg and macro_arg are the same
-type MacroArgResult = (Arc<tt::Subtree>, SyntaxFixupUndoInfo, Span) ;
+type MacroArgResult = (Arc<tt::Subtree>, SyntaxFixupUndoInfo, Span);
 /// Imagine the word smart in quotes.
 ///
 /// This resolves the [MacroCallId] to check if it is a derive macro if so get the [macro_arg] for the derive.
@@ -553,8 +553,7 @@ fn macro_expand(
     let (ExpandResult { value: tt, err }, span) = match loc.def.kind {
         MacroDefKind::ProcMacro(..) => return db.expand_proc_macro(macro_call_id).map(CowArc::Arc),
         _ => {
-            let (macro_arg, undo_info, span) =
-                smart_macro_arg(db, macro_call_id);
+            let (macro_arg, undo_info, span) = smart_macro_arg(db, macro_call_id);
 
             let arg = &*macro_arg;
             let res =

--- a/crates/hir-expand/src/lib.rs
+++ b/crates/hir-expand/src/lib.rs
@@ -228,6 +228,10 @@ pub enum MacroCallKind {
         /// We will resolve the same token tree for all derive macros in the same derive attribute.
         derive_macro_id: MacroCallId,
     },
+    DeriveAttr {
+        ast_id: AstId<ast::Adt>,
+        invoc_attr_index: AttrId,
+    },
     Attr {
         ast_id: AstId<ast::Item>,
         // FIXME: This shouldn't be here, we can derive this from `invoc_attr_index`
@@ -515,7 +519,8 @@ impl MacroCallLoc {
             MacroCallKind::FnLike { ast_id, .. } => {
                 ast_id.with_value(ast_id.to_node(db).syntax().clone())
             }
-            MacroCallKind::Derive { ast_id, derive_attr_index, .. } => {
+            MacroCallKind::Derive { ast_id, derive_attr_index, .. }
+            | MacroCallKind::DeriveAttr { ast_id, invoc_attr_index: derive_attr_index } => {
                 // FIXME: handle `cfg_attr`
                 ast_id.with_value(ast_id.to_node(db)).map(|it| {
                     collect_attrs(&it)
@@ -549,7 +554,7 @@ impl MacroCallLoc {
     fn expand_to(&self) -> ExpandTo {
         match self.kind {
             MacroCallKind::FnLike { expand_to, .. } => expand_to,
-            MacroCallKind::Derive { .. } => ExpandTo::Items,
+            MacroCallKind::Derive { .. } | MacroCallKind::DeriveAttr { .. } => ExpandTo::Items,
             MacroCallKind::Attr { .. } if self.def.is_attribute_derive() => ExpandTo::Items,
             MacroCallKind::Attr { .. } => {
                 // FIXME(stmt_expr_attributes)
@@ -583,6 +588,7 @@ impl MacroCallKind {
             MacroCallKind::FnLike { .. } => "macro call",
             MacroCallKind::Derive { .. } => "derive macro",
             MacroCallKind::Attr { .. } => "attribute macro",
+            MacroCallKind::DeriveAttr { .. } => "derive attribute",
         }
     }
 
@@ -591,6 +597,7 @@ impl MacroCallKind {
         match *self {
             MacroCallKind::FnLike { ast_id: InFile { file_id, .. }, .. }
             | MacroCallKind::Derive { ast_id: InFile { file_id, .. }, .. }
+            | MacroCallKind::DeriveAttr { ast_id: InFile { file_id, .. }, .. }
             | MacroCallKind::Attr { ast_id: InFile { file_id, .. }, .. } => file_id,
         }
     }
@@ -598,7 +605,8 @@ impl MacroCallKind {
     pub fn erased_ast_id(&self) -> ErasedFileAstId {
         match *self {
             MacroCallKind::FnLike { ast_id: InFile { value, .. }, .. } => value.erase(),
-            MacroCallKind::Derive { ast_id: InFile { value, .. }, .. } => value.erase(),
+            MacroCallKind::Derive { ast_id: InFile { value, .. }, .. }
+            | MacroCallKind::DeriveAttr { ast_id: InFile { value, .. }, .. } => value.erase(),
             MacroCallKind::Attr { ast_id: InFile { value, .. }, .. } => value.erase(),
         }
     }
@@ -619,7 +627,9 @@ impl MacroCallKind {
 
         let range = match kind {
             MacroCallKind::FnLike { ast_id, .. } => ast_id.to_ptr(db).text_range(),
-            MacroCallKind::Derive { ast_id, .. } => ast_id.to_ptr(db).text_range(),
+            MacroCallKind::Derive { ast_id, .. } | MacroCallKind::DeriveAttr { ast_id, .. } => {
+                ast_id.to_ptr(db).text_range()
+            }
             MacroCallKind::Attr { ast_id, .. } => ast_id.to_ptr(db).text_range(),
         };
 
@@ -665,6 +675,15 @@ impl MacroCallKind {
                     .syntax()
                     .text_range()
             }
+            MacroCallKind::DeriveAttr { ast_id, invoc_attr_index } => {
+                collect_attrs(&ast_id.to_node(db))
+                    .nth(invoc_attr_index.ast_index())
+                    .expect("missing attribute")
+                    .1
+                    .expect_left("attribute macro is a doc comment?")
+                    .syntax()
+                    .text_range()
+            }
         };
 
         FileRange { range, file_id }
@@ -675,7 +694,7 @@ impl MacroCallKind {
             MacroCallKind::FnLike { ast_id, .. } => {
                 ast_id.to_in_file_node(db).map(|it| Some(it.token_tree()?.syntax().clone()))
             }
-            MacroCallKind::Derive { ast_id, .. } => {
+            MacroCallKind::Derive { ast_id, .. } | MacroCallKind::DeriveAttr { ast_id, .. } => {
                 ast_id.to_in_file_node(db).syntax().cloned().map(Some)
             }
             MacroCallKind::Attr { ast_id, .. } => {

--- a/crates/hir-expand/src/lib.rs
+++ b/crates/hir-expand/src/lib.rs
@@ -224,6 +224,9 @@ pub enum MacroCallKind {
         derive_attr_index: AttrId,
         /// Index of the derive macro in the derive attribute
         derive_index: u32,
+        /// The "parent" macro call.
+        /// We will resolve the same token tree for all derive macros in the same derive attribute.
+        derive_macro_id: MacroCallId,
     },
     Attr {
         ast_id: AstId<ast::Item>,

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -972,7 +972,8 @@ fn precise_macro_call_location(
                 MacroKind::ProcMacro,
             )
         }
-        MacroCallKind::Derive { ast_id, derive_attr_index, derive_index } => {
+        // TODO: derive_macro_id
+        MacroCallKind::Derive { ast_id, derive_attr_index, derive_index, derive_macro_id } => {
             let node = ast_id.to_node(db.upcast());
             // Compute the precise location of the macro name's token in the derive
             // list.
@@ -3709,7 +3710,8 @@ impl Impl {
         let macro_file = src.file_id.macro_file()?;
         let loc = macro_file.macro_call_id.lookup(db.upcast());
         let (derive_attr, derive_index) = match loc.kind {
-            MacroCallKind::Derive { ast_id, derive_attr_index, derive_index } => {
+            // TODO: derive_macro_id
+            MacroCallKind::Derive { ast_id, derive_attr_index, derive_index, derive_macro_id } => {
                 let module_id = self.id.lookup(db.upcast()).container;
                 (
                     db.crate_def_map(module_id.krate())[module_id.local_id]

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -1022,26 +1022,6 @@ fn precise_macro_call_location(
                 MacroKind::Attr,
             )
         }
-        MacroCallKind::DeriveAttr { ast_id, invoc_attr_index } => {
-            let node = ast_id.to_node(db.upcast());
-            let attr = collect_attrs(&node)
-                .nth(invoc_attr_index.ast_index())
-                .and_then(|x| Either::left(x.1))
-                .unwrap_or_else(|| {
-                    panic!("cannot find attribute #{}", invoc_attr_index.ast_index())
-                });
-
-            (
-                ast_id.with_value(SyntaxNodePtr::from(AstPtr::new(&attr))),
-                Some(attr.syntax().text_range()),
-                attr.path()
-                    .and_then(|path| path.segment())
-                    .and_then(|seg| seg.name_ref())
-                    .as_ref()
-                    .map(ToString::to_string),
-                MacroKind::Attr,
-            )
-        }
     }
 }
 


### PR DESCRIPTION
The goal of this PR is to stop creating a token tree for each derive proc macro. 

This is done by giving the derive proc macros an id to its parent derive element. 

From running the analysis stat on the rust analyzer project I did see a small memory decrease.

```
Inference:           42.80s, 362ginstr, 591mb
MIR lowering:        8.67s, 67ginstr, 291mb
Mir failed bodies: 18 (0%)
Data layouts:        85.81ms, 609minstr, 8mb
Failed data layouts: 135 (6%)
Const evaluation:    440.57ms, 5235minstr, 13mb
Failed const evals: 1 (0%)
Total:               64.16s, 552ginstr, 1731mb
```
After Change
```
Inference:           40.32s, 340ginstr, 593mb
MIR lowering:        7.95s, 62ginstr, 292mb
Mir failed bodies: 18 (0%)
Data layouts:        87.97ms, 591minstr, 8mb
Failed data layouts: 135 (6%)
Const evaluation:    433.38ms, 5226minstr, 14mb
Failed const evals: 1 (0%)
Total:               60.49s, 523ginstr, 1680mb
```

Currently this breaks the expansion for the actual derive attribute. 

## TODO
- [x] Pick a better name for the function `smart_macro_arg`

