### PR TITLE
proc-macro-srv: make usage of RTLD_DEEPBIND portable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1377,6 +1377,7 @@ version = "0.0.0"
 dependencies = [
  "expect-test",
  "intern",
+ "libc",
  "libloading",
  "memmap2",
  "object 0.33.0",

--- a/crates/proc-macro-srv/Cargo.toml
+++ b/crates/proc-macro-srv/Cargo.toml
@@ -14,6 +14,7 @@ doctest = false
 
 [dependencies]
 object.workspace = true
+libc.workspace = true
 libloading.workspace = true
 memmap2.workspace = true
 


### PR DESCRIPTION
the constant is wrong on some platforms (e.g., on mips64el it's 0x10, and 0x8 is RTLD_NOLOAD which makes all this functionality broken), the libc crate takes care of those differences for us.

fallback to not setting the flag in non-glibc environments - some of them might have support for it using a different value that we don't know about, and some of them lack it entirely.
