### PR TITLE
minor: run `FlycheckHandle::restart_workspace` when `check_workspace` true 

### DIFF
--- a/crates/rust-analyzer/src/handlers/notification.rs
+++ b/crates/rust-analyzer/src/handlers/notification.rs
@@ -380,7 +380,7 @@ fn run_flycheck(state: &mut GlobalState, vfs_path: VfsPath) -> bool {
                     if id == flycheck.id() {
                         updated = true;
                         match package.filter(|_| {
-                            !world.config.flycheck_workspace(source_root_id) && target.is_some()
+                            !world.config.flycheck_workspace(source_root_id) || target.is_some()
                         }) {
                             Some(package) => flycheck
                                 .restart_for_package(package, target.clone().map(TupleExt::head)),

--- a/crates/rust-analyzer/src/handlers/notification.rs
+++ b/crates/rust-analyzer/src/handlers/notification.rs
@@ -379,9 +379,7 @@ fn run_flycheck(state: &mut GlobalState, vfs_path: VfsPath) -> bool {
                 for (id, package) in workspace_ids.clone() {
                     if id == flycheck.id() {
                         updated = true;
-                        match package.filter(|_| {
-                            !world.config.flycheck_workspace(source_root_id) || target.is_some()
-                        }) {
+                        match package.filter(|_| !world.config.flycheck_workspace(source_root_id)) {
                             Some(package) => flycheck
                                 .restart_for_package(package, target.clone().map(TupleExt::head)),
                             None => flycheck.restart_workspace(saved_file.clone()),


### PR DESCRIPTION
Our first attempt to make flycheck only check the current crate if the crate is one of bin/bench/test targets had caused `check_workspace` to be ignored, which should have been a config with higher precedence all along. This commit reverts #18197 and closes #18562 and closes #18506