### PR TITLE
Fix Run lens showing when lenses are disabled

### DIFF
--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -1776,7 +1776,7 @@ impl Config {
 
     pub fn lens(&self) -> LensConfig {
         LensConfig {
-            run: *self.lens_run_enable(),
+            run: *self.lens_enable() && *self.lens_run_enable(),
             debug: *self.lens_enable() && *self.lens_debug_enable(),
             interpret: *self.lens_enable() && *self.lens_run_enable() && *self.interpret_tests(),
             implementations: *self.lens_enable() && *self.lens_implementations_enable(),


### PR DESCRIPTION
I have disabled Rust Analyzer lenses in my VSCode settings, but noticed that the `Run` lens still showed. This surprised me, as the docs for `lens.run.enable` [state that it only applies when `lens.enable` is set](https://github.com/rust-lang/rust-analyzer/blob/25f59be62f6b915b44a4c2ec2defca56a5f766c1/crates/rust-analyzer/src/config.rs#L353-L355). I then found that where we set `LensConfig::run`, we don't check `lens_enable` like for the other settings. [We did this previously](https://github.com/rust-lang/rust-analyzer/blob/eab385e1f64f8e3b861effe91432785f8030191b/crates/rust-analyzer/src/config.rs#L1649), so this seems like a regression from refactoring. This PR tries to fix that.