### PR TITLE
feat: convert unmerge_use to SyntaxFactory SyntaxEditor abstraction

### DIFF
--- a/crates/syntax/src/ast/syntax_factory/constructors.rs
+++ b/crates/syntax/src/ast/syntax_factory/constructors.rs
@@ -2,7 +2,7 @@
 use itertools::Itertools;
 
 use crate::{
-    ast::{self, make, HasName},
+    ast::{self, make, HasName, HasVisibility, Use, UseTree},
     syntax_editor::SyntaxMappingBuilder,
     AstNode,
 };
@@ -106,5 +106,13 @@ impl SyntaxFactory {
         }
 
         ast
+    }
+
+    pub fn use_(&self, visibility: Option<ast::Visibility>, use_tree: ast::UseTree) -> ast::Use {
+        make::use_(visibility, use_tree)
+    }
+
+    pub fn use_tree(&self, path: ast::Path, use_tree_list: Option<ast::UseTreeList>, alias: Option<ast::Rename>, add_star: bool) -> ast::UseTree {
+        make::use_tree(path, use_tree_list, alias, add_star)
     }
 }

--- a/crates/syntax/src/ast/syntax_factory/constructors.rs
+++ b/crates/syntax/src/ast/syntax_factory/constructors.rs
@@ -109,10 +109,10 @@ impl SyntaxFactory {
     }
 
     pub fn use_(&self, visibility: Option<ast::Visibility>, use_tree: ast::UseTree) -> ast::Use {
-        make::use_(visibility, use_tree)
+        make::use_(visibility, use_tree).clone_for_update()
     }
 
     pub fn use_tree(&self, path: ast::Path, use_tree_list: Option<ast::UseTreeList>, alias: Option<ast::Rename>, add_star: bool) -> ast::UseTree {
-        make::use_tree(path, use_tree_list, alias, add_star)
+        make::use_tree(path, use_tree_list, alias, add_star).clone_for_update()
     }
 }


### PR DESCRIPTION
Contributes to issue #18285 

I think I fully converted this but tests are failing with the following output:

```
failures:

---- handlers::unmerge_use::tests::unmerge_glob_import stdout ----
thread 'handlers::unmerge_use::tests::unmerge_glob_import' panicked at /home/codespace/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rowan-0.15.15/src/cursor.rs:548:9:
assertion failed: !self.data().mutable
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

---- handlers::unmerge_use::tests::unmerge_indented_use_item stdout ----
thread 'handlers::unmerge_use::tests::unmerge_indented_use_item' panicked at /home/codespace/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rowan-0.15.15/src/cursor.rs:548:9:
assertion failed: !self.data().mutable

---- handlers::unmerge_use::tests::unmerge_nested_use_item stdout ----
thread 'handlers::unmerge_use::tests::unmerge_nested_use_item' panicked at /home/codespace/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rowan-0.15.15/src/cursor.rs:548:9:
assertion failed: !self.data().mutable

---- handlers::unmerge_use::tests::unmerge_renamed_use_item stdout ----
thread 'handlers::unmerge_use::tests::unmerge_renamed_use_item' panicked at /home/codespace/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rowan-0.15.15/src/cursor.rs:548:9:
assertion failed: !self.data().mutable

---- handlers::unmerge_use::tests::unmerge_use_item_on_self stdout ----
thread 'handlers::unmerge_use::tests::unmerge_use_item_on_self' panicked at /home/codespace/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rowan-0.15.15/src/cursor.rs:548:9:
assertion failed: !self.data().mutable

---- handlers::unmerge_use::tests::unmerge_use_item stdout ----
thread 'handlers::unmerge_use::tests::unmerge_use_item' panicked at /home/codespace/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rowan-0.15.15/src/cursor.rs:548:9:
assertion failed: !self.data().mutable

---- handlers::unmerge_use::tests::unmerge_use_item_with_visibility stdout ----
thread 'handlers::unmerge_use::tests::unmerge_use_item_with_visibility' panicked at /home/codespace/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rowan-0.15.15/src/cursor.rs:548:9:
assertion failed: !self.data().mutable

---- tests::generated::doctest_unmerge_use stdout ----
thread 'tests::generated::doctest_unmerge_use' panicked at /home/codespace/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rowan-0.15.15/src/cursor.rs:548:9:
assertion failed: !self.data().mutable


failures:
    handlers::unmerge_use::tests::unmerge_glob_import
    handlers::unmerge_use::tests::unmerge_indented_use_item
    handlers::unmerge_use::tests::unmerge_nested_use_item
    handlers::unmerge_use::tests::unmerge_renamed_use_item
    handlers::unmerge_use::tests::unmerge_use_item
    handlers::unmerge_use::tests::unmerge_use_item_on_self
    handlers::unmerge_use::tests::unmerge_use_item_with_visibility
    tests::generated::doctest_unmerge_use

test result: FAILED. 2323 passed; 8 failed; 1 ignored; 0 measured; 0 filtered out; finished in 2.38s
```