### PR TITLE
internal: Avoid newlines in fetch errors

### DIFF
--- a/crates/rust-analyzer/src/main_loop.rs
+++ b/crates/rust-analyzer/src/main_loop.rs
@@ -689,7 +689,7 @@ impl GlobalState {
                         self.fetch_workspaces_queue
                             .op_completed(Some((workspaces, force_reload_crate_graph)));
                         if let Err(e) = self.fetch_workspace_error() {
-                            error!("FetchWorkspaceError:\n{e}");
+                            error!("FetchWorkspaceError: {e}");
                         }
                         self.wants_to_switch = Some("fetched workspace".to_owned());
                         (Progress::End, None)
@@ -729,7 +729,7 @@ impl GlobalState {
                     BuildDataProgress::End(build_data_result) => {
                         self.fetch_build_data_queue.op_completed(build_data_result);
                         if let Err(e) = self.fetch_build_data_error() {
-                            error!("FetchBuildDataError:\n{e}");
+                            error!("FetchBuildDataError: {e}");
                         }
 
                         if self.wants_to_switch.is_none() {


### PR DESCRIPTION
Most logs lines don't have newlines, ensure fetch errors follow this pattern. This makes it easier to see which log line is associated with the error.

Before:

    2024-08-28T21:11:58.431856Z ERROR FetchWorkspaceError:
    rust-analyzer failed to discover workspace

After:

    2024-08-28T21:11:58.431856Z ERROR FetchWorkspaceError: rust-analyzer failed to discover workspace