### PR TITLE
Fix checking for `false` `labelDetailsSupport` value.

### DIFF
--- a/crates/rust-analyzer/src/lsp/capabilities.rs
+++ b/crates/rust-analyzer/src/lsp/capabilities.rs
@@ -210,10 +210,7 @@ impl ClientCapabilities {
                 .completion_item
                 .as_ref()?
                 .label_details_support
-                .as_ref()
-        })()
-        .copied()
-        .unwrap_or_default()
+        })() == Some(true)
     }
 
     fn completion_item(&self) -> Option<CompletionOptionsCompletionItem> {

--- a/crates/rust-analyzer/src/lsp/capabilities.rs
+++ b/crates/rust-analyzer/src/lsp/capabilities.rs
@@ -212,7 +212,8 @@ impl ClientCapabilities {
                 .label_details_support
                 .as_ref()
         })()
-        .is_some()
+        .copied()
+        .unwrap_or_default()
     }
 
     fn completion_item(&self) -> Option<CompletionOptionsCompletionItem> {


### PR DESCRIPTION
The check for `labelDetailsSupport` only checks for non-`None`, which means setting `labelDetailsSupport: false` incorrectly treats it as being supported.

For context: https://github.com/mrcjkb/rustaceanvim/discussions/414