### PR TITLE
Migrate `introduce_named_generic` Assist to Use `SyntaxFactory`

### DIFF
--- a/crates/ide-assists/src/handlers/introduce_named_generic.rs
+++ b/crates/ide-assists/src/handlers/introduce_named_generic.rs
@@ -42,8 +42,6 @@ pub(crate) fn introduce_named_generic(acc: &mut Assists, ctx: &AssistContext<'_>
         target,
         |edit| {
             let mut editor = edit.make_editor(&parent_node);
-            let impl_trait_type = edit.make_mut(impl_trait_type);
-            let fn_ = edit.make_mut(fn_);
             let fn_generic_param_list = fn_.get_or_create_generic_param_list();
 
             let existing_names = fn_generic_param_list

--- a/crates/ide-assists/src/handlers/introduce_named_generic.rs
+++ b/crates/ide-assists/src/handlers/introduce_named_generic.rs
@@ -56,13 +56,11 @@ pub(crate) fn introduce_named_generic(acc: &mut Assists, ctx: &AssistContext<'_>
             )
             .for_impl_trait_as_generic(&impl_trait_type);
 
-            let type_param = make
-                .type_param(make.name(&type_param_name), Some(type_bound_list))
-                .clone_for_update();
-            let new_ty = make.ty(&type_param_name).clone_for_update();
+            let type_param = make.type_param(make.name(&type_param_name), Some(type_bound_list));
+            let new_ty = make.ty(&type_param_name);
 
             editor.replace(impl_trait_type.syntax(), new_ty.syntax());
-            fn_generic_param_list.add_generic_param(type_param.into());
+            fn_generic_param_list.syntax_editor_add_generic_param(&mut editor, type_param.into());
 
             if let Some(cap) = ctx.config.snippet_cap {
                 if let Some(generic_param) =

--- a/crates/ide-assists/src/handlers/introduce_named_generic.rs
+++ b/crates/ide-assists/src/handlers/introduce_named_generic.rs
@@ -51,7 +51,7 @@ pub(crate) fn introduce_named_generic(acc: &mut Assists, ctx: &AssistContext<'_>
 
             editor.replace(impl_trait_type.syntax(), new_ty.syntax());
             let generic_param = syntax::ast::GenericParam::from(type_param);
-            fn_.syntax_editor_add_generic_param(&mut editor, generic_param.clone());
+            editor.syntax_editor_add_generic_param(fn_, generic_param.clone());
 
             if let Some(cap) = ctx.config.snippet_cap {
                 editor.add_annotation(generic_param.syntax(), builder.make_tabstop_before(cap));

--- a/crates/ide-assists/src/handlers/introduce_named_generic.rs
+++ b/crates/ide-assists/src/handlers/introduce_named_generic.rs
@@ -1,10 +1,7 @@
 use ide_db::syntax_helpers::suggest_name;
 use itertools::Itertools;
 use syntax::{
-    ast::{
-        self, edit_in_place::GenericParamsOwnerEdit, syntax_factory::SyntaxFactory, AstNode,
-        HasGenericParams, HasName,
-    },
+    ast::{self, syntax_factory::SyntaxFactory, AstNode, HasGenericParams, HasName},
     SyntaxElement,
 };
 
@@ -42,7 +39,8 @@ pub(crate) fn introduce_named_generic(acc: &mut Assists, ctx: &AssistContext<'_>
         target,
         |edit| {
             let mut editor = edit.make_editor(&parent_node);
-            let fn_generic_param_list = fn_.get_or_create_generic_param_list();
+            let fn_generic_param_list =
+                fn_.syntax_editor_get_or_create_generic_param_list(&mut editor);
 
             let existing_names = fn_generic_param_list
                 .generic_params()

--- a/crates/ide-assists/src/handlers/introduce_named_generic.rs
+++ b/crates/ide-assists/src/handlers/introduce_named_generic.rs
@@ -59,14 +59,11 @@ pub(crate) fn introduce_named_generic(acc: &mut Assists, ctx: &AssistContext<'_>
             let new_ty = make.ty(&type_param_name);
 
             editor.replace(impl_trait_type.syntax(), new_ty.syntax());
-            fn_.syntax_editor_add_generic_param(&mut editor, type_param.into());
+            let generic_param = syntax::ast::GenericParam::from(type_param);
+            fn_.syntax_editor_add_generic_param(&mut editor, generic_param.clone());
 
             if let Some(cap) = ctx.config.snippet_cap {
-                if let Some(generic_param) =
-                    fn_.generic_param_list().and_then(|it| it.generic_params().last())
-                {
-                    editor.add_annotation(generic_param.syntax(), edit.make_tabstop_before(cap));
-                }
+                editor.add_annotation(generic_param.syntax(), edit.make_tabstop_before(cap));
             }
 
             editor.add_mappings(make.finish_with_mappings());

--- a/crates/ide-assists/src/handlers/introduce_named_generic.rs
+++ b/crates/ide-assists/src/handlers/introduce_named_generic.rs
@@ -50,7 +50,7 @@ pub(crate) fn introduce_named_generic(acc: &mut Assists, ctx: &AssistContext<'_>
             let new_ty = make.ty(&type_param_name);
 
             editor.replace(impl_trait_type.syntax(), new_ty.syntax());
-            editor.syntax_editor_add_generic_param(fn_, type_param.clone().into());
+            editor.add_generic_param(&fn_, type_param.clone().into());
 
             if let Some(cap) = ctx.config.snippet_cap {
                 editor.add_annotation(type_param.syntax(), builder.make_tabstop_before(cap));

--- a/crates/ide-assists/src/handlers/introduce_named_generic.rs
+++ b/crates/ide-assists/src/handlers/introduce_named_generic.rs
@@ -50,11 +50,10 @@ pub(crate) fn introduce_named_generic(acc: &mut Assists, ctx: &AssistContext<'_>
             let new_ty = make.ty(&type_param_name);
 
             editor.replace(impl_trait_type.syntax(), new_ty.syntax());
-            let generic_param = syntax::ast::GenericParam::from(type_param);
-            editor.syntax_editor_add_generic_param(fn_, generic_param.clone());
+            editor.syntax_editor_add_generic_param(fn_, type_param.clone().into());
 
             if let Some(cap) = ctx.config.snippet_cap {
-                editor.add_annotation(generic_param.syntax(), builder.make_tabstop_before(cap));
+                editor.add_annotation(type_param.syntax(), builder.make_tabstop_before(cap));
             }
 
             editor.add_mappings(make.finish_with_mappings());

--- a/crates/syntax/src/ast/edit_in_place.rs
+++ b/crates/syntax/src/ast/edit_in_place.rs
@@ -64,40 +64,38 @@ impl ast::Fn {
     ) {
         match self.generic_param_list() {
             Some(generic_param_list) => match generic_param_list.generic_params().last() {
-                Some(_last_param) => {
+                Some(last_param) => {
                     // There exists a generic param list and it's not empty
                     let position = generic_param_list.r_angle_token().map_or_else(
                         || crate::syntax_editor::Position::last_child_of(self.syntax()),
                         crate::syntax_editor::Position::before,
                     );
 
-                    if let Some(last_param) = generic_param_list.generic_params().last() {
-                        if last_param
-                            .syntax()
-                            .next_sibling_or_token()
-                            .map_or(false, |it| it.kind() == SyntaxKind::COMMA)
-                        {
-                            editor.insert(
-                                crate::syntax_editor::Position::after(last_param.syntax()),
-                                new_param.syntax().clone(),
-                            );
-                            editor.insert(
-                                crate::syntax_editor::Position::after(last_param.syntax()),
-                                make::token(SyntaxKind::WHITESPACE),
-                            );
-                            editor.insert(
-                                crate::syntax_editor::Position::after(last_param.syntax()),
-                                make::token(SyntaxKind::COMMA),
-                            );
-                        } else {
-                            let elements = vec![
-                                make::token(SyntaxKind::COMMA).into(),
-                                make::token(SyntaxKind::WHITESPACE).into(),
-                                new_param.syntax().clone().into(),
-                            ];
-                            editor.insert_all(position, elements);
-                        }
-                    };
+                    if last_param
+                        .syntax()
+                        .next_sibling_or_token()
+                        .map_or(false, |it| it.kind() == SyntaxKind::COMMA)
+                    {
+                        editor.insert(
+                            crate::syntax_editor::Position::after(last_param.syntax()),
+                            new_param.syntax().clone(),
+                        );
+                        editor.insert(
+                            crate::syntax_editor::Position::after(last_param.syntax()),
+                            make::token(SyntaxKind::WHITESPACE),
+                        );
+                        editor.insert(
+                            crate::syntax_editor::Position::after(last_param.syntax()),
+                            make::token(SyntaxKind::COMMA),
+                        );
+                    } else {
+                        let elements = vec![
+                            make::token(SyntaxKind::COMMA).into(),
+                            make::token(SyntaxKind::WHITESPACE).into(),
+                            new_param.syntax().clone().into(),
+                        ];
+                        editor.insert_all(position, elements);
+                    }
                 }
                 None => {
                     // There exists a generic param list but it's empty

--- a/crates/syntax/src/ast/edit_in_place.rs
+++ b/crates/syntax/src/ast/edit_in_place.rs
@@ -121,7 +121,7 @@ impl ast::Fn {
                 let elements = vec![
                     make::token(SyntaxKind::L_ANGLE).into(),
                     new_param.syntax().clone().into(),
-                    make::token(T![>]).into(),
+                    make::token(SyntaxKind::R_ANGLE).into(),
                 ];
                 editor.insert_all(position, elements);
             }

--- a/crates/syntax/src/ast/edit_in_place.rs
+++ b/crates/syntax/src/ast/edit_in_place.rs
@@ -55,6 +55,29 @@ impl GenericParamsOwnerEdit for ast::Fn {
     }
 }
 
+impl ast::Fn {
+    pub fn syntax_editor_get_or_create_generic_param_list(
+        &self,
+        editor: &mut SyntaxEditor,
+    ) -> ast::GenericParamList {
+        match self.generic_param_list() {
+            Some(it) => it,
+            None => {
+                let position = if let Some(name) = self.name() {
+                    crate::syntax_editor::Position::after(name.syntax)
+                } else if let Some(fn_token) = self.fn_token() {
+                    crate::syntax_editor::Position::after(fn_token)
+                } else if let Some(param_list) = self.param_list() {
+                    crate::syntax_editor::Position::before(param_list.syntax)
+                } else {
+                    crate::syntax_editor::Position::last_child_of(self.syntax())
+                };
+                syntax_editor_create_generic_param_list(editor, position)
+            }
+        }
+    }
+}
+
 impl GenericParamsOwnerEdit for ast::Impl {
     fn get_or_create_generic_param_list(&self) -> ast::GenericParamList {
         match self.generic_param_list() {
@@ -188,6 +211,15 @@ fn create_where_clause(position: Position) {
 fn create_generic_param_list(position: Position) -> ast::GenericParamList {
     let gpl = make::generic_param_list(empty()).clone_for_update();
     ted::insert_raw(position, gpl.syntax());
+    gpl
+}
+
+fn syntax_editor_create_generic_param_list(
+    editor: &mut SyntaxEditor,
+    position: crate::syntax_editor::Position,
+) -> ast::GenericParamList {
+    let gpl = make::generic_param_list(empty()).clone_for_update();
+    editor.insert(position, gpl.syntax());
     gpl
 }
 

--- a/crates/syntax/src/ast/edit_in_place.rs
+++ b/crates/syntax/src/ast/edit_in_place.rs
@@ -7,6 +7,7 @@ use parser::{SyntaxKind, T};
 use crate::{
     algo::{self, neighbor},
     ast::{self, edit::IndentLevel, make, HasGenericArgs, HasGenericParams},
+    syntax_editor::SyntaxEditor,
     ted::{self, Position},
     AstNode, AstToken, Direction, SyntaxElement,
     SyntaxKind::{ATTR, COMMENT, WHITESPACE},
@@ -253,6 +254,29 @@ impl ast::GenericParamList {
             None => {
                 let after_l_angle = Position::after(self.l_angle_token().unwrap());
                 ted::insert(after_l_angle, generic_param.syntax());
+            }
+        }
+    }
+
+    pub fn syntax_editor_add_generic_param(
+        &self,
+        editor: &mut SyntaxEditor,
+        generic_param: ast::GenericParam,
+    ) {
+        match self.generic_params().last() {
+            Some(last_param) => {
+                let position = crate::syntax_editor::Position::after(last_param.syntax());
+                let elements = vec![
+                    make::token(T![,]).into(),
+                    make::tokens::single_space().into(),
+                    generic_param.syntax().clone().into(),
+                ];
+                editor.insert_all(position, elements);
+            }
+            None => {
+                let after_l_angle =
+                    crate::syntax_editor::Position::after(self.l_angle_token().unwrap());
+                editor.insert(after_l_angle, generic_param.syntax());
             }
         }
     }

--- a/crates/syntax/src/ast/edit_in_place.rs
+++ b/crates/syntax/src/ast/edit_in_place.rs
@@ -293,22 +293,21 @@ impl ast::GenericParamList {
     pub fn syntax_editor_add_generic_param(
         &self,
         editor: &mut SyntaxEditor,
-        generic_param: ast::GenericParam,
+        new_param: ast::GenericParam,
     ) {
         match self.generic_params().last() {
-            Some(last_param) => {
-                let position = crate::syntax_editor::Position::after(last_param.syntax());
-                let elements = vec![
-                    make::token(T![,]).into(),
-                    make::tokens::single_space().into(),
-                    generic_param.syntax().clone().into(),
-                ];
-                editor.insert_all(position, elements);
+            Some(_) => {
+                let mut params =
+                    self.generic_params().map(|param| param.clone()).collect::<Vec<_>>();
+                params.push(new_param.into());
+                let new_param_list = make::generic_param_list(params);
+
+                editor.replace(self.syntax(), new_param_list.syntax());
             }
             None => {
-                let after_l_angle =
-                    crate::syntax_editor::Position::after(self.l_angle_token().unwrap());
-                editor.insert(after_l_angle, generic_param.syntax());
+                let position = crate::syntax_editor::Position::after(self.l_angle_token().unwrap());
+                let new_param_list = make::generic_param_list(once(new_param.clone()));
+                editor.insert(position, new_param_list.syntax());
             }
         }
     }

--- a/crates/syntax/src/ast/edit_in_place.rs
+++ b/crates/syntax/src/ast/edit_in_place.rs
@@ -7,7 +7,6 @@ use parser::{SyntaxKind, T};
 use crate::{
     algo::{self, neighbor},
     ast::{self, edit::IndentLevel, make, HasGenericArgs, HasGenericParams},
-    syntax_editor::SyntaxEditor,
     ted::{self, Position},
     AstNode, AstToken, Direction, SyntaxElement,
     SyntaxKind::{ATTR, COMMENT, WHITESPACE},
@@ -52,78 +51,6 @@ impl GenericParamsOwnerEdit for ast::Fn {
             create_where_clause(position);
         }
         self.where_clause().unwrap()
-    }
-}
-
-impl ast::Fn {
-    /// Adds a new generic param to the function using `SyntaxEditor`
-    pub fn syntax_editor_add_generic_param(
-        &self,
-        editor: &mut SyntaxEditor,
-        new_param: GenericParam,
-    ) {
-        match self.generic_param_list() {
-            Some(generic_param_list) => match generic_param_list.generic_params().last() {
-                Some(last_param) => {
-                    // There exists a generic param list and it's not empty
-                    let position = generic_param_list.r_angle_token().map_or_else(
-                        || crate::syntax_editor::Position::last_child_of(self.syntax()),
-                        crate::syntax_editor::Position::before,
-                    );
-
-                    if last_param
-                        .syntax()
-                        .next_sibling_or_token()
-                        .map_or(false, |it| it.kind() == SyntaxKind::COMMA)
-                    {
-                        editor.insert(
-                            crate::syntax_editor::Position::after(last_param.syntax()),
-                            new_param.syntax().clone(),
-                        );
-                        editor.insert(
-                            crate::syntax_editor::Position::after(last_param.syntax()),
-                            make::token(SyntaxKind::WHITESPACE),
-                        );
-                        editor.insert(
-                            crate::syntax_editor::Position::after(last_param.syntax()),
-                            make::token(SyntaxKind::COMMA),
-                        );
-                    } else {
-                        let elements = vec![
-                            make::token(SyntaxKind::COMMA).into(),
-                            make::token(SyntaxKind::WHITESPACE).into(),
-                            new_param.syntax().clone().into(),
-                        ];
-                        editor.insert_all(position, elements);
-                    }
-                }
-                None => {
-                    // There exists a generic param list but it's empty
-                    let position = crate::syntax_editor::Position::after(
-                        generic_param_list.l_angle_token().unwrap(),
-                    );
-                    editor.insert(position, new_param.syntax());
-                }
-            },
-            None => {
-                // There was no generic param list
-                let position = if let Some(name) = self.name() {
-                    crate::syntax_editor::Position::after(name.syntax)
-                } else if let Some(fn_token) = self.fn_token() {
-                    crate::syntax_editor::Position::after(fn_token)
-                } else if let Some(param_list) = self.param_list() {
-                    crate::syntax_editor::Position::before(param_list.syntax)
-                } else {
-                    crate::syntax_editor::Position::last_child_of(self.syntax())
-                };
-                let elements = vec![
-                    make::token(SyntaxKind::L_ANGLE).into(),
-                    new_param.syntax().clone().into(),
-                    make::token(SyntaxKind::R_ANGLE).into(),
-                ];
-                editor.insert_all(position, elements);
-            }
-        }
     }
 }
 

--- a/crates/syntax/src/ast/syntax_factory/constructors.rs
+++ b/crates/syntax/src/ast/syntax_factory/constructors.rs
@@ -2,7 +2,7 @@
 use itertools::Itertools;
 
 use crate::{
-    ast::{self, make, HasName},
+    ast::{self, make, HasName, HasTypeBounds},
     syntax_editor::SyntaxMappingBuilder,
     AstNode,
 };
@@ -15,7 +15,6 @@ impl SyntaxFactory {
     }
 
     pub fn ty(&self, text: &str) -> ast::Type {
-        // FIXME: Is there anything to map here?
         make::ty(text).clone_for_update()
     }
 
@@ -29,6 +28,12 @@ impl SyntaxFactory {
         if let Some(mut mapping) = self.mappings() {
             let mut builder = SyntaxMappingBuilder::new(ast.syntax().clone());
             builder.map_node(name.syntax().clone(), ast.name().unwrap().syntax().clone());
+            if let Some(input) = bounds {
+                builder.map_node(
+                    input.syntax().clone(),
+                    ast.type_bound_list().unwrap().syntax().clone(),
+                );
+            }
             builder.finish(&mut mapping);
         }
 

--- a/crates/syntax/src/ast/syntax_factory/constructors.rs
+++ b/crates/syntax/src/ast/syntax_factory/constructors.rs
@@ -14,6 +14,27 @@ impl SyntaxFactory {
         make::name(name).clone_for_update()
     }
 
+    pub fn ty(&self, text: &str) -> ast::Type {
+        // FIXME: Is there anything to map here?
+        make::ty(text).clone_for_update()
+    }
+
+    pub fn type_param(
+        &self,
+        name: ast::Name,
+        bounds: Option<ast::TypeBoundList>,
+    ) -> ast::TypeParam {
+        let ast = make::type_param(name.clone(), bounds.clone()).clone_for_update();
+
+        if let Some(mut mapping) = self.mappings() {
+            let mut builder = SyntaxMappingBuilder::new(ast.syntax().clone());
+            builder.map_node(name.syntax().clone(), ast.name().unwrap().syntax().clone());
+            builder.finish(&mut mapping);
+        }
+
+        ast
+    }
+
     pub fn ident_pat(&self, ref_: bool, mut_: bool, name: ast::Name) -> ast::IdentPat {
         let ast = make::ident_pat(ref_, mut_, name.clone()).clone_for_update();
 

--- a/crates/syntax/src/syntax_editor.rs
+++ b/crates/syntax/src/syntax_editor.rs
@@ -16,6 +16,7 @@ use rustc_hash::FxHashMap;
 use crate::{SyntaxElement, SyntaxNode, SyntaxToken};
 
 mod edit_algo;
+mod edits;
 mod mapping;
 
 pub use mapping::{SyntaxMapping, SyntaxMappingBuilder};

--- a/crates/syntax/src/syntax_editor/edits.rs
+++ b/crates/syntax/src/syntax_editor/edits.rs
@@ -1,0 +1,72 @@
+//! Structural editing for ast using `SyntaxEditor`
+
+use crate::{
+    ast::make, ast::AstNode, ast::Fn, ast::GenericParam, ast::HasGenericParams, ast::HasName,
+    syntax_editor::Position, syntax_editor::SyntaxEditor, SyntaxKind,
+};
+
+impl SyntaxEditor {
+    /// Adds a new generic param to the function using `SyntaxEditor`
+    pub fn syntax_editor_add_generic_param(&mut self, function: Fn, new_param: GenericParam) {
+        match function.generic_param_list() {
+            Some(generic_param_list) => match generic_param_list.generic_params().last() {
+                Some(last_param) => {
+                    // There exists a generic param list and it's not empty
+                    let position = generic_param_list.r_angle_token().map_or_else(
+                        || Position::last_child_of(function.syntax()),
+                        Position::before,
+                    );
+
+                    if last_param
+                        .syntax()
+                        .next_sibling_or_token()
+                        .map_or(false, |it| it.kind() == SyntaxKind::COMMA)
+                    {
+                        self.insert(
+                            Position::after(last_param.syntax()),
+                            new_param.syntax().clone(),
+                        );
+                        self.insert(
+                            Position::after(last_param.syntax()),
+                            make::token(SyntaxKind::WHITESPACE),
+                        );
+                        self.insert(
+                            Position::after(last_param.syntax()),
+                            make::token(SyntaxKind::COMMA),
+                        );
+                    } else {
+                        let elements = vec![
+                            make::token(SyntaxKind::COMMA).into(),
+                            make::token(SyntaxKind::WHITESPACE).into(),
+                            new_param.syntax().clone().into(),
+                        ];
+                        self.insert_all(position, elements);
+                    }
+                }
+                None => {
+                    // There exists a generic param list but it's empty
+                    let position = Position::after(generic_param_list.l_angle_token().unwrap());
+                    self.insert(position, new_param.syntax());
+                }
+            },
+            None => {
+                // There was no generic param list
+                let position = if let Some(name) = function.name() {
+                    Position::after(name.syntax)
+                } else if let Some(fn_token) = function.fn_token() {
+                    Position::after(fn_token)
+                } else if let Some(param_list) = function.param_list() {
+                    Position::before(param_list.syntax)
+                } else {
+                    Position::last_child_of(function.syntax())
+                };
+                let elements = vec![
+                    make::token(SyntaxKind::L_ANGLE).into(),
+                    new_param.syntax().clone().into(),
+                    make::token(SyntaxKind::R_ANGLE).into(),
+                ];
+                self.insert_all(position, elements);
+            }
+        }
+    }
+}

--- a/crates/syntax/src/syntax_editor/edits.rs
+++ b/crates/syntax/src/syntax_editor/edits.rs
@@ -7,7 +7,7 @@ use crate::{
 
 impl SyntaxEditor {
     /// Adds a new generic param to the function using `SyntaxEditor`
-    pub fn syntax_editor_add_generic_param(&mut self, function: Fn, new_param: GenericParam) {
+    pub fn add_generic_param(&mut self, function: &Fn, new_param: GenericParam) {
         match function.generic_param_list() {
             Some(generic_param_list) => match generic_param_list.generic_params().last() {
                 Some(last_param) => {


### PR DESCRIPTION
This PR is part of #15710 and #18285.

**Changes Made**
- Followed the steps in #18285 for migration.
- Added a new `SyntaxFactory` method, `type_param`.
- Replaced `add_generic_param` (originally in `GenericParamList`) with a new method, `syntax_editor_add_generic_param`. This new method is similar but takes a `SyntaxEditor` instance instead of `ted` to avoid the “immutable tree” error.