### PR TITLE
fix: Do not report warnings from proc macros, ever

### DIFF
--- a/crates/hir-expand/src/lib.rs
+++ b/crates/hir-expand/src/lib.rs
@@ -269,6 +269,13 @@ pub enum MacroDefKind {
     ProcMacro(AstId<ast::Fn>, CustomProcMacroExpander, ProcMacroKind),
 }
 
+impl MacroDefKind {
+    #[inline]
+    pub fn is_declarative(&self) -> bool {
+        matches!(self, MacroDefKind::Declarative(..))
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct EagerCallInfo {
     /// The expanded argument of the eager macro.

--- a/crates/ide-diagnostics/src/lib.rs
+++ b/crates/ide-diagnostics/src/lib.rs
@@ -542,7 +542,13 @@ fn handle_diag_from_macros(
         sema.db.lookup_intern_syntax_context(span.ctx).outer_expn.is_some_and(|expansion| {
             let macro_call =
                 sema.db.lookup_intern_macro_call(expansion.as_macro_file().macro_call_id);
+            // We don't want to show diagnostics for non-local macros at all, but proc macros authors
+            // seem to rely on being able to emit non-warning-free code, so we don't want to show warnings
+            // for them even when the proc macro comes from the same workspace (in rustc that's not a
+            // problem because it doesn't have the concept of workspaces, and proc macros always reside
+            // in a different crate).
             !Crate::from(macro_call.def.krate).origin(sema.db).is_local()
+                || !macro_call.def.kind.is_declarative()
         })
     }) {
         // Disable suggestions for external macros, they'll change library code and it's just bad.


### PR DESCRIPTION
Because I got angry on the yellow squiggly lines below `query_group`, and decided to investigate it once and for all.