### PR TITLE
fix: Fix a stack overflow when computing the sizedness of a struct that includes itself as the tail field

### DIFF
--- a/crates/hir-ty/src/tests/traits.rs
+++ b/crates/hir-ty/src/tests/traits.rs
@@ -4790,3 +4790,24 @@ fn allowed3(baz: impl Baz<Assoc = Qux<impl Foo>>) {}
         "#]],
     )
 }
+
+#[test]
+fn recursive_tail_sized() {
+    check_infer(
+        r#"
+struct WeirdFoo(WeirdBar);
+struct WeirdBar(WeirdFoo);
+
+fn bar(v: *const ()) {
+    let _ = v as *const WeirdFoo;
+}
+    "#,
+        expect![[r#"
+            62..63 'v': *const ()
+            76..113 '{     ...Foo; }': ()
+            86..87 '_': *const WeirdFoo
+            90..91 'v': *const ()
+            90..110 'v as *...irdFoo': *const WeirdFoo
+        "#]],
+    );
+}


### PR DESCRIPTION
Fixes #18556.

**Warning to the reviewer:** If you are going to open this in your editor of choice (with r-a of course), r-a will restart again and again, because we provide (some) IDE functionality to our tests which implies this actually overflows the stack when the test is present... Ask me how I know.