### PR TITLE
fix: Revert changes to client capabilities in `bac0ed5`

### DIFF
--- a/editors/code/src/client.ts
+++ b/editors/code/src/client.ts
@@ -324,7 +324,7 @@ class ExperimentalFeatures implements lc.StaticFeature {
     }
     fillClientCapabilities(capabilities: lc.ClientCapabilities): void {
         capabilities.experimental = {
-            snippetTextEdit: false,
+            snippetTextEdit: true,
             codeActionGroup: true,
             hoverActions: true,
             serverStatusNotification: true,


### PR DESCRIPTION
part of #18679 