### PR TITLE
fix: When checking for forbidden expr kind matches, account for rawness

### DIFF
--- a/crates/hir-def/src/macro_expansion_tests/mbe/regression.rs
+++ b/crates/hir-def/src/macro_expansion_tests/mbe/regression.rs
@@ -1144,3 +1144,27 @@ mod any {
 "#]],
     );
 }
+
+#[test]
+fn regression_18148() {
+    check(
+        r#"
+macro_rules! m {
+    ( $e:expr ) => {};
+}
+
+fn foo() {
+    m!(r#const);
+}
+"#,
+        expect![[r#"
+macro_rules! m {
+    ( $e:expr ) => {};
+}
+
+fn foo() {
+    ;
+}
+"#]],
+    );
+}

--- a/crates/mbe/src/expander/matcher.rs
+++ b/crates/mbe/src/expander/matcher.rs
@@ -780,7 +780,7 @@ fn match_meta_var(
             // [1]: https://github.com/rust-lang/rust/blob/f0c4da499/compiler/rustc_expand/src/mbe/macro_parser.rs#L576
             match input.peek_n(0) {
                 Some(tt::TokenTree::Leaf(tt::Leaf::Ident(it))) => {
-                    let is_err = if matches!(expr, ExprKind::Expr2021) {
+                    let is_err = if it.is_raw.no() && matches!(expr, ExprKind::Expr2021) {
                         it.sym == sym::underscore || it.sym == sym::let_ || it.sym == sym::const_
                     } else {
                         it.sym == sym::let_


### PR DESCRIPTION
An expression starting with `r#const` etc. should be accepted even in edition <=2021.

Fixes #18148.

This was not fixed when testing with edition 2024, I wonder whether that means our check for edition is incorrect...