### PR TITLE
Avoid ref when using format! in compiler

### DIFF
--- a/crates/ide-assists/src/handlers/bind_unused_param.rs
+++ b/crates/ide-assists/src/handlers/bind_unused_param.rs
@@ -43,7 +43,7 @@ pub(crate) fn bind_unused_param(acc: &mut Assists, ctx: &AssistContext<'_>) -> O
 
     acc.add(
         AssistId("bind_unused_param", AssistKind::QuickFix),
-        &format!("Bind as `let _ = {};`", &ident_pat),
+        &format!("Bind as `let _ = {ident_pat};`"),
         param.syntax().text_range(),
         |builder| {
             let line_index = ctx.db().line_index(ctx.file_id().into());

--- a/crates/ide-completion/src/item.rs
+++ b/crates/ide-completion/src/item.rs
@@ -664,7 +664,7 @@ mod tests {
     /// If provided vec![vec![a], vec![b, c], vec![d]], then this will assert:
     ///     a.score < b.score == c.score < d.score
     fn check_relevance_score_ordered(expected_relevance_order: Vec<Vec<CompletionRelevance>>) {
-        let expected = format!("{:#?}", &expected_relevance_order);
+        let expected = format!("{expected_relevance_order:#?}");
 
         let actual_relevance_order = expected_relevance_order
             .into_iter()
@@ -685,7 +685,7 @@ mod tests {
             )
             .1;
 
-        let actual = format!("{:#?}", &actual_relevance_order);
+        let actual = format!("{actual_relevance_order:#?}");
 
         assert_eq_text!(&expected, &actual);
     }

--- a/crates/ide-diagnostics/src/handlers/typed_hole.rs
+++ b/crates/ide-diagnostics/src/handlers/typed_hole.rs
@@ -75,7 +75,7 @@ fn fixes(ctx: &DiagnosticsContext<'_>, d: &hir::TypedHole) -> Option<Vec<Assist>
         .unique()
         .map(|code| Assist {
             id: AssistId("typed-hole", AssistKind::QuickFix),
-            label: Label::new(format!("Replace `_` with `{}`", &code)),
+            label: Label::new(format!("Replace `_` with `{code}`")),
             group: Some(GroupLabel("Replace `_` with a term".to_owned())),
             target: original_range.range,
             source_change: Some(SourceChange::from_text_edit(

--- a/crates/ide/src/rename.rs
+++ b/crates/ide/src/rename.rs
@@ -516,7 +516,7 @@ mod tests {
         match result {
             Ok(RangeInfo { range, info: () }) => {
                 let source = analysis.file_text(position.file_id).unwrap();
-                expect.assert_eq(&format!("{range:?}: {}", &source[range]))
+                expect.assert_eq(&format!("{range:?}: {}", source[range]))
             }
             Err(RenameError(err)) => expect.assert_eq(&err),
         };

--- a/crates/ide/src/rename.rs
+++ b/crates/ide/src/rename.rs
@@ -516,7 +516,7 @@ mod tests {
         match result {
             Ok(RangeInfo { range, info: () }) => {
                 let source = analysis.file_text(position.file_id).unwrap();
-                expect.assert_eq(&format!("{range:?}: {}", source[range]))
+                expect.assert_eq(&format!("{range:?}: {}", &source[range]))
             }
             Err(RenameError(err)) => expect.assert_eq(&err),
         };

--- a/crates/rust-analyzer/src/cli/analysis_stats.rs
+++ b/crates/rust-analyzer/src/cli/analysis_stats.rs
@@ -422,7 +422,7 @@ impl flags::AnalysisStats {
                 if found_terms.is_empty() {
                     acc.tail_expr_no_term += 1;
                     acc.total_tail_exprs += 1;
-                    // println!("\n{}\n", &original_text);
+                    // println!("\n{original_text}\n");
                     continue;
                 };
 

--- a/crates/rust-analyzer/src/lsp/utils.rs
+++ b/crates/rust-analyzer/src/lsp/utils.rs
@@ -79,7 +79,7 @@ impl GlobalState {
     pub(crate) fn show_and_log_error(&mut self, message: String, additional_info: Option<String>) {
         match additional_info {
             Some(additional_info) => {
-                tracing::error!("{}:\n{}", &message, &additional_info);
+                tracing::error!("{message}:\n{additional_info}");
                 self.show_message(
                     lsp_types::MessageType::ERROR,
                     message,
@@ -87,7 +87,7 @@ impl GlobalState {
                 );
             }
             None => {
-                tracing::error!("{}", &message);
+                tracing::error!("{message}");
                 self.send_notification::<lsp_types::notification::ShowMessage>(
                     lsp_types::ShowMessageParams { typ: lsp_types::MessageType::ERROR, message },
                 );

--- a/crates/syntax/src/algo.rs
+++ b/crates/syntax/src/algo.rs
@@ -643,7 +643,7 @@ fn main() {
         let deletions = diff
             .deletions
             .iter()
-            .format_with("\n", |v, f| f(&format!("Line {}: {}", line_number(v), &fmt_syntax(v))));
+            .format_with("\n", |v, f| f(&format!("Line {}: {}", line_number(v), fmt_syntax(v))));
 
         let actual = format!(
             "insertions:\n\n{insertions}\n\nreplacements:\n\n{replacements}\n\ndeletions:\n\n{deletions}\n"

--- a/crates/syntax/src/ast/make.rs
+++ b/crates/syntax/src/ast/make.rs
@@ -179,18 +179,18 @@ pub fn ty_alias(
     }
 
     if let Some(list) = type_param_bounds {
-        s.push_str(&format!(" : {}", &list));
+        s.push_str(&format!(" : {list}"));
     }
 
     if let Some(cl) = where_clause {
-        s.push_str(&format!(" {}", &cl.to_string()));
+        s.push_str(&format!(" {cl}"));
     }
 
     if let Some(exp) = assignment {
         if let Some(cl) = exp.1 {
-            s.push_str(&format!(" = {} {}", &exp.0.to_string(), &cl.to_string()));
+            s.push_str(&format!(" = {} {cl}", exp.0));
         } else {
-            s.push_str(&format!(" = {}", &exp.0.to_string()));
+            s.push_str(&format!(" = {}", exp.0));
         }
     }
 


### PR DESCRIPTION
Clean up a few minor refs in `format!` macro, as it has a performance cost. Apparently the compiler is unable to inline `format!("{}", &variable)`, and does a run-time double-reference instead (format macro already does one level referencing). Inlining format args prevents accidental `&` misuse.

See https://github.com/rust-lang/rust-clippy/issues/10851