### PR TITLE
fix diagnostics clearing when flychecks run per-workspace

### DIFF
--- a/crates/flycheck/src/lib.rs
+++ b/crates/flycheck/src/lib.rs
@@ -163,6 +163,9 @@ pub enum Message {
     /// Request adding a diagnostic with fixes included to a file
     AddDiagnostic { id: usize, workspace_root: AbsPathBuf, diagnostic: Diagnostic },
 
+    /// Request clearing all previous diagnostics
+    ClearDiagnostics { id: usize },
+
     /// Request check progress notification to client
     Progress {
         /// Flycheck instance ID
@@ -180,6 +183,9 @@ impl fmt::Debug for Message {
                 .field("workspace_root", workspace_root)
                 .field("diagnostic_code", &diagnostic.code.as_ref().map(|it| &it.code))
                 .finish(),
+            Message::ClearDiagnostics { id } => {
+                f.debug_struct("ClearDiagnostics").field("id", id).finish()
+            }
             Message::Progress { id, progress } => {
                 f.debug_struct("Progress").field("id", id).field("progress", progress).finish()
             }
@@ -220,11 +226,20 @@ struct FlycheckActor {
     command_handle: Option<CommandHandle<CargoCheckMessage>>,
     /// The receiver side of the channel mentioned above.
     command_receiver: Option<Receiver<CargoCheckMessage>>,
+
+    status: FlycheckStatus,
 }
 
 enum Event {
     RequestStateChange(StateChange),
     CheckEvent(Option<CargoCheckMessage>),
+}
+
+#[derive(PartialEq)]
+enum FlycheckStatus {
+    Started,
+    DiagnosticSent,
+    Finished,
 }
 
 const SAVED_FILE_PLACEHOLDER: &str = "$saved_file";
@@ -248,6 +263,7 @@ impl FlycheckActor {
             manifest_path,
             command_handle: None,
             command_receiver: None,
+            status: FlycheckStatus::Finished,
         }
     }
 
@@ -298,12 +314,14 @@ impl FlycheckActor {
                             self.command_handle = Some(command_handle);
                             self.command_receiver = Some(receiver);
                             self.report_progress(Progress::DidStart);
+                            self.status = FlycheckStatus::Started;
                         }
                         Err(error) => {
                             self.report_progress(Progress::DidFailToRestart(format!(
                                 "Failed to run the following command: {} error={}",
                                 formatted_command, error
                             )));
+                            self.status = FlycheckStatus::Finished;
                         }
                     }
                 }
@@ -323,7 +341,11 @@ impl FlycheckActor {
                             error
                         );
                     }
+                    if self.status == FlycheckStatus::Started {
+                        self.send(Message::ClearDiagnostics { id: self.id });
+                    }
                     self.report_progress(Progress::DidFinish(res));
+                    self.status = FlycheckStatus::Finished;
                 }
                 Event::CheckEvent(Some(message)) => match message {
                     CargoCheckMessage::CompilerArtifact(msg) => {
@@ -341,11 +363,15 @@ impl FlycheckActor {
                             message = msg.message,
                             "diagnostic received"
                         );
+                        if self.status == FlycheckStatus::Started {
+                            self.send(Message::ClearDiagnostics { id: self.id });
+                        }
                         self.send(Message::AddDiagnostic {
                             id: self.id,
                             workspace_root: self.root.clone(),
                             diagnostic: msg,
                         });
+                        self.status = FlycheckStatus::DiagnosticSent;
                     }
                 },
             }
@@ -362,6 +388,7 @@ impl FlycheckActor {
             );
             command_handle.cancel();
             self.report_progress(Progress::DidCancel);
+            self.status = FlycheckStatus::Finished;
         }
     }
 

