### PR TITLE
Avoid clone when constructing runnable label.

### DIFF
--- a/crates/ide/src/runnables.rs
+++ b/crates/ide/src/runnables.rs
@@ -79,7 +79,7 @@ impl RunnableKind {
 
 impl Runnable {
     // test package::module::testname
-    pub fn label(&self, target: Option<String>) -> String {
+    pub fn label(&self, target: Option<&str>) -> String {
         match &self.kind {
             RunnableKind::Test { test_id, .. } => format!("test {test_id}"),
             RunnableKind::TestMod { path } => format!("test-mod {path}"),

--- a/crates/rust-analyzer/src/lsp/to_proto.rs
+++ b/crates/rust-analyzer/src/lsp/to_proto.rs
@@ -1364,10 +1364,10 @@ pub(crate) fn runnable(
         ide::RunnableKind::Bin { .. } => workspace_root.clone().map(|it| it.into()),
         _ => spec.as_ref().map(|it| it.cargo_toml.parent().into()),
     };
-    let target = spec.as_ref().map(|s| s.target.clone());
+    let target = spec.as_ref().map(|s| s.target.as_str());
+    let label = runnable.label(target);
     let (cargo_args, executable_args) =
         CargoTargetSpec::runnable_args(snap, spec, &runnable.kind, &runnable.cfg);
-    let label = runnable.label(target);
     let location = location_link(snap, None, runnable.nav)?;
 
     Ok(lsp_ext::Runnable {


### PR DESCRIPTION
I stumbled across this when reading this code. This seems like an unnecessary allocation (though likely small?)