### PR TITLE
feat: go-to-def and find-references on control-flow keywords

### DIFF
--- a/crates/ide-db/src/syntax_helpers/node_ext.rs
+++ b/crates/ide-db/src/syntax_helpers/node_ext.rs
@@ -36,10 +36,35 @@ pub fn walk_expr(expr: &ast::Expr, cb: &mut dyn FnMut(ast::Expr)) {
     })
 }
 
+pub fn is_closure_or_blk_with_modif(expr: &ast::Expr) -> bool {
+    match expr {
+        ast::Expr::BlockExpr(block_expr) => {
+            matches!(
+                block_expr.modifier(),
+                Some(
+                    ast::BlockModifier::Async(_)
+                        | ast::BlockModifier::Try(_)
+                        | ast::BlockModifier::Const(_)
+                )
+            )
+        }
+        ast::Expr::ClosureExpr(_) => true,
+        _ => false,
+    }
+}
+
 /// Preorder walk all the expression's child expressions preserving events.
 /// If the callback returns true on an [`WalkEvent::Enter`], the subtree of the expression will be skipped.
 /// Note that the subtree may already be skipped due to the context analysis this function does.
 pub fn preorder_expr(start: &ast::Expr, cb: &mut dyn FnMut(WalkEvent<ast::Expr>) -> bool) {
+    preorder_expr_with_ctx_checker(start, &is_closure_or_blk_with_modif, cb);
+}
+
+pub fn preorder_expr_with_ctx_checker(
+    start: &ast::Expr,
+    check_ctx: &dyn Fn(&ast::Expr) -> bool,
+    cb: &mut dyn FnMut(WalkEvent<ast::Expr>) -> bool,
+) {
     let mut preorder = start.syntax().preorder();
     while let Some(event) = preorder.next() {
         let node = match event {
@@ -71,20 +96,7 @@ pub fn preorder_expr(start: &ast::Expr, cb: &mut dyn FnMut(WalkEvent<ast::Expr>)
                 if ast::GenericArg::can_cast(node.kind()) {
                     preorder.skip_subtree();
                 } else if let Some(expr) = ast::Expr::cast(node) {
-                    let is_different_context = match &expr {
-                        ast::Expr::BlockExpr(block_expr) => {
-                            matches!(
-                                block_expr.modifier(),
-                                Some(
-                                    ast::BlockModifier::Async(_)
-                                        | ast::BlockModifier::Try(_)
-                                        | ast::BlockModifier::Const(_)
-                                )
-                            )
-                        }
-                        ast::Expr::ClosureExpr(_) => true,
-                        _ => false,
-                    } && expr.syntax() != start.syntax();
+                    let is_different_context = check_ctx(&expr) && expr.syntax() != start.syntax();
                     let skip = cb(WalkEvent::Enter(expr));
                     if skip || is_different_context {
                         preorder.skip_subtree();
@@ -394,7 +406,7 @@ fn for_each_break_expr(
     }
 }
 
-fn eq_label_lt(lt1: &Option<ast::Lifetime>, lt2: &Option<ast::Lifetime>) -> bool {
+pub fn eq_label_lt(lt1: &Option<ast::Lifetime>, lt2: &Option<ast::Lifetime>) -> bool {
     lt1.as_ref().zip(lt2.as_ref()).map_or(false, |(lt, lbl)| lt.text() == lbl.text())
 }
 

--- a/crates/ide/src/goto_definition.rs
+++ b/crates/ide/src/goto_definition.rs
@@ -386,7 +386,7 @@ fn nav_for_break_points(
                 ast::Expr::LoopExpr(loop_) => loop_.loop_token()?.text_range(),
                 ast::Expr::WhileExpr(while_) => while_.while_token()?.text_range(),
                 ast::Expr::ForExpr(for_) => for_.for_token()?.text_range(),
-                // We garentee that the label exists
+                // We guarantee that the label exists
                 ast::Expr::BlockExpr(blk) => blk.label().unwrap().syntax().text_range(),
                 _ => return None,
             };

--- a/crates/ide/src/goto_definition.rs
+++ b/crates/ide/src/goto_definition.rs
@@ -351,8 +351,8 @@ fn try_find_loop(
                     if blk.label().is_some() && label_matches(blk.label()) =>
                 {
                     let expr = ast::Expr::BlockExpr(blk.clone());
-                    let lbl_tok = blk.label().unwrap().lifetime()?.lifetime_ident_token()?.into();
-                    let nav = NavigationTarget::from_expr(db, InFile::new(file_id, expr), lbl_tok);
+                    let lbl = blk.label().unwrap().syntax().clone().into();
+                    let nav = NavigationTarget::from_expr(db, InFile::new(file_id, expr), lbl);
                     return Some(nav);
                 }
                 _ => {}
@@ -2618,7 +2618,7 @@ fn main() {
             r#"
 fn main() {
     'a:{
- // ^^
+ // ^^^
         break$0 'a;
     }
 }

--- a/crates/ide/src/goto_definition.rs
+++ b/crates/ide/src/goto_definition.rs
@@ -14,7 +14,6 @@ use ide_db::{
     FileId, RootDatabase,
 };
 use itertools::Itertools;
-use span::FileRange;
 use syntax::{
     ast::{self, HasLoopBody, Label},
     match_ast, AstNode, AstToken,

--- a/crates/ide/src/highlight_related.rs
+++ b/crates/ide/src/highlight_related.rs
@@ -2,10 +2,14 @@ use std::iter;
 
 use hir::{db, DescendPreference, FilePosition, FileRange, HirFileId, InFile, Semantics};
 use ide_db::{
-    defs::{Definition, IdentClass}, helpers::pick_best_token, search::{FileReference, ReferenceCategory, SearchScope}, syntax_helpers::node_ext::{
+    defs::{Definition, IdentClass},
+    helpers::pick_best_token,
+    search::{FileReference, ReferenceCategory, SearchScope},
+    syntax_helpers::node_ext::{
         eq_label_lt, for_each_tail_expr, full_path_of_name_ref, is_closure_or_blk_with_modif,
         preorder_expr_with_ctx_checker,
-    }, FxHashMap, FxHashSet, RootDatabase
+    },
+    FxHashMap, FxHashSet, RootDatabase,
 };
 use span::EditionedFileId;
 use syntax::{

--- a/crates/ide/src/highlight_related.rs
+++ b/crates/ide/src/highlight_related.rs
@@ -575,12 +575,20 @@ impl<'a> WalkExpandedExprCtx<'a> {
                     }
 
                     if let ast::Expr::MacroExpr(expr) = expr {
-                        if let Some(expanded) = expr
-                            .macro_call()
-                            .and_then(|call| self.sema.expand(&call))
-                            .and_then(ast::MacroStmts::cast)
+                        if let Some(expanded) =
+                            expr.macro_call().and_then(|call| self.sema.expand(&call))
                         {
-                            self.handle_expanded(expanded, cb);
+                            match_ast! {
+                                match expanded {
+                                    ast::MacroStmts(it) => {
+                                        self.handle_expanded(it, cb);
+                                    },
+                                    ast::Expr(it) => {
+                                        self.walk(&it, cb);
+                                    },
+                                    _ => {}
+                                }
+                            }
                         }
                     }
                 }

--- a/crates/ide/src/highlight_related.rs
+++ b/crates/ide/src/highlight_related.rs
@@ -1,12 +1,13 @@
 use std::iter;
 
-use hir::{DescendPreference, FilePosition, FileRange, Semantics};
+use hir::{db, DescendPreference, FilePosition, FileRange, HirFileId, InFile, Semantics};
 use ide_db::{
     defs::{Definition, IdentClass},
     helpers::pick_best_token,
     search::{FileReference, ReferenceCategory, SearchScope},
     syntax_helpers::node_ext::{
-        for_each_break_and_continue_expr, for_each_tail_expr, full_path_of_name_ref, walk_expr,
+        eq_label_lt, for_each_tail_expr, full_path_of_name_ref, is_closure_or_blk_with_modif,
+        preorder_expr_with_ctx_checker,
     },
     FxHashSet, RootDatabase,
 };
@@ -15,7 +16,7 @@ use syntax::{
     ast::{self, HasLoopBody},
     match_ast, AstNode,
     SyntaxKind::{self, IDENT, INT_NUMBER},
-    SyntaxToken, TextRange, T,
+    SyntaxToken, TextRange, WalkEvent, T,
 };
 
 use crate::{navigation_target::ToNav, NavigationTarget, TryToNav};
@@ -75,12 +76,12 @@ pub(crate) fn highlight_related(
             highlight_exit_points(sema, token)
         }
         T![fn] | T![return] | T![->] if config.exit_points => highlight_exit_points(sema, token),
-        T![await] | T![async] if config.yield_points => highlight_yield_points(token),
+        T![await] | T![async] if config.yield_points => highlight_yield_points(sema, token),
         T![for] if config.break_points && token.parent().and_then(ast::ForExpr::cast).is_some() => {
-            highlight_break_points(token)
+            highlight_break_points(sema, token)
         }
         T![break] | T![loop] | T![while] | T![continue] if config.break_points => {
-            highlight_break_points(token)
+            highlight_break_points(sema, token)
         }
         T![|] if config.closure_captures => highlight_closure_captures(sema, token, file_id),
         T![move] if config.closure_captures => highlight_closure_captures(sema, token, file_id),
@@ -276,50 +277,53 @@ fn highlight_references(
     }
 }
 
-fn highlight_exit_points(
+pub(crate) fn highlight_exit_points(
     sema: &Semantics<'_, RootDatabase>,
     token: SyntaxToken,
 ) -> Option<Vec<HighlightedRange>> {
     fn hl(
         sema: &Semantics<'_, RootDatabase>,
-        def_ranges: [Option<TextRange>; 2],
-        body: Option<ast::Expr>,
+        def_range: Option<TextRange>,
+        body: ast::Expr,
     ) -> Option<Vec<HighlightedRange>> {
         let mut highlights = Vec::new();
-        highlights.extend(
-            def_ranges
-                .into_iter()
-                .flatten()
-                .map(|range| HighlightedRange { category: ReferenceCategory::empty(), range }),
-        );
-        let body = body?;
-        walk_expr(&body, &mut |expr| match expr {
-            ast::Expr::ReturnExpr(expr) => {
-                if let Some(token) = expr.return_token() {
-                    highlights.push(HighlightedRange {
-                        category: ReferenceCategory::empty(),
-                        range: token.text_range(),
-                    });
+        if let Some(range) = def_range {
+            highlights.push(HighlightedRange { category: ReferenceCategory::empty(), range });
+        }
+
+        WalkExpandedExprCtx::new(sema).walk(&body, &mut |_, expr| {
+            let file_id = sema.hir_file_for(expr.syntax());
+
+            let text_range = match &expr {
+                ast::Expr::TryExpr(try_) => {
+                    try_.question_mark_token().map(|token| token.text_range())
                 }
-            }
-            ast::Expr::TryExpr(try_) => {
-                if let Some(token) = try_.question_mark_token() {
-                    highlights.push(HighlightedRange {
-                        category: ReferenceCategory::empty(),
-                        range: token.text_range(),
-                    });
+                ast::Expr::MethodCallExpr(_) | ast::Expr::CallExpr(_) | ast::Expr::MacroExpr(_)
+                    if sema.type_of_expr(&expr).map_or(false, |ty| ty.original.is_never()) =>
+                {
+                    Some(expr.syntax().text_range())
                 }
-            }
-            ast::Expr::MethodCallExpr(_) | ast::Expr::CallExpr(_) | ast::Expr::MacroExpr(_) => {
-                if sema.type_of_expr(&expr).map_or(false, |ty| ty.original.is_never()) {
-                    highlights.push(HighlightedRange {
-                        category: ReferenceCategory::empty(),
-                        range: expr.syntax().text_range(),
-                    });
-                }
-            }
-            _ => (),
+                _ => None,
+            };
+
         });
+
+        // We should handle `return` separately because when it is used in `try` block
+        // it will exit the outside function instead of the block it self.
+        WalkExpandedExprCtx::new(sema)
+            .with_check_ctx(&WalkExpandedExprCtx::is_async_const_block_or_closure)
+            .walk(&body, &mut |_, expr| {
+                let file_id = sema.hir_file_for(expr.syntax());
+
+                let text_range = match &expr {
+                    ast::Expr::ReturnExpr(expr) => {
+                        expr.return_token().map(|token| token.text_range())
+                    }
+                    _ => None,
+                };
+
+            });
+
         let tail = match body {
             ast::Expr::BlockExpr(b) => b.tail_expr(),
             e => Some(e),
@@ -338,26 +342,22 @@ fn highlight_exit_points(
         }
         Some(highlights)
     }
+
     for anc in token.parent_ancestors() {
         return match_ast! {
             match anc {
-                ast::Fn(fn_) => hl(sema, [fn_.fn_token().map(|it| it.text_range()), None], fn_.body().map(ast::Expr::BlockExpr)),
+                ast::Fn(fn_) => hl(sema, fn_.fn_token().map(|it| it.text_range()), ast::Expr::BlockExpr(fn_.body()?)),
                 ast::ClosureExpr(closure) => hl(
                     sema,
-                    closure.param_list().map_or([None; 2], |p| [p.l_paren_token().map(|it| it.text_range()), p.r_paren_token().map(|it| it.text_range())]),
-                    closure.body()
+                    closure.param_list().and_then(|p| p.pipe_token()).map(|tok| tok.text_range()),
+                    closure.body()?
                 ),
-                ast::BlockExpr(block_expr) => if matches!(block_expr.modifier(), Some(ast::BlockModifier::Async(_) | ast::BlockModifier::Try(_)| ast::BlockModifier::Const(_))) {
-                    hl(
-                        sema,
-                        [block_expr.modifier().and_then(|modifier| match modifier {
-                            ast::BlockModifier::Async(t) | ast::BlockModifier::Try(t) | ast::BlockModifier::Const(t) => Some(t.text_range()),
-                            _ => None,
-                        }), None],
-                        Some(block_expr.into())
-                    )
-                } else {
-                    continue;
+                ast::BlockExpr(blk) => match blk.modifier() {
+                    Some(ast::BlockModifier::Async(t)) => hl(sema, Some(t.text_range()), blk.into()),
+                    Some(ast::BlockModifier::Try(t)) if token.kind() != T![return] => {
+                        hl(sema, Some(t.text_range()), blk.into())
+                    },
+                    _ => continue,
                 },
                 _ => continue,
             }
@@ -366,44 +366,56 @@ fn highlight_exit_points(
     None
 }
 
-fn highlight_break_points(token: SyntaxToken) -> Option<Vec<HighlightedRange>> {
+pub(crate) fn highlight_break_points(
+    sema: &Semantics<'_, RootDatabase>,
+    token: SyntaxToken,
+) -> Option<Vec<HighlightedRange>> {
     fn hl(
+        sema: &Semantics<'_, RootDatabase>,
         cursor_token_kind: SyntaxKind,
-        token: Option<SyntaxToken>,
+        loop_token: Option<SyntaxToken>,
         label: Option<ast::Label>,
-        body: Option<ast::StmtList>,
+        expr: ast::Expr,
     ) -> Option<Vec<HighlightedRange>> {
         let mut highlights = Vec::new();
-        let range = cover_range(
-            token.map(|tok| tok.text_range()),
-            label.as_ref().map(|it| it.syntax().text_range()),
-        );
-        highlights.extend(
-            range.map(|range| HighlightedRange { category: ReferenceCategory::empty(), range }),
-        );
-        for_each_break_and_continue_expr(label, body, &mut |expr| {
-            let range: Option<TextRange> = match (cursor_token_kind, expr) {
-                (T![for] | T![while] | T![loop] | T![break], ast::Expr::BreakExpr(break_)) => {
-                    cover_range(
-                        break_.break_token().map(|it| it.text_range()),
-                        break_.lifetime().map(|it| it.syntax().text_range()),
-                    )
+
+        let (label_range, label_lt) = label
+            .map_or((None, None), |label| (Some(label.syntax().text_range()), label.lifetime()));
+
+        if let Some(range) = cover_range(loop_token.map(|tok| tok.text_range()), label_range) {
+            highlights.push(HighlightedRange { category: ReferenceCategory::empty(), range })
+        }
+
+        WalkExpandedExprCtx::new(sema)
+            .with_check_ctx(&WalkExpandedExprCtx::is_async_const_block_or_closure)
+            .walk(&expr, &mut |depth, expr| {
+                let file_id = sema.hir_file_for(expr.syntax());
+
+                // Only highlight the `break`s for `break` and `continue`s for `continue`
+                let (token, token_lt) = match expr {
+                    ast::Expr::BreakExpr(b) if cursor_token_kind != T![continue] => {
+                        (b.break_token(), b.lifetime())
+                    }
+                    ast::Expr::ContinueExpr(c) if cursor_token_kind != T![break] => {
+                        (c.continue_token(), c.lifetime())
+                    }
+                    _ => return,
+                };
+
+                if !(depth == 1 && token_lt.is_none() || eq_label_lt(&label_lt, &token_lt)) {
+                    return;
                 }
-                (
-                    T![for] | T![while] | T![loop] | T![continue],
-                    ast::Expr::ContinueExpr(continue_),
-                ) => cover_range(
-                    continue_.continue_token().map(|it| it.text_range()),
-                    continue_.lifetime().map(|it| it.syntax().text_range()),
-                ),
-                _ => None,
-            };
-            highlights.extend(
-                range.map(|range| HighlightedRange { category: ReferenceCategory::empty(), range }),
-            );
-        });
+
+                let text_range = cover_range(
+                    token.map(|it| it.text_range()),
+                    token_lt.map(|it| it.syntax().text_range()),
+                );
+
+            });
+
         Some(highlights)
     }
+
     let parent = token.parent()?;
     let lbl = match_ast! {
         match parent {
@@ -416,36 +428,27 @@ fn highlight_break_points(token: SyntaxToken) -> Option<Vec<HighlightedRange>> {
             _ => return None,
         }
     };
-    let lbl = lbl.as_ref();
-    let label_matches = |def_lbl: Option<ast::Label>| match lbl {
+
+    let label_matches = |def_lbl: Option<ast::Label>| match lbl.as_ref() {
         Some(lbl) => {
             Some(lbl.text()) == def_lbl.and_then(|it| it.lifetime()).as_ref().map(|it| it.text())
         }
         None => true,
     };
-    let token_kind = token.kind();
+
     for anc in token.parent_ancestors().flat_map(ast::Expr::cast) {
-        return match anc {
-            ast::Expr::LoopExpr(l) if label_matches(l.label()) => hl(
-                token_kind,
-                l.loop_token(),
-                l.label(),
-                l.loop_body().and_then(|it| it.stmt_list()),
-            ),
-            ast::Expr::ForExpr(f) if label_matches(f.label()) => hl(
-                token_kind,
-                f.for_token(),
-                f.label(),
-                f.loop_body().and_then(|it| it.stmt_list()),
-            ),
-            ast::Expr::WhileExpr(w) if label_matches(w.label()) => hl(
-                token_kind,
-                w.while_token(),
-                w.label(),
-                w.loop_body().and_then(|it| it.stmt_list()),
-            ),
+        return match &anc {
+            ast::Expr::LoopExpr(l) if label_matches(l.label()) => {
+                hl(sema, token.kind(), l.loop_token(), l.label(), anc)
+            }
+            ast::Expr::ForExpr(f) if label_matches(f.label()) => {
+                hl(sema, token.kind(), f.for_token(), f.label(), anc)
+            }
+            ast::Expr::WhileExpr(w) if label_matches(w.label()) => {
+                hl(sema, token.kind(), w.while_token(), w.label(), anc)
+            }
             ast::Expr::BlockExpr(e) if e.label().is_some() && label_matches(e.label()) => {
-                hl(token_kind, None, e.label(), e.stmt_list())
+                hl(sema, token.kind(), None, e.label(), anc)
             }
             _ => continue,
         };
@@ -453,8 +456,12 @@ fn highlight_break_points(token: SyntaxToken) -> Option<Vec<HighlightedRange>> {
     None
 }
 
-fn highlight_yield_points(token: SyntaxToken) -> Option<Vec<HighlightedRange>> {
+pub(crate) fn highlight_yield_points(
+    sema: &Semantics<'_, RootDatabase>,
+    token: SyntaxToken,
+) -> Option<Vec<HighlightedRange>> {
     fn hl(
+        sema: &Semantics<'_, RootDatabase>,
         async_token: Option<SyntaxToken>,
         body: Option<ast::Expr>,
     ) -> Option<Vec<HighlightedRange>> {
@@ -462,31 +469,35 @@ fn highlight_yield_points(token: SyntaxToken) -> Option<Vec<HighlightedRange>> {
             category: ReferenceCategory::empty(),
             range: async_token?.text_range(),
         }];
-        if let Some(body) = body {
-            walk_expr(&body, &mut |expr| {
-                if let ast::Expr::AwaitExpr(expr) = expr {
-                    if let Some(token) = expr.await_token() {
-                        highlights.push(HighlightedRange {
-                            category: ReferenceCategory::empty(),
-                            range: token.text_range(),
-                        });
-                    }
-                }
-            });
-        }
+        let Some(body) = body else {
+            return Some(highlights);
+        };
+
+        WalkExpandedExprCtx::new(sema).walk(&body, &mut |_, expr| {
+            let file_id = sema.hir_file_for(expr.syntax());
+
+            let token_range = match expr {
+                ast::Expr::AwaitExpr(expr) => expr.await_token(),
+                ast::Expr::ReturnExpr(expr) => expr.return_token(),
+                _ => None,
+            }
+            .map(|it| it.text_range());
+
+        });
+
         Some(highlights)
     }
     for anc in token.parent_ancestors() {
         return match_ast! {
             match anc {
-                ast::Fn(fn_) => hl(fn_.async_token(), fn_.body().map(ast::Expr::BlockExpr)),
+                ast::Fn(fn_) => hl(sema, fn_.async_token(), fn_.body().map(ast::Expr::BlockExpr)),
                 ast::BlockExpr(block_expr) => {
                     if block_expr.async_token().is_none() {
                         continue;
                     }
-                    hl(block_expr.async_token(), Some(block_expr.into()))
+                    hl(sema, block_expr.async_token(), Some(block_expr.into()))
                 },
-                ast::ClosureExpr(closure) => hl(closure.async_token(), closure.body()),
+                ast::ClosureExpr(closure) => hl(sema, closure.async_token(), closure.body()),
                 _ => continue,
             }
         };
@@ -509,6 +520,87 @@ fn find_defs(sema: &Semantics<'_, RootDatabase>, token: SyntaxToken) -> FxHashSe
         .filter_map(|token| IdentClass::classify_token(sema, &token))
         .flat_map(IdentClass::definitions_no_ops)
         .collect()
+}
+
+/// Preorder walk all the expression's child expressions.
+/// For macro calls, the callback will be called on the expanded expressions after
+/// visiting the macro call itself.
+struct WalkExpandedExprCtx<'a> {
+    sema: &'a Semantics<'a, RootDatabase>,
+    depth: usize,
+    check_ctx: &'static dyn Fn(&ast::Expr) -> bool,
+}
+
+impl<'a> WalkExpandedExprCtx<'a> {
+    fn new(sema: &'a Semantics<'a, RootDatabase>) -> Self {
+        Self { sema, depth: 0, check_ctx: &is_closure_or_blk_with_modif }
+    }
+
+    fn with_check_ctx(&self, check_ctx: &'static dyn Fn(&ast::Expr) -> bool) -> Self {
+        Self { check_ctx, ..*self }
+    }
+
+    fn walk(&mut self, expr: &ast::Expr, cb: &mut dyn FnMut(usize, ast::Expr)) {
+        preorder_expr_with_ctx_checker(expr, self.check_ctx, &mut |ev: WalkEvent<ast::Expr>| {
+            match ev {
+                syntax::WalkEvent::Enter(expr) => {
+                    cb(self.depth, expr.clone());
+
+                    if Self::should_change_depth(&expr) {
+                        self.depth += 1;
+                    }
+
+                    if let ast::Expr::MacroExpr(expr) = expr {
+                        if let Some(expanded) = expr
+                            .macro_call()
+                            .and_then(|call| self.sema.expand(&call))
+                            .and_then(ast::MacroStmts::cast)
+                        {
+                            self.handle_expanded(expanded, cb);
+                        }
+                    }
+                }
+                syntax::WalkEvent::Leave(expr) if Self::should_change_depth(&expr) => {
+                    self.depth -= 1;
+                }
+                _ => {}
+            }
+            false
+        })
+    }
+
+    fn handle_expanded(&mut self, expanded: ast::MacroStmts, cb: &mut dyn FnMut(usize, ast::Expr)) {
+        if let Some(expr) = expanded.expr() {
+            self.walk(&expr, cb);
+        }
+
+        for stmt in expanded.statements() {
+            if let ast::Stmt::ExprStmt(stmt) = stmt {
+                if let Some(expr) = stmt.expr() {
+                    self.walk(&expr, cb);
+                }
+            }
+        }
+    }
+
+    fn should_change_depth(expr: &ast::Expr) -> bool {
+        match expr {
+            ast::Expr::LoopExpr(_) | ast::Expr::WhileExpr(_) | ast::Expr::ForExpr(_) => true,
+            ast::Expr::BlockExpr(blk) if blk.label().is_some() => true,
+            _ => false,
+        }
+    }
+
+    fn is_async_const_block_or_closure(expr: &ast::Expr) -> bool {
+        match expr {
+            ast::Expr::BlockExpr(b) => matches!(
+                b.modifier(),
+                Some(ast::BlockModifier::Async(_) | ast::BlockModifier::Const(_))
+            ),
+            ast::Expr::ClosureExpr(_) => true,
+            _ => false,
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/ide/src/highlight_related.rs
+++ b/crates/ide/src/highlight_related.rs
@@ -541,11 +541,7 @@ fn original_range(
     file_id: HirFileId,
     text_range: Option<TextRange>,
 ) -> Option<TextRange> {
-    if text_range.is_none() || !file_id.is_macro() {
-        return text_range;
-    }
-
-    InFile::new(file_id, text_range.unwrap())
+    InFile::new(file_id, text_range?)
         .original_node_file_range_opt(db)
         .map(|(frange, _)| frange.range)
 }

--- a/crates/ide/src/navigation_target.rs
+++ b/crates/ide/src/navigation_target.rs
@@ -152,22 +152,7 @@ impl NavigationTarget {
         )
     }
 
-    pub(crate) fn from_expr(
-        db: &RootDatabase,
-        InFile { file_id, value }: InFile<ast::Expr>,
-        focus_range: Option<TextRange>,
-    ) -> UpmappingResult<NavigationTarget> {
-        let name: SmolStr = "<expr>".into();
-        let kind = SymbolKind::Label;
-
-        orig_range_with_focus_r(db, file_id, value.syntax().text_range(), focus_range).map(
-            |(FileRange { file_id, range: full_range }, focus_range)| {
-                NavigationTarget::from_syntax(file_id, name.clone(), focus_range, full_range, kind)
-            },
-        )
-    }
-
-    fn from_syntax(
+    pub(crate) fn from_syntax(
         file_id: FileId,
         name: SmolStr,
         focus_range: Option<TextRange>,
@@ -747,7 +732,7 @@ fn orig_range_with_focus(
     )
 }
 
-fn orig_range_with_focus_r(
+pub(crate) fn orig_range_with_focus_r(
     db: &RootDatabase,
     hir_file: HirFileId,
     value: TextRange,

--- a/crates/ide/src/navigation_target.rs
+++ b/crates/ide/src/navigation_target.rs
@@ -16,7 +16,7 @@ use ide_db::{
 use stdx::never;
 use syntax::{
     ast::{self, HasName},
-    format_smolstr, AstNode, SmolStr, SyntaxElement, SyntaxNode, TextRange, ToSmolStr,
+    format_smolstr, AstNode, SmolStr, SyntaxNode, TextRange, ToSmolStr,
 };
 
 /// `NavigationTarget` represents an element in the editor's UI which you can
@@ -155,11 +155,10 @@ impl NavigationTarget {
     pub(crate) fn from_expr(
         db: &RootDatabase,
         InFile { file_id, value }: InFile<ast::Expr>,
-        focus_syntax: SyntaxElement,
+        focus_range: Option<TextRange>,
     ) -> UpmappingResult<NavigationTarget> {
         let name: SmolStr = "<expr>".into();
         let kind = SymbolKind::Label;
-        let focus_range = Some(focus_syntax.text_range());
 
         orig_range_with_focus_r(db, file_id, value.syntax().text_range(), focus_range).map(
             |(FileRange { file_id, range: full_range }, focus_range)| {

--- a/crates/ide/src/references.rs
+++ b/crates/ide/src/references.rs
@@ -24,7 +24,7 @@ use syntax::{
     SyntaxNode, TextRange, TextSize, T,
 };
 
-use crate::{FilePosition, NavigationTarget, TryToNav};
+use crate::{highlight_related, FilePosition, HighlightedRange, NavigationTarget, TryToNav};
 
 #[derive(Debug, Clone)]
 pub struct ReferenceSearchResult {
@@ -102,6 +102,11 @@ pub(crate) fn find_all_refs(
             ReferenceSearchResult { declaration, references }
         }
     };
+
+    // Find references for control-flow keywords.
+    if let Some(res) = handle_control_flow_keywords(sema, position) {
+        return Some(vec![res]);
+    }
 
     match name_for_constructor_search(&syntax, position) {
         Some(name) => {
@@ -294,6 +299,34 @@ fn is_lit_name_ref(name_ref: &ast::NameRef) -> bool {
             }
         }
     }).unwrap_or(false)
+}
+
+fn handle_control_flow_keywords(
+    sema: &Semantics<'_, RootDatabase>,
+    FilePosition { file_id, offset }: FilePosition,
+) -> Option<ReferenceSearchResult> {
+    let file = sema.parse(file_id);
+    let token = file.syntax().token_at_offset(offset).find(|t| t.kind().is_keyword())?;
+
+    let refs = match token.kind() {
+        T![fn] | T![return] | T![try] => highlight_related::highlight_exit_points(sema, token)?,
+        T![async] => highlight_related::highlight_yield_points(sema, token)?,
+        T![loop] | T![while] | T![break] | T![continue] => {
+            highlight_related::highlight_break_points(sema, token)?
+        }
+        T![for] if token.parent().and_then(ast::ForExpr::cast).is_some() => {
+            highlight_related::highlight_break_points(sema, token)?
+        }
+        _ => return None,
+    }
+    .into_iter()
+    .map(|HighlightedRange { range, category }| (range, category))
+    .collect();
+
+    Some(ReferenceSearchResult {
+        declaration: None,
+        references: IntMap::from_iter([(file_id, refs)]),
+    })
 }
 
 #[cfg(test)]
@@ -2186,5 +2219,224 @@ fn test() {
                 FileId(0) 68..69 read
             "#]],
         );
+    }
+
+    #[test]
+    fn goto_ref_fn_kw() {
+        check(
+            r#"
+macro_rules! N {
+    ($i:ident, $x:expr, $blk:expr) => {
+        for $i in 0..$x {
+            $blk
+        }
+    };
+}
+
+fn main() {
+    $0fn f() {
+        N!(i, 5, {
+            println!("{}", i);
+            return;
+        });
+
+        for i in 1..5 {
+            return;
+        }
+
+       (|| {
+            return;
+        })();
+    }
+}
+"#,
+            expect![[r#"
+                FileId(0) 136..138
+                FileId(0) 207..213
+                FileId(0) 264..270
+            "#]],
+        )
+    }
+
+    #[test]
+    fn goto_ref_exit_points() {
+        check(
+            r#"
+fn$0 foo() -> u32 {
+    if true {
+        return 0;
+    }
+
+    0?;
+    0xDEAD_BEEF
+}
+"#,
+            expect![[r#"
+                FileId(0) 0..2
+                FileId(0) 62..63
+                FileId(0) 40..46
+                FileId(0) 69..80
+            "#]],
+        );
+    }
+
+    #[test]
+    fn test_ref_yield_points() {
+        check(
+            r#"
+pub async$0 fn foo() {
+    let x = foo()
+        .await
+        .await;
+    || { 0.await };
+    (async { 0.await }).await
+}
+"#,
+            expect![[r#"
+                FileId(0) 4..9
+                FileId(0) 63..68
+                FileId(0) 48..53
+                FileId(0) 114..119
+            "#]],
+        );
+    }
+
+    #[test]
+    fn goto_ref_for_kw() {
+        check(
+            r#"
+fn main() {
+    $0for i in 1..5 {
+        break;
+        continue;
+    }
+}
+"#,
+            expect![[r#"
+                FileId(0) 16..19
+                FileId(0) 40..45
+                FileId(0) 55..63
+            "#]],
+        )
+    }
+
+    #[test]
+    fn goto_ref_on_break_kw() {
+        check(
+            r#"
+fn main() {
+    for i in 1..5 {
+        $0break;
+        continue;
+    }
+}
+"#,
+            expect![[r#"
+                FileId(0) 16..19
+                FileId(0) 40..45
+            "#]],
+        )
+    }
+
+    #[test]
+    fn goto_ref_on_break_kw_for_block() {
+        check(
+            r#"
+fn main() {
+    'a:{
+        $0break 'a;
+    }
+}
+"#,
+            expect![[r#"
+                FileId(0) 16..19
+                FileId(0) 29..37
+            "#]],
+        )
+    }
+
+    #[test]
+    fn goto_ref_on_break_with_label() {
+        check(
+            r#"
+fn foo() {
+    'outer: loop {
+         break;
+         'inner: loop {
+            'innermost: loop {
+            }
+            $0break 'outer;
+            break;
+        }
+        break;
+    }
+}
+"#,
+            expect![[r#"
+                FileId(0) 15..27
+                FileId(0) 39..44
+                FileId(0) 127..139
+                FileId(0) 178..183
+            "#]],
+        );
+    }
+
+    #[test]
+    fn goto_ref_on_return_in_try() {
+        check(
+            r#"
+fn main() {
+    fn f() {
+        try {
+            $0return;
+        }
+
+        return;
+    }
+    return;
+}
+"#,
+            expect![[r#"
+                FileId(0) 16..18
+                FileId(0) 51..57
+                FileId(0) 78..84
+            "#]],
+        )
+    }
+
+    #[test]
+    fn goto_ref_on_break_in_try() {
+        check(
+            r#"
+fn main() {
+    for i in 1..100 {
+        let x: Result<(), ()> = try {
+            $0break;
+        };
+    }
+}
+"#,
+            expect![[r#"
+                FileId(0) 16..19
+                FileId(0) 84..89
+            "#]],
+        )
+    }
+
+    #[test]
+    fn goto_ref_on_return_in_async_block() {
+        check(
+            r#"
+fn main() {
+    $0async {
+        return;
+    }
+}
+"#,
+            expect![[r#"
+                FileId(0) 16..21
+                FileId(0) 32..38
+            "#]],
+        )
     }
 }


### PR DESCRIPTION
fix #17517.

This PR implements **go-to-definition** and **find-references** functionalities for control flow keywords, which is similar to the behaviors in the `highlight-related` module. Besides, this PR also fixes some incorrect behaviors in `highlight-related`.

## Changes

1. **Support for go-to-definition on control flow keywords**:  
   This PR introduces functionality allowing users to navigate on the definition of control flow keywords (`return`, `break`, `continue`).
   Commit: 2a3244ee147f898dd828c06352645ae1713c260f..7391e7a608634709db002a4cb09229de4d12c056.

2. **Bug fixes and refactoring in highlight-related**:
   - **Handling return/break/continue within try_blocks**:  
     This PR adjusted the behavior of these keywords when they occur within `try_blocks`. When encounter these keywords, the program should exit the outer function or loop which containing the `try_blocks`, rather than the `try_blocks` itself; while the `?` will cause the program to exit `try_blocks`.  
     Commit: 59d697e807f0197f59814b37dca1563959da4aa1.
   - **Support highlighting keywords in macro expansion for highlight-related**:  
     Commit: 88df24f01727c23a667a763ee3ee0cec22d5ad52.
   - Detailed description for the bug fixes
     + The previous implementation of `preorder_expr` incorrectly treated `try_blocks` as new contexts, thereby r-a will not continue to traverse inner `return` and `break/continue` statements. To resolve this, a new function `preorder_expr_with_ctx_checker` has been added, allowing users to specify which expressions to skip.
       * For example, when searching for the `?` in the context, r-a should skip `try_blocks` where the `?` insides just works for `try_blocks`. But when search for the `return` keyword, r-a should collect both the `return` keywords inside and outside the `try_blocks`
     + Thus, this PR added `WalkExpandedExprCtx` (builder pattern). It offers the following improvements: customizable context skipping, maintenance of loop depth (for `break`/`continue`), and handling macro expansion during traversal.

3. **Support for find-references on control flow keywords**:  
   This PR enables users to find all references to control flow keywords.  
   Commit: 9202a33f81218fb9c2edb5d42e6b4de85b0323a8.
