### PR TITLE
Don't mark `#[rustc_deprecated_safe_2024]` functions as unsafe

### DIFF
--- a/crates/hir-def/src/attr/builtin.rs
+++ b/crates/hir-def/src/attr/builtin.rs
@@ -628,6 +628,10 @@ pub const INERT_ATTRIBUTES: &[BuiltinAttribute] = &[
         rustc_safe_intrinsic, Normal, template!(Word), WarnFollowing,
         "the `#[rustc_safe_intrinsic]` attribute is used internally to mark intrinsics as safe"
     ),
+    rustc_attr!(
+        rustc_deprecated_safe_2024, Normal, template!(Word), WarnFollowing,
+        "the `#[rustc_safe_intrinsic]` marks functions as unsafe in Rust 2024",
+    ),
 
     // ==========================================================================
     // Internal attributes, Testing:

--- a/crates/hir-ty/src/utils.rs
+++ b/crates/hir-ty/src/utils.rs
@@ -534,6 +534,11 @@ fn parent_generic_def(db: &dyn DefDatabase, def: GenericDefId) -> Option<Generic
 pub fn is_fn_unsafe_to_call(db: &dyn HirDatabase, func: FunctionId) -> bool {
     let data = db.function_data(func);
     if data.has_unsafe_kw() {
+        // Functions that are `#[rustc_deprecated_safe_2024]` are safe to call before 2024.
+        if db.attrs(func.into()).by_key("rustc_deprecated_safe_2024").exists() {
+            // FIXME: Properly check the caller span and mark it as unsafe after 2024.
+            return false;
+        }
         return true;
     }
 

--- a/crates/ide-diagnostics/src/handlers/missing_unsafe.rs
+++ b/crates/ide-diagnostics/src/handlers/missing_unsafe.rs
@@ -183,6 +183,20 @@ fn main() {
     }
 
     #[test]
+    fn no_missing_unsafe_diagnostic_with_deprecated_safe_2024() {
+        check_diagnostics(
+            r#"
+#[rustc_deprecated_safe_2024]
+fn set_var() {}
+
+fn main() {
+    set_var();
+}
+"#,
+        );
+    }
+
+    #[test]
     fn add_unsafe_block_when_dereferencing_a_raw_pointer() {
         check_fix(
             r#"


### PR DESCRIPTION
`std::env::set_var` will be unsafe in edition 2024, but not before it. I couldn't quite figure out how to check for the span properly, so for now we just turn the false positives into false negatives, which are less bad.