### PR TITLE
add missing `Win32_Foundation` feature

### DIFF
--- a/crates/profile/Cargo.toml
+++ b/crates/profile/Cargo.toml
@@ -21,7 +21,11 @@ jemalloc-ctl = { version = "0.5.0", package = "tikv-jemalloc-ctl", optional = tr
 perf-event = "=0.4.7"
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.52", features = ["Win32_System_Threading", "Win32_System_ProcessStatus"] }
+windows-sys = { version = "0.52", features = [
+    "Win32_Foundation",
+    "Win32_System_Threading",
+    "Win32_System_ProcessStatus",
+] }
 
 [features]
 cpu_profiler = []


### PR DESCRIPTION
I tried using the crate `ra_ap_profile` from crates.io, but I encountered this error due to a missing feature:


```powershell
error[E0425]: cannot find function, tuple struct or tuple variant `GetCurrentProcess` in this scope
   --> C:\Users\gvozdvmozgu\.cargo\git\checkouts\rust-analyzer-cf7e117ee9ee1d0a\cd199ea\crates\profile\src\memory_usage.rs:43:37
    |
43  |                 let proc = unsafe { GetCurrentProcess() };
    |                                     ^^^^^^^^^^^^^^^^^ help: a function with a similar name exists: `GetCurrentProcessId`
    |
   ::: C:\Users\gvozdvmozgu\.cargo\registry\src\index.crates.io-6f17d22bba15001f\windows-sys-0.52.0\src\Windows\Win32\System\Threading\mod.rs:179:1
    |
179 | ::windows_targets::link!("kernel32.dll" "system" fn GetCurrentProcessId() -> u32);
    | --------------------------------------------------------------------------------- similarly named function `GetCurrentProcessId` defined here

error[E0425]: cannot find function, tuple struct or tuple variant `GetProcessMemoryInfo` in this scope
   --> C:\Users\gvozdvmozgu\.cargo\git\checkouts\rust-analyzer-cf7e117ee9ee1d0a\cd199ea\crates\profile\src\memory_usage.rs:46:36
    |
46  |                 let ret = unsafe { GetProcessMemoryInfo(proc, mem_counters.as_mut_ptr(), cb as u32) };
    |                                    ^^^^^^^^^^^^^^^^^^^^ help: a constant with a similar name exists: `ProcessAppMemoryInfo`
    |
   ::: C:\Users\gvozdvmozgu\.cargo\registry\src\index.crates.io-6f17d22bba15001f\windows-sys-0.52.0\src\Windows\Win32\System\Threading\mod.rs:793:1
    |
793 | pub const ProcessAppMemoryInfo: PROCESS_INFORMATION_CLASS = 2i32;
    | --------------------------------------------------------- similarly named constant `ProcessAppMemoryInfo` defined here
    ```
