### PR TITLE
fix: support auto-closing for triple backticks

### DIFF
--- a/editors/code/language-configuration.json
+++ b/editors/code/language-configuration.json
@@ -19,7 +19,8 @@
         { "open": "(", "close": ")" },
         { "open": "\"", "close": "\"", "notIn": ["string"] },
         { "open": "/*", "close": " */", "notIn": ["string"] },
-        { "open": "`", "close": "`", "notIn": ["string"] }
+        { "open": "`", "close": "`", "notIn": ["string"] },
+        { "open": "```", "close": "```", "notIn": ["string"] }
     ],
     "autoCloseBefore": ";:.,=}])> \n\t",
     "surroundingPairs": [
@@ -29,7 +30,8 @@
         ["<", ">"],
         ["\"", "\""],
         ["'", "'"],
-        ["`", "`"]
+        ["`", "`"],
+        ["```", "```"]
     ],
     "indentationRules": {
         "increaseIndentPattern": "^.*\\{[^}\"']*$|^.*\\([^\\)\"']*$",


### PR DESCRIPTION
It might fix #16051, see https://github.com/rust-lang/rust-analyzer/issues/16051#issuecomment-2042606030