### PR TITLE
fix: Nail destructuring assignment once and for all

### DIFF
--- a/crates/hir-def/src/body/lower.rs
+++ b/crates/hir-def/src/body/lower.rs
@@ -70,7 +70,6 @@ pub(super) fn lower(
         body: Body::default(),
         expander,
         current_try_block_label: None,
-        is_lowering_assignee_expr: false,
         is_lowering_coroutine: false,
         label_ribs: Vec::new(),
         current_binding_owner: None,
@@ -89,7 +88,6 @@ struct ExprCollector<'a> {
     body: Body,
     source_map: BodySourceMap,
 
-    is_lowering_assignee_expr: bool,
     is_lowering_coroutine: bool,
 
     current_try_block_label: Option<LabelId>,
@@ -359,14 +357,7 @@ impl ExprCollector<'_> {
                     } else {
                         Box::default()
                     };
-                    self.alloc_expr(
-                        Expr::Call {
-                            callee,
-                            args,
-                            is_assignee_expr: self.is_lowering_assignee_expr,
-                        },
-                        syntax_ptr,
-                    )
+                    self.alloc_expr(Expr::Call { callee, args }, syntax_ptr)
                 }
             }
             ast::Expr::MethodCallExpr(e) => {
@@ -457,7 +448,6 @@ impl ExprCollector<'_> {
             ast::Expr::RecordExpr(e) => {
                 let path =
                     e.path().and_then(|path| self.expander.parse_path(self.db, path)).map(Box::new);
-                let is_assignee_expr = self.is_lowering_assignee_expr;
                 let record_lit = if let Some(nfl) = e.record_expr_field_list() {
                     let fields = nfl
                         .fields()
@@ -476,16 +466,9 @@ impl ExprCollector<'_> {
                         })
                         .collect();
                     let spread = nfl.spread().map(|s| self.collect_expr(s));
-                    let ellipsis = nfl.dotdot_token().is_some();
-                    Expr::RecordLit { path, fields, spread, ellipsis, is_assignee_expr }
+                    Expr::RecordLit { path, fields, spread }
                 } else {
-                    Expr::RecordLit {
-                        path,
-                        fields: Box::default(),
-                        spread: None,
-                        ellipsis: false,
-                        is_assignee_expr,
-                    }
+                    Expr::RecordLit { path, fields: Box::default(), spread: None }
                 };
 
                 self.alloc_expr(record_lit, syntax_ptr)
@@ -602,12 +585,14 @@ impl ExprCollector<'_> {
             ast::Expr::BinExpr(e) => {
                 let op = e.op_kind();
                 if let Some(ast::BinaryOp::Assignment { op: None }) = op {
-                    self.is_lowering_assignee_expr = true;
+                    let target = self.collect_expr_as_pat_opt(e.lhs());
+                    let value = self.collect_expr_opt(e.rhs());
+                    self.alloc_expr(Expr::Assignment { target, value }, syntax_ptr)
+                } else {
+                    let lhs = self.collect_expr_opt(e.lhs());
+                    let rhs = self.collect_expr_opt(e.rhs());
+                    self.alloc_expr(Expr::BinaryOp { lhs, rhs, op }, syntax_ptr)
                 }
-                let lhs = self.collect_expr_opt(e.lhs());
-                self.is_lowering_assignee_expr = false;
-                let rhs = self.collect_expr_opt(e.rhs());
-                self.alloc_expr(Expr::BinaryOp { lhs, rhs, op }, syntax_ptr)
             }
             ast::Expr::TupleExpr(e) => {
                 let mut exprs: Vec<_> = e.fields().map(|expr| self.collect_expr(expr)).collect();
@@ -617,13 +602,7 @@ impl ExprCollector<'_> {
                     exprs.insert(0, self.missing_expr());
                 }
 
