### PR TITLE
fix: add a breaker to avoid infinite loops from source root cycles

### DIFF
--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -2531,12 +2531,21 @@ macro_rules! _impl_for_config_data {
                 #[allow(non_snake_case)]
                 $vis fn $field(&self, source_root: Option<SourceRootId>) -> &$ty {
                     let mut par: Option<SourceRootId> = source_root;
+                    let mut traversals = 0;
                     while let Some(source_root_id) = par {
                         par = self.source_root_parent_map.get(&source_root_id).copied();
                         if let Some((config, _)) = self.ratoml_files.get(&source_root_id) {
                             if let Some(value) = config.$field.as_ref() {
                                 return value;
                             }
+                        }
+                        // Prevent infinite loops caused by cycles by giving up when it's
+                        // clear that we must have either visited all source roots or
+                        // encountered a cycle.
+                        traversals += 1;
+                        if traversals >= self.source_root_parent_map.len() {
+                            // i.e. no source root contains the config we're looking for
+                            break;
                         }
                     }
 


### PR DESCRIPTION
See #17409 

This patch prevents infinite looping from cycles by giving up if the number of source roots checked for a config value reaches the total number of source roots.

Alternative more precise options include creating a set of all source roots visited and giving up as soon as a cycle is encountered, but I wasn't sure how costly an allocation would be here for performance.

Can confirm that locally this fixes the problem for me.