### PR TITLE
internal: Add public `direct_supertraits(…)` & `all_supertraits(…)` accessor methods to `hir::Trait`

### DIFF
--- a/crates/hir-ty/src/lib.rs
+++ b/crates/hir-ty/src/lib.rs
@@ -98,7 +98,7 @@ pub use mapping::{
 };
 pub use method_resolution::check_orphan_rules;
 pub use traits::TraitEnvironment;
-pub use utils::{all_super_traits, is_fn_unsafe_to_call};
+pub use utils::{all_super_traits, direct_super_traits, is_fn_unsafe_to_call};
 
 pub use chalk_ir::{
     cast::Cast,

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -68,7 +68,7 @@ use hir_ty::{
     all_super_traits, autoderef, check_orphan_rules,
     consteval::{try_const_usize, unknown_const_as_generic, ConstExt},
     diagnostics::BodyValidationDiagnostic,
-    error_lifetime, known_const_to_ast,
+    direct_super_traits, error_lifetime, known_const_to_ast,
     layout::{Layout as TyLayout, RustcEnumVariantIdx, RustcFieldIdx, TagEncoding},
     method_resolution,
     mir::{interpret_mir, MutBorrowKind},
@@ -2702,6 +2702,11 @@ impl Trait {
 
     pub fn name(self, db: &dyn HirDatabase) -> Name {
         db.trait_data(self.id).name.clone()
+    }
+
+    pub fn direct_supertraits(self, db: &dyn HirDatabase) -> Vec<Trait> {
+        let traits = direct_super_traits(db.upcast(), self.into());
+        traits.iter().map(|tr| Trait::from(*tr)).collect()
     }
 
     pub fn all_supertraits(self, db: &dyn HirDatabase) -> Vec<Trait> {

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -2714,8 +2714,7 @@ impl Trait {
     }
 
     pub fn items_with_supertraits(self, db: &dyn HirDatabase) -> Vec<AssocItem> {
-        let traits = all_super_traits(db.upcast(), self.into());
-        traits.iter().flat_map(|tr| Trait::from(*tr).items(db)).collect()
+        self.all_supertraits(db).into_iter().flat_map(|tr| tr.items(db)).collect()
     }
 
     pub fn is_auto(self, db: &dyn HirDatabase) -> bool {

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -2704,6 +2704,11 @@ impl Trait {
         db.trait_data(self.id).name.clone()
     }
 
+    pub fn all_supertraits(self, db: &dyn HirDatabase) -> Vec<Trait> {
+        let traits = all_super_traits(db.upcast(), self.into());
+        traits.iter().map(|tr| Trait::from(*tr)).collect()
+    }
+
     pub fn items(self, db: &dyn HirDatabase) -> Vec<AssocItem> {
         db.trait_data(self.id).items.iter().map(|(_name, it)| (*it).into()).collect()
     }


### PR DESCRIPTION
Hi @Veykril,

I need to access a trait's supertraits (as external user of `ra_ap`'s APIs) and while `hir_ty::all_super_traits()` already provides such capabilities to a limited degree I'd like to propose the following accessors on `hir::Trait` itself, it only does provide access to the entire trait hierarchy (while I only want the direct supertraits) and requires a descent into `hir_ty` land. I'd thus like to propose adding the following methods: `hir::Trait::direct_supertraits(db)` & `hir::Trait::all_supertraits(db)`.

---

There seems to be some naming inconsistency with regard to `supertrait` (43 occurrences) vs. `super_trait` (53 occurrences) in the codebase. (I'd be happy to open a follow-up PR unifying the project-wide naming, if so desired.)
I went with `supertraits` in this PR since that's what the already existing `hir::Trait::items_with_supertraits(…)` uses in close proximity to the newly added methods.