### PR TITLE
feat: Use oldest rustup rust-analyzer when toolchain override is present

### DIFF
--- a/editors/code/src/bootstrap.ts
+++ b/editors/code/src/bootstrap.ts
@@ -15,7 +15,7 @@ export async function bootstrap(
     if (!path) {
         throw new Error(
             "rust-analyzer Language Server is not available. " +
-                "Please, ensure its [proper installation](https://rust-analyzer.github.io/manual.html#installation).",
+            "Please, ensure its [proper installation](https://rust-analyzer.github.io/manual.html#installation).",
         );
     }
 
@@ -103,11 +103,11 @@ async function getServer(
 
     await vscode.window.showErrorMessage(
         "Unfortunately we don't ship binaries for your platform yet. " +
-            "You need to manually clone the rust-analyzer repository and " +
-            "run `cargo xtask install --server` to build the language server from sources. " +
-            "If you feel that your platform should be supported, please create an issue " +
-            "about that [here](https://github.com/rust-lang/rust-analyzer/issues) and we " +
-            "will consider it.",
+        "You need to manually clone the rust-analyzer repository and " +
+        "run `cargo xtask install --server` to build the language server from sources. " +
+        "If you feel that your platform should be supported, please create an issue " +
+        "about that [here](https://github.com/rust-lang/rust-analyzer/issues) and we " +
+        "will consider it.",
     );
     return undefined;
 }
@@ -153,7 +153,6 @@ function orderFromPath(
     path: string,
     raVersionResolver: (path: string) => string | undefined,
 ): string {
-    // It is a semver, so we must resolve Rust Analyzer's version.
     const raVersion = raVersionResolver(path);
     const raDate = raVersion?.match(/^rust-analyzer .*\(.* (\d{4}-\d{2}-\d{2})\)$/);
     if (raDate?.length === 2) {

--- a/editors/code/src/bootstrap.ts
+++ b/editors/code/src/bootstrap.ts
@@ -157,7 +157,7 @@ function orderFromPath(
     const raDate = raVersion?.match(/^rust-analyzer .*\(.* (\d{4}-\d{2}-\d{2})\)$/);
     if (raDate?.length === 2) {
         const precedence = path.includes("nightly-") ? "0" : "1";
-        return precedence + "-" + raDate[1];
+        return "0-" + raDate[1] + "/" + precedence;
     } else {
         return "2";
     }

--- a/editors/code/src/bootstrap.ts
+++ b/editors/code/src/bootstrap.ts
@@ -154,21 +154,16 @@ function orderFromPath(
     raVersionResolver: (path: string) => string | undefined,
 ): string {
     const capture = path.match(/^.*\/toolchains\/(.*)\/bin\/rust-analyzer$/);
-
     if (capture?.length === 2) {
         const toolchain = capture[1]!;
-        if (toolchain.startsWith("stable-")) {
-            return "1";
+        // It is a semver, so we must resolve Rust Analyzer's version.
+        const raVersion = raVersionResolver(path);
+        const raDate = raVersion?.match(/^rust-analyzer .*\(.* (\d{4}-\d{2}-\d{2})\)$/);
+        if (raDate?.length === 2) {
+            const precedence = toolchain.startsWith("nightly-") ? "/0" : "/1";
+            return "0-" + raDate[1] + precedence;
         } else {
-            // It is a semver, so we must resolve Rust Analyzer's version.
-            const raVersion = raVersionResolver(path);
-            const raDate = raVersion?.match(/^rust-analyzer .*\(.* (\d{4}-\d{2}-\d{2})\)$/);
-            if (raDate?.length === 2) {
-                const precedence = toolchain.startsWith("nightly-") ? "/0" : "/1";
-                return "0-" + raDate[1] + precedence;
-            } else {
-                return "2";
-            }
+            return "2";
         }
     } else {
         return "2";

--- a/editors/code/src/bootstrap.ts
+++ b/editors/code/src/bootstrap.ts
@@ -153,18 +153,12 @@ function orderFromPath(
     path: string,
     raVersionResolver: (path: string) => string | undefined,
 ): string {
-    const capture = path.match(/^.*\/toolchains\/(.*)\/bin\/rust-analyzer$/);
-    if (capture?.length === 2) {
-        const toolchain = capture[1]!;
-        // It is a semver, so we must resolve Rust Analyzer's version.
-        const raVersion = raVersionResolver(path);
-        const raDate = raVersion?.match(/^rust-analyzer .*\(.* (\d{4}-\d{2}-\d{2})\)$/);
-        if (raDate?.length === 2) {
-            const precedence = toolchain.startsWith("nightly-") ? "/0" : "/1";
-            return "0-" + raDate[1] + precedence;
-        } else {
-            return "2";
-        }
+    // It is a semver, so we must resolve Rust Analyzer's version.
+    const raVersion = raVersionResolver(path);
+    const raDate = raVersion?.match(/^rust-analyzer .*\(.* (\d{4}-\d{2}-\d{2})\)$/);
+    if (raDate?.length === 2) {
+        const precedence = path.includes("nightly-") ? "0" : "1";
+        return precedence + "-" + raDate[1];
     } else {
         return "2";
     }

--- a/editors/code/src/bootstrap.ts
+++ b/editors/code/src/bootstrap.ts
@@ -15,7 +15,7 @@ export async function bootstrap(
     if (!path) {
         throw new Error(
             "rust-analyzer Language Server is not available. " +
-            "Please, ensure its [proper installation](https://rust-analyzer.github.io/manual.html#installation).",
+                "Please, ensure its [proper installation](https://rust-analyzer.github.io/manual.html#installation).",
         );
     }
 
@@ -103,11 +103,11 @@ async function getServer(
 
     await vscode.window.showErrorMessage(
         "Unfortunately we don't ship binaries for your platform yet. " +
-        "You need to manually clone the rust-analyzer repository and " +
-        "run `cargo xtask install --server` to build the language server from sources. " +
-        "If you feel that your platform should be supported, please create an issue " +
-        "about that [here](https://github.com/rust-lang/rust-analyzer/issues) and we " +
-        "will consider it.",
+            "You need to manually clone the rust-analyzer repository and " +
+            "run `cargo xtask install --server` to build the language server from sources. " +
+            "If you feel that your platform should be supported, please create an issue " +
+            "about that [here](https://github.com/rust-lang/rust-analyzer/issues) and we " +
+            "will consider it.",
     );
     return undefined;
 }

--- a/editors/code/tests/unit/bootstrap.test.ts
+++ b/editors/code/tests/unit/bootstrap.test.ts
@@ -1,0 +1,89 @@
+import * as assert from "assert";
+import { _private } from "../../src/bootstrap";
+import type { Context } from ".";
+
+export async function getTests(ctx: Context) {
+    await ctx.suite("Bootstrap/Select toolchain RA", (suite) => {
+        suite.addTest("Order of nightly RA", async () => {
+            assert.deepStrictEqual(
+                _private.orderFromPath(
+                    "/Users/myuser/.rustup/toolchains/nightly-2022-11-22-aarch64-apple-darwin/bin/rust-analyzer",
+                    function (path: string) {
+                        assert.deepStrictEqual(
+                            path,
+                            "/Users/myuser/.rustup/toolchains/nightly-2022-11-22-aarch64-apple-darwin/bin/rust-analyzer",
+                        );
+                        return "rust-analyzer 1.67.0-nightly (b7bc90fe 2022-11-21)";
+                    },
+                ),
+                "0-2022-11-21/0",
+            );
+        });
+
+        suite.addTest("Order of versioned RA", async () => {
+            assert.deepStrictEqual(
+                _private.orderFromPath(
+                    "/Users/myuser/.rustup/toolchains/1.72.1-aarch64-apple-darwin/bin/rust-analyzer",
+                    function (path: string) {
+                        assert.deepStrictEqual(
+                            path,
+                            "/Users/myuser/.rustup/toolchains/1.72.1-aarch64-apple-darwin/bin/rust-analyzer",
+                        );
+                        return "rust-analyzer 1.72.1 (d5c2e9c3 2023-09-13)";
+                    },
+                ),
+                "0-2023-09-13/1",
+            );
+        });
+
+        suite.addTest("Order of versioned RA when unable to obtain version date", async () => {
+            assert.deepStrictEqual(
+                _private.orderFromPath(
+                    "/Users/myuser/.rustup/toolchains/1.72.1-aarch64-apple-darwin/bin/rust-analyzer",
+                    function () {
+                        return "rust-analyzer 1.72.1";
+                    },
+                ),
+                "2",
+            );
+        });
+
+        suite.addTest("Order of stable RA", async () => {
+            assert.deepStrictEqual(
+                _private.orderFromPath(
+                    "/Users/myuser/.rustup/toolchains/stable-aarch64-apple-darwin/bin/rust-analyzer",
+                    function () {
+                        assert.fail("Shouldn't get here.");
+                    },
+                ),
+                "1",
+            );
+        });
+
+        suite.addTest("Order with invalid path to RA", async () => {
+            assert.deepStrictEqual(
+                _private.orderFromPath("some-weird-path", function () {
+                    assert.fail("Shouldn't get here.");
+                }),
+                "2",
+            );
+        });
+
+        suite.addTest("Earliest RA between nightly and stable", async () => {
+            assert.deepStrictEqual(
+                _private.earliestToolchainPath(
+                    "/Users/myuser/.rustup/toolchains/stable-aarch64-apple-darwin/bin/rust-analyzer",
+                    "/Users/myuser/.rustup/toolchains/nightly-2022-11-22-aarch64-apple-darwin/bin/rust-analyzer",
+                    function (path: string) {
+                        assert.deepStrictEqual(
+                            path,
+                            "/Users/myuser/.rustup/toolchains/nightly-2022-11-22-aarch64-apple-darwin/bin/rust-analyzer",
+                        );
+                        return "rust-analyzer 1.67.0-nightly (b7bc90fe 2022-11-21)";
+                    },
+                ),
+                "/Users/myuser/.rustup/toolchains/nightly-2022-11-22-aarch64-apple-darwin/bin/rust-analyzer",
+            );
+        });
+    });
+}

--- a/editors/code/tests/unit/bootstrap.test.ts
+++ b/editors/code/tests/unit/bootstrap.test.ts
@@ -52,11 +52,15 @@ export async function getTests(ctx: Context) {
             assert.deepStrictEqual(
                 _private.orderFromPath(
                     "/Users/myuser/.rustup/toolchains/stable-aarch64-apple-darwin/bin/rust-analyzer",
-                    function () {
-                        assert.fail("Shouldn't get here.");
+                    function (path: string) {
+                        assert.deepStrictEqual(
+                            path,
+                            "/Users/myuser/.rustup/toolchains/stable-aarch64-apple-darwin/bin/rust-analyzer",
+                        );
+                        return "rust-analyzer 1.79.0 (129f3b99 2024-06-10)";
                     },
                 ),
-                "1",
+                "0-2024-06-10/1",
             );
         });
 
@@ -75,11 +79,14 @@ export async function getTests(ctx: Context) {
                     "/Users/myuser/.rustup/toolchains/stable-aarch64-apple-darwin/bin/rust-analyzer",
                     "/Users/myuser/.rustup/toolchains/nightly-2022-11-22-aarch64-apple-darwin/bin/rust-analyzer",
                     function (path: string) {
-                        assert.deepStrictEqual(
-                            path,
-                            "/Users/myuser/.rustup/toolchains/nightly-2022-11-22-aarch64-apple-darwin/bin/rust-analyzer",
-                        );
-                        return "rust-analyzer 1.67.0-nightly (b7bc90fe 2022-11-21)";
+                        if (
+                            path ===
+                            "/Users/myuser/.rustup/toolchains/nightly-2022-11-22-aarch64-apple-darwin/bin/rust-analyzer"
+                        ) {
+                            return "rust-analyzer 1.67.0-nightly (b7bc90fe 2022-11-21)";
+                        } else {
+                            return "rust-analyzer 1.79.0 (129f3b99 2024-06-10)";
+                        }
                     },
                 ),
                 "/Users/myuser/.rustup/toolchains/nightly-2022-11-22-aarch64-apple-darwin/bin/rust-analyzer",

--- a/editors/code/tests/unit/bootstrap.test.ts
+++ b/editors/code/tests/unit/bootstrap.test.ts
@@ -16,7 +16,7 @@ export async function getTests(ctx: Context) {
                         return "rust-analyzer 1.67.0-nightly (b7bc90fe 2022-11-21)";
                     },
                 ),
-                "0-2022-11-21",
+                "0-2022-11-21/0",
             );
         });
 
@@ -32,7 +32,7 @@ export async function getTests(ctx: Context) {
                         return "rust-analyzer 1.72.1 (d5c2e9c3 2023-09-13)";
                     },
                 ),
-                "1-2023-09-13",
+                "0-2023-09-13/1",
             );
         });
 
@@ -60,7 +60,7 @@ export async function getTests(ctx: Context) {
                         return "rust-analyzer 1.79.0 (129f3b99 2024-06-10)";
                     },
                 ),
-                "1-2024-06-10",
+                "0-2024-06-10/1",
             );
         });
 

