### PR TITLE
internal: Implement a linear storage type for salsa queries that use single (newtyped) integers as keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,6 +96,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
 
 [[package]]
+name = "boxcar"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e516014975db8769c0dcd1aba681c21079475fcddf77118bf54f9e2e013f6b29"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1671,6 +1677,7 @@ checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
 name = "salsa"
 version = "0.0.0"
 dependencies = [
+ "boxcar",
  "dissimilar",
  "expect-test",
  "indexmap",

--- a/crates/base-db/src/input.rs
+++ b/crates/base-db/src/input.rs
@@ -11,6 +11,7 @@ use std::{fmt, mem, ops};
 use cfg::CfgOptions;
 use la_arena::{Arena, Idx, RawIdx};
 use rustc_hash::{FxHashMap, FxHashSet};
+use salsa::LinearIndex;
 use span::Edition;
 use syntax::SmolStr;
 use triomphe::Arc;
@@ -22,6 +23,16 @@ pub type ProcMacroPaths = FxHashMap<CrateId, Result<(Option<String>, AbsPathBuf)
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct SourceRootId(pub u32);
+
+impl LinearIndex for SourceRootId {
+    fn as_u32(&self) -> u32 {
+        self.0
+    }
+
+    fn from_u32(u32: u32) -> Self {
+        SourceRootId(u32)
+    }
+}
 
 /// Files are grouped into source roots. A source root is a directory on the
 /// file systems which is watched for changes. Typically it corresponds to a

--- a/crates/base-db/src/lib.rs
+++ b/crates/base-db/src/lib.rs
@@ -104,6 +104,7 @@ pub trait SourceDatabaseExt: SourceDatabase {
     #[salsa::input]
     fn source_root(&self, id: SourceRootId) -> Arc<SourceRoot>;
 
+    #[salsa::linear]
     fn source_root_crates(&self, id: SourceRootId) -> Arc<[CrateId]>;
 }
 

--- a/crates/hir-def/src/db.rs
+++ b/crates/hir-def/src/db.rs
@@ -87,13 +87,17 @@ pub trait DefDatabase: InternDatabase + ExpandDatabase + Upcast<dyn ExpandDataba
     fn file_item_tree(&self, file_id: HirFileId) -> Arc<ItemTree>;
 
     #[salsa::invoke(ItemTree::block_item_tree_query)]
+    #[salsa::linear]
     fn block_item_tree(&self, block_id: BlockId) -> Arc<ItemTree>;
 
     #[salsa::invoke(DefMap::crate_def_map_query)]
+    // #[salsa::linear] FIXME: This needs some kind of proxy thing as we can't implement the
+    // required trait for la_arena::Idx
     fn crate_def_map(&self, krate: CrateId) -> Arc<DefMap>;
 
     /// Computes the block-level `DefMap`.
     #[salsa::invoke(DefMap::block_def_map_query)]
+    #[salsa::linear]
     fn block_def_map(&self, block: BlockId) -> Arc<DefMap>;
 
     fn macro_def(&self, m: MacroId) -> MacroDefId;
@@ -105,6 +109,7 @@ pub trait DefDatabase: InternDatabase + ExpandDatabase + Upcast<dyn ExpandDataba
     fn struct_data(&self, id: StructId) -> Arc<StructData>;
 
     #[salsa::invoke(StructData::struct_data_with_diagnostics_query)]
+    #[salsa::linear]
     fn struct_data_with_diagnostics(&self, id: StructId) -> (Arc<StructData>, DefDiagnostics);
 
     #[salsa::transparent]
@@ -112,9 +117,11 @@ pub trait DefDatabase: InternDatabase + ExpandDatabase + Upcast<dyn ExpandDataba
     fn union_data(&self, id: UnionId) -> Arc<StructData>;
 
     #[salsa::invoke(StructData::union_data_with_diagnostics_query)]
+    #[salsa::linear]
     fn union_data_with_diagnostics(&self, id: UnionId) -> (Arc<StructData>, DefDiagnostics);
 
     #[salsa::invoke(EnumData::enum_data_query)]
+    #[salsa::linear]
     fn enum_data(&self, e: EnumId) -> Arc<EnumData>;
 
     #[salsa::transparent]
@@ -122,6 +129,7 @@ pub trait DefDatabase: InternDatabase + ExpandDatabase + Upcast<dyn ExpandDataba
     fn enum_variant_data(&self, id: EnumVariantId) -> Arc<EnumVariantData>;
 
     #[salsa::invoke(EnumVariantData::enum_variant_data_with_diagnostics_query)]
+    #[salsa::linear]
     fn enum_variant_data_with_diagnostics(
         &self,
         id: EnumVariantId,
@@ -135,6 +143,7 @@ pub trait DefDatabase: InternDatabase + ExpandDatabase + Upcast<dyn ExpandDataba
     fn impl_data(&self, e: ImplId) -> Arc<ImplData>;
 
     #[salsa::invoke(ImplData::impl_data_with_diagnostics_query)]
+    #[salsa::linear]
     fn impl_data_with_diagnostics(&self, e: ImplId) -> (Arc<ImplData>, DefDiagnostics);
 
     #[salsa::transparent]
@@ -142,33 +151,43 @@ pub trait DefDatabase: InternDatabase + ExpandDatabase + Upcast<dyn ExpandDataba
     fn trait_data(&self, e: TraitId) -> Arc<TraitData>;
 
     #[salsa::invoke(TraitData::trait_data_with_diagnostics_query)]
+    #[salsa::linear]
     fn trait_data_with_diagnostics(&self, tr: TraitId) -> (Arc<TraitData>, DefDiagnostics);
 
     #[salsa::invoke(TraitAliasData::trait_alias_query)]
+    #[salsa::linear]
     fn trait_alias_data(&self, e: TraitAliasId) -> Arc<TraitAliasData>;
 
     #[salsa::invoke(TypeAliasData::type_alias_data_query)]
+    #[salsa::linear]
     fn type_alias_data(&self, e: TypeAliasId) -> Arc<TypeAliasData>;
 
     #[salsa::invoke(FunctionData::fn_data_query)]
+    #[salsa::linear]
     fn function_data(&self, func: FunctionId) -> Arc<FunctionData>;
 
     #[salsa::invoke(ConstData::const_data_query)]
+    #[salsa::linear]
     fn const_data(&self, konst: ConstId) -> Arc<ConstData>;
 
     #[salsa::invoke(StaticData::static_data_query)]
+    #[salsa::linear]
     fn static_data(&self, konst: StaticId) -> Arc<StaticData>;
 
     #[salsa::invoke(Macro2Data::macro2_data_query)]
+    #[salsa::linear]
     fn macro2_data(&self, makro: Macro2Id) -> Arc<Macro2Data>;
 
     #[salsa::invoke(MacroRulesData::macro_rules_data_query)]
+    #[salsa::linear]
     fn macro_rules_data(&self, makro: MacroRulesId) -> Arc<MacroRulesData>;
 
     #[salsa::invoke(ProcMacroData::proc_macro_data_query)]
+    #[salsa::linear]
     fn proc_macro_data(&self, makro: ProcMacroId) -> Arc<ProcMacroData>;
 
     #[salsa::invoke(ExternCrateDeclData::extern_crate_decl_data_query)]
+    #[salsa::linear]
     fn extern_crate_decl_data(&self, extern_crate: ExternCrateId) -> Arc<ExternCrateDeclData>;
 
     // endregion:data
@@ -209,6 +228,7 @@ pub trait DefDatabase: InternDatabase + ExpandDatabase + Upcast<dyn ExpandDataba
     fn lang_item(&self, start_crate: CrateId, item: LangItem) -> Option<LangItemTarget>;
 
     #[salsa::invoke(ImportMap::import_map_query)]
+    // #[salsa::linear] FIXME
     fn import_map(&self, krate: CrateId) -> Arc<ImportMap>;
 
     // region:visibilities
@@ -218,9 +238,11 @@ pub trait DefDatabase: InternDatabase + ExpandDatabase + Upcast<dyn ExpandDataba
 
     // FIXME: unify function_visibility and const_visibility?
     #[salsa::invoke(visibility::function_visibility_query)]
+    #[salsa::linear]
     fn function_visibility(&self, def: FunctionId) -> Visibility;
 
     #[salsa::invoke(visibility::const_visibility_query)]
+    #[salsa::linear]
     fn const_visibility(&self, def: ConstId) -> Visibility;
 
     // endregion:visibilities

--- a/crates/hir-ty/src/db.rs
+++ b/crates/hir-ty/src/db.rs
@@ -74,10 +74,12 @@ pub trait HirDatabase: DefDatabase + Upcast<dyn DefDatabase> {
 
     #[salsa::invoke(crate::consteval::const_eval_static_query)]
     #[salsa::cycle(crate::consteval::const_eval_static_recover)]
+    #[salsa::linear]
     fn const_eval_static(&self, def: StaticId) -> Result<Const, ConstEvalError>;
 
     #[salsa::invoke(crate::consteval::const_eval_discriminant_variant)]
     #[salsa::cycle(crate::consteval::const_eval_discriminant_recover)]
+    #[salsa::linear]
     fn const_eval_discriminant(&self, def: EnumVariantId) -> Result<i128, ConstEvalError>;
 
     // endregion:mir
@@ -93,12 +95,14 @@ pub trait HirDatabase: DefDatabase + Upcast<dyn DefDatabase> {
 
     #[salsa::invoke(crate::lower::impl_self_ty_query)]
     #[salsa::cycle(crate::lower::impl_self_ty_recover)]
+    #[salsa::linear]
     fn impl_self_ty(&self, def: ImplId) -> Binders<Ty>;
 
     #[salsa::invoke(crate::lower::const_param_ty_query)]
     fn const_param_ty(&self, def: ConstParamId) -> Ty;
 
     #[salsa::invoke(crate::lower::impl_trait_query)]
+    #[salsa::linear]
     fn impl_trait(&self, def: ImplId) -> Option<Binders<TraitRef>>;
 
     #[salsa::invoke(crate::lower::field_types_query)]
@@ -118,6 +122,7 @@ pub trait HirDatabase: DefDatabase + Upcast<dyn DefDatabase> {
     fn layout_of_ty(&self, ty: Ty, env: Arc<TraitEnvironment>) -> Result<Arc<Layout>, LayoutError>;
 
     #[salsa::invoke(crate::layout::target_data_layout_query)]
+    // #[salsa::linear] FIXME
     fn target_data_layout(&self, krate: CrateId) -> Result<Arc<TargetDataLayout>, Arc<str>>;
 
     #[salsa::invoke(crate::method_resolution::lookup_impl_method_query)]
@@ -132,9 +137,11 @@ pub trait HirDatabase: DefDatabase + Upcast<dyn DefDatabase> {
     fn callable_item_signature(&self, def: CallableDefId) -> PolyFnSig;
 
     #[salsa::invoke(crate::lower::return_type_impl_traits)]
+    #[salsa::linear]
     fn return_type_impl_traits(&self, def: FunctionId) -> Option<Arc<Binders<ImplTraits>>>;
 
     #[salsa::invoke(crate::lower::type_alias_impl_traits)]
+    #[salsa::linear]
     fn type_alias_impl_traits(&self, def: TypeAliasId) -> Option<Arc<Binders<ImplTraits>>>;
 
     #[salsa::invoke(crate::lower::generic_predicates_for_param_query)]
@@ -161,9 +168,11 @@ pub trait HirDatabase: DefDatabase + Upcast<dyn DefDatabase> {
     fn generic_defaults(&self, def: GenericDefId) -> Arc<[Binders<GenericArg>]>;
 
     #[salsa::invoke(InherentImpls::inherent_impls_in_crate_query)]
+    // #[salsa::linear] FIXME
     fn inherent_impls_in_crate(&self, krate: CrateId) -> Arc<InherentImpls>;
 
     #[salsa::invoke(InherentImpls::inherent_impls_in_block_query)]
+    #[salsa::linear]
     fn inherent_impls_in_block(&self, block: BlockId) -> Option<Arc<InherentImpls>>;
 
     /// Collects all crates in the dependency graph that have impls for the
@@ -178,12 +187,15 @@ pub trait HirDatabase: DefDatabase + Upcast<dyn DefDatabase> {
     ) -> SmallVec<[CrateId; 2]>;
 
     #[salsa::invoke(TraitImpls::trait_impls_in_crate_query)]
+    // #[salsa::linear] FIXME
     fn trait_impls_in_crate(&self, krate: CrateId) -> Arc<TraitImpls>;
 
     #[salsa::invoke(TraitImpls::trait_impls_in_block_query)]
+    #[salsa::linear]
     fn trait_impls_in_block(&self, block: BlockId) -> Option<Arc<TraitImpls>>;
 
     #[salsa::invoke(TraitImpls::trait_impls_in_deps_query)]
+    // #[salsa::linear] FIXME
     fn trait_impls_in_deps(&self, krate: CrateId) -> Arc<[Arc<TraitImpls>]>;
 
     // Interned IDs for Chalk integration

--- a/crates/ide-db/src/lib.rs
+++ b/crates/ide-db/src/lib.rs
@@ -327,6 +327,7 @@ impl salsa::ParallelDatabase for RootDatabase {
 
 #[salsa::query_group(LineIndexDatabaseStorage)]
 pub trait LineIndexDatabase: base_db::SourceDatabase {
+    // #[salsa::linear] FIXME
     fn line_index(&self, file_id: FileId) -> Arc<LineIndex>;
 }
 

--- a/crates/ide-db/src/symbol_index.rs
+++ b/crates/ide-db/src/symbol_index.rs
@@ -106,10 +106,12 @@ pub trait SymbolsDatabase: HirDatabase + SourceDatabaseExt + Upcast<dyn HirDatab
     fn module_symbols(&self, module: Module) -> Arc<SymbolIndex>;
 
     /// The symbol index for a given source root within library_roots.
+    #[salsa::linear]
     fn library_symbols(&self, source_root_id: SourceRootId) -> Arc<SymbolIndex>;
 
     #[salsa::transparent]
     /// The symbol indices of modules that make up a given crate.
+    // #[salsa::linear] FIXME
     fn crate_symbols(&self, krate: Crate) -> Box<[Arc<SymbolIndex>]>;
 
     /// The set of "local" (that is, from the current workspace) roots.

--- a/crates/salsa/Cargo.toml
+++ b/crates/salsa/Cargo.toml
@@ -22,6 +22,7 @@ smallvec = "1.0.0"
 oorandom = "11"
 triomphe = "0.1.11"
 itertools.workspace = true
+boxcar = "*"
 
 salsa-macros = { version = "0.0.0", path = "salsa-macros" }
 

--- a/crates/salsa/src/derived/linear.rs
+++ b/crates/salsa/src/derived/linear.rs
@@ -1,6 +1,11 @@
+//! A derived storage that requires its key to be a monotonically increasing index.
+// This is a copy paste from [`super::derived`], we could dedupe things with generics but I'm too
+// lazy for that.
 use crate::debug::TableEntry;
+use crate::derived::slot::Slot;
+use crate::derived::AlwaysMemoizeValue;
+use crate::derived::MemoizationPolicy;
 use crate::durability::Durability;
-use crate::hash::FxIndexMap;
 use crate::lru::Lru;
 use crate::plumbing::DerivedQueryStorageOps;
 use crate::plumbing::LruQueryStorageOps;
@@ -14,35 +19,43 @@ use parking_lot::RwLock;
 use std::marker::PhantomData;
 use triomphe::Arc;
 
-mod slot;
-use slot::Slot;
+pub trait LinearIndex {
+    fn index(&self) -> usize {
+        self.as_u32() as usize
+    }
+    fn as_u32(&self) -> u32;
+    fn from_u32(u32: u32) -> Self;
+}
 
-pub(crate) mod linear;
+impl<T: crate::InternKey> LinearIndex for T {
+    fn as_u32(&self) -> u32 {
+        self.as_intern_id().as_u32()
+    }
+
+    fn from_u32(u32: u32) -> Self {
+        Self::from_intern_id(crate::InternId::from(u32))
+    }
+}
 
 /// Memoized queries store the result plus a list of the other queries
 /// that they invoked. This means we can avoid recomputing them when
 /// none of those inputs have changed.
-pub type MemoizedStorage<Q> = DerivedStorage<Q, AlwaysMemoizeValue>;
-
-/// "Dependency" queries just track their dependencies and not the
-/// actual value (which they produce on demand). This lessens the
-/// storage requirements.
-pub type DependencyStorage<Q> = DerivedStorage<Q, NeverMemoizeValue>;
+pub type MemoizedLinearStorage<Q> = LinearStorage<Q, AlwaysMemoizeValue>;
 
 /// Handles storage where the value is 'derived' by executing a
 /// function (in contrast to "inputs").
-pub struct DerivedStorage<Q, MP>
+pub struct LinearStorage<Q, MP>
 where
     Q: QueryFunction,
     MP: MemoizationPolicy<Q>,
 {
     group_index: u16,
     lru_list: Lru<Slot<Q, MP>>,
-    slot_map: RwLock<FxIndexMap<Q::Key, Arc<Slot<Q, MP>>>>,
+    slots: RwLock<Vec<Arc<Slot<Q, MP>>>>,
     policy: PhantomData<MP>,
 }
 
-impl<Q, MP> std::panic::RefUnwindSafe for DerivedStorage<Q, MP>
+impl<Q, MP> std::panic::RefUnwindSafe for LinearStorage<Q, MP>
 where
     Q: QueryFunction,
     MP: MemoizationPolicy<Q>,
@@ -51,80 +64,54 @@ where
 {
 }
 
-pub trait MemoizationPolicy<Q>: Send + Sync
+impl<Q, MP> LinearStorage<Q, MP>
 where
     Q: QueryFunction,
-{
-    fn should_memoize_value(key: &Q::Key) -> bool;
-
-    fn memoized_value_eq(old_value: &Q::Value, new_value: &Q::Value) -> bool;
-}
-
-pub enum AlwaysMemoizeValue {}
-impl<Q> MemoizationPolicy<Q> for AlwaysMemoizeValue
-where
-    Q: QueryFunction,
-    Q::Value: Eq,
-{
-    fn should_memoize_value(_key: &Q::Key) -> bool {
-        true
-    }
-
-    fn memoized_value_eq(old_value: &Q::Value, new_value: &Q::Value) -> bool {
-        old_value == new_value
-    }
-}
-
-pub enum NeverMemoizeValue {}
-impl<Q> MemoizationPolicy<Q> for NeverMemoizeValue
-where
-    Q: QueryFunction,
-{
-    fn should_memoize_value(_key: &Q::Key) -> bool {
-        false
-    }
-
-    fn memoized_value_eq(_old_value: &Q::Value, _new_value: &Q::Value) -> bool {
-        panic!("cannot reach since we never memoize")
-    }
-}
-
-impl<Q, MP> DerivedStorage<Q, MP>
-where
-    Q: QueryFunction,
+    Q::Key: LinearIndex,
     MP: MemoizationPolicy<Q>,
 {
     fn slot(&self, key: &Q::Key) -> Arc<Slot<Q, MP>> {
-        if let Some(v) = self.slot_map.read().get(key) {
+        let key_index = key.index();
+        if let Some(v) = self.slots.read().get(key_index) {
             return v.clone();
         }
 
-        let mut write = self.slot_map.write();
-        let entry = write.entry(key.clone());
-        let key_index = entry.index() as u32;
-        entry
-            .or_insert_with(|| {
-                Arc::new(Slot::new(DatabaseKeyIndex {
+        let mut write = self.slots.write();
+        match write.get_mut(key_index) {
+            Some(entry) => entry.clone(),
+            None => {
+                for key_index in write.len()..key_index {
+                    write.push(Arc::new(Slot::new(DatabaseKeyIndex {
+                        group_index: self.group_index,
+                        query_index: Q::QUERY_INDEX,
+                        key_index: key_index as u32,
+                    })));
+                }
+
+                let slot = Arc::new(Slot::new(DatabaseKeyIndex {
                     group_index: self.group_index,
                     query_index: Q::QUERY_INDEX,
-                    key_index,
-                }))
-            })
-            .clone()
+                    key_index: key_index as u32,
+                }));
+                write.push(slot.clone());
+                slot
+            }
+        }
     }
 }
 
-impl<Q, MP> QueryStorageOps<Q> for DerivedStorage<Q, MP>
+impl<Q, MP> QueryStorageOps<Q> for LinearStorage<Q, MP>
 where
     Q: QueryFunction,
+    Q::Key: LinearIndex,
     MP: MemoizationPolicy<Q>,
 {
     const CYCLE_STRATEGY: crate::plumbing::CycleRecoveryStrategy = Q::CYCLE_STRATEGY;
 
     fn new(group_index: u16) -> Self {
-        DerivedStorage {
+        LinearStorage {
             group_index,
-            slot_map: RwLock::new(FxIndexMap::default()),
+            slots: RwLock::new(Vec::default()),
             lru_list: Default::default(),
             policy: PhantomData,
         }
@@ -136,9 +123,13 @@ where
         index: u32,
         fmt: &mut std::fmt::Formatter<'_>,
     ) -> std::fmt::Result {
-        let slot_map = self.slot_map.read();
-        let key = slot_map.get_index(index as usize).unwrap().0;
-        write!(fmt, "{}::{}({:?})", std::any::type_name::<Q>(), Q::QUERY_NAME, key)
+        write!(
+            fmt,
+            "{}::{}({:?})",
+            std::any::type_name::<Q>(),
+            Q::QUERY_NAME,
+            Q::Key::from_u32(index)
+        )
     }
 
     fn maybe_changed_after(
@@ -148,14 +139,14 @@ where
         revision: Revision,
     ) -> bool {
         debug_assert!(revision < db.salsa_runtime().current_revision());
-        let (key, slot) = {
-            let read = self.slot_map.read();
-            let Some((key, slot)) = read.get_index(index as usize) else {
+        let slot = {
+            let read = self.slots.read();
+            let Some(slot) = read.get(index as usize) else {
                 return false;
             };
-            (key.clone(), slot.clone())
+            slot.clone()
         };
-        slot.maybe_changed_after(db, revision, &key)
+        slot.maybe_changed_after(db, revision, &Q::Key::from_u32(index))
     }
 
     fn fetch(&self, db: &<Q as QueryDb<'_>>::DynDb, key: &Q::Key) -> Q::Value {
@@ -185,23 +176,27 @@ where
     where
         C: std::iter::FromIterator<TableEntry<Q::Key, Q::Value>>,
     {
-        let slot_map = self.slot_map.read();
-        slot_map.iter().filter_map(|(key, slot)| slot.as_table_entry(key)).collect()
+        let slot_map = self.slots.read();
+        slot_map
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, slot)| slot.as_table_entry(&Q::Key::from_u32(idx as u32)))
+            .collect()
     }
 }
 
-impl<Q, MP> QueryStorageMassOps for DerivedStorage<Q, MP>
+impl<Q, MP> QueryStorageMassOps for LinearStorage<Q, MP>
 where
     Q: QueryFunction,
     MP: MemoizationPolicy<Q>,
 {
     fn purge(&self) {
         self.lru_list.purge();
-        *self.slot_map.write() = Default::default();
+        *self.slots.write() = Default::default();
     }
 }
 
-impl<Q, MP> LruQueryStorageOps for DerivedStorage<Q, MP>
+impl<Q, MP> LruQueryStorageOps for LinearStorage<Q, MP>
 where
     Q: QueryFunction,
     MP: MemoizationPolicy<Q>,
@@ -211,16 +206,17 @@ where
     }
 }
 
-impl<Q, MP> DerivedQueryStorageOps<Q> for DerivedStorage<Q, MP>
+impl<Q, MP> DerivedQueryStorageOps<Q> for LinearStorage<Q, MP>
 where
     Q: QueryFunction,
+    Q::Key: LinearIndex,
     MP: MemoizationPolicy<Q>,
 {
     fn invalidate(&self, runtime: &mut Runtime, key: &Q::Key) {
         runtime.with_incremented_revision(|new_revision| {
-            let map_read = self.slot_map.read();
+            let map_read = self.slots.read();
 
-            if let Some(slot) = map_read.get(key) {
+            if let Some(slot) = map_read.get(key.index()) {
                 if let Some(durability) = slot.invalidate(new_revision) {
                     return Some(durability);
                 }

--- a/crates/salsa/src/interned.rs
+++ b/crates/salsa/src/interned.rs
@@ -182,8 +182,7 @@ where
     ) -> (Arc<Slot<Q::Key>>, InternId) {
         let revision_now = db.salsa_runtime().current_revision();
 
-        let mut tables = self.tables.write();
-        let tables = &mut *tables;
+        let tables = &mut *self.tables.write();
         let entry = match tables.map.entry(mapped_key) {
             Entry::Vacant(entry) => entry,
             Entry::Occupied(entry) => {

--- a/crates/salsa/src/lib.rs
+++ b/crates/salsa/src/lib.rs
@@ -38,6 +38,7 @@ use std::hash::Hash;
 use std::panic::AssertUnwindSafe;
 use std::panic::{self, UnwindSafe};
 
+pub use crate::derived::linear::LinearIndex;
 pub use crate::durability::Durability;
 pub use crate::intern_id::InternId;
 pub use crate::interned::{InternKey, InternValue};

--- a/crates/salsa/src/plumbing.rs
+++ b/crates/salsa/src/plumbing.rs
@@ -7,11 +7,11 @@ use crate::Database;
 use crate::Query;
 use crate::QueryTable;
 use crate::QueryTableMut;
-use std::borrow::Borrow;
 use std::fmt::Debug;
 use std::hash::Hash;
 use triomphe::Arc;
 
+pub use crate::derived::linear::MemoizedLinearStorage;
 pub use crate::derived::DependencyStorage;
 pub use crate::derived::MemoizedStorage;
 pub use crate::input::{InputStorage, UnitInputStorage};
@@ -235,10 +235,7 @@ pub trait DerivedQueryStorageOps<Q>
 where
     Q: Query,
 {
-    fn invalidate<S>(&self, runtime: &mut Runtime, key: &S)
-    where
-        S: Eq + Hash,
-        Q::Key: Borrow<S>;
+    fn invalidate(&self, runtime: &mut Runtime, key: &Q::Key);
 }
 
 pub type CycleParticipants = Arc<Vec<DatabaseKeyIndex>>;

--- a/crates/span/src/lib.rs
+++ b/crates/span/src/lib.rs
@@ -1,7 +1,7 @@
 //! File and span related types.
 use std::fmt::{self, Write};
 
-use salsa::InternId;
+use salsa::{InternId, LinearIndex};
 
 mod ast_id;
 mod hygiene;
@@ -161,6 +161,16 @@ impl fmt::Debug for HirFileId {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct MacroFileId {
     pub macro_call_id: MacroCallId,
+}
+
+impl LinearIndex for MacroFileId {
+    fn from_u32(v: u32) -> Self {
+        MacroFileId { macro_call_id: MacroCallId::from_u32(v) }
+    }
+
+    fn as_u32(&self) -> u32 {
+        self.macro_call_id.as_u32()
+    }
 }
 
 /// `MacroCallId` identifies a particular macro invocation, like


### PR DESCRIPTION
My hope was to be able to remove the outer `RwLock` around the hashmap, since the only write is to insert into it, though unfortunately I haven't found a concurrent append-only vec / slab that supports what we'd need here.