### PR TITLE
fix: resolve extern prelude for local mods in block modules

### DIFF
--- a/crates/hir-def/src/nameres/collector.rs
+++ b/crates/hir-def/src/nameres/collector.rs
@@ -395,6 +395,8 @@ impl DefCollector<'_> {
             .cfg()
             .map_or(true, |cfg| self.cfg_options.check(&cfg) != Some(false));
         if is_cfg_enabled {
+            self.inject_prelude();
+
             ModCollector {
                 def_collector: self,
                 macro_depth: 0,

--- a/crates/hir-def/src/nameres/path_resolution.rs
+++ b/crates/hir-def/src/nameres/path_resolution.rs
@@ -18,9 +18,7 @@ use crate::{
     db::DefDatabase,
     item_scope::{ImportOrExternCrate, BUILTIN_SCOPE},
     item_tree::Fields,
-    nameres::{
-        sub_namespace_match, BlockInfo, BuiltinShadowMode, DefMap, MacroSubNs, ModuleOrigin,
-    },
+    nameres::{sub_namespace_match, BlockInfo, BuiltinShadowMode, DefMap, MacroSubNs},
     path::{ModPath, PathKind},
     per_ns::PerNs,
     visibility::{RawVisibility, Visibility},
@@ -472,7 +470,7 @@ impl DefMap {
         };
 
         let extern_prelude = || {
-            if matches!(self[module].origin, ModuleOrigin::BlockExpr { .. }) {
+            if self.block.is_some() && module == DefMap::ROOT {
                 // Don't resolve extern prelude in pseudo-modules of blocks, because
                 // they might been shadowed by local names.
                 return PerNs::none();
@@ -518,7 +516,7 @@ impl DefMap {
             None => self[Self::ROOT].scope.get(name),
         };
         let from_extern_prelude = || {
-            if matches!(self[module].origin, ModuleOrigin::BlockExpr { .. }) {
+            if self.block.is_some() && module == DefMap::ROOT {
                 // Don't resolve extern prelude in pseudo-module of a block.
                 return PerNs::none();
             }


### PR DESCRIPTION
fix https://github.com/rust-lang/rust-analyzer/issues/17057, https://github.com/rust-lang/rust-analyzer/issues/17032.

We should use `ModuleOrigin` to check if the current module is a pseudo-module introduced by blocks (where names might be shadowed), rather than checking `block_def_map`.