### PR TITLE
feat: Add `rust-analyzer.cargo.allTargets` to configure passing `--all-targets` to cargo invocations

### DIFF
--- a/crates/project-model/src/build_scripts.rs
+++ b/crates/project-model/src/build_scripts.rs
@@ -86,7 +86,9 @@ impl WorkspaceBuildScripts {
                 // --all-targets includes tests, benches and examples in addition to the
                 // default lib and bins. This is an independent concept from the --target
                 // flag below.
-                cmd.arg("--all-targets");
+                if config.all_targets {
+                    cmd.arg("--all-targets");
+                }
 
                 if let Some(target) = &config.target {
                     cmd.args(["--target", target]);

--- a/crates/project-model/src/cargo_workspace.rs
+++ b/crates/project-model/src/cargo_workspace.rs
@@ -76,6 +76,8 @@ impl Default for CargoFeatures {
 
 #[derive(Default, Clone, Debug, PartialEq, Eq)]
 pub struct CargoConfig {
+    /// Whether to pass `--all-targets` to cargo invocations.
+    pub all_targets: bool,
     /// List of features to activate.
     pub features: CargoFeatures,
     /// rustc target

--- a/docs/user/generated_config.adoc
+++ b/docs/user/generated_config.adoc
@@ -19,6 +19,12 @@ Warm up caches on project load.
 --
 How many worker threads to handle priming caches. The default `0` means to pick automatically.
 --
+[[rust-analyzer.cargo.allTargets]]rust-analyzer.cargo.allTargets (default: `true`)::
++
+--
+Pass `--all-targets` to cargo invocation. Overridden by `#rust-analyzer.check.allTargets#`
+when the latter is set.
+--
 [[rust-analyzer.cargo.autoreload]]rust-analyzer.cargo.autoreload (default: `true`)::
 +
 --
@@ -164,10 +170,10 @@ Unsets the implicit `#[cfg(test)]` for the specified crates.
 --
 Run the check command for diagnostics on save.
 --
-[[rust-analyzer.check.allTargets]]rust-analyzer.check.allTargets (default: `true`)::
+[[rust-analyzer.check.allTargets]]rust-analyzer.check.allTargets (default: `null`)::
 +
 --
-Check all targets and tests (`--all-targets`).
+Check all targets and tests (`--all-targets`). Overrides `#rust-analyzer.cargo.allTargets#`.
 --
 [[rust-analyzer.check.command]]rust-analyzer.check.command (default: `"check"`)::
 +

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -546,6 +546,11 @@
                     "minimum": 0,
                     "maximum": 255
                 },
+                "rust-analyzer.cargo.allTargets": {
+                    "markdownDescription": "Pass `--all-targets` to cargo invocation. Overridden by `#rust-analyzer.check.allTargets#`\nwhen the latter is set.",
+                    "default": true,
+                    "type": "boolean"
+                },
                 "rust-analyzer.cargo.autoreload": {
                     "markdownDescription": "Automatically refresh project info via `cargo metadata` on\n`Cargo.toml` or `.cargo/config.toml` changes.",
                     "default": true,
@@ -707,9 +712,12 @@
                     "type": "boolean"
                 },
                 "rust-analyzer.check.allTargets": {
-                    "markdownDescription": "Check all targets and tests (`--all-targets`).",
-                    "default": true,
-                    "type": "boolean"
+                    "markdownDescription": "Check all targets and tests (`--all-targets`). Overrides `#rust-analyzer.cargo.allTargets#`.",
+                    "default": null,
+                    "type": [
+                        "null",
+                        "boolean"
+                    ]
                 },
                 "rust-analyzer.check.command": {
                     "markdownDescription": "Cargo command to use for `cargo check`.",


### PR DESCRIPTION
Closes #16859

## Unresolved question:

Should this be a setting for build scripts only ? All the other `--all-targets` I found where already covered by `checkOnSave.allTargets`