### PR TITLE
fix: set the right postfix snippets competion source range

### DIFF
--- a/crates/ide-completion/src/completions/postfix.rs
+++ b/crates/ide-completion/src/completions/postfix.rs
@@ -333,8 +333,7 @@ fn build_postfix_snippet_builder<'ctx>(
     ) -> impl Fn(&str, &str, &str) -> Builder + 'ctx {
         move |label, detail, snippet| {
             let edit = TextEdit::replace(delete_range, snippet.to_owned());
-            let mut item =
-                CompletionItem::new(CompletionItemKind::Snippet, ctx.source_range(), label);
+            let mut item = CompletionItem::new(CompletionItemKind::Snippet, delete_range, label);
             item.detail(detail).snippet_edit(cap, edit);
             let postfix_match = if ctx.original_token.text() == label {
                 cov_mark::hit!(postfix_exact_match_is_high_priority);


### PR DESCRIPTION
Hi :wave:,

Changed the completion item `source_range` to match the replaced text. Though in VS Code it may not be disturbing because the snippet is previewed in a box, but in Helix editor, it's previewed by applying the main text edit.

Before :
![image](https://github.com/rust-lang/rust-analyzer/assets/43814157/75960e02-64f0-4ecd-964f-7e1dd894c713)

After :
![image](https://github.com/rust-lang/rust-analyzer/assets/43814157/84102f0e-9c81-4e7c-8ab5-a25986630e6f)

Thanks