### PR TITLE
fix: Panic when a TAIT exists in a RPIT

### DIFF
--- a/crates/hir-ty/src/tests/regression.rs
+++ b/crates/hir-ty/src/tests/regression.rs
@@ -2211,3 +2211,20 @@ fn f() -> Foo {}
         "#]],
     );
 }
+
+#[test]
+fn issue_17921() {
+    check_infer(
+        r#"
+//- minicore: future
+trait Foo {}
+type Bar = impl Foo;
+
+async fn f<A, B, C>() -> Bar {}
+"#,
+        expect![[r#"
+            64..66 '{}': ()
+            64..66 '{}': impl Future<Output = ()>
+        "#]],
+    );
+}


### PR DESCRIPTION
Fixes  #17921

When there is a TAIT inside of a RPIT like;

```rust
trait Foo {}
type Bar = impl Foo;
fn foo<A>() -> impl Future<Output = Bar> { .. }
```

while inferencing `fn foo`, `insert_inference_vars_for_impl_trait` tries to substitute impl trait bounds of `Bar`, i.e. `Implemented(Foo)` with RPITs `placeholders`, and this causes panic

https://github.com/rust-lang/rust-analyzer/blob/fa003262474185fd62168379500fe906b331824b/crates/hir-ty/src/infer.rs#L903-L905