### PR TITLE
fix: Add missing cfg flags for `core` crate

### DIFF
--- a/crates/project-model/src/rustc_cfg.rs
+++ b/crates/project-model/src/rustc_cfg.rs
@@ -24,14 +24,15 @@ pub(crate) fn get(
     config: RustcCfgConfig<'_>,
 ) -> Vec<CfgAtom> {
     let _p = tracing::info_span!("rustc_cfg::get").entered();
-    let mut res: Vec<_> = Vec::with_capacity(6 * 2 + 1);
+    let mut res: Vec<_> = Vec::with_capacity(7 * 2 + 1);
 
     // Some nightly-only cfgs, which are required for stdlib
     res.push(CfgAtom::Flag(Symbol::intern("target_thread_local")));
-    for ty in ["8", "16", "32", "64", "cas", "ptr"] {
-        for key in ["target_has_atomic", "target_has_atomic_load_store"] {
+    for key in ["target_has_atomic", "target_has_atomic_load_store"] {
+        for ty in ["8", "16", "32", "64", "cas", "ptr"] {
             res.push(CfgAtom::KeyValue { key: Symbol::intern(key), value: Symbol::intern(ty) });
         }
+        res.push(CfgAtom::Flag(Symbol::intern(key)));
     }
 
     let rustc_cfgs = get_rust_cfgs(target, extra_env, config);


### PR DESCRIPTION
Some types in `core` are conditionally compiled based on `target_has_atomic` or `target_has_atomic_load_store` without an argument, for example `AtomicU64`.

This is less noticeable in Cargo projects, where rust-analyzer adds the output of `RUSTC_BOOTSTRAP=1 cargo rustc --print cfg` so it gets the full set of cfg flags.

This fixes go-to-definition on `std::sync::atomic::AtomicU64` in non-cargo projects.