### PR TITLE
fix: Don't enable the search fast path for short associated functions when a search scope is set

### DIFF
--- a/crates/ide-db/src/search.rs
+++ b/crates/ide-db/src/search.rs
@@ -528,6 +528,10 @@ impl<'a> FindUsages<'a> {
         search_scope: &SearchScope,
         name: &str,
     ) -> bool {
+        if self.scope.is_some() {
+            return false;
+        }
+
         let _p = tracing::info_span!("short_associated_function_fast_search").entered();
 
         let container = (|| {


### PR DESCRIPTION
In most places where we set a search scope it is a single file, and so the fast path will actually harm performance, since it has to search for aliases in the whole project. The only exception that qualifies for the fast path is SSR (there is an exception that don't qualify for the fast path as it search for `use` items). It sets the search scope to avoid dependencies. We could make it use the fast path, but I didn't bother.

I forgot this while working on #17927.