### PR TITLE
feat: Implement import ide layer handling

### DIFF
--- a/crates/hir-def/src/item_tree.rs
+++ b/crates/hir-def/src/item_tree.rs
@@ -1158,6 +1158,17 @@ pub enum ImportKind {
 }
 
 impl UseTree {
+    pub fn find(&self, idx: Idx<ast::UseTree>) -> Option<&UseTree> {
+        if self.index == idx {
+            return Some(self);
+        }
+        if let UseTreeKind::Prefixed { list, .. } = &self.kind {
+            list.iter().find_map(|it| it.find(idx))
+        } else {
+            None
+        }
+    }
+
     /// Expands the `UseTree` into individually imported `ModPath`s.
     pub fn expand(
         &self,

--- a/crates/hir-def/src/nameres.rs
+++ b/crates/hir-def/src/nameres.rs
@@ -79,7 +79,7 @@ use crate::{
     item_tree::{ItemTreeId, Mod, TreeId},
     nameres::{diagnostics::DefDiagnostic, path_resolution::ResolveMode},
     path::ModPath,
-    per_ns::PerNs,
+    per_ns::PerNsRes,
     visibility::{Visibility, VisibilityExplicitness},
     AstId, BlockId, BlockLoc, CrateRootModuleId, EnumId, EnumVariantId, ExternCrateId, FunctionId,
     FxIndexMap, LocalModuleId, Lookup, MacroExpander, MacroId, ModuleId, ProcMacroId, UseId,
@@ -603,7 +603,7 @@ impl DefMap {
         path: &ModPath,
         shadow: BuiltinShadowMode,
         expected_macro_subns: Option<MacroSubNs>,
-    ) -> (PerNs, Option<usize>) {
+    ) -> (PerNsRes, Option<usize>) {
         let res = self.resolve_path_fp_with_macro(
             db,
             ResolveMode::Other,
@@ -621,7 +621,7 @@ impl DefMap {
         original_module: LocalModuleId,
         path: &ModPath,
         shadow: BuiltinShadowMode,
-    ) -> (PerNs, Option<usize>) {
+    ) -> (PerNsRes, Option<usize>) {
         let res = self.resolve_path_fp_with_macro_single(
             db,
             ResolveMode::Other,

--- a/crates/hir-def/src/path.rs
+++ b/crates/hir-def/src/path.rs
@@ -32,6 +32,13 @@ pub enum ImportAlias {
 }
 
 impl ImportAlias {
+    pub fn name(&self) -> Option<Name> {
+        match self {
+            ImportAlias::Underscore => None,
+            ImportAlias::Alias(name) => Some(name.clone()),
+        }
+    }
+
     pub fn display(&self, edition: Edition) -> impl Display + '_ {
         ImportAliasDisplay { value: self, edition }
     }

--- a/crates/hir/src/attrs.rs
+++ b/crates/hir/src/attrs.rs
@@ -16,8 +16,8 @@ use span::SyntaxContextId;
 
 use crate::{
     Adt, AsAssocItem, AssocItem, BuiltinType, Const, ConstParam, DocLinkDef, Enum, ExternCrateDecl,
-    Field, Function, GenericParam, HasCrate, Impl, LifetimeParam, Macro, Module, ModuleDef, Static,
-    Struct, Trait, TraitAlias, Type, TypeAlias, TypeParam, Union, Variant, VariantDef,
+    Field, Function, GenericParam, HasCrate, Impl, Import, LifetimeParam, Macro, Module, ModuleDef,
+    Static, Struct, Trait, TraitAlias, Type, TypeAlias, TypeParam, Union, Use, Variant, VariantDef,
 };
 
 pub trait HasAttrs {
@@ -55,6 +55,7 @@ impl_has_attrs![
     (GenericParam, GenericParamId),
     (Impl, ImplId),
     (ExternCrateDecl, ExternCrateId),
+    (Use, UseId),
 ];
 
 macro_rules! impl_has_attrs_enum {
@@ -72,6 +73,16 @@ macro_rules! impl_has_attrs_enum {
 
 impl_has_attrs_enum![Struct, Union, Enum for Adt];
 impl_has_attrs_enum![TypeParam, ConstParam, LifetimeParam for GenericParam];
+
+impl HasAttrs for Import {
+    fn attrs(self, db: &dyn HirDatabase) -> AttrsWithOwner {
+        let def = AttrDefId::UseId(self.id.import);
+        AttrsWithOwner::new(db.upcast(), def)
+    }
+    fn attr_id(self) -> AttrDefId {
+        AttrDefId::UseId(self.id.import)
+    }
+}
 
 impl HasAttrs for AssocItem {
     fn attrs(self, db: &dyn HirDatabase) -> AttrsWithOwner {

--- a/crates/hir/src/from_id.rs
+++ b/crates/hir/src/from_id.rs
@@ -5,13 +5,14 @@
 
 use hir_def::{
     hir::{BindingId, LabelId},
+    item_scope::ImportId,
     AdtId, AssocItemId, DefWithBodyId, EnumVariantId, FieldId, GenericDefId, GenericParamId,
-    ModuleDefId, VariantId,
+    ModuleDefId, UseId, VariantId,
 };
 
 use crate::{
-    Adt, AssocItem, BuiltinType, DefWithBody, Field, GenericDef, GenericParam, ItemInNs, Label,
-    Local, ModuleDef, Variant, VariantDef,
+    Adt, AssocItem, BuiltinType, DefWithBody, Field, GenericDef, GenericParam, Import, ItemInNs,
+    Label, Local, ModuleDef, Use, Variant, VariantDef,
 };
 
 macro_rules! from_id {
@@ -50,6 +51,33 @@ from_id![
     (hir_def::MacroId, crate::Macro),
     (hir_def::ExternCrateId, crate::ExternCrateDecl),
 ];
+
+impl From<Use> for UseId {
+    fn from(value: Use) -> Self {
+        value.id
+    }
+}
+impl From<Import> for UseId {
+    fn from(value: Import) -> Self {
+        value.id.import
+    }
+}
+impl From<Import> for ImportId {
+    fn from(value: Import) -> Self {
+        value.id
+    }
+}
+
+impl From<UseId> for Use {
+    fn from(id: UseId) -> Self {
+        Use { id }
+    }
+}
+impl From<ImportId> for Import {
+    fn from(id: ImportId) -> Self {
+        Import { id }
+    }
+}
 
 impl From<AdtId> for Adt {
     fn from(id: AdtId) -> Self {

--- a/crates/hir/src/has_source.rs
+++ b/crates/hir/src/has_source.rs
@@ -14,8 +14,8 @@ use tt::TextRange;
 
 use crate::{
     db::HirDatabase, Adt, Callee, Const, Enum, ExternCrateDecl, Field, FieldSource, Function, Impl,
-    InlineAsmOperand, Label, LifetimeParam, LocalSource, Macro, Module, Param, SelfParam, Static,
-    Struct, Trait, TraitAlias, TypeAlias, TypeOrConstParam, Union, Variant,
+    Import, InlineAsmOperand, Label, LifetimeParam, LocalSource, Macro, Module, Param, SelfParam,
+    Static, Struct, Trait, TraitAlias, TypeAlias, TypeOrConstParam, Union, Variant,
 };
 
 pub trait HasSource {
@@ -290,6 +290,15 @@ impl HasSource for ExternCrateDecl {
 
     fn source(self, db: &dyn HirDatabase) -> Option<InFile<Self::Ast>> {
         Some(self.id.lookup(db.upcast()).source(db.upcast()))
+    }
+}
+
+impl HasSource for Import {
+    type Ast = ast::UseTree;
+
+    fn source(self, db: &dyn HirDatabase) -> Option<InFile<Self::Ast>> {
+        let source = self.id.import.child_source(db.upcast());
+        source.map(|it| it.get(self.id.idx).cloned()).transpose()
     }
 }
 

--- a/crates/ide-db/src/defs.rs
+++ b/crates/ide-db/src/defs.rs
@@ -13,9 +13,9 @@ use either::Either;
 use hir::{
     Adt, AsAssocItem, AsExternAssocItem, AssocItem, AttributeTemplate, BuiltinAttr, BuiltinType,
     Const, Crate, DefWithBody, DeriveHelper, DocLinkDef, ExternAssocItem, ExternCrateDecl, Field,
-    Function, GenericParam, HasVisibility, HirDisplay, Impl, InlineAsmOperand, Label, Local, Macro,
-    Module, ModuleDef, Name, PathResolution, Semantics, Static, StaticLifetime, Struct, ToolModule,
-    Trait, TraitAlias, TupleField, TypeAlias, Variant, VariantDef, Visibility,
+    Function, GenericParam, HasVisibility, HirDisplay, Impl, Import, InlineAsmOperand, Label,
+    Local, Macro, Module, ModuleDef, Name, PathResolution, Semantics, Static, StaticLifetime,
+    Struct, ToolModule, Trait, TraitAlias, TupleField, TypeAlias, Variant, VariantDef, Visibility,
 };
 use span::Edition;
 use stdx::{format_to, impl_from};
@@ -49,6 +49,7 @@ pub enum Definition {
     BuiltinAttr(BuiltinAttr),
     ToolModule(ToolModule),
     ExternCrateDecl(ExternCrateDecl),
+    Import(Import),
     InlineAsmRegOrRegClass(()),
     InlineAsmOperand(InlineAsmOperand),
 }
@@ -83,6 +84,7 @@ impl Definition {
             Definition::GenericParam(it) => it.module(db),
             Definition::Label(it) => it.module(db),
             Definition::ExternCrateDecl(it) => it.module(db),
+            Definition::Import(it) => it.module(db),
             Definition::DeriveHelper(it) => it.derive().module(db),
             Definition::InlineAsmOperand(it) => it.parent(db).module(db),
             Definition::BuiltinAttr(_)
@@ -115,6 +117,7 @@ impl Definition {
             Definition::TypeAlias(it) => it.visibility(db),
             Definition::Variant(it) => it.visibility(db),
             Definition::ExternCrateDecl(it) => it.visibility(db),
+            Definition::Import(it) => it.visibility(db),
             Definition::BuiltinType(_) | Definition::TupleField(_) => Visibility::Public,
             Definition::Macro(_) => return None,
             Definition::BuiltinAttr(_)
@@ -155,6 +158,7 @@ impl Definition {
             Definition::ToolModule(_) => return None,  // FIXME
             Definition::DeriveHelper(it) => it.name(db),
             Definition::ExternCrateDecl(it) => return it.alias_or_name(db),
+            Definition::Import(it) => return it.alias_or_name(db),
             Definition::InlineAsmRegOrRegClass(_) => return None,
             Definition::InlineAsmOperand(op) => return op.name(db),
         };
@@ -207,6 +211,7 @@ impl Definition {
             Definition::GenericParam(_) => None,
             Definition::Label(_) => None,
             Definition::ExternCrateDecl(it) => it.docs(db),
+            Definition::Import(it) => it.docs(db),
 
             Definition::BuiltinAttr(it) => {
                 let name = it.name(db);
@@ -283,6 +288,7 @@ impl Definition {
             Definition::GenericParam(it) => it.display(db, edition).to_string(),
             Definition::Label(it) => it.name(db).display(db, edition).to_string(),
             Definition::ExternCrateDecl(it) => it.display(db, edition).to_string(),
+            Definition::Import(it) => it.display(db, edition).to_string(),
             Definition::BuiltinAttr(it) => format!("#[{}]", it.name(db).display(db, edition)),
             Definition::ToolModule(it) => it.name(db).display(db, edition).to_string(),
             Definition::DeriveHelper(it) => {

--- a/crates/ide-db/src/rename.rs
+++ b/crates/ide-db/src/rename.rs
@@ -200,6 +200,20 @@ impl Definition {
                         .and_then(syn_ctx_is_root)
                 }
             }
+            Definition::Import(it) => {
+                let src = sema.source(it)?;
+                if let Some(rename) = src.value.rename() {
+                    let name = rename.name()?;
+                    src.with_value(name.syntax())
+                        .original_file_range_opt(sema.db)
+                        .and_then(syn_ctx_is_root)
+                } else {
+                    let name = src.value.path()?.segment()?.name_ref()?;
+                    src.with_value(name.syntax())
+                        .original_file_range_opt(sema.db)
+                        .and_then(syn_ctx_is_root)
+                }
+            }
             Definition::InlineAsmOperand(it) => name_range(it, sema).and_then(syn_ctx_is_root),
             Definition::BuiltinType(_)
             | Definition::BuiltinLifetime(_)

--- a/crates/ide-db/src/test_data/test_symbol_index_collection.txt
+++ b/crates/ide-db/src/test_data/test_symbol_index_collection.txt
@@ -879,6 +879,37 @@
         [
             FileSymbol {
                 name: "IsThisJustATrait",
+                def: Trait(
+                    Trait {
+                        id: TraitId(
+                            0,
+                        ),
+                    },
+                ),
+                loc: DeclarationLocation {
+                    hir_file_id: EditionedFileId(
+                        FileId(
+                            1,
+                        ),
+                        Edition2021,
+                    ),
+                    ptr: SyntaxNodePtr {
+                        kind: USE_TREE,
+                        range: 111..143,
+                    },
+                    name_ptr: AstPtr(
+                        SyntaxNodePtr {
+                            kind: NAME,
+                            range: 127..143,
+                        },
+                    ),
+                },
+                container_name: None,
+                is_alias: false,
+                is_assoc: false,
+            },
+            FileSymbol {
+                name: "IsThisJustATrait",
                 def: Macro(
                     Macro {
                         id: Macro2Id(

--- a/crates/ide/src/doc_links.rs
+++ b/crates/ide/src/doc_links.rs
@@ -211,6 +211,7 @@ pub(crate) fn resolve_doc_path_for_def(
         Definition::Field(it) => it.resolve_doc_path(db, link, ns),
         Definition::SelfType(it) => it.resolve_doc_path(db, link, ns),
         Definition::ExternCrateDecl(it) => it.resolve_doc_path(db, link, ns),
+        Definition::Import(it) => it.resolve_doc_path(db, link, ns),
         Definition::BuiltinAttr(_)
         | Definition::BuiltinType(_)
         | Definition::BuiltinLifetime(_)
@@ -666,6 +667,9 @@ fn filename_and_frag_for_def(
         }
         Definition::ExternCrateDecl(it) => {
             format!("{}/index.html", it.name(db).unescaped().display(db.upcast()))
+        }
+        Definition::Import(it) => {
+            return filename_and_frag_for_def(db, it.resolve_fully(db).iter().next()?.into())
         }
         Definition::Local(_)
         | Definition::GenericParam(_)

--- a/crates/ide/src/moniker.rs
+++ b/crates/ide/src/moniker.rs
@@ -229,6 +229,9 @@ pub(crate) fn def_to_kind(db: &RootDatabase, def: Definition) -> SymbolInformati
         Definition::ToolModule(..) => Module,
         Definition::ExternCrateDecl(..) => Module,
         Definition::InlineAsmRegOrRegClass(..) => Module,
+        Definition::Import(_) => {
+            unreachable!()
+        }
     }
 }
 
@@ -377,6 +380,9 @@ pub(crate) fn def_to_moniker(
         }
         Definition::ExternCrateDecl(m) => {
             MonikerDescriptor { name: m.name(db).display(db, edition).to_string(), desc }
+        }
+        Definition::Import(_) => {
+            unreachable!()
         }
     };
 

--- a/crates/ide/src/syntax_highlighting/highlight.rs
+++ b/crates/ide/src/syntax_highlighting/highlight.rs
@@ -538,6 +538,9 @@ pub(super) fn highlight_def(
             }
             highlight
         }
+        Definition::Import(_) => {
+            unreachable!()
+        }
         Definition::Label(_) => Highlight::new(HlTag::Symbol(SymbolKind::Label)),
         Definition::BuiltinAttr(_) => Highlight::new(HlTag::Symbol(SymbolKind::BuiltinAttr)),
         Definition::ToolModule(_) => Highlight::new(HlTag::Symbol(SymbolKind::ToolModule)),

--- a/crates/ide/src/syntax_highlighting/inject.rs
+++ b/crates/ide/src/syntax_highlighting/inject.rs
@@ -317,6 +317,7 @@ fn module_def_to_hl_tag(def: Definition) -> HlTag {
         Definition::DeriveHelper(_) => SymbolKind::DeriveHelper,
         Definition::InlineAsmRegOrRegClass(_) => SymbolKind::InlineAsmRegOrRegClass,
         Definition::InlineAsmOperand(_) => SymbolKind::Local,
+        Definition::Import(_) => unreachable!(),
     };
     HlTag::Symbol(symbol)
 }


### PR DESCRIPTION
Only implements the type driven changes so far for threading things through. It doesn't actually resolve to imports yet as I am currently thinking about whether to put `Import` (and `ExternCrate`) as `ModuleDef` variants or not
Closes https://github.com/rust-lang/rust-analyzer/issues/14079