### PR TITLE
fix: auto-complete import for aliased function and module

### DIFF
--- a/crates/ide-completion/src/render.rs
+++ b/crates/ide-completion/src/render.rs
@@ -281,13 +281,7 @@ pub(crate) fn render_resolution_with_import(
     import_edit: LocatedImport,
 ) -> Option<Builder> {
     let resolution = ScopeDef::from(import_edit.original_item);
-    // Use the last segment when `item_to_import` matches `original_item`,
-    // as it will take the aliased name into account.
-    let local_name = if import_edit.item_to_import == import_edit.original_item {
-        import_edit.import_path.segments().last()?.clone()
-    } else {
-        scope_def_to_name(resolution, &ctx, &import_edit)?
-    };
+    let local_name = get_import_name(resolution, &ctx, &import_edit)?;
     // This now just renders the alias text, but we need to find the aliases earlier and call this with the alias instead.
     let doc_aliases = ctx.completion.doc_aliases_in_scope(resolution);
     let ctx = ctx.doc_aliases(doc_aliases);
@@ -361,6 +355,24 @@ pub(crate) fn render_expr(
     }
 
     Some(item)
+}
+
+fn get_import_name(
+    resolution: ScopeDef,
+    ctx: &RenderContext<'_>,
+    import_edit: &LocatedImport,
+) -> Option<hir::Name> {
+    // FIXME: Temporary workaround for handling aliased import.
+    // This should be removed after we have proper support for importing alias.
+    // <https://github.com/rust-lang/rust-analyzer/issues/14079>
+
+    // If `item_to_import` matches `original_item`, we are importing the item itself (not its parent module).
+    // In this case, we can use the last segment of `import_path`, as it accounts for the aliased name.
+    if import_edit.item_to_import == import_edit.original_item {
+        import_edit.import_path.segments().last().cloned()
+    } else {
+        scope_def_to_name(resolution, ctx, import_edit)
+    }
 }
 
 fn scope_def_to_name(

--- a/crates/ide-completion/src/render.rs
+++ b/crates/ide-completion/src/render.rs
@@ -281,8 +281,14 @@ pub(crate) fn render_resolution_with_import(
     import_edit: LocatedImport,
 ) -> Option<Builder> {
     let resolution = ScopeDef::from(import_edit.original_item);
-    let local_name = scope_def_to_name(resolution, &ctx, &import_edit)?;
-    //this now just renders the alias text, but we need to find the aliases earlier and call this with the alias instead
+    // Use the last segment when `item_to_import` matches `original_item`,
+    // as it will take the aliased name into account.
+    let local_name = if import_edit.item_to_import == import_edit.original_item {
+        import_edit.import_path.segments().last()?.clone()
+    } else {
+        scope_def_to_name(resolution, &ctx, &import_edit)?
+    };
+    // This now just renders the alias text, but we need to find the aliases earlier and call this with the alias instead.
     let doc_aliases = ctx.completion.doc_aliases_in_scope(resolution);
     let ctx = ctx.doc_aliases(doc_aliases);
     Some(render_resolution_path(ctx, path_ctx, local_name, Some(import_edit), resolution))

--- a/crates/ide-completion/src/render.rs
+++ b/crates/ide-completion/src/render.rs
@@ -294,7 +294,7 @@ pub(crate) fn render_resolution_with_import_pat(
     import_edit: LocatedImport,
 ) -> Option<Builder> {
     let resolution = ScopeDef::from(import_edit.original_item);
-    let local_name = scope_def_to_name(resolution, &ctx, &import_edit)?;
+    let local_name = get_import_name(resolution, &ctx, &import_edit)?;
     Some(render_resolution_pat(ctx, pattern_ctx, local_name, Some(import_edit), resolution))
 }
 

--- a/crates/ide-completion/src/tests/flyimport.rs
+++ b/crates/ide-completion/src/tests/flyimport.rs
@@ -1671,43 +1671,52 @@ mod module {
 }
 
 #[test]
-fn re_export_aliased_function() {
+fn re_export_aliased() {
     check(
         r#"
-//- /lib.rs crate:bar
-pub fn func(_: i32) -> i32 {}
-
-//- /lib.rs crate:foo deps:bar
-pub use bar::func as my_func;
-
-//- /main.rs crate:main deps:foo
-fn main() {
-    m$0
+mod outer {
+    mod inner {
+        pub struct BarStruct;
+        pub fn bar_fun() {}
+        pub mod bar {}
+    }
+    pub use inner::bar as foo;
+    pub use inner::bar_fun as foo_fun;
+    pub use inner::BarStruct as FooStruct;
+}
+fn function() {
+    foo$0
 }
 "#,
         expect![[r#"
-            fn my_func(…) (use foo::my_func) fn(i32) -> i32
+            st FooStruct (use outer::FooStruct) BarStruct
+            md foo (use outer::foo)
+            fn foo_fun() (use outer::foo_fun) fn()
         "#]],
     );
 }
 
 #[test]
-fn re_export_aliased_module() {
+fn re_export_aliased_pattern() {
     check(
         r#"
-//- /lib.rs crate:bar
-pub mod baz {}
-
-//- /lib.rs crate:foo deps:bar
-pub use bar::baz as my_baz;
-
-//- /main.rs crate:main deps:foo
-fn main() {
-    m$0
+mod outer {
+    mod inner {
+        pub struct BarStruct;
+        pub fn bar_fun() {}
+        pub mod bar {}
+    }
+    pub use inner::bar as foo;
+    pub use inner::bar_fun as foo_fun;
+    pub use inner::BarStruct as FooStruct;
+}
+fn function() {
+    let foo$0
 }
 "#,
         expect![[r#"
-            md my_baz (use foo::my_baz)
+            st FooStruct (use outer::FooStruct)
+            md foo (use outer::foo)
         "#]],
     );
 }

--- a/crates/ide-completion/src/tests/flyimport.rs
+++ b/crates/ide-completion/src/tests/flyimport.rs
@@ -1669,3 +1669,45 @@ mod module {
         "#]],
     );
 }
+
+#[test]
+fn re_export_aliased_function() {
+    check(
+        r#"
+//- /lib.rs crate:bar
+pub fn func(_: i32) -> i32 {}
+
+//- /lib.rs crate:foo deps:bar
+pub use bar::func as my_func;
+
+//- /main.rs crate:main deps:foo
+fn main() {
+    m$0
+}
+"#,
+        expect![[r#"
+            fn my_func(…) (use foo::my_func) fn(i32) -> i32
+        "#]],
+    );
+}
+
+#[test]
+fn re_export_aliased_module() {
+    check(
+        r#"
+//- /lib.rs crate:bar
+pub mod baz {}
+
+//- /lib.rs crate:foo deps:bar
+pub use bar::baz as my_baz;
+
+//- /main.rs crate:main deps:foo
+fn main() {
+    m$0
+}
+"#,
+        expect![[r#"
+            md my_baz (use foo::my_baz)
+        "#]],
+    );
+}


### PR DESCRIPTION
Close #17042 

Get the aliased name from `import_path` to use for import instead of name defined inside local module.

![image](https://github.com/user-attachments/assets/e69be963-3a78-4b62-b5ba-0990cd94c5e2)
