### PR TITLE
Remove salsa from proc-macro server dep tree

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1352,7 +1352,6 @@ dependencies = [
 name = "proc-macro-api"
 version = "0.0.0"
 dependencies = [
- "base-db",
  "indexmap",
  "intern",
  "paths",
@@ -1369,7 +1368,6 @@ dependencies = [
 name = "proc-macro-srv"
 version = "0.0.0"
 dependencies = [
- "base-db",
  "expect-test",
  "intern",
  "libloading",

--- a/crates/load-cargo/src/lib.rs
+++ b/crates/load-cargo/src/lib.rs
@@ -487,7 +487,7 @@ impl ProcMacroExpander for Expander {
         match self.0.expand(
             subtree,
             attrs,
-            env.clone(),
+            env.clone().into(),
             def_site,
             call_site,
             mixed_site,

--- a/crates/proc-macro-api/Cargo.toml
+++ b/crates/proc-macro-api/Cargo.toml
@@ -23,11 +23,9 @@ indexmap.workspace = true
 paths = { workspace = true, features = ["serde1"] }
 tt.workspace = true
 stdx.workspace = true
-# Ideally this crate would not depend on salsa things, but we need span information here which wraps
-# InternIds for the syntax context
-span.workspace = true
-# only here due to the `Env` newtype :/
-base-db.workspace = true
+# span = {workspace = true, default-features = false} does not work
+span = { path = "../span", version = "0.0.0", default-features = false}
+
 intern.workspace = true
 
 [lints]

--- a/crates/proc-macro-api/src/lib.rs
+++ b/crates/proc-macro-api/src/lib.rs
@@ -9,7 +9,6 @@ pub mod json;
 pub mod msg;
 mod process;
 
-use base_db::Env;
 use paths::{AbsPath, AbsPathBuf};
 use span::Span;
 use std::{fmt, io, sync::Arc};
@@ -148,7 +147,7 @@ impl ProcMacro {
         &self,
         subtree: &tt::Subtree<Span>,
         attr: Option<&tt::Subtree<Span>>,
-        env: Env,
+        env: Vec<(String, String)>,
         def_site: Span,
         call_site: Span,
         mixed_site: Span,
@@ -179,7 +178,7 @@ impl ProcMacro {
                 },
             },
             lib: self.dylib_path.to_path_buf().into(),
-            env: env.into(),
+            env,
             current_dir,
         };
 

--- a/crates/proc-macro-srv/Cargo.toml
+++ b/crates/proc-macro-srv/Cargo.toml
@@ -21,8 +21,8 @@ stdx.workspace = true
 tt.workspace = true
 syntax-bridge.workspace = true
 paths.workspace = true
-base-db.workspace = true
-span.workspace = true
+# span = {workspace = true, default-features = false} does not work
+span = { path = "../span", version = "0.0.0", default-features = false}
 proc-macro-api.workspace = true
 intern.workspace = true
 

--- a/crates/span/Cargo.toml
+++ b/crates/span/Cargo.toml
@@ -12,7 +12,7 @@ authors.workspace = true
 
 [dependencies]
 la-arena.workspace = true
-ra-salsa.workspace = true
+ra-salsa = { workspace = true, optional = true }
 rustc-hash.workspace = true
 hashbrown.workspace = true
 text-size.workspace = true
@@ -21,6 +21,9 @@ text-size.workspace = true
 vfs.workspace = true
 syntax.workspace = true
 stdx.workspace = true
+
+[features]
+default = ["ra-salsa"]
 
 [lints]
 workspace = true

--- a/crates/span/src/hygiene.rs
+++ b/crates/span/src/hygiene.rs
@@ -21,6 +21,9 @@
 //! `ExpnData::call_site` in rustc, [`MacroCallLoc::call_site`] in rust-analyzer.
 use std::fmt;
 
+#[cfg(not(feature = "ra-salsa"))]
+use crate::InternId;
+#[cfg(feature = "ra-salsa")]
 use ra_salsa::{InternId, InternValue};
 
 use crate::MacroCallId;
@@ -39,6 +42,7 @@ impl fmt::Debug for SyntaxContextId {
     }
 }
 
+#[cfg(feature = "ra-salsa")]
 impl ra_salsa::InternKey for SyntaxContextId {
     fn from_intern_id(v: ra_salsa::InternId) -> Self {
         SyntaxContextId(v)
@@ -92,6 +96,7 @@ pub struct SyntaxContextData {
     pub opaque_and_semitransparent: SyntaxContextId,
 }
 
+#[cfg(feature = "ra-salsa")]
 impl InternValue for SyntaxContextData {
     type Key = (SyntaxContextId, Option<MacroCallId>, Transparency);
 

--- a/crates/span/src/lib.rs
+++ b/crates/span/src/lib.rs
@@ -1,6 +1,7 @@
 //! File and span related types.
 use std::fmt::{self, Write};
 
+#[cfg(feature = "ra-salsa")]
 use ra_salsa::InternId;
 
 mod ast_id;
@@ -355,3 +356,71 @@ impl HirFileId {
         }
     }
 }
+
+#[cfg(not(feature = "ra-salsa"))]
+mod intern_id_proxy {
+    use std::fmt;
+    use std::num::NonZeroU32;
+
+    pub(super) struct InternId {
+        value: NonZeroU32,
+    }
+
+    impl InternId {
+        pub(super) const MAX: u32 = 0xFFFF_FF00;
+
+        pub(super) const unsafe fn new_unchecked(value: u32) -> Self {
+            debug_assert!(value < InternId::MAX);
+            let value = unsafe { NonZeroU32::new_unchecked(value + 1) };
+            InternId { value }
+        }
+
+        pub(super) fn as_u32(self) -> u32 {
+            self.value.get() - 1
+        }
+
+        pub(super) fn as_usize(self) -> usize {
+            self.as_u32() as usize
+        }
+    }
+
+    impl From<InternId> for u32 {
+        fn from(raw: InternId) -> u32 {
+            raw.as_u32()
+        }
+    }
+
+    impl From<InternId> for usize {
+        fn from(raw: InternId) -> usize {
+            raw.as_usize()
+        }
+    }
+
+    impl From<u32> for InternId {
+        fn from(id: u32) -> InternId {
+            assert!(id < InternId::MAX);
+            unsafe { InternId::new_unchecked(id) }
+        }
+    }
+
+    impl From<usize> for InternId {
+        fn from(id: usize) -> InternId {
+            assert!(id < (InternId::MAX as usize));
+            unsafe { InternId::new_unchecked(id as u32) }
+        }
+    }
+
+    impl fmt::Debug for InternId {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            self.as_usize().fmt(f)
+        }
+    }
+
+    impl fmt::Display for InternId {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            self.as_usize().fmt(f)
+        }
+    }
+}
+#[cfg(not(feature = "ra-salsa"))]
+use intern_id_proxy::InternId;

--- a/crates/syntax-bridge/Cargo.toml
+++ b/crates/syntax-bridge/Cargo.toml
@@ -21,7 +21,8 @@ syntax.workspace = true
 parser.workspace = true
 tt.workspace = true
 stdx.workspace = true
-span.workspace = true
+# span = {workspace = true, default-features = false} does not work
+span = { path = "../span", version = "0.0.0", default-features = false}
 intern.workspace = true
 
 [dev-dependencies]


### PR DESCRIPTION
It should never attempt to use salsa anyways and it only depends on it due spans requiring the ID