### PR TITLE
Filter builtin macro expansion

### DIFF
--- a/crates/hir/src/semantics.rs
+++ b/crates/hir/src/semantics.rs
@@ -345,7 +345,13 @@ impl<'db> SemanticsImpl<'db> {
             ) => {
                 // Do nothing and allow matching macros to be expanded
             }
-            _ => return None,
+
+            hir_expand::MacroDefKind::BuiltIn(_, _)
+            | hir_expand::MacroDefKind::BuiltInAttr(_, _)
+            | hir_expand::MacroDefKind::BuiltInEager(_, _)
+            | hir_expand::MacroDefKind::BuiltInDerive(_, _) => return None,
+
+            _ => (),
         }
 
         let node = self.parse_or_expand(file_id.into());

--- a/crates/hir/src/semantics.rs
+++ b/crates/hir/src/semantics.rs
@@ -347,8 +347,7 @@ impl<'db> SemanticsImpl<'db> {
                 BuiltinFnLikeExpander::Cfg
                 | BuiltinFnLikeExpander::StdPanic
                 | BuiltinFnLikeExpander::Stringify
-                | BuiltinFnLikeExpander::CorePanic
-                | BuiltinFnLikeExpander::FormatArgs,
+                | BuiltinFnLikeExpander::CorePanic,
             )
             | hir_expand::MacroDefKind::BuiltInEager(
                 _,

--- a/crates/hir/src/semantics.rs
+++ b/crates/hir/src/semantics.rs
@@ -323,6 +323,22 @@ impl<'db> SemanticsImpl<'db> {
         } else {
             sa.expand(self.db, macro_call)?
         };
+
+        let node = self.parse_or_expand(file_id.into());
+        Some(node)
+    }
+
+    pub fn expand_allowed_builtins(&self, macro_call: &ast::MacroCall) -> Option<SyntaxNode> {
+        let sa = self.analyze_no_infer(macro_call.syntax())?;
+
+        let macro_call = InFile::new(sa.file_id, macro_call);
+        let file_id = if let Some(call) =
+            <ast::MacroCall as crate::semantics::ToDef>::to_def(self, macro_call)
+        {
+            call.as_macro_file()
+        } else {
+            sa.expand(self.db, macro_call)?
+        };
         let macro_call = self.db.lookup_intern_macro_call(file_id.macro_call_id);
 
         match macro_call.def.kind {

--- a/crates/hir/src/semantics.rs
+++ b/crates/hir/src/semantics.rs
@@ -331,7 +331,8 @@ impl<'db> SemanticsImpl<'db> {
                 BuiltinFnLikeExpander::Cfg
                 | BuiltinFnLikeExpander::StdPanic
                 | BuiltinFnLikeExpander::Stringify
-                | BuiltinFnLikeExpander::CorePanic,
+                | BuiltinFnLikeExpander::CorePanic
+                | BuiltinFnLikeExpander::FormatArgs,
             )
             | hir_expand::MacroDefKind::BuiltInEager(
                 _,

--- a/crates/ide/src/expand_macro.rs
+++ b/crates/ide/src/expand_macro.rs
@@ -233,8 +233,8 @@ mod tests {
     fn expand_allowed_builtin_macro() {
         check(
             r#"
-            //- minicore: concat
-            $0concat!("test", 10, 'b', true);"#,
+//- minicore: concat
+$0concat!("test", 10, 'b', true);"#,
             expect![[r#"
                 concat!
                 "test10btrue""#]],
@@ -245,8 +245,8 @@ mod tests {
     fn do_not_expand_disallowed_macro() {
         let (analysis, pos) = fixture::position(
             r#"
-        //- minicore: asm
-        $0asm!("0x300, x0");"#,
+//- minicore: asm
+$0asm!("0x300, x0");"#,
         );
         let expansion = analysis.expand_macro(pos).unwrap();
         assert!(expansion.is_none());

--- a/crates/ide/src/expand_macro.rs
+++ b/crates/ide/src/expand_macro.rs
@@ -230,29 +230,26 @@ mod tests {
     }
 
     #[test]
-    fn only_expand_allowed_builtin_macro() {
-        let fail_tests = [r#"
-        //- minicore: asm
-        $0asm!("0x300, x0");
-            "#];
-
-        for test in fail_tests {
-            let (analysis, pos) = fixture::position(test);
-            let expansion = analysis.expand_macro(pos).unwrap();
-            assert!(expansion.is_none());
-        }
-
-        let tests = [(
+    fn expand_allowed_builtin_macro() {
+        check(
             r#"
             //- minicore: concat
             $0concat!("test", 10, 'b', true);"#,
             expect![[r#"
                 concat!
                 "test10btrue""#]],
-        )];
-        for (test, expect) in tests {
-            check(test, expect);
-        }
+        );
+    }
+
+    #[test]
+    fn do_not_expand_disallowed_macro() {
+        let (analysis, pos) = fixture::position(
+            r#"
+        //- minicore: asm
+        $0asm!("0x300, x0");"#,
+        );
+        let expansion = analysis.expand_macro(pos).unwrap();
+        assert!(expansion.is_none());
     }
 
     #[test]

--- a/crates/ide/src/expand_macro.rs
+++ b/crates/ide/src/expand_macro.rs
@@ -111,9 +111,10 @@ fn expand_macro_recur(
     macro_call: &ast::Item,
 ) -> Option<SyntaxNode> {
     let expanded = match macro_call {
-        item @ ast::Item::MacroCall(macro_call) => {
-            sema.expand_attr_macro(item).or_else(|| sema.expand(macro_call))?.clone_for_update()
-        }
+        item @ ast::Item::MacroCall(macro_call) => sema
+            .expand_attr_macro(item)
+            .or_else(|| sema.expand_allowed_builtins(macro_call))?
+            .clone_for_update(),
         item => sema.expand_attr_macro(item)?.clone_for_update(),
     };
     expand(sema, expanded)

--- a/crates/ide/src/expand_macro.rs
+++ b/crates/ide/src/expand_macro.rs
@@ -229,6 +229,32 @@ mod tests {
     }
 
     #[test]
+    fn only_expand_allowed_builtin_macro() {
+        let fail_tests = [r#"
+        //- minicore: asm
+        $0asm!("0x300, x0");
+            "#];
+
+        for test in fail_tests {
+            let (analysis, pos) = fixture::position(test);
+            let expansion = analysis.expand_macro(pos).unwrap();
+            assert!(expansion.is_none());
+        }
+
+        let tests = [(
+            r#"
+            //- minicore: concat
+            $0concat!("test", 10, 'b', true);"#,
+            expect![[r#"
+                concat!
+                "test10btrue""#]],
+        )];
+        for (test, expect) in tests {
+            check(test, expect);
+        }
+    }
+
+    #[test]
     fn macro_expand_as_keyword() {
         check(
             r#"


### PR DESCRIPTION
This PR adds a filter on the types of built in macros that are allowed to be expanded. 

Currently, This list of allowed macros contains, `stringify, cfg, core_panic, std_panic, concat, concat_bytes, include, include_str, include_bytes, env` and `option_env`.

Fixes #14177