### PR TITLE
Parser inline test codegen panics and/or does not run

### DIFF
--- a/crates/parser/test_data/generated/runner.rs
+++ b/crates/parser/test_data/generated/runner.rs
@@ -721,14 +721,14 @@ mod err {
     #[test]
     fn bad_asm_expr() { run_and_expect_errors("test_data/parser/inline/err/bad_asm_expr.rs"); }
     #[test]
+    fn comma_after_default_values_syntax() {
+        run_and_expect_errors("test_data/parser/inline/err/comma_after_default_values_syntax.rs");
+    }
+    #[test]
     fn comma_after_functional_update_syntax() {
         run_and_expect_errors(
             "test_data/parser/inline/err/comma_after_functional_update_syntax.rs",
         );
-    }
-    #[test]
-    fn comma_after_default_values_syntax() {
-        run_and_expect_errors("test_data/parser/inline/err/comma_after_default_values_syntax.rs");
     }
     #[test]
     fn crate_visibility_empty_recover() {


### PR DESCRIPTION
When running `cargo codegen` the cwd is "rust-analyzer" however when running the tests in `xtask` the cwd is"rust-analyzer/xtask" which makes the codegen panic in various places. This is observed because the path is hard coded to `"crates/parser"` were it instead should be `project_root().join("crates/parser")`.

Furthermore, the parser inline test codegen has two generation targets: 1. the data files in `crates/parser/test_data/inline/**` and 2. the `crates/parser/test_data/generated/runner.rs`. The codegen for the second target is only run when the first target is updated. However, this can make it outdated in some cases. E.g. if the file is manually edited or if the source inline comment and both *.rast and *.rs data files are missing.
