### PR TITLE
hir-ty: change struct constructor formatting.

### DIFF
--- a/crates/hir-ty/src/display.rs
+++ b/crates/hir-ty/src/display.rs
@@ -1008,7 +1008,7 @@ impl HirDisplay for Ty {
                 if let Safety::Unsafe = sig.safety {
                     write!(f, "unsafe ")?;
                 }
-                if !matches!(sig.abi, FnAbi::Rust) {
+                if !matches!(sig.abi, FnAbi::Rust | FnAbi::RustCall) {
                     f.write_str("extern \"")?;
                     f.write_str(sig.abi.as_str())?;
                     f.write_str("\" ")?;
@@ -1025,6 +1025,7 @@ impl HirDisplay for Ty {
                         )?
                     }
                     CallableDefId::StructId(s) => {
+                        write!(f, "fn ")?;
                         f.start_location_link(def.into());
                         write!(f, "{}", db.struct_data(s).name.display(f.db.upcast(), f.edition()))?
                     }

--- a/crates/hir-ty/src/tests/macros.rs
+++ b/crates/hir-ty/src/tests/macros.rs
@@ -64,7 +64,7 @@ fn infer_macros_expanded() {
         "#,
         expect![[r#"
             !0..17 '{Foo(v...,2,])}': Foo
-            !1..4 'Foo': extern "rust-call" Foo({unknown}) -> Foo
+            !1..4 'Foo': fn Foo({unknown}) -> Foo
             !1..16 'Foo(vec![1,2,])': Foo
             !5..15 'vec![1,2,]': {unknown}
             155..181 '{     ...,2); }': ()
@@ -97,7 +97,7 @@ fn infer_legacy_textual_scoped_macros_expanded() {
         "#,
         expect![[r#"
             !0..17 '{Foo(v...,2,])}': Foo
-            !1..4 'Foo': extern "rust-call" Foo({unknown}) -> Foo
+            !1..4 'Foo': fn Foo({unknown}) -> Foo
             !1..16 'Foo(vec![1,2,])': Foo
             !5..15 'vec![1,2,]': {unknown}
             194..250 '{     ...,2); }': ()

--- a/crates/hir-ty/src/tests/patterns.rs
+++ b/crates/hir-ty/src/tests/patterns.rs
@@ -227,13 +227,13 @@ fn infer_pattern_match_ergonomics() {
             37..41 'A(n)': A<i32>
             39..40 'n': &'? i32
             44..49 '&A(1)': &'? A<i32>
-            45..46 'A': extern "rust-call" A<i32>(i32) -> A<i32>
+            45..46 'A': fn A<i32>(i32) -> A<i32>
             45..49 'A(1)': A<i32>
             47..48 '1': i32
             59..63 'A(n)': A<i32>
             61..62 'n': &'? mut i32
             66..75 '&mut A(1)': &'? mut A<i32>
-            71..72 'A': extern "rust-call" A<i32>(i32) -> A<i32>
+            71..72 'A': fn A<i32>(i32) -> A<i32>
             71..75 'A(1)': A<i32>
             73..74 '1': i32
         "#]],
@@ -548,18 +548,18 @@ impl Foo {
             56..64 'Self(s,)': Foo
             61..62 's': &'? usize
             67..75 '&Foo(0,)': &'? Foo
-            68..71 'Foo': extern "rust-call" Foo(usize) -> Foo
+            68..71 'Foo': fn Foo(usize) -> Foo
             68..75 'Foo(0,)': Foo
             72..73 '0': usize
             89..97 'Self(s,)': Foo
             94..95 's': &'? mut usize
             100..112 '&mut Foo(0,)': &'? mut Foo
-            105..108 'Foo': extern "rust-call" Foo(usize) -> Foo
+            105..108 'Foo': fn Foo(usize) -> Foo
             105..112 'Foo(0,)': Foo
             109..110 '0': usize
             126..134 'Self(s,)': Foo
             131..132 's': usize
-            137..140 'Foo': extern "rust-call" Foo(usize) -> Foo
+            137..140 'Foo': fn Foo(usize) -> Foo
             137..144 'Foo(0,)': Foo
             141..142 '0': usize
         "#]],
@@ -933,7 +933,7 @@ fn foo(foo: Foo) {
             48..51 'foo': Foo
             62..84 'const ... 32) }': Foo
             68..84 '{ Foo(... 32) }': Foo
-            70..73 'Foo': extern "rust-call" Foo(usize) -> Foo
+            70..73 'Foo': fn Foo(usize) -> Foo
             70..82 'Foo(15 + 32)': Foo
             74..76 '15': usize
             74..81 '15 + 32': usize

--- a/crates/hir-ty/src/tests/regression.rs
+++ b/crates/hir-ty/src/tests/regression.rs
@@ -645,7 +645,7 @@ fn issue_4953() {
         "#,
         expect![[r#"
             58..72 '{ Self(0i64) }': Foo
-            60..64 'Self': extern "rust-call" Foo(i64) -> Foo
+            60..64 'Self': fn Foo(i64) -> Foo
             60..70 'Self(0i64)': Foo
             65..69 '0i64': i64
         "#]],
@@ -659,7 +659,7 @@ fn issue_4953() {
         "#,
         expect![[r#"
             64..78 '{ Self(0i64) }': Foo<i64>
-            66..70 'Self': extern "rust-call" Foo<i64>(i64) -> Foo<i64>
+            66..70 'Self': fn Foo<i64>(i64) -> Foo<i64>
             66..76 'Self(0i64)': Foo<i64>
             71..75 '0i64': i64
         "#]],
@@ -859,7 +859,7 @@ fn main() {
             94..96 '{}': ()
             109..160 '{     ...10); }': ()
             119..120 's': S<i32>
-            123..124 'S': extern "rust-call" S<i32>() -> S<i32>
+            123..124 'S': fn S<i32>() -> S<i32>
             123..126 'S()': S<i32>
             132..133 's': S<i32>
             132..144 's.g(|_x| {})': ()
@@ -1616,7 +1616,7 @@ fn main() {
             37..48 'S(.., a, b)': S
             43..44 'a': usize
             46..47 'b': {unknown}
-            51..52 'S': extern "rust-call" S(usize) -> S
+            51..52 'S': fn S(usize) -> S
             51..55 'S(1)': S
             53..54 '1': usize
             65..75 '(.., a, b)': (i32, {unknown})

--- a/crates/hir-ty/src/tests/simple.rs
+++ b/crates/hir-ty/src/tests/simple.rs
@@ -236,14 +236,14 @@ fn test() {
         expect![[r#"
             71..153 '{     ...a.c; }': ()
             81..82 'c': C
-            85..86 'C': extern "rust-call" C(usize) -> C
+            85..86 'C': fn C(usize) -> C
             85..89 'C(1)': C
             87..88 '1': usize
             95..96 'B': B
             106..107 'a': A
             113..132 'A { b:...C(1) }': A
             120..121 'B': B
-            126..127 'C': extern "rust-call" C(usize) -> C
+            126..127 'C': fn C(usize) -> C
             126..130 'C(1)': C
             128..129 '1': usize
             138..139 'a': A
@@ -629,12 +629,12 @@ impl E {
             86..107 '{     ...     }': ()
             96..100 'Self': S1
             134..158 '{     ...     }': ()
-            144..148 'Self': extern "rust-call" S2(isize) -> S2
+            144..148 'Self': fn S2(isize) -> S2
             144..151 'Self(1)': S2
             149..150 '1': isize
             184..230 '{     ...     }': ()
             194..202 'Self::V1': E
-            212..220 'Self::V2': extern "rust-call" V2(u32) -> E
+            212..220 'Self::V2': V2(u32) -> E
             212..223 'Self::V2(1)': E
             221..222 '1': u32
         "#]],
@@ -860,11 +860,11 @@ fn test() {
             256..277 'A::foo...42))))': &'? i32
             263..276 '&&B(B(A(42)))': &'? &'? B<B<A<i32>>>
             264..276 '&B(B(A(42)))': &'? B<B<A<i32>>>
-            265..266 'B': extern "rust-call" B<B<A<i32>>>(B<A<i32>>) -> B<B<A<i32>>>
+            265..266 'B': fn B<B<A<i32>>>(B<A<i32>>) -> B<B<A<i32>>>
             265..276 'B(B(A(42)))': B<B<A<i32>>>
-            267..268 'B': extern "rust-call" B<A<i32>>(A<i32>) -> B<A<i32>>
+            267..268 'B': fn B<A<i32>>(A<i32>) -> B<A<i32>>
             267..275 'B(A(42))': B<A<i32>>
-            269..270 'A': extern "rust-call" A<i32>(i32) -> A<i32>
+            269..270 'A': fn A<i32>(i32) -> A<i32>
             269..274 'A(42)': A<i32>
             271..273 '42': i32
         "#]],
@@ -914,16 +914,16 @@ fn test(a: A<i32>) {
             253..254 'a': A<i32>
             264..310 '{     ...))); }': ()
             274..275 't': &'? i32
-            278..279 'A': extern "rust-call" A<i32>(*mut i32) -> A<i32>
+            278..279 'A': fn A<i32>(*mut i32) -> A<i32>
             278..292 'A(0 as *mut _)': A<i32>
             278..307 'A(0 as...B(a)))': &'? i32
             280..281 '0': usize
             280..291 '0 as *mut _': *mut i32
             297..306 '&&B(B(a))': &'? &'? B<B<A<i32>>>
             298..306 '&B(B(a))': &'? B<B<A<i32>>>
-            299..300 'B': extern "rust-call" B<B<A<i32>>>(B<A<i32>>) -> B<B<A<i32>>>
+            299..300 'B': fn B<B<A<i32>>>(B<A<i32>>) -> B<B<A<i32>>>
             299..306 'B(B(a))': B<B<A<i32>>>
-            301..302 'B': extern "rust-call" B<A<i32>>(A<i32>) -> B<A<i32>>
+            301..302 'B': fn B<A<i32>>(A<i32>) -> B<A<i32>>
             301..305 'B(a)': B<A<i32>>
             303..304 'a': A<i32>
         "#]],
@@ -1277,16 +1277,16 @@ fn infer_tuple_struct_generics() {
         "#,
         expect![[r#"
             75..183 '{     ...one; }': ()
-            81..82 'A': extern "rust-call" A<i32>(i32) -> A<i32>
+            81..82 'A': fn A<i32>(i32) -> A<i32>
             81..86 'A(42)': A<i32>
             83..85 '42': i32
-            92..93 'A': extern "rust-call" A<u128>(u128) -> A<u128>
+            92..93 'A': fn A<u128>(u128) -> A<u128>
             92..101 'A(42u128)': A<u128>
             94..100 '42u128': u128
-            107..111 'Some': extern "rust-call" Some<&'static str>(&'static str) -> Option<&'static str>
+            107..111 'Some': Some<&'static str>(&'static str) -> Option<&'static str>
             107..116 'Some("x")': Option<&'static str>
             112..115 '"x"': &'static str
-            122..134 'Option::Some': extern "rust-call" Some<&'static str>(&'static str) -> Option<&'static str>
+            122..134 'Option::Some': Some<&'static str>(&'static str) -> Option<&'static str>
             122..139 'Option...e("x")': Option<&'static str>
             135..138 '"x"': &'static str
             145..149 'None': Option<{unknown}>
@@ -1572,7 +1572,7 @@ fn infer_type_alias() {
             204..207 'z.y': i8
             298..362 '{     ... &e; }': ()
             308..309 'e': Enum
-            312..325 'm::Alias::Foo': extern "rust-call" Foo(u8) -> Enum
+            312..325 'm::Alias::Foo': Foo(u8) -> Enum
             312..328 'm::Ali...Foo(0)': Enum
             326..327 '0': u8
             338..354 'm::Ali...Foo(x)': Enum
@@ -2191,10 +2191,10 @@ fn main() {
             103..231 '{     ... }); }': ()
             109..161 'async ...     }': impl Future<Output = Result<(), ()>>
             125..139 'return Err(())': !
-            132..135 'Err': extern "rust-call" Err<(), ()>(()) -> Result<(), ()>
+            132..135 'Err': Err<(), ()>(()) -> Result<(), ()>
             132..139 'Err(())': Result<(), ()>
             136..138 '()': ()
-            149..151 'Ok': extern "rust-call" Ok<(), ()>(()) -> Result<(), ()>
+            149..151 'Ok': Ok<(), ()>(()) -> Result<(), ()>
             149..155 'Ok(())': Result<(), ()>
             152..154 '()': ()
             167..171 'test': fn test<(), (), impl FnMut() -> impl Future<Output = Result<(), ()>>, impl Future<Output = Result<(), ()>>>(impl FnMut() -> impl Future<Output = Result<(), ()>>)
@@ -2202,10 +2202,10 @@ fn main() {
             172..227 '|| asy...     }': impl FnMut() -> impl Future<Output = Result<(), ()>>
             175..227 'async ...     }': impl Future<Output = Result<(), ()>>
             191..205 'return Err(())': !
-            198..201 'Err': extern "rust-call" Err<(), ()>(()) -> Result<(), ()>
+            198..201 'Err': Err<(), ()>(()) -> Result<(), ()>
             198..205 'Err(())': Result<(), ()>
             202..204 '()': ()
-            215..217 'Ok': extern "rust-call" Ok<(), ()>(()) -> Result<(), ()>
+            215..217 'Ok': Ok<(), ()>(()) -> Result<(), ()>
             215..221 'Ok(())': Result<(), ()>
             218..220 '()': ()
         "#]],
@@ -2234,7 +2234,7 @@ fn infer_generic_from_later_assignment() {
             94..127 '{     ...     }': ()
             104..107 'end': Option<bool>
             104..120 'end = ...(true)': ()
-            110..114 'Some': extern "rust-call" Some<bool>(bool) -> Option<bool>
+            110..114 'Some': Some<bool>(bool) -> Option<bool>
             110..120 'Some(true)': Option<bool>
             115..119 'true': bool
         "#]],
@@ -2269,7 +2269,7 @@ fn infer_loop_break_with_val() {
             111..121 'break None': !
             117..121 'None': Option<bool>
             142..158 'break ...(true)': !
-            148..152 'Some': extern "rust-call" Some<bool>(bool) -> Option<bool>
+            148..152 'Some': Some<bool>(bool) -> Option<bool>
             148..158 'Some(true)': Option<bool>
             153..157 'true': bool
         "#]],
@@ -2516,7 +2516,7 @@ fn generic_default_in_struct_literal() {
             254..281 'OtherT...1i32 }': OtherThing<i32>
             275..279 '1i32': i32
             291..292 'b': OtherThing<i32>
-            295..310 'OtherThing::Two': extern "rust-call" Two<i32>(i32) -> OtherThing<i32>
+            295..310 'OtherThing::Two': Two<i32>(i32) -> OtherThing<i32>
             295..316 'OtherT...(1i32)': OtherThing<i32>
             311..315 '1i32': i32
         "#]],
@@ -3028,7 +3028,7 @@ fn f() {
         expect![[r#"
             72..166 '{     ...   } }': ()
             78..164 'match ...     }': ()
-            84..92 'Foo::Bar': extern "rust-call" Bar(i32) -> Foo
+            84..92 'Foo::Bar': Bar(i32) -> Foo
             84..95 'Foo::Bar(3)': Foo
             93..94 '3': i32
             106..119 'Qux::Bar(bar)': Foo
@@ -3087,9 +3087,9 @@ fn main() {
             322..324 '{}': Foo<T>
             338..559 '{     ...r(); }': ()
             348..353 'boxed': Box<Foo<i32>>
-            356..359 'Box': extern "rust-call" Box<Foo<i32>>(Foo<i32>) -> Box<Foo<i32>>
+            356..359 'Box': fn Box<Foo<i32>>(Foo<i32>) -> Box<Foo<i32>>
             356..371 'Box(Foo(0_i32))': Box<Foo<i32>>
-            360..363 'Foo': extern "rust-call" Foo<i32>(i32) -> Foo<i32>
+            360..363 'Foo': fn Foo<i32>(i32) -> Foo<i32>
             360..370 'Foo(0_i32)': Foo<i32>
             364..369 '0_i32': i32
             382..386 'bad1': &'? i32

--- a/crates/hir-ty/src/tests/traits.rs
+++ b/crates/hir-ty/src/tests/traits.rs
@@ -523,7 +523,7 @@ fn test() -> u64 {
         expect![[r#"
             37..86 '{     ... a.1 }': u64
             47..48 'a': S
-            51..52 'S': extern "rust-call" S(i32, u64) -> S
+            51..52 'S': fn S(i32, u64) -> S
             51..58 'S(4, 6)': S
             53..54 '4': i32
             56..57 '6': u64
@@ -549,7 +549,7 @@ fn test() -> u64 {
         expect![[r#"
             43..108 '{     ...0(2) }': u64
             53..54 'a': S
-            57..58 'S': extern "rust-call" S(fn(u32) -> u64) -> S
+            57..58 'S': fn S(fn(u32) -> u64) -> S
             57..74 'S(|i| ...s u64)': S
             59..73 '|i| 2*i as u64': impl Fn(u32) -> u64
             60..61 'i': u32
@@ -1027,7 +1027,7 @@ fn test(x: impl Trait<u64>, y: &impl Trait<u32>) {
             201..202 'x': impl Trait<u64>
             208..209 'y': &'? impl Trait<u32>
             219..220 'z': S<u16>
-            223..224 'S': extern "rust-call" S<u16>(u16) -> S<u16>
+            223..224 'S': fn S<u16>(u16) -> S<u16>
             223..227 'S(1)': S<u16>
             225..226 '1': u16
             233..236 'bar': fn bar(S<u16>)
@@ -1269,10 +1269,10 @@ fn bar() {
             226..229 'foo': fn foo<i32>([R<(), i32>; 2]) -> i32
             226..250 'foo([R...B(7)])': i32
             230..249 '[R::A(...:B(7)]': [R<(), i32>; 2]
-            231..235 'R::A': extern "rust-call" A<(), i32>(()) -> R<(), i32>
+            231..235 'R::A': A<(), i32>(()) -> R<(), i32>
             231..239 'R::A(())': R<(), i32>
             236..238 '()': ()
-            241..245 'R::B': extern "rust-call" B<(), i32>(i32) -> R<(), i32>
+            241..245 'R::B': B<(), i32>(i32) -> R<(), i32>
             241..248 'R::B(7)': R<(), i32>
             246..247 '7': i32
         "#]],
@@ -1421,7 +1421,7 @@ fn foo<const C: u8, T>() -> (impl FnOnce(&str, T), impl Trait<u8>) {
             142..147 'input': &'? str
             149..150 't': T
             152..154 '{}': ()
-            156..159 'Bar': extern "rust-call" Bar<u8>(u8) -> Bar<u8>
+            156..159 'Bar': fn Bar<u8>(u8) -> Bar<u8>
             156..162 'Bar(C)': Bar<u8>
             160..161 'C': u8
         "#]],
@@ -2046,7 +2046,7 @@ fn test() {
             118..120 '{}': ()
             136..255 '{     ... 1); }': ()
             146..147 'x': Option<u32>
-            150..162 'Option::Some': extern "rust-call" Some<u32>(u32) -> Option<u32>
+            150..162 'Option::Some': Some<u32>(u32) -> Option<u32>
             150..168 'Option...(1u32)': Option<u32>
             163..167 '1u32': u32
             174..175 'x': Option<u32>
@@ -2602,7 +2602,7 @@ fn test() -> impl Trait<i32> {
             178..180 '{}': ()
             213..309 '{     ...t()) }': S<i32>
             223..225 's1': S<u32>
-            228..229 'S': extern "rust-call" S<u32>(u32) -> S<u32>
+            228..229 'S': fn S<u32>(u32) -> S<u32>
             228..240 'S(default())': S<u32>
             230..237 'default': fn default<u32>() -> u32
             230..239 'default()': u32
@@ -2612,11 +2612,11 @@ fn test() -> impl Trait<i32> {
             263..264 'x': i32
             272..275 'bar': fn bar<i32>(S<i32>) -> i32
             272..289 'bar(S(...lt()))': i32
-            276..277 'S': extern "rust-call" S<i32>(i32) -> S<i32>
+            276..277 'S': fn S<i32>(i32) -> S<i32>
             276..288 'S(default())': S<i32>
             278..285 'default': fn default<i32>() -> i32
             278..287 'default()': i32
-            295..296 'S': extern "rust-call" S<i32>(i32) -> S<i32>
+            295..296 'S': fn S<i32>(i32) -> S<i32>
             295..307 'S(default())': S<i32>
             297..304 'default': fn default<i32>() -> i32
             297..306 'default()': i32
@@ -2846,7 +2846,7 @@ fn main() {
             1036..1041 'x > 0': bool
             1040..1041 '0': i32
             1042..1060 '{ Some...u32) }': Option<u32>
-            1044..1048 'Some': extern "rust-call" Some<u32>(u32) -> Option<u32>
+            1044..1048 'Some': Some<u32>(u32) -> Option<u32>
             1044..1058 'Some(x as u32)': Option<u32>
             1049..1050 'x': i32
             1049..1057 'x as u32': u32
@@ -2982,9 +2982,9 @@ fn test() {
             175..185 'foo.test()': bool
             191..194 'bar': fn bar<{unknown}>({unknown}) -> {unknown}
             191..201 'bar.test()': bool
-            207..213 'Struct': extern "rust-call" Struct(usize) -> Struct
+            207..213 'Struct': fn Struct(usize) -> Struct
             207..220 'Struct.test()': bool
-            226..239 'Enum::Variant': extern "rust-call" Variant(usize) -> Enum
+            226..239 'Enum::Variant': Variant(usize) -> Enum
             226..246 'Enum::...test()': bool
         "#]],
     );
@@ -3563,12 +3563,12 @@ fn main(){
             95..99 'self': Wrapper
             101..104 'rhs': u32
             122..150 '{     ...     }': Wrapper
-            132..139 'Wrapper': extern "rust-call" Wrapper(u32) -> Wrapper
+            132..139 'Wrapper': fn Wrapper(u32) -> Wrapper
             132..144 'Wrapper(rhs)': Wrapper
             140..143 'rhs': u32
             162..248 '{     ...um;  }': ()
             172..179 'wrapped': Wrapper
-            182..189 'Wrapper': extern "rust-call" Wrapper(u32) -> Wrapper
+            182..189 'Wrapper': fn Wrapper(u32) -> Wrapper
             182..193 'Wrapper(10)': Wrapper
             190..192 '10': u32
             203..206 'num': u32


### PR DESCRIPTION
before, when formatting struct constructor for `struct S(usize, usize)` it would format as:

    extern "rust-call" S(usize, usize) -> S

but after this change, we'll format as:

    fn S(usize, usize) -> S
    

fixes #18259