### PR TITLE
Correct manual installation command for terminal usage

### DIFF
--- a/docs/book/src/installation.md
+++ b/docs/book/src/installation.md
@@ -13,7 +13,7 @@ editor](./other_editors.html).
 rust-analyzer will attempt to install the standard library source code
 automatically. You can also install it manually with `rustup`.
 
-    $ rustup component add rust-src
+    $ rustup component add rust-analyzer
 
 Only the latest stable standard library source is officially supported
 for use with rust-analyzer. If you are using an older toolchain or have


### PR DESCRIPTION
The previous command installed the rust-src component, not rust-analyzer. Changed to match the correct usage on https://rust-analyzer.github.io/book/rust_analyzer_binary.html