### PR TITLE
#17497 - Invalid RA diagnostic error: expected 2 arguments, found 1

### DIFF
--- a/crates/hir-ty/src/tests/method_resolution.rs
+++ b/crates/hir-ty/src/tests/method_resolution.rs
@@ -2050,3 +2050,42 @@ fn test() {
 "#,
     );
 }
+
+#[test]
+fn mismatched_args_due_to_subtraits_with_deref() {
+    check_no_mismatches(
+        r#"
+//- minicore: deref
+use core::ops::Deref;
+
+trait Trait1 {
+    type Assoc: Deref<Target = String>;
+}
+
+trait Trait2: Trait1 {
+}
+
+trait Trait3 {
+    type T1: Trait1;
+    type T2: Trait2;
+    fn bar(&self, x: bool, y: bool);
+}
+
+struct Foo;
+
+impl Foo {
+    fn bar(&mut self, _: &'static str) {}
+}
+
+impl Deref for Foo {
+    type Target = u32;
+    fn deref(&self) -> &Self::Target { &0 }
+}
+
+fn problem_method<T: Trait3>() {
+    let mut foo = Foo;
+    foo.bar("hello"); // Rustc ok, RA errors (mismatched args)
+}
+"#,
+    );
+}


### PR DESCRIPTION
Fix for #17497 and  #17233

The issue occurs because in some configurations of traits where one of them has `Deref` as a supertrait, RA's type inference algorithm fails to fully resolve a trait's self type, and instead uses a `TyKind::BoundVar`. This then erroneously matches with types that do not implement the trait. In other words, unconnected types appear to inherit the trait's methods.

The fix is to insert a heuristic when invoking `lookup_method()` that allows the caller to determine if the returned method is a good match. If the returned method would result in diagnostic errors, the caller instructs the algorithm to continue iterating the possible methods to see if a better one exists (i.e. one that won't result in diagnostic errors).

Includes a unit test that only passes after applying the fixes in this commit.