### PR TITLE
Revert to the crates.io version of rustc_pattern_analysis

### DIFF
--- a/crates/hir-ty/src/lib.rs
+++ b/crates/hir-ty/src/lib.rs
@@ -15,10 +15,8 @@ extern crate rustc_abi;
 #[cfg(not(feature = "in-rust-tree"))]
 extern crate ra_ap_rustc_abi as rustc_abi;
 
-#[cfg(feature = "in-rust-tree")]
-extern crate rustc_pattern_analysis;
-
-#[cfg(not(feature = "in-rust-tree"))]
+// Use the crates.io version unconditionally until the API settles enough that we can switch to
+// using the in-tree one.
 extern crate ra_ap_rustc_pattern_analysis as rustc_pattern_analysis;
 
 mod builder;


### PR DESCRIPTION
The API hasn't fully settled yet, and there's an extra wrinkle with `IdxContainer` which blocked the [subtree update](https://github.com/rust-lang/rust/pull/122981). Let's just keep using the crates.io version for a bit longer.

r? @lnicola 