### PR TITLE
fix: if item exsits on module, resolve as module instead of type

### DIFF
--- a/crates/ide/src/goto_definition.rs
+++ b/crates/ide/src/goto_definition.rs
@@ -3290,4 +3290,38 @@ fn main() {
     "#,
         );
     }
+
+    #[test]
+    fn shadow_builtin_type_by_module() {
+        check(
+            r#"
+mod Foo{
+pub mod str {
+     // ^^^
+    pub fn foo() {}
+}
+}
+
+fn main() {
+    use Foo::str;
+    let s = st$0r::foo();
+}
+"#,
+        );
+    }
+
+    #[test]
+    fn not_goto_module_because_str_is_builtin_type() {
+        check(
+            r#"
+mod str {
+pub fn foo() {}
+}
+
+fn main() {
+    let s = st$0r::f();
+}
+"#,
+        );
+    }
 }


### PR DESCRIPTION
fix : https://github.com/rust-lang/rust-analyzer/issues/18941, https://github.com/rust-lang/rust-analyzer/issues/19107

This PR resolves modules if items exist in the module and treats them as modules.

https://github.com/user-attachments/assets/c4a9f8d2-9b99-49b1-858e-ba94aa6ceaff


If a type import overwrites a module, this PR ensures it is resolved as a type

https://github.com/user-attachments/assets/577488e1-357d-42cc-86b8-58a0246d0517

