### PR TITLE
Introduce `$CONFIG_DIR/rust-analyzer/rust-analyzer.toml`

### DIFF
--- a/crates/load-cargo/src/lib.rs
+++ b/crates/load-cargo/src/lib.rs
@@ -123,7 +123,7 @@ pub fn load_workspace(
             .collect()
     };
 
-    let project_folders = ProjectFolders::new(std::slice::from_ref(&ws), &[]);
+    let project_folders = ProjectFolders::new(std::slice::from_ref(&ws), &[], None);
     loader.set_config(vfs::loader::Config {
         load: project_folders.load,
         watch: vec![],
@@ -153,7 +153,11 @@ pub struct ProjectFolders {
 }
 
 impl ProjectFolders {
-    pub fn new(workspaces: &[ProjectWorkspace], global_excludes: &[AbsPathBuf]) -> ProjectFolders {
+    pub fn new(
+        workspaces: &[ProjectWorkspace],
+        global_excludes: &[AbsPathBuf],
+        user_config_dir_path: Option<&'static AbsPath>,
+    ) -> ProjectFolders {
         let mut res = ProjectFolders::default();
         let mut fsc = FileSetConfig::builder();
         let mut local_filesets = vec![];
@@ -284,6 +288,22 @@ impl ProjectFolders {
                 local_filesets.push(fsc.len() as u64);
                 fsc.add_file_set(file_set_roots)
             }
+        }
+
+        if let Some(user_config_path) = user_config_dir_path {
+            let ratoml_path = {
+                let mut p = user_config_path.to_path_buf();
+                p.push("rust-analyzer.toml");
+                p
+            };
+
+            let file_set_roots: Vec<VfsPath> = vec![VfsPath::from(ratoml_path.to_owned())];
+            let entry = vfs::loader::Entry::Files(vec![ratoml_path.to_owned()]);
+
+            res.watch.push(res.load.len());
+            res.load.push(entry);
+            local_filesets.push(fsc.len() as u64);
+            fsc.add_file_set(file_set_roots)
         }
 
         let fsc = fsc.build();

--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -768,22 +768,14 @@ impl std::ops::Deref for Config {
 }
 
 impl Config {
-    /// Path to the root configuration file. This can be seen as a generic way to define what would be `$XDG_CONFIG_HOME/rust-analyzer/rust-analyzer.toml` in Linux.
-    /// This path is equal to:
-    ///
-    /// |Platform | Value                                 | Example                                  |
-    /// | ------- | ------------------------------------- | ---------------------------------------- |
-    /// | Linux   | `$XDG_CONFIG_HOME` or `$HOME`/.config | /home/alice/.config                      |
-    /// | macOS   | `$HOME`/Library/Application Support   | /Users/Alice/Library/Application Support |
-    /// | Windows | `{FOLDERID_RoamingAppData}`           | C:\Users\Alice\AppData\Roaming           |
-    pub fn user_config_path() -> Option<&'static AbsPath> {
+    /// Path to the user configuration dir. This can be seen as a generic way to define what would be `$XDG_CONFIG_HOME/rust-analyzer` in Linux.
+    pub fn user_config_dir_path() -> Option<&'static AbsPath> {
         static USER_CONFIG_PATH: LazyLock<Option<AbsPathBuf>> = LazyLock::new(|| {
             let user_config_path = if let Some(path) = env::var_os("__TEST_RA_USER_CONFIG_DIR") {
                 std::path::PathBuf::from(path)
             } else {
                 dirs::config_dir()?.join("rust-analyzer")
-            }
-            .join("rust-analyzer.toml");
+            };
             Some(AbsPathBuf::assert_utf8(user_config_path))
         });
         USER_CONFIG_PATH.as_deref()

--- a/crates/rust-analyzer/src/global_state.rs
+++ b/crates/rust-analyzer/src/global_state.rs
@@ -380,7 +380,14 @@ impl GlobalState {
             || !self.config.same_source_root_parent_map(&self.local_roots_parent_map)
         {
             let config_change = {
-                let user_config_path = Config::user_config_path();
+                let user_config_path = {
+                    let mut p = Config::user_config_dir_path().unwrap().to_path_buf();
+                    p.push("rust-analyzer.toml");
+                    p
+                };
+
+                let user_config_abs_path = Some(user_config_path.as_path());
+
                 let mut change = ConfigChange::default();
                 let db = self.analysis_host.raw_database();
 
@@ -399,7 +406,7 @@ impl GlobalState {
                     .collect_vec();
 
                 for (file_id, (_change_kind, vfs_path)) in modified_ratoml_files {
-                    if vfs_path.as_path() == user_config_path {
+                    if vfs_path.as_path() == user_config_abs_path {
                         change.change_user_config(Some(db.file_text(file_id)));
                         continue;
                     }

--- a/crates/rust-analyzer/src/lsp/ext.rs
+++ b/crates/rust-analyzer/src/lsp/ext.rs
@@ -16,9 +16,22 @@ use serde::{Deserialize, Serialize};
 
 pub enum InternalTestingFetchConfig {}
 
+#[derive(Deserialize, Serialize, Debug)]
+pub enum InternalTestingFetchConfigOption {
+    AssistEmitMustUse,
+    CheckWorkspace,
+}
+
+#[derive(Deserialize, Serialize, Debug, PartialEq, Eq)]
+pub enum InternalTestingFetchConfigResponse {
+    AssistEmitMustUse(bool),
+    CheckWorkspace(bool),
+}
+
 impl Request for InternalTestingFetchConfig {
     type Params = InternalTestingFetchConfigParams;
-    type Result = serde_json::Value;
+    // Option is solely to circumvent Default bound.
+    type Result = Option<InternalTestingFetchConfigResponse>;
     const METHOD: &'static str = "rust-analyzer-internal/internalTestingFetchConfig";
 }
 
@@ -26,7 +39,7 @@ impl Request for InternalTestingFetchConfig {
 #[serde(rename_all = "camelCase")]
 pub struct InternalTestingFetchConfigParams {
     pub text_document: Option<TextDocumentIdentifier>,
-    pub config: String,
+    pub config: InternalTestingFetchConfigOption,
 }
 pub enum AnalyzerStatus {}
 

--- a/crates/rust-analyzer/src/reload.rs
+++ b/crates/rust-analyzer/src/reload.rs
@@ -583,7 +583,7 @@ impl GlobalState {
             }
 
             watchers.extend(
-                iter::once(Config::user_config_path())
+                iter::once(Config::user_config_dir_path())
                     .chain(self.workspaces.iter().map(|ws| ws.manifest().map(ManifestPath::as_ref)))
                     .flatten()
                     .map(|glob_pattern| lsp_types::FileSystemWatcher {
@@ -606,7 +606,11 @@ impl GlobalState {
         }
 
         let files_config = self.config.files();
-        let project_folders = ProjectFolders::new(&self.workspaces, &files_config.exclude);
+        let project_folders = ProjectFolders::new(
+            &self.workspaces,
+            &files_config.exclude,
+            Config::user_config_dir_path().to_owned(),
+        );
 
         if (self.proc_macro_clients.is_empty() || !same_workspaces)
             && self.config.expand_proc_macros()

--- a/crates/rust-analyzer/tests/slow-tests/ratoml.rs
+++ b/crates/rust-analyzer/tests/slow-tests/ratoml.rs
@@ -9,17 +9,12 @@ use lsp_types::{
 use paths::Utf8PathBuf;
 
 use rust_analyzer::config::Config;
-use rust_analyzer::lsp::ext::{InternalTestingFetchConfig, InternalTestingFetchConfigParams};
+use rust_analyzer::lsp::ext::{
+    InternalTestingFetchConfig, InternalTestingFetchConfigOption, InternalTestingFetchConfigParams,
+    InternalTestingFetchConfigResponse,
+};
 use serde_json::json;
 use test_utils::skip_slow_tests;
-
-enum QueryType {
-    Local,
-    /// A query whose config key is a part of the global configs, so that
-    /// testing for changes to this config means testing if global changes
-    /// take affect.
-    Workspace,
-}
 
 struct RatomlTest {
     urls: Vec<Url>,
@@ -158,20 +153,24 @@ impl RatomlTest {
         });
     }
 
-    fn query(&self, query: QueryType, source_file_idx: usize) -> bool {
-        let config = match query {
-            QueryType::Local => "local".to_owned(),
-            QueryType::Workspace => "workspace".to_owned(),
-        };
+    fn query(
+        &self,
+        query: InternalTestingFetchConfigOption,
+        source_file_idx: usize,
+        expected: InternalTestingFetchConfigResponse,
+    ) {
         let res = self.server.send_request::<InternalTestingFetchConfig>(
             InternalTestingFetchConfigParams {
                 text_document: Some(TextDocumentIdentifier {
                     uri: self.urls[source_file_idx].clone(),
                 }),
-                config,
+                config: query,
             },
         );
-        res.as_bool().unwrap()
+        assert_eq!(
+            serde_json::from_value::<InternalTestingFetchConfigResponse>(res).unwrap(),
+            expected
+        )
     }
 }
 
@@ -206,7 +205,11 @@ enum Value {
         })),
     );
 
-    assert!(server.query(QueryType::Local, 1));
+    server.query(
+        InternalTestingFetchConfigOption::AssistEmitMustUse,
+        1,
+        InternalTestingFetchConfigResponse::AssistEmitMustUse(true),
+    );
 }
 
 /// Checks if client config can be modified.
@@ -311,7 +314,11 @@ enum Value {
         None,
     );
 
-    assert!(server.query(QueryType::Local, 2));
+    server.query(
+        InternalTestingFetchConfigOption::AssistEmitMustUse,
+        2,
+        InternalTestingFetchConfigResponse::AssistEmitMustUse(true),
+    );
 }
 
 #[test]
@@ -341,12 +348,20 @@ enum Value {
         None,
     );
 
-    assert!(!server.query(QueryType::Local, 1));
+    server.query(
+        InternalTestingFetchConfigOption::AssistEmitMustUse,
+        1,
+        InternalTestingFetchConfigResponse::AssistEmitMustUse(false),
+    );
     server.create(
         "//- /$$CONFIG_DIR$$/rust-analyzer/rust-analyzer.toml",
         RatomlTest::EMIT_MUST_USE.to_owned(),
     );
-    assert!(server.query(QueryType::Local, 1));
+    server.query(
+        InternalTestingFetchConfigOption::AssistEmitMustUse,
+        1,
+        InternalTestingFetchConfigResponse::AssistEmitMustUse(true),
+    );
 }
 
 #[test]
@@ -378,9 +393,17 @@ assist.emitMustUse = true"#,
         None,
     );
 
-    assert!(server.query(QueryType::Local, 1));
+    server.query(
+        InternalTestingFetchConfigOption::AssistEmitMustUse,
+        1,
+        InternalTestingFetchConfigResponse::AssistEmitMustUse(true),
+    );
     server.edit(2, String::new());
-    assert!(!server.query(QueryType::Local, 1));
+    server.query(
+        InternalTestingFetchConfigOption::AssistEmitMustUse,
+        1,
+        InternalTestingFetchConfigResponse::AssistEmitMustUse(false),
+    );
 }
 
 #[test]
@@ -412,9 +435,17 @@ assist.emitMustUse = true"#,
         None,
     );
 
-    assert!(server.query(QueryType::Local, 1));
+    server.query(
+        InternalTestingFetchConfigOption::AssistEmitMustUse,
+        1,
+        InternalTestingFetchConfigResponse::AssistEmitMustUse(true),
+    );
     server.delete(2);
-    assert!(!server.query(QueryType::Local, 1));
+    server.query(
+        InternalTestingFetchConfigOption::AssistEmitMustUse,
+        1,
+        InternalTestingFetchConfigResponse::AssistEmitMustUse(false),
+    );
 }
 
 #[test]
@@ -461,7 +492,11 @@ pub fn add(left: usize, right: usize) -> usize {
         None,
     );
 
-    assert!(server.query(QueryType::Local, 3));
+    server.query(
+        InternalTestingFetchConfigOption::AssistEmitMustUse,
+        3,
+        InternalTestingFetchConfigResponse::AssistEmitMustUse(true),
+    );
 }
 
 #[test]
@@ -508,9 +543,17 @@ pub fn add(left: usize, right: usize) -> usize {
         None,
     );
 
-    assert!(!server.query(QueryType::Local, 3));
+    server.query(
+        InternalTestingFetchConfigOption::AssistEmitMustUse,
+        3,
+        InternalTestingFetchConfigResponse::AssistEmitMustUse(false),
+    );
     server.edit(1, "assist.emitMustUse = true".to_owned());
-    assert!(server.query(QueryType::Local, 3));
+    server.query(
+        InternalTestingFetchConfigOption::AssistEmitMustUse,
+        3,
+        InternalTestingFetchConfigResponse::AssistEmitMustUse(true),
+    );
 }
 
 #[test]
@@ -557,9 +600,17 @@ pub fn add(left: usize, right: usize) -> usize {
         None,
     );
 
-    assert!(server.query(QueryType::Local, 3));
+    server.query(
+        InternalTestingFetchConfigOption::AssistEmitMustUse,
+        3,
+        InternalTestingFetchConfigResponse::AssistEmitMustUse(true),
+    );
     server.delete(1);
-    assert!(!server.query(QueryType::Local, 3));
+    server.query(
+        InternalTestingFetchConfigOption::AssistEmitMustUse,
+        3,
+        InternalTestingFetchConfigResponse::AssistEmitMustUse(false),
+    );
 }
 
 #[test]
@@ -606,9 +657,17 @@ pub fn add(left: usize, right: usize) -> usize {
         None,
     );
 
-    assert!(server.query(QueryType::Local, 3));
+    server.query(
+        InternalTestingFetchConfigOption::AssistEmitMustUse,
+        3,
+        InternalTestingFetchConfigResponse::AssistEmitMustUse(true),
+    );
     server.create("//- /p1/p2/rust-analyzer.toml", RatomlTest::EMIT_MUST_NOT_USE.to_owned());
-    assert!(!server.query(QueryType::Local, 3));
+    server.query(
+        InternalTestingFetchConfigOption::AssistEmitMustUse,
+        3,
+        InternalTestingFetchConfigResponse::AssistEmitMustUse(false),
+    );
 }
 
 #[test]
