### PR TITLE
fix: Fix diagnostics being cleared right after being received

### DIFF
--- a/crates/rust-analyzer/src/flycheck.rs
+++ b/crates/rust-analyzer/src/flycheck.rs
@@ -401,7 +401,9 @@ impl FlycheckActor {
                             package_id = package_id.as_ref().map(|it| &it.repr),
                             "diagnostic received"
                         );
-                        self.diagnostics_received = DiagnosticsReceived::Yes;
+                        if self.diagnostics_received == DiagnosticsReceived::No {
+                            self.diagnostics_received = DiagnosticsReceived::Yes;
+                        }
                         if let Some(package_id) = &package_id {
                             if self.diagnostics_cleared_for.insert(package_id.clone()) {
                                 tracing::trace!(


### PR DESCRIPTION
cc @Veykril [this predicate](https://github.com/rust-lang/rust-analyzer/commit/5e18ad0#diff-8028b5acd2856fbdc72fafd05032eb259143fc51f4eecc6d1d87b1022475f857R417-R418) `self.diagnostics_received != DiagnosticsReceived::YesAndClearedForAll` will always evaluate to `true` as you're setting `self.diagnostics_received` to `DiagnosticsReceived::Yes` just before.

This breaks most Clippy diagnostics from displaying in our codebase.