### PR TITLE
Fix `debug_assertions` broken in 1c5a125

### DIFF
--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -582,7 +582,7 @@ config_data! {
         cargo_buildScripts_useRustcWrapper: bool = true,
         /// List of cfg options to enable with the given values.
         cargo_cfgs: Vec<String> = {
-            vec!["debug_assertion".into(), "miri".into()]
+            vec!["debug_assertions".into(), "miri".into()]
         },
         /// Extra arguments that are passed to every cargo invocation.
         cargo_extraArgs: Vec<String> = vec![],

--- a/docs/user/generated_config.adoc
+++ b/docs/user/generated_config.adoc
@@ -95,7 +95,7 @@ avoid checking unnecessary things.
 Default:
 ----
 [
-  "debug_assertion",
+  "debug_assertions",
   "miri"
 ]
 ----

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -816,7 +816,7 @@
                     "rust-analyzer.cargo.cfgs": {
                         "markdownDescription": "List of cfg options to enable with the given values.",
                         "default": [
-                            "debug_assertion",
+                            "debug_assertions",
                             "miri"
                         ],
                         "type": "array",


### PR DESCRIPTION
There is a typo (missing `s` in `debug_assertions`) introduced in 1c5a125beb35725ccc2ade005db9870db734bf23 causing rust-analyzer to incorrectly mark `#[cfg(debug_assertions)]`, `#[cfg_attr(debug_assertions, ...]` as inactive

I would appretiate vscode marketplace release with this bugfix, thanks