--- a/crates/rust-analyzer/src/global_state.rs
+++ b/crates/rust-analyzer/src/global_state.rs
@@ -87,7 +87,6 @@ pub(crate) struct GlobalState {
     pub(crate) flycheck_sender: Sender<flycheck::Message>,
     pub(crate) flycheck_receiver: Receiver<flycheck::Message>,
     pub(crate) last_flycheck_error: Option<String>,
-    pub(crate) flycheck_status: FxHashMap<usize, FlycheckStatus>,
 
     // Test explorer
     pub(crate) test_run_session: Option<Vec<flycheck::CargoTestHandle>>,
@@ -166,14 +165,6 @@ pub(crate) struct GlobalStateSnapshot {
     pub(crate) flycheck: Arc<[FlycheckHandle]>,
 }
 
-#[derive(Debug, Clone)]
-pub(crate) enum FlycheckStatus {
-    Unknown,
-    Started,
-    DiagnosticReceived,
-    Finished,
-}
-
 impl std::panic::UnwindSafe for GlobalStateSnapshot {}
 
 impl GlobalState {
@@ -233,7 +224,6 @@ impl GlobalState {
             flycheck_sender,
             flycheck_receiver,
             last_flycheck_error: None,
-            flycheck_status: FxHashMap::default(),
 
             test_run_session: None,
             test_run_sender,
@@ -520,13 +510,4 @@ pub(crate) fn url_to_file_id(vfs: &vfs::Vfs, url: &Url) -> anyhow::Result<FileId
     let path = from_proto::vfs_path(url)?;
     let res = vfs.file_id(&path).ok_or_else(|| anyhow::format_err!("file not found: {path}"))?;
     Ok(res)
-}
-
-impl FlycheckStatus {
-    pub(crate) fn should_clear_old_diagnostics(&self) -> bool {
-        match self {
-            FlycheckStatus::Unknown | FlycheckStatus::Started => false,
-            FlycheckStatus::DiagnosticReceived | FlycheckStatus::Finished => true,
-        }
-    }
 }

--- a/crates/rust-analyzer/src/global_state.rs
+++ b/crates/rust-analyzer/src/global_state.rs
@@ -87,7 +87,7 @@ pub(crate) struct GlobalState {
     pub(crate) flycheck_sender: Sender<flycheck::Message>,
     pub(crate) flycheck_receiver: Receiver<flycheck::Message>,
     pub(crate) last_flycheck_error: Option<String>,
-    pub(crate) diagnostics_received: bool,
+    pub(crate) diagnostics_received: FxHashMap<usize, bool>,
 
     // Test explorer
     pub(crate) test_run_session: Option<Vec<flycheck::CargoTestHandle>>,
@@ -225,7 +225,7 @@ impl GlobalState {
             flycheck_sender,
             flycheck_receiver,
             last_flycheck_error: None,
-            diagnostics_received: false,
+            diagnostics_received: FxHashMap::default(),
 
             test_run_session: None,
             test_run_sender,

--- a/crates/rust-analyzer/src/main_loop.rs
+++ b/crates/rust-analyzer/src/main_loop.rs
@@ -19,7 +19,7 @@ use crate::{
     config::Config,
     diagnostics::fetch_native_diagnostics,
     dispatch::{NotificationDispatcher, RequestDispatcher},
-    global_state::{file_id_to_url, url_to_file_id, GlobalState},
+    global_state::{file_id_to_url, url_to_file_id, FlycheckStatus, GlobalState},
     hack_recover_crate_name,
     lsp::{
         from_proto, to_proto,
@@ -804,10 +804,13 @@ impl GlobalState {
     fn handle_flycheck_msg(&mut self, message: flycheck::Message) {
         match message {
             flycheck::Message::AddDiagnostic { id, workspace_root, diagnostic } => {
-                if !self.diagnostics_received.get(&id).copied().unwrap_or_default() {
+                let flycheck_status =
+                    self.flycheck_status.entry(id).or_insert(FlycheckStatus::Unknown);
+
+                if !flycheck_status.should_clear_old_diagnostics() {
                     self.diagnostics.clear_check(id);
-                    self.diagnostics_received.insert(id, true);
                 }
+                *flycheck_status = FlycheckStatus::DiagnosticReceived;
                 let snap = self.snapshot();
                 let diagnostics = crate::diagnostics::to_proto::map_rust_diagnostic_to_lsp(
                     &self.config.diagnostics_map(),
@@ -836,25 +839,32 @@ impl GlobalState {
             flycheck::Message::Progress { id, progress } => {
                 let (state, message) = match progress {
                     flycheck::Progress::DidStart => {
-                        self.diagnostics_received.insert(id, false);
+                        self.flycheck_status.insert(id, FlycheckStatus::Started);
                         (Progress::Begin, None)
                     }
                     flycheck::Progress::DidCheckCrate(target) => (Progress::Report, Some(target)),
                     flycheck::Progress::DidCancel => {
                         self.last_flycheck_error = None;
+                        // We do not clear
+                        self.flycheck_status.insert(id, FlycheckStatus::Finished);
                         (Progress::End, None)
                     }
                     flycheck::Progress::DidFailToRestart(err) => {
                         self.last_flycheck_error =
                             Some(format!("cargo check failed to start: {err}"));
+                        self.flycheck_status.insert(id, FlycheckStatus::Finished);
                         return;
                     }
                     flycheck::Progress::DidFinish(result) => {
                         self.last_flycheck_error =
                             result.err().map(|err| format!("cargo check failed to start: {err}"));
-                        if !self.diagnostics_received.get(&id).copied().unwrap_or_default() {
+                        let flycheck_status =
+                            self.flycheck_status.entry(id).or_insert(FlycheckStatus::Unknown);
+
+                        if !flycheck_status.should_clear_old_diagnostics() {
                             self.diagnostics.clear_check(id);
                         }
+                        *flycheck_status = FlycheckStatus::Finished;
                         (Progress::End, None)
                     }
                 };


### PR DESCRIPTION
This might be causing #17300 or it's a different bug with the same functionality.

I wonder if the decision to clear diagnostics should stay in the main loop or maybe the flycheck itself should track it and tell the mainloop?

I have used a hash map but we could just as well use a vector since the IDs are `usizes` in some given range starting at 0. It would be probably faster but this just felt a bit cleaner and it allows us to change the ID to newtype later and we can just use a hasher that returns the underlying integer.