### PR TITLE
minor: Set tracing level to debug when `cargo config get env` fails

### DIFF
--- a/crates/project-model/src/env.rs
+++ b/crates/project-model/src/env.rs
@@ -81,7 +81,7 @@ pub(crate) fn cargo_config_env(
             tracing::debug!("Discovered cargo config env: {:?}", env);
         })
         .inspect_err(|err| {
-            tracing::error!("Failed to discover cargo config env: {:?}", err);
+            tracing::debug!("Failed to discover cargo config env: {:?}", err);
         })
         .unwrap_or_default()
 }


### PR DESCRIPTION
fixes #17739 