### PR TITLE
refactor test helpers within ide-completions

### DIFF
--- a/crates/ide-completion/src/completions/dot.rs
+++ b/crates/ide-completion/src/completions/dot.rs
@@ -214,25 +214,13 @@ fn complete_methods(
 
 #[cfg(test)]
 mod tests {
-    use expect_test::{expect, Expect};
+    use expect_test::expect;
 
-    use crate::tests::{
-        check_edit, completion_list_no_kw, completion_list_no_kw_with_private_editable,
-    };
-
-    fn check(ra_fixture: &str, expect: Expect) {
-        let actual = completion_list_no_kw(ra_fixture);
-        expect.assert_eq(&actual);
-    }
-
-    fn check_with_private_editable(ra_fixture: &str, expect: Expect) {
-        let actual = completion_list_no_kw_with_private_editable(ra_fixture);
-        expect.assert_eq(&actual);
-    }
+    use crate::tests::{check_edit, check_no_kw, check_with_private_editable};
 
     #[test]
     fn test_struct_field_and_method_completion() {
-        check(
+        check_no_kw(
             r#"
 struct S { foo: u32 }
 impl S {
@@ -249,7 +237,7 @@ fn foo(s: S) { s.$0 }
 
     #[test]
     fn no_unstable_method_on_stable() {
-        check(
+        check_no_kw(
             r#"
 //- /main.rs crate:main deps:std
 fn foo(s: std::S) { s.$0 }
@@ -266,7 +254,7 @@ impl S {
 
     #[test]
     fn unstable_method_on_nightly() {
-        check(
+        check_no_kw(
             r#"
 //- toolchain:nightly
 //- /main.rs crate:main deps:std
@@ -286,7 +274,7 @@ impl S {
 
     #[test]
     fn test_struct_field_completion_self() {
-        check(
+        check_no_kw(
             r#"
 struct S { the_field: (u32,) }
 impl S {
@@ -302,7 +290,7 @@ impl S {
 
     #[test]
     fn test_struct_field_completion_autoderef() {
-        check(
+        check_no_kw(
             r#"
 struct A { the_field: (u32, i32) }
 impl A {
@@ -318,7 +306,7 @@ impl A {
 
     #[test]
     fn test_no_struct_field_completion_for_method_call() {
-        check(
+        check_no_kw(
             r#"
 struct A { the_field: u32 }
 fn foo(a: A) { a.$0() }
@@ -329,7 +317,7 @@ fn foo(a: A) { a.$0() }
 
     #[test]
     fn test_visibility_filtering() {
-        check(
+        check_no_kw(
             r#"
 //- /lib.rs crate:lib new_source_root:local
 pub mod m {
@@ -348,7 +336,7 @@ fn foo(a: lib::m::A) { a.$0 }
             "#]],
         );
 
-        check(
+        check_no_kw(
             r#"
 //- /lib.rs crate:lib new_source_root:library
 pub mod m {
@@ -367,7 +355,7 @@ fn foo(a: lib::m::A) { a.$0 }
             "#]],
         );
 
-        check(
+        check_no_kw(
             r#"
 //- /lib.rs crate:lib new_source_root:library
 pub mod m {
@@ -384,7 +372,7 @@ fn foo(a: lib::m::A) { a.$0 }
             "#]],
         );
 
-        check(
+        check_no_kw(
             r#"
 //- /lib.rs crate:lib new_source_root:local
 pub struct A {}
@@ -402,7 +390,7 @@ fn foo(a: lib::A) { a.$0 }
                 me pub_method() fn(&self)
             "#]],
         );
-        check(
+        check_no_kw(
             r#"
 //- /lib.rs crate:lib new_source_root:library
 pub struct A {}
@@ -524,7 +512,7 @@ fn foo(a: lib::A) { a.$0 }
 
     #[test]
     fn test_local_impls() {
-        check(
+        check_no_kw(
             r#"
 pub struct A {}
 mod m {
@@ -553,7 +541,7 @@ fn foo(a: A) {
 
     #[test]
     fn test_doc_hidden_filtering() {
-        check(
+        check_no_kw(
             r#"
 //- /lib.rs crate:lib deps:dep
 fn foo(a: dep::A) { a.$0 }
@@ -580,7 +568,7 @@ impl A {
 
     #[test]
     fn test_union_field_completion() {
-        check(
+        check_no_kw(
             r#"
 union U { field: u8, other: u16 }
 fn foo(u: U) { u.$0 }
@@ -594,7 +582,7 @@ fn foo(u: U) { u.$0 }
 
     #[test]
     fn test_method_completion_only_fitting_impls() {
-        check(
+        check_no_kw(
             r#"
 struct A<T> {}
 impl A<u32> {
@@ -613,7 +601,7 @@ fn foo(a: A<u32>) { a.$0 }
 
     #[test]
     fn test_trait_method_completion() {
-        check(
+        check_no_kw(
             r#"
 struct A {}
 trait Trait { fn the_method(&self); }
@@ -643,7 +631,7 @@ fn foo(a: A) { a.the_method();$0 }
 
     #[test]
     fn test_trait_method_completion_deduplicated() {
-        check(
+        check_no_kw(
             r"
 struct A {}
 trait Trait { fn the_method(&self); }
@@ -658,7 +646,7 @@ fn foo(a: &A) { a.$0 }
 
     #[test]
     fn completes_trait_method_from_other_module() {
-        check(
+        check_no_kw(
             r"
 struct A {}
 mod m {
@@ -676,7 +664,7 @@ fn foo(a: A) { a.$0 }
 
     #[test]
     fn test_no_non_self_method() {
-        check(
+        check_no_kw(
             r#"
 struct A {}
 impl A {
@@ -692,7 +680,7 @@ fn foo(a: A) {
 
     #[test]
     fn test_tuple_field_completion() {
-        check(
+        check_no_kw(
             r#"
 fn foo() {
    let b = (0, 3.14);
@@ -708,7 +696,7 @@ fn foo() {
 
     #[test]
     fn test_tuple_struct_field_completion() {
-        check(
+        check_no_kw(
             r#"
 struct S(i32, f64);
 fn foo() {
@@ -725,7 +713,7 @@ fn foo() {
 
     #[test]
     fn test_tuple_field_inference() {
-        check(
+        check_no_kw(
             r#"
 pub struct S;
 impl S { pub fn blah(&self) {} }
@@ -747,7 +735,7 @@ impl T {
 
     #[test]
     fn test_field_no_same_name() {
-        check(
+        check_no_kw(
             r#"
 //- minicore: deref
 struct A { field: u8 }
@@ -770,7 +758,7 @@ fn test(a: A) {
 
     #[test]
     fn test_tuple_field_no_same_index() {
-        check(
+        check_no_kw(
             r#"
 //- minicore: deref
 struct A(u8);
@@ -793,7 +781,7 @@ fn test(a: A) {
 
     #[test]
     fn test_tuple_struct_deref_to_tuple_no_same_index() {
-        check(
+        check_no_kw(
             r#"
 //- minicore: deref
 struct A(u8);
@@ -815,7 +803,7 @@ fn test(a: A) {
 
     #[test]
     fn test_completion_works_in_consts() {
-        check(
+        check_no_kw(
             r#"
 struct A { the_field: u32 }
 const X: u32 = {
@@ -830,7 +818,7 @@ const X: u32 = {
 
     #[test]
     fn works_in_simple_macro_1() {
-        check(
+        check_no_kw(
             r#"
 macro_rules! m { ($e:expr) => { $e } }
 struct A { the_field: u32 }
@@ -847,7 +835,7 @@ fn foo(a: A) {
     #[test]
     fn works_in_simple_macro_2() {
         // this doesn't work yet because the macro doesn't expand without the token -- maybe it can be fixed with better recovery
-        check(
+        check_no_kw(
             r#"
 macro_rules! m { ($e:expr) => { $e } }
 struct A { the_field: u32 }
@@ -863,7 +851,7 @@ fn foo(a: A) {
 
     #[test]
     fn works_in_simple_macro_recursive_1() {
-        check(
+        check_no_kw(
             r#"
 macro_rules! m { ($e:expr) => { $e } }
 struct A { the_field: u32 }
@@ -879,7 +867,7 @@ fn foo(a: A) {
 
     #[test]
     fn macro_expansion_resilient() {
-        check(
+        check_no_kw(
             r#"
 macro_rules! d {
     () => {};
@@ -905,7 +893,7 @@ fn foo(a: A) {
 
     #[test]
     fn test_method_completion_issue_3547() {
-        check(
+        check_no_kw(
             r#"
 struct HashSet<T> {}
 impl<T> HashSet<T> {
@@ -924,7 +912,7 @@ fn foo() {
 
     #[test]
     fn completes_method_call_when_receiver_is_a_macro_call() {
-        check(
+        check_no_kw(
             r#"
 struct S;
 impl S { fn foo(&self) {} }
@@ -939,7 +927,7 @@ fn main() { make_s!().f$0; }
 
     #[test]
     fn completes_after_macro_call_in_submodule() {
-        check(
+        check_no_kw(
             r#"
 macro_rules! empty {
     () => {};
@@ -967,7 +955,7 @@ mod foo {
 
     #[test]
     fn issue_8931() {
-        check(
+        check_no_kw(
             r#"
 //- minicore: fn
 struct S;
@@ -994,7 +982,7 @@ impl S {
 
     #[test]
     fn completes_bare_fields_and_methods_in_methods() {
-        check(
+        check_no_kw(
             r#"
 struct Foo { field: i32 }
 
@@ -1008,7 +996,7 @@ impl Foo { fn foo(&self) { $0 } }"#,
                 bt u32              u32
             "#]],
         );
-        check(
+        check_no_kw(
             r#"
 struct Foo(i32);
 
@@ -1026,7 +1014,7 @@ impl Foo { fn foo(&mut self) { $0 } }"#,
 
     #[test]
     fn macro_completion_after_dot() {
-        check(
+        check_no_kw(
             r#"
 macro_rules! m {
     ($e:expr) => { $e };
@@ -1051,7 +1039,7 @@ fn f() {
 
     #[test]
     fn completes_method_call_when_receiver_type_has_errors_issue_10297() {
-        check(
+        check_no_kw(
             r#"
 //- minicore: iterator, sized
 struct Vec<T>;
@@ -1102,7 +1090,7 @@ fn main() {
 
     #[test]
     fn issue_12484() {
-        check(
+        check_no_kw(
             r#"
 //- minicore: sized
 trait SizeUser {
@@ -1124,7 +1112,7 @@ fn test(thing: impl Encrypt) {
 
     #[test]
     fn only_consider_same_type_once() {
-        check(
+        check_no_kw(
             r#"
 //- minicore: deref
 struct A(u8);
@@ -1150,7 +1138,7 @@ fn test(a: A) {
 
     #[test]
     fn no_inference_var_in_completion() {
-        check(
+        check_no_kw(
             r#"
 struct S<T>(T);
 fn test(s: S<Unknown>) {
@@ -1165,7 +1153,7 @@ fn test(s: S<Unknown>) {
 
     #[test]
     fn assoc_impl_1() {
-        check(
+        check_no_kw(
             r#"
 //- minicore: deref
 fn main() {
@@ -1206,7 +1194,7 @@ impl<F: core::ops::Deref<Target = impl Bar>> Foo<F> {
 
     #[test]
     fn assoc_impl_2() {
-        check(
+        check_no_kw(
             r#"
 //- minicore: deref
 fn main() {
@@ -1242,7 +1230,7 @@ impl<B: Bar, F: core::ops::Deref<Target = B>> Foo<F> {
 
     #[test]
     fn test_struct_function_field_completion() {
-        check(
+        check_no_kw(
             r#"
 struct S { va_field: u32, fn_field: fn() }
 fn foo() { S { va_field: 0, fn_field: || {} }.fi$0() }
@@ -1267,7 +1255,7 @@ fn foo() { (S { va_field: 0, fn_field: || {} }.fn_field)() }
 
     #[test]
     fn test_tuple_function_field_completion() {
-        check(
+        check_no_kw(
             r#"
 struct B(u32, fn())
 fn foo() {
@@ -1301,7 +1289,7 @@ fn foo() {
 
     #[test]
     fn test_fn_field_dot_access_method_has_parens_false() {
-        check(
+        check_no_kw(
             r#"
 struct Foo { baz: fn() }
 impl Foo {

--- a/crates/ide-completion/src/completions/extern_abi.rs
+++ b/crates/ide-completion/src/completions/extern_abi.rs
@@ -65,18 +65,13 @@ pub(crate) fn complete_extern_abi(
 
 #[cfg(test)]
 mod tests {
-    use expect_test::{expect, Expect};
+    use expect_test::expect;
 
-    use crate::tests::{check_edit, completion_list_no_kw};
-
-    fn check(ra_fixture: &str, expect: Expect) {
-        let actual = completion_list_no_kw(ra_fixture);
-        expect.assert_eq(&actual);
-    }
+    use crate::tests::{check_edit, check_no_kw};
 
     #[test]
     fn only_completes_in_string_literals() {
-        check(
+        check_no_kw(
             r#"
 $0 fn foo {}
 "#,
@@ -86,7 +81,7 @@ $0 fn foo {}
 
     #[test]
     fn requires_extern_prefix() {
-        check(
+        check_no_kw(
             r#"
 "$0" fn foo {}
 "#,
@@ -96,7 +91,7 @@ $0 fn foo {}
 
     #[test]
     fn works() {
-        check(
+        check_no_kw(
             r#"
 extern "$0" fn foo {}
 "#,

--- a/crates/ide-completion/src/completions/format_string.rs
+++ b/crates/ide-completion/src/completions/format_string.rs
@@ -61,18 +61,13 @@ pub(crate) fn format_string(
 
 #[cfg(test)]
 mod tests {
-    use expect_test::{expect, Expect};
+    use expect_test::expect;
 
-    use crate::tests::{check_edit, completion_list_no_kw};
-
-    fn check(ra_fixture: &str, expect: Expect) {
-        let actual = completion_list_no_kw(ra_fixture);
-        expect.assert_eq(&actual);
-    }
+    use crate::tests::{check_edit, check_no_kw};
 
     #[test]
     fn works_when_wrapped() {
-        check(
+        check_no_kw(
             r#"
 //- minicore: fmt
 macro_rules! print {
@@ -89,7 +84,7 @@ fn main() {
 
     #[test]
     fn no_completion_without_brace() {
-        check(
+        check_no_kw(
             r#"
 //- minicore: fmt
 fn main() {

--- a/crates/ide-completion/src/completions/item_list/trait_impl.rs
+++ b/crates/ide-completion/src/completions/item_list/trait_impl.rs
@@ -514,18 +514,13 @@ fn function_declaration(
 
 #[cfg(test)]
 mod tests {
-    use expect_test::{expect, Expect};
+    use expect_test::expect;
 
-    use crate::tests::{check_edit, completion_list_no_kw};
-
-    fn check(ra_fixture: &str, expect: Expect) {
-        let actual = completion_list_no_kw(ra_fixture);
-        expect.assert_eq(&actual)
-    }
+    use crate::tests::{check_edit, check_no_kw};
 
     #[test]
     fn no_completion_inside_fn() {
-        check(
+        check_no_kw(
             r"
 trait Test { fn test(); fn test2(); }
 struct T;
@@ -544,7 +539,7 @@ impl Test for T {
             "#]],
         );
 
-        check(
+        check_no_kw(
             r"
 trait Test { fn test(); fn test2(); }
 struct T;
@@ -558,7 +553,7 @@ impl Test for T {
             expect![[""]],
         );
 
-        check(
+        check_no_kw(
             r"
 trait Test { fn test(); fn test2(); }
 struct T;
@@ -573,7 +568,7 @@ impl Test for T {
         );
 
         // https://github.com/rust-lang/rust-analyzer/pull/5976#issuecomment-692332191
-        check(
+        check_no_kw(
             r"
 trait Test { fn test(); fn test2(); }
 struct T;
@@ -587,7 +582,7 @@ impl Test for T {
             expect![[r#""#]],
         );
 
-        check(
+        check_no_kw(
             r"
 trait Test { fn test(_: i32); fn test2(); }
 struct T;
@@ -606,7 +601,7 @@ impl Test for T {
             "#]],
         );
 
-        check(
+        check_no_kw(
             r"
 trait Test { fn test(_: fn()); fn test2(); }
 struct T;
@@ -624,7 +619,7 @@ impl Test for T {
 
     #[test]
     fn no_completion_inside_const() {
-        check(
+        check_no_kw(
             r"
 trait Test { const TEST: fn(); const TEST2: u32; type Test; fn test(); }
 struct T;
@@ -636,7 +631,7 @@ impl Test for T {
             expect![[r#""#]],
         );
 
-        check(
+        check_no_kw(
             r"
 trait Test { const TEST: u32; const TEST2: u32; type Test; fn test(); }
 struct T;
@@ -653,7 +648,7 @@ impl Test for T {
             "#]],
         );
 
-        check(
+        check_no_kw(
             r"
 trait Test { const TEST: u32; const TEST2: u32; type Test; fn test(); }
 struct T;
@@ -670,7 +665,7 @@ impl Test for T {
             "#]],
         );
 
-        check(
+        check_no_kw(
             r"
 trait Test { const TEST: u32; const TEST2: u32; type Test; fn test(); }
 struct T;
@@ -689,7 +684,7 @@ impl Test for T {
             "#]],
         );
 
-        check(
+        check_no_kw(
             r"
 trait Test { const TEST: u32; const TEST2: u32; type Test; fn test(); }
 struct T;
@@ -703,7 +698,7 @@ impl Test for T {
             expect![[""]],
         );
 
-        check(
+        check_no_kw(
             r"
 trait Test { const TEST: u32; const TEST2: u32; type Test; fn test(); }
 struct T;
@@ -720,7 +715,7 @@ impl Test for T {
 
     #[test]
     fn no_completion_inside_type() {
-        check(
+        check_no_kw(
             r"
 trait Test { type Test; type Test2; fn test(); }
 struct T;
@@ -737,7 +732,7 @@ impl Test for T {
             "#]],
         );
 
-        check(
+        check_no_kw(
             r"
 trait Test { type Test; type Test2; fn test(); }
 struct T;
@@ -1263,7 +1258,7 @@ impl Foo<u32> for Bar {
 
     #[test]
     fn works_directly_in_impl() {
-        check(
+        check_no_kw(
             r#"
 trait Tr {
     fn required();
@@ -1277,7 +1272,7 @@ impl Tr for () {
             fn fn required()
         "#]],
         );
-        check(
+        check_no_kw(
             r#"
 trait Tr {
     fn provided() {}

--- a/crates/ide-completion/src/completions/keyword.rs
+++ b/crates/ide-completion/src/completions/keyword.rs
@@ -32,14 +32,9 @@ pub(crate) fn complete_for_and_where(
 
 #[cfg(test)]
 mod tests {
-    use expect_test::{expect, Expect};
+    use expect_test::expect;
 
-    use crate::tests::{check_edit, completion_list};
-
-    fn check(ra_fixture: &str, expect: Expect) {
-        let actual = completion_list(ra_fixture);
-        expect.assert_eq(&actual)
-    }
+    use crate::tests::{check, check_edit};
 
     #[test]
     fn test_else_edit_after_if() {

--- a/crates/ide-completion/src/completions/lifetime.rs
+++ b/crates/ide-completion/src/completions/lifetime.rs
@@ -59,14 +59,9 @@ pub(crate) fn complete_label(
 
 #[cfg(test)]
 mod tests {
-    use expect_test::{expect, Expect};
+    use expect_test::expect;
 
-    use crate::tests::{check_edit, completion_list};
-
-    fn check(ra_fixture: &str, expect: Expect) {
-        let actual = completion_list(ra_fixture);
-        expect.assert_eq(&actual);
-    }
+    use crate::tests::{check, check_edit};
 
     #[test]
     fn check_lifetime_edit() {

--- a/crates/ide-completion/src/completions/mod_.rs
+++ b/crates/ide-completion/src/completions/mod_.rs
@@ -159,14 +159,9 @@ fn module_chain_to_containing_module_file(
 
 #[cfg(test)]
 mod tests {
-    use expect_test::{expect, Expect};
+    use expect_test::expect;
 
-    use crate::tests::completion_list;
-
-    fn check(ra_fixture: &str, expect: Expect) {
-        let actual = completion_list(ra_fixture);
-        expect.assert_eq(&actual);
-    }
+    use crate::tests::check;
 
     #[test]
     fn lib_module_completion() {

--- a/crates/ide-completion/src/completions/postfix.rs
+++ b/crates/ide-completion/src/completions/postfix.rs
@@ -401,17 +401,12 @@ fn add_custom_postfix_completions(
 
 #[cfg(test)]
 mod tests {
-    use expect_test::{expect, Expect};
+    use expect_test::expect;
 
     use crate::{
-        tests::{check_edit, check_edit_with_config, completion_list, TEST_CONFIG},
+        tests::{check, check_edit, check_edit_with_config, TEST_CONFIG},
         CompletionConfig, Snippet,
     };
-
-    fn check(ra_fixture: &str, expect: Expect) {
-        let actual = completion_list(ra_fixture);
-        expect.assert_eq(&actual)
-    }
 
     #[test]
     fn postfix_completion_works_for_trivial_path_expression() {

--- a/crates/ide-completion/src/tests.rs
+++ b/crates/ide-completion/src/tests.rs
@@ -253,9 +253,32 @@ pub(crate) fn check_edit_with_config(
     assert_eq_text!(&ra_fixture_after, &actual)
 }
 
-fn check_empty(ra_fixture: &str, expect: Expect) {
+pub(crate) fn check(ra_fixture: &str, expect: Expect) {
     let actual = completion_list(ra_fixture);
     expect.assert_eq(&actual);
+}
+
+pub(crate) fn check_with_base_items(ra_fixture: &str, expect: Expect) {
+    check(&format!("{BASE_ITEMS_FIXTURE}{ra_fixture}"), expect)
+}
+
+pub(crate) fn check_no_kw(ra_fixture: &str, expect: Expect) {
+    let actual = completion_list_no_kw(ra_fixture);
+    expect.assert_eq(&actual)
+}
+
+pub(crate) fn check_with_private_editable(ra_fixture: &str, expect: Expect) {
+    let actual = completion_list_no_kw_with_private_editable(ra_fixture);
+    expect.assert_eq(&actual);
+}
+
+pub(crate) fn check_with_trigger_character(
+    ra_fixture: &str,
+    trigger_character: Option<char>,
+    expect: Expect,
+) {
+    let actual = completion_list_with_trigger_character(ra_fixture, trigger_character);
+    expect.assert_eq(&actual)
 }
 
 pub(crate) fn get_all_items(

--- a/crates/ide-completion/src/tests/attribute.rs
+++ b/crates/ide-completion/src/tests/attribute.rs
@@ -1,12 +1,7 @@
 //! Completion tests for attributes.
-use expect_test::{expect, Expect};
+use expect_test::expect;
 
-use crate::tests::{check_edit, completion_list};
-
-fn check(ra_fixture: &str, expect: Expect) {
-    let actual = completion_list(ra_fixture);
-    expect.assert_eq(&actual);
-}
+use crate::tests::{check, check_edit};
 
 #[test]
 fn derive_helpers() {
@@ -788,14 +783,9 @@ mod cfg {
 mod derive {
     use super::*;
 
-    fn check_derive(ra_fixture: &str, expect: Expect) {
-        let actual = completion_list(ra_fixture);
-        expect.assert_eq(&actual);
-    }
-
     #[test]
     fn no_completion_for_incorrect_derive() {
-        check_derive(
+        check(
             r#"
 //- minicore: derive, copy, clone, ord, eq, default, fmt
 #[derive{$0)] struct Test;
@@ -806,7 +796,7 @@ mod derive {
 
     #[test]
     fn empty_derive() {
-        check_derive(
+        check(
             r#"
 //- minicore: derive, copy, clone, ord, eq, default, fmt
 #[derive($0)] struct Test;
@@ -828,7 +818,7 @@ mod derive {
 
     #[test]
     fn derive_with_input_before() {
-        check_derive(
+        check(
             r#"
 //- minicore: derive, copy, clone, ord, eq, default, fmt
 #[derive(serde::Serialize, PartialEq, $0)] struct Test;
@@ -849,7 +839,7 @@ mod derive {
 
     #[test]
     fn derive_with_input_after() {
-        check_derive(
+        check(
             r#"
 //- minicore: derive, copy, clone, ord, eq, default, fmt
 #[derive($0 serde::Serialize, PartialEq)] struct Test;
@@ -870,7 +860,7 @@ mod derive {
 
     #[test]
     fn derive_with_existing_derives() {
-        check_derive(
+        check(
             r#"
 //- minicore: derive, copy, clone, ord, eq, default, fmt
 #[derive(PartialEq, Eq, Or$0)] struct Test;
@@ -890,7 +880,7 @@ mod derive {
 
     #[test]
     fn derive_flyimport() {
-        check_derive(
+        check(
             r#"
 //- proc_macros: derive_identity
 //- minicore: derive
@@ -904,7 +894,7 @@ mod derive {
                 kw self::
             "#]],
         );
-        check_derive(
+        check(
             r#"
 //- proc_macros: derive_identity
 //- minicore: derive
@@ -940,7 +930,7 @@ use proc_macros::DeriveIdentity;
 
     #[test]
     fn qualified() {
-        check_derive(
+        check(
             r#"
 //- proc_macros: derive_identity
 //- minicore: derive, copy, clone
@@ -950,7 +940,7 @@ use proc_macros::DeriveIdentity;
                 de DeriveIdentity proc_macro DeriveIdentity
             "#]],
         );
-        check_derive(
+        check(
             r#"
 //- proc_macros: derive_identity
 //- minicore: derive, copy, clone
@@ -1056,19 +1046,14 @@ mod lint {
 mod repr {
     use super::*;
 
-    fn check_repr(ra_fixture: &str, expect: Expect) {
-        let actual = completion_list(ra_fixture);
-        expect.assert_eq(&actual);
-    }
-
     #[test]
     fn no_completion_for_incorrect_repr() {
-        check_repr(r#"#[repr{$0)] struct Test;"#, expect![[]])
+        check(r#"#[repr{$0)] struct Test;"#, expect![[]])
     }
 
     #[test]
     fn empty() {
-        check_repr(
+        check(
             r#"#[repr($0)] struct Test;"#,
             expect![[r#"
                 ba C
@@ -1093,12 +1078,12 @@ mod repr {
 
     #[test]
     fn transparent() {
-        check_repr(r#"#[repr(transparent, $0)] struct Test;"#, expect![[r#""#]]);
+        check(r#"#[repr(transparent, $0)] struct Test;"#, expect![[r#""#]]);
     }
 
     #[test]
     fn align() {
-        check_repr(
+        check(
             r#"#[repr(align(1), $0)] struct Test;"#,
             expect![[r#"
                 ba C
@@ -1121,7 +1106,7 @@ mod repr {
 
     #[test]
     fn packed() {
-        check_repr(
+        check(
             r#"#[repr(packed, $0)] struct Test;"#,
             expect![[r#"
                 ba C
@@ -1144,7 +1129,7 @@ mod repr {
 
     #[test]
     fn c() {
-        check_repr(
+        check(
             r#"#[repr(C, $0)] struct Test;"#,
             expect![[r#"
                 ba align($0)
@@ -1167,7 +1152,7 @@ mod repr {
 
     #[test]
     fn prim() {
-        check_repr(
+        check(
             r#"#[repr(usize, $0)] struct Test;"#,
             expect![[r#"
                 ba C

--- a/crates/ide-completion/src/tests/fn_param.rs
+++ b/crates/ide-completion/src/tests/fn_param.rs
@@ -1,16 +1,6 @@
-use expect_test::{expect, Expect};
+use expect_test::expect;
 
-use crate::tests::{completion_list, completion_list_with_trigger_character};
-
-fn check(ra_fixture: &str, expect: Expect) {
-    let actual = completion_list(ra_fixture);
-    expect.assert_eq(&actual);
-}
-
-fn check_with_trigger_character(ra_fixture: &str, trigger_character: char, expect: Expect) {
-    let actual = completion_list_with_trigger_character(ra_fixture, Some(trigger_character));
-    expect.assert_eq(&actual)
-}
+use crate::tests::{check, check_with_trigger_character};
 
 #[test]
 fn only_param() {
@@ -124,7 +114,7 @@ fn trigger_by_l_paren() {
         r#"
 fn foo($0)
 "#,
-        '(',
+        Some('('),
         expect![[]],
     )
 }

--- a/crates/ide-completion/src/tests/item.rs
+++ b/crates/ide-completion/src/tests/item.rs
@@ -2,20 +2,13 @@
 //!
 //! Except for use items which are tested in [super::use_tree] and mod declarations with are tested
 //! in [crate::completions::mod_].
-use expect_test::{expect, Expect};
+use expect_test::expect;
 
-use crate::tests::{completion_list, BASE_ITEMS_FIXTURE};
-
-use super::check_edit;
-
-fn check(ra_fixture: &str, expect: Expect) {
-    let actual = completion_list(&format!("{BASE_ITEMS_FIXTURE}{ra_fixture}"));
-    expect.assert_eq(&actual)
-}
+use crate::tests::{check_edit, check_with_base_items};
 
 #[test]
 fn target_type_or_trait_in_impl_block() {
-    check(
+    check_with_base_items(
         r#"
 impl Tra$0
 "#,
@@ -37,7 +30,7 @@ impl Tra$0
 
 #[test]
 fn target_type_in_trait_impl_block() {
-    check(
+    check_with_base_items(
         r#"
 impl Trait for Str$0
 "#,
@@ -59,7 +52,7 @@ impl Trait for Str$0
 
 #[test]
 fn after_trait_name_in_trait_def() {
-    check(
+    check_with_base_items(
         r"trait A $0",
         expect![[r#"
             kw where
@@ -69,21 +62,21 @@ fn after_trait_name_in_trait_def() {
 
 #[test]
 fn after_target_name_in_impl() {
-    check(
+    check_with_base_items(
         r"impl Trait $0",
         expect![[r#"
             kw for
             kw where
         "#]],
     );
-    check(
+    check_with_base_items(
         r"impl Trait f$0",
         expect![[r#"
             kw for
             kw where
         "#]],
     );
-    check(
+    check_with_base_items(
         r"impl Trait for Type $0",
         expect![[r#"
             kw where
@@ -93,44 +86,44 @@ fn after_target_name_in_impl() {
 
 #[test]
 fn completes_where() {
-    check(
+    check_with_base_items(
         r"struct Struct $0",
         expect![[r#"
         kw where
     "#]],
     );
-    check(
+    check_with_base_items(
         r"struct Struct $0 {}",
         expect![[r#"
         kw where
     "#]],
     );
     // FIXME: This shouldn't be completed here
-    check(
+    check_with_base_items(
         r"struct Struct $0 ()",
         expect![[r#"
         kw where
     "#]],
     );
-    check(
+    check_with_base_items(
         r"fn func() $0",
         expect![[r#"
         kw where
     "#]],
     );
-    check(
+    check_with_base_items(
         r"enum Enum $0",
         expect![[r#"
         kw where
     "#]],
     );
-    check(
+    check_with_base_items(
         r"enum Enum $0 {}",
         expect![[r#"
         kw where
     "#]],
     );
-    check(
+    check_with_base_items(
         r"trait Trait $0 {}",
         expect![[r#"
         kw where
@@ -140,7 +133,7 @@ fn completes_where() {
 
 #[test]
 fn before_record_field() {
-    check(
+    check_with_base_items(
         r#"
 struct Foo {
     $0
@@ -244,7 +237,7 @@ impl Copy for S where $0
 
 #[test]
 fn test_is_not_considered_macro() {
-    check(
+    check_with_base_items(
         r#"
 #[rustc_builtin]
 pub macro test($item:item) {

--- a/crates/ide-completion/src/tests/item_list.rs
+++ b/crates/ide-completion/src/tests/item_list.rs
@@ -1,16 +1,11 @@
 //! Completion tests for item list position.
-use expect_test::{expect, Expect};
+use expect_test::expect;
 
-use crate::tests::{check_edit, check_empty, completion_list, BASE_ITEMS_FIXTURE};
-
-fn check(ra_fixture: &str, expect: Expect) {
-    let actual = completion_list(&format!("{BASE_ITEMS_FIXTURE}{ra_fixture}"));
-    expect.assert_eq(&actual)
-}
+use crate::tests::{check, check_edit, check_with_base_items};
 
 #[test]
 fn in_mod_item_list() {
-    check(
+    check_with_base_items(
         r#"mod tests { $0 }"#,
         expect![[r#"
             ma makro!(…) macro_rules! makro
@@ -43,7 +38,7 @@ fn in_mod_item_list() {
 
 #[test]
 fn in_source_file_item_list() {
-    check(
+    check_with_base_items(
         r#"$0"#,
         expect![[r#"
             ma makro!(…) macro_rules! makro
@@ -76,7 +71,7 @@ fn in_source_file_item_list() {
 
 #[test]
 fn in_item_list_after_attr() {
-    check(
+    check_with_base_items(
         r#"#[attr] $0"#,
         expect![[r#"
             ma makro!(…) macro_rules! makro
@@ -109,7 +104,7 @@ fn in_item_list_after_attr() {
 
 #[test]
 fn in_qualified_path() {
-    check(
+    check_with_base_items(
         r#"crate::$0"#,
         expect![[r#"
             ma makro!(…) macro_rules! makro
@@ -120,7 +115,7 @@ fn in_qualified_path() {
 
 #[test]
 fn after_unsafe_token() {
-    check(
+    check_with_base_items(
         r#"unsafe $0"#,
         expect![[r#"
             kw async
@@ -134,7 +129,7 @@ fn after_unsafe_token() {
 
 #[test]
 fn after_async_token() {
-    check(
+    check_with_base_items(
         r#"async $0"#,
         expect![[r#"
             kw fn
@@ -145,7 +140,7 @@ fn after_async_token() {
 
 #[test]
 fn after_visibility() {
-    check(
+    check_with_base_items(
         r#"pub $0"#,
         expect![[r#"
             kw async
@@ -167,7 +162,7 @@ fn after_visibility() {
 
 #[test]
 fn after_visibility_unsafe() {
-    check(
+    check_with_base_items(
         r#"pub unsafe $0"#,
         expect![[r#"
             kw async
@@ -179,7 +174,7 @@ fn after_visibility_unsafe() {
 
 #[test]
 fn in_impl_assoc_item_list() {
-    check(
+    check_with_base_items(
         r#"impl Struct { $0 }"#,
         expect![[r#"
             ma makro!(…) macro_rules! makro
@@ -199,7 +194,7 @@ fn in_impl_assoc_item_list() {
 
 #[test]
 fn in_impl_assoc_item_list_after_attr() {
-    check(
+    check_with_base_items(
         r#"impl Struct { #[attr] $0 }"#,
         expect![[r#"
             ma makro!(…) macro_rules! makro
@@ -219,7 +214,7 @@ fn in_impl_assoc_item_list_after_attr() {
 
 #[test]
 fn in_trait_assoc_item_list() {
-    check(
+    check_with_base_items(
         r"trait Foo { $0 }",
         expect![[r#"
             ma makro!(…) macro_rules! makro
@@ -237,7 +232,7 @@ fn in_trait_assoc_item_list() {
 
 #[test]
 fn in_trait_assoc_fn_missing_body() {
-    check(
+    check_with_base_items(
         r#"trait Foo { fn function(); $0 }"#,
         expect![[r#"
             ma makro!(…) macro_rules! makro
@@ -255,7 +250,7 @@ fn in_trait_assoc_fn_missing_body() {
 
 #[test]
 fn in_trait_assoc_const_missing_body() {
-    check(
+    check_with_base_items(
         r#"trait Foo { const CONST: (); $0 }"#,
         expect![[r#"
             ma makro!(…) macro_rules! makro
@@ -273,7 +268,7 @@ fn in_trait_assoc_const_missing_body() {
 
 #[test]
 fn in_trait_assoc_type_aliases_missing_ty() {
-    check(
+    check_with_base_items(
         r#"trait Foo { type Type; $0 }"#,
         expect![[r#"
             ma makro!(…) macro_rules! makro
@@ -291,7 +286,7 @@ fn in_trait_assoc_type_aliases_missing_ty() {
 
 #[test]
 fn in_trait_impl_assoc_item_list() {
-    check(
+    check_with_base_items(
         r#"
 trait Test {
     type Type0;
@@ -326,7 +321,7 @@ impl Test for () {
 
 #[test]
 fn in_trait_impl_no_unstable_item_on_stable() {
-    check_empty(
+    check(
         r#"
 trait Test {
     #[unstable]
@@ -350,7 +345,7 @@ impl Test for () {
 
 #[test]
 fn in_trait_impl_unstable_item_on_nightly() {
-    check_empty(
+    check(
         r#"
 //- toolchain:nightly
 trait Test {
@@ -378,7 +373,7 @@ impl Test for () {
 
 #[test]
 fn after_unit_struct() {
-    check(
+    check_with_base_items(
         r#"struct S; f$0"#,
         expect![[r#"
             ma makro!(…) macro_rules! makro
@@ -500,7 +495,7 @@ type O = $0;
 #[test]
 fn inside_extern_blocks() {
     // Should suggest `fn`, `static`, `unsafe`
-    check(
+    check_with_base_items(
         r#"extern { $0 }"#,
         expect![[r#"
             ma makro!(…) macro_rules! makro
@@ -517,7 +512,7 @@ fn inside_extern_blocks() {
     );
 
     // Should suggest `fn`, `static`, `safe`, `unsafe`
-    check(
+    check_with_base_items(
         r#"unsafe extern { $0 }"#,
         expect![[r#"
             ma makro!(…) macro_rules! makro
@@ -534,7 +529,7 @@ fn inside_extern_blocks() {
         "#]],
     );
 
-    check(
+    check_with_base_items(
         r#"unsafe extern { pub safe $0 }"#,
         expect![[r#"
             kw fn
@@ -542,7 +537,7 @@ fn inside_extern_blocks() {
         "#]],
     );
 
-    check(
+    check_with_base_items(
         r#"unsafe extern { pub unsafe $0 }"#,
         expect![[r#"
             kw fn

--- a/crates/ide-completion/src/tests/pattern.rs
+++ b/crates/ide-completion/src/tests/pattern.rs
@@ -1,16 +1,11 @@
 //! Completion tests for pattern position.
-use expect_test::{expect, Expect};
+use expect_test::expect;
 
-use crate::tests::{check_edit, check_empty, completion_list, BASE_ITEMS_FIXTURE};
-
-fn check(ra_fixture: &str, expect: Expect) {
-    let actual = completion_list(&format!("{BASE_ITEMS_FIXTURE}\n{ra_fixture}"));
-    expect.assert_eq(&actual)
-}
+use crate::tests::{check, check_edit, check_with_base_items};
 
 #[test]
 fn wildcard() {
-    check(
+    check_with_base_items(
         r#"
 fn quux() {
     let _$0
@@ -22,7 +17,7 @@ fn quux() {
 
 #[test]
 fn ident_rebind_pat() {
-    check_empty(
+    check(
         r#"
 fn quux() {
     let en$0 @ x
@@ -37,7 +32,7 @@ fn quux() {
 
 #[test]
 fn ident_ref_pat() {
-    check_empty(
+    check(
         r#"
 fn quux() {
     let ref en$0
@@ -47,7 +42,7 @@ fn quux() {
             kw mut
         "#]],
     );
-    check_empty(
+    check(
         r#"
 fn quux() {
     let ref en$0 @ x
@@ -61,7 +56,7 @@ fn quux() {
 
 #[test]
 fn ident_ref_mut_pat() {
-    check_empty(
+    check(
         r#"
 fn quux() {
     let ref mut en$0
@@ -69,7 +64,7 @@ fn quux() {
 "#,
         expect![[r#""#]],
     );
-    check_empty(
+    check(
         r#"
 fn quux() {
     let ref mut en$0 @ x
@@ -81,7 +76,7 @@ fn quux() {
 
 #[test]
 fn ref_pat() {
-    check_empty(
+    check(
         r#"
 fn quux() {
     let &en$0
@@ -91,7 +86,7 @@ fn quux() {
             kw mut
         "#]],
     );
-    check_empty(
+    check(
         r#"
 fn quux() {
     let &mut en$0
@@ -99,7 +94,7 @@ fn quux() {
 "#,
         expect![[r#""#]],
     );
-    check_empty(
+    check(
         r#"
 fn foo() {
     for &$0 in () {}
@@ -113,7 +108,7 @@ fn foo() {
 
 #[test]
 fn refutable() {
-    check(
+    check_with_base_items(
         r#"
 fn foo() {
     if let a$0
@@ -139,7 +134,7 @@ fn foo() {
 
 #[test]
 fn irrefutable() {
-    check(
+    check_with_base_items(
         r#"
 enum SingleVariantEnum {
     Variant
@@ -168,7 +163,7 @@ fn foo() {
 
 #[test]
 fn in_param() {
-    check(
+    check_with_base_items(
         r#"
 fn foo(a$0) {
 }
@@ -185,7 +180,7 @@ fn foo(a$0) {
             kw ref
         "#]],
     );
-    check(
+    check_with_base_items(
         r#"
 fn foo(a$0: Tuple) {
 }
@@ -207,7 +202,7 @@ fn foo(a$0: Tuple) {
 
 #[test]
 fn only_fn_like_macros() {
-    check_empty(
+    check(
         r#"
 macro_rules! m { ($e:expr) => { $e } }
 
@@ -228,7 +223,7 @@ fn foo() {
 
 #[test]
 fn in_simple_macro_call() {
-    check_empty(
+    check(
         r#"
 macro_rules! m { ($e:expr) => { $e } }
 enum E { X }
@@ -249,7 +244,7 @@ fn foo() {
 
 #[test]
 fn omits_private_fields_pat() {
-    check_empty(
+    check(
         r#"
 mod foo {
     pub struct Record { pub field: i32, _field: i32 }
@@ -277,7 +272,7 @@ fn outer() {
 
 #[test]
 fn completes_self_pats() {
-    check_empty(
+    check(
         r#"
 struct Foo(i32);
 impl Foo {
@@ -301,7 +296,7 @@ impl Foo {
 
 #[test]
 fn enum_qualified() {
-    check(
+    check_with_base_items(
         r#"
 impl Enum {
     type AssocType = ();
@@ -323,7 +318,7 @@ fn func() {
 
 #[test]
 fn completes_in_record_field_pat() {
-    check_empty(
+    check(
         r#"
 struct Foo { bar: Bar }
 struct Bar(u32);
@@ -342,7 +337,7 @@ fn outer(Foo { bar: $0 }: Foo) {}
 
 #[test]
 fn skips_in_record_field_pat_name() {
-    check_empty(
+    check(
         r#"
 struct Foo { bar: Bar }
 struct Bar(u32);
@@ -357,7 +352,7 @@ fn outer(Foo { bar$0 }: Foo) {}
 
 #[test]
 fn completes_in_record_field_pat_with_generic_type_alias() {
-    check_empty(
+    check(
         r#"
 type Wrap<T> = T;
 
@@ -386,7 +381,7 @@ fn main() {
 
 #[test]
 fn completes_in_fn_param() {
-    check_empty(
+    check(
         r#"
 struct Foo { bar: Bar }
 struct Bar(u32);
@@ -405,7 +400,7 @@ fn foo($0) {}
 
 #[test]
 fn completes_in_closure_param() {
-    check_empty(
+    check(
         r#"
 struct Foo { bar: Bar }
 struct Bar(u32);
@@ -426,7 +421,7 @@ fn foo() {
 
 #[test]
 fn completes_no_delims_if_existing() {
-    check_empty(
+    check(
         r#"
 struct Bar(u32);
 fn foo() {
@@ -441,7 +436,7 @@ fn foo() {
             kw self::
         "#]],
     );
-    check_empty(
+    check(
         r#"
 struct Foo { bar: u32 }
 fn foo() {
@@ -456,7 +451,7 @@ fn foo() {
             kw self::
         "#]],
     );
-    check_empty(
+    check(
         r#"
 enum Enum {
     TupleVariant(u32)
@@ -471,7 +466,7 @@ fn foo() {
             bn TupleVariant TupleVariant
         "#]],
     );
-    check_empty(
+    check(
         r#"
 enum Enum {
     RecordVariant { field: u32 }
@@ -519,7 +514,7 @@ fn foo() {
 #[test]
 fn completes_enum_variant_pat_escape() {
     cov_mark::check!(enum_variant_pattern_path);
-    check_empty(
+    check(
         r#"
 enum Enum {
     A,
@@ -544,7 +539,7 @@ fn foo() {
         "#]],
     );
 
-    check_empty(
+    check(
         r#"
 enum Enum {
     A,
@@ -569,7 +564,7 @@ fn foo() {
 
 #[test]
 fn completes_associated_const() {
-    check_empty(
+    check(
         r#"
 #[derive(PartialEq, Eq)]
 struct Ty(u8);
@@ -590,7 +585,7 @@ fn f(t: Ty) {
         "#]],
     );
 
-    check_empty(
+    check(
         r#"
 enum MyEnum {}
 
@@ -612,7 +607,7 @@ fn f(e: MyEnum) {
         "#]],
     );
 
-    check_empty(
+    check(
         r#"
 union U {
     i: i32,
@@ -637,7 +632,7 @@ fn f(u: U) {
         "#]],
     );
 
-    check_empty(
+    check(
         r#"
 #![rustc_coherence_is_core]
 #[lang = "u32"]
@@ -659,7 +654,7 @@ fn f(v: u32) {
 
 #[test]
 fn in_method_param() {
-    check_empty(
+    check(
         r#"
 struct Ty(u8);
 
@@ -680,7 +675,7 @@ impl Ty {
             kw ref
         "#]],
     );
-    check_empty(
+    check(
         r#"
 struct Ty(u8);
 
@@ -701,7 +696,7 @@ impl Ty {
             kw ref
         "#]],
     );
-    check_empty(
+    check(
         r#"
 struct Ty(u8);
 
@@ -722,7 +717,7 @@ impl Ty {
             kw ref
         "#]],
     );
-    check_empty(
+    check(
         r#"
 struct Ty(u8);
 
@@ -743,7 +738,7 @@ impl Ty {
 
 #[test]
 fn through_alias() {
-    check_empty(
+    check(
         r#"
 enum Enum<T> {
     Unit,
@@ -770,7 +765,7 @@ fn f(x: EnumAlias<u8>) {
 
 #[test]
 fn pat_no_unstable_item_on_stable() {
-    check_empty(
+    check(
         r#"
 //- /main.rs crate:main deps:std
 use std::*;
@@ -795,7 +790,7 @@ pub enum Enum {
 
 #[test]
 fn pat_unstable_item_on_nightly() {
-    check_empty(
+    check(
         r#"
 //- toolchain:nightly
 //- /main.rs crate:main deps:std
@@ -908,7 +903,7 @@ fn foo() {
     );
 
     // Do not suggest reserved keywords
-    check_empty(
+    check(
         r#"
 struct Struct;
 
@@ -926,7 +921,7 @@ fn foo() {
 
 #[test]
 fn private_item_in_module_in_function_body() {
-    check_empty(
+    check(
         r#"
 fn main() {
     mod foo {

--- a/crates/ide-completion/src/tests/predicate.rs
+++ b/crates/ide-completion/src/tests/predicate.rs
@@ -1,17 +1,12 @@
 //! Completion tests for predicates and bounds.
-use expect_test::{expect, Expect};
+use expect_test::expect;
 
-use crate::tests::{check_empty, completion_list, BASE_ITEMS_FIXTURE};
-
-fn check(ra_fixture: &str, expect: Expect) {
-    let actual = completion_list(&format!("{BASE_ITEMS_FIXTURE}\n{ra_fixture}"));
-    expect.assert_eq(&actual)
-}
+use crate::tests::{check, check_with_base_items};
 
 #[test]
 fn predicate_start() {
     // FIXME: `for` kw
-    check(
+    check_with_base_items(
         r#"
 struct Foo<'lt, T, const C: usize> where $0 {}
 "#,
@@ -34,7 +29,7 @@ struct Foo<'lt, T, const C: usize> where $0 {}
 
 #[test]
 fn bound_for_type_pred() {
-    check(
+    check_with_base_items(
         r#"
 struct Foo<'lt, T, const C: usize> where T: $0 {}
 "#,
@@ -52,7 +47,7 @@ struct Foo<'lt, T, const C: usize> where T: $0 {}
 fn bound_for_lifetime_pred() {
     // FIXME: should only show lifetimes here, that is we shouldn't get any completions here when not typing
     // a `'`
-    check(
+    check_with_base_items(
         r#"
 struct Foo<'lt, T, const C: usize> where 'lt: $0 {}
 "#,
@@ -68,7 +63,7 @@ struct Foo<'lt, T, const C: usize> where 'lt: $0 {}
 
 #[test]
 fn bound_for_for_pred() {
-    check(
+    check_with_base_items(
         r#"
 struct Foo<'lt, T, const C: usize> where for<'a> T: $0 {}
 "#,
@@ -84,7 +79,7 @@ struct Foo<'lt, T, const C: usize> where for<'a> T: $0 {}
 
 #[test]
 fn param_list_for_for_pred() {
-    check(
+    check_with_base_items(
         r#"
 struct Foo<'lt, T, const C: usize> where for<'a> $0 {}
 "#,
@@ -107,7 +102,7 @@ struct Foo<'lt, T, const C: usize> where for<'a> $0 {}
 
 #[test]
 fn pred_on_fn_in_impl() {
-    check(
+    check_with_base_items(
         r#"
 impl Record {
     fn method(self) where $0 {}
@@ -132,7 +127,7 @@ impl Record {
 
 #[test]
 fn pred_no_unstable_item_on_stable() {
-    check_empty(
+    check(
         r#"
 //- /main.rs crate:main deps:std
 use std::*;
@@ -151,7 +146,7 @@ pub trait Trait {}
 
 #[test]
 fn pred_unstable_item_on_nightly() {
-    check_empty(
+    check(
         r#"
 //- toolchain:nightly
 //- /main.rs crate:main deps:std

--- a/crates/ide-completion/src/tests/proc_macros.rs
+++ b/crates/ide-completion/src/tests/proc_macros.rs
@@ -1,12 +1,7 @@
 //! Completion tests for expressions.
-use expect_test::{expect, Expect};
+use expect_test::expect;
 
-use crate::tests::completion_list;
-
-fn check(ra_fixture: &str, expect: Expect) {
-    let actual = completion_list(ra_fixture);
-    expect.assert_eq(&actual)
-}
+use crate::tests::check;
 
 #[test]
 fn complete_dot_in_attr() {

--- a/crates/ide-completion/src/tests/record.rs
+++ b/crates/ide-completion/src/tests/record.rs
@@ -1,13 +1,8 @@
-use expect_test::{expect, Expect};
+use expect_test::expect;
 
-use crate::tests::completion_list;
+use crate::tests::check;
 
 use super::check_edit;
-
-fn check(ra_fixture: &str, expect: Expect) {
-    let actual = completion_list(ra_fixture);
-    expect.assert_eq(&actual);
-}
 
 #[test]
 fn without_default_impl() {

--- a/crates/ide-completion/src/tests/special.rs
+++ b/crates/ide-completion/src/tests/special.rs
@@ -5,31 +5,11 @@ use ide_db::SymbolKind;
 
 use crate::{
     tests::{
-        check_edit, completion_list, completion_list_no_kw, completion_list_with_trigger_character,
+        check, check_edit, check_no_kw, check_with_trigger_character, do_completion_with_config,
+        TEST_CONFIG,
     },
     CompletionItemKind,
 };
-
-use super::{do_completion_with_config, TEST_CONFIG};
-
-fn check_no_kw(ra_fixture: &str, expect: Expect) {
-    let actual = completion_list_no_kw(ra_fixture);
-    expect.assert_eq(&actual)
-}
-
-fn check(ra_fixture: &str, expect: Expect) {
-    let actual = completion_list(ra_fixture);
-    expect.assert_eq(&actual)
-}
-
-pub(crate) fn check_with_trigger_character(
-    ra_fixture: &str,
-    trigger_character: Option<char>,
-    expect: Expect,
-) {
-    let actual = completion_list_with_trigger_character(ra_fixture, trigger_character);
-    expect.assert_eq(&actual)
-}
 
 #[test]
 fn completes_if_prefix_is_keyword() {

--- a/crates/ide-completion/src/tests/type_pos.rs
+++ b/crates/ide-completion/src/tests/type_pos.rs
@@ -1,16 +1,11 @@
 //! Completion tests for type position.
-use expect_test::{expect, Expect};
+use expect_test::expect;
 
-use crate::tests::{check_empty, completion_list, BASE_ITEMS_FIXTURE};
-
-fn check(ra_fixture: &str, expect: Expect) {
-    let actual = completion_list(&format!("{BASE_ITEMS_FIXTURE}\n{ra_fixture}"));
-    expect.assert_eq(&actual)
-}
+use crate::tests::{check, check_with_base_items};
 
 #[test]
 fn record_field_ty() {
-    check(
+    check_with_base_items(
         r#"
 struct Foo<'lt, T, const C: usize> {
     f: $0
@@ -37,7 +32,7 @@ struct Foo<'lt, T, const C: usize> {
 
 #[test]
 fn tuple_struct_field() {
-    check(
+    check_with_base_items(
         r#"
 struct Foo<'lt, T, const C: usize>(f$0);
 "#,
@@ -65,7 +60,7 @@ struct Foo<'lt, T, const C: usize>(f$0);
 
 #[test]
 fn fn_return_type() {
-    check(
+    check_with_base_items(
         r#"
 fn x<'lt, T, const C: usize>() -> $0
 "#,
@@ -88,7 +83,7 @@ fn x<'lt, T, const C: usize>() -> $0
 
 #[test]
 fn fn_return_type_no_local_items() {
-    check(
+    check_with_base_items(
         r#"
 fn foo() -> B$0 {
     struct Bar;
@@ -118,7 +113,7 @@ fn foo() -> B$0 {
 
 #[test]
 fn inferred_type_const() {
-    check(
+    check_with_base_items(
         r#"
 struct Foo<T>(T);
 const FOO: $0 = Foo(2);
@@ -143,7 +138,7 @@ const FOO: $0 = Foo(2);
 
 #[test]
 fn inferred_type_closure_param() {
-    check(
+    check_with_base_items(
         r#"
 fn f1(f: fn(i32) -> i32) {}
 fn f2() {
@@ -169,7 +164,7 @@ fn f2() {
 
 #[test]
 fn inferred_type_closure_return() {
-    check(
+    check_with_base_items(
         r#"
 fn f1(f: fn(u64) -> u64) {}
 fn f2() {
@@ -197,7 +192,7 @@ fn f2() {
 
 #[test]
 fn inferred_type_fn_return() {
-    check(
+    check_with_base_items(
         r#"
 fn f2(x: u64) -> $0 {
     x + 5
@@ -222,7 +217,7 @@ fn f2(x: u64) -> $0 {
 
 #[test]
 fn inferred_type_fn_param() {
-    check(
+    check_with_base_items(
         r#"
 fn f1(x: i32) {}
 fn f2(x: $0) {
@@ -248,7 +243,7 @@ fn f2(x: $0) {
 
 #[test]
 fn inferred_type_not_in_the_scope() {
-    check(
+    check_with_base_items(
         r#"
 mod a {
     pub struct Foo<T>(T);
@@ -282,7 +277,7 @@ fn foo<'lt, T, const C: usize>() {
 
 #[test]
 fn inferred_type_let() {
-    check(
+    check_with_base_items(
         r#"
 struct Foo<T>(T);
 fn foo<'lt, T, const C: usize>() {
@@ -311,7 +306,7 @@ fn foo<'lt, T, const C: usize>() {
 
 #[test]
 fn body_type_pos() {
-    check(
+    check_with_base_items(
         r#"
 fn foo<'lt, T, const C: usize>() {
     let local = ();
@@ -333,7 +328,7 @@ fn foo<'lt, T, const C: usize>() {
             kw self::
         "#]],
     );
-    check(
+    check_with_base_items(
         r#"
 fn foo<'lt, T, const C: usize>() {
     let local = ();
@@ -356,7 +351,7 @@ fn foo<'lt, T, const C: usize>() {
 #[test]
 fn completes_types_and_const_in_arg_list() {
     cov_mark::check!(complete_assoc_type_in_generics_list);
-    check(
+    check_with_base_items(
         r#"
 trait Trait1 {
     type Super;
@@ -372,7 +367,7 @@ fn foo<'lt, T: Trait2<$0>, const CONST_PARAM: usize>(_: T) {}
             ta Super =  (as Trait1) type Super
         "#]],
     );
-    check(
+    check_with_base_items(
         r#"
 trait Trait1 {
     type Super;
@@ -400,7 +395,7 @@ fn foo<'lt, T: Trait2<$0>, const CONST_PARAM: usize>(_: T) {}
             kw self::
         "#]],
     );
-    check(
+    check_with_base_items(
         r#"
 trait Trait2<T> {
     type Foo;
@@ -424,7 +419,7 @@ fn foo<'lt, T: Trait2<self::$0>, const CONST_PARAM: usize>(_: T) {}
 
 #[test]
 fn no_assoc_completion_outside_type_bounds() {
-    check(
+    check_with_base_items(
         r#"
 struct S;
 trait Tr<T> {
@@ -454,7 +449,7 @@ impl Tr<$0
 
 #[test]
 fn enum_qualified() {
-    check(
+    check_with_base_items(
         r#"
 impl Enum {
     type AssocType = ();
@@ -471,7 +466,7 @@ fn func(_: Enum::$0) {}
 
 #[test]
 fn completes_type_parameter_or_associated_type() {
-    check(
+    check_with_base_items(
         r#"
 trait MyTrait<T, U> {
     type Item1;
@@ -496,7 +491,7 @@ fn f(t: impl MyTrait<u$0
         "#]],
     );
 
-    check(
+    check_with_base_items(
         r#"
 trait MyTrait<T, U> {
     type Item1;
@@ -521,7 +516,7 @@ fn f(t: impl MyTrait<u8, u$0
         "#]],
     );
 
-    check(
+    check_with_base_items(
         r#"
 trait MyTrait<T, U> {
     type Item1;
@@ -539,7 +534,7 @@ fn f(t: impl MyTrait<u8, u8, I$0
 
 #[test]
 fn completes_type_parameter_or_associated_type_with_default_value() {
-    check(
+    check_with_base_items(
         r#"
 trait MyTrait<T, U = u8> {
     type Item1;
@@ -564,7 +559,7 @@ fn f(t: impl MyTrait<u$0
         "#]],
     );
 
-    check(
+    check_with_base_items(
         r#"
 trait MyTrait<T, U = u8> {
     type Item1;
@@ -591,7 +586,7 @@ fn f(t: impl MyTrait<u8, u$0
         "#]],
     );
 
-    check(
+    check_with_base_items(
         r#"
 trait MyTrait<T, U = u8> {
     type Item1;
@@ -609,7 +604,7 @@ fn f(t: impl MyTrait<u8, u8, I$0
 
 #[test]
 fn completes_types_after_associated_type() {
-    check(
+    check_with_base_items(
         r#"
 trait MyTrait {
     type Item1;
@@ -634,7 +629,7 @@ fn f(t: impl MyTrait<Item1 = $0
         "#]],
     );
 
-    check(
+    check_with_base_items(
         r#"
 trait MyTrait {
     type Item1;
@@ -659,7 +654,7 @@ fn f(t: impl MyTrait<Item1 = u8, Item2 = $0
         "#]],
     );
 
-    check(
+    check_with_base_items(
         r#"
 trait MyTrait {
     const C: usize;
@@ -678,7 +673,7 @@ fn f(t: impl MyTrait<C = $0
 
 #[test]
 fn type_pos_no_unstable_type_on_stable() {
-    check_empty(
+    check(
         r#"
 //- /main.rs crate:main deps:std
 use std::*;
@@ -702,7 +697,7 @@ pub struct S;
 
 #[test]
 fn type_pos_unstable_type_on_nightly() {
-    check_empty(
+    check(
         r#"
 //- toolchain:nightly
 //- /main.rs crate:main deps:std
@@ -729,7 +724,7 @@ pub struct S;
 #[test]
 fn completes_const_and_type_generics_separately() {
     // Function generic params
-    check(
+    check_with_base_items(
         r#"
     struct Foo;
     const X: usize = 0;
@@ -756,7 +751,7 @@ fn completes_const_and_type_generics_separately() {
     // FIXME: This should probably also suggest completions for types, at least those that have
     // associated constants usable in this position. For example, a user could be typing
     // `foo::<_, { usize::MAX }>()`, but we currently don't suggest `usize` in constant position.
-    check(
+    check_with_base_items(
         r#"
     struct Foo;
     const X: usize = 0;
@@ -775,7 +770,7 @@ fn completes_const_and_type_generics_separately() {
     );
 
     // Method generic params
-    check(
+    check_with_base_items(
         r#"
     const X: usize = 0;
     struct Foo;
@@ -799,7 +794,7 @@ fn completes_const_and_type_generics_separately() {
             kw self::
         "#]],
     );
-    check(
+    check_with_base_items(
         r#"
     const X: usize = 0;
     struct Foo;
@@ -818,7 +813,7 @@ fn completes_const_and_type_generics_separately() {
     );
 
     // Associated type generic params
-    check(
+    check_with_base_items(
         r#"
     const X: usize = 0;
     struct Foo;
@@ -843,7 +838,7 @@ fn completes_const_and_type_generics_separately() {
             kw self::
         "#]],
     );
-    check(
+    check_with_base_items(
         r#"
     const X: usize = 0;
     struct Foo;
@@ -862,7 +857,7 @@ fn completes_const_and_type_generics_separately() {
     );
 
     // Type generic params
-    check(
+    check_with_base_items(
         r#"
     const X: usize = 0;
     struct Foo<T, const N: usize>(T);
@@ -880,7 +875,7 @@ fn completes_const_and_type_generics_separately() {
     );
 
     // Type alias generic params
-    check(
+    check_with_base_items(
         r#"
     const X: usize = 0;
     struct Foo<T, const N: usize>(T);
@@ -899,7 +894,7 @@ fn completes_const_and_type_generics_separately() {
     );
 
     // Enum variant params
-    check(
+    check_with_base_items(
         r#"
     const X: usize = 0;
     enum Foo<T, const N: usize> { A(T), B }
@@ -917,7 +912,7 @@ fn completes_const_and_type_generics_separately() {
     );
 
     // Trait params
-    check(
+    check_with_base_items(
         r#"
     const X: usize = 0;
     trait Foo<T, const N: usize> {}
@@ -933,7 +928,7 @@ fn completes_const_and_type_generics_separately() {
     );
 
     // Trait alias params
-    check(
+    check_with_base_items(
         r#"
     #![feature(trait_alias)]
     const X: usize = 0;
@@ -951,7 +946,7 @@ fn completes_const_and_type_generics_separately() {
     );
 
     // Omitted lifetime params
-    check(
+    check_with_base_items(
         r#"
 struct S<'a, 'b, const C: usize, T>(core::marker::PhantomData<&'a &'b T>);
 fn foo<'a>() { S::<F$0, _>; }
@@ -964,7 +959,7 @@ fn foo<'a>() { S::<F$0, _>; }
         "#]],
     );
     // Explicit lifetime params
-    check(
+    check_with_base_items(
         r#"
 struct S<'a, 'b, const C: usize, T>(core::marker::PhantomData<&'a &'b T>);
 fn foo<'a>() { S::<'static, 'static, F$0, _>; }
@@ -976,7 +971,7 @@ fn foo<'a>() { S::<'static, 'static, F$0, _>; }
             kw self::
         "#]],
     );
-    check(
+    check_with_base_items(
         r#"
 struct S<'a, 'b, const C: usize, T>(core::marker::PhantomData<&'a &'b T>);
 fn foo<'a>() { S::<'static, F$0, _, _>; }
@@ -992,7 +987,7 @@ fn foo<'a>() { S::<'static, F$0, _, _>; }
 
 #[test]
 fn complete_traits_on_impl_trait_block() {
-    check(
+    check_with_base_items(
         r#"
 trait Foo {}
 
@@ -1012,7 +1007,7 @@ impl $0 for Bar { }
 
 #[test]
 fn complete_traits_with_path_on_impl_trait_block() {
-    check(
+    check_with_base_items(
         r#"
 mod outer {
     pub trait Foo {}

--- a/crates/ide-completion/src/tests/use_tree.rs
+++ b/crates/ide-completion/src/tests/use_tree.rs
@@ -1,12 +1,7 @@
 //! Completion tests for use trees.
-use expect_test::{expect, Expect};
+use expect_test::expect;
 
-use crate::tests::completion_list;
-
-fn check(ra_fixture: &str, expect: Expect) {
-    let actual = completion_list(ra_fixture);
-    expect.assert_eq(&actual)
-}
+use crate::tests::check;
 
 #[test]
 fn use_tree_completion() {

--- a/crates/ide-completion/src/tests/visibility.rs
+++ b/crates/ide-completion/src/tests/visibility.rs
@@ -1,17 +1,7 @@
 //! Completion tests for visibility modifiers.
-use expect_test::{expect, Expect};
+use expect_test::expect;
 
-use crate::tests::{completion_list, completion_list_with_trigger_character};
-
-fn check(ra_fixture: &str, expect: Expect) {
-    let actual = completion_list(ra_fixture);
-    expect.assert_eq(&actual)
-}
-
-fn check_with_trigger_character(ra_fixture: &str, trigger_character: char, expect: Expect) {
-    let actual = completion_list_with_trigger_character(ra_fixture, Some(trigger_character));
-    expect.assert_eq(&actual)
-}
+use crate::tests::{check, check_with_trigger_character};
 
 #[test]
 fn empty_pub() {
@@ -20,7 +10,7 @@ fn empty_pub() {
         r#"
 pub($0)
 "#,
-        '(',
+        Some('('),
         expect![[r#"
             kw crate
             kw in


### PR DESCRIPTION
This PR moves common helper functions within the test files of the ide-completions crate to `tests.rs`.