### PR TITLE
fix: Fix TokenStream::to_string implementation dropping quotation marks

### DIFF
--- a/crates/proc-macro-srv/src/server_impl/rust_analyzer_span.rs
+++ b/crates/proc-macro-srv/src/server_impl/rust_analyzer_span.rs
@@ -142,7 +142,13 @@ impl server::TokenStream for RaSpanServer {
         stream.is_empty()
     }
     fn from_str(&mut self, src: &str) -> Self::TokenStream {
-        Self::TokenStream::from_str(src, self.call_site).expect("cannot parse string")
+        Self::TokenStream::from_str(src, self.call_site).unwrap_or_else(|e| {
+            Self::TokenStream::from_str(
+                &format!("compile_error!(\"failed to parse str to token stream: {e}\")"),
+                self.call_site,
+            )
+            .unwrap()
+        })
     }
     fn to_string(&mut self, stream: &Self::TokenStream) -> String {
         stream.to_string()

--- a/crates/proc-macro-srv/src/server_impl/rust_analyzer_span.rs
+++ b/crates/proc-macro-srv/src/server_impl/rust_analyzer_span.rs
@@ -507,12 +507,17 @@ mod tests {
                         close: span,
                         kind: tt::DelimiterKind::Brace,
                     },
-                    token_trees: Box::new([]),
+                    token_trees: Box::new([tt::TokenTree::Leaf(tt::Leaf::Literal(tt::Literal {
+                        kind: tt::LitKind::Str,
+                        symbol: Symbol::intern("string"),
+                        suffix: None,
+                        span,
+                    }))]),
                 }),
             ],
         };
 
-        assert_eq!(s.to_string(), "struct T {}");
+        assert_eq!(s.to_string(), "struct T {\"string\"}");
     }
 
     #[test]

--- a/crates/proc-macro-srv/src/server_impl/token_id.rs
+++ b/crates/proc-macro-srv/src/server_impl/token_id.rs
@@ -131,7 +131,13 @@ impl server::TokenStream for TokenIdServer {
         stream.is_empty()
     }
     fn from_str(&mut self, src: &str) -> Self::TokenStream {
-        Self::TokenStream::from_str(src, self.call_site).expect("cannot parse string")
+        Self::TokenStream::from_str(src, self.call_site).unwrap_or_else(|e| {
+            Self::TokenStream::from_str(
+                &format!("compile_error!(\"failed to parse str to token stream: {e}\")"),
+                self.call_site,
+            )
+            .unwrap()
+        })
     }
     fn to_string(&mut self, stream: &Self::TokenStream) -> String {
         stream.to_string()

--- a/crates/proc-macro-srv/src/server_impl/token_stream.rs
+++ b/crates/proc-macro-srv/src/server_impl/token_stream.rs
@@ -131,7 +131,7 @@ pub(super) mod token_stream {
                 call_site,
                 src,
             )
-            .ok_or("lexing error")?;
+            .ok_or_else(|| format!("lexing error: {src}"))?;
 
             Ok(TokenStream::with_subtree(subtree))
         }

--- a/crates/tt/src/lib.rs
+++ b/crates/tt/src/lib.rs
@@ -603,7 +603,7 @@ pub fn pretty<S>(tkns: &[TokenTree<S>]) -> String {
             TokenTree::Leaf(Leaf::Ident(ident)) => {
                 format!("{}{}", ident.is_raw.as_str(), ident.sym)
             }
-            TokenTree::Leaf(Leaf::Literal(literal)) => literal.symbol.as_str().to_owned(),
+            TokenTree::Leaf(Leaf::Literal(literal)) => format!("{literal}"),
             TokenTree::Leaf(Leaf::Punct(punct)) => format!("{}", punct.char),
             TokenTree::Subtree(subtree) => {
                 let content = pretty(&subtree.token_trees);


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust-analyzer/issues/17986
We might wanna consider backporting this to beta if that's simple enough to do