### PR TITLE
fix(codegen): do not generate docs with `--check`

### DIFF
--- a/xtask/src/codegen/assists_doc_tests.rs
+++ b/xtask/src/codegen/assists_doc_tests.rs
@@ -53,6 +53,11 @@ r#####"
         );
     }
 
+    // Do not generate assists manual when run with `--check`
+    if check {
+        return;
+    }
+
     {
         // Generate assists manual. Note that we do _not_ commit manual to the
         // git repo. Instead, `cargo xtask release` runs this test before making

--- a/xtask/src/codegen/diagnostics_docs.rs
+++ b/xtask/src/codegen/diagnostics_docs.rs
@@ -10,13 +10,15 @@ use crate::{
 
 pub(crate) fn generate(check: bool) {
     let diagnostics = Diagnostic::collect().unwrap();
-    if !check {
-        let contents =
-            diagnostics.into_iter().map(|it| it.to_string()).collect::<Vec<_>>().join("\n\n");
-        let contents = add_preamble(crate::flags::CodegenType::DiagnosticsDocs, contents);
-        let dst = project_root().join("docs/book/src/diagnostics_generated.md");
-        fs::write(dst, contents).unwrap();
+    // Do not generate docs when run with `--check`
+    if check {
+        return;
     }
+    let contents =
+        diagnostics.into_iter().map(|it| it.to_string()).collect::<Vec<_>>().join("\n\n");
+    let contents = add_preamble(crate::flags::CodegenType::DiagnosticsDocs, contents);
+    let dst = project_root().join("docs/book/src/diagnostics_generated.md");
+    fs::write(dst, contents).unwrap();
 }
 
 #[derive(Debug)]

--- a/xtask/src/codegen/feature_docs.rs
+++ b/xtask/src/codegen/feature_docs.rs
@@ -8,8 +8,12 @@ use crate::{
     util::list_rust_files,
 };
 
-pub(crate) fn generate(_check: bool) {
+pub(crate) fn generate(check: bool) {
     let features = Feature::collect().unwrap();
+    // Do not generate docs when run with `--check`
+    if check {
+        return;
+    }
     let contents = features.into_iter().map(|it| it.to_string()).collect::<Vec<_>>().join("\n\n");
     let contents = add_preamble(crate::flags::CodegenType::FeatureDocs, contents);
     let dst = project_root().join("docs/book/src/features_generated.md");


### PR DESCRIPTION
`cargo test -p xtask` regenerates bindings with xtask. If any of these changes are relevant to a PR, they should a part of the PR. This change causes the CI to fail if a commit does not include the corresponding changes to generated files.

EDIT: The command already panics if any non-doc files are modified. This patch disables doc file generation with `--check`.