### PR TITLE
fix: Make test_runner::TestState::stdout optional to fix parsing cargo test json output

### DIFF
--- a/crates/rust-analyzer/src/test_runner.rs
+++ b/crates/rust-analyzer/src/test_runner.rs
@@ -18,7 +18,11 @@ pub(crate) enum TestState {
     Started,
     Ok,
     Ignored,
-    Failed { stdout: String },
+    Failed {
+        // the stdout field is not always present depending on cargo test flags
+        #[serde(skip_serializing_if = "String::is_empty", default)]
+        stdout: String,
+    },
 }
 
 #[derive(Debug, Deserialize)]


### PR DESCRIPTION
For issue #18896 - `cargo test` json output does not include a `stdout` field if given the `--nocapture` flag.

RA only records the stdout for failed tests. It would be possible to move the `stdout` field to `CargoTestMessage` so that the user can inspect the stdout of passing tests too.