### PR TITLE
feat: do not add new enum if it already exists

### DIFF
--- a/crates/ide-assists/src/handlers/bool_to_enum.rs
+++ b/crates/ide-assists/src/handlers/bool_to_enum.rs
@@ -96,7 +96,7 @@ struct BoolNodeData {
 
 /// Attempts to find an appropriate node to apply the action to.
 fn find_bool_node(ctx: &AssistContext<'_>) -> Option<BoolNodeData> {
-    let name: ast::Name = ctx.find_node_at_offset()?;
+    let name = ctx.find_node_at_offset::<ast::Name>()?;
 
     if let Some(ident_pat) = name.syntax().parent().and_then(ast::IdentPat::cast) {
         let def = ctx.sema.to_def(&ident_pat)?;


### PR DESCRIPTION
## Summary

This PR introduces a check for the existence of another enum within the current scope, and if it exist, we skip `add_enum_def`.

## Why?

Currently, when using the `bool_to_enum` assist more than once, it is possible to add multiple enum definitions. For example, the following snippet,

```rs
#[derive(PartialEq, Eq)]
enum Bool {
    True,
    False,
}

fn main() {
    let a = Bool::True;
    let b = true;
    println!("Hello, world!");
}
```

will be transformed into,

```rs
#[derive(PartialEq, Eq)]
enum Bool {
    True,
    False,
}

#[derive(PartialEq, Eq)]
enum Bool {
    True,
    False,
}

fn main() {
    let a = Bool::True;
    let b = Bool::True;
    println!("Hello, world!");
}
```

This can be annoying for users to clean up. 