### PR TITLE
internal: Do not require a special env var to be set for the proc-macro-srv

### DIFF
--- a/crates/proc-macro-srv-cli/src/main.rs
+++ b/crates/proc-macro-srv-cli/src/main.rs
@@ -6,21 +6,16 @@
 #[cfg(feature = "in-rust-tree")]
 extern crate rustc_driver as _;
 
-use proc_macro_api::json::{read_json, write_json};
-
 use std::io;
 
 fn main() -> std::io::Result<()> {
     let v = std::env::var("RUST_ANALYZER_INTERNALS_DO_NOT_USE");
-    match v.as_deref() {
-        Ok("this is unstable") => {
-            // very well, if you must
-        }
-        _ => {
-            eprintln!("If you're rust-analyzer, you can use this tool by exporting RUST_ANALYZER_INTERNALS_DO_NOT_USE='this is unstable'.");
-            eprintln!("If not, you probably shouldn't use this tool. But do what you want: I'm an error message, not a cop.");
-            std::process::exit(122);
-        }
+    if v.is_err() {
+        eprintln!("This is an IDE implementation detail, you can use this tool by exporting RUST_ANALYZER_INTERNALS_DO_NOT_USE.");
+        eprintln!(
+            "Note that this tool's API is highly unstable and may break without prior notice"
+        );
+        std::process::exit(122);
     }
 
     run()
@@ -28,40 +23,19 @@ fn main() -> std::io::Result<()> {
 
 #[cfg(not(any(feature = "sysroot-abi", rust_analyzer)))]
 fn run() -> io::Result<()> {
-    let err = "proc-macro-srv-cli needs to be compiled with the `sysroot-abi` feature to function";
-    eprintln!("{err}");
-    use proc_macro_api::msg::{self, Message};
-
-    let read_request =
-        |buf: &mut String| msg::Request::read(read_json, &mut io::stdin().lock(), buf);
-
-    let write_response = |msg: msg::Response| msg.write(write_json, &mut io::stdout().lock());
-
-    let mut buf = String::new();
-
-    while let Some(req) = read_request(&mut buf)? {
-        let res = match req {
-            msg::Request::ListMacros { .. } => msg::Response::ListMacros(Err(err.to_owned())),
-            msg::Request::ExpandMacro(_) => {
-                msg::Response::ExpandMacro(Err(msg::PanicMessage(err.to_owned())))
-            }
-            msg::Request::ApiVersionCheck {} => {
-                msg::Response::ApiVersionCheck(proc_macro_api::msg::CURRENT_API_VERSION)
-            }
-            msg::Request::SetConfig(_) => {
-                msg::Response::SetConfig(proc_macro_api::msg::ServerConfig {
-                    span_mode: msg::SpanMode::Id,
-                })
-            }
-        };
-        write_response(res)?
-    }
-    Ok(())
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        "proc-macro-srv-cli needs to be compiled with the `sysroot-abi` feature to function"
+            .to_owned(),
+    ))
 }
 
 #[cfg(any(feature = "sysroot-abi", rust_analyzer))]
 fn run() -> io::Result<()> {
-    use proc_macro_api::msg::{self, Message};
+    use proc_macro_api::{
+        json::{read_json, write_json},
+        msg::{self, Message},
+    };
     use proc_macro_srv::EnvSnapshot;
 
     let read_request =


### PR DESCRIPTION
It feels a bit silly to require this at this point