### PR TITLE
fix: Fix pretty-printing of `@` patterns

### DIFF
--- a/crates/hir-def/src/body/pretty.rs
+++ b/crates/hir-def/src/body/pretty.rs
@@ -685,6 +685,7 @@ impl Printer<'_> {
                 self.print_binding(*id);
                 if let Some(pat) = subpat {
                     self.whitespace();
+                    w!(self, "@ ");
                     self.print_pat(*pat);
                 }
             }

--- a/crates/hir-def/src/body/tests.rs
+++ b/crates/hir-def/src/body/tests.rs
@@ -426,3 +426,21 @@ fn f() {
         "should have a binding for `B`",
     );
 }
+
+#[test]
+fn regression_pretty_print_bind_pat() {
+    let (db, body, owner) = lower(
+        r#"
+fn foo() {
+    let v @ u = 123;
+}
+"#,
+    );
+    let printed = body.pretty_print(&db, owner, Edition::CURRENT);
+    assert_eq!(
+        printed,
+        r#"fn foo() -> () {
+    let v @ u = 123;
+}"#
+    );
+}


### PR DESCRIPTION
It didn't print the `@`.