### PR TITLE
Improve crate manifests, adding missing `[package.repository]` and `[package.description]` fields

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ rust-version = "1.78"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["rust-analyzer team"]
+repository = "https://github.com/rust-lang/rust-analyzer"
 
 [profile.dev]
 debug = 1

--- a/crates/base-db/Cargo.toml
+++ b/crates/base-db/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "base-db"
 version = "0.0.0"
-repository = "https://github.com/rust-lang/rust-analyzer"
+repository.workspace = true
 description = "Basic database traits for rust-analyzer. The concrete DB is defined by `ide` (aka `ra_ap_ide`)."
 
 authors.workspace = true

--- a/crates/base-db/Cargo.toml
+++ b/crates/base-db/Cargo.toml
@@ -2,7 +2,7 @@
 name = "base-db"
 version = "0.0.0"
 repository = "https://github.com/rust-lang/rust-analyzer"
-description = "Basic database traits. The concrete DB is defined by `ide` (aka `ra_ap_ide`)."
+description = "Basic database traits for rust-analyzer. The concrete DB is defined by `ide` (aka `ra_ap_ide`)."
 
 authors.workspace = true
 edition.workspace = true

--- a/crates/base-db/Cargo.toml
+++ b/crates/base-db/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "base-db"
 version = "0.0.0"
-description = "TBD"
+description = "Basic database traits. The concrete DB is defined by `ra_ap_ide`."
 
 authors.workspace = true
 edition.workspace = true

--- a/crates/base-db/Cargo.toml
+++ b/crates/base-db/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "base-db"
 version = "0.0.0"
+repository = "https://github.com/rust-lang/rust-analyzer"
 description = "Basic database traits. The concrete DB is defined by `ra_ap_ide`."
 
 authors.workspace = true

--- a/crates/base-db/Cargo.toml
+++ b/crates/base-db/Cargo.toml
@@ -2,7 +2,7 @@
 name = "base-db"
 version = "0.0.0"
 repository = "https://github.com/rust-lang/rust-analyzer"
-description = "Basic database traits. The concrete DB is defined by `ra_ap_ide`."
+description = "Basic database traits. The concrete DB is defined by `ide` (aka `ra_ap_ide`)."
 
 authors.workspace = true
 edition.workspace = true

--- a/crates/cfg/Cargo.toml
+++ b/crates/cfg/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cfg"
 version = "0.0.0"
 repository = "https://github.com/rust-lang/rust-analyzer"
-description = "Conditional compiling options, `cfg` attribute parser and evaluator."
+description = "Conditional compiling options, `cfg` attribute parser and evaluator for rust-analyzer."
 
 authors.workspace = true
 edition.workspace = true

--- a/crates/cfg/Cargo.toml
+++ b/crates/cfg/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cfg"
 version = "0.0.0"
-description = "TBD"
+description = "Conditional compiling options, `cfg` attribute parser and evaluator."
 
 authors.workspace = true
 edition.workspace = true

--- a/crates/cfg/Cargo.toml
+++ b/crates/cfg/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "cfg"
 version = "0.0.0"
+repository = "https://github.com/rust-lang/rust-analyzer"
 description = "Conditional compiling options, `cfg` attribute parser and evaluator."
 
 authors.workspace = true

--- a/crates/cfg/Cargo.toml
+++ b/crates/cfg/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cfg"
 version = "0.0.0"
-repository = "https://github.com/rust-lang/rust-analyzer"
+repository.workspace = true
 description = "Conditional compiling options, `cfg` attribute parser and evaluator for rust-analyzer."
 
 authors.workspace = true

--- a/crates/flycheck/Cargo.toml
+++ b/crates/flycheck/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "flycheck"
 version = "0.0.0"
+repository = "https://github.com/rust-lang/rust-analyzer"
 description = "Functionality needed to run `cargo` commands in a background thread."
 
 authors.workspace = true

--- a/crates/flycheck/Cargo.toml
+++ b/crates/flycheck/Cargo.toml
@@ -2,7 +2,7 @@
 name = "flycheck"
 version = "0.0.0"
 repository = "https://github.com/rust-lang/rust-analyzer"
-description = "Functionality needed to run `cargo` commands in a background thread."
+description = "Functionality needed for rust-analyzer to run `cargo` commands in a background thread."
 
 authors.workspace = true
 edition.workspace = true

--- a/crates/flycheck/Cargo.toml
+++ b/crates/flycheck/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "flycheck"
 version = "0.0.0"
-repository = "https://github.com/rust-lang/rust-analyzer"
+repository.workspace = true
 description = "Functionality needed for rust-analyzer to run `cargo` commands in a background thread."
 
 authors.workspace = true

--- a/crates/flycheck/Cargo.toml
+++ b/crates/flycheck/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "flycheck"
 version = "0.0.0"
