### PR TITLE
internal: Pretty-print Config in status command

### DIFF
--- a/crates/rust-analyzer/src/handlers/request.rs
+++ b/crates/rust-analyzer/src/handlers/request.rs
@@ -119,7 +119,7 @@ pub(crate) fn handle_analyzer_status(
     format_to!(buf, "{}", crate::version());
 
     buf.push_str("\nConfiguration: \n");
-    format_to!(buf, "{:?}", snap.config);
+    format_to!(buf, "{:#?}", snap.config);
 
     Ok(buf)
 }


### PR DESCRIPTION
Config can become very big, even for relatively small rust projects, and printing everything on one line makes reading the output in VS Code harder.