### PR TITLE
Re-add `rust-analyzer.cargo.sysrootQueryMetadata`

### DIFF
--- a/crates/project-model/src/cargo_workspace.rs
+++ b/crates/project-model/src/cargo_workspace.rs
@@ -13,7 +13,7 @@ use serde_json::from_value;
 use span::Edition;
 use toolchain::Tool;
 
-use crate::{utf8_stdout, ManifestPath, Sysroot};
+use crate::{utf8_stdout, ManifestPath, Sysroot, SysrootQueryMetadata};
 use crate::{CfgOverrides, InvocationStrategy};
 
 /// [`CargoWorkspace`] represents the logical structure of, well, a Cargo
@@ -85,6 +85,8 @@ pub struct CargoConfig {
     pub target: Option<String>,
     /// Sysroot loading behavior
     pub sysroot: Option<RustLibSource>,
+    /// How to query metadata for the sysroot crate.
+    pub sysroot_query_metadata: SysrootQueryMetadata,
     pub sysroot_src: Option<AbsPathBuf>,
     /// rustc private crate source
     pub rustc_source: Option<RustLibSource>,

--- a/crates/project-model/src/lib.rs
+++ b/crates/project-model/src/lib.rs
@@ -240,3 +240,10 @@ fn parse_cfg(s: &str) -> Result<cfg::CfgAtom, String> {
     };
     Ok(res)
 }
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum SysrootQueryMetadata {
+    #[default]
+    CargoMetadata,
+    None,
+}

--- a/crates/project-model/src/sysroot.rs
+++ b/crates/project-model/src/sysroot.rs
@@ -14,7 +14,7 @@ use paths::{AbsPath, AbsPathBuf, Utf8PathBuf};
 use rustc_hash::FxHashMap;
 use toolchain::{probe_for_binary, Tool};
 
