### PR TITLE
fix: Native diagnostics not working

### DIFF
--- a/crates/rust-analyzer/src/diagnostics.rs
+++ b/crates/rust-analyzer/src/diagnostics.rs
@@ -110,7 +110,7 @@ impl DiagnosticCollection {
                     })
                 {
                     // don't signal an update if the diagnostics are the same
-                    return;
+                    continue;
                 }
                 if *old_gen < generation || generation == 0 {
                     target.insert(file_id, (generation, diagnostics));


### PR DESCRIPTION
              This should be a `continue` now

_Originally posted by @Veykril in https://github.com/rust-lang/rust-analyzer/pull/17775#discussion_r1706845633_

I've tested the release compile output with IDE in the original PR, but my test workspace had only one `.rs` file 🤦 😢 