### PR TITLE
internal: switch remaining OpQueues to use named structs

### DIFF
--- a/crates/rust-analyzer/src/global_state.rs
+++ b/crates/rust-analyzer/src/global_state.rs
@@ -51,6 +51,11 @@ pub(crate) struct FetchWorkspaceResponse {
     pub(crate) force_crate_graph_reload: bool,
 }
 
+pub(crate) struct FetchBuildDataResponse {
+    pub(crate) workspaces: Arc<Vec<ProjectWorkspace>>,
+    pub(crate) build_scripts: Vec<anyhow::Result<WorkspaceBuildScripts>>,
+}
+
 // Enforces drop order
 pub(crate) struct Handle<H, C> {
     pub(crate) handle: H,
@@ -152,8 +157,7 @@ pub(crate) struct GlobalState {
 
     // op queues
     pub(crate) fetch_workspaces_queue: OpQueue<FetchWorkspaceRequest, FetchWorkspaceResponse>,
-    pub(crate) fetch_build_data_queue:
-        OpQueue<(), (Arc<Vec<ProjectWorkspace>>, Vec<anyhow::Result<WorkspaceBuildScripts>>)>,
+    pub(crate) fetch_build_data_queue: OpQueue<(), FetchBuildDataResponse>,
     pub(crate) fetch_proc_macros_queue: OpQueue<Vec<ProcMacroPaths>, bool>,
     pub(crate) prime_caches_queue: OpQueue,
     pub(crate) discover_workspace_queue: OpQueue,

--- a/crates/rust-analyzer/src/main_loop.rs
+++ b/crates/rust-analyzer/src/main_loop.rs
@@ -23,7 +23,8 @@ use crate::{
     discover::{DiscoverArgument, DiscoverCommand, DiscoverProjectMessage},
     flycheck::{self, FlycheckMessage},
     global_state::{
-        file_id_to_url, url_to_file_id, FetchWorkspaceRequest, FetchWorkspaceResponse, GlobalState,
+        file_id_to_url, url_to_file_id, FetchBuildDataResponse, FetchWorkspaceRequest,
+        FetchWorkspaceResponse, GlobalState,
     },
     hack_recover_crate_name,
     handlers::dispatch::{NotificationDispatcher, RequestDispatcher},
@@ -738,8 +739,10 @@ impl GlobalState {
                 let (state, msg) = match progress {
                     BuildDataProgress::Begin => (Some(Progress::Begin), None),
                     BuildDataProgress::Report(msg) => (Some(Progress::Report), Some(msg)),
-                    BuildDataProgress::End(build_data_result) => {
-                        self.fetch_build_data_queue.op_completed(build_data_result);
+                    BuildDataProgress::End((workspaces, build_scripts)) => {
+                        let resp = FetchBuildDataResponse { workspaces, build_scripts };
+                        self.fetch_build_data_queue.op_completed(resp);
+
                         if let Err(e) = self.fetch_build_data_error() {
                             error!("FetchBuildDataError: {e}");
                         }

--- a/crates/rust-analyzer/src/reload.rs
+++ b/crates/rust-analyzer/src/reload.rs
@@ -33,7 +33,9 @@ use vfs::{AbsPath, AbsPathBuf, ChangeKind};
 use crate::{
     config::{Config, FilesWatcher, LinkedProject},
     flycheck::{FlycheckConfig, FlycheckHandle},
-    global_state::{FetchWorkspaceRequest, FetchWorkspaceResponse, GlobalState},
+    global_state::{
+        FetchBuildDataResponse, FetchWorkspaceRequest, FetchWorkspaceResponse, GlobalState,
+    },
     lsp_ext,
     main_loop::{DiscoverProjectParam, Task},
     op_queue::Cause,
@@ -475,7 +477,9 @@ impl GlobalState {
 
         if same_workspaces {
             let (workspaces, build_scripts) = match self.fetch_build_data_queue.last_op_result() {
-                Some((workspaces, build_scripts)) => (workspaces.clone(), build_scripts.as_slice()),
+                Some(FetchBuildDataResponse { workspaces, build_scripts }) => {
+                    (workspaces.clone(), build_scripts.as_slice())
+                }
                 None => (Default::default(), Default::default()),
             };
 
@@ -769,12 +773,14 @@ impl GlobalState {
     pub(super) fn fetch_build_data_error(&self) -> Result<(), String> {
         let mut buf = String::new();
 
-        let Some((_, ws)) = &self.fetch_build_data_queue.last_op_result() else {
+        let Some(FetchBuildDataResponse { build_scripts, .. }) =
+            &self.fetch_build_data_queue.last_op_result()
+        else {
             return Ok(());
         };
 
-        for ws in ws {
-            match ws {
+        for script in build_scripts {
+            match script {
                 Ok(data) => {
                     if let Some(stderr) = data.error() {
                         stdx::format_to!(buf, "{:#}\n", stderr)


### PR DESCRIPTION
Building atop of https://github.com/rust-lang/rust-analyzer/pull/18195, I switched `GlobalState::fetch_build_data_queue` to use a struct instead of a tuple.

(I didn't switch `fetch_proc_macros_queue` to not return a bool, as the return value is only used in one spot.)