### PR TITLE
fix: incorrect formatting of hover actions

### DIFF
--- a/crates/ide/src/hover.rs
+++ b/crates/ide/src/hover.rs
@@ -375,8 +375,8 @@ pub(crate) fn hover_for_definition(
     HoverResult {
         markup: render::process_markup(sema.db, def, &markup, config),
         actions: [
-            show_implementations_action(sema.db, def),
             show_fn_references_action(sema.db, def),
+            show_implementations_action(sema.db, def),
             runnable_action(sema, def, file_id),
             goto_type_action_for_def(sema.db, def, &notable_traits),
         ]

--- a/editors/code/src/client.ts
+++ b/editors/code/src/client.ts
@@ -63,7 +63,7 @@ function renderHoverActions(actions: ra.CommandLinkGroup[]): vscode.MarkdownStri
                 (group.title ? group.title + " " : "") +
                 group.commands.map(renderCommand).join(" | "),
         )
-        .join("___");
+        .join(" | ");
 
     const result = new vscode.MarkdownString(text);
     result.isTrusted = true;


### PR DESCRIPTION
fix #12728.

### Changes

- Use ` | ` as the separator for actions. (I'm not sure why we use `___` previously)
- Reorder actions to match codelens