### PR TITLE
Add warning and debug information when `cargo metadata` fails

### DIFF
--- a/crates/project-model/src/cargo_workspace.rs
+++ b/crates/project-model/src/cargo_workspace.rs
@@ -300,10 +300,9 @@ impl CargoWorkspace {
         if let Ok((_, Some(ref e))) = res {
             tracing::warn!(
                 %cargo_toml,
-                %e,
+                ?e,
                 "`cargo metadata` failed, but retry with `--no-deps` succeeded"
             );
-            tracing::debug!("{e:?}");
         }
         res
     }

--- a/crates/project-model/src/cargo_workspace.rs
+++ b/crates/project-model/src/cargo_workspace.rs
@@ -299,7 +299,9 @@ impl CargoWorkspace {
         );
         if let Ok((_, Some(ref e))) = res {
             tracing::warn!(
-                "`cargo metadata` failed on `{cargo_toml}`, but retry with `--no-deps` succeeded"
+                %cargo_toml,
+                %e,
+                "`cargo metadata` failed, but retry with `--no-deps` succeeded"
             );
             tracing::debug!("{e:?}");
         }

--- a/crates/project-model/src/cargo_workspace.rs
+++ b/crates/project-model/src/cargo_workspace.rs
@@ -288,7 +288,22 @@ impl CargoWorkspace {
         locked: bool,
         progress: &dyn Fn(String),
     ) -> anyhow::Result<(cargo_metadata::Metadata, Option<anyhow::Error>)> {
-        Self::fetch_metadata_(cargo_toml, current_dir, config, sysroot, locked, false, progress)
+        let res = Self::fetch_metadata_(
+            cargo_toml,
+            current_dir,
+            config,
+            sysroot,
+            locked,
+            false,
+            progress,
+        );
+        if let Ok((_, Some(ref e))) = res {
+            tracing::warn!(
+                "`cargo metadata` failed on `{cargo_toml}`, but retry with `--no-deps` succeeded"
+            );
+            tracing::debug!("{e:?}");
+        }
+        res
     }
 
     fn fetch_metadata_(


### PR DESCRIPTION
The errors are silently dropped elsewhere, which make it really hard to debug issues due to dependency download failures.

