### PR TITLE
Add macro expansion test for raw variable names

### DIFF
--- a/crates/hir-def/src/macro_expansion_tests/mbe/matching.rs
+++ b/crates/hir-def/src/macro_expansion_tests/mbe/matching.rs
@@ -184,3 +184,31 @@ fn test() {
 "#]],
     );
 }
+
+#[test]
+fn meta_variable_raw_name_equals_non_raw() {
+    check(
+        r#"
+macro_rules! m {
+    ($r#name:tt) => {
+        $name
+    }
+}
+
+fn test() {
+    m!(1234)
+}
+"#,
+        expect![[r#"
+macro_rules! m {
+    ($r#name:tt) => {
+        $name
+    }
+}
+
+fn test() {
+    1234
+}
+"#]],
+    );
+}


### PR DESCRIPTION
Adds a test covering #17785. Should close that issue.
This seemed like the right location for the test.

The test correctly fails on release 2024-07-15, with:
~~~
---- macro_expansion_tests::mbe::matching::meta_variable_raw_name_equals_non_raw stdout ----
thread 'macro_expansion_tests::mbe::matching::meta_variable_raw_name_equals_non_raw' panicked at crates/hir-def/src/macro_expansion_tests/mbe/matching.rs:190:5:
parse errors in expansion:
[
    SyntaxError(
        "expected expression, item or let statement",
        0..0,
    ),
]
```
$name
```
~~~