### PR TITLE
Feature: Add IDE assist for to move ADT definitions + impls to separate files

### DIFF
--- a/crates/ide-assists/src/handlers/move_definition_to_file.rs
+++ b/crates/ide-assists/src/handlers/move_definition_to_file.rs
@@ -1,0 +1,238 @@
+use ide_db::base_db::AnchoredPathBuf;
+use stdx::to_lower_snake_case;
+use syntax::{
+    ast::{self, HasName, HasVisibility},
+    AstNode,
+};
+
+use crate::{utils::find_struct_impl, AssistContext, AssistId, AssistKind, Assists};
+
+// Assist: move_definition_to_file
+//
+// Moves the selected ADT and its impl to a separate file as a new module.
+//
+// ```
+// struct $0Foo {
+//     x: i32,
+// }
+// impl Foo {
+//     fn new(x: i32) -> Self {
+//         Self { x }
+//     }
+// }
+// ```
+// ->
+// ```
+// mod foo;
+// use foo::*;
+// ```
+pub(crate) fn move_definition_to_file(acc: &mut Assists, ctx: &AssistContext<'_>) -> Option<()> {
+    let adt = ctx.find_node_at_offset::<ast::Adt>()?;
+    let adt_name = adt.name()?;
+    let adt_text = adt.syntax().text().to_string();
+
+    let impl_def = find_struct_impl(ctx, &adt, &[]).flatten();
+    let target = adt.syntax().text_range();
+
+    acc.add(
+        AssistId("move_definition_to_file", AssistKind::RefactorExtract),
+        "Extract definition to file",
+        target,
+        |builder| {
+            let module_name = to_lower_snake_case(&adt_name.text());
+            let path = format!("./{}.rs", module_name);
+
+            let mut content = adt_text.to_string();
+            if let Some(impl_def) = impl_def {
+                content.push_str("\n\n");
+                content.push_str(&impl_def.syntax().text().to_string());
+                builder.delete(impl_def.syntax().text_range());
+            }
+
+            let visibility = adt.visibility().map(|v| v.to_string() + " ");
+            let visibility = visibility.as_deref().unwrap_or("");
+            let mod_and_use_declaration = format!(
+                "{}mod {};\n{}use {}::*;",
+                visibility, module_name, visibility, module_name
+            );
+            builder.replace(target, mod_and_use_declaration);
+
+            let dst = AnchoredPathBuf { anchor: ctx.file_id(), path };
+            builder.create_file(dst, content);
+        },
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::tests::{check_assist, check_assist_not_applicable};
+
+    use super::*;
+
+    #[test]
+    fn extract_struct_without_impls() {
+        check_assist(
+            move_definition_to_file,
+            r#"
+//- /main.rs
+struct $0Foo {
+    x: i32,
+}
+"#,
+            r#"
+//- /main.rs
+mod foo;
+use foo::*;
+//- /foo.rs
+struct Foo {
+    x: i32,
+}"#,
+        );
+    }
+
+    #[test]
+    fn extract_struct_with_pub_mod() {
+        check_assist(
+            move_definition_to_file,
+            r#"
+    //- /main.rs
+    pub(crate) struct $0Foo {
+        x: i32,
+    }
+    "#,
+            r#"
+    //- /main.rs
+    pub(crate) mod foo;
+    pub(crate) use foo::*;
+    //- /foo.rs
+    pub(crate) struct Foo {
+        x: i32,
+    }"#,
+        );
+    }
+
+    #[test]
+    fn extract_struct_with_impl() {
+        check_assist(
+            move_definition_to_file,
+            r#"
+//- /main.rs
+#[derive(Debug)]
+struct $0FooBar {
+    x: i32,
+}
+
+impl FooBar {
+    fn new(x: i32) -> Self {
+        Self { x }
+    }
+}
+"#,
+            r#"
+//- /main.rs
+mod foo_bar;
+use foo_bar::*;
+
+
+//- /foo_bar.rs
+#[derive(Debug)]
+struct FooBar {
+    x: i32,
+}
+
+impl FooBar {
+    fn new(x: i32) -> Self {
+        Self { x }
+    }
+}"#,
+        );
+    }
+
+    #[test]
+    fn extract_enum() {
+        check_assist(
+            move_definition_to_file,
+            r#"
+//- /main.rs
+enum $0MyEnum {
+    Variant1,
+    Variant2(i32),
+}
+"#,
+            r#"
+//- /main.rs
+mod my_enum;
+use my_enum::*;
+//- /my_enum.rs
+enum MyEnum {
+    Variant1,
+    Variant2(i32),
+}"#,
+        );
+    }
+
+    #[test]
+    fn extract_enum_with_impl() {
+        check_assist(
+            move_definition_to_file,
+            r#"
+//- /main.rs
+enum $0MyEnum {
+    Variant1,
+    Variant2(i32),
+}
+
+impl MyEnum {
+    fn new_variant2(value: i32) -> Self {
+        MyEnum::Variant2(value)
+    }
+}
+"#,
+            r#"
+//- /main.rs
+mod my_enum;
+use my_enum::*;
+
+
+//- /my_enum.rs
+enum MyEnum {
+    Variant1,
+    Variant2(i32),
+}
+
+impl MyEnum {
+    fn new_variant2(value: i32) -> Self {
+        MyEnum::Variant2(value)
+    }
+}"#,
+        );
+    }
+
+    #[test]
+    fn extract_enum_without_variants() {
+        check_assist(
+            move_definition_to_file,
+            r#"
+//- /main.rs
+enum $0EmptyEnum {}
+"#,
+            r#"
+//- /main.rs
+mod empty_enum;
+use empty_enum::*;
+//- /empty_enum.rs
+enum EmptyEnum {}"#,
+        );
+    }
+
+    #[test]
+    fn no_struct_or_trait_selected() {
+        check_assist_not_applicable(
+            move_definition_to_file,
+            r#"
+//- /main.rs
+fn $0foo() {}
+"#,
+        );
+    }
+}

--- a/crates/ide-assists/src/handlers/move_definition_to_file.rs
+++ b/crates/ide-assists/src/handlers/move_definition_to_file.rs
@@ -28,6 +28,7 @@ use syntax::{
 // ```
 // mod foo;
 // use foo::*;
+//
 // ```
 pub(crate) fn move_definition_to_file(acc: &mut Assists, ctx: &AssistContext<'_>) -> Option<()> {
     let adt = ctx.find_node_at_offset::<ast::Adt>()?;
@@ -48,7 +49,7 @@ pub(crate) fn move_definition_to_file(acc: &mut Assists, ctx: &AssistContext<'_>
             let module_name = to_lower_snake_case(&adt_name.text());
             let path = construct_path(ctx, &parent_module, module_ast, &module_name);
 
-            let mut buf = adt_text.clone();
+            let mut buf = format!("use super::*;\n{}", adt_text);
             for impl_def in impls {
                 buf.push_str("\n\n");
                 buf.push_str(&impl_def.syntax().text().to_string());
@@ -147,6 +148,7 @@ struct $0Foo {
 mod foo;
 use foo::*;
 //- /foo.rs
+use super::*;
 struct Foo {
     x: i32,
 }"#,
@@ -168,6 +170,7 @@ pub(crate) struct $0Foo {
 pub(crate) mod foo;
 pub(crate) use foo::*;
 //- /foo.rs
+use super::*;
 pub(crate) struct Foo {
     x: i32,
 }"#,
@@ -198,6 +201,7 @@ use foo_bar::*;
 
 
 //- /foo_bar.rs
+use super::*;
 #[derive(Debug)]
 struct FooBar {
     x: i32,
@@ -236,6 +240,7 @@ use foo::*;
 
 
 //- /services/foo.rs
+use super::*;
 struct Foo {
     id: u32,
 }
@@ -279,6 +284,7 @@ use baz::*;
     }
 }
 //- /foo/bar/baz.rs
+use super::*;
 struct Baz {
     y: i32,
 }
@@ -322,6 +328,7 @@ use foo::*;
 
 
 //- /foo.rs
+use super::*;
 struct Foo {
     x: i32,
 }
@@ -356,6 +363,7 @@ enum $0MyEnum {
 mod my_enum;
 use my_enum::*;
 //- /my_enum.rs
+use super::*;
 enum MyEnum {
     Variant1,
     Variant2(i32),
@@ -387,6 +395,7 @@ use my_enum::*;
 
 
 //- /my_enum.rs
+use super::*;
 enum MyEnum {
     Variant1,
     Variant2(i32),
@@ -413,6 +422,7 @@ enum $0EmptyEnum {}
 mod empty_enum;
 use empty_enum::*;
 //- /empty_enum.rs
+use super::*;
 enum EmptyEnum {}"#,
         );
     }

--- a/crates/ide-assists/src/handlers/move_definition_to_file.rs
+++ b/crates/ide-assists/src/handlers/move_definition_to_file.rs
@@ -76,7 +76,7 @@ fn construct_path(
     module_name: &str,
 ) -> String {
     let db = ctx.db();
-    let mut path_segments = vec![".".to_string()];
+    let mut path_segments = vec![".".to_owned()];
     if let Some(name) = parent_module.name(db) {
         if !parent_module.is_mod_rs(db)
             && parent_module.attrs(db).by_key("path").string_value_unescape().is_none()
@@ -87,7 +87,7 @@ fn construct_path(
 
     let module_segments = iter::successors(module_ast, |module| module.parent())
         .filter_map(|it| it.name())
-        .map(|name| name.text().trim_start_matches("r#").to_string())
+        .map(|name| name.text().trim_start_matches("r#").to_owned())
         .collect::<Vec<_>>();
 
     path_segments.extend(module_segments.into_iter().rev());

--- a/crates/ide-assists/src/handlers/move_definition_to_file.rs
+++ b/crates/ide-assists/src/handlers/move_definition_to_file.rs
@@ -6,7 +6,7 @@ use ide_db::base_db::AnchoredPathBuf;
 use stdx::to_lower_snake_case;
 use syntax::{
     ast::{self, HasName, HasVisibility},
-    AstNode, SmolStr,
+    AstNode,
 };
 
 // Assist: move_definition_to_file

--- a/crates/ide-assists/src/lib.rs
+++ b/crates/ide-assists/src/lib.rs
@@ -177,6 +177,7 @@ mod handlers {
     mod merge_nested_if;
     mod move_bounds;
     mod move_const_to_impl;
+    mod move_definition_to_file;
     mod move_from_mod_rs;
     mod move_guard;
     mod move_module_to_file;
@@ -299,6 +300,7 @@ mod handlers {
             merge_nested_if::merge_nested_if,
             move_bounds::move_bounds_to_where_clause,
             move_const_to_impl::move_const_to_impl,
+            move_definition_to_file::move_definition_to_file,
             move_guard::move_arm_cond_to_match_guard,
             move_guard::move_guard_to_arm_body,
             move_module_to_file::move_module_to_file,

--- a/crates/ide-assists/src/tests.rs
+++ b/crates/ide-assists/src/tests.rs
@@ -334,6 +334,7 @@ fn assist_order_field_struct() {
     assert_eq!(assists.next().expect("expected assist").label, "Generate a setter method");
     assert_eq!(assists.next().expect("expected assist").label, "Add `#[derive]`");
     assert_eq!(assists.next().expect("expected assist").label, "Generate `new`");
+    assert_eq!(assists.next().expect("expected assist").label, "Extract definition to file");
     assert_eq!(assists.next().map(|it| it.label.to_string()), None);
 }
 

--- a/crates/ide-assists/src/tests/generated.rs
+++ b/crates/ide-assists/src/tests/generated.rs
@@ -2234,6 +2234,27 @@ impl S {
 }
 
 #[test]
+fn doctest_move_definition_to_file() {
+    check_doc_test(
+        "move_definition_to_file",
+        r#####"
+struct $0Foo {
+    x: i32,
+}
+impl Foo {
+    fn new(x: i32) -> Self {
+        Self { x }
+    }
+}
+"#####,
+        r#####"
+mod foo;
+use foo::*;
+"#####,
+    )
+}
+
+#[test]
 fn doctest_move_from_mod_rs() {
     check_doc_test(
         "move_from_mod_rs",

--- a/crates/ide-assists/src/tests/generated.rs
+++ b/crates/ide-assists/src/tests/generated.rs
@@ -2250,6 +2250,7 @@ impl Foo {
         r#####"
 mod foo;
 use foo::*;
+
 "#####,
     )
 }


### PR DESCRIPTION
I've added a new IDE assist for moving the selected struct or enum, along with all of its impls, to a separate file as a new module. 

I've relied on similar refactorings when using IDEs for Scala. It's quite nice to be able to define new structs in the current file, allowing one to experiment more rapidly without getting bogged down by module organization.

I've added a good number of tests here, ensuring that it handles various module hierarchies correctly. It also attempts to preserve the visibility of the initial ADT definition, so that this operation doesn't break compilation.

### Example

**Before**
```rust
// main.rs
struct Foo {
    x: i32,
}

impl Foo {
    fn new(x: i32) -> Self {
        Self { x }
    }
}
```

**After**
```rust
// main.rs
mod foo;
use foo::*;

// foo.rs
use super::*;
struct Foo {
    x: i32,
}

impl Foo {
    fn new(x: i32) -> Self {
        Self { x }
    }
}
```

### TODOs

- [x] Copy all necessary `use` statements into the new module, as to not break compilation.
  - I've simply added `use super::*`. Which works, but might be too heavy handed.
- [x] Fix windows/linux tests

#### Note

In my excitement, I hadn't read `CONTRIBUTING.md` until just now, which recommends opening an issue before a PR 😅. Alas, as I've already written this code, I might as well share it. However, I will remain perfectly happy if this is rejected outright. It was a lovely learning experience. Thank you for your consideration and for building such a wonderful tool! 🥰