### PR TITLE
Fix bug of "fill match arm" action in tokio::main macro

### DIFF
--- a/crates/ide-assists/src/handlers/add_missing_match_arms.rs
+++ b/crates/ide-assists/src/handlers/add_missing_match_arms.rs
@@ -261,7 +261,9 @@ pub(crate) fn add_missing_match_arms(acc: &mut Assists, ctx: &AssistContext<'_>)
             }
 
             if let Some(cap) = ctx.config.snippet_cap {
-                if let Some(it) = first_new_arm.and_then(|arm| arm.syntax().descendants().find_map(ast::WildcardPat::cast)) {
+                if let Some(it) = first_new_arm
+                    .and_then(|arm| arm.syntax().descendants().find_map(ast::WildcardPat::cast))
+                {
                     edit.add_placeholder_snippet(cap, it);
                 }
 
@@ -287,14 +289,10 @@ pub(crate) fn add_missing_match_arms(acc: &mut Assists, ctx: &AssistContext<'_>)
                         syntax::SyntaxElement::from(edit.make_syntax_mut(it))
                     }
                     syntax::SyntaxElement::Token(it) => {
-                        // Don't have a way to make tokens mut, so instead make the parent mut
-                        // and find the token again
-                        let parent =
-                            edit.make_syntax_mut(it.parent().expect("Token must have a parent."));
-                        let mut_token =
-                            parent.covering_element(it.text_range()).into_token().expect("Covering element cannot be found. Range may be beyond the current node's range");
-
-                        syntax::SyntaxElement::from(mut_token)
+                        // If a token is found, it is '{' or '}'
+                        // The parent is `{ ... }`
+                        let parent = it.parent().expect("Token must have a parent.");
+                        syntax::SyntaxElement::from(edit.make_syntax_mut(parent))
                     }
                 }
             };


### PR DESCRIPTION
close #18027 

![スクリーンショット 2024-12-30 20 07 37](https://github.com/user-attachments/assets/d9ae88f4-bdee-4775-a1d2-5b5eca21bd45)
![スクリーンショット 2024-12-30 20 07 44](https://github.com/user-attachments/assets/b0cff93e-ae2c-45d9-8155-6ec650313b75)
