### PR TITLE
Use completion item indices instead of property matching when searching for the completion item to resolve

### DIFF
--- a/crates/rust-analyzer/src/handlers/request.rs
+++ b/crates/rust-analyzer/src/handlers/request.rs
@@ -1131,7 +1131,7 @@ pub(crate) fn handle_completion_resolve(
     else {
         return Ok(original_completion);
     };
-    let resolved_completions = to_proto::completion_items(
+    let mut resolved_completions = to_proto::completion_items(
         &snap.config,
         &forced_resolve_completions_config.fields_to_resolve,
         &line_index,
@@ -1140,15 +1140,13 @@ pub(crate) fn handle_completion_resolve(
         resolve_data.trigger_character,
         resolved_completions,
     );
-    let Some(mut resolved_completion) = resolved_completions.into_iter().find(|completion| {
-        completion.label == original_completion.label
-            && completion.kind == original_completion.kind
-            && completion.deprecated == original_completion.deprecated
-            && completion.preselect == original_completion.preselect
-            && completion.sort_text == original_completion.sort_text
-    }) else {
-        return Ok(original_completion);
-    };
+
+    let mut resolved_completion =
+        if resolved_completions.get(resolve_data.completion_item_index).is_some() {
+            resolved_completions.swap_remove(resolve_data.completion_item_index)
+        } else {
+            return Ok(original_completion);
+        };
 
     if !resolve_data.imports.is_empty() {
         let additional_edits = snap

--- a/crates/rust-analyzer/src/lsp/ext.rs
+++ b/crates/rust-analyzer/src/lsp/ext.rs
@@ -826,6 +826,7 @@ pub struct CompletionResolveData {
     pub imports: Vec<CompletionImport>,
     pub version: Option<i32>,
     pub trigger_character: Option<char>,
+    pub completion_item_index: usize,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/crates/rust-analyzer/src/lsp/to_proto.rs
+++ b/crates/rust-analyzer/src/lsp/to_proto.rs
@@ -392,18 +392,36 @@ fn completion_item(
         } else {
             Vec::new()
         };
-    if something_to_resolve || !imports.is_empty() {
-        let data = lsp_ext::CompletionResolveData {
+    let (ref_resolve_data, resolve_data) = if something_to_resolve || !imports.is_empty() {
+        let mut item_index = acc.len();
+        let ref_resolve_data = if ref_match.is_some() {
+            let ref_resolve_data = lsp_ext::CompletionResolveData {
+                position: tdpp.clone(),
+                imports: Vec::new(),
+                version,
+                trigger_character: completion_trigger_character,
+                completion_item_index: item_index,
+            };
+            item_index += 1;
+            Some(to_value(ref_resolve_data).unwrap())
+        } else {
+            None
+        };
+        let resolve_data = lsp_ext::CompletionResolveData {
             position: tdpp.clone(),
             imports,
             version,
             trigger_character: completion_trigger_character,
+            completion_item_index: item_index,
         };
-        lsp_item.data = Some(to_value(data).unwrap());
-    }
+        (ref_resolve_data, Some(to_value(resolve_data).unwrap()))
+    } else {
+        (None, None)
+    };
 
     if let Some((label, indel, relevance)) = ref_match {
-        let mut lsp_item_with_ref = lsp_types::CompletionItem { label, ..lsp_item.clone() };
+        let mut lsp_item_with_ref =
+            lsp_types::CompletionItem { label, data: ref_resolve_data, ..lsp_item.clone() };
         lsp_item_with_ref
             .additional_text_edits
             .get_or_insert_with(Default::default)
@@ -412,6 +430,7 @@ fn completion_item(
         acc.push(lsp_item_with_ref);
     };
 
+    lsp_item.data = resolve_data;
     acc.push(lsp_item);
 
     fn set_score(

--- a/docs/dev/lsp-extensions.md
+++ b/docs/dev/lsp-extensions.md
@@ -1,5 +1,5 @@
 <!---
-lsp/ext.rs hash: 90cf7718d54fe3c2
+lsp/ext.rs hash: 96f88b7a5d0080c6
 
 If you need to change the above hash to make the test pass, please check if you
 need to adjust this doc as well and ping this issue:


### PR DESCRIPTION
Part of https://github.com/rust-lang/rust-analyzer/issues/18363
Closes https://github.com/rust-lang/rust-analyzer/pull/18501

Previously, completions for resolution were re-queried with the same completion parameters, and then picked by matching their properties as

```rs
let Some(mut resolved_completion) = resolved_completions.into_iter().find(|completion| {
        completion.label == original_completion.label
            && completion.kind == original_completion.kind
            && completion.deprecated == original_completion.deprecated
            && completion.preselect == original_completion.preselect
            && completion.sort_text == original_completion.sort_text
    }) else {
        return Ok(original_completion);
    };
```

this is incorrect, as 
1. `completion.deprecated == original_completion.deprecated` check may never success due to the property being unresolved initially (other properties are fine and are not resolved)
2. Equal labels and other parameters can happen for various traits with the same name, that might have different imports associated with them.

So, instead, follow a less fragile approach: since we resolve completions for the same document state and same query, we can rely on the `Vec<CompletionItem>` order to return the same set of the completion items, in the same order.

This is also fragile, but seems to work and definitely works better than the previous version.

--------------

It would be great to see if we can derive a better "id" for such items, but I'm clueless here.
If this approach does not seem to be good, we'd better follow https://github.com/rust-lang/rust-analyzer/pull/18501 path and revert this entirely (bringing back tons of useless json in responses though)


cc @traviscross
