### PR TITLE
update: add editor/extension information to bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -22,6 +22,8 @@ Otherwise please try to provide information which will help us to fix the issue 
 
 **rustc version**: (eg. output of `rustc -V`)
 
+**editor or extension**: (eg. VSCode, Vim, Emacs, etc. For VSCode users, specify your extension version; for users of other editors, provide the distribution if applicable)
+
 **relevant settings**: (eg. client settings, or environment variables like `CARGO`, `RUSTC`, `RUSTUP_HOME` or `CARGO_HOME`)
 
 **repository link (if public, optional)**: (eg. [rust-analyzer](https://github.com/rust-lang/rust-analyzer))


### PR DESCRIPTION
When attempting to reproduce issues, I encounter difficulties due to differences in versions of LSP clients and editors (such as #16985, #16867, and more)

This sometimes consumes a lot of efforts from contributors to communicate the details about LSP client information. Therefore, I believe adding editor/extension information to the issue template would be helpful for problem reproduction.