### PR TITLE
Replace Design label with C-Architecture

### DIFF
--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -47,10 +47,6 @@ https://rust-lang.zulipchat.com/#narrow/stream/185405-t-compiler.2Frust-analyzer
   Each triaged issue should have one of these labels.
 * [fun](https://github.com/rust-lang/rust-analyzer/issues?q=is%3Aopen+is%3Aissue+label%3Afun)
   is for cool, but probably hard stuff.
-* [Design](https://github.com/rust-lang/rust-analyzer/issues?q=is%3Aopen+is%3Aissue+label%Design)
-  is for moderate/large scale architecture discussion.
-  Also a kind of fun.
-  These issues should generally include a link to a Zulip discussion thread.
 
 # Code Style & Review Process
 

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -47,6 +47,10 @@ https://rust-lang.zulipchat.com/#narrow/stream/185405-t-compiler.2Frust-analyzer
   Each triaged issue should have one of these labels.
 * [fun](https://github.com/rust-lang/rust-analyzer/issues?q=is%3Aopen+is%3Aissue+label%3Afun)
   is for cool, but probably hard stuff.
+* [C-Architecture](https://github.com/rust-lang/rust-analyzer/issues?q=is%3Aissue%20state%3Aopen%20label%3AC-Architecture)
+  is for moderate/large scale architecture discussion.
+  Also a kind of fun.
+  These issues should generally include a link to a Zulip discussion thread.
 
 # Code Style & Review Process
 


### PR DESCRIPTION
 #7445 added an item to `docs/dev/README.md` describing and linking to the "Design" issue label, which I assume existed at the time. Later, #12722 updated that URL to point to the new repo location. However, this bullet point is now confusing for two reasons:

1. The URL https://github.com/rust-lang/rust-analyzer/issues?q=is%3Aopen+is%3Aissue+label%Design is malformed. Clicking it in Firefox produces a blank page. Interestingly, clicking the URL while editing this Markdown file inside VS Code changes it to the different URL https://github.com/rust-lang/rust-analyzer/issues?q=is:open+is:issue+label%25Design which is no longer malformed, but that just corresponds to the search string "is:open is:issue label%Design" which is not very meaningful.

2. There are currently no issues labeled "Design". The corrected search URL https://github.com/rust-lang/rust-analyzer/issues?q=is:open+is:issue+label:Design causes GitHub to display this warning message:

   > Filter contains 1 issue:
   > - Invalid value `Design` for `label`

Therefore, this PR replaces that bullet point with a link to the [C-Architecture](https://github.com/rust-lang/rust-analyzer/issues?q=is%3Aissue%20state%3Aopen%20label%3AC-Architecture) tag.