### PR TITLE
internal: Bump rust-cache action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -71,7 +71,7 @@ jobs:
         run: echo "::add-matcher::.github/rust.json"
 
       - name: Cache Dependencies
-        uses: Swatinem/rust-cache@988c164c3d0e93c4dbab36aaf5bbeb77425b2894
+        uses: Swatinem/rust-cache@640a22190e7a783d4c409684cea558f081f92012
         with:
           key: ${{ env.RUST_CHANNEL }}
 
@@ -140,7 +140,7 @@ jobs:
           rustup target add ${{ env.targets }} ${{ env.targets_ide }}
 
       - name: Cache Dependencies
-        uses: Swatinem/rust-cache@988c164c3d0e93c4dbab36aaf5bbeb77425b2894
+        uses: Swatinem/rust-cache@640a22190e7a783d4c409684cea558f081f92012
 
       - name: Check
         run: |


### PR DESCRIPTION
Fixes a Node 16 deprecation warning and also pulls in https://github.com/Swatinem/rust-cache/pull/147, which sounds interesting.