### PR TITLE
Add Configurable Option to Exclude Trigger Characters for Typing Assists

### DIFF
--- a/crates/ide/src/lib.rs
+++ b/crates/ide/src/lib.rs
@@ -410,14 +410,10 @@ impl Analysis {
         &self,
         position: FilePosition,
         char_typed: char,
-        autoclose: bool,
         chars_to_exclude: Option<String>,
     ) -> Cancellable<Option<SourceChange>> {
         // Fast path to not even parse the file.
         if !typing::TRIGGER_CHARS.contains(char_typed) {
-            return Ok(None);
-        }
-        if char_typed == '<' && !autoclose {
             return Ok(None);
         }
         if let Some(chars_to_exclude) = chars_to_exclude {

--- a/crates/ide/src/lib.rs
+++ b/crates/ide/src/lib.rs
@@ -411,6 +411,7 @@ impl Analysis {
         position: FilePosition,
         char_typed: char,
         autoclose: bool,
+        chars_to_exclude: Option<String>,
     ) -> Cancellable<Option<SourceChange>> {
         // Fast path to not even parse the file.
         if !typing::TRIGGER_CHARS.contains(char_typed) {
@@ -418,6 +419,11 @@ impl Analysis {
         }
         if char_typed == '<' && !autoclose {
             return Ok(None);
+        }
+        if let Some(chars_to_exclude) = chars_to_exclude {
+            if chars_to_exclude.contains(char_typed) {
+                return Ok(None);
+            }
         }
 
         self.with_db(|db| typing::on_char_typed(db, position, char_typed))

--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -310,6 +310,8 @@ config_data! {
 
         /// Whether to insert closing angle brackets when typing an opening angle bracket of a generic argument list.
         typing_autoClosingAngleBrackets_enable: bool = false,
+        /// Specify the characters to exclude from triggering typing assists. The default trigger characters are `.`, `=`, `<`, `>`, `{`, and `(`. Setting this to a string will disable typing assists for the specified characters.
+        typing_excludeChars: Option<String> = None,
 
 
         /// Enables automatic discovery of projects using [`DiscoverWorkspaceConfig::command`].
@@ -2158,6 +2160,10 @@ impl Config {
 
     pub fn typing_autoclose_angle(&self) -> bool {
         *self.typing_autoClosingAngleBrackets_enable()
+    }
+
+    pub fn typing_exclude_chars(&self) -> Option<String> {
+        self.typing_excludeChars().clone()
     }
 
     // VSCode is our reference implementation, so we allow ourselves to work around issues by

--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -308,8 +308,6 @@ config_data! {
         /// Show documentation.
         signatureInfo_documentation_enable: bool                       = true,
 
-        /// Whether to insert closing angle brackets when typing an opening angle bracket of a generic argument list.
-        typing_autoClosingAngleBrackets_enable: bool = false,
         /// Specify the characters to exclude from triggering typing assists. The default trigger characters are `.`, `=`, `<`, `>`, `{`, and `(`. Setting this to a string will disable typing assists for the specified characters.
         typing_excludeChars: Option<String> = None,
 
@@ -2156,10 +2154,6 @@ impl Config {
             &Some(NumThreads::Concrete(n)) => n,
             Some(NumThreads::Logical) => num_cpus::get(),
         }
-    }
-
-    pub fn typing_autoclose_angle(&self) -> bool {
-        *self.typing_autoClosingAngleBrackets_enable()
     }
 
     pub fn typing_exclude_chars(&self) -> Option<String> {

--- a/crates/rust-analyzer/src/handlers/request.rs
+++ b/crates/rust-analyzer/src/handlers/request.rs
@@ -461,12 +461,7 @@ pub(crate) fn handle_on_type_formatting(
     }
     let chars_to_exclude = snap.config.typing_exclude_chars();
 
-    let edit = snap.analysis.on_char_typed(
-        position,
-        char_typed,
-        snap.config.typing_autoclose_angle(),
-        chars_to_exclude,
-    )?;
+    let edit = snap.analysis.on_char_typed(position, char_typed, chars_to_exclude)?;
     let edit = match edit {
         Some(it) => it,
         None => return Ok(None),

--- a/crates/rust-analyzer/src/handlers/request.rs
+++ b/crates/rust-analyzer/src/handlers/request.rs
@@ -459,9 +459,14 @@ pub(crate) fn handle_on_type_formatting(
     if char_typed == '>' {
         return Ok(None);
     }
+    let chars_to_exclude = snap.config.typing_exclude_chars();
 
-    let edit =
-        snap.analysis.on_char_typed(position, char_typed, snap.config.typing_autoclose_angle())?;
+    let edit = snap.analysis.on_char_typed(
+        position,
+        char_typed,
+        snap.config.typing_autoclose_angle(),
+        chars_to_exclude,
+    )?;
     let edit = match edit {
         Some(it) => it,
         None => return Ok(None),

--- a/docs/user/generated_config.adoc
+++ b/docs/user/generated_config.adoc
@@ -992,11 +992,6 @@ Show full signature of the callable. Only shows parameters if disabled.
 --
 Show documentation.
 --
-[[rust-analyzer.typing.autoClosingAngleBrackets.enable]]rust-analyzer.typing.autoClosingAngleBrackets.enable (default: `false`)::
-+
---
-Whether to insert closing angle brackets when typing an opening angle bracket of a generic argument list.
---
 [[rust-analyzer.typing.excludeChars]]rust-analyzer.typing.excludeChars (default: `null`)::
 +
 --

--- a/docs/user/generated_config.adoc
+++ b/docs/user/generated_config.adoc
@@ -997,6 +997,11 @@ Show documentation.
 --
 Whether to insert closing angle brackets when typing an opening angle bracket of a generic argument list.
 --
+[[rust-analyzer.typing.excludeChars]]rust-analyzer.typing.excludeChars (default: `null`)::
++
+--
+Specify the characters to exclude from triggering typing assists. The default trigger characters are `.`, `=`, `<`, `>`, `{`, and `(`. Setting this to a string will disable typing assists for the specified characters.
+--
 [[rust-analyzer.workspace.discoverConfig]]rust-analyzer.workspace.discoverConfig (default: `null`)::
 +
 --

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -2613,6 +2613,19 @@
                 }
             },
             {
+                "title": "typing",
+                "properties": {
+                    "rust-analyzer.typing.excludeChars": {
+                        "markdownDescription": "Specify the characters to exclude from triggering typing assists. The default trigger characters are `.`, `=`, `<`, `>`, `{`, and `(`. Setting this to a string will disable typing assists for the specified characters.",
+                        "default": null,
+                        "type": [
+                            "null",
+                            "string"
+                        ]
+                    }
+                }
+            },
+            {
                 "title": "workspace",
                 "properties": {
                     "rust-analyzer.workspace.discoverConfig": {

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -2605,16 +2605,6 @@
             {
                 "title": "typing",
                 "properties": {
-                    "rust-analyzer.typing.autoClosingAngleBrackets.enable": {
-                        "markdownDescription": "Whether to insert closing angle brackets when typing an opening angle bracket of a generic argument list.",
-                        "default": false,
-                        "type": "boolean"
-                    }
-                }
-            },
-            {
-                "title": "typing",
-                "properties": {
                     "rust-analyzer.typing.excludeChars": {
                         "markdownDescription": "Specify the characters to exclude from triggering typing assists. The default trigger characters are `.`, `=`, `<`, `>`, `{`, and `(`. Setting this to a string will disable typing assists for the specified characters.",
                         "default": null,


### PR DESCRIPTION
This PR addresses #16084 by adding a new configuration option: `rust-analyzer.typing.excludeChars`.


cc: @darichey 
### Changes
- Added `rust-analyzer.typing.excludeChars` configuration.
    - Defaults to `None`, meaning all trigger characters (`.=<>{(`) are active by default.
    - Users can specify a string of characters to exclude from triggering assists.
- Updated documentation and configuration schema to reflect this new option.