### PR TITLE
Add --keep-going to the check command

### DIFF
--- a/crates/flycheck/src/lib.rs
+++ b/crates/flycheck/src/lib.rs
@@ -426,6 +426,8 @@ impl FlycheckActor {
                     }
                 }
 
+                cmd.arg("--keep-going");
+
                 options.apply_on_command(&mut cmd);
                 (cmd, options.extra_args.clone())
             }


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rustlings/issues/1628

@Veykril I am not sure about what you meant with "unconditionally" in https://github.com/rust-lang/rustlings/issues/1628#issuecomment-2212492230, but I didn't find out how to get the version of the toolchain anyway to do a check like in [this snippet](https://github.com/rust-lang/rust-analyzer/blob/a5b21ea0aa644dffd7cf958b43f11f221d53404e/crates/project-model/src/build_scripts.rs#L125-L127). Is this check even required if rust-analyzer was installed with the toolchain?

`--keep-going` was [stabilized in 1.74](https://github.com/rust-lang/cargo/blob/master/CHANGELOG.md#cargo-174-2023-11-16)