### PR TITLE
minor : Fix duplicate snippets showing up on hover.

### DIFF
--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -844,6 +844,9 @@ impl Config {
             config.source_root_parent_map = source_root_map;
         }
 
+        // IMPORTANT : This holds as long as ` completion_snippets_custom` is declared `client`.
+        config.snippets = vec![];
+
         let snips = self.completion_snippets_custom().to_owned();
 
         for (name, def) in snips.iter() {

--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -845,7 +845,7 @@ impl Config {
         }
 
         // IMPORTANT : This holds as long as ` completion_snippets_custom` is declared `client`.
-        config.snippets = vec![];
+        config.snippets.clear();
 
         let snips = self.completion_snippets_custom().to_owned();
 


### PR DESCRIPTION
With each `config::apply_change` duplicate configs were being added.
Now we first drain the vec that holds these and then start adding. This fixes #17485