### PR TITLE
Revert "Use jemalloc for releases"

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -95,7 +95,7 @@ jobs:
         run: sudo apt-get install gcc-arm-linux-gnueabihf
 
       - name: Dist
-        run: cargo xtask dist --jemalloc --client-patch-version ${{ github.run_number }}
+        run: cargo xtask dist --client-patch-version ${{ github.run_number }}
 
       - run: npm ci
         working-directory: editors/code
@@ -159,7 +159,7 @@ jobs:
           fetch-depth: ${{ env.FETCH_DEPTH }}
 
       - name: Dist
-        run: cargo xtask dist --jemalloc --client-patch-version ${{ github.run_number }}
+        run: cargo xtask dist --client-patch-version ${{ github.run_number }}
 
       - run: npm ci
         working-directory: editors/code


### PR DESCRIPTION
This reverts commit 692c41e5937d821a30045990c11573ddb66bbccd: https://github.com/rust-lang/rust-analyzer/actions/runs/8592641551/job/23542950551.