### PR TITLE
vscode: Only show status bar item in relevant files

### DIFF
--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -425,6 +425,41 @@
                         ],
                         "default": "openLogs",
                         "markdownDescription": "Action to run when clicking the extension status bar item."
+                    },
+                    "rust-analyzer.statusBar.documentSelector": {
+                        "type": [
+                            "array",
+                            "null"
+                        ],
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "language": {
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ]
+                                },
+                                "pattern": {
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ]
+                                }
+                            }
+                        },
+                        "default": [
+                            {
+                                "language": "rust"
+                            },
+                            {
+                                "pattern": "**/Cargo.toml"
+                            },
+                            {
+                                "pattern": "**/Cargo.lock"
+                            }
+                        ],
+                        "markdownDescription": "Determines when to show the extension status bar item based on the currently open file. Use `{ \"pattern\": \"**\" }` to always show. Use `null` to never show."
                     }
                 }
             },

--- a/editors/code/src/config.ts
+++ b/editors/code/src/config.ts
@@ -348,6 +348,10 @@ export class Config {
         return this.get<string>("statusBar.clickAction");
     }
 
+    get statusBarDocumentSelector() {
+        return this.get<vscode.DocumentSelector>("statusBar.documentSelector");
+    }
+
     get initializeStopped() {
         return this.get<boolean>("initializeStopped");
     }


### PR DESCRIPTION
The status bar can become a bit crowded with many extensions adding status bar items. rust-analyzer can be a good citizen and hide itself unless the user is looking at relevant files.

I've set the default to show on Rust files and Cargo.toml. It could be reasonable to instead keep the current always-show behavior as the default, just giving users the option to configure it. I'm open to discussion!

This could also be a workaround for #15068.