### PR TITLE
internal: Cleanup label structure of `CompletionItem`

### DIFF
--- a/crates/ide-completion/src/completions/dot.rs
+++ b/crates/ide-completion/src/completions/dot.rs
@@ -205,7 +205,7 @@ impl S {
 fn foo(s: S) { s.$0 }
 "#,
             expect![[r#"
-                fd foo   u32
+                fd foo         u32
                 me bar() fn(&self)
             "#]],
         );
@@ -259,7 +259,7 @@ impl S {
 "#,
             expect![[r#"
                 fd the_field (u32,)
-                me foo()     fn(self)
+                me foo()   fn(self)
             "#]],
         )
     }
@@ -275,7 +275,7 @@ impl A {
 "#,
             expect![[r#"
                 fd the_field (u32, i32)
-                me foo()     fn(&self)
+                me foo()      fn(&self)
             "#]],
         )
     }
@@ -536,7 +536,7 @@ impl A {
 }
             "#,
             expect![[r#"
-                fd pub_field    u32
+                fd pub_field          u32
                 me pub_method() fn(&self)
             "#]],
         )
@@ -550,7 +550,7 @@ union U { field: u8, other: u16 }
 fn foo(u: U) { u.$0 }
 "#,
             expect![[r#"
-                fd field u8
+                fd field  u8
                 fd other u16
             "#]],
         );
@@ -725,8 +725,8 @@ fn test(a: A) {
 }
 "#,
             expect![[r#"
-                fd another                u32
-                fd field                  u8
+                fd another                                                          u32
+                fd field                                                             u8
                 me deref() (use core::ops::Deref) fn(&self) -> &<Self as Deref>::Target
             "#]],
         );
@@ -748,8 +748,8 @@ fn test(a: A) {
 }
 "#,
             expect![[r#"
-                fd 0                      u8
-                fd 1                      u32
+                fd 0                                                                 u8
+                fd 1                                                                u32
                 me deref() (use core::ops::Deref) fn(&self) -> &<Self as Deref>::Target
             "#]],
         );
@@ -770,8 +770,8 @@ fn test(a: A) {
 }
 "#,
             expect![[r#"
-                fd 0                      u8
-                fd 1                      u32
+                fd 0                                                                 u8
+                fd 1                                                                u32
                 me deref() (use core::ops::Deref) fn(&self) -> &<Self as Deref>::Target
             "#]],
         );
@@ -964,12 +964,12 @@ struct Foo { field: i32 }
 
 impl Foo { fn foo(&self) { $0 } }"#,
             expect![[r#"
-                fd self.field i32
+                fd self.field       i32
                 me self.foo() fn(&self)
-                lc self       &Foo
-                sp Self       Foo
-                st Foo        Foo
-                bt u32        u32
+                lc self            &Foo
+                sp Self             Foo
+                st Foo              Foo
+                bt u32              u32
             "#]],
         );
         check(
@@ -978,12 +978,12 @@ struct Foo(i32);
 
 impl Foo { fn foo(&mut self) { $0 } }"#,
             expect![[r#"
-                fd self.0     i32
+                fd self.0               i32
                 me self.foo() fn(&mut self)
-                lc self       &mut Foo
-                sp Self       Foo
-                st Foo        Foo
-                bt u32        u32
+                lc self            &mut Foo
+                sp Self                 Foo
+                st Foo                  Foo
+                bt u32                  u32
             "#]],
         );
     }
@@ -1106,7 +1106,7 @@ fn test(a: A) {
 }
 "#,
             expect![[r#"
-                fd 0                      u8
+                fd 0                                                                 u8
                 me deref() (use core::ops::Deref) fn(&self) -> &<Self as Deref>::Target
             "#]],
         );
@@ -1162,7 +1162,7 @@ impl<F: core::ops::Deref<Target = impl Bar>> Foo<F> {
 }
 "#,
             expect![[r#"
-                fd foo      &u8
+                fd foo            &u8
                 me foobar() fn(&self)
             "#]],
         );
@@ -1199,8 +1199,8 @@ impl<B: Bar, F: core::ops::Deref<Target = B>> Foo<F> {
 }
 "#,
             expect![[r#"
-            fd foo &u8
-        "#]],
+                fd foo &u8
+            "#]],
         );
     }
 

--- a/crates/ide-completion/src/completions/item_list/trait_impl.rs
+++ b/crates/ide-completion/src/completions/item_list/trait_impl.rs
@@ -537,10 +537,10 @@ impl Test for T {
 }
 ",
             expect![[r#"
-                sp Self T
-                st T    T
+                sp Self  T
+                st T     T
                 tt Test
-                bt u32  u32
+                bt u32 u32
             "#]],
         );
 
@@ -646,10 +646,10 @@ impl Test for T {
 }
 ",
             expect![[r#"
-                sp Self T
-                st T    T
+                sp Self  T
+                st T     T
                 tt Test
-                bt u32  u32
+                bt u32 u32
             "#]],
         );
 
@@ -663,10 +663,10 @@ impl Test for T {
 }
 ",
             expect![[r#"
-                sp Self T
-                st T    T
+                sp Self  T
+                st T     T
                 tt Test
-                bt u32  u32
+                bt u32 u32
             "#]],
         );
 
@@ -682,10 +682,10 @@ impl Test for T {
 }
 ",
             expect![[r#"
-                sp Self T
-                st T    T
+                sp Self  T
+                st T     T
                 tt Test
-                bt u32  u32
+                bt u32 u32
             "#]],
         );
 
@@ -730,10 +730,10 @@ impl Test for T {
 }
 ",
             expect![[r#"
-                sp Self T
-                st T    T
+                sp Self  T
+                st T     T
                 tt Test
-                bt u32  u32
+                bt u32 u32
             "#]],
         );
 

--- a/crates/ide-completion/src/completions/keyword.rs
+++ b/crates/ide-completion/src/completions/keyword.rs
@@ -78,19 +78,19 @@ fn foo(a: A) { a.$0 }
 "#,
             expect![[r#"
                 me into_future() (as IntoFuture) fn(self) -> <Self as IntoFuture>::IntoFuture
-                kw await                  expr.await
-                sn box                    Box::new(expr)
-                sn call                   function(expr)
-                sn dbg                    dbg!(expr)
-                sn dbgr                   dbg!(&expr)
-                sn deref                  *expr
-                sn let                    let
-                sn letm                   let mut
-                sn match                  match expr {}
-                sn ref                    &expr
-                sn refm                   &mut expr
-                sn return                 return expr
-                sn unsafe                 unsafe {}
+                kw await                                                           expr.await
+                sn box                                                         Box::new(expr)
+                sn call                                                        function(expr)
+                sn dbg                                                             dbg!(expr)
+                sn dbgr                                                           dbg!(&expr)
+                sn deref                                                                *expr
+                sn let                                                                    let
+                sn letm                                                               let mut
+                sn match                                                        match expr {}
+                sn ref                                                                  &expr
+                sn refm                                                             &mut expr
+                sn return                                                         return expr
+                sn unsafe                                                           unsafe {}
             "#]],
         );
 
@@ -105,19 +105,19 @@ fn foo() {
 "#,
             expect![[r#"
                 me into_future() (use core::future::IntoFuture) fn(self) -> <Self as IntoFuture>::IntoFuture
-                kw await                  expr.await
-                sn box                    Box::new(expr)
-                sn call                   function(expr)
-                sn dbg                    dbg!(expr)
-                sn dbgr                   dbg!(&expr)
-                sn deref                  *expr
-                sn let                    let
-                sn letm                   let mut
-                sn match                  match expr {}
-                sn ref                    &expr
-                sn refm                   &mut expr
-                sn return                 return expr
-                sn unsafe                 unsafe {}
+                kw await                                                                          expr.await
+                sn box                                                                        Box::new(expr)
+                sn call                                                                       function(expr)
+                sn dbg                                                                            dbg!(expr)
+                sn dbgr                                                                          dbg!(&expr)
+                sn deref                                                                               *expr
+                sn let                                                                                   let
+                sn letm                                                                              let mut
+                sn match                                                                       match expr {}
+                sn ref                                                                                 &expr
+                sn refm                                                                            &mut expr
+                sn return                                                                        return expr
+                sn unsafe                                                                          unsafe {}
             "#]],
         );
     }
@@ -134,19 +134,19 @@ fn foo(a: A) { a.$0 }
 "#,
             expect![[r#"
                 me into_future() (as IntoFuture) fn(self) -> <Self as IntoFuture>::IntoFuture
-                kw await                  expr.await
-                sn box                    Box::new(expr)
-                sn call                   function(expr)
-                sn dbg                    dbg!(expr)
-                sn dbgr                   dbg!(&expr)
-                sn deref                  *expr
-                sn let                    let
-                sn letm                   let mut
-                sn match                  match expr {}
-                sn ref                    &expr
-                sn refm                   &mut expr
-                sn return                 return expr
-                sn unsafe                 unsafe {}
+                kw await                                                           expr.await
+                sn box                                                         Box::new(expr)
+                sn call                                                        function(expr)
+                sn dbg                                                             dbg!(expr)
+                sn dbgr                                                           dbg!(&expr)
+                sn deref                                                                *expr
+                sn let                                                                    let
+                sn letm                                                               let mut
+                sn match                                                        match expr {}
+                sn ref                                                                  &expr
+                sn refm                                                             &mut expr
+                sn return                                                         return expr
+                sn unsafe                                                           unsafe {}
             "#]],
         );
     }

--- a/crates/ide-completion/src/completions/postfix.rs
+++ b/crates/ide-completion/src/completions/postfix.rs
@@ -423,21 +423,21 @@ fn main() {
 }
 "#,
             expect![[r#"
-                sn box    Box::new(expr)
-                sn call   function(expr)
-                sn dbg    dbg!(expr)
-                sn dbgr   dbg!(&expr)
-                sn deref  *expr
-                sn if     if expr {}
-                sn let    let
-                sn letm   let mut
-                sn match  match expr {}
-                sn not    !expr
-                sn ref    &expr
-                sn refm   &mut expr
-                sn return return expr
-                sn unsafe unsafe {}
-                sn while  while expr {}
+                sn box  Box::new(expr)
+                sn call function(expr)
+                sn dbg      dbg!(expr)
+                sn dbgr    dbg!(&expr)
+                sn deref         *expr
+                sn if       if expr {}
+                sn let             let
+                sn letm        let mut
+                sn match match expr {}
+                sn not           !expr
+                sn ref           &expr
+                sn refm      &mut expr
+                sn return  return expr
+                sn unsafe    unsafe {}
+                sn while while expr {}
             "#]],
         );
     }
@@ -456,19 +456,19 @@ fn main() {
 }
 "#,
             expect![[r#"
-                sn box    Box::new(expr)
-                sn call   function(expr)
-                sn dbg    dbg!(expr)
-                sn dbgr   dbg!(&expr)
-                sn deref  *expr
-                sn if     if expr {}
-                sn match  match expr {}
-                sn not    !expr
-                sn ref    &expr
-                sn refm   &mut expr
-                sn return return expr
-                sn unsafe unsafe {}
-                sn while  while expr {}
+                sn box  Box::new(expr)
+                sn call function(expr)
+                sn dbg      dbg!(expr)
+                sn dbgr    dbg!(&expr)
+                sn deref         *expr
+                sn if       if expr {}
+                sn match match expr {}
+                sn not           !expr
+                sn ref           &expr
+                sn refm      &mut expr
+                sn return  return expr
+                sn unsafe    unsafe {}
+                sn while while expr {}
             "#]],
         );
     }
@@ -483,18 +483,18 @@ fn main() {
 }
 "#,
             expect![[r#"
-                sn box    Box::new(expr)
-                sn call   function(expr)
-                sn dbg    dbg!(expr)
-                sn dbgr   dbg!(&expr)
-                sn deref  *expr
-                sn let    let
-                sn letm   let mut
-                sn match  match expr {}
-                sn ref    &expr
-                sn refm   &mut expr
-                sn return return expr
-                sn unsafe unsafe {}
+                sn box  Box::new(expr)
+                sn call function(expr)
+                sn dbg      dbg!(expr)
+                sn dbgr    dbg!(&expr)
+                sn deref         *expr
+                sn let             let
+                sn letm        let mut
+                sn match match expr {}
+                sn ref           &expr
+                sn refm      &mut expr
+                sn return  return expr
+                sn unsafe    unsafe {}
             "#]],
         )
     }
@@ -509,21 +509,21 @@ fn main() {
 }
 "#,
             expect![[r#"
-                sn box    Box::new(expr)
-                sn call   function(expr)
-                sn dbg    dbg!(expr)
-                sn dbgr   dbg!(&expr)
-                sn deref  *expr
-                sn if     if expr {}
-                sn let    let
-                sn letm   let mut
-                sn match  match expr {}
-                sn not    !expr
-                sn ref    &expr
-                sn refm   &mut expr
-                sn return return expr
-                sn unsafe unsafe {}
-                sn while  while expr {}
+                sn box  Box::new(expr)
+                sn call function(expr)
+                sn dbg      dbg!(expr)
+                sn dbgr    dbg!(&expr)
+                sn deref         *expr
+                sn if       if expr {}
+                sn let             let
+                sn letm        let mut
+                sn match match expr {}
+                sn not           !expr
+                sn ref           &expr
+                sn refm      &mut expr
+                sn return  return expr
+                sn unsafe    unsafe {}
+                sn while while expr {}
             "#]],
         );
     }

--- a/crates/ide-completion/src/render.rs
+++ b/crates/ide-completion/src/render.rs
@@ -748,9 +748,9 @@ mod tests {
                 let tag = it.kind.tag();
                 let relevance = display_relevance(it.relevance);
                 items.push(format!(
-                    "{tag} {}{} {relevance}\n",
-                    it.label,
-                    it.label_detail.clone().unwrap_or_default(),
+                    "{tag} {} {} {relevance}\n",
+                    it.label.primary,
+                    it.label.detail_right.clone().unwrap_or_default(),
                 ));
 
                 if let Some((label, _indel, relevance)) = it.ref_match() {
@@ -812,13 +812,13 @@ fn main() {
 }
 "#,
             expect![[r#"
-                st dep::test_mod_b::Struct {…} [type_could_unify]
-                ex dep::test_mod_b::Struct {  } [type_could_unify]
-                st Struct (use dep::test_mod_b::Struct) [type_could_unify+requires_import]
-                fn main() []
-                fn test(…) []
-                md dep []
-                st Struct (use dep::test_mod_a::Struct) [requires_import]
+                st dep::test_mod_b::Struct {…} dep::test_mod_b::Struct {  } [type_could_unify]
+                ex dep::test_mod_b::Struct {  }  [type_could_unify]
+                st Struct Struct [type_could_unify+requires_import]
+                fn main() fn() []
+                fn test(…) fn(Struct) []
+                md dep  []
+                st Struct Struct [requires_import]
             "#]],
         );
     }
@@ -852,11 +852,11 @@ fn main() {
 }
 "#,
             expect![[r#"
-                un Union (use dep::test_mod_b::Union) [type_could_unify+requires_import]
-                fn main() []
-                fn test(…) []
-                md dep []
-                en Union (use dep::test_mod_a::Union) [requires_import]
+                un Union Union [type_could_unify+requires_import]
+                fn main() fn() []
+                fn test(…) fn(Union) []
+                md dep  []
+                en Union Union [requires_import]
             "#]],
         );
     }
@@ -888,13 +888,13 @@ fn main() {
 }
 "#,
             expect![[r#"
-                ev dep::test_mod_b::Enum::variant [type_could_unify]
-                ex dep::test_mod_b::Enum::variant [type_could_unify]
-                en Enum (use dep::test_mod_b::Enum) [type_could_unify+requires_import]
-                fn main() []
-                fn test(…) []
-                md dep []
-                en Enum (use dep::test_mod_a::Enum) [requires_import]
+                ev dep::test_mod_b::Enum::variant dep::test_mod_b::Enum::variant [type_could_unify]
+                ex dep::test_mod_b::Enum::variant  [type_could_unify]
+                en Enum Enum [type_could_unify+requires_import]
+                fn main() fn() []
+                fn test(…) fn(Enum) []
+                md dep  []
+                en Enum Enum [requires_import]
             "#]],
         );
     }
@@ -926,11 +926,11 @@ fn main() {
 }
 "#,
             expect![[r#"
-                ev dep::test_mod_b::Enum::Variant [type_could_unify]
-                ex dep::test_mod_b::Enum::Variant [type_could_unify]
-                fn main() []
-                fn test(…) []
-                md dep []
+                ev dep::test_mod_b::Enum::Variant dep::test_mod_b::Enum::Variant [type_could_unify]
+                ex dep::test_mod_b::Enum::Variant  [type_could_unify]
+                fn main() fn() []
+                fn test(…) fn(Enum) []
+                md dep  []
             "#]],
         );
     }
@@ -958,11 +958,11 @@ fn main() {
 }
 "#,
             expect![[r#"
-                fn main() []
-                fn test(…) []
-                md dep []
-                fn function (use dep::test_mod_a::function) [requires_import]
-                fn function(…) (use dep::test_mod_b::function) [requires_import]
+                fn main() fn() []
+                fn test(…) fn(fn(usize) -> i32) []
+                md dep  []
+                fn function fn(usize) -> i32 [requires_import]
+                fn function(…) fn(isize) -> i32 [requires_import]
             "#]],
         );
     }
@@ -990,11 +990,11 @@ fn main() {
 }
 "#,
             expect![[r#"
-                ct CONST (use dep::test_mod_b::CONST) [type_could_unify+requires_import]
-                fn main() []
-                fn test(…) []
-                md dep []
-                ct CONST (use dep::test_mod_a::CONST) [requires_import]
+                ct CONST i32 [type_could_unify+requires_import]
+                fn main() fn() []
+                fn test(…) fn(i32) []
+                md dep  []
+                ct CONST i64 [requires_import]
             "#]],
         );
     }
@@ -1022,11 +1022,11 @@ fn main() {
 }
 "#,
             expect![[r#"
-                sc STATIC (use dep::test_mod_b::STATIC) [type_could_unify+requires_import]
-                fn main() []
-                fn test(…) []
-                md dep []
-                sc STATIC (use dep::test_mod_a::STATIC) [requires_import]
+                sc STATIC i32 [type_could_unify+requires_import]
+                fn main() fn() []
+                fn test(…) fn(i32) []
+                md dep  []
+                sc STATIC i64 [requires_import]
             "#]],
         );
     }
@@ -1058,7 +1058,7 @@ fn main() {
 
 "#,
             expect![[r#"
-                me Function []
+                me Function fn(&self, i32) -> bool []
             "#]],
         );
     }
@@ -1081,14 +1081,14 @@ fn func(input: Struct) { }
 
 "#,
             expect![[r#"
-                st Struct [type]
-                st Self [type]
-                sp Self [type]
-                st Struct [type]
-                ex Struct [type]
-                lc self [local]
-                fn func(…) []
-                me self.test() []
+                st Struct Struct [type]
+                st Self Self [type]
+                sp Self Struct [type]
+                st Struct Struct [type]
+                ex Struct  [type]
+                lc self &Struct [local]
+                fn func(…) fn(Struct) []
+                me self.test() fn(&self) []
             "#]],
         );
     }
@@ -1109,13 +1109,13 @@ fn main() {
 }
 "#,
             expect![[r#"
-                lc input [type+name+local]
-                ex input [type]
-                ex true [type]
-                ex false [type]
-                lc inputbad [local]
-                fn main() []
-                fn test(…) []
+                lc input bool [type+name+local]
+                ex input  [type]
+                ex true  [type]
+                ex false  [type]
+                lc inputbad i32 [local]
+                fn main() fn() []
+                fn test(…) fn(bool) []
             "#]],
         );
     }
@@ -1133,6 +1133,10 @@ fn main() { Foo::Fo$0 }
                 [
                     CompletionItem {
                         label: "Foo {…}",
+                        detail_left: None,
+                        detail_right: Some(
+                            "Foo { x: i32, y: i32 }",
+                        ),
                         source_range: 54..56,
                         delete: 54..56,
                         insert: "Foo { x: ${1:()}, y: ${2:()} }$0",
@@ -1161,6 +1165,10 @@ fn main() { Foo::Fo$0 }
                 [
                     CompletionItem {
                         label: "Foo(…)",
+                        detail_left: None,
+                        detail_right: Some(
+                            "Foo(i32, i32)",
+                        ),
                         source_range: 46..48,
                         delete: 46..48,
                         insert: "Foo(${1:()}, ${2:()})$0",
@@ -1189,6 +1197,10 @@ fn main() { fo$0 }
                 [
                     CompletionItem {
                         label: "foo(…)",
+                        detail_left: None,
+                        detail_right: Some(
+                            "fn(u32, u32, T) -> (u32, T)",
+                        ),
                         source_range: 68..70,
                         delete: 68..70,
                         insert: "foo(${1:a}, ${2:b}, ${3:t})$0",
@@ -1201,6 +1213,10 @@ fn main() { fo$0 }
                     },
                     CompletionItem {
                         label: "main()",
+                        detail_left: None,
+                        detail_right: Some(
+                            "fn()",
+                        ),
                         source_range: 68..70,
                         delete: 68..70,
                         insert: "main();$0",
@@ -1228,6 +1244,10 @@ fn main() { Foo::Fo$0 }
                 [
                     CompletionItem {
                         label: "Foo",
+                        detail_left: None,
+                        detail_right: Some(
+                            "Foo",
+                        ),
                         source_range: 35..37,
                         delete: 35..37,
                         insert: "Foo$0",
@@ -1260,6 +1280,10 @@ fn main() { let _: m::Spam = S$0 }
                 [
                     CompletionItem {
                         label: "main()",
+                        detail_left: None,
+                        detail_right: Some(
+                            "fn()",
+                        ),
                         source_range: 75..76,
                         delete: 75..76,
                         insert: "main();$0",
@@ -1271,6 +1295,8 @@ fn main() { let _: m::Spam = S$0 }
                     },
                     CompletionItem {
                         label: "m",
+                        detail_left: None,
+                        detail_right: None,
                         source_range: 75..76,
                         delete: 75..76,
                         insert: "m",
@@ -1280,6 +1306,10 @@ fn main() { let _: m::Spam = S$0 }
                     },
                     CompletionItem {
                         label: "m::Spam::Bar(…)",
+                        detail_left: None,
+                        detail_right: Some(
+                            "m::Spam::Bar(i32)",
+                        ),
                         source_range: 75..76,
                         delete: 75..76,
                         insert: "m::Spam::Bar(${1:()})$0",
@@ -1305,6 +1335,10 @@ fn main() { let _: m::Spam = S$0 }
                     },
                     CompletionItem {
                         label: "m::Spam::Foo",
+                        detail_left: None,
+                        detail_right: Some(
+                            "m::Spam::Foo",
+                        ),
                         source_range: 75..76,
                         delete: 75..76,
                         insert: "m::Spam::Foo$0",
@@ -1347,6 +1381,10 @@ fn main() { som$0 }
                 [
                     CompletionItem {
                         label: "main()",
+                        detail_left: None,
+                        detail_right: Some(
+                            "fn()",
+                        ),
                         source_range: 56..59,
                         delete: 56..59,
                         insert: "main();$0",
@@ -1358,6 +1396,10 @@ fn main() { som$0 }
                     },
                     CompletionItem {
                         label: "something_deprecated()",
+                        detail_left: None,
+                        detail_right: Some(
+                            "fn()",
+                        ),
                         source_range: 56..59,
                         delete: 56..59,
                         insert: "something_deprecated();$0",
@@ -1382,6 +1424,10 @@ fn foo() { A { the$0 } }
                 [
                     CompletionItem {
                         label: "the_field",
+                        detail_left: None,
+                        detail_right: Some(
+                            "u32",
+                        ),
                         source_range: 57..60,
                         delete: 57..60,
                         insert: "the_field",
@@ -1429,6 +1475,10 @@ impl S {
                 [
                     CompletionItem {
                         label: "bar()",
+                        detail_left: None,
+                        detail_right: Some(
+                            "fn(self)",
+                        ),
                         source_range: 94..94,
                         delete: 94..94,
                         insert: "bar();$0",
@@ -1460,6 +1510,10 @@ impl S {
                     },
                     CompletionItem {
                         label: "foo",
+                        detail_left: None,
+                        detail_right: Some(
+                            "{unknown}",
+                        ),
                         source_range: 94..94,
                         delete: 94..94,
                         insert: "foo",
@@ -1498,6 +1552,8 @@ use self::E::*;
                 [
                     CompletionItem {
                         label: "my",
+                        detail_left: None,
+                        detail_right: None,
                         source_range: 10..12,
                         delete: 10..12,
                         insert: "my",
@@ -1510,6 +1566,10 @@ use self::E::*;
                     },
                     CompletionItem {
                         label: "V",
+                        detail_left: None,
+                        detail_right: Some(
+                            "V",
+                        ),
                         source_range: 10..12,
                         delete: 10..12,
                         insert: "V$0",
@@ -1524,6 +1584,10 @@ use self::E::*;
                     },
                     CompletionItem {
                         label: "E",
+                        detail_left: None,
+                        detail_right: Some(
+                            "E",
+                        ),
                         source_range: 10..12,
                         delete: 10..12,
                         insert: "E",
@@ -1556,6 +1620,10 @@ fn foo(s: S) { s.$0 }
                 [
                     CompletionItem {
                         label: "the_method()",
+                        detail_left: None,
+                        detail_right: Some(
+                            "fn(&self)",
+                        ),
                         source_range: 81..81,
                         delete: 81..81,
                         insert: "the_method();$0",
@@ -1729,9 +1797,9 @@ fn test(bar: u32) { }
 fn foo(s: S) { test(s.$0) }
 "#,
             expect![[r#"
-                fd bar [type+name]
-                fd baz [type]
-                fd foo []
+                fd bar u32 [type+name]
+                fd baz u32 [type]
+                fd foo i64 []
             "#]],
         );
     }
@@ -1745,9 +1813,9 @@ struct B { x: (), y: f32, bar: u32 }
 fn foo(a: A) { B { bar: a.$0 }; }
 "#,
             expect![[r#"
-                fd bar [type+name]
-                fd baz [type]
-                fd foo []
+                fd bar u32 [type+name]
+                fd baz u32 [type]
+                fd foo i64 []
             "#]],
         )
     }
@@ -1768,6 +1836,10 @@ fn f() -> i32 {
                 [
                     CompletionItem {
                         label: "0",
+                        detail_left: None,
+                        detail_right: Some(
+                            "i32",
+                        ),
                         source_range: 56..57,
                         delete: 56..57,
                         insert: "0",
@@ -1804,9 +1876,9 @@ fn f(foo: i64) {  }
 fn foo(a: A) { B { bar: f(a.$0) }; }
 "#,
             expect![[r#"
-                fd foo [type+name]
-                fd bar []
-                fd baz []
+                fd foo i64 [type+name]
+                fd bar u32 []
+                fd baz u32 []
             "#]],
         );
         check_relevance(
@@ -1817,9 +1889,9 @@ fn f(foo: i64) {  }
 fn foo(a: A) { f(B { bar: a.$0 }); }
 "#,
             expect![[r#"
-                fd bar [type+name]
-                fd baz [type]
-                fd foo []
+                fd bar u32 [type+name]
+                fd baz u32 [type]
+                fd foo i64 []
             "#]],
         );
     }
@@ -1832,13 +1904,13 @@ struct WorldSnapshot { _f: () };
 fn go(world: &WorldSnapshot) { go(w$0) }
 "#,
             expect![[r#"
-                lc world [type+name+local]
-                ex world [type]
-                st WorldSnapshot {…} []
+                lc world &WorldSnapshot [type+name+local]
+                ex world  [type]
+                st WorldSnapshot {…} WorldSnapshot { _f: () } []
                 st &WorldSnapshot {…} [type]
-                st WorldSnapshot []
+                st WorldSnapshot WorldSnapshot []
                 st &WorldSnapshot [type]
-                fn go(…) []
+                fn go(…) fn(&WorldSnapshot) []
             "#]],
         );
     }
@@ -1852,9 +1924,9 @@ struct Foo;
 fn f(foo: &Foo) { f(foo, w$0) }
 "#,
             expect![[r#"
-                lc foo [local]
-                st Foo []
-                fn f(…) []
+                lc foo &Foo [local]
+                st Foo Foo []
+                fn f(…) fn(&Foo) []
             "#]],
         );
     }
@@ -1869,12 +1941,12 @@ fn bar() -> u8 { 0 }
 fn f() { A { bar: b$0 }; }
 "#,
             expect![[r#"
-                fn bar() [type+name]
-                fn baz() [type]
-                ex bar() [type]
-                ex baz() [type]
-                st A []
-                fn f() []
+                fn bar() fn() -> u8 [type+name]
+                fn baz() fn() -> u8 [type]
+                ex bar()  [type]
+                ex baz()  [type]
+                st A A []
+                fn f() fn() []
             "#]],
         );
     }
@@ -1895,9 +1967,9 @@ fn f() {
 }
 "#,
             expect![[r#"
-                me aaa() [type+name]
-                me bbb() [type]
-                me ccc() []
+                me aaa() fn(&self) -> u32 [type+name]
+                me bbb() fn(&self) -> u32 [type]
+                me ccc() fn(&self) -> u64 []
             "#]],
         );
     }
@@ -1916,7 +1988,7 @@ fn f() {
 }
 "#,
             expect![[r#"
-                me aaa() [name]
+                me aaa() fn(&self) -> u64 [name]
             "#]],
         );
     }
@@ -1934,14 +2006,14 @@ fn main() {
 }
             "#,
             expect![[r#"
-                lc s [name+local]
+                lc s S [name+local]
                 lc &mut s [type+name+local]
-                st S []
+                st S S []
                 st &mut S [type]
-                st S []
+                st S S []
                 st &mut S [type]
-                fn foo(…) []
-                fn main() []
+                fn foo(…) fn(&mut S) []
+                fn main() fn() []
             "#]],
         );
         check_relevance(
@@ -1954,13 +2026,13 @@ fn main() {
 }
             "#,
             expect![[r#"
-                lc s [type+name+local]
-                st S [type]
-                st S [type]
-                ex s [type]
-                ex S [type]
-                fn foo(…) []
-                fn main() []
+                lc s S [type+name+local]
+                st S S [type]
+                st S S [type]
+                ex s  [type]
+                ex S  [type]
+                fn foo(…) fn(&mut S) []
+                fn main() fn() []
             "#]],
         );
         check_relevance(
@@ -1973,13 +2045,13 @@ fn main() {
 }
             "#,
             expect![[r#"
-                lc ssss [type+local]
-                st S [type]
-                st S [type]
-                ex ssss [type]
-                ex S [type]
-                fn foo(…) []
-                fn main() []
+                lc ssss S [type+local]
+                st S S [type]
+                st S S [type]
+                ex ssss  [type]
+                ex S  [type]
+                fn foo(…) fn(&mut S) []
+                fn main() fn() []
             "#]],
         );
     }
@@ -2010,19 +2082,19 @@ fn main() {
 }
             "#,
             expect![[r#"
-                ex core::ops::Deref::deref(&t) (use core::ops::Deref) [type_could_unify]
-                lc m [local]
-                lc t [local]
+                ex core::ops::Deref::deref(&t)  [type_could_unify]
+                lc m i32 [local]
+                lc t T [local]
                 lc &t [type+local]
-                st S []
+                st S S []
                 st &S [type]
-                st S []
+                st S S []
                 st &S [type]
-                st T []
+                st T T []
                 st &T [type]
-                fn foo(…) []
-                fn main() []
-                md core []
+                fn foo(…) fn(&S) []
+                fn main() fn() []
+                md core  []
             "#]],
         )
     }
@@ -2059,19 +2131,19 @@ fn main() {
 }
             "#,
             expect![[r#"
-                ex core::ops::DerefMut::deref_mut(&mut t) (use core::ops::DerefMut) [type_could_unify]
-                lc m [local]
-                lc t [local]
+                ex core::ops::DerefMut::deref_mut(&mut t)  [type_could_unify]
+                lc m i32 [local]
+                lc t T [local]
                 lc &mut t [type+local]
-                st S []
+                st S S []
                 st &mut S [type]
-                st S []
+                st S S []
                 st &mut S [type]
-                st T []
+                st T T []
                 st &mut T [type]
-                fn foo(…) []
-                fn main() []
-                md core []
+                fn foo(…) fn(&mut S) []
+                fn main() fn() []
+                md core  []
             "#]],
         )
     }
@@ -2087,9 +2159,9 @@ fn foo(bar: u32) {
 }
 "#,
             expect![[r#"
-                lc baz [local]
-                lc bar [local]
-                fn foo(…) []
+                lc baz i32 [local]
+                lc bar u32 [local]
+                fn foo(…) fn(u32) []
             "#]],
         );
     }
@@ -2105,13 +2177,13 @@ fn foo() {
 fn bar(t: Foo) {}
 "#,
             expect![[r#"
-                ev Foo::A [type]
-                ev Foo::B [type]
-                en Foo [type]
-                ex Foo::A [type]
-                ex Foo::B [type]
-                fn bar(…) []
-                fn foo() []
+                ev Foo::A Foo::A [type]
+                ev Foo::B Foo::B [type]
+                en Foo Foo [type]
+                ex Foo::A  [type]
+                ex Foo::B  [type]
+                fn bar(…) fn(Foo) []
+                fn foo() fn() []
             "#]],
         );
     }
@@ -2127,14 +2199,14 @@ fn foo() {
 fn bar(t: &Foo) {}
 "#,
             expect![[r#"
-                ev Foo::A []
+                ev Foo::A Foo::A []
                 ev &Foo::A [type]
-                ev Foo::B []
+                ev Foo::B Foo::B []
                 ev &Foo::B [type]
-                en Foo []
+                en Foo Foo []
                 en &Foo [type]
-                fn bar(…) []
-                fn foo() []
+                fn bar(…) fn(&Foo) []
+                fn foo() fn() []
             "#]],
         );
     }
@@ -2163,18 +2235,18 @@ fn main() {
 }
 "#,
             expect![[r#"
-                ex core::ops::Deref::deref(&bar()) (use core::ops::Deref) [type_could_unify]
-                st S []
+                ex core::ops::Deref::deref(&bar())  [type_could_unify]
+                st S S []
                 st &S [type]
-                st S []
+                st S S []
                 st &S [type]
-                st T []
+                st T T []
                 st &T [type]
-                fn bar() []
+                fn bar() fn() -> T []
                 fn &bar() [type]
-                fn foo(…) []
-                fn main() []
-                md core []
+                fn foo(…) fn(&S) []
+                fn main() fn() []
+                md core  []
             "#]],
         )
     }
@@ -2191,7 +2263,7 @@ impl Sub for u32 {}
 fn foo(a: u32) { a.$0 }
 "#,
             expect![[r#"
-                me sub(…) (as Sub) [op_method]
+                me sub(…) fn(self, Self) -> Self [op_method]
             "#]],
         );
         check_relevance(
@@ -2212,9 +2284,9 @@ fn main() {
 }
 "#,
             expect![[r#"
-                fn new() []
-                me eq(…) (as PartialEq) [op_method]
-                me ne(…) (as PartialEq) [op_method]
+                fn new() fn() -> Foo []
+                me eq(…) fn(&self, &Rhs) -> bool [op_method]
+                me ne(…) fn(&self, &Rhs) -> bool [op_method]
             "#]],
         );
     }
@@ -2238,9 +2310,9 @@ fn test() {
 }
 "#,
             expect![[r#"
-                fn fn_ctr() [type_could_unify]
-                fn fn_ctr_self() [type_could_unify]
-                fn fn_another(…) [type_could_unify]
+                fn fn_ctr() fn() -> Foo [type_could_unify]
+                fn fn_ctr_self() fn() -> Option<Foo> [type_could_unify]
+                fn fn_another(…) fn(u32) -> Other [type_could_unify]
             "#]],
         );
     }
@@ -2384,12 +2456,12 @@ fn test() {
             // Constructor
             // Others
             expect![[r#"
-                fn fn_direct_ctr() [type_could_unify]
-                fn fn_ctr_with_args(…) [type_could_unify]
-                fn fn_builder() [type_could_unify]
-                fn fn_ctr() [type_could_unify]
-                me fn_no_ret(…) [type_could_unify]
-                fn fn_other() [type_could_unify]
+                fn fn_direct_ctr() fn() -> Foo [type_could_unify]
+                fn fn_ctr_with_args(…) fn(u32) -> Foo [type_could_unify]
+                fn fn_builder() fn() -> FooBuilder [type_could_unify]
+                fn fn_ctr() fn() -> Result<Foo> [type_could_unify]
+                me fn_no_ret(…) fn(&self) [type_could_unify]
+                fn fn_other() fn() -> Result<u32> [type_could_unify]
             "#]],
         );
 
@@ -2420,14 +2492,14 @@ fn test() {
 }
                 "#,
             expect![[r#"
-                        fn fn_direct_ctr() [type_could_unify]
-                        fn fn_ctr_with_args(…) [type_could_unify]
-                        fn fn_builder() [type_could_unify]
-                        fn fn_ctr_wrapped() [type_could_unify]
-                        fn fn_ctr_wrapped_2() [type_could_unify]
-                        me fn_returns_unit(…) [type_could_unify]
-                        fn fn_other() [type_could_unify]
-                    "#]],
+                fn fn_direct_ctr() fn() -> Foo<T> [type_could_unify]
+                fn fn_ctr_with_args(…) fn(T) -> Foo<T> [type_could_unify]
+                fn fn_builder() fn() -> FooBuilder [type_could_unify]
+                fn fn_ctr_wrapped() fn() -> Option<Foo<T>> [type_could_unify]
+                fn fn_ctr_wrapped_2() fn() -> Result<Foo<T>, u32> [type_could_unify]
+                me fn_returns_unit(…) fn(&self) [type_could_unify]
+                fn fn_other() fn() -> Option<u32> [type_could_unify]
+            "#]],
         );
     }
 
@@ -2456,13 +2528,13 @@ fn test() {
 }
                 "#,
             expect![[r#"
-                fn fn_direct_ctr() [type_could_unify]
-                fn fn_ctr_with_args(…) [type_could_unify]
-                fn fn_builder() [type_could_unify]
-                fn fn_ctr() [type_could_unify]
-                fn fn_ctr2() [type_could_unify]
-                me fn_no_ret(…) [type_could_unify]
-                fn fn_other() [type_could_unify]
+                fn fn_direct_ctr() fn() -> Foo<T> [type_could_unify]
+                fn fn_ctr_with_args(…) fn(T) -> Foo<T> [type_could_unify]
+                fn fn_builder() fn() -> FooBuilder [type_could_unify]
+                fn fn_ctr() fn() -> Option<Foo<T>> [type_could_unify]
+                fn fn_ctr2() fn() -> Result<Foo<T>, u32> [type_could_unify]
+                me fn_no_ret(…) fn(&self) [type_could_unify]
+                fn fn_other() fn() -> Option<u32> [type_could_unify]
             "#]],
         );
     }
@@ -2484,6 +2556,10 @@ fn foo(f: Foo) { let _: &u32 = f.b$0 }
                 [
                     CompletionItem {
                         label: "baz()",
+                        detail_left: None,
+                        detail_right: Some(
+                            "fn(&self) -> u32",
+                        ),
                         source_range: 109..110,
                         delete: 109..110,
                         insert: "baz()$0",
@@ -2513,6 +2589,10 @@ fn foo(f: Foo) { let _: &u32 = f.b$0 }
                     },
                     CompletionItem {
                         label: "bar",
+                        detail_left: None,
+                        detail_right: Some(
+                            "u32",
+                        ),
                         source_range: 109..110,
                         delete: 109..110,
                         insert: "bar",
@@ -2524,6 +2604,10 @@ fn foo(f: Foo) { let _: &u32 = f.b$0 }
                     },
                     CompletionItem {
                         label: "qux",
+                        detail_left: None,
+                        detail_right: Some(
+                            "fn()",
+                        ),
                         source_range: 109..110,
                         text_edit: TextEdit {
                             indels: [
@@ -2562,6 +2646,10 @@ fn foo() {
                 [
                     CompletionItem {
                         label: "field",
+                        detail_left: None,
+                        detail_right: Some(
+                            "fn()",
+                        ),
                         source_range: 76..78,
                         delete: 76..78,
                         insert: "field",
@@ -2610,6 +2698,10 @@ fn main() {
                 [
                     CompletionItem {
                         label: "foo()",
+                        detail_left: None,
+                        detail_right: Some(
+                            "fn() -> S",
+                        ),
                         source_range: 95..95,
                         delete: 95..95,
                         insert: "foo()$0",
@@ -2661,15 +2753,15 @@ fn foo() {
 }
 "#,
             expect![[r#"
-                lc foo [type+local]
-                ex foo [type]
-                ex Foo::B [type]
-                ev Foo::A(…) [type_could_unify]
-                ev Foo::B [type_could_unify]
-                en Foo [type_could_unify]
-                fn foo() []
-                fn bar() []
-                fn baz() []
+                lc foo Foo<u32> [type+local]
+                ex foo  [type]
+                ex Foo::B  [type]
+                ev Foo::A(…) Foo::A(T) [type_could_unify]
+                ev Foo::B Foo::B [type_could_unify]
+                en Foo Foo<{unknown}> [type_could_unify]
+                fn foo() fn() []
+                fn bar() fn() -> Foo<u8> []
+                fn baz() fn() -> Foo<T> []
             "#]],
         );
     }
@@ -2697,20 +2789,20 @@ fn main() {
     "#,
             &[CompletionItemKind::Snippet, CompletionItemKind::SymbolKind(SymbolKind::Method)],
             expect![[r#"
-                sn not [snippet]
-                me not() (use ops::Not) [type_could_unify+requires_import]
-                sn if []
-                sn while []
-                sn ref []
-                sn refm []
-                sn deref []
-                sn unsafe []
-                sn match []
-                sn box []
-                sn dbg []
-                sn dbgr []
-                sn call []
-                sn return []
+                sn not !expr [snippet]
+                me not() fn(self) -> <Self as Not>::Output [type_could_unify+requires_import]
+                sn if if expr {} []
+                sn while while expr {} []
+                sn ref &expr []
+                sn refm &mut expr []
+                sn deref *expr []
+                sn unsafe unsafe {} []
+                sn match match expr {} []
+                sn box Box::new(expr) []
+                sn dbg dbg!(expr) []
+                sn dbgr dbg!(&expr) []
+                sn call function(expr) []
+                sn return return expr []
             "#]],
         );
     }
@@ -2730,19 +2822,19 @@ fn main() {
     "#,
             &[CompletionItemKind::Snippet, CompletionItemKind::SymbolKind(SymbolKind::Method)],
             expect![[r#"
-                me f() []
-                sn ref []
-                sn refm []
-                sn deref []
-                sn unsafe []
-                sn match []
-                sn box []
-                sn dbg []
-                sn dbgr []
-                sn call []
-                sn let []
-                sn letm []
-                sn return []
+                me f() fn(&self) []
+                sn ref &expr []
+                sn refm &mut expr []
+                sn deref *expr []
+                sn unsafe unsafe {} []
+                sn match match expr {} []
+                sn box Box::new(expr) []
+                sn dbg dbg!(expr) []
+                sn dbgr dbg!(&expr) []
+                sn call function(expr) []
+                sn let let []
+                sn letm let mut []
+                sn return return expr []
             "#]],
         );
     }
@@ -2765,12 +2857,12 @@ fn f() {
 }
 "#,
             expect![[r#"
-                st Buffer []
-                fn f() []
-                md std []
-                tt BufRead (use std::io::BufRead) [requires_import]
-                st BufReader (use std::io::BufReader) [requires_import]
-                st BufWriter (use std::io::BufWriter) [requires_import]
+                st Buffer Buffer []
+                fn f() fn() []
+                md std  []
+                tt BufRead  [requires_import]
+                st BufReader BufReader [requires_import]
+                st BufWriter BufWriter [requires_import]
             "#]],
         );
     }
@@ -2979,6 +3071,12 @@ fn main() {
                 [
                     CompletionItem {
                         label: "flush()",
+                        detail_left: Some(
+                            "(as Write)",
+                        ),
+                        detail_right: Some(
+                            "fn(&self)",
+                        ),
                         source_range: 193..193,
                         delete: 193..193,
                         insert: "flush();$0",
@@ -3006,6 +3104,12 @@ fn main() {
                     },
                     CompletionItem {
                         label: "write()",
+                        detail_left: Some(
+                            "(as Write)",
+                        ),
+                        detail_right: Some(
+                            "fn(&self)",
+                        ),
                         source_range: 193..193,
                         delete: 193..193,
                         insert: "write();$0",

--- a/crates/ide-completion/src/tests/attribute.rs
+++ b/crates/ide-completion/src/tests/attribute.rs
@@ -33,7 +33,7 @@ pub struct Foo(#[m$0] i32);
             at cold
             at deny(…)
             at deprecated
-            at derive                 macro derive
+            at derive                                  macro derive
             at derive(…)
             at doc = "…"
             at doc(alias = "…")
@@ -367,9 +367,9 @@ struct Foo;
             at cfg_attr(…)
             at deny(…)
             at deprecated
-            at derive           macro derive
+            at derive             macro derive
             at derive(…)
-            at derive_const     macro derive_const
+            at derive_const macro derive_const
             at doc = "…"
             at doc(alias = "…")
             at doc(hidden)
@@ -790,10 +790,10 @@ mod derive {
 #[derive($0)] struct Test;
 "#,
             expect![[r#"
-                de Clone                  macro Clone
+                de Clone              macro Clone
                 de Clone, Copy
-                de Default                macro Default
-                de PartialEq              macro PartialEq
+                de Default          macro Default
+                de PartialEq      macro PartialEq
                 de PartialEq, Eq
                 de PartialEq, Eq, PartialOrd, Ord
                 de PartialEq, PartialOrd
@@ -812,9 +812,9 @@ mod derive {
 #[derive(serde::Serialize, PartialEq, $0)] struct Test;
 "#,
             expect![[r#"
-                de Clone               macro Clone
+                de Clone     macro Clone
                 de Clone, Copy
-                de Default             macro Default
+                de Default macro Default
                 de Eq
                 de Eq, PartialOrd, Ord
                 de PartialOrd
@@ -833,9 +833,9 @@ mod derive {
 #[derive($0 serde::Serialize, PartialEq)] struct Test;
 "#,
             expect![[r#"
-                de Clone               macro Clone
+                de Clone     macro Clone
                 de Clone, Copy
-                de Default             macro Default
+                de Default macro Default
                 de Eq
                 de Eq, PartialOrd, Ord
                 de PartialOrd
@@ -854,9 +854,9 @@ mod derive {
 #[derive(PartialEq, Eq, Or$0)] struct Test;
 "#,
             expect![[r#"
-                de Clone           macro Clone
+                de Clone     macro Clone
                 de Clone, Copy
-                de Default         macro Default
+                de Default macro Default
                 de PartialOrd
                 de PartialOrd, Ord
                 md core

--- a/crates/ide-completion/src/tests/expression.rs
+++ b/crates/ide-completion/src/tests/expression.rs
@@ -26,22 +26,22 @@ fn baz() {
             "#,
         // This should not contain `FooDesc {…}`.
         expect![[r#"
-            ct CONST         Unit
-            en Enum          Enum
-            fn baz()         fn()
-            fn create_foo(…) fn(&FooDesc)
-            fn function()    fn()
-            ma makro!(…)     macro_rules! makro
+            ct CONST                   Unit
+            en Enum                    Enum
+            fn baz()                   fn()
+            fn create_foo(…)   fn(&FooDesc)
+            fn function()              fn()
+            ma makro!(…) macro_rules! makro
             md _69latrick
             md module
-            sc STATIC        Unit
-            st FooDesc       FooDesc
-            st Record        Record
-            st Tuple         Tuple
-            st Unit          Unit
-            un Union         Union
-            ev TupleV(…)     TupleV(u32)
-            bt u32           u32
+            sc STATIC                  Unit
+            st FooDesc              FooDesc
+            st Record                Record
+            st Tuple                  Tuple
+            st Unit                    Unit
+            un Union                  Union
+            ev TupleV(…)        TupleV(u32)
+            bt u32                      u32
             kw crate::
             kw false
             kw for
@@ -76,14 +76,14 @@ fn func(param0 @ (param1, param2): (i32, i32)) {
 }
 "#,
         expect![[r#"
-            fn func(…)    fn((i32, i32))
-            lc ifletlocal i32
-            lc letlocal   i32
-            lc matcharm   i32
-            lc param0     (i32, i32)
-            lc param1     i32
-            lc param2     i32
-            bt u32        u32
+            fn func(…) fn((i32, i32))
+            lc ifletlocal         i32
+            lc letlocal           i32
+            lc matcharm           i32
+            lc param0      (i32, i32)
+            lc param1             i32
+            lc param2             i32
+            bt u32                u32
             kw crate::
             kw false
             kw for
@@ -122,25 +122,25 @@ impl Unit {
 "#,
         // `self` is in here twice, once as the module, once as the local
         expect![[r#"
-            ct CONST        Unit
+            ct CONST                   Unit
             cp CONST_PARAM
-            en Enum         Enum
-            fn function()   fn()
-            fn local_func() fn()
-            me self.foo()   fn(self)
-            lc self         Unit
-            ma makro!(…)    macro_rules! makro
+            en Enum                    Enum
+            fn function()              fn()
+            fn local_func()            fn()
+            me self.foo()          fn(self)
+            lc self                    Unit
+            ma makro!(…) macro_rules! makro
             md module
             md qualified
-            sp Self         Unit
-            sc STATIC       Unit
-            st Record       Record
-            st Tuple        Tuple
-            st Unit         Unit
+            sp Self                    Unit
+            sc STATIC                  Unit
+            st Record                Record
+            st Tuple                  Tuple
+            st Unit                    Unit
             tp TypeParam
-            un Union        Union
-            ev TupleV(…)    TupleV(u32)
-            bt u32          u32
+            un Union                  Union
+            ev TupleV(…)        TupleV(u32)
+            bt u32                      u32
             kw async
             kw const
             kw crate::
@@ -187,19 +187,19 @@ impl Unit {
 }
 "#,
         expect![[r#"
-            ct CONST      Unit
-            en Enum       Enum
-            fn function() fn()
-            ma makro!(…)  macro_rules! makro
+            ct CONST                   Unit
+            en Enum                    Enum
+            fn function()              fn()
+            ma makro!(…) macro_rules! makro
             md module
             md qualified
-            sc STATIC     Unit
-            st Record     Record
-            st Tuple      Tuple
-            st Unit       Unit
+            sc STATIC                  Unit
+            st Record                Record
+            st Tuple                  Tuple
+            st Unit                    Unit
             tt Trait
-            un Union      Union
-            ev TupleV(…)  TupleV(u32)
+            un Union                  Union
+            ev TupleV(…)        TupleV(u32)
             ?? Unresolved
         "#]],
     );
@@ -216,8 +216,8 @@ fn complete_in_block() {
     }
 "#,
         expect![[r#"
-            fn foo()       fn()
-            bt u32         u32
+            fn foo()  fn()
+            bt u32     u32
             kw async
             kw const
             kw crate::
@@ -264,8 +264,8 @@ fn complete_after_if_expr() {
     }
 "#,
         expect![[r#"
-            fn foo()       fn()
-            bt u32         u32
+            fn foo()  fn()
+            bt u32     u32
             kw async
             kw const
             kw crate::
@@ -313,8 +313,8 @@ fn complete_in_match_arm() {
     }
 "#,
         expect![[r#"
-            fn foo()     fn()
-            bt u32       u32
+            fn foo() fn()
+            bt u32    u32
             kw crate::
             kw false
             kw for
@@ -337,8 +337,8 @@ fn completes_in_loop_ctx() {
     check_empty(
         r"fn my() { loop { $0 } }",
         expect![[r#"
-            fn my()        fn()
-            bt u32         u32
+            fn my()   fn()
+            bt u32     u32
             kw async
             kw break
             kw const
@@ -376,22 +376,22 @@ fn completes_in_loop_ctx() {
     check_empty(
         r"fn my() { loop { foo.$0 } }",
         expect![[r#"
-            sn box    Box::new(expr)
-            sn break  break expr
-            sn call   function(expr)
-            sn dbg    dbg!(expr)
-            sn dbgr   dbg!(&expr)
-            sn deref  *expr
-            sn if     if expr {}
-            sn let    let
-            sn letm   let mut
-            sn match  match expr {}
-            sn not    !expr
-            sn ref    &expr
-            sn refm   &mut expr
-            sn return return expr
-            sn unsafe unsafe {}
-            sn while  while expr {}
+            sn box  Box::new(expr)
+            sn break    break expr
+            sn call function(expr)
+            sn dbg      dbg!(expr)
+            sn dbgr    dbg!(&expr)
+            sn deref         *expr
+            sn if       if expr {}
+            sn let             let
+            sn letm        let mut
+            sn match match expr {}
+            sn not           !expr
+            sn ref           &expr
+            sn refm      &mut expr
+            sn return  return expr
+            sn unsafe    unsafe {}
+            sn while while expr {}
         "#]],
     );
 }
@@ -401,8 +401,8 @@ fn completes_in_let_initializer() {
     check_empty(
         r#"fn main() { let _ = $0 }"#,
         expect![[r#"
-            fn main()    fn()
-            bt u32       u32
+            fn main() fn()
+            bt u32     u32
             kw crate::
             kw false
             kw for
@@ -434,9 +434,9 @@ fn foo() {
 }
 "#,
         expect![[r#"
-            fn foo()     fn()
-            st Foo       Foo
-            bt u32       u32
+            fn foo() fn()
+            st Foo    Foo
+            bt u32    u32
             kw crate::
             kw false
             kw for
@@ -469,9 +469,9 @@ fn foo() {
 }
 "#,
         expect![[r#"
-            fn foo()     fn()
-            lc bar       i32
-            bt u32       u32
+            fn foo() fn()
+            lc bar    i32
+            bt u32    u32
             kw crate::
             kw false
             kw for
@@ -499,10 +499,10 @@ fn quux(x: i32) {
 }
 "#,
         expect![[r#"
-            fn quux(…)   fn(i32)
-            lc x         i32
-            ma m!(…)     macro_rules! m
-            bt u32       u32
+            fn quux(…)      fn(i32)
+            lc x                i32
+            ma m!(…) macro_rules! m
+            bt u32              u32
             kw crate::
             kw false
             kw for
@@ -526,10 +526,10 @@ fn quux(x: i32) {
 }
 ",
         expect![[r#"
-            fn quux(…)   fn(i32)
-            lc x         i32
-            ma m!(…)     macro_rules! m
-            bt u32       u32
+            fn quux(…)      fn(i32)
+            lc x                i32
+            ma m!(…) macro_rules! m
+            bt u32              u32
             kw crate::
             kw false
             kw for
@@ -554,11 +554,11 @@ fn quux(x: i32) {
 }
 "#,
         expect![[r#"
-            fn quux(…)   fn(i32)
-            lc x         i32
-            lc y         i32
-            ma m!(…)     macro_rules! m
-            bt u32       u32
+            fn quux(…)      fn(i32)
+            lc x                i32
+            lc y                i32
+            ma m!(…) macro_rules! m
+            bt u32              u32
             kw crate::
             kw false
             kw for
@@ -590,12 +590,12 @@ fn func() {
 }
 "#,
         expect![[r#"
-            ct ASSOC_CONST const ASSOC_CONST: ()
-            fn assoc_fn()  fn()
-            ta AssocType   type AssocType = ()
+            ct ASSOC_CONST  const ASSOC_CONST: ()
+            fn assoc_fn()                    fn()
+            ta AssocType      type AssocType = ()
             ev RecordV {…} RecordV { field: u32 }
-            ev TupleV(…)   TupleV(u32)
-            ev UnitV       UnitV
+            ev TupleV(…)              TupleV(u32)
+            ev UnitV                        UnitV
         "#]],
     );
 }
@@ -633,7 +633,7 @@ fn func() {
 "#,
         expect![[r#"
             fn variant fn() -> Enum
-            ev Variant Variant
+            ev Variant      Variant
         "#]],
     );
 }
@@ -650,8 +650,8 @@ fn main() {
 }
 ",
         expect![[r#"
-            fn foo()  fn() -> impl Trait<U>
-            fn main() fn()
+            fn foo() fn() -> impl Trait<U>
+            fn main()                 fn()
             tt Trait
         "#]],
     );
@@ -670,9 +670,9 @@ fn main() {
 }
 "#,
         expect![[r#"
-            fn bar()  async fn() -> impl Trait<U>
-            fn foo()  async fn() -> u8
-            fn main() fn()
+            fn bar() async fn() -> impl Trait<U>
+            fn foo()            async fn() -> u8
+            fn main()                       fn()
             tt Trait
         "#]],
     );
@@ -692,9 +692,9 @@ fn main() {
     Foo::$0
 }
 ",
-        expect![[r"
+        expect![[r#"
             fn bar(…) fn(impl Trait<U>)
-        "]],
+        "#]],
     );
 }
 
@@ -712,7 +712,7 @@ fn main() {
 }
 "#,
         expect![[r#"
-            fn test()       fn() -> Zulu
+            fn test() fn() -> Zulu
             ex Zulu
             ex Zulu::test()
         "#]],
@@ -736,11 +736,11 @@ fn brr() {
 }
 "#,
         expect![[r#"
-            en HH              HH
-            fn brr()           fn()
-            st YoloVariant     YoloVariant
+            en HH                                    HH
+            fn brr()                               fn()
+            st YoloVariant                  YoloVariant
             st YoloVariant {…} YoloVariant { f: usize }
-            bt u32             u32
+            bt u32                                  u32
             kw crate::
             kw false
             kw for
@@ -801,8 +801,8 @@ fn else_completion_after_if() {
 fn foo() { if foo {} $0 }
 "#,
         expect![[r#"
-            fn foo()       fn()
-            bt u32         u32
+            fn foo()  fn()
+            bt u32     u32
             kw async
             kw const
             kw crate::
@@ -842,8 +842,8 @@ fn foo() { if foo {} $0 }
 fn foo() { if foo {} el$0 }
 "#,
         expect![[r#"
-            fn foo()       fn()
-            bt u32         u32
+            fn foo()  fn()
+            bt u32     u32
             kw async
             kw const
             kw crate::
@@ -883,8 +883,8 @@ fn foo() { if foo {} el$0 }
 fn foo() { bar(if foo {} $0) }
 "#,
         expect![[r#"
-            fn foo()     fn()
-            bt u32       u32
+            fn foo() fn()
+            bt u32    u32
             kw crate::
             kw else
             kw else if
@@ -907,8 +907,8 @@ fn foo() { bar(if foo {} $0) }
 fn foo() { bar(if foo {} el$0) }
 "#,
         expect![[r#"
-            fn foo()     fn()
-            bt u32       u32
+            fn foo() fn()
+            bt u32    u32
             kw crate::
             kw else
             kw else if
@@ -931,8 +931,8 @@ fn foo() { bar(if foo {} el$0) }
 fn foo() { if foo {} $0 let x = 92; }
 "#,
         expect![[r#"
-            fn foo()       fn()
-            bt u32         u32
+            fn foo()  fn()
+            bt u32     u32
             kw async
             kw const
             kw crate::
@@ -972,8 +972,8 @@ fn foo() { if foo {} $0 let x = 92; }
 fn foo() { if foo {} el$0 let x = 92; }
 "#,
         expect![[r#"
-            fn foo()       fn()
-            bt u32         u32
+            fn foo()  fn()
+            bt u32     u32
             kw async
             kw const
             kw crate::
@@ -1013,8 +1013,8 @@ fn foo() { if foo {} el$0 let x = 92; }
 fn foo() { if foo {} el$0 { let x = 92; } }
 "#,
         expect![[r#"
-            fn foo()       fn()
-            bt u32         u32
+            fn foo()  fn()
+            bt u32     u32
             kw async
             kw const
             kw crate::
@@ -1065,9 +1065,9 @@ fn main() {
 pub struct UnstableThisShouldNotBeListed;
 "#,
         expect![[r#"
-            fn main()      fn()
+            fn main() fn()
             md std
-            bt u32         u32
+            bt u32     u32
             kw async
             kw const
             kw crate::
@@ -1117,10 +1117,10 @@ fn main() {
 pub struct UnstableButWeAreOnNightlyAnyway;
 "#,
         expect![[r#"
-            fn main()                 fn()
+            fn main()                                                     fn()
             md std
             st UnstableButWeAreOnNightlyAnyway UnstableButWeAreOnNightlyAnyway
-            bt u32                    u32
+            bt u32                                                         u32
             kw async
             kw const
             kw crate::
@@ -1170,17 +1170,17 @@ fn main() {
 }
 "#,
         expect![[r#"
-            me foo()  fn(&self)
-            sn box    Box::new(expr)
-            sn call   function(expr)
-            sn dbg    dbg!(expr)
-            sn dbgr   dbg!(&expr)
-            sn deref  *expr
-            sn match  match expr {}
-            sn ref    &expr
-            sn refm   &mut expr
-            sn return return expr
-            sn unsafe unsafe {}
+            me foo()     fn(&self)
+            sn box  Box::new(expr)
+            sn call function(expr)
+            sn dbg      dbg!(expr)
+            sn dbgr    dbg!(&expr)
+            sn deref         *expr
+            sn match match expr {}
+            sn ref           &expr
+            sn refm      &mut expr
+            sn return  return expr
+            sn unsafe    unsafe {}
         "#]],
     );
     check_empty(
@@ -1196,17 +1196,17 @@ fn main() {
 }
 "#,
         expect![[r#"
-            me foo()  fn(&self)
-            sn box    Box::new(expr)
-            sn call   function(expr)
-            sn dbg    dbg!(expr)
-            sn dbgr   dbg!(&expr)
-            sn deref  *expr
-            sn match  match expr {}
-            sn ref    &expr
-            sn refm   &mut expr
-            sn return return expr
-            sn unsafe unsafe {}
+            me foo()     fn(&self)
+            sn box  Box::new(expr)
+            sn call function(expr)
+            sn dbg      dbg!(expr)
+            sn dbgr    dbg!(&expr)
+            sn deref         *expr
+            sn match match expr {}
+            sn ref           &expr
+            sn refm      &mut expr
+            sn return  return expr
+            sn unsafe    unsafe {}
         "#]],
     );
 }
@@ -1226,17 +1226,17 @@ fn main() {
 }
 "#,
         expect![[r#"
-            me foo()  fn(&self)
-            sn box    Box::new(expr)
-            sn call   function(expr)
-            sn dbg    dbg!(expr)
-            sn dbgr   dbg!(&expr)
-            sn deref  *expr
-            sn match  match expr {}
-            sn ref    &expr
-            sn refm   &mut expr
-            sn return return expr
-            sn unsafe unsafe {}
+            me foo()     fn(&self)
+            sn box  Box::new(expr)
+            sn call function(expr)
+            sn dbg      dbg!(expr)
+            sn dbgr    dbg!(&expr)
+            sn deref         *expr
+            sn match match expr {}
+            sn ref           &expr
+            sn refm      &mut expr
+            sn return  return expr
+            sn unsafe    unsafe {}
         "#]],
     );
     check_empty(
@@ -1252,17 +1252,17 @@ fn main() {
 }
 "#,
         expect![[r#"
-            me foo()  fn(&self)
-            sn box    Box::new(expr)
-            sn call   function(expr)
-            sn dbg    dbg!(expr)
-            sn dbgr   dbg!(&expr)
-            sn deref  *expr
-            sn match  match expr {}
-            sn ref    &expr
-            sn refm   &mut expr
-            sn return return expr
-            sn unsafe unsafe {}
+            me foo()     fn(&self)
+            sn box  Box::new(expr)
+            sn call function(expr)
+            sn dbg      dbg!(expr)
+            sn dbgr    dbg!(&expr)
+            sn deref         *expr
+            sn match match expr {}
+            sn ref           &expr
+            sn refm      &mut expr
+            sn return  return expr
+            sn unsafe    unsafe {}
         "#]],
     );
     check_empty(
@@ -1278,17 +1278,17 @@ fn main() {
 }
 "#,
         expect![[r#"
-            me foo()  fn(&self)
-            sn box    Box::new(expr)
-            sn call   function(expr)
-            sn dbg    dbg!(expr)
-            sn dbgr   dbg!(&expr)
-            sn deref  *expr
-            sn match  match expr {}
-            sn ref    &expr
-            sn refm   &mut expr
-            sn return return expr
-            sn unsafe unsafe {}
+            me foo()     fn(&self)
+            sn box  Box::new(expr)
+            sn call function(expr)
+            sn dbg      dbg!(expr)
+            sn dbgr    dbg!(&expr)
+            sn deref         *expr
+            sn match match expr {}
+            sn ref           &expr
+            sn refm      &mut expr
+            sn return  return expr
+            sn unsafe    unsafe {}
         "#]],
     );
     check_empty(
@@ -1304,19 +1304,19 @@ fn main() {
 }
 "#,
         expect![[r#"
-            sn box    Box::new(expr)
-            sn call   function(expr)
-            sn dbg    dbg!(expr)
-            sn dbgr   dbg!(&expr)
-            sn deref  *expr
-            sn if     if expr {}
-            sn match  match expr {}
-            sn not    !expr
-            sn ref    &expr
-            sn refm   &mut expr
-            sn return return expr
-            sn unsafe unsafe {}
-            sn while  while expr {}
+            sn box  Box::new(expr)
+            sn call function(expr)
+            sn dbg      dbg!(expr)
+            sn dbgr    dbg!(&expr)
+            sn deref         *expr
+            sn if       if expr {}
+            sn match match expr {}
+            sn not           !expr
+            sn ref           &expr
+            sn refm      &mut expr
+            sn return  return expr
+            sn unsafe    unsafe {}
+            sn while while expr {}
         "#]],
     );
 }

--- a/crates/ide-completion/src/tests/flyimport.rs
+++ b/crates/ide-completion/src/tests/flyimport.rs
@@ -139,9 +139,9 @@ fn main() {
 }
 "#,
         expect![[r#"
-            st Rc (use dep::Rc)       Rc
-            st Rcar (use dep::Rcar)   Rcar
-            st Rc (use dep::some_module::Rc) Rc
+            st Rc (use dep::Rc)                    Rc
+            st Rcar (use dep::Rcar)              Rcar
+            st Rc (use dep::some_module::Rc)       Rc
             st Rcar (use dep::some_module::Rcar) Rcar
         "#]],
     );
@@ -165,11 +165,11 @@ fn main() {
 }
 "#,
         expect![[r#"
-            ct RC (use dep::RC)       ()
-            st Rc (use dep::Rc)       Rc
-            st Rcar (use dep::Rcar)   Rcar
-            ct RC (use dep::some_module::RC) ()
-            st Rc (use dep::some_module::Rc) Rc
+            ct RC (use dep::RC)                    ()
+            st Rc (use dep::Rc)                    Rc
+            st Rcar (use dep::Rcar)              Rcar
+            ct RC (use dep::some_module::RC)       ()
+            st Rc (use dep::some_module::Rc)       Rc
             st Rcar (use dep::some_module::Rcar) Rcar
         "#]],
     );
@@ -193,7 +193,7 @@ fn main() {
 }
 "#,
         expect![[r#"
-            ct RC (use dep::RC)       ()
+            ct RC (use dep::RC)              ()
             ct RC (use dep::some_module::RC) ()
         "#]],
     );
@@ -227,7 +227,7 @@ fn main() {
 }
 "#,
         expect![[r#"
-            st ThirdStruct (use dep::some_module::ThirdStruct) ThirdStruct
+            st ThirdStruct (use dep::some_module::ThirdStruct)                ThirdStruct
             st AfterThirdStruct (use dep::some_module::AfterThirdStruct) AfterThirdStruct
             st ThiiiiiirdStruct (use dep::some_module::ThiiiiiirdStruct) ThiiiiiirdStruct
         "#]],
@@ -263,8 +263,8 @@ fn trait_function_fuzzy_completion() {
     check(
         fixture,
         expect![[r#"
-                fn weird_function() (use dep::test_mod::TestTrait) fn()
-            "#]],
+            fn weird_function() (use dep::test_mod::TestTrait) fn()
+        "#]],
     );
 
     check_edit(
@@ -356,8 +356,8 @@ fn trait_method_fuzzy_completion() {
     check(
         fixture,
         expect![[r#"
-                me random_method() (use dep::test_mod::TestTrait) fn(&self)
-            "#]],
+            me random_method() (use dep::test_mod::TestTrait) fn(&self)
+        "#]],
     );
 
     check_edit(
@@ -401,8 +401,8 @@ fn main() {
     check(
         fixture,
         expect![[r#"
-        me some_method() (use foo::TestTrait) fn(&self)
-    "#]],
+            me some_method() (use foo::TestTrait) fn(&self)
+        "#]],
     );
 
     check_edit(
@@ -448,8 +448,8 @@ fn main() {
     check(
         fixture,
         expect![[r#"
-        me some_method() (use foo::TestTrait) fn(&self)
-    "#]],
+            me some_method() (use foo::TestTrait) fn(&self)
+        "#]],
     );
 
     check_edit(
@@ -496,8 +496,8 @@ fn completion<T: Wrapper>(whatever: T) {
     check(
         fixture,
         expect![[r#"
-        me not_in_scope() (use foo::NotInScope) fn(&self)
-    "#]],
+            me not_in_scope() (use foo::NotInScope) fn(&self)
+        "#]],
     );
 
     check_edit(
@@ -539,8 +539,8 @@ fn main() {
     check(
         fixture,
         expect![[r#"
-    me into() (use test_trait::TestInto) fn(self) -> T
-    "#]],
+            me into() (use test_trait::TestInto) fn(self) -> T
+        "#]],
     );
 }
 
@@ -568,8 +568,8 @@ fn main() {
     check(
         fixture,
         expect![[r#"
-                fn random_method() (use dep::test_mod::TestTrait) fn()
-            "#]],
+            fn random_method() (use dep::test_mod::TestTrait) fn()
+        "#]],
     );
 
     check_edit(
@@ -737,8 +737,8 @@ fn main() {
 }
         "#,
         expect![[r#"
-                me random_method() (use dep::test_mod::TestTrait) fn(&self) DEPRECATED
-            "#]],
+            me random_method() (use dep::test_mod::TestTrait) fn(&self) DEPRECATED
+        "#]],
     );
 
     check(
@@ -767,8 +767,8 @@ fn main() {
 }
 "#,
         expect![[r#"
-            ct SPECIAL_CONST (use dep::test_mod::TestTrait) u8 DEPRECATED
-            fn weird_function() (use dep::test_mod::TestTrait) fn() DEPRECATED
+            ct SPECIAL_CONST (use dep::test_mod::TestTrait)           u8 DEPRECATED
+            fn weird_function() (use dep::test_mod::TestTrait)      fn() DEPRECATED
             me random_method(…) (use dep::test_mod::TestTrait) fn(&self) DEPRECATED
         "#]],
     );
@@ -1117,7 +1117,7 @@ fn main() {
     tes$0
 }"#,
         expect![[r#"
-            ct TEST_CONST (use foo::TEST_CONST) usize
+            ct TEST_CONST (use foo::TEST_CONST)               usize
             fn test_function() (use foo::test_function) fn() -> i32
         "#]],
     );
@@ -1175,8 +1175,8 @@ fn main() {
 }
 "#,
         expect![[r#"
-                fn some_fn() (use m::some_fn) fn() -> i32
-            "#]],
+            fn some_fn() (use m::some_fn) fn() -> i32
+        "#]],
     );
 }
 
@@ -1691,7 +1691,7 @@ fn function() {
         expect![[r#"
             st FooStruct (use outer::FooStruct) BarStruct
             md foo (use outer::foo)
-            fn foo_fun() (use outer::foo_fun) fn()
+            fn foo_fun() (use outer::foo_fun)        fn()
         "#]],
     );
 }
@@ -1740,8 +1740,8 @@ fn intrinsics() {
     }
     "#,
         expect![[r#"
-                fn transmute(…) (use core::mem::transmute) unsafe fn(Src) -> Dst
-            "#]],
+            fn transmute(…) (use core::mem::transmute) unsafe fn(Src) -> Dst
+        "#]],
     );
     check(
         r#"

--- a/crates/ide-completion/src/tests/fn_param.rs
+++ b/crates/ide-completion/src/tests/fn_param.rs
@@ -140,7 +140,7 @@ fn foo2($0) {}
         expect![[r#"
             st Bar
             bn Bar { bar }: Bar
-            bn Bar {…}          Bar { bar$1 }: Bar$0
+            bn Bar {…} Bar { bar$1 }: Bar$0
             kw mut
             kw ref
         "#]],

--- a/crates/ide-completion/src/tests/item.rs
+++ b/crates/ide-completion/src/tests/item.rs
@@ -20,15 +20,15 @@ fn target_type_or_trait_in_impl_block() {
 impl Tra$0
 "#,
         expect![[r#"
-            en Enum      Enum
+            en Enum                    Enum
             ma makro!(…) macro_rules! makro
             md module
-            st Record    Record
-            st Tuple     Tuple
-            st Unit      Unit
+            st Record                Record
+            st Tuple                  Tuple
+            st Unit                    Unit
             tt Trait
-            un Union     Union
-            bt u32       u32
+            un Union                  Union
+            bt u32                      u32
             kw crate::
             kw self::
         "#]],
@@ -42,15 +42,15 @@ fn target_type_in_trait_impl_block() {
 impl Trait for Str$0
 "#,
         expect![[r#"
-            en Enum      Enum
+            en Enum                    Enum
             ma makro!(…) macro_rules! makro
             md module
-            st Record    Record
-            st Tuple     Tuple
-            st Unit      Unit
+            st Record                Record
+            st Tuple                  Tuple
+            st Unit                    Unit
             tt Trait
-            un Union     Union
-            bt u32       u32
+            un Union                  Union
+            bt u32                      u32
             kw crate::
             kw self::
         "#]],

--- a/crates/ide-completion/src/tests/item_list.rs
+++ b/crates/ide-completion/src/tests/item_list.rs
@@ -13,7 +13,7 @@ fn in_mod_item_list() {
     check(
         r#"mod tests { $0 }"#,
         expect![[r#"
-            ma makro!(…)           macro_rules! makro
+            ma makro!(…) macro_rules! makro
             kw async
             kw const
             kw crate::
@@ -46,7 +46,7 @@ fn in_source_file_item_list() {
     check(
         r#"$0"#,
         expect![[r#"
-            ma makro!(…)           macro_rules! makro
+            ma makro!(…) macro_rules! makro
             md module
             kw async
             kw const
@@ -79,7 +79,7 @@ fn in_item_list_after_attr() {
     check(
         r#"#[attr] $0"#,
         expect![[r#"
-            ma makro!(…)           macro_rules! makro
+            ma makro!(…) macro_rules! makro
             md module
             kw async
             kw const
@@ -182,7 +182,7 @@ fn in_impl_assoc_item_list() {
     check(
         r#"impl Struct { $0 }"#,
         expect![[r#"
-            ma makro!(…)  macro_rules! makro
+            ma makro!(…) macro_rules! makro
             md module
             kw async
             kw const
@@ -202,7 +202,7 @@ fn in_impl_assoc_item_list_after_attr() {
     check(
         r#"impl Struct { #[attr] $0 }"#,
         expect![[r#"
-            ma makro!(…)  macro_rules! makro
+            ma makro!(…) macro_rules! makro
             md module
             kw async
             kw const
@@ -315,7 +315,7 @@ impl Test for () {
             fn async fn function2()
             fn fn function1()
             fn fn function2()
-            ma makro!(…)            macro_rules! makro
+            ma makro!(…) macro_rules! makro
             md module
             ta type Type1 =
             kw crate::
@@ -381,7 +381,7 @@ fn after_unit_struct() {
     check(
         r#"struct S; f$0"#,
         expect![[r#"
-            ma makro!(…)           macro_rules! makro
+            ma makro!(…) macro_rules! makro
             md module
             kw async
             kw const
@@ -503,7 +503,7 @@ fn inside_extern_blocks() {
     check(
         r#"extern { $0 }"#,
         expect![[r#"
-            ma makro!(…)  macro_rules! makro
+            ma makro!(…) macro_rules! makro
             md module
             kw crate::
             kw fn
@@ -520,7 +520,7 @@ fn inside_extern_blocks() {
     check(
         r#"unsafe extern { $0 }"#,
         expect![[r#"
-            ma makro!(…)  macro_rules! makro
+            ma makro!(…) macro_rules! makro
             md module
             kw crate::
             kw fn

--- a/crates/ide-completion/src/tests/pattern.rs
+++ b/crates/ide-completion/src/tests/pattern.rs
@@ -122,15 +122,15 @@ fn foo() {
         expect![[r#"
             ct CONST
             en Enum
-            ma makro!(…)  macro_rules! makro
+            ma makro!(…)    macro_rules! makro
             md module
             st Record
             st Tuple
             st Unit
             ev TupleV
             bn Record {…} Record { field$1 }$0
-            bn Tuple(…)   Tuple($1)$0
-            bn TupleV(…)  TupleV($1)$0
+            bn Tuple(…)            Tuple($1)$0
+            bn TupleV(…)          TupleV($1)$0
             kw mut
             kw ref
         "#]],
@@ -151,15 +151,15 @@ fn foo() {
 "#,
         expect![[r#"
             en SingleVariantEnum
-            ma makro!(…)         macro_rules! makro
+            ma makro!(…)    macro_rules! makro
             md module
             st Record
             st Tuple
             st Unit
             ev Variant
-            bn Record {…}        Record { field$1 }$0
-            bn Tuple(…)          Tuple($1)$0
-            bn Variant           Variant$0
+            bn Record {…} Record { field$1 }$0
+            bn Tuple(…)            Tuple($1)$0
+            bn Variant               Variant$0
             kw mut
             kw ref
         "#]],
@@ -174,13 +174,13 @@ fn foo(a$0) {
 }
 "#,
         expect![[r#"
-            ma makro!(…)  macro_rules! makro
+            ma makro!(…)            macro_rules! makro
             md module
             st Record
             st Tuple
             st Unit
             bn Record {…} Record { field$1 }: Record$0
-            bn Tuple(…)   Tuple($1): Tuple$0
+            bn Tuple(…)             Tuple($1): Tuple$0
             kw mut
             kw ref
         "#]],
@@ -191,13 +191,13 @@ fn foo(a$0: Tuple) {
 }
 "#,
         expect![[r#"
-            ma makro!(…)  macro_rules! makro
+            ma makro!(…)    macro_rules! makro
             md module
             st Record
             st Tuple
             st Unit
             bn Record {…} Record { field$1 }$0
-            bn Tuple(…)   Tuple($1)$0
+            bn Tuple(…)            Tuple($1)$0
             bn tuple
             kw mut
             kw ref
@@ -240,7 +240,7 @@ fn foo() {
         expect![[r#"
             en E
             ma m!(…) macro_rules! m
-            bn E::X  E::X$0
+            bn E::X          E::X$0
             kw mut
             kw ref
         "#]],
@@ -268,7 +268,7 @@ fn outer() {
             st Record
             st Tuple
             bn Record {…} Record { field$1, .. }$0
-            bn Tuple(…)   Tuple($1, ..)$0
+            bn Tuple(…)            Tuple($1, ..)$0
             kw mut
             kw ref
         "#]],
@@ -291,7 +291,7 @@ impl Foo {
         expect![[r#"
             sp Self
             st Foo
-            bn Foo(…)  Foo($1)$0
+            bn Foo(…)   Foo($1)$0
             bn Self(…) Self($1)$0
             kw mut
             kw ref
@@ -315,8 +315,8 @@ fn func() {
         expect![[r#"
             ct ASSOC_CONST const ASSOC_CONST: ()
             bn RecordV {…} RecordV { field$1 }$0
-            bn TupleV(…)   TupleV($1)$0
-            bn UnitV       UnitV$0
+            bn TupleV(…)            TupleV($1)$0
+            bn UnitV                     UnitV$0
         "#]],
     );
 }
@@ -332,7 +332,7 @@ fn outer(Foo { bar: $0 }: Foo) {}
         expect![[r#"
             st Bar
             st Foo
-            bn Bar(…)  Bar($1)$0
+            bn Bar(…)        Bar($1)$0
             bn Foo {…} Foo { bar$1 }$0
             kw mut
             kw ref
@@ -395,7 +395,7 @@ fn foo($0) {}
         expect![[r#"
             st Bar
             st Foo
-            bn Bar(…)  Bar($1): Bar$0
+            bn Bar(…)        Bar($1): Bar$0
             bn Foo {…} Foo { bar$1 }: Foo$0
             kw mut
             kw ref
@@ -416,7 +416,7 @@ fn foo() {
         expect![[r#"
             st Bar
             st Foo
-            bn Bar(…)  Bar($1)$0
+            bn Bar(…)        Bar($1)$0
             bn Foo {…} Foo { bar$1 }$0
             kw mut
             kw ref
@@ -436,7 +436,7 @@ fn foo() {
 }
 "#,
         expect![[r#"
-            st Bar     Bar
+            st Bar Bar
             kw crate::
             kw self::
         "#]],
@@ -451,7 +451,7 @@ fn foo() {
 }
 "#,
         expect![[r#"
-            st Foo     Foo
+            st Foo Foo
             kw crate::
             kw self::
         "#]],
@@ -535,10 +535,10 @@ fn foo() {
 "#,
         expect![[r#"
             en Enum
-            bn Enum::A          Enum::A$0
-            bn Enum::B {…}      Enum::B { r#type$1 }$0
+            bn Enum::A                              Enum::A$0
+            bn Enum::B {…}             Enum::B { r#type$1 }$0
             bn Enum::struct {…} Enum::r#struct { r#type$1 }$0
-            bn Enum::type       Enum::r#type$0
+            bn Enum::type                      Enum::r#type$0
             kw mut
             kw ref
         "#]],
@@ -559,10 +559,10 @@ fn foo() {
 }
 "#,
         expect![[r#"
-            bn A          A$0
-            bn B {…}      B { r#type$1 }$0
+            bn A                              A$0
+            bn B {…}             B { r#type$1 }$0
             bn struct {…} r#struct { r#type$1 }$0
-            bn type       r#type$0
+            bn type                      r#type$0
         "#]],
     );
 }
@@ -672,8 +672,8 @@ impl Ty {
             st Ty
             bn &mut self
             bn &self
-            bn Self(…)   Self($1): Self$0
-            bn Ty(…)     Ty($1): Ty$0
+            bn Self(…) Self($1): Self$0
+            bn Ty(…)       Ty($1): Ty$0
             bn mut self
             bn self
             kw mut
@@ -693,8 +693,8 @@ impl Ty {
             st Ty
             bn &mut self
             bn &self
-            bn Self(…)   Self($1): Self$0
-            bn Ty(…)     Ty($1): Ty$0
+            bn Self(…) Self($1): Self$0
+            bn Ty(…)       Ty($1): Ty$0
             bn mut self
             bn self
             kw mut
@@ -714,8 +714,8 @@ impl Ty {
             st Ty
             bn &mut self
             bn &self
-            bn Self(…)   Self($1): Self$0
-            bn Ty(…)     Ty($1): Ty$0
+            bn Self(…) Self($1): Self$0
+            bn Ty(…)       Ty($1): Ty$0
             bn mut self
             bn self
             kw mut
@@ -734,7 +734,7 @@ impl Ty {
             sp Self
             st Ty
             bn Self(…) Self($1): Self$0
-            bn Ty(…)   Ty($1): Ty$0
+            bn Ty(…)       Ty($1): Ty$0
             kw mut
             kw ref
         "#]],
@@ -763,7 +763,7 @@ fn f(x: EnumAlias<u8>) {
 "#,
         expect![[r#"
             bn Tuple(…) Tuple($1)$0
-            bn Unit     Unit$0
+            bn Unit          Unit$0
         "#]],
     );
 }

--- a/crates/ide-completion/src/tests/predicate.rs
+++ b/crates/ide-completion/src/tests/predicate.rs
@@ -16,16 +16,16 @@ fn predicate_start() {
 struct Foo<'lt, T, const C: usize> where $0 {}
 "#,
         expect![[r#"
-            en Enum      Enum
+            en Enum                    Enum
             ma makro!(…) macro_rules! makro
             md module
-            st Foo<…>    Foo<'_, {unknown}, _>
-            st Record    Record
-            st Tuple     Tuple
-            st Unit      Unit
+            st Foo<…> Foo<'_, {unknown}, _>
+            st Record                Record
+            st Tuple                  Tuple
+            st Unit                    Unit
             tt Trait
-            un Union     Union
-            bt u32       u32
+            un Union                  Union
+            bt u32                      u32
             kw crate::
             kw self::
         "#]],
@@ -89,16 +89,16 @@ fn param_list_for_for_pred() {
 struct Foo<'lt, T, const C: usize> where for<'a> $0 {}
 "#,
         expect![[r#"
-            en Enum      Enum
+            en Enum                    Enum
             ma makro!(…) macro_rules! makro
             md module
-            st Foo<…>    Foo<'_, {unknown}, _>
-            st Record    Record
-            st Tuple     Tuple
-            st Unit      Unit
+            st Foo<…> Foo<'_, {unknown}, _>
+            st Record                Record
+            st Tuple                  Tuple
+            st Unit                    Unit
             tt Trait
-            un Union     Union
-            bt u32       u32
+            un Union                  Union
+            bt u32                      u32
             kw crate::
             kw self::
         "#]],
@@ -114,16 +114,16 @@ impl Record {
 }
 "#,
         expect![[r#"
-            en Enum      Enum
+            en Enum                    Enum
             ma makro!(…) macro_rules! makro
             md module
-            sp Self      Record
-            st Record    Record
-            st Tuple     Tuple
-            st Unit      Unit
+            sp Self                  Record
+            st Record                Record
+            st Tuple                  Tuple
+            st Unit                    Unit
             tt Trait
-            un Union     Union
-            bt u32       u32
+            un Union                  Union
+            bt u32                      u32
             kw crate::
             kw self::
         "#]],

--- a/crates/ide-completion/src/tests/proc_macros.rs
+++ b/crates/ide-completion/src/tests/proc_macros.rs
@@ -24,19 +24,19 @@ fn main() {
 }
 "#,
         expect![[r#"
-            me foo()  fn(&self)
-            sn box    Box::new(expr)
-            sn call   function(expr)
-            sn dbg    dbg!(expr)
-            sn dbgr   dbg!(&expr)
-            sn deref  *expr
-            sn let    let
-            sn letm   let mut
-            sn match  match expr {}
-            sn ref    &expr
-            sn refm   &mut expr
-            sn return return expr
-            sn unsafe unsafe {}
+            me foo()     fn(&self)
+            sn box  Box::new(expr)
+            sn call function(expr)
+            sn dbg      dbg!(expr)
+            sn dbgr    dbg!(&expr)
+            sn deref         *expr
+            sn let             let
+            sn letm        let mut
+            sn match match expr {}
+            sn ref           &expr
+            sn refm      &mut expr
+            sn return  return expr
+            sn unsafe    unsafe {}
         "#]],
     )
 }
@@ -57,19 +57,19 @@ fn main() {
 }
 "#,
         expect![[r#"
-            me foo()  fn(&self)
-            sn box    Box::new(expr)
-            sn call   function(expr)
-            sn dbg    dbg!(expr)
-            sn dbgr   dbg!(&expr)
-            sn deref  *expr
-            sn let    let
-            sn letm   let mut
-            sn match  match expr {}
-            sn ref    &expr
-            sn refm   &mut expr
-            sn return return expr
-            sn unsafe unsafe {}
+            me foo()     fn(&self)
+            sn box  Box::new(expr)
+            sn call function(expr)
+            sn dbg      dbg!(expr)
+            sn dbgr    dbg!(&expr)
+            sn deref         *expr
+            sn let             let
+            sn letm        let mut
+            sn match match expr {}
+            sn ref           &expr
+            sn refm      &mut expr
+            sn return  return expr
+            sn unsafe    unsafe {}
         "#]],
     )
 }
@@ -92,19 +92,19 @@ impl Foo {
 fn main() {}
 "#,
         expect![[r#"
-            me foo()  fn(&self)
-            sn box    Box::new(expr)
-            sn call   function(expr)
-            sn dbg    dbg!(expr)
-            sn dbgr   dbg!(&expr)
-            sn deref  *expr
-            sn let    let
-            sn letm   let mut
-            sn match  match expr {}
-            sn ref    &expr
-            sn refm   &mut expr
-            sn return return expr
-            sn unsafe unsafe {}
+            me foo()     fn(&self)
+            sn box  Box::new(expr)
+            sn call function(expr)
+            sn dbg      dbg!(expr)
+            sn dbgr    dbg!(&expr)
+            sn deref         *expr
+            sn let             let
+            sn letm        let mut
+            sn match match expr {}
+            sn ref           &expr
+            sn refm      &mut expr
+            sn return  return expr
+            sn unsafe    unsafe {}
         "#]],
     )
 }
@@ -127,19 +127,19 @@ impl Foo {
 fn main() {}
 "#,
         expect![[r#"
-            me foo()  fn(&self)
-            sn box    Box::new(expr)
-            sn call   function(expr)
-            sn dbg    dbg!(expr)
-            sn dbgr   dbg!(&expr)
-            sn deref  *expr
-            sn let    let
-            sn letm   let mut
-            sn match  match expr {}
-            sn ref    &expr
-            sn refm   &mut expr
-            sn return return expr
-            sn unsafe unsafe {}
+            me foo()     fn(&self)
+            sn box  Box::new(expr)
+            sn call function(expr)
+            sn dbg      dbg!(expr)
+            sn dbgr    dbg!(&expr)
+            sn deref         *expr
+            sn let             let
+            sn letm        let mut
+            sn match match expr {}
+            sn ref           &expr
+            sn refm      &mut expr
+            sn return  return expr
+            sn unsafe    unsafe {}
         "#]],
     )
 }

--- a/crates/ide-completion/src/tests/record.rs
+++ b/crates/ide-completion/src/tests/record.rs
@@ -70,8 +70,8 @@ fn foo(baz: Baz) {
             ev Ok
             bn Baz::Bar Baz::Bar$0
             bn Baz::Foo Baz::Foo$0
-            bn Err(…)   Err($1)$0
-            bn Ok(…)    Ok($1)$0
+            bn Err(…)    Err($1)$0
+            bn Ok(…)      Ok($1)$0
             kw mut
             kw ref
         "#]],
@@ -91,20 +91,20 @@ fn foo(baz: Baz) {
 }
  "#,
         expect![[r#"
-         en Baz
-         en Result
-         md core
-         ev Bar
-         ev Err
-         ev Foo
-         ev Ok
-         bn Bar    Bar$0
-         bn Err(…) Err($1)$0
-         bn Foo    Foo$0
-         bn Ok(…)  Ok($1)$0
-         kw mut
-         kw ref
-         "#]],
+            en Baz
+            en Result
+            md core
+            ev Bar
+            ev Err
+            ev Foo
+            ev Ok
+            bn Bar        Bar$0
+            bn Err(…) Err($1)$0
+            bn Foo        Foo$0
+            bn Ok(…)   Ok($1)$0
+            kw mut
+            kw ref
+        "#]],
     );
 }
 
@@ -184,14 +184,14 @@ fn main() {
 "#,
         expect![[r#"
             fd ..Default::default()
-            fn main()               fn()
-            lc foo                  Foo
-            lc thing                i32
+            fn main()                          fn()
+            lc foo                              Foo
+            lc thing                            i32
             md core
-            st Foo                  Foo
-            st Foo {…}              Foo { foo1: u32, foo2: u32 }
+            st Foo                              Foo
+            st Foo {…} Foo { foo1: u32, foo2: u32 }
             tt Default
-            bt u32                  u32
+            bt u32                              u32
             kw crate::
             kw self::
             ex Foo::default()
@@ -238,8 +238,8 @@ fn main() {
 "#,
         expect![[r#"
             fd ..Default::default()
-            fd foo1                 u32
-            fd foo2                 u32
+            fd foo1             u32
+            fd foo2             u32
         "#]],
     );
 }

--- a/crates/ide-completion/src/tests/special.rs
+++ b/crates/ide-completion/src/tests/special.rs
@@ -87,7 +87,7 @@ pub mod prelude {
         expect![[r#"
             md std
             st Option Option
-            bt u32    u32
+            bt u32       u32
         "#]],
     );
 }
@@ -113,10 +113,10 @@ mod macros {
 }
 "#,
         expect![[r#"
-            fn f()        fn()
+            fn f()                       fn()
             ma concat!(…) macro_rules! concat
             md std
-            bt u32        u32
+            bt u32                        u32
         "#]],
     );
 }
@@ -146,7 +146,7 @@ pub mod prelude {
             md core
             md std
             st String String
-            bt u32    u32
+            bt u32       u32
         "#]],
     );
 }
@@ -174,7 +174,7 @@ pub mod prelude {
         expect![[r#"
             fn f() fn()
             md std
-            bt u32 u32
+            bt u32  u32
         "#]],
     );
 }
@@ -226,9 +226,9 @@ impl S {
 fn foo() { let _ = lib::S::$0 }
 "#,
         expect![[r#"
-            ct PUBLIC_CONST    pub const PUBLIC_CONST: u32
-            fn public_method() fn()
-            ta PublicType      pub type PublicType = u32
+            ct PUBLIC_CONST pub const PUBLIC_CONST: u32
+            fn public_method()                     fn()
+            ta PublicType     pub type PublicType = u32
         "#]],
     );
 }
@@ -317,14 +317,14 @@ trait Sub: Super {
 fn foo<T: Sub>() { T::$0 }
 "#,
         expect![[r#"
-            ct C2 (as Sub)           const C2: ()
-            ct CONST (as Super)      const CONST: u8
-            fn func() (as Super)     fn()
-            fn subfunc() (as Sub)    fn()
-            me method(…) (as Super)  fn(&self)
-            me submethod(…) (as Sub) fn(&self)
+            ct C2 (as Sub)         const C2: ()
+            ct CONST (as Super) const CONST: u8
+            fn func() (as Super)           fn()
+            fn subfunc() (as Sub)          fn()
+            me method(…) (as Super)   fn(&self)
+            me submethod(…) (as Sub)  fn(&self)
             ta SubTy (as Sub)        type SubTy
-            ta Ty (as Super)         type Ty
+            ta Ty (as Super)            type Ty
         "#]],
     );
 }
@@ -357,14 +357,14 @@ impl<T> Sub for Wrap<T> {
 }
 "#,
         expect![[r#"
-            ct C2 (as Sub)           const C2: ()
-            ct CONST (as Super)      const CONST: u8
-            fn func() (as Super)     fn()
-            fn subfunc() (as Sub)    fn()
-            me method(…) (as Super)  fn(&self)
-            me submethod(…) (as Sub) fn(&self)
+            ct C2 (as Sub)         const C2: ()
+            ct CONST (as Super) const CONST: u8
+            fn func() (as Super)           fn()
+            fn subfunc() (as Sub)          fn()
+            me method(…) (as Super)   fn(&self)
+            me submethod(…) (as Sub)  fn(&self)
             ta SubTy (as Sub)        type SubTy
-            ta Ty (as Super)         type Ty
+            ta Ty (as Super)            type Ty
         "#]],
     );
 }
@@ -381,9 +381,9 @@ impl T { fn bar() {} }
 fn main() { T::$0; }
 "#,
         expect![[r#"
-                fn bar() fn()
-                fn foo() fn()
-            "#]],
+            fn bar() fn()
+            fn foo() fn()
+        "#]],
     );
 }
 
@@ -397,7 +397,7 @@ macro_rules! foo { () => {} }
 fn main() { let _ = crate::$0 }
 "#,
         expect![[r#"
-            fn main()  fn()
+            fn main()              fn()
             ma foo!(…) macro_rules! foo
         "#]],
     );
@@ -447,9 +447,9 @@ mod p {
 }
 "#,
         expect![[r#"
-            ct RIGHT_CONST u32
-            fn right_fn()  fn()
-            st RightType   WrongType
+            ct RIGHT_CONST     u32
+            fn right_fn()     fn()
+            st RightType WrongType
         "#]],
     );
 
@@ -495,9 +495,9 @@ fn main() { m!(self::f$0); }
 fn foo() {}
 "#,
         expect![[r#"
-                fn foo()  fn()
-                fn main() fn()
-            "#]],
+            fn foo()  fn()
+            fn main() fn()
+        "#]],
     );
 }
 
@@ -513,9 +513,9 @@ mod m {
 }
 "#,
         expect![[r#"
-                fn z() fn()
-                md z
-            "#]],
+            fn z() fn()
+            md z
+        "#]],
     );
 }
 
@@ -534,8 +534,8 @@ fn foo() {
 }
 "#,
         expect![[r#"
-                fn new() fn() -> HashMap<K, V, RandomState>
-            "#]],
+            fn new() fn() -> HashMap<K, V, RandomState>
+        "#]],
     );
 }
 
@@ -557,8 +557,8 @@ impl Foo {
 "#,
         expect![[r#"
             me foo(…) fn(self)
-            ev Bar    Bar
-            ev Baz    Baz
+            ev Bar         Bar
+            ev Baz         Baz
         "#]],
     );
 }
@@ -578,9 +578,9 @@ fn foo(self) {
 }
 "#,
         expect![[r#"
-                ev Bar Bar
-                ev Baz Baz
-            "#]],
+            ev Bar Bar
+            ev Baz Baz
+        "#]],
     );
 
     check_no_kw(
@@ -598,8 +598,8 @@ enum Foo {
 }
 "#,
         expect![[r#"
-                ev Baz Baz
-            "#]],
+            ev Baz Baz
+        "#]],
     );
 }
 
@@ -623,9 +623,9 @@ impl u8 {
 }
 "#,
         expect![[r#"
-                ct MAX     pub const MAX: Self
-                me func(…) fn(self)
-            "#]],
+            ct MAX pub const MAX: Self
+            me func(…)        fn(self)
+        "#]],
     );
 }
 
@@ -643,8 +643,8 @@ fn main() {
 }
 "#,
         expect![[r#"
-                ev Bar Bar
-            "#]],
+            ev Bar Bar
+        "#]],
     );
 }
 
@@ -723,7 +723,7 @@ fn bar() -> Bar {
 }
 "#,
         expect![[r#"
-            fn bar()          fn()
+            fn bar()                  fn()
             fn foo() (as Foo) fn() -> Self
             ex Bar
             ex bar()
@@ -787,7 +787,7 @@ fn main() {
 }
 "#,
         expect![[r#"
-            me by_macro() (as MyTrait) fn(&self)
+            me by_macro() (as MyTrait)     fn(&self)
             me not_by_macro() (as MyTrait) fn(&self)
         "#]],
     )
@@ -827,7 +827,7 @@ fn main() {
 }
 "#,
         expect![[r#"
-            me by_macro() (as MyTrait) fn(&self)
+            me by_macro() (as MyTrait)     fn(&self)
             me not_by_macro() (as MyTrait) fn(&self)
         "#]],
     )
@@ -885,10 +885,10 @@ fn main() {
 }
 "#,
         expect![[r#"
-            fn main() fn()
-            lc foobar i32
-            ma x!(…)  macro_rules! x
-            bt u32    u32
+            fn main()          fn()
+            lc foobar           i32
+            ma x!(…) macro_rules! x
+            bt u32              u32
         "#]],
     )
 }
@@ -1014,7 +1014,7 @@ fn here_we_go() {
 }
 "#,
         expect![[r#"
-            fn here_we_go()    fn()
+            fn here_we_go()   fn()
             st Foo (alias Bar) Foo
             bt u32             u32
             kw async
@@ -1064,9 +1064,9 @@ fn here_we_go() {
 }
 "#,
         expect![[r#"
-            fn here_we_go()           fn()
+            fn here_we_go()             fn()
             st Foo (alias Bar, Qux, Baz) Foo
-            bt u32                    u32
+            bt u32                       u32
             kw async
             kw const
             kw crate::
@@ -1160,20 +1160,20 @@ fn here_we_go() {
 }
 "#,
         expect![[r#"
-            fd bar               u8
+            fd bar                            u8
             me baz() (alias qux) fn(&self) -> u8
-            sn box               Box::new(expr)
-            sn call              function(expr)
-            sn dbg               dbg!(expr)
-            sn dbgr              dbg!(&expr)
-            sn deref             *expr
-            sn let               let
-            sn letm              let mut
-            sn match             match expr {}
-            sn ref               &expr
-            sn refm              &mut expr
-            sn return            return expr
-            sn unsafe            unsafe {}
+            sn box                Box::new(expr)
+            sn call               function(expr)
+            sn dbg                    dbg!(expr)
+            sn dbgr                  dbg!(&expr)
+            sn deref                       *expr
+            sn let                           let
+            sn letm                      let mut
+            sn match               match expr {}
+            sn ref                         &expr
+            sn refm                    &mut expr
+            sn return                return expr
+            sn unsafe                  unsafe {}
         "#]],
     );
 }
@@ -1189,7 +1189,7 @@ fn bar() { qu$0 }
         expect![[r#"
             fn bar()             fn()
             fn foo() (alias qux) fn()
-            bt u32               u32
+            bt u32                u32
             kw async
             kw const
             kw crate::
@@ -1277,10 +1277,10 @@ fn here_we_go() {
 }
 "#,
         expect![[r#"
-            fn here_we_go()           fn()
+            fn here_we_go()                  fn()
             md foo
             st Bar (alias Qux) (use foo::Bar) Bar
-            bt u32                    u32
+            bt u32                            u32
             kw crate::
             kw false
             kw for
@@ -1315,10 +1315,9 @@ use krate::e;
 fn main() {
     e::$0
 }"#,
-        expect![
-            "fn i_am_public() fn()
-"
-        ],
+        expect![[r#"
+            fn i_am_public() fn()
+        "#]],
     )
 }
 
@@ -1444,8 +1443,8 @@ fn foo() {
 "#,
         Some('_'),
         expect![[r#"
-            fn foo()       fn()
-            bt u32         u32
+            fn foo()  fn()
+            bt u32     u32
             kw async
             kw const
             kw crate::
@@ -1498,7 +1497,7 @@ fn foo(_: a_$0) { }
 "#,
         Some('_'),
         expect![[r#"
-            bt u32     u32
+            bt u32 u32
             kw crate::
             kw self::
         "#]],
@@ -1512,7 +1511,7 @@ fn foo<T>() {
         Some('_'),
         expect![[r#"
             tp T
-            bt u32     u32
+            bt u32 u32
             kw crate::
             kw self::
         "#]],

--- a/crates/ide-completion/src/tests/type_pos.rs
+++ b/crates/ide-completion/src/tests/type_pos.rs
@@ -17,18 +17,18 @@ struct Foo<'lt, T, const C: usize> {
 }
 "#,
         expect![[r#"
-            en Enum      Enum
+            en Enum                    Enum
             ma makro!(…) macro_rules! makro
             md module
-            sp Self      Foo<'_, {unknown}, _>
-            st Foo<…>    Foo<'_, {unknown}, _>
-            st Record    Record
-            st Tuple     Tuple
-            st Unit      Unit
+            sp Self   Foo<'_, {unknown}, _>
+            st Foo<…> Foo<'_, {unknown}, _>
+            st Record                Record
+            st Tuple                  Tuple
+            st Unit                    Unit
             tt Trait
             tp T
-            un Union     Union
-            bt u32       u32
+            un Union                  Union
+            bt u32                      u32
             kw crate::
             kw self::
         "#]],
@@ -42,18 +42,18 @@ fn tuple_struct_field() {
 struct Foo<'lt, T, const C: usize>(f$0);
 "#,
         expect![[r#"
-            en Enum       Enum
-            ma makro!(…)  macro_rules! makro
+            en Enum                    Enum
+            ma makro!(…) macro_rules! makro
             md module
-            sp Self       Foo<'_, {unknown}, _>
-            st Foo<…>     Foo<'_, {unknown}, _>
-            st Record     Record
-            st Tuple      Tuple
-            st Unit       Unit
+            sp Self   Foo<'_, {unknown}, _>
+            st Foo<…> Foo<'_, {unknown}, _>
+            st Record                Record
+            st Tuple                  Tuple
+            st Unit                    Unit
             tt Trait
             tp T
-            un Union      Union
-            bt u32        u32
+            un Union                  Union
+            bt u32                      u32
             kw crate::
             kw pub
             kw pub(crate)
@@ -70,16 +70,16 @@ fn fn_return_type() {
 fn x<'lt, T, const C: usize>() -> $0
 "#,
         expect![[r#"
-            en Enum      Enum
+            en Enum                    Enum
             ma makro!(…) macro_rules! makro
             md module
-            st Record    Record
-            st Tuple     Tuple
-            st Unit      Unit
+            st Record                Record
+            st Tuple                  Tuple
+            st Unit                    Unit
             tt Trait
             tp T
-            un Union     Union
-            bt u32       u32
+            un Union                  Union
+            bt u32                      u32
             kw crate::
             kw self::
         "#]],
@@ -100,15 +100,15 @@ fn foo() -> B$0 {
 }
 "#,
         expect![[r#"
-            en Enum      Enum
+            en Enum                    Enum
             ma makro!(…) macro_rules! makro
             md module
-            st Record    Record
-            st Tuple     Tuple
-            st Unit      Unit
+            st Record                Record
+            st Tuple                  Tuple
+            st Unit                    Unit
             tt Trait
-            un Union     Union
-            bt u32       u32
+            un Union                  Union
+            bt u32                      u32
             it ()
             kw crate::
             kw self::
@@ -124,16 +124,16 @@ struct Foo<T>(T);
 const FOO: $0 = Foo(2);
 "#,
         expect![[r#"
-            en Enum      Enum
+            en Enum                    Enum
             ma makro!(…) macro_rules! makro
             md module
-            st Foo<…>    Foo<{unknown}>
-            st Record    Record
-            st Tuple     Tuple
-            st Unit      Unit
+            st Foo<…>        Foo<{unknown}>
+            st Record                Record
+            st Tuple                  Tuple
+            st Unit                    Unit
             tt Trait
-            un Union     Union
-            bt u32       u32
+            un Union                  Union
+            bt u32                      u32
             it Foo<i32>
             kw crate::
             kw self::
@@ -151,15 +151,15 @@ fn f2() {
 }
 "#,
         expect![[r#"
-            en Enum      Enum
+            en Enum                    Enum
             ma makro!(…) macro_rules! makro
             md module
-            st Record    Record
-            st Tuple     Tuple
-            st Unit      Unit
+            st Record                Record
+            st Tuple                  Tuple
+            st Unit                    Unit
             tt Trait
-            un Union     Union
-            bt u32       u32
+            un Union                  Union
+            bt u32                      u32
             it i32
             kw crate::
             kw self::
@@ -179,15 +179,15 @@ fn f2() {
 }
 "#,
         expect![[r#"
-            en Enum      Enum
+            en Enum                    Enum
             ma makro!(…) macro_rules! makro
             md module
-            st Record    Record
-            st Tuple     Tuple
-            st Unit      Unit
+            st Record                Record
+            st Tuple                  Tuple
+            st Unit                    Unit
             tt Trait
-            un Union     Union
-            bt u32       u32
+            un Union                  Union
+            bt u32                      u32
             it u64
             kw crate::
             kw self::
@@ -204,15 +204,15 @@ fn f2(x: u64) -> $0 {
 }
 "#,
         expect![[r#"
-            en Enum      Enum
+            en Enum                    Enum
             ma makro!(…) macro_rules! makro
             md module
-            st Record    Record
-            st Tuple     Tuple
-            st Unit      Unit
+            st Record                Record
+            st Tuple                  Tuple
+            st Unit                    Unit
             tt Trait
-            un Union     Union
-            bt u32       u32
+            un Union                  Union
+            bt u32                      u32
             it u64
             kw crate::
             kw self::
@@ -230,15 +230,15 @@ fn f2(x: $0) {
 }
 "#,
         expect![[r#"
-            en Enum      Enum
+            en Enum                    Enum
             ma makro!(…) macro_rules! makro
             md module
-            st Record    Record
-            st Tuple     Tuple
-            st Unit      Unit
+            st Record                Record
+            st Tuple                  Tuple
+            st Unit                    Unit
             tt Trait
-            un Union     Union
-            bt u32       u32
+            un Union                  Union
+            bt u32                      u32
             it i32
             kw crate::
             kw self::
@@ -262,17 +262,17 @@ fn foo<'lt, T, const C: usize>() {
 }
 "#,
         expect![[r#"
-            en Enum                Enum
-            ma makro!(…)           macro_rules! makro
+            en Enum                    Enum
+            ma makro!(…) macro_rules! makro
             md a
             md module
-            st Record              Record
-            st Tuple               Tuple
-            st Unit                Unit
+            st Record                Record
+            st Tuple                  Tuple
+            st Unit                    Unit
             tt Trait
             tp T
-            un Union               Union
-            bt u32                 u32
+            un Union                  Union
+            bt u32                      u32
             it a::Foo<a::Foo<i32>>
             kw crate::
             kw self::
@@ -291,17 +291,17 @@ fn foo<'lt, T, const C: usize>() {
 }
 "#,
         expect![[r#"
-            en Enum      Enum
+            en Enum                    Enum
             ma makro!(…) macro_rules! makro
             md module
-            st Foo<…>    Foo<{unknown}>
-            st Record    Record
-            st Tuple     Tuple
-            st Unit      Unit
+            st Foo<…>        Foo<{unknown}>
+            st Record                Record
+            st Tuple                  Tuple
+            st Unit                    Unit
             tt Trait
             tp T
-            un Union     Union
-            bt u32       u32
+            un Union                  Union
+            bt u32                      u32
             it Foo<i32>
             kw crate::
             kw self::
@@ -319,16 +319,16 @@ fn foo<'lt, T, const C: usize>() {
 }
 "#,
         expect![[r#"
-            en Enum      Enum
+            en Enum                    Enum
             ma makro!(…) macro_rules! makro
             md module
-            st Record    Record
-            st Tuple     Tuple
-            st Unit      Unit
+            st Record                Record
+            st Tuple                  Tuple
+            st Unit                    Unit
             tt Trait
             tp T
-            un Union     Union
-            bt u32       u32
+            un Union                  Union
+            bt u32                      u32
             kw crate::
             kw self::
         "#]],
@@ -341,14 +341,14 @@ fn foo<'lt, T, const C: usize>() {
 }
 "#,
         expect![[r#"
-            en Enum      Enum
+            en Enum                    Enum
             ma makro!(…) macro_rules! makro
             md module
-            st Record    Record
-            st Tuple     Tuple
-            st Unit      Unit
+            st Record                Record
+            st Tuple                  Tuple
+            st Unit                    Unit
             tt Trait
-            un Union     Union
+            un Union                  Union
         "#]],
     );
 }
@@ -368,7 +368,7 @@ trait Trait2: Trait1 {
 fn foo<'lt, T: Trait2<$0>, const CONST_PARAM: usize>(_: T) {}
 "#,
         expect![[r#"
-            ta Foo =  (as Trait2)   type Foo
+            ta Foo =  (as Trait2)     type Foo
             ta Super =  (as Trait1) type Super
         "#]],
     );
@@ -384,18 +384,18 @@ trait Trait2<T>: Trait1 {
 fn foo<'lt, T: Trait2<$0>, const CONST_PARAM: usize>(_: T) {}
 "#,
         expect![[r#"
-            en Enum      Enum
+            en Enum                    Enum
             ma makro!(…) macro_rules! makro
             md module
-            st Record    Record
-            st Tuple     Tuple
-            st Unit      Unit
+            st Record                Record
+            st Tuple                  Tuple
+            st Unit                    Unit
             tt Trait
             tt Trait1
             tt Trait2
             tp T
-            un Union     Union
-            bt u32       u32
+            un Union                  Union
+            bt u32                      u32
             kw crate::
             kw self::
         "#]],
@@ -409,15 +409,15 @@ trait Trait2<T> {
 fn foo<'lt, T: Trait2<self::$0>, const CONST_PARAM: usize>(_: T) {}
     "#,
         expect![[r#"
-            en Enum      Enum
+            en Enum                    Enum
             ma makro!(…) macro_rules! makro
             md module
-            st Record    Record
-            st Tuple     Tuple
-            st Unit      Unit
+            st Record                Record
+            st Tuple                  Tuple
+            st Unit                    Unit
             tt Trait
             tt Trait2
-            un Union     Union
+            un Union                  Union
         "#]],
     );
 }
@@ -434,18 +434,18 @@ trait Tr<T> {
 impl Tr<$0
     "#,
         expect![[r#"
-            en Enum      Enum
+            en Enum                    Enum
             ma makro!(…) macro_rules! makro
             md module
-            sp Self      dyn Tr<{unknown}>
-            st Record    Record
-            st S         S
-            st Tuple     Tuple
-            st Unit      Unit
+            sp Self       dyn Tr<{unknown}>
+            st Record                Record
+            st S                          S
+            st Tuple                  Tuple
+            st Unit                    Unit
             tt Tr
             tt Trait
-            un Union     Union
-            bt u32       u32
+            un Union                  Union
+            bt u32                      u32
             kw crate::
             kw self::
         "#]],
@@ -481,16 +481,16 @@ trait MyTrait<T, U> {
 fn f(t: impl MyTrait<u$0
 "#,
         expect![[r#"
-            en Enum      Enum
+            en Enum                    Enum
             ma makro!(…) macro_rules! makro
             md module
-            st Record    Record
-            st Tuple     Tuple
-            st Unit      Unit
+            st Record                Record
+            st Tuple                  Tuple
+            st Unit                    Unit
             tt MyTrait
             tt Trait
-            un Union     Union
-            bt u32       u32
+            un Union                  Union
+            bt u32                      u32
             kw crate::
             kw self::
         "#]],
@@ -506,16 +506,16 @@ trait MyTrait<T, U> {
 fn f(t: impl MyTrait<u8, u$0
 "#,
         expect![[r#"
-            en Enum      Enum
+            en Enum                    Enum
             ma makro!(…) macro_rules! makro
             md module
-            st Record    Record
-            st Tuple     Tuple
-            st Unit      Unit
+            st Record                Record
+            st Tuple                  Tuple
+            st Unit                    Unit
             tt MyTrait
             tt Trait
-            un Union     Union
-            bt u32       u32
+            un Union                  Union
+            bt u32                      u32
             kw crate::
             kw self::
         "#]],
@@ -549,16 +549,16 @@ trait MyTrait<T, U = u8> {
 fn f(t: impl MyTrait<u$0
 "#,
         expect![[r#"
-            en Enum      Enum
+            en Enum                    Enum
             ma makro!(…) macro_rules! makro
             md module
-            st Record    Record
-            st Tuple     Tuple
-            st Unit      Unit
+            st Record                Record
+            st Tuple                  Tuple
+            st Unit                    Unit
             tt MyTrait
             tt Trait
-            un Union     Union
-            bt u32       u32
+            un Union                  Union
+            bt u32                      u32
             kw crate::
             kw self::
         "#]],
@@ -574,18 +574,18 @@ trait MyTrait<T, U = u8> {
 fn f(t: impl MyTrait<u8, u$0
 "#,
         expect![[r#"
-            en Enum                  Enum
-            ma makro!(…)             macro_rules! makro
+            en Enum                        Enum
+            ma makro!(…)     macro_rules! makro
             md module
-            st Record                Record
-            st Tuple                 Tuple
-            st Unit                  Unit
+            st Record                    Record
+            st Tuple                      Tuple
+            st Unit                        Unit
             tt MyTrait
             tt Trait
             ta Item1 =  (as MyTrait) type Item1
             ta Item2 =  (as MyTrait) type Item2
-            un Union                 Union
-            bt u32                   u32
+            un Union                      Union
+            bt u32                          u32
             kw crate::
             kw self::
         "#]],
@@ -619,16 +619,16 @@ trait MyTrait {
 fn f(t: impl MyTrait<Item1 = $0
 "#,
         expect![[r#"
-            en Enum      Enum
+            en Enum                    Enum
             ma makro!(…) macro_rules! makro
             md module
-            st Record    Record
-            st Tuple     Tuple
-            st Unit      Unit
+            st Record                Record
+            st Tuple                  Tuple
+            st Unit                    Unit
             tt MyTrait
             tt Trait
-            un Union     Union
-            bt u32       u32
+            un Union                  Union
+            bt u32                      u32
             kw crate::
             kw self::
         "#]],
@@ -644,16 +644,16 @@ trait MyTrait {
 fn f(t: impl MyTrait<Item1 = u8, Item2 = $0
 "#,
         expect![[r#"
-            en Enum      Enum
+            en Enum                    Enum
             ma makro!(…) macro_rules! makro
             md module
-            st Record    Record
-            st Tuple     Tuple
-            st Unit      Unit
+            st Record                Record
+            st Tuple                  Tuple
+            st Unit                    Unit
             tt MyTrait
             tt Trait
-            un Union     Union
-            bt u32       u32
+            un Union                  Union
+            bt u32                      u32
             kw crate::
             kw self::
         "#]],
@@ -668,7 +668,7 @@ trait MyTrait {
 fn f(t: impl MyTrait<C = $0
 "#,
         expect![[r#"
-            ct CONST     Unit
+            ct CONST                   Unit
             ma makro!(…) macro_rules! makro
             kw crate::
             kw self::
@@ -691,9 +691,9 @@ pub struct S;
 "#,
         expect![[r#"
             md std
-            sp Self    Foo
-            st Foo     Foo
-            bt u32     u32
+            sp Self Foo
+            st Foo  Foo
+            bt u32  u32
             kw crate::
             kw self::
         "#]],
@@ -716,10 +716,10 @@ pub struct S;
 "#,
         expect![[r#"
             md std
-            sp Self    Foo
-            st Foo     Foo
-            st S       S
-            bt u32     u32
+            sp Self Foo
+            st Foo  Foo
+            st S      S
+            bt u32  u32
             kw crate::
             kw self::
         "#]],
@@ -739,16 +739,16 @@ fn completes_const_and_type_generics_separately() {
     }
             "#,
         expect![[r#"
-            en Enum      Enum
+            en Enum                    Enum
             ma makro!(…) macro_rules! makro
             md module
-            st Foo       Foo
-            st Record    Record
-            st Tuple     Tuple
-            st Unit      Unit
+            st Foo                      Foo
+            st Record                Record
+            st Tuple                  Tuple
+            st Unit                    Unit
             tt Trait
-            un Union     Union
-            bt u32       u32
+            un Union                  Union
+            bt u32                      u32
             kw crate::
             kw self::
         "#]],
@@ -766,8 +766,8 @@ fn completes_const_and_type_generics_separately() {
     }
             "#,
         expect![[r#"
-            ct CONST     Unit
-            ct X         usize
+            ct CONST                   Unit
+            ct X                      usize
             ma makro!(…) macro_rules! makro
             kw crate::
             kw self::
@@ -785,16 +785,16 @@ fn completes_const_and_type_generics_separately() {
     }
             "#,
         expect![[r#"
-            en Enum      Enum
+            en Enum                    Enum
             ma makro!(…) macro_rules! makro
             md module
-            st Foo       Foo
-            st Record    Record
-            st Tuple     Tuple
-            st Unit      Unit
+            st Foo                      Foo
+            st Record                Record
+            st Tuple                  Tuple
+            st Unit                    Unit
             tt Trait
-            un Union     Union
-            bt u32       u32
+            un Union                  Union
+            bt u32                      u32
             kw crate::
             kw self::
         "#]],
@@ -809,8 +809,8 @@ fn completes_const_and_type_generics_separately() {
     }
             "#,
         expect![[r#"
-            ct CONST     Unit
-            ct X         usize
+            ct CONST                   Unit
+            ct X                      usize
             ma makro!(…) macro_rules! makro
             kw crate::
             kw self::
@@ -828,17 +828,17 @@ fn completes_const_and_type_generics_separately() {
     fn foo(_: impl Bar<Baz<F$0, 0> = ()>) {}
             "#,
         expect![[r#"
-            en Enum      Enum
+            en Enum                    Enum
             ma makro!(…) macro_rules! makro
             md module
-            st Foo       Foo
-            st Record    Record
-            st Tuple     Tuple
-            st Unit      Unit
+            st Foo                      Foo
+            st Record                Record
+            st Tuple                  Tuple
+            st Unit                    Unit
             tt Bar
             tt Trait
-            un Union     Union
-            bt u32       u32
+            un Union                  Union
+            bt u32                      u32
             kw crate::
             kw self::
         "#]],
@@ -853,8 +853,8 @@ fn completes_const_and_type_generics_separately() {
     fn foo<T: Bar<Baz<(), $0> = ()>>() {}
             "#,
         expect![[r#"
-            ct CONST     Unit
-            ct X         usize
+            ct CONST                   Unit
+            ct X                      usize
             ma makro!(…) macro_rules! makro
             kw crate::
             kw self::
@@ -871,8 +871,8 @@ fn completes_const_and_type_generics_separately() {
     }
             "#,
         expect![[r#"
-            ct CONST     Unit
-            ct X         usize
+            ct CONST                   Unit
+            ct X                      usize
             ma makro!(…) macro_rules! makro
             kw crate::
             kw self::
@@ -890,8 +890,8 @@ fn completes_const_and_type_generics_separately() {
     }
             "#,
         expect![[r#"
-            ct CONST     Unit
-            ct X         usize
+            ct CONST                   Unit
+            ct X                      usize
             ma makro!(…) macro_rules! makro
             kw crate::
             kw self::
@@ -908,8 +908,8 @@ fn completes_const_and_type_generics_separately() {
     }
             "#,
         expect![[r#"
-            ct CONST     Unit
-            ct X         usize
+            ct CONST                   Unit
+            ct X                      usize
             ma makro!(…) macro_rules! makro
             kw crate::
             kw self::
@@ -924,8 +924,8 @@ fn completes_const_and_type_generics_separately() {
     impl Foo<(), $0> for () {}
             "#,
         expect![[r#"
-            ct CONST     Unit
-            ct X         usize
+            ct CONST                   Unit
+            ct X                      usize
             ma makro!(…) macro_rules! makro
             kw crate::
             kw self::
@@ -942,8 +942,8 @@ fn completes_const_and_type_generics_separately() {
     fn foo<T: Bar<X$0, ()>>() {}
             "#,
         expect![[r#"
-            ct CONST     Unit
-            ct X         usize
+            ct CONST                   Unit
+            ct X                      usize
             ma makro!(…) macro_rules! makro
             kw crate::
             kw self::
@@ -957,7 +957,7 @@ struct S<'a, 'b, const C: usize, T>(core::marker::PhantomData<&'a &'b T>);
 fn foo<'a>() { S::<F$0, _>; }
         "#,
         expect![[r#"
-            ct CONST     Unit
+            ct CONST                   Unit
             ma makro!(…) macro_rules! makro
             kw crate::
             kw self::
@@ -970,7 +970,7 @@ struct S<'a, 'b, const C: usize, T>(core::marker::PhantomData<&'a &'b T>);
 fn foo<'a>() { S::<'static, 'static, F$0, _>; }
         "#,
         expect![[r#"
-            ct CONST     Unit
+            ct CONST                   Unit
             ma makro!(…) macro_rules! makro
             kw crate::
             kw self::

--- a/crates/ide-completion/src/tests/use_tree.rs
+++ b/crates/ide-completion/src/tests/use_tree.rs
@@ -92,7 +92,7 @@ use self::{foo::*, bar$0};
 "#,
         expect![[r#"
             md foo
-            st S   S
+            st S S
         "#]],
     );
 }
@@ -179,7 +179,7 @@ struct Bar;
 "#,
         expect![[r#"
             ma foo macro_rules! foo_
-            st Foo Foo
+            st Foo               Foo
         "#]],
     );
 }
@@ -203,8 +203,8 @@ impl Foo {
 "#,
         expect![[r#"
             ev RecordVariant RecordVariant
-            ev TupleVariant  TupleVariant
-            ev UnitVariant   UnitVariant
+            ev TupleVariant   TupleVariant
+            ev UnitVariant     UnitVariant
         "#]],
     );
 }
@@ -257,7 +257,7 @@ mod a {
 }
 "#,
         expect![[r#"
-            ct A       usize
+            ct A usize
             md b
             kw super::
         "#]],
@@ -450,9 +450,9 @@ pub fn foo() {}
 marco_rules! m { () => {} }
 "#,
         expect![[r#"
-            fn foo  fn()
+            fn foo fn()
             md simd
-            st S    S
+            st S      S
         "#]],
     );
 }

--- a/crates/rust-analyzer/src/handlers/request.rs
+++ b/crates/rust-analyzer/src/handlers/request.rs
@@ -1144,7 +1144,7 @@ pub(crate) fn handle_completion_resolve(
     let Some(corresponding_completion) = completions.into_iter().find(|completion_item| {
         // Avoid computing hashes for items that obviously do not match
         // r-a might append a detail-based suffix to the label, so we cannot check for equality
-        original_completion.label.starts_with(completion_item.label.as_str())
+        original_completion.label.starts_with(completion_item.label.primary.as_str())
             && resolve_data_hash == completion_item_hash(completion_item, resolve_data.for_ref)
     }) else {
         return Ok(original_completion);

--- a/crates/rust-analyzer/src/lib.rs
+++ b/crates/rust-analyzer/src/lib.rs
@@ -114,8 +114,11 @@ fn completion_item_hash(item: &CompletionItem, is_ref_completion: bool) -> [u8; 
         u8::from(item.deprecated),
         u8::from(item.trigger_call_info),
     ]);
-    hasher.update(&item.label);
-    if let Some(label_detail) = &item.label_detail {
+    hasher.update(&item.label.primary);
+    if let Some(label_detail) = &item.label.detail_left {
+        hasher.update(label_detail);
+    }
+    if let Some(label_detail) = &item.label.detail_right {
         hasher.update(label_detail);
     }
     // NB: do not hash edits or source range, as those may change between the time the client sends the resolve request

--- a/crates/rust-analyzer/src/lsp/to_proto.rs
+++ b/crates/rust-analyzer/src/lsp/to_proto.rs
@@ -354,7 +354,7 @@ fn completion_item(
     };
 
     let mut lsp_item = lsp_types::CompletionItem {
-        label: item.label.to_string(),
+        label: item.label.primary.to_string(),
         detail,
         filter_text,
         kind: Some(completion_item_kind(item.kind)),
@@ -374,13 +374,13 @@ fn completion_item(
     if config.completion_label_details_support() {
         if fields_to_resolve.resolve_label_details {
             something_to_resolve |= true;
-        } else if item.label_detail.is_some() || item.detail.is_some() {
+        } else if item.label.detail_left.is_some() || item.label.detail_left.is_some() {
             lsp_item.label_details = Some(lsp_types::CompletionItemLabelDetails {
-                detail: item.label_detail.as_ref().map(ToString::to_string),
-                description: item.detail.clone(),
+                detail: item.label.detail_left.clone(),
+                description: item.label.detail_right.clone(),
             });
         }
-    } else if let Some(label_detail) = &item.label_detail {
+    } else if let Some(label_detail) = &item.label.detail_left {
         lsp_item.label.push_str(label_detail.as_str());
     }
 


### PR DESCRIPTION
Lots of test output changes as I had to adjust things for test rendering. The actual changes are in https://github.com/rust-lang/rust-analyzer/pull/18713/files#diff-1f818ad963401fe13a8a29e158447fa51390f3026ecba9de2e38a1cbdcaf9f4c and the rust-analyzer crate