### PR TITLE
Remove rust-analyzer.workspace.discoverProjectRunner

### DIFF
--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -330,14 +330,6 @@
                         "default": false,
                         "type": "boolean"
                     },
-                    "rust-analyzer.discoverProjectRunner": {
-                        "markdownDescription": "Sets the extension responsible for determining which extension the rust-analyzer extension uses to generate `rust-project.json` files. This should should only be used\n if a build system like Buck or Bazel is also in use.",
-                        "default": null,
-                        "type": [
-                            "null",
-                            "string"
-                        ]
-                    },
                     "rust-analyzer.showUnlinkedFileNotification": {
                         "markdownDescription": "Whether to show a notification for unlinked files asking the user to add the corresponding Cargo.toml to the linked projects setting.",
                         "default": true,

--- a/editors/code/src/config.ts
+++ b/editors/code/src/config.ts
@@ -252,10 +252,6 @@ export class Config {
         await this.cfg.update("checkOnSave", !(value || false), target || null, overrideInLanguage);
     }
 
-    get discoverProjectRunner(): string | undefined {
-        return this.get<string | undefined>("discoverProjectRunner");
-    }
-
     get problemMatcher(): string[] {
         return this.get<string[]>("runnables.problemMatcher") || [];
     }


### PR DESCRIPTION
The functionality for this vscode config option was removed in #17395, so it doesn't do anything anymore.