-description = "TBD"
+description = "Functionality needed to run `cargo` commands in a background thread."
 
 authors.workspace = true
 edition.workspace = true

--- a/crates/hir-def/Cargo.toml
+++ b/crates/hir-def/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hir-def"
 version = "0.0.0"
-description = "TBD"
+description = "Everything between macro expansion and type inference for rust-analyzer."
 
 authors.workspace = true
 edition.workspace = true

--- a/crates/hir-def/Cargo.toml
+++ b/crates/hir-def/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "hir-def"
 version = "0.0.0"
+repository = "https://github.com/rust-lang/rust-analyzer"
 description = "Everything between macro expansion and type inference for rust-analyzer."
 
 authors.workspace = true

--- a/crates/hir-def/Cargo.toml
+++ b/crates/hir-def/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hir-def"
 version = "0.0.0"
-repository = "https://github.com/rust-lang/rust-analyzer"
+repository.workspace = true
 description = "RPC Api for the `proc-macro-srv` crate of rust-analyzer."
 
 authors.workspace = true

--- a/crates/hir-def/Cargo.toml
+++ b/crates/hir-def/Cargo.toml
@@ -2,7 +2,7 @@
 name = "hir-def"
 version = "0.0.0"
 repository = "https://github.com/rust-lang/rust-analyzer"
-description = "Everything between macro expansion and type inference for rust-analyzer."
+description = "RPC Api for the `proc-macro-srv` crate of rust-analyzer."
 
 authors.workspace = true
 edition.workspace = true

--- a/crates/hir-expand/Cargo.toml
+++ b/crates/hir-expand/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hir-expand"
 version = "0.0.0"
-description = "TBD"
+description = "Macro expansion for rust-analyzer."
 
 authors.workspace = true
 edition.workspace = true

--- a/crates/hir-expand/Cargo.toml
+++ b/crates/hir-expand/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hir-expand"
 version = "0.0.0"
-repository = "https://github.com/rust-lang/rust-analyzer"
+repository.workspace = true
 description = "Macro expansion for rust-analyzer."
 
 authors.workspace = true

--- a/crates/hir-expand/Cargo.toml
+++ b/crates/hir-expand/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "hir-expand"
 version = "0.0.0"
+repository = "https://github.com/rust-lang/rust-analyzer"
 description = "Macro expansion for rust-analyzer."
 
 authors.workspace = true

--- a/crates/hir-ty/Cargo.toml
+++ b/crates/hir-ty/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hir-ty"
 version = "0.0.0"
-description = "TBD"
+description = "The type system for rust-analyzer."
 
 authors.workspace = true
 edition.workspace = true

--- a/crates/hir-ty/Cargo.toml
+++ b/crates/hir-ty/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hir-ty"
 version = "0.0.0"
-repository = "https://github.com/rust-lang/rust-analyzer"
+repository.workspace = true
 description = "The type system for rust-analyzer."
 
 authors.workspace = true

--- a/crates/hir-ty/Cargo.toml
+++ b/crates/hir-ty/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "hir-ty"
 version = "0.0.0"
+repository = "https://github.com/rust-lang/rust-analyzer"
 description = "The type system for rust-analyzer."
 
 authors.workspace = true

--- a/crates/hir/Cargo.toml
+++ b/crates/hir/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hir"
 version = "0.0.0"
-description = "TBD"
+description = "A high-level object oriented access to Rust code."
 
 authors.workspace = true
 edition.workspace = true

--- a/crates/hir/Cargo.toml
+++ b/crates/hir/Cargo.toml
@@ -2,7 +2,7 @@
 name = "hir"
 version = "0.0.0"
 repository = "https://github.com/rust-lang/rust-analyzer"
-description = "A high-level object-oriented access to Rust code."
+description = "A high-level object-oriented access to Rust code for rust-analyzer."
 
 authors.workspace = true
 edition.workspace = true

--- a/crates/hir/Cargo.toml
+++ b/crates/hir/Cargo.toml
@@ -2,7 +2,7 @@
 name = "hir"
 version = "0.0.0"
 repository = "https://github.com/rust-lang/rust-analyzer"
-description = "A high-level object oriented access to Rust code."
+description = "A high-level object-oriented access to Rust code."
 
 authors.workspace = true
 edition.workspace = true

--- a/crates/hir/Cargo.toml
+++ b/crates/hir/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "hir"
 version = "0.0.0"
+repository = "https://github.com/rust-lang/rust-analyzer"
 description = "A high-level object oriented access to Rust code."
 
 authors.workspace = true

--- a/crates/hir/Cargo.toml
+++ b/crates/hir/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hir"
 version = "0.0.0"
