### PR TITLE
Show status bar in RA output

### DIFF
--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -501,6 +501,10 @@
                                 },
                                 {
                                     "pattern": "**/Cargo.lock"
+                                },
+                                {
+                                    "scheme": "output",
+                                    "pattern": "extension-output-rust-lang.rust-analyzer*"
                                 }
                             ]
                         }


### PR DESCRIPTION
After #18592, opening the Rust Analyzer Language Server output in vscode hides the rust-analyzer status bar item which is kind of annoying. Add `output:extension-output-rust-lang.rust-analyzer*` document selector to default allow list for showing the status bar item. 