### PR TITLE
Fix panic when json project has relative buildfile paths

### DIFF
--- a/crates/project-model/src/workspace.rs
+++ b/crates/project-model/src/workspace.rs
@@ -553,7 +553,7 @@ impl ProjectWorkspace {
             ProjectWorkspaceKind::Json(project) => project
                 .crates()
                 .filter_map(|(_, krate)| krate.build.as_ref().map(|build| build.build_file.clone()))
-                .map(AbsPathBuf::assert)
+                .map(|build_file| self.workspace_root().join(build_file))
                 .collect(),
             _ => vec![],
         }


### PR DESCRIPTION
The `build_file` path may be relative to the workspace root.