### PR TITLE
internal: Consider ADT generic parameter defaults for unsubstituted layout calculations

### DIFF
--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -1418,16 +1418,14 @@ impl Adt {
     }
 
     pub fn layout(self, db: &dyn HirDatabase) -> Result<Layout, LayoutError> {
-        if !db.generic_params(self.into()).is_empty() {
-            return Err(LayoutError::HasPlaceholder);
-        }
-        let krate = self.krate(db).id;
         db.layout_of_adt(
             self.into(),
-            Substitution::empty(Interner),
+            TyBuilder::adt(db, self.into())
+                .fill_with_defaults(db, || TyKind::Error.intern(Interner))
+                .build_into_subst(),
             db.trait_environment(self.into()),
         )
-        .map(|layout| Layout(layout, db.target_data_layout(krate).unwrap()))
+        .map(|layout| Layout(layout, db.target_data_layout(self.krate(db).id).unwrap()))
     }
 
     /// Turns this ADT into a type. Any type parameters of the ADT will be

--- a/crates/ide/src/hover/tests.rs
+++ b/crates/ide/src/hover/tests.rs
@@ -2323,6 +2323,49 @@ fn test_hover_layout_of_variant() {
 }
 
 #[test]
+fn test_hover_layout_of_variant_generic() {
+    check(
+        r#"enum Option<T> {
+    Some(T),
+    None$0
+}"#,
+        expect![[r#"
+            *None*
+
+            ```rust
+            test::Option
+            ```
+
+            ```rust
+            None
+            ```
+        "#]],
+    );
+}
+
+#[test]
+fn test_hover_layout_generic_unused() {
+    check(
+        r#"
+//- minicore: phantom_data
+struct S$0<T>(core::marker::PhantomData<T>);
+"#,
+        expect![[r#"
+            *S*
+
+            ```rust
+            test
+            ```
+
+            ```rust
+            // size = 0, align = 1
+            struct S<T>(PhantomData<T>)
+            ```
+        "#]],
+    );
+}
+
+#[test]
 fn test_hover_layout_of_enum() {
     check(
         r#"enum $0Foo {
@@ -3673,6 +3716,7 @@ struct S$0T<const C: usize = 1, T = Foo>(T);
             ```
 
             ```rust
+            // size = 0, align = 1
             struct ST<const C: usize = 1, T = Foo>(T)
             ```
         "#]],
@@ -3694,6 +3738,7 @@ struct S$0T<const C: usize = {40 + 2}, T = Foo>(T);
             ```
 
             ```rust
+            // size = 0, align = 1
             struct ST<const C: usize = {const}, T = Foo>(T)
             ```
         "#]],
@@ -3716,6 +3761,7 @@ struct S$0T<const C: usize = VAL, T = Foo>(T);
             ```
 
             ```rust
+            // size = 0, align = 1
             struct ST<const C: usize = VAL, T = Foo>(T)
             ```
         "#]],
@@ -7872,6 +7918,7 @@ struct Pedro$0<'a> {
             ```
 
             ```rust
+            // size = 16 (0x10), align = 8, niches = 1
             struct Pedro<'a>
             ```
         "#]],

--- a/crates/proc-macro-api/src/lib.rs
+++ b/crates/proc-macro-api/src/lib.rs
@@ -37,7 +37,7 @@ pub enum ProcMacroKind {
     CustomDerive,
     Attr,
     // This used to be called FuncLike, so that's what the server expects currently.
-    #[serde(alias = "bang")]
+    #[serde(alias = "Bang")]
     #[serde(rename(serialize = "FuncLike", deserialize = "FuncLike"))]
     Bang,
 }


### PR DESCRIPTION
For one, this brings back layout information for lifetime generic ADTs (which "regressed" when we started adding lifetimes to chalks-ir), but it also allows layout calculation to work for definitions that don't actually use the generics (where its only used in a `PhantomData` for example)