### PR TITLE
internal: Use local time when formatting logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1188,6 +1188,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "object"
 version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2093,10 +2102,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
+ "itoa",
+ "libc",
  "num-conv",
+ "num_threads",
  "powerfmt",
  "serde",
  "time-core",
+ "time-macros",
 ]
 
 [[package]]
@@ -2104,6 +2117,16 @@ name = "time-core"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+
+[[package]]
+name = "time-macros"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
 
 [[package]]
 name = "tinyvec"
@@ -2213,6 +2236,7 @@ checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
 dependencies = [
  "sharded-slab",
  "thread_local",
+ "time",
  "tracing-core",
  "tracing-log",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,6 +153,9 @@ tracing-tree = "0.3.0"
 tracing-subscriber = { version = "0.3.18", default-features = false, features = [
   "registry",
   "fmt",
+  "local-time",
+  "std",
+  "time",
   "tracing-log",
 ] }
 triomphe = { version = "0.1.10", default-features = false, features = ["std"] }

--- a/crates/rust-analyzer/src/tracing/config.rs
+++ b/crates/rust-analyzer/src/tracing/config.rs
@@ -7,7 +7,7 @@ use anyhow::Context;
 use tracing::level_filters::LevelFilter;
 use tracing_subscriber::{
     filter::{filter_fn, Targets},
-    fmt::MakeWriter,
+    fmt::{time, MakeWriter},
     layer::SubscriberExt,
     Layer, Registry,
 };
@@ -58,6 +58,10 @@ where
         let writer = self.writer;
 
         let ra_fmt_layer = tracing_subscriber::fmt::layer()
+            .with_timer(
+                time::OffsetTime::local_rfc_3339()
+                    .expect("Could not get local offset, make sure you're on the main thread"),
+            )
             .with_target(false)
             .with_ansi(false)
             .with_writer(writer)


### PR DESCRIPTION
When debugging rust-analyzer and looking at logs, it's much easier to read when the timestamp is in the local timezone.

Before:

    2024-08-28T20:55:38.792321Z  INFO ParseQuery: invoked at R18460

After:

    2024-08-28T13:55:38.792321-07:00  INFO ParseQuery: invoked at R18460