### PR TITLE
fix: Fix `env`/`option_env` macro check disregarding macro_rules definitions 

### DIFF
--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -3046,14 +3046,23 @@ impl Macro {
             MacroId::Macro2Id(it) => {
                 matches!(it.lookup(db.upcast()).expander, MacroExpander::BuiltInEager(eager) if eager.is_env_or_option_env())
             }
-            MacroId::MacroRulesId(_) | MacroId::ProcMacroId(_) => false,
+            MacroId::MacroRulesId(it) => {
+                matches!(it.lookup(db.upcast()).expander, MacroExpander::BuiltInEager(eager) if eager.is_env_or_option_env())
+            }
+            MacroId::ProcMacroId(_) => false,
         }
     }
 
     pub fn is_asm_or_global_asm(&self, db: &dyn HirDatabase) -> bool {
-        matches!(self.id, MacroId::Macro2Id(it) if {
-            matches!(it.lookup(db.upcast()).expander, MacroExpander::BuiltIn(m) if m.is_asm())
-        })
+        match self.id {
+            MacroId::Macro2Id(it) => {
+                matches!(it.lookup(db.upcast()).expander, MacroExpander::BuiltIn(m) if m.is_asm())
+            }
+            MacroId::MacroRulesId(it) => {
+                matches!(it.lookup(db.upcast()).expander, MacroExpander::BuiltIn(m) if m.is_asm())
+            }
+            MacroId::ProcMacroId(_) => false,
+        }
     }
 
     pub fn is_attr(&self, db: &dyn HirDatabase) -> bool {

--- a/crates/ide-completion/src/completions/env_vars.rs
+++ b/crates/ide-completion/src/completions/env_vars.rs
@@ -68,43 +68,40 @@ pub(crate) fn complete_cargo_env_vars(
 mod tests {
     use crate::tests::{check_edit, completion_list};
 
-    fn check(macro_name: &str) {
-        check_edit(
-            "CARGO_BIN_NAME",
-            &format!(
-                r#"
-            #[rustc_builtin_macro]
-            macro {macro_name} {{
-                ($var:literal) => {{ 0 }}
-            }}
-
-            fn main() {{
-                let foo = {macro_name}!("CAR$0");
-            }}
-        "#
-            ),
-            &format!(
-                r#"
-            #[rustc_builtin_macro]
-            macro {macro_name} {{
-                ($var:literal) => {{ 0 }}
-            }}
-
-            fn main() {{
-                let foo = {macro_name}!("CARGO_BIN_NAME");
-            }}
-        "#
-            ),
-        );
-    }
     #[test]
     fn completes_env_variable_in_env() {
-        check("env")
+        check_edit(
+            "CARGO_BIN_NAME",
+            r#"
+//- minicore: env
+fn main() {
+    let foo = env!("CAR$0");
+}
+        "#,
+            r#"
+fn main() {
+    let foo = env!("CARGO_BIN_NAME");
+}
+        "#,
+        );
     }
 
     #[test]
     fn completes_env_variable_in_option_env() {
-        check("option_env");
+        check_edit(
+            "CARGO_BIN_NAME",
+            r#"
+//- minicore: env
+fn main() {
+    let foo = option_env!("CAR$0");
+}
+        "#,
+            r#"
+fn main() {
+    let foo = option_env!("CARGO_BIN_NAME");
+}
+        "#,
+        );
     }
 
     #[test]


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust-analyzer/issues/18883