### PR TITLE
Remove redundant associated type bounds from `dyn TypeFolder`

### DIFF
--- a/crates/hir-ty/src/infer/unify.rs
+++ b/crates/hir-ty/src/infer/unify.rs
@@ -666,7 +666,7 @@ impl<'a> InferenceTable<'a> {
             highest_known_var: InferenceVar,
         }
         impl TypeFolder<Interner> for VarFudger<'_, '_> {
-            fn as_dyn(&mut self) -> &mut dyn TypeFolder<Interner, Error = Self::Error> {
+            fn as_dyn(&mut self) -> &mut dyn TypeFolder<Interner> {
                 self
             }
 
@@ -1004,7 +1004,7 @@ mod resolve {
     where
         F: Fn(InferenceVar, VariableKind, GenericArg, DebruijnIndex) -> GenericArg,
     {
-        fn as_dyn(&mut self) -> &mut dyn TypeFolder<Interner, Error = Self::Error> {
+        fn as_dyn(&mut self) -> &mut dyn TypeFolder<Interner> {
             self
         }
 

--- a/crates/hir-ty/src/lib.rs
+++ b/crates/hir-ty/src/lib.rs
@@ -646,7 +646,7 @@ pub(crate) fn fold_free_vars<T: HasInterner<Interner = Interner> + TypeFoldable<
             F2: FnMut(Ty, BoundVar, DebruijnIndex) -> Const,
         > TypeFolder<Interner> for FreeVarFolder<F1, F2>
     {
-        fn as_dyn(&mut self) -> &mut dyn TypeFolder<Interner, Error = Self::Error> {
+        fn as_dyn(&mut self) -> &mut dyn TypeFolder<Interner> {
             self
         }
 
@@ -697,7 +697,7 @@ pub(crate) fn fold_tys_and_consts<T: HasInterner<Interner = Interner> + TypeFold
     impl<F: FnMut(Either<Ty, Const>, DebruijnIndex) -> Either<Ty, Const>> TypeFolder<Interner>
         for TyFolder<F>
     {
-        fn as_dyn(&mut self) -> &mut dyn TypeFolder<Interner, Error = Self::Error> {
+        fn as_dyn(&mut self) -> &mut dyn TypeFolder<Interner> {
             self
         }
 


### PR DESCRIPTION
Remove a redundant associated type bound from the return type of `TypeFolder::as_dyn` in some impls. This associated type is already constrained by the definition of `trait TypeFolder`:

```
pub trait TypeFolder<I: Interner>: FallibleTypeFolder<I, Error = Infallible> { ... }
```

And so specifying it is unnecessary. 

Removing this bound may also be necessary to avoid unintended breakage while fixing https://github.com/rust-lang/rust/issues/133361, though this usage **is not unsound**, it's just hard to support while also fixing the underlying issue.