### PR TITLE
fix: Comment out cast checks for unknown ptr kind

### DIFF
--- a/crates/hir-ty/src/infer/cast.rs
+++ b/crates/hir-ty/src/infer/cast.rs
@@ -70,8 +70,9 @@ pub enum CastError {
     NeedViaThinPtr,
     NeedViaInt,
     NonScalar,
-    UnknownCastPtrKind,
-    UnknownExprPtrKind,
+    // We don't want to report errors with unknown types currently.
+    // UnknownCastPtrKind,
+    // UnknownExprPtrKind,
 }
 
 impl CastError {
@@ -272,9 +273,10 @@ impl CastCheck {
 
         match (src_kind, dst_kind) {
             (Some(PointerKind::Error), _) | (_, Some(PointerKind::Error)) => Ok(()),
-            (_, None) => Err(CastError::UnknownCastPtrKind),
+            // (_, None) => Err(CastError::UnknownCastPtrKind),
+            // (None, _) => Err(CastError::UnknownExprPtrKind),
+            (_, None) | (None, _) => Ok(()),
             (_, Some(PointerKind::Thin)) => Ok(()),
-            (None, _) => Err(CastError::UnknownExprPtrKind),
             (Some(PointerKind::Thin), _) => Err(CastError::SizedUnsizedCast),
             (Some(PointerKind::VTable(src_tty)), Some(PointerKind::VTable(dst_tty))) => {
                 let principal = |tty: &Binders<QuantifiedWhereClauses>| {
@@ -315,7 +317,8 @@ impl CastCheck {
         expr_ty: &Ty,
     ) -> Result<(), CastError> {
         match pointer_kind(expr_ty, table).map_err(|_| CastError::Unknown)? {
-            None => Err(CastError::UnknownExprPtrKind),
+            // None => Err(CastError::UnknownExprPtrKind),
+            None => Ok(()),
             Some(PointerKind::Error) => Ok(()),
             Some(PointerKind::Thin) => Ok(()),
             _ => Err(CastError::NeedViaThinPtr),
@@ -328,7 +331,8 @@ impl CastCheck {
         cast_ty: &Ty,
     ) -> Result<(), CastError> {
         match pointer_kind(cast_ty, table).map_err(|_| CastError::Unknown)? {
-            None => Err(CastError::UnknownCastPtrKind),
+            // None => Err(CastError::UnknownCastPtrKind),
+            None => Ok(()),
             Some(PointerKind::Error) => Ok(()),
             Some(PointerKind::Thin) => Ok(()),
             Some(PointerKind::VTable(_)) => Err(CastError::IntToFatCast),
@@ -343,7 +347,8 @@ impl CastCheck {
         cast_ty: &Ty,
     ) -> Result<(), CastError> {
         match pointer_kind(cast_ty, table).map_err(|_| CastError::Unknown)? {
-            None => Err(CastError::UnknownCastPtrKind),
+            // None => Err(CastError::UnknownCastPtrKind),
+            None => Ok(()),
             Some(PointerKind::Error) => Ok(()),
             Some(PointerKind::Thin) => Ok(()),
             _ => Err(CastError::IllegalCast),

--- a/crates/ide-diagnostics/src/handlers/invalid_cast.rs
+++ b/crates/ide-diagnostics/src/handlers/invalid_cast.rs
@@ -95,10 +95,10 @@ pub(crate) fn invalid_cast(ctx: &DiagnosticsContext<'_>, d: &hir::InvalidCast) -
             DiagnosticCode::RustcHardError("E0605"),
             format_ty!(ctx, "non-primitive cast: `{}` as `{}`", d.expr_ty, d.cast_ty),
         ),
-        CastError::UnknownCastPtrKind | CastError::UnknownExprPtrKind => (
-            DiagnosticCode::RustcHardError("E0641"),
-            "cannot cast to a pointer of an unknown kind".to_owned(),
-        ),
+        // CastError::UnknownCastPtrKind | CastError::UnknownExprPtrKind => (
+        //     DiagnosticCode::RustcHardError("E0641"),
+        //     "cannot cast to a pointer of an unknown kind".to_owned(),
+        // ),
     };
     Diagnostic::new(code, message, display_range)
 }
@@ -457,20 +457,20 @@ fn foo<T: ?Sized>() {
         );
     }
 
-    #[test]
-    fn order_dependent_cast_inference() {
-        check_diagnostics(
-            r#"
-//- minicore: sized
-fn main() {
-    let x = &"hello";
-    let mut y = 0 as *const _;
-              //^^^^^^^^^^^^^ error: cannot cast to a pointer of an unknown kind
-    y = x as *const _;
-}
-"#,
-        );
-    }
+    //     #[test]
+    //     fn order_dependent_cast_inference() {
+    //         check_diagnostics(
+    //             r#"
+    // //- minicore: sized
+    // fn main() {
+    //     let x = &"hello";
+    //     let mut y = 0 as *const _;
+    //               //^^^^^^^^^^^^^ error: cannot cast to a pointer of an unknown kind
+    //     y = x as *const _;
+    // }
+    // "#,
+    //         );
+    //     }
 
     #[test]
     fn ptr_to_ptr_different_regions() {
@@ -1109,6 +1109,24 @@ fn foo() {
     0 as char;
 }
             "#,
+        );
+    }
+
+    #[test]
+    fn cast_isize_to_infer_pointer() {
+        check_diagnostics(
+            r#"
+//- minicore: coerce_unsized
+struct Foo {}
+
+struct Wrap<'a>(&'a mut Foo);
+
+fn main() {
+    let lparam: isize = 0;
+
+    let _wrap = Wrap(unsafe { &mut *(lparam as *mut _) });
+}
+        "#,
         );
     }
 }


### PR DESCRIPTION
Just like we don't check for types containing unknown.

Fixes #18214.

See also https://rust-lang.zulipchat.com/#narrow/stream/185405-t-compiler.2Frust-analyzer/topic/Another.20case.20of.20.2318064.3F.