### PR TITLE
fix: Apply adjustments to proper expr when invoking `CoerceMany`

### DIFF
--- a/crates/hir-ty/src/mir/eval/tests.rs
+++ b/crates/hir-ty/src/mir/eval/tests.rs
@@ -912,3 +912,36 @@ fn main() {
         "",
     );
 }
+
+#[test]
+fn regression_19021() {
+    check_pass(
+        r#"
+//- minicore: deref
+use core::ops::Deref;
+
+#[lang = "owned_box"]
+struct Box<T>(T);
+
+impl<T> Deref for Box<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+struct Foo;
+
+fn main() {
+    let x = Box(Foo);
+    let y = &Foo;
+
+    || match x {
+        ref x => x,
+        _ => y,
+    };
+}
+"#,
+    );
+}

--- a/crates/hir-ty/src/tests/coercion.rs
+++ b/crates/hir-ty/src/tests/coercion.rs
@@ -185,11 +185,10 @@ fn test() {
     let t = &mut 1;
     let x = match 1 {
         1 => t as *mut i32,
+           //^^^^^^^^^^^^^ adjustments: Pointer(MutToConstPointer)
         2 => t as &i32,
            //^^^^^^^^^ expected *mut i32, got &'? i32
         _ => t as *const i32,
-          // ^^^^^^^^^^^^^^^ adjustments: Pointer(MutToConstPointer)
-
     };
     x;
   //^ type: *const i32


### PR DESCRIPTION
Fixes #19021

I think that this issue was quite hard to find (I wonder how David found this out 😄 )

For instance, removing lang item annotation `#[lang = "owned_box"]`, making the last expression of the `fn main()` into a plain match expression instead of a closure, or annotating the closure return type to the following code won't trigger the issue.

```rust
use core::ops::Deref;

#[lang = "owned_box"]
struct Box<T>(T);

impl<T> Deref for Box<T> {
    type Target = T;
    fn deref(&self) -> &Self::Target {
        &self.0
    }
}

struct Foo;

fn main() {
    let x = Box(Foo);
    let y = &Foo;
    || match x {
        ref x => x,
        _ => y,
    };
}
```

The path in which above code triggers the issue is quite interweaven, but the root cause is that we are applying resulting adjustments of the `CoreceMany` to the wrong expression; we are applying it always to the very expression that we are coercing from.

If the next arm/branch of the `CoerceMany` can coerce into the previous `merge_ty`, this is not a problem.
But if the previous `merge_ty` has to be coerced into the type of next arm/branch, the adjustments must be applied to the previous `CoerceMany` expressions.

So, in the above code, when calling `CoerceMany::coerce` with the second arm, the match expression's type is inferred as `&Foo` and the first branch must be coerced into it.
But adjustments for this coercion `[Deref, Deref, Borrow]` is applied to the next arm, `y`, and since `y = &Foo` cannot be dereferenced twice, and this causes the issue.