### PR TITLE
internal: Fix editorconfig glob

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,5 +13,5 @@ max_line_length = 100
 [*.md]
 indent_size = 2
 
-[*.{yml, yaml}]
+[*.{yml,yaml}]
 indent_size = 2


### PR DESCRIPTION
Had been testing Zed's editorconfig branch on r-a and noticed that something was odd with yaml files.

https://spec.editorconfig.org/#glob-expressions

> {s1,s2,s3}
	
> any of the strings given (separated by commas, can be nested) (But {s1} only matches {s1} literally.)