### PR TITLE
allow targetDir to be an absolute path

### DIFF
--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -2129,8 +2129,7 @@ impl Config {
                 Some(Utf8PathBuf::from("target/rust-analyzer"))
             }
             TargetDirectory::UseSubdirectory(false) => None,
-            TargetDirectory::Directory(dir) if dir.is_relative() => Some(dir.clone()),
-            TargetDirectory::Directory(_) => None,
+            TargetDirectory::Directory(dir) => Some(dir.clone()),
         })
     }
 


### PR DESCRIPTION
Using an absolute path for cargo's build dir is allowed. I would like to have a global build dir for rust-analyzer as well, but _not_ use the same one as cargo (to avoid waiting for locks to release).

This was previously allowed, but was changed by @Veykril in c8fdcea85c273c386d1024815b955af6edae3fa2. Unsure of the reason for the change, using an absolute path seems to work fine.