### PR TITLE
Fix formatting on welcome page, read only paths setting example

### DIFF
--- a/editors/code/.vscodeignore
+++ b/editors/code/.vscodeignore
@@ -12,3 +12,4 @@
 !ra_syntax_tree.tmGrammar.json
 !server
 !README.md
+!walkthrough-setup-tips.md

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -3224,10 +3224,9 @@
                     {
                         "id": "setup",
                         "title": "Useful Setup Tips",
-                        "description": "There are a couple of things you might want to configure upfront to your tastes. We'll name a few here but be sure to check out the docs linked below!\n\n**Marking library sources as readonly**\n\nAdding the following to your settings.json will mark all Rust library sources as readonly:\n```json\n\"files.readonlyInclude\": {\n    \"**/.cargo/registry/src/**/*.rs\": true,\n    \"**/lib/rustlib/src/rust/library/**/*.rs\": true,\n},\n```\n\n**Check on Save**\n\nBy default, rust-analyzer will run `cargo check` on your codebase when you save a file, rendering diagnostics emitted by `cargo check` within your code. This can potentially collide with other `cargo` commands running concurrently, blocking them from running for a certain amount of time. In these cases it is recommended to disable the `rust-analyzer.checkOnSave` configuration and running the `rust-analyzer: Run flycheck` command on-demand instead.",
+                        "description": "There are a couple of things you might want to configure upfront to your tastes. We'll name a few here but be sure to check out the docs linked below!\n\n**Marking library sources as readonly**\n\nAdding the snippet on the right to your settings.json will mark all Rust library sources as readonly.\n\n**Check on Save**\n\nBy default, rust-analyzer will run ``cargo check`` on your codebase when you save a file, rendering diagnostics emitted by ``cargo check`` within your code. This can potentially collide with other ``cargo`` commands running concurrently, blocking them from running for a certain amount of time. In these cases it is recommended to disable the ``rust-analyzer.checkOnSave`` configuration and running the ``rust-analyzer: Run flycheck`` command on-demand instead.",
                         "media": {
-                            "image": "./icon.png",
-                            "altText": "rust-analyzer logo"
+                            "markdown": "./walkthrough-setup-tips.md"
                         }
                     },
                     {
@@ -3245,7 +3244,7 @@
                     {
                         "id": "faq",
                         "title": "FAQ",
-                        "description": "What are these code hints that are being inserted into my code?\n\nThese hints are called inlay hints which rust-analyzer support and are enabled by default in VSCode. If you wish to disable them you can do so via the `editor.inlayHints.enabled` setting.",
+                        "description": "What are these code hints that are being inserted into my code?\n\nThese hints are called inlay hints which rust-analyzer support and are enabled by default in VSCode. If you wish to disable them you can do so via the ``editor.inlayHints.enabled`` setting.",
                         "media": {
                             "image": "icon.png",
                             "altText": "rust-analyzer logo"

--- a/editors/code/walkthrough-setup-tips.md
+++ b/editors/code/walkthrough-setup-tips.md
@@ -1,0 +1,10 @@
+# Settings Example
+
+Add the following to settings.json to mark Rust library sources as read-only:
+
+```json
+"files.readonlyInclude": {
+  "**/.cargo/registry/src/**/*.rs": true,
+  "**/lib/rustlib/src/rust/library/**/*.rs": true,
+},
+```


### PR DESCRIPTION
This attempts to resolve https://github.com/rust-lang/rust-analyzer/issues/17788.

It looks like the description text of the "walkthrough" steps doesn't support Markdown code blocks, but you can provide a Markdown file that will be rendered on the right half of the page in place of the logo image. This file does support code blocks and syntax highlighting, and as an added bonus, the text can be selected/copied.

The final result looks like this:
![image](https://github.com/user-attachments/assets/52977a64-1497-4a79-9f58-610edf4a14a6)

Additionally, it looks like this renderer expects double backticks for inline code snippets, so I updated the descriptions of the other walkthrough steps accordingly.