### PR TITLE
fix: Censor cfg_attr for attribute macros

### DIFF
--- a/crates/hir-def/src/macro_expansion_tests/proc_macros.rs
+++ b/crates/hir-def/src/macro_expansion_tests/proc_macros.rs
@@ -5,7 +5,7 @@
 //! in-memory macros.
 use expect_test::expect;
 
-use crate::macro_expansion_tests::check;
+use crate::macro_expansion_tests::{check, check_errors};
 
 #[test]
 fn attribute_macro_attr_censoring() {
@@ -214,5 +214,23 @@ struct S;
 #[doc = " doc string \\n with newline"]
 #[doc = "\n     MultiLines Doc\n     MultiLines Doc\n"]
 #[doc = "doc attr"] struct S;"##]],
+    );
+}
+
+#[test]
+fn cfg_evaluated_before_attr_macros() {
+    check_errors(
+        r#"
+//- proc_macros: disallow_cfg
+
+use proc_macros::disallow_cfg;
+
+#[disallow_cfg] #[cfg(false)] fn foo() {}
+// True cfg are kept.
+// #[disallow_cfg] #[cfg(true)] fn bar() {}
+#[disallow_cfg] #[cfg_attr(false, inline)] fn baz() {}
+#[disallow_cfg] #[cfg_attr(true, inline)] fn qux() {}
+    "#,
+        expect![[r#""#]],
     );
 }


### PR DESCRIPTION
This is not documented (and I discovered that from experimenting and looking at the compiler's source code), but cfg_attrs *on the same level* as the attribute macro should be processed before it is expanded. cfg_attrs *below* should not (and this is contrary to what happens with derive macros, where both should be processed).

Fixes #19121.