### PR TITLE
Migrate `merge_imports` Assist to Use `SyntaxFactory`

### DIFF
--- a/crates/ide-assists/src/handlers/merge_imports.rs
+++ b/crates/ide-assists/src/handlers/merge_imports.rs
@@ -6,8 +6,10 @@ use ide_db::imports::{
 use itertools::Itertools;
 use syntax::{
     algo::neighbor,
-    ast::{self, edit_in_place::EditorRemovable, syntax_factory::SyntaxFactory},
-    match_ast, AstNode, SyntaxElement, SyntaxNode,
+    ast::{self, syntax_factory::SyntaxFactory},
+    match_ast,
+    syntax_editor::edits::Removable,
+    AstNode, SyntaxElement, SyntaxNode,
 };
 
 use crate::{
@@ -68,7 +70,6 @@ pub(crate) fn merge_imports(acc: &mut Assists, ctx: &AssistContext<'_>) -> Optio
         (selection_range, edits?)
     };
 
-    // FIXME: Is this the best to get a `SyntaxNode` object? We need one for `SourceChangeBuilder::make_editor`.
     let parent_node = match ctx.covering_element() {
         SyntaxElement::Node(n) => n,
         SyntaxElement::Token(t) => t.parent()?,

--- a/crates/ide-assists/src/handlers/merge_imports.rs
+++ b/crates/ide-assists/src/handlers/merge_imports.rs
@@ -6,8 +6,8 @@ use ide_db::imports::{
 use itertools::Itertools;
 use syntax::{
     algo::neighbor,
-    ast::{self, edit_in_place::Removable},
-    match_ast, ted, AstNode, SyntaxElement, SyntaxNode,
+    ast::{self, edit_in_place::Removable, syntax_factory::SyntaxFactory},
+    match_ast, AstNode, SyntaxElement, SyntaxNode,
 };
 
 use crate::{
@@ -68,11 +68,19 @@ pub(crate) fn merge_imports(acc: &mut Assists, ctx: &AssistContext<'_>) -> Optio
         (selection_range, edits?)
     };
 
+    // FIXME: Is this the best to get a `SyntaxNode` object? We need one for `SourceChangeBuilder::make_editor`.
+    let parent_node = match ctx.covering_element() {
+        SyntaxElement::Node(n) => n,
+        SyntaxElement::Token(t) => t.parent()?,
+    };
+    let make = SyntaxFactory::new();
+
     acc.add(
         AssistId("merge_imports", AssistKind::RefactorRewrite),
         "Merge imports",
         target,
         |builder| {
+            let mut editor = builder.make_editor(&parent_node);
             let edits_mut: Vec<Edit> = edits
                 .into_iter()
                 .map(|it| match it {
@@ -85,7 +93,7 @@ pub(crate) fn merge_imports(acc: &mut Assists, ctx: &AssistContext<'_>) -> Optio
                 match edit {
                     Remove(it) => it.as_ref().either(Removable::remove, Removable::remove),
                     Replace(old, new) => {
-                        ted::replace(old, &new);
+                        editor.replace(old, &new);
 
                         // If there's a selection and we're replacing a use tree in a tree list,
                         // normalize the parent use tree if it only contains the merged subtree.
@@ -109,12 +117,14 @@ pub(crate) fn merge_imports(acc: &mut Assists, ctx: &AssistContext<'_>) -> Optio
                                 });
                             if let Some((old_tree, new_tree)) = normalized_use_tree {
                                 cov_mark::hit!(replace_parent_with_normalized_use_tree);
-                                ted::replace(old_tree.syntax(), new_tree.syntax());
+                                editor.replace(old_tree.syntax(), new_tree.syntax());
                             }
                         }
                     }
                 }
             }
+            editor.add_mappings(make.finish_with_mappings());
+            builder.add_file_edits(ctx.file_id(), editor);
         },
     )
 }

--- a/crates/syntax/src/ast/edit_in_place.rs
+++ b/crates/syntax/src/ast/edit_in_place.rs
@@ -6,11 +6,7 @@ use parser::{SyntaxKind, T};
 
 use crate::{
     algo::{self, neighbor},
-    ast::{
-        self, edit::IndentLevel, make, syntax_factory::SyntaxFactory, HasGenericArgs,
-        HasGenericParams,
-    },
-    syntax_editor::SyntaxEditor,
+    ast::{self, edit::IndentLevel, make, HasGenericArgs, HasGenericParams},
     ted::{self, Position},
     AstNode, AstToken, Direction, SyntaxElement,
     SyntaxKind::{ATTR, COMMENT, WHITESPACE},
@@ -389,10 +385,6 @@ pub trait Removable: AstNode {
     fn remove(&self);
 }
 
-pub trait EditorRemovable: AstNode {
-    fn remove(&self, editor: &mut SyntaxEditor);
-}
-
 impl Removable for ast::TypeBoundList {
     fn remove(&self) {
         match self.syntax().siblings_with_tokens(Direction::Prev).find(|it| it.kind() == T![:]) {
@@ -447,35 +439,16 @@ impl Removable for ast::UseTree {
     }
 }
 
-impl EditorRemovable for ast::UseTree {
-    fn remove(&self, editor: &mut SyntaxEditor) {
-        for dir in [Direction::Next, Direction::Prev] {
-            if let Some(next_use_tree) = neighbor(self, dir) {
-                let separators = self
-                    .syntax()
-                    .siblings_with_tokens(dir)
-                    .skip(1)
-                    .take_while(|it| it.as_node() != Some(next_use_tree.syntax()));
-                for sep in separators {
-                    editor.delete(sep);
-                }
-                break;
-            }
-        }
-        editor.delete(self.syntax());
-    }
-}
-
 impl ast::UseTree {
     /// Deletes the usetree node represented by the input. Recursively removes parents, including use nodes that become empty.
     pub fn remove_recursive(self) {
         let parent = self.syntax().parent();
 
-        Removable::remove(&self);
+        self.remove();
 
         if let Some(u) = parent.clone().and_then(ast::Use::cast) {
             if u.use_tree().is_none() {
-                Removable::remove(&u);
+                u.remove()
             }
         } else if let Some(u) = parent.and_then(ast::UseTreeList::cast) {
             if u.use_trees().next().is_none() {
@@ -640,45 +613,6 @@ impl Removable for ast::Use {
         }
 
         ted::remove(self.syntax());
-    }
-}
-
-impl EditorRemovable for ast::Use {
-    fn remove(&self, editor: &mut SyntaxEditor) {
-        let make = SyntaxFactory::new();
-
-        let next_ws = self
-            .syntax()
-            .next_sibling_or_token()
-            .and_then(|it| it.into_token())
-            .and_then(ast::Whitespace::cast);
-        if let Some(next_ws) = next_ws {
-            let ws_text = next_ws.syntax().text();
-            if let Some(rest) = ws_text.strip_prefix('\n') {
-                if rest.is_empty() {
-                    editor.delete(next_ws.syntax());
-                } else {
-                    editor.replace(next_ws.syntax(), make.whitespace(rest));
-                }
-            }
-        }
-        let prev_ws = self
-            .syntax()
-            .prev_sibling_or_token()
-            .and_then(|it| it.into_token())
-            .and_then(ast::Whitespace::cast);
-        if let Some(prev_ws) = prev_ws {
-            let ws_text = prev_ws.syntax().text();
-            let prev_newline = ws_text.rfind('\n').map(|x| x + 1).unwrap_or(0);
-            let rest = &ws_text[0..prev_newline];
-            if rest.is_empty() {
-                editor.delete(prev_ws.syntax());
-            } else {
-                editor.replace(prev_ws.syntax(), make.whitespace(rest));
-            }
-        }
-
-        editor.delete(self.syntax());
     }
 }
 

--- a/crates/syntax/src/ast/edit_in_place.rs
+++ b/crates/syntax/src/ast/edit_in_place.rs
@@ -448,7 +448,7 @@ impl ast::UseTree {
 
         if let Some(u) = parent.clone().and_then(ast::Use::cast) {
             if u.use_tree().is_none() {
-                u.remove()
+                u.remove();
             }
         } else if let Some(u) = parent.and_then(ast::UseTreeList::cast) {
             if u.use_trees().next().is_none() {

--- a/crates/syntax/src/syntax_editor.rs
+++ b/crates/syntax/src/syntax_editor.rs
@@ -16,7 +16,7 @@ use rustc_hash::FxHashMap;
 use crate::{SyntaxElement, SyntaxNode, SyntaxToken};
 
 mod edit_algo;
-mod edits;
+pub mod edits;
 mod mapping;
 
 pub use mapping::{SyntaxMapping, SyntaxMappingBuilder};

--- a/crates/syntax/src/syntax_editor/edits.rs
+++ b/crates/syntax/src/syntax_editor/edits.rs
@@ -167,21 +167,6 @@ impl Removable for ast::Use {
                 }
             }
         }
-        let prev_ws = self
-            .syntax()
-            .prev_sibling_or_token()
-            .and_then(|it| it.into_token())
-            .and_then(ast::Whitespace::cast);
-        if let Some(prev_ws) = prev_ws {
-            let ws_text = prev_ws.syntax().text();
-            let prev_newline = ws_text.rfind('\n').map(|x| x + 1).unwrap_or(0);
-            let rest = &ws_text[0..prev_newline];
-            if rest.is_empty() {
-                editor.delete(prev_ws.syntax());
-            } else {
-                editor.replace(prev_ws.syntax(), make.whitespace(rest));
-            }
-        }
 
         editor.delete(self.syntax());
     }


### PR DESCRIPTION
This PR is part of #15710 and #18285.

**Changes Made**
- Followed the steps in #18285 for migration.
- Removed the `edits_mut` vector from `crates/ide-assists/src/handlers/merge_imports.rs`
- Added a new `SyntaxFactory` method `whitespace`
	- There are no mappings needed as far as I am concerned
	- Currently named `whitespace` as it mirrors `make::tokens::whitespace` but `tokens_whitespace` might be a more fitting name.
- Replaced the `edit_in_place::Removable` trait with `edit_in_place::EditorRemovable` ([Relevant conversation here](https://rust-lang.zulipchat.com/#narrow/channel/185405-t-compiler.2Frust-analyzer/topic/.60SyntaxEditor.60.20replacement.20for.20Mutable.20Syntax.20trees/near/479370360))
	- This trait requires a `SyntaxEditor` instance in the `remove` method to use instead of `ted`.
	- Implemented for `ast::Use` and `ast::UseTree`
	- Most implementations remain the same, except that I used `SyntaxEditor::delete` instead of `ted::remove` and` ted::remove_all_iter`. Since `SyntaxEditor::remove` doesn’t exist, I assumed delete would perform the same function—though this might be causing issues.
