### PR TITLE
fix: Insert a generic arg for `impl Trait` when lowering generic args

### DIFF
--- a/crates/hir-def/src/path/lower.rs
+++ b/crates/hir-def/src/path/lower.rs
@@ -194,6 +194,11 @@ pub(super) fn lower_generic_args(
         match generic_arg {
             ast::GenericArg::TypeArg(type_arg) => {
                 let type_ref = TypeRef::from_ast_opt(lower_ctx, type_arg.ty());
+                type_ref.walk(&mut |tr| {
+                    if let TypeRef::ImplTrait(bounds) = tr {
+                        lower_ctx.update_impl_traits_bounds(bounds.clone());
+                    }
+                });
                 args.push(GenericArg::Type(type_ref));
             }
             ast::GenericArg::AssocTypeArg(assoc_type_arg) => {

--- a/crates/hir-ty/src/tests/regression.rs
+++ b/crates/hir-ty/src/tests/regression.rs
@@ -2122,3 +2122,22 @@ fn test() {
 "#,
     )
 }
+
+#[test]
+fn issue_17191() {
+    check_types(
+        r#"
+trait A {
+    type Item;
+}
+
+trait B<T> {}
+
+fn foo<T: B<impl A>>() {}
+
+fn test() {
+    let f = foo;
+      //^ fn foo<{unknown}>()
+}"#,
+    );
+}


### PR DESCRIPTION
Fixes #17191 

We are not inserting a generic arg when lowering generics like
```rust
fn foo<T: B<impl A>(..) { ... }
```
but when we are lowering predicates we do;

https://github.com/rust-lang/rust-analyzer/blob/aa00ddcf654a35ba0eafe17247cf189958d33182/crates/hir-ty/src/lower.rs#L1697-L1718
https://github.com/rust-lang/rust-analyzer/blob/aa00ddcf654a35ba0eafe17247cf189958d33182/crates/hir-ty/src/lower.rs#L310

and this mismatch causes index out of bound panic while substituting the predicates