### PR TITLE
Add static modifier to static variables

### DIFF
--- a/crates/ide/src/syntax_highlighting/highlight.rs
+++ b/crates/ide/src/syntax_highlighting/highlight.rs
@@ -493,7 +493,7 @@ pub(super) fn highlight_def(
                 h |= HlMod::Unsafe;
             }
 
-            h
+            h | HlMod::Static
         }
         Definition::SelfType(_) => Highlight::new(HlTag::Symbol(SymbolKind::Impl)),
         Definition::GenericParam(it) => match it {

--- a/crates/ide/src/syntax_highlighting/tags.rs
+++ b/crates/ide/src/syntax_highlighting/tags.rs
@@ -154,7 +154,7 @@ impl HlTag {
                 SymbolKind::Module => "module",
                 SymbolKind::SelfParam => "self_keyword",
                 SymbolKind::SelfType => "self_type_keyword",
-                SymbolKind::Static => "static",
+                SymbolKind::Static => "static_kind",
                 SymbolKind::Struct => "struct",
                 SymbolKind::ToolModule => "tool_module",
                 SymbolKind::Trait => "trait",

--- a/crates/ide/src/syntax_highlighting/test_data/highlight_unsafe.html
+++ b/crates/ide/src/syntax_highlighting/test_data/highlight_unsafe.html
@@ -55,8 +55,8 @@ pre                 { color: #DCDCCC; background: #3F3F3F; font-size: 22px; padd
         <span class="punctuation">*</span><span class="parenthesis">(</span><span class="punctuation">&</span><span class="parenthesis">(</span><span class="parenthesis">)</span> <span class="keyword">as</span> <span class="punctuation">*</span><span class="keyword">const</span> <span class="parenthesis">(</span><span class="parenthesis">)</span><span class="parenthesis">)</span>
     <span class="brace">}</span><span class="semicolon">;</span>
 <span class="brace">}</span>
-<span class="keyword">static</span> <span class="keyword">mut</span> <span class="static declaration mutable unsafe">MUT_GLOBAL</span><span class="colon">:</span> <span class="struct">Struct</span> <span class="operator">=</span> <span class="struct">Struct</span> <span class="brace">{</span> <span class="field">field</span><span class="colon">:</span> <span class="numeric_literal">0</span> <span class="brace">}</span><span class="semicolon">;</span>
-<span class="keyword">static</span> <span class="static declaration">GLOBAL</span><span class="colon">:</span> <span class="struct">Struct</span> <span class="operator">=</span> <span class="struct">Struct</span> <span class="brace">{</span> <span class="field">field</span><span class="colon">:</span> <span class="numeric_literal">0</span> <span class="brace">}</span><span class="semicolon">;</span>
+<span class="keyword">static</span> <span class="keyword">mut</span> <span class="static_kind declaration mutable static unsafe">MUT_GLOBAL</span><span class="colon">:</span> <span class="struct">Struct</span> <span class="operator">=</span> <span class="struct">Struct</span> <span class="brace">{</span> <span class="field">field</span><span class="colon">:</span> <span class="numeric_literal">0</span> <span class="brace">}</span><span class="semicolon">;</span>
+<span class="keyword">static</span> <span class="static_kind declaration static">GLOBAL</span><span class="colon">:</span> <span class="struct">Struct</span> <span class="operator">=</span> <span class="struct">Struct</span> <span class="brace">{</span> <span class="field">field</span><span class="colon">:</span> <span class="numeric_literal">0</span> <span class="brace">}</span><span class="semicolon">;</span>
 <span class="keyword unsafe">unsafe</span> <span class="keyword">fn</span> <span class="function declaration unsafe">unsafe_fn</span><span class="parenthesis">(</span><span class="parenthesis">)</span> <span class="brace">{</span><span class="brace">}</span>
 
 <span class="keyword">union</span> <span class="union declaration">Union</span> <span class="brace">{</span>
@@ -113,8 +113,8 @@ pre                 { color: #DCDCCC; background: #3F3F3F; font-size: 22px; padd
         <span class="operator unsafe">*</span><span class="variable">x</span><span class="semicolon">;</span>
 
         <span class="comment">// unsafe access to a static mut</span>
-        <span class="static mutable unsafe">MUT_GLOBAL</span><span class="operator">.</span><span class="field">field</span><span class="semicolon">;</span>
-        <span class="static">GLOBAL</span><span class="operator">.</span><span class="field">field</span><span class="semicolon">;</span>
+        <span class="static_kind mutable static unsafe">MUT_GLOBAL</span><span class="operator">.</span><span class="field">field</span><span class="semicolon">;</span>
+        <span class="static_kind static">GLOBAL</span><span class="operator">.</span><span class="field">field</span><span class="semicolon">;</span>
 
         <span class="comment">// unsafe ref of packed fields</span>
         <span class="keyword">let</span> <span class="variable declaration">packed</span> <span class="operator">=</span> <span class="struct">Packed</span> <span class="brace">{</span> <span class="field">a</span><span class="colon">:</span> <span class="numeric_literal">0</span> <span class="brace">}</span><span class="semicolon">;</span>


### PR DESCRIPTION
Fixes #16894

It seems that there is a name collision between `SymbolKind::Static` and `HlMod::Static` resulting in a wired looking test diff (`static mutable static unsafe`), that's why I decided to rename `SymbolKind::Static`. I don't think that any of these are exposed to a user, however, not fully sure, I was not able to break my configuration with either of these name changes.

Tested with the following config static colors configuration:

```json
    "editor.semanticTokenColorCustomizations": {
        "enabled": true,
        "rules": {
            "namespace": "#80E0E0",
            "function": {
                "bold": true,
                "foreground": "#80F080",
            },
            "variable": "#FFFFFF",
            "variable.static": {
                "bold": true,
                "foreground": "#cc711d",
            },
            "variable.constant": {
                "bold": true,
                "foreground": "#F0F080",
            },
        }
    }
```

![image](https://github.com/rust-lang/rust-analyzer/assets/23321756/121cc0f8-bf09-4524-b30b-bee0f4fb7f87)


```rs
// semantic token type : modifiers

// variable : declaration constant
const A: u32 = 0;
// variable : declaration static
static B: u32 = 0;

fn foo() {
    // variable : declaration
    let _c = 0;
}
```