### PR TITLE
refactor: struct holding cargo cfgs settings

### DIFF
--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -571,12 +571,10 @@ config_data! {
         /// avoid checking unnecessary things.
         cargo_buildScripts_useRustcWrapper: bool = true,
         /// List of cfg options to enable with the given values.
-        cargo_cfgs: FxHashMap<String, Option<String>> = {
-            let mut m = FxHashMap::default();
-            m.insert("debug_assertions".to_owned(), None);
-            m.insert("miri".to_owned(), None);
-            m
-        },
+        cargo_cfgs: Vec<String> = {
+            vec!["debug_assertion".into(), "miri".into()]
+        }
+        ,
         /// Extra arguments that are passed to every cargo invocation.
         cargo_extraArgs: Vec<String> = vec![],
         /// Extra environment variables that will be set when running cargo, rustc
@@ -1944,6 +1942,17 @@ impl Config {
                 global: CfgDiff::new(
                     self.cargo_cfgs(source_root)
                         .iter()
+                        // parse any cfg setting formatted as key=value
+                        .map(|s| {
+                            let mut sp = s.splitn(2, "=");
+                            let key = sp.next();
+                            let val = sp.next();
+                            (key, val)
+                        })
+                        // we filter out anything with a None key
+                        .filter(|(key, _)| key.is_some())
+                        // unwrap cannot panic here as we are sure key is Some
+                        .map(|(key, val)| (key.unwrap(), val))
                         .map(|(key, val)| match val {
                             Some(val) => CfgAtom::KeyValue {
                                 key: Symbol::intern(key),

--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -573,8 +573,7 @@ config_data! {
         /// List of cfg options to enable with the given values.
         cargo_cfgs: Vec<String> = {
             vec!["debug_assertion".into(), "miri".into()]
-        }
-        ,
+        },
         /// Extra arguments that are passed to every cargo invocation.
         cargo_extraArgs: Vec<String> = vec![],
         /// Extra environment variables that will be set when running cargo, rustc
@@ -1942,17 +1941,13 @@ impl Config {
                 global: CfgDiff::new(
                     self.cargo_cfgs(source_root)
                         .iter()
-                        // parse any cfg setting formatted as key=value
-                        .map(|s| {
+                        // parse any cfg setting formatted as key=value or just key (without value)
+                        .filter_map(|s| {
                             let mut sp = s.splitn(2, "=");
                             let key = sp.next();
                             let val = sp.next();
-                            (key, val)
+                            key.map(|key| (key, val))
                         })
-                        // we filter out anything with a None key
-                        .filter(|(key, _)| key.is_some())
-                        // unwrap cannot panic here as we are sure key is Some
-                        .map(|(key, val)| (key.unwrap(), val))
                         .map(|(key, val)| match val {
                             Some(val) => CfgAtom::KeyValue {
                                 key: Symbol::intern(key),

--- a/docs/user/generated_config.adoc
+++ b/docs/user/generated_config.adoc
@@ -94,10 +94,10 @@ avoid checking unnecessary things.
 --
 Default:
 ----
-{
-  "miri": null,
-  "debug_assertions": null
-}
+[
+  "debug_assertion",
+  "miri"
+]
 ----
 List of cfg options to enable with the given values.
 

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -791,11 +791,14 @@
                 "properties": {
                     "rust-analyzer.cargo.cfgs": {
                         "markdownDescription": "List of cfg options to enable with the given values.",
-                        "default": {
-                            "miri": null,
-                            "debug_assertions": null
-                        },
-                        "type": "object"
+                        "default": [
+                            "debug_assertion",
+                            "miri"
+                        ],
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     }
                 }
             },


### PR DESCRIPTION
# Change to `rust-analyzer.cargo.cfgs` Setting

This PR replaces the current structure (a `HashMap`) for the `rust-analyzer.cargo.cfgs` setting with a `Vec<String>`. The use of a vector seems more appropriate for the following reasons:

- Repeated same `cfg` keys can be used (currently impossible due to the use of a `HashMap`).
- In the end, the original `HashMap` is turned into a vector of (key, value) tuples, so it seems there is no benefit to using a `HashMap` to hold these settings.

A beneficial side effect of this change is that `rust-analyzer` can have partial support for multi-target analysis through this setting (see the following configuration example).

## New Format Example

```json
{
  "rust-analyzer.cargo.cfgs": [
    "debug_assertion",
    "miri",
    "target_arch=x86_64",
    "target_arch=aarch64",
  ]
}
