### PR TITLE
internal: Correct Neovim 0.10 inlay hints config example

### DIFF
--- a/docs/user/manual.adoc
+++ b/docs/user/manual.adoc
@@ -376,7 +376,7 @@ If you're running Neovim 0.10 or later, you can enable inlay hints via `on_attac
 ----
 lspconfig.rust_analyzer.setup({
     on_attach = function(client, bufnr)
-        vim.lsp.inlay_hint.enable(bufnr)
+        vim.lsp.inlay_hint.enable(true, { bufnr = bufnr })
     end
 })
 ----


### PR DESCRIPTION
This change is what I had to do to make inlay hints work on Neovim 0.10.  The current example produces errors about wrong argument type to `.enable()`.