### PR TITLE
minor: Show build scripts errors in server status 

### DIFF
--- a/crates/rust-analyzer/src/reload.rs
+++ b/crates/rust-analyzer/src/reload.rs
@@ -139,10 +139,10 @@ impl GlobalState {
                 "Proc-macros and/or build scripts have changed and need to be rebuilt.\n\n",
             );
         }
-        if let Err(build_data_err) = self.fetch_build_data_error() {
-            status.health |= lsp_ext::Health::Error;
+        if self.fetch_build_data_error().is_err() {
+            status.health |= lsp_ext::Health::Warning;
             message.push_str("Failed to run build scripts of some packages.\n\n");
-            format_to!(message, "{build_data_err}\n");
+            message.push_str("Please refer to the logs for more details on the errors.");
         }
         if let Some(err) = &self.config_errors {
             status.health |= lsp_ext::Health::Warning;

--- a/crates/rust-analyzer/src/reload.rs
+++ b/crates/rust-analyzer/src/reload.rs
@@ -139,9 +139,10 @@ impl GlobalState {
                 "Proc-macros and/or build scripts have changed and need to be rebuilt.\n\n",
             );
         }
-        if self.fetch_build_data_error().is_err() {
-            status.health |= lsp_ext::Health::Warning;
+        if let Err(build_data_err) = self.fetch_build_data_error() {
+            status.health |= lsp_ext::Health::Error;
             message.push_str("Failed to run build scripts of some packages.\n\n");
+            format_to!(message, "{build_data_err}\n");
         }
         if let Some(err) = &self.config_errors {
             status.health |= lsp_ext::Health::Warning;


### PR DESCRIPTION
Not the prettiest PR so I want to suggest a few things : ( fixes #19184 )

1. While I was tinkering with our build script runners, I saw that we ignore any Warn level diagnostics but if there are any errors, warnings would also be included in the "problems". Since the PR simply adds showing what `cargo check` outputs as a server status message, users will now also see these warning when there are errors and not see them where there are not. This tells me that we can add a `DiagnosticLevel` guard to filter warnings out.
2. I could better format error messages, since they are not very pleasant to look at.