### PR TITLE
Only keep lib/ in publish-libs

### DIFF
--- a/.github/workflows/publish-libs.yaml
+++ b/.github/workflows/publish-libs.yaml
@@ -30,7 +30,6 @@ jobs:
         run: |
           git config --global user.email "runner@gha.local"
           git config --global user.name "GitHub Action"
-          # Remove r-a crates from the workspaces so we don't auto-publish them as well
-          sed -i 's/"crates\/\*"//' ./Cargo.toml
-          sed -i 's/"xtask\/"//' ./Cargo.toml
+          # Only publish the crates under lib/
+          sed -i 's|^members = .*$|members = ["lib/*"]|' Cargo.toml
           cargo workspaces publish --yes --exact --from-git --no-git-commit --allow-dirty


### PR DESCRIPTION
Follow-up to #17860, see https://github.com/rust-lang/rust-analyzer/actions/runs/10350212090/job/28646162590.