### PR TITLE
fix: Fix `inline_const_as_literal` error when the number >= 10

### DIFF
--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -2553,6 +2553,17 @@ impl Const {
         Type::from_value_def(db, self.id)
     }
 
+    /// Evaluate the constant and return the result as a string.
+    ///
+    /// This function is intended for IDE assistance, different from [`Const::render_eval`].
+    pub fn eval(self, db: &dyn HirDatabase, edition: Edition) -> Result<String, ConstEvalError> {
+        let c = db.const_eval(self.id.into(), Substitution::empty(Interner), None)?;
+        Ok(format!("{}", c.display(db, edition)))
+    }
+
+    /// Evaluate the constant and return the result as a string, with more detailed information.
+    ///
+    /// This function is intended for user-facing display.
     pub fn render_eval(
         self,
         db: &dyn HirDatabase,

--- a/crates/ide-assists/src/handlers/inline_const_as_literal.rs
+++ b/crates/ide-assists/src/handlers/inline_const_as_literal.rs
@@ -53,10 +53,7 @@ pub(crate) fn inline_const_as_literal(acc: &mut Assists, ctx: &AssistContext<'_>
             | ast::Expr::BinExpr(_)
             | ast::Expr::CallExpr(_) => {
                 let edition = ctx.sema.scope(variable.syntax())?.krate().edition(ctx.db());
-                match konst.render_eval(ctx.sema.db, edition) {
-                    Ok(result) => result,
-                    Err(_) => return None,
-                }
+                konst.eval(ctx.sema.db, edition).ok()?
             }
             _ => return None,
         };
@@ -127,12 +124,14 @@ mod tests {
         ("u64", "0", NUMBER),
         ("u128", "0", NUMBER),
         ("usize", "0", NUMBER),
+        ("usize", "16", NUMBER),
         ("i8", "0", NUMBER),
         ("i16", "0", NUMBER),
         ("i32", "0", NUMBER),
         ("i64", "0", NUMBER),
         ("i128", "0", NUMBER),
         ("isize", "0", NUMBER),
+        ("isize", "16", NUMBER),
         ("bool", "false", BOOL),
         ("&str", "\"str\"", STR),
         ("char", "'c'", CHAR),


### PR DESCRIPTION
## Description

### The Bug

This PR fixes a small bug in the IDE assistence (`inline_const_as_literal`). When the being-inlined constant is a number and it is greater than or equal to 10, the assistence inserts unexpected string `(0x...)` after the number itself. A simple example is followed:

Current `inline_const_as_literal` changes

```rs
const A: usize = 16;

fn f() -> usize {
    A  // inline the constant
}
```

into

```rs
const A: usize = 16;

fn f() -> usize {
    16 (0x10)
}
```

The bug originates from #14925 & #15306 . #14925 added some unittests, but it just tested the number-inlining behavior when the number is `0`.

https://github.com/rust-lang/rust-analyzer/blob/50882fbfa204027c84753e6d51a1a12884dc1b19/crates/ide-assists/src/handlers/inline_const_as_literal.rs#L124-L138

And #15306 modified the behavior of `Const::render_eval` and added the `(0x...)` part after the number (if the number >= `10`). Because of insufficient unittests in #14925, changes about `Const::render_eval` in #15306 introduced this bug with no CI failure.

### The Fix

I think `Const::render_eval` is intended for user-facing value displaying (e.g. hover) and not designed for `inline_const_as_literal`. To fix the bug, I defined a new function named `Const::eval`, which evaluates the value itself faithfully and simply and does nothing else.

## Thanks

Thanks @roife for your kind help. Your guidance helped me better understand the code.