### PR TITLE
Log build script error output in `load_cargo::load_workspace_at`

### DIFF
--- a/crates/load-cargo/src/lib.rs
+++ b/crates/load-cargo/src/lib.rs
@@ -45,10 +45,18 @@ pub fn load_workspace_at(
 ) -> anyhow::Result<(RootDatabase, vfs::Vfs, Option<ProcMacroClient>)> {
     let root = AbsPathBuf::assert_utf8(std::env::current_dir()?.join(root));
     let root = ProjectManifest::discover_single(&root)?;
+    let manifest_path = root.manifest_path().clone();
     let mut workspace = ProjectWorkspace::load(root, cargo_config, progress)?;
 
     if load_config.load_out_dirs_from_check {
         let build_scripts = workspace.run_build_scripts(cargo_config, progress)?;
+        if let Some(error) = build_scripts.error() {
+            tracing::debug!(
+                "Errors occurred while running build scripts for {}: {}",
+                manifest_path,
+                error
+            );
+        }
         workspace.set_build_scripts(build_scripts)
     }
 


### PR DESCRIPTION
@Veykril This pull request adds some logging for build script error output. I'm not sure this is the best place for the log statement. I picked the `load_workspace_at` because it's the place where the `ProjectWorkspace` and the error messages it may contain is dropped. The other functions have access to the `ProjectWorkspace` so calling application code can handle the errors itself if it wishes to do so. If you want to always log the errors then perhaps the `ProjectWorkspace::set_build_scripts()` method would be a better place for the log statement.

This log output would have been really helpful for figuring out some  undefined `OUT_DIR` error messages I was debugging earlier, so I was hoping it can be logged to make things easier in the future ;-) 