### PR TITLE
fix: Panic in debug profile for tuple deconstruct with arity mismatch

### DIFF
--- a/crates/hir-ty/src/diagnostics/match_check/pat_analysis.rs
+++ b/crates/hir-ty/src/diagnostics/match_check/pat_analysis.rs
@@ -86,6 +86,15 @@ impl<'db> MatchCheckCtx<'db> {
         arms: &[MatchArm<'db>],
         scrut_ty: Ty,
     ) -> Result<UsefulnessReport<'db, Self>, ()> {
+        if scrut_ty.contains_unknown() {
+            return Err(());
+        }
+        for arm in arms {
+            if arm.pat.ty().contains_unknown() {
+                return Err(());
+            }
+        }
+
         // FIXME: Determine place validity correctly. For now, err on the safe side.
         let place_validity = PlaceValidity::MaybeInvalid;
         // Measured to take ~100ms on modern hardware.

--- a/crates/ide-diagnostics/src/handlers/type_mismatch.rs
+++ b/crates/ide-diagnostics/src/handlers/type_mismatch.rs
@@ -748,4 +748,16 @@ fn f() {
 "#,
         );
     }
+
+    #[test]
+    fn regression_17585() {
+        check_diagnostics(
+            r#"
+fn f() {
+    let (_, _, _, ..) = (true, 42);
+     // ^^^^^^^^^^^^^ error: expected (bool, i32), found (bool, i32, {unknown})
+}
+"#,
+        );
+    }
 }


### PR DESCRIPTION
Fixes #17585, which doesn't affect daily use cases but quite annoying in development of r-a itself like writing tests.

This PR applies similar approach as in #17534, skipping match usefulness check for patterns containing errors