### PR TITLE
Improve SCIP symbols

### DIFF
--- a/crates/hir-ty/src/display.rs
+++ b/crates/hir-ty/src/display.rs
@@ -474,7 +474,9 @@ impl HirDisplay for ProjectionTy {
 
         let trait_ref = self.trait_ref(f.db);
         write!(f, "<")?;
-        fmt_trait_ref(f, &trait_ref, TraitRefFormat::SelfAsTrait)?;
+        trait_ref.self_type_parameter(Interner).hir_fmt(f)?;
+        write!(f, " as ")?;
+        trait_ref.hir_fmt(f)?;
         write!(
             f,
             ">::{}",
@@ -1775,50 +1777,14 @@ fn write_bounds_like_dyn_trait(
     Ok(())
 }
 
-#[derive(Clone, Copy)]
-pub enum TraitRefFormat {
-    SelfAsTrait,
-    SelfImplementsTrait,
-    OnlyTrait,
-}
-
-fn fmt_trait_ref(
-    f: &mut HirFormatter<'_>,
-    tr: &TraitRef,
-    format: TraitRefFormat,
-) -> Result<(), HirDisplayError> {
-    if f.should_truncate() {
-        return write!(f, "{TYPE_HINT_TRUNCATION}");
-    }
-
-    match format {
-        TraitRefFormat::SelfAsTrait => {
-            tr.self_type_parameter(Interner).hir_fmt(f)?;
-            write!(f, " as ")?;
-        }
-        TraitRefFormat::SelfImplementsTrait => {
-            tr.self_type_parameter(Interner).hir_fmt(f)?;
-            write!(f, ": ")?;
-        }
-        TraitRefFormat::OnlyTrait => {}
-    }
-
-    let trait_ = tr.hir_trait_id();
-    f.start_location_link(trait_.into());
-    write!(f, "{}", f.db.trait_data(trait_).name.display(f.db.upcast(), f.edition()))?;
-    f.end_location_link();
-    let substs = tr.substitution.as_slice(Interner);
-    hir_fmt_generics(f, &substs[1..], None, substs[0].ty(Interner))
-}
-
-pub struct TraitRefDisplayWrapper {
-    pub trait_ref: TraitRef,
-    pub format: TraitRefFormat,
-}
-
-impl HirDisplay for TraitRefDisplayWrapper {
+impl HirDisplay for TraitRef {
     fn hir_fmt(&self, f: &mut HirFormatter<'_>) -> Result<(), HirDisplayError> {
-        fmt_trait_ref(f, &self.trait_ref, self.format)
+        let trait_ = self.hir_trait_id();
+        f.start_location_link(trait_.into());
+        write!(f, "{}", f.db.trait_data(trait_).name.display(f.db.upcast(), f.edition()))?;
+        f.end_location_link();
+        let substs = self.substitution.as_slice(Interner);
+        hir_fmt_generics(f, &substs[1..], None, substs[0].ty(Interner))
     }
 }
 
@@ -1830,11 +1796,16 @@ impl HirDisplay for WhereClause {
 
         match self {
             WhereClause::Implemented(trait_ref) => {
-                fmt_trait_ref(f, trait_ref, TraitRefFormat::SelfImplementsTrait)?;
+                trait_ref.self_type_parameter(Interner).hir_fmt(f)?;
+                write!(f, ": ")?;
+                trait_ref.hir_fmt(f)?;
             }
             WhereClause::AliasEq(AliasEq { alias: AliasTy::Projection(projection_ty), ty }) => {
                 write!(f, "<")?;
-                fmt_trait_ref(f, &projection_ty.trait_ref(f.db), TraitRefFormat::SelfAsTrait)?;
+                let trait_ref = &projection_ty.trait_ref(f.db);
+                trait_ref.self_type_parameter(Interner).hir_fmt(f)?;
+                write!(f, " as ")?;
+                trait_ref.hir_fmt(f)?;
                 write!(f, ">::",)?;
                 let type_alias = from_assoc_type_id(projection_ty.associated_ty_id);
                 f.start_location_link(type_alias.into());

--- a/crates/hir/src/display.rs
+++ b/crates/hir/src/display.rs
@@ -743,18 +743,9 @@ impl HirDisplay for Static {
     }
 }
 
-pub struct TraitRefDisplayWrapper {
-    pub trait_ref: TraitRef,
-    pub format: hir_ty::display::TraitRefFormat,
-}
-
-impl HirDisplay for TraitRefDisplayWrapper {
+impl HirDisplay for TraitRef {
     fn hir_fmt(&self, f: &mut HirFormatter<'_>) -> Result<(), HirDisplayError> {
-        hir_ty::display::TraitRefDisplayWrapper {
-            format: self.format,
-            trait_ref: self.trait_ref.trait_ref.clone(),
-        }
-        .hir_fmt(f)
+        self.trait_ref.hir_fmt(f)
     }
 }
 

--- a/crates/hir/src/display.rs
+++ b/crates/hir/src/display.rs
@@ -22,7 +22,7 @@ use itertools::Itertools;
 use crate::{
     Adt, AsAssocItem, AssocItem, AssocItemContainer, Const, ConstParam, Enum, ExternCrateDecl,
     Field, Function, GenericParam, HasCrate, HasVisibility, Impl, LifetimeParam, Macro, Module,
-    SelfParam, Static, Struct, Trait, TraitAlias, TupleField, TyBuilder, Type, TypeAlias,
+    SelfParam, Static, Struct, Trait, TraitAlias, TraitRef, TupleField, TyBuilder, Type, TypeAlias,
     TypeOrConstParam, TypeParam, Union, Variant,
 };
 
@@ -740,6 +740,21 @@ impl HirDisplay for Static {
         write!(f, "{}: ", data.name.display(f.db.upcast(), f.edition()))?;
         data.type_ref.hir_fmt(f, &data.types_map)?;
         Ok(())
+    }
+}
+
+pub struct TraitRefDisplayWrapper {
+    pub trait_ref: TraitRef,
+    pub format: hir_ty::display::TraitRefFormat,
+}
+
+impl HirDisplay for TraitRefDisplayWrapper {
+    fn hir_fmt(&self, f: &mut HirFormatter<'_>) -> Result<(), HirDisplayError> {
+        hir_ty::display::TraitRefDisplayWrapper {
+            format: self.format,
+            trait_ref: self.trait_ref.trait_ref.clone(),
+        }
+        .hir_fmt(f)
     }
 }
 

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -96,7 +96,6 @@ use crate::db::{DefDatabase, HirDatabase};
 pub use crate::{
     attrs::{resolve_doc_path_on, HasAttrs},
     diagnostics::*,
-    display::TraitRefDisplayWrapper,
     has_source::HasSource,
     semantics::{
         PathResolution, Semantics, SemanticsImpl, SemanticsScope, TypeInfo, VisibleTraits,
@@ -149,7 +148,7 @@ pub use {
     hir_ty::{
         consteval::ConstEvalError,
         diagnostics::UnsafetyReason,
-        display::{ClosureStyle, HirDisplay, HirDisplayError, HirWrite, TraitRefFormat},
+        display::{ClosureStyle, HirDisplay, HirDisplayError, HirWrite},
         dyn_compatibility::{DynCompatibilityViolation, MethodViolationCode},
         layout::LayoutError,
         mir::{MirEvalError, MirLowerError},

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -96,6 +96,7 @@ use crate::db::{DefDatabase, HirDatabase};
 pub use crate::{
     attrs::{resolve_doc_path_on, HasAttrs},
     diagnostics::*,
+    display::TraitRefDisplayWrapper,
     has_source::HasSource,
     semantics::{
         PathResolution, Semantics, SemanticsImpl, SemanticsScope, TypeInfo, VisibleTraits,
@@ -148,7 +149,7 @@ pub use {
     hir_ty::{
         consteval::ConstEvalError,
         diagnostics::UnsafetyReason,
-        display::{ClosureStyle, HirDisplay, HirDisplayError, HirWrite},
+        display::{ClosureStyle, HirDisplay, HirDisplayError, HirWrite, TraitRefFormat},
         dyn_compatibility::{DynCompatibilityViolation, MethodViolationCode},
         layout::LayoutError,
         mir::{MirEvalError, MirLowerError},

--- a/crates/ide-db/src/defs.rs
+++ b/crates/ide-db/src/defs.rs
@@ -13,10 +13,10 @@ use either::Either;
 use hir::{
     Adt, AsAssocItem, AsExternAssocItem, AssocItem, AttributeTemplate, BuiltinAttr, BuiltinType,
     Const, Crate, DefWithBody, DeriveHelper, DocLinkDef, ExternAssocItem, ExternCrateDecl, Field,
-    Function, GenericParam, GenericSubstitution, HasVisibility, HirDisplay, Impl, InlineAsmOperand,
-    Label, Local, Macro, Module, ModuleDef, Name, PathResolution, Semantics, Static,
-    StaticLifetime, Struct, ToolModule, Trait, TraitAlias, TupleField, TypeAlias, Variant,
-    VariantDef, Visibility,
+    Function, GenericDef, GenericParam, GenericSubstitution, HasContainer, HasVisibility,
+    HirDisplay, Impl, InlineAsmOperand, ItemContainer, Label, Local, Macro, Module, ModuleDef,
+    Name, PathResolution, Semantics, Static, StaticLifetime, Struct, ToolModule, Trait, TraitAlias,
+    TupleField, TypeAlias, Variant, VariantDef, Visibility,
 };
 use span::Edition;
 use stdx::{format_to, impl_from};
@@ -98,8 +98,30 @@ impl Definition {
 
     pub fn enclosing_definition(&self, db: &RootDatabase) -> Option<Definition> {
         match self {
+            Definition::Macro(it) => Some(it.module(db).into()),
+            Definition::Module(it) => it.parent(db).map(Definition::Module),
+            Definition::Field(it) => Some(it.parent_def(db).into()),
+            Definition::Function(it) => it.container(db).try_into().ok(),
+            Definition::Adt(it) => Some(it.module(db).into()),
+            Definition::Const(it) => it.container(db).try_into().ok(),
+            Definition::Static(it) => it.container(db).try_into().ok(),
+            Definition::Trait(it) => it.container(db).try_into().ok(),
+            Definition::TraitAlias(it) => it.container(db).try_into().ok(),
+            Definition::TypeAlias(it) => it.container(db).try_into().ok(),
+            Definition::Variant(it) => Some(Adt::Enum(it.parent_enum(db)).into()),
+            Definition::SelfType(it) => Some(it.module(db).into()),
             Definition::Local(it) => it.parent(db).try_into().ok(),
-            _ => None,
+            Definition::GenericParam(it) => Some(it.parent().into()),
+            Definition::Label(it) => it.parent(db).try_into().ok(),
+            Definition::ExternCrateDecl(it) => it.container(db).try_into().ok(),
+            Definition::DeriveHelper(it) => Some(it.derive().module(db).into()),
+            Definition::InlineAsmOperand(it) => it.parent(db).try_into().ok(),
+            Definition::BuiltinAttr(_)
+            | Definition::BuiltinType(_)
+            | Definition::BuiltinLifetime(_)
+            | Definition::TupleField(_)
+            | Definition::ToolModule(_)
+            | Definition::InlineAsmRegOrRegClass(_) => None,
         }
     }
 
@@ -929,6 +951,32 @@ impl TryFrom<DefWithBody> for Definition {
             DefWithBody::Const(it) => Ok(it.into()),
             DefWithBody::Variant(it) => Ok(it.into()),
             DefWithBody::InTypeConst(_) => Err(()),
+        }
+    }
+}
+
+impl TryFrom<ItemContainer> for Definition {
+    type Error = ();
+    fn try_from(container: ItemContainer) -> Result<Self, Self::Error> {
+        match container {
+            ItemContainer::Trait(it) => Ok(it.into()),
+            ItemContainer::Impl(it) => Ok(it.into()),
+            ItemContainer::Module(it) => Ok(it.into()),
+            ItemContainer::ExternBlock() | ItemContainer::Crate(_) => Err(()),
+        }
+    }
+}
+
+impl From<GenericDef> for Definition {
+    fn from(def: GenericDef) -> Self {
+        match def {
+            GenericDef::Function(it) => it.into(),
+            GenericDef::Adt(it) => it.into(),
+            GenericDef::Trait(it) => it.into(),
+            GenericDef::TraitAlias(it) => it.into(),
+            GenericDef::TypeAlias(it) => it.into(),
+            GenericDef::Impl(it) => it.into(),
+            GenericDef::Const(it) => it.into(),
         }
     }
 }

--- a/crates/ide/src/lib.rs
+++ b/crates/ide/src/lib.rs
@@ -96,8 +96,8 @@ pub use crate::{
     join_lines::JoinLinesConfig,
     markup::Markup,
     moniker::{
-        MonikerDescriptorKind, MonikerKind, MonikerResult, PackageInformation,
-        SymbolInformationKind,
+        Moniker, MonikerDescriptorKind, MonikerIdentifier, MonikerKind, MonikerResult,
+        PackageInformation, SymbolInformationKind,
     },
     move_item::Direction,
     navigation_target::{NavigationTarget, TryToNav, UpmappingResult},

--- a/crates/ide/src/moniker.rs
+++ b/crates/ide/src/moniker.rs
@@ -415,8 +415,7 @@ fn display<T: HirDisplay>(
         Err(_) => {
             let fallback_result = it.display(db, edition).to_string();
             tracing::error!(
-                "display_source_code failed. Falling back to using display, which has result: {}",
-                fallback_result
+                display = %fallback_result, "`display_source_code` failed; falling back to using display"
             );
             fallback_result
         }

--- a/crates/ide/src/moniker.rs
+++ b/crates/ide/src/moniker.rs
@@ -353,8 +353,7 @@ fn def_to_non_local_moniker(
                         Definition::Module(module) if module.is_crate_root() => {}
                         _ => {
                             tracing::error!(
-                                "Encountered enclosing definition with no name: {:?}",
-                                def
+                                ?def, "Encountered enclosing definition with no name"
                             );
                         }
                     }

--- a/crates/ide/src/moniker.rs
+++ b/crates/ide/src/moniker.rs
@@ -289,15 +289,6 @@ fn def_to_non_local_moniker(
     definition: Definition,
     from_crate: Crate,
 ) -> Option<Moniker> {
-    match definition {
-        // Not possible to give sensible unique symbols for inherent impls, as multiple can be
-        // defined for the same type.
-        Definition::SelfType(impl_) if impl_.trait_(db).is_none() => {
-            return None;
-        }
-        _ => {}
-    }
-
     let module = definition.module(db)?;
     let krate = module.krate();
     let edition = krate.edition(db);

--- a/crates/ide/src/moniker.rs
+++ b/crates/ide/src/moniker.rs
@@ -3,7 +3,10 @@
 
 use core::fmt;
 
-use hir::{Adt, AsAssocItem, AssocItemContainer, Crate, MacroKind, Semantics};
+use hir::{
+    Adt, AsAssocItem, Crate, HirDisplay, MacroKind, Semantics, TraitRefDisplayWrapper,
+    TraitRefFormat,
+};
 use ide_db::{
     base_db::{CrateOrigin, LangCrateOrigin},
     defs::{Definition, IdentClass},
@@ -11,6 +14,7 @@ use ide_db::{
     FilePosition, RootDatabase,
 };
 use itertools::Itertools;
+use span::Edition;
 use syntax::{AstNode, SyntaxKind::*, T};
 
 use crate::{doc_links::token_as_doc_comment, parent_module::crates_for, RangeInfo};
@@ -57,8 +61,8 @@ pub enum SymbolInformationKind {
 impl From<SymbolInformationKind> for MonikerDescriptorKind {
     fn from(value: SymbolInformationKind) -> Self {
         match value {
-            SymbolInformationKind::AssociatedType => Self::TypeParameter,
-            SymbolInformationKind::Attribute => Self::Macro,
+            SymbolInformationKind::AssociatedType => Self::Type,
+            SymbolInformationKind::Attribute => Self::Meta,
             SymbolInformationKind::Constant => Self::Term,
             SymbolInformationKind::Enum => Self::Type,
             SymbolInformationKind::EnumMember => Self::Type,
@@ -70,7 +74,7 @@ impl From<SymbolInformationKind> for MonikerDescriptorKind {
             SymbolInformationKind::Parameter => Self::Parameter,
             SymbolInformationKind::SelfParameter => Self::Parameter,
             SymbolInformationKind::StaticMethod => Self::Method,
-            SymbolInformationKind::StaticVariable => Self::Meta,
+            SymbolInformationKind::StaticVariable => Self::Term,
             SymbolInformationKind::Struct => Self::Type,
             SymbolInformationKind::Trait => Self::Type,
             SymbolInformationKind::TraitMethod => Self::Method,
@@ -109,16 +113,27 @@ pub enum MonikerKind {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct MonikerResult {
-    pub identifier: MonikerIdentifier,
-    pub kind: MonikerKind,
-    pub package_information: PackageInformation,
+pub enum MonikerResult {
+    /// Uniquely identifies a definition.
+    Moniker(Moniker),
+    /// Specifies that the definition is a local, and so does not have a unique identifier. Provides
+    /// a unique identifier for the container.
+    Local { enclosing_moniker: Option<Moniker> },
 }
 
 impl MonikerResult {
     pub fn from_def(db: &RootDatabase, def: Definition, from_crate: Crate) -> Option<Self> {
         def_to_moniker(db, def, from_crate)
     }
+}
+
+/// Information which uniquely identifies a definition which might be referenceable outside of the
+/// source file. Visibility declarations do not affect presence.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Moniker {
+    pub identifier: MonikerIdentifier,
+    pub kind: MonikerKind,
+    pub package_information: PackageInformation,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -232,157 +247,129 @@ pub(crate) fn def_to_kind(db: &RootDatabase, def: Definition) -> SymbolInformati
     }
 }
 
+/// Computes a `MonikerResult` for a definition. Result cases:
+///
+/// `Some(MonikerResult::Moniker(_))` provides a unique `Moniker` which refers to a definition.
+///
+/// `Some(MonikerResult::Local { .. })` provides a `Moniker` for the definition enclosing a local.
+///
+/// `None` is returned in the following cases:
+///
+/// * Inherent impl definitions, as they cannot be uniquely identified (multiple are allowed for the
+///   same type).
+///
+/// * Definitions which are not in a module: `BuiltinAttr`, `BuiltinType`, `BuiltinLifetime`,
+///   `TupleField`, `ToolModule`, and `InlineAsmRegOrRegClass`. TODO: it might be sensible to
+///   provide monikers that refer to some non-existent crate of compiler builtin definitions.
 pub(crate) fn def_to_moniker(
     db: &RootDatabase,
-    def: Definition,
+    definition: Definition,
     from_crate: Crate,
 ) -> Option<MonikerResult> {
-    if matches!(
-        def,
-        Definition::GenericParam(_)
-            | Definition::Label(_)
-            | Definition::DeriveHelper(_)
-            | Definition::BuiltinAttr(_)
-            | Definition::ToolModule(_)
-    ) {
-        return None;
+    match definition {
+        // Not possible to give sensible unique symbols for inherent impls, as multiple can be
+        // defined for the same type.
+        Definition::SelfType(impl_) if impl_.trait_(db).is_none() => {
+            return None;
+        }
+        Definition::Local(_) | Definition::Label(_) | Definition::GenericParam(_) => {
+            return Some(MonikerResult::Local {
+                enclosing_moniker: enclosing_def_to_moniker(db, definition, from_crate),
+            });
+        }
+        _ => {}
+    }
+    Some(MonikerResult::Moniker(def_to_non_local_moniker(db, definition, from_crate)?))
+}
+
+fn enclosing_def_to_moniker(
+    db: &RootDatabase,
+    mut def: Definition,
+    from_crate: Crate,
+) -> Option<Moniker> {
+    loop {
+        let enclosing_def = def.enclosing_definition(db)?;
+        if let Some(enclosing_moniker) = def_to_non_local_moniker(db, enclosing_def, from_crate) {
+            return Some(enclosing_moniker);
+        }
+        def = enclosing_def;
+    }
+}
+
+fn def_to_non_local_moniker(
+    db: &RootDatabase,
+    definition: Definition,
+    from_crate: Crate,
+) -> Option<Moniker> {
+    match definition {
+        // Not possible to give sensible unique symbols for inherent impls, as multiple can be
+        // defined for the same type.
+        Definition::SelfType(impl_) if impl_.trait_(db).is_none() => {
+            return None;
+        }
+        _ => {}
     }
 
-    let module = def.module(db)?;
+    let module = definition.module(db)?;
     let krate = module.krate();
     let edition = krate.edition(db);
-    let mut description = vec![];
-    description.extend(module.path_to_root(db).into_iter().filter_map(|x| {
-        Some(MonikerDescriptor {
-            name: x.name(db)?.display(db, edition).to_string(),
-            desc: def_to_kind(db, x.into()).into(),
-        })
-    }));
 
-    // Handle associated items within a trait
-    if let Some(assoc) = def.as_assoc_item(db) {
-        let container = assoc.container(db);
-        match container {
-            AssocItemContainer::Trait(trait_) => {
-                // Because different traits can have functions with the same name,
-                // we have to include the trait name as part of the moniker for uniqueness.
-                description.push(MonikerDescriptor {
-                    name: trait_.name(db).display(db, edition).to_string(),
-                    desc: def_to_kind(db, trait_.into()).into(),
-                });
-            }
-            AssocItemContainer::Impl(impl_) => {
-                // Because a struct can implement multiple traits, for implementations
-                // we add both the struct name and the trait name to the path
-                if let Some(adt) = impl_.self_ty(db).as_adt() {
-                    description.push(MonikerDescriptor {
-                        name: adt.name(db).display(db, edition).to_string(),
-                        desc: def_to_kind(db, adt.into()).into(),
+    // Add descriptors for this definition and every enclosing definition.
+    let mut reverse_description = vec![];
+    let mut def = definition;
+    loop {
+        match def {
+            Definition::SelfType(impl_) => {
+                if let Some(trait_ref) = impl_.trait_ref(db) {
+                    // Trait impls use `trait_type` constraint syntax for the 2nd parameter.
+                    let trait_ref_for_display =
+                        TraitRefDisplayWrapper { trait_ref, format: TraitRefFormat::OnlyTrait };
+                    reverse_description.push(MonikerDescriptor {
+                        name: display(db, edition, module, trait_ref_for_display),
+                        desc: MonikerDescriptorKind::TypeParameter,
                     });
                 }
-
-                if let Some(trait_) = impl_.trait_(db) {
-                    description.push(MonikerDescriptor {
-                        name: trait_.name(db).display(db, edition).to_string(),
-                        desc: def_to_kind(db, trait_.into()).into(),
+                // Both inherent and trait impls use `self_type` as the first parameter.
+                reverse_description.push(MonikerDescriptor {
+                    name: display(db, edition, module, impl_.self_ty(db)),
+                    desc: MonikerDescriptorKind::TypeParameter,
+                });
+                reverse_description.push(MonikerDescriptor {
+                    name: "impl".to_owned(),
+                    desc: MonikerDescriptorKind::Type,
+                });
+            }
+            _ => {
+                if let Some(name) = def.name(db) {
+                    reverse_description.push(MonikerDescriptor {
+                        name: name.display(db, edition).to_string(),
+                        desc: def_to_kind(db, def).into(),
                     });
+                } else if reverse_description.is_empty() {
+                    // Don't allow the last descriptor to be absent.
+                    return None;
+                } else {
+                    match def {
+                        Definition::Module(module) if module.is_crate_root() => {}
+                        _ => {
+                            tracing::error!(
+                                "Encountered enclosing definition with no name: {:?}",
+                                def
+                            );
+                        }
+                    }
                 }
             }
         }
+        let Some(next_def) = def.enclosing_definition(db) else {
+            break;
+        };
+        def = next_def;
     }
+    reverse_description.reverse();
+    let description = reverse_description;
 
-    if let Definition::Field(it) = def {
-        description.push(MonikerDescriptor {
-            name: it.parent_def(db).name(db).display(db, edition).to_string(),
-            desc: def_to_kind(db, it.parent_def(db).into()).into(),
-        });
-    }
-
-    // Qualify locals/parameters by their parent definition name.
-    if let Definition::Local(it) = def {
-        let parent = Definition::try_from(it.parent(db)).ok();
-        if let Some(parent) = parent {
-            let parent_name = parent.name(db);
-            if let Some(name) = parent_name {
-                description.push(MonikerDescriptor {
-                    name: name.display(db, edition).to_string(),
-                    desc: def_to_kind(db, parent).into(),
-                });
-            }
-        }
-    }
-
-    let desc = def_to_kind(db, def).into();
-
-    let name_desc = match def {
-        // These are handled by top-level guard (for performance).
-        Definition::GenericParam(_)
-        | Definition::Label(_)
-        | Definition::DeriveHelper(_)
-        | Definition::BuiltinLifetime(_)
-        | Definition::BuiltinAttr(_)
-        | Definition::ToolModule(_)
-        | Definition::InlineAsmRegOrRegClass(_)
-        | Definition::InlineAsmOperand(_) => return None,
-
-        Definition::Local(local) => {
-            if !local.is_param(db) {
-                return None;
-            }
-
-            MonikerDescriptor { name: local.name(db).display(db, edition).to_string(), desc }
-        }
-        Definition::Macro(m) => {
-            MonikerDescriptor { name: m.name(db).display(db, edition).to_string(), desc }
-        }
-        Definition::Function(f) => {
-            MonikerDescriptor { name: f.name(db).display(db, edition).to_string(), desc }
-        }
-        Definition::Variant(v) => {
-            MonikerDescriptor { name: v.name(db).display(db, edition).to_string(), desc }
-        }
-        Definition::Const(c) => {
-            MonikerDescriptor { name: c.name(db)?.display(db, edition).to_string(), desc }
-        }
-        Definition::Trait(trait_) => {
-            MonikerDescriptor { name: trait_.name(db).display(db, edition).to_string(), desc }
-        }
-        Definition::TraitAlias(ta) => {
-            MonikerDescriptor { name: ta.name(db).display(db, edition).to_string(), desc }
-        }
-        Definition::TypeAlias(ta) => {
-            MonikerDescriptor { name: ta.name(db).display(db, edition).to_string(), desc }
-        }
-        Definition::Module(m) => {
-            MonikerDescriptor { name: m.name(db)?.display(db, edition).to_string(), desc }
-        }
-        Definition::BuiltinType(b) => {
-            MonikerDescriptor { name: b.name().display(db, edition).to_string(), desc }
-        }
-        Definition::SelfType(imp) => MonikerDescriptor {
-            name: imp.self_ty(db).as_adt()?.name(db).display(db, edition).to_string(),
-            desc,
-        },
-        Definition::Field(it) => {
-            MonikerDescriptor { name: it.name(db).display(db, edition).to_string(), desc }
-        }
-        Definition::TupleField(it) => {
-            MonikerDescriptor { name: it.name().display(db, edition).to_string(), desc }
-        }
-        Definition::Adt(adt) => {
-            MonikerDescriptor { name: adt.name(db).display(db, edition).to_string(), desc }
-        }
-        Definition::Static(s) => {
-            MonikerDescriptor { name: s.name(db).display(db, edition).to_string(), desc }
-        }
-        Definition::ExternCrateDecl(m) => {
-            MonikerDescriptor { name: m.name(db).display(db, edition).to_string(), desc }
-        }
-    };
-
-    description.push(name_desc);
-
-    Some(MonikerResult {
+    Some(Moniker {
         identifier: MonikerIdentifier {
             crate_name: krate.display_name(db)?.crate_name().to_string(),
             description,
@@ -417,17 +404,58 @@ pub(crate) fn def_to_moniker(
     })
 }
 
+fn display<T: HirDisplay>(
+    db: &RootDatabase,
+    edition: Edition,
+    module: hir::Module,
+    it: T,
+) -> String {
+    match it.display_source_code(db, module.into(), true) {
+        Ok(result) => result,
+        // Fallback on display variant that always succeeds
+        Err(_) => {
+            let fallback_result = it.display(db, edition).to_string();
+            tracing::error!(
+                "display_source_code failed. Falling back to using display, which has result: {}",
+                fallback_result
+            );
+            fallback_result
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use crate::fixture;
+    use crate::{fixture, MonikerResult};
 
     use super::MonikerKind;
 
+    #[allow(dead_code)]
     #[track_caller]
     fn no_moniker(ra_fixture: &str) {
         let (analysis, position) = fixture::position(ra_fixture);
         if let Some(x) = analysis.moniker(position).unwrap() {
-            assert_eq!(x.info.len(), 0, "Moniker founded but no moniker expected: {x:?}");
+            assert_eq!(x.info.len(), 0, "Moniker found but no moniker expected: {x:?}");
+        }
+    }
+
+    #[track_caller]
+    fn check_local_moniker(ra_fixture: &str, identifier: &str, package: &str, kind: MonikerKind) {
+        let (analysis, position) = fixture::position(ra_fixture);
+        let x = analysis.moniker(position).unwrap().expect("no moniker found").info;
+        assert_eq!(x.len(), 1);
+        match x.into_iter().next().unwrap() {
+            MonikerResult::Local { enclosing_moniker: Some(x) } => {
+                assert_eq!(identifier, x.identifier.to_string());
+                assert_eq!(package, format!("{:?}", x.package_information));
+                assert_eq!(kind, x.kind);
+            }
+            MonikerResult::Local { enclosing_moniker: None } => {
+                panic!("Unexpected local with no enclosing moniker");
+            }
+            MonikerResult::Moniker(_) => {
+                panic!("Unexpected non-local moniker");
+            }
         }
     }
 
@@ -436,10 +464,16 @@ mod tests {
         let (analysis, position) = fixture::position(ra_fixture);
         let x = analysis.moniker(position).unwrap().expect("no moniker found").info;
         assert_eq!(x.len(), 1);
-        let x = x.into_iter().next().unwrap();
-        assert_eq!(identifier, x.identifier.to_string());
-        assert_eq!(package, format!("{:?}", x.package_information));
-        assert_eq!(kind, x.kind);
+        match x.into_iter().next().unwrap() {
+            MonikerResult::Local { enclosing_moniker } => {
+                panic!("Unexpected local enclosed in {:?}", enclosing_moniker);
+            }
+            MonikerResult::Moniker(x) => {
+                assert_eq!(identifier, x.identifier.to_string());
+                assert_eq!(package, format!("{:?}", x.package_information));
+                assert_eq!(kind, x.kind);
+            }
+        }
     }
 
     #[test]
@@ -538,15 +572,13 @@ pub mod module {
     pub trait MyTrait {
         pub fn func() {}
     }
-
     struct MyStruct {}
-
     impl MyTrait for MyStruct {
         pub fn func$0() {}
     }
 }
 "#,
-            "foo::module::MyStruct::MyTrait::func",
+            "foo::module::impl::MyStruct::MyTrait::func",
             r#"PackageInformation { name: "foo", repo: Some("https://a.b/foo.git"), version: Some("0.1.0") }"#,
             MonikerKind::Export,
         );
@@ -573,8 +605,8 @@ pub struct St {
     }
 
     #[test]
-    fn no_moniker_for_local() {
-        no_moniker(
+    fn local() {
+        check_local_moniker(
             r#"
 //- /lib.rs crate:main deps:foo
 use foo::module::func;
@@ -588,6 +620,9 @@ pub mod module {
     }
 }
 "#,
+            "foo::module::func",
+            r#"PackageInformation { name: "foo", repo: Some("https://a.b/foo.git"), version: Some("0.1.0") }"#,
+            MonikerKind::Export,
         );
     }
 }

--- a/crates/ide/src/moniker.rs
+++ b/crates/ide/src/moniker.rs
@@ -3,10 +3,7 @@
 
 use core::fmt;
 
-use hir::{
-    Adt, AsAssocItem, Crate, HirDisplay, MacroKind, Semantics, TraitRefDisplayWrapper,
-    TraitRefFormat,
-};
+use hir::{Adt, AsAssocItem, Crate, HirDisplay, MacroKind, Semantics};
 use ide_db::{
     base_db::{CrateOrigin, LangCrateOrigin},
     defs::{Definition, IdentClass},
@@ -312,15 +309,13 @@ fn def_to_non_local_moniker(
         match def {
             Definition::SelfType(impl_) => {
                 if let Some(trait_ref) = impl_.trait_ref(db) {
-                    // Trait impls use `trait_type` constraint syntax for the 2nd parameter.
-                    let trait_ref_for_display =
-                        TraitRefDisplayWrapper { trait_ref, format: TraitRefFormat::OnlyTrait };
+                    // Trait impls use the trait type for the 2nd parameter.
                     reverse_description.push(MonikerDescriptor {
-                        name: display(db, edition, module, trait_ref_for_display),
+                        name: display(db, edition, module, trait_ref),
                         desc: MonikerDescriptorKind::TypeParameter,
                     });
                 }
-                // Both inherent and trait impls use `self_type` as the first parameter.
+                // Both inherent and trait impls use the self type for the first parameter.
                 reverse_description.push(MonikerDescriptor {
                     name: display(db, edition, module, impl_.self_ty(db)),
                     desc: MonikerDescriptorKind::TypeParameter,

--- a/crates/ide/src/static_index.rs
+++ b/crates/ide/src/static_index.rs
@@ -48,7 +48,6 @@ pub struct TokenStaticData {
     pub references: Vec<ReferenceData>,
     pub moniker: Option<MonikerResult>,
     pub display_name: Option<String>,
-    pub enclosing_moniker: Option<MonikerResult>,
     pub signature: Option<String>,
     pub kind: SymbolInformationKind,
 }
@@ -225,9 +224,6 @@ impl StaticIndex<'_> {
                     display_name: def
                         .name(self.db)
                         .map(|name| name.display(self.db, edition).to_string()),
-                    enclosing_moniker: current_crate
-                        .zip(def.enclosing_definition(self.db))
-                        .and_then(|(cc, enclosing_def)| def_to_moniker(self.db, enclosing_def, cc)),
                     signature: Some(def.label(self.db, edition)),
                     kind: def_to_kind(self.db, def),
                 });

--- a/crates/rust-analyzer/src/cli/lsif.rs
+++ b/crates/rust-analyzer/src/cli/lsif.rs
@@ -4,8 +4,9 @@ use std::env;
 use std::time::Instant;
 
 use ide::{
-    Analysis, AnalysisHost, FileId, FileRange, MonikerKind, PackageInformation, RootDatabase,
-    StaticIndex, StaticIndexedFile, TokenId, TokenStaticData, VendoredLibrariesConfig,
+    Analysis, AnalysisHost, FileId, FileRange, MonikerKind, MonikerResult, PackageInformation,
+    RootDatabase, StaticIndex, StaticIndexedFile, TokenId, TokenStaticData,
+    VendoredLibrariesConfig,
 };
 use ide_db::{line_index::WideEncoding, LineIndexDatabase};
 use load_cargo::{load_workspace, LoadCargoConfig, ProcMacroServerChoice};
@@ -167,7 +168,7 @@ impl LsifManager<'_, '_> {
                 out_v: result_set_id.into(),
             }));
         }
-        if let Some(moniker) = token.moniker {
+        if let Some(MonikerResult::Moniker(moniker)) = token.moniker {
             let package_id = self.get_package_id(moniker.package_information);
             let moniker_id = self.add_vertex(lsif::Vertex::Moniker(lsp_types::Moniker {
                 scheme: "rust-analyzer".to_owned(),

--- a/crates/rust-analyzer/src/cli/scip.rs
+++ b/crates/rust-analyzer/src/cli/scip.rs
@@ -151,7 +151,6 @@ impl flags::Scip {
                                 text_range,
                             );
                             symbols.push(compute_symbol_info(
-                                relative_path.clone(),
                                 symbol.clone(),
                                 enclosing_symbol,
                                 token,
@@ -238,12 +237,7 @@ impl flags::Scip {
                 &line_index,
                 text_range,
             );
-            external_symbols.push(compute_symbol_info(
-                relative_path.clone(),
-                symbol.clone(),
-                enclosing_symbol,
-                token,
-            ));
+            external_symbols.push(compute_symbol_info(symbol.clone(), enclosing_symbol, token));
         }
 
         let index = scip_types::Index {
@@ -289,7 +283,6 @@ Duplicate symbols encountered:
 ";
 
 fn compute_symbol_info(
-    relative_path: String,
     symbol: String,
     enclosing_symbol: Option<String>,
     token: &TokenStaticData,
@@ -301,7 +294,7 @@ fn compute_symbol_info(
 
     let position_encoding = scip_types::PositionEncoding::UTF8CodeUnitOffsetFromLineStart.into();
     let signature_documentation = token.signature.clone().map(|text| scip_types::Document {
-        relative_path,
+        relative_path: "".to_owned(),
         language: "rust".to_owned(),
         text,
         position_encoding,

--- a/crates/rust-analyzer/src/cli/scip.rs
+++ b/crates/rust-analyzer/src/cli/scip.rs
@@ -271,13 +271,13 @@ Encountered duplicate scip symbols, indicating an internal rust-analyzer bug. Th
 included in the output, but this causes information lookup to be ambiguous and so information about
 these symbols presented by downstream tools may be incorrect.
 
-Known cases that can cause this:
+Known rust-analyzer bugs that can cause this:
 
   * Definitions in crate example binaries which have the same symbol as definitions in the library
-  or some other example.
+    or some other example.
 
-  * When a struct/enum/const/static/impl is defined with a function, it erroneously appears to be
-  defined at the same level as the function.
+  * Struct/enum/const/static/impl definitions nested in a function do not mention the function name.
+    See #18771.
 
 Duplicate symbols encountered:
 ";

--- a/crates/rust-analyzer/src/cli/scip.rs
+++ b/crates/rust-analyzer/src/cli/scip.rs
@@ -109,8 +109,10 @@ impl flags::Scip {
              text_range: TextRange| {
                 let is_local = symbol.starts_with("local ");
                 if !is_local && !nonlocal_symbols_emitted.insert(symbol.clone()) {
-                    // See #18772. Duplicate SymbolInformation for inherent impls is omitted.
                     if is_inherent_impl {
+                        // FIXME: See #18772. Duplicate SymbolInformation for inherent impls is
+                        // omitted. It would be preferable to emit them with numbers with
+                        // disambiguation, but this is more complex to implement.
                         false
                     } else {
                         let source_location =
@@ -283,7 +285,7 @@ impl flags::Scip {
     }
 }
 
-// TODO: Fix the known buggy cases described here.
+// FIXME: Known buggy cases are described here.
 const DUPLICATE_SYMBOLS_MESSAGE: &str = "
 Encountered duplicate scip symbols, indicating an internal rust-analyzer bug. These duplicates are
 included in the output, but this causes information lookup to be ambiguous and so information about
@@ -802,7 +804,7 @@ pub mod example_mod {
         );
     }
 
-    // TODO: This test represents current misbehavior.
+    // FIXME: This test represents current misbehavior.
     #[test]
     fn symbol_for_nested_function() {
         check_symbol(
@@ -813,12 +815,12 @@ pub mod example_mod {
     }
     "#,
             "rust-analyzer cargo main . inner_func().",
-            // TODO: This should be a local:
+            // FIXME: This should be a local:
             // "local enclosed by rust-analyzer cargo main . func().",
         );
     }
 
-    // TODO: This test represents current misbehavior.
+    // FIXME: This test represents current misbehavior.
     #[test]
     fn symbol_for_struct_in_function() {
         check_symbol(
@@ -829,12 +831,12 @@ pub mod example_mod {
     }
     "#,
             "rust-analyzer cargo main . SomeStruct#",
-            // TODO: This should be a local:
+            // FIXME: This should be a local:
             // "local enclosed by rust-analyzer cargo main . func().",
         );
     }
 
-    // TODO: This test represents current misbehavior.
+    // FIXME: This test represents current misbehavior.
     #[test]
     fn symbol_for_const_in_function() {
         check_symbol(
@@ -845,12 +847,12 @@ pub mod example_mod {
     }
     "#,
             "rust-analyzer cargo main . SOME_CONST.",
-            // TODO: This should be a local:
+            // FIXME: This should be a local:
             // "local enclosed by rust-analyzer cargo main . func().",
         );
     }
 
-    // TODO: This test represents current misbehavior.
+    // FIXME: This test represents current misbehavior.
     #[test]
     fn symbol_for_static_in_function() {
         check_symbol(
@@ -861,7 +863,7 @@ pub mod example_mod {
     }
     "#,
             "rust-analyzer cargo main . SOME_STATIC.",
-            // TODO: This should be a local:
+            // FIXME: This should be a local:
             // "local enclosed by rust-analyzer cargo main . func().",
         );
     }


### PR DESCRIPTION
In particular, the symbol generation before this change creates a lot of symbols with the same name for different definitions. This change makes progress on symbol uniqueness, but does not fix a couple cases where it was unclear to me how to fix (see TODOs in `scip.rs`)

Before this change `SymbolInformation` provided by a document was the
info for all encountered symbols that have not yet been emitted. So,
the symbol information on a `Document` was a mishmash of symbols
defined in the documents, symbols from other documents, and external
symbols.

After this change, the `SymbolInformation` on documents is just the
locals and defined symbols from the document.  All symbols referenced
and not from emitted documents are included in `external_symbols`.

Other behavior changes:

* `scip` command now reports symbol information omitted due to symbol collisions. Iterating with this on a large codebase (Zed!) resulted in the other improvements in this change.

* Generally fixes providing the path to nested definitions in symbols. Instead of having special cases for a couple limited cases of nesting, implements `Definition::enclosing_definition` and uses this to walk definitions.

* Parameter variables are now treated like locals.

    - This fixes a bug where closure captures also received symbols scoped to the containing function.  To bring back parameter symbols I would want a way to filter these out, since they can cause symbol collisions.

    - Having symbols for them seems to be intentional in 27e2eea54fbd1edeefa2b47ddd4f552a04b86582, but no particular use is specified there. For the typical indexing purposes of SCIP I don't see why parameter symbols are useful or sensible, as function parameters are not referencable by anything but position. I can imagine they might be useful in representing diagnostics or something.

* Inherent impls are now represented as `impl#[SelfType]` - a type named `impl` which takes a single type parameter.

* Trait impls are now represented as `impl#[SelfType][TraitType]` - a type named `impl` which takes two type parameters.

* Associated types in traits and impls are now treated like types instead of type parameters, and so are now suffixed with `#` instead of wrapped with `[]`.  Treating them as type parameters seems to have been intentional in 73d9c77f2aeed394cf131dce55807be2d3f54064 but it doesn't make sense to me, so changing it.

* Static variables are now treated as terms instead of `Meta`, and so receive `.` suffix instead of `:`.

* Attributes are now treated as `Meta` instead of `Macro`, and so receive `:` suffix instead of `!`.

* `enclosing_symbol` is now provided for labels and generic params, which are local symbols.

* Fixes a bug where presence of `'` causes a descriptor name to get double wrapped in backticks, since both `fn new_descriptor` and `scip::symbol::format_symbol` have logic for wrapping in backticks. Solution is to simply delete the redundant logic.