-repository = "https://github.com/rust-lang/rust-analyzer"
+repository.workspace = true
 description = "A high-level object-oriented access to Rust code for rust-analyzer."
 
 authors.workspace = true

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -1,4 +1,4 @@
-//! HIR (previously known as descriptors) provides a high-level object oriented
+//! HIR (previously known as descriptors) provides a high-level object-oriented
 //! access to Rust code.
 //!
 //! The principal difference between HIR and syntax trees is that HIR is bound

--- a/crates/ide-assists/Cargo.toml
+++ b/crates/ide-assists/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ide-assists"
 version = "0.0.0"
-description = "TBD"
+description = "Code assists for rust-analyzer."
 
 authors.workspace = true
 edition.workspace = true

--- a/crates/ide-assists/Cargo.toml
+++ b/crates/ide-assists/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ide-assists"
 version = "0.0.0"
-repository = "https://github.com/rust-lang/rust-analyzer"
+repository.workspace = true
 description = "Code assists for rust-analyzer."
 
 authors.workspace = true

--- a/crates/ide-assists/Cargo.toml
+++ b/crates/ide-assists/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "ide-assists"
 version = "0.0.0"
+repository = "https://github.com/rust-lang/rust-analyzer"
 description = "Code assists for rust-analyzer."
 
 authors.workspace = true

--- a/crates/ide-completion/Cargo.toml
+++ b/crates/ide-completion/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ide-completion"
 version = "0.0.0"
-description = "TBD"
+description = "Utilities for generating completions of user input."
 
 authors.workspace = true
 edition.workspace = true

--- a/crates/ide-completion/Cargo.toml
+++ b/crates/ide-completion/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ide-completion"
 version = "0.0.0"
-repository = "https://github.com/rust-lang/rust-analyzer"
+repository.workspace = true
 description = "Utilities for generating completions of user input for rust-analyzer."
 
 authors.workspace = true

--- a/crates/ide-completion/Cargo.toml
+++ b/crates/ide-completion/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "ide-completion"
 version = "0.0.0"
+repository = "https://github.com/rust-lang/rust-analyzer"
 description = "Utilities for generating completions of user input."
 
 authors.workspace = true

--- a/crates/ide-completion/Cargo.toml
+++ b/crates/ide-completion/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ide-completion"
 version = "0.0.0"
 repository = "https://github.com/rust-lang/rust-analyzer"
-description = "Utilities for generating completions of user input."
+description = "Utilities for generating completions of user input for rust-analyzer."
 
 authors.workspace = true
 edition.workspace = true

--- a/crates/ide-db/Cargo.toml
+++ b/crates/ide-db/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ide-db"
 version = "0.0.0"
 repository = "https://github.com/rust-lang/rust-analyzer"
-description = "Core data structure representing IDE state."
+description = "Core data structure representing IDE state for rust-analyzer."
 
 authors.workspace = true
 edition.workspace = true

--- a/crates/ide-db/Cargo.toml
+++ b/crates/ide-db/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ide-db"
 version = "0.0.0"
-repository = "https://github.com/rust-lang/rust-analyzer"
+repository.workspace = true
 description = "Core data structure representing IDE state for rust-analyzer."
 
 authors.workspace = true

--- a/crates/ide-db/Cargo.toml
+++ b/crates/ide-db/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ide-db"
 version = "0.0.0"
-description = "TBD"
+description = "Core data-structure representing IDE state."
 
 authors.workspace = true
 edition.workspace = true

--- a/crates/ide-db/Cargo.toml
+++ b/crates/ide-db/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "ide-db"
 version = "0.0.0"
+repository = "https://github.com/rust-lang/rust-analyzer"
 description = "Core data-structure representing IDE state."
 
 authors.workspace = true

--- a/crates/ide-db/Cargo.toml
+++ b/crates/ide-db/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ide-db"
 version = "0.0.0"
 repository = "https://github.com/rust-lang/rust-analyzer"
-description = "Core data-structure representing IDE state."
+description = "Core data structure representing IDE state."
 
 authors.workspace = true
 edition.workspace = true

--- a/crates/ide-db/src/lib.rs
+++ b/crates/ide-db/src/lib.rs
@@ -1,4 +1,4 @@
-//! This crate defines the core datastructure representing IDE state -- `RootDatabase`.
+//! This crate defines the core data structure representing IDE state -- `RootDatabase`.
 //!
 //! It is mainly a `HirDatabase` for semantic analysis, plus a `SymbolsDatabase`, for fuzzy search.
 

--- a/crates/ide-diagnostics/Cargo.toml
+++ b/crates/ide-diagnostics/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ide-diagnostics"
 version = "0.0.0"
-repository = "https://github.com/rust-lang/rust-analyzer"
+repository.workspace = true
 description = "Diagnostics rendering and fixits for rust-analyzer."
 
 authors.workspace = true

--- a/crates/ide-diagnostics/Cargo.toml
+++ b/crates/ide-diagnostics/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ide-diagnostics"
 version = "0.0.0"
