### PR TITLE
doc: missed the L for the line number

### DIFF
--- a/xtask/src/codegen.rs
+++ b/xtask/src/codegen.rs
@@ -119,7 +119,7 @@ impl fmt::Display for Location {
         let name = self.file.file_name().unwrap();
         write!(
             f,
-            " [{}](https://github.com/rust-lang/rust-analyzer/blob/master/{}#{}) ",
+            " [{}](https://github.com/rust-lang/rust-analyzer/blob/master/{}#L{}) ",
             name.to_str().unwrap(),
             path,
             self.line


### PR DESCRIPTION
Apologies for the churn, missed the `L` to link directly to the line number correctly.
