### PR TITLE
fix: Panic when displaying generic params with defaults, again

### DIFF
--- a/crates/ide/src/hover/tests.rs
+++ b/crates/ide/src/hover/tests.rs
@@ -9465,4 +9465,39 @@ fn main() {
             size = 0, align = 1
         "#]],
     );
+
+    check(
+        r#"
+//- minicore: eq
+pub struct RandomState;
+pub struct HashMap<K, V, S = RandomState>(K, V, S);
+
+impl<K, V> HashMap<K, V, RandomState> {
+    pub fn new() -> HashMap<K, V, RandomState> {
+        loop {}
+    }
+}
+
+impl<K, V, S> PartialEq for HashMap<K, V, S> {
+    fn eq(&self, other: &HashMap<K, V, S>) -> bool {
+        false
+    }
+}
+
+fn main() {
+    let s$0 = HashMap::<_, u64>::ne;
+}
+"#,
+        expect![[r#"
+            *s*
+
+            ```rust
+            let s: fn ne<HashMap<{unknown}, u64>>(&HashMap<{unknown}, u64>, &HashMap<{unknown}, u64>) -> bool
+            ```
+
+            ---
+
+            size = 0, align = 1
+        "#]],
+    );
 }


### PR DESCRIPTION
So, basically functions cannot have default params, but they can if they are something like

```rust
struct Foo<T = i32>(T);

let foo = Foo; // foo is fn<T = i32>(t: T) -> Foo<T>
```

I was puzzled to those things and fixed the previous issue in a wrong way, so it has been panicking for "normal" functions without default parameters for themselves, but for their parents 😅 

Fixes #18664