### PR TITLE
manual: Fix URLs to rustdoc pages

### DIFF
--- a/xtask/src/codegen.rs
+++ b/xtask/src/codegen.rs
@@ -117,7 +117,7 @@ impl fmt::Display for Location {
         let path = self.file.strip_prefix(project_root()).unwrap().display().to_string();
         let path = path.replace('\\', "/");
         let name = self.file.file_name().unwrap();
-        write!(f, " [{}]({}#{}) ", name.to_str().unwrap(), path, self.line)
+        write!(f, " [{}](/{}#{}) ", name.to_str().unwrap(), path, self.line)
     }
 }
 


### PR DESCRIPTION
Now that the manual lives at /manual/, we need to use absolute URLs to link to rustdoc content.