### PR TITLE
fix: Fix "Unwrap block" assist with block modifiers

### DIFF
--- a/crates/ide-assists/src/handlers/unwrap_block.rs
+++ b/crates/ide-assists/src/handlers/unwrap_block.rs
@@ -128,10 +128,12 @@ fn update_expr_string_without_newline(expr_string: String) -> String {
 }
 
 fn update_expr_string_with_pat(expr_str: String, whitespace_pat: &[char]) -> String {
-    // Remove leading whitespace, index [1..] to remove the leading '{',
+    // Remove leading whitespace, index to remove the leading '{',
     // then continue to remove leading whitespace.
-    let expr_str =
-        expr_str.trim_start_matches(whitespace_pat)[1..].trim_start_matches(whitespace_pat);
+    // We cannot assume the `{` is the first character because there are block modifiers
+    // (`unsafe`, `async` etc.).
+    let after_open_brace_index = expr_str.find('{').map_or(0, |it| it + 1);
+    let expr_str = expr_str[after_open_brace_index..].trim_start_matches(whitespace_pat);
 
     // Remove trailing whitespace, index [..expr_str.len() - 1] to remove the trailing '}',
     // then continue to remove trailing whitespace.
@@ -823,6 +825,56 @@ fn main() {
 fn main() {
     let a = 1;
     let x = foo;
+}
+"#,
+        );
+    }
+
+    #[test]
+    fn unwrap_block_with_modifiers() {
+        // https://github.com/rust-lang/rust-analyzer/issues/17964
+        check_assist(
+            unwrap_block,
+            r#"
+fn main() {
+    unsafe $0{
+        bar;
+    }
+}
+"#,
+            r#"
+fn main() {
+    bar;
+}
+"#,
+        );
+        check_assist(
+            unwrap_block,
+            r#"
+fn main() {
+    async move $0{
+        bar;
+    }
+}
+"#,
+            r#"
+fn main() {
+    bar;
+}
+"#,
+        );
+        check_assist(
+            unwrap_block,
+            r#"
+fn main() {
+    try $0{
+        bar;
+    }
+}
+"#,
+            r#"
+fn main() {
+    bar;
 }
 "#,
         );


### PR DESCRIPTION
The assist just assumes the `{` will be the first character, which led to strange outputs such as `nsafe {`.

Fixes #17964.