### PR TITLE
docs: Prioritize rustup over manual installation

### DIFF
--- a/docs/user/manual.adoc
+++ b/docs/user/manual.adoc
@@ -133,6 +133,18 @@ Specifically, `rustup` includes a proxy called `rust-analyzer`, which can cause 
 === rust-analyzer Language Server Binary
 
 Other editors generally require the `rust-analyzer` binary to be in `$PATH`.
+
+==== rustup
+
+`rust-analyzer` is available in `rustup`:
+
+[source,bash]
+----
+$ rustup component add rust-analyzer
+----
+
+==== Manual installation
+
 You can download pre-built binaries from the https://github.com/rust-lang/rust-analyzer/releases[releases] page.
 You will need to uncompress and rename the binary for your platform, e.g. from `rust-analyzer-aarch64-apple-darwin.gz` on Mac OS to `rust-analyzer`, make it executable, then move it into a directory in your `$PATH`.
 
@@ -160,15 +172,6 @@ $ cargo xtask install --server
 
 If your editor can't find the binary even though the binary is on your `$PATH`, the likely explanation is that it doesn't see the same `$PATH` as the shell, see https://github.com/rust-lang/rust-analyzer/issues/1811[this issue].
 On Unix, running the editor from a shell or changing the `.desktop` file to set the environment should help.
-
-==== rustup
-
-`rust-analyzer` is available in `rustup`:
-
-[source,bash]
-----
-$ rustup component add rust-analyzer
-----
 
 ==== Arch Linux
 


### PR DESCRIPTION
Unless I'm missing something, it seems weird to have the manual installation instructions above the `rustup` one. It's more complicated, platform-dependent and doesn't update automatically.

Many of the individual editor instructions link to this section (Helix, Neovim, Emacs) so it would be great if this is simple and straight-forward.