-description = "TBD"
+description = "Diagnostics rendering and fixits."
 
 authors.workspace = true
 edition.workspace = true

--- a/crates/ide-diagnostics/Cargo.toml
+++ b/crates/ide-diagnostics/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ide-diagnostics"
 version = "0.0.0"
 repository = "https://github.com/rust-lang/rust-analyzer"
-description = "Diagnostics rendering and fixits."
+description = "Diagnostics rendering and fixits for rust-analyzer."
 
 authors.workspace = true
 edition.workspace = true

--- a/crates/ide-diagnostics/Cargo.toml
+++ b/crates/ide-diagnostics/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "ide-diagnostics"
 version = "0.0.0"
+repository = "https://github.com/rust-lang/rust-analyzer"
 description = "Diagnostics rendering and fixits."
 
 authors.workspace = true

--- a/crates/ide-ssr/Cargo.toml
+++ b/crates/ide-ssr/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "ide-ssr"
 version = "0.0.0"
-description = "Structural search and replace of Rust code"
 repository = "https://github.com/rust-lang/rust-analyzer"
+description = "Structural search and replace of Rust code."
 
 authors.workspace = true
 edition.workspace = true

--- a/crates/ide-ssr/Cargo.toml
+++ b/crates/ide-ssr/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ide-ssr"
 version = "0.0.0"
-repository = "https://github.com/rust-lang/rust-analyzer"
+repository.workspace = true
 description = "Structural search and replace of Rust code for rust-analyzer."
 
 authors.workspace = true

--- a/crates/ide-ssr/Cargo.toml
+++ b/crates/ide-ssr/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ide-ssr"
 version = "0.0.0"
 repository = "https://github.com/rust-lang/rust-analyzer"
-description = "Structural search and replace of Rust code."
+description = "Structural search and replace of Rust code for rust-analyzer."
 
 authors.workspace = true
 edition.workspace = true

--- a/crates/ide/Cargo.toml
+++ b/crates/ide/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ide"
 version = "0.0.0"
-repository = "https://github.com/rust-lang/rust-analyzer"
+repository.workspace = true
 description = "IDE-centric APIs for rust-analyzer."
 
 authors.workspace = true

--- a/crates/ide/Cargo.toml
+++ b/crates/ide/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ide"
 version = "0.0.0"
-description = "TBD"
+description = "IDE-centric APIs for rust-analyzer."
 
 authors.workspace = true
 edition.workspace = true

--- a/crates/ide/Cargo.toml
+++ b/crates/ide/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "ide"
 version = "0.0.0"
+repository = "https://github.com/rust-lang/rust-analyzer"
 description = "IDE-centric APIs for rust-analyzer."
 
 authors.workspace = true

--- a/crates/intern/Cargo.toml
+++ b/crates/intern/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "intern"
 version = "0.0.0"
-description = "TBD"
+description = "Global `Arc`-based object interning infrastructure."
 
 authors.workspace = true
 edition.workspace = true

--- a/crates/intern/Cargo.toml
+++ b/crates/intern/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "intern"
 version = "0.0.0"
+repository = "https://github.com/rust-lang/rust-analyzer"
 description = "Global `Arc`-based object interning infrastructure."
 
 authors.workspace = true

--- a/crates/intern/Cargo.toml
+++ b/crates/intern/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "intern"
 version = "0.0.0"
-repository = "https://github.com/rust-lang/rust-analyzer"
+repository.workspace = true
 description = "Global `Arc`-based object interning infrastructure for rust-analyzer."
 
 authors.workspace = true

--- a/crates/intern/Cargo.toml
+++ b/crates/intern/Cargo.toml
@@ -2,7 +2,7 @@
 name = "intern"
 version = "0.0.0"
 repository = "https://github.com/rust-lang/rust-analyzer"
-description = "Global `Arc`-based object interning infrastructure."
+description = "Global `Arc`-based object interning infrastructure for rust-analyzer."
 
 authors.workspace = true
 edition.workspace = true

--- a/crates/limit/Cargo.toml
+++ b/crates/limit/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "limit"
 version = "0.0.0"
+repository = "https://github.com/rust-lang/rust-analyzer"
 description = "A struct to enforce limits."
 
 authors.workspace = true

--- a/crates/limit/Cargo.toml
+++ b/crates/limit/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "limit"
 version = "0.0.0"
-description = "TBD"
+description = "A struct to enforce limits."
 
 authors.workspace = true
 edition.workspace = true

--- a/crates/limit/Cargo.toml
+++ b/crates/limit/Cargo.toml
@@ -2,7 +2,7 @@
 name = "limit"
 version = "0.0.0"
 repository = "https://github.com/rust-lang/rust-analyzer"
-description = "A struct to enforce limits."
+description = "A struct to enforce limits for rust-analyzer."
 
 authors.workspace = true
 edition.workspace = true

