### PR TITLE
different error code of "no such field" error based on variant type

### DIFF
--- a/crates/hir-ty/src/infer.rs
+++ b/crates/hir-ty/src/infer.rs
@@ -198,6 +198,7 @@ pub enum InferenceDiagnostic {
     NoSuchField {
         field: ExprOrPatId,
         private: bool,
+        variant: VariantId,
     },
     PrivateField {
         expr: ExprId,

--- a/crates/hir-ty/src/infer/expr.rs
+++ b/crates/hir-ty/src/infer/expr.rs
@@ -563,6 +563,7 @@ impl InferenceContext<'_> {
                                                 InferenceDiagnostic::NoSuchField {
                                                     field: field.expr.into(),
                                                     private: true,
+                                                    variant: def,
                                                 },
                                             );
                                         }
@@ -572,6 +573,7 @@ impl InferenceContext<'_> {
                                         self.push_diagnostic(InferenceDiagnostic::NoSuchField {
                                             field: field.expr.into(),
                                             private: false,
+                                            variant: def,
                                         });
                                         None
                                     }

--- a/crates/hir-ty/src/infer/pat.rs
+++ b/crates/hir-ty/src/infer/pat.rs
@@ -177,6 +177,7 @@ impl InferenceContext<'_> {
                                     self.push_diagnostic(InferenceDiagnostic::NoSuchField {
                                         field: inner.into(),
                                         private: true,
+                                        variant: def,
                                     });
                                 }
                                 let f = field_types[local_id].clone();
@@ -190,6 +191,7 @@ impl InferenceContext<'_> {
                                 self.push_diagnostic(InferenceDiagnostic::NoSuchField {
                                     field: inner.into(),
                                     private: false,
+                                    variant: def,
                                 });
                                 self.err_ty()
                             }

--- a/crates/ide-diagnostics/src/handlers/no_such_field.rs
+++ b/crates/ide-diagnostics/src/handlers/no_such_field.rs
@@ -1,5 +1,5 @@
 use either::Either;
-use hir::{db::ExpandDatabase, HasSource, HirDisplay, HirFileIdExt, Semantics};
+use hir::{db::ExpandDatabase, HasSource, HirDisplay, HirFileIdExt, Semantics, VariantId};
 use ide_db::{base_db::FileId, source_change::SourceChange, RootDatabase};
 use syntax::{
     ast::{self, edit::IndentLevel, make},
@@ -25,7 +25,10 @@ pub(crate) fn no_such_field(ctx: &DiagnosticsContext<'_>, d: &hir::NoSuchField) 
     } else {
         Diagnostic::new_with_syntax_node_ptr(
             ctx,
-            DiagnosticCode::RustcHardError("E0559"),
+            match d.variant {
+                VariantId::EnumVariantId(_) => DiagnosticCode::RustcHardError("E0559"),
+                _ => DiagnosticCode::RustcHardError("E0560"),
+            },
             "no such field",
             node,
         )


### PR DESCRIPTION
fix #17107 

Pass variant information down to diagnostic, so that we can get different error code based on variant type.

After fix:

- structure

  <img width="868" alt="Screenshot 2024-04-23 at 21 03 27" src="https://github.com/rust-lang/rust-analyzer/assets/71200607/c2d1e389-5b62-4e9a-a133-9ae41f80615f">

- enum's structure variant

  <img width="937" alt="Screenshot 2024-04-23 at 21 04 41" src="https://github.com/rust-lang/rust-analyzer/assets/71200607/ad8558a7-d809-4968-b290-2f6bbb8d6b8c">


