### PR TITLE
Fix: Detect missing errors for } braces before else in let...else statements

### DIFF
--- a/crates/parser/src/event.rs
+++ b/crates/parser/src/event.rs
@@ -12,7 +12,7 @@ use crate::{
 /// `Parser` produces a flat list of `Event`s.
 /// They are converted to a tree-structure in
 /// a separate pass, via `TreeBuilder`.
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub(crate) enum Event {
     /// This event signifies the start of the node.
     /// It should be either abandoned (in which case the

--- a/crates/parser/src/grammar.rs
+++ b/crates/parser/src/grammar.rs
@@ -204,8 +204,9 @@ impl BlockLike {
         self == BlockLike::Block
     }
 
-    fn is_blocklike(kind: SyntaxKind) -> bool {
-        matches!(kind, BLOCK_EXPR | IF_EXPR | WHILE_EXPR | FOR_EXPR | LOOP_EXPR | MATCH_EXPR)
+    fn is_blocklike(expr: &CompletedMarker, p: &Parser<'_>) -> bool {
+        matches!(expr.kind(), BLOCK_EXPR | IF_EXPR | WHILE_EXPR | FOR_EXPR | LOOP_EXPR | MATCH_EXPR)
+            || (expr.last_token(p) == Some(T!['}']) && !matches!(expr.kind(), CLOSURE_EXPR))
     }
 }
 

--- a/crates/parser/src/grammar.rs
+++ b/crates/parser/src/grammar.rs
@@ -204,9 +204,8 @@ impl BlockLike {
         self == BlockLike::Block
     }
 
-    fn is_blocklike(expr: &CompletedMarker, p: &Parser<'_>) -> bool {
-        matches!(expr.kind(), BLOCK_EXPR | IF_EXPR | WHILE_EXPR | FOR_EXPR | LOOP_EXPR | MATCH_EXPR)
-            || (expr.last_token(p) == Some(T!['}']) && !matches!(expr.kind(), CLOSURE_EXPR))
+    fn is_blocklike(kind: SyntaxKind) -> bool {
+        matches!(kind, BLOCK_EXPR | IF_EXPR | WHILE_EXPR | FOR_EXPR | LOOP_EXPR | MATCH_EXPR)
     }
 }
 

--- a/crates/parser/src/grammar/expressions.rs
+++ b/crates/parser/src/grammar/expressions.rs
@@ -134,10 +134,12 @@ pub(super) fn let_stmt(p: &mut Parser<'_>, with_semi: Semicolon) {
         // test_err let_else_right_curly_brace
         // fn func() { let Some(_) = {Some(1)} else { panic!("h") };}
         if let Some(expr) = expr_after_eq {
-            if BlockLike::is_blocklike(&expr, p) {
-                p.error(
-                    "right curly brace `}` before `else` in a `let...else` statement not allowed",
-                )
+            if let Some(token) = expr.last_token(p) {
+                if token == T!['}'] {
+                    p.error(
+                        "right curly brace `}` before `else` in a `let...else` statement not allowed"
+                    )
+                }
             }
         }
 

--- a/crates/parser/src/grammar/expressions.rs
+++ b/crates/parser/src/grammar/expressions.rs
@@ -134,10 +134,12 @@ pub(super) fn let_stmt(p: &mut Parser<'_>, with_semi: Semicolon) {
         // test_err let_else_right_curly_brace
         // fn func() { let Some(_) = {Some(1)} else { panic!("h") };}
         if let Some(expr) = expr_after_eq {
-            if BlockLike::is_blocklike(expr.kind()) {
-                p.error(
-                    "right curly brace `}` before `else` in a `let...else` statement not allowed",
-                )
+            if let Some(token) = expr.last_token(p) {
+                if token == T!['}'] {
+                    p.error(
+                        "right curly brace `}` before `else` in a `let...else` statement not allowed"
+                    )
+                }
             }
         }
 

--- a/crates/parser/src/grammar/expressions.rs
+++ b/crates/parser/src/grammar/expressions.rs
@@ -134,12 +134,10 @@ pub(super) fn let_stmt(p: &mut Parser<'_>, with_semi: Semicolon) {
         // test_err let_else_right_curly_brace
         // fn func() { let Some(_) = {Some(1)} else { panic!("h") };}
         if let Some(expr) = expr_after_eq {
-            if let Some(token) = expr.last_token(p) {
-                if token == T!['}'] {
-                    p.error(
-                        "right curly brace `}` before `else` in a `let...else` statement not allowed"
-                    )
-                }
+            if BlockLike::is_blocklike(&expr, p) {
+                p.error(
+                    "right curly brace `}` before `else` in a `let...else` statement not allowed",
+                )
             }
         }
 

--- a/crates/parser/src/grammar/expressions/atom.rs
+++ b/crates/parser/src/grammar/expressions/atom.rs
@@ -198,7 +198,7 @@ pub(super) fn atom_expr(
         }
     };
     let blocklike =
-        if BlockLike::is_blocklike(&done, p) { BlockLike::Block } else { BlockLike::NotBlock };
+        if BlockLike::is_blocklike(done.kind()) { BlockLike::Block } else { BlockLike::NotBlock };
     Some((done, blocklike))
 }
 

--- a/crates/parser/src/grammar/expressions/atom.rs
+++ b/crates/parser/src/grammar/expressions/atom.rs
@@ -198,7 +198,7 @@ pub(super) fn atom_expr(
         }
     };
     let blocklike =
-        if BlockLike::is_blocklike(done.kind()) { BlockLike::Block } else { BlockLike::NotBlock };
+        if BlockLike::is_blocklike(&done, p) { BlockLike::Block } else { BlockLike::NotBlock };
     Some((done, blocklike))
 }
 

--- a/crates/parser/src/parser.rs
+++ b/crates/parser/src/parser.rs
@@ -391,9 +391,7 @@ impl CompletedMarker {
 
     pub(crate) fn last_token(&self, p: &Parser<'_>) -> Option<SyntaxKind> {
         let end_pos = self.end_pos as usize;
-        if end_pos > p.events.len() {
-            return None;
-        }
+        debug_assert_eq!(p.events[end_pos - 1], Event::Finish);
         p.events[..end_pos].iter().rev().find_map(|event| match event {
             Event::Token { kind, .. } => Some(*kind),
             _ => None,

--- a/crates/parser/src/parser.rs
+++ b/crates/parser/src/parser.rs
@@ -318,7 +318,8 @@ impl Marker {
             _ => unreachable!(),
         }
         p.push_event(Event::Finish);
-        CompletedMarker::new(self.pos, kind)
+        let end_pos = p.events.len() as u32;
+        CompletedMarker::new(self.pos, end_pos, kind)
     }
 
     /// Abandons the syntax tree node. All its children
@@ -336,13 +337,14 @@ impl Marker {
 }
 
 pub(crate) struct CompletedMarker {
-    pos: u32,
+    start_pos: u32,
+    end_pos: u32,
     kind: SyntaxKind,
 }
 
 impl CompletedMarker {
-    fn new(pos: u32, kind: SyntaxKind) -> Self {
-        CompletedMarker { pos, kind }
+    fn new(start_pos: u32, end_pos: u32, kind: SyntaxKind) -> Self {
+        CompletedMarker { start_pos, end_pos, kind }
     }
 
     /// This method allows to create a new node which starts
@@ -360,10 +362,10 @@ impl CompletedMarker {
     /// distance to `NEWSTART` into forward_parent(=2 in this case);
     pub(crate) fn precede(self, p: &mut Parser<'_>) -> Marker {
         let new_pos = p.start();
-        let idx = self.pos as usize;
+        let idx = self.start_pos as usize;
         match &mut p.events[idx] {
             Event::Start { forward_parent, .. } => {
-                *forward_parent = Some(new_pos.pos - self.pos);
+                *forward_parent = Some(new_pos.pos - self.start_pos);
             }
             _ => unreachable!(),
         }
@@ -376,7 +378,7 @@ impl CompletedMarker {
         let idx = m.pos as usize;
         match &mut p.events[idx] {
             Event::Start { forward_parent, .. } => {
-                *forward_parent = Some(self.pos - m.pos);
+                *forward_parent = Some(self.start_pos - m.pos);
             }
             _ => unreachable!(),
         }
@@ -385,5 +387,16 @@ impl CompletedMarker {
 
     pub(crate) fn kind(&self) -> SyntaxKind {
         self.kind
+    }
+
+    pub(crate) fn last_token(&self, p: &Parser<'_>) -> Option<SyntaxKind> {
+        let end_pos = self.end_pos as usize;
+        if end_pos > p.events.len() {
+            return None;
+        }
+        p.events[..end_pos].iter().rev().find_map(|event| match event {
+            Event::Token { kind, .. } => Some(*kind),
+            _ => None,
+        })
     }
 }

--- a/crates/parser/test_data/parser/err/0056_let_else_right_curly_brace_struct.rast
+++ b/crates/parser/test_data/parser/err/0056_let_else_right_curly_brace_struct.rast
@@ -1,0 +1,66 @@
+SOURCE_FILE
+  STRUCT
+    STRUCT_KW "struct"
+    WHITESPACE " "
+    NAME
+      IDENT "X"
+    WHITESPACE " "
+    RECORD_FIELD_LIST
+      L_CURLY "{"
+      RECORD_FIELD
+        NAME
+          IDENT "a"
+        COLON ":"
+        WHITESPACE " "
+        PATH_TYPE
+          PATH
+            PATH_SEGMENT
+              NAME_REF
+                IDENT "i32"
+      R_CURLY "}"
+  WHITESPACE "\r\n"
+  ERROR
+    LET_KW "let"
+    WHITESPACE " "
+    IDENT_PAT
+      NAME
+        IDENT "foo"
+    WHITESPACE " "
+    EQ "="
+    WHITESPACE " "
+    RECORD_EXPR
+      PATH
+        PATH_SEGMENT
+          NAME_REF
+            IDENT "X"
+      WHITESPACE " "
+      RECORD_EXPR_FIELD_LIST
+        L_CURLY "{"
+        WHITESPACE "\r\n    "
+        RECORD_EXPR_FIELD
+          NAME_REF
+            IDENT "a"
+          COLON ":"
+          WHITESPACE " "
+          LITERAL
+            INT_NUMBER "1"
+        WHITESPACE "\r\n"
+        R_CURLY "}"
+    WHITESPACE " "
+    LET_ELSE
+      ELSE_KW "else"
+      WHITESPACE " "
+      BLOCK_EXPR
+        STMT_LIST
+          L_CURLY "{"
+          WHITESPACE "\r\n    "
+          EXPR_STMT
+            RETURN_EXPR
+              RETURN_KW "return"
+            SEMICOLON ";"
+          WHITESPACE "\r\n"
+          R_CURLY "}"
+    SEMICOLON ";"
+  WHITESPACE "\r\n"
+error 19: expected an item
+error 45: right curly brace `}` before `else` in a `let...else` statement not allowed

--- a/crates/parser/test_data/parser/err/0056_let_else_right_curly_brace_struct.rast
+++ b/crates/parser/test_data/parser/err/0056_let_else_right_curly_brace_struct.rast
@@ -18,49 +18,62 @@ SOURCE_FILE
               NAME_REF
                 IDENT "i32"
       R_CURLY "}"
-  WHITESPACE "\r\n"
-  ERROR
-    LET_KW "let"
+  WHITESPACE "\n"
+  FN
+    FN_KW "fn"
     WHITESPACE " "
-    IDENT_PAT
-      NAME
-        IDENT "foo"
+    NAME
+      IDENT "f"
+    PARAM_LIST
+      L_PAREN "("
+      R_PAREN ")"
     WHITESPACE " "
-    EQ "="
-    WHITESPACE " "
-    RECORD_EXPR
-      PATH
-        PATH_SEGMENT
-          NAME_REF
-            IDENT "X"
-      WHITESPACE " "
-      RECORD_EXPR_FIELD_LIST
+    BLOCK_EXPR
+      STMT_LIST
         L_CURLY "{"
-        WHITESPACE "\r\n    "
-        RECORD_EXPR_FIELD
-          NAME_REF
-            IDENT "a"
-          COLON ":"
+        WHITESPACE "\n    "
+        LET_STMT
+          LET_KW "let"
           WHITESPACE " "
-          LITERAL
-            INT_NUMBER "1"
-        WHITESPACE "\r\n"
+          IDENT_PAT
+            NAME
+              IDENT "foo"
+          WHITESPACE " "
+          EQ "="
+          WHITESPACE " "
+          RECORD_EXPR
+            PATH
+              PATH_SEGMENT
+                NAME_REF
+                  IDENT "X"
+            WHITESPACE " "
+            RECORD_EXPR_FIELD_LIST
+              L_CURLY "{"
+              WHITESPACE "\n        "
+              RECORD_EXPR_FIELD
+                NAME_REF
+                  IDENT "a"
+                COLON ":"
+                WHITESPACE " "
+                LITERAL
+                  INT_NUMBER "1"
+              WHITESPACE "\n    "
+              R_CURLY "}"
+          WHITESPACE " "
+          LET_ELSE
+            ELSE_KW "else"
+            WHITESPACE " "
+            BLOCK_EXPR
+              STMT_LIST
+                L_CURLY "{"
+                WHITESPACE "\n        "
+                EXPR_STMT
+                  RETURN_EXPR
+                    RETURN_KW "return"
+                  SEMICOLON ";"
+                WHITESPACE "\n    "
+                R_CURLY "}"
+          SEMICOLON ";"
+        WHITESPACE "\n"
         R_CURLY "}"
-    WHITESPACE " "
-    LET_ELSE
-      ELSE_KW "else"
-      WHITESPACE " "
-      BLOCK_EXPR
-        STMT_LIST
-          L_CURLY "{"
-          WHITESPACE "\r\n    "
-          EXPR_STMT
-            RETURN_EXPR
-              RETURN_KW "return"
-            SEMICOLON ";"
-          WHITESPACE "\r\n"
-          R_CURLY "}"
-    SEMICOLON ";"
-  WHITESPACE "\r\n"
-error 19: expected an item
-error 45: right curly brace `}` before `else` in a `let...else` statement not allowed
+error 63: right curly brace `}` before `else` in a `let...else` statement not allowed

--- a/crates/parser/test_data/parser/err/0056_let_else_right_curly_brace_struct.rs
+++ b/crates/parser/test_data/parser/err/0056_let_else_right_curly_brace_struct.rs
@@ -1,6 +1,8 @@
 struct X {a: i32}
-let foo = X {
-    a: 1
-} else {
-    return;
-};
+fn f() {
+    let foo = X {
+        a: 1
+    } else {
+        return;
+    };
+}

--- a/crates/parser/test_data/parser/err/0056_let_else_right_curly_brace_struct.rs
+++ b/crates/parser/test_data/parser/err/0056_let_else_right_curly_brace_struct.rs
@@ -1,0 +1,6 @@
+struct X {a: i32}
+let foo = X {
+    a: 1
+} else {
+    return;
+};

--- a/crates/parser/test_data/parser/err/0057_let_else_right_curly_brace_arithmetic.rast
+++ b/crates/parser/test_data/parser/err/0057_let_else_right_curly_brace_arithmetic.rast
@@ -1,0 +1,42 @@
+SOURCE_FILE
+  ERROR
+    LET_KW "let"
+    WHITESPACE " "
+    IDENT_PAT
+      NAME
+        IDENT "foo"
+    WHITESPACE " "
+    EQ "="
+    WHITESPACE " "
+    BIN_EXPR
+      LITERAL
+        INT_NUMBER "1"
+      WHITESPACE " "
+      PLUS "+"
+      WHITESPACE " "
+      BLOCK_EXPR
+        STMT_LIST
+          L_CURLY "{"
+          WHITESPACE "\r\n    "
+          LITERAL
+            INT_NUMBER "1"
+          WHITESPACE "\r\n"
+          R_CURLY "}"
+    WHITESPACE " "
+    LET_ELSE
+      ELSE_KW "else"
+      WHITESPACE " "
+      BLOCK_EXPR
+        STMT_LIST
+          L_CURLY "{"
+          WHITESPACE "\r\n    "
+          EXPR_STMT
+            RETURN_EXPR
+              RETURN_KW "return"
+            SEMICOLON ";"
+          WHITESPACE "\r\n"
+          R_CURLY "}"
+    SEMICOLON ";"
+  WHITESPACE "\r\n"
+error 0: expected an item
+error 25: right curly brace `}` before `else` in a `let...else` statement not allowed

--- a/crates/parser/test_data/parser/err/0057_let_else_right_curly_brace_arithmetic.rast
+++ b/crates/parser/test_data/parser/err/0057_let_else_right_curly_brace_arithmetic.rast
@@ -17,10 +17,10 @@ SOURCE_FILE
       BLOCK_EXPR
         STMT_LIST
           L_CURLY "{"
-          WHITESPACE "\r\n    "
+          WHITESPACE "\n    "
           LITERAL
             INT_NUMBER "1"
-          WHITESPACE "\r\n"
+          WHITESPACE "\n"
           R_CURLY "}"
     WHITESPACE " "
     LET_ELSE
@@ -29,14 +29,14 @@ SOURCE_FILE
       BLOCK_EXPR
         STMT_LIST
           L_CURLY "{"
-          WHITESPACE "\r\n    "
+          WHITESPACE "\n    "
           EXPR_STMT
             RETURN_EXPR
               RETURN_KW "return"
             SEMICOLON ";"
-          WHITESPACE "\r\n"
+          WHITESPACE "\n"
           R_CURLY "}"
     SEMICOLON ";"
-  WHITESPACE "\r\n"
+  WHITESPACE "\n"
 error 0: expected an item
-error 25: right curly brace `}` before `else` in a `let...else` statement not allowed
+error 23: right curly brace `}` before `else` in a `let...else` statement not allowed

--- a/crates/parser/test_data/parser/err/0057_let_else_right_curly_brace_arithmetic.rs
+++ b/crates/parser/test_data/parser/err/0057_let_else_right_curly_brace_arithmetic.rs
@@ -1,0 +1,5 @@
+let foo = 1 + {
+    1
+} else {
+    return;
+};

--- a/crates/parser/test_data/parser/err/0057_let_else_right_curly_brace_format_args.rast
+++ b/crates/parser/test_data/parser/err/0057_let_else_right_curly_brace_format_args.rast
@@ -11,7 +11,7 @@ SOURCE_FILE
     BLOCK_EXPR
       STMT_LIST
         L_CURLY "{"
-        WHITESPACE "\r\n    "
+        WHITESPACE "\n    "
         LET_STMT
           LET_KW "let"
           WHITESPACE " "
@@ -47,7 +47,7 @@ SOURCE_FILE
                 WHITESPACE " "
                 R_CURLY "}"
           SEMICOLON ";"
-        WHITESPACE "\r\n\r\n    "
+        WHITESPACE "\n\n    "
         LET_STMT
           LET_KW "let"
           WHITESPACE " "
@@ -84,7 +84,7 @@ SOURCE_FILE
                 WHITESPACE " "
                 R_CURLY "}"
           SEMICOLON ";"
-        WHITESPACE "\r\n"
+        WHITESPACE "\n"
         R_CURLY "}"
-  WHITESPACE "\r\n"
-error 92: right curly brace `}` before `else` in a `let...else` statement not allowed
+  WHITESPACE "\n"
+error 89: right curly brace `}` before `else` in a `let...else` statement not allowed

--- a/crates/parser/test_data/parser/err/0057_let_else_right_curly_brace_format_args.rast
+++ b/crates/parser/test_data/parser/err/0057_let_else_right_curly_brace_format_args.rast
@@ -1,0 +1,90 @@
+SOURCE_FILE
+  FN
+    FN_KW "fn"
+    WHITESPACE " "
+    NAME
+      IDENT "r"
+    PARAM_LIST
+      L_PAREN "("
+      R_PAREN ")"
+    WHITESPACE " "
+    BLOCK_EXPR
+      STMT_LIST
+        L_CURLY "{"
+        WHITESPACE "\r\n    "
+        LET_STMT
+          LET_KW "let"
+          WHITESPACE " "
+          IDENT_PAT
+            NAME
+              IDENT "ok"
+          WHITESPACE " "
+          EQ "="
+          WHITESPACE " "
+          MACRO_EXPR
+            MACRO_CALL
+              PATH
+                PATH_SEGMENT
+                  NAME_REF
+                    IDENT "format_args"
+              BANG "!"
+              TOKEN_TREE
+                L_PAREN "("
+                STRING "\"\""
+                R_PAREN ")"
+          WHITESPACE " "
+          LET_ELSE
+            ELSE_KW "else"
+            WHITESPACE " "
+            BLOCK_EXPR
+              STMT_LIST
+                L_CURLY "{"
+                WHITESPACE " "
+                EXPR_STMT
+                  RETURN_EXPR
+                    RETURN_KW "return"
+                  SEMICOLON ";"
+                WHITESPACE " "
+                R_CURLY "}"
+          SEMICOLON ";"
+        WHITESPACE "\r\n\r\n    "
+        LET_STMT
+          LET_KW "let"
+          WHITESPACE " "
+          IDENT_PAT
+            NAME
+              IDENT "bad"
+          WHITESPACE " "
+          EQ "="
+          WHITESPACE " "
+          MACRO_EXPR
+            MACRO_CALL
+              PATH
+                PATH_SEGMENT
+                  NAME_REF
+                    IDENT "format_args"
+              BANG "!"
+              WHITESPACE " "
+              TOKEN_TREE
+                L_CURLY "{"
+                STRING "\"\""
+                R_CURLY "}"
+          WHITESPACE " "
+          LET_ELSE
+            ELSE_KW "else"
+            WHITESPACE " "
+            BLOCK_EXPR
+              STMT_LIST
+                L_CURLY "{"
+                WHITESPACE " "
+                EXPR_STMT
+                  RETURN_EXPR
+                    RETURN_KW "return"
+                  SEMICOLON ";"
+                WHITESPACE " "
+                R_CURLY "}"
+          SEMICOLON ";"
+        WHITESPACE "\r\n"
+        R_CURLY "}"
+  WHITESPACE "\r\n"
+error 92: right curly brace `}` before `else` in a `let...else` statement not allowed

--- a/crates/parser/test_data/parser/err/0057_let_else_right_curly_brace_format_args.rs
+++ b/crates/parser/test_data/parser/err/0057_let_else_right_curly_brace_format_args.rs
@@ -1,0 +1,5 @@
+fn r() {
+    let ok = format_args!("") else { return; };
+
+    let bad = format_args! {""} else { return; };
+}

--- a/crates/parser/test_data/parser/err/0058_let_else_right_curly_brace_range.rast
+++ b/crates/parser/test_data/parser/err/0058_let_else_right_curly_brace_range.rast
@@ -15,10 +15,10 @@ SOURCE_FILE
       BLOCK_EXPR
         STMT_LIST
           L_CURLY "{"
-          WHITESPACE "\r\n    "
+          WHITESPACE "\n    "
           LITERAL
             INT_NUMBER "1"
-          WHITESPACE "\r\n"
+          WHITESPACE "\n"
           R_CURLY "}"
     WHITESPACE " "
     LET_ELSE
@@ -27,14 +27,14 @@ SOURCE_FILE
       BLOCK_EXPR
         STMT_LIST
           L_CURLY "{"
-          WHITESPACE "\r\n    "
+          WHITESPACE "\n    "
           EXPR_STMT
             RETURN_EXPR
               RETURN_KW "return"
             SEMICOLON ";"
-          WHITESPACE "\r\n"
+          WHITESPACE "\n"
           R_CURLY "}"
     SEMICOLON ";"
-  WHITESPACE "\r\n"
+  WHITESPACE "\n"
 error 0: expected an item
-error 24: right curly brace `}` before `else` in a `let...else` statement not allowed
+error 22: right curly brace `}` before `else` in a `let...else` statement not allowed

--- a/crates/parser/test_data/parser/err/0058_let_else_right_curly_brace_range.rast
+++ b/crates/parser/test_data/parser/err/0058_let_else_right_curly_brace_range.rast
@@ -1,0 +1,40 @@
+SOURCE_FILE
+  ERROR
+    LET_KW "let"
+    WHITESPACE " "
+    IDENT_PAT
+      NAME
+        IDENT "foo"
+    WHITESPACE " "
+    EQ "="
+    WHITESPACE " "
+    RANGE_EXPR
+      LITERAL
+        INT_NUMBER "1"
+      DOT2 ".."
+      BLOCK_EXPR
+        STMT_LIST
+          L_CURLY "{"
+          WHITESPACE "\r\n    "
+          LITERAL
+            INT_NUMBER "1"
+          WHITESPACE "\r\n"
+          R_CURLY "}"
+    WHITESPACE " "
+    LET_ELSE
+      ELSE_KW "else"
+      WHITESPACE " "
+      BLOCK_EXPR
+        STMT_LIST
+          L_CURLY "{"
+          WHITESPACE "\r\n    "
+          EXPR_STMT
+            RETURN_EXPR
+              RETURN_KW "return"
+            SEMICOLON ";"
+          WHITESPACE "\r\n"
+          R_CURLY "}"
+    SEMICOLON ";"
+  WHITESPACE "\r\n"
+error 0: expected an item
+error 24: right curly brace `}` before `else` in a `let...else` statement not allowed

--- a/crates/parser/test_data/parser/err/0058_let_else_right_curly_brace_range.rs
+++ b/crates/parser/test_data/parser/err/0058_let_else_right_curly_brace_range.rs
@@ -1,0 +1,5 @@
+let foo = 1..{
+    1
+} else {
+    return;
+};

--- a/crates/parser/test_data/parser/err/0059_let_else_right_curly_brace_closure.rast
+++ b/crates/parser/test_data/parser/err/0059_let_else_right_curly_brace_closure.rast
@@ -1,0 +1,55 @@
+SOURCE_FILE
+  ERROR
+    LET_KW "let"
+    WHITESPACE " "
+    IDENT_PAT
+      NAME
+        IDENT "foo"
+    WHITESPACE " "
+    EQ "="
+    WHITESPACE " "
+    CLOSURE_EXPR
+      PARAM_LIST
+        PIPE "|"
+        PARAM
+          IDENT_PAT
+            NAME
+              IDENT "x"
+          COLON ":"
+          WHITESPACE " "
+          PATH_TYPE
+            PATH
+              PATH_SEGMENT
+                NAME_REF
+                  IDENT "i32"
+        PIPE "|"
+      WHITESPACE " "
+      BLOCK_EXPR
+        STMT_LIST
+          L_CURLY "{"
+          WHITESPACE "\r\n    "
+          PATH_EXPR
+            PATH
+              PATH_SEGMENT
+                NAME_REF
+                  IDENT "x"
+          WHITESPACE "\r\n"
+          R_CURLY "}"
+    WHITESPACE " "
+    LET_ELSE
+      ELSE_KW "else"
+      WHITESPACE " "
+      BLOCK_EXPR
+        STMT_LIST
+          L_CURLY "{"
+          WHITESPACE "\r\n    "
+          EXPR_STMT
+            RETURN_EXPR
+              RETURN_KW "return"
+            SEMICOLON ";"
+          WHITESPACE "\r\n"
+          R_CURLY "}"
+    SEMICOLON ";"
+  WHITESPACE "\r\n"
+error 0: expected an item
+error 30: right curly brace `}` before `else` in a `let...else` statement not allowed

--- a/crates/parser/test_data/parser/err/0059_let_else_right_curly_brace_closure.rast
+++ b/crates/parser/test_data/parser/err/0059_let_else_right_curly_brace_closure.rast
@@ -27,13 +27,13 @@ SOURCE_FILE
       BLOCK_EXPR
         STMT_LIST
           L_CURLY "{"
-          WHITESPACE "\r\n    "
+          WHITESPACE "\n    "
           PATH_EXPR
             PATH
               PATH_SEGMENT
                 NAME_REF
                   IDENT "x"
-          WHITESPACE "\r\n"
+          WHITESPACE "\n"
           R_CURLY "}"
     WHITESPACE " "
     LET_ELSE
@@ -42,14 +42,14 @@ SOURCE_FILE
       BLOCK_EXPR
         STMT_LIST
           L_CURLY "{"
-          WHITESPACE "\r\n    "
+          WHITESPACE "\n    "
           EXPR_STMT
             RETURN_EXPR
               RETURN_KW "return"
             SEMICOLON ";"
-          WHITESPACE "\r\n"
+          WHITESPACE "\n"
           R_CURLY "}"
     SEMICOLON ";"
-  WHITESPACE "\r\n"
+  WHITESPACE "\n"
 error 0: expected an item
-error 30: right curly brace `}` before `else` in a `let...else` statement not allowed
+error 28: right curly brace `}` before `else` in a `let...else` statement not allowed

--- a/crates/parser/test_data/parser/err/0059_let_else_right_curly_brace_closure.rs
+++ b/crates/parser/test_data/parser/err/0059_let_else_right_curly_brace_closure.rs
@@ -1,0 +1,5 @@
+let foo = |x: i32| {
+    x
+} else {
+    return;
+};

--- a/crates/parser/test_data/parser/err/0060_let_else_right_curly_brace_unary.rast
+++ b/crates/parser/test_data/parser/err/0060_let_else_right_curly_brace_unary.rast
@@ -1,0 +1,38 @@
+SOURCE_FILE
+  ERROR
+    LET_KW "let"
+    WHITESPACE " "
+    IDENT_PAT
+      NAME
+        IDENT "foo"
+    WHITESPACE " "
+    EQ "="
+    WHITESPACE " "
+    PREFIX_EXPR
+      MINUS "-"
+      BLOCK_EXPR
+        STMT_LIST
+          L_CURLY "{"
+          WHITESPACE "\r\n    "
+          LITERAL
+            INT_NUMBER "1"
+          WHITESPACE "\r\n"
+          R_CURLY "}"
+    WHITESPACE " "
+    LET_ELSE
+      ELSE_KW "else"
+      WHITESPACE " "
+      BLOCK_EXPR
+        STMT_LIST
+          L_CURLY "{"
+          WHITESPACE "\r\n    "
+          EXPR_STMT
+            RETURN_EXPR
+              RETURN_KW "return"
+            SEMICOLON ";"
+          WHITESPACE "\r\n"
+          R_CURLY "}"
+    SEMICOLON ";"
+  WHITESPACE "\r\n"
+error 0: expected an item
+error 22: right curly brace `}` before `else` in a `let...else` statement not allowed

--- a/crates/parser/test_data/parser/err/0060_let_else_right_curly_brace_unary.rast
+++ b/crates/parser/test_data/parser/err/0060_let_else_right_curly_brace_unary.rast
@@ -13,10 +13,10 @@ SOURCE_FILE
       BLOCK_EXPR
         STMT_LIST
           L_CURLY "{"
-          WHITESPACE "\r\n    "
+          WHITESPACE "\n    "
           LITERAL
             INT_NUMBER "1"
-          WHITESPACE "\r\n"
+          WHITESPACE "\n"
           R_CURLY "}"
     WHITESPACE " "
     LET_ELSE
@@ -25,14 +25,14 @@ SOURCE_FILE
       BLOCK_EXPR
         STMT_LIST
           L_CURLY "{"
-          WHITESPACE "\r\n    "
+          WHITESPACE "\n    "
           EXPR_STMT
             RETURN_EXPR
               RETURN_KW "return"
             SEMICOLON ";"
-          WHITESPACE "\r\n"
+          WHITESPACE "\n"
           R_CURLY "}"
     SEMICOLON ";"
-  WHITESPACE "\r\n"
+  WHITESPACE "\n"
 error 0: expected an item
-error 22: right curly brace `}` before `else` in a `let...else` statement not allowed
+error 20: right curly brace `}` before `else` in a `let...else` statement not allowed

--- a/crates/parser/test_data/parser/err/0060_let_else_right_curly_brace_unary.rs
+++ b/crates/parser/test_data/parser/err/0060_let_else_right_curly_brace_unary.rs
@@ -1,0 +1,5 @@
+let foo = -{
+    1
+} else {
+    return;
+};

--- a/crates/parser/test_data/parser/err/0061_let_else_right_curly_brace_do_yeet.rast
+++ b/crates/parser/test_data/parser/err/0061_let_else_right_curly_brace_do_yeet.rast
@@ -1,0 +1,90 @@
+SOURCE_FILE
+  FN
+    FN_KW "fn"
+    WHITESPACE " "
+    NAME
+      IDENT "o"
+    PARAM_LIST
+      L_PAREN "("
+      R_PAREN ")"
+    WHITESPACE " "
+    RET_TYPE
+      THIN_ARROW "->"
+      WHITESPACE " "
+      PATH_TYPE
+        PATH
+          PATH_SEGMENT
+            NAME_REF
+              IDENT "Result"
+            GENERIC_ARG_LIST
+              L_ANGLE "<"
+              TYPE_ARG
+                TUPLE_TYPE
+                  L_PAREN "("
+                  R_PAREN ")"
+              COMMA ","
+              WHITESPACE " "
+              TYPE_ARG
+                TUPLE_TYPE
+                  L_PAREN "("
+                  R_PAREN ")"
+              R_ANGLE ">"
+    WHITESPACE " "
+    BLOCK_EXPR
+      STMT_LIST
+        L_CURLY "{"
+        WHITESPACE "\r\n    "
+        LET_STMT
+          LET_KW "let"
+          WHITESPACE " "
+          IDENT_PAT
+            NAME
+              IDENT "foo"
+          WHITESPACE " "
+          EQ "="
+          WHITESPACE " "
+          YEET_EXPR
+            DO_KW "do"
+            WHITESPACE " "
+            YEET_KW "yeet"
+            WHITESPACE " "
+            BLOCK_EXPR
+              STMT_LIST
+                L_CURLY "{"
+                WHITESPACE "\r\n        "
+                TUPLE_EXPR
+                  L_PAREN "("
+                  R_PAREN ")"
+                WHITESPACE "\r\n    "
+                R_CURLY "}"
+          WHITESPACE " "
+          LET_ELSE
+            ELSE_KW "else"
+            WHITESPACE " "
+            BLOCK_EXPR
+              STMT_LIST
+                L_CURLY "{"
+                WHITESPACE "\r\n        "
+                EXPR_STMT
+                  RETURN_EXPR
+                    RETURN_KW "return"
+                    WHITESPACE " "
+                    CALL_EXPR
+                      PATH_EXPR
+                        PATH
+                          PATH_SEGMENT
+                            NAME_REF
+                              IDENT "Ok"
+                      ARG_LIST
+                        L_PAREN "("
+                        TUPLE_EXPR
+                          L_PAREN "("
+                          R_PAREN ")"
+                        R_PAREN ")"
+                  SEMICOLON ";"
+                WHITESPACE "\r\n    "
+                R_CURLY "}"
+          SEMICOLON ";"
+        WHITESPACE "\r\n"
+        R_CURLY "}"
+error 70: right curly brace `}` before `else` in a `let...else` statement not allowed

--- a/crates/parser/test_data/parser/err/0061_let_else_right_curly_brace_do_yeet.rast
+++ b/crates/parser/test_data/parser/err/0061_let_else_right_curly_brace_do_yeet.rast
@@ -33,7 +33,7 @@ SOURCE_FILE
     BLOCK_EXPR
       STMT_LIST
         L_CURLY "{"
-        WHITESPACE "\r\n    "
+        WHITESPACE "\n    "
         LET_STMT
           LET_KW "let"
           WHITESPACE " "
@@ -51,11 +51,11 @@ SOURCE_FILE
             BLOCK_EXPR
               STMT_LIST
                 L_CURLY "{"
-                WHITESPACE "\r\n        "
+                WHITESPACE "\n        "
                 TUPLE_EXPR
                   L_PAREN "("
                   R_PAREN ")"
-                WHITESPACE "\r\n    "
+                WHITESPACE "\n    "
                 R_CURLY "}"
           WHITESPACE " "
           LET_ELSE
@@ -64,7 +64,7 @@ SOURCE_FILE
             BLOCK_EXPR
               STMT_LIST
                 L_CURLY "{"
-                WHITESPACE "\r\n        "
+                WHITESPACE "\n        "
                 EXPR_STMT
                   RETURN_EXPR
                     RETURN_KW "return"
@@ -82,9 +82,9 @@ SOURCE_FILE
                           R_PAREN ")"
                         R_PAREN ")"
                   SEMICOLON ";"
-                WHITESPACE "\r\n    "
+                WHITESPACE "\n    "
                 R_CURLY "}"
           SEMICOLON ";"
-        WHITESPACE "\r\n"
+        WHITESPACE "\n"
         R_CURLY "}"
-error 70: right curly brace `}` before `else` in a `let...else` statement not allowed
+error 67: right curly brace `}` before `else` in a `let...else` statement not allowed

--- a/crates/parser/test_data/parser/err/0061_let_else_right_curly_brace_do_yeet.rs
+++ b/crates/parser/test_data/parser/err/0061_let_else_right_curly_brace_do_yeet.rs
@@ -1,0 +1,7 @@
+fn o() -> Result<(), ()> {
+    let foo = do yeet {
+        ()
+    } else {
+        return Ok(());
+    };
+}

--- a/crates/parser/test_data/parser/err/0062_let_else_right_curly_brace_become.rast
+++ b/crates/parser/test_data/parser/err/0062_let_else_right_curly_brace_become.rast
@@ -14,11 +14,11 @@ SOURCE_FILE
       BLOCK_EXPR
         STMT_LIST
           L_CURLY "{"
-          WHITESPACE "\r\n    "
+          WHITESPACE "\n    "
           TUPLE_EXPR
             L_PAREN "("
             R_PAREN ")"
-          WHITESPACE "\r\n"
+          WHITESPACE "\n"
           R_CURLY "}"
     WHITESPACE " "
     LET_ELSE
@@ -27,14 +27,14 @@ SOURCE_FILE
       BLOCK_EXPR
         STMT_LIST
           L_CURLY "{"
-          WHITESPACE "\r\n    "
+          WHITESPACE "\n    "
           EXPR_STMT
             RETURN_EXPR
               RETURN_KW "return"
             SEMICOLON ";"
-          WHITESPACE "\r\n"
+          WHITESPACE "\n"
           R_CURLY "}"
     SEMICOLON ";"
-  WHITESPACE "\r\n"
+  WHITESPACE "\n"
 error 0: expected an item
-error 29: right curly brace `}` before `else` in a `let...else` statement not allowed
+error 27: right curly brace `}` before `else` in a `let...else` statement not allowed

--- a/crates/parser/test_data/parser/err/0062_let_else_right_curly_brace_become.rast
+++ b/crates/parser/test_data/parser/err/0062_let_else_right_curly_brace_become.rast
@@ -1,0 +1,40 @@
+SOURCE_FILE
+  ERROR
+    LET_KW "let"
+    WHITESPACE " "
+    IDENT_PAT
+      NAME
+        IDENT "foo"
+    WHITESPACE " "
+    EQ "="
+    WHITESPACE " "
+    BECOME_EXPR
+      BECOME_KW "become"
+      WHITESPACE " "
+      BLOCK_EXPR
+        STMT_LIST
+          L_CURLY "{"
+          WHITESPACE "\r\n    "
+          TUPLE_EXPR
+            L_PAREN "("
+            R_PAREN ")"
+          WHITESPACE "\r\n"
+          R_CURLY "}"
+    WHITESPACE " "
+    LET_ELSE
+      ELSE_KW "else"
+      WHITESPACE " "
+      BLOCK_EXPR
+        STMT_LIST
+          L_CURLY "{"
+          WHITESPACE "\r\n    "
+          EXPR_STMT
+            RETURN_EXPR
+              RETURN_KW "return"
+            SEMICOLON ";"
+          WHITESPACE "\r\n"
+          R_CURLY "}"
+    SEMICOLON ";"
+  WHITESPACE "\r\n"
+error 0: expected an item
+error 29: right curly brace `}` before `else` in a `let...else` statement not allowed

--- a/crates/parser/test_data/parser/err/0062_let_else_right_curly_brace_become.rs
+++ b/crates/parser/test_data/parser/err/0062_let_else_right_curly_brace_become.rs
@@ -1,0 +1,5 @@
+let foo = become {
+    ()
+} else {
+    return;
+};

--- a/crates/parser/test_data/parser/err/0063_let_else_right_curly_brace_reference.rast
+++ b/crates/parser/test_data/parser/err/0063_let_else_right_curly_brace_reference.rast
@@ -1,0 +1,38 @@
+SOURCE_FILE
+  ERROR
+    LET_KW "let"
+    WHITESPACE " "
+    IDENT_PAT
+      NAME
+        IDENT "foo"
+    WHITESPACE " "
+    EQ "="
+    WHITESPACE " "
+    REF_EXPR
+      AMP "&"
+      BLOCK_EXPR
+        STMT_LIST
+          L_CURLY "{"
+          WHITESPACE "\r\n    "
+          LITERAL
+            INT_NUMBER "1"
+          WHITESPACE "\r\n"
+          R_CURLY "}"
+    WHITESPACE " "
+    LET_ELSE
+      ELSE_KW "else"
+      WHITESPACE " "
+      BLOCK_EXPR
+        STMT_LIST
+          L_CURLY "{"
+          WHITESPACE "\r\n    "
+          EXPR_STMT
+            RETURN_EXPR
+              RETURN_KW "return"
+            SEMICOLON ";"
+          WHITESPACE "\r\n"
+          R_CURLY "}"
+    SEMICOLON ";"
+  WHITESPACE "\r\n"
+error 0: expected an item
+error 22: right curly brace `}` before `else` in a `let...else` statement not allowed

--- a/crates/parser/test_data/parser/err/0063_let_else_right_curly_brace_reference.rast
+++ b/crates/parser/test_data/parser/err/0063_let_else_right_curly_brace_reference.rast
@@ -13,10 +13,10 @@ SOURCE_FILE
       BLOCK_EXPR
         STMT_LIST
           L_CURLY "{"
-          WHITESPACE "\r\n    "
+          WHITESPACE "\n    "
           LITERAL
             INT_NUMBER "1"
-          WHITESPACE "\r\n"
+          WHITESPACE "\n"
           R_CURLY "}"
     WHITESPACE " "
     LET_ELSE
@@ -25,14 +25,14 @@ SOURCE_FILE
       BLOCK_EXPR
         STMT_LIST
           L_CURLY "{"
-          WHITESPACE "\r\n    "
+          WHITESPACE "\n    "
           EXPR_STMT
             RETURN_EXPR
               RETURN_KW "return"
             SEMICOLON ";"
-          WHITESPACE "\r\n"
+          WHITESPACE "\n"
           R_CURLY "}"
     SEMICOLON ";"
-  WHITESPACE "\r\n"
+  WHITESPACE "\n"
 error 0: expected an item
-error 22: right curly brace `}` before `else` in a `let...else` statement not allowed
+error 20: right curly brace `}` before `else` in a `let...else` statement not allowed

--- a/crates/parser/test_data/parser/err/0063_let_else_right_curly_brace_reference.rs
+++ b/crates/parser/test_data/parser/err/0063_let_else_right_curly_brace_reference.rs
@@ -1,0 +1,5 @@
+let foo = &{
+    1
+} else {
+    return;
+};

--- a/crates/parser/test_data/parser/err/0064_let_else_right_curly_brace_assignment.rast
+++ b/crates/parser/test_data/parser/err/0064_let_else_right_curly_brace_assignment.rast
@@ -1,0 +1,45 @@
+SOURCE_FILE
+  ERROR
+    LET_KW "let"
+    WHITESPACE " "
+    IDENT_PAT
+      NAME
+        IDENT "foo"
+    WHITESPACE " "
+    EQ "="
+    WHITESPACE " "
+    BIN_EXPR
+      PATH_EXPR
+        PATH
+          PATH_SEGMENT
+            NAME_REF
+              IDENT "bar"
+      WHITESPACE " "
+      EQ "="
+      WHITESPACE " "
+      BLOCK_EXPR
+        STMT_LIST
+          L_CURLY "{"
+          WHITESPACE "\r\n    "
+          LITERAL
+            INT_NUMBER "1"
+          WHITESPACE "\r\n"
+          R_CURLY "}"
+    WHITESPACE " "
+    LET_ELSE
+      ELSE_KW "else"
+      WHITESPACE " "
+      BLOCK_EXPR
+        STMT_LIST
+          L_CURLY "{"
+          WHITESPACE "\r\n    "
+          EXPR_STMT
+            RETURN_EXPR
+              RETURN_KW "return"
+            SEMICOLON ";"
+          WHITESPACE "\r\n"
+          R_CURLY "}"
+    SEMICOLON ";"
+  WHITESPACE "\r\n"
+error 0: expected an item
+error 27: right curly brace `}` before `else` in a `let...else` statement not allowed

--- a/crates/parser/test_data/parser/err/0064_let_else_right_curly_brace_assignment.rast
+++ b/crates/parser/test_data/parser/err/0064_let_else_right_curly_brace_assignment.rast
@@ -20,10 +20,10 @@ SOURCE_FILE
       BLOCK_EXPR
         STMT_LIST
           L_CURLY "{"
-          WHITESPACE "\r\n    "
+          WHITESPACE "\n    "
           LITERAL
             INT_NUMBER "1"
-          WHITESPACE "\r\n"
+          WHITESPACE "\n"
           R_CURLY "}"
     WHITESPACE " "
     LET_ELSE
@@ -32,14 +32,14 @@ SOURCE_FILE
       BLOCK_EXPR
         STMT_LIST
           L_CURLY "{"
-          WHITESPACE "\r\n    "
+          WHITESPACE "\n    "
           EXPR_STMT
             RETURN_EXPR
               RETURN_KW "return"
             SEMICOLON ";"
-          WHITESPACE "\r\n"
+          WHITESPACE "\n"
           R_CURLY "}"
     SEMICOLON ";"
-  WHITESPACE "\r\n"
+  WHITESPACE "\n"
 error 0: expected an item
-error 27: right curly brace `}` before `else` in a `let...else` statement not allowed
+error 25: right curly brace `}` before `else` in a `let...else` statement not allowed

--- a/crates/parser/test_data/parser/err/0064_let_else_right_curly_brace_assignment.rs
+++ b/crates/parser/test_data/parser/err/0064_let_else_right_curly_brace_assignment.rs
@@ -1,0 +1,5 @@
+let foo = bar = {
+    1
+} else {
+    return;
+};


### PR DESCRIPTION
fixes #18345 - rust-analyzer fails to emit errors for let...else statements when the initializer expression ends in a block-like construct

- Updated `CompletedMarker` to store the position where the node was completed.
- Introduced a new `last_token` function that walks back through the parsing events from the completion position to find the last emitted token.