### PR TITLE
Revert "fix: set the right postfix snippets competion source range"

### DIFF
--- a/crates/ide-completion/src/completions/postfix.rs
+++ b/crates/ide-completion/src/completions/postfix.rs
@@ -336,7 +336,8 @@ fn build_postfix_snippet_builder<'ctx>(
     ) -> impl Fn(&str, &str, &str) -> Builder + 'ctx {
         move |label, detail, snippet| {
             let edit = TextEdit::replace(delete_range, snippet.to_owned());
-            let mut item = CompletionItem::new(CompletionItemKind::Snippet, delete_range, label);
+            let mut item =
+                CompletionItem::new(CompletionItemKind::Snippet, ctx.source_range(), label);
             item.detail(detail).snippet_edit(cap, edit);
             let postfix_match = if ctx.original_token.text() == label {
                 cov_mark::hit!(postfix_exact_match_is_high_priority);


### PR DESCRIPTION
This reverts commit c5686c89413b3c6eead7b39637381ee353f8c05c.

Fix #17036. See https://github.com/rust-lang/rust-analyzer/issues/17036#issuecomment-2050185641