### PR TITLE
doc: add xtask codegen command in development README as well

### DIFF
--- a/docs/book/README.md
+++ b/docs/book/README.md
@@ -26,4 +26,4 @@ Start with the mdbook [User Guide](https://rust-lang.github.io/mdBook/guide/inst
 Four sections are generated dynamically: assists, configuration, diagnostics and features. Their content is found in the `generated.md` files
 of the respective book section, for example `src/configuration_generated.md`, and are included in the book via mdbook's
 [include](https://rust-lang.github.io/mdBook/format/mdbook.html#including-files) functionality. Generated files can be rebuilt by running the various
-test cases that generate them, or by simply running all of the `rust-analyzer` tests with `cargo test`.
+test cases that generate them, or by simply running all of the `rust-analyzer` tests with `cargo test` and `cargo xtask codegen`.


### PR DESCRIPTION
We suggest running both `cargo test` and `cargo xtask codgen` to generate the docs in the book's top level README.md but not in `docs/book/README.md`. Add it there too.