### PR TITLE
fix: Don't assert paths being utf8 when filtering them in the watcher

### DIFF
--- a/crates/paths/src/lib.rs
+++ b/crates/paths/src/lib.rs
@@ -13,7 +13,7 @@ use std::{
 pub use camino::*;
 
 /// Wrapper around an absolute [`Utf8PathBuf`].
-#[derive(Debug, Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
+#[derive(Debug, Clone, Ord, PartialOrd, Eq, Hash)]
 pub struct AbsPathBuf(Utf8PathBuf);
 
 impl From<AbsPathBuf> for Utf8PathBuf {
@@ -92,9 +92,9 @@ impl TryFrom<&str> for AbsPathBuf {
     }
 }
 
-impl PartialEq<AbsPath> for AbsPathBuf {
-    fn eq(&self, other: &AbsPath) -> bool {
-        self.as_path() == other
+impl<P: AsRef<Path> + ?Sized> PartialEq<P> for AbsPathBuf {
+    fn eq(&self, other: &P) -> bool {
+        self.0.as_std_path() == other.as_ref()
     }
 }
 
@@ -144,9 +144,15 @@ impl fmt::Display for AbsPathBuf {
 }
 
 /// Wrapper around an absolute [`Utf8Path`].
-#[derive(Debug, Ord, PartialOrd, Eq, PartialEq, Hash)]
+#[derive(Debug, Ord, PartialOrd, Eq, Hash)]
 #[repr(transparent)]
 pub struct AbsPath(Utf8Path);
+
+impl<P: AsRef<Path> + ?Sized> PartialEq<P> for AbsPath {
+    fn eq(&self, other: &P) -> bool {
+        self.0.as_std_path() == other.as_ref()
+    }
+}
 
 impl AsRef<Utf8Path> for AbsPath {
     fn as_ref(&self) -> &Utf8Path {

--- a/crates/project-model/src/cargo_workspace.rs
+++ b/crates/project-model/src/cargo_workspace.rs
@@ -406,7 +406,7 @@ impl CargoWorkspace {
     pub fn target_by_root(&self, root: &AbsPath) -> Option<Target> {
         self.packages()
             .filter(|&pkg| self[pkg].is_member)
-            .find_map(|pkg| self[pkg].targets.iter().find(|&&it| &self[it].root == root))
+            .find_map(|pkg| self[pkg].targets.iter().find(|&&it| self[it].root == root))
             .copied()
     }
 

--- a/crates/vfs-notify/src/lib.rs
+++ b/crates/vfs-notify/src/lib.rs
@@ -13,7 +13,7 @@ use std::fs;
 
 use crossbeam_channel::{never, select, unbounded, Receiver, Sender};
 use notify::{Config, RecommendedWatcher, RecursiveMode, Watcher};
-use paths::{AbsPath, AbsPathBuf, Utf8Path};
+use paths::{AbsPath, AbsPathBuf};
 use vfs::loader;
 use walkdir::WalkDir;
 
@@ -205,7 +205,7 @@ impl NotifyActor {
                             if !entry.file_type().is_dir() {
                                 return true;
                             }
-                            let path = AbsPath::assert(Utf8Path::from_path(entry.path()).unwrap());
+                            let path = entry.path();
                             root == path
                                 || dirs.exclude.iter().chain(&dirs.include).all(|it| it != path)
                         });


### PR DESCRIPTION
Closes https://github.com/rust-lang/rust-analyzer/issues/16914