-use crate::{utf8_stdout, CargoConfig, CargoWorkspace, ManifestPath};
+use crate::{utf8_stdout, CargoConfig, CargoWorkspace, ManifestPath, SysrootQueryMetadata};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Sysroot {
@@ -123,27 +123,43 @@ impl Sysroot {
 // FIXME: Expose a builder api as loading the sysroot got way too modular and complicated.
 impl Sysroot {
     /// Attempts to discover the toolchain's sysroot from the given `dir`.
-    pub fn discover(dir: &AbsPath, extra_env: &FxHashMap<String, String>) -> Sysroot {
+    pub fn discover(
+        dir: &AbsPath,
+        extra_env: &FxHashMap<String, String>,
+        sysroot_query_metadata: SysrootQueryMetadata,
+    ) -> Sysroot {
         let sysroot_dir = discover_sysroot_dir(dir, extra_env);
         let sysroot_src_dir = sysroot_dir.as_ref().ok().map(|sysroot_dir| {
             discover_sysroot_src_dir_or_add_component(sysroot_dir, dir, extra_env)
         });
-        Sysroot::load_core_check(Some(sysroot_dir), sysroot_src_dir)
+        Sysroot::load_core_check(Some(sysroot_dir), sysroot_src_dir, sysroot_query_metadata)
     }
 
     pub fn discover_with_src_override(
         current_dir: &AbsPath,
         extra_env: &FxHashMap<String, String>,
         sysroot_src_dir: AbsPathBuf,
+        sysroot_query_metadata: SysrootQueryMetadata,
     ) -> Sysroot {
         let sysroot_dir = discover_sysroot_dir(current_dir, extra_env);
-        Sysroot::load_core_check(Some(sysroot_dir), Some(Ok(sysroot_src_dir)))
+        Sysroot::load_core_check(
+            Some(sysroot_dir),
+            Some(Ok(sysroot_src_dir)),
+            sysroot_query_metadata,
+        )
     }
 
-    pub fn discover_sysroot_src_dir(sysroot_dir: AbsPathBuf) -> Sysroot {
+    pub fn discover_sysroot_src_dir(
+        sysroot_dir: AbsPathBuf,
+        sysroot_query_metadata: SysrootQueryMetadata,
+    ) -> Sysroot {
         let sysroot_src_dir = discover_sysroot_src_dir(&sysroot_dir)
             .ok_or_else(|| format_err!("can't find standard library sources in {sysroot_dir}"));
-        Sysroot::load_core_check(Some(Ok(sysroot_dir)), Some(sysroot_src_dir))
+        Sysroot::load_core_check(
+            Some(Ok(sysroot_dir)),
+            Some(sysroot_src_dir),
+            sysroot_query_metadata,
+        )
     }
 
     pub fn discover_rustc_src(&self) -> Option<ManifestPath> {
@@ -186,15 +202,20 @@ impl Sysroot {
             })
     }
 
-    pub fn load(sysroot_dir: Option<AbsPathBuf>, sysroot_src_dir: Option<AbsPathBuf>) -> Sysroot {
-        Self::load_core_check(sysroot_dir.map(Ok), sysroot_src_dir.map(Ok))
+    pub fn load(
+        sysroot_dir: Option<AbsPathBuf>,
+        sysroot_src_dir: Option<AbsPathBuf>,
+        sysroot_query_metadata: SysrootQueryMetadata,
+    ) -> Sysroot {
+        Self::load_core_check(sysroot_dir.map(Ok), sysroot_src_dir.map(Ok), sysroot_query_metadata)
     }
 
     fn load_core_check(
         sysroot_dir: Option<Result<AbsPathBuf, anyhow::Error>>,
         sysroot_src_dir: Option<Result<AbsPathBuf, anyhow::Error>>,
+        sysroot_query_metadata: SysrootQueryMetadata,
     ) -> Sysroot {
-        let mut sysroot = Self::load_(sysroot_dir, sysroot_src_dir);
+        let mut sysroot = Self::load_(sysroot_dir, sysroot_src_dir, sysroot_query_metadata);
         if sysroot.error.is_none() {
             if let Some(src_root) = &sysroot.src_root {
                 let has_core = match &sysroot.mode {
@@ -220,6 +241,7 @@ impl Sysroot {
     fn load_(
         sysroot_dir: Option<Result<AbsPathBuf, anyhow::Error>>,
         sysroot_src_dir: Option<Result<AbsPathBuf, anyhow::Error>>,
+        sysroot_query_metadata: SysrootQueryMetadata,
     ) -> Sysroot {
         let sysroot_dir = match sysroot_dir {
             Some(Ok(sysroot_dir)) => Some(sysroot_dir),
@@ -252,12 +274,15 @@ impl Sysroot {
                 }
             }
         };
-        let library_manifest = ManifestPath::try_from(sysroot_src_dir.join("Cargo.toml")).unwrap();
-        if fs::metadata(&library_manifest).is_ok() {
-            if let Some(sysroot) =
-                Self::load_library_via_cargo(library_manifest, &sysroot_dir, &sysroot_src_dir)
-            {
-                return sysroot;
+        if sysroot_query_metadata == SysrootQueryMetadata::CargoMetadata {
+            let library_manifest =
+                ManifestPath::try_from(sysroot_src_dir.join("Cargo.toml")).unwrap();
+            if fs::metadata(&library_manifest).is_ok() {
+                if let Some(sysroot) =
+                    Self::load_library_via_cargo(library_manifest, &sysroot_dir, &sysroot_src_dir)
+                {
+                    return sysroot;
+                }
             }
         }
         tracing::debug!("Stitching sysroot library: {sysroot_src_dir}");

--- a/crates/project-model/src/tests.rs
+++ b/crates/project-model/src/tests.rs
@@ -13,7 +13,8 @@ use triomphe::Arc;
 
 use crate::{
     sysroot::SysrootMode, workspace::ProjectWorkspaceKind, CargoWorkspace, CfgOverrides,
-    ManifestPath, ProjectJson, ProjectJsonData, ProjectWorkspace, Sysroot, WorkspaceBuildScripts,
+    ManifestPath, ProjectJson, ProjectJsonData, ProjectWorkspace, Sysroot, SysrootQueryMetadata,
+    WorkspaceBuildScripts,
 };
 
 fn load_cargo(file: &str) -> (CrateGraph, ProcMacroPaths) {
@@ -116,7 +117,7 @@ fn get_fake_sysroot() -> Sysroot {
     // fake sysroot, so we give them both the same path:
     let sysroot_dir = AbsPathBuf::assert(sysroot_path);
     let sysroot_src_dir = sysroot_dir.clone();
-    Sysroot::load(Some(sysroot_dir), Some(sysroot_src_dir))
+    Sysroot::load(Some(sysroot_dir), Some(sysroot_src_dir), SysrootQueryMetadata::CargoMetadata)
 }
 
 fn rooted_project_json(data: ProjectJsonData) -> ProjectJson {
@@ -231,6 +232,7 @@ fn smoke_test_real_sysroot_cargo() {
     let sysroot = Sysroot::discover(
         AbsPath::assert(Utf8Path::new(env!("CARGO_MANIFEST_DIR"))),
         &Default::default(),
+        SysrootQueryMetadata::CargoMetadata,
     );
     assert!(matches!(sysroot.mode(), SysrootMode::Workspace(_)));
     let project_workspace = ProjectWorkspace {

--- a/crates/rust-analyzer/src/cli/analysis_stats.rs
+++ b/crates/rust-analyzer/src/cli/analysis_stats.rs
@@ -65,6 +65,10 @@ impl flags::AnalysisStats {
                 true => None,
                 false => Some(RustLibSource::Discover),
             },
+            sysroot_query_metadata: match self.no_query_sysroot_metadata {
+                true => project_model::SysrootQueryMetadata::None,
+                false => project_model::SysrootQueryMetadata::CargoMetadata,
+            },
             all_targets: true,
             set_test: !self.no_test,
             cfg_overrides: CfgOverrides {

--- a/crates/rust-analyzer/src/cli/flags.rs
+++ b/crates/rust-analyzer/src/cli/flags.rs
@@ -71,6 +71,9 @@ xflags::xflags! {
             optional --with-deps
             /// Don't load sysroot crates (`std`, `core` & friends).
             optional --no-sysroot
+            /// Don't run cargo metadata on the sysroot to analyze its third-party dependencies.
+            /// Requires --no-sysroot to not be set.
+            optional --no-query-sysroot-metadata
             /// Don't set #[cfg(test)].
             optional --no-test
 
@@ -235,6 +238,7 @@ pub struct AnalysisStats {
     pub only: Option<String>,
     pub with_deps: bool,
     pub no_sysroot: bool,
+    pub no_query_sysroot_metadata: bool,
     pub no_test: bool,
     pub disable_build_scripts: bool,
     pub disable_proc_macros: bool,

--- a/crates/rust-analyzer/src/cli/rustc_tests.rs
+++ b/crates/rust-analyzer/src/cli/rustc_tests.rs
@@ -13,7 +13,7 @@ use profile::StopWatch;
 use project_model::target_data_layout::RustcDataLayoutConfig;
 use project_model::{
     target_data_layout, CargoConfig, ManifestPath, ProjectWorkspace, ProjectWorkspaceKind,
-    RustLibSource, Sysroot,
+    RustLibSource, Sysroot, SysrootQueryMetadata,
 };
 
 use load_cargo::{load_workspace, LoadCargoConfig, ProcMacroServerChoice};
@@ -74,7 +74,11 @@ impl Tester {
             ..Default::default()
         };
 
-        let sysroot = Sysroot::discover(tmp_file.parent().unwrap(), &cargo_config.extra_env);
+        let sysroot = Sysroot::discover(
+            tmp_file.parent().unwrap(),
+            &cargo_config.extra_env,
+            SysrootQueryMetadata::CargoMetadata,
+        );
         let data_layout = target_data_layout::get(
             RustcDataLayoutConfig::Rustc(&sysroot),
             None,

--- a/crates/rust-analyzer/src/reload.rs
+++ b/crates/rust-analyzer/src/reload.rs
@@ -316,9 +316,7 @@ impl GlobalState {
                         LinkedProject::InlineJsonProject(it) => {
                             let workspace = project_model::ProjectWorkspace::load_inline(
                                 it.clone(),
-                                cargo_config.target.as_deref(),
-                                &cargo_config.extra_env,
-                                &cargo_config.cfg_overrides,
+                                &cargo_config,
                             );
                             Ok(workspace)
                         }

--- a/docs/user/generated_config.adoc
+++ b/docs/user/generated_config.adoc
@@ -135,6 +135,12 @@ Unsetting this disables sysroot loading.
 
 This option does not take effect until rust-analyzer is restarted.
 --
+[[rust-analyzer.cargo.sysrootQueryMetadata]]rust-analyzer.cargo.sysrootQueryMetadata (default: `"cargo_metadata"`)::
++
+--
+How to query metadata for the sysroot crate. Using cargo metadata allows rust-analyzer
+to analyze third-party dependencies of the standard libraries.
+--
 [[rust-analyzer.cargo.sysrootSrc]]rust-analyzer.cargo.sysrootSrc (default: `null`)::
 +
 --

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -819,6 +819,24 @@
             {
                 "title": "cargo",
                 "properties": {
+                    "rust-analyzer.cargo.sysrootQueryMetadata": {
+                        "markdownDescription": "How to query metadata for the sysroot crate. Using cargo metadata allows rust-analyzer\nto analyze third-party dependencies of the standard libraries.",
+                        "default": "cargo_metadata",
+                        "type": "string",
+                        "enum": [
+                            "none",
+                            "cargo_metadata"
+                        ],
+                        "enumDescriptions": [
+                            "Do not query sysroot metadata, always use stitched sysroot.",
+                            "Use `cargo metadata` to query sysroot metadata."
+                        ]
+                    }
+                }
+            },
+            {
+                "title": "cargo",
+                "properties": {
                     "rust-analyzer.cargo.sysrootSrc": {
                         "markdownDescription": "Relative path to the sysroot library sources. If left unset, this will default to\n`{cargo.sysroot}/lib/rustlib/src/rust/library`.\n\nThis option does not take effect until rust-analyzer is restarted.",
                         "default": null,


### PR DESCRIPTION
#17795 removed this option, turning it on for everyone. This commit adds it back, still on by default.

At work, users are effectively offline, so the initial `cargo metadata` will always fail. The `--no-deps` retry will succeed, but the experience with this path is very poor, because a ton of std stuff fails to resolve (some still works, I can't tell the pattern). Something like this is probably happening in #17759.
<img width="397" alt="Screenshot 2024-11-14 at 12 32 23 PM" src="https://github.com/user-attachments/assets/a1398b85-9937-4e72-a492-3f34fc501c15">

We want this config option so we can turn it off by default for our users and always use the stitched sysroot library.
