### PR TITLE
fix(completion): complete async keyword

### DIFF
--- a/crates/ide-completion/src/completions/item_list.rs
+++ b/crates/ide-completion/src/completions/item_list.rs
@@ -100,6 +100,7 @@ fn add_keywords(acc: &mut Completions, ctx: &CompletionContext<'_>, kind: Option
             add_keyword("enum", "enum $1 {\n    $0\n}");
             add_keyword("mod", "mod $0");
             add_keyword("static", "static $0");
+            add_keyword("async", "async $0");
             add_keyword("struct", "struct $0");
             add_keyword("trait", "trait $1 {\n    $0\n}");
             add_keyword("union", "union $1 {\n    $0\n}");

--- a/crates/ide-completion/src/tests/expression.rs
+++ b/crates/ide-completion/src/tests/expression.rs
@@ -141,6 +141,7 @@ impl Unit {
             un Union        Union
             ev TupleV(…)    TupleV(u32)
             bt u32          u32
+            kw async
             kw const
             kw crate::
             kw enum
@@ -217,6 +218,7 @@ fn complete_in_block() {
         expect![[r#"
             fn foo()       fn()
             bt u32         u32
+            kw async
             kw const
             kw crate::
             kw enum
@@ -264,6 +266,7 @@ fn complete_after_if_expr() {
         expect![[r#"
             fn foo()       fn()
             bt u32         u32
+            kw async
             kw const
             kw crate::
             kw else
@@ -336,6 +339,7 @@ fn completes_in_loop_ctx() {
         expect![[r#"
             fn my()        fn()
             bt u32         u32
+            kw async
             kw break
             kw const
             kw continue
@@ -799,6 +803,7 @@ fn foo() { if foo {} $0 }
         expect![[r#"
             fn foo()       fn()
             bt u32         u32
+            kw async
             kw const
             kw crate::
             kw else
@@ -839,6 +844,7 @@ fn foo() { if foo {} el$0 }
         expect![[r#"
             fn foo()       fn()
             bt u32         u32
+            kw async
             kw const
             kw crate::
             kw else
@@ -927,6 +933,7 @@ fn foo() { if foo {} $0 let x = 92; }
         expect![[r#"
             fn foo()       fn()
             bt u32         u32
+            kw async
             kw const
             kw crate::
             kw else
@@ -967,6 +974,7 @@ fn foo() { if foo {} el$0 let x = 92; }
         expect![[r#"
             fn foo()       fn()
             bt u32         u32
+            kw async
             kw const
             kw crate::
             kw else
@@ -1007,6 +1015,7 @@ fn foo() { if foo {} el$0 { let x = 92; } }
         expect![[r#"
             fn foo()       fn()
             bt u32         u32
+            kw async
             kw const
             kw crate::
             kw else
@@ -1059,6 +1068,7 @@ pub struct UnstableThisShouldNotBeListed;
             fn main()      fn()
             md std
             bt u32         u32
+            kw async
             kw const
             kw crate::
             kw enum
@@ -1111,6 +1121,7 @@ pub struct UnstableButWeAreOnNightlyAnyway;
             md std
             st UnstableButWeAreOnNightlyAnyway UnstableButWeAreOnNightlyAnyway
             bt u32                    u32
+            kw async
             kw const
             kw crate::
             kw enum

--- a/crates/ide-completion/src/tests/item_list.rs
+++ b/crates/ide-completion/src/tests/item_list.rs
@@ -14,6 +14,7 @@ fn in_mod_item_list() {
         r#"mod tests { $0 }"#,
         expect![[r#"
             ma makro!(…)           macro_rules! makro
+            kw async
             kw const
             kw crate::
             kw enum
@@ -47,6 +48,7 @@ fn in_source_file_item_list() {
         expect![[r#"
             ma makro!(…)           macro_rules! makro
             md module
+            kw async
             kw const
             kw crate::
             kw enum
@@ -79,6 +81,7 @@ fn in_item_list_after_attr() {
         expect![[r#"
             ma makro!(…)           macro_rules! makro
             md module
+            kw async
             kw const
             kw crate::
             kw enum
@@ -132,6 +135,7 @@ fn after_visibility() {
     check(
         r#"pub $0"#,
         expect![[r#"
+            kw async
             kw const
             kw enum
             kw extern
@@ -356,6 +360,7 @@ fn after_unit_struct() {
         expect![[r#"
             ma makro!(…)           macro_rules! makro
             md module
+            kw async
             kw const
             kw crate::
             kw enum

--- a/crates/ide-completion/src/tests/special.rs
+++ b/crates/ide-completion/src/tests/special.rs
@@ -1017,6 +1017,7 @@ fn here_we_go() {
             fn here_we_go()    fn()
             st Foo (alias Bar) Foo
             bt u32             u32
+            kw async
             kw const
             kw crate::
             kw enum
@@ -1066,6 +1067,7 @@ fn here_we_go() {
             fn here_we_go()           fn()
             st Foo (alias Bar, Qux, Baz) Foo
             bt u32                    u32
+            kw async
             kw const
             kw crate::
             kw enum
@@ -1188,6 +1190,7 @@ fn bar() { qu$0 }
             fn bar()             fn()
             fn foo() (alias qux) fn()
             bt u32               u32
+            kw async
             kw const
             kw crate::
             kw enum
@@ -1443,6 +1446,7 @@ fn foo() {
         expect![[r#"
             fn foo()       fn()
             bt u32         u32
+            kw async
             kw const
             kw crate::
             kw enum


### PR DESCRIPTION
Fixes #17452 

Not entirely confident of the fix here, but my logic is that `async` should in general be offered in similar semantic scenarios as other keywords like `static` or `pub`.