### PR TITLE
Support hovering limits for adts

### DIFF
--- a/crates/hir/src/display.rs
+++ b/crates/hir/src/display.rs
@@ -249,19 +249,23 @@ fn display_fields(
         }
     } else {
         f.write_char('{')?;
-        f.write_char(separator)?;
-        for field in &fields[..count] {
-            f.write_str(indent)?;
-            field.hir_fmt(f)?;
-            f.write_char(',')?;
+
+        if !fields.is_empty() {
             f.write_char(separator)?;
+            for field in &fields[..count] {
+                f.write_str(indent)?;
+                field.hir_fmt(f)?;
+                f.write_char(',')?;
+                f.write_char(separator)?;
+            }
+
+            if fields.len() > count {
+                f.write_str(indent)?;
+                f.write_str("/* … */")?;
+                f.write_char(separator)?;
+            }
         }
 
-        if fields.len() > count {
-            f.write_str(indent)?;
-            f.write_str("/* … */")?;
-            f.write_char(separator)?;
-        }
         f.write_str("}")?;
     }
 

--- a/crates/hir/src/display.rs
+++ b/crates/hir/src/display.rs
@@ -188,12 +188,7 @@ impl HirDisplay for Struct {
             StructKind::Record => {
                 let has_where_clause = write_where_clause(def_id, f)?;
                 if let Some(limit) = f.entity_limit {
-                    display_fields_or_variants(
-                        &self.fields(f.db),
-                        has_where_clause,
-                        limit,
-                        f,
-                    )?;
+                    display_fields_or_variants(&self.fields(f.db), has_where_clause, limit, f)?;
                 }
             }
             StructKind::Unit => _ = write_where_clause(def_id, f)?,
@@ -213,12 +208,7 @@ impl HirDisplay for Enum {
 
         let has_where_clause = write_where_clause(def_id, f)?;
         if let Some(limit) = f.entity_limit {
-            display_fields_or_variants(
-                &self.variants(f.db),
-                has_where_clause,
-                limit,
-                f,
-            )?;
+            display_fields_or_variants(&self.variants(f.db), has_where_clause, limit, f)?;
         }
 
         Ok(())
@@ -235,12 +225,7 @@ impl HirDisplay for Union {
 
         let has_where_clause = write_where_clause(def_id, f)?;
         if let Some(limit) = f.entity_limit {
-            display_fields_or_variants(
-                &self.fields(f.db),
-                has_where_clause,
-                limit,
-                f,
-            )?;
+            display_fields_or_variants(&self.fields(f.db), has_where_clause, limit, f)?;
         }
         Ok(())
     }
@@ -251,7 +236,7 @@ fn display_fields_or_variants<T: HirDisplay>(
     has_where_clause: bool,
     limit: usize,
     f: &mut HirFormatter<'_>,
-)-> Result<(), HirDisplayError> {
+) -> Result<(), HirDisplayError> {
     let count = fields_or_variants.len().min(limit);
     f.write_char(if !has_where_clause { ' ' } else { '\n' })?;
     if count == 0 {

--- a/crates/ide/src/hover.rs
+++ b/crates/ide/src/hover.rs
@@ -33,7 +33,7 @@ pub struct HoverConfig {
     pub keywords: bool,
     pub format: HoverDocFormat,
     pub max_trait_assoc_items_count: Option<usize>,
-    pub max_struct_or_union_fields_count: Option<usize>,
+    pub max_fields_count: Option<usize>,
     pub max_enum_variants_count: Option<usize>,
 }
 

--- a/crates/ide/src/hover.rs
+++ b/crates/ide/src/hover.rs
@@ -33,7 +33,8 @@ pub struct HoverConfig {
     pub keywords: bool,
     pub format: HoverDocFormat,
     pub max_trait_assoc_items_count: Option<usize>,
-    pub max_adt_fields_or_variants_count: Option<usize>,
+    pub max_struct_or_union_fields_count: Option<usize>,
+    pub max_enum_variants_count: Option<usize>,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]

--- a/crates/ide/src/hover.rs
+++ b/crates/ide/src/hover.rs
@@ -33,7 +33,7 @@ pub struct HoverConfig {
     pub keywords: bool,
     pub format: HoverDocFormat,
     pub max_trait_assoc_items_count: Option<usize>,
-    pub max_struct_field_count: Option<usize>,
+    pub max_adt_fields_or_variants_count: Option<usize>,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]

--- a/crates/ide/src/hover/render.rs
+++ b/crates/ide/src/hover/render.rs
@@ -410,14 +410,17 @@ pub(super) fn definition(
         Definition::Trait(trait_) => {
             trait_.display_limited(db, config.max_trait_assoc_items_count).to_string()
         }
-        Definition::Adt(adt) => {
-            adt.display_limited(db, config.max_adt_fields_or_variants_count).to_string()
+        Definition::Adt(adt @ (Adt::Struct(_) | Adt::Union(_))) => {
+            adt.display_limited(db, config.max_struct_or_union_fields_count).to_string()
+        }
+        Definition::Adt(adt @ Adt::Enum(_)) => {
+            adt.display_limited(db, config.max_enum_variants_count).to_string()
         }
         Definition::SelfType(impl_def) => {
             let self_ty = &impl_def.self_ty(db);
             match self_ty.as_adt() {
                 Some(adt) => {
-                    adt.display_limited(db, config.max_adt_fields_or_variants_count).to_string()
+                    adt.display_limited(db, config.max_struct_or_union_fields_count).to_string()
                 }
                 None => self_ty.display(db).to_string(),
             }

--- a/crates/ide/src/hover/render.rs
+++ b/crates/ide/src/hover/render.rs
@@ -413,6 +413,15 @@ pub(super) fn definition(
         Definition::Adt(adt) => {
             adt.display_limited(db, config.max_adt_fields_or_variants_count).to_string()
         }
+        Definition::SelfType(impl_def) => {
+            let self_ty = &impl_def.self_ty(db);
+            match self_ty.as_adt() {
+                Some(adt) => {
+                    adt.display_limited(db, config.max_adt_fields_or_variants_count).to_string()
+                }
+                None => self_ty.display(db).to_string(),
+            }
+        }
         _ => def.label(db),
     };
     let docs = def.docs(db, famous_defs);

--- a/crates/ide/src/hover/render.rs
+++ b/crates/ide/src/hover/render.rs
@@ -411,7 +411,10 @@ pub(super) fn definition(
             trait_.display_limited(db, config.max_trait_assoc_items_count).to_string()
         }
         Definition::Adt(adt @ (Adt::Struct(_) | Adt::Union(_))) => {
-            adt.display_limited(db, config.max_struct_or_union_fields_count).to_string()
+            adt.display_limited(db, config.max_fields_count).to_string()
+        }
+        Definition::Variant(variant) => {
+            variant.display_limited(db, config.max_fields_count).to_string()
         }
         Definition::Adt(adt @ Adt::Enum(_)) => {
             adt.display_limited(db, config.max_enum_variants_count).to_string()
@@ -419,9 +422,7 @@ pub(super) fn definition(
         Definition::SelfType(impl_def) => {
             let self_ty = &impl_def.self_ty(db);
             match self_ty.as_adt() {
-                Some(adt) => {
-                    adt.display_limited(db, config.max_struct_or_union_fields_count).to_string()
-                }
+                Some(adt) => adt.display_limited(db, config.max_fields_count).to_string(),
                 None => self_ty.display(db).to_string(),
             }
         }

--- a/crates/ide/src/hover/render.rs
+++ b/crates/ide/src/hover/render.rs
@@ -410,8 +410,8 @@ pub(super) fn definition(
         Definition::Trait(trait_) => {
             trait_.display_limited(db, config.max_trait_assoc_items_count).to_string()
         }
-        Definition::Adt(Adt::Struct(struct_)) => {
-            struct_.display_limited(db, config.max_struct_field_count).to_string()
+        Definition::Adt(adt) => {
+            adt.display_limited(db, config.max_adt_fields_or_variants_count).to_string()
         }
         _ => def.label(db),
     };

--- a/crates/ide/src/hover/tests.rs
+++ b/crates/ide/src/hover/tests.rs
@@ -1624,6 +1624,28 @@ impl Thing {
                 ```
 
                 ```rust
+                struct Thing {
+                    x: u32,
+                }
+                ```
+            "#]],
+    );
+    check_hover_adt_fields_or_variants_limit(
+        None,
+        r#"
+struct Thing { x: u32 }
+impl Thing {
+    fn new() -> Self { Self$0 { x: 0 } }
+}
+"#,
+        expect![[r#"
+                *Self*
+
+                ```rust
+                test
+                ```
+
+                ```rust
                 struct Thing
                 ```
             "#]],
@@ -1643,7 +1665,9 @@ impl Thing {
                 ```
 
                 ```rust
-                struct Thing
+                struct Thing {
+                    x: u32,
+                }
                 ```
             "#]],
     );
@@ -1662,7 +1686,9 @@ impl Thing {
             ```
 
             ```rust
-            enum Thing
+            enum Thing {
+                A,
+            }
             ```
         "#]],
     );
@@ -1681,7 +1707,9 @@ impl Thing {
             ```
 
             ```rust
-            enum Thing
+            enum Thing {
+                A,
+            }
             ```
         "#]],
     );

--- a/crates/ide/src/hover/tests.rs
+++ b/crates/ide/src/hover/tests.rs
@@ -18,7 +18,7 @@ const HOVER_BASE_CONFIG: HoverConfig = HoverConfig {
     format: HoverDocFormat::Markdown,
     keywords: true,
     max_trait_assoc_items_count: None,
-    max_adt_fields_or_variants_count: Some(10),
+    max_adt_fields_or_variants_count: Some(5),
 };
 
 fn check_hover_no_result(ra_fixture: &str) {
@@ -1018,7 +1018,7 @@ fn hover_record_struct_limit() {
 #[test]
 fn hover_enum_limit() {
     check_hover_adt_fields_or_variants_limit(
-        Some(10),
+        Some(5),
         r#"enum Foo$0 { A, B }"#,
         expect![[r#"
             *Foo*
@@ -1092,7 +1092,7 @@ fn hover_enum_limit() {
 #[test]
 fn hover_union_limit() {
     check_hover_adt_fields_or_variants_limit(
-        Some(10),
+        Some(5),
         r#"union Foo$0 { a: u32, b: i32 }"#,
         expect![[r#"
             *Foo*

--- a/crates/ide/src/hover/tests.rs
+++ b/crates/ide/src/hover/tests.rs
@@ -1039,7 +1039,27 @@ fn hover_record_struct_limit() {
             struct Foo { /* … */ }
             ```
         "#]],
-    )
+    );
+
+    // No extra spaces within `{}` when there are no fields
+    check_hover_fields_limit(
+        5,
+        r#"
+    struct Foo$0 {}
+    "#,
+        expect![[r#"
+            *Foo*
+
+            ```rust
+            test
+            ```
+
+            ```rust
+            // size = 0, align = 1
+            struct Foo {}
+            ```
+        "#]],
+    );
 }
 
 #[test]

--- a/crates/ide/src/static_index.rs
+++ b/crates/ide/src/static_index.rs
@@ -167,7 +167,7 @@ impl StaticIndex<'_> {
             keywords: true,
             format: crate::HoverDocFormat::Markdown,
             max_trait_assoc_items_count: None,
-            max_adt_fields_or_variants_count: Some(10),
+            max_adt_fields_or_variants_count: Some(5),
         };
         let tokens = tokens.filter(|token| {
             matches!(

--- a/crates/ide/src/static_index.rs
+++ b/crates/ide/src/static_index.rs
@@ -167,7 +167,7 @@ impl StaticIndex<'_> {
             keywords: true,
             format: crate::HoverDocFormat::Markdown,
             max_trait_assoc_items_count: None,
-            max_struct_or_union_fields_count: Some(5),
+            max_fields_count: Some(5),
             max_enum_variants_count: Some(5),
         };
         let tokens = tokens.filter(|token| {

--- a/crates/ide/src/static_index.rs
+++ b/crates/ide/src/static_index.rs
@@ -167,7 +167,8 @@ impl StaticIndex<'_> {
             keywords: true,
             format: crate::HoverDocFormat::Markdown,
             max_trait_assoc_items_count: None,
-            max_adt_fields_or_variants_count: Some(5),
+            max_struct_or_union_fields_count: Some(5),
+            max_enum_variants_count: Some(5),
         };
         let tokens = tokens.filter(|token| {
             matches!(

--- a/crates/ide/src/static_index.rs
+++ b/crates/ide/src/static_index.rs
@@ -167,7 +167,7 @@ impl StaticIndex<'_> {
             keywords: true,
             format: crate::HoverDocFormat::Markdown,
             max_trait_assoc_items_count: None,
-            max_struct_field_count: None,
+            max_adt_fields_or_variants_count: Some(10),
         };
         let tokens = tokens.filter(|token| {
             matches!(

--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -313,7 +313,7 @@ config_data! {
         hover_memoryLayout_size: Option<MemoryLayoutHoverRenderKindDef> = Some(MemoryLayoutHoverRenderKindDef::Both),
 
         /// How many fields or variants of an ADT (struct, enum or union) to display when hovering on. Show none if empty.
-        hover_show_adtFieldsOrVariants: Option<usize> = Some(10),
+        hover_show_adtFieldsOrVariants: Option<usize> = Some(5),
         /// How many associated items of a trait to display when hovering a trait.
         hover_show_traitAssocItems: Option<usize> = None,
 

--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -314,8 +314,8 @@ config_data! {
 
         /// How many variants of an enum to display when hovering on. Show none if empty.
         hover_show_enumVariants: Option<usize> = Some(5),
-        /// How many fields of a struct or union to display when hovering on. Show none if empty.
-        hover_show_structOrUnionFields: Option<usize> = Some(5),
+        /// How many fields of a struct, variant or union to display when hovering on. Show none if empty.
+        hover_show_fields: Option<usize> = Some(5),
         /// How many associated items of a trait to display when hovering a trait.
         hover_show_traitAssocItems: Option<usize> = None,
 
@@ -1114,7 +1114,7 @@ impl Config {
             },
             keywords: self.hover_documentation_keywords_enable().to_owned(),
             max_trait_assoc_items_count: self.hover_show_traitAssocItems().to_owned(),
-            max_struct_or_union_fields_count: self.hover_show_structOrUnionFields().to_owned(),
+            max_fields_count: self.hover_show_fields().to_owned(),
             max_enum_variants_count: self.hover_show_enumVariants().to_owned(),
         }
     }

--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -312,7 +312,7 @@ config_data! {
         /// How to render the size information in a memory layout hover.
         hover_memoryLayout_size: Option<MemoryLayoutHoverRenderKindDef> = Some(MemoryLayoutHoverRenderKindDef::Both),
 
-        /// How many fields or variants of an ADT (struct, enum or union) to display when hovering on. Show all if empty.
+        /// How many fields or variants of an ADT (struct, enum or union) to display when hovering on. Show none if empty.
         hover_show_adtFieldsOrVariants: Option<usize> = Some(10),
         /// How many associated items of a trait to display when hovering a trait.
         hover_show_traitAssocItems: Option<usize> = None,

--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -312,8 +312,10 @@ config_data! {
         /// How to render the size information in a memory layout hover.
         hover_memoryLayout_size: Option<MemoryLayoutHoverRenderKindDef> = Some(MemoryLayoutHoverRenderKindDef::Both),
 
-        /// How many fields or variants of an ADT (struct, enum or union) to display when hovering on. Show none if empty.
-        hover_show_adtFieldsOrVariants: Option<usize> = Some(5),
+        /// How many variants of an enum to display when hovering on. Show none if empty.
+        hover_show_enumVariants: Option<usize> = Some(5),
+        /// How many fields of a struct or union to display when hovering on. Show none if empty.
+        hover_show_structOrUnionFields: Option<usize> = Some(5),
         /// How many associated items of a trait to display when hovering a trait.
         hover_show_traitAssocItems: Option<usize> = None,
 
@@ -1112,7 +1114,8 @@ impl Config {
             },
             keywords: self.hover_documentation_keywords_enable().to_owned(),
             max_trait_assoc_items_count: self.hover_show_traitAssocItems().to_owned(),
-            max_adt_fields_or_variants_count: self.hover_show_adtFieldsOrVariants().to_owned(),
+            max_struct_or_union_fields_count: self.hover_show_structOrUnionFields().to_owned(),
+            max_enum_variants_count: self.hover_show_enumVariants().to_owned(),
         }
     }
 

--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -312,8 +312,8 @@ config_data! {
         /// How to render the size information in a memory layout hover.
         hover_memoryLayout_size: Option<MemoryLayoutHoverRenderKindDef> = Some(MemoryLayoutHoverRenderKindDef::Both),
 
-        /// How many fields of a struct to display when hovering a struct.
-        hover_show_structFields: Option<usize> = None,
+        /// How many fields or variants of an ADT (struct, enum or union) to display when hovering on. Show all if empty.
+        hover_show_adtFieldsOrVariants: Option<usize> = Some(10),
         /// How many associated items of a trait to display when hovering a trait.
         hover_show_traitAssocItems: Option<usize> = None,
 
@@ -1112,7 +1112,7 @@ impl Config {
             },
             keywords: self.hover_documentation_keywords_enable().to_owned(),
             max_trait_assoc_items_count: self.hover_show_traitAssocItems().to_owned(),
-            max_struct_field_count: self.hover_show_structFields().to_owned(),
+            max_adt_fields_or_variants_count: self.hover_show_adtFieldsOrVariants().to_owned(),
         }
     }
 

--- a/docs/user/generated_config.adoc
+++ b/docs/user/generated_config.adoc
@@ -533,10 +533,10 @@ How to render the offset information in a memory layout hover.
 --
 How to render the size information in a memory layout hover.
 --
-[[rust-analyzer.hover.show.structFields]]rust-analyzer.hover.show.structFields (default: `null`)::
+[[rust-analyzer.hover.show.adtFieldsOrVariants]]rust-analyzer.hover.show.adtFieldsOrVariants (default: `10`)::
 +
 --
-How many fields of a struct to display when hovering a struct.
+How many fields or variants of an ADT (struct, enum or union) to display when hovering on. Show none if empty.
 --
 [[rust-analyzer.hover.show.traitAssocItems]]rust-analyzer.hover.show.traitAssocItems (default: `null`)::
 +

--- a/docs/user/generated_config.adoc
+++ b/docs/user/generated_config.adoc
@@ -533,10 +533,15 @@ How to render the offset information in a memory layout hover.
 --
 How to render the size information in a memory layout hover.
 --
-[[rust-analyzer.hover.show.adtFieldsOrVariants]]rust-analyzer.hover.show.adtFieldsOrVariants (default: `5`)::
+[[rust-analyzer.hover.show.enumVariants]]rust-analyzer.hover.show.enumVariants (default: `5`)::
 +
 --
-How many fields or variants of an ADT (struct, enum or union) to display when hovering on. Show none if empty.
+How many variants of an enum to display when hovering on. Show none if empty.
+--
+[[rust-analyzer.hover.show.structOrUnionFields]]rust-analyzer.hover.show.structOrUnionFields (default: `5`)::
++
+--
+How many fields of a struct or union to display when hovering on. Show none if empty.
 --
 [[rust-analyzer.hover.show.traitAssocItems]]rust-analyzer.hover.show.traitAssocItems (default: `null`)::
 +

--- a/docs/user/generated_config.adoc
+++ b/docs/user/generated_config.adoc
@@ -533,7 +533,7 @@ How to render the offset information in a memory layout hover.
 --
 How to render the size information in a memory layout hover.
 --
-[[rust-analyzer.hover.show.adtFieldsOrVariants]]rust-analyzer.hover.show.adtFieldsOrVariants (default: `10`)::
+[[rust-analyzer.hover.show.adtFieldsOrVariants]]rust-analyzer.hover.show.adtFieldsOrVariants (default: `5`)::
 +
 --
 How many fields or variants of an ADT (struct, enum or union) to display when hovering on. Show none if empty.

--- a/docs/user/generated_config.adoc
+++ b/docs/user/generated_config.adoc
@@ -538,10 +538,10 @@ How to render the size information in a memory layout hover.
 --
 How many variants of an enum to display when hovering on. Show none if empty.
 --
-[[rust-analyzer.hover.show.structOrUnionFields]]rust-analyzer.hover.show.structOrUnionFields (default: `5`)::
+[[rust-analyzer.hover.show.fields]]rust-analyzer.hover.show.fields (default: `5`)::
 +
 --
-How many fields of a struct or union to display when hovering on. Show none if empty.
+How many fields of a struct, variant or union to display when hovering on. Show none if empty.
 --
 [[rust-analyzer.hover.show.traitAssocItems]]rust-analyzer.hover.show.traitAssocItems (default: `null`)::
 +

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -1152,9 +1152,9 @@
                         }
                     ]
                 },
-                "rust-analyzer.hover.show.structFields": {
-                    "markdownDescription": "How many fields of a struct to display when hovering a struct.",
-                    "default": null,
+                "rust-analyzer.hover.show.adtFieldsOrVariants": {
+                    "markdownDescription": "How many fields or variants of an ADT (struct, enum or union) to display when hovering on. Show none if empty.",
+                    "default": 10,
                     "type": [
                         "null",
                         "integer"

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -1161,8 +1161,8 @@
                     ],
                     "minimum": 0
                 },
-                "rust-analyzer.hover.show.structOrUnionFields": {
-                    "markdownDescription": "How many fields of a struct or union to display when hovering on. Show none if empty.",
+                "rust-analyzer.hover.show.fields": {
+                    "markdownDescription": "How many fields of a struct, variant or union to display when hovering on. Show none if empty.",
                     "default": 5,
                     "type": [
                         "null",

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -1152,8 +1152,17 @@
                         }
                     ]
                 },
-                "rust-analyzer.hover.show.adtFieldsOrVariants": {
-                    "markdownDescription": "How many fields or variants of an ADT (struct, enum or union) to display when hovering on. Show none if empty.",
+                "rust-analyzer.hover.show.enumVariants": {
+                    "markdownDescription": "How many variants of an enum to display when hovering on. Show none if empty.",
+                    "default": 5,
+                    "type": [
+                        "null",
+                        "integer"
+                    ],
+                    "minimum": 0
+                },
+                "rust-analyzer.hover.show.structOrUnionFields": {
+                    "markdownDescription": "How many fields of a struct or union to display when hovering on. Show none if empty.",
                     "default": 5,
                     "type": [
                         "null",

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -1154,7 +1154,7 @@
                 },
                 "rust-analyzer.hover.show.adtFieldsOrVariants": {
                     "markdownDescription": "How many fields or variants of an ADT (struct, enum or union) to display when hovering on. Show none if empty.",
-                    "default": 10,
+                    "default": 5,
                     "type": [
                         "null",
                         "integer"


### PR DESCRIPTION
Fix #17009

1. Currently, r-a supports limiting the number of struct fields displayed when hovering. This PR extends it to support enum variants and union fields. Since the display of these three (ADTs) is similar, this PR extends 'hover_show_structFields' to 'hover_show_adtFieldsOrVariants'.
2. This PR also resolved the problem that the layout of ADT was not restricted by display limitations when hovering on the Self type.
3. Additionally, this PR changes the default value of display limitations to `10` (instead of the original `null`), which helps users discover this feature.