### PR TITLE
doc: use fully qualified url for source path

### DIFF
--- a/xtask/src/codegen.rs
+++ b/xtask/src/codegen.rs
@@ -117,7 +117,13 @@ impl fmt::Display for Location {
         let path = self.file.strip_prefix(project_root()).unwrap().display().to_string();
         let path = path.replace('\\', "/");
         let name = self.file.file_name().unwrap();
-        write!(f, " [{}](/{}#{}) ", name.to_str().unwrap(), path, self.line)
+        write!(
+            f,
+            " [{}](https://github.com/rust-lang/rust-analyzer/blob/master/{}#{}) ",
+            name.to_str().unwrap(),
+            path,
+            self.line
+        )
     }
 }
 


### PR DESCRIPTION
I just realized that the links to source files in three of the four generated doc files are wrong because they assume relative paths but they point to the doc site url instead of the repository itself (configuration is correct because its a single static link in `configuration.md`). 

This fix just points to the full URL to this repo instead, not sure if there is a better option. 