@@ -656,9 +715,17 @@ pub fn add(left: usize, right: usize) -> usize {
         None,
     );
 
-    assert!(server.query(QueryType::Local, 3));
+    server.query(
+        InternalTestingFetchConfigOption::AssistEmitMustUse,
+        3,
+        InternalTestingFetchConfigResponse::AssistEmitMustUse(true),
+    );
     server.delete(1);
-    assert!(!server.query(QueryType::Local, 3));
+    server.query(
+        InternalTestingFetchConfigOption::AssistEmitMustUse,
+        3,
+        InternalTestingFetchConfigResponse::AssistEmitMustUse(false),
+    );
 }
 
 #[test]
@@ -705,8 +772,16 @@ enum Value {
         None,
     );
 
-    assert!(server.query(QueryType::Local, 3));
-    assert!(server.query(QueryType::Local, 4));
+    server.query(
+        InternalTestingFetchConfigOption::AssistEmitMustUse,
+        3,
+        InternalTestingFetchConfigResponse::AssistEmitMustUse(true),
+    );
+    server.query(
+        InternalTestingFetchConfigOption::AssistEmitMustUse,
+        4,
+        InternalTestingFetchConfigResponse::AssistEmitMustUse(true),
+    );
 }
 
 #[test]
@@ -744,7 +819,11 @@ fn ratoml_multiple_ratoml_in_single_source_root() {
         None,
     );
 
