### PR TITLE
Improve crate manifest of 'syntax-bridge', adding missing `[package.repository]` and `[package.description]` fields

### DIFF
--- a/crates/syntax-bridge/Cargo.toml
+++ b/crates/syntax-bridge/Cargo.toml
@@ -2,6 +2,7 @@
 name = "syntax-bridge"
 version = "0.0.0"
 description = "TBD"
+repository.workspace = true
 
 authors.workspace = true
 edition.workspace = true

--- a/crates/syntax-bridge/Cargo.toml
+++ b/crates/syntax-bridge/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "syntax-bridge"
 version = "0.0.0"
-description = "TBD"
 repository.workspace = true
+description = "Conversions between syntax nodes and token trees for rust-analyzer."
 
 authors.workspace = true
 edition.workspace = true


### PR DESCRIPTION
This is a follow-up of https://github.com/rust-lang/rust-analyzer/pull/17745, specifically [this comment](https://github.com/rust-lang/rust-analyzer/pull/17745#issuecomment-2271102382) by @lnicola.

It refines the manifest of the newly added 'syntax-bridge' crate, adding a `[package.repository]` as `workspace = true` and changes the existing `[package.description]` from "TBD" to a more useful description.
