### PR TITLE
Use proper `ImplTraits` in `insert_inference_vars_for_impl_trait`

### DIFF
--- a/crates/hir-ty/src/tests/regression.rs
+++ b/crates/hir-ty/src/tests/regression.rs
@@ -1999,3 +1999,22 @@ where
 "#,
     );
 }
+
+#[test]
+fn tait_async_stack_overflow_17199() {
+    check_types(
+        r#"
+    //- minicore: fmt, future
+    type Foo = impl core::fmt::Debug;
+
+    async fn foo() -> Foo {
+        ()
+    }
+
+    async fn test() {
+        let t = foo().await;
+         // ^ impl Debug
+    }
+"#,
+    );
+}


### PR DESCRIPTION
Fixes #17199 and fixes #17403

In the previous implementation, I passed `rpits` as a function parameter and used `idx` of `ImplTraitId` for indexing `ImplTrait`.

https://github.com/rust-lang/rust-analyzer/blob/4e836c622a7bdab41be8e82733dd9fe40af128b2/crates/hir-ty/src/infer.rs#L881-L887

But that `idx` is rather a "local" one, so in the cases like mentioned issues, the async function that can be expanded roughly as

```rust
type TypeAlias = impl Something;
fn expanded_async() -> impl Future<Output = TypeAlias> { ... }
```

there are two bundles of `ImplTraits`; one for the `impl Future` and the other one for `TypeAlias`.
So using `idx` with `rpits` returns `ImplTrait` for `impl Future` even if we are asking for `TypeAlias` and this caused a stack overflow.

This PR is a fix for that implementation miss 😅 
