### PR TITLE
minor: Mark `rust-analyzer.showSyntaxTree` config option as requiring server restart

### DIFF
--- a/editors/code/src/config.ts
+++ b/editors/code/src/config.ts
@@ -27,6 +27,7 @@ export class Config {
         "server",
         "files",
         "cfg",
+        "showSyntaxTree",
     ].map((opt) => `${this.rootSection}.${opt}`);
 
     private readonly requiresWindowReloadOpts = ["testExplorer"].map(


### PR DESCRIPTION
We register the provider when we start the server. It confused me why I set the option and it didn't work, so probably better to have it hint people.