### PR TITLE
Document enabling the flatpak rust SDK extension

### DIFF
--- a/docs/user/manual.adoc
+++ b/docs/user/manual.adoc
@@ -210,7 +210,10 @@ While the sandbox can be disabled for some directories, `/usr/bin` will always b
 This prevents access to the system's C compiler, a system-wide installation of Rust, or any other libraries you might want to link to.
 Some compilers and libraries can be acquired as Flatpak SDKs, such as `org.freedesktop.Sdk.Extension.rust-stable` or `org.freedesktop.Sdk.Extension.llvm15`.
 
-If you use a Flatpak SDK for Rust, there should be no extra steps necessary.
+If you use a Flatpak SDK for Rust, it must be in your `PATH`:
+
+ * install the SDK extensions with `flatpak install org.freedesktop.Sdk.Extension.{llvm15,rust-stable}//23.08`
+ * enable SDK extensions in the editor with the environment variable `FLATPAK_ENABLE_SDK_EXT=llvm15,rust-stable` (this can be done using flatseal or `flatpak override`)
 
 If you want to use Flatpak in combination with `rustup`, the following steps might help:
 


### PR DESCRIPTION
Just having `org.freedesktop.Sdk.Extension.rust-stable` and `org.freedesktop.Sdk.Extension.llvm15` installed is not enough.
`/usr/lib/sdk/rust-stable/bin` at least needs to be added to the `PATH`.

In the case of VSCodium [ide-flatpak-wrapper](https://github.com/noonsleeper/ide-flatpak-wrapper) in included to do this.