### PR TITLE
Add `identifier` to pull diagnostic LSP capabilities

### DIFF
--- a/crates/rust-analyzer/src/lsp/capabilities.rs
+++ b/crates/rust-analyzer/src/lsp/capabilities.rs
@@ -165,7 +165,7 @@ pub fn server_capabilities(config: &Config) -> ServerCapabilities {
         })),
         diagnostic_provider: Some(lsp_types::DiagnosticServerCapabilities::Options(
             lsp_types::DiagnosticOptions {
-                identifier: None,
+                identifier: Some("rust-analyzer".to_owned()),
                 inter_file_dependencies: true,
                 // FIXME
                 workspace_diagnostics: false,


### PR DESCRIPTION
This field in the server capabilities instructs the client to maintain the diagnostics received from a `textDocument/diagnostic` pull request as a separate set from other diagnostics: namely those sent with classic "push" diagnostics, `textDocument/publishDiagnostic`. rust-analyzer emits "native" diagnostics (computed by rust-analyzer itself) in pull diagnostics and separately emits cargo-based diagnostics with push, so push and pull diagnostics should be different sets. Setting this field instructs the client to avoid clearing push diagnostics when new pull diagnostics arrive and vice versa.

Also see discussion in #18709