### PR TITLE
fix: Apply cast expr coercion adjustments

### DIFF
--- a/crates/hir-ty/src/infer.rs
+++ b/crates/hir-ty/src/infer.rs
@@ -669,7 +669,9 @@ impl<'a> InferenceContext<'a> {
         // Even though coercion casts provide type hints, we check casts after fallback for
         // backwards compatibility. This makes fallback a stronger type hint than a cast coercion.
         for cast in deferred_cast_checks {
-            cast.check(&mut table);
+            cast.check(&mut table, |expr, adjusts| {
+                expr_adjustments.insert(expr, adjusts);
+            });
         }
 
         // FIXME resolve obligations as well (use Guidance if necessary)

--- a/crates/hir-ty/src/infer/cast.rs
+++ b/crates/hir-ty/src/infer/cast.rs
@@ -1,19 +1,26 @@
 //! Type cast logic. Basically coercion + additional casts.
 
-use crate::{infer::unify::InferenceTable, Interner, Ty, TyExt, TyKind};
+use hir_def::hir::ExprId;
+
+use crate::{infer::unify::InferenceTable, Adjustment, Interner, Ty, TyExt, TyKind};
 
 #[derive(Clone, Debug)]
 pub(super) struct CastCheck {
+    expr: ExprId,
     expr_ty: Ty,
     cast_ty: Ty,
 }
 
 impl CastCheck {
-    pub(super) fn new(expr_ty: Ty, cast_ty: Ty) -> Self {
-        Self { expr_ty, cast_ty }
+    pub(super) fn new(expr: ExprId, expr_ty: Ty, cast_ty: Ty) -> Self {
+        Self { expr, expr_ty, cast_ty }
     }
 
-    pub(super) fn check(self, table: &mut InferenceTable<'_>) {
+    pub(super) fn check(
+        self,
+        table: &mut InferenceTable<'_>,
+        mut coercion_success_cb: impl FnMut(ExprId, Vec<Adjustment>),
+    ) {
         // FIXME: This function currently only implements the bits that influence the type
         // inference. We should return the adjustments on success and report diagnostics on error.
         let expr_ty = table.resolve_ty_shallow(&self.expr_ty);
@@ -23,29 +30,35 @@ impl CastCheck {
             return;
         }
 
-        if table.coerce(&expr_ty, &cast_ty).is_ok() {
+        if let Ok((adjusts, _)) = table.coerce(&expr_ty, &cast_ty) {
+            coercion_success_cb(self.expr, adjusts);
             return;
         }
 
-        if check_ref_to_ptr_cast(expr_ty, cast_ty, table) {
+        if let Ok(adjusts) = check_ref_to_ptr_cast(expr_ty, cast_ty, table) {
             // Note that this type of cast is actually split into a coercion to a
             // pointer type and a cast:
             // &[T; N] -> *[T; N] -> *T
+            coercion_success_cb(self.expr, adjusts);
         }
 
         // FIXME: Check other kinds of non-coercion casts and report error if any?
     }
 }
 
-fn check_ref_to_ptr_cast(expr_ty: Ty, cast_ty: Ty, table: &mut InferenceTable<'_>) -> bool {
+fn check_ref_to_ptr_cast(
+    expr_ty: Ty,
+    cast_ty: Ty,
+    table: &mut InferenceTable<'_>,
+) -> Result<Vec<Adjustment>, ()> {
     let Some((expr_inner_ty, _, _)) = expr_ty.as_reference() else {
-        return false;
+        return Err(());
     };
     let Some((cast_inner_ty, _)) = cast_ty.as_raw_ptr() else {
-        return false;
+        return Err(());
     };
     let TyKind::Array(expr_elt_ty, _) = expr_inner_ty.kind(Interner) else {
-        return false;
+        return Err(());
     };
-    table.coerce(expr_elt_ty, cast_inner_ty).is_ok()
+    table.coerce(expr_elt_ty, cast_inner_ty).map_or(Err(()), |r| Ok(r.0))
 }

--- a/crates/hir-ty/src/infer/expr.rs
+++ b/crates/hir-ty/src/infer/expr.rs
@@ -606,7 +606,7 @@ impl InferenceContext<'_> {
             Expr::Cast { expr, type_ref } => {
                 let cast_ty = self.make_ty(type_ref);
                 let expr_ty = self.infer_expr(*expr, &Expectation::Castable(cast_ty.clone()));
-                self.deferred_cast_checks.push(CastCheck::new(expr_ty, cast_ty.clone()));
+                self.deferred_cast_checks.push(CastCheck::new(*expr, expr_ty, cast_ty.clone()));
                 cast_ty
             }
             Expr::Ref { expr, rawness, mutability } => {

--- a/crates/ide-diagnostics/src/handlers/moved_out_of_ref.rs
+++ b/crates/ide-diagnostics/src/handlers/moved_out_of_ref.rs
@@ -177,6 +177,18 @@ fn main() {
     }
 
     #[test]
+    fn no_false_positive_cast_into_const_ptr() {
+        check_diagnostics(
+            r#"
+//- minicore: copy
+fn test() {
+    let _x = (&(&mut (),)).0 as *const ();
+}
+            "#,
+        )
+    }
+
+    #[test]
     fn regression_15787() {
         check_diagnostics(
             r#"


### PR DESCRIPTION
Surprisingly, this fixes #16564; the cause of it is that
https://github.com/rust-lang/rust-analyzer/blob/7c2bb75bc85d94d075e7f6ce8c1a9fdce2c77e45/crates/hir-ty/src/infer/coerce.rs#L342-L348
those adjustment aren't applied.