### PR TITLE
Hash completion items to properly match them during /resolve

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,6 +85,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1649,6 +1655,7 @@ version = "0.0.0"
 dependencies = [
  "always-assert",
  "anyhow",
+ "base64",
  "cargo_metadata",
  "cfg",
  "crossbeam-channel",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1659,6 +1659,7 @@ dependencies = [
  "hir-def",
  "hir-ty",
  "ide",
+ "ide-completion",
  "ide-db",
  "ide-ssr",
  "intern",
@@ -1687,6 +1688,7 @@ dependencies = [
  "stdx",
  "syntax",
  "syntax-bridge",
+ "tenthash",
  "test-fixture",
  "test-utils",
  "tikv-jemallocator",
@@ -1989,6 +1991,12 @@ dependencies = [
  "tracing",
  "tt",
 ]
+
+[[package]]
+name = "tenthash"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d67f9f3cf70e0852941d7bc3cb884b49b24b8ee956baf91ad0abae31f5ef11fb"
 
 [[package]]
 name = "test-fixture"

--- a/crates/ide-completion/src/item.rs
+++ b/crates/ide-completion/src/item.rs
@@ -346,8 +346,7 @@ pub enum CompletionItemKind {
 impl_from!(SymbolKind for CompletionItemKind);
 
 impl CompletionItemKind {
-    #[cfg(test)]
-    pub(crate) fn tag(self) -> &'static str {
+    pub fn tag(self) -> &'static str {
         match self {
             CompletionItemKind::SymbolKind(kind) => match kind {
                 SymbolKind::Attribute => "at",

--- a/crates/ide-completion/src/lib.rs
+++ b/crates/ide-completion/src/lib.rs
@@ -34,6 +34,7 @@ pub use crate::{
     config::{CallableSnippets, CompletionConfig},
     item::{
         CompletionItem, CompletionItemKind, CompletionRelevance, CompletionRelevancePostfixMatch,
+        CompletionRelevanceReturnType, CompletionRelevanceTypeMatch,
     },
     snippet::{Snippet, SnippetScope},
 };

--- a/crates/rust-analyzer/Cargo.toml
+++ b/crates/rust-analyzer/Cargo.toml
@@ -24,6 +24,7 @@ anyhow.workspace = true
 crossbeam-channel.workspace = true
 dirs = "5.0.1"
 dissimilar.workspace = true
+ide-completion.workspace = true
 itertools.workspace = true
 scip = "0.5.1"
 lsp-types = { version = "=0.95.0", features = ["proposed"] }
@@ -34,6 +35,7 @@ rayon.workspace = true
 rustc-hash.workspace = true
 serde_json = { workspace = true, features = ["preserve_order"] }
 serde.workspace = true
+tenthash = "0.4.0"
 num_cpus = "1.15.0"
 mimalloc = { version = "0.1.30", default-features = false, optional = true }
 lsp-server.workspace = true
@@ -90,13 +92,13 @@ jemalloc = ["jemallocator", "profile/jemalloc"]
 force-always-assert = ["always-assert/force"]
 sysroot-abi = []
 in-rust-tree = [
-  "sysroot-abi",
-  "syntax/in-rust-tree",
-  "parser/in-rust-tree",
-  "hir/in-rust-tree",
-  "hir-def/in-rust-tree",
-  "hir-ty/in-rust-tree",
-  "load-cargo/in-rust-tree",
+    "sysroot-abi",
+    "syntax/in-rust-tree",
+    "parser/in-rust-tree",
+    "hir/in-rust-tree",
+    "hir-def/in-rust-tree",
+    "hir-ty/in-rust-tree",
+    "load-cargo/in-rust-tree",
 ]
 
 [lints]

--- a/crates/rust-analyzer/Cargo.toml
+++ b/crates/rust-analyzer/Cargo.toml
@@ -92,13 +92,13 @@ jemalloc = ["jemallocator", "profile/jemalloc"]
 force-always-assert = ["always-assert/force"]
 sysroot-abi = []
 in-rust-tree = [
-    "sysroot-abi",
-    "syntax/in-rust-tree",
-    "parser/in-rust-tree",
-    "hir/in-rust-tree",
-    "hir-def/in-rust-tree",
-    "hir-ty/in-rust-tree",
-    "load-cargo/in-rust-tree",
+  "sysroot-abi",
+  "syntax/in-rust-tree",
+  "parser/in-rust-tree",
+  "hir/in-rust-tree",
+  "hir-def/in-rust-tree",
+  "hir-ty/in-rust-tree",
+  "load-cargo/in-rust-tree",
 ]
 
 [lints]

--- a/crates/rust-analyzer/Cargo.toml
+++ b/crates/rust-analyzer/Cargo.toml
@@ -21,6 +21,7 @@ path = "src/bin/main.rs"
 
 [dependencies]
 anyhow.workspace = true
+base64 = "0.22"
 crossbeam-channel.workspace = true
 dirs = "5.0.1"
 dissimilar.workspace = true

--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -1440,7 +1440,7 @@ impl Config {
             limit: self.completion_limit(source_root).to_owned(),
             enable_term_search: self.completion_termSearch_enable(source_root).to_owned(),
             term_search_fuel: self.completion_termSearch_fuel(source_root).to_owned() as u64,
-            fields_to_resolve: if self.client_is_helix() || self.client_is_neovim() {
+            fields_to_resolve: if self.client_is_neovim() {
                 CompletionFieldsToResolve::empty()
             } else {
                 CompletionFieldsToResolve::from_client_capabilities(&client_capability_fields)

--- a/crates/rust-analyzer/src/handlers/request.rs
+++ b/crates/rust-analyzer/src/handlers/request.rs
@@ -1138,7 +1138,7 @@ pub(crate) fn handle_completion_resolve(
     };
 
     let Some(corresponding_completion) = completions.into_iter().find(|completion_item| {
-        let hash = completion_item_hash(&completion_item, resolve_data.for_ref);
+        let hash = completion_item_hash(completion_item, resolve_data.for_ref);
         hash == resolve_data.hash
     }) else {
         return Ok(original_completion);

--- a/crates/rust-analyzer/src/handlers/request.rs
+++ b/crates/rust-analyzer/src/handlers/request.rs
@@ -1123,9 +1123,6 @@ pub(crate) fn handle_completion_resolve(
         return Ok(original_completion);
     };
     let source_root = snap.analysis.source_root_id(file_id)?;
-    let Some(completion_hash_for_resolve) = &resolve_data.completion_item_hash else {
-        return Ok(original_completion);
-    };
 
     let mut forced_resolve_completions_config = snap.config.completion(Some(source_root));
     forced_resolve_completions_config.fields_to_resolve = CompletionFieldsToResolve::empty();
@@ -1142,7 +1139,7 @@ pub(crate) fn handle_completion_resolve(
 
     let Some(corresponding_completion) = completions.into_iter().find(|completion_item| {
         let hash = completion_item_hash(&completion_item, resolve_data.for_ref);
-        &hash == completion_hash_for_resolve
+        hash == resolve_data.hash
     }) else {
         return Ok(original_completion);
     };

--- a/crates/rust-analyzer/src/lib.rs
+++ b/crates/rust-analyzer/src/lib.rs
@@ -47,7 +47,9 @@ use self::lsp::ext as lsp_ext;
 #[cfg(test)]
 mod integrated_benchmarks;
 
+use ide::{CompletionItem, CompletionRelevance, TextEdit, TextRange};
 use serde::de::DeserializeOwned;
+use tenthash::TentHasher;
 
 pub use crate::{
     lsp::capabilities::server_capabilities, main_loop::main_loop, reload::ws_to_crate_graph,
@@ -60,4 +62,91 @@ pub fn from_json<T: DeserializeOwned>(
 ) -> anyhow::Result<T> {
     serde_json::from_value(json.clone())
         .map_err(|e| anyhow::format_err!("Failed to deserialize {what}: {e}; {json}"))
+}
+
+fn completion_item_hash(item: &CompletionItem, is_ref_completion: bool) -> [u8; 20] {
+    fn hash_text_range(hasher: &mut TentHasher, text_range: &TextRange) {
+        hasher.update(u32::from(text_range.start()).to_le_bytes());
+        hasher.update(u32::from(text_range.end()).to_le_bytes());
+    }
+
+    fn hash_text_edit(hasher: &mut TentHasher, edit: &TextEdit) {
+        for indel in edit.iter() {
+            hasher.update(&indel.insert);
+            hash_text_range(hasher, &indel.delete);
+        }
+    }
+
+    fn has_completion_relevance(hasher: &mut TentHasher, relevance: &CompletionRelevance) {
+        use ide_completion::{
+            CompletionRelevancePostfixMatch, CompletionRelevanceReturnType,
+            CompletionRelevanceTypeMatch,
+        };
+
+        if let Some(type_match) = &relevance.type_match {
+            let label = match type_match {
+                CompletionRelevanceTypeMatch::CouldUnify => "could_unify",
+                CompletionRelevanceTypeMatch::Exact => "exact",
+            };
+            hasher.update(label);
+        }
+        hasher.update(&[u8::from(relevance.exact_name_match), u8::from(relevance.is_local)]);
+        if let Some(trait_) = &relevance.trait_ {
+            hasher.update(&[u8::from(trait_.is_op_method), u8::from(trait_.notable_trait)]);
+        }
+        hasher.update(&[
+            u8::from(relevance.is_name_already_imported),
+            u8::from(relevance.requires_import),
+            u8::from(relevance.is_private_editable),
+        ]);
+        if let Some(postfix_match) = &relevance.postfix_match {
+            let label = match postfix_match {
+                CompletionRelevancePostfixMatch::NonExact => "non_exact",
+                CompletionRelevancePostfixMatch::Exact => "exact",
+            };
+            hasher.update(label);
+        }
+        if let Some(function) = &relevance.function {
+            hasher.update(&[u8::from(function.has_params), u8::from(function.has_self_param)]);
+            let label = match function.return_type {
+                CompletionRelevanceReturnType::Other => "other",
+                CompletionRelevanceReturnType::DirectConstructor => "direct_constructor",
+                CompletionRelevanceReturnType::Constructor => "constructor",
+                CompletionRelevanceReturnType::Builder => "builder",
+            };
+            hasher.update(label);
+        }
+    }
+
+    let mut hasher = TentHasher::new();
+    hasher.update(&[
+        u8::from(is_ref_completion),
+        u8::from(item.is_snippet),
+        u8::from(item.deprecated),
+        u8::from(item.trigger_call_info),
+    ]);
+    hasher.update(&item.label);
+    if let Some(label_detail) = &item.label_detail {
+        hasher.update(label_detail);
+    }
+    hash_text_range(&mut hasher, &item.source_range);
+    hash_text_edit(&mut hasher, &item.text_edit);
+    hasher.update(item.kind.tag());
+    hasher.update(&item.lookup);
+    if let Some(detail) = &item.detail {
+        hasher.update(detail);
+    }
+    if let Some(documentation) = &item.documentation {
+        hasher.update(documentation.as_str());
+    }
+    has_completion_relevance(&mut hasher, &item.relevance);
+    if let Some((mutability, text_size)) = &item.ref_match {
+        hasher.update(mutability.as_keyword_for_ref());
+        hasher.update(u32::from(*text_size).to_le_bytes());
+    }
+    for (import_path, import_name) in &item.import_to_add {
+        hasher.update(import_path);
+        hasher.update(import_name);
+    }
+    hasher.finalize()
 }

--- a/crates/rust-analyzer/src/lib.rs
+++ b/crates/rust-analyzer/src/lib.rs
@@ -120,13 +120,13 @@ fn completion_item_hash(item: &CompletionItem, is_ref_completion: bool) -> [u8; 
     }
     // NB: do not hash edits or source range, as those may change between the time the client sends the resolve request
     // and the time it receives it: some editors do allow changing the buffer between that, leading to ranges being different.
+    //
+    // Documentation hashing is skipped too, as it's a large blob to process,
+    // while not really making completion properties more unique as they are already.
     hasher.update(item.kind.tag());
     hasher.update(&item.lookup);
     if let Some(detail) = &item.detail {
         hasher.update(detail);
-    }
-    if let Some(documentation) = &item.documentation {
-        hasher.update(documentation.as_str());
     }
     hash_completion_relevance(&mut hasher, &item.relevance);
     if let Some((mutability, text_size)) = &item.ref_match {

--- a/crates/rust-analyzer/src/lib.rs
+++ b/crates/rust-analyzer/src/lib.rs
@@ -71,7 +71,7 @@ fn completion_item_hash(item: &CompletionItem, is_ref_completion: bool) -> [u8; 
             CompletionRelevanceTypeMatch,
         };
 
-        hasher.update(&[
+        hasher.update([
             u8::from(relevance.exact_name_match),
             u8::from(relevance.is_local),
             u8::from(relevance.is_name_already_imported),
@@ -86,7 +86,7 @@ fn completion_item_hash(item: &CompletionItem, is_ref_completion: bool) -> [u8; 
             hasher.update(label);
         }
         if let Some(trait_) = &relevance.trait_ {
-            hasher.update(&[u8::from(trait_.is_op_method), u8::from(trait_.notable_trait)]);
+            hasher.update([u8::from(trait_.is_op_method), u8::from(trait_.notable_trait)]);
         }
         if let Some(postfix_match) = &relevance.postfix_match {
             let label = match postfix_match {
@@ -96,7 +96,7 @@ fn completion_item_hash(item: &CompletionItem, is_ref_completion: bool) -> [u8; 
             hasher.update(label);
         }
         if let Some(function) = &relevance.function {
-            hasher.update(&[u8::from(function.has_params), u8::from(function.has_self_param)]);
+            hasher.update([u8::from(function.has_params), u8::from(function.has_self_param)]);
             let label = match function.return_type {
                 CompletionRelevanceReturnType::Other => "other",
                 CompletionRelevanceReturnType::DirectConstructor => "direct_constructor",
@@ -108,7 +108,7 @@ fn completion_item_hash(item: &CompletionItem, is_ref_completion: bool) -> [u8; 
     }
 
     let mut hasher = TentHasher::new();
-    hasher.update(&[
+    hasher.update([
         u8::from(is_ref_completion),
         u8::from(item.is_snippet),
         u8::from(item.deprecated),

--- a/crates/rust-analyzer/src/lsp/capabilities.rs
+++ b/crates/rust-analyzer/src/lsp/capabilities.rs
@@ -41,7 +41,7 @@ pub fn server_capabilities(config: &Config) -> ServerCapabilities {
         })),
         hover_provider: Some(HoverProviderCapability::Simple(true)),
         completion_provider: Some(CompletionOptions {
-            resolve_provider: if config.client_is_helix() || config.client_is_neovim() {
+            resolve_provider: if config.client_is_neovim() {
                 config.completion_item_edit_resolve().then_some(true)
             } else {
                 Some(config.caps().completions_resolve_provider())

--- a/crates/rust-analyzer/src/lsp/ext.rs
+++ b/crates/rust-analyzer/src/lsp/ext.rs
@@ -826,7 +826,8 @@ pub struct CompletionResolveData {
     pub imports: Vec<CompletionImport>,
     pub version: Option<i32>,
     pub trigger_character: Option<char>,
-    pub completion_item_index: usize,
+    pub for_ref: bool,
+    pub completion_item_hash: Option<[u8; 20]>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/crates/rust-analyzer/src/lsp/ext.rs
+++ b/crates/rust-analyzer/src/lsp/ext.rs
@@ -827,7 +827,7 @@ pub struct CompletionResolveData {
     pub version: Option<i32>,
     pub trigger_character: Option<char>,
     pub for_ref: bool,
-    pub completion_item_hash: Option<[u8; 20]>,
+    pub hash: [u8; 20],
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/crates/rust-analyzer/src/lsp/ext.rs
+++ b/crates/rust-analyzer/src/lsp/ext.rs
@@ -827,7 +827,7 @@ pub struct CompletionResolveData {
     pub version: Option<i32>,
     pub trigger_character: Option<char>,
     pub for_ref: bool,
-    pub hash: [u8; 20],
+    pub hash: String,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/crates/rust-analyzer/src/lsp/to_proto.rs
+++ b/crates/rust-analyzer/src/lsp/to_proto.rs
@@ -5,6 +5,7 @@ use std::{
     sync::atomic::{AtomicU32, Ordering},
 };
 
+use base64::{prelude::BASE64_STANDARD, Engine};
 use ide::{
     Annotation, AnnotationKind, Assist, AssistKind, Cancellable, CompletionFieldsToResolve,
     CompletionItem, CompletionItemKind, CompletionRelevance, Documentation, FileId, FileRange,
@@ -402,7 +403,7 @@ fn completion_item(
                 version,
                 trigger_character: completion_trigger_character,
                 for_ref: true,
-                hash: completion_item_hash(&item, true),
+                hash: BASE64_STANDARD.encode(completion_item_hash(&item, true)),
             };
             Some(to_value(ref_resolve_data).unwrap())
         } else {
@@ -414,7 +415,7 @@ fn completion_item(
             version,
             trigger_character: completion_trigger_character,
             for_ref: false,
-            hash: completion_item_hash(&item, false),
+            hash: BASE64_STANDARD.encode(completion_item_hash(&item, false)),
         };
         (ref_resolve_data, Some(to_value(resolve_data).unwrap()))
     } else {

--- a/crates/rust-analyzer/src/lsp/to_proto.rs
+++ b/crates/rust-analyzer/src/lsp/to_proto.rs
@@ -275,11 +275,7 @@ fn completion_item(
     completion_trigger_character: Option<char>,
     item: CompletionItem,
 ) {
-    let original_completion_item = if fields_to_resolve == &CompletionFieldsToResolve::empty() {
-        None
-    } else {
-        Some(item.clone())
-    };
+    let original_completion_item = item.clone();
     let insert_replace_support = config.insert_replace_support().then_some(tdpp.position);
     let ref_match = item.ref_match();
 
@@ -406,9 +402,7 @@ fn completion_item(
                 version,
                 trigger_character: completion_trigger_character,
                 for_ref: true,
-                completion_item_hash: original_completion_item
-                    .as_ref()
-                    .map(|item| completion_item_hash(item, true)),
+                hash: completion_item_hash(&original_completion_item, true),
             };
             Some(to_value(ref_resolve_data).unwrap())
         } else {
@@ -420,9 +414,7 @@ fn completion_item(
             version,
             trigger_character: completion_trigger_character,
             for_ref: false,
-            completion_item_hash: original_completion_item
-                .as_ref()
-                .map(|item| completion_item_hash(item, false)),
+            hash: completion_item_hash(&original_completion_item, false),
         };
         (ref_resolve_data, Some(to_value(resolve_data).unwrap()))
     } else {

--- a/docs/dev/lsp-extensions.md
+++ b/docs/dev/lsp-extensions.md
@@ -1,5 +1,5 @@
 <!---
-lsp/ext.rs hash: 96f88b7a5d0080c6
+lsp/ext.rs hash: 7d77940d7e63a8b
 
 If you need to change the above hash to make the test pass, please check if you
 need to adjust this doc as well and ping this issue:

--- a/docs/dev/lsp-extensions.md
+++ b/docs/dev/lsp-extensions.md
@@ -1,5 +1,5 @@
 <!---
-lsp/ext.rs hash: 7d77940d7e63a8b
+lsp/ext.rs hash: c4c37ab0bcf7ccb0
 
 If you need to change the above hash to make the test pass, please check if you
 need to adjust this doc as well and ping this issue:

--- a/docs/dev/lsp-extensions.md
+++ b/docs/dev/lsp-extensions.md
@@ -1,5 +1,5 @@
 <!---
-lsp/ext.rs hash: c4c37ab0bcf7ccb0
+lsp/ext.rs hash: 14b7fb1309f5bb00
 
 If you need to change the above hash to make the test pass, please check if you
 need to adjust this doc as well and ping this issue:


### PR DESCRIPTION
Closes https://github.com/rust-lang/rust-analyzer/issues/18547
Closes https://github.com/rust-lang/rust-analyzer/issues/18640

Follows https://github.com/rust-lang/rust-analyzer/issues/18547#issuecomment-2525373488 proposal and adds completion items hashing, using all their data possible, that does not change between the edits.