### PR TITLE
Report document symbols of kind `variable` for let statements

### DIFF
--- a/crates/ide/src/file_structure.rs
+++ b/crates/ide/src/file_structure.rs
@@ -187,6 +187,24 @@ fn structure_node(node: &SyntaxNode) -> Option<StructureNode> {
                 };
                 Some(node)
             },
+            ast::LetStmt(it) => {
+                let pat = it.pat()?;
+
+                let mut label = String::new();
+                collapse_ws(pat.syntax(), &mut label);
+
+                let node = StructureNode {
+                    parent: None,
+                    label,
+                    navigation_range: pat.syntax().text_range(),
+                    node_range: it.syntax().text_range(),
+                    kind: StructureNodeKind::SymbolKind(SymbolKind::Local),
+                    detail: it.ty().map(|ty| ty.to_string()),
+                    deprecated: false,
+                };
+
+                Some(node)
+            },
             ast::Macro(it) => decl(it, StructureNodeKind::SymbolKind(SymbolKind::Macro)),
             _ => None,
         }

--- a/crates/ide/src/file_structure.rs
+++ b/crates/ide/src/file_structure.rs
@@ -326,6 +326,17 @@ fn f() {}
 // endregion
 fn g() {}
 }
+
+fn let_statements() {
+    let x = 42;
+    let mut y = x;
+    let Foo {
+        ..
+    } = Foo { x };
+    if let None = Some(x) {}
+    _ = ();
+    let _ = g();
+}
 "#,
             expect![[r#"
                 [
@@ -649,6 +660,71 @@ fn g() {}
                         detail: Some(
                             "fn()",
                         ),
+                        deprecated: false,
+                    },
+                    StructureNode {
+                        parent: None,
+                        label: "let_statements",
+                        navigation_range: 641..655,
+                        node_range: 638..798,
+                        kind: SymbolKind(
+                            Function,
+                        ),
+                        detail: Some(
+                            "fn()",
+                        ),
+                        deprecated: false,
+                    },
+                    StructureNode {
+                        parent: Some(
+                            26,
+                        ),
+                        label: "x",
+                        navigation_range: 668..669,
+                        node_range: 664..675,
+                        kind: SymbolKind(
+                            Local,
+                        ),
+                        detail: None,
+                        deprecated: false,
+                    },
+                    StructureNode {
+                        parent: Some(
+                            26,
+                        ),
+                        label: "mut y",
+                        navigation_range: 684..689,
+                        node_range: 680..694,
+                        kind: SymbolKind(
+                            Local,
+                        ),
+                        detail: None,
+                        deprecated: false,
+                    },
+                    StructureNode {
+                        parent: Some(
+                            26,
+                        ),
+                        label: "Foo { .. }",
+                        navigation_range: 703..725,
+                        node_range: 699..738,
+                        kind: SymbolKind(
+                            Local,
+                        ),
+                        detail: None,
+                        deprecated: false,
+                    },
+                    StructureNode {
+                        parent: Some(
+                            26,
+                        ),
+                        label: "_",
+                        navigation_range: 788..789,
+                        node_range: 784..796,
+                        kind: SymbolKind(
+                            Local,
+                        ),
+                        detail: None,
                         deprecated: false,
                     },
                 ]


### PR DESCRIPTION
initially i had implemented a bunch more kinds, but eventually realized that `ide_db::SymbolKind` != `lsp_types::SymbolKind` and that many of the former kind are mapped to the same latter kind, which could cause annoyances when e.g. the user wants their outline view in vscode to show `ide_db::SymbolKind::Const` and `ide_db::SymbolKind::Static` but not `ide_db::SymbolKind::ConstParam` (which wouldn't be possible to configure in vscode since all of them are mapped to `lsp_types::SymbolKind::CONSTANT`) so i decided to take a conservative approach and ended up removing all but 1 kind