### PR TITLE
feat: update insta inline snapshot when clicking 'Update Test' runnable

### DIFF
--- a/crates/ide/src/lib.rs
+++ b/crates/ide/src/lib.rs
@@ -104,7 +104,7 @@ pub use crate::{
     navigation_target::{NavigationTarget, TryToNav, UpmappingResult},
     references::ReferenceSearchResult,
     rename::RenameError,
-    runnables::{Runnable, RunnableKind, TestId},
+    runnables::{Runnable, RunnableKind, TestId, UpdateTest},
     signature_help::SignatureHelp,
     static_index::{
         StaticIndex, StaticIndexedFile, TokenId, TokenStaticData, VendoredLibrariesConfig,

--- a/crates/rust-analyzer/src/handlers/request.rs
+++ b/crates/rust-analyzer/src/handlers/request.rs
@@ -941,9 +941,7 @@ pub(crate) fn handle_runnables(
 
         let update_test = runnable.update_test;
         if let Some(mut runnable) = to_proto::runnable(&snap, runnable)? {
-            if let Some(runnable) =
-                to_proto::make_update_runnable(&runnable, &update_test.label(), &update_test.env())
-            {
+            if let Some(runnable) = to_proto::make_update_runnable(&runnable, update_test) {
                 res.push(runnable);
             }
 
@@ -2158,7 +2156,7 @@ fn runnable_action_links(
 
     if hover_actions_config.update_test && client_commands_config.run_single {
         let label = update_test.label();
-        if let Some(r) = to_proto::make_update_runnable(&r, &label, &update_test.env()) {
+        if let Some(r) = to_proto::make_update_runnable(&r, update_test) {
             let update_command = to_proto::command::run_single(&r, label.unwrap().as_str());
             group.commands.push(to_command_link(update_command, r.label.clone()));
         }

--- a/crates/rust-analyzer/src/lsp/to_proto.rs
+++ b/crates/rust-analyzer/src/lsp/to_proto.rs
@@ -14,13 +14,13 @@ use ide::{
     InlayFieldsToResolve, InlayHint, InlayHintLabel, InlayHintLabelPart, InlayKind, LazyProperty,
     Markup, NavigationTarget, ReferenceCategory, RenameError, Runnable, Severity, SignatureHelp,
     SnippetEdit, SourceChange, StructureNodeKind, SymbolKind, TextEdit, TextRange, TextSize,
+    UpdateTest,
 };
 use ide_db::{assists, rust_doc::format_docs, FxHasher};
 use itertools::Itertools;
 use paths::{Utf8Component, Utf8Prefix};
 use semver::VersionReq;
 use serde_json::to_value;
-use syntax::SmolStr;
 use vfs::AbsPath;
 
 use crate::{
@@ -1623,8 +1623,7 @@ pub(crate) fn code_lens(
                     }
                     if lens_config.update_test && client_commands_config.run_single {
                         let label = update_test.label();
-                        let env = update_test.env();
-                        if let Some(r) = make_update_runnable(&r, &label, &env) {
+                        if let Some(r) = make_update_runnable(&r, update_test) {
                             let command = command::run_single(&r, label.unwrap().as_str());
                             acc.push(lsp_types::CodeLens {
                                 range: annotation_range,
@@ -1871,22 +1870,22 @@ pub(crate) mod command {
 
 pub(crate) fn make_update_runnable(
     runnable: &lsp_ext::Runnable,
-    label: &Option<SmolStr>,
-    env: &[(&str, &str)],
+    update_test: UpdateTest,
 ) -> Option<lsp_ext::Runnable> {
-    if !matches!(runnable.args, lsp_ext::RunnableArgs::Cargo(_)) {
-        return None;
-    }
-    let label = label.as_ref()?;
+    let label = update_test.label()?;
 
     let mut runnable = runnable.clone();
     runnable.label = format!("{} + {}", runnable.label, label);
 
     let lsp_ext::RunnableArgs::Cargo(r) = &mut runnable.args else {
-        unreachable!();
+        return None;
     };
 
-    r.environment.extend(env.iter().map(|(k, v)| (k.to_string(), v.to_string())));
+    r.environment.extend(update_test.env().iter().map(|(k, v)| (k.to_string(), v.to_string())));
+
+    if update_test.insta {
+        r.cargo_args.insert(0, "insta".to_string());
+    }
 
     Some(runnable)
 }

--- a/crates/rust-analyzer/src/lsp/to_proto.rs
+++ b/crates/rust-analyzer/src/lsp/to_proto.rs
@@ -1884,7 +1884,7 @@ pub(crate) fn make_update_runnable(
     r.environment.extend(update_test.env().iter().map(|(k, v)| (k.to_string(), v.to_string())));
 
     if update_test.insta {
-        r.cargo_args.insert(0, "insta".to_string());
+        r.cargo_args.insert(0, "insta".to_owned());
     }
 
     Some(runnable)


### PR DESCRIPTION
The 'Update Test' runnable was implemented in [PR #18757](https://github.com/rust-lang/rust-analyzer/pull/18757).

It was found that the `insta` snapshot library does not update inline snapshots using the 'Update Test' runnable because it only sets the environment variable `INSTA_UPDATE=always` which does not affect inline snapshots.

`insta` supports updating snapshots using `cargo-nextest`, which run each test in a single process, requiring the external tool `cargo-insta` to collect diffs and apply changes. Thus, updating inline snapshots with plain `cargo test` is not feasible([insta #490](https://github.com/mitsuhiko/insta/issues/490)).

This PR changes the 'Update Test' runnables to use `cargo insta test` instead of `cargo test ...` when the test involves `insta`. This change is justified since `cargo insta test` is compatible with other snapshot libraries and it is assumed that `insta` users have `cargo-insta` installed.