### PR TITLE
Remove panicbit.cargo extension warning

### DIFF
--- a/editors/code/src/main.ts
+++ b/editors/code/src/main.ts
@@ -204,14 +204,4 @@ function checkConflictingExtensions() {
             )
             .then(() => {}, console.error);
     }
-
-    if (vscode.extensions.getExtension("panicbit.cargo")) {
-        vscode.window
-            .showWarningMessage(
-                `You have both the rust-analyzer (rust-lang.rust-analyzer) and Cargo (panicbit.cargo) plugins enabled, ` +
-                    'you can disable it or set {"cargo.automaticCheck": false} in settings.json to avoid invoking cargo twice',
-                "Got it",
-            )
-            .then(() => {}, console.error);
-    }
 }


### PR DESCRIPTION
A warning was introduced regarding the incompatabilities between `rust-analyzer` and `panicbit.cargo`'s diagnostics / `cargo check` functionality.

This functionality has been removed in the latest version of the cargo extension (`0.3.0`), which is why the warning can be removed now.