### PR TITLE
Set `RUSTC_TOOLCHAIN` for runnables

### DIFF
--- a/crates/rust-analyzer/src/global_state.rs
+++ b/crates/rust-analyzer/src/global_state.rs
@@ -579,6 +579,7 @@ impl GlobalStateSnapshot {
                         target_kind: target_data.kind,
                         required_features: target_data.required_features.clone(),
                         features: package_data.features.keys().cloned().collect(),
+                        sysroot_root: workspace.sysroot.root().map(ToOwned::to_owned),
                     }));
                 }
                 ProjectWorkspaceKind::Json(project) => {

--- a/crates/rust-analyzer/src/lsp/to_proto.rs
+++ b/crates/rust-analyzer/src/lsp/to_proto.rs
@@ -1399,7 +1399,11 @@ pub(crate) fn runnable(
                     cargo_args,
                     cwd: cwd.into(),
                     executable_args,
-                    environment: Default::default(),
+                    environment: spec
+                        .sysroot_root
+                        .map(|root| ("RUSTC_TOOLCHAIN".to_owned(), root.to_string()))
+                        .into_iter()
+                        .collect(),
                 }),
             }))
         }

--- a/crates/rust-analyzer/src/target_spec.rs
+++ b/crates/rust-analyzer/src/target_spec.rs
@@ -57,6 +57,7 @@ pub(crate) struct CargoTargetSpec {
     pub(crate) crate_id: CrateId,
     pub(crate) required_features: Vec<String>,
     pub(crate) features: FxHashSet<String>,
+    pub(crate) sysroot_root: Option<vfs::AbsPathBuf>,
 }
 
 #[derive(Clone, Debug)]

--- a/editors/code/src/run.ts
+++ b/editors/code/src/run.ts
@@ -8,7 +8,6 @@ import { makeDebugConfig } from "./debug";
 import type { Config, RunnableEnvCfg, RunnableEnvCfgItem } from "./config";
 import type { LanguageClient } from "vscode-languageclient/node";
 import { unwrapUndefinable, type RustEditor } from "./util";
-import * as toolchain from "./toolchain";
 
 const quickPickButtons = [
     { iconPath: new vscode.ThemeIcon("save"), tooltip: "Save as a launch.json configuration." },
@@ -115,7 +114,7 @@ export async function createTaskFromRunnable(
 
     let definition: tasks.TaskDefinition;
     let options;
-    let cargo;
+    let cargo = "cargo";
     if (runnable.kind === "cargo") {
         const runnableArgs = runnable.args;
         let args = createCargoArgs(runnableArgs);
@@ -126,8 +125,6 @@ export async function createTaskFromRunnable(
 
             cargo = unwrapUndefinable(cargoParts[0]);
             args = [...cargoParts.slice(1), ...args];
-        } else {
-            cargo = await toolchain.cargoPath();
         }
 
         definition = {
@@ -200,7 +197,7 @@ async function getRunnables(
             continue;
         }
 
-        if (debuggeeOnly && (r.label.startsWith("doctest") || r.label.startsWith("cargo"))) {
+        if (debuggeeOnly && r.label.startsWith("doctest")) {
             continue;
         }
         items.push(new RunnableQuickPick(r));

--- a/editors/code/src/tasks.ts
+++ b/editors/code/src/tasks.ts
@@ -125,7 +125,7 @@ export async function targetToExecution(
     let command, args;
     if (isCargoTask(definition)) {
         // FIXME: The server should provide cargo
-        command = cargo || (await toolchain.cargoPath());
+        command = cargo || (await toolchain.cargoPath(options?.env));
         args = [definition.command].concat(definition.args || []);
     } else {
         command = definition.command;


### PR DESCRIPTION
With this the client doesn't necessarily need to guess the sysroot anymore