### PR TITLE
fix: do not apply editorconfig to git commit msg

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -15,3 +15,6 @@ indent_size = 2
 
 [*.{yml,yaml}]
 indent_size = 2
+
+[COMMIT_EDITMSG]
+max_line_length = unset


### PR DESCRIPTION
The `max_line_length` property was set to 100 for all filetypes, which led to git commit messages being wrapped at 100 characters instead of the usual 75. This introduces an exception for the special file used by git to write commit messages.