### PR TITLE
fix: Properly resolve prelude paths inside modules inside blocks

### DIFF
--- a/crates/ide-diagnostics/src/handlers/unresolved_macro_call.rs
+++ b/crates/ide-diagnostics/src/handlers/unresolved_macro_call.rs
@@ -82,4 +82,29 @@ self::m!(); self::m2!();
 "#,
         );
     }
+
+    #[test]
+    fn no_unresolved_panic_inside_mod_inside_fn() {
+        check_diagnostics(
+            r#"
+//- /core.rs library crate:core
+#[macro_export]
+macro_rules! panic {
+    () => {};
+}
+
+//- /lib.rs crate:foo deps:core
+#[macro_use]
+extern crate core;
+
+fn foo() {
+    mod init {
+        pub fn init() {
+            panic!();
+        }
+    }
+}
+    "#,
+        );
+    }
 }


### PR DESCRIPTION
I.e. the following situation:
```
fn foo() {
    mod bar {
        fn qux() {
            // Prelude path here (e.g. macro use prelude or extern prelude).
        }
    }
}
```
Those were previously unresolved, because, in order to support `self` and `super` properly, since #15148 we do not ascend block paths when there is a module in between, but only crate def maps register preludes, not block def maps, and we can't change this because block def map prelude can always be overridden by another block. E.g.
```
fn foo() {
    struct WithTheSameNameAsPreludeItem;
    {
        WithTheSameNameAsPreludeItem
    }
}
```
Here `WithTheSameNameAsPreludeItem` refer to the item from the top block, but if we would register prelude items in each block the child block would overwrite it incorrectly.

Fixes #18411.

I don't like the approach I took with the code, but I thought many times and couldn't find something better. I extracted a lot into functions. Still, name resolution is a meh (because it's a meh in Rust, not because of our implementation).