### PR TITLE
fix: Fix diagnostics not clearing between flychecks

### DIFF
--- a/crates/rust-analyzer/src/flycheck.rs
+++ b/crates/rust-analyzer/src/flycheck.rs
@@ -398,14 +398,12 @@ impl FlycheckActor {
                                     package_id: Some(package_id.clone()),
                                 });
                             }
-                        } else {
-                            if !self.diagnostics_cleared_for_all {
-                                self.diagnostics_cleared_for_all = true;
-                                self.send(FlycheckMessage::ClearDiagnostics {
-                                    id: self.id,
-                                    package_id: None,
-                                });
-                            }
+                        } else if !self.diagnostics_cleared_for_all {
+                            self.diagnostics_cleared_for_all = true;
+                            self.send(FlycheckMessage::ClearDiagnostics {
+                                id: self.id,
+                                package_id: None,
+                            });
                         }
                         self.send(FlycheckMessage::AddDiagnostic {
                             id: self.id,


### PR DESCRIPTION
While https://github.com/rust-lang/rust-analyzer/pull/18848 fixed an issue with diagnostics clearing too eagerly, and https://github.com/rust-lang/rust-analyzer/commit/140f91b04503dc9265db27e4fef43e6039fbb2e7 fixed an issue with diagnostics state not being properly reset between flychecks, we're still facing an issue where diagnostics are not cleared at all between flychecks runs.

Indeed, if the diagnostic doesn't have a corresponding package_id (as is the case with rustc diagnostics), it won't get cleared between flychecks.

This diff adds a `diagnostics_cleared_for_all` flag to keep track of such diagnostics, and moves the diagnostics state clearing to its own method.