### PR TITLE
fix: panic in flycheck

### DIFF
--- a/crates/rust-analyzer/src/handlers/notification.rs
+++ b/crates/rust-analyzer/src/handlers/notification.rs
@@ -329,8 +329,11 @@ fn run_flycheck(state: &mut GlobalState, vfs_path: VfsPath) -> bool {
                             } => *cargo.workspace_root() == root,
                             _ => false,
                         });
-                    if let Some((idx, _)) = workspace {
-                        world.flycheck[idx].restart_for_package(package, target);
+                    if let Some((idx, ws)) = workspace {
+                        match world.flycheck.get(idx) {
+                            Some(fh) => fh.restart_for_package(package, target),
+                            None => tracing::error!(?target, ?ws, "out of bound flycheck handle"),
+                        }
                     }
                 }
             }


### PR DESCRIPTION
This is a temporary fix for issue: https://github.com/rust-lang/rust-analyzer/issues/18954

Prevents r-a from panicking yet transforming the panic into an error message until a fix addressing the root cause of the issue is found.