### PR TITLE
fix: Don't send empty inlay hints over LSP

### DIFF
--- a/crates/rust-analyzer/src/lsp/to_proto.rs
+++ b/crates/rust-analyzer/src/lsp/to_proto.rs
@@ -557,6 +557,7 @@ fn inlay_hint_label(
             let parts = label
                 .parts
                 .into_iter()
+                .filter(|part| !part.text.is_empty())
                 .map(|part| {
                     let tooltip = if needs_resolve && fields_to_resolve.resolve_label_tooltip {
                         *something_to_resolve |= part.tooltip.is_some();


### PR DESCRIPTION
LSP states that inlay hints should never be empty:

    /**
     * The label of this hint. A human readable string or an array of
     * InlayHintLabelPart label parts. * * *Note* that neither the string nor the label part can be empty.
     */
    label: string | InlayHintLabelPart[];

https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#inlayHint

rust-analyzer would sometimes return empty inlay label parts, leading to this warning in the VS Code devtools console:

> INVALID inlay hint, empty label part rust-analyzer