### PR TITLE
fix: Fix unconfigured diagnostic being attached to the wrong file for modules

### DIFF
--- a/crates/hir-def/src/nameres/collector.rs
+++ b/crates/hir-def/src/nameres/collector.rs
@@ -2003,7 +2003,7 @@ impl ModCollector<'_, '_> {
                             Err(cfg) => {
                                 self.emit_unconfigured_diagnostic(
                                     self.tree_id,
-                                    AttrOwner::TopLevel,
+                                    AttrOwner::ModItem(module_id.into()),
                                     &cfg,
                                 );
                             }

--- a/crates/ide-diagnostics/src/handlers/inactive_code.rs
+++ b/crates/ide-diagnostics/src/handlers/inactive_code.rs
@@ -42,7 +42,10 @@ mod tests {
     use crate::{tests::check_diagnostics_with_config, DiagnosticsConfig};
 
     pub(crate) fn check(ra_fixture: &str) {
-        let config = DiagnosticsConfig::test_sample();
+        let config = DiagnosticsConfig {
+            disabled: std::iter::once("unlinked-file".to_owned()).collect(),
+            ..DiagnosticsConfig::test_sample()
+        };
         check_diagnostics_with_config(config, ra_fixture)
     }
 
@@ -168,6 +171,27 @@ union FooBar {
   #[cfg(a)] baz: u32,
 //^^^^^^^^^^^^^^^^^^ weak: code is inactive due to #[cfg] directives: a is disabled
 }
+"#,
+        );
+    }
+
+    #[test]
+    fn modules() {
+        check(
+            r#"
+//- /main.rs
+  #[cfg(outline)] mod outline;
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^ weak: code is inactive due to #[cfg] directives: outline is disabled
+
+  mod outline_inner;
+//^^^^^^^^^^^^^^^^^^ weak: code is inactive due to #[cfg] directives: outline_inner is disabled
+
+  #[cfg(inline)] mod inline {}
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^ weak: code is inactive due to #[cfg] directives: inline is disabled
+
+//- /outline_inner.rs
+#![cfg(outline_inner)]
+//- /outline.rs
 "#,
         );
     }


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust-analyzer/issues/17817