-    assert!(server.query(QueryType::Local, 3));
+    server.query(
+        InternalTestingFetchConfigOption::AssistEmitMustUse,
+        3,
+        InternalTestingFetchConfigResponse::AssistEmitMustUse(true),
+    );
 }
 
 /// If a root is non-local, so we cannot find what its parent is
@@ -836,7 +915,7 @@ edition = "2021"
         "#,
             r#"
 //- /p1/rust-analyzer.toml
-rustfmt.rangeFormatting.enable = true
+check.workspace = false
         "#,
             r#"
 //- /p1/src/lib.rs
@@ -848,7 +927,11 @@ fn main() {
         None,
     );
 
-    assert!(server.query(QueryType::Workspace, 2));
+    server.query(
+        InternalTestingFetchConfigOption::CheckWorkspace,
+        2,
+        InternalTestingFetchConfigResponse::CheckWorkspace(false),
+    )
 }
 
 #[test]
@@ -868,7 +951,7 @@ edition = "2021"
         "#,
             r#"
 //- /p1/rust-analyzer.toml
-rustfmt.rangeFormatting.enable = true
+check.workspace = false
     "#,
             r#"
 //- /p1/src/lib.rs
@@ -880,9 +963,17 @@ fn main() {
         None,
     );
 
-    assert!(server.query(QueryType::Workspace, 2));
-    server.edit(1, "rustfmt.rangeFormatting.enable = false".to_owned());
-    assert!(!server.query(QueryType::Workspace, 2));
+    server.query(
+        InternalTestingFetchConfigOption::CheckWorkspace,
+        2,
+        InternalTestingFetchConfigResponse::CheckWorkspace(false),
+    );
+    server.edit(1, "check.workspace = true".to_owned());
+    server.query(
+        InternalTestingFetchConfigOption::CheckWorkspace,
+        2,
+        InternalTestingFetchConfigResponse::CheckWorkspace(true),
+    );
 }
 
 #[test]
