### PR TITLE
internal: remove rust-analyzer.openFAQ

### DIFF
--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -310,11 +310,6 @@
                 "command": "rust-analyzer.openWalkthrough",
                 "title": "Open Walkthrough",
                 "category": "rust-analyzer"
-            },
-            {
-                "command": "rust-analyzer.openFAQ",
-                "title": "Open FAQ",
-                "category": "rust-analyzer"
             }
         ],
         "keybindings": [
@@ -3221,9 +3216,6 @@
                 },
                 {
                     "command": "rust-analyzer.openWalkthrough"
-                },
-                {
-                    "command": "rust-analyzer.openFAQ"
                 }
             ],
             "editor/context": [

--- a/editors/code/src/commands.ts
+++ b/editors/code/src/commands.ts
@@ -1518,13 +1518,3 @@ export function openWalkthrough(_: Ctx): Cmd {
         );
     };
 }
-
-export function openFAQ(_: Ctx): Cmd {
-    return async () => {
-        await vscode.commands.executeCommand(
-            "workbench.action.openWalkthrough",
-            "rust-lang.rust-analyzer#faq",
-            true,
-        );
-    };
-}

--- a/editors/code/src/main.ts
+++ b/editors/code/src/main.ts
@@ -179,7 +179,6 @@ function createCommands(): Record<string, CommandFactory> {
         toggleCheckOnSave: { enabled: commands.toggleCheckOnSave },
         toggleLSPLogs: { enabled: commands.toggleLSPLogs },
         openWalkthrough: { enabled: commands.openWalkthrough },
-        openFAQ: { enabled: commands.openFAQ },
         // Internal commands which are invoked by the server.
         applyActionGroup: { enabled: commands.applyActionGroup },
         applySnippetWorkspaceEdit: { enabled: commands.applySnippetWorkspaceEditCommand },


### PR DESCRIPTION
Removed no longer functional `rust-analyzer.openFAQ` command created in #17508