### PR TITLE
fix: resolve extern prelude for local mods in block modules

### DIFF
--- a/crates/hir-def/src/nameres.rs
+++ b/crates/hir-def/src/nameres.rs
@@ -67,7 +67,7 @@ use itertools::Itertools;
 use la_arena::Arena;
 use rustc_hash::{FxHashMap, FxHashSet};
 use span::{Edition, FileAstId, ROOT_ERASED_FILE_AST_ID};
-use stdx::format_to;
+use stdx::{format_to, IsNoneOr};
 use syntax::{ast, SmolStr};
 use triomphe::Arc;
 use tt::TextRange;
@@ -476,6 +476,10 @@ impl DefMap {
 
     pub fn crate_root(&self) -> CrateRootModuleId {
         CrateRootModuleId { krate: self.krate }
+    }
+
+    pub fn is_root_block_in_module(&self) -> bool {
+        self.block.is_none_or(|block| !block.parent.is_block_module())
     }
 
     /// This is the same as [`Self::crate_root`] for crate def maps, but for block def maps, it

--- a/crates/hir-def/src/nameres/collector.rs
+++ b/crates/hir-def/src/nameres/collector.rs
@@ -395,6 +395,8 @@ impl DefCollector<'_> {
             .cfg()
             .map_or(true, |cfg| self.cfg_options.check(&cfg) != Some(false));
         if is_cfg_enabled {
+            self.inject_prelude();
+
             ModCollector {
                 def_collector: self,
                 macro_depth: 0,

--- a/crates/hir-def/src/nameres/path_resolution.rs
+++ b/crates/hir-def/src/nameres/path_resolution.rs
@@ -470,7 +470,7 @@ impl DefMap {
         };
 
         let extern_prelude = || {
-            if self.block.is_some() {
+            if self.block.is_some() && !self.is_root_block_in_module() {
                 // Don't resolve extern prelude in block `DefMap`s, defer it to the crate def map so
                 // that blocks can properly shadow them
                 return PerNs::none();
@@ -515,7 +515,7 @@ impl DefMap {
             None => self[Self::ROOT].scope.get(name),
         };
         let from_extern_prelude = || {
-            if self.block.is_some() {
+            if self.block.is_some() && !self.is_root_block_in_module() {
                 // Don't resolve extern prelude in block `DefMap`s.
                 return PerNs::none();
             }


### PR DESCRIPTION
fix #17057, #17032

Add a check: if we `use` preludes in the root block of a module, then r-a should try resolving names in extern preludes.