### PR TITLE
Fix typo in error message for invalid casting

### DIFF
--- a/crates/ide-diagnostics/src/handlers/invalid_cast.rs
+++ b/crates/ide-diagnostics/src/handlers/invalid_cast.rs
@@ -59,7 +59,7 @@ pub(crate) fn invalid_cast(ctx: &DiagnosticsContext<'_>, d: &hir::InvalidCast) -
             DiagnosticCode::RustcHardError("E0606"),
             format_ty!(
                 ctx,
-                "casting `{}` as `{}` is invalid: needs defererence or removal of unneeded borrow",
+                "casting `{}` as `{}` is invalid: needs dereference or removal of unneeded borrow",
                 d.expr_ty,
                 d.cast_ty
             ),


### PR DESCRIPTION
Corrected the spelling of "defererence" to "dereference" in the error message that informs users about invalid casting requirements.