### PR TITLE
Log flycheck errors

### DIFF
--- a/crates/flycheck/src/lib.rs
+++ b/crates/flycheck/src/lib.rs
@@ -286,7 +286,7 @@ impl FlycheckActor {
                     tracing::debug!(?command, "will restart flycheck");
                     match CommandHandle::spawn(command) {
                         Ok(command_handle) => {
-                            tracing::debug!(command = formatted_command, "did  restart flycheck");
+                            tracing::debug!(command = formatted_command, "did restart flycheck");
                             self.command_handle = Some(command_handle);
                             self.report_progress(Progress::DidStart);
                         }
@@ -306,10 +306,11 @@ impl FlycheckActor {
                     let formatted_handle = format!("{:?}", command_handle);
 
                     let res = command_handle.join();
-                    if res.is_err() {
+                    if let Err(error) = &res {
                         tracing::error!(
-                            "Flycheck failed to run the following command: {}",
-                            formatted_handle
+                            "Flycheck failed to run the following command: {}, error={}",
+                            formatted_handle,
+                            error
                         );
                     }
                     self.report_progress(Progress::DidFinish(res));


### PR DESCRIPTION
Resolves #16969

The non-cargo messages are appended to the error strings here;

https://github.com/rust-lang/rust-analyzer/blob/7a8374c162c64c17e865b98aad282d16b16e96d6/crates/flycheck/src/lib.rs#L460-L482

that one is formatted into `Err` here;

https://github.com/rust-lang/rust-analyzer/blob/7a8374c162c64c17e865b98aad282d16b16e96d6/crates/flycheck/src/command.rs#L144-L155

and finally, this PR appends it at the end of existing Flycheck error message