### PR TITLE
doc: toc for other editors

### DIFF
--- a/docs/book/src/other_editors.md
+++ b/docs/book/src/other_editors.md
@@ -6,6 +6,8 @@ Protocol](https://microsoft.github.io/language-server-protocol/).
 This page assumes that you have already [installed the rust-analyzer
 binary](./rust_analyzer_binary.html).
 
+<!-- toc -->
+
 ## Emacs
 
 To use `rust-analyzer`, you need to install and enable one of the two


### PR DESCRIPTION
The `Other Editors` section is a bit long, and presumably someone going there wants to find the config for their editor quickly. Add a table of contents.