### PR TITLE
Partially back out "fix: Fix sourceroot construction for virtual manifests"

### DIFF
--- a/crates/load-cargo/src/lib.rs
+++ b/crates/load-cargo/src/lib.rs
@@ -242,9 +242,6 @@ impl ProjectFolders {
                     }
                 }
 
-                if dirs.include.is_empty() {
-                    continue;
-                }
                 vfs::loader::Entry::Directories(dirs)
             };
 
@@ -267,7 +264,7 @@ impl ProjectFolders {
             };
 
             let file_set_roots = vec![VfsPath::from(ratoml_path.to_owned())];
-            let entry = vfs::loader::Entry::Files(vec![ratoml_path]);
+            let entry = vfs::loader::Entry::Files(vec![ratoml_path.to_owned()]);
 
             res.watch.push(res.load.len());
             res.load.push(entry);


### PR DESCRIPTION

This caused a bunch of issues, likely due to this changing the way we partition the source roots, this also removes a bit more of our rust-analyzer.toml loading for now, effectively disabling most loading for it (will note that down int he tracking issue), the source root system is just too brittle to support this right now and so the toml support is blocked on our VFS rewrite.


Closes https://github.com/rust-lang/rust-analyzer/issues/18886 
Closes https://github.com/rust-lang/rust-analyzer/issues/18748