### PR TITLE
Expand proc-macros in workspace root, not package root

### DIFF
--- a/crates/hir-ty/src/display.rs
+++ b/crates/hir-ty/src/display.rs
@@ -34,7 +34,7 @@ use rustc_apfloat::{
 };
 use smallvec::SmallVec;
 use span::Edition;
-use stdx::{never, IsNoneOr};
+use stdx::never;
 use triomphe::Arc;
 
 use crate::{
@@ -1489,12 +1489,14 @@ fn generic_args_sans_defaults<'ga>(
                     }
                     // otherwise, if the arg is equal to the param default, hide it (unless the
                     // default is an error which can happen for the trait Self type)
-                    #[allow(unstable_name_collisions)]
-                    default_parameters.get(i).is_none_or(|default_parameter| {
-                        // !is_err(default_parameter.skip_binders())
-                        //     &&
-                        arg != &default_parameter.clone().substitute(Interner, &parameters)
-                    })
+                    match default_parameters.get(i) {
+                        None => true,
+                        Some(default_parameter) => {
+                            // !is_err(default_parameter.skip_binders())
+                            // &&
+                            arg != &default_parameter.clone().substitute(Interner, &parameters)
+                        }
+                    }
                 };
                 let mut default_from = 0;
                 for (i, parameter) in parameters.iter().enumerate() {

--- a/crates/proc-macro-api/src/lib.rs
+++ b/crates/proc-macro-api/src/lib.rs
@@ -154,7 +154,8 @@ impl ProcMacro {
         mixed_site: Span,
     ) -> Result<Result<tt::Subtree<Span>, PanicMessage>, ServerError> {
         let version = self.process.version();
-        let current_dir = env.get("CARGO_MANIFEST_DIR");
+        let current_dir =
+            env.get("CARGO_RUSTC_CURRENT_DIR").or_else(|| env.get("CARGO_MANIFEST_DIR"));
 
         let mut span_data_table = SpanDataIndexMap::default();
         let def_site = span_data_table.insert_full(def_site).0;

--- a/crates/project-model/src/cargo_workspace.rs
+++ b/crates/project-model/src/cargo_workspace.rs
@@ -243,6 +243,10 @@ impl TargetKind {
     pub fn is_executable(self) -> bool {
         matches!(self, TargetKind::Bin | TargetKind::Example)
     }
+
+    pub fn is_proc_macro(self) -> bool {
+        matches!(self, TargetKind::Lib { is_proc_macro: true })
+    }
 }
 
 // Deserialize helper for the cargo metadata

--- a/crates/project-model/src/env.rs
+++ b/crates/project-model/src/env.rs
@@ -3,7 +3,7 @@ use base_db::Env;
 use rustc_hash::FxHashMap;
 use toolchain::Tool;
 
-use crate::{utf8_stdout, ManifestPath, PackageData, Sysroot, TargetKind};
+use crate::{utf8_stdout, CargoWorkspace, ManifestPath, PackageData, Sysroot, TargetKind};
 
 /// Recreates the compile-time environment variables that Cargo sets.
 ///
@@ -50,13 +50,23 @@ pub(crate) fn inject_cargo_env(env: &mut Env) {
     env.set("CARGO", Tool::Cargo.path().to_string());
 }
 
-pub(crate) fn inject_rustc_tool_env(env: &mut Env, cargo_name: &str, kind: TargetKind) {
+pub(crate) fn inject_rustc_tool_env(
+    env: &mut Env,
+    cargo: &CargoWorkspace,
+    cargo_name: &str,
+    kind: TargetKind,
+) {
     _ = kind;
     // FIXME
     // if kind.is_executable() {
     //     env.set("CARGO_BIN_NAME", cargo_name);
     // }
     env.set("CARGO_CRATE_NAME", cargo_name.replace('-', "_"));
+    // NOTE: Technically we should set this for all crates, but that will worsen the deduplication
+    // logic so for now just keeping it proc-macros ought to be fine.
+    if kind.is_proc_macro() {
+        env.set("CARGO_RUSTC_CURRENT_DIR", cargo.manifest_path().to_string());
+    }
 }
 
 pub(crate) fn cargo_config_env(

--- a/crates/project-model/src/tests.rs
+++ b/crates/project-model/src/tests.rs
@@ -270,7 +270,7 @@ fn crate_graph_dedup() {
     assert_eq!(regex_crate_graph.iter().count(), 60);
 
     crate_graph.extend(regex_crate_graph, &mut regex_proc_macros, |(_, a), (_, b)| a == b);
-    assert_eq!(crate_graph.iter().count(), 118);
+    assert_eq!(crate_graph.iter().count(), 119);
 }
 
 #[test]

--- a/crates/project-model/src/workspace.rs
+++ b/crates/project-model/src/workspace.rs
@@ -1020,6 +1020,7 @@ fn cargo_to_crate_graph(
             let crate_id = add_target_crate_root(
                 crate_graph,
                 proc_macros,
+                cargo,
                 pkg_data,
                 build_data,
                 cfg_options.clone(),
@@ -1239,6 +1240,7 @@ fn handle_rustc_crates(
                     let crate_id = add_target_crate_root(
                         crate_graph,
                         proc_macros,
+                        rustc_workspace,
                         &rustc_workspace[pkg],
                         build_scripts.get_output(pkg),
                         cfg_options.clone(),
@@ -1298,6 +1300,7 @@ fn handle_rustc_crates(
 fn add_target_crate_root(
     crate_graph: &mut CrateGraph,
     proc_macros: &mut ProcMacroPaths,
+    cargo: &CargoWorkspace,
     pkg: &PackageData,
     build_data: Option<&BuildScriptOutput>,
     cfg_options: CfgOptions,
@@ -1331,7 +1334,7 @@ fn add_target_crate_root(
     let mut env = Env::default();
     inject_cargo_package_env(&mut env, pkg);
     inject_cargo_env(&mut env);
-    inject_rustc_tool_env(&mut env, cargo_name, kind);
+    inject_rustc_tool_env(&mut env, cargo, cargo_name, kind);
 
     if let Some(envs) = build_data.map(|it| &it.envs) {
         for (k, v) in envs {

--- a/crates/rust-analyzer/tests/crate_graph.rs
+++ b/crates/rust-analyzer/tests/crate_graph.rs
@@ -93,7 +93,7 @@ fn test_deduplicate_origin_dev() {
         }
     }
 
-    assert!(crates_named_p2.len() == 1);
+    assert_eq!(crates_named_p2.len(), 1);
     let p2 = crates_named_p2[0];
     assert!(p2.origin.is_local());
 }
@@ -119,7 +119,7 @@ fn test_deduplicate_origin_dev_rev() {
         }
     }
 
-    assert!(crates_named_p2.len() == 1);
+    assert_eq!(crates_named_p2.len(), 1);
     let p2 = crates_named_p2[0];
     assert!(p2.origin.is_local());
 }


### PR DESCRIPTION
Should fix https://github.com/rust-lang/rust-analyzer/issues/17748. The approach is generally not perfect though as rust-project.json projects don't benefit from this (still, nothing changes in that regard)