### PR TITLE
fix: Rename `func_like` to `FuncLike`

### DIFF
--- a/crates/proc-macro-api/src/lib.rs
+++ b/crates/proc-macro-api/src/lib.rs
@@ -38,7 +38,7 @@ pub enum ProcMacroKind {
     Attr,
     // This used to be called FuncLike, so that's what the server expects currently.
     #[serde(alias = "bang")]
-    #[serde(rename(serialize = "func_like", deserialize = "func_like"))]
+    #[serde(rename(serialize = "FuncLike", deserialize = "FuncLike"))]
     Bang,
 }
 


### PR DESCRIPTION
Should fix #16926. Please check the issue for more information.