### PR TITLE
fix: Improve hover text in unlinked file diagnostics

### DIFF
--- a/crates/ide-diagnostics/src/handlers/unlinked_file.rs
+++ b/crates/ide-diagnostics/src/handlers/unlinked_file.rs
@@ -30,10 +30,12 @@ pub(crate) fn unlinked_file(
     // FIXME: This is a hack for the vscode extension to notice whether there is an autofix or not before having to resolve diagnostics.
     // This is to prevent project linking popups from appearing when there is an autofix. https://github.com/rust-lang/rust-analyzer/issues/14523
     let message = if fixes.is_none() {
-        "file not included in crate hierarchy"
+        "This file is not included in any crates, so rust-analyzer can't offer IDE services."
     } else {
-        "file not included in module tree"
+        "This file is not included anywhere in the module tree, so rust-analyzer can't offer IDE services."
     };
+
+    let message = format!("{message}\n\nIf you're intentionally working on unowned files, you can silence this warning by adding \"unlinked-file\" to rust-analyzer.diagnostics.disabled in your settings.");
 
     let mut range = ctx.sema.db.parse(file_id).syntax_node().text_range();
     let mut unused = true;

--- a/editors/code/src/client.ts
+++ b/editors/code/src/client.ts
@@ -76,7 +76,8 @@ export async function createClient(
                         // value === "unlinked-file" &&
                         value === "temporary-disabled" &&
                         !unlinkedFiles.includes(uri) &&
-                        diag.message !== "file not included in module tree"
+                        (diag.message === "file not included in crate hierarchy" ||
+                            diag.message.startsWith("This file is not included in any crates"))
                     ) {
                         const config = vscode.workspace.getConfiguration("rust-analyzer");
                         if (config.get("showUnlinkedFileNotification")) {


### PR DESCRIPTION
Use full sentences, and mention how to disable the diagnostic if users are intentionally working on unowned files.

![Screenshot 2024-06-12 at 5 55 48 PM](https://github.com/rust-lang/rust-analyzer/assets/70800/c91ee1ed-1c72-495a-9ee3-9e360a5c6977)

(Full disclosure: I've tested a rust-analyzer build in VS Code, but the pop-up logic is currently disabled due to #17062, so I haven't tested that.)