### PR TITLE
fix: Prevent public re-export of private item

### DIFF
--- a/crates/hir-def/src/find_path.rs
+++ b/crates/hir-def/src/find_path.rs
@@ -1025,7 +1025,7 @@ pub mod ast {
         check_found_path(
             r#"
 mod bar {
-    mod foo { pub(super) struct S; }
+    mod foo { pub(crate) struct S; }
     pub(crate) use foo::*;
 }
 $0
@@ -1047,7 +1047,7 @@ $0
         check_found_path(
             r#"
 mod bar {
-    mod foo { pub(super) struct S; }
+    mod foo { pub(crate) struct S; }
     pub(crate) use foo::S as U;
 }
 $0

--- a/crates/hir-def/src/visibility.rs
+++ b/crates/hir-def/src/visibility.rs
@@ -191,6 +191,11 @@ impl Visibility {
                     return None;
                 }
 
+                let def_block = def_map.block_id();
+                if (mod_a.containing_block(), mod_b.containing_block()) != (def_block, def_block) {
+                    return None;
+                }
+
                 let mut a_ancestors =
                     iter::successors(Some(mod_a.local_id), |&m| def_map[m].parent);
                 let mut b_ancestors =
@@ -204,6 +209,43 @@ impl Visibility {
                 if b_ancestors.any(|m| m == mod_a.local_id) {
                     // A is above B
                     return Some(Visibility::Module(mod_a, expl_a));
+                }
+
+                None
+            }
+        }
+    }
+
+    /// Returns the least permissive visibility of `self` and `other`.
+    ///
+    /// If there is no subset relation between `self` and `other`, returns `None` (ie. they're only
+    /// visible in unrelated modules).
+    pub(crate) fn min(self, other: Visibility, def_map: &DefMap) -> Option<Visibility> {
+        match (self, other) {
+            (vis, Visibility::Public) | (Visibility::Public, vis) => Some(vis),
+            (Visibility::Module(mod_a, expl_a), Visibility::Module(mod_b, expl_b)) => {
+                if mod_a.krate != mod_b.krate {
+                    return None;
+                }
+
+                let def_block = def_map.block_id();
+                if (mod_a.containing_block(), mod_b.containing_block()) != (def_block, def_block) {
+                    return None;
+                }
+
+                let mut a_ancestors =
+                    iter::successors(Some(mod_a.local_id), |&m| def_map[m].parent);
+                let mut b_ancestors =
+                    iter::successors(Some(mod_b.local_id), |&m| def_map[m].parent);
+
+                if a_ancestors.any(|m| m == mod_b.local_id) {
+                    // B is above A
+                    return Some(Visibility::Module(mod_a, expl_b));
+                }
+
+                if b_ancestors.any(|m| m == mod_a.local_id) {
+                    // A is above B
+                    return Some(Visibility::Module(mod_b, expl_a));
                 }
 
                 None


### PR DESCRIPTION
Fixes #18308

The original issue is quite complicated.
`polar-rs` monorepo has the following structure;

```rust
// crate polars-core
pub mod prelude {
    pub use crate::datatype::DataType;
}

// crate polars-ops
pub mod frame {
    pub use join::*;

    pub mod join {
        pub use hash_join::*;
        use polars_core::prelude::*;

        mod hash_join {
            pub use super::*;
        }
    }
}
```

1. The glob import `pub use super::*` inside `mod hash_join` reexports the visibility of the glob import `use polars_core::prelude::*` inside the `mod join` as "public", which was previously "module(join)"
2. The glob import `pub use hash_join::*` inside `mod join` overrides visibility of the previous visibility of the glob import `use polars_core::prelude::*` with "public" in 1., which was previously "module(join)"

The problematic step is 1., as rustc doesn't allow such re-export with E0603.
This PR prevent such "more visible" re-export by taking minimum of resolved item visibility and the re-export visibility