--- a/crates/limit/Cargo.toml
+++ b/crates/limit/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "limit"
 version = "0.0.0"
-repository = "https://github.com/rust-lang/rust-analyzer"
+repository.workspace = true
 description = "A struct to enforce limits for rust-analyzer."
 
 authors.workspace = true

--- a/crates/load-cargo/Cargo.toml
+++ b/crates/load-cargo/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "load-cargo"
 version = "0.0.0"
-repository = "https://github.com/rust-lang/rust-analyzer"
+repository.workspace = true
 description = "Loads a Cargo project into a static instance of rust-analyzer for analysis."
 
 rust-version.workspace = true

--- a/crates/load-cargo/Cargo.toml
+++ b/crates/load-cargo/Cargo.toml
@@ -2,7 +2,7 @@
 name = "load-cargo"
 version = "0.0.0"
 repository = "https://github.com/rust-lang/rust-analyzer"
-description = "Loads a Cargo project into a static instance of analysis."
+description = "Loads a Cargo project into a static instance of rust-analyzer for analysis."
 
 rust-version.workspace = true
 edition.workspace = true

--- a/crates/load-cargo/Cargo.toml
+++ b/crates/load-cargo/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "load-cargo"
 version = "0.0.0"
-description = "TBD"
+description = "Loads a Cargo project into a static instance of analysis."
 
 rust-version.workspace = true
 edition.workspace = true

--- a/crates/load-cargo/Cargo.toml
+++ b/crates/load-cargo/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "load-cargo"
 version = "0.0.0"
+repository = "https://github.com/rust-lang/rust-analyzer"
 description = "Loads a Cargo project into a static instance of analysis."
 
 rust-version.workspace = true

--- a/crates/mbe/Cargo.toml
+++ b/crates/mbe/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "mbe"
 version = "0.0.0"
+repository = "https://github.com/rust-lang/rust-analyzer"
 description = "Handling of `macro_rules` macros for rust-analyzer."
 
 authors.workspace = true

--- a/crates/mbe/Cargo.toml
+++ b/crates/mbe/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mbe"
 version = "0.0.0"
-repository = "https://github.com/rust-lang/rust-analyzer"
+repository.workspace = true
 description = "Handling of `macro_rules` macros for rust-analyzer."
 
 authors.workspace = true

--- a/crates/mbe/Cargo.toml
+++ b/crates/mbe/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mbe"
 version = "0.0.0"
-description = "TBD"
+description = "Handling of `macro_rules` macros for rust-analyzer."
 
 authors.workspace = true
 edition.workspace = true

--- a/crates/parser/Cargo.toml
+++ b/crates/parser/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "parser"
 version = "0.0.0"
-repository = "https://github.com/rust-lang/rust-analyzer"
+repository.workspace = true
 description = "The Rust parser for rust-analyzer."
 
 authors.workspace = true

--- a/crates/parser/Cargo.toml
+++ b/crates/parser/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "parser"
 version = "0.0.0"
-description = "TBD"
+description = "The Rust parser for rust-analyzer."
 
 authors.workspace = true
 edition.workspace = true

--- a/crates/parser/Cargo.toml
+++ b/crates/parser/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "parser"
 version = "0.0.0"
+repository = "https://github.com/rust-lang/rust-analyzer"
 description = "The Rust parser for rust-analyzer."
 
 authors.workspace = true

--- a/crates/paths/Cargo.toml
+++ b/crates/paths/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "paths"
 version = "0.0.0"
-repository = "https://github.com/rust-lang/rust-analyzer"
+repository.workspace = true
 description = "Path wrappers for absolute and relative paths rust-analyzer."
 
 authors.workspace = true

--- a/crates/paths/Cargo.toml
+++ b/crates/paths/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "paths"
 version = "0.0.0"
+repository = "https://github.com/rust-lang/rust-analyzer"
 description = "Path wrappers for absolute and relative paths."
 
 authors.workspace = true

--- a/crates/paths/Cargo.toml
+++ b/crates/paths/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "paths"
 version = "0.0.0"
-description = "TBD"
+description = "Path wrappers for absolute and relative paths."
 
 authors.workspace = true
 edition.workspace = true

--- a/crates/paths/Cargo.toml
+++ b/crates/paths/Cargo.toml
@@ -2,7 +2,7 @@
 name = "paths"
 version = "0.0.0"
 repository = "https://github.com/rust-lang/rust-analyzer"
-description = "Path wrappers for absolute and relative paths."
+description = "Path wrappers for absolute and relative paths rust-analyzer."
 
 authors.workspace = true
 edition.workspace = true

--- a/crates/proc-macro-api/Cargo.toml
+++ b/crates/proc-macro-api/Cargo.toml
@@ -2,7 +2,7 @@
 name = "proc-macro-api"
 version = "0.0.0"
 repository = "https://github.com/rust-lang/rust-analyzer"
