### PR TITLE
Fix incorrect generic parameter hint defaults

### DIFF
--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -511,9 +511,9 @@ config_data! {
         /// Whether to show inlay hints as postfix ops (`.*` instead of `*`, etc).
         inlayHints_expressionAdjustmentHints_mode: AdjustmentHintsModeDef = AdjustmentHintsModeDef::Prefix,
         /// Whether to show const generic parameter name inlay hints.
-        inlayHints_genericParameterHints_const_enable: bool= false,
+        inlayHints_genericParameterHints_const_enable: bool= true,
         /// Whether to show generic lifetime parameter name inlay hints.
-        inlayHints_genericParameterHints_lifetime_enable: bool = true,
+        inlayHints_genericParameterHints_lifetime_enable: bool = false,
         /// Whether to show generic type parameter name inlay hints.
         inlayHints_genericParameterHints_type_enable: bool = false,
         /// Whether to show implicit drop hints.

--- a/docs/user/generated_config.adoc
+++ b/docs/user/generated_config.adoc
@@ -655,12 +655,12 @@ Whether to hide inlay hints for type adjustments outside of `unsafe` blocks.
 --
 Whether to show inlay hints as postfix ops (`.*` instead of `*`, etc).
 --
-[[rust-analyzer.inlayHints.genericParameterHints.const.enable]]rust-analyzer.inlayHints.genericParameterHints.const.enable (default: `false`)::
+[[rust-analyzer.inlayHints.genericParameterHints.const.enable]]rust-analyzer.inlayHints.genericParameterHints.const.enable (default: `true`)::
 +
 --
 Whether to show const generic parameter name inlay hints.
 --
-[[rust-analyzer.inlayHints.genericParameterHints.lifetime.enable]]rust-analyzer.inlayHints.genericParameterHints.lifetime.enable (default: `true`)::
+[[rust-analyzer.inlayHints.genericParameterHints.lifetime.enable]]rust-analyzer.inlayHints.genericParameterHints.lifetime.enable (default: `false`)::
 +
 --
 Whether to show generic lifetime parameter name inlay hints.

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -1914,7 +1914,7 @@
                 "properties": {
                     "rust-analyzer.inlayHints.genericParameterHints.const.enable": {
                         "markdownDescription": "Whether to show const generic parameter name inlay hints.",
-                        "default": false,
+                        "default": true,
                         "type": "boolean"
                     }
                 }
@@ -1924,7 +1924,7 @@
                 "properties": {
                     "rust-analyzer.inlayHints.genericParameterHints.lifetime.enable": {
                         "markdownDescription": "Whether to show generic lifetime parameter name inlay hints.",
-                        "default": true,
+                        "default": false,
                         "type": "boolean"
                     }
                 }


### PR DESCRIPTION
Missed this in the review but we should show const param hints, not lifetime param hints by default