### PR TITLE
fix: Wrong `Sized` predicate for `generic_predicates_for_param`

### DIFF
--- a/crates/hir-ty/src/lower.rs
+++ b/crates/hir-ty/src/lower.rs
@@ -1551,6 +1551,10 @@ pub(crate) fn generic_predicates_for_param_query(
                 }
             };
             if invalid_target {
+                // If this is filtered out without lowering, `?Sized` is not gathered into `ctx.unsized_types`
+                if let TypeBound::Path(_, TraitBoundModifier::Maybe) = &**bound {
+                    ctx.lower_where_predicate(pred, &def, true).for_each(drop);
+                }
                 return false;
             }
 


### PR DESCRIPTION
I found this gathers wrong `Self: Sized` bound while implementing object safety, though I couldn't find proper test for this.

If we call `generic_predicates_for_param` to `Bar` in the following code;
```rust
trait Foo<T: ?Sized> {}
trait Bar<T: Foo<Self> + ?Sized> {}
```
it returns `T: Sized` and `Self: Sized` bound, because normaly, the `?Sized` bound applied properly in L1059 with;
https://github.com/rust-lang/rust-analyzer/blob/3723e5910c14f0ffbd13de474b8a8fcc74db04ce/crates/hir-ty/src/lower.rs#L1035-L1061

But we filter them before it is lowered with that function here;

https://github.com/rust-lang/rust-analyzer/blob/3723e5910c14f0ffbd13de474b8a8fcc74db04ce/crates/hir-ty/src/lower.rs#L1540-L1586

So, the `?Sized` bounded params are not gathered into `ctx.unsized_types` and thus we are applying them implicit `Sized` bound here;

https://github.com/rust-lang/rust-analyzer/blob/3723e5910c14f0ffbd13de474b8a8fcc74db04ce/crates/hir-ty/src/lower.rs#L1591-L1602