### PR TITLE
internal: log original syntax on panic

### DIFF
--- a/crates/span/src/ast_id.rs
+++ b/crates/span/src/ast_id.rs
@@ -224,9 +224,10 @@ impl AstIdMap {
         match self.map.raw_entry().from_hash(hash, |&idx| self.arena[idx] == ptr) {
             Some((&idx, &())) => ErasedFileAstId(idx.into_raw().into_u32()),
             None => panic!(
-                "Can't find {:?} in AstIdMap:\n{:?}",
+                "Can't find {:?} in AstIdMap:\n{:?}\n source text: {}",
                 item,
                 self.arena.iter().map(|(_id, i)| i).collect::<Vec<_>>(),
+                item
             ),
         }
     }


### PR DESCRIPTION
This _doesn't_ solve https://github.com/rust-lang/rust-analyzer/issues/18387, but should make the debugging the issue a lot easier.