### PR TITLE
feat(ide-completion): explictly show `async` keyword on `impl trait` methods

### DIFF
--- a/crates/ide-completion/src/completions/item_list/trait_impl.rs
+++ b/crates/ide-completion/src/completions/item_list/trait_impl.rs
@@ -195,9 +195,13 @@ fn add_function_impl(
     });
 
     let mut item = CompletionItem::new(completion_kind, replacement_range, label);
-    item.lookup_by(format!("{}fn {}", if is_async { "async "} else { "" },fn_name.display(ctx.db)))
-        .set_documentation(func.docs(ctx.db))
-        .set_relevance(CompletionRelevance { is_item_from_trait: true, ..Default::default() });
+    item.lookup_by(format!(
+        "{}fn {}",
+        if is_async { "async " } else { "" },
+        fn_name.display(ctx.db)
+    ))
+    .set_documentation(func.docs(ctx.db))
+    .set_relevance(CompletionRelevance { is_item_from_trait: true, ..Default::default() });
 
     if let Some(source) = ctx.sema.source(func) {
         let assoc_item = ast::AssocItem::Fn(source.value);

--- a/crates/ide-completion/src/completions/item_list/trait_impl.rs
+++ b/crates/ide-completion/src/completions/item_list/trait_impl.rs
@@ -180,8 +180,10 @@ fn add_function_impl(
 ) {
     let fn_name = func.name(ctx.db);
 
+    let is_async = func.is_async(ctx.db);
     let label = format_smolstr!(
-        "fn {}({})",
+        "{}fn {}({})",
+        if is_async { "async " } else { "" },
         fn_name.display(ctx.db),
         if func.assoc_fn_params(ctx.db).is_empty() { "" } else { ".." }
     );
@@ -193,7 +195,7 @@ fn add_function_impl(
     });
 
     let mut item = CompletionItem::new(completion_kind, replacement_range, label);
-    item.lookup_by(format!("fn {}", fn_name.display(ctx.db)))
+    item.lookup_by(format!("{}fn {}", if is_async { "async "} else { "" },fn_name.display(ctx.db)))
         .set_documentation(func.docs(ctx.db))
         .set_relevance(CompletionRelevance { is_item_from_trait: true, ..Default::default() });
 

--- a/crates/ide-completion/src/tests/item_list.rs
+++ b/crates/ide-completion/src/tests/item_list.rs
@@ -299,6 +299,7 @@ trait Test {
     const CONST1: ();
     fn function0();
     fn function1();
+    async fn function2();
 }
 
 impl Test for () {
@@ -310,8 +311,9 @@ impl Test for () {
 "#,
         expect![[r#"
             ct const CONST1: () =
+            fn async fn function2()
             fn fn function1()
-            ma makro!(…)          macro_rules! makro
+            ma makro!(…)            macro_rules! makro
             md module
             ta type Type1 =
             kw crate::

--- a/crates/ide-diagnostics/src/handlers/trait_impl_missing_assoc_item.rs
+++ b/crates/ide-diagnostics/src/handlers/trait_impl_missing_assoc_item.rs
@@ -13,7 +13,7 @@ pub(crate) fn trait_impl_missing_assoc_item(
 ) -> Diagnostic {
     let missing = d.missing.iter().format_with(", ", |(name, item), f| {
         f(&match *item {
-            hir::AssocItem::Function(func) if func.is_async(ctx.sema.db)  => "`async fn ",
+            hir::AssocItem::Function(func) if func.is_async(ctx.sema.db) => "`async fn ",
             hir::AssocItem::Function(_) => "`fn ",
             hir::AssocItem::Const(_) => "`const ",
             hir::AssocItem::TypeAlias(_) => "`type ",

--- a/crates/ide-diagnostics/src/handlers/trait_impl_missing_assoc_item.rs
+++ b/crates/ide-diagnostics/src/handlers/trait_impl_missing_assoc_item.rs
@@ -13,6 +13,7 @@ pub(crate) fn trait_impl_missing_assoc_item(
 ) -> Diagnostic {
     let missing = d.missing.iter().format_with(", ", |(name, item), f| {
         f(&match *item {
+            hir::AssocItem::Function(func) if func.is_async(ctx.sema.db)  => "`async fn ",
             hir::AssocItem::Function(_) => "`fn ",
             hir::AssocItem::Const(_) => "`const ",
             hir::AssocItem::TypeAlias(_) => "`type ",
@@ -56,22 +57,25 @@ trait Trait {
     const C: ();
     type T;
     fn f();
+    async fn async_f();
 }
 
 impl Trait for () {
     const C: () = ();
     type T = ();
     fn f() {}
+    async fn async_f() {}
 }
 
 impl Trait for () {
    //^^^^^ error: not all trait items implemented, missing: `const C`
     type T = ();
     fn f() {}
+    async fn async_f() {}
 }
 
 impl Trait for () {
-   //^^^^^ error: not all trait items implemented, missing: `const C`, `type T`, `fn f`
+   //^^^^^ error: not all trait items implemented, missing: `const C`, `type T`, `fn f`, `async fn async_f`
 }
 
 "#,

--- a/crates/ide-diagnostics/src/handlers/trait_impl_missing_assoc_item.rs
+++ b/crates/ide-diagnostics/src/handlers/trait_impl_missing_assoc_item.rs
@@ -13,7 +13,6 @@ pub(crate) fn trait_impl_missing_assoc_item(
 ) -> Diagnostic {
     let missing = d.missing.iter().format_with(", ", |(name, item), f| {
         f(&match *item {
-            hir::AssocItem::Function(func) if func.is_async(ctx.sema.db) => "`async fn ",
             hir::AssocItem::Function(_) => "`fn ",
             hir::AssocItem::Const(_) => "`const ",
             hir::AssocItem::TypeAlias(_) => "`type ",
@@ -57,25 +56,22 @@ trait Trait {
     const C: ();
     type T;
     fn f();
-    async fn async_f();
 }
 
 impl Trait for () {
     const C: () = ();
     type T = ();
     fn f() {}
-    async fn async_f() {}
 }
 
 impl Trait for () {
    //^^^^^ error: not all trait items implemented, missing: `const C`
     type T = ();
     fn f() {}
-    async fn async_f() {}
 }
 
 impl Trait for () {
-   //^^^^^ error: not all trait items implemented, missing: `const C`, `type T`, `fn f`, `async fn async_f`
+   //^^^^^ error: not all trait items implemented, missing: `const C`, `type T`, `fn f`
 }
 
 "#,


### PR DESCRIPTION
OLD:

<img width="676" alt="image" src="https://github.com/user-attachments/assets/f6fa626f-6b6d-4c22-af27-b0755e7a6bf8">


Now:

<img width="684" alt="image" src="https://github.com/user-attachments/assets/efbaac0e-c805-4dd2-859d-3e44b2886dbb">

---

This is an preparation for https://github.com/rust-lang/rust-analyzer/issues/17719.

```rust
use std::future::Future;

trait DesugaredAsyncTrait {
    fn foo(&self) -> impl Future<Output = usize> + Send;
    fn bar(&self) -> impl Future<Output = usize> + Send;
}

struct Foo;

impl DesugaredAsyncTrait for Foo {
    fn foo(&self) -> impl Future<Output = usize> + Send {
        async { 1 }
    }

    //
    async fn bar(&self) -> usize {
        1
    }
}

fn main() {
    let fut = Foo.bar();
    fn _assert_send<T: Send>(_: T) {}
    _assert_send(fut);
}
```

If we don't distinguish `async` or not. It would be confusing to generate sugared version `async fn foo ....` and original form `fn foo`  for `async fn in trait` that is defined in desugar form.
