### PR TITLE
feature: Make generate function assist generate a function as a constructor if the generated function has the name "new" and is an asscociated function.

### DIFF
--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -1489,6 +1489,14 @@ impl Adt {
             .map(|arena| arena.1.clone())
     }
 
+    pub fn as_struct(&self) -> Option<Struct> {
+        if let Self::Struct(v) = self {
+            Some(*v)
+        } else {
+            None
+        }
+    }
+
     pub fn as_enum(&self) -> Option<Enum> {
         if let Self::Enum(v) = self {
             Some(*v)


### PR DESCRIPTION
close #17050
This PR makes `generate function assist` generate a function as a constructor if the generated function has the name "new" and is an asscociated function.
If the asscociate type is a record struct, it generates the constructor like this.
```rust
impl Foo {
    fn new() -> Self {
        Self { field_1: todo!(), field_2: todo!() }
    } 
}
``` 
If the asscociate type is a tuple struct, it generates the constructor like this. 
```rust
impl Foo {
    fn new() -> Self {
        Self(todo!(), todo!())
    } 
}
``` 
If the asscociate type is a unit struct, it generates the constructor like this. 
```rust
impl Foo {
    fn new() -> Self {
        Self
    } 
}
``` 
If the asscociate type is another adt, it generates the constructor like this. 
```rust
impl Foo {
    fn new() -> Self {
        todo!()
    } 
}
``` 


