### PR TITLE
Wait for discover command on Finished/Error

### DIFF
--- a/crates/rust-analyzer/src/discover.rs
+++ b/crates/rust-analyzer/src/discover.rs
@@ -62,7 +62,7 @@ impl DiscoverCommand {
         cmd.args(args);
 
         Ok(DiscoverHandle {
-            _handle: CommandHandle::spawn(cmd, self.sender.clone())?,
+            handle: CommandHandle::spawn(cmd, self.sender.clone())?,
             span: info_span!("discover_command").entered(),
         })
     }
@@ -71,9 +71,15 @@ impl DiscoverCommand {
 /// A handle to a spawned [Discover].
 #[derive(Debug)]
 pub(crate) struct DiscoverHandle {
-    _handle: CommandHandle<DiscoverProjectMessage>,
+    handle: CommandHandle<DiscoverProjectMessage>,
     #[allow(dead_code)] // not accessed, but used to log on drop.
     span: EnteredSpan,
+}
+
+impl DiscoverHandle {
+    pub(crate) fn join(self) -> io::Result<()> {
+        self.handle.join()
+    }
 }
 
 /// An enum containing either progress messages, an error,


### PR DESCRIPTION
Currently, we [kill](https://github.com/rust-lang/rust-analyzer/blob/0fb804acb375b02a3beeaceeb75b71969ef37b15/crates/rust-analyzer/src/command.rs#L92) the discover process upon receiving Finished/Error which prevents it from completing gracefully and doing any cleanup/logging ([as we want to do in rust-project](https://github.com/facebook/buck2/blob/66be61717ff358cd9a4da4acd2acffc2f52d7052/integrations/rust-project/src/cli/develop.rs#L222)). Wait for it to exit instead.