-description = "Client-side proc-macros for rust-analyzer."
+description = "RPC Api for the `proc-macro-srv` crate of rust-analyzer."
 
 authors.workspace = true
 edition.workspace = true

--- a/crates/proc-macro-api/Cargo.toml
+++ b/crates/proc-macro-api/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "proc-macro-api"
 version = "0.0.0"
-description = "TBD"
+description = "Client-side proc-macros for rust-analyzer."
 
 authors.workspace = true
 edition.workspace = true

--- a/crates/proc-macro-api/Cargo.toml
+++ b/crates/proc-macro-api/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "proc-macro-api"
 version = "0.0.0"
+repository = "https://github.com/rust-lang/rust-analyzer"
 description = "Client-side proc-macros for rust-analyzer."
 
 authors.workspace = true

--- a/crates/proc-macro-api/Cargo.toml
+++ b/crates/proc-macro-api/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "proc-macro-api"
 version = "0.0.0"
-repository = "https://github.com/rust-lang/rust-analyzer"
+repository.workspace = true
 description = "RPC Api for the `proc-macro-srv` crate of rust-analyzer."
 
 authors.workspace = true

--- a/crates/proc-macro-srv-cli/Cargo.toml
+++ b/crates/proc-macro-srv-cli/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "proc-macro-srv-cli"
 version = "0.0.0"
+repository = "https://github.com/rust-lang/rust-analyzer"
 description = "A standalone binary for `proc-macro-srv`."
 
 authors.workspace = true

--- a/crates/proc-macro-srv-cli/Cargo.toml
+++ b/crates/proc-macro-srv-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "proc-macro-srv-cli"
 version = "0.0.0"
-repository = "https://github.com/rust-lang/rust-analyzer"
+repository.workspace = true
 description = "A standalone binary for the `proc-macro-srv` crate of rust-analyzer."
 
 authors.workspace = true

--- a/crates/proc-macro-srv-cli/Cargo.toml
+++ b/crates/proc-macro-srv-cli/Cargo.toml
@@ -2,7 +2,7 @@
 name = "proc-macro-srv-cli"
 version = "0.0.0"
 repository = "https://github.com/rust-lang/rust-analyzer"
-description = "A standalone binary for `proc-macro-srv`."
+description = "A standalone binary for the `proc-macro-srv` crate of rust-analyzer."
 
 authors.workspace = true
 edition.workspace = true

--- a/crates/proc-macro-srv-cli/Cargo.toml
+++ b/crates/proc-macro-srv-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "proc-macro-srv-cli"
 version = "0.0.0"
-description = "TBD"
+description = "A standalone binary for `proc-macro-srv`."
 
 authors.workspace = true
 edition.workspace = true

--- a/crates/proc-macro-srv/Cargo.toml
+++ b/crates/proc-macro-srv/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "proc-macro-srv"
 version = "0.0.0"
-description = "TBD"
+description = "Proc-macro server for rust-analyzer."
 
 authors.workspace = true
 edition.workspace = true

--- a/crates/proc-macro-srv/Cargo.toml
+++ b/crates/proc-macro-srv/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "proc-macro-srv"
 version = "0.0.0"
-repository = "https://github.com/rust-lang/rust-analyzer"
+repository.workspace = true
 description = "Proc-macro server for rust-analyzer."
 
 authors.workspace = true

--- a/crates/proc-macro-srv/Cargo.toml
+++ b/crates/proc-macro-srv/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "proc-macro-srv"
 version = "0.0.0"
+repository = "https://github.com/rust-lang/rust-analyzer"
 description = "Proc-macro server for rust-analyzer."
 
 authors.workspace = true

--- a/crates/profile/Cargo.toml
+++ b/crates/profile/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "profile"
 version = "0.0.0"
-description = "TBD"
+description = "A collection of tools for profiling rust-analyzer."
 
 authors.workspace = true
 edition.workspace = true

--- a/crates/profile/Cargo.toml
+++ b/crates/profile/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "profile"
 version = "0.0.0"
+repository = "https://github.com/rust-lang/rust-analyzer"
 description = "A collection of tools for profiling rust-analyzer."
 
 authors.workspace = true

--- a/crates/profile/Cargo.toml
+++ b/crates/profile/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "profile"
 version = "0.0.0"
-repository = "https://github.com/rust-lang/rust-analyzer"
+repository.workspace = true
 description = "A collection of tools for profiling rust-analyzer."
 
 authors.workspace = true

--- a/crates/project-model/Cargo.toml
+++ b/crates/project-model/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "project-model"
 version = "0.0.0"
-description = "TBD"
+description = "A representation for a Cargo project for rust-analyzer."
 
 authors.workspace = true
 edition.workspace = true

--- a/crates/project-model/Cargo.toml
+++ b/crates/project-model/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "project-model"
 version = "0.0.0"
