### PR TITLE
feat(hir-ty): minimal implementations of deref patterns to str

### DIFF
--- a/crates/hir-ty/src/infer/pat.rs
+++ b/crates/hir-ty/src/infer/pat.rs
@@ -13,7 +13,6 @@ use hir_expand::name::Name;
 use stdx::TupleExt;
 
 use crate::{
-    chalk_db::AdtId,
     consteval::{self, try_const_usize, usize_const},
     infer::{
         coerce::CoerceNever, expr::ExprIsRead, BindingMode, Expectation, InferenceContext,
@@ -554,16 +553,15 @@ impl InferenceContext<'_> {
                 }
             }
         } else if let Expr::Literal(Literal::String(_)) = self.body[expr] {
-            match expected.kind(Interner) {
-                TyKind::Adt(chalk_ir::AdtId(hir_def::AdtId::StructId(struct_id)), _) => {
-                    let struct_data = self
-                        .resolve_lang_item(LangItem::String)
-                        .and_then(|lang_item| lang_item.as_struct());
-                    if Some(*struct_id) == struct_data {
-                        return expected.clone();
-                    }
+            if let TyKind::Adt(chalk_ir::AdtId(hir_def::AdtId::StructId(struct_id)), _) =
+                expected.kind(Interner)
+            {
+                let struct_data = self
+                    .resolve_lang_item(LangItem::String)
+                    .and_then(|lang_item| lang_item.as_struct());
+                if Some(*struct_id) == struct_data {
+                    return expected.clone();
                 }
-                _ => {}
             }
         }
 

--- a/crates/hir-ty/src/tests/patterns.rs
+++ b/crates/hir-ty/src/tests/patterns.rs
@@ -1259,3 +1259,18 @@ fn main() {
             "#,
     );
 }
+
+#[test]
+fn type_mismatch_string_str() {
+    check_no_mismatches(
+        r#"
+fn main() {
+    match String::new() {
+        "" => (),
+        _ => (),
+    }
+}
+
+            "#,
+    );
+}


### PR DESCRIPTION
minimal implementation of string deref patterns checking if the pattern literal is equal to the language item, its the same as the string_deref_patterns implementation of rustc

closes #17768