### PR TITLE
chore: Update Cargo.lock to avoid yanked version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -891,9 +891,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.154"
+version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae743338b92ff9146ce83992f766a31066a91a8c84a45e0e9f21e7cf6de6d346"
+checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "libloading"


### PR DESCRIPTION
Building rust-analyzer currently generates a warning because libc 0.2.154 has been yanked. Update to 0.2.155 in Cargo.lock.