### PR TITLE
internal: Use Swatinem/rust-cache for metrics CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -63,8 +63,8 @@ jobs:
       - name: Install Rust toolchain
         run: |
           rustup update --no-self-update ${{ env.RUST_CHANNEL }}
-          rustup component add --toolchain ${{ env.RUST_CHANNEL }} rustfmt rust-src
           rustup default ${{ env.RUST_CHANNEL }}
+          rustup component add --toolchain ${{ env.RUST_CHANNEL }} rustfmt rust-src
       # https://github.com/actions-rust-lang/setup-rust-toolchain/blob/main/rust.json
       - name: Install Rust Problem Matcher
         if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -71,7 +71,7 @@ jobs:
         run: echo "::add-matcher::.github/rust.json"
 
       - name: Cache Dependencies
-        uses: Swatinem/rust-cache@640a22190e7a783d4c409684cea558f081f92012
+        uses: Swatinem/rust-cache@9bdad043e88c75890e36ad3bbc8d27f0090dd609
         with:
           key: ${{ env.RUST_CHANNEL }}
 
@@ -140,7 +140,7 @@ jobs:
           rustup target add ${{ env.targets }} ${{ env.targets_ide }}
 
       - name: Cache Dependencies
-        uses: Swatinem/rust-cache@640a22190e7a783d4c409684cea558f081f92012
+        uses: Swatinem/rust-cache@9bdad043e88c75890e36ad3bbc8d27f0090dd609
 
       - name: Check
         run: |

--- a/.github/workflows/metrics.yaml
+++ b/.github/workflows/metrics.yaml
@@ -18,17 +18,14 @@ jobs:
       - name: Install Rust toolchain
         run: |
           rustup update --no-self-update stable
-          rustup component add rustfmt rust-src
           rustup default stable
+          rustup component add --toolchain stable rustfmt rust-src
+
       - name: Cache cargo
-        uses: actions/cache@v4
+        uses: Swatinem/rust-cache@640a22190e7a783d4c409684cea558f081f92012
         with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
           key: ${{ runner.os }}-cargo-${{ github.sha }}
+          cache-targets: "false"
 
   build_metrics:
     runs-on: ubuntu-latest
@@ -39,23 +36,19 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Restore cargo cache
-        uses: actions/cache@v4
+        uses: Swatinem/rust-cache@640a22190e7a783d4c409684cea558f081f92012
         with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
           key: ${{ runner.os }}-cargo-${{ github.sha }}
+          cache-targets: "false"
 
       - name: Collect build metrics
         run: cargo xtask metrics build
 
       - name: Cache target
-        uses: actions/cache@v4
+        uses: Swatinem/rust-cache@640a22190e7a783d4c409684cea558f081f92012
         with:
-          path: target/
-          key: ${{ runner.os }}-target-${{ github.sha }}
+          key: ${{ runner.os }}-cargo-${{ github.sha }}
+          cache-targets: "true"
 
       - name: Upload build metrics
         uses: actions/upload-artifact@v4
@@ -76,20 +69,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Restore cargo cache
-        uses: actions/cache@v4
+        uses: Swatinem/rust-cache@640a22190e7a783d4c409684cea558f081f92012
         with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
           key: ${{ runner.os }}-cargo-${{ github.sha }}
-
-      - name: Restore target cache
-        uses: actions/cache@v4
-        with:
-          path: target/
-          key: ${{ runner.os }}-target-${{ github.sha }}
+          cache-targets: "true"
 
       - name: Collect metrics
         run: cargo xtask metrics "${{ matrix.names }}"


### PR DESCRIPTION
Current metrics caching uses a base cache action, whereas I think the one we use for general ci works here as well. Saw this while noticing that our metrics CI is broken as it for some reason uses an outdated rust stable? (unsure why that is)
