### PR TITLE
docs: Reference cov_mark crate instead of test_utils/mark

### DIFF
--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -408,7 +408,7 @@ It has a much richer vocabulary of types than `ide`, but the basic testing setup
 For comparisons, we use the `expect` crate for snapshot testing.
 
 To test various analysis corner cases and avoid forgetting about old tests, we use so-called marks.
-See the `marks` module in the `test_utils` crate for more.
+See the [cov_mark](https://docs.rs/cov-mark/latest/cov_mark/) crate documentation for more.
 
 **Architecture Invariant:** rust-analyzer tests do not use libcore or libstd.
 All required library code must be a part of the tests.


### PR DESCRIPTION
Seems this was switched over in https://github.com/rust-lang/rust-analyzer/issues/7922

I'm guessing this should skip the changelog because it's so minor, right? Reading through https://github.com/rust-lang/rust-analyzer/blob/master/docs/dev/style.md and trying to get up to speed here =)