### PR TITLE
Refactor extension to support arbitrary shell command runnables

### DIFF
--- a/editors/code/src/run.ts
+++ b/editors/code/src/run.ts
@@ -115,8 +115,7 @@ export async function createTask(runnable: ra.Runnable, config: Config): Promise
 
     const definition: tasks.RustTargetDefinition = {
         type: tasks.TASK_TYPE,
-        command: args[0], // run, test, etc...
-        args: args.slice(1),
+        args,
         cwd: runnable.args.workspaceRoot || ".",
         env: prepareEnv(runnable, config.runnablesExtraEnv),
         overrideCargo: runnable.args.overrideCargo,
@@ -128,7 +127,6 @@ export async function createTask(runnable: ra.Runnable, config: Config): Promise
         target,
         definition,
         runnable.label,
-        args,
         config.problemMatcher,
         config.cargoRunner,
         true,

--- a/editors/code/src/run.ts
+++ b/editors/code/src/run.ts
@@ -113,7 +113,7 @@ export async function createTask(runnable: ra.Runnable, config: Config): Promise
 
     const args = createArgs(runnable);
 
-    const definition: tasks.CargoTaskDefinition = {
+    const definition: tasks.RustTargetDefinition = {
         type: tasks.TASK_TYPE,
         command: args[0], // run, test, etc...
         args: args.slice(1),
@@ -124,7 +124,7 @@ export async function createTask(runnable: ra.Runnable, config: Config): Promise
 
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
     const target = vscode.workspace.workspaceFolders![0]; // safe, see main activate()
-    const cargoTask = await tasks.buildCargoTask(
+    const task = await tasks.buildRustTask(
         target,
         definition,
         runnable.label,
@@ -134,12 +134,12 @@ export async function createTask(runnable: ra.Runnable, config: Config): Promise
         true,
     );
 
-    cargoTask.presentationOptions.clear = true;
+    task.presentationOptions.clear = true;
     // Sadly, this doesn't prevent focus stealing if the terminal is currently
     // hidden, and will become revealed due to task execution.
-    cargoTask.presentationOptions.focus = false;
+    task.presentationOptions.focus = false;
 
-    return cargoTask;
+    return task;
 }
 
 export function createArgs(runnable: ra.Runnable): string[] {

--- a/editors/code/src/tasks.ts
+++ b/editors/code/src/tasks.ts
@@ -9,7 +9,7 @@ import { unwrapUndefinable } from "./undefinable";
 export const TASK_TYPE = "cargo";
 export const TASK_SOURCE = "rust";
 
-export interface CargoTaskDefinition extends vscode.TaskDefinition {
+export interface RustTargetDefinition extends vscode.TaskDefinition {
     command?: string;
     args?: string[];
     cwd?: string;
@@ -17,7 +17,7 @@ export interface CargoTaskDefinition extends vscode.TaskDefinition {
     overrideCargo?: string;
 }
 
-class CargoTaskProvider implements vscode.TaskProvider {
+class RustTaskProvider implements vscode.TaskProvider {
     private readonly config: Config;
 
     constructor(config: Config) {
@@ -42,7 +42,7 @@ class CargoTaskProvider implements vscode.TaskProvider {
         const tasks: vscode.Task[] = [];
         for (const workspaceTarget of vscode.workspace.workspaceFolders || []) {
             for (const def of defs) {
-                const vscodeTask = await buildCargoTask(
+                const vscodeTask = await buildRustTask(
                     workspaceTarget,
                     { type: TASK_TYPE, command: def.command },
                     `cargo ${def.command}`,
@@ -63,11 +63,11 @@ class CargoTaskProvider implements vscode.TaskProvider {
         // we need to inform VSCode how to execute that command by creating
         // a ShellExecution for it.
 
-        const definition = task.definition as CargoTaskDefinition;
+        const definition = task.definition as RustTargetDefinition;
 
         if (definition.type === TASK_TYPE && definition.command) {
             const args = [definition.command].concat(definition.args ?? []);
-            return await buildCargoTask(
+            return await buildRustTask(
                 task.scope,
                 definition,
                 task.name,
@@ -81,9 +81,9 @@ class CargoTaskProvider implements vscode.TaskProvider {
     }
 }
 
-export async function buildCargoTask(
+export async function buildRustTask(
     scope: vscode.WorkspaceFolder | vscode.TaskScope | undefined,
-    definition: CargoTaskDefinition,
+    definition: RustTargetDefinition,
     name: string,
     args: string[],
     problemMatcher: string[],
@@ -138,6 +138,6 @@ export async function buildCargoTask(
 }
 
 export function activateTaskProvider(config: Config): vscode.Disposable {
-    const provider = new CargoTaskProvider(config);
+    const provider = new RustTaskProvider(config);
     return vscode.tasks.registerTaskProvider(TASK_TYPE, provider);
 }


### PR DESCRIPTION
Currently, the extension assumes that all runnables invoke cargo. Arguments are sometimes full CLI arguments, and sometimes arguments passed to a cargo subcommand.

Refactor the extension so that tasks are just a `program` and a list of strings `args`, and rename `CargoTask` to `RustTask` to make it generic.

(This was factored out of #16135 and tidied.)