### PR TITLE
fix: Fix flycheck panicking with "once" invocation strategy

### DIFF
--- a/crates/rust-analyzer/src/flycheck.rs
+++ b/crates/rust-analyzer/src/flycheck.rs
@@ -88,6 +88,17 @@ pub(crate) enum FlycheckConfig {
     },
 }
 
+impl FlycheckConfig {
+    pub(crate) fn invocation_strategy_once(&self) -> bool {
+        match self {
+            FlycheckConfig::CargoCommand { .. } => false,
+            FlycheckConfig::CustomCommand { invocation_strategy, .. } => {
+                *invocation_strategy == InvocationStrategy::Once
+            }
+        }
+    }
+}
+
 impl fmt::Display for FlycheckConfig {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {


### PR DESCRIPTION
We only ever have one flycheck runner no matter the number of workspaces, so just kick off flycheck for it immediately.

Supercedes/Closes https://github.com/rust-lang/rust-analyzer/pull/19010, fixes https://github.com/rust-lang/rust-analyzer/issues/18954