### PR TITLE
fix: Handle errors and lints from external macros

### DIFF
--- a/crates/ide-diagnostics/src/handlers/incorrect_case.rs
+++ b/crates/ide-diagnostics/src/handlers/incorrect_case.rs
@@ -370,6 +370,23 @@ mod F {
     }
 
     #[test]
+    fn external_macro() {
+        check_diagnostics(
+            r#"
+//- /library.rs library crate:library
+#[macro_export]
+macro_rules! trigger_lint {
+    () => { let FOO: () };
+}
+//- /user.rs crate:user deps:library
+fn foo() {
+    library::trigger_lint!();
+}
+    "#,
+        );
+    }
+
+    #[test]
     fn complex_ignore() {
         check_diagnostics(
             r#"


### PR DESCRIPTION
Some lints should not be reported if they originate from an external macro, and quickfixes should be disabled (or they'll change library code).

Fixes #18122.
Closes #18124.