### PR TITLE
do not normalize `use foo::{self}` to `use foo`

### DIFF
--- a/crates/ide-assists/src/handlers/merge_imports.rs
+++ b/crates/ide-assists/src/handlers/merge_imports.rs
@@ -490,6 +490,25 @@ use foo::bar;
     }
 
     #[test]
+    fn test_merge_nested_empty_and_self_with_other() {
+        check_assist(
+            merge_imports,
+            r"
+use foo::$0{bar};
+use foo::{bar::{self, other}};
+",
+            r"
+use foo::bar::{self, other};
+",
+        );
+        check_assist_import_one_variations!(
+            "foo::$0{bar}",
+            "foo::{bar::{self, other}}",
+            "use {foo::bar::{self, other}};"
+        );
+    }
+
+    #[test]
     fn test_merge_nested_list_self_and_glob() {
         check_assist(
             merge_imports,

--- a/crates/ide-assists/src/handlers/normalize_import.rs
+++ b/crates/ide-assists/src/handlers/normalize_import.rs
@@ -120,9 +120,38 @@ mod tests {
     }
 
     #[test]
+    fn test_braces_kept() {
+        check_assist_not_applicable_variations!("foo::bar::{$0self}");
+
+        // This code compiles but transforming "bar::{self}" into "bar" causes a
+        // compilation error (the name `bar` is defined multiple times).
+        // Therefore, the normalize_input assist must not apply here.
+        check_assist_not_applicable(
+            normalize_import,
+            r"
+mod foo {
+
+    pub mod bar {}
+
+    pub const bar: i32 = 8;
+}
+
+use foo::bar::{$0self};
+
+const bar: u32 = 99;
+
+fn main() {
+    let local_bar = bar;
+}
+
+",
+        );
+    }
+
+    #[test]
     fn test_redundant_braces() {
         check_assist_variations!("foo::{bar::{baz, Qux}}", "foo::bar::{baz, Qux}");
-        check_assist_variations!("foo::{bar::{self}}", "foo::bar");
+        check_assist_variations!("foo::{bar::{self}}", "foo::bar::{self}");
         check_assist_variations!("foo::{bar::{*}}", "foo::bar::*");
         check_assist_variations!("foo::{bar::{Qux as Quux}}", "foo::bar::Qux as Quux");
         check_assist_variations!(


### PR DESCRIPTION
It changes behaviour and can cause collisions. E.g. for the following snippet

```rs
mod foo {

    pub mod bar {}

    pub const bar: i32 = 8;
}

// transforming the below to `use foo::bar;` causes the error:
//
//   the name `bar` is defined multiple times
use foo::bar::{self};

const bar: u32 = 99;

fn main() {
    let local_bar = bar;
}
```

we still normalize

```rs
use foo::bar;
use foo::bar::{self};
```

to `use foo::bar;` because this cannot cause collisions.

See: https://github.com/rust-lang/rust-analyzer/pull/17140#issuecomment-2079189725
