### PR TITLE
fix: Disable `<` typing handler again

### DIFF
--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -309,7 +309,7 @@ config_data! {
         signatureInfo_documentation_enable: bool                       = true,
 
         /// Specify the characters to exclude from triggering typing assists. The default trigger characters are `.`, `=`, `<`, `>`, `{`, and `(`. Setting this to a string will disable typing assists for the specified characters.
-        typing_excludeChars: Option<String> = None,
+        typing_excludeChars: Option<String> = Some("<".to_owned()),
 
 
         /// Enables automatic discovery of projects using [`DiscoverWorkspaceConfig::command`].

--- a/docs/user/generated_config.adoc
+++ b/docs/user/generated_config.adoc
@@ -992,7 +992,7 @@ Show full signature of the callable. Only shows parameters if disabled.
 --
 Show documentation.
 --
-[[rust-analyzer.typing.excludeChars]]rust-analyzer.typing.excludeChars (default: `null`)::
+[[rust-analyzer.typing.excludeChars]]rust-analyzer.typing.excludeChars (default: `"<"`)::
 +
 --
 Specify the characters to exclude from triggering typing assists. The default trigger characters are `.`, `=`, `<`, `>`, `{`, and `(`. Setting this to a string will disable typing assists for the specified characters.

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -2607,7 +2607,7 @@
                 "properties": {
                     "rust-analyzer.typing.excludeChars": {
                         "markdownDescription": "Specify the characters to exclude from triggering typing assists. The default trigger characters are `.`, `=`, `<`, `>`, `{`, and `(`. Setting this to a string will disable typing assists for the specified characters.",
-                        "default": null,
+                        "default": "<",
                         "type": [
                             "null",
                             "string"


### PR DESCRIPTION
This got accidentally re-enabled even though its still bugged