### PR TITLE
minor: Enable triagebot `transfer` feature

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -19,3 +19,5 @@ exclude_titles = [ # exclude syncs from subtree in rust-lang/rust
     "sync from rust",
 ]
 labels = ["has-merge-commits", "S-waiting-on-author"]
+
+[transfer]


### PR DESCRIPTION
Same as https://github.com/rust-lang/cargo/pull/14777

> The source repository must have an empty transfer table to enable transfers from that repository. Issues can be transferred to any repository in the rust-lang org.

CC @Urgau