-                self.alloc_expr(
-                    Expr::Tuple {
-                        exprs: exprs.into_boxed_slice(),
-                        is_assignee_expr: self.is_lowering_assignee_expr,
-                    },
-                    syntax_ptr,
-                )
+                self.alloc_expr(Expr::Tuple { exprs: exprs.into_boxed_slice() }, syntax_ptr)
             }
             ast::Expr::ArrayExpr(e) => {
                 let kind = e.kind();
@@ -631,13 +610,7 @@ impl ExprCollector<'_> {
                 match kind {
                     ArrayExprKind::ElementList(e) => {
                         let elements = e.map(|expr| self.collect_expr(expr)).collect();
-                        self.alloc_expr(
-                            Expr::Array(Array::ElementList {
-                                elements,
-                                is_assignee_expr: self.is_lowering_assignee_expr,
-                            }),
-                            syntax_ptr,
-                        )
+                        self.alloc_expr(Expr::Array(Array::ElementList { elements }), syntax_ptr)
                     }
                     ArrayExprKind::Repeat { initializer, repeat } => {
                         let initializer = self.collect_expr_opt(initializer);
@@ -664,8 +637,7 @@ impl ExprCollector<'_> {
             ast::Expr::IndexExpr(e) => {
                 let base = self.collect_expr_opt(e.base());
                 let index = self.collect_expr_opt(e.index());
-                let is_assignee_expr = self.is_lowering_assignee_expr;
-                self.alloc_expr(Expr::Index { base, index, is_assignee_expr }, syntax_ptr)
+                self.alloc_expr(Expr::Index { base, index }, syntax_ptr)
             }
             ast::Expr::RangeExpr(e) => {
                 let lhs = e.start().map(|lhs| self.collect_expr(lhs));
@@ -703,6 +675,178 @@ impl ExprCollector<'_> {
             }
             ast::Expr::FormatArgsExpr(f) => self.collect_format_args(f, syntax_ptr),
         })
+    }
+
+    fn collect_expr_as_pat_opt(&mut self, expr: Option<ast::Expr>) -> PatId {
+        match expr {
+            Some(expr) => self.collect_expr_as_pat(expr),
+            _ => self.missing_pat(),
+        }
+    }
+
+    fn collect_expr_as_pat(&mut self, expr: ast::Expr) -> PatId {
+        self.maybe_collect_expr_as_pat(&expr).unwrap_or_else(|| {
+            let syntax_ptr = AstPtr::new(&expr);
+            let expr = self.collect_expr(expr);
+            self.alloc_pat_from_expr(Pat::Expr(expr), syntax_ptr)
+        })
+    }
+
+    fn maybe_collect_expr_as_pat(&mut self, expr: &ast::Expr) -> Option<PatId> {
+        self.check_cfg(expr)?;
+        let syntax_ptr = AstPtr::new(expr);
+
+        let result = match expr {
+            ast::Expr::UnderscoreExpr(_) => self.alloc_pat_from_expr(Pat::Wild, syntax_ptr),
+            ast::Expr::ParenExpr(e) => {
+                // We special-case `(..)` for consistency with patterns.
+                if let Some(ast::Expr::RangeExpr(range)) = e.expr() {
+                    if range.is_range_full() {
+                        return Some(self.alloc_pat_from_expr(
+                            Pat::Tuple { args: Box::default(), ellipsis: Some(0) },
+                            syntax_ptr,
+                        ));
+                    }
+                }
+                return e.expr().and_then(|expr| self.maybe_collect_expr_as_pat(&expr));
+            }
+            ast::Expr::TupleExpr(e) => {
+                let (ellipsis, args) = collect_tuple(self, e.fields());
+                self.alloc_pat_from_expr(Pat::Tuple { args, ellipsis }, syntax_ptr)
+            }
+            ast::Expr::ArrayExpr(e) => {
+                if e.semicolon_token().is_some() {
+                    return None;
+                }
+
+                let mut elements = e.exprs();
+                let prefix = elements
+                    .by_ref()
+                    .map_while(|elem| collect_possibly_rest(self, elem).left())
+                    .collect();
+                let suffix = elements.map(|elem| self.collect_expr_as_pat(elem)).collect();
+                self.alloc_pat_from_expr(Pat::Slice { prefix, slice: None, suffix }, syntax_ptr)
+            }
+            ast::Expr::CallExpr(e) => {
+                let path = collect_path(self, e.expr()?)?;
+                let path = path
+                    .path()
+                    .and_then(|path| self.expander.parse_path(self.db, path))
+                    .map(Box::new);
+                let (ellipsis, args) = collect_tuple(self, e.arg_list()?.args());
+                self.alloc_pat_from_expr(Pat::TupleStruct { path, args, ellipsis }, syntax_ptr)
+            }
+            ast::Expr::PathExpr(e) => {
+                let path = Box::new(self.expander.parse_path(self.db, e.path()?)?);
+                self.alloc_pat_from_expr(Pat::Path(path), syntax_ptr)
+            }
+            ast::Expr::MacroExpr(e) => {
+                let e = e.macro_call()?;
+                let macro_ptr = AstPtr::new(&e);
+                let id = self.collect_macro_call(e, macro_ptr, true, |this, expansion| {
+                    expansion.map(|it| this.collect_expr_as_pat(it))
+                });
+                match id {
+                    Some(id) => {
+                        // FIXME: Insert pat into source map.
+                        id
+                    }
+                    None => self.alloc_pat_from_expr(Pat::Missing, syntax_ptr),
+                }
+            }
+            ast::Expr::RecordExpr(e) => {
+                let path =
+                    e.path().and_then(|path| self.expander.parse_path(self.db, path)).map(Box::new);
+                let record_field_list = e.record_expr_field_list()?;
+                let ellipsis = record_field_list.dotdot_token().is_some();
+                // FIXME: Report an error here if `record_field_list.spread().is_some()`.
+                let args = record_field_list
+                    .fields()
+                    .filter_map(|f| {
+                        self.check_cfg(&f)?;
+                        let field_expr = f.expr()?;
+                        let pat = self.collect_expr_as_pat(field_expr);
+                        let name = f.field_name()?.as_name();
+                        // FIXME: Enable this.
+                        // let src = self.expander.in_file(AstPtr::new(&f));
+                        // self.source_map.pat_field_map_back.insert(pat, src);
+                        Some(RecordFieldPat { name, pat })
+                    })
+                    .collect();
+                self.alloc_pat_from_expr(Pat::Record { path, args, ellipsis }, syntax_ptr)
+            }
+            _ => return None,
+        };
+        return Some(result);
+
+        fn collect_path(this: &mut ExprCollector<'_>, expr: ast::Expr) -> Option<ast::PathExpr> {
+            match expr {
+                ast::Expr::PathExpr(e) => Some(e),
+                ast::Expr::MacroExpr(mac) => {
+                    let call = mac.macro_call()?;
+                    {
+                        let macro_ptr = AstPtr::new(&call);
+                        this.collect_macro_call(call, macro_ptr, true, |this, expanded_path| {
+                            collect_path(this, expanded_path?)
+                        })
+                    }
+                }
+                _ => None,
+            }
+        }
+
+        fn collect_possibly_rest(
+            this: &mut ExprCollector<'_>,
+            expr: ast::Expr,
+        ) -> Either<PatId, ()> {
+            match &expr {
+                ast::Expr::RangeExpr(e) if e.is_range_full() => Either::Right(()),
+                ast::Expr::MacroExpr(mac) => match mac.macro_call() {
+                    Some(call) => {
+                        let macro_ptr = AstPtr::new(&call);
+                        let pat = this.collect_macro_call(
+                            call,
+                            macro_ptr,
+                            true,
+                            |this, expanded_expr| match expanded_expr {
+                                Some(expanded_pat) => collect_possibly_rest(this, expanded_pat),
+                                None => Either::Left(this.missing_pat()),
+                            },
+                        );
+                        // FIXME: Insert pat into source map.
+                        pat
+                    }
+                    None => {
+                        let ptr = AstPtr::new(&expr);
+                        Either::Left(this.alloc_pat_from_expr(Pat::Missing, ptr))
+                    }
+                },
+                _ => Either::Left(this.collect_expr_as_pat(expr)),
+            }
+        }
+
+        fn collect_tuple(
+            this: &mut ExprCollector<'_>,
+            fields: ast::AstChildren<ast::Expr>,
+        ) -> (Option<u32>, Box<[la_arena::Idx<Pat>]>) {
+            let mut ellipsis = None;
+            let args = fields
+                .enumerate()
+                .filter_map(|(idx, elem)| {
+                    match collect_possibly_rest(this, elem) {
+                        Either::Left(pat) => Some(pat),
+                        Either::Right(()) => {
+                            if ellipsis.is_none() {
+                                ellipsis = Some(idx as u32);
+                            }
+                            // FIXME: Report an error here otherwise.
+                            None
+                        }
+                    }
+                })
+                .collect();
+            (ellipsis, args)
+        }
     }
 
     fn initialize_binding_owner(
@@ -755,17 +899,13 @@ impl ExprCollector<'_> {
 
         let callee = self.alloc_expr_desugared_with_ptr(Expr::Path(try_from_output), ptr);
         let next_tail = match btail {
-            Some(tail) => self.alloc_expr_desugared_with_ptr(
-                Expr::Call { callee, args: Box::new([tail]), is_assignee_expr: false },
-                ptr,
-            ),
+            Some(tail) => self
+                .alloc_expr_desugared_with_ptr(Expr::Call { callee, args: Box::new([tail]) }, ptr),
             None => {
-                let unit = self.alloc_expr_desugared_with_ptr(
-                    Expr::Tuple { exprs: Box::new([]), is_assignee_expr: false },
-                    ptr,
-                );
+                let unit =
+                    self.alloc_expr_desugared_with_ptr(Expr::Tuple { exprs: Box::new([]) }, ptr);
                 self.alloc_expr_desugared_with_ptr(
-                    Expr::Call { callee, args: Box::new([unit]), is_assignee_expr: false },
+                    Expr::Call { callee, args: Box::new([unit]) },
                     ptr,
                 )
             }
@@ -851,11 +991,7 @@ impl ExprCollector<'_> {
         let head = self.collect_expr_opt(e.iterable());
         let into_iter_fn_expr = self.alloc_expr(Expr::Path(into_iter_fn), syntax_ptr);
         let iterator = self.alloc_expr(
-            Expr::Call {
-                callee: into_iter_fn_expr,
-                args: Box::new([head]),
-                is_assignee_expr: false,
-            },
+            Expr::Call { callee: into_iter_fn_expr, args: Box::new([head]) },
             syntax_ptr,
         );
         let none_arm = MatchArm {
@@ -884,11 +1020,7 @@ impl ExprCollector<'_> {
         );
         let iter_next_fn_expr = self.alloc_expr(Expr::Path(iter_next_fn), syntax_ptr);
         let iter_next_expr = self.alloc_expr(
-            Expr::Call {
-                callee: iter_next_fn_expr,
-                args: Box::new([iter_expr_mut]),
-                is_assignee_expr: false,
-            },
+            Expr::Call { callee: iter_next_fn_expr, args: Box::new([iter_expr_mut]) },
             syntax_ptr,
         );
         let loop_inner = self.alloc_expr(
@@ -942,10 +1074,8 @@ impl ExprCollector<'_> {
         };
         let operand = self.collect_expr_opt(e.expr());
         let try_branch = self.alloc_expr(Expr::Path(try_branch), syntax_ptr);
-        let expr = self.alloc_expr(
-            Expr::Call { callee: try_branch, args: Box::new([operand]), is_assignee_expr: false },
-            syntax_ptr,
-        );
+        let expr = self
+            .alloc_expr(Expr::Call { callee: try_branch, args: Box::new([operand]) }, syntax_ptr);
         let continue_name = Name::generate_new_name(self.body.bindings.len());
         let continue_binding =
             self.alloc_binding(continue_name.clone(), BindingAnnotation::Unannotated);
@@ -975,10 +1105,8 @@ impl ExprCollector<'_> {
             expr: {
                 let it = self.alloc_expr(Expr::Path(Path::from(break_name)), syntax_ptr);
                 let callee = self.alloc_expr(Expr::Path(try_from_residual), syntax_ptr);
-                let result = self.alloc_expr(
-                    Expr::Call { callee, args: Box::new([it]), is_assignee_expr: false },
-                    syntax_ptr,
-                );
+                let result =
+                    self.alloc_expr(Expr::Call { callee, args: Box::new([it]) }, syntax_ptr);
                 self.alloc_expr(
                     match self.current_try_block_label {
                         Some(label) => Expr::Break { expr: Some(result), label: Some(label) },
@@ -1723,10 +1851,8 @@ impl ExprCollector<'_> {
                 }
             })
             .collect();
-        let lit_pieces = self.alloc_expr_desugared(Expr::Array(Array::ElementList {
-            elements: lit_pieces,
-            is_assignee_expr: false,
-        }));
+        let lit_pieces =
+            self.alloc_expr_desugared(Expr::Array(Array::ElementList { elements: lit_pieces }));
         let lit_pieces = self.alloc_expr_desugared(Expr::Ref {
             expr: lit_pieces,
             rawness: Rawness::Ref,
@@ -1743,10 +1869,7 @@ impl ExprCollector<'_> {
                     Some(self.make_format_spec(placeholder, &mut argmap))
                 })
                 .collect();
-            let array = self.alloc_expr_desugared(Expr::Array(Array::ElementList {
-                elements,
-                is_assignee_expr: false,
-            }));
+            let array = self.alloc_expr_desugared(Expr::Array(Array::ElementList { elements }));
             self.alloc_expr_desugared(Expr::Ref {
                 expr: array,
                 rawness: Rawness::Ref,
@@ -1756,10 +1879,8 @@ impl ExprCollector<'_> {
         let arguments = &*fmt.arguments.arguments;
 
         let args = if arguments.is_empty() {
-            let expr = self.alloc_expr_desugared(Expr::Array(Array::ElementList {
-                elements: Box::default(),
-                is_assignee_expr: false,
-            }));
+            let expr = self
+                .alloc_expr_desugared(Expr::Array(Array::ElementList { elements: Box::default() }));
             self.alloc_expr_desugared(Expr::Ref {
                 expr,
                 rawness: Rawness::Ref,
@@ -1786,10 +1907,8 @@ impl ExprCollector<'_> {
                     self.make_argument(arg, ty)
                 })
                 .collect();
-            let array = self.alloc_expr_desugared(Expr::Array(Array::ElementList {
-                elements: args,
-                is_assignee_expr: false,
-            }));
+            let array =
+                self.alloc_expr_desugared(Expr::Array(Array::ElementList { elements: args }));
             self.alloc_expr_desugared(Expr::Ref {
                 expr: array,
                 rawness: Rawness::Ref,
@@ -1822,11 +1941,8 @@ impl ExprCollector<'_> {
         let new_v1_formatted = self.alloc_expr_desugared(Expr::Path(new_v1_formatted));
 
         let unsafe_arg_new = self.alloc_expr_desugared(Expr::Path(unsafe_arg_new));
-        let unsafe_arg_new = self.alloc_expr_desugared(Expr::Call {
-            callee: unsafe_arg_new,
-            args: Box::default(),
-            is_assignee_expr: false,
-        });
+        let unsafe_arg_new =
+            self.alloc_expr_desugared(Expr::Call { callee: unsafe_arg_new, args: Box::default() });
         let unsafe_arg_new = self.alloc_expr_desugared(Expr::Unsafe {
             id: None,
             // We collect the unused expressions here so that we still infer them instead of
@@ -1843,7 +1959,6 @@ impl ExprCollector<'_> {
             Expr::Call {
                 callee: new_v1_formatted,
                 args: Box::new([lit_pieces, args, format_options, unsafe_arg_new]),
-                is_assignee_expr: false,
             },
             syntax_ptr,
         );
@@ -1938,7 +2053,6 @@ impl ExprCollector<'_> {
         self.alloc_expr_desugared(Expr::Call {
             callee: format_placeholder_new,
             args: Box::new([position, fill, align, flags, precision, width]),
-            is_assignee_expr: false,
         })
     }
 
@@ -1980,11 +2094,7 @@ impl ExprCollector<'_> {
                     Some(count_is) => self.alloc_expr_desugared(Expr::Path(count_is)),
                     None => self.missing_expr(),
                 };
-                self.alloc_expr_desugared(Expr::Call {
-                    callee: count_is,
-                    args: Box::new([args]),
-                    is_assignee_expr: false,
-                })
+                self.alloc_expr_desugared(Expr::Call { callee: count_is, args: Box::new([args]) })
             }
             Some(FormatCount::Argument(arg)) => {
                 if let Ok(arg_index) = arg.index {
@@ -2005,7 +2115,6 @@ impl ExprCollector<'_> {
                     self.alloc_expr_desugared(Expr::Call {
                         callee: count_param,
                         args: Box::new([args]),
-                        is_assignee_expr: false,
                     })
                 } else {
                     // FIXME: This drops arg causing it to potentially not be resolved/type checked
@@ -2054,11 +2163,7 @@ impl ExprCollector<'_> {
             Some(new_fn) => self.alloc_expr_desugared(Expr::Path(new_fn)),
             None => self.missing_expr(),
         };
-        self.alloc_expr_desugared(Expr::Call {
-            callee: new_fn,
-            args: Box::new([arg]),
-            is_assignee_expr: false,
-        })
+        self.alloc_expr_desugared(Expr::Call { callee: new_fn, args: Box::new([arg]) })
     }
 
     // endregion: format
@@ -2110,6 +2215,10 @@ impl ExprCollector<'_> {
         binding
     }
 
+    fn alloc_pat_from_expr(&mut self, pat: Pat, _ptr: ExprPtr) -> PatId {
+        // FIXME: Insert into source map.
+        self.body.pats.alloc(pat)
+    }
     fn alloc_pat(&mut self, pat: Pat, ptr: PatPtr) -> PatId {
         let src = self.expander.in_file(ptr);
         let id = self.body.pats.alloc(pat);

--- a/crates/hir-def/src/body/pretty.rs
+++ b/crates/hir-def/src/body/pretty.rs
@@ -277,7 +277,7 @@ impl Printer<'_> {
                 w!(self, "loop ");
                 self.print_expr(*body);
             }
-            Expr::Call { callee, args, is_assignee_expr: _ } => {
+            Expr::Call { callee, args } => {
                 self.print_expr(*callee);
                 w!(self, "(");
                 if !args.is_empty() {
@@ -372,7 +372,7 @@ impl Printer<'_> {
                     self.print_expr(*expr);
                 }
             }
-            Expr::RecordLit { path, fields, spread, ellipsis, is_assignee_expr: _ } => {
+            Expr::RecordLit { path, fields, spread } => {
                 match path {
                     Some(path) => self.print_path(path),
                     None => w!(self, "�"),
@@ -390,9 +390,6 @@ impl Printer<'_> {
                         w!(p, "..");
                         p.print_expr(*spread);
                         wln!(p);
-                    }
-                    if *ellipsis {
-                        wln!(p, "..");
                     }
                 });
                 w!(self, "}}");
@@ -466,7 +463,7 @@ impl Printer<'_> {
                     w!(self, ") ");
                 }
             }
-            Expr::Index { base, index, is_assignee_expr: _ } => {
+            Expr::Index { base, index } => {
                 self.print_expr(*base);
                 w!(self, "[");
                 self.print_expr(*index);
@@ -507,7 +504,7 @@ impl Printer<'_> {
                 self.whitespace();
                 self.print_expr(*body);
             }
-            Expr::Tuple { exprs, is_assignee_expr: _ } => {
+            Expr::Tuple { exprs } => {
                 w!(self, "(");
                 for expr in exprs.iter() {
                     self.print_expr(*expr);
@@ -519,7 +516,7 @@ impl Printer<'_> {
                 w!(self, "[");
                 if !matches!(arr, Array::ElementList { elements, .. } if elements.is_empty()) {
                     self.indented(|p| match arr {
-                        Array::ElementList { elements, is_assignee_expr: _ } => {
+                        Array::ElementList { elements } => {
                             for elem in elements.iter() {
                                 p.print_expr(*elem);
                                 w!(p, ", ");
@@ -550,6 +547,11 @@ impl Printer<'_> {
             }
             Expr::Const(id) => {
                 w!(self, "const {{ /* {id:?} */ }}");
+            }
+            &Expr::Assignment { target, value } => {
+                self.print_pat(target);
+                w!(self, " = ");
+                self.print_expr(value);
             }
         }
     }
@@ -718,6 +720,9 @@ impl Printer<'_> {
             Pat::ConstBlock(c) => {
                 w!(self, "const ");
                 self.print_expr(*c);
+            }
+            Pat::Expr(expr) => {
+                self.print_expr(*expr);
             }
         }
     }

--- a/crates/hir-def/src/body/scope.rs
+++ b/crates/hir-def/src/body/scope.rs
@@ -282,7 +282,7 @@ fn compute_expr_scopes(
             *scope = scopes.new_scope(*scope);
             scopes.add_pat_bindings(body, *scope, pat);
         }
-        e => e.walk_child_exprs(|e| compute_expr_scopes(scopes, e, scope)),
+        _ => body.walk_child_exprs(expr, |e| compute_expr_scopes(scopes, e, scope)),
     };
 }
 

--- a/crates/hir-def/src/body/scope.rs
+++ b/crates/hir-def/src/body/scope.rs
@@ -333,6 +333,8 @@ mod tests {
 
         let expr_id = source_map
             .node_expr(InFile { file_id: file_id.into(), value: &marker.into() })
+            .unwrap()
+            .as_expr()
             .unwrap();
         let scope = scopes.scope_for(expr_id);
 
@@ -488,8 +490,11 @@ fn foo() {
 
         let expr_scope = {
             let expr_ast = name_ref.syntax().ancestors().find_map(ast::Expr::cast).unwrap();
-            let expr_id =
-                source_map.node_expr(InFile { file_id: file_id.into(), value: &expr_ast }).unwrap();
+            let expr_id = source_map
+                .node_expr(InFile { file_id: file_id.into(), value: &expr_ast })
+                .unwrap()
+                .as_expr()
+                .unwrap();
             scopes.scope_for(expr_id).unwrap()
         };
 

--- a/crates/hir-def/src/hir.rs
+++ b/crates/hir-def/src/hir.rs
@@ -48,6 +48,22 @@ pub enum ExprOrPatId {
     ExprId(ExprId),
     PatId(PatId),
 }
+
+impl ExprOrPatId {
+    pub fn as_expr(self) -> Option<ExprId> {
+        match self {
+            Self::ExprId(v) => Some(v),
+            _ => None,
+        }
+    }
+
+    pub fn as_pat(self) -> Option<PatId> {
+        match self {
+            Self::PatId(v) => Some(v),
+            _ => None,
+        }
+    }
+}
 stdx::impl_from!(ExprId, PatId for ExprOrPatId);
 
 #[derive(Debug, Clone, Eq, PartialEq)]

--- a/crates/hir-def/src/hir.rs
+++ b/crates/hir-def/src/hir.rs
@@ -204,7 +204,6 @@ pub enum Expr {
     Call {
         callee: ExprId,
         args: Box<[ExprId]>,
-        is_assignee_expr: bool,
     },
     MethodCall {
         receiver: ExprId,
@@ -239,8 +238,6 @@ pub enum Expr {
         path: Option<Box<Path>>,
         fields: Box<[RecordLitField]>,
         spread: Option<ExprId>,
-        ellipsis: bool,
-        is_assignee_expr: bool,
     },
     Field {
         expr: ExprId,
@@ -265,10 +262,16 @@ pub enum Expr {
         expr: ExprId,
         op: UnaryOp,
     },
+    /// `op` cannot be bare `=` (but can be `op=`), these are lowered to `Assignment` instead.
     BinaryOp {
         lhs: ExprId,
         rhs: ExprId,
         op: Option<BinaryOp>,
+    },
+    // Assignments need a special treatment because of destructuring assignment.
+    Assignment {
+        target: PatId,
+        value: ExprId,
     },
     Range {
         lhs: Option<ExprId>,
@@ -278,7 +281,6 @@ pub enum Expr {
     Index {
         base: ExprId,
         index: ExprId,
-        is_assignee_expr: bool,
     },
     Closure {
         args: Box<[PatId]>,
@@ -290,7 +292,6 @@ pub enum Expr {
     },
     Tuple {
         exprs: Box<[ExprId]>,
-        is_assignee_expr: bool,
     },
     Array(Array),
     Literal(Literal),
@@ -446,7 +447,7 @@ pub enum Movability {
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum Array {
-    ElementList { elements: Box<[ExprId]>, is_assignee_expr: bool },
+    ElementList { elements: Box<[ExprId]> },
     Repeat { initializer: ExprId, repeat: ExprId },
 }
 
@@ -478,130 +479,6 @@ pub enum Statement {
     // At the moment, we only use this to figure out if a return expression
     // is really the last statement of a block. See #16566
     Item,
-}
-
-impl Expr {
-    pub fn walk_child_exprs(&self, mut f: impl FnMut(ExprId)) {
-        match self {
-            Expr::Missing => {}
-            Expr::Path(_) | Expr::OffsetOf(_) => {}
-            Expr::InlineAsm(it) => it.operands.iter().for_each(|(_, op)| match op {
-                AsmOperand::In { expr, .. }
-                | AsmOperand::Out { expr: Some(expr), .. }
-                | AsmOperand::InOut { expr, .. } => f(*expr),
-                AsmOperand::SplitInOut { in_expr, out_expr, .. } => {
-                    f(*in_expr);
-                    if let Some(out_expr) = out_expr {
-                        f(*out_expr);
-                    }
-                }
-                AsmOperand::Out { expr: None, .. }
-                | AsmOperand::Const(_)
-                | AsmOperand::Label(_)
-                | AsmOperand::Sym(_) => (),
-            }),
-            Expr::If { condition, then_branch, else_branch } => {
-                f(*condition);
-                f(*then_branch);
-                if let &Some(else_branch) = else_branch {
-                    f(else_branch);
-                }
-            }
-            Expr::Let { expr, .. } => {
-                f(*expr);
-            }
-            Expr::Const(_) => (),
-            Expr::Block { statements, tail, .. }
-            | Expr::Unsafe { statements, tail, .. }
-            | Expr::Async { statements, tail, .. } => {
-                for stmt in statements.iter() {
-                    match stmt {
-                        Statement::Let { initializer, else_branch, .. } => {
-                            if let &Some(expr) = initializer {
-                                f(expr);
-                            }
-                            if let &Some(expr) = else_branch {
-                                f(expr);
-                            }
-                        }
-                        Statement::Expr { expr: expression, .. } => f(*expression),
-                        Statement::Item => (),
-                    }
-                }
-                if let &Some(expr) = tail {
-                    f(expr);
-                }
-            }
-            Expr::Loop { body, .. } => f(*body),
-            Expr::Call { callee, args, .. } => {
-                f(*callee);
-                args.iter().copied().for_each(f);
-            }
-            Expr::MethodCall { receiver, args, .. } => {
-                f(*receiver);
-                args.iter().copied().for_each(f);
-            }
-            Expr::Match { expr, arms } => {
-                f(*expr);
-                arms.iter().map(|arm| arm.expr).for_each(f);
-            }
-            Expr::Continue { .. } => {}
-            Expr::Break { expr, .. }
-            | Expr::Return { expr }
-            | Expr::Yield { expr }
-            | Expr::Yeet { expr } => {
-                if let &Some(expr) = expr {
-                    f(expr);
-                }
-            }
-            Expr::Become { expr } => f(*expr),
-            Expr::RecordLit { fields, spread, .. } => {
-                for field in fields.iter() {
-                    f(field.expr);
-                }
-                if let &Some(expr) = spread {
-                    f(expr);
-                }
-            }
-            Expr::Closure { body, .. } => {
-                f(*body);
-            }
-            Expr::BinaryOp { lhs, rhs, .. } => {
-                f(*lhs);
-                f(*rhs);
-            }
-            Expr::Range { lhs, rhs, .. } => {
-                if let &Some(lhs) = rhs {
-                    f(lhs);
-                }
-                if let &Some(rhs) = lhs {
-                    f(rhs);
-                }
-            }
-            Expr::Index { base, index, .. } => {
-                f(*base);
-                f(*index);
-            }
-            Expr::Field { expr, .. }
-            | Expr::Await { expr }
-            | Expr::Cast { expr, .. }
-            | Expr::Ref { expr, .. }
-            | Expr::UnaryOp { expr, .. }
-            | Expr::Box { expr } => {
-                f(*expr);
-            }
-            Expr::Tuple { exprs, .. } => exprs.iter().copied().for_each(f),
-            Expr::Array(a) => match a {
-                Array::ElementList { elements, .. } => elements.iter().copied().for_each(f),
-                Array::Repeat { initializer, repeat } => {
-                    f(*initializer);
-                    f(*repeat)
-                }
-            },
-            Expr::Literal(_) => {}
-            Expr::Underscore => {}
-        }
-    }
 }
 
 /// Explicit binding annotations given in the HIR for a binding. Note
@@ -665,18 +542,49 @@ pub struct RecordFieldPat {
 pub enum Pat {
     Missing,
     Wild,
-    Tuple { args: Box<[PatId]>, ellipsis: Option<u32> },
+    Tuple {
+        args: Box<[PatId]>,
+        ellipsis: Option<u32>,
+    },
     Or(Box<[PatId]>),
-    Record { path: Option<Box<Path>>, args: Box<[RecordFieldPat]>, ellipsis: bool },
-    Range { start: Option<Box<LiteralOrConst>>, end: Option<Box<LiteralOrConst>> },
-    Slice { prefix: Box<[PatId]>, slice: Option<PatId>, suffix: Box<[PatId]> },
+    Record {
+        path: Option<Box<Path>>,
+        args: Box<[RecordFieldPat]>,
+        ellipsis: bool,
+    },
+    Range {
+        start: Option<Box<LiteralOrConst>>,
+        end: Option<Box<LiteralOrConst>>,
+    },
+    Slice {
+        prefix: Box<[PatId]>,
+        slice: Option<PatId>,
+        suffix: Box<[PatId]>,
+    },
+    /// This might refer to a variable if a single segment path (specifically, on destructuring assignment).
     Path(Box<Path>),
     Lit(ExprId),
-    Bind { id: BindingId, subpat: Option<PatId> },
-    TupleStruct { path: Option<Box<Path>>, args: Box<[PatId]>, ellipsis: Option<u32> },
-    Ref { pat: PatId, mutability: Mutability },
-    Box { inner: PatId },
+    Bind {
+        id: BindingId,
+        subpat: Option<PatId>,
+    },
+    TupleStruct {
+        path: Option<Box<Path>>,
+        args: Box<[PatId]>,
+        ellipsis: Option<u32>,
+    },
+    Ref {
+        pat: PatId,
+        mutability: Mutability,
+    },
+    Box {
+        inner: PatId,
+    },
     ConstBlock(ExprId),
+    /// An expression inside a pattern. That can only occur inside assignments.
+    ///
+    /// E.g. in `(a, *b) = (1, &mut 2)`, `*b` is an expression.
+    Expr(ExprId),
 }
 
 impl Pat {
@@ -687,7 +595,8 @@ impl Pat {
             | Pat::Path(..)
             | Pat::ConstBlock(..)
             | Pat::Wild
-            | Pat::Missing => {}
+            | Pat::Missing
+            | Pat::Expr(_) => {}
             Pat::Bind { subpat, .. } => {
                 subpat.iter().copied().for_each(f);
             }

--- a/crates/hir-def/src/test_db.rs
+++ b/crates/hir-def/src/test_db.rs
@@ -198,7 +198,10 @@ impl TestDB {
             .filter_map(|node| {
                 let block = ast::BlockExpr::cast(node)?;
                 let expr = ast::Expr::from(block);
-                let expr_id = source_map.node_expr(InFile::new(position.file_id.into(), &expr))?;
+                let expr_id = source_map
+                    .node_expr(InFile::new(position.file_id.into(), &expr))?
+                    .as_expr()
+                    .unwrap();
                 let scope = scopes.scope_for(expr_id).unwrap();
                 Some(scope)
             });

--- a/crates/hir-ty/src/consteval.rs
+++ b/crates/hir-ty/src/consteval.rs
@@ -319,7 +319,7 @@ pub(crate) fn eval_to_const(
             return true;
         }
         let mut r = false;
-        body[expr].walk_child_exprs(|idx| r |= has_closure(body, idx));
+        body.walk_child_exprs(expr, |idx| r |= has_closure(body, idx));
         r
     }
     if has_closure(ctx.body, expr) {

--- a/crates/hir-ty/src/diagnostics/expr.rs
+++ b/crates/hir-ty/src/diagnostics/expr.rs
@@ -546,10 +546,7 @@ pub fn record_literal_missing_fields(
     expr: &Expr,
 ) -> Option<(VariantId, Vec<LocalFieldId>, /*exhaustive*/ bool)> {
     let (fields, exhaustive) = match expr {
-        Expr::RecordLit { fields, spread, ellipsis, is_assignee_expr, .. } => {
-            let exhaustive = if *is_assignee_expr { !*ellipsis } else { spread.is_none() };
-            (fields, exhaustive)
-        }
+        Expr::RecordLit { fields, spread, .. } => (fields, spread.is_none()),
         _ => return None,
     };
 

--- a/crates/hir-ty/src/diagnostics/unsafe_check.rs
+++ b/crates/hir-ty/src/diagnostics/unsafe_check.rs
@@ -3,7 +3,7 @@
 
 use hir_def::{
     body::Body,
-    hir::{Expr, ExprId, UnaryOp},
+    hir::{Expr, ExprId, ExprOrPatId, Pat, UnaryOp},
     resolver::{resolver_for_expr, ResolveValueResult, Resolver, ValueNs},
     type_ref::Rawness,
     DefWithBodyId,
@@ -16,7 +16,7 @@ use crate::{
 /// Returns `(unsafe_exprs, fn_is_unsafe)`.
 ///
 /// If `fn_is_unsafe` is false, `unsafe_exprs` are hard errors. If true, they're `unsafe_op_in_unsafe_fn`.
-pub fn missing_unsafe(db: &dyn HirDatabase, def: DefWithBodyId) -> (Vec<ExprId>, bool) {
+pub fn missing_unsafe(db: &dyn HirDatabase, def: DefWithBodyId) -> (Vec<ExprOrPatId>, bool) {
     let _p = tracing::info_span!("missing_unsafe").entered();
 
     let mut res = Vec::new();
@@ -32,7 +32,7 @@ pub fn missing_unsafe(db: &dyn HirDatabase, def: DefWithBodyId) -> (Vec<ExprId>,
     let infer = db.infer(def);
     unsafe_expressions(db, &infer, def, &body, body.body_expr, &mut |expr| {
         if !expr.inside_unsafe_block {
-            res.push(expr.expr);
+            res.push(expr.node);
         }
     });
 
@@ -40,7 +40,7 @@ pub fn missing_unsafe(db: &dyn HirDatabase, def: DefWithBodyId) -> (Vec<ExprId>,
 }
 
 pub struct UnsafeExpr {
-    pub expr: ExprId,
+    pub node: ExprOrPatId,
     pub inside_unsafe_block: bool,
 }
 
@@ -75,26 +75,28 @@ fn walk_unsafe(
     inside_unsafe_block: bool,
     unsafe_expr_cb: &mut dyn FnMut(UnsafeExpr),
 ) {
+    let mut mark_unsafe_path = |path, node| {
+        let g = resolver.update_to_inner_scope(db.upcast(), def, current);
+        let value_or_partial = resolver.resolve_path_in_value_ns(db.upcast(), path);
+        if let Some(ResolveValueResult::ValueNs(ValueNs::StaticId(id), _)) = value_or_partial {
+            let static_data = db.static_data(id);
+            if static_data.mutable || (static_data.is_extern && !static_data.has_safe_kw) {
+                unsafe_expr_cb(UnsafeExpr { node, inside_unsafe_block });
+            }
+        }
+        resolver.reset_to_guard(g);
+    };
+
     let expr = &body.exprs[current];
     match expr {
         &Expr::Call { callee, .. } => {
             if let Some(func) = infer[callee].as_fn_def(db) {
                 if is_fn_unsafe_to_call(db, func) {
-                    unsafe_expr_cb(UnsafeExpr { expr: current, inside_unsafe_block });
+                    unsafe_expr_cb(UnsafeExpr { node: current.into(), inside_unsafe_block });
                 }
             }
         }
-        Expr::Path(path) => {
-            let g = resolver.update_to_inner_scope(db.upcast(), def, current);
-            let value_or_partial = resolver.resolve_path_in_value_ns(db.upcast(), path);
-            if let Some(ResolveValueResult::ValueNs(ValueNs::StaticId(id), _)) = value_or_partial {
-                let static_data = db.static_data(id);
-                if static_data.mutable || (static_data.is_extern && !static_data.has_safe_kw) {
-                    unsafe_expr_cb(UnsafeExpr { expr: current, inside_unsafe_block });
-                }
-            }
-            resolver.reset_to_guard(g);
-        }
+        Expr::Path(path) => mark_unsafe_path(path, current.into()),
         Expr::Ref { expr, rawness: Rawness::RawPtr, mutability: _ } => {
             if let Expr::Path(_) = body.exprs[*expr] {
                 // Do not report unsafe for `addr_of[_mut]!(EXTERN_OR_MUT_STATIC)`,
@@ -108,17 +110,24 @@ fn walk_unsafe(
                 .map(|(func, _)| is_fn_unsafe_to_call(db, func))
                 .unwrap_or(false)
             {
-                unsafe_expr_cb(UnsafeExpr { expr: current, inside_unsafe_block });
+                unsafe_expr_cb(UnsafeExpr { node: current.into(), inside_unsafe_block });
             }
         }
         Expr::UnaryOp { expr, op: UnaryOp::Deref } => {
             if let TyKind::Raw(..) = &infer[*expr].kind(Interner) {
-                unsafe_expr_cb(UnsafeExpr { expr: current, inside_unsafe_block });
+                unsafe_expr_cb(UnsafeExpr { node: current.into(), inside_unsafe_block });
             }
         }
         Expr::Unsafe { .. } => {
             return body.walk_child_exprs(current, |child| {
                 walk_unsafe(db, infer, body, resolver, def, child, true, unsafe_expr_cb);
+            });
+        }
+        &Expr::Assignment { target, value: _ } => {
+            body.walk_pats(target, &mut |pat| {
+                if let Pat::Path(path) = &body[pat] {
+                    mark_unsafe_path(path, pat.into());
+                }
             });
         }
         _ => {}

--- a/crates/hir-ty/src/diagnostics/unsafe_check.rs
+++ b/crates/hir-ty/src/diagnostics/unsafe_check.rs
@@ -117,14 +117,14 @@ fn walk_unsafe(
             }
         }
         Expr::Unsafe { .. } => {
-            return expr.walk_child_exprs(|child| {
+            return body.walk_child_exprs(current, |child| {
                 walk_unsafe(db, infer, body, resolver, def, child, true, unsafe_expr_cb);
             });
         }
         _ => {}
     }
 
-    expr.walk_child_exprs(|child| {
+    body.walk_child_exprs(current, |child| {
         walk_unsafe(db, infer, body, resolver, def, child, inside_unsafe_block, unsafe_expr_cb);
     });
 }

--- a/crates/hir-ty/src/infer.rs
+++ b/crates/hir-ty/src/infer.rs
@@ -228,7 +228,7 @@ pub enum InferenceDiagnostic {
         id: ExprOrPatId,
     },
     UnresolvedIdent {
-        expr: ExprId,
+        id: ExprOrPatId,
     },
     // FIXME: This should be emitted in body lowering
     BreakOutsideOfLoop {
@@ -561,6 +561,9 @@ pub(crate) struct InferenceContext<'a> {
     diverges: Diverges,
     breakables: Vec<BreakableContext>,
 
+    /// Whether we are inside the pattern of a destructuring assignment.
+    inside_assignment: bool,
+
     deferred_cast_checks: Vec<CastCheck>,
 
     // fields related to closure capture
@@ -656,6 +659,7 @@ impl<'a> InferenceContext<'a> {
             current_closure: None,
             deferred_closures: FxHashMap::default(),
             closure_dependencies: FxHashMap::default(),
+            inside_assignment: false,
         }
     }
 

--- a/crates/hir-ty/src/infer.rs
+++ b/crates/hir-ty/src/infer.rs
@@ -482,11 +482,26 @@ impl InferenceResult {
     pub fn variant_resolution_for_pat(&self, id: PatId) -> Option<VariantId> {
         self.variant_resolutions.get(&id.into()).copied()
     }
+    pub fn variant_resolution_for_expr_or_pat(&self, id: ExprOrPatId) -> Option<VariantId> {
+        match id {
+            ExprOrPatId::ExprId(id) => self.variant_resolution_for_expr(id),
+            ExprOrPatId::PatId(id) => self.variant_resolution_for_pat(id),
+        }
+    }
     pub fn assoc_resolutions_for_expr(&self, id: ExprId) -> Option<(AssocItemId, Substitution)> {
         self.assoc_resolutions.get(&id.into()).cloned()
     }
     pub fn assoc_resolutions_for_pat(&self, id: PatId) -> Option<(AssocItemId, Substitution)> {
         self.assoc_resolutions.get(&id.into()).cloned()
+    }
+    pub fn assoc_resolutions_for_expr_or_pat(
+        &self,
+        id: ExprOrPatId,
+    ) -> Option<(AssocItemId, Substitution)> {
+        match id {
+            ExprOrPatId::ExprId(id) => self.assoc_resolutions_for_expr(id),
+            ExprOrPatId::PatId(id) => self.assoc_resolutions_for_pat(id),
+        }
     }
     pub fn type_mismatch_for_expr(&self, expr: ExprId) -> Option<&TypeMismatch> {
         self.type_mismatches.get(&expr.into())
@@ -506,6 +521,12 @@ impl InferenceResult {
     pub fn closure_info(&self, closure: &ClosureId) -> &(Vec<CapturedItem>, FnTrait) {
         self.closure_info.get(closure).unwrap()
     }
+    pub fn type_of_expr_or_pat(&self, id: ExprOrPatId) -> Option<&Ty> {
+        match id {
+            ExprOrPatId::ExprId(id) => self.type_of_expr.get(id),
+            ExprOrPatId::PatId(id) => self.type_of_pat.get(id),
+        }
+    }
 }
 
 impl Index<ExprId> for InferenceResult {
@@ -521,6 +542,14 @@ impl Index<PatId> for InferenceResult {
 
     fn index(&self, pat: PatId) -> &Ty {
         self.type_of_pat.get(pat).unwrap_or(&self.standard_types.unknown)
+    }
+}
+
+impl Index<ExprOrPatId> for InferenceResult {
+    type Output = Ty;
+
+    fn index(&self, id: ExprOrPatId) -> &Ty {
+        self.type_of_expr_or_pat(id).unwrap_or(&self.standard_types.unknown)
     }
 }
 

--- a/crates/hir-ty/src/infer/mutability.rs
+++ b/crates/hir-ty/src/infer/mutability.rs
@@ -4,7 +4,8 @@
 use chalk_ir::{cast::Cast, Mutability};
 use hir_def::{
     hir::{
-        Array, AsmOperand, BinaryOp, BindingAnnotation, Expr, ExprId, PatId, Statement, UnaryOp,
+        Array, AsmOperand, BinaryOp, BindingAnnotation, Expr, ExprId, Pat, PatId, Statement,
+        UnaryOp,
     },
     lang_item::LangItem,
 };
@@ -96,7 +97,7 @@ impl InferenceContext<'_> {
                 }
             }
             Expr::MethodCall { receiver: it, method_name: _, args, generic_args: _ }
-            | Expr::Call { callee: it, args, is_assignee_expr: _ } => {
+            | Expr::Call { callee: it, args } => {
                 self.infer_mut_not_expr_iter(args.iter().copied().chain(Some(*it)));
             }
             Expr::Match { expr, arms } => {
@@ -120,10 +121,10 @@ impl InferenceContext<'_> {
             Expr::Become { expr } => {
                 self.infer_mut_expr(*expr, Mutability::Not);
             }
-            Expr::RecordLit { path: _, fields, spread, ellipsis: _, is_assignee_expr: _ } => {
+            Expr::RecordLit { path: _, fields, spread } => {
                 self.infer_mut_not_expr_iter(fields.iter().map(|it| it.expr).chain(*spread))
             }
-            &Expr::Index { base, index, is_assignee_expr } => {
+            &Expr::Index { base, index } => {
                 if mutability == Mutability::Mut {
                     if let Some((f, _)) = self.result.method_resolutions.get_mut(&tgt_expr) {
                         if let Some(index_trait) = self
@@ -148,11 +149,8 @@ impl InferenceContext<'_> {
                                     target,
                                 }) = base_adjustments
                                 {
-                                    // For assignee exprs `IndexMut` obligations are already applied
-                                    if !is_assignee_expr {
-                                        if let TyKind::Ref(_, _, ty) = target.kind(Interner) {
-                                            base_ty = Some(ty.clone());
-                                        }
+                                    if let TyKind::Ref(_, _, ty) = target.kind(Interner) {
+                                        base_ty = Some(ty.clone());
                                     }
                                     *mutability = Mutability::Mut;
                                 }
@@ -233,6 +231,14 @@ impl InferenceContext<'_> {
                 self.infer_mut_expr(*lhs, Mutability::Mut);
                 self.infer_mut_expr(*rhs, Mutability::Not);
             }
+            &Expr::Assignment { target, value } => {
+                self.body.walk_pats(target, &mut |pat| match self.body[pat] {
+                    Pat::Expr(expr) => self.infer_mut_expr(expr, Mutability::Mut),
+                    Pat::ConstBlock(block) => self.infer_mut_expr(block, Mutability::Not),
+                    _ => {}
+                });
+                self.infer_mut_expr(value, Mutability::Not);
+            }
             Expr::Array(Array::Repeat { initializer: lhs, repeat: rhs })
             | Expr::BinaryOp { lhs, rhs, op: _ }
             | Expr::Range { lhs: Some(lhs), rhs: Some(rhs), range_type: _ } => {
@@ -242,8 +248,7 @@ impl InferenceContext<'_> {
             Expr::Closure { body, .. } => {
                 self.infer_mut_expr(*body, Mutability::Not);
             }
-            Expr::Tuple { exprs, is_assignee_expr: _ }
-            | Expr::Array(Array::ElementList { elements: exprs, is_assignee_expr: _ }) => {
+            Expr::Tuple { exprs } | Expr::Array(Array::ElementList { elements: exprs }) => {
                 self.infer_mut_not_expr_iter(exprs.iter().copied());
             }
             // These don't need any action, as they don't have sub expressions

--- a/crates/hir-ty/src/mir/lower.rs
+++ b/crates/hir-ty/src/mir/lower.rs
@@ -13,7 +13,7 @@ use hir_def::{
     },
     lang_item::{LangItem, LangItemTarget},
     path::Path,
-    resolver::{resolver_for_expr, HasResolver, ResolveValueResult, ValueNs},
+    resolver::{HasResolver, ResolveValueResult, Resolver, ValueNs},
     AdtId, DefWithBodyId, EnumVariantId, GeneralConstId, HasModule, ItemContainerId, LocalFieldId,
     Lookup, TraitId, TupleId, TypeOrConstParamId,
 };
@@ -76,6 +76,7 @@ struct MirLowerCtx<'a> {
     db: &'a dyn HirDatabase,
     body: &'a Body,
     infer: &'a InferenceResult,
+    resolver: Resolver,
     drop_scopes: Vec<DropScope>,
 }
 
@@ -278,6 +279,7 @@ impl<'ctx> MirLowerCtx<'ctx> {
             owner,
             closures: vec![],
         };
+        let resolver = owner.resolver(db.upcast());
 
         MirLowerCtx {
             result: mir,
@@ -285,6 +287,7 @@ impl<'ctx> MirLowerCtx<'ctx> {
             infer,
             body,
             owner,
+            resolver,
             current_loop_blocks: None,
             labeled_loop_blocks: Default::default(),
             discr_temp: None,
@@ -410,43 +413,48 @@ impl<'ctx> MirLowerCtx<'ctx> {
                 Err(MirLowerError::IncompleteExpr)
             }
             Expr::Path(p) => {
-                let pr =
-                    if let Some((assoc, subst)) = self.infer.assoc_resolutions_for_expr(expr_id) {
-                        match assoc {
-                            hir_def::AssocItemId::ConstId(c) => {
-                                self.lower_const(
-                                    c.into(),
-                                    current,
-                                    place,
-                                    subst,
-                                    expr_id.into(),
-                                    self.expr_ty_without_adjust(expr_id),
-                                )?;
-                                return Ok(Some(current));
-                            }
-                            hir_def::AssocItemId::FunctionId(_) => {
-                                // FnDefs are zero sized, no action is needed.
-                                return Ok(Some(current));
-                            }
-                            hir_def::AssocItemId::TypeAliasId(_) => {
-                                // FIXME: If it is unreachable, use proper error instead of `not_supported`.
-                                not_supported!("associated functions and types")
-                            }
+                let pr = if let Some((assoc, subst)) =
+                    self.infer.assoc_resolutions_for_expr(expr_id)
+                {
+                    match assoc {
+                        hir_def::AssocItemId::ConstId(c) => {
+                            self.lower_const(
+                                c.into(),
+                                current,
+                                place,
+                                subst,
+                                expr_id.into(),
+                                self.expr_ty_without_adjust(expr_id),
+                            )?;
+                            return Ok(Some(current));
                         }
-                    } else if let Some(variant) = self.infer.variant_resolution_for_expr(expr_id) {
-                        match variant {
-                            VariantId::EnumVariantId(e) => ValueNs::EnumVariantId(e),
-                            VariantId::StructId(s) => ValueNs::StructId(s),
-                            VariantId::UnionId(_) => implementation_error!("Union variant as path"),
+                        hir_def::AssocItemId::FunctionId(_) => {
+                            // FnDefs are zero sized, no action is needed.
+                            return Ok(Some(current));
                         }
-                    } else {
-                        let unresolved_name =
-                            || MirLowerError::unresolved_path(self.db, p, self.edition());
-                        let resolver = resolver_for_expr(self.db.upcast(), self.owner, expr_id);
-                        resolver
-                            .resolve_path_in_value_ns_fully(self.db.upcast(), p)
-                            .ok_or_else(unresolved_name)?
-                    };
+                        hir_def::AssocItemId::TypeAliasId(_) => {
+                            // FIXME: If it is unreachable, use proper error instead of `not_supported`.
+                            not_supported!("associated functions and types")
+                        }
+                    }
+                } else if let Some(variant) = self.infer.variant_resolution_for_expr(expr_id) {
+                    match variant {
+                        VariantId::EnumVariantId(e) => ValueNs::EnumVariantId(e),
+                        VariantId::StructId(s) => ValueNs::StructId(s),
+                        VariantId::UnionId(_) => implementation_error!("Union variant as path"),
+                    }
+                } else {
+                    let resolver_guard =
+                        self.resolver.update_to_inner_scope(self.db.upcast(), self.owner, expr_id);
+                    let result = self
+                        .resolver
+                        .resolve_path_in_value_ns_fully(self.db.upcast(), p)
+                        .ok_or_else(|| {
+                            MirLowerError::unresolved_path(self.db, p, self.edition())
+                        })?;
+                    self.resolver.reset_to_guard(resolver_guard);
+                    result
+                };
                 match pr {
                     ValueNs::LocalBinding(_) | ValueNs::StaticId(_) => {
                         let Some((temp, current)) =
@@ -553,8 +561,11 @@ impl<'ctx> MirLowerCtx<'ctx> {
                     return Ok(None);
                 };
                 self.push_fake_read(current, cond_place, expr_id.into());
+                let resolver_guard =
+                    self.resolver.update_to_inner_scope(self.db.upcast(), self.owner, expr_id);
                 let (then_target, else_target) =
                     self.pattern_match(current, None, cond_place, *pat)?;
+                self.resolver.reset_to_guard(resolver_guard);
                 self.write_bytes_to_place(
                     then_target,
                     place,
@@ -688,6 +699,8 @@ impl<'ctx> MirLowerCtx<'ctx> {
                 };
                 self.push_fake_read(current, cond_place, expr_id.into());
                 let mut end = None;
+                let resolver_guard =
+                    self.resolver.update_to_inner_scope(self.db.upcast(), self.owner, expr_id);
                 for MatchArm { pat, guard, expr } in arms.iter() {
                     let (then, mut otherwise) =
                         self.pattern_match(current, None, cond_place, *pat)?;
@@ -721,6 +734,7 @@ impl<'ctx> MirLowerCtx<'ctx> {
                         }
                     }
                 }
+                self.resolver.reset_to_guard(resolver_guard);
                 if self.is_unterminated(current) {
                     self.set_terminator(current, TerminatorKind::Unreachable, expr_id.into());
                 }
@@ -795,7 +809,7 @@ impl<'ctx> MirLowerCtx<'ctx> {
             }
             Expr::Become { .. } => not_supported!("tail-calls"),
             Expr::Yield { .. } => not_supported!("yield"),
-            Expr::RecordLit { fields, path, spread, ellipsis: _, is_assignee_expr: _ } => {
+            Expr::RecordLit { fields, path, spread } => {
                 let spread_place = match spread {
                     &Some(it) => {
                         let Some((p, c)) = self.lower_expr_as_place(current, it, true)? else {
@@ -1010,35 +1024,28 @@ impl<'ctx> MirLowerCtx<'ctx> {
                         );
                     }
                 }
-                if let hir_def::hir::BinaryOp::Assignment { op } = op {
-                    if let Some(op) = op {
-                        // last adjustment is `&mut` which we don't want it.
-                        let adjusts = self
-                            .infer
-                            .expr_adjustments
-                            .get(lhs)
-                            .and_then(|it| it.split_last())
-                            .map(|it| it.1)
-                            .ok_or(MirLowerError::TypeError(
-                                "adjustment of binary op was missing",
-                            ))?;
-                        let Some((lhs_place, current)) =
-                            self.lower_expr_as_place_with_adjust(current, *lhs, false, adjusts)?
-                        else {
-                            return Ok(None);
-                        };
-                        let Some((rhs_op, current)) =
-                            self.lower_expr_to_some_operand(*rhs, current)?
-                        else {
-                            return Ok(None);
-                        };
-                        let r_value =
-                            Rvalue::CheckedBinaryOp(op.into(), Operand::Copy(lhs_place), rhs_op);
-                        self.push_assignment(current, lhs_place, r_value, expr_id.into());
-                        return Ok(Some(current));
-                    } else {
-                        return self.lower_assignment(current, *lhs, *rhs, expr_id.into());
-                    }
+                if let hir_def::hir::BinaryOp::Assignment { op: Some(op) } = op {
+                    // last adjustment is `&mut` which we don't want it.
+                    let adjusts = self
+                        .infer
+                        .expr_adjustments
+                        .get(lhs)
+                        .and_then(|it| it.split_last())
+                        .map(|it| it.1)
+                        .ok_or(MirLowerError::TypeError("adjustment of binary op was missing"))?;
+                    let Some((lhs_place, current)) =
+                        self.lower_expr_as_place_with_adjust(current, *lhs, false, adjusts)?
+                    else {
+                        return Ok(None);
+                    };
+                    let Some((rhs_op, current)) = self.lower_expr_to_some_operand(*rhs, current)?
+                    else {
+                        return Ok(None);
+                    };
+                    let r_value =
+                        Rvalue::CheckedBinaryOp(op.into(), Operand::Copy(lhs_place), rhs_op);
+                    self.push_assignment(current, lhs_place, r_value, expr_id.into());
+                    return Ok(Some(current));
                 }
                 let Some((lhs_op, current)) = self.lower_expr_to_some_operand(*lhs, current)?
                 else {
@@ -1095,6 +1102,18 @@ impl<'ctx> MirLowerCtx<'ctx> {
                     ),
                     expr_id.into(),
                 );
+                Ok(Some(current))
+            }
+            &Expr::Assignment { target, value } => {
+                let Some((value, mut current)) = self.lower_expr_as_place(current, value, true)?
+                else {
+                    return Ok(None);
+                };
+                self.push_fake_read(current, value, expr_id.into());
+                let resolver_guard =
+                    self.resolver.update_to_inner_scope(self.db.upcast(), self.owner, expr_id);
+                current = self.pattern_match_assignment(current, value, target)?;
+                self.resolver.reset_to_guard(resolver_guard);
                 Ok(Some(current))
             }
             &Expr::Range { lhs, rhs, range_type: _ } => {
@@ -1213,7 +1232,7 @@ impl<'ctx> MirLowerCtx<'ctx> {
                 );
                 Ok(Some(current))
             }
-            Expr::Tuple { exprs, is_assignee_expr: _ } => {
+            Expr::Tuple { exprs } => {
                 let Some(values) = exprs
                     .iter()
                     .map(|it| {
@@ -1291,73 +1310,6 @@ impl<'ctx> MirLowerCtx<'ctx> {
         }
     }
 
-    fn lower_destructing_assignment(
-        &mut self,
-        mut current: BasicBlockId,
-        lhs: ExprId,
-        rhs: Place,
-        span: MirSpan,
-    ) -> Result<Option<BasicBlockId>> {
-        match &self.body.exprs[lhs] {
-            Expr::Tuple { exprs, is_assignee_expr: _ } => {
-                for (i, expr) in exprs.iter().enumerate() {
-                    let rhs = rhs.project(
-                        ProjectionElem::Field(Either::Right(TupleFieldId {
-                            tuple: TupleId(!0), // Dummy this as its unused
-                            index: i as u32,
-                        })),
-                        &mut self.result.projection_store,
-                    );
-                    let Some(c) = self.lower_destructing_assignment(current, *expr, rhs, span)?
-                    else {
-                        return Ok(None);
-                    };
-                    current = c;
-                }
-                Ok(Some(current))
-            }
-            Expr::Underscore => Ok(Some(current)),
-            _ => {
-                let Some((lhs_place, current)) = self.lower_expr_as_place(current, lhs, false)?
-                else {
-                    return Ok(None);
-                };
-                self.push_assignment(current, lhs_place, Operand::Copy(rhs).into(), span);
-                Ok(Some(current))
-            }
-        }
-    }
-
-    fn lower_assignment(
-        &mut self,
-        current: BasicBlockId,
-        lhs: ExprId,
-        rhs: ExprId,
-        span: MirSpan,
-    ) -> Result<Option<BasicBlockId>> {
-        let Some((rhs_op, current)) = self.lower_expr_to_some_operand(rhs, current)? else {
-            return Ok(None);
-        };
-        if matches!(&self.body.exprs[lhs], Expr::Underscore) {
-            self.push_fake_read_for_operand(current, rhs_op, span);
-            return Ok(Some(current));
-        }
-        if matches!(
-            &self.body.exprs[lhs],
-            Expr::Tuple { .. } | Expr::RecordLit { .. } | Expr::Call { .. }
-        ) {
-            let temp = self.temp(self.expr_ty_after_adjustments(rhs), current, rhs.into())?;
-            let temp = Place::from(temp);
-            self.push_assignment(current, temp, rhs_op.into(), span);
-            return self.lower_destructing_assignment(current, lhs, temp, span);
-        }
-        let Some((lhs_place, current)) = self.lower_expr_as_place(current, lhs, false)? else {
-            return Ok(None);
-        };
-        self.push_assignment(current, lhs_place, rhs_op.into(), span);
-        Ok(Some(current))
-    }
-
     fn placeholder_subst(&mut self) -> Substitution {
         match self.owner.as_generic_def_id(self.db.upcast()) {
             Some(it) => TyBuilder::placeholder_subst(self.db, it),
@@ -1407,8 +1359,8 @@ impl<'ctx> MirLowerCtx<'ctx> {
                 let edition = self.edition();
                 let unresolved_name =
                     || MirLowerError::unresolved_path(self.db, c.as_ref(), edition);
-                let resolver = self.owner.resolver(self.db.upcast());
-                let pr = resolver
+                let pr = self
+                    .resolver
                     .resolve_path_in_value_ns(self.db.upcast(), c.as_ref())
                     .ok_or_else(unresolved_name)?;
                 match pr {
@@ -1632,12 +1584,6 @@ impl<'ctx> MirLowerCtx<'ctx> {
         self.push_statement(block, StatementKind::FakeRead(p).with_span(span));
     }
 
-    fn push_fake_read_for_operand(&mut self, block: BasicBlockId, operand: Operand, span: MirSpan) {
-        if let Operand::Move(p) | Operand::Copy(p) = operand {
-            self.push_fake_read(block, p, span);
-        }
-    }
-
     fn push_assignment(
         &mut self,
         block: BasicBlockId,
@@ -1791,8 +1737,16 @@ impl<'ctx> MirLowerCtx<'ctx> {
                         };
                         current = c;
                         self.push_fake_read(current, init_place, span);
+                        // Using the initializer for the resolver scope is good enough for us, as it cannot create new declarations
+                        // and has all declarations of the `let`.
+                        let resolver_guard = self.resolver.update_to_inner_scope(
+                            self.db.upcast(),
+                            self.owner,
+                            *expr_id,
+                        );
                         (current, else_block) =
                             self.pattern_match(current, None, init_place, *pat)?;
+                        self.resolver.reset_to_guard(resolver_guard);
                         match (else_block, else_branch) {
                             (None, _) => (),
                             (Some(else_block), None) => {
@@ -2066,11 +2020,13 @@ pub fn mir_body_for_closure_query(
     let Some(sig) = ClosureSubst(substs).sig_ty().callable_sig(db) else {
         implementation_error!("closure has not callable sig");
     };
+    let resolver_guard = ctx.resolver.update_to_inner_scope(db.upcast(), owner, expr);
     let current = ctx.lower_params_and_bindings(
         args.iter().zip(sig.params().iter()).map(|(it, y)| (*it, y.clone())),
         None,
         |_| true,
     )?;
+    ctx.resolver.reset_to_guard(resolver_guard);
     if let Some(current) = ctx.lower_expr_to_place(*root, return_slot().into(), current)? {
         let current = ctx.pop_drop_scope_assert_finished(current, root.into())?;
         ctx.set_terminator(current, TerminatorKind::Return, (*root).into());

--- a/crates/hir-ty/src/mir/lower/pattern_matching.rs
+++ b/crates/hir-ty/src/mir/lower/pattern_matching.rs
@@ -1,6 +1,6 @@
 //! MIR lowering for patterns
 
-use hir_def::{hir::LiteralOrConst, resolver::HasResolver, AssocItemId};
+use hir_def::{hir::LiteralOrConst, AssocItemId};
 
 use crate::{
     mir::{
@@ -46,6 +46,8 @@ enum MatchingMode {
     Check,
     /// Assume that this pattern matches, fill bindings
     Bind,
+    /// Assume that this pattern matches, assign to existing variables.
+    Assign,
 }
 
 impl MirLowerCtx<'_> {
@@ -80,6 +82,17 @@ impl MirLowerCtx<'_> {
             MatchingMode::Bind,
         )?;
         Ok((current, current_else))
+    }
+
+    pub(super) fn pattern_match_assignment(
+        &mut self,
+        current: BasicBlockId,
+        value: Place,
+        pattern: PatId,
+    ) -> Result<BasicBlockId> {
+        let (current, _) =
+            self.pattern_match_inner(current, None, value, pattern, MatchingMode::Assign)?;
+        Ok(current)
     }
 
     pub(super) fn match_self_param(
@@ -155,14 +168,8 @@ impl MirLowerCtx<'_> {
                         *pat,
                         MatchingMode::Check,
                     )?;
-                    if mode == MatchingMode::Bind {
-                        (next, _) = self.pattern_match_inner(
-                            next,
-                            None,
-                            cond_place,
-                            *pat,
-                            MatchingMode::Bind,
-                        )?;
+                    if mode != MatchingMode::Check {
+                        (next, _) = self.pattern_match_inner(next, None, cond_place, *pat, mode)?;
                     }
                     self.set_goto(next, then_target, pattern.into());
                     match next_else {
@@ -176,11 +183,11 @@ impl MirLowerCtx<'_> {
                     }
                 }
                 if !finished {
-                    if mode == MatchingMode::Bind {
-                        self.set_terminator(current, TerminatorKind::Unreachable, pattern.into());
-                    } else {
+                    if mode == MatchingMode::Check {
                         let ce = *current_else.get_or_insert_with(|| self.new_basic_block());
                         self.set_goto(current, ce, pattern.into());
+                    } else {
+                        self.set_terminator(current, TerminatorKind::Unreachable, pattern.into());
                     }
                 }
                 (then_target, current_else)
@@ -300,7 +307,7 @@ impl MirLowerCtx<'_> {
                         self.pattern_match_inner(current, current_else, next_place, pat, mode)?;
                 }
                 if let &Some(slice) = slice {
-                    if mode == MatchingMode::Bind {
+                    if mode != MatchingMode::Check {
                         if let Pat::Bind { id, subpat: _ } = self.body[slice] {
                             let next_place = cond_place.project(
                                 ProjectionElem::Subslice {
@@ -342,17 +349,34 @@ impl MirLowerCtx<'_> {
                     mode,
                 )?,
                 None => {
-                    // The path is not a variant, so it is a const
+                    let unresolved_name =
+                        || MirLowerError::unresolved_path(self.db, p, self.edition());
+                    let pr = self
+                        .resolver
+                        .resolve_path_in_value_ns(self.db.upcast(), p)
+                        .ok_or_else(unresolved_name)?;
+
+                    if let (
+                        MatchingMode::Assign,
+                        ResolveValueResult::ValueNs(ValueNs::LocalBinding(binding), _),
+                    ) = (mode, &pr)
+                    {
+                        let local = self.binding_local(*binding)?;
+                        self.push_match_assignment(
+                            current,
+                            local,
+                            BindingMode::Move,
+                            cond_place,
+                            pattern.into(),
+                        );
+                        return Ok((current, current_else));
+                    }
+
+                    // The path is not a variant or a local, so it is a const
                     if mode != MatchingMode::Check {
                         // A const don't bind anything. Only needs check.
                         return Ok((current, current_else));
                     }
-                    let unresolved_name =
-                        || MirLowerError::unresolved_path(self.db, p, self.edition());
-                    let resolver = self.owner.resolver(self.db.upcast());
-                    let pr = resolver
-                        .resolve_path_in_value_ns(self.db.upcast(), p)
-                        .ok_or_else(unresolved_name)?;
                     let (c, subst) = 'b: {
                         if let Some(x) = self.infer.assoc_resolutions_for_pat(pattern) {
                             if let AssocItemId::ConstId(c) = x.0 {
@@ -415,7 +439,7 @@ impl MirLowerCtx<'_> {
                     (current, current_else) =
                         self.pattern_match_inner(current, current_else, cond_place, *subpat, mode)?
                 }
-                if mode == MatchingMode::Bind {
+                if mode != MatchingMode::Check {
                     let mode = self.infer.binding_modes[pattern];
                     self.pattern_match_binding(
                         *id,
@@ -448,6 +472,23 @@ impl MirLowerCtx<'_> {
                     cond_place.project(ProjectionElem::Deref, &mut self.result.projection_store);
                 self.pattern_match_inner(current, current_else, cond_place, *pat, mode)?
             }
+            &Pat::Expr(expr) => {
+                stdx::always!(
+                    mode == MatchingMode::Assign,
+                    "Pat::Expr can only come in destructuring assignments"
+                );
+                let Some((lhs_place, current)) = self.lower_expr_as_place(current, expr, false)?
+                else {
+                    return Ok((current, current_else));
+                };
+                self.push_assignment(
+                    current,
+                    lhs_place,
+                    Operand::Copy(cond_place).into(),
+                    expr.into(),
+                );
+                (current, current_else)
+            }
             Pat::Box { .. } => not_supported!("box pattern"),
             Pat::ConstBlock(_) => not_supported!("const block pattern"),
         })
@@ -464,6 +505,18 @@ impl MirLowerCtx<'_> {
     ) -> Result<(BasicBlockId, Option<BasicBlockId>)> {
         let target_place = self.binding_local(id)?;
         self.push_storage_live(id, current)?;
+        self.push_match_assignment(current, target_place, mode, cond_place, span);
+        Ok((current, current_else))
+    }
+
+    fn push_match_assignment(
+        &mut self,
+        current: BasicBlockId,
+        target_place: LocalId,
+        mode: BindingMode,
+        cond_place: Place,
+        span: MirSpan,
+    ) {
         self.push_assignment(
             current,
             target_place.into(),
@@ -476,7 +529,6 @@ impl MirLowerCtx<'_> {
             },
             span,
         );
-        Ok((current, current_else))
     }
 
     fn pattern_match_const(

--- a/crates/hir-ty/src/tests/simple.rs
+++ b/crates/hir-ty/src/tests/simple.rs
@@ -3418,11 +3418,11 @@ struct TS(usize);
 fn main() {
     let x;
     [x,] = &[1,];
-  //^^^^expected &'? [i32; 1], got [{unknown}; _]
+  //^^^^expected &'? [i32; 1], got [{unknown}]
 
     let x;
     [(x,),] = &[(1,),];
-  //^^^^^^^expected &'? [(i32,); 1], got [{unknown}; _]
+  //^^^^^^^expected &'? [(i32,); 1], got [{unknown}]
 
     let x;
     ((x,),) = &((1,),);

--- a/crates/hir/src/diagnostics.rs
+++ b/crates/hir/src/diagnostics.rs
@@ -257,7 +257,7 @@ pub struct PrivateField {
 
 #[derive(Debug)]
 pub struct MissingUnsafe {
-    pub expr: InFile<AstPtr<ast::Expr>>,
+    pub expr: InFile<AstPtr<Either<ast::Expr, ast::Pat>>>,
     /// If true, the diagnostics is an `unsafe_op_in_unsafe_fn` lint instead of a hard error.
     pub only_lint: bool,
 }
@@ -398,56 +398,46 @@ impl AnyDiagnostic {
                     .map(|idx| variant_data.fields()[idx].name.clone())
                     .collect();
 
-                match record {
-                    Either::Left(record_expr) => match source_map.expr_syntax(record_expr) {
-                        Ok(source_ptr) => {
-                            let root = source_ptr.file_syntax(db.upcast());
-                            if let ast::Expr::RecordExpr(record_expr) =
-                                source_ptr.value.to_node(&root)
-                            {
-                                if record_expr.record_expr_field_list().is_some() {
-                                    let field_list_parent_path =
-                                        record_expr.path().map(|path| AstPtr::new(&path));
-                                    return Some(
-                                        MissingFields {
-                                            file: source_ptr.file_id,
-                                            field_list_parent: AstPtr::new(&Either::Left(
-                                                record_expr,
-                                            )),
-                                            field_list_parent_path,
-                                            missed_fields,
-                                        }
-                                        .into(),
-                                    );
+                let record = match record {
+                    Either::Left(record_expr) => {
+                        source_map.expr_syntax(record_expr).ok()?.map(AstPtr::wrap_left)
+                    }
+                    Either::Right(record_pat) => source_map.pat_syntax(record_pat).ok()?,
+                };
+                let file = record.file_id;
+                let root = record.file_syntax(db.upcast());
+                match record.value.to_node(&root) {
+                    Either::Left(ast::Expr::RecordExpr(record_expr)) => {
+                        if record_expr.record_expr_field_list().is_some() {
+                            let field_list_parent_path =
+                                record_expr.path().map(|path| AstPtr::new(&path));
+                            return Some(
+                                MissingFields {
+                                    file,
+                                    field_list_parent: AstPtr::new(&Either::Left(record_expr)),
+                                    field_list_parent_path,
+                                    missed_fields,
                                 }
-                            }
+                                .into(),
+                            );
                         }
-                        Err(SyntheticSyntax) => (),
-                    },
-                    Either::Right(record_pat) => match source_map.pat_syntax(record_pat) {
-                        Ok(source_ptr) => {
-                            if let Some(ptr) = source_ptr.value.cast::<ast::RecordPat>() {
-                                let root = source_ptr.file_syntax(db.upcast());
-                                let record_pat = ptr.to_node(&root);
-                                if record_pat.record_pat_field_list().is_some() {
-                                    let field_list_parent_path =
-                                        record_pat.path().map(|path| AstPtr::new(&path));
-                                    return Some(
-                                        MissingFields {
-                                            file: source_ptr.file_id,
-                                            field_list_parent: AstPtr::new(&Either::Right(
-                                                record_pat,
-                                            )),
-                                            field_list_parent_path,
-                                            missed_fields,
-                                        }
-                                        .into(),
-                                    );
+                    }
+                    Either::Right(ast::Pat::RecordPat(record_pat)) => {
+                        if record_pat.record_pat_field_list().is_some() {
+                            let field_list_parent_path =
+                                record_pat.path().map(|path| AstPtr::new(&path));
+                            return Some(
+                                MissingFields {
+                                    file,
+                                    field_list_parent: AstPtr::new(&Either::Right(record_pat)),
+                                    field_list_parent_path,
+                                    missed_fields,
                                 }
-                            }
+                                .into(),
+                            );
                         }
-                        Err(SyntheticSyntax) => (),
-                    },
+                    }
+                    _ => {}
                 }
             }
             BodyValidationDiagnostic::ReplaceFilterMapNextWithFindMap { method_call_expr } => {
@@ -543,7 +533,7 @@ impl AnyDiagnostic {
         };
         let expr_or_pat_syntax = |id| match id {
             ExprOrPatId::ExprId(expr) => expr_syntax(expr).map(|it| it.map(AstPtr::wrap_left)),
-            ExprOrPatId::PatId(pat) => pat_syntax(pat).map(|it| it.map(AstPtr::wrap_right)),
+            ExprOrPatId::PatId(pat) => pat_syntax(pat),
         };
         Some(match d {
             &InferenceDiagnostic::NoSuchField { field: expr, private, variant } => {
@@ -551,9 +541,7 @@ impl AnyDiagnostic {
                     ExprOrPatId::ExprId(expr) => {
                         source_map.field_syntax(expr).map(AstPtr::wrap_left)
                     }
-                    ExprOrPatId::PatId(pat) => {
-                        source_map.pat_field_syntax(pat).map(AstPtr::wrap_right)
-                    }
+                    ExprOrPatId::PatId(pat) => source_map.pat_field_syntax(pat),
                 };
                 NoSuchField { field: expr_or_pat, private, variant }.into()
             }

--- a/crates/hir/src/semantics.rs
+++ b/crates/hir/src/semantics.rs
@@ -11,7 +11,7 @@ use std::{
 
 use either::Either;
 use hir_def::{
-    hir::Expr,
+    hir::{Expr, ExprOrPatId},
     lower::LowerCtx,
     nameres::{MacroSubNs, ModuleOrigin},
     path::ModPath,
@@ -1755,7 +1755,9 @@ impl<'db> SemanticsImpl<'db> {
             }
 
             if let Some(parent) = ast::Expr::cast(parent.clone()) {
-                if let Some(expr_id) = source_map.node_expr(InFile { file_id, value: &parent }) {
+                if let Some(ExprOrPatId::ExprId(expr_id)) =
+                    source_map.node_expr(InFile { file_id, value: &parent })
+                {
                     if let Expr::Unsafe { .. } = body[expr_id] {
                         break true;
                     }

--- a/crates/hir/src/semantics/source_to_def.rs
+++ b/crates/hir/src/semantics/source_to_def.rs
@@ -306,7 +306,7 @@ impl SourceToDefCtx<'_, '_> {
             .position(|it| it == *src.value)?;
         let container = self.find_pat_or_label_container(src.syntax_ref())?;
         let (_, source_map) = self.db.body_with_source_map(container);
-        let expr = source_map.node_expr(src.with_value(&ast::Expr::AsmExpr(asm)))?;
+        let expr = source_map.node_expr(src.with_value(&ast::Expr::AsmExpr(asm)))?.as_expr()?;
         Some(InlineAsmOperand { owner: container, expr, index })
     }
 
@@ -350,7 +350,8 @@ impl SourceToDefCtx<'_, '_> {
         let break_or_continue = ast::Expr::cast(src.value.syntax().parent()?)?;
         let container = self.find_pat_or_label_container(src.syntax_ref())?;
         let (body, source_map) = self.db.body_with_source_map(container);
-        let break_or_continue = source_map.node_expr(src.with_value(&break_or_continue))?;
+        let break_or_continue =
+            source_map.node_expr(src.with_value(&break_or_continue))?.as_expr()?;
         let (Expr::Break { label, .. } | Expr::Continue { label }) = body[break_or_continue] else {
             return None;
         };

--- a/crates/ide-diagnostics/src/handlers/missing_fields.rs
+++ b/crates/ide-diagnostics/src/handlers/missing_fields.rs
@@ -308,22 +308,27 @@ struct T(S);
 fn regular(a: S) {
     let s;
     S { s, .. } = a;
+    _ = s;
 }
 fn nested(a: S2) {
     let s;
     S2 { s: S { s, .. }, .. } = a;
+    _ = s;
 }
 fn in_tuple(a: (S,)) {
     let s;
     (S { s, .. },) = a;
+    _ = s;
 }
 fn in_array(a: [S;1]) {
     let s;
     [S { s, .. },] = a;
+    _ = s;
 }
 fn in_tuple_struct(a: T) {
     let s;
     T(S { s, .. }) = a;
+    _ = s;
 }
             ",
         );

--- a/crates/ide-diagnostics/src/handlers/missing_unsafe.rs
+++ b/crates/ide-diagnostics/src/handlers/missing_unsafe.rs
@@ -32,7 +32,8 @@ fn fixes(ctx: &DiagnosticsContext<'_>, d: &hir::MissingUnsafe) -> Option<Vec<Ass
     }
 
     let root = ctx.sema.db.parse_or_expand(d.expr.file_id);
-    let expr = d.expr.value.to_node(&root);
+    let node = d.expr.value.to_node(&root);
+    let expr = node.syntax().ancestors().find_map(ast::Expr::cast)?;
 
     let node_to_add_unsafe_block = pick_best_node_to_add_unsafe_block(&expr)?;
 

--- a/crates/ide-diagnostics/src/handlers/mutability_errors.rs
+++ b/crates/ide-diagnostics/src/handlers/mutability_errors.rs
@@ -8,10 +8,6 @@ use crate::{fix, Diagnostic, DiagnosticCode, DiagnosticsContext};
 //
 // This diagnostic is triggered on mutating an immutable variable.
 pub(crate) fn need_mut(ctx: &DiagnosticsContext<'_>, d: &hir::NeedMut) -> Option<Diagnostic> {
-    if d.span.file_id.macro_file().is_some() {
-        // FIXME: Our infra can't handle allow from within macro expansions rn
-        return None;
-    }
     let fixes = (|| {
         if d.local.is_ref(ctx.sema.db) {
             // There is no simple way to add `mut` to `ref x` and `ref mut x`
@@ -53,10 +49,6 @@ pub(crate) fn need_mut(ctx: &DiagnosticsContext<'_>, d: &hir::NeedMut) -> Option
 // This diagnostic is triggered when a mutable variable isn't actually mutated.
 pub(crate) fn unused_mut(ctx: &DiagnosticsContext<'_>, d: &hir::UnusedMut) -> Option<Diagnostic> {
     let ast = d.local.primary_source(ctx.sema.db).syntax_ptr();
-    if ast.file_id.macro_file().is_some() {
-        // FIXME: Our infra can't handle allow from within macro expansions rn
-        return None;
-    }
     let fixes = (|| {
         let file_id = ast.file_id.file_id()?;
         let mut edit_builder = TextEdit::builder();

--- a/crates/ide-diagnostics/src/handlers/mutability_errors.rs
+++ b/crates/ide-diagnostics/src/handlers/mutability_errors.rs
@@ -1275,4 +1275,19 @@ fn main() {
 "#,
         );
     }
+
+    #[test]
+    fn destructuring_assignment_needs_mut() {
+        check_diagnostics(
+            r#"
+//- minicore: fn
+
+fn main() {
+	let mut var = 1;
+	let mut func = || (var,) = (2,);
+	func();
+}
+        "#,
+        );
+    }
 }

--- a/crates/ide-diagnostics/src/handlers/unresolved_ident.rs
+++ b/crates/ide-diagnostics/src/handlers/unresolved_ident.rs
@@ -11,7 +11,7 @@ pub(crate) fn unresolved_ident(
         ctx,
         DiagnosticCode::RustcHardError("E0425"),
         "no such value in this scope",
-        d.expr.map(Into::into),
+        d.expr_or_pat.map(Into::into),
     )
     .experimental()
 }

--- a/crates/syntax/src/ast/expr_ext.rs
+++ b/crates/syntax/src/ast/expr_ext.rs
@@ -232,6 +232,10 @@ impl ast::RangeExpr {
             Some((ix, token, bin_op))
         })
     }
+
+    pub fn is_range_full(&self) -> bool {
+        support::children::<Expr>(&self.syntax).next().is_none()
+    }
 }
 
 impl RangeItem for ast::RangeExpr {


### PR DESCRIPTION
By lowering it into patterns instead of expressions.

This is a large PR (phew!) but it also removes a lot of code, almost as much as it inserts. All present and probably even future code dedicated to handling destructuring assignments is thrown out of the window. Besides fixing a bunch of bugs, this also means that any future expansion is going to work much less to work with destructuring assignments, and is much more likely to not have bugs/rough edges/forgotten cases.

rustc goes even more than this and desugars destructuring assignment completely; coming to the HIR it vanishes. But we cannot do that, because this will severely affect our ability to map destructuring assignments up and down the lowering chain (for instance, consider what happens when a macro expands to the "pattern". With rustc's approach, the macro expansion will be split, and we have no way to represent that).

Fixes #18209.