### PR TITLE
fix: Implement mixed site hygiene

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -556,6 +556,7 @@ dependencies = [
  "syntax-bridge",
  "test-fixture",
  "test-utils",
+ "text-size",
  "tracing",
  "triomphe",
  "tt",

--- a/crates/hir-def/Cargo.toml
+++ b/crates/hir-def/Cargo.toml
@@ -29,6 +29,7 @@ smallvec.workspace = true
 hashbrown.workspace = true
 triomphe.workspace = true
 rustc_apfloat = "0.2.0"
+text-size.workspace = true
 
 ra-ap-rustc_parse_format.workspace = true
 ra-ap-rustc_abi.workspace = true

--- a/crates/hir-def/src/body.rs
+++ b/crates/hir-def/src/body.rs
@@ -35,7 +35,7 @@ use crate::{
 
 /// A wrapper around [`span::SyntaxContextId`] that is intended only for comparisons.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct HygieneId(span::SyntaxContextId);
+pub struct HygieneId(pub(crate) span::SyntaxContextId);
 
 impl HygieneId {
     pub const ROOT: Self = Self(span::SyntaxContextId::ROOT);
@@ -44,7 +44,7 @@ impl HygieneId {
         Self(ctx)
     }
 
-    fn is_root(self) -> bool {
+    pub(crate) fn is_root(self) -> bool {
         self.0.is_root()
     }
 }
@@ -420,7 +420,7 @@ impl Body {
                             self.walk_exprs_in_pat(*pat, &mut f);
                         }
                         Statement::Expr { expr: expression, .. } => f(*expression),
-                        Statement::Item => (),
+                        Statement::Item(_) => (),
                     }
                 }
                 if let &Some(expr) = tail {

--- a/crates/hir-def/src/body/pretty.rs
+++ b/crates/hir-def/src/body/pretty.rs
@@ -753,7 +753,7 @@ impl Printer<'_> {
                 }
                 wln!(self);
             }
-            Statement::Item => (),
+            Statement::Item(_) => (),
         }
     }
 

--- a/crates/hir-def/src/expander.rs
+++ b/crates/hir-def/src/expander.rs
@@ -49,6 +49,10 @@ impl Expander {
         }
     }
 
+    pub(crate) fn span_map(&self, db: &dyn DefDatabase) -> &SpanMap {
+        self.span_map.get_or_init(|| db.span_map(self.current_file_id))
+    }
+
     pub fn krate(&self) -> CrateId {
         self.module.krate
     }

--- a/crates/hir-def/src/hir.rs
+++ b/crates/hir-def/src/hir.rs
@@ -17,7 +17,7 @@ pub mod type_ref;
 
 use std::fmt;
 
-use hir_expand::name::Name;
+use hir_expand::{name::Name, MacroDefId};
 use intern::{Interned, Symbol};
 use la_arena::{Idx, RawIdx};
 use rustc_apfloat::ieee::{Half as f16, Quad as f128};
@@ -492,9 +492,13 @@ pub enum Statement {
         expr: ExprId,
         has_semi: bool,
     },
-    // At the moment, we only use this to figure out if a return expression
-    // is really the last statement of a block. See #16566
-    Item,
+    Item(Item),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Item {
+    MacroDef(Box<MacroDefId>),
+    Other,
 }
 
 /// Explicit binding annotations given in the HIR for a binding. Note

--- a/crates/hir-expand/src/name.rs
+++ b/crates/hir-expand/src/name.rs
@@ -18,6 +18,8 @@ use syntax::utils::is_raw_identifier;
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct Name {
     symbol: Symbol,
+    // If you are making this carry actual hygiene, beware that the special handling for variables and labels
+    // in bodies can go.
     ctx: (),
 }
 

