### PR TITLE
fix: Binding wrong associated type when lowering bounds like `T: Trait<Assoc = U>`

### DIFF
--- a/crates/hir-ty/src/lower/path.rs
+++ b/crates/hir-ty/src/lower/path.rs
@@ -837,15 +837,16 @@ impl<'a, 'b> PathLoweringContext<'a, 'b> {
                         }
                         (_, ImplTraitLoweringMode::Param | ImplTraitLoweringMode::Variable) => {
                             // Find the generic index for the target of our `bound`
-                            let target_param_idx =
-                                self.ctx.resolver.where_predicates_in_scope().find_map(|(p, _)| {
-                                    match p {
-                                        WherePredicate::TypeBound {
-                                            target: WherePredicateTypeTarget::TypeOrConstParam(idx),
-                                            bound: b,
-                                        } if b == bound => Some(idx),
-                                        _ => None,
-                                    }
+                            let target_param_idx = self
+                                .ctx
+                                .resolver
+                                .where_predicates_in_scope()
+                                .find_map(|(p, (_, types_map))| match p {
+                                    WherePredicate::TypeBound {
+                                        target: WherePredicateTypeTarget::TypeOrConstParam(idx),
+                                        bound: b,
+                                    } if b == bound && self.ctx.types_map == types_map => Some(idx),
+                                    _ => None,
                                 });
                             let ty = if let Some(target_param_idx) = target_param_idx {
                                 let mut counter = 0;


### PR DESCRIPTION
Fixes #19177

The panic happens while borrow checking the following function in the mentioned crate
https://github.com/PingPongun/egui_struct/blob/b9549e51491e02a6c471e1cf7a6bd4b77bd87203/src/lib.rs#L774-L779
```rust
fn show_combobox<'a, T: Clone + ToString + PartialEq>(
    sel: &mut T,
    ui: &mut Ui,
    config: Option<&'a mut dyn Iterator<Item = T>>,
    id: impl Hash + Clone,
) -> Response {
```

When lowering trait object `dyn Iterator<Item = T>` on the following lines
https://github.com/rust-lang/rust-analyzer/blob/9691da7707ea7c50922fe1647b1c2af47934b9fa/crates/hir-ty/src/lower.rs#L693-L704
on `L704`, the bound `TraitObject: Iterator<Item = T>` passed to the following lines
https://github.com/rust-lang/rust-analyzer/blob/9691da7707ea7c50922fe1647b1c2af47934b9fa/crates/hir-ty/src/lower.rs#L647-L663
and then passed to the following function through `L661`.
https://github.com/rust-lang/rust-analyzer/blob/9691da7707ea7c50922fe1647b1c2af47934b9fa/crates/hir-ty/src/lower/path.rs#L787-L791
But in that function, while trying to find `target_param_idx` in the following lines,
(note that the problematic behaviour happens only when `target` is `WherePredicateTypeTarget::TypeOrConstParam` in `L844`, which means we have desugared `impl Trait` generic type as a function's parameter type) 
https://github.com/rust-lang/rust-analyzer/blob/9691da7707ea7c50922fe1647b1c2af47934b9fa/crates/hir-ty/src/lower/path.rs#L840-L846
we check whether the two type bounds are equal(`b == bound`) with `<TypeBound as PartialEq>::Eq`

However, the `TypeBounds` is somewhat like a local pointer bound to the `TypesMap` that contains the actual `TypeRef` it is pointing out(the `PathId` is actually `Idx<TypeRef>` 
https://github.com/rust-lang/rust-analyzer/blob/9691da7707ea7c50922fe1647b1c2af47934b9fa/crates/hir-def/src/hir/type_ref.rs#L253-L260
and if `bound` and `b` are from two different `TypesMap` but have the same `Idx`, our associated type in trait ref bound is bound to a wrong parameter, and this caused panic inside chalk.

Adding equality check for two `TypeBound`s' provenance `TypesMap` fixes this issue, but I'm so scared because similar "Local `Idx` comparison between different `Arena`s" might be happening somewhere in our codebase 😨   