### PR TITLE
fix: Fix project discovery not checking whether the `Cargo.toml` actually exists

### DIFF
--- a/crates/project-model/src/lib.rs
+++ b/crates/project-model/src/lib.rs
@@ -126,6 +126,7 @@ impl ProjectManifest {
             entities
                 .filter_map(Result::ok)
                 .map(|it| it.path().join("Cargo.toml"))
+                .filter(|it| it.exists())
                 .map(AbsPathBuf::try_from)
                 .filter_map(|it| it.ok()?.try_into().ok())
                 .collect()


### PR DESCRIPTION
Got dropped in https://github.com/rust-lang/rust-analyzer/pull/16889, somehow r-a's codebase itself doesn't even run into this so I didn't see it when testing ...