### PR TITLE
Correctly parse `use` in generic parameters

### DIFF
--- a/crates/parser/src/grammar/generic_params.rs
+++ b/crates/parser/src/grammar/generic_params.rs
@@ -145,7 +145,7 @@ fn type_bound(p: &mut Parser<'_>) -> bool {
         T![for] => types::for_type(p, false),
         // test precise_capturing
         // fn captures<'a: 'a, 'b: 'b, T>() -> impl Sized + use<'b, T> {}
-        T![use] => {
+        T![use] if p.nth_at(1, T![<]) => {
             p.bump_any();
             generic_param_list(p)
         }

--- a/crates/parser/test_data/parser/err/0055_impl_use.rast
+++ b/crates/parser/test_data/parser/err/0055_impl_use.rast
@@ -1,0 +1,26 @@
+SOURCE_FILE
+  IMPL
+    IMPL_KW "impl"
+    GENERIC_PARAM_LIST
+      L_ANGLE "<"
+      TYPE_PARAM
+        NAME
+          IDENT "T"
+        COLON ":"
+        WHITESPACE "\n"
+        TYPE_BOUND_LIST
+    ERROR
+      USE_KW "use"
+  WHITESPACE " "
+  MACRO_CALL
+    PATH
+      PATH_SEGMENT
+        NAME_REF
+          IDENT "std"
+    SEMICOLON ";"
+  WHITESPACE "\n"
+error 8: expected R_ANGLE
+error 8: expected type
+error 11: expected `{`
+error 15: expected BANG
+error 15: expected `{`, `[`, `(`

--- a/crates/parser/test_data/parser/err/0055_impl_use.rs
+++ b/crates/parser/test_data/parser/err/0055_impl_use.rs
@@ -1,0 +1,2 @@
+impl<T:
+use std;


### PR DESCRIPTION
Fixes: #18225