### PR TITLE
#17470 - run unit tests at the crate level not workspace

### DIFF
--- a/crates/flycheck/src/lib.rs
+++ b/crates/flycheck/src/lib.rs
@@ -24,7 +24,7 @@ pub mod project_json;
 mod test_runner;
 
 use command::{CommandHandle, ParseFromLine};
-pub use test_runner::{CargoTestHandle, CargoTestMessage, TestState};
+pub use test_runner::{CargoTestHandle, CargoTestMessage, TestState, TestTarget};
 
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
 pub enum InvocationStrategy {

--- a/crates/flycheck/src/test_runner.rs
+++ b/crates/flycheck/src/test_runner.rs
@@ -59,19 +59,38 @@ pub struct CargoTestHandle {
 }
 
 // Example of a cargo test command:
-// cargo test --workspace --no-fail-fast -- module::func -Z unstable-options --format=json
+// cargo test --workspace --no-fail-fast -- -Z unstable-options --format=json
+// or
+// cargo test --package my-package --no-fail-fast -- module::func -Z unstable-options --format=json
+
+#[derive(Debug)]
+pub enum TestTarget {
+    Workspace,
+    Package(String),
+}
 
 impl CargoTestHandle {
     pub fn new(
         path: Option<&str>,
         options: CargoOptions,
         root: &AbsPath,
+        test_target: TestTarget,
         sender: Sender<CargoTestMessage>,
     ) -> std::io::Result<Self> {
         let mut cmd = Command::new(Tool::Cargo.path());
         cmd.env("RUSTC_BOOTSTRAP", "1");
         cmd.arg("test");
-        cmd.arg("--workspace");
+
+        match &test_target {
+            TestTarget::Package(package) => {
+                cmd.arg("--package");
+                cmd.arg(package);
+            }
+            TestTarget::Workspace => {
+                cmd.arg("--workspace");
+            }
+        };
+
         // --no-fail-fast is needed to ensure that all requested tests will run
         cmd.arg("--no-fail-fast");
         cmd.arg("--manifest-path");


### PR DESCRIPTION
For https://github.com/rust-lang/rust-analyzer/issues/17470

Use the test path to identify a package in the workspace and run the unit test there instead of at the workspace.