--- a/editors/code/tests/unit/bootstrap.test.ts
+++ b/editors/code/tests/unit/bootstrap.test.ts
@@ -16,7 +16,7 @@ export async function getTests(ctx: Context) {
                         return "rust-analyzer 1.67.0-nightly (b7bc90fe 2022-11-21)";
                     },
                 ),
-                "0-2022-11-21/0",
+                "0-2022-11-21",
             );
         });
 
@@ -32,7 +32,7 @@ export async function getTests(ctx: Context) {
                         return "rust-analyzer 1.72.1 (d5c2e9c3 2023-09-13)";
                     },
                 ),
-                "0-2023-09-13/1",
+                "1-2023-09-13",
             );
         });
 
@@ -60,14 +60,14 @@ export async function getTests(ctx: Context) {
                         return "rust-analyzer 1.79.0 (129f3b99 2024-06-10)";
                     },
                 ),
-                "0-2024-06-10/1",
+                "1-2024-06-10",
             );
         });
 
         suite.addTest("Order with invalid path to RA", async () => {
             assert.deepStrictEqual(
                 _private.orderFromPath("some-weird-path", function () {
-                    assert.fail("Shouldn't get here.");
+                    return undefined;
                 }),
                 "2",
             );


### PR DESCRIPTION
Selects a rust-toolchain declared RA based on its date. The earliest (oldest) RA wins and becomes the one that the workspace uses as a whole.

In terms of precedence:

nightly > stable-with-version > stable

With stable-with-version, we invoke the RA with a `--version` arg and attempt to extract a date. Given the same date as a nightly, the nightly RA will win.

Fixes #17663