### PR TITLE
#17497 - Invalid RA diagnostic error: expected 2 arguments, found 1

### DIFF
--- a/crates/ide/src/syntax_highlighting/tests.rs
+++ b/crates/ide/src/syntax_highlighting/tests.rs
@@ -1238,7 +1238,7 @@ fn benchmark_syntax_highlighting_parser() {
             })
             .count()
     };
-    assert_eq!(hash, 1169);
+    assert_eq!(hash, 1167);
 }
 
 #[test]


### PR DESCRIPTION
Fix for #17497

The issue occurs because in some configurations of traits where one of them has `Deref` as a supertrait, RA's type inference algorithm fails to resolve the `Deref::Target` type, and instead uses a `TyKind::BoundVar` (i.e. an unknown type). This "autoderefed" type then incorrectly acts as if it implements all traits in scope.

The fix is to re-apply the same sanity-check that is done in [`iterate_method_candidates_with_autoref()`](https://github.com/rust-lang/rust-analyzer/blob/9463d9eea4b87e651e7d8ed8425a9c92f23b1cdf/crates/hir-ty/src/method_resolution.rs#L1008), that is: don't try to resolve methods on unknown types. This same sanity-check is now done on each autoderefed type for which trait methods are about to be checked. If the autoderefed type is unknown, then the iterating of the trait methods for that type is skipped.

Includes a unit test that only passes after applying the fixes in this commit.

Includes a change to the assertion count in test `syntax_highlighting::tests::benchmark_syntax_highlighting_parser` as suggested by Lukas Wirth during review.

Includes a change to the sanity-check code as suggested by Florian Diebold during review.