### PR TITLE
fix: Disable invalid cast diagnostics for casts like `&T as &dyn Trait`

### DIFF
--- a/crates/hir-ty/src/infer/cast.rs
+++ b/crates/hir-ty/src/infer/cast.rs
@@ -193,7 +193,7 @@ impl CastCheck {
                     // under current chalk trait solver. (See #11847 and #18047)
                     // So, emit no diagnostic for casts like `&T as &dyn Trait` for now,
                     // to prevent false positive diagnositcs.
-                    // Direct cast without ref like `T as dyn Trait` is prohibitied by
+                    // Direct cast without ref like `T as dyn Trait` is prohibited by
                     // `InferenceDiagnostic::CastToUnsized`, so allowing this diagnostics bypass
                     // only to `&T as &dyn Trait` is sufficient
                     if let (TyKind::Ref(m_expr, _, _), TyKind::Ref(m_cast, _, t_cast)) =


### PR DESCRIPTION
Hope this might suppress false positive diagnostics like #18047