### PR TITLE
fix(hir): `VariantDef` is `impl HasSource`

### DIFF
--- a/crates/hir/src/has_source.rs
+++ b/crates/hir/src/has_source.rs
@@ -15,7 +15,7 @@ use tt::TextRange;
 use crate::{
     db::HirDatabase, Adt, Callee, Const, Enum, ExternCrateDecl, Field, FieldSource, Function, Impl,
     InlineAsmOperand, Label, LifetimeParam, LocalSource, Macro, Module, Param, SelfParam, Static,
-    Struct, Trait, TraitAlias, TypeAlias, TypeOrConstParam, Union, Variant,
+    Struct, Trait, TraitAlias, TypeAlias, TypeOrConstParam, Union, Variant, VariantDef,
 };
 
 pub trait HasSource {
@@ -107,6 +107,16 @@ impl HasSource for Adt {
             Adt::Struct(s) => Some(s.source(db)?.map(ast::Adt::Struct)),
             Adt::Union(u) => Some(u.source(db)?.map(ast::Adt::Union)),
             Adt::Enum(e) => Some(e.source(db)?.map(ast::Adt::Enum)),
+        }
+    }
+}
+impl HasSource for VariantDef {
+    type Ast = ast::VariantDef;
+    fn source(self, db: &dyn HirDatabase) -> Option<InFile<Self::Ast>> {
+        match self {
+            VariantDef::Struct(s) => Some(s.source(db)?.map(ast::VariantDef::Struct)),
+            VariantDef::Union(u) => Some(u.source(db)?.map(ast::VariantDef::Union)),
+            VariantDef::Variant(v) => Some(v.source(db)?.map(ast::VariantDef::Variant)),
         }
     }
 }

--- a/crates/parser/src/syntax_kind/generated.rs
+++ b/crates/parser/src/syntax_kind/generated.rs
@@ -315,6 +315,7 @@ pub enum SyntaxKind {
     USE_TREE,
     USE_TREE_LIST,
     VARIANT,
+    VARIANT_DEF,
     VARIANT_LIST,
     VISIBILITY,
     WHERE_CLAUSE,
@@ -501,6 +502,7 @@ impl SyntaxKind {
             | USE_TREE
             | USE_TREE_LIST
             | VARIANT
+            | VARIANT_DEF
             | VARIANT_LIST
             | VISIBILITY
             | WHERE_CLAUSE

--- a/crates/syntax/rust.ungram
+++ b/crates/syntax/rust.ungram
@@ -279,6 +279,11 @@ Adt =
 | Struct
 | Union
 
+VariantDef =
+  Struct
+| Union
+| Variant
+
 Const =
   Attr* Visibility?
   'default'?

--- a/crates/syntax/src/ast/generated/nodes.rs
+++ b/crates/syntax/src/ast/generated/nodes.rs
@@ -2447,6 +2447,17 @@ pub enum UseBoundGenericArg {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum VariantDef {
+    Struct(Struct),
+    Union(Union),
+    Variant(Variant),
+}
+impl ast::HasAttrs for VariantDef {}
+impl ast::HasDocComments for VariantDef {}
+impl ast::HasName for VariantDef {}
+impl ast::HasVisibility for VariantDef {}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct AnyHasArgList {
     pub(crate) syntax: SyntaxNode,
 }
@@ -6738,6 +6749,40 @@ impl AstNode for UseBoundGenericArg {
         }
     }
 }
+impl From<Struct> for VariantDef {
+    #[inline]
+    fn from(node: Struct) -> VariantDef { VariantDef::Struct(node) }
+}
+impl From<Union> for VariantDef {
+    #[inline]
+    fn from(node: Union) -> VariantDef { VariantDef::Union(node) }
+}
+impl From<Variant> for VariantDef {
+    #[inline]
+    fn from(node: Variant) -> VariantDef { VariantDef::Variant(node) }
+}
+impl AstNode for VariantDef {
+    #[inline]
+    fn can_cast(kind: SyntaxKind) -> bool { matches!(kind, STRUCT | UNION | VARIANT) }
+    #[inline]
+    fn cast(syntax: SyntaxNode) -> Option<Self> {
+        let res = match syntax.kind() {
+            STRUCT => VariantDef::Struct(Struct { syntax }),
+            UNION => VariantDef::Union(Union { syntax }),
+            VARIANT => VariantDef::Variant(Variant { syntax }),
+            _ => return None,
+        };
+        Some(res)
+    }
+    #[inline]
+    fn syntax(&self) -> &SyntaxNode {
+        match self {
+            VariantDef::Struct(it) => &it.syntax,
+            VariantDef::Union(it) => &it.syntax,
+            VariantDef::Variant(it) => &it.syntax,
+        }
+    }
+}
 impl AnyHasArgList {
     #[inline]
     pub fn new<T: ast::HasArgList>(node: T) -> AnyHasArgList {
@@ -7749,6 +7794,11 @@ impl std::fmt::Display for Type {
     }
 }
 impl std::fmt::Display for UseBoundGenericArg {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl std::fmt::Display for VariantDef {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         std::fmt::Display::fmt(self.syntax(), f)
     }

--- a/docs/book/src/assists_generated.md
+++ b/docs/book/src/assists_generated.md
@@ -1070,7 +1070,7 @@ pub use foo::{Bar, Baz};
 
 
 ### `expand_record_rest_pattern`
-**Source:**  [expand_rest_pattern.rs](https://github.com/rust-lang/rust-analyzer/blob/master/crates/ide-assists/src/handlers/expand_rest_pattern.rs#L24) 
+**Source:**  [expand_rest_pattern.rs](https://github.com/rust-lang/rust-analyzer/blob/master/crates/ide-assists/src/handlers/expand_rest_pattern.rs#L26) 
 
 Fills fields by replacing rest pattern in record patterns.
 
@@ -1094,7 +1094,7 @@ fn foo(bar: Bar) {
 
 
 ### `expand_tuple_struct_rest_pattern`
-**Source:**  [expand_rest_pattern.rs](https://github.com/rust-lang/rust-analyzer/blob/master/crates/ide-assists/src/handlers/expand_rest_pattern.rs#L80) 
+**Source:**  [expand_rest_pattern.rs](https://github.com/rust-lang/rust-analyzer/blob/master/crates/ide-assists/src/handlers/expand_rest_pattern.rs#L82) 
 
 Fills fields by replacing rest pattern in tuple struct patterns.
 


### PR DESCRIPTION
A new syntax node `ast::VariantDef` has been introduced to map between the HIR node and the AST. The files have been updated with `cargo test -p xtask`.

Fixes #19302