### PR TITLE
#17497 - Invalid RA diagnostic error: expected 2 arguments, found 1

### DIFF
--- a/crates/hir-ty/src/infer/expr.rs
+++ b/crates/hir-ty/src/infer/expr.rs
@@ -1574,6 +1574,7 @@ impl InferenceContext<'_> {
                     self.get_traits_in_scope().as_ref().left_or_else(|&it| it),
                     VisibleFromModule::Filter(self.resolver.module()),
                     name,
+                    method_resolution::LookupHeuristic::Default,
                 );
                 self.result.diagnostics.push(InferenceDiagnostic::UnresolvedField {
                     expr: tgt_expr,
@@ -1623,6 +1624,7 @@ impl InferenceContext<'_> {
             self.get_traits_in_scope().as_ref().left_or_else(|&it| it),
             VisibleFromModule::Filter(self.resolver.module()),
             method_name,
+            method_resolution::LookupHeuristic::PreferResolvedAutoderef,
         );
         let (receiver_ty, method_ty, substs) = match resolved {
             Some((adjust, func, visible)) => {

--- a/crates/hir-ty/src/tests/method_resolution.rs
+++ b/crates/hir-ty/src/tests/method_resolution.rs
@@ -2050,3 +2050,42 @@ fn test() {
 "#,
     );
 }
+
+#[test]
+fn mismatched_args_due_to_deref_with_nested_traits() {
+    check_no_mismatches(
+        r#"
+//- minicore: deref
+use core::ops::Deref;
+
+trait Trait1 {
+    type Assoc: Deref<Target = String>;
+}
+
+trait Trait2: Trait1 {
+}
+
+trait Trait3 {
+    type T1: Trait1;
+    type T2: Trait2;
+    fn bar(&self, x: bool, y: bool);
+}
+
+struct Foo;
+
+impl Foo {
+    fn bar(&mut self, _: &'static str) {}
+}
+
+impl Deref for Foo {
+    type Target = u32;
+    fn deref(&self) -> &Self::Target { &0 }
+}
+
+fn problem_method<T: Trait3>() {
+    let mut foo = Foo;
+    foo.bar("hello"); // Rustc ok, RA errors (mismatched args)
+}
+"#,
+    );
+}


### PR DESCRIPTION
Fix for #17497

The issue occurs because in some configurations of traits where one of them has `Deref` as a supertrait, RA's type inference algorithm fails to fully resolve a trait's self type, and instead uses a `TyKind::BoundVar`. This then erroneously matches with types that do not implement the trait. In other words, unconnected types appear to inherit the trait's methods.

The fix is to insert an optional heuristic that tells the method-lookup algorithm to continue looking for other possibly better matches, in the case where the initial match is affected by the above situation. It may find a better match, or else will fall back to returning the initial match.

Includes a unit test that only passes after applying the fixes in this commit.