### PR TITLE
feat: add inlay hint support for block expr with lifetime label

### DIFF
--- a/crates/ide/src/inlay_hints/closing_brace.rs
+++ b/crates/ide/src/inlay_hints/closing_brace.rs
@@ -53,7 +53,8 @@ pub(super) fn hints(
         let module = ast::Module::cast(list.syntax().parent()?)?;
         (format!("mod {}", module.name()?), module.name().map(name))
     } else if let Some(label) = ast::Label::cast(node.clone()) {
-        // in this case, `ast::Label` could be seen as a part of `ast::BlockExpr`, to respect the `min_lines` config
+        // in this case, `ast::Label` could be seen as a part of `ast::BlockExpr`
+        // the actual number of lines in this case should be the line count of the parent BlockExpr, which the `min_lines` config care about
         node = node.parent()?;
         let block = label.syntax().parent().and_then(ast::BlockExpr::cast)?;
         closing_token = block.stmt_list()?.r_curly_token()?;

--- a/crates/ide/src/inlay_hints/closing_brace.rs
+++ b/crates/ide/src/inlay_hints/closing_brace.rs
@@ -18,7 +18,7 @@ pub(super) fn hints(
     sema: &Semantics<'_, RootDatabase>,
     config: &InlayHintsConfig,
     file_id: EditionedFileId,
-    node: SyntaxNode,
+    mut node: SyntaxNode,
 ) -> Option<()> {
     let min_lines = config.closing_brace_hints_min_lines?;
 
@@ -52,6 +52,13 @@ pub(super) fn hints(
 
         let module = ast::Module::cast(list.syntax().parent()?)?;
         (format!("mod {}", module.name()?), module.name().map(name))
+    } else if let Some(label) = ast::Label::cast(node.clone()) {
+        // in this case, `ast::Label` could be seen as a part of `ast::BlockExpr`, to respect the `min_lines` config
+        node = node.parent()?;
+        let block = label.syntax().parent().and_then(ast::BlockExpr::cast)?;
+        closing_token = block.stmt_list()?.r_curly_token()?;
+        let lifetime = label.lifetime().map_or_else(String::new, |it| it.to_string());
+        (lifetime, Some(label.syntax().text_range()))
     } else if let Some(block) = ast::BlockExpr::cast(node.clone()) {
         closing_token = block.stmt_list()?.r_curly_token()?;
 

--- a/crates/ide/src/inlay_hints/closing_brace.rs
+++ b/crates/ide/src/inlay_hints/closing_brace.rs
@@ -199,4 +199,27 @@ fn f() {
 "#,
         );
     }
+
+    #[test]
+    fn hints_closing_brace_for_block_expr() {
+        check_with_config(
+            InlayHintsConfig { closing_brace_hints_min_lines: Some(2), ..DISABLED_CONFIG },
+            r#"
+fn test() {
+    'end: {
+        'do_a: {
+            'do_b: {
+
+            }
+          //^ 'do_b
+            break 'end;
+        }
+      //^ 'do_a
+    }
+  //^ 'end
+  }
+//^ fn test
+"#,
+        );
+    }
 }


### PR DESCRIPTION
![block_expr_with_label](https://github.com/user-attachments/assets/efede15b-d2ba-4aad-9775-a795b6cd473b)

close https://github.com/rust-lang/rust-analyzer/issues/17582