### PR TITLE
minor: improve name suggestion for destructure_tuple_binding

### DIFF
--- a/crates/ide-assists/src/assist_context.rs
+++ b/crates/ide-assists/src/assist_context.rs
@@ -3,6 +3,7 @@
 use hir::{FileRange, Semantics};
 use ide_db::EditionedFileId;
 use ide_db::{label::Label, FileId, RootDatabase};
+use syntax::Edition;
 use syntax::{
     algo::{self, find_node_at_offset, find_node_at_range},
     AstNode, AstToken, Direction, SourceFile, SyntaxElement, SyntaxKind, SyntaxToken, TextRange,
@@ -92,6 +93,10 @@ impl<'a> AssistContext<'a> {
 
     pub(crate) fn file_id(&self) -> EditionedFileId {
         self.frange.file_id
+    }
+
+    pub(crate) fn edition(&self) -> Edition {
+        self.frange.file_id.edition()
     }
 
     pub(crate) fn has_empty_selection(&self) -> bool {

--- a/crates/ide-db/src/syntax_helpers/suggest_name.rs
+++ b/crates/ide-db/src/syntax_helpers/suggest_name.rs
@@ -377,6 +377,8 @@ fn name_of_type(ty: &hir::Type, db: &RootDatabase, edition: Edition) -> Option<S
             return None;
         }
         name
+    } else if let Some(inner_ty) = ty.remove_ref() {
+        return name_of_type(&inner_ty, db, edition);
     } else {
         return None;
     };


### PR DESCRIPTION
Use `ide_db::syntax_helpers::suggest_name` to suggest names in `destructure_tuple_binding`. If `NameGenerator` fails to generate new names, it will default to `_{idx}`.