### PR TITLE
Fix incorrect symbol definitions in SCIP output

### DIFF
--- a/crates/rust-analyzer/src/cli/scip.rs
+++ b/crates/rust-analyzer/src/cli/scip.rs
@@ -142,7 +142,9 @@ impl flags::Scip {
                 let mut symbol_roles = Default::default();
 
                 if let Some(def) = token.definition {
-                    if def.range == text_range {
+                    // if the the range of the def and the range of the token are the same, this must be the definition.
+                    // they also must be in the same file. See https://github.com/rust-lang/rust-analyzer/pull/17988
+                    if def.file_id == file_id && def.range == text_range {
                         symbol_roles |= scip_types::SymbolRole::Definition as i32;
                     }
 


### PR DESCRIPTION
The SCIP output incorrectly marks some symbols as definitions because it doesn't account for the file ID when comparing the token's range to its definition's range.

This means that if a symbol is referenced in a file at the same position at which it is defined in another file, that reference will be marked as a definition. I was quite surprised by how common this is. For example, `PartialEq` is defined [here](https://github.com/rust-lang/rust/blob/1.80.1/library/core/src/cmp.rs#L273) and `uuid` references it [here](https://github.com/uuid-rs/uuid/blob/1.8.0/src/lib.rs#L329). And what do you know, they're both at offset 10083! In our large monorepo, this happens for basically every common stdlib type!