### PR TITLE
fix: `std::error::Error` is object unsafe

### DIFF
--- a/crates/hir-ty/src/db.rs
+++ b/crates/hir-ty/src/db.rs
@@ -154,6 +154,9 @@ pub trait HirDatabase: DefDatabase + Upcast<dyn DefDatabase> {
     #[salsa::invoke(crate::lower::generic_predicates_query)]
     fn generic_predicates(&self, def: GenericDefId) -> GenericPredicates;
 
+    #[salsa::invoke(crate::lower::generic_predicates_without_parent_query)]
+    fn generic_predicates_without_parent(&self, def: GenericDefId) -> GenericPredicates;
+
     #[salsa::invoke(crate::lower::trait_environment_for_body_query)]
     #[salsa::transparent]
     fn trait_environment_for_body(&self, def: DefWithBodyId) -> Arc<TraitEnvironment>;

--- a/crates/hir-ty/src/object_safety/tests.rs
+++ b/crates/hir-ty/src/object_safety/tests.rs
@@ -361,3 +361,20 @@ pub trait Trait {
         [("Trait", vec![])],
     );
 }
+
+#[test]
+fn std_error_is_object_safe() {
+    check_object_safety(
+        r#"
+//- minicore: fmt, dispatch_from_dyn
+trait Erased<'a>: 'a {}
+
+pub struct Request<'a>(dyn Erased<'a> + 'a);
+
+pub trait Error: core::fmt::Debug + core::fmt::Display {
+    fn provide<'a>(&'a self, request: &mut Request<'a>);
+}
+"#,
+        [("Error", vec![])],
+    );
+}


### PR DESCRIPTION
Fixes #17998

I tried to get generic predicates of assoc function itself, not inherited from the parent here;

https://github.com/rust-lang/rust-analyzer/blob/0ae42bd42576566540a84c62e118aa823edcf2ec/crates/hir-ty/src/object_safety.rs#L420-L442

But this naive equality check approach doesn't work when the assoc function has one or more generic paramters like;

```rust
trait Foo {}
trait Bar: Foo {
    fn bar(&self);
}
```

because the generic predicates of the parent, `Bar` is `[^1.0 implements Foo]` and the generic predicates of `fn bar` is `[^1.1 implements Foo]`, which are different.

This PR implements a correct logic for filtering out parent generic predicates for this.