### PR TITLE
Inspect named constants for `DefMap` collecting during method resolution

### DIFF
--- a/crates/ide-diagnostics/src/handlers/non_exhaustive_let.rs
+++ b/crates/ide-diagnostics/src/handlers/non_exhaustive_let.rs
@@ -44,4 +44,28 @@ fn main() {
 "#,
         );
     }
+
+    #[test]
+    fn regression_issue_17031() {
+        check_diagnostics(
+            r#"
+pub trait Foo {
+    type Bar;
+    fn foo(bar: Self::Bar);
+}
+
+pub struct FooImpl;
+
+const FOO_IMPL: () = {
+    impl Foo for FooImpl {
+        type Bar = ();
+
+        fn foo(bar: Self::Bar) {
+            let () = bar;
+        }
+    }
+};
+"#,
+        );
+    }
 }


### PR DESCRIPTION
Fixes #17031 

Besides that issue, this won't fix the cases like;

```rust
pub trait Foo {
    type Bar;
    fn foo(bar: Self::Bar);
}

pub struct FooImpl;

fn foo_impl() {
    impl Foo for FooImpl {
        type Bar = ();

        fn foo(_bar: Self::Bar) {
            let () = _bar; // non-exhaustive pattern: `_` not covered reported here
        }
    }
}
```

which simply replaces the const block in the example code of the original issue with a function 😢 

Rust Analyzer doesn't inspect all the blocks and bodies but only some "closer" ones for implementation searching and I think that makes sense since for IDE, we cannot wait very long time for such full-search.
But sometimes this makes some false-positive diagnostics like in the above code or some failures in associated type inferences.

I wonder what is the proper way to handle such cases.
Maybe we can just do the same as now for the "first pass", and if there are some inference failures or diagnostics, (rollback to a snapshot if needed and) search more blocks and bodies 🤔 