### PR TITLE
fix: avoid creating case diagnostics for macro generated code

### DIFF
--- a/crates/hir-ty/src/diagnostics/decl_check.rs
+++ b/crates/hir-ty/src/diagnostics/decl_check.rs
@@ -627,6 +627,10 @@ impl<'a> DeclValidator<'a> {
     ) where
         T: AstNode + HasName + fmt::Debug,
     {
+        if file_id.is_macro() {
+            return;
+        }
+
         let Some(name_ast) = node.name() else {
             never!(
                 "Replacement ({:?}) was generated for a {:?} without a name: {:?}",


### PR DESCRIPTION
fixes #18122 by disallow creating diagnostics for macro generated code. 