### PR TITLE
internal: Treat cfg fetching failures as a warning

### DIFF
--- a/crates/project-model/src/toolchain_info/rustc_cfg.rs
+++ b/crates/project-model/src/toolchain_info/rustc_cfg.rs
@@ -19,7 +19,7 @@ pub fn get(
     let rustc_cfgs = match rustc_cfgs {
         Ok(cfgs) => cfgs,
         Err(e) => {
-            tracing::error!(?e, "failed to get rustc cfgs");
+            tracing::warn!(?e, "failed to get rustc cfgs");
             return vec![];
         }
     };


### PR DESCRIPTION
If the user doesn't have rustc on $PATH, rust-analyzer won't be able to run `rustc --print cfg`. This isn't really an error, as rust-analyzer can still proceed without it.

This is particularly noticeable when loading crates defined in a rust-project.json. Until the configuration is loaded, the opened files are briefly treated as detached files and users see this error.

Environments with rust-project.json generally have a sysroot and rustc elsewhere, so the error confuses users.