### PR TITLE
feat: support initializeStopped setting

### DIFF
--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -349,6 +349,11 @@
                         "markdownDescription": "Whether to show the test explorer.",
                         "default": false,
                         "type": "boolean"
+                    },
+                    "rust-analyzer.initializeStopped": {
+                        "markdownDescription": "Do not start rust-analyzer server when the extension is activated.",
+                        "default": false,
+                        "type": "boolean"
                     }
                 }
             },

--- a/editors/code/src/config.ts
+++ b/editors/code/src/config.ts
@@ -330,6 +330,10 @@ export class Config {
     get statusBarClickAction() {
         return this.get<string>("statusBar.clickAction");
     }
+
+    get initializeStopped() {
+        return this.get<boolean>("initializeStopped");
+    }
 }
 
 export function prepareVSCodeConfig<T>(resp: T): T {

--- a/editors/code/src/main.ts
+++ b/editors/code/src/main.ts
@@ -107,7 +107,14 @@ async function activateServer(ctx: Ctx): Promise<RustAnalyzerExtensionApi> {
         initializeDebugSessionTrackingAndRebuild(ctx);
     }
 
-    await ctx.start();
+    if (ctx.config.initializeStopped) {
+        ctx.setServerStatus({
+            health: "stopped",
+        });
+    } else {
+        await ctx.start();
+    }
+
     return ctx;
 }
 


### PR DESCRIPTION
See #18356

Add option to start rust-analyzer in "stopped" state when the extension activates.