### PR TITLE
Allow post-fix match to parse

### DIFF
--- a/crates/parser/src/grammar/expressions.rs
+++ b/crates/parser/src/grammar/expressions.rs
@@ -2,6 +2,8 @@ mod atom;
 
 use crate::grammar::attributes::ATTRIBUTE_FIRST;
 
+use self::atom::match_expr;
+
 use super::*;
 
 pub(crate) use atom::{block_expr, match_arm_list};
@@ -468,6 +470,15 @@ fn postfix_dot_expr<const FLOAT_RECOVERY: bool>(
         }
         p.bump(T![await]);
         return Ok(m.complete(p, AWAIT_EXPR));
+    }
+
+    // Post-fix match
+    if p.nth(nth1) == T![match] {
+        if !FLOAT_RECOVERY {
+            p.bump(T![.]);
+        }
+        let m = lhs.precede(p);
+        return Ok(match_expr(p, Some(m)));
     }
 
     if p.at(T![..=]) || p.at(T![..]) {

--- a/crates/parser/test_data/parser/inline/ok/0071_match_expr.rast
+++ b/crates/parser/test_data/parser/inline/ok/0071_match_expr.rast
@@ -91,6 +91,167 @@ SOURCE_FILE
               L_CURLY "{"
               R_CURLY "}"
           SEMICOLON ";"
+        WHITESPACE "\n\n    "
+        EXPR_STMT
+          MATCH_EXPR
+            PATH_EXPR
+              PATH
+                PATH_SEGMENT
+                  NAME_REF
+                    IDENT "S"
+            DOT "."
+            MATCH_KW "match"
+            WHITESPACE " "
+            MATCH_ARM_LIST
+              L_CURLY "{"
+              WHITESPACE " "
+              MATCH_ARM
+                WILDCARD_PAT
+                  UNDERSCORE "_"
+                WHITESPACE " "
+                FAT_ARROW "=>"
+                WHITESPACE " "
+                TUPLE_EXPR
+                  L_PAREN "("
+                  R_PAREN ")"
+              WHITESPACE " "
+              R_CURLY "}"
+          SEMICOLON ";"
+        WHITESPACE "\n    "
+        EXPR_STMT
+          MATCH_EXPR
+            MATCH_EXPR
+              PATH_EXPR
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      IDENT "S"
+              DOT "."
+              MATCH_KW "match"
+              WHITESPACE " "
+              MATCH_ARM_LIST
+                L_CURLY "{"
+                WHITESPACE " "
+                R_CURLY "}"
+            DOT "."
+            MATCH_KW "match"
+            WHITESPACE " "
+            MATCH_ARM_LIST
+              L_CURLY "{"
+              WHITESPACE " "
+              R_CURLY "}"
+          SEMICOLON ";"
+        WHITESPACE "\n    "
+        EXPR_STMT
+          MATCH_EXPR
+            LITERAL
+              INT_NUMBER "1"
+            DOT "."
+            MATCH_KW "match"
+            WHITESPACE " "
+            MATCH_ARM_LIST
+              L_CURLY "{"
+              WHITESPACE " "
+              R_CURLY "}"
+          SEMICOLON ";"
+        WHITESPACE "\n    "
+        EXPR_STMT
+          MATCH_EXPR
+            FIELD_EXPR
+              PATH_EXPR
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      IDENT "x"
+              DOT "."
+              NAME_REF
+                INT_NUMBER "0"
+            DOT "."
+            MATCH_KW "match"
+            WHITESPACE " "
+            MATCH_ARM_LIST
+              L_CURLY "{"
+              WHITESPACE " "
+              R_CURLY "}"
+          SEMICOLON ";"
+        WHITESPACE "\n    "
+        EXPR_STMT
+          METHOD_CALL_EXPR
+            TRY_EXPR
+              MATCH_EXPR
+                CALL_EXPR
+                  FIELD_EXPR
+                    PATH_EXPR
+                      PATH
+                        PATH_SEGMENT
+                          NAME_REF
+                            IDENT "x"
+                    DOT "."
+                    NAME_REF
+                      INT_NUMBER "0"
+                  ARG_LIST
+                    L_PAREN "("
+                    R_PAREN ")"
+                DOT "."
+                MATCH_KW "match"
+                WHITESPACE " "
+                MATCH_ARM_LIST
+                  L_CURLY "{"
+                  WHITESPACE " "
+                  R_CURLY "}"
+              QUESTION "?"
+            DOT "."
+            NAME_REF
+              IDENT "hello"
+            ARG_LIST
+              L_PAREN "("
+              R_PAREN ")"
+          SEMICOLON ";"
+        WHITESPACE "\n    "
+        EXPR_STMT
+          MATCH_EXPR
+            FIELD_EXPR
+              FIELD_EXPR
+                PATH_EXPR
+                  PATH
+                    PATH_SEGMENT
+                      NAME_REF
+                        IDENT "x"
+                DOT "."
+                NAME_REF
+                  INT_NUMBER "0"
+              DOT "."
+              NAME_REF
+                INT_NUMBER "0"
+            DOT "."
+            MATCH_KW "match"
+            WHITESPACE " "
+            MATCH_ARM_LIST
+              L_CURLY "{"
+              WHITESPACE " "
+              R_CURLY "}"
+          SEMICOLON ";"
+        WHITESPACE "\n    "
+        EXPR_STMT
+          MATCH_EXPR
+            FIELD_EXPR
+              PATH_EXPR
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      IDENT "x"
+              DOT "."
+              NAME_REF
+                INT_NUMBER "0"
+            DOT "."
+            WHITESPACE " "
+            MATCH_KW "match"
+            WHITESPACE " "
+            MATCH_ARM_LIST
+              L_CURLY "{"
+              WHITESPACE " "
+              R_CURLY "}"
+          SEMICOLON ";"
         WHITESPACE "\n"
         R_CURLY "}"
   WHITESPACE "\n"

--- a/crates/parser/test_data/parser/inline/ok/0071_match_expr.rs
+++ b/crates/parser/test_data/parser/inline/ok/0071_match_expr.rs
@@ -3,4 +3,12 @@ fn foo() {
     match S {};
     match { } { _ => () };
     match { S {} } {};
+
+    S.match { _ => () };
+    S.match { }.match { };
+    1.match { };
+    x.0.match { };
+    x.0().match { }?.hello();
+    x.0.0.match { };
+    x.0. match { };
 }

--- a/crates/syntax/rust.ungram
+++ b/crates/syntax/rust.ungram
@@ -512,7 +512,7 @@ RangeExpr =
   Attr* start:Expr? op:('..' | '..=') end:Expr?
 
 MatchExpr =
-  Attr* 'match' Expr MatchArmList
+  Attr* 'match' Expr MatchArmList |  Attr* Expr '.' 'match' MatchArmList
 
 MatchArmList =
   '{'

--- a/crates/syntax/src/ast/generated/nodes.rs
+++ b/crates/syntax/src/ast/generated/nodes.rs
@@ -759,6 +759,7 @@ impl ast::HasAttrs for MatchExpr {}
 impl MatchExpr {
     pub fn expr(&self) -> Option<Expr> { support::child(&self.syntax) }
     pub fn match_arm_list(&self) -> Option<MatchArmList> { support::child(&self.syntax) }
+    pub fn dot_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![.]) }
     pub fn match_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![match]) }
 }
 


### PR DESCRIPTION
I am not very confident in how I handled the float recovery logic, but the RAST looks like how I believe it should.

re: rust-lang/rust#121619 rust-lang/rust#121618