### PR TITLE
internal: Drop proc-macro server support for ~1.66.0 and older toolchains

### DIFF
--- a/crates/proc-macro-api/src/msg/flat.rs
+++ b/crates/proc-macro-api/src/msg/flat.rs
@@ -42,7 +42,7 @@ use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
 use span::{EditionedFileId, ErasedFileAstId, Span, SpanAnchor, SyntaxContextId, TextRange};
 
-use crate::msg::{ENCODE_CLOSE_SPAN_VERSION, EXTENDED_LEAF_DATA};
+use crate::msg::EXTENDED_LEAF_DATA;
 
 pub type SpanDataIndexMap =
     indexmap::IndexSet<Span, std::hash::BuildHasherDefault<rustc_hash::FxHasher>>;
@@ -145,11 +145,7 @@ impl FlatTree {
         w.write(subtree);
 
         FlatTree {
-            subtree: if version >= ENCODE_CLOSE_SPAN_VERSION {
-                write_vec(w.subtree, SubtreeRepr::write_with_close_span)
-            } else {
-                write_vec(w.subtree, SubtreeRepr::write)
-            },
+            subtree: write_vec(w.subtree, SubtreeRepr::write),
             literal: if version >= EXTENDED_LEAF_DATA {
                 write_vec(w.literal, LiteralRepr::write_with_kind)
             } else {
@@ -183,11 +179,7 @@ impl FlatTree {
         w.write(subtree);
 
         FlatTree {
-            subtree: if version >= ENCODE_CLOSE_SPAN_VERSION {
-                write_vec(w.subtree, SubtreeRepr::write_with_close_span)
-            } else {
-                write_vec(w.subtree, SubtreeRepr::write)
-            },
+            subtree: write_vec(w.subtree, SubtreeRepr::write),
             literal: if version >= EXTENDED_LEAF_DATA {
                 write_vec(w.literal, LiteralRepr::write_with_kind)
             } else {
@@ -210,11 +202,7 @@ impl FlatTree {
         span_data_table: &SpanDataIndexMap,
     ) -> tt::Subtree<Span> {
         Reader {
-            subtree: if version >= ENCODE_CLOSE_SPAN_VERSION {
-                read_vec(self.subtree, SubtreeRepr::read_with_close_span)
-            } else {
-                read_vec(self.subtree, SubtreeRepr::read)
-            },
+            subtree: read_vec(self.subtree, SubtreeRepr::read),
             literal: if version >= EXTENDED_LEAF_DATA {
                 read_vec(self.literal, LiteralRepr::read_with_kind)
             } else {
@@ -236,11 +224,7 @@ impl FlatTree {
 
     pub fn to_subtree_unresolved(self, version: u32) -> tt::Subtree<TokenId> {
         Reader {
-            subtree: if version >= ENCODE_CLOSE_SPAN_VERSION {
-                read_vec(self.subtree, SubtreeRepr::read_with_close_span)
-            } else {
-                read_vec(self.subtree, SubtreeRepr::read)
-            },
+            subtree: read_vec(self.subtree, SubtreeRepr::read),
             literal: if version >= EXTENDED_LEAF_DATA {
                 read_vec(self.literal, LiteralRepr::read_with_kind)
             } else {
@@ -273,26 +257,7 @@ fn write_vec<T, F: Fn(T) -> [u32; N], const N: usize>(xs: Vec<T>, f: F) -> Vec<u
 }
 
 impl SubtreeRepr {
-    fn write(self) -> [u32; 4] {
-        let kind = match self.kind {
-            tt::DelimiterKind::Invisible => 0,
-            tt::DelimiterKind::Parenthesis => 1,
-            tt::DelimiterKind::Brace => 2,
-            tt::DelimiterKind::Bracket => 3,
-        };
-        [self.open.0, kind, self.tt[0], self.tt[1]]
-    }
-    fn read([open, kind, lo, len]: [u32; 4]) -> SubtreeRepr {
-        let kind = match kind {
-            0 => tt::DelimiterKind::Invisible,
-            1 => tt::DelimiterKind::Parenthesis,
-            2 => tt::DelimiterKind::Brace,
-            3 => tt::DelimiterKind::Bracket,
-            other => panic!("bad kind {other}"),
-        };
-        SubtreeRepr { open: TokenId(open), close: TokenId(!0), kind, tt: [lo, len] }
-    }
-    fn write_with_close_span(self) -> [u32; 5] {
+    fn write(self) -> [u32; 5] {
         let kind = match self.kind {
             tt::DelimiterKind::Invisible => 0,
             tt::DelimiterKind::Parenthesis => 1,
@@ -301,7 +266,7 @@ impl SubtreeRepr {
         };
         [self.open.0, self.close.0, kind, self.tt[0], self.tt[1]]
     }
-    fn read_with_close_span([open, close, kind, lo, len]: [u32; 5]) -> SubtreeRepr {
+    fn read([open, close, kind, lo, len]: [u32; 5]) -> SubtreeRepr {
         let kind = match kind {
             0 => tt::DelimiterKind::Invisible,
             1 => tt::DelimiterKind::Parenthesis,

--- a/crates/proc-macro-api/src/process.rs
+++ b/crates/proc-macro-api/src/process.rs
@@ -56,8 +56,25 @@ impl ProcMacroProcessSrv {
         match srv.version_check() {
             Ok(v) if v > CURRENT_API_VERSION => Err(io::Error::new(
                 io::ErrorKind::Other,
-                format!( "The version of the proc-macro server ({v}) in your Rust toolchain is newer than the version supported by your rust-analyzer ({CURRENT_API_VERSION}).
-            This will prevent proc-macro expansion from working. Please consider updating your rust-analyzer to ensure compatibility with your current toolchain."
+                format!(
+                    "The version of the proc-macro server ({v}) in your Rust toolchain \
+                is newer than the version supported by your rust-analyzer ({CURRENT_API_VERSION}).
+\
+                This will prevent proc-macro expansion from working. \
+                Please consider updating your rust-analyzer to ensure compatibility with your \
+                current toolchain."
+                ),
+            )),
+            Ok(v) if v < RUST_ANALYZER_SPAN_SUPPORT => Err(io::Error::new(
+                io::ErrorKind::Other,
+                format!(
+                    "The version of the proc-macro server ({v}) in your Rust toolchain \
+                is too old and no longer supported by your rust-analyzer which requires\
+                version {RUST_ANALYZER_SPAN_SUPPORT} or higher.
+\
+                This will prevent proc-macro expansion from working. \
+                Please consider updating your toolchain or downgrading your rust-analyzer \
+                to ensure compatibility with your current toolchain."
                 ),
             )),
             Ok(v) => {
@@ -72,10 +89,10 @@ impl ProcMacroProcessSrv {
                 tracing::info!("Proc-macro server span mode: {:?}", srv.mode);
                 Ok(srv)
             }
-            Err(e) => {
-                tracing::info!(%e, "proc-macro version check failed, restarting and assuming version 0");
-                create_srv(false)
-            }
+            Err(e) => Err(io::Error::new(
+                io::ErrorKind::Other,
+                format!("Failed to fetch proc-macro server version: {e}"),
+            )),
         }
     }
 


### PR DESCRIPTION
That is toolchains older than ~20 months from today on where this version was released. Reason is to simplify the codebase, and we likely don't even support version that old due to other reasons anymore either