### PR TITLE
Enable privateEditable by default

### DIFF
--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -497,7 +497,7 @@ config_data! {
         /// Whether to show postfix snippets like `dbg`, `if`, `not`, etc.
         completion_postfix_enable: bool         = true,
         /// Enables completions of private items and fields that are defined in the current workspace even if they are not visible at the current position.
-        completion_privateEditable_enable: bool = false,
+        completion_privateEditable_enable: bool = true,
         /// Whether to enable term search based snippets like `Some(foo.bar().baz())`.
         completion_termSearch_enable: bool = false,
         /// Term search fuel in "units of work" for autocompletion (Defaults to 1000).

--- a/docs/book/src/configuration_generated.md
+++ b/docs/book/src/configuration_generated.md
@@ -361,7 +361,7 @@ Note that the trait themselves can still be completed.
  Whether to show postfix snippets like `dbg`, `if`, `not`, etc.
 
 
-**rust-analyzer.completion.privateEditable.enable** (default: false)
+**rust-analyzer.completion.privateEditable.enable** (default: true)
 
  Enables completions of private items and fields that are defined in the current workspace even if they are not visible at the current position.
 
@@ -1202,5 +1202,3 @@ Other clients requires all results upfront and might require a higher limit.
 **rust-analyzer.workspace.symbol.search.scope** (default: "workspace")
 
  Workspace symbol search scope.
-
-

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -1314,7 +1314,7 @@
                 "properties": {
                     "rust-analyzer.completion.privateEditable.enable": {
                         "markdownDescription": "Enables completions of private items and fields that are defined in the current workspace even if they are not visible at the current position.",
-                        "default": false,
+                        "default": true,
                         "type": "boolean"
                     }
                 }


### PR DESCRIPTION
This is a useful option because it's quite common to forget to make something public, and then when you go to use it instead of autocompleting successfully, giving an error (and potentially an auto-fix in future), and ctrl-clicking the item to jump to it... you have to manually nagivate to the item and add `pub`. It's much more tedious.

Turning it on by default also makes it more discoverable. Because I assumed that everybody would want this behaviour if available I didn't even consider that there might be an option. I only discovered that there was when I tried to implement it myself!

I think one thing that would improve this is if the autocomplete popup said which items were private. Currently there is no indication.

See #9850