@@ -902,7 +993,7 @@ edition = "2021"
         "#,
             r#"
 //- /p1/rust-analyzer.toml
-rustfmt.rangeFormatting.enable = true
+check.workspace = false
        "#,
             r#"
 //- /p1/src/lib.rs
@@ -914,7 +1005,15 @@ fn main() {
         None,
     );
 
-    assert!(server.query(QueryType::Workspace, 2));
+    server.query(
+        InternalTestingFetchConfigOption::CheckWorkspace,
+        2,
+        InternalTestingFetchConfigResponse::CheckWorkspace(false),
+    );
     server.delete(1);
-    assert!(!server.query(QueryType::Workspace, 2));
+    server.query(
+        InternalTestingFetchConfigOption::CheckWorkspace,
+        2,
+        InternalTestingFetchConfigResponse::CheckWorkspace(true),
+    );
 }

--- a/crates/rust-analyzer/tests/slow-tests/support.rs
+++ b/crates/rust-analyzer/tests/slow-tests/support.rs
@@ -1,6 +1,6 @@
 use std::{
     cell::{Cell, RefCell},
-    fs,
+    env, fs,
     sync::Once,
     time::Duration,
 };
@@ -85,7 +85,30 @@ impl Project<'_> {
     }
 
     pub(crate) fn server(self) -> Server {
+        Project::server_with_lock(self, false)
+    }
+
+    /// `prelock` : Forcefully acquire a lock that will maintain the path to the config dir throughout the whole test.
+    ///
+    /// When testing we set the user config dir by setting an envvar `__TEST_RA_USER_CONFIG_DIR`.
+    /// This value must be maintained until the end of a test case. When tests run in parallel
+    /// this value may change thus making the tests flaky. As such, we use a `MutexGuard` that locks
+    /// the process until `Server` is dropped. To optimize parallelization we use a lock only when it is
+    /// needed, that is when a test uses config directory to do stuff. Our naive approach is to use a lock
+    /// if there is a path to config dir in the test fixture. However, in certain cases we create a
+    /// file in the config dir after server is run, something where our naive approach comes short.
+    /// Using a `prelock` allows us to force a lock when we know we need it.
+    pub(crate) fn server_with_lock(self, prelock: bool) -> Server {
         static CONFIG_DIR_LOCK: Mutex<()> = Mutex::new(());
+
+        let mut config_dir_guard = if prelock {
+            let v = Some(CONFIG_DIR_LOCK.lock());
+            env::set_var("__TEST_RA_USER_CONFIG_DIR", TestDir::new().path());
+            v
+        } else {
+            None
+        };
+
         let tmp_dir = self.tmp_dir.unwrap_or_else(|| {
             if self.root_dir_contains_symlink {
                 TestDir::new_symlink()
@@ -117,13 +140,14 @@ impl Project<'_> {
         assert!(mini_core.is_none());
         assert!(toolchain.is_none());
 
-        let mut config_dir_guard = None;
         for entry in fixture {
             if let Some(pth) = entry.path.strip_prefix("/$$CONFIG_DIR$$") {
                 if config_dir_guard.is_none() {
                     config_dir_guard = Some(CONFIG_DIR_LOCK.lock());
+                    env::set_var("__TEST_RA_USER_CONFIG_DIR", TestDir::new().path());
                 }
-                let path = Config::user_config_path().unwrap().join(&pth['/'.len_utf8()..]);
+
+                let path = Config::user_config_dir_path().unwrap().join(&pth['/'.len_utf8()..]);
                 fs::create_dir_all(path.parent().unwrap()).unwrap();
                 fs::write(path.as_path(), entry.text.as_bytes()).unwrap();
             } else {

--- a/docs/dev/lsp-extensions.md
+++ b/docs/dev/lsp-extensions.md
@@ -1,5 +1,5 @@
 <!---
-lsp/ext.rs hash: c6e83d3d08d993de
+lsp/ext.rs hash: 6292ee8d88d4c9ec
 
 If you need to change the above hash to make the test pass, please check if you
 need to adjust this doc as well and ping this issue:


### PR DESCRIPTION
This PR makes the use of `rust-analyzer.toml` under user config directory possible. The reason why this is a draft is that some of the tests are flaky due to the way we set user config directory in our tests. Basically, to redirect server to a different path than the usual user config dir ( `~/.config/rust-analyzer/rust-analyzer.toml`) we set an envvar called `__TEST_RA_USER_CONFIG_DIR`. During parallel executions this value gets rewritten although we use a lock to prevent this. 

In short, I am looking for some help on how to fix this.  

And this PR is based on another that has currently not been merged ( #18057 ) so I will kindly ask you to focus on the most recent commit ( `9f70fb3d` )  only.