### PR TITLE
internal: wrap `salsa::Cycle`

### DIFF
--- a/crates/ra-salsa/src/lib.rs
+++ b/crates/ra-salsa/src/lib.rs
@@ -610,9 +610,11 @@ where
 #[non_exhaustive]
 pub enum Cancelled {
     /// The query was operating on revision R, but there is a pending write to move to revision R+1.
+    #[non_exhaustive]
     PendingWrite,
 
     /// The query was blocked on another thread, and that thread panicked.
+    #[non_exhaustive]
     PropagatedPanic,
 }
 

--- a/crates/rust-analyzer/src/handlers/dispatch.rs
+++ b/crates/rust-analyzer/src/handlers/dispatch.rs
@@ -308,10 +308,31 @@ impl RequestDispatcher<'_> {
     }
 }
 
+#[derive(Debug)]
+enum HandlerCancelledError {
+    PropagatedPanic,
+    Inner(ide::Cancelled),
+}
+
+impl std::error::Error for HandlerCancelledError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            HandlerCancelledError::PropagatedPanic => None,
+            HandlerCancelledError::Inner(cancelled) => Some(cancelled),
+        }
+    }
+}
+
+impl fmt::Display for HandlerCancelledError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Cancelled")
+    }
+}
+
 fn thread_result_to_response<R>(
     id: lsp_server::RequestId,
     result: thread::Result<anyhow::Result<R::Result>>,
-) -> Result<lsp_server::Response, Cancelled>
+) -> Result<lsp_server::Response, HandlerCancelledError>
 where
     R: lsp_types::request::Request,
     R::Params: DeserializeOwned,
@@ -331,10 +352,10 @@ where
                 message.push_str(panic_message)
             } else if let Some(cycle) = panic.downcast_ref::<Cycle>() {
                 tracing::error!("Cycle propagated out of salsa! This is a bug: {cycle:?}");
-                return Err(Cancelled::PropagatedPanic);
+                return Err(HandlerCancelledError::PropagatedPanic);
             } else if let Ok(cancelled) = panic.downcast::<Cancelled>() {
                 tracing::error!("Cancellation propagated out of salsa! This is a bug");
-                return Err(*cancelled);
+                return Err(HandlerCancelledError::Inner(*cancelled));
             }
 
             Ok(lsp_server::Response::new_err(
@@ -349,7 +370,7 @@ where
 fn result_to_response<R>(
     id: lsp_server::RequestId,
     result: anyhow::Result<R::Result>,
-) -> Result<lsp_server::Response, Cancelled>
+) -> Result<lsp_server::Response, HandlerCancelledError>
 where
     R: lsp_types::request::Request,
     R::Params: DeserializeOwned,
@@ -360,7 +381,7 @@ where
         Err(e) => match e.downcast::<LspError>() {
             Ok(lsp_error) => lsp_server::Response::new_err(id, lsp_error.code, lsp_error.message),
             Err(e) => match e.downcast::<Cancelled>() {
-                Ok(cancelled) => return Err(cancelled),
+                Ok(cancelled) => return Err(HandlerCancelledError::Inner(cancelled)),
                 Err(e) => lsp_server::Response::new_err(
                     id,
                     lsp_server::ErrorCode::InternalError as i32,


### PR DESCRIPTION
The caller doesn't really care about the contents of the error; it only cares whether the error is _present_.

I also made `ra_salsa::Cancelled`'s variants `#[non_exhaustive]` again.