### PR TITLE
Add preference modifier for workspace-local crates when using auto import.

### DIFF
--- a/crates/ide-assists/src/handlers/auto_import.rs
+++ b/crates/ide-assists/src/handlers/auto_import.rs
@@ -272,8 +272,10 @@ fn module_distance_heuristic(db: &dyn HirDatabase, current: &Module, item: &Modu
     // cost of importing from another crate
     let crate_boundary_cost = if current.krate() == item.krate() {
         0
-    } else if item.krate().is_builtin(db) {
+    } else if item.krate().origin(db).is_local() {
         2
+    } else if item.krate().is_builtin(db) {
+        3
     } else {
         4
     };
@@ -362,6 +364,49 @@ pub struct HashMap;
         check_auto_import_order(
             before,
             &["Import `collections::hash_map::HashMap`", "Import `foo::HashMap`"],
+        )
+    }
+
+    #[test]
+    fn prefer_workspace() {
+        let before = r"
+//- /main.rs crate:main deps:foo,bar
+HashMap$0::new();
+
+//- /lib.rs crate:foo
+pub mod module {
+    pub struct HashMap;
+}
+
+//- /lib.rs crate:bar library
+pub struct HashMap;
+        ";
+
+        check_auto_import_order(before, &["Import `foo::module::HashMap`", "Import `bar::HashMap`"])
+    }
+
+    #[test]
+    fn prefer_non_local_over_long_path() {
+        let before = r"
+//- /main.rs crate:main deps:foo,bar
+HashMap$0::new();
+
+//- /lib.rs crate:foo
+pub mod deeply {
+    pub mod nested {
+        pub mod module {
+            pub struct HashMap;
+        }
+    }
+}
+
+//- /lib.rs crate:bar library
+pub struct HashMap;
+        ";
+
+        check_auto_import_order(
+            before,
+            &["Import `bar::HashMap`", "Import `foo::deeply::nested::module::HashMap`"],
         )
     }
 


### PR DESCRIPTION
@joshka pointed out some odd behavior of auto import ordering. It doesn't seem that the current heuristics were applying any sort of precedence to imports from the workspace. I've went ahead and added that.

I hope to get some feedback on the modifier numbers here. I just went with something that felt like it balanced giving more power to workspace crates without completely ignoring relative path distance.

closes https://github.com/rust-lang/rust-analyzer/issues/17303