### PR TITLE
fix: include description in label details when detail field is marked for …

### DIFF
--- a/crates/rust-analyzer/src/lsp/to_proto.rs
+++ b/crates/rust-analyzer/src/lsp/to_proto.rs
@@ -339,7 +339,7 @@ fn completion_item(
         something_to_resolve = item.detail.is_some();
         None
     } else {
-        item.detail
+        item.detail.clone()
     };
 
     let documentation = if fields_to_resolve.resolve_documentation {
@@ -370,7 +370,7 @@ fn completion_item(
         } else {
             lsp_item.label_details = Some(lsp_types::CompletionItemLabelDetails {
                 detail: item.label_detail.as_ref().map(ToString::to_string),
-                description: lsp_item.detail.clone(),
+                description: item.detail,
             });
         }
     } else if let Some(label_detail) = item.label_detail {


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust-analyzer/issues/18231. 

When omitting the autocomplete detail field, the autocomplete label details can still be returned. Currently the label details are missing the description field if the detail field is included in resolveSupport since it is being overwritten as None and opted to be sent with `completionItem/resolve`.

Example completion capabilities.
```
completion = {          
    completionItem = {            
        commitCharactersSupport = true,            
        deprecatedSupport = true,            
        documentationFormat = { "markdown", "plaintext" },            
        insertReplaceSupport = true,            
        insertTextModeSupport = {              
            valueSet = { 1, 2 }            
        },            
        labelDetailsSupport = true,            
        preselectSupport = true,            
        resolveSupport = {              
            properties = { "documentation", "detail", "additionalTextEdits", "sortText", "filterText", "insertText", "textEdit", "insertTextFormat", "insertTextMode" }            
        },            
        snippetSupport = true,            
        tagSupport = {              
            valueSet = { 1 }            
        }          
}
```