### PR TITLE
Use `size_of` from the prelude instead of imported

### DIFF
--- a/crates/hir-def/src/hir/type_ref.rs
+++ b/crates/hir-def/src/hir/type_ref.rs
@@ -260,7 +260,7 @@ pub enum TypeBound {
 }
 
 #[cfg(target_pointer_width = "64")]
-const _: [(); 24] = [(); ::std::mem::size_of::<TypeBound>()];
+const _: [(); 24] = [(); size_of::<TypeBound>()];
 
 #[derive(Clone, PartialEq, Eq, Hash, Debug)]
 pub enum UseArgRef {

--- a/crates/hir-ty/src/consteval/tests.rs
+++ b/crates/hir-ty/src/consteval/tests.rs
@@ -2713,12 +2713,11 @@ fn const_trait_assoc() {
         r#"
     //- minicore: size_of, fn
     //- /a/lib.rs crate:a
-    use core::mem::size_of;
     pub struct S<T>(T);
     impl<T> S<T> {
         pub const X: usize = {
             let k: T;
-            let f = || core::mem::size_of::<T>();
+            let f = || size_of::<T>();
             f()
         };
     }

--- a/crates/hir-ty/src/display.rs
+++ b/crates/hir-ty/src/display.rs
@@ -4,7 +4,7 @@
 
 use std::{
     fmt::{self, Debug},
-    mem::{self, size_of},
+    mem,
 };
 
 use base_db::CrateId;

--- a/crates/hir-ty/src/mir/eval.rs
+++ b/crates/hir-ty/src/mir/eval.rs
@@ -302,7 +302,7 @@ impl Address {
         }
     }
 
-    fn to_bytes(&self) -> [u8; mem::size_of::<usize>()] {
+    fn to_bytes(&self) -> [u8; size_of::<usize>()] {
         usize::to_le_bytes(self.to_usize())
     }
 
@@ -589,7 +589,7 @@ pub fn interpret_mir(
     let ty = body.locals[return_slot()].ty.clone();
     let mut evaluator = Evaluator::new(db, body.owner, assert_placeholder_ty_is_unused, trait_env)?;
     let it: Result<Const> = (|| {
-        if evaluator.ptr_size() != std::mem::size_of::<usize>() {
+        if evaluator.ptr_size() != size_of::<usize>() {
             not_supported!("targets with different pointer size from host");
         }
         let interval = evaluator.interpret_mir(body.clone(), None.into_iter())?;

--- a/crates/hir-ty/src/mir/lower.rs
+++ b/crates/hir-ty/src/mir/lower.rs
@@ -1394,7 +1394,7 @@ impl<'ctx> MirLowerCtx<'ctx> {
                 .layout_of_ty(ty.clone(), self.db.trait_environment_for_body(self.owner))
                 .map(|it| it.size.bytes_usize())
         };
-        const USIZE_SIZE: usize = mem::size_of::<usize>();
+        const USIZE_SIZE: usize = size_of::<usize>();
         let bytes: Box<[_]> = match l {
             hir_def::hir::Literal::String(b) => {
                 let b = b.as_str();

--- a/crates/ide-completion/src/tests/expression.rs
+++ b/crates/ide-completion/src/tests/expression.rs
@@ -1920,6 +1920,7 @@ fn bar() {
             md rust_2015 (use core::prelude::rust_2015)
             md rust_2018 (use core::prelude::rust_2018)
             md rust_2021 (use core::prelude::rust_2021)
+            md rust_2024 (use core::prelude::rust_2024)
             tt Clone
             tt Copy
             tt IntoIterator

--- a/crates/ide-db/src/generated/lints.rs
+++ b/crates/ide-db/src/generated/lints.rs
@@ -15086,7 +15086,7 @@ cannot be represented as the underlying type without loss."##,
     },
     Lint {
         label: "clippy::manual_bits",
-        description: r##"Checks for usage of `std::mem::size_of::<T>() * 8` when
+        description: r##"Checks for usage of `size_of::<T>() * 8` when
 `T::BITS` is available."##,
         default_severity: Severity::Allow,
         warn_since: None,
@@ -17428,7 +17428,7 @@ count of elements of type `T`"##,
     },
     Lint {
         label: "clippy::size_of_ref",
-        description: r##"Checks for calls to `std::mem::size_of_val()` where the argument is
+        description: r##"Checks for calls to `size_of_val()` where the argument is
 a reference to a reference."##,
         default_severity: Severity::Allow,
         warn_since: None,

--- a/crates/ide-db/src/symbol_index.rs
+++ b/crates/ide-db/src/symbol_index.rs
@@ -24,7 +24,6 @@ use std::{
     cmp::Ordering,
     fmt,
     hash::{Hash, Hasher},
-    mem,
     ops::ControlFlow,
 };
 
@@ -299,7 +298,7 @@ impl SymbolIndex {
     }
 
     pub fn memory_size(&self) -> usize {
-        self.map.as_fst().size() + self.symbols.len() * mem::size_of::<FileSymbol>()
+        self.map.as_fst().size() + self.symbols.len() * size_of::<FileSymbol>()
     }
 
     fn range_to_map_value(start: usize, end: usize) -> u64 {

--- a/crates/ide/src/status.rs
+++ b/crates/ide/src/status.rs
@@ -268,8 +268,7 @@ struct AttrsStats {
 
 impl fmt::Display for AttrsStats {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let size =
-            self.entries * std::mem::size_of::<Attrs>() + self.total * std::mem::size_of::<Attr>();
+        let size = self.entries * size_of::<Attrs>() + self.total * size_of::<Attr>();
         let size = Bytes::new(size as _);
         write!(
             fmt,

--- a/crates/intern/src/symbol.rs
+++ b/crates/intern/src/symbol.rs
@@ -18,20 +18,17 @@ use triomphe::Arc;
 pub mod symbols;
 
 // some asserts for layout compatibility
-const _: () = assert!(std::mem::size_of::<Box<str>>() == std::mem::size_of::<&str>());
-const _: () = assert!(std::mem::align_of::<Box<str>>() == std::mem::align_of::<&str>());
+const _: () = assert!(size_of::<Box<str>>() == size_of::<&str>());
+const _: () = assert!(align_of::<Box<str>>() == align_of::<&str>());
 
-const _: () = assert!(std::mem::size_of::<Arc<Box<str>>>() == std::mem::size_of::<&&str>());
-const _: () = assert!(std::mem::align_of::<Arc<Box<str>>>() == std::mem::align_of::<&&str>());
+const _: () = assert!(size_of::<Arc<Box<str>>>() == size_of::<&&str>());
+const _: () = assert!(align_of::<Arc<Box<str>>>() == align_of::<&&str>());
 
-const _: () =
-    assert!(std::mem::size_of::<*const *const str>() == std::mem::size_of::<TaggedArcPtr>());
-const _: () =
-    assert!(std::mem::align_of::<*const *const str>() == std::mem::align_of::<TaggedArcPtr>());
+const _: () = assert!(size_of::<*const *const str>() == size_of::<TaggedArcPtr>());
+const _: () = assert!(align_of::<*const *const str>() == align_of::<TaggedArcPtr>());
 
-const _: () = assert!(std::mem::size_of::<Arc<Box<str>>>() == std::mem::size_of::<TaggedArcPtr>());
-const _: () =
-    assert!(std::mem::align_of::<Arc<Box<str>>>() == std::mem::align_of::<TaggedArcPtr>());
+const _: () = assert!(size_of::<Arc<Box<str>>>() == size_of::<TaggedArcPtr>());
+const _: () = assert!(align_of::<Arc<Box<str>>>() == align_of::<TaggedArcPtr>());
 
 /// A pointer that points to a pointer to a `str`, it may be backed as a `&'static &'static str` or
 /// `Arc<Box<str>>` but its size is that of a thin pointer. The active variant is encoded as a tag
@@ -49,9 +46,7 @@ impl TaggedArcPtr {
     const BOOL_BITS: usize = true as usize;
 
     const fn non_arc(r: &'static &'static str) -> Self {
-        assert!(
-            mem::align_of::<&'static &'static str>().trailing_zeros() as usize > Self::BOOL_BITS
-        );
+        assert!(align_of::<&'static &'static str>().trailing_zeros() as usize > Self::BOOL_BITS);
         // SAFETY: The pointer is non-null as it is derived from a reference
         // Ideally we would call out to `pack_arc` but for a `false` tag, unfortunately the
         // packing stuff requires reading out the pointer to an integer which is not supported
@@ -64,9 +59,7 @@ impl TaggedArcPtr {
     }
 
     fn arc(arc: Arc<Box<str>>) -> Self {
-        assert!(
-            mem::align_of::<&'static &'static str>().trailing_zeros() as usize > Self::BOOL_BITS
-        );
+        assert!(align_of::<&'static &'static str>().trailing_zeros() as usize > Self::BOOL_BITS);
         Self {
             packed: Self::pack_arc(
                 // Safety: `Arc::into_raw` always returns a non null pointer
@@ -131,8 +124,8 @@ impl fmt::Debug for Symbol {
     }
 }
 
-const _: () = assert!(std::mem::size_of::<Symbol>() == std::mem::size_of::<NonNull<()>>());
-const _: () = assert!(std::mem::align_of::<Symbol>() == std::mem::align_of::<NonNull<()>>());
+const _: () = assert!(size_of::<Symbol>() == size_of::<NonNull<()>>());
+const _: () = assert!(align_of::<Symbol>() == align_of::<NonNull<()>>());
 
 static MAP: OnceLock<DashMap<SymbolProxy, (), BuildHasherDefault<FxHasher>>> = OnceLock::new();
 

--- a/crates/profile/src/memory_usage.rs
+++ b/crates/profile/src/memory_usage.rs
@@ -38,7 +38,7 @@ impl MemoryUsage {
                 // approximate that by using the Commit Charge value.
 
                 use windows_sys::Win32::System::{Threading::*, ProcessStatus::*};
-                use std::mem::{MaybeUninit, size_of};
+                use std::mem::MaybeUninit;
 
                 let proc = unsafe { GetCurrentProcess() };
                 let mut mem_counters = MaybeUninit::uninit();

--- a/crates/test-utils/src/minicore.rs
+++ b/crates/test-utils/src/minicore.rs
@@ -1874,6 +1874,7 @@ pub mod prelude {
             marker::Sized,                           // :sized
             marker::Sync,                            // :sync
             mem::drop,                               // :drop
+            mem::size_of,                            // :size_of
             ops::Drop,                               // :drop
             ops::{AsyncFn, AsyncFnMut, AsyncFnOnce}, // :async_fn
             ops::{Fn, FnMut, FnOnce},                // :fn
@@ -1893,6 +1894,10 @@ pub mod prelude {
     }
 
     pub mod rust_2021 {
+        pub use super::v1::*;
+    }
+
+    pub mod rust_2024 {
         pub use super::v1::*;
     }
 }

--- a/crates/test-utils/src/minicore.rs
+++ b/crates/test-utils/src/minicore.rs
@@ -1825,7 +1825,7 @@ macro_rules! impl_int {
     ($($t:ty)*) => {
         $(
             impl $t {
-                pub const fn from_ne_bytes(bytes: [u8; mem::size_of::<Self>()]) -> Self {
+                pub const fn from_ne_bytes(bytes: [u8; size_of::<Self>()]) -> Self {
                     unsafe { mem::transmute(bytes) }
                 }
             }


### PR DESCRIPTION
Use `std::mem::{size_of, size_of_val, align_of, align_of_val}` from the prelude instead of importing or qualifying them.

These functions were added to all preludes in Rust 1.80.