### PR TITLE
fix: Skip match exhaustiveness checking if pattern type contains errors

### DIFF
--- a/crates/hir-ty/src/diagnostics/expr.rs
+++ b/crates/hir-ty/src/diagnostics/expr.rs
@@ -196,6 +196,9 @@ impl ExprValidator {
             let Some(pat_ty) = self.infer.type_of_pat.get(arm.pat) else {
                 return;
             };
+            if pat_ty.contains_unknown() {
+                return;
+            }
 
             // We only include patterns whose type matches the type
             // of the scrutinee expression. If we had an InvalidMatchArmPattern


### PR DESCRIPTION
Should fix https://github.com/rust-lang/rust-analyzer/issues/17509, checking when errors are involved is generally a bad idea as the algorithm doesn't really expect error types in the first place I believe