### PR TITLE
internal: Remove faq landing page, improve main one

### DIFF
--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -3186,12 +3186,10 @@
                     "when": "inRustProject"
                 },
                 {
-                    "command": "rust-analyzer.openWalkthrough",
-                    "when": "inRustProject"
+                    "command": "rust-analyzer.openWalkthrough"
                 },
                 {
-                    "command": "rust-analyzer.openFAQ",
-                    "when": "inRustProject"
+                    "command": "rust-analyzer.openFAQ"
                 }
             ],
             "editor/context": [
@@ -3229,6 +3227,15 @@
                 "description": "A brief introduction to get started with rust-analyzer. Learn about key features and resources to help you get the most out of the extension.",
                 "steps": [
                     {
+                        "id": "setup",
+                        "title": "Useful Setup Tips",
+                        "description": "There are a couple of things you might want to configure upfront to your tastes. We'll name a few here but be sure to check out the docs linked below!\n\n**Marking library sources as readonly**\n\nAdding the following to your settings.json will mark all Rust library sources as readonly:\n```json\n\"files.readonlyInclude\": {\n    \"**/.cargo/registry/src/**/*.rs\": true,\n    \"**/lib/rustlib/src/rust/library/**/*.rs\": true,\n},\n```\n\n**Check on Save**\n\nBy default, rust-analyzer will run `cargo check` on your codebase when you save a file, rendering diagnostics emitted by `cargo check` within your code. This can potentially collide with other `cargo` commands running concurrently, blocking them from running for a certain amount of time. In these cases it is recommended to disable the `rust-analyzer.checkOnSave` configuration and running the `rust-analyzer: Run flycheck` command on-demand instead.",
+                        "media": {
+                            "image": "./icon.png",
+                            "altText": "rust-analyzer logo"
+                        }
+                    },
+                    {
                         "id": "docs",
                         "title": "Visit the docs!",
                         "description": "Confused about configurations? Want to learn more about rust-analyzer? Visit the [User Manual](https://rust-analyzer.github.io/manual.html)!",
@@ -3243,7 +3250,7 @@
                     {
                         "id": "faq",
                         "title": "FAQ",
-                        "description": "Have questions about rust-analyzer? Check out the [FAQ Walkthrough](command:rust-analyzer.openFAQ)!",
+                        "description": "What are these code hints that are being inserted into my code?\n\nThese hints are called inlay hints which rust-analyzer support and are enabled by default in VSCode. If you wish to disable them you can do so via the `editor.inlayHints.enabled` setting.",
                         "media": {
                             "image": "icon.png",
                             "altText": "rust-analyzer logo"
@@ -3259,52 +3266,6 @@
                         },
                         "completionEvents": [
                             "onLink:https://rust-analyzer.github.io/thisweek"
-                        ]
-                    },
-                    {
-                        "id": "revisit",
-                        "title": "Want to revisit a walkthrough?",
-                        "description": "Use the ``Welcome: Open Walkthrough`` command to revisit any walkthrough!",
-                        "media": {
-                            "image": "icon.png",
-                            "altText": "rust-analyzer logo"
-                        }
-                    }
-                ]
-            },
-            {
-                "id": "faq",
-                "title": "FAQ",
-                "description": "Here are some frequently asked questions about rust-analyzer.",
-                "steps": [
-                    {
-                        "id": "faq1",
-                        "title": "What is rust-analyzer?",
-                        "description": "rust-analyzer is a language server for Rust. It provides features like code completion, find references, and more.",
-                        "media": {
-                            "image": "icon.png",
-                            "altText": "rust-analyzer logo"
-                        }
-                    },
-                    {
-                        "id": "faq2",
-                        "title": "Why are all of these type hints showing up in my code?",
-                        "description": "By default, rust-analyzer displays __inlay hints__ to help you understand your code better. You can disable them in your settings.json file with ``\"editor.inlayHints.enabled\": \"off\"``",
-                        "media": {
-                            "image": "icon.png",
-                            "altText": "rust-analyzer logo"
-                        }
-                    },
-                    {
-                        "id": "faq3",
-                        "title": "Where can I find more information about rust-analyzer?",
-                        "description": "You can find more information about rust-analyzer in the [User Manual](https://rust-analyzer.github.io/manual.html).",
-                        "media": {
-                            "image": "icon.png",
-                            "altText": "rust-analyzer logo"
-                        },
-                        "completionEvents": [
-                            "onLink:https://rust-analyzer.github.io/manual.html"
                         ]
                     }
                 ]


### PR DESCRIPTION
Having more than one is potentialyl annoying as both will get opened upon install, using walkthroughs for this is not ideal. So this merges the two and also adds a couple tips, fixes https://github.com/rust-lang/rust-analyzer/issues/17569