### PR TITLE
fix: Consider `Enum::Variant` even when it comes from a different crate

### DIFF
--- a/crates/hir-def/src/nameres/collector.rs
+++ b/crates/hir-def/src/nameres/collector.rs
@@ -38,7 +38,7 @@ use crate::{
         attr_resolution::{attr_macro_as_call_id, derive_macro_as_call_id},
         diagnostics::DefDiagnostic,
         mod_resolution::ModDir,
-        path_resolution::{ReachedFixedPoint, ResolvePathResultPrefixInfo},
+        path_resolution::ReachedFixedPoint,
         proc_macro::{parse_macro_name_and_helper_attrs, ProcMacroDef, ProcMacroKind},
         sub_namespace_match, BuiltinShadowMode, DefMap, MacroSubNs, ModuleData, ModuleOrigin,
         ResolveMode,
@@ -797,7 +797,7 @@ impl DefCollector<'_> {
             return PartialResolvedImport::Unresolved;
         }
 
-        if let ResolvePathResultPrefixInfo::DifferingCrate = res.prefix_info {
+        if res.prefix_info.differing_crate {
             return PartialResolvedImport::Resolved(
                 def.filter_visibility(|v| matches!(v, Visibility::Public)),
             );

--- a/crates/hir-def/src/resolver.rs
+++ b/crates/hir-def/src/resolver.rs
@@ -293,7 +293,7 @@ impl Resolver {
                         },
                         None,
                     ),
-                    ResolvePathResultPrefixInfo::None,
+                    ResolvePathResultPrefixInfo::default(),
                 ))
             }
             Path::LangItem(l, Some(_)) => {
@@ -310,7 +310,7 @@ impl Resolver {
                 };
                 return Some((
                     ResolveValueResult::Partial(type_ns, 1, None),
-                    ResolvePathResultPrefixInfo::None,
+                    ResolvePathResultPrefixInfo::default(),
                 ));
             }
         };
@@ -346,7 +346,7 @@ impl Resolver {
                                     ValueNs::LocalBinding(e.binding()),
                                     None,
                                 ),
-                                ResolvePathResultPrefixInfo::None,
+                                ResolvePathResultPrefixInfo::default(),
                             ));
                         }
                     }
@@ -370,7 +370,7 @@ impl Resolver {
                             let val = ValueNs::GenericParam(id);
                             return Some((
                                 ResolveValueResult::ValueNs(val, None),
-                                ResolvePathResultPrefixInfo::None,
+                                ResolvePathResultPrefixInfo::default(),
                             ));
                         }
                     }
@@ -378,7 +378,7 @@ impl Resolver {
                         if *first_name == sym::Self_.clone() {
                             return Some((
                                 ResolveValueResult::ValueNs(ValueNs::ImplSelf(impl_), None),
-                                ResolvePathResultPrefixInfo::None,
+                                ResolvePathResultPrefixInfo::default(),
                             ));
                         }
                     }
@@ -400,7 +400,7 @@ impl Resolver {
                             let ty = TypeNs::GenericParam(id);
                             return Some((
                                 ResolveValueResult::Partial(ty, 1, None),
-                                ResolvePathResultPrefixInfo::None,
+                                ResolvePathResultPrefixInfo::default(),
                             ));
                         }
                     }
@@ -408,7 +408,7 @@ impl Resolver {
                         if *first_name == sym::Self_.clone() {
                             return Some((
                                 ResolveValueResult::Partial(TypeNs::SelfType(impl_), 1, None),
-                                ResolvePathResultPrefixInfo::None,
+                                ResolvePathResultPrefixInfo::default(),
                             ));
                         }
                     }
@@ -417,7 +417,7 @@ impl Resolver {
                             let ty = TypeNs::AdtSelfType(*adt);
                             return Some((
                                 ResolveValueResult::Partial(ty, 1, None),
-                                ResolvePathResultPrefixInfo::None,
+                                ResolvePathResultPrefixInfo::default(),
                             ));
                         }
                     }
@@ -441,7 +441,7 @@ impl Resolver {
             if let Some(builtin) = BuiltinType::by_name(first_name) {
                 return Some((
                     ResolveValueResult::Partial(TypeNs::BuiltinType(builtin), 1, None),
-                    ResolvePathResultPrefixInfo::None,
+                    ResolvePathResultPrefixInfo::default(),
                 ));
             }
         }

--- a/crates/hir-ty/src/lower.rs
+++ b/crates/hir-ty/src/lower.rs
@@ -32,7 +32,7 @@ use hir_def::{
         WherePredicateTypeTarget,
     },
     lang_item::LangItem,
-    nameres::{MacroSubNs, ResolvePathResultPrefixInfo},
+    nameres::MacroSubNs,
     path::{GenericArg, GenericArgs, ModPath, Path, PathKind, PathSegment, PathSegments},
     resolver::{HasResolver, LifetimeNs, ResolveValueResult, Resolver, TypeNs, ValueNs},
     type_ref::{
@@ -826,7 +826,7 @@ impl<'a> TyLoweringContext<'a> {
                 (segments.take(unresolved_segment - 1), None)
             }
             ResolveValueResult::ValueNs(ValueNs::EnumVariantId(_), _)
-                if prefix_info == ResolvePathResultPrefixInfo::Enum =>
+                if prefix_info.enum_variant =>
             {
                 (segments.strip_last_two(), segments.len().checked_sub(2))
             }

--- a/crates/ide-diagnostics/src/handlers/generic_args_prohibited.rs
+++ b/crates/ide-diagnostics/src/handlers/generic_args_prohibited.rs
@@ -579,4 +579,29 @@ fn bar() {
         "#,
         );
     }
+
+    #[test]
+    fn regression_18768() {
+        check_diagnostics(
+            r#"
+//- minicore: result
+//- /foo.rs crate:foo edition:2018
+pub mod lib {
+    mod core {
+        pub use core::*;
+    }
+    pub use self::core::result;
+}
+
+pub mod __private {
+    pub use crate::lib::result::Result::{self, Err, Ok};
+}
+
+//- /bar.rs crate:bar deps:foo edition:2018
+fn bar() {
+    _ = foo::__private::Result::<(), ()>::Ok;
+}
+        "#,
+        );
+    }
 }


### PR DESCRIPTION
Fixes #18768.