### PR TITLE
doc: remove unused plugin config

### DIFF
--- a/docs/book/book.toml
+++ b/docs/book/book.toml
@@ -34,8 +34,3 @@ use-boolean-and = true
 [output.html.fold]
 enable = true
 level = 3
-
-[preprocessor.toc]
-command = "mdbook-toc"
-renderer = ["html"]
-max-level = 3


### PR DESCRIPTION
I had originally incorporated the [mdbook-toc](https://github.com/badboy/mdbook-toc) plugin to generate a table of contents for some of the generated content but the results were just too big to be of any use. Looks like we still have the config in the `book.toml` which doesn't break anything but probably emits an error in the book build output. Remove the config. It might be useful to create a toc somehow since the generated pages are so big. 

It would be cool to create a foldable sub-toc in the nav that just linked to the spot in the page. Not sure if that's possible in mdbook, but I'll look into it.