### PR TITLE
Pin `rowan` to `0.15.15`

### DIFF
--- a/crates/syntax/Cargo.toml
+++ b/crates/syntax/Cargo.toml
@@ -16,7 +16,7 @@ doctest = false
 cov-mark = "2.0.0-pre.1"
 either.workspace = true
 itertools.workspace = true
-rowan = "0.15.15"
+rowan = "=0.15.15"
 rustc-hash.workspace = true
 indexmap.workspace = true
 smol_str.workspace = true


### PR DESCRIPTION
To prevent #17914, I think that it would be safer pinning this before we fix it correctly