### PR TITLE
Disable `Receiver` based autoderef temporarily

### DIFF
--- a/crates/hir-ty/src/autoderef.rs
+++ b/crates/hir-ty/src/autoderef.rs
@@ -194,7 +194,11 @@ pub(crate) fn deref_by_trait(
     }
 
     let trait_id = || {
-        if use_receiver_trait {
+        // FIXME: Remove the `false` once `Receiver` needs to be stabilized, doing so will
+        // effectively bump the MSRV of rust-analyzer to 1.84 due to 1.83 and below lacking the
+        // blanked impl on `Deref`.
+        #[expect(clippy::overly_complex_bool_expr)]
+        if use_receiver_trait && false {
             if let Some(receiver) =
                 db.lang_item(table.trait_env.krate, LangItem::Receiver).and_then(|l| l.as_trait())
             {

--- a/crates/hir-ty/src/tests/method_resolution.rs
+++ b/crates/hir-ty/src/tests/method_resolution.rs
@@ -2163,9 +2163,9 @@ impl Receiver for Bar {
 fn main() {
     let bar = Bar;
     let _v1 = bar.foo1();
-      //^^^ type: i32
+      //^^^ type: {unknown}
     let _v2 = bar.foo2();
-      //^^^ type: bool
+      //^^^ type: {unknown}
 }
 "#,
     );

--- a/crates/ide-completion/src/completions/dot.rs
+++ b/crates/ide-completion/src/completions/dot.rs
@@ -1500,9 +1500,7 @@ fn main() {
     bar.$0
 }
 "#,
-            expect![[r#"
-    me foo() fn(self: Bar)
-"#]],
+            expect![[r#""#]],
         );
     }
 


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust-analyzer/issues/19059, will kick off another release after this as this breaks all toolchains <1.84