### PR TITLE
Omit changelog header from GitHub release notes

### DIFF
--- a/xtask/src/publish.rs
+++ b/xtask/src/publish.rs
@@ -7,24 +7,15 @@ use xshell::{cmd, Shell};
 
 impl flags::PublishReleaseNotes {
     pub(crate) fn run(self, sh: &Shell) -> anyhow::Result<()> {
-        let asciidoc = sh.read_file(&self.changelog)?;
+        let mut asciidoc = sh.read_file(&self.changelog)?;
+        // Remove '#' in front of changelog number; GitHub misinterprets it as issue reference
+        let changelog_header_prefix = "= Changelog ";
+        let header_hash_sign_index =
+            asciidoc.find(changelog_header_prefix).expect("should contain changelog header")
+                + changelog_header_prefix.len();
+        asciidoc.remove(header_hash_sign_index);
+
         let mut markdown = notes::convert_asciidoc_to_markdown(std::io::Cursor::new(&asciidoc))?;
-
-        // Remove changelog header because GitHub misinterprets the changelog number as issue reference
-        let changelog_header_prefix = "# Changelog #";
-        let mut changelog_header_start =
-            markdown.find(changelog_header_prefix).expect("should contain changelog header");
-        changelog_header_start =
-            markdown[..changelog_header_start].rfind('\n').map_or(0, |i| i + 1);
-        let mut changelog_header_end = changelog_header_start + changelog_header_prefix.len();
-        changelog_header_end += markdown[changelog_header_end..].find('\n').unwrap() + 1;
-        while changelog_header_end < markdown.len()
-            && markdown.as_bytes()[changelog_header_end] == b'\n'
-        {
-            changelog_header_end += 1;
-        }
-        markdown.replace_range(changelog_header_start..changelog_header_end, "");
-
         let file_name = check_file_name(self.changelog)?;
         let tag_name = &file_name[0..10];
         let original_changelog_url = create_original_changelog_url(&file_name);


### PR DESCRIPTION
Resolves #16455

I wasn't sure whether one of you maintainers wanted to implement this, so I gave it a try. Feedback is appreciated! No worries if you reject this pull request (and implement the changes yourself) in case these changes here are not clean enough.

I have tested this using `test_data/input.adoc` (renamed to `2024-01-01.adoc`) with the following command:
```
cargo run --package xtask --bin xtask publish-release-notes --dry-run xtask/test_data/2024-01-01.adoc
```
It seems to work correctly, but would be good if you could double check.