### PR TITLE
Hide syntax tree view by default

### DIFF
--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -366,7 +366,7 @@
                     },
                     "rust-analyzer.showSyntaxTree": {
                         "markdownDescription": "Whether to show the syntax tree view.",
-                        "default": true,
+                        "default": false,
                         "type": "boolean"
                     },
                     "rust-analyzer.testExplorer": {


### PR DESCRIPTION
The new syntax tree view is awesome, but I suspect that it is only useful to a subset of rust-analyzer users who can enable it when they need it. With many extensions installed, the sidebar can become cluttered.

cc @Giga-Bowser what do you think?