### PR TITLE
Allow "package/feature" format feature flag

### DIFF
--- a/crates/project-model/src/cargo_workspace.rs
+++ b/crates/project-model/src/cargo_workspace.rs
@@ -594,7 +594,9 @@ impl CargoWorkspace {
             .filter_map(|package| {
                 let package = &self[package];
                 if package.is_member {
-                    Some(package.features.keys().cloned())
+                    Some(package.features.keys().cloned().chain(
+                        package.features.keys().map(|key| format!("{}/{key}", package.name)),
+                    ))
                 } else {
                     None
                 }


### PR DESCRIPTION
On multi package workspace, cargo accepts "package-name/feature-name" format feature flags to specify package features for specific workspace members.

However, rust-analyzer doesn't forward these features to cargo and several errors are occured. Especially, optional depended proc-macro crates are not build and then `proc-macro crate build data is missing dylib path` error is shown.

So I fixed it.