### PR TITLE
fix: use lldb when debugging with C++ extension on MacOS

### DIFF
--- a/editors/code/src/debug.ts
+++ b/editors/code/src/debug.ts
@@ -203,6 +203,10 @@ function getCCppDebugConfig(
         cwd: cargoWorkspace || runnable.args.workspaceRoot,
         sourceFileMap,
         env,
+        // See https://github.com/rust-lang/rust-analyzer/issues/16901#issuecomment-2024486941
+        osx: {
+            MIMode: "lldb",
+        },
     };
 }
 


### PR DESCRIPTION
See https://github.com/rust-lang/rust-analyzer/issues/16901#issuecomment-2024486941

This PR resolves the issue of being unable to debug using the C++ extension on macOS. By using special configurations for the `MIMode` on macOS, it enables the C++ extension to connect to lldb when debugging (without affecting other platforms).