### PR TITLE
Fix link syntax

### DIFF
--- a/crates/rust-analyzer/src/reload.rs
+++ b/crates/rust-analyzer/src/reload.rs
@@ -159,7 +159,7 @@ impl GlobalState {
         {
             status.health |= lsp_ext::Health::Warning;
             message.push_str("Failed to discover workspace.\n");
-            message.push_str("Consider adding the `Cargo.toml` of the workspace to the [`linkedProjects`](https://rust-analyzer.github.io/manual.html#rust-analyzer.linkedProjects) setting.\n\n");
+            message.push_str("Consider adding the `Cargo.toml` of the workspace to the [linkedProjects](https://rust-analyzer.github.io/manual.html#rust-analyzer.linkedProjects) setting.\n\n");
         }
         if self.fetch_workspace_error().is_err() {
             status.health |= lsp_ext::Health::Error;


### PR DESCRIPTION
There's a small bug in the Markdown syntax for the below dialog:

<img width="522" alt="Screenshot 2024-10-17 at 14 18 58" src="https://github.com/user-attachments/assets/1df7dd10-a836-4558-8cb0-b9003cadaaad">

Removing the backticks should fix this.