### PR TITLE
internal: Prefer .expect() over .unwrap() in flycheck

### DIFF
--- a/crates/flycheck/src/lib.rs
+++ b/crates/flycheck/src/lib.rs
@@ -328,7 +328,8 @@ impl FlycheckActor {
                     tracing::debug!(flycheck_id = self.id, "flycheck finished");
 
                     // Watcher finished
-                    let command_handle = self.command_handle.take().unwrap();
+                    let command_handle =
+                        self.command_handle.take().expect("expected a flycheck command handle");
                     self.command_receiver.take();
                     let formatted_handle = format!("{command_handle:?}");
 

--- a/crates/rust-analyzer/src/reload.rs
+++ b/crates/rust-analyzer/src/reload.rs
@@ -695,7 +695,7 @@ impl GlobalState {
         self.flycheck = match invocation_strategy {
             flycheck::InvocationStrategy::Once => vec![FlycheckHandle::spawn(
                 0,
-                Box::new(move |msg| sender.send(msg).unwrap()),
+                Box::new(move |msg| sender.send(msg).expect("flycheck channel should be connected during spawning")),
                 config,
                 None,
                 self.config.root_path().clone(),
@@ -733,7 +733,7 @@ impl GlobalState {
                         let sender = sender.clone();
                         FlycheckHandle::spawn(
                             id,
-                            Box::new(move |msg| sender.send(msg).unwrap()),
+                            Box::new(move |msg| sender.send(msg).expect("flycheck channel should be connected during per-workspace spawning")),
                             config.clone(),
                             sysroot_root,
                             root.to_path_buf(),


### PR DESCRIPTION
I managed to hit these `.unwrap()` calls a few times when debugging, so replace them with `.expect()` calls with unique text descriptions.