### PR TITLE
Fix logical error in PR #19297

### DIFF
--- a/crates/ide-completion/src/item.rs
+++ b/crates/ide-completion/src/item.rs
@@ -252,14 +252,14 @@ impl CompletionRelevance {
     /// Provides a relevance score. Higher values are more relevant.
     ///
     /// The absolute value of the relevance score is not meaningful, for
-    /// example a value of 0 doesn't mean "not relevant", rather
+    /// example a value of (!(0 as u32) / 2) doesn't mean "not relevant", rather
     /// it means "least relevant". The score value should only be used
     /// for relative ordering.
     ///
     /// See is_relevant if you need to make some judgement about score
     /// in an absolute sense.
     pub fn score(self) -> u32 {
-        let mut score = !0 / 2;
+        let mut score = !(0 as u32) / 2;
         let CompletionRelevance {
             exact_name_match,
             type_match,
@@ -350,7 +350,7 @@ impl CompletionRelevance {
     /// some threshold such that we think it is especially likely
     /// to be relevant.
     pub fn is_relevant(&self) -> bool {
-        self.score() > (!0 / 2)
+        self.score() > !(0 as u32) / 2
     }
 }
 

--- a/crates/ide-completion/src/item.rs
+++ b/crates/ide-completion/src/item.rs
@@ -252,14 +252,16 @@ impl CompletionRelevance {
     /// Provides a relevance score. Higher values are more relevant.
     ///
     /// The absolute value of the relevance score is not meaningful, for
-    /// example a value of (!(0 as u32) / 2) doesn't mean "not relevant", rather
+    /// example a value of BASE_SCORE doesn't mean "not relevant", rather
     /// it means "least relevant". The score value should only be used
     /// for relative ordering.
     ///
     /// See is_relevant if you need to make some judgement about score
     /// in an absolute sense.
+    const BASE_SCORE: u32 = u32::MAX / 2;
+
     pub fn score(self) -> u32 {
-        let mut score = !(0 as u32) / 2;
+        let mut score = Self::BASE_SCORE;
         let CompletionRelevance {
             exact_name_match,
             type_match,
@@ -350,7 +352,7 @@ impl CompletionRelevance {
     /// some threshold such that we think it is especially likely
     /// to be relevant.
     pub fn is_relevant(&self) -> bool {
-        self.score() > !(0 as u32) / 2
+        self.score() > Self::BASE_SCORE
     }
 }
 


### PR DESCRIPTION
In PR #19297, we overlooked the type inconsistency caused by the new scope for `!0/2` (which then led to logical errors)

---
The rationale is as follows:  
![image](https://github.com/user-attachments/assets/7e3c4ca2-3120-42a5-814c-f69e3a4355be)

---

Although we modified the threshold expression in PR #19297:
```diff
    pub fn is_relevant(&self) -> bool {
-        self.score() > 0
+        self.score() > (!0 / 2)
    }
```
We neglected some type-related issues within a new function scope, which resulted in only modifying the "apparent value" while the actual value remained 0 (as shown in the image above)

---
The reason I chose the first fix option is that it expresses the intent more clearly and avoids ambiguity