### PR TITLE
fix: Highlight unlinked files consistently with inactive files

### DIFF
--- a/crates/ide-diagnostics/src/handlers/unlinked_file.rs
+++ b/crates/ide-diagnostics/src/handlers/unlinked_file.rs
@@ -11,7 +11,7 @@ use ide_db::{
 use paths::Utf8Component;
 use syntax::{
     ast::{self, edit::IndentLevel, HasModuleItem, HasName},
-    AstNode, TextRange,
+    AstNode,
 };
 use text_edit::TextEdit;
 
@@ -26,8 +26,6 @@ pub(crate) fn unlinked_file(
     acc: &mut Vec<Diagnostic>,
     file_id: FileId,
 ) {
-    // Limit diagnostic to the first few characters in the file. This matches how VS Code
-    // renders it with the full span, but on other editors, and is less invasive.
     let fixes = fixes(ctx, file_id);
     // FIXME: This is a hack for the vscode extension to notice whether there is an autofix or not before having to resolve diagnostics.
     // This is to prevent project linking popups from appearing when there is an autofix. https://github.com/rust-lang/rust-analyzer/issues/14523
@@ -38,13 +36,6 @@ pub(crate) fn unlinked_file(
     };
 
     let range = ctx.sema.db.parse(file_id).syntax_node().text_range();
-    let range = FileLoader::file_text(ctx.sema.db, file_id)
-        .char_indices()
-        .take(3)
-        .last()
-        .map(|(i, _)| i)
-        .map(|i| TextRange::up_to(i.try_into().unwrap()))
-        .unwrap_or(range);
 
     acc.push(
         Diagnostic::new(
@@ -52,6 +43,7 @@ pub(crate) fn unlinked_file(
             message,
             FileRange { file_id, range },
         )
+        .with_unused(true)
         .with_fixes(fixes),
     );
 }


### PR DESCRIPTION
Currently, rust-analyzer highlights the entire region when a `cfg` is inactive (e.g. `#[cfg(windows)]` on a Linux machine). However, unlinked files only highlight the first three characters of the file.

This was introduced in #8444, but users have repeatedly found themselves with no rust-analyzer support for a file and unsure why (see e.g. #13226 and the intentionally prominent pop-up added in PR #14366).

(Anecdotally, we see this issue bite our users regularly, particularly people new to Rust.)

Instead, highlight the entire inactive file, but mark it as all as unused. This allows users to hover and run the quickfix from any line.

Whilst this is marginally more prominent, it's less invasive than a pop-up, and users do want to know why they're getting no rust-analyzer support in certain files.

Before (note the subtle grey underline is only at the beginning of the first line):

![Screenshot 2024-06-05 at 5 41 17 PM](https://github.com/rust-lang/rust-analyzer/assets/70800/96f5d778-612e-4838-876d-35d9647fe2aa)

After (user can hover and fix from any line):

![Screenshot 2024-06-05 at 5 42 13 PM](https://github.com/rust-lang/rust-analyzer/assets/70800/6af90b79-018c-42b9-b3c5-f497de2ccbff)
