### PR TITLE
fix: clear diagnostics on cancel unconditionally

### DIFF
--- a/crates/rust-analyzer/src/flycheck.rs
+++ b/crates/rust-analyzer/src/flycheck.rs
@@ -419,9 +419,9 @@ impl FlycheckActor {
             command_handle.cancel();
             self.command_receiver.take();
             self.report_progress(Progress::DidCancel);
-            self.diagnostics_cleared_for.clear();
-            self.diagnostics_received = false;
         }
+        self.diagnostics_cleared_for.clear();
+        self.diagnostics_received = false;
     }
 
     /// Construct a `Command` object for checking the user's code. If the user


### PR DESCRIPTION
This _should_ fix #18854.

This is just an impl of [Lukas's comment](https://github.com/rust-lang/rust-analyzer/pull/18848/files#r1904656621); I tested this on rust-analyzer, canceled flycheck while it was running, and saw diagnostics get cleared when they previously wouldn't.