### PR TITLE
fix: Renaming both struct and function with the same name

### DIFF
--- a/crates/ide/src/rename.rs
+++ b/crates/ide/src/rename.rs
@@ -3276,7 +3276,7 @@ mod foo {
         size: usize,
     }
 
-    pub fn bar() -> bar {
+    pub fn bar(size: usize) -> bar {
         bar { size: 0 }
     }
 }
@@ -3294,7 +3294,7 @@ mod foo {
         size: usize,
     }
 
-    pub fn baz() -> baz {
+    pub fn baz(size: usize) -> baz {
         baz { size: 0 }
     }
 }


### PR DESCRIPTION
fixes #18892.

## Note
Although the original issue did not specify whether to rename both definitions or only one, since the original code exports both under the same name, it is preferable for rust-analyzer’s behavior to rename both.
This implementation therefore renames both the struct and the function, ensuring consistency.

## Important
This implementation is limited to handling struct/function pairs. It does not cover other combinations (e.g. enum variants with associated functions, constants paired with functions, or trait methods).
If needed, separate issues should be created to address those other cases individually.