### PR TITLE
Cleanup TypeRef lowering

### DIFF
--- a/crates/hir-def/src/expander.rs
+++ b/crates/hir-def/src/expander.rs
@@ -161,14 +161,14 @@ impl Expander {
         types_map: &mut TypesMap,
         types_source_map: &mut TypesSourceMap,
     ) -> Option<Path> {
-        let ctx = LowerCtx::with_span_map_cell(
+        let mut ctx = LowerCtx::with_span_map_cell(
             db,
             self.current_file_id,
             self.span_map.clone(),
             types_map,
             types_source_map,
         );
-        Path::from_src(&ctx, path)
+        Path::from_src(&mut ctx, path)
     }
 
     fn within_limit<F, T: ast::AstNode>(

--- a/crates/hir-def/src/generics.rs
+++ b/crates/hir-def/src/generics.rs
@@ -451,7 +451,7 @@ pub(crate) struct GenericParamsCollector {
 impl GenericParamsCollector {
     pub(crate) fn fill(
         &mut self,
-        lower_ctx: &LowerCtx<'_>,
+        lower_ctx: &mut LowerCtx<'_>,
         node: &dyn HasGenericParams,
         add_param_attrs: impl FnMut(
             Either<LocalTypeOrConstParamId, LocalLifetimeParamId>,
@@ -468,7 +468,7 @@ impl GenericParamsCollector {
 
     pub(crate) fn fill_bounds(
         &mut self,
-        lower_ctx: &LowerCtx<'_>,
+        lower_ctx: &mut LowerCtx<'_>,
         type_bounds: Option<ast::TypeBoundList>,
         target: Either<TypeRefId, LifetimeRef>,
     ) {
@@ -479,7 +479,7 @@ impl GenericParamsCollector {
 
     fn fill_params(
         &mut self,
-        lower_ctx: &LowerCtx<'_>,
+        lower_ctx: &mut LowerCtx<'_>,
         params: ast::GenericParamList,
         mut add_param_attrs: impl FnMut(
             Either<LocalTypeOrConstParamId, LocalLifetimeParamId>,
@@ -535,7 +535,11 @@ impl GenericParamsCollector {
         }
     }
 
-    fn fill_where_predicates(&mut self, lower_ctx: &LowerCtx<'_>, where_clause: ast::WhereClause) {
+    fn fill_where_predicates(
+        &mut self,
+        lower_ctx: &mut LowerCtx<'_>,
+        where_clause: ast::WhereClause,
+    ) {
         for pred in where_clause.predicates() {
             let target = if let Some(type_ref) = pred.ty() {
                 Either::Left(TypeRef::from_ast(lower_ctx, type_ref))
@@ -569,7 +573,7 @@ impl GenericParamsCollector {
 
     fn add_where_predicate_from_bound(
         &mut self,
-        lower_ctx: &LowerCtx<'_>,
+        lower_ctx: &mut LowerCtx<'_>,
         bound: ast::TypeBound,
         hrtb_lifetimes: Option<&[Name]>,
         target: Either<TypeRefId, LifetimeRef>,
@@ -670,8 +674,9 @@ impl GenericParamsCollector {
                 {
                     let (mut macro_types_map, mut macro_types_source_map) =
                         (TypesMap::default(), TypesSourceMap::default());
-                    let ctx = expander.ctx(db, &mut macro_types_map, &mut macro_types_source_map);
-                    let type_ref = TypeRef::from_ast(&ctx, expanded.tree());
+                    let mut ctx =
+                        expander.ctx(db, &mut macro_types_map, &mut macro_types_source_map);
+                    let type_ref = TypeRef::from_ast(&mut ctx, expanded.tree());
                     self.fill_implicit_impl_trait_args(
                         db,
                         generics_types_map,

--- a/crates/hir-def/src/path.rs
+++ b/crates/hir-def/src/path.rs
@@ -121,7 +121,7 @@ pub enum GenericArg {
 impl Path {
     /// Converts an `ast::Path` to `Path`. Works with use trees.
     /// It correctly handles `$crate` based path from macro call.
-    pub fn from_src(ctx: &LowerCtx<'_>, path: ast::Path) -> Option<Path> {
+    pub fn from_src(ctx: &mut LowerCtx<'_>, path: ast::Path) -> Option<Path> {
         lower::lower_path(ctx, path)
     }
 
@@ -284,7 +284,7 @@ impl<'a> PathSegments<'a> {
 
 impl GenericArgs {
     pub(crate) fn from_ast(
-        lower_ctx: &LowerCtx<'_>,
+        lower_ctx: &mut LowerCtx<'_>,
         node: ast::GenericArgList,
     ) -> Option<GenericArgs> {
         lower::lower_generic_args(lower_ctx, node)

--- a/crates/hir-ty/src/display.rs
+++ b/crates/hir-ty/src/display.rs
@@ -2033,7 +2033,7 @@ impl HirDisplayWithTypesMap for TypeRefId {
             TypeRef::Macro(macro_call) => {
                 let (mut types_map, mut types_source_map) =
                     (TypesMap::default(), TypesSourceMap::default());
-                let ctx = hir_def::lower::LowerCtx::new(
+                let mut ctx = hir_def::lower::LowerCtx::new(
                     f.db.upcast(),
                     macro_call.file_id,
                     &mut types_map,
@@ -2041,7 +2041,7 @@ impl HirDisplayWithTypesMap for TypeRefId {
                 );
                 let macro_call = macro_call.to_node(f.db.upcast());
                 match macro_call.path() {
-                    Some(path) => match Path::from_src(&ctx, path) {
+                    Some(path) => match Path::from_src(&mut ctx, path) {
                         Some(path) => path.hir_fmt(f, &types_map)?,
                         None => write!(f, "{{macro}}")?,
                     },

--- a/crates/hir-ty/src/lower.rs
+++ b/crates/hir-ty/src/lower.rs
@@ -465,13 +465,13 @@ impl<'a> TyLoweringContext<'a> {
                             let (mut types_map, mut types_source_map) =
                                 (TypesMap::default(), TypesSourceMap::default());
 
-                            let ctx = expander.ctx(
+                            let mut ctx = expander.ctx(
                                 self.db.upcast(),
                                 &mut types_map,
                                 &mut types_source_map,
                             );
                             // FIXME: Report syntax errors in expansion here
-                            let type_ref = TypeRef::from_ast(&ctx, expanded.tree());
+                            let type_ref = TypeRef::from_ast(&mut ctx, expanded.tree());
 
                             drop(expander);
 

--- a/crates/hir/src/semantics.rs
+++ b/crates/hir/src/semantics.rs
@@ -1271,9 +1271,9 @@ impl<'db> SemanticsImpl<'db> {
         let analyze = self.analyze(ty.syntax())?;
         let (mut types_map, mut types_source_map) =
             (TypesMap::default(), TypesSourceMap::default());
-        let ctx =
+        let mut ctx =
             LowerCtx::new(self.db.upcast(), analyze.file_id, &mut types_map, &mut types_source_map);
-        let type_ref = crate::TypeRef::from_ast(&ctx, ty.clone());
+        let type_ref = crate::TypeRef::from_ast(&mut ctx, ty.clone());
         let ty = hir_ty::TyLoweringContext::new_maybe_unowned(
             self.db,
             &analyze.resolver,
@@ -1289,9 +1289,9 @@ impl<'db> SemanticsImpl<'db> {
         let analyze = self.analyze(path.syntax())?;
         let (mut types_map, mut types_source_map) =
             (TypesMap::default(), TypesSourceMap::default());
-        let ctx =
+        let mut ctx =
             LowerCtx::new(self.db.upcast(), analyze.file_id, &mut types_map, &mut types_source_map);
-        let hir_path = Path::from_src(&ctx, path.clone())?;
+        let hir_path = Path::from_src(&mut ctx, path.clone())?;
         match analyze.resolver.resolve_path_in_type_ns_fully(self.db.upcast(), &hir_path)? {
             TypeNs::TraitId(id) => Some(Trait { id }),
             _ => None,
@@ -1974,9 +1974,9 @@ impl SemanticsScope<'_> {
     pub fn speculative_resolve(&self, ast_path: &ast::Path) -> Option<PathResolution> {
         let (mut types_map, mut types_source_map) =
             (TypesMap::default(), TypesSourceMap::default());
-        let ctx =
+        let mut ctx =
             LowerCtx::new(self.db.upcast(), self.file_id, &mut types_map, &mut types_source_map);
-        let path = Path::from_src(&ctx, ast_path.clone())?;
+        let path = Path::from_src(&mut ctx, ast_path.clone())?;
         resolve_hir_path(
             self.db,
             &self.resolver,

--- a/crates/hir/src/source_analyzer.rs
+++ b/crates/hir/src/source_analyzer.rs
@@ -616,9 +616,9 @@ impl SourceAnalyzer {
     ) -> Option<Macro> {
         let (mut types_map, mut types_source_map) =
             (TypesMap::default(), TypesSourceMap::default());
-        let ctx =
+        let mut ctx =
             LowerCtx::new(db.upcast(), macro_call.file_id, &mut types_map, &mut types_source_map);
-        let path = macro_call.value.path().and_then(|ast| Path::from_src(&ctx, ast))?;
+        let path = macro_call.value.path().and_then(|ast| Path::from_src(&mut ctx, ast))?;
         self.resolver
             .resolve_path_as_macro(db.upcast(), path.mod_path()?, Some(MacroSubNs::Bang))
             .map(|(it, _)| it.into())
@@ -731,8 +731,9 @@ impl SourceAnalyzer {
 
         let (mut types_map, mut types_source_map) =
             (TypesMap::default(), TypesSourceMap::default());
-        let ctx = LowerCtx::new(db.upcast(), self.file_id, &mut types_map, &mut types_source_map);
-        let hir_path = Path::from_src(&ctx, path.clone())?;
+        let mut ctx =
+            LowerCtx::new(db.upcast(), self.file_id, &mut types_map, &mut types_source_map);
+        let hir_path = Path::from_src(&mut ctx, path.clone())?;
 
         // Case where path is a qualifier of a use tree, e.g. foo::bar::{Baz, Qux} where we are
         // trying to resolve foo::bar.


### PR DESCRIPTION
By removing interior mutability from it.

I tried to also cleanup `TyLoweringContext`, but it is much more cursed... I will continue to try.