### PR TITLE
Use correct format for setting environment variables when debugging with cpptools

### DIFF
--- a/editors/code/src/debug.ts
+++ b/editors/code/src/debug.ts
@@ -195,7 +195,7 @@ function getCCppDebugConfig(
         cwd: runnable.args.cwd || runnable.args.workspaceRoot || ".",
         sourceFileMap,
         environment: Object.entries(env).map(entry => {
-            return { "name": entry[0], "value": entry[1] }
+            return { "name": entry[0], "value": entry[1] };
         }),
         // See https://github.com/rust-lang/rust-analyzer/issues/16901#issuecomment-2024486941
         osx: {

--- a/editors/code/src/debug.ts
+++ b/editors/code/src/debug.ts
@@ -194,7 +194,9 @@ function getCCppDebugConfig(
         args: runnable.args.executableArgs,
         cwd: runnable.args.cwd || runnable.args.workspaceRoot || ".",
         sourceFileMap,
-        env,
+        environment: Object.entries(env).map(entry => {
+            return { "name": entry[0], "value": entry[1] }
+        }),
         // See https://github.com/rust-lang/rust-analyzer/issues/16901#issuecomment-2024486941
         osx: {
             MIMode: "lldb",

--- a/editors/code/src/debug.ts
+++ b/editors/code/src/debug.ts
@@ -194,8 +194,8 @@ function getCCppDebugConfig(
         args: runnable.args.executableArgs,
         cwd: runnable.args.cwd || runnable.args.workspaceRoot || ".",
         sourceFileMap,
-        environment: Object.entries(env).map(entry => {
-            return { "name": entry[0], "value": entry[1] };
+        environment: Object.entries(env).map((entry) => {
+            return { name: entry[0], value: entry[1] };
         }),
         // See https://github.com/rust-lang/rust-analyzer/issues/16901#issuecomment-2024486941
         osx: {

--- a/editors/code/src/debug.ts
+++ b/editors/code/src/debug.ts
@@ -194,9 +194,10 @@ function getCCppDebugConfig(
         args: runnable.args.executableArgs,
         cwd: runnable.args.cwd || runnable.args.workspaceRoot || ".",
         sourceFileMap,
-        environment: Object.entries(env).map((entry) => {
-            return { name: entry[0], value: entry[1] };
-        }),
+        environment: Object.entries(env).map((entry) => ({
+            name: entry[0],
+            value: entry[1],
+        })),
         // See https://github.com/rust-lang/rust-analyzer/issues/16901#issuecomment-2024486941
         osx: {
             MIMode: "lldb",


### PR DESCRIPTION
The RA VSCode extension uses an incorrect format for the environment variables in the `launch.json` when debugging with the C/C++ Extension. This extension uses a different format than CodeLLDB or NativeDebug, which means that the environment variables are not actually set for the debuggee.

What it currently looks like:
```json
"env": {
  "NAME": "VALUE"
}
```

What the C/C++ extension expects:
```json
"environment": [
  { "name": "NAME", "value": "VALUE" }
]
```

For reference: https://code.visualstudio.com/docs/cpp/launch-json-reference#_environment