### PR TITLE
Test for word boundary in `FindUsages`

### DIFF
--- a/crates/ide-db/src/search.rs
+++ b/crates/ide-db/src/search.rs
@@ -503,6 +503,20 @@ impl<'a> FindUsages<'a> {
                 if !search_range.contains_inclusive(offset) {
                     return None;
                 }
+                // If this is not a word boundary, that means this is only part of an identifier,
+                // so it can't be what we're looking for.
+                // This speeds up short identifiers significantly.
+                if text[..idx]
+                    .chars()
+                    .next_back()
+                    .is_some_and(|ch| matches!(ch, 'A'..='Z' | 'a'..='z' | '_'))
+                    || text[idx + finder.needle().len()..]
+                        .chars()
+                        .next()
+                        .is_some_and(|ch| matches!(ch, 'A'..='Z' | 'a'..='z' | '_' | '0'..='9'))
+                {
+                    return None;
+                }
                 Some(offset)
             })
         }


### PR DESCRIPTION
This speeds up short identifiers search significantly, while unlikely to have an effect on long identifiers (the analysis takes much longer than some character comparison).

Tested by finding all references to `eq()` (from `PartialEq`) in the rust-analyzer repo. Total time went down from 100s to 10s (a 10x reduction!).

Feel free to close this if you consider this a non-issue, as most short identifiers are local.