### PR TITLE
fix: Remove check that text of `parse_expr_from_str()` matches the produced parsed tree

### DIFF
--- a/crates/ide-diagnostics/src/handlers/incorrect_case.rs
+++ b/crates/ide-diagnostics/src/handlers/incorrect_case.rs
@@ -996,4 +996,17 @@ fn BAR() {
         "#,
         );
     }
+
+    #[test]
+    fn allow_with_comment() {
+        check_diagnostics(
+            r#"
+#[allow(
+    // Yo, sup
+    non_snake_case
+)]
+fn foo(_HelloWorld: ()) {}
+        "#,
+        );
+    }
 }

--- a/crates/syntax/src/hacks.rs
+++ b/crates/syntax/src/hacks.rs
@@ -8,10 +8,15 @@ use crate::{ast, AstNode};
 
 pub fn parse_expr_from_str(s: &str, edition: Edition) -> Option<ast::Expr> {
     let s = s.trim();
-    let file = ast::SourceFile::parse(&format!("const _: () = {s};"), edition);
-    let expr = file.syntax_node().descendants().find_map(ast::Expr::cast)?;
-    if expr.syntax().text() != s {
-        return None;
-    }
-    Some(expr)
+
+    let file = ast::SourceFile::parse(
+        // Need a newline because the text may contain line comments.
+        &format!("const _: () = ({s}\n);"),
+        edition,
+    );
+    let expr = file.syntax_node().descendants().find_map(ast::ParenExpr::cast)?;
+    // Can't check the text because the original text may contain whitespace and comments.
+    // Wrap in parentheses to better allow for verification. Of course, the real fix is
+    // to get rid of this hack.
+    expr.expr()
 }


### PR DESCRIPTION
This check is incorrect when we have comments and whitespace in the text.

We can strip comments, but then we still have whitespace, which we cannot strip without changing meaning for the parser. So instead I opt to remove the check, and wrap the expression in parentheses (asserting what produced is a parenthesized expression) to strengthen verification.

Fixes #18144.