### PR TITLE
Publish test-fixture => ra_ap_test_fixture

### DIFF
--- a/.github/workflows/autopublish.yaml
+++ b/.github/workflows/autopublish.yaml
@@ -51,6 +51,7 @@ jobs:
           cargo workspaces rename --from proc-macro-api proc_macro_api
           cargo workspaces rename --from proc-macro-srv proc_macro_srv
           cargo workspaces rename --from project-model project_model
+          cargo workspaces rename --from test-fixture test_fixture
           cargo workspaces rename --from test-utils test_utils
           cargo workspaces rename --from text-edit text_edit
           # Remove library crates from the workspaces so we don't auto-publish them as well

--- a/crates/test-fixture/Cargo.toml
+++ b/crates/test-fixture/Cargo.toml
@@ -5,7 +5,6 @@ rust-version.workspace = true
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
-publish = false
 
 [dependencies]
 hir-expand.workspace = true


### PR DESCRIPTION
Currently it's possible to build rust-analyzer from the ra_ap crates, but not
possible to build their tests, as test-fixture isn't published.

If there isn't a particular reason to exclude this crate, I'd like to publish
it so that tests can be built and run from crates.io sources.

Context: I'm importing rust-analyzer code into a non-cargo build environment
(using Bazel). We'd prefer to import from crates.io for uniformity with other
libraries, and to build and run all tests to make sure we didn't break anything.
