### PR TITLE
fix: Fixed another bug with glob imports

### DIFF
--- a/crates/hir-def/src/nameres/collector.rs
+++ b/crates/hir-def/src/nameres/collector.rs
@@ -910,8 +910,13 @@ impl DefCollector<'_> {
                             self.update(module_id, &items, vis, Some(ImportType::Glob(id)));
                             // record the glob import in case we add further items
                             let glob = self.glob_imports.entry(m.local_id).or_default();
-                            if !glob.iter().any(|(mid, _, _)| *mid == module_id) {
-                                glob.push((module_id, vis, id));
+                            match glob.iter_mut().find(|(mid, _, _)| *mid == module_id) {
+                                None => glob.push((module_id, vis, id)),
+                                Some((_, old_vis, _)) => {
+                                    if let Some(new_vis) = old_vis.max(vis, &self.def_map) {
+                                        *old_vis = new_vis;
+                                    }
+                                }
                             }
                         }
                     }

--- a/crates/hir-def/src/nameres/tests/globs.rs
+++ b/crates/hir-def/src/nameres/tests/globs.rs
@@ -451,3 +451,42 @@ mod glob_target {
         "#]],
     );
 }
+
+#[test]
+fn regression_18580() {
+    check(
+        r#"
+pub mod libs {
+    pub struct Placeholder;
+}
+
+pub mod reexport_2 {
+    use reexport_1::*;
+    pub use reexport_1::*;
+
+    pub mod reexport_1 {
+        pub use crate::libs::*;
+    }
+}
+
+use reexport_2::*;
+"#,
+        expect![[r#"
+            crate
+            Placeholder: t v
+            libs: t
+            reexport_1: t
+            reexport_2: t
+
+            crate::libs
+            Placeholder: t v
+
+            crate::reexport_2
+            Placeholder: t v
+            reexport_1: t
+
+            crate::reexport_2::reexport_1
+            Placeholder: t v
+        "#]],
+    );
+}


### PR DESCRIPTION
Polars yet again reveals issues with our nameres process due to its complex modules structure (and the cursedness of nameres).

When a glob import overriding the visibility of a previous glob import was not properly resolved when the items are only available in the next fixpoint iteration.

The bug was hidden until #18390.

And thanks to @usamoi for minimizing the bug.

Fixes #18580.