### PR TITLE
Feat: hide double underscored symbols from symbol search

### DIFF
--- a/crates/ide-db/src/symbol_index.rs
+++ b/crates/ide-db/src/symbol_index.rs
@@ -381,7 +381,7 @@ impl Query {
                     if non_type_for_type_only_query || !self.matches_assoc_mode(symbol.is_assoc) {
                         continue;
                     }
-                    if self.should_hide_query(&symbol) {
+                    if self.should_hide_query(symbol) {
                         continue;
                     }
                     if self.mode.check(&self.query, self.case_sensitive, &symbol.name) {

--- a/crates/ide-db/src/symbol_index.rs
+++ b/crates/ide-db/src/symbol_index.rs
@@ -381,7 +381,7 @@ impl Query {
                     if non_type_for_type_only_query || !self.matches_assoc_mode(symbol.is_assoc) {
                         continue;
                     }
-                    if !self.include_hidden && symbol.name.starts_with("__") {
+                    if self.should_hide_query(&symbol) {
                         continue;
                     }
                     if self.mode.check(&self.query, self.case_sensitive, &symbol.name) {
@@ -390,6 +390,11 @@ impl Query {
                 }
             }
         }
+    }
+
+    fn should_hide_query(&self, symbol: &FileSymbol) -> bool {
+        // Hide symbols that start with `__` unless the query starts with `__`
+        !self.include_hidden && symbol.name.starts_with("__") && !self.query.starts_with("__")
     }
 
     fn matches_assoc_mode(&self, is_trait_assoc_item: bool) -> bool {

--- a/crates/ide/src/navigation_target.rs
+++ b/crates/ide/src/navigation_target.rs
@@ -926,4 +926,25 @@ struct Foo;
         let navs = analysis.symbol_search(Query::new("foo".to_owned()), !0).unwrap();
         assert_eq!(navs.len(), 2)
     }
+
+    #[test]
+    fn test_ensure_hidden_symbols_are_not_returned() {
+        let (analysis, _) = fixture::file(
+            r#"
+fn foo() {}
+struct Foo;
+static __FOO_CALLSITE: () = ();
+"#,
+        );
+
+        // It doesn't show the hidden symbol
+        let navs = analysis.symbol_search(Query::new("foo".to_owned()), !0).unwrap();
+        assert_eq!(navs.len(), 2);
+
+        // Unless we configure a query to show hidden symbols
+        let mut query = Query::new("foo".to_owned());
+        query.include_hidden();
+        let navs = analysis.symbol_search(query, !0).unwrap();
+        assert_eq!(navs.len(), 3);
+    }
 }

--- a/crates/ide/src/navigation_target.rs
+++ b/crates/ide/src/navigation_target.rs
@@ -940,11 +940,12 @@ static __FOO_CALLSITE: () = ();
         // It doesn't show the hidden symbol
         let navs = analysis.symbol_search(Query::new("foo".to_owned()), !0).unwrap();
         assert_eq!(navs.len(), 2);
+        let navs = analysis.symbol_search(Query::new("_foo".to_owned()), !0).unwrap();
+        assert_eq!(navs.len(), 0);
 
-        // Unless we configure a query to show hidden symbols
-        let mut query = Query::new("foo".to_owned());
-        query.include_hidden();
+        // Unless we explicitly search for a `__` prefix
+        let query = Query::new("__foo".to_owned());
         let navs = analysis.symbol_search(query, !0).unwrap();
-        assert_eq!(navs.len(), 3);
+        assert_eq!(navs.len(), 1);
     }
 }


### PR DESCRIPTION
Fixes #17272 by changing the default behavior of query to skip results that start with `__` (two underscores).

Not sure if this has any far reaching implications - a review would help to understand if this is the right place to do the filtering, and if it's fine to do it by default on the query.

If you type `__` as your search, then we'll show the matching double unders, just in case you actually need the symbol.