### PR TITLE
manual: remove suggestion of rust-project.json example

### DIFF
--- a/docs/user/manual.adoc
+++ b/docs/user/manual.adoc
@@ -787,8 +787,6 @@ There are three ways to feed `rust-project.json` to rust-analyzer:
 
 Relative paths are interpreted relative to `rust-project.json` file location or (for inline JSON) relative to `rootUri`.
 
-See https://github.com/rust-analyzer/rust-project.json-example for a small example.
-
 You can set the `RA_LOG` environment variable to `rust_analyzer=info` to inspect how rust-analyzer handles config and project loading.
 
 Note that calls to `cargo check` are disabled when using `rust-project.json` by default, so compilation errors and warnings will no longer be sent to your LSP client.


### PR DESCRIPTION
The manual has been linking to the repo

https://github.com/rust-analyzer/rust-project.json-example/tree/master

This repo does not contain a rust-project.json, does not appear to have _ever_ contained a rust-project.json, and my bug report about this has gone untouched: https://github.com/rust-analyzer/rust-project.json-example/issues/4

Since I can't figure out an example, this commit removes the link pending better documentation.