### PR TITLE
Implement allow lint diagnostics with `expect`

### DIFF
--- a/crates/hir-ty/src/diagnostics/decl_check.rs
+++ b/crates/hir-ty/src/diagnostics/decl_check.rs
@@ -166,12 +166,14 @@ impl<'a> DeclValidator<'a> {
             let attrs = self.db.attrs(def_id);
             // don't bug the user about directly no_mangle annotated stuff, they can't do anything about it
             (!recursing && attrs.by_key(&sym::no_mangle).exists())
-                || attrs.by_key(&sym::allow).tt_values().any(|tt| {
-                    let allows = tt.to_string();
-                    allows.contains(allow_name)
-                        || allows.contains(allow::BAD_STYLE)
-                        || allows.contains(allow::NONSTANDARD_STYLE)
-                })
+                || [&sym::allow, &sym::expect].iter().flat_map(|a| attrs.by_key(a).tt_values()).any(
+                    |tt| {
+                        let allows = tt.to_string();
+                        allows.contains(allow_name)
+                            || allows.contains(allow::BAD_STYLE)
+                            || allows.contains(allow::NONSTANDARD_STYLE)
+                    },
+                )
         };
         let db = self.db.upcast();
         let file_id_is_derive = || {

--- a/crates/ide-diagnostics/src/handlers/incorrect_case.rs
+++ b/crates/ide-diagnostics/src/handlers/incorrect_case.rs
@@ -561,6 +561,62 @@ trait BAD_TRAIT {
     }
 
     #[test]
+    fn expect_attributes() {
+        check_diagnostics(
+            r#"
+#[expect(non_snake_case)]
+fn NonSnakeCaseName(SOME_VAR: u8) -> u8{
+    // cov_flags generated output from elsewhere in this file
+    extern "C" {
+        #[no_mangle]
+        static lower_case: u8;
+    }
+
+    let OtherVar = SOME_VAR + 1;
+    OtherVar
+}
+
+#[expect(nonstandard_style)]
+mod CheckNonstandardStyle {
+    fn HiImABadFnName() {}
+}
+
+#[expect(bad_style)]
+mod CheckBadStyle {
+    struct fooo;
+}
+
+mod F {
+    #![expect(non_snake_case)]
+    fn CheckItWorksWithModAttr(BAD_NAME_HI: u8) {
+        _ = BAD_NAME_HI;
+    }
+}
+
+#[expect(non_snake_case, non_camel_case_types)]
+pub struct some_type {
+    SOME_FIELD: u8,
+    SomeField: u16,
+}
+
+#[expect(non_upper_case_globals)]
+pub const some_const: u8 = 10;
+
+#[expect(non_upper_case_globals)]
+pub static SomeStatic: u8 = 10;
+
+#[expect(non_snake_case, non_camel_case_types, non_upper_case_globals)]
+trait BAD_TRAIT {
+    const bad_const: u8;
+    type BAD_TYPE;
+    fn BAD_FUNCTION(BAD_PARAM: u8);
+    fn BadFunction();
+}
+    "#,
+        );
+    }
+
+    #[test]
     fn deny_attributes() {
         check_diagnostics(
             r#"

--- a/crates/ide-diagnostics/src/lib.rs
+++ b/crates/ide-diagnostics/src/lib.rs
@@ -661,7 +661,7 @@ fn parse_lint_attribute(
         return;
     };
     let severity = match tag.as_str() {
-        "allow" => Severity::Allow,
+        "allow" | "expect" => Severity::Allow,
         "warn" => Severity::Warning,
         "forbid" | "deny" => Severity::Error,
         _ => return,

--- a/crates/intern/src/symbol/symbols.rs
+++ b/crates/intern/src/symbol/symbols.rs
@@ -207,6 +207,7 @@ define_symbols! {
     Err,
     exchange_malloc,
     exhaustive_patterns,
+    expect,
     export_name,
     f128,
     f16,


### PR DESCRIPTION
Makes `#[expect(_)]` have the same effect on diagnostics as  `#[allow(_)]`.

Fixes #18056