### PR TITLE
minor: let diagnostics.enable's scope be limited to DiagnosticsCode::Ra only

### DIFF
--- a/crates/ide-diagnostics/src/lib.rs
+++ b/crates/ide-diagnostics/src/lib.rs
@@ -408,7 +408,8 @@ pub fn diagnostics(
     }
 
     res.retain(|d| {
-        !(ctx.config.disabled.contains(d.code.as_str())
+        !(matches!(d.code, DiagnosticCode::Ra(..)) && !ctx.config.enabled
+            || ctx.config.disabled.contains(d.code.as_str())
             || ctx.config.disable_experimental && d.experimental)
     });
 

--- a/crates/ide/src/lib.rs
+++ b/crates/ide/src/lib.rs
@@ -686,7 +686,7 @@ impl Analysis {
         };
 
         self.with_db(|db| {
-            let diagnostic_assists = if diagnostics_config.enabled && include_fixes {
+            let diagnostic_assists = if include_fixes {
                 ide_diagnostics::diagnostics(db, diagnostics_config, &resolve, frange.file_id)
                     .into_iter()
                     .flat_map(|it| it.fixes.unwrap_or_default())


### PR DESCRIPTION
The documentation for the config `rust-analyzer.diagnostics.enable` states :  *"Whether to show native rust-analyzer diagnostics"*. However as I further investigated #17048 I came to the conclusion that the thing it currently does is to disable/enable diagnostics completely. I am not sure if that's the desired behavior. If so, this PR should better be closed. 
If not this PR changes the said config to regulate whether we should show diagnostics with diagnostics code `DiagnosticCode::Ra` or not and thereby fixes #17048. 

As to the new test : It only serves the purpose of demonstrating what the change means. As soon as it becomes clear that this PR has any sense I will write a test under ide_diagnostics