### PR TITLE
fix: Don't add reference when it isn't needed for the "Extract variable" assist

### DIFF
--- a/crates/ide-assists/src/tests/generated.rs
+++ b/crates/ide-assists/src/tests/generated.rs
@@ -994,7 +994,7 @@ fn main() {
 "#####,
         r#####"
 fn main() {
-    let $0var_name = (1 + 2);
+    let $0var_name = 1 + 2;
     var_name * 4;
 }
 "#####,


### PR DESCRIPTION
I.e. don't generate `let var_name = &foo()`. Because it always irritates me when I need to fix that.

Anything that creates a new value don't need a reference. That excludes mostly field accesses and indexing.

I had a thought that we can also not generate a reference for fields and indexing as long as the type is `Copy`, but sometimes people impl `Copy` even when they don't want to copy the values (e.g. a large type), so I didn't do that.