### PR TITLE
minor: `ra-salsa` in `profile.dev.package`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ rustc-hash.opt-level = 3
 smol_str.opt-level = 3
 text-size.opt-level = 3
 serde.opt-level = 3
-ra-salsa.opt-level = 3
+salsa.opt-level = 3
 # This speeds up `cargo xtask dist`.
 miniz_oxide.opt-level = 3
 


### PR DESCRIPTION
Since `ra-salsa`'s package name is actually `salsa` it makes the following warning in `cargo` commands; 

```
warning: profile package spec `ra-salsa` in profile `dev` did not match any packages
```

and the opt level isn't applied to it. 
