### PR TITLE
fix: Make changes in `arbitrary-self-types` work with rustc < 1.84

### DIFF
--- a/crates/ide-completion/src/completions/dot.rs
+++ b/crates/ide-completion/src/completions/dot.rs
@@ -1500,7 +1500,9 @@ fn main() {
     bar.$0
 }
 "#,
-            expect![[r#""#]],
+            expect![[r#"
+                me foo() fn(self: Bar)
+            "#]],
         );
     }
 


### PR DESCRIPTION
This makes `arbitrary-self-types` work again, without backward compatibility issues like #19059

I'm afraid that this might interrupt migration to next-gen solver as this uses chalk types.
So, please consider this as a PoC rather than a final PR if it does.