### PR TITLE
Improve text description of check command

### DIFF
--- a/crates/rust-analyzer/src/main_loop.rs
+++ b/crates/rust-analyzer/src/main_loop.rs
@@ -668,7 +668,7 @@ impl GlobalState {
                 let title = if self.flycheck.len() == 1 {
                     format!("{}", self.config.flycheck())
                 } else {
-                    format!("cargo check (#{})", id + 1)
+                    format!("{} (#{})", self.config.flycheck(), id + 1)
                 };
                 self.report_progress(
                     &title,


### PR DESCRIPTION
Previously, rust-analyzer assumed that the command was always `clippy check` when multiple commands were running. This isn't true when users have overridden the check command.