### PR TITLE
Fix case where completion inside macro that expands to `#[test]` was unavailable

### DIFF
--- a/crates/hir-def/src/nameres/collector.rs
+++ b/crates/hir-def/src/nameres/collector.rs
@@ -1316,6 +1316,7 @@ impl DefCollector<'_> {
                     // being cfg'ed out).
                     // Ideally we will just expand them to nothing here. But we are only collecting macro calls,
                     // not expanding them, so we have no way to do that.
+                    // If you add an ignored attribute here, also add it to `Semantics::might_be_inside_macro_call()`.
                     if matches!(
                         def.kind,
                         MacroDefKind::BuiltInAttr(_, expander)

--- a/crates/ide-completion/src/tests/item.rs
+++ b/crates/ide-completion/src/tests/item.rs
@@ -241,3 +241,75 @@ impl Copy for S where $0
 "#,
     );
 }
+
+#[test]
+fn test_is_not_considered_macro() {
+    check(
+        r#"
+#[rustc_builtin]
+pub macro test($item:item) {
+    /* compiler built-in */
+}
+
+macro_rules! expand_to_test {
+    ( $i:ident ) => {
+        #[test]
+        fn foo() { $i; }
+    };
+}
+
+fn bar() {
+    let value = 5;
+    expand_to_test!(v$0);
+}
+    "#,
+        expect![[r#"
+            ct CONST                                     Unit
+            en Enum                                      Enum
+            fn bar()                                     fn()
+            fn foo()                                     fn()
+            fn function()                                fn()
+            ma expand_to_test!(…) macro_rules! expand_to_test
+            ma makro!(…)                   macro_rules! makro
+            ma test!(…)                            macro test
+            md module
+            sc STATIC                                    Unit
+            st Record                                  Record
+            st Tuple                                    Tuple
+            st Unit                                      Unit
+            un Union                                    Union
+            ev TupleV(…)                          TupleV(u32)
+            bt u32                                        u32
+            kw async
+            kw const
+            kw crate::
+            kw enum
+            kw extern
+            kw false
+            kw fn
+            kw for
+            kw if
+            kw if let
+            kw impl
+            kw let
+            kw loop
+            kw match
+            kw mod
+            kw return
+            kw self::
+            kw static
+            kw struct
+            kw trait
+            kw true
+            kw type
+            kw union
+            kw unsafe
+            kw use
+            kw while
+            kw while let
+            sn macro_rules
+            sn pd
+            sn ppd
+        "#]],
+    );
+}


### PR DESCRIPTION
We ignore `#[test]` in the def map, so that's why it failed.

Fixes #18834.