### PR TITLE
fix: Only refresh syntax tree view when the active document changes

### DIFF
--- a/editors/code/src/ctx.ts
+++ b/editors/code/src/ctx.ts
@@ -361,7 +361,14 @@ export class Ctx implements RustAnalyzerExtensionApi {
             }
         });
 
-        vscode.workspace.onDidChangeTextDocument(async () => {
+        vscode.workspace.onDidChangeTextDocument(async (e) => {
+            if (
+                vscode.window.activeTextEditor?.document !== e.document ||
+                e.contentChanges.length === 0
+            ) {
+                return;
+            }
+
             if (this.syntaxTreeView?.visible) {
                 await this.syntaxTreeProvider?.refresh();
             }


### PR DESCRIPTION
I don't think this entirely fixes #18959, but at least when debugging, it made whatever race condition is necessary way less common. I'll keep looking into it.