### PR TITLE
Require rust 1.81

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["crates/proc-macro-srv/proc-macro-test/imp"]
 resolver = "2"
 
 [workspace.package]
-rust-version = "1.80"
+rust-version = "1.81"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["rust-analyzer team"]


### PR DESCRIPTION
rust-analyzer doesn't build on 1.80 because we use `#[expect(lint)]`:
```
error[E0658]: the `#[expect]` attribute is an experimental feature
  --> crates/hir-expand/src/prettify_macro_expansion_.rs:11:1
   |
11 | #[expect(deprecated)]
   | ^^^^^^^^^^^^^^^^^^^^^
   |
   = note: see issue #54503 <https://github.com/rust-lang/rust/issues/54503> for more information
```
