### PR TITLE
fix: Fix generated markers not being patchable in package.json

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -4,6 +4,7 @@ tq = "test -- -q"
 qt = "tq"
 lint = "clippy --all-targets -- --cap-lints warn"
 codegen = "run --package xtask --bin xtask -- codegen"
+dist = "run --package xtask --bin xtask -- dist"
 
 [target.x86_64-pc-windows-msvc]
 linker = "rust-lld"

--- a/xtask/src/dist.rs
+++ b/xtask/src/dist.rs
@@ -70,11 +70,8 @@ fn dist_client(
             &format!(r#""version": "{version}""#),
         )
         .replace(r#""releaseTag": null"#, &format!(r#""releaseTag": "{release_tag}""#))
-        .replace(
-            "            {\n                \"title\": \"$generated-start\"\n            },\n",
-            "",
-        )
-        .replace("            { \"title\": \"$generated-end\" }\n", "")
+        .replace(r#""title": "$generated-start""#, "")
+        .replace(r#""title": "$generated-end""#, "")
         .replace(r#""enabledApiProposals": [],"#, r#""#);
     patch.commit(sh)?;
 


### PR DESCRIPTION
I think the newlines are tripping up CI, so I hope clearing the property to leave an empty object won't make VSCode made here.