### PR TITLE
Rename `rust-analyzer.statusBar.documentSelector` to `showStatusBar`, add "always" and "never" options.

### DIFF
--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -426,40 +426,55 @@
                         "default": "openLogs",
                         "markdownDescription": "Action to run when clicking the extension status bar item."
                     },
-                    "rust-analyzer.statusBar.documentSelector": {
-                        "type": [
-                            "array",
-                            "null"
-                        ],
-                        "items": {
-                            "type": "object",
-                            "properties": {
-                                "language": {
-                                    "type": [
-                                        "string",
-                                        "null"
-                                    ]
-                                },
-                                "pattern": {
-                                    "type": [
-                                        "string",
-                                        "null"
-                                    ]
+                    "rust-analyzer.statusBar.showStatusBar": {
+                        "markdownDescription": "When to show the extension status bar.\n\n`\"always\"` Always show the status bar.\n\n`\"never\"` Never show the status bar.\n\n`{ documentSelector: <DocumentSelector>[] }` Show the status bar if the open file matches any of the given document selectors.\n\nSee [VS Code -- DocumentSelector](https://code.visualstudio.com/api/references/document-selector) for more information.",
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "enum": [
+                                    "always",
+                                    "never"
+                                ]
+                            },
+                            {
+                                "type": "object",
+                                "properties": {
+                                    "documentSelector": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "object",
+                                            "properties": {
+                                                "language": {
+                                                    "type": "string"
+                                                },
+                                                "notebookType": {
+                                                    "type": "string"
+                                                },
+                                                "scheme": {
+                                                    "type": "string"
+                                                },
+                                                "pattern": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        }
+                                    }
                                 }
                             }
-                        },
-                        "default": [
-                            {
-                                "language": "rust"
-                            },
-                            {
-                                "pattern": "**/Cargo.toml"
-                            },
-                            {
-                                "pattern": "**/Cargo.lock"
-                            }
                         ],
-                        "markdownDescription": "Determines when to show the extension status bar item based on the currently open file. Use `{ \"pattern\": \"**\" }` to always show. Use `null` to never show."
+                        "default": {
+                            "documentSelector": [
+                                {
+                                    "language": "rust"
+                                },
+                                {
+                                    "pattern": "**/Cargo.toml"
+                                },
+                                {
+                                    "pattern": "**/Cargo.lock"
+                                }
+                            ]
+                        }
                     }
                 }
             },

--- a/editors/code/src/config.ts
+++ b/editors/code/src/config.ts
@@ -13,6 +13,13 @@ export type RunnableEnvCfgItem = {
 };
 export type RunnableEnvCfg = Record<string, string> | RunnableEnvCfgItem[];
 
+type ShowStatusBar =
+    | "always"
+    | "never"
+    | {
+          documentSelector: vscode.DocumentSelector;
+      };
+
 export class Config {
     readonly extensionId = "rust-lang.rust-analyzer";
     configureLang: vscode.Disposable | undefined;
@@ -348,8 +355,8 @@ export class Config {
         return this.get<string>("statusBar.clickAction");
     }
 
-    get statusBarDocumentSelector() {
-        return this.get<vscode.DocumentSelector>("statusBar.documentSelector");
+    get statusBarShowStatusBar() {
+        return this.get<ShowStatusBar>("statusBar.showStatusBar");
     }
 
     get initializeStopped() {

--- a/editors/code/src/ctx.ts
+++ b/editors/code/src/ctx.ts
@@ -478,14 +478,19 @@ export class Ctx implements RustAnalyzerExtensionApi {
     }
 
     private updateStatusBarVisibility(editor: vscode.TextEditor | undefined) {
-        const documentSelector = this.config.statusBarDocumentSelector;
-        if (documentSelector != null) {
+        const showStatusBar = this.config.statusBarShowStatusBar;
+        if (showStatusBar == null || showStatusBar === "never") {
+            this.statusBar.hide();
+        } else if (showStatusBar === "always") {
+            this.statusBar.show();
+        } else {
+            const documentSelector = showStatusBar.documentSelector;
             if (editor != null && vscode.languages.match(documentSelector, editor.document) > 0) {
                 this.statusBar.show();
-                return;
+            } else {
+                this.statusBar.hide();
             }
         }
-        this.statusBar.hide();
     }
 
     pushExtCleanup(d: Disposable) {


### PR DESCRIPTION
Closes #18665.

`rust-analyzer.statusBar.showStatusBar` can be `"always"`, `"never"` or `{ "documentSelector": <DocumentSelector>[] }`.
I added `DocumentSelector.notebookType` and `.scheme` as possible properties. The array is passed directly to `vscode.languages.match(documentSelector, editor.document)`, so the properties should Just Work.

Manually  testing, `"always"`, `"never"`, and `{ "documentSelector": ... }` seemed to work correctly.

I think the renamed setting is clearer, but it will break previous `statusBar.documentSelector` configs.