### PR TITLE
Add config setting which allows adding additional include paths to the VFS.

### DIFF
--- a/crates/project-model/src/cargo_workspace.rs
+++ b/crates/project-model/src/cargo_workspace.rs
@@ -92,6 +92,8 @@ pub struct CargoConfig {
     pub sysroot_src: Option<AbsPathBuf>,
     /// rustc private crate source
     pub rustc_source: Option<RustLibSource>,
+    /// Extra includes to add to the VFS.
+    pub extra_includes: Vec<AbsPathBuf>,
     pub cfg_overrides: CfgOverrides,
     /// Invoke `cargo check` through the RUSTC_WRAPPER.
     pub wrap_rustc_in_build_scripts: bool,

--- a/crates/project-model/src/tests.rs
+++ b/crates/project-model/src/tests.rs
@@ -49,6 +49,7 @@ fn load_workspace_from_metadata(file: &str) -> ProjectWorkspace {
         rustc_cfg: Vec::new(),
         toolchain: None,
         target_layout: Err("target_data_layout not loaded".into()),
+        extra_includes: Vec::new(),
     }
 }
 
@@ -63,6 +64,7 @@ fn load_rust_project(file: &str) -> (CrateGraph, ProcMacroPaths) {
         toolchain: None,
         target_layout: Err(Arc::from("test has no data layout")),
         cfg_overrides: Default::default(),
+        extra_includes: Vec::new(),
     };
     to_crate_graph(project_workspace, &mut Default::default())
 }
@@ -284,6 +286,7 @@ fn smoke_test_real_sysroot_cargo() {
         cfg_overrides: Default::default(),
         toolchain: None,
         target_layout: Err("target_data_layout not loaded".into()),
+        extra_includes: Vec::new(),
     };
     project_workspace.to_crate_graph(
         &mut {

--- a/crates/rust-analyzer/src/cli/rustc_tests.rs
+++ b/crates/rust-analyzer/src/cli/rustc_tests.rs
@@ -93,6 +93,7 @@ impl Tester {
             toolchain: None,
             target_layout: data_layout.map(Arc::from).map_err(|it| Arc::from(it.to_string())),
             cfg_overrides: Default::default(),
+            extra_includes: vec![],
         };
         let load_cargo_config = LoadCargoConfig {
             load_out_dirs_from_check: false,

--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -728,6 +728,10 @@ config_data! {
         /// available on a nightly build.
         rustfmt_rangeFormatting_enable: bool = false,
 
+        /// Additional paths to include in the VFS. Generally for code that is
+        /// generated or otherwise managed by a build system outside of Cargo,
+        /// though Cargo might be the eventual consumer.
+        vfs_extraIncludes: Vec<String> = vec![],
 
         /// Workspace symbol search kind.
         workspace_symbol_search_kind: WorkspaceSymbolSearchKindDef = WorkspaceSymbolSearchKindDef::OnlyTypes,
@@ -1926,6 +1930,13 @@ impl Config {
         });
         let sysroot_src =
             self.cargo_sysrootSrc(source_root).as_ref().map(|sysroot| self.root_path.join(sysroot));
+        let extra_includes = self
+            .vfs_extraIncludes(source_root)
+            .iter()
+            .map(String::as_str)
+            .map(AbsPathBuf::try_from)
+            .filter_map(Result::ok)
+            .collect();
 
         CargoConfig {
             all_targets: *self.cargo_allTargets(source_root),
@@ -1940,6 +1951,7 @@ impl Config {
             sysroot,
             sysroot_src,
             rustc_source,
+            extra_includes,
             cfg_overrides: project_model::CfgOverrides {
                 global: CfgDiff::new(
                     self.cargo_cfgs(source_root)

--- a/docs/user/generated_config.adoc
+++ b/docs/user/generated_config.adoc
@@ -1051,6 +1051,13 @@ Show documentation.
 --
 Specify the characters to exclude from triggering typing assists. The default trigger characters are `.`, `=`, `<`, `>`, `{`, and `(`.
 --
+[[rust-analyzer.vfs.extraIncludes]]rust-analyzer.vfs.extraIncludes (default: `[]`)::
++
+--
+Additional paths to include in the VFS. Generally for code that is
+generated or otherwise managed by a build system outside of Cargo,
+though Cargo might be the eventual consumer.
+--
 [[rust-analyzer.workspace.discoverConfig]]rust-analyzer.workspace.discoverConfig (default: `null`)::
 +
 --

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -2719,6 +2719,19 @@
                 }
             },
             {
+                "title": "vfs",
+                "properties": {
+                    "rust-analyzer.vfs.extraIncludes": {
+                        "markdownDescription": "Additional paths to include in the VFS. Generally for code that is\ngenerated or otherwise managed by a build system outside of Cargo,\nthough Cargo might be the eventual consumer.",
+                        "default": [],
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                }
+            },
+            {
                 "title": "workspace",
                 "properties": {
                     "rust-analyzer.workspace.discoverConfig": {


### PR DESCRIPTION
The motivation for this is resolving unresolved symbols for Firefox. We build Rust code with cargo but generate some code via our primary build system mach. Additionally, we bundle the windows crate in an out-of-source and out-of-build location. Essentially the same idea as discussed [here](https://rust-lang.zulipchat.com/#narrow/channel/185405-t-compiler.2Frust-analyzer/topic/include!.20failing.20for.20some.20paths), Firefox issue tracked [here](https://bugzilla.mozilla.org/show_bug.cgi?id=1890431).

I investigated instead populating the vfs via rustc's `--emit=dep-info` as cargo already emits .d files but at this time cargo [does not relay .d file changes](https://github.com/rust-lang/cargo/issues/13672#issuecomment-2147772916) as it hazards the unspecified cargo directory layout becoming defacto specified.

This change therefore instead adds a config option to manually specify extra includes for the VFS as suggested in the above Zulip conversation and in this [bug](https://github.com/rust-lang/rust-analyzer/issues/17040#issuecomment-2105778865) (similarly motivated by Firefox's needs).

I don't believe this change ready to land but it's in a place where it's sufficient to anchor a conversation on what's necessary beyond a minimal implementation, and I've verified this works with both Firefox's XPCOM generated functions and windows includes.