--- a/crates/hir-ty/src/consteval.rs
+++ b/crates/hir-ty/src/consteval.rs
@@ -3,7 +3,7 @@
 use base_db::{ra_salsa::Cycle, CrateId};
 use chalk_ir::{cast::Cast, BoundVar, DebruijnIndex};
 use hir_def::{
-    body::Body,
+    body::{Body, HygieneId},
     hir::{Expr, ExprId},
     path::Path,
     resolver::{Resolver, ValueNs},
@@ -80,7 +80,7 @@ pub(crate) fn path_to_const<'g>(
     debruijn: DebruijnIndex,
     expected_ty: Ty,
 ) -> Option<Const> {
-    match resolver.resolve_path_in_value_ns_fully(db.upcast(), path) {
+    match resolver.resolve_path_in_value_ns_fully(db.upcast(), path, HygieneId::ROOT) {
         Some(ValueNs::GenericParam(p)) => {
             let ty = db.const_param_ty(p);
             let value = match mode {

--- a/crates/hir-ty/src/diagnostics/expr.rs
+++ b/crates/hir-ty/src/diagnostics/expr.rs
@@ -289,10 +289,12 @@ impl ExprValidator {
         match &self.body[scrutinee_expr] {
             Expr::UnaryOp { op: UnaryOp::Deref, .. } => false,
             Expr::Path(path) => {
-                let value_or_partial = self
-                    .owner
-                    .resolver(db.upcast())
-                    .resolve_path_in_value_ns_fully(db.upcast(), path);
+                let value_or_partial =
+                    self.owner.resolver(db.upcast()).resolve_path_in_value_ns_fully(
+                        db.upcast(),
+                        path,
+                        self.body.expr_path_hygiene(scrutinee_expr),
+                    );
                 value_or_partial.map_or(true, |v| !matches!(v, ValueNs::StaticId(_)))
             }
             Expr::Field { expr, .. } => match self.infer.type_of_expr[*expr].kind(Interner) {

--- a/crates/hir-ty/src/diagnostics/unsafe_check.rs
+++ b/crates/hir-ty/src/diagnostics/unsafe_check.rs
@@ -77,7 +77,8 @@ fn walk_unsafe(
 ) {
     let mut mark_unsafe_path = |path, node| {
         let g = resolver.update_to_inner_scope(db.upcast(), def, current);
-        let value_or_partial = resolver.resolve_path_in_value_ns(db.upcast(), path);
+        let hygiene = body.expr_or_pat_path_hygiene(node);
+        let value_or_partial = resolver.resolve_path_in_value_ns(db.upcast(), path, hygiene);
         if let Some(ResolveValueResult::ValueNs(ValueNs::StaticId(id), _)) = value_or_partial {
             let static_data = db.static_data(id);
             if static_data.mutable || (static_data.is_extern && !static_data.has_safe_kw) {

--- a/crates/hir-ty/src/infer.rs
+++ b/crates/hir-ty/src/infer.rs
@@ -33,7 +33,7 @@ use chalk_ir::{
 };
 use either::Either;
 use hir_def::{
-    body::Body,
+    body::{Body, HygieneId},
     builtin_type::{BuiltinInt, BuiltinType, BuiltinUint},
     data::{ConstData, StaticData},
     hir::{BindingAnnotation, BindingId, ExprId, ExprOrPatId, LabelId, PatId},
@@ -1398,7 +1398,7 @@ impl<'a> InferenceContext<'a> {
         };
         let ctx = crate::lower::TyLoweringContext::new(self.db, &self.resolver, self.owner.into());
         let (resolution, unresolved) = if value_ns {
-            match self.resolver.resolve_path_in_value_ns(self.db.upcast(), path) {
+            match self.resolver.resolve_path_in_value_ns(self.db.upcast(), path, HygieneId::ROOT) {
                 Some(ResolveValueResult::ValueNs(value, _)) => match value {
                     ValueNs::EnumVariantId(var) => {
                         let substs = ctx.substs_from_path(path, var.into(), true);

--- a/crates/hir-ty/src/infer/closure.rs
+++ b/crates/hir-ty/src/infer/closure.rs
@@ -747,7 +747,7 @@ impl InferenceContext<'_> {
                         Statement::Expr { expr, has_semi: _ } => {
                             self.consume_expr(*expr);
                         }
-                        Statement::Item => (),
+                        Statement::Item(_) => (),
                     }
                 }
                 if let Some(tail) = tail {

--- a/crates/hir-ty/src/infer/closure.rs
+++ b/crates/hir-ty/src/infer/closure.rs
@@ -514,8 +514,11 @@ impl InferenceContext<'_> {
         if path.type_anchor().is_some() {
             return None;
         }
-        let result = self.resolver.resolve_path_in_value_ns_fully(self.db.upcast(), path).and_then(
-            |result| match result {
+        let hygiene = self.body.expr_or_pat_path_hygiene(id);
+        let result = self
+            .resolver
+            .resolve_path_in_value_ns_fully(self.db.upcast(), path, hygiene)
+            .and_then(|result| match result {
                 ValueNs::LocalBinding(binding) => {
                     let mir_span = match id {
                         ExprOrPatId::ExprId(id) => MirSpan::ExprId(id),
@@ -525,8 +528,7 @@ impl InferenceContext<'_> {
                     Some(HirPlace { local: binding, projections: Vec::new() })
                 }
                 _ => None,
-            },
-        );
+            });
         result
     }
 

--- a/crates/hir-ty/src/infer/expr.rs
+++ b/crates/hir-ty/src/infer/expr.rs
@@ -1656,7 +1656,7 @@ impl InferenceContext<'_> {
                                 );
                             }
                         }
-                        Statement::Item => (),
+                        Statement::Item(_) => (),
                     }
                 }
 

--- a/crates/hir-ty/src/infer/expr.rs
+++ b/crates/hir-ty/src/infer/expr.rs
@@ -201,7 +201,11 @@ impl InferenceContext<'_> {
             Expr::Path(Path::Normal { type_anchor: Some(_), .. }) => false,
             Expr::Path(path) => self
                 .resolver
-                .resolve_path_in_value_ns_fully(self.db.upcast(), path)
+                .resolve_path_in_value_ns_fully(
+                    self.db.upcast(),
+                    path,
+                    self.body.expr_path_hygiene(expr),
+                )
                 .map_or(true, |res| matches!(res, ValueNs::LocalBinding(_) | ValueNs::StaticId(_))),
             Expr::Underscore => true,
             Expr::UnaryOp { op: UnaryOp::Deref, .. } => true,

--- a/crates/hir-ty/src/infer/mutability.rs
+++ b/crates/hir-ty/src/infer/mutability.rs
@@ -89,7 +89,7 @@ impl InferenceContext<'_> {
                         Statement::Expr { expr, has_semi: _ } => {
                             self.infer_mut_expr(*expr, Mutability::Not);
                         }
-                        Statement::Item => (),
+                        Statement::Item(_) => (),
                     }
                 }
                 if let Some(tail) = tail {

--- a/crates/hir-ty/src/infer/path.rs
+++ b/crates/hir-ty/src/infer/path.rs
@@ -164,9 +164,10 @@ impl InferenceContext<'_> {
             let ty = self.table.normalize_associated_types_in(ty);
             self.resolve_ty_assoc_item(ty, last.name, id).map(|(it, substs)| (it, Some(substs)))?
         } else {
+            let hygiene = self.body.expr_or_pat_path_hygiene(id);
             // FIXME: report error, unresolved first path segment
             let value_or_partial =
-                self.resolver.resolve_path_in_value_ns(self.db.upcast(), path)?;
+                self.resolver.resolve_path_in_value_ns(self.db.upcast(), path, hygiene)?;
 
             match value_or_partial {
                 ResolveValueResult::ValueNs(it, _) => (it, None),

--- a/crates/hir-ty/src/mir/eval.rs
+++ b/crates/hir-ty/src/mir/eval.rs
@@ -6,6 +6,7 @@ use base_db::CrateId;
 use chalk_ir::{cast::Cast, Mutability};
 use either::Either;
 use hir_def::{
+    body::HygieneId,
     builtin_type::BuiltinType,
     data::adt::{StructFlags, VariantData},
     lang_item::LangItem,
@@ -2953,6 +2954,7 @@ pub fn render_const_using_debug_impl(
     let Some(ValueNs::FunctionId(format_fn)) = resolver.resolve_path_in_value_ns_fully(
         db.upcast(),
         &hir_def::path::Path::from_known_path_with_no_generic(path![std::fmt::format]),
+        HygieneId::ROOT,
     ) else {
         not_supported!("std::fmt::format not found");
     };

--- a/crates/hir-ty/src/mir/lower.rs
+++ b/crates/hir-ty/src/mir/lower.rs
@@ -1783,7 +1783,7 @@ impl<'ctx> MirLowerCtx<'ctx> {
                     self.push_fake_read(c, p, expr.into());
                     current = scope2.pop_and_drop(self, c, expr.into());
                 }
-                hir_def::hir::Statement::Item => (),
+                hir_def::hir::Statement::Item(_) => (),
             }
         }
         if let Some(tail) = tail {

--- a/crates/hir-ty/src/mir/lower/as_place.rs
+++ b/crates/hir-ty/src/mir/lower/as_place.rs
@@ -137,7 +137,9 @@ impl MirLowerCtx<'_> {
             Expr::Path(p) => {
                 let resolver_guard =
                     self.resolver.update_to_inner_scope(self.db.upcast(), self.owner, expr_id);
-                let resolved = self.resolver.resolve_path_in_value_ns_fully(self.db.upcast(), p);
+                let hygiene = self.body.expr_path_hygiene(expr_id);
+                let resolved =
+                    self.resolver.resolve_path_in_value_ns_fully(self.db.upcast(), p, hygiene);
                 self.resolver.reset_to_guard(resolver_guard);
                 let Some(pr) = resolved else {
                     return try_rvalue(self);

--- a/crates/hir-ty/src/mir/lower/pattern_matching.rs
+++ b/crates/hir-ty/src/mir/lower/pattern_matching.rs
@@ -351,9 +351,10 @@ impl MirLowerCtx<'_> {
                 None => {
                     let unresolved_name =
                         || MirLowerError::unresolved_path(self.db, p, self.edition());
+                    let hygiene = self.body.pat_path_hygiene(pattern);
                     let pr = self
                         .resolver
-                        .resolve_path_in_value_ns(self.db.upcast(), p)
+                        .resolve_path_in_value_ns(self.db.upcast(), p, hygiene)
                         .ok_or_else(unresolved_name)?;
 
                     if let (

--- a/crates/hir-ty/src/tests/simple.rs
+++ b/crates/hir-ty/src/tests/simple.rs
@@ -3737,3 +3737,68 @@ fn foo() {
         "#,
     );
 }
+
+#[test]
+fn macro_expansion_can_refer_variables_defined_before_macro_definition() {
+    check_types(
+        r#"
+fn foo() {
+    let v: i32 = 0;
+    macro_rules! m {
+        () => { v };
+    }
+    let v: bool = true;
+    m!();
+ // ^^^^ i32
+}
+        "#,
+    );
+}
+
+#[test]
+fn macro_rules_shadowing_works_with_hygiene() {
+    check_types(
+        r#"
+fn foo() {
+    let v: bool;
+    macro_rules! m { () => { v } }
+    m!();
+ // ^^^^ bool
+
+    let v: char;
+    macro_rules! m { () => { v } }
+    m!();
+ // ^^^^ char
+
+    {
+        let v: u8;
+        macro_rules! m { () => { v } }
+        m!();
+     // ^^^^ u8
+
+        let v: i8;
+        macro_rules! m { () => { v } }
+        m!();
+     // ^^^^ i8
+
+        let v: i16;
+        macro_rules! m { () => { v } }
+        m!();
+     // ^^^^ i16
+
+        {
+            let v: u32;
+            macro_rules! m { () => { v } }
+            m!();
+         // ^^^^ u32
+
+            let v: u64;
+            macro_rules! m { () => { v } }
+            m!();
+         // ^^^^ u64
+        }
+    }
+}
+        "#,
+    );
+}

--- a/crates/hir-ty/src/tests/simple.rs
+++ b/crates/hir-ty/src/tests/simple.rs
@@ -3720,3 +3720,20 @@ fn test() -> bool {
         "#]],
     );
 }
+
+#[test]
+fn macro_semitransparent_hygiene() {
+    check_types(
+        r#"
+macro_rules! m {
+    () => { let bar: i32; };
+}
+fn foo() {
+    let bar: bool;
+    m!();
+    bar;
+ // ^^^ bool
+}
+        "#,
+    );
+}

--- a/crates/ide-diagnostics/src/handlers/undeclared_label.rs
+++ b/crates/ide-diagnostics/src/handlers/undeclared_label.rs
@@ -107,4 +107,34 @@ async fn foo() {
 "#,
         );
     }
+
+    #[test]
+    fn macro_expansion_can_refer_label_defined_before_macro_definition() {
+        check_diagnostics(
+            r#"
+fn foo() {
+    'bar: loop {
+        macro_rules! m {
+            () => { break 'bar };
+        }
+        m!();
+    }
+}
+"#,
+        );
+        check_diagnostics(
+            r#"
+fn foo() {
+    'bar: loop {
+        macro_rules! m {
+            () => { break 'bar };
+        }
+        'bar: loop {
+            m!();
+        }
+    }
+}
+"#,
+        );
+    }
 }

--- a/crates/ide/src/goto_definition.rs
+++ b/crates/ide/src/goto_definition.rs
@@ -3002,4 +3002,24 @@ use foo::m;
 "#,
         );
     }
+
+    #[test]
+    fn macro_label_hygiene() {
+        check(
+            r#"
+macro_rules! m {
+    ($x:stmt) => {
+        'bar: loop { $x }
+    };
+}
+
+fn foo() {
+    'bar: loop {
+ // ^^^^
+        m!(continue 'bar$0);
+    }
+}
+"#,
+        );
+    }
 }


### PR DESCRIPTION
The realization that made me do this (as explained in detail in the first commit) is that while def-site hygiene is incredibly hard for us, mixed-site hygiene should be easy (well, I underestimated it due to the need of the second commit, but still). And the best part in that is that mixed-site hygiene rules: def-site hygiene is available only on nightly and without a clear path to stabilization, and even when (if) it will stabilize this will still help solving the case of variables/labels.

This brings diagnostics on self down to four (from five, I think? or more) 🎉 and the remaining diagnostics all require next solver (three due to coercion issue, one due to the issue of trait bounds not being preferred).

Best reviewed commit by commit.

Fixes #18262.
Fixes #16342.
Fixes #13758.
Fixes #11681.
Fixes #10535.

(Wow, so many issues! That's heart-filling :heart:)