### PR TITLE
fix: Allow public re-export of `extern crate` import

### DIFF
--- a/crates/hir-def/src/item_tree.rs
+++ b/crates/hir-def/src/item_tree.rs
@@ -967,6 +967,11 @@ impl UseTree {
         self.expand_impl(None, &mut cb)
     }
 
+    /// The [`UseTreeKind`] of this `UseTree`.
+    pub fn kind(&self) -> &UseTreeKind {
+        &self.kind
+    }
+
     fn expand_impl(
         &self,
         prefix: Option<ModPath>,


### PR DESCRIPTION
MCVE:

```rust
//- /main.rs crate:main deps:test_crate
use test_crate::foo; // not resolving this!

use foo::Foo;

//- /lib.rs crate:test_crate deps:test_crate2
extern crate test_crate2;

pub use test_crate2 as foo;

//- /lib2.rs crate:test_crate2
pub struct Foo;
```

It seems that I should exempt min visibility for `extern crate`, as it seems to be exceptional in rustc 🤔

_Originally posted by @ShoyuVanilla in https://github.com/rust-lang/rust-analyzer/issues/18390#issuecomment-2438253336_

Should fix the regression made by #18390 
Thank you @lnicola for pointing out this regression 👍 