### PR TITLE
Allow flycheck process to exit gracefully

### DIFF
--- a/crates/rust-analyzer/src/command.rs
+++ b/crates/rust-analyzer/src/command.rs
@@ -148,7 +148,6 @@ impl<T: ParseFromLine> CommandHandle<T> {
     }
 
     pub(crate) fn join(mut self) -> io::Result<()> {
-        let _ = self.child.0.kill();
         let exit_status = self.child.0.wait()?;
         let (read_at_least_one_message, error) = self.thread.join()?;
         if read_at_least_one_message || exit_status.success() {


### PR DESCRIPTION
Assuming it isn't cancelled. Closes #17902.

The only place CommandHandle::join() is used is when the flycheck command
finishes, so this commit changes the behavior of the method itself.

The only reason I can see for the existing behavior is if the command is somehow holding onto a build lock longer than it should, this would force it to be released. But it would be a pretty heavy-handed way to solve that issue. I'm not aware of this occurring in practice.