### PR TITLE
feat: Add landing/faq walkthrough pages

### DIFF
--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -305,6 +305,16 @@
                 "command": "rust-analyzer.toggleLSPLogs",
                 "title": "Toggle LSP Logs",
                 "category": "rust-analyzer"
+            },
+            {
+                "command": "rust-analyzer.openWalkthrough",
+                "title": "Open Walkthrough",
+                "category": "rust-analyzer"
+            },
+            {
+                "command": "rust-analyzer.openFAQ",
+                "title": "Open FAQ",
+                "category": "rust-analyzer"
             }
         ],
         "keybindings": [
@@ -3132,6 +3142,14 @@
                 {
                     "command": "rust-analyzer.toggleLSPLogs",
                     "when": "inRustProject"
+                },
+                {
+                    "command": "rust-analyzer.openWalkthrough",
+                    "when": "inRustProject"
+                },
+                {
+                    "command": "rust-analyzer.openFAQ",
+                    "when": "inRustProject"
                 }
             ],
             "editor/context": [
@@ -3160,6 +3178,94 @@
             {
                 "fileMatch": "rust-project.json",
                 "url": "https://json.schemastore.org/rust-project.json"
+            }
+        ],
+        "walkthroughs": [
+            {
+                "id": "landing",
+                "title": "Learn about rust-analyzer",
+                "description": "A brief introduction to get started with rust-analyzer. Learn about key features and resources to help you get the most out of the extension.",
+                "steps": [
+                    {
+                        "id": "docs",
+                        "title": "Visit the docs!",
+                        "description": "Confused about configurations? Want to learn more about rust-analyzer? Visit the [User Manual](https://rust-analyzer.github.io/manual.html)!",
+                        "media": {
+                            "image": "./icon.png",
+                            "altText": "rust-analyzer logo"
+                        },
+                        "completionEvents": [
+                            "onLink:https://rust-analyzer.github.io/manual.html"
+                        ]
+                    },
+                    {
+                        "id": "faq",
+                        "title": "FAQ",
+                        "description": "Have questions about rust-analyzer? Check out the [FAQ Walkthrough](command:rust-analyzer.openFAQ)!",
+                        "media": {
+                            "image": "icon.png",
+                            "altText": "rust-analyzer logo"
+                        }
+                    },
+                    {
+                        "id": "changelog",
+                        "title": "Changelog",
+                        "description": "Stay up-to-date with the latest changes in rust-analyzer. Check out the changelog [here](https://rust-analyzer.github.io/thisweek)!",
+                        "media": {
+                            "image": "icon.png",
+                            "altText": "rust-analyzer logo"
+                        },
+                        "completionEvents": [
+                            "onLink:https://rust-analyzer.github.io/thisweek"
+                        ]
+                    },
+                    {
+                        "id": "revisit",
+                        "title": "Want to revisit a walkthrough?",
+                        "description": "Use the ``Welcome: Open Walkthrough`` command to revisit any walkthrough!",
+                        "media": {
+                            "image": "icon.png",
+                            "altText": "rust-analyzer logo"
+                        }
+                    }
+                ]
+            },
+            {
+                "id": "faq",
+                "title": "FAQ",
+                "description": "Here are some frequently asked questions about rust-analyzer.",
+                "steps": [
+                    {
+                        "id": "faq1",
+                        "title": "What is rust-analyzer?",
+                        "description": "rust-analyzer is a language server for Rust. It provides features like code completion, find references, and more.",
+                        "media": {
+                            "image": "icon.png",
+                            "altText": "rust-analyzer logo"
+                        }
+                    },
+                    {
+                        "id": "faq2",
+                        "title": "Why are all of these type hints showing up in my code?",
+                        "description": "By default, rust-analyzer displays __inlay hints__ to help you understand your code better. You can disable them in your settings.json file with ``\"editor.inlayHints.enabled\": \"off\"``",
+                        "media": {
+                            "image": "icon.png",
+                            "altText": "rust-analyzer logo"
+                        }
+                    },
+                    {
+                        "id": "faq3",
+                        "title": "Where can I find more information about rust-analyzer?",
+                        "description": "You can find more information about rust-analyzer in the [User Manual](https://rust-analyzer.github.io/manual.html).",
+                        "media": {
+                            "image": "icon.png",
+                            "altText": "rust-analyzer logo"
+                        },
+                        "completionEvents": [
+                            "onLink:https://rust-analyzer.github.io/manual.html"
+                        ]
+                    }
+                ]
             }
         ]
     }

--- a/editors/code/src/commands.ts
+++ b/editors/code/src/commands.ts
@@ -1502,3 +1502,23 @@ export function toggleLSPLogs(ctx: Ctx): Cmd {
         }
     };
 }
+
+export function openWalkthrough(_: Ctx): Cmd {
+    return async () => {
+        await vscode.commands.executeCommand(
+            "workbench.action.openWalkthrough",
+            "rust-lang.rust-analyzer#landing",
+            false,
+        );
+    };
+}
+
+export function openFAQ(_: Ctx): Cmd {
+    return async () => {
+        await vscode.commands.executeCommand(
+            "workbench.action.openWalkthrough",
+            "rust-lang.rust-analyzer#faq",
+            true,
+        );
+    };
+}

--- a/editors/code/src/main.ts
+++ b/editors/code/src/main.ts
@@ -178,6 +178,8 @@ function createCommands(): Record<string, CommandFactory> {
         viewMemoryLayout: { enabled: commands.viewMemoryLayout },
         toggleCheckOnSave: { enabled: commands.toggleCheckOnSave },
         toggleLSPLogs: { enabled: commands.toggleLSPLogs },
+        openWalkthrough: { enabled: commands.openWalkthrough },
+        openFAQ: { enabled: commands.openFAQ },
         // Internal commands which are invoked by the server.
         applyActionGroup: { enabled: commands.applyActionGroup },
         applySnippetWorkspaceEdit: { enabled: commands.applySnippetWorkspaceEditCommand },


### PR DESCRIPTION
This is a basic implementation of a landing and FAQ page; I've included the bare-bones information as well as a [recommended section on inlay hints](https://rust-lang.zulipchat.com/#narrow/stream/185405-t-compiler.2Frust-analyzer/topic/Landing.20Page/near/446135321).

I've also added `rust-analyzer: Open Walkthrough` and `rust-analyzer: Open FAQ` commands for ease of access.

I am hoping to create a small list of FAQ to include that might be useful as well as any other information I may have missed in the landing page. Feel free to share any suggestions!

![landing/faq page demo](https://github.com/rust-lang/rust-analyzer/assets/100006388/4644e4f0-4555-4b29-83c1-b048084ad63d)

cc #13351 