### PR TITLE
fix: tyck for non-ADT types when searching refs for `Self` kw

### DIFF
--- a/crates/ide-db/src/search.rs
+++ b/crates/ide-db/src/search.rs
@@ -663,9 +663,16 @@ impl<'a> FindUsages<'a> {
         name_ref: &ast::NameRef,
         sink: &mut dyn FnMut(EditionedFileId, FileReference) -> bool,
     ) -> bool {
+        // See https://github.com/rust-lang/rust-analyzer/pull/15864/files/e0276dc5ddc38c65240edb408522bb869f15afb4#r1389848845
+        let ty_eq = |ty: hir::Type| match (ty.as_adt(), self_ty.as_adt()) {
+            (Some(ty), Some(self_ty)) => ty == self_ty,
+            (None, None) => ty == *self_ty,
+            _ => false,
+        };
+
         match NameRefClass::classify(self.sema, name_ref) {
             Some(NameRefClass::Definition(Definition::SelfType(impl_)))
-                if impl_.self_ty(self.sema.db).as_adt() == self_ty.as_adt() =>
+                if ty_eq(impl_.self_ty(self.sema.db)) =>
             {
                 let FileRange { file_id, range } = self.sema.original_range(name_ref.syntax());
                 let reference = FileReference {

--- a/crates/ide/src/references.rs
+++ b/crates/ide/src/references.rs
@@ -60,7 +60,6 @@ pub(crate) fn find_all_refs(
         move |def: Definition| {
             let mut usages =
                 def.usages(sema).set_scope(search_scope.as_ref()).include_self_refs().all();
-
             if literal_search {
                 retain_adt_literal_usages(&mut usages, def, sema);
             }
@@ -813,6 +812,30 @@ impl<T> S<T> {
             FileId(0) 48..49
             FileId(0) 71..75
             FileId(0) 86..90
+            "#]],
+        )
+    }
+
+    #[test]
+    fn test_self_inside_not_adt_impl() {
+        check(
+            r#"
+pub trait TestTrait {
+    type Assoc;
+    fn stuff() -> Self;
+}
+impl TestTrait for () {
+    type Assoc$0 = u8;
+    fn stuff() -> Self {
+        let me: Self = ();
+        me
+    }
+}
+"#,
+            expect![[r#"
+                Assoc TypeAlias FileId(0) 92..108 97..102
+
+                FileId(0) 31..36
             "#]],
         )
     }


### PR DESCRIPTION
See https://github.com/rust-lang/rust-analyzer/pull/15864/files/e0276dc5ddc38c65240edb408522bb869f15afb4#r1389848845

For ADTs, to handle `{error}` in generic args, we should to convert them to ADT for comparisons; for others, we can directly compare the types.