### PR TITLE
Drop unnecessary tracing::warn

### DIFF
--- a/crates/mbe/src/expander/transcriber.rs
+++ b/crates/mbe/src/expander/transcriber.rs
@@ -462,11 +462,6 @@ fn expand_repeat(
 
         counter += 1;
         if counter == limit {
-            tracing::warn!(
-                "expand_tt in repeat pattern exceed limit => {:#?}\n{:#?}",
-                template,
-                ctx
-            );
             err = Some(ExpandError::new(ctx.call_site, ExpandErrorKind::LimitExceeded));
             break;
         }


### PR DESCRIPTION
We already emit an error. This also printed the entire token tree which can be gigantic.