### PR TITLE
Propogate error types in mir type projections

### DIFF
--- a/crates/ide-diagnostics/src/handlers/unused_variables.rs
+++ b/crates/ide-diagnostics/src/handlers/unused_variables.rs
@@ -263,4 +263,17 @@ fn main() {
 "#,
         );
     }
+
+    // regression test as we used to panic in this scenario
+    #[test]
+    fn unknown_struct_pattern_param_type() {
+        check_diagnostics(
+            r#"
+struct S { field : u32 }
+fn f(S { field }: error) {
+      // ^^^^^ 💡 warn: unused variable
+}
+"#,
+        );
+    }
 }


### PR DESCRIPTION
If you have the `never`/`always` asserts enabled you'll run into frequent panics (which get our diagnostics stuck ...) due to us building mir with error types existing, so this works around  that.