### PR TITLE
internal: Performance optimizations

### DIFF
--- a/crates/rust-analyzer/src/flycheck.rs
+++ b/crates/rust-analyzer/src/flycheck.rs
@@ -388,7 +388,7 @@ impl FlycheckActor {
         package: Option<&str>,
         saved_file: Option<&AbsPath>,
     ) -> Option<Command> {
-        let (mut cmd, args) = match &self.config {
+        match &self.config {
             FlycheckConfig::CargoCommand { command, options, ansi_color_output } => {
                 let mut cmd = Command::new(Tool::Cargo.path());
                 if let Some(sysroot_root) = &self.sysroot_root {
@@ -419,7 +419,8 @@ impl FlycheckActor {
                 cmd.arg("--keep-going");
 
                 options.apply_on_command(&mut cmd);
-                (cmd, options.extra_args.clone())
+                cmd.args(&options.extra_args);
+                Some(cmd)
             }
             FlycheckConfig::CustomCommand {
                 command,
@@ -448,34 +449,31 @@ impl FlycheckActor {
                     }
                 }
 
-                if args.contains(&SAVED_FILE_PLACEHOLDER.to_owned()) {
-                    // If the custom command has a $saved_file placeholder, and
-                    // we're saving a file, replace the placeholder in the arguments.
-                    if let Some(saved_file) = saved_file {
-                        let args = args
-                            .iter()
-                            .map(|arg| {
-                                if arg == SAVED_FILE_PLACEHOLDER {
-                                    saved_file.to_string()
-                                } else {
-                                    arg.clone()
-                                }
-                            })
-                            .collect();
-                        (cmd, args)
-                    } else {
-                        // The custom command has a $saved_file placeholder,
-                        // but we had an IDE event that wasn't a file save. Do nothing.
-                        return None;
+                // If the custom command has a $saved_file placeholder, and
+                // we're saving a file, replace the placeholder in the arguments.
+                if let Some(saved_file) = saved_file {
+                    for arg in args {
+                        if arg == SAVED_FILE_PLACEHOLDER {
+                            cmd.arg(saved_file);
+                        } else {
+                            cmd.arg(arg);
+                        }
                     }
                 } else {
-                    (cmd, args.clone())
-                }
-            }
-        };
+                    for arg in args {
+                        if arg == SAVED_FILE_PLACEHOLDER {
+                            // The custom command has a $saved_file placeholder,
+                            // but we had an IDE event that wasn't a file save. Do nothing.
+                            return None;
+                        }
 
-        cmd.args(args);
-        Some(cmd)
+                        cmd.arg(arg);
+                    }
+                }
+
+                Some(cmd)
+            }
+        }
     }
 
     fn send(&self, check_task: FlycheckMessage) {


### PR DESCRIPTION
- Use `Command::arg` directly
- Avoid the overhead of the `select!` macro when possible
- Use `select_biased!`