+repository = "https://github.com/rust-lang/rust-analyzer"
 description = "A representation for a Cargo project for rust-analyzer."
 
 authors.workspace = true

--- a/crates/project-model/Cargo.toml
+++ b/crates/project-model/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "project-model"
 version = "0.0.0"
-repository = "https://github.com/rust-lang/rust-analyzer"
+repository.workspace = true
 description = "A representation for a Cargo project for rust-analyzer."
 
 authors.workspace = true

--- a/crates/rust-analyzer/Cargo.toml
+++ b/crates/rust-analyzer/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rust-analyzer"
 version = "0.0.0"
 homepage = "https://rust-analyzer.github.io/"
-repository = "https://github.com/rust-analyzer/rust-analyzer"
+repository = "https://github.com/rust-lang/rust-analyzer"
 description = "A language server for the Rust programming language"
 documentation = "https://rust-analyzer.github.io/manual.html"
 autobins = false

--- a/crates/rust-analyzer/Cargo.toml
+++ b/crates/rust-analyzer/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rust-analyzer"
 version = "0.0.0"
 homepage = "https://rust-analyzer.github.io/"
-repository = "https://github.com/rust-lang/rust-analyzer"
+repository.workspace = true
 description = "A language server for the Rust programming language"
 documentation = "https://rust-analyzer.github.io/manual.html"
 autobins = false

--- a/crates/span/Cargo.toml
+++ b/crates/span/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "span"
 version = "0.0.0"
-repository = "https://github.com/rust-lang/rust-analyzer"
+repository.workspace = true
 description = "File and span related types for rust-analyzer."
 
 rust-version.workspace = true

--- a/crates/span/Cargo.toml
+++ b/crates/span/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "span"
 version = "0.0.0"
-description = "TBD"
+description = "File and span related types for rust-analyzer."
 
 rust-version.workspace = true
 edition.workspace = true

--- a/crates/span/Cargo.toml
+++ b/crates/span/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "span"
 version = "0.0.0"
+repository = "https://github.com/rust-lang/rust-analyzer"
 description = "File and span related types for rust-analyzer."
 
 rust-version.workspace = true

--- a/crates/stdx/Cargo.toml
+++ b/crates/stdx/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "stdx"
 version = "0.0.0"
-repository = "https://github.com/rust-lang/rust-analyzer"
+repository.workspace = true
 description = "Missing batteries for standard libraries for rust-analyzer."
 
 authors.workspace = true

--- a/crates/stdx/Cargo.toml
+++ b/crates/stdx/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "stdx"
 version = "0.0.0"
+repository = "https://github.com/rust-lang/rust-analyzer"
 description = "Missing batteries for standard libraries for rust-analyzer."
 
 authors.workspace = true

--- a/crates/stdx/Cargo.toml
+++ b/crates/stdx/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "stdx"
 version = "0.0.0"
-description = "TBD"
+description = "Missing batteries for standard libraries for rust-analyzer."
 
 authors.workspace = true
 edition.workspace = true

--- a/crates/syntax/Cargo.toml
+++ b/crates/syntax/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "syntax"
 version = "0.0.0"
-repository = "https://github.com/rust-lang/rust-analyzer"
+repository.workspace = true
 description = "Concrete syntax tree definitions for rust-analyzer."
 
 authors.workspace = true

--- a/crates/syntax/Cargo.toml
+++ b/crates/syntax/Cargo.toml
@@ -2,7 +2,7 @@
 name = "syntax"
 version = "0.0.0"
 repository = "https://github.com/rust-lang/rust-analyzer"
-description = "Comment and whitespace preserving parser for the Rust language"
+description = "Concrete syntax tree definitions for rust-analyzer."
 
 authors.workspace = true
 edition.workspace = true

--- a/crates/syntax/Cargo.toml
+++ b/crates/syntax/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "syntax"
 version = "0.0.0"
-description = "Comment and whitespace preserving parser for the Rust language"
 repository = "https://github.com/rust-lang/rust-analyzer"
+description = "Comment and whitespace preserving parser for the Rust language"
 
 authors.workspace = true
 edition.workspace = true

--- a/crates/test-utils/Cargo.toml
+++ b/crates/test-utils/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "test-utils"
 version = "0.0.0"
-repository = "https://github.com/rust-lang/rust-analyzer"
+repository.workspace = true
 description = "Assorted testing utilities for rust-analyzer."
 
 authors.workspace = true

--- a/crates/test-utils/Cargo.toml
+++ b/crates/test-utils/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "test-utils"
 version = "0.0.0"
-description = "TBD"
+description = "Assorted testing utilities for rust-analyzer."
 
 authors.workspace = true
 edition.workspace = true

--- a/crates/test-utils/Cargo.toml
+++ b/crates/test-utils/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "test-utils"
 version = "0.0.0"
