### PR TITLE
Fix crate IDs when multiple workspaces are loaded

### DIFF
--- a/crates/project-model/src/project_json.rs
+++ b/crates/project-model/src/project_json.rs
@@ -49,8 +49,7 @@
 //! user explores them belongs to that extension (it's totally valid to change
 //! rust-project.json over time via configuration request!)
 
-use base_db::{CrateDisplayName, CrateId, CrateName, Dependency};
-use la_arena::RawIdx;
+use base_db::{CrateDisplayName, CrateName};
 use paths::{AbsPath, AbsPathBuf, Utf8PathBuf};
 use rustc_hash::FxHashMap;
 use serde::{de, Deserialize};
@@ -77,7 +76,7 @@ pub struct Crate {
     pub root_module: AbsPathBuf,
     pub(crate) edition: Edition,
     pub(crate) version: Option<String>,
-    pub(crate) deps: Vec<Dependency>,
+    pub(crate) deps: Vec<Dep>,
     pub(crate) cfg: Vec<CfgFlag>,
     pub(crate) target: Option<String>,
     pub(crate) env: FxHashMap<String, String>,
@@ -128,16 +127,7 @@ impl ProjectJson {
                         root_module,
                         edition: crate_data.edition.into(),
                         version: crate_data.version.as_ref().map(ToString::to_string),
-                        deps: crate_data
-                            .deps
-                            .into_iter()
-                            .map(|dep_data| {
-                                Dependency::new(
-                                    dep_data.name,
-                                    CrateId::from_raw(RawIdx::from(dep_data.krate as u32)),
-                                )
-                            })
-                            .collect::<Vec<_>>(),
+                        deps: crate_data.deps,
                         cfg: crate_data.cfg,
                         target: crate_data.target,
                         env: crate_data.env,
@@ -161,11 +151,8 @@ impl ProjectJson {
     }
 
     /// Returns an iterator over the crates in the project.
-    pub fn crates(&self) -> impl Iterator<Item = (CrateId, &Crate)> + '_ {
-        self.crates
-            .iter()
-            .enumerate()
-            .map(|(idx, krate)| (CrateId::from_raw(RawIdx::from(idx as u32)), krate))
+    pub fn crates(&self) -> impl Iterator<Item = (CrateArrayIdx, &Crate)> {
+        self.crates.iter().enumerate().map(|(idx, krate)| (CrateArrayIdx(idx), krate))
     }
 
     /// Returns the path to the project's root folder.
@@ -188,7 +175,7 @@ struct CrateData {
     edition: EditionData,
     #[serde(default)]
     version: Option<semver::Version>,
-    deps: Vec<DepData>,
+    deps: Vec<Dep>,
     #[serde(default)]
     cfg: Vec<CfgFlag>,
     target: Option<String>,
@@ -227,13 +214,21 @@ impl From<EditionData> for Edition {
     }
 }
 
-#[derive(Deserialize, Debug, Clone)]
-struct DepData {
+/// Identifies a crate by position in the crates array.
+///
+/// This will differ from `CrateId` when multiple `ProjectJson`
+/// workspaces are loaded.
+#[derive(Deserialize, Debug, Clone, Copy, Eq, PartialEq, Hash)]
+#[serde(transparent)]
+pub struct CrateArrayIdx(pub usize);
+
+#[derive(Deserialize, Debug, Clone, Eq, PartialEq)]
+pub(crate) struct Dep {
     /// Identifies a crate by position in the crates array.
     #[serde(rename = "crate")]
-    krate: usize,
+    pub(crate) krate: CrateArrayIdx,
     #[serde(deserialize_with = "deserialize_crate_name")]
-    name: CrateName,
+    pub(crate) name: CrateName,
 }
 
 #[derive(Deserialize, Debug, Clone)]

--- a/crates/project-model/src/project_json.rs
+++ b/crates/project-model/src/project_json.rs
@@ -74,7 +74,7 @@ pub struct ProjectJson {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Crate {
     pub(crate) display_name: Option<CrateDisplayName>,
-    pub(crate) root_module: AbsPathBuf,
+    pub root_module: AbsPathBuf,
     pub(crate) edition: Edition,
     pub(crate) version: Option<String>,
     pub(crate) deps: Vec<Dependency>,

--- a/crates/rust-analyzer/src/handlers/notification.rs
+++ b/crates/rust-analyzer/src/handlers/notification.rs
@@ -296,10 +296,9 @@ fn run_flycheck(state: &mut GlobalState, vfs_path: VfsPath) -> bool {
                         })
                     }
                     project_model::ProjectWorkspace::Json { project, .. } => {
-                        if !project
-                            .crates()
-                            .any(|(c, _)| crate_ids.iter().any(|&crate_id| crate_id == c))
-                        {
+                        if !project.crates().any(|(_, krate)| {
+                            crate_root_paths.contains(&krate.root_module.as_path())
+                        }) {
                             return None;
                         }
                         None


### PR DESCRIPTION
Previously, we assumed that the crate numbers in a `rust-project.json` always matched the `CrateId` values in the crate graph. This isn't true when there are multiple workspaces, because the crate graphs are merged and the `CrateId` values in the merged graph are different.

This broke flycheck (see first commit), because we were unable to find the workspace when a file changed, so we every single flycheck, producing duplicate compilation errors.

Instead, use the crate root module path to look up the relevant flycheck. This makes `ProjectWorkspace::Json` consistenet with `ProjectWorkspace::Cargo`.

Also, define a separate JSON crate number type, to prevent bugs like this happening again.