### PR TITLE
fix: avoid hint items shadow local item from completions

### DIFF
--- a/crates/ide-completion/src/tests/flyimport.rs
+++ b/crates/ide-completion/src/tests/flyimport.rs
@@ -1460,7 +1460,8 @@ enum Foo {
 
 #[test]
 fn flyimport_enum_variant_not_shadow_by_fn() {
-    check(r#"
+    check(
+        r#"
 //- /std.rs crate:std
 pub enum Result<T, E> {
     Ok(T),
@@ -1477,7 +1478,8 @@ fn main() -> Result<(), ()> {
     Ok$0
 }
 "#,
-    expect![[r#""#]])
+        expect![[r#""#]],
+    )
 }
 
 #[test]

--- a/crates/ide-completion/src/tests/flyimport.rs
+++ b/crates/ide-completion/src/tests/flyimport.rs
@@ -1459,6 +1459,28 @@ enum Foo {
 }
 
 #[test]
+fn flyimport_enum_variant_not_shadow_by_fn() {
+    check(r#"
+//- /std.rs crate:std
+pub enum Result<T, E> {
+    Ok(T),
+    Err(E)
+}
+
+//- /dep.rs crate:dep deps:std
+use std::Result;
+pub fn Ok<T>(t: T) -> Result<T, ()> {}
+
+//- /main.rs crate:main deps:std,dep
+use std::{Result, Result::Ok};
+fn main() -> Result<(), ()> {
+    Ok$0
+}
+"#,
+    expect![[r#""#]])
+}
+
+#[test]
 fn flyimport_attribute() {
     check(
         r#"

--- a/crates/ide-db/src/imports/import_assets.rs
+++ b/crates/ide-db/src/imports/import_assets.rs
@@ -288,28 +288,42 @@ impl ImportAssets {
                     };
                     fn will_shadow(db: &dyn HirDatabase, cur: ModuleDef, other: ModuleDef) -> bool {
                         match (cur, other) {
-                            (ModuleDef::Module(a), ModuleDef::Module(b)) => a.name(db) == b.name(db),
-                            (ModuleDef::Function(a), ModuleDef::Function(b)) => a.name(db) == b.name(db),
+                            (ModuleDef::Module(a), ModuleDef::Module(b)) => {
+                                a.name(db) == b.name(db)
+                            }
+                            (ModuleDef::Function(a), ModuleDef::Function(b)) => {
+                                a.name(db) == b.name(db)
+                            }
                             (ModuleDef::Adt(a), ModuleDef::Adt(b)) => a.name(db) == b.name(db),
-                            (ModuleDef::Variant(a), ModuleDef::Variant(b)) => a.name(db) == b.name(db),
-                            (ModuleDef::Variant(a), ModuleDef::Function(b)) => a.name(db) == b.name(db),
+                            (ModuleDef::Variant(a), ModuleDef::Variant(b)) => {
+                                a.name(db) == b.name(db)
+                            }
+                            (ModuleDef::Variant(a), ModuleDef::Function(b)) => {
+                                a.name(db) == b.name(db)
+                            }
                             (ModuleDef::Const(a), ModuleDef::Const(b)) => a.name(db) == b.name(db),
-                            (ModuleDef::Static(a), ModuleDef::Static(b)) => a.name(db) == b.name(db),
+                            (ModuleDef::Static(a), ModuleDef::Static(b)) => {
+                                a.name(db) == b.name(db)
+                            }
                             (ModuleDef::Trait(a), ModuleDef::Trait(b)) => a.name(db) == b.name(db),
-                            (ModuleDef::TraitAlias(a), ModuleDef::TraitAlias(b)) => a.name(db) == b.name(db),
-                            (ModuleDef::TypeAlias(a), ModuleDef::TypeAlias(b)) => a.name(db) == b.name(db),
+                            (ModuleDef::TraitAlias(a), ModuleDef::TraitAlias(b)) => {
+                                a.name(db) == b.name(db)
+                            }
+                            (ModuleDef::TypeAlias(a), ModuleDef::TypeAlias(b)) => {
+                                a.name(db) == b.name(db)
+                            }
                             (ModuleDef::Macro(a), ModuleDef::Macro(b)) => a.name(db) == b.name(db),
                             (_, _) => false,
                         }
                     }
 
                     !scope_definitions.contains(&ScopeDef::from(item_to_import))
-                        && scope_definitions.iter().find(|&&scope_def| match scope_def {
+                        && !scope_definitions.iter().any(|&scope_def| match scope_def {
                             ScopeDef::ModuleDef(module_def) => {
                                 will_shadow(sema.db, module_def, import_def)
-                            },
-                            _ => false
-                    }).is_none()
+                            }
+                            _ => false,
+                        })
                 })
             }
             ImportCandidate::TraitAssocItem(trait_candidate)


### PR DESCRIPTION
# Relevant Issues
#18398 Don't auto import items when one is already in scope
#17164 Block specific items from being auto-imported

# Fixed Problem
Now completions will not hint item that could shadow local item.

# Problems that May Arise
## Unexpected behavior
Maybe we can auto rename or use long path to disambiguation, and add a option to control the behavior.
