### PR TITLE
internal: Disable GitHub releases for now

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -244,12 +244,12 @@ jobs:
           path: dist
       - run: ls -al ./dist
 
-      - name: Publish Release
-        uses: ./.github/actions/github-release
-        with:
-          files: "dist/*"
-          name: ${{ env.TAG }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+      # - name: Publish Release
+      #   uses: ./.github/actions/github-release
+      #   with:
+      #     files: "dist/*"
+      #     name: ${{ env.TAG }}
+      #     token: ${{ secrets.GITHUB_TOKEN }}
 
       - run: rm dist/rust-analyzer-no-server.vsix
 


### PR DESCRIPTION
These are currently throwing `Error: HttpError: Resource not accessible by integration` because of the organization change, let's disable them for today's release.