+repository = "https://github.com/rust-lang/rust-analyzer"
 description = "Assorted testing utilities for rust-analyzer."
 
 authors.workspace = true

--- a/crates/text-edit/Cargo.toml
+++ b/crates/text-edit/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "text-edit"
 version = "0.0.0"
-description = "TBD"
+description = "Representation of a `TextEdit` for rust-analyzer."
 
 authors.workspace = true
 edition.workspace = true

--- a/crates/text-edit/Cargo.toml
+++ b/crates/text-edit/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "text-edit"
 version = "0.0.0"
+repository = "https://github.com/rust-lang/rust-analyzer"
 description = "Representation of a `TextEdit` for rust-analyzer."
 
 authors.workspace = true

--- a/crates/text-edit/Cargo.toml
+++ b/crates/text-edit/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "text-edit"
 version = "0.0.0"
-repository = "https://github.com/rust-lang/rust-analyzer"
+repository.workspace = true
 description = "Representation of a `TextEdit` for rust-analyzer."
 
 authors.workspace = true

--- a/crates/toolchain/Cargo.toml
+++ b/crates/toolchain/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "toolchain"
 version = "0.0.0"
-description = "TBD"
+description = "Discovery of `cargo` & `rustc` executables for rust-analyzer."
 
 authors.workspace = true
 edition.workspace = true

--- a/crates/toolchain/Cargo.toml
+++ b/crates/toolchain/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "toolchain"
 version = "0.0.0"
+repository = "https://github.com/rust-lang/rust-analyzer"
 description = "Discovery of `cargo` & `rustc` executables for rust-analyzer."
 
 authors.workspace = true

--- a/crates/toolchain/Cargo.toml
+++ b/crates/toolchain/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "toolchain"
 version = "0.0.0"
-repository = "https://github.com/rust-lang/rust-analyzer"
+repository.workspace = true
 description = "Discovery of `cargo` & `rustc` executables for rust-analyzer."
 
 authors.workspace = true

--- a/crates/tt/Cargo.toml
+++ b/crates/tt/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "tt"
 version = "0.0.0"
+repository = "https://github.com/rust-lang/rust-analyzer"
 description = "A `TokenTree` data structure for rust-analyzer."
 
 authors.workspace = true

--- a/crates/tt/Cargo.toml
+++ b/crates/tt/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tt"
 version = "0.0.0"
-description = "TBD"
+description = "A `TokenTree` data structure for rust-analyzer."
 
 authors.workspace = true
 edition.workspace = true

--- a/crates/tt/Cargo.toml
+++ b/crates/tt/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tt"
 version = "0.0.0"
-repository = "https://github.com/rust-lang/rust-analyzer"
+repository.workspace = true
 description = "A `TokenTree` data structure for rust-analyzer."
 
 authors.workspace = true

--- a/crates/vfs-notify/Cargo.toml
+++ b/crates/vfs-notify/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vfs-notify"
 version = "0.0.0"
-repository = "https://github.com/rust-lang/rust-analyzer"
+repository.workspace = true
 description = "Implementation of `loader::Handle` for rust-analyzer."
 
 authors.workspace = true

--- a/crates/vfs-notify/Cargo.toml
+++ b/crates/vfs-notify/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vfs-notify"
 version = "0.0.0"
-description = "TBD"
+description = "Implementation of `loader::Handle` for rust-analyzer."
 
 authors.workspace = true
 edition.workspace = true

--- a/crates/vfs-notify/Cargo.toml
+++ b/crates/vfs-notify/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "vfs-notify"
 version = "0.0.0"
+repository = "https://github.com/rust-lang/rust-analyzer"
 description = "Implementation of `loader::Handle` for rust-analyzer."
 
 authors.workspace = true

--- a/crates/vfs/Cargo.toml
+++ b/crates/vfs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vfs"
 version = "0.0.0"
-repository = "https://github.com/rust-lang/rust-analyzer"
+repository.workspace = true
 description = "A virtual file system for rust-analyzer."
 
 authors.workspace = true

--- a/crates/vfs/Cargo.toml
+++ b/crates/vfs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vfs"
 version = "0.0.0"
-description = "TBD"
+description = "A virtual file system for rust-analyzer."
 
 authors.workspace = true
 edition.workspace = true

--- a/crates/vfs/Cargo.toml
+++ b/crates/vfs/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "vfs"
 version = "0.0.0"
+repository = "https://github.com/rust-lang/rust-analyzer"
 description = "A virtual file system for rust-analyzer."
 
 authors.workspace = true


### PR DESCRIPTION
As [discussed on Zulip](https://rust-lang.zulipchat.com/#narrow/stream/185405-t-compiler.2Frust-analyzer/topic/Could.20we.20add.20repository.20url.20to.20.60ra_ap_.60.20crates.20on.20crates.2Eio.3F/near/455095161).

cc @Veykril @lnicola