### PR TITLE
fix dyn incompatible hint message

### DIFF
--- a/crates/ide/src/hover/render.rs
+++ b/crates/ide/src/hover/render.rs
@@ -1042,7 +1042,7 @@ fn render_dyn_compatibility(
         }
         DynCompatibilityViolation::HasNonCompatibleSuperTrait(super_trait) => {
             let name = hir::Trait::from(super_trait).name(db);
-            format_to!(buf, "has a object unsafe supertrait `{}`", name.as_str());
+            format_to!(buf, "has a dyn incompatible supertrait `{}`", name.as_str());
         }
     }
 }


### PR DESCRIPTION
![Screenshot_20241023_181051](https://github.com/user-attachments/assets/97f197c6-5e36-4152-b82b-484c82fc7e32)
It's missing in #18205