### PR TITLE
fix: Parse lifetime bounds in lifetime param into TypeBoundList

### DIFF
--- a/crates/hir-def/src/item_tree/pretty.rs
+++ b/crates/hir-def/src/item_tree/pretty.rs
@@ -648,9 +648,9 @@ impl Printer<'_> {
                 let (target, bound) = match pred {
                     WherePredicate::TypeBound { target, bound } => (target, bound),
                     WherePredicate::Lifetime { target, bound } => {
-                        wln!(
+                        w!(
                             this,
-                            "{}: {},",
+                            "{}: {}",
                             target.name.display(self.db.upcast(), edition),
                             bound.name.display(self.db.upcast(), edition)
                         );

--- a/crates/hir-def/src/item_tree/tests.rs
+++ b/crates/hir-def/src/item_tree/tests.rs
@@ -351,7 +351,8 @@ trait Tr<'a, T: 'a>: Super where Self: for<'a> Tr<'a, T> {}
             where
                 T: Copy,
                 T: 'a,
-                T: 'b
+                T: 'b,
+                'b: 'a
             {
                 pub(self) field: &'a &'b T,
             }
@@ -370,7 +371,8 @@ trait Tr<'a, T: 'a>: Super where Self: for<'a> Tr<'a, T> {}
             where
                 T: Copy,
                 T: 'a,
-                T: 'b
+                T: 'b,
+                'b: 'a
             {
                 // AstId: 9
                 pub(self) fn f<G>(

--- a/crates/hir-ty/src/tests/traits.rs
+++ b/crates/hir-ty/src/tests/traits.rs
@@ -1631,6 +1631,29 @@ fn test<'lifetime>(
 }
 
 #[test]
+fn lifetime_bounds() {
+    check_infer(
+        r#"
+//- minicore: sized, coerce_unsized
+trait Trait<'a>: Sized {
+    fn f(&'a self) {}
+}
+fn test<'a, 'b: 'a>(it: impl Trait<'a>){
+    it.f();
+}
+"#,
+        expect![[r#"
+            38..42 'self': &'a Self
+            44..46 '{}': ()
+            69..71 'it': impl Trait<'a>
+            88..103 '{     it.f(); }': ()
+            94..96 'it': impl Trait<'a>
+            94..100 'it.f()': ()
+        "#]],
+    );
+}
+
+#[test]
 fn error_bound_chalk() {
     check_types(
         r#"

--- a/crates/hir/src/semantics.rs
+++ b/crates/hir/src/semantics.rs
@@ -2026,6 +2026,10 @@ impl SemanticsScope<'_> {
         )
     }
 
+    pub fn generic_def(&self) -> Option<crate::GenericDef> {
+        self.resolver.generic_def().map(|id| id.into())
+    }
+
     pub fn extern_crates(&self) -> impl Iterator<Item = (Name, Module)> + '_ {
         self.resolver.extern_crates_in_scope().map(|(name, id)| (name, Module { id }))
     }

--- a/crates/ide-completion/src/context.rs
+++ b/crates/ide-completion/src/context.rs
@@ -290,15 +290,14 @@ pub(crate) struct ParamContext {
 /// The state of the lifetime we are completing.
 #[derive(Debug)]
 pub(crate) struct LifetimeContext {
-    pub(crate) lifetime: Option<ast::Lifetime>,
     pub(crate) kind: LifetimeKind,
 }
 
 /// The kind of lifetime we are completing.
 #[derive(Debug)]
 pub(crate) enum LifetimeKind {
-    LifetimeParam { is_decl: bool, param: ast::LifetimeParam },
-    Lifetime,
+    LifetimeParam,
+    Lifetime { in_lifetime_param_bound: bool, def: Option<hir::GenericDef> },
     LabelRef,
     LabelDef,
 }

--- a/crates/ide-db/src/defs.rs
+++ b/crates/ide-db/src/defs.rs
@@ -772,16 +772,6 @@ impl NameRefClass {
                 .map(GenericParam::LifetimeParam)
                 .map(Definition::GenericParam)
                 .map(NameRefClass::Definition),
-            // lifetime bounds, as in the 'b in 'a: 'b aren't wrapped in TypeBound nodes so we gotta check
-            // if our lifetime is in a LifetimeParam without being the constrained lifetime
-            _ if ast::LifetimeParam::cast(parent).and_then(|param| param.lifetime()).as_ref()
-                != Some(lifetime) =>
-            {
-                sema.resolve_lifetime_param(lifetime)
-                    .map(GenericParam::LifetimeParam)
-                    .map(Definition::GenericParam)
-                    .map(NameRefClass::Definition)
-            }
             _ => None,
         }
     }

--- a/crates/intern/src/symbol/symbols.rs
+++ b/crates/intern/src/symbol/symbols.rs
@@ -80,6 +80,7 @@ define_symbols! {
     self_ = "self",
     Self_ = "Self",
     tick_static = "'static",
+    tick_underscore = "'_",
     dollar_crate = "$crate",
     MISSING_NAME = "[missing name]",
     fn_ = "fn",

--- a/crates/parser/src/grammar/generic_params.rs
+++ b/crates/parser/src/grammar/generic_params.rs
@@ -56,7 +56,7 @@ fn generic_param(p: &mut Parser<'_>, m: Marker) -> bool {
 fn lifetime_param(p: &mut Parser<'_>, m: Marker) {
     assert!(p.at(LIFETIME_IDENT));
     lifetime(p);
-    if p.at(T![:]) {
+    if p.eat(T![:]) {
         lifetime_bounds(p);
     }
     m.complete(p, LIFETIME_PARAM);
@@ -106,14 +106,19 @@ fn const_param(p: &mut Parser<'_>, m: Marker) {
 }
 
 fn lifetime_bounds(p: &mut Parser<'_>) {
-    assert!(p.at(T![:]));
-    p.bump(T![:]);
-    while p.at(LIFETIME_IDENT) {
-        lifetime(p);
+    let marker = p.start();
+    while {
+        if !matches!(p.current(), LIFETIME_IDENT | T![>] | T![,]) {
+            p.error("expected lifetime");
+        }
+
+        type_bound(p)
+    } {
         if !p.eat(T![+]) {
             break;
         }
     }
+    marker.complete(p, TYPE_BOUND_LIST);
 }
 
 // test type_param_bounds

--- a/crates/parser/test_data/parser/inline/ok/lifetime_param.rast
+++ b/crates/parser/test_data/parser/inline/ok/lifetime_param.rast
@@ -11,8 +11,10 @@ SOURCE_FILE
           LIFETIME_IDENT "'a"
         COLON ":"
         WHITESPACE " "
-        LIFETIME
-          LIFETIME_IDENT "'b"
+        TYPE_BOUND_LIST
+          TYPE_BOUND
+            LIFETIME
+              LIFETIME_IDENT "'b"
       R_ANGLE ">"
     PARAM_LIST
       L_PAREN "("

--- a/crates/parser/test_data/parser/inline/ok/precise_capturing.rast
+++ b/crates/parser/test_data/parser/inline/ok/precise_capturing.rast
@@ -11,8 +11,10 @@ SOURCE_FILE
           LIFETIME_IDENT "'a"
         COLON ":"
         WHITESPACE " "
-        LIFETIME
-          LIFETIME_IDENT "'a"
+        TYPE_BOUND_LIST
+          TYPE_BOUND
+            LIFETIME
+              LIFETIME_IDENT "'a"
       COMMA ","
       WHITESPACE " "
       LIFETIME_PARAM
@@ -20,8 +22,10 @@ SOURCE_FILE
           LIFETIME_IDENT "'b"
         COLON ":"
         WHITESPACE " "
-        LIFETIME
-          LIFETIME_IDENT "'b"
+        TYPE_BOUND_LIST
+          TYPE_BOUND
+            LIFETIME
+              LIFETIME_IDENT "'b"
       COMMA ","
       WHITESPACE " "
       TYPE_PARAM

--- a/crates/parser/test_data/parser/ok/0018_struct_type_params.rast
+++ b/crates/parser/test_data/parser/ok/0018_struct_type_params.rast
@@ -96,6 +96,7 @@ SOURCE_FILE
         LIFETIME
           LIFETIME_IDENT "'a"
         COLON ":"
+        TYPE_BOUND_LIST
       R_ANGLE ">"
     SEMICOLON ";"
   WHITESPACE "\n"
@@ -111,8 +112,10 @@ SOURCE_FILE
           LIFETIME_IDENT "'a"
         COLON ":"
         WHITESPACE " "
-        LIFETIME
-          LIFETIME_IDENT "'b"
+        TYPE_BOUND_LIST
+          TYPE_BOUND
+            LIFETIME
+              LIFETIME_IDENT "'b"
       R_ANGLE ">"
     SEMICOLON ";"
   WHITESPACE "\n"
@@ -128,10 +131,12 @@ SOURCE_FILE
           LIFETIME_IDENT "'a"
         COLON ":"
         WHITESPACE " "
-        LIFETIME
-          LIFETIME_IDENT "'b"
-        WHITESPACE " "
-        PLUS "+"
+        TYPE_BOUND_LIST
+          TYPE_BOUND
+            LIFETIME
+              LIFETIME_IDENT "'b"
+          WHITESPACE " "
+          PLUS "+"
       WHITESPACE " "
       R_ANGLE ">"
     SEMICOLON ";"
@@ -148,13 +153,16 @@ SOURCE_FILE
           LIFETIME_IDENT "'a"
         COLON ":"
         WHITESPACE " "
-        LIFETIME
-          LIFETIME_IDENT "'b"
-        WHITESPACE " "
-        PLUS "+"
-        WHITESPACE " "
-        LIFETIME
-          LIFETIME_IDENT "'c"
+        TYPE_BOUND_LIST
+          TYPE_BOUND
+            LIFETIME
+              LIFETIME_IDENT "'b"
+          WHITESPACE " "
+          PLUS "+"
+          WHITESPACE " "
+          TYPE_BOUND
+            LIFETIME
+              LIFETIME_IDENT "'c"
       R_ANGLE ">"
     SEMICOLON ";"
   WHITESPACE "\n"
@@ -202,9 +210,11 @@ SOURCE_FILE
           LIFETIME_IDENT "'a"
         COLON ":"
         WHITESPACE " "
-        LIFETIME
-          LIFETIME_IDENT "'b"
-        PLUS "+"
+        TYPE_BOUND_LIST
+          TYPE_BOUND
+            LIFETIME
+              LIFETIME_IDENT "'b"
+          PLUS "+"
       COMMA ","
       WHITESPACE " "
       LIFETIME_PARAM
@@ -212,8 +222,10 @@ SOURCE_FILE
           LIFETIME_IDENT "'b"
         COLON ":"
         WHITESPACE " "
-        LIFETIME
-          LIFETIME_IDENT "'c"
+        TYPE_BOUND_LIST
+          TYPE_BOUND
+            LIFETIME
+              LIFETIME_IDENT "'c"
       COMMA ","
       R_ANGLE ">"
     SEMICOLON ";"

--- a/crates/parser/test_data/parser/ok/0020_type_param_bounds.rast
+++ b/crates/parser/test_data/parser/ok/0020_type_param_bounds.rast
@@ -237,8 +237,10 @@ SOURCE_FILE
           LIFETIME_IDENT "'a"
         COLON ":"
         WHITESPACE " "
-        LIFETIME
-          LIFETIME_IDENT "'d"
+        TYPE_BOUND_LIST
+          TYPE_BOUND
+            LIFETIME
+              LIFETIME_IDENT "'d"
       COMMA ","
       WHITESPACE " "
       LIFETIME_PARAM
@@ -246,13 +248,16 @@ SOURCE_FILE
           LIFETIME_IDENT "'d"
         COLON ":"
         WHITESPACE " "
-        LIFETIME
-          LIFETIME_IDENT "'a"
-        WHITESPACE " "
-        PLUS "+"
-        WHITESPACE " "
-        LIFETIME
-          LIFETIME_IDENT "'b"
+        TYPE_BOUND_LIST
+          TYPE_BOUND
+            LIFETIME
+              LIFETIME_IDENT "'a"
+          WHITESPACE " "
+          PLUS "+"
+          WHITESPACE " "
+          TYPE_BOUND
+            LIFETIME
+              LIFETIME_IDENT "'b"
       COMMA ","
       WHITESPACE " "
       TYPE_PARAM


### PR DESCRIPTION
This mainly aids in error recovery but also makes it a bit easier to handle lifetime resolution. While doing so it also came apparent that we were not actually lowering lifetime outlives relationships within lifetime parameter declaration bounds, so this fixes that.