### PR TITLE
Always show error lifetime arguments as `'_`

### DIFF
--- a/crates/hir-ty/src/display.rs
+++ b/crates/hir-ty/src/display.rs
@@ -1438,17 +1438,7 @@ fn hir_fmt_generics(
 
     let parameters_to_write = generic_args_sans_defaults(f, generic_def, parameters);
 
-    // FIXME: Remote this
-    // most of our lifetimes will be errors as we lack elision and inference
-    // so don't render them for now
-    let only_err_lifetimes = !cfg!(test)
-        && parameters_to_write.iter().all(|arg| {
-            matches!(
-                arg.data(Interner),
-                chalk_ir::GenericArgData::Lifetime(it) if *it.data(Interner) == LifetimeData::Error
-            )
-        });
-    if !parameters_to_write.is_empty() && !only_err_lifetimes {
+    if !parameters_to_write.is_empty() {
         write!(f, "<")?;
         hir_fmt_generic_arguments(f, parameters_to_write, self_)?;
         write!(f, ">")?;
@@ -1881,7 +1871,7 @@ impl HirDisplay for DomainGoal {
                 wc.hir_fmt(f)?;
                 write!(f, ")")?;
             }
-            _ => write!(f, "?")?,
+            _ => write!(f, "_")?,
         }
         Ok(())
     }

--- a/crates/ide-assists/src/handlers/extract_function.rs
+++ b/crates/ide-assists/src/handlers/extract_function.rs
@@ -5649,7 +5649,7 @@ fn func<T: Debug>(i: Struct<'_, T>) {
     fun_name(i);
 }
 
-fn $0fun_name(i: Struct<T>) {
+fn $0fun_name(i: Struct<'_, T>) {
     foo(i);
 }
 "#,

--- a/crates/ide-completion/src/tests/predicate.rs
+++ b/crates/ide-completion/src/tests/predicate.rs
@@ -19,7 +19,7 @@ struct Foo<'lt, T, const C: usize> where $0 {}
             en Enum      Enum
             ma makro!(…) macro_rules! makro
             md module
-            st Foo<…>    Foo<{unknown}, _>
+            st Foo<…>    Foo<'_, {unknown}, _>
             st Record    Record
             st Tuple     Tuple
             st Unit      Unit
@@ -92,7 +92,7 @@ struct Foo<'lt, T, const C: usize> where for<'a> $0 {}
             en Enum      Enum
             ma makro!(…) macro_rules! makro
             md module
-            st Foo<…>    Foo<{unknown}, _>
+            st Foo<…>    Foo<'_, {unknown}, _>
             st Record    Record
             st Tuple     Tuple
             st Unit      Unit

--- a/crates/ide-completion/src/tests/type_pos.rs
+++ b/crates/ide-completion/src/tests/type_pos.rs
@@ -20,8 +20,8 @@ struct Foo<'lt, T, const C: usize> {
             en Enum      Enum
             ma makro!(…) macro_rules! makro
             md module
-            sp Self      Foo<{unknown}, _>
-            st Foo<…>    Foo<{unknown}, _>
+            sp Self      Foo<'_, {unknown}, _>
+            st Foo<…>    Foo<'_, {unknown}, _>
             st Record    Record
             st Tuple     Tuple
             st Unit      Unit
@@ -45,8 +45,8 @@ struct Foo<'lt, T, const C: usize>(f$0);
             en Enum       Enum
             ma makro!(…)  macro_rules! makro
             md module
-            sp Self       Foo<{unknown}, _>
-            st Foo<…>     Foo<{unknown}, _>
+            sp Self       Foo<'_, {unknown}, _>
+            st Foo<…>     Foo<'_, {unknown}, _>
             st Record     Record
             st Tuple      Tuple
             st Unit       Unit

--- a/crates/ide/src/inlay_hints/bind_pat.rs
+++ b/crates/ide/src/inlay_hints/bind_pat.rs
@@ -342,7 +342,7 @@ fn f<'a>() {
     let x = S::<'static>;
       //^ S<'static>
     let y = S::<'_>;
-      //^ S
+      //^ S<'_>
     let z = S::<'a>;
       //^ S<'a>
 


### PR DESCRIPTION
Fixes #17947

Changed error lifetime argument presentation in non-test environment to `'_` and now showing them even if all of args are error lifetimes.

This also influenced some of the other tests like `extract_function.rs`, `predicate.rs` and `type_pos.rs`. Not sure whether I need to refrain from adding lifetimes args there. Happy to fix if needed