### PR TITLE
doc: fix mdbook repository paths

### DIFF
--- a/docs/book/book.toml
+++ b/docs/book/book.toml
@@ -9,10 +9,10 @@ title = "rust-analyzer"
 edition = "2021"
 
 [output.html]
-edit-url-template = "https://github.com/rust-lang/rust-analyzer/edit/master/manual/{path}"
-git-repository-url = "https://github.com/rust-lang/rust-analyzer/tree/master/manual"
+edit-url-template = "https://github.com/rust-lang/rust-analyzer/edit/master/docs/book/{path}"
+git-repository-url = "https://github.com/rust-lang/rust-analyzer/tree/master/docs/book"
 mathjax-support = true
-site-url = "/manual/"
+site-url = "/book/"
 
 [output.html.playground]
 editable = true


### PR DESCRIPTION
The paths that point to the `Repository` and `Suggest an edit` links are incorrect (based on the original PR's assumption of `/manual`). 