### PR TITLE
fix: Do not compute `prettify_macro_expansion()` unless the "Inline macro" assist has actually been invoked

### DIFF
--- a/crates/ide-assists/src/handlers/inline_macro.rs
+++ b/crates/ide-assists/src/handlers/inline_macro.rs
@@ -40,19 +40,19 @@ pub(crate) fn inline_macro(acc: &mut Assists, ctx: &AssistContext<'_>) -> Option
     let macro_call = ctx.sema.to_def(&unexpanded)?;
     let expanded = ctx.sema.parse_or_expand(macro_call.as_file());
     let span_map = ctx.sema.db.expansion_span_map(macro_call.as_macro_file());
-    let expanded = prettify_macro_expansion(
-        ctx.db(),
-        expanded,
-        &span_map,
-        ctx.sema.file_to_module_def(ctx.file_id())?.krate().into(),
-    );
+    let target_crate_id = ctx.sema.file_to_module_def(ctx.file_id())?.krate().into();
     let text_range = unexpanded.syntax().text_range();
 
     acc.add(
         AssistId("inline_macro", AssistKind::RefactorInline),
         "Inline macro".to_owned(),
         text_range,
-        |builder| builder.replace(text_range, expanded.to_string()),
+        |builder| {
+            // Don't call `prettify_macro_expansion()` outside the actual assist action; it does some heavy rowan tree manipulation,
+            // which can be very costly for big macros when it is done *even without the assist being invoked*.
+            let expanded = prettify_macro_expansion(ctx.db(), expanded, &span_map, target_crate_id);
+            builder.replace(text_range, expanded.to_string())
+        },
     )
 }
 


### PR DESCRIPTION
And not just called to be listed.

This was a major performance hang when repeatedly switching back-and-forth between a large `include!`d file, aka. #18879 (but there are others). This does not fix this issue because, well, it was a major hurdle hiding everything else in the profiler, but now that it's fixed other things show up (and it's still slow).

To categorize the main reasons remained, as analyzed by my profiler:

We have a lot of diagnostics, influenced mainly by two salsa queries, `body_with_source_map()` and `borrowck()`. These two are lru'ed so they of course evict with such large files with lots of small bodies. If I didn't let the file to analyze well before starting my back-and-forth, we also have a lot of calls to `infer()`, half of them are blocking on the other. This is also expected since we cancel them when we switch out of the file, so they never complete and cached, only consume CPU.

There is an important observation here, though: diagnostics are called twice. Once for assists and the other for, well, diagnostics. Since some diagnostics are not fully cached in the db this may cause actual slowdown for real users. We probably want to fix this, perhaps by measure of caching the diagnostics of the last file.

There is also a fair share of semantic highlighting, which is also fair, given that a lot of its work doesn't (and couldn't) be cached in the db. Another large part is assist, that tend to execute a lot of code when listing them, for deciding whether they are available or not. Perhaps we could improve on this metric too.

Overall, I'm tending to close (oh no GitHub, don't close it!) #18879 as "won't fix" given this is a very atypical scenario. But perhaps there are still a few points we can improve in, guided by the information from this issue.