### PR TITLE
Remove lens.forceCustomCommands config

### DIFF
--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -655,9 +655,6 @@ config_data! {
         lens_debug_enable: bool            = true,
         /// Whether to show CodeLens in Rust files.
         lens_enable: bool           = true,
-        /// Internal config: use custom client-side commands even when the
-        /// client doesn't set the corresponding capability.
-        lens_forceCustomCommands: bool = true,
         /// Whether to show `Implementations` lens. Only applies when
         /// `#rust-analyzer.lens.enable#` is set.
         lens_implementations_enable: bool  = true,
@@ -2031,11 +2028,9 @@ impl Config {
     }
 
     pub fn client_commands(&self) -> ClientCommandsConfig {
-        let commands = self.commands();
-        let force = commands.is_none() && *self.lens_forceCustomCommands();
-        let commands = commands.map(|it| it.commands).unwrap_or_default();
+        let commands = self.commands().map(|it| it.commands).unwrap_or_default();
 
-        let get = |name: &str| commands.iter().any(|it| it == name) || force;
+        let get = |name: &str| commands.iter().any(|it| it == name);
 
         ClientCommandsConfig {
             run_single: get("rust-analyzer.runSingle"),

--- a/docs/user/generated_config.adoc
+++ b/docs/user/generated_config.adoc
@@ -764,12 +764,6 @@ Whether to show `Debug` lens. Only applies when
 --
 Whether to show CodeLens in Rust files.
 --
-[[rust-analyzer.lens.forceCustomCommands]]rust-analyzer.lens.forceCustomCommands (default: `true`)::
-+
---
-Internal config: use custom client-side commands even when the
-client doesn't set the corresponding capability.
---
 [[rust-analyzer.lens.implementations.enable]]rust-analyzer.lens.implementations.enable (default: `true`)::
 +
 --

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -2141,16 +2141,6 @@
             {
                 "title": "lens",
                 "properties": {
-                    "rust-analyzer.lens.forceCustomCommands": {
-                        "markdownDescription": "Internal config: use custom client-side commands even when the\nclient doesn't set the corresponding capability.",
-                        "default": true,
-                        "type": "boolean"
-                    }
-                }
-            },
-            {
-                "title": "lens",
-                "properties": {
                     "rust-analyzer.lens.implementations.enable": {
                         "markdownDescription": "Whether to show `Implementations` lens. Only applies when\n`#rust-analyzer.lens.enable#` is set.",
                         "default": true,


### PR DESCRIPTION
Closes https://github.com/rust-lang/rust-analyzer/issues/17643
A very simple PR that removes the lens.forceCustomCommands config feature without side effects.