### PR TITLE
Revert "Resolve completion items"

### DIFF
--- a/crates/rust-analyzer/src/handlers/request.rs
+++ b/crates/rust-analyzer/src/handlers/request.rs
@@ -11,9 +11,9 @@ use std::{
 use anyhow::Context;
 
 use ide::{
-    AnnotationConfig, AssistKind, AssistResolveStrategy, Cancellable, CompletionFieldsToResolve,
-    FilePosition, FileRange, HoverAction, HoverGotoTypeData, InlayFieldsToResolve, Query,
-    RangeInfo, ReferenceCategory, Runnable, RunnableKind, SingleResolve, SourceChange, TextEdit,
+    AnnotationConfig, AssistKind, AssistResolveStrategy, Cancellable, FilePosition, FileRange,
+    HoverAction, HoverGotoTypeData, InlayFieldsToResolve, Query, RangeInfo, ReferenceCategory,
+    Runnable, RunnableKind, SingleResolve, SourceChange, TextEdit,
 };
 use ide_db::{FxHashMap, SymbolKind};
 use itertools::Itertools;
@@ -1119,43 +1119,12 @@ pub(crate) fn handle_completion_resolve(
     };
     let source_root = snap.analysis.source_root_id(file_id)?;
 
-    let mut forced_resolve_completions_config = snap.config.completion(Some(source_root));
-    forced_resolve_completions_config.fields_to_resolve = CompletionFieldsToResolve::empty();
-
-    let position = FilePosition { file_id, offset };
-    let Some(resolved_completions) = snap.analysis.completions(
-        &forced_resolve_completions_config,
-        position,
-        resolve_data.trigger_character,
-    )?
-    else {
-        return Ok(original_completion);
-    };
-    let resolved_completions = to_proto::completion_items(
-        &snap.config,
-        &forced_resolve_completions_config.fields_to_resolve,
-        &line_index,
-        snap.file_version(position.file_id),
-        resolve_data.position,
-        resolve_data.trigger_character,
-        resolved_completions,
-    );
-    let Some(mut resolved_completion) = resolved_completions.into_iter().find(|completion| {
-        completion.label == original_completion.label
-            && completion.kind == original_completion.kind
-            && completion.deprecated == original_completion.deprecated
-            && completion.preselect == original_completion.preselect
-            && completion.sort_text == original_completion.sort_text
-    }) else {
-        return Ok(original_completion);
-    };
-
     if !resolve_data.imports.is_empty() {
         let additional_edits = snap
             .analysis
             .resolve_completion_edits(
-                &forced_resolve_completions_config,
-                position,
+                &snap.config.completion(Some(source_root)),
+                FilePosition { file_id, offset },
                 resolve_data
                     .imports
                     .into_iter()
@@ -1165,7 +1134,7 @@ pub(crate) fn handle_completion_resolve(
             .flat_map(|edit| edit.into_iter().map(|indel| to_proto::text_edit(&line_index, indel)))
             .collect::<Vec<_>>();
 
-        if !all_edits_are_disjoint(&resolved_completion, &additional_edits) {
+        if !all_edits_are_disjoint(&original_completion, &additional_edits) {
             return Err(LspError::new(
                 ErrorCode::InternalError as i32,
                 "Import edit overlaps with the original completion edits, this is not LSP-compliant"
@@ -1174,15 +1143,15 @@ pub(crate) fn handle_completion_resolve(
             .into());
         }
 
-        if let Some(original_additional_edits) = resolved_completion.additional_text_edits.as_mut()
+        if let Some(original_additional_edits) = original_completion.additional_text_edits.as_mut()
         {
             original_additional_edits.extend(additional_edits)
         } else {
-            resolved_completion.additional_text_edits = Some(additional_edits);
+            original_completion.additional_text_edits = Some(additional_edits);
         }
     }
 
-    Ok(resolved_completion)
+    Ok(original_completion)
 }
 
 pub(crate) fn handle_folding_range(

--- a/crates/rust-analyzer/src/lsp/ext.rs
+++ b/crates/rust-analyzer/src/lsp/ext.rs
@@ -825,7 +825,7 @@ pub struct CompletionResolveData {
     pub position: lsp_types::TextDocumentPositionParams,
     pub imports: Vec<CompletionImport>,
     pub version: Option<i32>,
-    pub trigger_character: Option<char>,
+    pub completion_trigger_character: Option<char>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/crates/rust-analyzer/src/lsp/to_proto.rs
+++ b/crates/rust-analyzer/src/lsp/to_proto.rs
@@ -397,7 +397,7 @@ fn completion_item(
             position: tdpp.clone(),
             imports,
             version,
-            trigger_character: completion_trigger_character,
+            completion_trigger_character,
         };
         lsp_item.data = Some(to_value(data).unwrap());
     }


### PR DESCRIPTION
Reverting this commit fixes automatic importing in many editors.

Certainly there's probably a better way to fix this than a straight revert.  Feel free to close this, of course, if that path is taken.

This fixes #18363.

This reverts commit 950bb83f818342d9f9ed472c1d30492db324f5a6.