### PR TITLE
Test function imports replaced by module imports.

### DIFF
--- a/crates/ide-assists/src/handlers/auto_import.rs
+++ b/crates/ide-assists/src/handlers/auto_import.rs
@@ -1722,4 +1722,39 @@ mod foo {
             ",
         );
     }
+
+    #[test]
+    fn check_understands_function_and_module_imports() {
+        // FIXME(18347): import of `bar` should not be converted
+        // to `bar::{self}`. The former is a function, the latter is a module.
+        check_assist(
+            auto_import,
+            r"
+            use foo::bar;
+
+            mod foo {
+                pub fn bar() {}
+
+                pub mod bar {
+                    pub fn baz() {}
+                }
+            }
+
+            baz$0();
+            ",
+            r"
+            use foo::bar::{self, baz};
+
+            mod foo {
+                pub fn bar() {}
+
+                pub mod bar {
+                    pub fn baz() {}
+                }
+            }
+
+            baz();
+            ",
+        );
+    }
 }

--- a/crates/ide-assists/src/handlers/merge_imports.rs
+++ b/crates/ide-assists/src/handlers/merge_imports.rs
@@ -802,4 +802,36 @@ use top::{a::A, b::{B as D, B as C}};
 ",
         );
     }
+
+    #[test]
+    fn test_doesnt_convert_function_to_module() {
+        // FIXME(18347): import of `bar` should not be converted
+        // to `bar::{self}`. The former is a function, the latter is a module.
+        check_assist(
+            merge_imports,
+            r"
+mod foo {
+    pub fn bar() {}
+
+    pub mod bar {
+        pub fn baz() {}
+    }
+}
+
+use foo::bar;
+use $0foo::bar::baz;
+",
+            r"
+mod foo {
+    pub fn bar() {}
+
+    pub mod bar {
+        pub fn baz() {}
+    }
+}
+
+use foo::bar::{self, baz};
+",
+        );
+    }
 }


### PR DESCRIPTION
Test for #18347.
The issue affects all code using import merging. When a function and a module share the same identifier, e.g.

```rust
pub fn foo() {}
pub mod foo { pub fn bar() {} }
```

rust analyzer often confuses the function with the module, generating invalid code.