### PR TITLE
Fix JSON project `PackageRoot` buildfile inclusion

### DIFF
--- a/crates/project-model/src/workspace.rs
+++ b/crates/project-model/src/workspace.rs
@@ -606,18 +606,18 @@ impl ProjectWorkspace {
             ProjectWorkspaceKind::Json(project) => project
                 .crates()
                 .map(|(_, krate)| {
-                    let build_files = project
-                        .crates()
-                        .filter_map(|(_, krate)| {
-                            krate.build.as_ref().map(|build| build.build_file.clone())
-                        })
-                        // FIXME: PackageRoots dont allow specifying files, only directories
-                        .filter_map(|build_file| {
-                            self.workspace_root().join(build_file).parent().map(ToOwned::to_owned)
-                        });
+                    // FIXME: PackageRoots dont allow specifying files, only directories
+                    let build_file = krate
+                        .build
+                        .as_ref()
+                        .map(|build| self.workspace_root().join(&build.build_file))
+                        .as_deref()
+                        .and_then(AbsPath::parent)
+                        .map(ToOwned::to_owned);
+
                     PackageRoot {
                         is_local: krate.is_workspace_member,
-                        include: krate.include.iter().cloned().chain(build_files).collect(),
+                        include: krate.include.iter().cloned().chain(build_file).collect(),
                         exclude: krate.exclude.clone(),
                     }
                 })


### PR DESCRIPTION
The `PackageRoot` construction for JSON projects was wrongly including buildfiles from all crates for each crate root. Correcting this fixes the issue where build file watching is not working correctly and the workspace does not get fetched again when build files get modified in non-cargo projects.

Fixes #18865.