### PR TITLE
feat: show type bounds from containers when hovering on functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -512,6 +512,7 @@ dependencies = [
  "hir-def",
  "hir-expand",
  "hir-ty",
+ "intern",
  "itertools",
  "once_cell",
  "rustc-hash",

--- a/crates/hir/Cargo.toml
+++ b/crates/hir/Cargo.toml
@@ -27,6 +27,7 @@ cfg.workspace = true
 hir-def.workspace = true
 hir-expand.workspace = true
 hir-ty.workspace = true
+intern.workspace = true
 stdx.workspace = true
 syntax.workspace = true
 tt.workspace = true

--- a/crates/hir/src/display.rs
+++ b/crates/hir/src/display.rs
@@ -36,13 +36,13 @@ impl HirDisplay for Function {
 
         match container {
             Some(AssocItemContainer::Trait(trait_)) => {
-                if f.show_container_bounds() {
+                if f.show_container_bounds() && !f.db.generic_params(trait_.id.into()).is_empty() {
                     write_trait_header(&trait_, f)?;
                     f.write_str("\n")?;
                 }
             }
             Some(AssocItemContainer::Impl(impl_)) => {
-                if f.show_container_bounds() {
+                if f.show_container_bounds() && !f.db.generic_params(impl_.id.into()).is_empty() {
                     write_impl_header(&impl_, f)?;
                     f.write_str("\n")?;
                 }

--- a/crates/ide/src/hover/render.rs
+++ b/crates/ide/src/hover/render.rs
@@ -430,6 +430,7 @@ pub(super) fn definition(
             }
             label
         }
+        Definition::Function(fn_) => fn_.display_with_container_bounds(db, true).to_string(),
         _ => def.label(db),
     };
     let docs = def.docs(db, famous_defs);


### PR DESCRIPTION
fix #12917.

### Changes

1. Added Support for displaying the container and type bounds from it when hovering on functions with generic types.
2. Added a user config to determine whether to display container bounds (enabled by default).
3. Added regression tests.
4. Simplified and refactored `hir/display.rs` to improve readability.