### PR TITLE
Migrate `sort_items` Assist to Use `SyntaxFactory`

### DIFF
--- a/crates/ide-assists/src/handlers/sort_items.rs
+++ b/crates/ide-assists/src/handlers/sort_items.rs
@@ -4,7 +4,7 @@ use itertools::Itertools;
 
 use syntax::{
     ast::{self, HasName},
-    ted, AstNode, TextRange,
+    AstNode, SyntaxNode,
 };
 
 use crate::{utils::get_methods, AssistContext, AssistId, AssistKind, Assists};
@@ -114,7 +114,7 @@ trait AddRewrite {
         label: &str,
         old: Vec<T>,
         new: Vec<T>,
-        target: TextRange,
+        target: SyntaxNode,
     ) -> Option<()>;
 }
 
@@ -124,15 +124,24 @@ impl AddRewrite for Assists {
         label: &str,
         old: Vec<T>,
         new: Vec<T>,
-        target: TextRange,
+        target: SyntaxNode,
     ) -> Option<()> {
-        self.add(AssistId("sort_items", AssistKind::RefactorRewrite), label, target, |builder| {
-            let mutable: Vec<T> = old.into_iter().map(|it| builder.make_mut(it)).collect();
-            mutable
-                .into_iter()
-                .zip(new)
-                .for_each(|(old, new)| ted::replace(old.syntax(), new.clone_for_update().syntax()));
-        })
+        let node = old.first().unwrap().syntax().parent().unwrap();
+        self.add(
+            AssistId("sort_items", AssistKind::RefactorRewrite),
+            label,
+            target.text_range(),
+            |builder| {
+                let mut editor = builder.make_editor(&node);
+
+                old.into_iter().zip(new).for_each(|(old, new)| {
+                    // FIXME: remove `clone_for_update` when `SyntaxEditor` handles it for us
+                    editor.replace(old.syntax(), new.clone_for_update().syntax())
+                });
+
+                builder.add_file_edits(builder.file_id, editor)
+            },
+        )
     }
 }
 
@@ -167,7 +176,7 @@ fn add_sort_methods_assist(
         return None;
     }
 
-    acc.add_rewrite("Sort methods alphabetically", methods, sorted, item_list.syntax().text_range())
+    acc.add_rewrite("Sort methods alphabetically", methods, sorted, item_list.syntax().clone())
 }
 
 fn add_sort_fields_assist(
@@ -186,7 +195,7 @@ fn add_sort_fields_assist(
         "Sort fields alphabetically",
         fields,
         sorted,
-        record_field_list.syntax().text_range(),
+        record_field_list.syntax().clone(),
     )
 }
 
@@ -199,12 +208,7 @@ fn add_sort_variants_assist(acc: &mut Assists, variant_list: ast::VariantList) -
         return None;
     }
 
-    acc.add_rewrite(
-        "Sort variants alphabetically",
-        variants,
-        sorted,
-        variant_list.syntax().text_range(),
-    )
+    acc.add_rewrite("Sort variants alphabetically", variants, sorted, variant_list.syntax().clone())
 }
 
 fn sort_by_name<T: HasName + Clone>(initial: &[T]) -> Vec<T> {

--- a/crates/ide-assists/src/handlers/sort_items.rs
+++ b/crates/ide-assists/src/handlers/sort_items.rs
@@ -114,7 +114,7 @@ trait AddRewrite {
         label: &str,
         old: Vec<T>,
         new: Vec<T>,
-        target: SyntaxNode,
+        target: &SyntaxNode,
     ) -> Option<()>;
 }
 
@@ -124,15 +124,14 @@ impl AddRewrite for Assists {
         label: &str,
         old: Vec<T>,
         new: Vec<T>,
-        target: SyntaxNode,
+        target: &SyntaxNode,
     ) -> Option<()> {
-        let node = old.first().unwrap().syntax().parent().unwrap();
         self.add(
             AssistId("sort_items", AssistKind::RefactorRewrite),
             label,
             target.text_range(),
             |builder| {
-                let mut editor = builder.make_editor(&node);
+                let mut editor = builder.make_editor(target);
 
                 old.into_iter().zip(new).for_each(|(old, new)| {
                     // FIXME: remove `clone_for_update` when `SyntaxEditor` handles it for us
@@ -176,7 +175,7 @@ fn add_sort_methods_assist(
         return None;
     }
 
-    acc.add_rewrite("Sort methods alphabetically", methods, sorted, item_list.syntax().clone())
+    acc.add_rewrite("Sort methods alphabetically", methods, sorted, item_list.syntax())
 }
 
 fn add_sort_fields_assist(
@@ -191,12 +190,7 @@ fn add_sort_fields_assist(
         return None;
     }
 
-    acc.add_rewrite(
-        "Sort fields alphabetically",
-        fields,
-        sorted,
-        record_field_list.syntax().clone(),
-    )
+    acc.add_rewrite("Sort fields alphabetically", fields, sorted, record_field_list.syntax())
 }
 
 fn add_sort_variants_assist(acc: &mut Assists, variant_list: ast::VariantList) -> Option<()> {
@@ -208,7 +202,7 @@ fn add_sort_variants_assist(acc: &mut Assists, variant_list: ast::VariantList) -
         return None;
     }
 
-    acc.add_rewrite("Sort variants alphabetically", variants, sorted, variant_list.syntax().clone())
+    acc.add_rewrite("Sort variants alphabetically", variants, sorted, variant_list.syntax())
 }
 
 fn sort_by_name<T: HasName + Clone>(initial: &[T]) -> Vec<T> {


### PR DESCRIPTION
part of #15710 and #18285
For this one, I had to pass `AssistContext` to other methods as well in order to get the file ID.