### PR TITLE
minor: Revert "internal: Disable GitHub releases for now"

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -244,12 +244,12 @@ jobs:
           path: dist
       - run: ls -al ./dist
 
-      # - name: Publish Release
-      #   uses: ./.github/actions/github-release
-      #   with:
-      #     files: "dist/*"
-      #     name: ${{ env.TAG }}
-      #     token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Publish Release
+        uses: ./.github/actions/github-release
+        with:
+          files: "dist/*"
+          name: ${{ env.TAG }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - run: rm dist/rust-analyzer-no-server.vsix
 


### PR DESCRIPTION
Turns out, this wasn't needed for long.