### PR TITLE
Salsify the crate graph

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2418,6 +2418,7 @@ dependencies = [
  "span",
  "stdx",
  "test-utils",
+ "triomphe",
  "tt",
 ]
 

--- a/crates/base-db/src/input.rs
+++ b/crates/base-db/src/input.rs
@@ -6,17 +6,23 @@
 //! actual IO. See `vfs` and `project_model` in the `rust-analyzer` crate for how
 //! actual IO is done and lowered to input.
 
+use std::hash::BuildHasherDefault;
 use std::{fmt, mem, ops};
 
-use cfg::CfgOptions;
+use cfg::{CfgOptions, HashableCfgOptions};
+use dashmap::mapref::entry::Entry;
+use dashmap::DashMap;
 use intern::Symbol;
 use la_arena::{Arena, Idx, RawIdx};
-use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hash::{FxHashMap, FxHashSet, FxHasher};
+use salsa::{Durability, Setter};
 use span::{Edition, EditionedFileId};
 use triomphe::Arc;
 use vfs::{file_set::FileSet, AbsPathBuf, AnchoredPath, FileId, VfsPath};
 
-pub type ProcMacroPaths = FxHashMap<CrateId, Result<(String, AbsPathBuf), String>>;
+use crate::{CrateWorkspaceData, RootQueryDb};
+
+pub type ProcMacroPaths = FxHashMap<CrateBuilderId, Result<(String, AbsPathBuf), String>>;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct SourceRootId(pub u32);
@@ -64,38 +70,37 @@ impl SourceRoot {
     }
 }
 
-/// `CrateGraph` is a bit of information which turns a set of text files into a
-/// number of Rust crates.
-///
-/// Each crate is defined by the `FileId` of its root module, the set of enabled
-/// `cfg` flags and the set of dependencies.
-///
-/// Note that, due to cfg's, there might be several crates for a single `FileId`!
-///
-/// For the purposes of analysis, a crate does not have a name. Instead, names
-/// are specified on dependency edges. That is, a crate might be known under
-/// different names in different dependent crates.
-///
-/// Note that `CrateGraph` is build-system agnostic: it's a concept of the Rust
-/// language proper, not a concept of the build system. In practice, we get
-/// `CrateGraph` by lowering `cargo metadata` output.
-///
-/// `CrateGraph` is `!Serialize` by design, see
-/// <https://github.com/rust-lang/rust-analyzer/blob/master/docs/dev/architecture.md#serialization>
-#[derive(Clone, Default)]
-pub struct CrateGraph {
-    arena: Arena<CrateData>,
+#[derive(Default, Clone)]
+pub struct CrateGraphBuilder {
+    arena: Arena<CrateBuilder>,
 }
 
-impl fmt::Debug for CrateGraph {
+pub type CrateBuilderId = Idx<CrateBuilder>;
+
+impl ops::Index<CrateBuilderId> for CrateGraphBuilder {
+    type Output = CrateBuilder;
+
+    fn index(&self, index: CrateBuilderId) -> &Self::Output {
+        &self.arena[index]
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CrateBuilder {
+    pub basic: CrateDataBuilder,
+    pub extra: ExtraCrateData,
+    pub cfg_options: Arc<CfgOptions>,
+    pub env: Env,
+    ws_data: Arc<CrateWorkspaceData>,
+}
+
+impl fmt::Debug for CrateGraphBuilder {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_map()
             .entries(self.arena.iter().map(|(id, data)| (u32::from(id.into_raw()), data)))
             .finish()
     }
 }
-
-pub type CrateId = Idx<CrateData>;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct CrateName(Symbol);
@@ -272,10 +277,46 @@ impl ReleaseChannel {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct CrateData {
+/// The crate data from which we derive the `Crate`.
+///
+/// We want this to contain as little data as possible, because if it contains dependencies and
+/// something changes, this crate and all of its dependencies ids are invalidated, which causes
+/// pretty much everything to be recomputed. If the crate id is not invalidated, only this crate's
+/// information needs to be recomputed.
+///
+/// *Most* different crates have different root files (actually, pretty much all of them).
+/// Still, it is possible to have crates distinguished by other factors (e.g. dependencies).
+/// So we store only the root file - unless we find that this crate has the same root file as
+/// another crate, in which case we store all data for one of them (if one is a dependency of
+/// the other, we store for it, because it has more dependencies to be invalidated).
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct UniqueCrateData {
+    root_file_id: FileId,
+    disambiguator: Option<Box<(BuiltCrateData, HashableCfgOptions)>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct CrateData<Id> {
     pub root_file_id: FileId,
     pub edition: Edition,
+    /// The dependencies of this crate.
+    ///
+    /// Note that this may contain more dependencies than the crate actually uses.
+    /// A common example is the test crate which is included but only actually is active when
+    /// declared in source via `extern crate test`.
+    pub dependencies: Vec<Dependency<Id>>,
+    pub origin: CrateOrigin,
+    pub is_proc_macro: bool,
+    /// The working directory to run proc-macros in. This is the workspace root of the cargo workspace
+    /// for workspace members, the crate manifest dir otherwise.
+    pub proc_macro_cwd: Option<AbsPathBuf>,
+}
+
+pub type CrateDataBuilder = CrateData<CrateBuilderId>;
+pub type BuiltCrateData = CrateData<Crate>;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExtraCrateData {
     pub version: Option<String>,
     /// A name used in the package's project declaration: for Cargo projects,
     /// its `[package].name` can be different for other project types or even
@@ -284,21 +325,8 @@ pub struct CrateData {
     /// For purposes of analysis, crates are anonymous (only names in
     /// `Dependency` matters), this name should only be used for UI.
     pub display_name: Option<CrateDisplayName>,
-    pub cfg_options: Arc<CfgOptions>,
     /// The cfg options that could be used by the crate
-    pub potential_cfg_options: Option<Arc<CfgOptions>>,
-    pub env: Env,
-    /// The dependencies of this crate.
-    ///
-    /// Note that this may contain more dependencies than the crate actually uses.
-    /// A common example is the test crate which is included but only actually is active when
-    /// declared in source via `extern crate test`.
-    pub dependencies: Vec<Dependency>,
-    pub origin: CrateOrigin,
-    pub is_proc_macro: bool,
-    /// The working directory to run proc-macros in. This is the workspace root of the cargo workspace
-    /// for workspace members, the crate manifest dir otherwise.
-    pub proc_macro_cwd: Option<AbsPathBuf>,
+    pub potential_cfg_options: Option<CfgOptions>,
 }
 
 #[derive(Default, Clone, PartialEq, Eq)]
@@ -326,22 +354,32 @@ impl fmt::Debug for Env {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct Dependency {
-    pub crate_id: CrateId,
+pub struct Dependency<Id> {
+    pub crate_id: Id,
     pub name: CrateName,
     prelude: bool,
     sysroot: bool,
 }
 
-impl Dependency {
-    pub fn new(name: CrateName, crate_id: CrateId) -> Self {
+pub type DependencyBuilder = Dependency<CrateBuilderId>;
+pub type BuiltDependency = Dependency<Crate>;
+
+impl DependencyBuilder {
+    pub fn new(name: CrateName, crate_id: CrateBuilderId) -> Self {
         Self { name, crate_id, prelude: true, sysroot: false }
     }
 
-    pub fn with_prelude(name: CrateName, crate_id: CrateId, prelude: bool, sysroot: bool) -> Self {
+    pub fn with_prelude(
+        name: CrateName,
+        crate_id: CrateBuilderId,
+        prelude: bool,
+        sysroot: bool,
+    ) -> Self {
         Self { name, crate_id, prelude, sysroot }
     }
+}
 
+impl BuiltDependency {
     /// Whether this dependency is to be added to the depending crate's extern prelude.
     pub fn is_prelude(&self) -> bool {
         self.prelude
@@ -353,7 +391,32 @@ impl Dependency {
     }
 }
 
-impl CrateGraph {
+pub type CratesIdMap = FxHashMap<CrateBuilderId, Crate>;
+
+#[salsa::input]
+pub struct Crate {
+    #[return_ref]
+    pub data: BuiltCrateData,
+    /// Crate data that is not needed for analysis.
+    ///
+    /// This is split into a separate field to increase incrementality.
+    #[return_ref]
+    pub extra_data: ExtraCrateData,
+    // This is in `Arc` because it is shared for all crates in a workspace.
+    #[return_ref]
+    pub workspace_data: Arc<CrateWorkspaceData>,
+    // FIXME: Remove this `Arc`.
+    #[return_ref]
+    pub cfg_options: Arc<CfgOptions>,
+    #[return_ref]
+    pub env: Env,
+}
+
+/// The mapping from [`UniqueCrateData`] to their [`Crate`] input.
+#[derive(Debug, Default)]
+pub struct CratesMap(DashMap<UniqueCrateData, Crate, BuildHasherDefault<FxHasher>>);
+
+impl CrateGraphBuilder {
     pub fn add_crate_root(
         &mut self,
         root_file_id: FileId,
@@ -361,33 +424,34 @@ impl CrateGraph {
         display_name: Option<CrateDisplayName>,
         version: Option<String>,
         cfg_options: Arc<CfgOptions>,
-        potential_cfg_options: Option<Arc<CfgOptions>>,
+        potential_cfg_options: Option<CfgOptions>,
         mut env: Env,
         origin: CrateOrigin,
         is_proc_macro: bool,
         proc_macro_cwd: Option<AbsPathBuf>,
-    ) -> CrateId {
+        ws_data: Arc<CrateWorkspaceData>,
+    ) -> CrateBuilderId {
         env.entries.shrink_to_fit();
-        let data = CrateData {
-            root_file_id,
-            edition,
-            version,
-            display_name,
+        self.arena.alloc(CrateBuilder {
+            basic: CrateData {
+                root_file_id,
+                edition,
+                dependencies: Vec::new(),
+                origin,
+                is_proc_macro,
+                proc_macro_cwd,
+            },
+            extra: ExtraCrateData { version, display_name, potential_cfg_options },
             cfg_options,
-            potential_cfg_options,
             env,
-            dependencies: Vec::new(),
-            origin,
-            is_proc_macro,
-            proc_macro_cwd,
-        };
-        self.arena.alloc(data)
+            ws_data,
+        })
     }
 
     pub fn add_dep(
         &mut self,
-        from: CrateId,
-        dep: Dependency,
+        from: CrateBuilderId,
+        dep: DependencyBuilder,
     ) -> Result<(), CyclicDependenciesError> {
         let _p = tracing::info_span!("add_dep").entered();
 
@@ -395,37 +459,160 @@ impl CrateGraph {
         // that out, look for a  path in the *opposite* direction, from `to` to
         // `from`.
         if let Some(path) = self.find_path(&mut FxHashSet::default(), dep.crate_id, from) {
-            let path = path.into_iter().map(|it| (it, self[it].display_name.clone())).collect();
+            let path =
+                path.into_iter().map(|it| (it, self[it].extra.display_name.clone())).collect();
             let err = CyclicDependenciesError { path };
             assert!(err.from().0 == from && err.to().0 == dep.crate_id);
             return Err(err);
         }
 
-        self.arena[from].add_dep(dep);
+        self.arena[from].basic.dependencies.push(dep);
         Ok(())
     }
 
-    pub fn is_empty(&self) -> bool {
-        self.arena.is_empty()
+    pub fn set_in_db(self, db: &mut dyn RootQueryDb) -> CratesIdMap {
+        let mut all_crates = Vec::with_capacity(self.arena.len());
+        let mut visited = FxHashMap::default();
+        let mut visited_root_files = FxHashSet::default();
+
+        let old_all_crates = db.all_crates();
+
+        let crates_map = db.crates_map();
+        // salsa doesn't compare new input to old input to see if they are the same, so here we are doing all the work ourselves.
+        for krate in self.iter() {
+            go(
+                &self,
+                db,
+                &crates_map,
+                &mut visited,
+                &mut visited_root_files,
+                &mut all_crates,
+                krate,
+            );
+        }
+
+        if **old_all_crates != *all_crates {
+            db.set_all_crates_with_durability(
+                Arc::new(all_crates.into_boxed_slice()),
+                Durability::HIGH,
+            );
+        }
+
+        return visited;
+
+        fn go(
+            graph: &CrateGraphBuilder,
+            db: &mut dyn RootQueryDb,
+            crates_map: &CratesMap,
+            visited: &mut FxHashMap<CrateBuilderId, Crate>,
+            visited_root_files: &mut FxHashSet<FileId>,
+            all_crates: &mut Vec<Crate>,
+            source: CrateBuilderId,
+        ) -> Crate {
+            if let Some(&crate_id) = visited.get(&source) {
+                return crate_id;
+            }
+            let krate = &graph[source];
+            let dependencies = krate
+                .basic
+                .dependencies
+                .iter()
+                .map(|dep| BuiltDependency {
+                    crate_id: go(
+                        graph,
+                        db,
+                        crates_map,
+                        visited,
+                        visited_root_files,
+                        all_crates,
+                        dep.crate_id,
+                    ),
+                    name: dep.name.clone(),
+                    prelude: dep.prelude,
+                    sysroot: dep.sysroot,
+                })
+                .collect::<Vec<_>>();
+            let crate_data = BuiltCrateData {
+                dependencies,
+                edition: krate.basic.edition,
+                is_proc_macro: krate.basic.is_proc_macro,
+                origin: krate.basic.origin.clone(),
+                root_file_id: krate.basic.root_file_id,
+                proc_macro_cwd: krate.basic.proc_macro_cwd.clone(),
+            };
+            let disambiguator = if visited_root_files.insert(krate.basic.root_file_id) {
+                None
+            } else {
+                Some(Box::new((crate_data.clone(), krate.cfg_options.to_hashable())))
+            };
+
+            let unique_crate_data =
+                UniqueCrateData { root_file_id: krate.basic.root_file_id, disambiguator };
+            let crate_input = match crates_map.0.entry(unique_crate_data) {
+                Entry::Occupied(entry) => {
+                    let old_crate = *entry.get();
+                    if crate_data != *old_crate.data(db) {
+                        old_crate.set_data(db).with_durability(Durability::HIGH).to(crate_data);
+                    }
+                    if krate.extra != *old_crate.extra_data(db) {
+                        old_crate
+                            .set_extra_data(db)
+                            .with_durability(Durability::HIGH)
+                            .to(krate.extra.clone());
+                    }
+                    if krate.cfg_options != *old_crate.cfg_options(db) {
+                        old_crate
+                            .set_cfg_options(db)
+                            .with_durability(Durability::HIGH)
+                            .to(krate.cfg_options.clone());
+                    }
+                    if krate.env != *old_crate.env(db) {
+                        old_crate
+                            .set_env(db)
+                            .with_durability(Durability::HIGH)
+                            .to(krate.env.clone());
+                    }
+                    if krate.ws_data != *old_crate.workspace_data(db) {
+                        old_crate
+                            .set_workspace_data(db)
+                            .with_durability(Durability::HIGH)
+                            .to(krate.ws_data.clone());
+                    }
+                    old_crate
+                }
+                Entry::Vacant(entry) => {
+                    let input = Crate::builder(
+                        crate_data,
+                        krate.extra.clone(),
+                        krate.ws_data.clone(),
+                        krate.cfg_options.clone(),
+                        krate.env.clone(),
+                    )
+                    .durability(Durability::HIGH)
+                    .new(db);
+                    entry.insert(input);
+                    input
+                }
+            };
+            all_crates.push(crate_input);
+            visited.insert(source, crate_input);
+            crate_input
+        }
     }
 
-    pub fn len(&self) -> usize {
-        self.arena.len()
-    }
-
-    pub fn iter(&self) -> impl Iterator<Item = CrateId> + '_ {
+    pub fn iter(&self) -> impl Iterator<Item = CrateBuilderId> + '_ {
         self.arena.iter().map(|(idx, _)| idx)
     }
 
     // FIXME: used for fixing up the toolchain sysroot, should be removed and done differently
     #[doc(hidden)]
-    pub fn iter_mut(&mut self) -> impl Iterator<Item = (CrateId, &mut CrateData)> + '_ {
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = (CrateBuilderId, &mut CrateBuilder)> + '_ {
         self.arena.iter_mut()
     }
 
     /// Returns an iterator over all transitive dependencies of the given crate,
     /// including the crate itself.
-    pub fn transitive_deps(&self, of: CrateId) -> impl Iterator<Item = CrateId> {
+    pub fn transitive_deps(&self, of: CrateBuilderId) -> impl Iterator<Item = CrateBuilderId> {
         let mut worklist = vec![of];
         let mut deps = FxHashSet::default();
 
@@ -434,42 +621,15 @@ impl CrateGraph {
                 continue;
             }
 
-            worklist.extend(self[krate].dependencies.iter().map(|dep| dep.crate_id));
+            worklist.extend(self[krate].basic.dependencies.iter().map(|dep| dep.crate_id));
         }
 
         deps.into_iter()
     }
 
-    /// Returns all transitive reverse dependencies of the given crate,
-    /// including the crate itself.
-    pub fn transitive_rev_deps(&self, of: CrateId) -> impl Iterator<Item = CrateId> {
-        let mut worklist = vec![of];
-        let mut rev_deps = FxHashSet::default();
-        rev_deps.insert(of);
-
-        let mut inverted_graph = FxHashMap::<_, Vec<_>>::default();
-        self.arena.iter().for_each(|(krate, data)| {
-            data.dependencies
-                .iter()
-                .for_each(|dep| inverted_graph.entry(dep.crate_id).or_default().push(krate))
-        });
-
-        while let Some(krate) = worklist.pop() {
-            if let Some(krate_rev_deps) = inverted_graph.get(&krate) {
-                krate_rev_deps
-                    .iter()
-                    .copied()
-                    .filter(|&rev_dep| rev_deps.insert(rev_dep))
-                    .for_each(|rev_dep| worklist.push(rev_dep));
-            }
-        }
-
-        rev_deps.into_iter()
-    }
-
     /// Returns all crates in the graph, sorted in topological order (ie. dependencies of a crate
     /// come before the crate itself).
-    pub fn crates_in_topological_order(&self) -> Vec<CrateId> {
+    fn crates_in_topological_order(&self) -> Vec<CrateBuilderId> {
         let mut res = Vec::new();
         let mut visited = FxHashSet::default();
 
@@ -480,15 +640,15 @@ impl CrateGraph {
         return res;
 
         fn go(
-            graph: &CrateGraph,
-            visited: &mut FxHashSet<CrateId>,
-            res: &mut Vec<CrateId>,
-            source: CrateId,
+            graph: &CrateGraphBuilder,
+            visited: &mut FxHashSet<CrateBuilderId>,
+            res: &mut Vec<CrateBuilderId>,
+            source: CrateBuilderId,
         ) {
             if !visited.insert(source) {
                 return;
             }
-            for dep in graph[source].dependencies.iter() {
+            for dep in graph[source].basic.dependencies.iter() {
                 go(graph, visited, res, dep.crate_id)
             }
             res.push(source)
@@ -504,23 +664,27 @@ impl CrateGraph {
     /// Returns a map mapping `other`'s IDs to the new IDs in `self`.
     pub fn extend(
         &mut self,
-        mut other: CrateGraph,
+        mut other: CrateGraphBuilder,
         proc_macros: &mut ProcMacroPaths,
-    ) -> FxHashMap<CrateId, CrateId> {
+    ) -> FxHashMap<CrateBuilderId, CrateBuilderId> {
         // Sorting here is a bit pointless because the input is likely already sorted.
         // However, the overhead is small and it makes the `extend` method harder to misuse.
         self.arena
             .iter_mut()
-            .for_each(|(_, data)| data.dependencies.sort_by_key(|dep| dep.crate_id));
+            .for_each(|(_, data)| data.basic.dependencies.sort_by_key(|dep| dep.crate_id));
 
-        let m = self.len();
+        let m = self.arena.len();
         let topo = other.crates_in_topological_order();
-        let mut id_map: FxHashMap<CrateId, CrateId> = FxHashMap::default();
+        let mut id_map: FxHashMap<CrateBuilderId, CrateBuilderId> = FxHashMap::default();
         for topo in topo {
             let crate_data = &mut other.arena[topo];
 
-            crate_data.dependencies.iter_mut().for_each(|dep| dep.crate_id = id_map[&dep.crate_id]);
-            crate_data.dependencies.sort_by_key(|dep| dep.crate_id);
+            crate_data
+                .basic
+                .dependencies
+                .iter_mut()
+                .for_each(|dep| dep.crate_id = id_map[&dep.crate_id]);
+            crate_data.basic.dependencies.sort_by_key(|dep| dep.crate_id);
 
             let find = self.arena.iter().take(m).find_map(|(k, v)| (v == crate_data).then_some(k));
             let new_id = find.unwrap_or_else(|| self.arena.alloc(crate_data.clone()));
@@ -534,10 +698,10 @@ impl CrateGraph {
 
     fn find_path(
         &self,
-        visited: &mut FxHashSet<CrateId>,
-        from: CrateId,
-        to: CrateId,
-    ) -> Option<Vec<CrateId>> {
+        visited: &mut FxHashSet<CrateBuilderId>,
+        from: CrateBuilderId,
+        to: CrateBuilderId,
+    ) -> Option<Vec<CrateBuilderId>> {
         if !visited.insert(from) {
             return None;
         }
@@ -546,7 +710,7 @@ impl CrateGraph {
             return Some(vec![to]);
         }
 
-        for dep in &self[from].dependencies {
+        for dep in &self[from].basic.dependencies {
             let crate_id = dep.crate_id;
             if let Some(mut path) = self.find_path(visited, crate_id, to) {
                 path.push(from);
@@ -559,7 +723,10 @@ impl CrateGraph {
 
     /// Removes all crates from this crate graph except for the ones in `to_keep` and fixes up the dependencies.
     /// Returns a mapping from old crate ids to new crate ids.
-    pub fn remove_crates_except(&mut self, to_keep: &[CrateId]) -> Vec<Option<CrateId>> {
+    pub fn remove_crates_except(
+        &mut self,
+        to_keep: &[CrateBuilderId],
+    ) -> Vec<Option<CrateBuilderId>> {
         let mut id_map = vec![None; self.arena.len()];
         self.arena = std::mem::take(&mut self.arena)
             .into_iter()
@@ -567,12 +734,12 @@ impl CrateGraph {
             .enumerate()
             .map(|(new_id, (id, data))| {
                 id_map[id.into_raw().into_u32() as usize] =
-                    Some(CrateId::from_raw(RawIdx::from_u32(new_id as u32)));
+                    Some(CrateBuilderId::from_raw(RawIdx::from_u32(new_id as u32)));
                 data
             })
             .collect();
         for (_, data) in self.arena.iter_mut() {
-            data.dependencies.iter_mut().for_each(|dep| {
+            data.basic.dependencies.iter_mut().for_each(|dep| {
                 dep.crate_id =
                     id_map[dep.crate_id.into_raw().into_u32() as usize].expect("crate was filtered")
             });
@@ -585,20 +752,34 @@ impl CrateGraph {
     }
 }
 
-impl ops::Index<CrateId> for CrateGraph {
-    type Output = CrateData;
-    fn index(&self, crate_id: CrateId) -> &CrateData {
-        &self.arena[crate_id]
+pub(crate) fn transitive_rev_deps(db: &dyn RootQueryDb, of: Crate) -> FxHashSet<Crate> {
+    let mut worklist = vec![of];
+    let mut rev_deps = FxHashSet::default();
+    rev_deps.insert(of);
+
+    let mut inverted_graph = FxHashMap::<_, Vec<_>>::default();
+    db.all_crates().iter().for_each(|&krate| {
+        krate
+            .data(db)
+            .dependencies
+            .iter()
+            .for_each(|dep| inverted_graph.entry(dep.crate_id).or_default().push(krate))
+    });
+
+    while let Some(krate) = worklist.pop() {
+        if let Some(crate_rev_deps) = inverted_graph.get(&krate) {
+            crate_rev_deps
+                .iter()
+                .copied()
+                .filter(|&rev_dep| rev_deps.insert(rev_dep))
+                .for_each(|rev_dep| worklist.push(rev_dep));
+        }
     }
+
+    rev_deps
 }
 
-impl CrateData {
-    /// Add a dependency to `self` without checking if the dependency
-    // is existent among `self.dependencies`.
-    fn add_dep(&mut self, dep: Dependency) {
-        self.dependencies.push(dep)
-    }
-
+impl BuiltCrateData {
     pub fn root_file_id(&self) -> EditionedFileId {
         EditionedFileId::new(self.root_file_id, self.edition)
     }
@@ -657,21 +838,21 @@ impl<'a> IntoIterator for &'a Env {
 
 #[derive(Debug)]
 pub struct CyclicDependenciesError {
-    path: Vec<(CrateId, Option<CrateDisplayName>)>,
+    path: Vec<(CrateBuilderId, Option<CrateDisplayName>)>,
 }
 
 impl CyclicDependenciesError {
-    fn from(&self) -> &(CrateId, Option<CrateDisplayName>) {
+    fn from(&self) -> &(CrateBuilderId, Option<CrateDisplayName>) {
         self.path.first().unwrap()
     }
-    fn to(&self) -> &(CrateId, Option<CrateDisplayName>) {
+    fn to(&self) -> &(CrateBuilderId, Option<CrateDisplayName>) {
         self.path.last().unwrap()
     }
 }
 
 impl fmt::Display for CyclicDependenciesError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let render = |(id, name): &(CrateId, Option<CrateDisplayName>)| match name {
+        let render = |(id, name): &(CrateBuilderId, Option<CrateDisplayName>)| match name {
             Some(it) => format!("{it}({id:?})"),
             None => format!("{id:?}"),
         };
@@ -688,13 +869,19 @@ impl fmt::Display for CyclicDependenciesError {
 
 #[cfg(test)]
 mod tests {
-    use crate::CrateOrigin;
+    use triomphe::Arc;
 
-    use super::{CrateGraph, CrateName, Dependency, Edition::Edition2018, Env, FileId};
+    use crate::{CrateWorkspaceData, DependencyBuilder};
+
+    use super::{CrateGraphBuilder, CrateName, CrateOrigin, Edition::Edition2018, Env, FileId};
+
+    fn empty_ws_data() -> Arc<CrateWorkspaceData> {
+        Arc::new(CrateWorkspaceData { data_layout: Err("".into()), toolchain: None })
+    }
 
     #[test]
     fn detect_cyclic_dependency_indirect() {
-        let mut graph = CrateGraph::default();
+        let mut graph = CrateGraphBuilder::default();
         let crate1 = graph.add_crate_root(
             FileId::from_raw(1u32),
             Edition2018,
@@ -706,6 +893,7 @@ mod tests {
             CrateOrigin::Local { repo: None, name: None },
             false,
             None,
+            empty_ws_data(),
         );
         let crate2 = graph.add_crate_root(
             FileId::from_raw(2u32),
@@ -718,6 +906,7 @@ mod tests {
             CrateOrigin::Local { repo: None, name: None },
             false,
             None,
+            empty_ws_data(),
         );
         let crate3 = graph.add_crate_root(
             FileId::from_raw(3u32),
@@ -730,21 +919,22 @@ mod tests {
             CrateOrigin::Local { repo: None, name: None },
             false,
             None,
+            empty_ws_data(),
         );
         assert!(graph
-            .add_dep(crate1, Dependency::new(CrateName::new("crate2").unwrap(), crate2,))
+            .add_dep(crate1, DependencyBuilder::new(CrateName::new("crate2").unwrap(), crate2,))
             .is_ok());
         assert!(graph
-            .add_dep(crate2, Dependency::new(CrateName::new("crate3").unwrap(), crate3,))
+            .add_dep(crate2, DependencyBuilder::new(CrateName::new("crate3").unwrap(), crate3,))
             .is_ok());
         assert!(graph
-            .add_dep(crate3, Dependency::new(CrateName::new("crate1").unwrap(), crate1,))
+            .add_dep(crate3, DependencyBuilder::new(CrateName::new("crate1").unwrap(), crate1,))
             .is_err());
     }
 
     #[test]
     fn detect_cyclic_dependency_direct() {
-        let mut graph = CrateGraph::default();
+        let mut graph = CrateGraphBuilder::default();
         let crate1 = graph.add_crate_root(
             FileId::from_raw(1u32),
             Edition2018,
@@ -756,6 +946,7 @@ mod tests {
             CrateOrigin::Local { repo: None, name: None },
             false,
             None,
+            empty_ws_data(),
         );
         let crate2 = graph.add_crate_root(
             FileId::from_raw(2u32),
@@ -768,18 +959,19 @@ mod tests {
             CrateOrigin::Local { repo: None, name: None },
             false,
             None,
+            empty_ws_data(),
         );
         assert!(graph
-            .add_dep(crate1, Dependency::new(CrateName::new("crate2").unwrap(), crate2,))
+            .add_dep(crate1, DependencyBuilder::new(CrateName::new("crate2").unwrap(), crate2,))
             .is_ok());
         assert!(graph
-            .add_dep(crate2, Dependency::new(CrateName::new("crate2").unwrap(), crate2,))
+            .add_dep(crate2, DependencyBuilder::new(CrateName::new("crate2").unwrap(), crate2,))
             .is_err());
     }
 
     #[test]
     fn it_works() {
-        let mut graph = CrateGraph::default();
+        let mut graph = CrateGraphBuilder::default();
         let crate1 = graph.add_crate_root(
             FileId::from_raw(1u32),
             Edition2018,
@@ -791,6 +983,7 @@ mod tests {
             CrateOrigin::Local { repo: None, name: None },
             false,
             None,
+            empty_ws_data(),
         );
         let crate2 = graph.add_crate_root(
             FileId::from_raw(2u32),
@@ -803,6 +996,7 @@ mod tests {
             CrateOrigin::Local { repo: None, name: None },
             false,
             None,
+            empty_ws_data(),
         );
         let crate3 = graph.add_crate_root(
             FileId::from_raw(3u32),
@@ -815,18 +1009,19 @@ mod tests {
             CrateOrigin::Local { repo: None, name: None },
             false,
             None,
+            empty_ws_data(),
         );
         assert!(graph
-            .add_dep(crate1, Dependency::new(CrateName::new("crate2").unwrap(), crate2,))
+            .add_dep(crate1, DependencyBuilder::new(CrateName::new("crate2").unwrap(), crate2,))
             .is_ok());
         assert!(graph
-            .add_dep(crate2, Dependency::new(CrateName::new("crate3").unwrap(), crate3,))
+            .add_dep(crate2, DependencyBuilder::new(CrateName::new("crate3").unwrap(), crate3,))
             .is_ok());
     }
 
     #[test]
     fn dashes_are_normalized() {
-        let mut graph = CrateGraph::default();
+        let mut graph = CrateGraphBuilder::default();
         let crate1 = graph.add_crate_root(
             FileId::from_raw(1u32),
             Edition2018,
@@ -838,6 +1033,7 @@ mod tests {
             CrateOrigin::Local { repo: None, name: None },
             false,
             None,
+            empty_ws_data(),
         );
         let crate2 = graph.add_crate_root(
             FileId::from_raw(2u32),
@@ -850,16 +1046,22 @@ mod tests {
             CrateOrigin::Local { repo: None, name: None },
             false,
             None,
+            empty_ws_data(),
         );
         assert!(graph
             .add_dep(
                 crate1,
-                Dependency::new(CrateName::normalize_dashes("crate-name-with-dashes"), crate2,)
+                DependencyBuilder::new(
+                    CrateName::normalize_dashes("crate-name-with-dashes"),
+                    crate2,
+                )
             )
             .is_ok());
         assert_eq!(
-            graph[crate1].dependencies,
-            vec![Dependency::new(CrateName::new("crate_name_with_dashes").unwrap(), crate2,)]
+            graph.arena[crate1].basic.dependencies,
+            vec![
+                DependencyBuilder::new(CrateName::new("crate_name_with_dashes").unwrap(), crate2,)
+            ]
         );
     }
 }

--- a/crates/cfg/src/lib.rs
+++ b/crates/cfg/src/lib.rs
@@ -104,6 +104,12 @@ impl CfgOptions {
             _ => None,
         })
     }
+
+    pub fn to_hashable(&self) -> HashableCfgOptions {
+        let mut enabled = self.enabled.iter().cloned().collect::<Box<[_]>>();
+        enabled.sort_unstable();
+        HashableCfgOptions { _enabled: enabled }
+    }
 }
 
 impl Extend<CfgAtom> for CfgOptions {
@@ -255,4 +261,10 @@ impl fmt::Display for InactiveReason {
 
         Ok(())
     }
+}
+
+/// A `CfgOptions` that implements `Hash`, for the sake of hashing only.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct HashableCfgOptions {
+    _enabled: Box<[CfgAtom]>,
 }

--- a/crates/hir-def/src/attr.rs
+++ b/crates/hir-def/src/attr.rs
@@ -2,7 +2,7 @@
 
 use std::{borrow::Cow, hash::Hash, ops};
 
-use base_db::CrateId;
+use base_db::Crate;
 use cfg::{CfgExpr, CfgOptions};
 use either::Either;
 use hir_expand::{
@@ -44,7 +44,7 @@ impl Attrs {
         (**self).iter().find(|attr| attr.id == id)
     }
 
-    pub(crate) fn filter(db: &dyn DefDatabase, krate: CrateId, raw_attrs: RawAttrs) -> Attrs {
+    pub(crate) fn filter(db: &dyn DefDatabase, krate: Crate, raw_attrs: RawAttrs) -> Attrs {
         Attrs(raw_attrs.filter(db.upcast(), krate))
     }
 }
@@ -76,7 +76,6 @@ impl Attrs {
         // FIXME: There should be some proper form of mapping between item tree field ids and hir field ids
         let mut res = ArenaMap::default();
 
-        let crate_graph = db.crate_graph();
         let item_tree;
         let (parent, fields, krate) = match v {
             VariantId::EnumVariantId(it) => {
@@ -102,7 +101,7 @@ impl Attrs {
             }
         };
 
-        let cfg_options = &crate_graph[krate].cfg_options;
+        let cfg_options = krate.cfg_options(db);
 
         let mut idx = 0;
         for (id, _field) in fields.iter().enumerate() {

--- a/crates/hir-def/src/data.rs
+++ b/crates/hir-def/src/data.rs
@@ -2,7 +2,7 @@
 
 pub mod adt;
 
-use base_db::CrateId;
+use base_db::Crate;
 use hir_expand::{
     name::Name, AstId, ExpandResult, HirFileId, InFile, MacroCallId, MacroCallKind, MacroDefKind,
 };
@@ -22,7 +22,7 @@ use crate::{
         attr_resolution::ResolvedAttr,
         diagnostics::{DefDiagnostic, DefDiagnostics},
         proc_macro::{parse_macro_name_and_helper_attrs, ProcMacroKind},
-        DefMap, MacroSubNs,
+        DefMap, LocalDefMap, MacroSubNs,
     },
     path::ImportAlias,
     type_ref::{TraitRef, TypeBound, TypeRefId, TypesMap},
@@ -57,8 +57,7 @@ impl FunctionData {
             item_tree[func.visibility].clone()
         };
 
-        let crate_graph = db.crate_graph();
-        let cfg_options = &crate_graph[krate].cfg_options;
+        let cfg_options = krate.cfg_options(db);
         let attr_owner = |idx| {
             item_tree::AttrOwner::Param(loc.id.value, Idx::from_raw(RawIdx::from(idx as u32)))
         };
@@ -525,7 +524,7 @@ pub struct ExternCrateDeclData {
     pub name: Name,
     pub alias: Option<ImportAlias>,
     pub visibility: RawVisibility,
-    pub crate_id: Option<CrateId>,
+    pub crate_id: Option<Crate>,
 }
 
 impl ExternCrateDeclData {
@@ -542,7 +541,7 @@ impl ExternCrateDeclData {
         let crate_id = if name == sym::self_.clone() {
             Some(krate)
         } else {
-            db.crate_graph()[krate].dependencies.iter().find_map(|dep| {
+            krate.data(db).dependencies.iter().find_map(|dep| {
                 if dep.name.symbol() == name.symbol() {
                     Some(dep.crate_id)
                 } else {
@@ -633,6 +632,7 @@ struct AssocItemCollector<'a> {
     db: &'a dyn DefDatabase,
     module_id: ModuleId,
     def_map: Arc<DefMap>,
+    local_def_map: Arc<LocalDefMap>,
     diagnostics: Vec<DefDiagnostic>,
     container: ItemContainerId,
     expander: Expander,
@@ -648,10 +648,12 @@ impl<'a> AssocItemCollector<'a> {
         file_id: HirFileId,
         container: ItemContainerId,
     ) -> Self {
+        let (def_map, local_def_map) = module_id.local_def_map(db);
         Self {
             db,
             module_id,
-            def_map: module_id.def_map(db),
+            def_map,
+            local_def_map,
             container,
             expander: Expander::new(db, file_id, module_id),
             items: Vec::new(),
@@ -697,6 +699,7 @@ impl<'a> AssocItemCollector<'a> {
                 let ast_id_with_path = AstIdWithPath { path: attr.path.clone(), ast_id };
 
                 match self.def_map.resolve_attr_macro(
+                    &self.local_def_map,
                     self.db,
                     self.module_id.local_id,
                     ast_id_with_path,
@@ -780,6 +783,7 @@ impl<'a> AssocItemCollector<'a> {
                 let resolver = |path: &_| {
                     self.def_map
                         .resolve_path(
+                            &self.local_def_map,
                             self.db,
                             module,
                             path,

--- a/crates/hir-def/src/data/adt.rs
+++ b/crates/hir-def/src/data/adt.rs
@@ -1,6 +1,6 @@
 //! Defines hir-level representation of structs, enums and unions
 
-use base_db::CrateId;
+use base_db::Crate;
 use bitflags::bitflags;
 use cfg::CfgOptions;
 use either::Either;
@@ -90,7 +90,7 @@ pub struct FieldData {
 
 fn repr_from_value(
     db: &dyn DefDatabase,
-    krate: CrateId,
+    krate: Crate,
     item_tree: &ItemTree,
     of: AttrOwner,
 ) -> Option<ReprOptions> {
@@ -222,7 +222,7 @@ impl StructData {
             loc.container.local_id,
             loc.id.tree_id(),
             &item_tree,
-            &db.crate_graph()[krate].cfg_options,
+            krate.cfg_options(db),
             FieldParent::Struct(loc.id.value),
             &strukt.fields,
             None,
@@ -274,7 +274,7 @@ impl StructData {
             loc.container.local_id,
             loc.id.tree_id(),
             &item_tree,
-            &db.crate_graph()[krate].cfg_options,
+            krate.cfg_options(db),
             FieldParent::Union(loc.id.value),
             &union.fields,
             None,
@@ -377,7 +377,7 @@ impl EnumVariantData {
             container.local_id,
             loc.id.tree_id(),
             &item_tree,
-            &db.crate_graph()[krate].cfg_options,
+            krate.cfg_options(db),
             FieldParent::Variant(loc.id.value),
             &variant.fields,
             Some(item_tree[loc.parent.lookup(db).id.value].visibility),
@@ -448,7 +448,7 @@ pub enum StructKind {
 
 fn lower_fields(
     db: &dyn DefDatabase,
-    krate: CrateId,
+    krate: Crate,
     container: LocalModuleId,
     tree_id: TreeId,
     item_tree: &ItemTree,

--- a/crates/hir-def/src/expander.rs
+++ b/crates/hir-def/src/expander.rs
@@ -2,7 +2,7 @@
 
 use std::cell::OnceCell;
 
-use base_db::CrateId;
+use base_db::Crate;
 use cfg::CfgOptions;
 use drop_bomb::DropBomb;
 use hir_expand::{
@@ -44,7 +44,7 @@ impl Expander {
             module,
             recursion_depth: 0,
             recursion_limit,
-            cfg_options: db.crate_graph()[module.krate].cfg_options.clone(),
+            cfg_options: Arc::clone(module.krate.cfg_options(db)),
             span_map: OnceCell::new(),
         }
     }
@@ -53,7 +53,7 @@ impl Expander {
         self.span_map.get_or_init(|| db.span_map(self.current_file_id))
     }
 
-    pub fn krate(&self) -> CrateId {
+    pub fn krate(&self) -> Crate {
         self.module.krate
     }
 

--- a/crates/hir-def/src/expr_store/body.rs
+++ b/crates/hir-def/src/expr_store/body.rs
@@ -86,7 +86,6 @@ impl Body {
                         let item_tree = f.id.item_tree(db);
                         let func = &item_tree[f.id.value];
                         let krate = f.container.module(db).krate;
-                        let crate_graph = db.crate_graph();
                         (
                             param_list,
                             (0..func.params.len()).map(move |idx| {
@@ -99,7 +98,7 @@ impl Body {
                                             Idx::from_raw(RawIdx::from(idx as u32)),
                                         ),
                                     )
-                                    .is_cfg_enabled(&crate_graph[krate].cfg_options)
+                                    .is_cfg_enabled(krate.cfg_options(db))
                             }),
                         )
                     });

--- a/crates/hir-def/src/expr_store/tests.rs
+++ b/crates/hir-def/src/expr_store/tests.rs
@@ -293,7 +293,7 @@ impl SsrError {
     assert_eq!(db.body_with_source_map(def).1.diagnostics(), &[]);
     expect![[r#"
         fn main() -> () {
-            _ = $crate::error::SsrError::new(
+            _ = ra_test_fixture::error::SsrError::new(
                 builtin#lang(Arguments::new_v1_formatted)(
                     &[
                         "Failed to resolve path `", "`",
@@ -353,7 +353,7 @@ fn f(a: i32, b: u32) -> String {
     expect![[r#"
         fn f(a: i32, b: u32) -> String {
             {
-                $crate::panicking::panic_fmt(
+                core::panicking::panic_fmt(
                     builtin#lang(Arguments::new_v1_formatted)(
                         &[
                             "cc",

--- a/crates/hir-def/src/find_path.rs
+++ b/crates/hir-def/src/find_path.rs
@@ -2,7 +2,7 @@
 
 use std::{cell::Cell, cmp::Ordering, iter};
 
-use base_db::{CrateId, CrateOrigin, LangCrateOrigin};
+use base_db::{Crate, CrateOrigin, LangCrateOrigin};
 use hir_expand::{
     name::{AsName, Name},
     Lookup,
@@ -50,7 +50,7 @@ pub fn find_path(
             prefix: prefix_kind,
             cfg,
             ignore_local_imports,
-            is_std_item: db.crate_graph()[item_module.krate()].origin.is_lang(),
+            is_std_item: item_module.krate().data(db).origin.is_lang(),
             from,
             from_def_map: &from.def_map(db),
             fuel: Cell::new(FIND_PATH_FUEL),
@@ -174,9 +174,9 @@ fn find_path_for_module(
         }
         // - otherwise if the item is the crate root of a dependency crate, return the name from the extern prelude
 
-        let root_def_map = ctx.from.derive_crate_root().def_map(ctx.db);
+        let root_local_def_map = ctx.from.derive_crate_root().local_def_map(ctx.db).1;
         // rev here so we prefer looking at renamed extern decls first
-        for (name, (def_id, _extern_crate)) in root_def_map.extern_prelude().rev() {
+        for (name, (def_id, _extern_crate)) in root_local_def_map.extern_prelude().rev() {
             if crate_root != def_id {
                 continue;
             }
@@ -360,7 +360,7 @@ fn calculate_best_path(
         // too (unless we can't name it at all). It could *also* be (re)exported by the same crate
         // that wants to import it here, but we always prefer to use the external path here.
 
-        ctx.db.crate_graph()[ctx.from.krate].dependencies.iter().for_each(|dep| {
+        ctx.from.krate.data(ctx.db).dependencies.iter().for_each(|dep| {
             find_in_dep(ctx, visited_modules, item, max_len, best_choice, dep.crate_id)
         });
     }
@@ -373,11 +373,10 @@ fn find_in_sysroot(
     max_len: usize,
     best_choice: &mut Option<Choice>,
 ) {
-    let crate_graph = ctx.db.crate_graph();
-    let dependencies = &crate_graph[ctx.from.krate].dependencies;
+    let dependencies = &ctx.from.krate.data(ctx.db).dependencies;
     let mut search = |lang, best_choice: &mut _| {
         if let Some(dep) = dependencies.iter().filter(|it| it.is_sysroot()).find(|dep| {
-            match crate_graph[dep.crate_id].origin {
+            match dep.crate_id.data(ctx.db).origin {
                 CrateOrigin::Lang(l) => l == lang,
                 _ => false,
             }
@@ -419,7 +418,7 @@ fn find_in_dep(
     item: ItemInNs,
     max_len: usize,
     best_choice: &mut Option<Choice>,
-    dep: CrateId,
+    dep: Crate,
 ) {
     let import_map = ctx.db.import_map(dep);
     let Some(import_info_for) = import_map.import_info_for(item) else {
@@ -688,9 +687,10 @@ mod tests {
         })
         .unwrap();
 
-        let def_map = module.def_map(&db);
+        let (def_map, local_def_map) = module.local_def_map(&db);
         let resolved = def_map
             .resolve_path(
+                &local_def_map,
                 &db,
                 module.local_id,
                 &mod_path,

--- a/crates/hir-def/src/item_scope.rs
+++ b/crates/hir-def/src/item_scope.rs
@@ -3,7 +3,7 @@
 
 use std::sync::LazyLock;
 
-use base_db::CrateId;
+use base_db::Crate;
 use hir_expand::{attrs::AttrId, db::ExpandDatabase, name::Name, AstId, MacroCallId};
 use indexmap::map::Entry;
 use itertools::Itertools;
@@ -916,7 +916,7 @@ impl ItemInNs {
     }
 
     /// Returns the crate defining this item (or `None` if `self` is built-in).
-    pub fn krate(&self, db: &dyn DefDatabase) -> Option<CrateId> {
+    pub fn krate(&self, db: &dyn DefDatabase) -> Option<Crate> {
         match self {
             ItemInNs::Types(id) | ItemInNs::Values(id) => id.module(db).map(|m| m.krate),
             ItemInNs::Macros(id) => Some(id.module(db).krate),

--- a/crates/hir-def/src/item_tree.rs
+++ b/crates/hir-def/src/item_tree.rs
@@ -44,7 +44,7 @@ use std::{
 };
 
 use ast::{AstNode, StructKind};
-use base_db::CrateId;
+use base_db::Crate;
 use either::Either;
 use hir_expand::{attrs::RawAttrs, name::Name, ExpandTo, HirFileId, InFile};
 use intern::{Interned, Symbol};
@@ -202,7 +202,7 @@ impl ItemTree {
     }
 
     /// Returns the inner attributes of the source file.
-    pub fn top_level_attrs(&self, db: &dyn DefDatabase, krate: CrateId) -> Attrs {
+    pub fn top_level_attrs(&self, db: &dyn DefDatabase, krate: Crate) -> Attrs {
         Attrs::filter(
             db,
             krate,
@@ -214,7 +214,7 @@ impl ItemTree {
         self.attrs.get(&of).unwrap_or(&RawAttrs::EMPTY)
     }
 
-    pub(crate) fn attrs(&self, db: &dyn DefDatabase, krate: CrateId, of: AttrOwner) -> Attrs {
+    pub(crate) fn attrs(&self, db: &dyn DefDatabase, krate: Crate, of: AttrOwner) -> Attrs {
         Attrs::filter(db, krate, self.raw_attrs(of).clone())
     }
 

--- a/crates/hir-def/src/macro_expansion_tests/mod.rs
+++ b/crates/hir-def/src/macro_expansion_tests/mod.rs
@@ -376,4 +376,8 @@ impl ProcMacroExpander for IdentityWhenValidProcMacroExpander {
             panic!("got invalid macro input: {:?}", parse.errors());
         }
     }
+
+    fn eq_dyn(&self, other: &dyn ProcMacroExpander) -> bool {
+        other.as_any().type_id() == std::any::TypeId::of::<Self>()
+    }
 }

--- a/crates/hir-def/src/nameres/attr_resolution.rs
+++ b/crates/hir-def/src/nameres/attr_resolution.rs
@@ -1,6 +1,6 @@
 //! Post-nameres attribute resolution.
 
-use base_db::CrateId;
+use base_db::Crate;
 use hir_expand::{
     attrs::{Attr, AttrId, AttrInput},
     inert_attr_macro::find_builtin_attr_idx,
@@ -13,7 +13,7 @@ use triomphe::Arc;
 use crate::{
     db::DefDatabase,
     item_scope::BuiltinShadowMode,
-    nameres::path_resolution::ResolveMode,
+    nameres::{path_resolution::ResolveMode, LocalDefMap},
     path::{self, ModPath, PathKind},
     AstIdWithPath, LocalModuleId, MacroId, UnresolvedMacro,
 };
@@ -30,6 +30,7 @@ pub enum ResolvedAttr {
 impl DefMap {
     pub(crate) fn resolve_attr_macro(
         &self,
+        local_def_map: &LocalDefMap,
         db: &dyn DefDatabase,
         original_module: LocalModuleId,
         ast_id: AstIdWithPath<ast::Item>,
@@ -42,6 +43,7 @@ impl DefMap {
         }
 
         let resolved_res = self.resolve_path_fp_with_macro(
+            local_def_map,
             db,
             ResolveMode::Other,
             original_module,
@@ -105,7 +107,7 @@ pub(super) fn attr_macro_as_call_id(
     db: &dyn DefDatabase,
     item_attr: &AstIdWithPath<ast::Item>,
     macro_attr: &Attr,
-    krate: CrateId,
+    krate: Crate,
     def: MacroDefId,
 ) -> MacroCallId {
     let arg = match macro_attr.input.as_deref() {
@@ -136,7 +138,7 @@ pub(super) fn derive_macro_as_call_id(
     derive_attr_index: AttrId,
     derive_pos: u32,
     call_site: SyntaxContextId,
-    krate: CrateId,
+    krate: Crate,
     resolver: impl Fn(&path::ModPath) -> Option<(MacroId, MacroDefId)>,
     derive_macro_id: MacroCallId,
 ) -> Result<(MacroId, MacroDefId, MacroCallId), UnresolvedMacro> {

--- a/crates/hir-def/src/nameres/tests/macros.rs
+++ b/crates/hir-def/src/nameres/tests/macros.rs
@@ -1095,7 +1095,7 @@ pub fn derive_macro_2(_item: TokenStream) -> TokenStream {
 }
 "#,
     );
-    let krate = db.crate_graph().iter().next().unwrap();
+    let krate = *db.all_crates().last().unwrap();
     let def_map = db.crate_def_map(krate);
 
     assert_eq!(def_map.data.exported_derives.len(), 1);
@@ -1445,7 +1445,7 @@ struct TokenStream;
 fn proc_attr(a: TokenStream, b: TokenStream) -> TokenStream { a }
     "#,
     );
-    let krate = db.crate_graph().iter().next().unwrap();
+    let krate = *db.all_crates().last().unwrap();
     let def_map = db.crate_def_map(krate);
 
     let root_module = &def_map[DefMap::ROOT].scope;

--- a/crates/hir-def/src/pretty.rs
+++ b/crates/hir-def/src/pretty.rs
@@ -80,7 +80,16 @@ pub(crate) fn print_path(
             }
             PathKind::Crate => write!(buf, "crate")?,
             PathKind::Abs => {}
-            PathKind::DollarCrate(_) => write!(buf, "$crate")?,
+            PathKind::DollarCrate(krate) => write!(
+                buf,
+                "{}",
+                krate
+                    .extra_data(db)
+                    .display_name
+                    .as_ref()
+                    .map(|it| it.crate_name().symbol().as_str())
+                    .unwrap_or("$crate")
+            )?,
         },
     }
 

--- a/crates/hir-def/src/src.rs
+++ b/crates/hir-def/src/src.rs
@@ -158,7 +158,7 @@ impl HasChildSource<LocalFieldId> for VariantId {
         let mut map = ArenaMap::new();
         match &src.value {
             ast::StructKind::Tuple(fl) => {
-                let cfg_options = &db.crate_graph()[container.krate].cfg_options;
+                let cfg_options = container.krate.cfg_options(db);
                 let mut idx = 0;
                 for (i, fd) in fl.fields().enumerate() {
                     let attrs = item_tree.attrs(
@@ -177,7 +177,7 @@ impl HasChildSource<LocalFieldId> for VariantId {
                 }
             }
             ast::StructKind::Record(fl) => {
-                let cfg_options = &db.crate_graph()[container.krate].cfg_options;
+                let cfg_options = container.krate.cfg_options(db);
                 let mut idx = 0;
                 for (i, fd) in fl.fields().enumerate() {
                     let attrs = item_tree.attrs(

--- a/crates/hir-expand/src/builtin/fn_macro.rs
+++ b/crates/hir-expand/src/builtin/fn_macro.rs
@@ -231,7 +231,7 @@ fn assert_expand(
     let cond = expect_fragment(
         &mut iter,
         parser::PrefixEntryPoint::Expr,
-        db.crate_graph()[id.lookup(db).krate].edition,
+        id.lookup(db).krate.data(db).edition,
         tt.top_subtree().delimiter.delim_span(),
     );
     _ = iter.expect_char(',');
@@ -333,7 +333,7 @@ fn cfg_expand(
 ) -> ExpandResult<tt::TopSubtree> {
     let loc = db.lookup_intern_macro_call(id);
     let expr = CfgExpr::parse(tt);
-    let enabled = db.crate_graph()[loc.krate].cfg_options.check(&expr) != Some(false);
+    let enabled = loc.krate.cfg_options(db).check(&expr) != Some(false);
     let expanded = if enabled { quote!(span=>true) } else { quote!(span=>false) };
     ExpandResult::ok(expanded)
 }
@@ -669,7 +669,7 @@ fn relative_file(
     if res == call_site && !allow_recursion {
         Err(ExpandError::other(err_span, format!("recursive inclusion of `{path_str}`")))
     } else {
-        Ok(EditionedFileId::new(res, db.crate_graph()[lookup.krate].edition))
+        Ok(EditionedFileId::new(res, lookup.krate.data(db).edition))
     }
 }
 
@@ -812,7 +812,7 @@ fn include_str_expand(
 
 fn get_env_inner(db: &dyn ExpandDatabase, arg_id: MacroCallId, key: &Symbol) -> Option<String> {
     let krate = db.lookup_intern_macro_call(arg_id).krate;
-    db.crate_graph()[krate].env.get(key.as_str())
+    krate.env(db).get(key.as_str())
 }
 
 fn env_expand(

--- a/crates/hir-expand/src/change.rs
+++ b/crates/hir-expand/src/change.rs
@@ -1,17 +1,16 @@
 //! Defines a unit of change that can applied to the database to get the next
 //! state. Changes are transactional.
-use base_db::{CrateGraph, CrateId, CrateWorkspaceData, FileChange, SourceRoot};
-use rustc_hash::FxHashMap;
+use base_db::{CrateGraphBuilder, FileChange, SourceRoot};
 use salsa::Durability;
 use span::FileId;
 use triomphe::Arc;
 
-use crate::{db::ExpandDatabase, proc_macro::ProcMacros};
+use crate::{db::ExpandDatabase, proc_macro::ProcMacrosBuilder};
 
 #[derive(Debug, Default)]
 pub struct ChangeWithProcMacros {
     pub source_change: FileChange,
-    pub proc_macros: Option<ProcMacros>,
+    pub proc_macros: Option<ProcMacrosBuilder>,
 }
 
 impl ChangeWithProcMacros {
@@ -20,8 +19,13 @@ impl ChangeWithProcMacros {
     }
 
     pub fn apply(self, db: &mut impl ExpandDatabase) {
-        self.source_change.apply(db);
+        let crates_id_map = self.source_change.apply(db);
         if let Some(proc_macros) = self.proc_macros {
+            let proc_macros = proc_macros.build(
+                crates_id_map
+                    .as_ref()
+                    .expect("cannot set proc macros without setting the crate graph too"),
+            );
             db.set_proc_macros_with_durability(Arc::new(proc_macros), Durability::HIGH);
         }
     }
@@ -30,16 +34,11 @@ impl ChangeWithProcMacros {
         self.source_change.change_file(file_id, new_text)
     }
 
-    pub fn set_crate_graph(
-        &mut self,
-        graph: CrateGraph,
-        ws_data: FxHashMap<CrateId, Arc<CrateWorkspaceData>>,
-    ) {
+    pub fn set_crate_graph(&mut self, graph: CrateGraphBuilder) {
         self.source_change.set_crate_graph(graph);
-        self.source_change.set_ws_data(ws_data);
     }
 
-    pub fn set_proc_macros(&mut self, proc_macros: ProcMacros) {
+    pub fn set_proc_macros(&mut self, proc_macros: ProcMacrosBuilder) {
         self.proc_macros = Some(proc_macros);
     }
 

--- a/crates/hir-expand/src/eager.rs
+++ b/crates/hir-expand/src/eager.rs
@@ -18,7 +18,7 @@
 //!
 //!
 //! See the full discussion : <https://rust-lang.zulipchat.com/#narrow/stream/131828-t-compiler/topic/Eager.20expansion.20of.20built-in.20macros>
-use base_db::CrateId;
+use base_db::Crate;
 use span::SyntaxContextId;
 use syntax::{ted, Parse, SyntaxElement, SyntaxNode, TextSize, WalkEvent};
 use syntax_bridge::DocCommentDesugarMode;
@@ -34,7 +34,7 @@ use crate::{
 
 pub fn expand_eager_macro_input(
     db: &dyn ExpandDatabase,
-    krate: CrateId,
+    krate: Crate,
     macro_call: &ast::MacroCall,
     ast_id: AstId<ast::MacroCall>,
     def: MacroDefId,
@@ -115,7 +115,7 @@ fn lazy_expand(
     def: &MacroDefId,
     macro_call: &ast::MacroCall,
     ast_id: AstId<ast::MacroCall>,
-    krate: CrateId,
+    krate: Crate,
     call_site: SyntaxContextId,
 ) -> ExpandResult<(InFile<Parse<SyntaxNode>>, Arc<ExpansionSpanMap>)> {
     let expand_to = ExpandTo::from_call_site(macro_call);
@@ -137,7 +137,7 @@ fn eager_macro_recur(
     expanded_map: &mut ExpansionSpanMap,
     mut offset: TextSize,
     curr: InFile<SyntaxNode>,
-    krate: CrateId,
+    krate: Crate,
     call_site: SyntaxContextId,
     macro_resolver: &dyn Fn(&ModPath) -> Option<MacroDefId>,
 ) -> ExpandResult<Option<(SyntaxNode, TextSize)>> {
@@ -176,7 +176,7 @@ fn eager_macro_recur(
             Some(path) => match macro_resolver(&path) {
                 Some(def) => def,
                 None => {
-                    let edition = db.crate_graph()[krate].edition;
+                    let edition = krate.data(db).edition;
                     error = Some(ExpandError::other(
                         span_map.span_at(call.syntax().text_range().start()),
                         format!("unresolved macro {}", path.display(db, edition)),

--- a/crates/hir-expand/src/mod_path.rs
+++ b/crates/hir-expand/src/mod_path.rs
@@ -11,7 +11,7 @@ use crate::{
     name::{AsName, Name},
     tt,
 };
-use base_db::CrateId;
+use base_db::Crate;
 use intern::sym;
 use smallvec::SmallVec;
 use span::{Edition, SyntaxContextId};
@@ -33,7 +33,7 @@ pub enum PathKind {
     Abs,
     // FIXME: Can we remove this somehow?
     /// `$crate` from macro expansion
-    DollarCrate(CrateId),
+    DollarCrate(Crate),
 }
 
 impl PathKind {
@@ -333,7 +333,7 @@ fn convert_path_tt(db: &dyn ExpandDatabase, tt: tt::TokenTreesView<'_>) -> Optio
     Some(ModPath { kind, segments })
 }
 
-pub fn resolve_crate_root(db: &dyn ExpandDatabase, mut ctxt: SyntaxContextId) -> Option<CrateId> {
+pub fn resolve_crate_root(db: &dyn ExpandDatabase, mut ctxt: SyntaxContextId) -> Option<Crate> {
     // When resolving `$crate` from a `macro_rules!` invoked in a `macro`,
     // we don't want to pretend that the `macro_rules!` definition is in the `macro`
     // as described in `SyntaxContextId::apply_mark`, so we ignore prepended opaque marks.

--- a/crates/hir-expand/src/name.rs
+++ b/crates/hir-expand/src/name.rs
@@ -260,7 +260,7 @@ impl AsName for ast::FieldKind {
     }
 }
 
-impl AsName for base_db::Dependency {
+impl AsName for base_db::BuiltDependency {
     fn as_name(&self) -> Name {
         Name::new_symbol_root((*self.name).clone())
     }

--- a/crates/hir-expand/src/prettify_macro_expansion_.rs
+++ b/crates/hir-expand/src/prettify_macro_expansion_.rs
@@ -1,6 +1,6 @@
 //! Pretty printing of macros output.
 
-use base_db::CrateId;
+use base_db::Crate;
 use rustc_hash::FxHashMap;
 use syntax::NodeOrToken;
 use syntax::{ast::make, SyntaxNode};
@@ -13,13 +13,12 @@ pub fn prettify_macro_expansion(
     db: &dyn ExpandDatabase,
     syn: SyntaxNode,
     span_map: &ExpansionSpanMap,
-    target_crate_id: CrateId,
+    target_crate_id: Crate,
 ) -> SyntaxNode {
     // Because `syntax_bridge::prettify_macro_expansion::prettify_macro_expansion()` clones subtree for `syn`,
     // that means it will be offsetted to the beginning.
     let span_offset = syn.text_range().start();
-    let crate_graph = db.crate_graph();
-    let target_crate = &crate_graph[target_crate_id];
+    let target_crate = target_crate_id.data(db);
     let mut syntax_ctx_id_to_dollar_crate_replacement = FxHashMap::default();
     syntax_bridge::prettify_macro_expansion::prettify_macro_expansion(syn, &mut |dollar_crate| {
         let ctx = span_map.span_at(dollar_crate.text_range().start() + span_offset).ctx;
@@ -41,7 +40,7 @@ pub fn prettify_macro_expansion(
                     target_crate.dependencies.iter().find(|dep| dep.crate_id == macro_def_crate)
                 {
                     make::tokens::ident(dep.name.as_str())
-                } else if let Some(crate_name) = &crate_graph[macro_def_crate].display_name {
+                } else if let Some(crate_name) = &macro_def_crate.extra_data(db).display_name {
                     make::tokens::ident(crate_name.crate_name().as_str())
                 } else {
                     return dollar_crate.clone();

--- a/crates/hir-expand/src/proc_macro.rs
+++ b/crates/hir-expand/src/proc_macro.rs
@@ -1,24 +1,36 @@
 //! Proc Macro Expander stuff
 
 use core::fmt;
+use std::any::Any;
 use std::{panic::RefUnwindSafe, sync};
 
-use base_db::{CrateId, Env};
+use base_db::{Crate, CrateBuilderId, CratesIdMap, Env};
 use intern::Symbol;
 use rustc_hash::FxHashMap;
 use span::Span;
+use triomphe::Arc;
 
 use crate::{db::ExpandDatabase, tt, ExpandError, ExpandErrorKind, ExpandResult};
 
-#[derive(Copy, Clone, Eq, PartialEq, Debug, Hash)]
+#[derive(Copy, Clone, Eq, PartialEq, PartialOrd, Ord, Debug, Hash)]
 pub enum ProcMacroKind {
     CustomDerive,
     Bang,
     Attr,
 }
 
+pub trait AsAny: Any {
+    fn as_any(&self) -> &dyn Any;
+}
+
+impl<T: Any> AsAny for T {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
 /// A proc-macro expander implementation.
-pub trait ProcMacroExpander: fmt::Debug + Send + Sync + RefUnwindSafe {
+pub trait ProcMacroExpander: fmt::Debug + Send + Sync + RefUnwindSafe + AsAny {
     /// Run the expander with the given input subtree, optional attribute input subtree (for
     /// [`ProcMacroKind::Attr`]), environment variables, and span information.
     fn expand(
@@ -31,7 +43,17 @@ pub trait ProcMacroExpander: fmt::Debug + Send + Sync + RefUnwindSafe {
         mixed_site: Span,
         current_dir: Option<String>,
     ) -> Result<tt::TopSubtree, ProcMacroExpansionError>;
+
+    fn eq_dyn(&self, other: &dyn ProcMacroExpander) -> bool;
 }
+
+impl PartialEq for dyn ProcMacroExpander {
+    fn eq(&self, other: &Self) -> bool {
+        self.eq_dyn(other)
+    }
+}
+
+impl Eq for dyn ProcMacroExpander {}
 
 #[derive(Debug)]
 pub enum ProcMacroExpansionError {
@@ -45,41 +67,68 @@ pub type ProcMacroLoadResult = Result<Vec<ProcMacro>, (String, bool)>;
 type StoredProcMacroLoadResult = Result<Box<[ProcMacro]>, (Box<str>, bool)>;
 
 #[derive(Default, Debug)]
-pub struct ProcMacrosBuilder(FxHashMap<CrateId, StoredProcMacroLoadResult>);
+pub struct ProcMacrosBuilder(FxHashMap<CrateBuilderId, Arc<CrateProcMacros>>);
+
 impl ProcMacrosBuilder {
-    pub fn insert(&mut self, proc_macros_crate: CrateId, proc_macro: ProcMacroLoadResult) {
+    pub fn insert(
+        &mut self,
+        proc_macros_crate: CrateBuilderId,
+        mut proc_macro: ProcMacroLoadResult,
+    ) {
+        if let Ok(proc_macros) = &mut proc_macro {
+            // Sort proc macros to improve incrementality when only their order has changed (ideally the build system
+            // will not change their order, but just to be sure).
+            proc_macros
+                .sort_unstable_by_key(|proc_macro| (proc_macro.name.clone(), proc_macro.kind));
+        }
         self.0.insert(
             proc_macros_crate,
             match proc_macro {
-                Ok(it) => Ok(it.into_boxed_slice()),
-                Err((e, hard_err)) => Err((e.into_boxed_str(), hard_err)),
+                Ok(it) => Arc::new(CrateProcMacros(Ok(it.into_boxed_slice()))),
+                Err((e, hard_err)) => {
+                    Arc::new(CrateProcMacros(Err((e.into_boxed_str(), hard_err))))
+                }
             },
         );
     }
-    pub fn build(mut self) -> ProcMacros {
-        self.0.shrink_to_fit();
-        ProcMacros(self.0)
+
+    pub(crate) fn build(self, crates_id_map: &CratesIdMap) -> ProcMacros {
+        let mut map = self
+            .0
+            .into_iter()
+            .map(|(krate, proc_macro)| (crates_id_map[&krate], proc_macro))
+            .collect::<FxHashMap<_, _>>();
+        map.shrink_to_fit();
+        ProcMacros(map)
     }
 }
 
-#[derive(Default, Debug)]
-pub struct ProcMacros(FxHashMap<CrateId, StoredProcMacroLoadResult>);
-
-impl FromIterator<(CrateId, ProcMacroLoadResult)> for ProcMacros {
-    fn from_iter<T: IntoIterator<Item = (CrateId, ProcMacroLoadResult)>>(iter: T) -> Self {
+impl FromIterator<(CrateBuilderId, ProcMacroLoadResult)> for ProcMacrosBuilder {
+    fn from_iter<T: IntoIterator<Item = (CrateBuilderId, ProcMacroLoadResult)>>(iter: T) -> Self {
         let mut builder = ProcMacrosBuilder::default();
         for (k, v) in iter {
             builder.insert(k, v);
         }
-        builder.build()
+        builder
     }
 }
 
+#[derive(Debug, PartialEq, Eq)]
+pub struct CrateProcMacros(StoredProcMacroLoadResult);
+
+#[derive(Default, Debug)]
+pub struct ProcMacros(FxHashMap<Crate, Arc<CrateProcMacros>>);
 impl ProcMacros {
-    fn get(&self, krate: CrateId, idx: u32, err_span: Span) -> Result<&ProcMacro, ExpandError> {
-        let proc_macros = match self.0.get(&krate) {
-            Some(Ok(proc_macros)) => proc_macros,
-            Some(Err(_)) | None => {
+    fn get(&self, krate: Crate) -> Option<Arc<CrateProcMacros>> {
+        self.0.get(&krate).cloned()
+    }
+}
+
+impl CrateProcMacros {
+    fn get(&self, idx: u32, err_span: Span) -> Result<&ProcMacro, ExpandError> {
+        let proc_macros = match &self.0 {
+            Ok(proc_macros) => proc_macros,
+            Err(_) => {
                 return Err(ExpandError::other(
                     err_span,
                     "internal error: no proc macros for crate",
@@ -98,18 +147,17 @@ impl ProcMacros {
         )
     }
 
-    pub fn get_error_for_crate(&self, krate: CrateId) -> Option<(&str, bool)> {
-        self.0.get(&krate).and_then(|it| it.as_ref().err()).map(|(e, hard_err)| (&**e, *hard_err))
+    pub fn get_error(&self) -> Option<(&str, bool)> {
+        self.0.as_ref().err().map(|(e, hard_err)| (&**e, *hard_err))
     }
 
     /// Fetch the [`CustomProcMacroExpander`]s and their corresponding names for the given crate.
-    pub fn for_crate(
+    pub fn list(
         &self,
-        krate: CrateId,
         def_site_ctx: span::SyntaxContextId,
     ) -> Option<Box<[(crate::name::Name, CustomProcMacroExpander, bool)]>> {
-        match self.0.get(&krate) {
-            Some(Ok(proc_macros)) => Some({
+        match &self.0 {
+            Ok(proc_macros) => Some(
                 proc_macros
                     .iter()
                     .enumerate()
@@ -117,15 +165,15 @@ impl ProcMacros {
                         let name = crate::name::Name::new_symbol(it.name.clone(), def_site_ctx);
                         (name, CustomProcMacroExpander::new(idx as u32), it.disabled)
                     })
-                    .collect()
-            }),
+                    .collect(),
+            ),
             _ => None,
         }
     }
 }
 
 /// A loaded proc-macro.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Eq)]
 pub struct ProcMacro {
     /// The name of the proc macro.
     pub name: Symbol,
@@ -135,6 +183,23 @@ pub struct ProcMacro {
     /// Whether this proc-macro is disabled for early name resolution. Notably, the
     /// [`Self::expander`] is still usable.
     pub disabled: bool,
+}
+
+// `#[derive(PartialEq)]` generates a strange "cannot move" error.
+impl PartialEq for ProcMacro {
+    fn eq(&self, other: &Self) -> bool {
+        let Self { name, kind, expander, disabled } = self;
+        let Self {
+            name: other_name,
+            kind: other_kind,
+            expander: other_expander,
+            disabled: other_disabled,
+        } = other;
+        name == other_name
+            && kind == other_kind
+            && expander == other_expander
+            && disabled == other_disabled
+    }
 }
 
 /// A custom proc-macro expander handle. This handle together with its crate resolves to a [`ProcMacro`]
@@ -187,7 +252,7 @@ impl CustomProcMacroExpander {
     }
 
     /// The macro is explicitly disabled due to proc-macro attribute expansion being disabled.
-    pub fn as_expand_error(&self, def_crate: CrateId) -> Option<ExpandErrorKind> {
+    pub fn as_expand_error(&self, def_crate: Crate) -> Option<ExpandErrorKind> {
         match self.proc_macro_id {
             Self::PROC_MACRO_ATTR_DISABLED => Some(ExpandErrorKind::ProcMacroAttrExpansionDisabled),
             Self::DISABLED_ID => Some(ExpandErrorKind::MacroDisabled),
@@ -199,8 +264,8 @@ impl CustomProcMacroExpander {
     pub fn expand(
         self,
         db: &dyn ExpandDatabase,
-        def_crate: CrateId,
-        calling_crate: CrateId,
+        def_crate: Crate,
+        calling_crate: Crate,
         tt: &tt::TopSubtree,
         attr_arg: Option<&tt::TopSubtree>,
         def_site: Span,
@@ -221,8 +286,22 @@ impl CustomProcMacroExpander {
                 ExpandError::new(call_site, ExpandErrorKind::MacroDisabled),
             ),
             id => {
-                let proc_macros = db.proc_macros();
-                let proc_macro = match proc_macros.get(def_crate, id, call_site) {
+                let proc_macros = match db.proc_macros_for_crate(def_crate) {
+                    Some(it) => it,
+                    None => {
+                        return ExpandResult::new(
+                            tt::TopSubtree::empty(tt::DelimSpan {
+                                open: call_site,
+                                close: call_site,
+                            }),
+                            ExpandError::other(
+                                call_site,
+                                "internal error: no proc macros for crate",
+                            ),
+                        )
+                    }
+                };
+                let proc_macro = match proc_macros.get(id, call_site) {
                     Ok(proc_macro) => proc_macro,
                     Err(e) => {
                         return ExpandResult::new(
@@ -235,11 +314,10 @@ impl CustomProcMacroExpander {
                     }
                 };
 
-                let krate_graph = db.crate_graph();
                 // Proc macros have access to the environment variables of the invoking crate.
-                let env = &krate_graph[calling_crate].env;
+                let env = calling_crate.env(db);
                 let current_dir =
-                    krate_graph[calling_crate].proc_macro_cwd.as_deref().map(ToString::to_string);
+                    calling_crate.data(db).proc_macro_cwd.as_deref().map(ToString::to_string);
 
                 match proc_macro.expander.expand(
                     tt,
@@ -277,4 +355,11 @@ impl CustomProcMacroExpander {
             }
         }
     }
+}
+
+pub(crate) fn proc_macros_for_crate(
+    db: &dyn ExpandDatabase,
+    krate: Crate,
+) -> Option<Arc<CrateProcMacros>> {
+    db.proc_macros().get(krate)
 }

--- a/crates/hir-ty/src/consteval.rs
+++ b/crates/hir-ty/src/consteval.rs
@@ -1,6 +1,6 @@
 //! Constant evaluation details
 
-use base_db::CrateId;
+use base_db::Crate;
 use chalk_ir::{cast::Cast, BoundVar, DebruijnIndex};
 use hir_def::{
     expr_store::{Body, HygieneId},
@@ -162,7 +162,7 @@ pub fn intern_const_ref(
     db: &dyn HirDatabase,
     value: &LiteralConstRef,
     ty: Ty,
-    krate: CrateId,
+    krate: Crate,
 ) -> Const {
     let layout = db.layout_of_ty(ty.clone(), TraitEnvironment::empty(krate));
     let bytes = match value {
@@ -185,7 +185,7 @@ pub fn intern_const_ref(
 }
 
 /// Interns a possibly-unknown target usize
-pub fn usize_const(db: &dyn HirDatabase, value: Option<u128>, krate: CrateId) -> Const {
+pub fn usize_const(db: &dyn HirDatabase, value: Option<u128>, krate: Crate) -> Const {
     intern_const_ref(
         db,
         &value.map_or(LiteralConstRef::Unknown, LiteralConstRef::UInt),

--- a/crates/hir-ty/src/consteval/tests.rs
+++ b/crates/hir-ty/src/consteval/tests.rs
@@ -101,10 +101,7 @@ fn check_answer(
 fn pretty_print_err(e: ConstEvalError, db: TestDB) -> String {
     let mut err = String::new();
     let span_formatter = |file, range| format!("{file:?} {range:?}");
-    let display_target = DisplayTarget::from_crate(
-        &db,
-        *db.crate_graph().crates_in_topological_order().last().unwrap(),
-    );
+    let display_target = DisplayTarget::from_crate(&db, *db.all_crates().last().unwrap());
     match e {
         ConstEvalError::MirLowerError(e) => {
             e.pretty_print(&mut err, &db, span_formatter, display_target)

--- a/crates/hir-ty/src/diagnostics/decl_check.rs
+++ b/crates/hir-ty/src/diagnostics/decl_check.rs
@@ -288,7 +288,7 @@ impl<'a> DeclValidator<'a> {
 
     fn edition(&self, id: impl HasModule) -> span::Edition {
         let krate = id.krate(self.db.upcast());
-        self.db.crate_graph()[krate].edition
+        krate.data(self.db).edition
     }
 
     fn validate_struct(&mut self, struct_id: StructId) {

--- a/crates/hir-ty/src/diagnostics/expr.rs
+++ b/crates/hir-ty/src/diagnostics/expr.rs
@@ -4,7 +4,7 @@
 
 use std::fmt;
 
-use base_db::CrateId;
+use base_db::Crate;
 use chalk_solve::rust_ir::AdtKind;
 use either::Either;
 use hir_def::{
@@ -630,7 +630,7 @@ fn missing_match_arms<'p>(
     scrut_ty: &Ty,
     witnesses: Vec<WitnessPat<'p>>,
     arms_is_empty: bool,
-    krate: CrateId,
+    krate: Crate,
 ) -> String {
     struct DisplayWitness<'a, 'p>(&'a WitnessPat<'p>, &'a MatchCheckCtx<'p>, DisplayTarget);
     impl fmt::Display for DisplayWitness<'_, '_> {

--- a/crates/hir-ty/src/diagnostics/unsafe_check.rs
+++ b/crates/hir-ty/src/diagnostics/unsafe_check.rs
@@ -160,7 +160,7 @@ impl<'a> UnsafeVisitor<'a> {
             DefWithBodyId::FunctionId(func) => TargetFeatures::from_attrs(&db.attrs(func.into())),
             _ => TargetFeatures::default(),
         };
-        let edition = db.crate_graph()[resolver.module().krate()].edition;
+        let edition = resolver.module().krate().data(db).edition;
         Self {
             db,
             infer,

--- a/crates/hir-ty/src/display.rs
+++ b/crates/hir-ty/src/display.rs
@@ -7,7 +7,7 @@ use std::{
     mem,
 };
 
-use base_db::CrateId;
+use base_db::Crate;
 use chalk_ir::{BoundVar, Safety, TyKind};
 use either::Either;
 use hir_def::{
@@ -339,7 +339,7 @@ pub trait HirDisplay {
 }
 
 impl HirFormatter<'_> {
-    pub fn krate(&self) -> CrateId {
+    pub fn krate(&self) -> Crate {
         self.display_target.krate
     }
 
@@ -408,13 +408,13 @@ impl HirFormatter<'_> {
 
 #[derive(Debug, Clone, Copy)]
 pub struct DisplayTarget {
-    krate: CrateId,
+    krate: Crate,
     pub edition: Edition,
 }
 
 impl DisplayTarget {
-    pub fn from_crate(db: &dyn HirDatabase, krate: CrateId) -> Self {
-        let edition = db.crate_graph()[krate].edition;
+    pub fn from_crate(db: &dyn HirDatabase, krate: Crate) -> Self {
+        let edition = krate.data(db).edition;
         Self { krate, edition }
     }
 }
@@ -1711,7 +1711,7 @@ fn fn_traits(db: &dyn DefDatabase, trait_: TraitId) -> impl Iterator<Item = Trai
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub enum SizedByDefault {
     NotSized,
-    Sized { anchor: CrateId },
+    Sized { anchor: Crate },
 }
 
 impl SizedByDefault {
@@ -2266,8 +2266,8 @@ impl HirDisplayWithTypesMap for Path {
                 // Resolve `$crate` to the crate's display name.
                 // FIXME: should use the dependency name instead if available, but that depends on
                 // the crate invoking `HirDisplay`
-                let crate_graph = f.db.crate_graph();
-                let name = crate_graph[*id]
+                let crate_data = id.extra_data(f.db);
+                let name = crate_data
                     .display_name
                     .as_ref()
                     .map(|name| name.canonical_name())

--- a/crates/hir-ty/src/infer/closure.rs
+++ b/crates/hir-ty/src/infer/closure.rs
@@ -307,7 +307,7 @@ impl CapturedItem {
                 }
             }
         }
-        if is_raw_identifier(&result, db.crate_graph()[owner.module(db.upcast()).krate()].edition) {
+        if is_raw_identifier(&result, owner.module(db.upcast()).krate().data(db).edition) {
             result.insert_str(0, "r#");
         }
         result
@@ -316,7 +316,7 @@ impl CapturedItem {
     pub fn display_place_source_code(&self, owner: DefWithBodyId, db: &dyn HirDatabase) -> String {
         let body = db.body(owner);
         let krate = owner.krate(db.upcast());
-        let edition = db.crate_graph()[krate].edition;
+        let edition = krate.data(db).edition;
         let mut result = body[self.place.local].name.display(db.upcast(), edition).to_string();
         for proj in &self.place.projections {
             match proj {
@@ -368,7 +368,7 @@ impl CapturedItem {
     pub fn display_place(&self, owner: DefWithBodyId, db: &dyn HirDatabase) -> String {
         let body = db.body(owner);
         let krate = owner.krate(db.upcast());
-        let edition = db.crate_graph()[krate].edition;
+        let edition = krate.data(db).edition;
         let mut result = body[self.place.local].name.display(db.upcast(), edition).to_string();
         let mut field_need_paren = false;
         for proj in &self.place.projections {

--- a/crates/hir-ty/src/layout/target.rs
+++ b/crates/hir-ty/src/layout/target.rs
@@ -1,6 +1,6 @@
 //! Target dependent parameters needed for layouts
 
-use base_db::CrateId;
+use base_db::Crate;
 use hir_def::layout::TargetDataLayout;
 use rustc_abi::{AlignFromBytesError, TargetDataLayoutErrors};
 use triomphe::Arc;
@@ -9,9 +9,9 @@ use crate::db::HirDatabase;
 
 pub fn target_data_layout_query(
     db: &dyn HirDatabase,
-    krate: CrateId,
+    krate: Crate,
 ) -> Result<Arc<TargetDataLayout>, Arc<str>> {
-    match &db.crate_workspace_data()[&krate].data_layout {
+    match &krate.workspace_data(db).data_layout {
         Ok(it) => match TargetDataLayout::parse_from_llvm_datalayout_string(it) {
             Ok(it) => Ok(Arc::new(it)),
             Err(e) => {

--- a/crates/hir-ty/src/mir.rs
+++ b/crates/hir-ty/src/mir.rs
@@ -12,7 +12,7 @@ use crate::{
     CallableDefId, ClosureId, Const, ConstScalar, InferenceResult, Interner, MemoryMap,
     Substitution, TraitEnvironment, Ty, TyExt, TyKind,
 };
-use base_db::CrateId;
+use base_db::Crate;
 use chalk_ir::Mutability;
 use either::Either;
 use hir_def::{
@@ -143,7 +143,7 @@ impl<V, T> ProjectionElem<V, T> {
         mut base: Ty,
         db: &dyn HirDatabase,
         closure_field: impl FnOnce(ClosureId, &Substitution, usize) -> Ty,
-        krate: CrateId,
+        krate: Crate,
     ) -> Ty {
         // we only bail on mir building when there are type mismatches
         // but error types may pop up resulting in us still attempting to build the mir

--- a/crates/hir-ty/src/mir/eval.rs
+++ b/crates/hir-ty/src/mir/eval.rs
@@ -2,7 +2,7 @@
 
 use std::{borrow::Cow, cell::RefCell, fmt::Write, iter, mem, ops::Range};
 
-use base_db::CrateId;
+use base_db::Crate;
 use chalk_ir::{cast::Cast, Mutability};
 use either::Either;
 use hir_def::{
@@ -186,7 +186,7 @@ pub struct Evaluator<'a> {
     cached_fn_trait_func: Option<FunctionId>,
     cached_fn_mut_trait_func: Option<FunctionId>,
     cached_fn_once_trait_func: Option<FunctionId>,
-    crate_id: CrateId,
+    crate_id: Crate,
     // FIXME: This is a workaround, see the comment on `interpret_mir`
     assert_placeholder_ty_is_unused: bool,
     /// A general limit on execution, to prevent non terminating programs from breaking r-a main process
@@ -2785,7 +2785,7 @@ impl Evaluator<'_> {
                 let db = self.db.upcast();
                 let loc = variant.lookup(db);
                 let enum_loc = loc.parent.lookup(db);
-                let edition = self.db.crate_graph()[self.crate_id].edition;
+                let edition = self.crate_id.data(self.db).edition;
                 let name = format!(
                     "{}::{}",
                     enum_loc.id.item_tree(db)[enum_loc.id.value].name.display(db.upcast(), edition),

--- a/crates/hir-ty/src/mir/eval/shim.rs
+++ b/crates/hir-ty/src/mir/eval/shim.rs
@@ -569,7 +569,7 @@ impl Evaluator<'_> {
                     }
                     String::from_utf8_lossy(&name_buf)
                 };
-                let value = self.db.crate_graph()[self.crate_id].env.get(&name);
+                let value = self.crate_id.env(self.db).get(&name);
                 match value {
                     None => {
                         // Write null as fail

--- a/crates/hir-ty/src/mir/lower.rs
+++ b/crates/hir-ty/src/mir/lower.rs
@@ -2,7 +2,7 @@
 
 use std::{fmt::Write, iter, mem};
 
-use base_db::{salsa::Cycle, CrateId};
+use base_db::{salsa::Cycle, Crate};
 use chalk_ir::{BoundVar, ConstData, DebruijnIndex, TyKind};
 use hir_def::{
     data::adt::{StructKind, VariantData},
@@ -1920,10 +1920,10 @@ impl<'ctx> MirLowerCtx<'ctx> {
     }
 
     fn edition(&self) -> Edition {
-        self.db.crate_graph()[self.krate()].edition
+        self.krate().data(self.db).edition
     }
 
-    fn krate(&self) -> CrateId {
+    fn krate(&self) -> Crate {
         self.owner.krate(self.db.upcast())
     }
 
@@ -2121,7 +2121,7 @@ pub fn mir_body_for_closure_query(
 
 pub fn mir_body_query(db: &dyn HirDatabase, def: DefWithBodyId) -> Result<Arc<MirBody>> {
     let krate = def.krate(db.upcast());
-    let edition = db.crate_graph()[krate].edition;
+    let edition = krate.data(db).edition;
     let detail = match def {
         DefWithBodyId::FunctionId(it) => {
             db.function_data(it).name.display(db.upcast(), edition).to_string()

--- a/crates/hir-ty/src/tests.rs
+++ b/crates/hir-ty/src/tests.rs
@@ -15,7 +15,7 @@ mod type_alias_impl_traits;
 use std::env;
 use std::sync::LazyLock;
 
-use base_db::{CrateId, SourceDatabase};
+use base_db::{Crate, SourceDatabase};
 use expect_test::Expect;
 use hir_def::{
     db::DefDatabase,
@@ -124,7 +124,7 @@ fn check_impl(
     }
     assert!(had_annotations || allow_none, "no `//^` annotations found");
 
-    let mut defs: Vec<(DefWithBodyId, CrateId)> = Vec::new();
+    let mut defs: Vec<(DefWithBodyId, Crate)> = Vec::new();
     for file_id in files {
         let module = db.module_for_file_opt(file_id);
         let module = match module {
@@ -302,7 +302,7 @@ fn infer_with_mismatches(content: &str, include_mismatches: bool) -> String {
     let mut infer_def = |inference_result: Arc<InferenceResult>,
                          body: Arc<Body>,
                          body_source_map: Arc<BodySourceMap>,
-                         krate: CrateId| {
+                         krate: Crate| {
         let display_target = DisplayTarget::from_crate(&db, krate);
         let mut types: Vec<(InFile<SyntaxNode>, &Ty)> = Vec::new();
         let mut mismatches: Vec<(InFile<SyntaxNode>, &TypeMismatch)> = Vec::new();
@@ -391,7 +391,7 @@ fn infer_with_mismatches(content: &str, include_mismatches: bool) -> String {
     let module = db.module_for_file(file_id);
     let def_map = module.def_map(&db);
 
-    let mut defs: Vec<(DefWithBodyId, CrateId)> = Vec::new();
+    let mut defs: Vec<(DefWithBodyId, Crate)> = Vec::new();
     visit_module(&db, &def_map, module.local_id, &mut |it| {
         let def = match it {
             ModuleDefId::FunctionId(it) => it.into(),

--- a/crates/hir-ty/src/traits.rs
+++ b/crates/hir-ty/src/traits.rs
@@ -7,7 +7,7 @@ use chalk_ir::{fold::TypeFoldable, DebruijnIndex, GoalData};
 use chalk_recursive::Cache;
 use chalk_solve::{logging_db::LoggingRustIrDatabase, rust_ir, Solver};
 
-use base_db::CrateId;
+use base_db::Crate;
 use hir_def::{
     lang_item::{LangItem, LangItemTarget},
     BlockId, TraitId,
@@ -30,7 +30,7 @@ const CHALK_SOLVER_FUEL: i32 = 1000;
 #[derive(Debug, Copy, Clone)]
 pub(crate) struct ChalkContext<'a> {
     pub(crate) db: &'a dyn HirDatabase,
-    pub(crate) krate: CrateId,
+    pub(crate) krate: Crate,
     pub(crate) block: Option<BlockId>,
 }
 
@@ -48,7 +48,7 @@ fn create_chalk_solver() -> chalk_recursive::RecursiveSolver<Interner> {
 /// we assume that `T: Default`.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct TraitEnvironment {
-    pub krate: CrateId,
+    pub krate: Crate,
     pub block: Option<BlockId>,
     // FIXME make this a BTreeMap
     traits_from_clauses: Box<[(Ty, TraitId)]>,
@@ -56,7 +56,7 @@ pub struct TraitEnvironment {
 }
 
 impl TraitEnvironment {
-    pub fn empty(krate: CrateId) -> Arc<Self> {
+    pub fn empty(krate: Crate) -> Arc<Self> {
         Arc::new(TraitEnvironment {
             krate,
             block: None,
@@ -66,7 +66,7 @@ impl TraitEnvironment {
     }
 
     pub fn new(
-        krate: CrateId,
+        krate: Crate,
         block: Option<BlockId>,
         traits_from_clauses: Box<[(Ty, TraitId)]>,
         env: chalk_ir::Environment<Interner>,
@@ -109,7 +109,7 @@ pub(crate) fn normalize_projection_query(
 /// Solve a trait goal using Chalk.
 pub(crate) fn trait_solve_query(
     db: &dyn HirDatabase,
-    krate: CrateId,
+    krate: Crate,
     block: Option<BlockId>,
     goal: Canonical<InEnvironment<Goal>>,
 ) -> Option<Solution> {
@@ -148,7 +148,7 @@ pub(crate) fn trait_solve_query(
 
 fn solve(
     db: &dyn HirDatabase,
-    krate: CrateId,
+    krate: Crate,
     block: Option<BlockId>,
     goal: &chalk_ir::UCanonical<chalk_ir::InEnvironment<chalk_ir::Goal<Interner>>>,
 ) -> Option<chalk_solve::Solution<Interner>> {
@@ -294,7 +294,7 @@ impl FnTrait {
         }
     }
 
-    pub fn get_id(self, db: &dyn HirDatabase, krate: CrateId) -> Option<TraitId> {
+    pub fn get_id(self, db: &dyn HirDatabase, krate: Crate) -> Option<TraitId> {
         let target = db.lang_item(krate, self.lang_item())?;
         match target {
             LangItemTarget::Trait(t) => Some(t),

--- a/crates/hir-ty/src/utils.rs
+++ b/crates/hir-ty/src/utils.rs
@@ -3,7 +3,7 @@
 
 use std::{hash::Hash, iter};
 
-use base_db::CrateId;
+use base_db::Crate;
 use chalk_ir::{
     fold::{FallibleTypeFolder, Shift},
     DebruijnIndex,
@@ -34,10 +34,7 @@ use crate::{
     TraitRefExt, Ty, WhereClause,
 };
 
-pub(crate) fn fn_traits(
-    db: &dyn DefDatabase,
-    krate: CrateId,
-) -> impl Iterator<Item = TraitId> + '_ {
+pub(crate) fn fn_traits(db: &dyn DefDatabase, krate: Crate) -> impl Iterator<Item = TraitId> + '_ {
     [LangItem::Fn, LangItem::FnMut, LangItem::FnOnce]
         .into_iter()
         .filter_map(move |lang| db.lang_item(krate, lang))

--- a/crates/hir/src/from_id.rs
+++ b/crates/hir/src/from_id.rs
@@ -30,7 +30,7 @@ macro_rules! from_id {
 }
 
 from_id![
-    (base_db::CrateId, crate::Crate),
+    (base_db::Crate, crate::Crate),
     (hir_def::ModuleId, crate::Module),
     (hir_def::StructId, crate::Struct),
     (hir_def::UnionId, crate::Union),

--- a/crates/hir/src/semantics.rs
+++ b/crates/hir/src/semantics.rs
@@ -318,7 +318,7 @@ impl<'db> SemanticsImpl<'db> {
     pub fn first_crate_or_default(&self, file: FileId) -> Crate {
         match self.file_to_module_defs(file).next() {
             Some(module) => module.krate(),
-            None => (*self.db.crate_graph().crates_in_topological_order().last().unwrap()).into(),
+            None => (*self.db.all_crates().last().unwrap()).into(),
         }
     }
 

--- a/crates/hir/src/symbols.rs
+++ b/crates/hir/src/symbols.rs
@@ -77,10 +77,7 @@ impl<'a> SymbolCollector<'a> {
             symbols: Default::default(),
             work: Default::default(),
             current_container_name: None,
-            display_target: DisplayTarget::from_crate(
-                db,
-                *db.crate_graph().crates_in_topological_order().last().unwrap(),
-            ),
+            display_target: DisplayTarget::from_crate(db, *db.all_crates().last().unwrap()),
         }
     }
 

--- a/crates/ide-assists/src/handlers/inline_call.rs
+++ b/crates/ide-assists/src/handlers/inline_call.rs
@@ -7,7 +7,7 @@ use hir::{
     sym, FileRange, PathResolution, Semantics, TypeInfo,
 };
 use ide_db::{
-    base_db::CrateId,
+    base_db::Crate,
     defs::Definition,
     imports::insert_use::remove_path_if_in_use_stmt,
     path_transform::PathTransform,
@@ -251,11 +251,11 @@ struct CallInfo {
     node: ast::CallableExpr,
     arguments: Vec<ast::Expr>,
     generic_arg_list: Option<ast::GenericArgList>,
-    krate: CrateId,
+    krate: Crate,
 }
 
 impl CallInfo {
-    fn from_name_ref(name_ref: ast::NameRef, krate: CrateId) -> Option<CallInfo> {
+    fn from_name_ref(name_ref: ast::NameRef, krate: Crate) -> Option<CallInfo> {
         let parent = name_ref.syntax().parent()?;
         if let Some(call) = ast::MethodCallExpr::cast(parent.clone()) {
             let receiver = call.receiver()?;

--- a/crates/ide-db/src/apply_change.rs
+++ b/crates/ide-db/src/apply_change.rs
@@ -233,7 +233,13 @@ impl RootDatabase {
             // // SourceDatabase
             // base_db::ParseQuery
             // base_db::ParseErrorsQuery
-            // base_db::CrateGraphQuery
+            // base_db::AllCratesQuery
+            // base_db::InternUniqueCrateDataQuery
+            // base_db::InternUniqueCrateDataLookupQuery
+            // base_db::CrateDataQuery
+            // base_db::ExtraCrateDataQuery
+            // base_db::CrateCfgQuery
+            // base_db::CrateEnvQuery
             // base_db::CrateWorkspaceDataQuery
 
             // // SourceDatabaseExt

--- a/crates/ide-db/src/famous_defs.rs
+++ b/crates/ide-db/src/famous_defs.rs
@@ -1,6 +1,6 @@
 //! See [`FamousDefs`].
 
-use base_db::{CrateOrigin, LangCrateOrigin, RootQueryDb as _};
+use base_db::{CrateOrigin, LangCrateOrigin};
 use hir::{Crate, Enum, Function, Macro, Module, ScopeDef, Semantics, Trait};
 
 use crate::RootDatabase;
@@ -198,11 +198,10 @@ impl FamousDefs<'_, '_> {
     fn find_lang_crate(&self, origin: LangCrateOrigin) -> Option<Crate> {
         let krate = self.1;
         let db = self.0.db;
-        let crate_graph = self.0.db.crate_graph();
         let res = krate
             .dependencies(db)
             .into_iter()
-            .find(|dep| crate_graph[dep.krate.into()].origin == CrateOrigin::Lang(origin))?
+            .find(|dep| dep.krate.origin(db) == CrateOrigin::Lang(origin))?
             .krate;
         Some(res)
     }

--- a/crates/ide-db/src/prime_caches.rs
+++ b/crates/ide-db/src/prime_caches.rs
@@ -11,7 +11,7 @@ use itertools::Itertools;
 use salsa::{Cancelled, Database};
 
 use crate::{
-    base_db::{CrateId, RootQueryDb},
+    base_db::{Crate, RootQueryDb},
     symbol_index::SymbolsDatabase,
     FxIndexMap, RootDatabase,
 };
@@ -35,20 +35,22 @@ pub fn parallel_prime_caches(
 ) {
     let _p = tracing::info_span!("parallel_prime_caches").entered();
 
-    let graph = db.crate_graph();
     let mut crates_to_prime = {
+        // FIXME: We already have the crate list topologically sorted (but without the things
+        // `TopologicalSortIter` gives us). Maybe there is a way to avoid using it and rip it out
+        // of the codebase?
         let mut builder = topologic_sort::TopologicalSortIter::builder();
 
-        for crate_id in graph.iter() {
-            builder.add(crate_id, graph[crate_id].dependencies.iter().map(|d| d.crate_id));
+        for &crate_id in db.all_crates().iter() {
+            builder.add(crate_id, crate_id.data(db).dependencies.iter().map(|d| d.crate_id));
         }
 
         builder.build()
     };
 
     enum ParallelPrimeCacheWorkerProgress {
-        BeginCrate { crate_id: CrateId, crate_name: Symbol },
-        EndCrate { crate_id: CrateId },
+        BeginCrate { crate_id: Crate, crate_name: Symbol },
+        EndCrate { crate_id: Crate },
     }
 
     // We split off def map computation from other work,
@@ -108,16 +110,14 @@ pub fn parallel_prime_caches(
     while crates_done < crates_total {
         db.unwind_if_revision_cancelled();
 
-        for crate_id in &mut crates_to_prime {
-            let krate = &graph[crate_id];
-            let name = krate
-                .display_name
-                .as_deref()
-                .cloned()
-                .unwrap_or_else(|| Symbol::integer(crate_id.into_raw().into_u32() as usize));
-            if krate.origin.is_lang() {
-                additional_phases.push((crate_id, name.clone(), PrimingPhase::ImportMap));
-            } else if krate.origin.is_local() {
+        for krate in &mut crates_to_prime {
+            let name = krate.extra_data(db).display_name.as_deref().cloned().unwrap_or_else(|| {
+                Symbol::integer(salsa::plumbing::AsId::as_id(&krate).as_u32() as usize)
+            });
+            let origin = &krate.data(db).origin;
+            if origin.is_lang() {
+                additional_phases.push((krate, name.clone(), PrimingPhase::ImportMap));
+            } else if origin.is_local() {
                 // Compute the symbol search index.
                 // This primes the cache for `ide_db::symbol_index::world_symbols()`.
                 //
@@ -127,10 +127,10 @@ pub fn parallel_prime_caches(
                 // FIXME: We should do it unconditionally if the configuration is set to default to
                 // searching dependencies (rust-analyzer.workspace.symbol.search.scope), but we
                 // would need to pipe that configuration information down here.
-                additional_phases.push((crate_id, name.clone(), PrimingPhase::CrateSymbols));
+                additional_phases.push((krate, name.clone(), PrimingPhase::CrateSymbols));
             }
 
-            work_sender.send((crate_id, name, PrimingPhase::DefMap)).ok();
+            work_sender.send((krate, name, PrimingPhase::DefMap)).ok();
         }
 
         // recv_timeout is somewhat a hack, we need a way to from this thread check to see if the current salsa revision

--- a/crates/ide-db/src/search.rs
+++ b/crates/ide-db/src/search.rs
@@ -162,13 +162,13 @@ impl SearchScope {
     fn crate_graph(db: &RootDatabase) -> SearchScope {
         let mut entries = FxHashMap::default();
 
-        let graph = db.crate_graph();
-        for krate in graph.iter() {
-            let root_file = graph[krate].root_file_id;
-            let source_root = db.file_source_root(root_file).source_root_id(db);
+        let all_crates = db.all_crates();
+        for &krate in all_crates.iter() {
+            let crate_data = krate.data(db);
+            let source_root = db.file_source_root(crate_data.root_file_id).source_root_id(db);
             let source_root = db.source_root(source_root).source_root(db);
             entries.extend(
-                source_root.iter().map(|id| (EditionedFileId::new(id, graph[krate].edition), None)),
+                source_root.iter().map(|id| (EditionedFileId::new(id, crate_data.edition), None)),
             );
         }
         SearchScope { entries }

--- a/crates/ide-db/src/test_data/test_doc_alias.txt
+++ b/crates/ide-db/src/test_data/test_doc_alias.txt
@@ -2,7 +2,9 @@
     (
         Module {
             id: ModuleId {
-                krate: Idx::<CrateData>(0),
+                krate: Crate {
+                    [salsa id]: Id(2c00),
+                },
                 block: None,
                 local_id: Idx::<ModuleData>(0),
             },

--- a/crates/ide-db/src/test_data/test_symbol_index_collection.txt
+++ b/crates/ide-db/src/test_data/test_symbol_index_collection.txt
@@ -2,7 +2,9 @@
     (
         Module {
             id: ModuleId {
-                krate: Idx::<CrateData>(0),
+                krate: Crate {
+                    [salsa id]: Id(2c00),
+                },
                 block: None,
                 local_id: Idx::<ModuleData>(0),
             },
@@ -532,7 +534,9 @@
                 def: Module(
                     Module {
                         id: ModuleId {
-                            krate: Idx::<CrateData>(0),
+                            krate: Crate {
+                                [salsa id]: Id(2c00),
+                            },
                             block: None,
                             local_id: Idx::<ModuleData>(1),
                         },
@@ -565,7 +569,9 @@
                 def: Module(
                     Module {
                         id: ModuleId {
-                            krate: Idx::<CrateData>(0),
+                            krate: Crate {
+                                [salsa id]: Id(2c00),
+                            },
                             block: None,
                             local_id: Idx::<ModuleData>(2),
                         },
@@ -827,7 +833,9 @@
     (
         Module {
             id: ModuleId {
-                krate: Idx::<CrateData>(0),
+                krate: Crate {
+                    [salsa id]: Id(2c00),
+                },
                 block: None,
                 local_id: Idx::<ModuleData>(1),
             },
@@ -871,7 +879,9 @@
     (
         Module {
             id: ModuleId {
-                krate: Idx::<CrateData>(0),
+                krate: Crate {
+                    [salsa id]: Id(2c00),
+                },
                 block: None,
                 local_id: Idx::<ModuleData>(2),
             },

--- a/crates/ide-diagnostics/src/lib.rs
+++ b/crates/ide-diagnostics/src/lib.rs
@@ -389,9 +389,9 @@ pub fn semantic_diagnostics(
         module.and_then(|m| db.toolchain_channel(m.krate().into())),
         Some(ReleaseChannel::Nightly) | None
     );
-    let krate = module.map(|module| module.krate()).unwrap_or_else(|| {
-        (*db.crate_graph().crates_in_topological_order().last().unwrap()).into()
-    });
+    let krate = module
+        .map(|module| module.krate())
+        .unwrap_or_else(|| (*db.all_crates().last().unwrap()).into());
     let display_target = krate.to_display_target(db);
     let ctx = DiagnosticsContext { config, sema, resolve, edition, is_nightly, display_target };
 

--- a/crates/ide-ssr/src/matching.rs
+++ b/crates/ide-ssr/src/matching.rs
@@ -626,11 +626,11 @@ impl<'db, 'sema> Matcher<'db, 'sema> {
                 match_error!("Failed to get receiver type for `{}`", expr.syntax().text())
             })?
             .original;
-        let krate = self.sema.scope(expr.syntax()).map(|it| it.krate()).unwrap_or_else(|| {
-            hir::Crate::from(
-                *self.sema.db.crate_graph().crates_in_topological_order().last().unwrap(),
-            )
-        });
+        let krate = self
+            .sema
+            .scope(expr.syntax())
+            .map(|it| it.krate())
+            .unwrap_or_else(|| hir::Crate::from(*self.sema.db.all_crates().last().unwrap()));
         let res = code_type
             .autoderef(self.sema.db)
             .enumerate()

--- a/crates/ide/src/doc_links.rs
+++ b/crates/ide/src/doc_links.rs
@@ -504,9 +504,7 @@ fn get_doc_base_urls(
 
     let Some(krate) = krate else { return Default::default() };
     let Some(display_name) = krate.display_name(db) else { return Default::default() };
-    let crate_data = &db.crate_graph()[krate.into()];
-
-    let (web_base, local_base) = match &crate_data.origin {
+    let (web_base, local_base) = match krate.origin(db) {
         // std and co do not specify `html_root_url` any longer so we gotta handwrite this ourself.
         // FIXME: Use the toolchains channel instead of nightly
         CrateOrigin::Lang(

--- a/crates/ide/src/expand_macro.rs
+++ b/crates/ide/src/expand_macro.rs
@@ -1,8 +1,8 @@
 use hir::db::ExpandDatabase;
 use hir::{ExpandResult, InFile, MacroFileIdExt, Semantics};
-use ide_db::base_db::CrateId;
 use ide_db::{
-    helpers::pick_best_token, syntax_helpers::prettify_macro_expansion, FileId, RootDatabase,
+    base_db::Crate, helpers::pick_best_token, syntax_helpers::prettify_macro_expansion, FileId,
+    RootDatabase,
 };
 use span::{Edition, SpanMap, SyntaxContextId, TextRange, TextSize};
 use stdx::format_to;
@@ -208,7 +208,7 @@ fn format(
     file_id: FileId,
     expanded: SyntaxNode,
     span_map: &SpanMap<SyntaxContextId>,
-    krate: CrateId,
+    krate: Crate,
 ) -> String {
     let expansion = prettify_macro_expansion(db, expanded, span_map, krate).to_string();
 
@@ -249,7 +249,7 @@ fn _format(
 
     let upcast_db = ide_db::base_db::Upcast::<dyn ide_db::base_db::RootQueryDb>::upcast(db);
     let &crate_id = upcast_db.relevant_crates(file_id).iter().next()?;
-    let edition = upcast_db.crate_graph()[crate_id].edition;
+    let edition = crate_id.data(upcast_db).edition;
 
     #[allow(clippy::disallowed_methods)]
     let mut cmd = std::process::Command::new(toolchain::Tool::Rustfmt.path());

--- a/crates/ide/src/fetch_crates.rs
+++ b/crates/ide/src/fetch_crates.rs
@@ -20,21 +20,24 @@ pub struct CrateInfo {
 //
 // ![Show Dependency Tree](https://user-images.githubusercontent.com/5748995/229394139-2625beab-f4c9-484b-84ed-ad5dee0b1e1a.png)
 pub(crate) fn fetch_crates(db: &RootDatabase) -> FxIndexSet<CrateInfo> {
-    let crate_graph = db.crate_graph();
-    crate_graph
+    db.all_crates()
         .iter()
-        .map(|crate_id| &crate_graph[crate_id])
-        .filter(|&data| !matches!(data.origin, CrateOrigin::Local { .. }))
-        .map(crate_info)
+        .copied()
+        .map(|crate_id| (crate_id.data(db), crate_id.extra_data(db)))
+        .filter(|(data, _)| !matches!(data.origin, CrateOrigin::Local { .. }))
+        .map(|(data, extra_data)| crate_info(data, extra_data))
         .collect()
 }
 
-fn crate_info(data: &ide_db::base_db::CrateData) -> CrateInfo {
-    let crate_name = crate_name(data);
-    let version = data.version.clone();
+fn crate_info(
+    data: &ide_db::base_db::BuiltCrateData,
+    extra_data: &ide_db::base_db::ExtraCrateData,
+) -> CrateInfo {
+    let crate_name = crate_name(extra_data);
+    let version = extra_data.version.clone();
     CrateInfo { name: crate_name, version, root_file_id: data.root_file_id }
 }
 
-fn crate_name(data: &ide_db::base_db::CrateData) -> Option<String> {
+fn crate_name(data: &ide_db::base_db::ExtraCrateData) -> Option<String> {
     data.display_name.as_ref().map(|it| it.canonical_name().as_str().to_owned())
 }

--- a/crates/ide/src/hover/render.rs
+++ b/crates/ide/src/hover/render.rs
@@ -8,7 +8,6 @@ use hir::{
     MethodViolationCode, Name, Semantics, Symbol, Trait, Type, TypeInfo, VariantDef,
 };
 use ide_db::{
-    base_db::RootQueryDb,
     defs::Definition,
     documentation::HasDocs,
     famous_defs::FamousDefs,
@@ -466,8 +465,7 @@ pub(super) fn path(
     item_name: Option<String>,
     edition: Edition,
 ) -> String {
-    let crate_name =
-        db.crate_graph()[module.krate().into()].display_name.as_ref().map(|it| it.to_string());
+    let crate_name = module.krate().display_name(db).as_ref().map(|it| it.to_string());
     let module_path = module
         .path_to_root(db)
         .into_iter()

--- a/crates/ide/src/hover/tests.rs
+++ b/crates/ide/src/hover/tests.rs
@@ -9252,7 +9252,7 @@ fn main() {
             S
             ```
             ___
-            Implements notable traits: Notable, Future<Output = u32>, Iterator<Item = S>"#]],
+            Implements notable traits: Future<Output = u32>, Iterator<Item = S>, Notable"#]],
     );
 }
 

--- a/crates/ide/src/inlay_hints/bind_pat.rs
+++ b/crates/ide/src/inlay_hints/bind_pat.rs
@@ -868,15 +868,15 @@ fn main() {
 //- minicore: fn
 fn main() {
     let x = || 2;
-      //^ {closure#26624}
+      //^ {closure#25600}
     let y = |t: i32| x() + t;
-      //^ {closure#26625}
+      //^ {closure#25601}
     let mut t = 5;
           //^ i32
     let z = |k: i32| { t += k; };
-      //^ {closure#26626}
+      //^ {closure#25602}
     let p = (y, z);
-      //^ ({closure#26625}, {closure#26626})
+      //^ ({closure#25601}, {closure#25602})
 }
             "#,
         );

--- a/crates/ide/src/lib.rs
+++ b/crates/ide/src/lib.rs
@@ -57,7 +57,7 @@ mod view_memory_layout;
 mod view_mir;
 mod view_syntax_tree;
 
-use std::{iter, panic::UnwindSafe};
+use std::panic::UnwindSafe;
 
 use cfg::CfgOptions;
 use fetch_crates::CrateInfo;
@@ -125,7 +125,7 @@ pub use ide_completion::{
 };
 pub use ide_db::text_edit::{Indel, TextEdit};
 pub use ide_db::{
-    base_db::{CrateGraph, CrateId, FileChange, SourceRoot, SourceRootId},
+    base_db::{Crate, CrateGraphBuilder, FileChange, SourceRoot, SourceRootId},
     documentation::Documentation,
     label::Label,
     line_index::{LineCol, LineIndex},
@@ -239,7 +239,7 @@ impl Analysis {
 
         let mut change = ChangeWithProcMacros::new();
         change.set_roots(vec![source_root]);
-        let mut crate_graph = CrateGraph::default();
+        let mut crate_graph = CrateGraphBuilder::default();
         // FIXME: cfg options
         // Default to enable test for single file.
         let mut cfg_options = CfgOptions::default();
@@ -255,16 +255,13 @@ impl Analysis {
             CrateOrigin::Local { repo: None, name: None },
             false,
             None,
-        );
-        change.change_file(file_id, Some(text));
-        let ws_data = crate_graph
-            .iter()
-            .zip(iter::repeat(Arc::new(CrateWorkspaceData {
+            Arc::new(CrateWorkspaceData {
                 data_layout: Err("fixture has no layout".into()),
                 toolchain: None,
-            })))
-            .collect();
-        change.set_crate_graph(crate_graph, ws_data);
+            }),
+        );
+        change.change_file(file_id, Some(text));
+        change.set_crate_graph(crate_graph);
 
         host.apply_change(change);
         (host.analysis(), file_id)
@@ -372,7 +369,7 @@ impl Analysis {
         self.with_db(|db| test_explorer::discover_tests_in_crate_by_test_id(db, crate_id))
     }
 
-    pub fn discover_tests_in_crate(&self, crate_id: CrateId) -> Cancellable<Vec<TestItem>> {
+    pub fn discover_tests_in_crate(&self, crate_id: Crate) -> Cancellable<Vec<TestItem>> {
         self.with_db(|db| test_explorer::discover_tests_in_crate(db, crate_id))
     }
 
@@ -602,17 +599,17 @@ impl Analysis {
     }
 
     /// Returns crates that this file belongs to.
-    pub fn crates_for(&self, file_id: FileId) -> Cancellable<Vec<CrateId>> {
+    pub fn crates_for(&self, file_id: FileId) -> Cancellable<Vec<Crate>> {
         self.with_db(|db| parent_module::crates_for(db, file_id))
     }
 
     /// Returns crates that this file belongs to.
-    pub fn transitive_rev_deps(&self, crate_id: CrateId) -> Cancellable<Vec<CrateId>> {
-        self.with_db(|db| db.crate_graph().transitive_rev_deps(crate_id).collect())
+    pub fn transitive_rev_deps(&self, crate_id: Crate) -> Cancellable<Vec<Crate>> {
+        self.with_db(|db| Vec::from_iter(db.transitive_rev_deps(crate_id)))
     }
 
     /// Returns crates that this file *might* belong to.
-    pub fn relevant_crates_for(&self, file_id: FileId) -> Cancellable<Vec<CrateId>> {
+    pub fn relevant_crates_for(&self, file_id: FileId) -> Cancellable<Vec<Crate>> {
         self.with_db(|db| {
             let db = Upcast::<dyn RootQueryDb>::upcast(db);
             db.relevant_crates(file_id).iter().copied().collect()
@@ -620,18 +617,23 @@ impl Analysis {
     }
 
     /// Returns the edition of the given crate.
-    pub fn crate_edition(&self, crate_id: CrateId) -> Cancellable<Edition> {
-        self.with_db(|db| db.crate_graph()[crate_id].edition)
+    pub fn crate_edition(&self, crate_id: Crate) -> Cancellable<Edition> {
+        self.with_db(|db| crate_id.data(db).edition)
+    }
+
+    /// Returns whether the given crate is a proc macro.
+    pub fn is_proc_macro_crate(&self, crate_id: Crate) -> Cancellable<bool> {
+        self.with_db(|db| crate_id.data(db).is_proc_macro)
     }
 
     /// Returns true if this crate has `no_std` or `no_core` specified.
-    pub fn is_crate_no_std(&self, crate_id: CrateId) -> Cancellable<bool> {
+    pub fn is_crate_no_std(&self, crate_id: Crate) -> Cancellable<bool> {
         self.with_db(|db| hir::db::DefDatabase::crate_def_map(db, crate_id).is_no_std())
     }
 
     /// Returns the root file of the given crate.
-    pub fn crate_root(&self, crate_id: CrateId) -> Cancellable<FileId> {
-        self.with_db(|db| db.crate_graph()[crate_id].root_file_id)
+    pub fn crate_root(&self, crate_id: Crate) -> Cancellable<FileId> {
+        self.with_db(|db| crate_id.data(db).root_file_id)
     }
 
     /// Returns the set of possible targets to run for the current file.

--- a/crates/ide/src/parent_module.rs
+++ b/crates/ide/src/parent_module.rs
@@ -1,6 +1,6 @@
 use hir::{db::DefDatabase, Semantics};
 use ide_db::{
-    base_db::{CrateId, RootQueryDb, Upcast},
+    base_db::{Crate, RootQueryDb, Upcast},
     FileId, FilePosition, RootDatabase,
 };
 use itertools::Itertools;
@@ -53,7 +53,7 @@ pub(crate) fn parent_module(db: &RootDatabase, position: FilePosition) -> Vec<Na
 }
 
 /// This returns `Vec` because a module may be included from several places.
-pub(crate) fn crates_for(db: &RootDatabase, file_id: FileId) -> Vec<CrateId> {
+pub(crate) fn crates_for(db: &RootDatabase, file_id: FileId) -> Vec<Crate> {
     let root_db = Upcast::<dyn RootQueryDb>::upcast(db);
     root_db
         .relevant_crates(file_id)

--- a/crates/ide/src/runnables.rs
+++ b/crates/ide/src/runnables.rs
@@ -498,9 +498,8 @@ fn module_def_doctest(db: &RootDatabase, def: Definition) -> Option<Runnable> {
     };
     let krate = def.krate(db);
     let edition = krate.map(|it| it.edition(db)).unwrap_or(Edition::CURRENT);
-    let display_target = krate
-        .unwrap_or_else(|| (*db.crate_graph().crates_in_topological_order().last().unwrap()).into())
-        .to_display_target(db);
+    let display_target =
+        krate.unwrap_or_else(|| (*db.all_crates().last().unwrap()).into()).to_display_target(db);
     if !has_runnable_doc_test(&attrs) {
         return None;
     }

--- a/crates/ide/src/static_index.rs
+++ b/crates/ide/src/static_index.rs
@@ -119,9 +119,7 @@ fn documentation_for_definition(
         sema.db,
         famous_defs.as_ref(),
         def.krate(sema.db)
-            .unwrap_or_else(|| {
-                (*sema.db.crate_graph().crates_in_topological_order().last().unwrap()).into()
-            })
+            .unwrap_or_else(|| (*sema.db.all_crates().last().unwrap()).into())
             .to_display_target(sema.db),
     )
 }

--- a/crates/ide/src/test_explorer.rs
+++ b/crates/ide/src/test_explorer.rs
@@ -1,17 +1,15 @@
 //! Discovers tests
 
 use hir::{Crate, Module, ModuleDef, Semantics};
-use ide_db::{
-    base_db::{CrateGraph, CrateId, RootQueryDb},
-    FileId, RootDatabase,
-};
+use ide_db::base_db;
+use ide_db::{base_db::RootQueryDb, FileId, RootDatabase};
 use syntax::TextRange;
 
 use crate::{runnables::runnable_fn, NavigationTarget, Runnable, TryToNav};
 
 #[derive(Debug)]
 pub enum TestItemKind {
-    Crate(CrateId),
+    Crate(base_db::Crate),
     Module,
     Function,
 }
@@ -28,12 +26,12 @@ pub struct TestItem {
 }
 
 pub(crate) fn discover_test_roots(db: &RootDatabase) -> Vec<TestItem> {
-    let crate_graph = db.crate_graph();
-    crate_graph
+    db.all_crates()
         .iter()
-        .filter(|&id| crate_graph[id].origin.is_local())
+        .copied()
+        .filter(|&id| id.data(db).origin.is_local())
         .filter_map(|id| {
-            let test_id = crate_graph[id].display_name.as_ref()?.to_string();
+            let test_id = id.extra_data(db).display_name.as_ref()?.to_string();
             Some(TestItem {
                 kind: TestItemKind::Crate(id),
                 label: test_id.clone(),
@@ -47,12 +45,12 @@ pub(crate) fn discover_test_roots(db: &RootDatabase) -> Vec<TestItem> {
         .collect()
 }
 
-fn find_crate_by_id(crate_graph: &CrateGraph, crate_id: &str) -> Option<CrateId> {
+fn find_crate_by_id(db: &RootDatabase, crate_id: &str) -> Option<base_db::Crate> {
     // here, we use display_name as the crate id. This is not super ideal, but it works since we
     // only show tests for the local crates.
-    crate_graph.iter().find(|&id| {
-        crate_graph[id].origin.is_local()
-            && crate_graph[id].display_name.as_ref().is_some_and(|x| x.to_string() == crate_id)
+    db.all_crates().iter().copied().find(|&id| {
+        id.data(db).origin.is_local()
+            && id.extra_data(db).display_name.as_ref().is_some_and(|x| x.to_string() == crate_id)
     })
 }
 
@@ -115,8 +113,7 @@ pub(crate) fn discover_tests_in_crate_by_test_id(
     db: &RootDatabase,
     crate_test_id: &str,
 ) -> Vec<TestItem> {
-    let crate_graph = db.crate_graph();
-    let Some(crate_id) = find_crate_by_id(&crate_graph, crate_test_id) else {
+    let Some(crate_id) = find_crate_by_id(db, crate_test_id) else {
         return vec![];
     };
     discover_tests_in_crate(db, crate_id)
@@ -171,12 +168,14 @@ fn find_module_id_and_test_parents(
     Some((r, id))
 }
 
-pub(crate) fn discover_tests_in_crate(db: &RootDatabase, crate_id: CrateId) -> Vec<TestItem> {
-    let crate_graph = db.crate_graph();
-    if !crate_graph[crate_id].origin.is_local() {
+pub(crate) fn discover_tests_in_crate(
+    db: &RootDatabase,
+    crate_id: base_db::Crate,
+) -> Vec<TestItem> {
+    if !crate_id.data(db).origin.is_local() {
         return vec![];
     }
-    let Some(crate_test_id) = &crate_graph[crate_id].display_name else {
+    let Some(crate_test_id) = &crate_id.extra_data(db).display_name else {
         return vec![];
     };
     let kind = TestItemKind::Crate(crate_id);

--- a/crates/ide/src/view_crate_graph.rs
+++ b/crates/ide/src/view_crate_graph.rs
@@ -1,9 +1,10 @@
 use dot::{Id, LabelText};
 use ide_db::{
-    base_db::{CrateGraph, CrateId, Dependency, RootQueryDb, SourceDatabase, Upcast},
-    FxHashSet, RootDatabase,
+    base_db::{
+        BuiltCrateData, BuiltDependency, Crate, ExtraCrateData, RootQueryDb, SourceDatabase,
+    },
+    FxHashMap, RootDatabase,
 };
-use triomphe::Arc;
 
 // Feature: View Crate Graph
 //
@@ -16,77 +17,80 @@ use triomphe::Arc;
 // |---------|-------------|
 // | VS Code | **rust-analyzer: View Crate Graph** |
 pub(crate) fn view_crate_graph(db: &RootDatabase, full: bool) -> Result<String, String> {
-    let crate_graph = Upcast::<dyn RootQueryDb>::upcast(db).crate_graph();
-    let crates_to_render = crate_graph
+    let all_crates = db.all_crates();
+    let crates_to_render = all_crates
         .iter()
-        .filter(|krate| {
+        .copied()
+        .map(|krate| (krate, (krate.data(db), krate.extra_data(db))))
+        .filter(|(_, (crate_data, _))| {
             if full {
                 true
             } else {
                 // Only render workspace crates
-                let root_id =
-                    db.file_source_root(crate_graph[*krate].root_file_id).source_root_id(db);
+                let root_id = db.file_source_root(crate_data.root_file_id).source_root_id(db);
                 !db.source_root(root_id).source_root(db).is_library
             }
         })
         .collect();
-    let graph = DotCrateGraph { graph: crate_graph, crates_to_render };
+    let graph = DotCrateGraph { crates_to_render };
 
     let mut dot = Vec::new();
     dot::render(&graph, &mut dot).unwrap();
     Ok(String::from_utf8(dot).unwrap())
 }
 
-struct DotCrateGraph {
-    graph: Arc<CrateGraph>,
-    crates_to_render: FxHashSet<CrateId>,
+struct DotCrateGraph<'db> {
+    crates_to_render: FxHashMap<Crate, (&'db BuiltCrateData, &'db ExtraCrateData)>,
 }
 
-type Edge<'a> = (CrateId, &'a Dependency);
+type Edge<'a> = (Crate, &'a BuiltDependency);
 
-impl<'a> dot::GraphWalk<'a, CrateId, Edge<'a>> for DotCrateGraph {
-    fn nodes(&'a self) -> dot::Nodes<'a, CrateId> {
-        self.crates_to_render.iter().copied().collect()
+impl<'a> dot::GraphWalk<'a, Crate, Edge<'a>> for DotCrateGraph<'_> {
+    fn nodes(&'a self) -> dot::Nodes<'a, Crate> {
+        self.crates_to_render.keys().copied().collect()
     }
 
     fn edges(&'a self) -> dot::Edges<'a, Edge<'a>> {
         self.crates_to_render
             .iter()
-            .flat_map(|krate| {
-                self.graph[*krate]
+            .flat_map(|(krate, (crate_data, _))| {
+                crate_data
                     .dependencies
                     .iter()
-                    .filter(|dep| self.crates_to_render.contains(&dep.crate_id))
+                    .filter(|dep| self.crates_to_render.contains_key(&dep.crate_id))
                     .map(move |dep| (*krate, dep))
             })
             .collect()
     }
 
-    fn source(&'a self, edge: &Edge<'a>) -> CrateId {
+    fn source(&'a self, edge: &Edge<'a>) -> Crate {
         edge.0
     }
 
-    fn target(&'a self, edge: &Edge<'a>) -> CrateId {
+    fn target(&'a self, edge: &Edge<'a>) -> Crate {
         edge.1.crate_id
     }
 }
 
-impl<'a> dot::Labeller<'a, CrateId, Edge<'a>> for DotCrateGraph {
+impl<'a> dot::Labeller<'a, Crate, Edge<'a>> for DotCrateGraph<'_> {
     fn graph_id(&'a self) -> Id<'a> {
         Id::new("rust_analyzer_crate_graph").unwrap()
     }
 
-    fn node_id(&'a self, n: &CrateId) -> Id<'a> {
-        Id::new(format!("_{}", u32::from(n.into_raw()))).unwrap()
+    fn node_id(&'a self, n: &Crate) -> Id<'a> {
+        Id::new(format!("_{:?}", n)).unwrap()
     }
 
-    fn node_shape(&'a self, _node: &CrateId) -> Option<LabelText<'a>> {
+    fn node_shape(&'a self, _node: &Crate) -> Option<LabelText<'a>> {
         Some(LabelText::LabelStr("box".into()))
     }
 
-    fn node_label(&'a self, n: &CrateId) -> LabelText<'a> {
-        let name =
-            self.graph[*n].display_name.as_ref().map_or("(unnamed crate)", |name| name.as_str());
+    fn node_label(&'a self, n: &Crate) -> LabelText<'a> {
+        let name = self.crates_to_render[n]
+            .1
+            .display_name
+            .as_ref()
+            .map_or("(unnamed crate)", |name| name.as_str());
         LabelText::LabelStr(name.into())
     }
 }

--- a/crates/intern/src/symbol.rs
+++ b/crates/intern/src/symbol.rs
@@ -42,6 +42,18 @@ struct TaggedArcPtr {
 unsafe impl Send for TaggedArcPtr {}
 unsafe impl Sync for TaggedArcPtr {}
 
+impl Ord for TaggedArcPtr {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.as_str().cmp(other.as_str())
+    }
+}
+
+impl PartialOrd for TaggedArcPtr {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
 impl TaggedArcPtr {
     const BOOL_BITS: usize = true as usize;
 
@@ -113,7 +125,7 @@ impl TaggedArcPtr {
     }
 }
 
-#[derive(PartialEq, Eq, Hash)]
+#[derive(PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct Symbol {
     repr: TaggedArcPtr,
 }

--- a/crates/proc-macro-srv/src/tests/mod.rs
+++ b/crates/proc-macro-srv/src/tests/mod.rs
@@ -12,7 +12,7 @@ fn test_derive_empty() {
         "DeriveEmpty",
         r#"struct S;"#,
         expect!["SUBTREE $$ 1 1"],
-        expect!["SUBTREE $$ 42:2@0..100#2 42:2@0..100#2"],
+        expect!["SUBTREE $$ 42:2@0..100#4294967037 42:2@0..100#4294967037"],
     );
 }
 
@@ -29,12 +29,12 @@ fn test_derive_error() {
                 LITERAL Str #[derive(DeriveError)] struct S ; 1
               PUNCH   ; [alone] 1"#]],
         expect![[r#"
-            SUBTREE $$ 42:2@0..100#2 42:2@0..100#2
-              IDENT   compile_error 42:2@0..100#2
-              PUNCH   ! [alone] 42:2@0..100#2
-              SUBTREE () 42:2@0..100#2 42:2@0..100#2
-                LITERAL Str #[derive(DeriveError)] struct S ; 42:2@0..100#2
-              PUNCH   ; [alone] 42:2@0..100#2"#]],
+            SUBTREE $$ 42:2@0..100#4294967037 42:2@0..100#4294967037
+              IDENT   compile_error 42:2@0..100#4294967037
+              PUNCH   ! [alone] 42:2@0..100#4294967037
+              SUBTREE () 42:2@0..100#4294967037 42:2@0..100#4294967037
+                LITERAL Str #[derive(DeriveError)] struct S ; 42:2@0..100#4294967037
+              PUNCH   ; [alone] 42:2@0..100#4294967037"#]],
     );
 }
 
@@ -53,14 +53,14 @@ fn test_fn_like_macro_noop() {
               PUNCH   , [alone] 1
               SUBTREE [] 1 1"#]],
         expect![[r#"
-            SUBTREE $$ 42:2@0..100#2 42:2@0..100#2
-              IDENT   ident 42:2@0..5#2
-              PUNCH   , [alone] 42:2@5..6#2
-              LITERAL Integer 0 42:2@7..8#2
-              PUNCH   , [alone] 42:2@8..9#2
-              LITERAL Integer 1 42:2@10..11#2
-              PUNCH   , [alone] 42:2@11..12#2
-              SUBTREE [] 42:2@13..14#2 42:2@14..15#2"#]],
+            SUBTREE $$ 42:2@0..100#4294967037 42:2@0..100#4294967037
+              IDENT   ident 42:2@0..5#4294967037
+              PUNCH   , [alone] 42:2@5..6#4294967037
+              LITERAL Integer 0 42:2@7..8#4294967037
+              PUNCH   , [alone] 42:2@8..9#4294967037
+              LITERAL Integer 1 42:2@10..11#4294967037
+              PUNCH   , [alone] 42:2@11..12#4294967037
+              SUBTREE [] 42:2@13..14#4294967037 42:2@14..15#4294967037"#]],
     );
 }
 
@@ -75,10 +75,10 @@ fn test_fn_like_macro_clone_ident_subtree() {
               PUNCH   , [alone] 1
               SUBTREE [] 1 1"#]],
         expect![[r#"
-            SUBTREE $$ 42:2@0..100#2 42:2@0..100#2
-              IDENT   ident 42:2@0..5#2
-              PUNCH   , [alone] 42:2@5..6#2
-              SUBTREE [] 42:2@7..8#2 42:2@7..8#2"#]],
+            SUBTREE $$ 42:2@0..100#4294967037 42:2@0..100#4294967037
+              IDENT   ident 42:2@0..5#4294967037
+              PUNCH   , [alone] 42:2@5..6#4294967037
+              SUBTREE [] 42:2@7..8#4294967037 42:2@7..8#4294967037"#]],
     );
 }
 
@@ -91,8 +91,8 @@ fn test_fn_like_macro_clone_raw_ident() {
             SUBTREE $$ 1 1
               IDENT   r#async 1"#]],
         expect![[r#"
-            SUBTREE $$ 42:2@0..100#2 42:2@0..100#2
-              IDENT   r#async 42:2@0..7#2"#]],
+            SUBTREE $$ 42:2@0..100#4294967037 42:2@0..100#4294967037
+              IDENT   r#async 42:2@0..7#4294967037"#]],
     );
 }
 
@@ -105,8 +105,8 @@ fn test_fn_like_fn_like_span_join() {
             SUBTREE $$ 1 1
               IDENT   r#joined 1"#]],
         expect![[r#"
-            SUBTREE $$ 42:2@0..100#2 42:2@0..100#2
-              IDENT   r#joined 42:2@0..11#2"#]],
+            SUBTREE $$ 42:2@0..100#4294967037 42:2@0..100#4294967037
+              IDENT   r#joined 42:2@0..11#4294967037"#]],
     );
 }
 
@@ -121,10 +121,10 @@ fn test_fn_like_fn_like_span_ops() {
               IDENT   resolved_at_def_site 1
               IDENT   start_span 1"#]],
         expect![[r#"
-            SUBTREE $$ 42:2@0..100#2 42:2@0..100#2
-              IDENT   set_def_site 41:1@0..150#2
-              IDENT   resolved_at_def_site 42:2@13..33#2
-              IDENT   start_span 42:2@34..34#2"#]],
+            SUBTREE $$ 42:2@0..100#4294967037 42:2@0..100#4294967037
+              IDENT   set_def_site 41:1@0..150#4294967037
+              IDENT   resolved_at_def_site 42:2@13..33#4294967037
+              IDENT   start_span 42:2@34..34#4294967037"#]],
     );
 }
 
@@ -143,14 +143,14 @@ fn test_fn_like_mk_literals() {
               LITERAL Integer 123i64 1
               LITERAL Integer 123 1"#]],
         expect![[r#"
-            SUBTREE $$ 42:2@0..100#2 42:2@0..100#2
-              LITERAL ByteStr byte_string 42:2@0..100#2
-              LITERAL Char c 42:2@0..100#2
-              LITERAL Str string 42:2@0..100#2
-              LITERAL Float 3.14f64 42:2@0..100#2
-              LITERAL Float 3.14 42:2@0..100#2
-              LITERAL Integer 123i64 42:2@0..100#2
-              LITERAL Integer 123 42:2@0..100#2"#]],
+            SUBTREE $$ 42:2@0..100#4294967037 42:2@0..100#4294967037
+              LITERAL ByteStr byte_string 42:2@0..100#4294967037
+              LITERAL Char c 42:2@0..100#4294967037
+              LITERAL Str string 42:2@0..100#4294967037
+              LITERAL Float 3.14f64 42:2@0..100#4294967037
+              LITERAL Float 3.14 42:2@0..100#4294967037
+              LITERAL Integer 123i64 42:2@0..100#4294967037
+              LITERAL Integer 123 42:2@0..100#4294967037"#]],
     );
 }
 
@@ -164,9 +164,9 @@ fn test_fn_like_mk_idents() {
               IDENT   standard 1
               IDENT   r#raw 1"#]],
         expect![[r#"
-            SUBTREE $$ 42:2@0..100#2 42:2@0..100#2
-              IDENT   standard 42:2@0..100#2
-              IDENT   r#raw 42:2@0..100#2"#]],
+            SUBTREE $$ 42:2@0..100#4294967037 42:2@0..100#4294967037
+              IDENT   standard 42:2@0..100#4294967037
+              IDENT   r#raw 42:2@0..100#4294967037"#]],
     );
 }
 
@@ -198,27 +198,27 @@ fn test_fn_like_macro_clone_literals() {
               PUNCH   , [alone] 1
               LITERAL CStr null 1"#]],
         expect![[r#"
-            SUBTREE $$ 42:2@0..100#2 42:2@0..100#2
-              LITERAL Integer 1u16 42:2@0..4#2
-              PUNCH   , [alone] 42:2@4..5#2
-              LITERAL Integer 2_u32 42:2@6..11#2
-              PUNCH   , [alone] 42:2@11..12#2
-              PUNCH   - [alone] 42:2@13..14#2
-              LITERAL Integer 4i64 42:2@14..18#2
-              PUNCH   , [alone] 42:2@18..19#2
-              LITERAL Float 3.14f32 42:2@20..27#2
-              PUNCH   , [alone] 42:2@27..28#2
-              LITERAL Str hello bridge 42:2@29..43#2
-              PUNCH   , [alone] 42:2@43..44#2
-              LITERAL Str suffixedsuffix 42:2@45..61#2
-              PUNCH   , [alone] 42:2@61..62#2
-              LITERAL StrRaw(2) raw 42:2@63..73#2
-              PUNCH   , [alone] 42:2@73..74#2
-              LITERAL Char a 42:2@75..78#2
-              PUNCH   , [alone] 42:2@78..79#2
-              LITERAL Byte b 42:2@80..84#2
-              PUNCH   , [alone] 42:2@84..85#2
-              LITERAL CStr null 42:2@86..93#2"#]],
+            SUBTREE $$ 42:2@0..100#4294967037 42:2@0..100#4294967037
+              LITERAL Integer 1u16 42:2@0..4#4294967037
+              PUNCH   , [alone] 42:2@4..5#4294967037
+              LITERAL Integer 2_u32 42:2@6..11#4294967037
+              PUNCH   , [alone] 42:2@11..12#4294967037
+              PUNCH   - [alone] 42:2@13..14#4294967037
+              LITERAL Integer 4i64 42:2@14..18#4294967037
+              PUNCH   , [alone] 42:2@18..19#4294967037
+              LITERAL Float 3.14f32 42:2@20..27#4294967037
+              PUNCH   , [alone] 42:2@27..28#4294967037
+              LITERAL Str hello bridge 42:2@29..43#4294967037
+              PUNCH   , [alone] 42:2@43..44#4294967037
+              LITERAL Str suffixedsuffix 42:2@45..61#4294967037
+              PUNCH   , [alone] 42:2@61..62#4294967037
+              LITERAL StrRaw(2) raw 42:2@63..73#4294967037
+              PUNCH   , [alone] 42:2@73..74#4294967037
+              LITERAL Char a 42:2@75..78#4294967037
+              PUNCH   , [alone] 42:2@78..79#4294967037
+              LITERAL Byte b 42:2@80..84#4294967037
+              PUNCH   , [alone] 42:2@84..85#4294967037
+              LITERAL CStr null 42:2@86..93#4294967037"#]],
     );
 }
 
@@ -239,12 +239,12 @@ fn test_attr_macro() {
                 LITERAL Str #[attr_error(some arguments)] mod m {} 1
               PUNCH   ; [alone] 1"#]],
         expect![[r#"
-            SUBTREE $$ 42:2@0..100#2 42:2@0..100#2
-              IDENT   compile_error 42:2@0..100#2
-              PUNCH   ! [alone] 42:2@0..100#2
-              SUBTREE () 42:2@0..100#2 42:2@0..100#2
-                LITERAL Str #[attr_error(some arguments)] mod m {} 42:2@0..100#2
-              PUNCH   ; [alone] 42:2@0..100#2"#]],
+            SUBTREE $$ 42:2@0..100#4294967037 42:2@0..100#4294967037
+              IDENT   compile_error 42:2@0..100#4294967037
+              PUNCH   ! [alone] 42:2@0..100#4294967037
+              SUBTREE () 42:2@0..100#4294967037 42:2@0..100#4294967037
+                LITERAL Str #[attr_error(some arguments)] mod m {} 42:2@0..100#4294967037
+              PUNCH   ; [alone] 42:2@0..100#4294967037"#]],
     );
 }
 

--- a/crates/project-model/src/project_json.rs
+++ b/crates/project-model/src/project_json.rs
@@ -452,7 +452,7 @@ pub enum TargetKindData {
 }
 /// Identifies a crate by position in the crates array.
 ///
-/// This will differ from `CrateId` when multiple `ProjectJson`
+/// This will differ from `Crate` when multiple `ProjectJson`
 /// workspaces are loaded.
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, Eq, PartialEq, Hash)]
 #[serde(transparent)]

--- a/crates/project-model/src/tests.rs
+++ b/crates/project-model/src/tests.rs
@@ -1,4 +1,4 @@
-use base_db::{CrateGraph, ProcMacroPaths};
+use base_db::{CrateGraphBuilder, ProcMacroPaths};
 use cargo_metadata::Metadata;
 use cfg::{CfgAtom, CfgDiff};
 use expect_test::{expect_file, ExpectFile};
@@ -15,7 +15,7 @@ use crate::{
     Sysroot, WorkspaceBuildScripts,
 };
 
-fn load_cargo(file: &str) -> (CrateGraph, ProcMacroPaths) {
+fn load_cargo(file: &str) -> (CrateGraphBuilder, ProcMacroPaths) {
     let project_workspace = load_workspace_from_metadata(file);
     to_crate_graph(project_workspace, &mut Default::default())
 }
@@ -23,7 +23,7 @@ fn load_cargo(file: &str) -> (CrateGraph, ProcMacroPaths) {
 fn load_cargo_with_overrides(
     file: &str,
     cfg_overrides: CfgOverrides,
-) -> (CrateGraph, ProcMacroPaths) {
+) -> (CrateGraphBuilder, ProcMacroPaths) {
     let project_workspace =
         ProjectWorkspace { cfg_overrides, ..load_workspace_from_metadata(file) };
     to_crate_graph(project_workspace, &mut Default::default())
@@ -51,7 +51,7 @@ fn load_workspace_from_metadata(file: &str) -> ProjectWorkspace {
     }
 }
 
-fn load_rust_project(file: &str) -> (CrateGraph, ProcMacroPaths) {
+fn load_rust_project(file: &str) -> (CrateGraphBuilder, ProcMacroPaths) {
     let data = get_test_json_file(file);
     let project = rooted_project_json(data);
     let sysroot = get_fake_sysroot();
@@ -142,7 +142,7 @@ fn rooted_project_json(data: ProjectJsonData) -> ProjectJson {
 fn to_crate_graph(
     project_workspace: ProjectWorkspace,
     file_map: &mut FxHashMap<AbsPathBuf, FileId>,
-) -> (CrateGraph, ProcMacroPaths) {
+) -> (CrateGraphBuilder, ProcMacroPaths) {
     project_workspace.to_crate_graph(
         &mut {
             |path| {
@@ -154,7 +154,7 @@ fn to_crate_graph(
     )
 }
 
-fn check_crate_graph(crate_graph: CrateGraph, expect: ExpectFile) {
+fn check_crate_graph(crate_graph: CrateGraphBuilder, expect: ExpectFile) {
     let mut crate_graph = format!("{crate_graph:#?}");
 
     replace_root(&mut crate_graph, false);

--- a/crates/project-model/test_data/output/cargo_hello_world_project_model.txt
+++ b/crates/project-model/test_data/output/cargo_hello_world_project_model.txt
@@ -1,20 +1,47 @@
 {
-    0: CrateData {
-        root_file_id: FileId(
-            1,
-        ),
-        edition: Edition2018,
-        version: Some(
-            "0.1.0",
-        ),
-        display_name: Some(
-            CrateDisplayName {
-                crate_name: CrateName(
-                    "hello_world",
+    0: CrateBuilder {
+        basic: CrateData {
+            root_file_id: FileId(
+                1,
+            ),
+            edition: Edition2018,
+            dependencies: [
+                Dependency {
+                    crate_id: Idx::<CrateBuilder>(4),
+                    name: CrateName(
+                        "libc",
+                    ),
+                    prelude: true,
+                    sysroot: false,
+                },
+            ],
+            origin: Local {
+                repo: None,
+                name: Some(
+                    "hello-world",
                 ),
-                canonical_name: "hello-world",
             },
-        ),
+            is_proc_macro: false,
+            proc_macro_cwd: Some(
+                AbsPathBuf(
+                    "$ROOT$hello-world",
+                ),
+            ),
+        },
+        extra: ExtraCrateData {
+            version: Some(
+                "0.1.0",
+            ),
+            display_name: Some(
+                CrateDisplayName {
+                    crate_name: CrateName(
+                        "hello_world",
+                    ),
+                    canonical_name: "hello-world",
+                },
+            ),
+            potential_cfg_options: None,
+        },
         cfg_options: CfgOptions(
             [
                 "rust_analyzer",
@@ -22,7 +49,6 @@
                 "true",
             ],
         ),
-        potential_cfg_options: None,
         env: Env {
             entries: {
                 "CARGO": "$CARGO$",
@@ -44,45 +70,64 @@
                 "CARGO_PKG_VERSION_PRE": "",
             },
         },
-        dependencies: [
-            Dependency {
-                crate_id: Idx::<CrateData>(4),
-                name: CrateName(
-                    "libc",
+        ws_data: CrateWorkspaceData {
+            data_layout: Err(
+                "target_data_layout not loaded",
+            ),
+            toolchain: None,
+        },
+    },
+    1: CrateBuilder {
+        basic: CrateData {
+            root_file_id: FileId(
+                2,
+            ),
+            edition: Edition2018,
+            dependencies: [
+                Dependency {
+                    crate_id: Idx::<CrateBuilder>(0),
+                    name: CrateName(
+                        "hello_world",
+                    ),
+                    prelude: true,
+                    sysroot: false,
+                },
+                Dependency {
+                    crate_id: Idx::<CrateBuilder>(4),
+                    name: CrateName(
+                        "libc",
+                    ),
+                    prelude: true,
+                    sysroot: false,
+                },
+            ],
+            origin: Local {
+                repo: None,
+                name: Some(
+                    "hello-world",
                 ),
-                prelude: true,
-                sysroot: false,
             },
-        ],
-        origin: Local {
-            repo: None,
-            name: Some(
-                "hello-world",
+            is_proc_macro: false,
+            proc_macro_cwd: Some(
+                AbsPathBuf(
+                    "$ROOT$hello-world",
+                ),
             ),
         },
-        is_proc_macro: false,
-        proc_macro_cwd: Some(
-            AbsPathBuf(
-                "$ROOT$hello-world",
+        extra: ExtraCrateData {
+            version: Some(
+                "0.1.0",
             ),
-        ),
-    },
-    1: CrateData {
-        root_file_id: FileId(
-            2,
-        ),
-        edition: Edition2018,
-        version: Some(
-            "0.1.0",
-        ),
-        display_name: Some(
-            CrateDisplayName {
-                crate_name: CrateName(
-                    "hello_world",
-                ),
-                canonical_name: "hello-world",
-            },
-        ),
+            display_name: Some(
+                CrateDisplayName {
+                    crate_name: CrateName(
+                        "hello_world",
+                    ),
+                    canonical_name: "hello-world",
+                },
+            ),
+            potential_cfg_options: None,
+        },
         cfg_options: CfgOptions(
             [
                 "rust_analyzer",
@@ -90,7 +135,6 @@
                 "true",
             ],
         ),
-        potential_cfg_options: None,
         env: Env {
             entries: {
                 "CARGO": "$CARGO$",
@@ -112,53 +156,64 @@
                 "CARGO_PKG_VERSION_PRE": "",
             },
         },
-        dependencies: [
-            Dependency {
-                crate_id: Idx::<CrateData>(0),
-                name: CrateName(
-                    "hello_world",
+        ws_data: CrateWorkspaceData {
+            data_layout: Err(
+                "target_data_layout not loaded",
+            ),
+            toolchain: None,
+        },
+    },
+    2: CrateBuilder {
+        basic: CrateData {
+            root_file_id: FileId(
+                3,
+            ),
+            edition: Edition2018,
+            dependencies: [
+                Dependency {
+                    crate_id: Idx::<CrateBuilder>(0),
+                    name: CrateName(
+                        "hello_world",
+                    ),
+                    prelude: true,
+                    sysroot: false,
+                },
+                Dependency {
+                    crate_id: Idx::<CrateBuilder>(4),
+                    name: CrateName(
+                        "libc",
+                    ),
+                    prelude: true,
+                    sysroot: false,
+                },
+            ],
+            origin: Local {
+                repo: None,
+                name: Some(
+                    "hello-world",
                 ),
-                prelude: true,
-                sysroot: false,
             },
-            Dependency {
-                crate_id: Idx::<CrateData>(4),
-                name: CrateName(
-                    "libc",
+            is_proc_macro: false,
+            proc_macro_cwd: Some(
+                AbsPathBuf(
+                    "$ROOT$hello-world",
                 ),
-                prelude: true,
-                sysroot: false,
-            },
-        ],
-        origin: Local {
-            repo: None,
-            name: Some(
-                "hello-world",
             ),
         },
-        is_proc_macro: false,
-        proc_macro_cwd: Some(
-            AbsPathBuf(
-                "$ROOT$hello-world",
+        extra: ExtraCrateData {
+            version: Some(
+                "0.1.0",
             ),
-        ),
-    },
-    2: CrateData {
-        root_file_id: FileId(
-            3,
-        ),
-        edition: Edition2018,
-        version: Some(
-            "0.1.0",
-        ),
-        display_name: Some(
-            CrateDisplayName {
-                crate_name: CrateName(
-                    "an_example",
-                ),
-                canonical_name: "an-example",
-            },
-        ),
+            display_name: Some(
+                CrateDisplayName {
+                    crate_name: CrateName(
+                        "an_example",
+                    ),
+                    canonical_name: "an-example",
+                },
+            ),
+            potential_cfg_options: None,
+        },
         cfg_options: CfgOptions(
             [
                 "rust_analyzer",
@@ -166,7 +221,6 @@
                 "true",
             ],
         ),
-        potential_cfg_options: None,
         env: Env {
             entries: {
                 "CARGO": "$CARGO$",
@@ -188,53 +242,64 @@
                 "CARGO_PKG_VERSION_PRE": "",
             },
         },
-        dependencies: [
-            Dependency {
-                crate_id: Idx::<CrateData>(0),
-                name: CrateName(
-                    "hello_world",
+        ws_data: CrateWorkspaceData {
+            data_layout: Err(
+                "target_data_layout not loaded",
+            ),
+            toolchain: None,
+        },
+    },
+    3: CrateBuilder {
+        basic: CrateData {
+            root_file_id: FileId(
+                4,
+            ),
+            edition: Edition2018,
+            dependencies: [
+                Dependency {
+                    crate_id: Idx::<CrateBuilder>(0),
+                    name: CrateName(
+                        "hello_world",
+                    ),
+                    prelude: true,
+                    sysroot: false,
+                },
+                Dependency {
+                    crate_id: Idx::<CrateBuilder>(4),
+                    name: CrateName(
+                        "libc",
+                    ),
+                    prelude: true,
+                    sysroot: false,
+                },
+            ],
+            origin: Local {
+                repo: None,
+                name: Some(
+                    "hello-world",
                 ),
-                prelude: true,
-                sysroot: false,
             },
-            Dependency {
-                crate_id: Idx::<CrateData>(4),
-                name: CrateName(
-                    "libc",
+            is_proc_macro: false,
+            proc_macro_cwd: Some(
+                AbsPathBuf(
+                    "$ROOT$hello-world",
                 ),
-                prelude: true,
-                sysroot: false,
-            },
-        ],
-        origin: Local {
-            repo: None,
-            name: Some(
-                "hello-world",
             ),
         },
-        is_proc_macro: false,
-        proc_macro_cwd: Some(
-            AbsPathBuf(
-                "$ROOT$hello-world",
+        extra: ExtraCrateData {
+            version: Some(
+                "0.1.0",
             ),
-        ),
-    },
-    3: CrateData {
-        root_file_id: FileId(
-            4,
-        ),
-        edition: Edition2018,
-        version: Some(
-            "0.1.0",
-        ),
-        display_name: Some(
-            CrateDisplayName {
-                crate_name: CrateName(
-                    "it",
-                ),
-                canonical_name: "it",
-            },
-        ),
+            display_name: Some(
+                CrateDisplayName {
+                    crate_name: CrateName(
+                        "it",
+                    ),
+                    canonical_name: "it",
+                },
+            ),
+            potential_cfg_options: None,
+        },
         cfg_options: CfgOptions(
             [
                 "rust_analyzer",
@@ -242,7 +307,6 @@
                 "true",
             ],
         ),
-        potential_cfg_options: None,
         env: Env {
             entries: {
                 "CARGO": "$CARGO$",
@@ -264,73 +328,66 @@
                 "CARGO_PKG_VERSION_PRE": "",
             },
         },
-        dependencies: [
-            Dependency {
-                crate_id: Idx::<CrateData>(0),
-                name: CrateName(
-                    "hello_world",
+        ws_data: CrateWorkspaceData {
+            data_layout: Err(
+                "target_data_layout not loaded",
+            ),
+            toolchain: None,
+        },
+    },
+    4: CrateBuilder {
+        basic: CrateData {
+            root_file_id: FileId(
+                5,
+            ),
+            edition: Edition2015,
+            dependencies: [],
+            origin: Library {
+                repo: Some(
+                    "https://github.com/rust-lang/libc",
                 ),
-                prelude: true,
-                sysroot: false,
+                name: "libc",
             },
-            Dependency {
-                crate_id: Idx::<CrateData>(4),
-                name: CrateName(
-                    "libc",
+            is_proc_macro: false,
+            proc_macro_cwd: Some(
+                AbsPathBuf(
+                    "$ROOT$.cargo/registry/src/github.com-1ecc6299db9ec823/libc-0.2.98",
                 ),
-                prelude: true,
-                sysroot: false,
-            },
-        ],
-        origin: Local {
-            repo: None,
-            name: Some(
-                "hello-world",
             ),
         },
-        is_proc_macro: false,
-        proc_macro_cwd: Some(
-            AbsPathBuf(
-                "$ROOT$hello-world",
+        extra: ExtraCrateData {
+            version: Some(
+                "0.2.98",
             ),
-        ),
-    },
-    4: CrateData {
-        root_file_id: FileId(
-            5,
-        ),
-        edition: Edition2015,
-        version: Some(
-            "0.2.98",
-        ),
-        display_name: Some(
-            CrateDisplayName {
-                crate_name: CrateName(
-                    "libc",
+            display_name: Some(
+                CrateDisplayName {
+                    crate_name: CrateName(
+                        "libc",
+                    ),
+                    canonical_name: "libc",
+                },
+            ),
+            potential_cfg_options: Some(
+                CfgOptions(
+                    [
+                        "feature=align",
+                        "feature=const-extern-fn",
+                        "feature=default",
+                        "feature=extra_traits",
+                        "feature=rustc-dep-of-std",
+                        "feature=std",
+                        "feature=use_std",
+                        "true",
+                    ],
                 ),
-                canonical_name: "libc",
-            },
-        ),
+            ),
+        },
         cfg_options: CfgOptions(
             [
                 "feature=default",
                 "feature=std",
                 "true",
             ],
-        ),
-        potential_cfg_options: Some(
-            CfgOptions(
-                [
-                    "feature=align",
-                    "feature=const-extern-fn",
-                    "feature=default",
-                    "feature=extra_traits",
-                    "feature=rustc-dep-of-std",
-                    "feature=std",
-                    "feature=use_std",
-                    "true",
-                ],
-            ),
         ),
         env: Env {
             entries: {
@@ -353,18 +410,11 @@
                 "CARGO_PKG_VERSION_PRE": "",
             },
         },
-        dependencies: [],
-        origin: Library {
-            repo: Some(
-                "https://github.com/rust-lang/libc",
+        ws_data: CrateWorkspaceData {
+            data_layout: Err(
+                "target_data_layout not loaded",
             ),
-            name: "libc",
+            toolchain: None,
         },
-        is_proc_macro: false,
-        proc_macro_cwd: Some(
-            AbsPathBuf(
-                "$ROOT$.cargo/registry/src/github.com-1ecc6299db9ec823/libc-0.2.98",
-            ),
-        ),
     },
 }

--- a/crates/project-model/test_data/output/cargo_hello_world_project_model_with_selective_overrides.txt
+++ b/crates/project-model/test_data/output/cargo_hello_world_project_model_with_selective_overrides.txt
@@ -1,20 +1,47 @@
 {
-    0: CrateData {
-        root_file_id: FileId(
-            1,
-        ),
-        edition: Edition2018,
-        version: Some(
-            "0.1.0",
-        ),
-        display_name: Some(
-            CrateDisplayName {
-                crate_name: CrateName(
-                    "hello_world",
+    0: CrateBuilder {
+        basic: CrateData {
+            root_file_id: FileId(
+                1,
+            ),
+            edition: Edition2018,
+            dependencies: [
+                Dependency {
+                    crate_id: Idx::<CrateBuilder>(4),
+                    name: CrateName(
+                        "libc",
+                    ),
+                    prelude: true,
+                    sysroot: false,
+                },
+            ],
+            origin: Local {
+                repo: None,
+                name: Some(
+                    "hello-world",
                 ),
-                canonical_name: "hello-world",
             },
-        ),
+            is_proc_macro: false,
+            proc_macro_cwd: Some(
+                AbsPathBuf(
+                    "$ROOT$hello-world",
+                ),
+            ),
+        },
+        extra: ExtraCrateData {
+            version: Some(
+                "0.1.0",
+            ),
+            display_name: Some(
+                CrateDisplayName {
+                    crate_name: CrateName(
+                        "hello_world",
+                    ),
+                    canonical_name: "hello-world",
+                },
+            ),
+            potential_cfg_options: None,
+        },
         cfg_options: CfgOptions(
             [
                 "rust_analyzer",
@@ -22,7 +49,6 @@
                 "true",
             ],
         ),
-        potential_cfg_options: None,
         env: Env {
             entries: {
                 "CARGO": "$CARGO$",
@@ -44,45 +70,64 @@
                 "CARGO_PKG_VERSION_PRE": "",
             },
         },
-        dependencies: [
-            Dependency {
-                crate_id: Idx::<CrateData>(4),
-                name: CrateName(
-                    "libc",
+        ws_data: CrateWorkspaceData {
+            data_layout: Err(
+                "target_data_layout not loaded",
+            ),
+            toolchain: None,
+        },
+    },
+    1: CrateBuilder {
+        basic: CrateData {
+            root_file_id: FileId(
+                2,
+            ),
+            edition: Edition2018,
+            dependencies: [
+                Dependency {
+                    crate_id: Idx::<CrateBuilder>(0),
+                    name: CrateName(
+                        "hello_world",
+                    ),
+                    prelude: true,
+                    sysroot: false,
+                },
+                Dependency {
+                    crate_id: Idx::<CrateBuilder>(4),
+                    name: CrateName(
+                        "libc",
+                    ),
+                    prelude: true,
+                    sysroot: false,
+                },
+            ],
+            origin: Local {
+                repo: None,
+                name: Some(
+                    "hello-world",
                 ),
-                prelude: true,
-                sysroot: false,
             },
-        ],
-        origin: Local {
-            repo: None,
-            name: Some(
-                "hello-world",
+            is_proc_macro: false,
+            proc_macro_cwd: Some(
+                AbsPathBuf(
+                    "$ROOT$hello-world",
+                ),
             ),
         },
-        is_proc_macro: false,
-        proc_macro_cwd: Some(
-            AbsPathBuf(
-                "$ROOT$hello-world",
+        extra: ExtraCrateData {
+            version: Some(
+                "0.1.0",
             ),
-        ),
-    },
-    1: CrateData {
-        root_file_id: FileId(
-            2,
-        ),
-        edition: Edition2018,
-        version: Some(
-            "0.1.0",
-        ),
-        display_name: Some(
-            CrateDisplayName {
-                crate_name: CrateName(
-                    "hello_world",
-                ),
-                canonical_name: "hello-world",
-            },
-        ),
+            display_name: Some(
+                CrateDisplayName {
+                    crate_name: CrateName(
+                        "hello_world",
+                    ),
+                    canonical_name: "hello-world",
+                },
+            ),
+            potential_cfg_options: None,
+        },
         cfg_options: CfgOptions(
             [
                 "rust_analyzer",
@@ -90,7 +135,6 @@
                 "true",
             ],
         ),
-        potential_cfg_options: None,
         env: Env {
             entries: {
                 "CARGO": "$CARGO$",
@@ -112,53 +156,64 @@
                 "CARGO_PKG_VERSION_PRE": "",
             },
         },
-        dependencies: [
-            Dependency {
-                crate_id: Idx::<CrateData>(0),
-                name: CrateName(
-                    "hello_world",
+        ws_data: CrateWorkspaceData {
+            data_layout: Err(
+                "target_data_layout not loaded",
+            ),
+            toolchain: None,
+        },
+    },
+    2: CrateBuilder {
+        basic: CrateData {
+            root_file_id: FileId(
+                3,
+            ),
+            edition: Edition2018,
+            dependencies: [
+                Dependency {
+                    crate_id: Idx::<CrateBuilder>(0),
+                    name: CrateName(
+                        "hello_world",
+                    ),
+                    prelude: true,
+                    sysroot: false,
+                },
+                Dependency {
+                    crate_id: Idx::<CrateBuilder>(4),
+                    name: CrateName(
+                        "libc",
+                    ),
+                    prelude: true,
+                    sysroot: false,
+                },
+            ],
+            origin: Local {
+                repo: None,
+                name: Some(
+                    "hello-world",
                 ),
-                prelude: true,
-                sysroot: false,
             },
-            Dependency {
-                crate_id: Idx::<CrateData>(4),
-                name: CrateName(
-                    "libc",
+            is_proc_macro: false,
+            proc_macro_cwd: Some(
+                AbsPathBuf(
+                    "$ROOT$hello-world",
                 ),
-                prelude: true,
-                sysroot: false,
-            },
-        ],
-        origin: Local {
-            repo: None,
-            name: Some(
-                "hello-world",
             ),
         },
-        is_proc_macro: false,
-        proc_macro_cwd: Some(
-            AbsPathBuf(
-                "$ROOT$hello-world",
+        extra: ExtraCrateData {
+            version: Some(
+                "0.1.0",
             ),
-        ),
-    },
-    2: CrateData {
-        root_file_id: FileId(
-            3,
-        ),
-        edition: Edition2018,
-        version: Some(
-            "0.1.0",
-        ),
-        display_name: Some(
-            CrateDisplayName {
-                crate_name: CrateName(
-                    "an_example",
-                ),
-                canonical_name: "an-example",
-            },
-        ),
+            display_name: Some(
+                CrateDisplayName {
+                    crate_name: CrateName(
+                        "an_example",
+                    ),
+                    canonical_name: "an-example",
+                },
+            ),
+            potential_cfg_options: None,
+        },
         cfg_options: CfgOptions(
             [
                 "rust_analyzer",
@@ -166,7 +221,6 @@
                 "true",
             ],
         ),
-        potential_cfg_options: None,
         env: Env {
             entries: {
                 "CARGO": "$CARGO$",
@@ -188,53 +242,64 @@
                 "CARGO_PKG_VERSION_PRE": "",
             },
         },
-        dependencies: [
-            Dependency {
-                crate_id: Idx::<CrateData>(0),
-                name: CrateName(
-                    "hello_world",
+        ws_data: CrateWorkspaceData {
+            data_layout: Err(
+                "target_data_layout not loaded",
+            ),
+            toolchain: None,
+        },
+    },
+    3: CrateBuilder {
+        basic: CrateData {
+            root_file_id: FileId(
+                4,
+            ),
+            edition: Edition2018,
+            dependencies: [
+                Dependency {
+                    crate_id: Idx::<CrateBuilder>(0),
+                    name: CrateName(
+                        "hello_world",
+                    ),
+                    prelude: true,
+                    sysroot: false,
+                },
+                Dependency {
+                    crate_id: Idx::<CrateBuilder>(4),
+                    name: CrateName(
+                        "libc",
+                    ),
+                    prelude: true,
+                    sysroot: false,
+                },
+            ],
+            origin: Local {
+                repo: None,
+                name: Some(
+                    "hello-world",
                 ),
-                prelude: true,
-                sysroot: false,
             },
-            Dependency {
-                crate_id: Idx::<CrateData>(4),
-                name: CrateName(
-                    "libc",
+            is_proc_macro: false,
+            proc_macro_cwd: Some(
+                AbsPathBuf(
+                    "$ROOT$hello-world",
                 ),
-                prelude: true,
-                sysroot: false,
-            },
-        ],
-        origin: Local {
-            repo: None,
-            name: Some(
-                "hello-world",
             ),
         },
-        is_proc_macro: false,
-        proc_macro_cwd: Some(
-            AbsPathBuf(
-                "$ROOT$hello-world",
+        extra: ExtraCrateData {
+            version: Some(
+                "0.1.0",
             ),
-        ),
-    },
-    3: CrateData {
-        root_file_id: FileId(
-            4,
-        ),
-        edition: Edition2018,
-        version: Some(
-            "0.1.0",
-        ),
-        display_name: Some(
-            CrateDisplayName {
-                crate_name: CrateName(
-                    "it",
-                ),
-                canonical_name: "it",
-            },
-        ),
+            display_name: Some(
+                CrateDisplayName {
+                    crate_name: CrateName(
+                        "it",
+                    ),
+                    canonical_name: "it",
+                },
+            ),
+            potential_cfg_options: None,
+        },
         cfg_options: CfgOptions(
             [
                 "rust_analyzer",
@@ -242,7 +307,6 @@
                 "true",
             ],
         ),
-        potential_cfg_options: None,
         env: Env {
             entries: {
                 "CARGO": "$CARGO$",
@@ -264,73 +328,66 @@
                 "CARGO_PKG_VERSION_PRE": "",
             },
         },
-        dependencies: [
-            Dependency {
-                crate_id: Idx::<CrateData>(0),
-                name: CrateName(
-                    "hello_world",
+        ws_data: CrateWorkspaceData {
+            data_layout: Err(
+                "target_data_layout not loaded",
+            ),
+            toolchain: None,
+        },
+    },
+    4: CrateBuilder {
+        basic: CrateData {
+            root_file_id: FileId(
+                5,
+            ),
+            edition: Edition2015,
+            dependencies: [],
+            origin: Library {
+                repo: Some(
+                    "https://github.com/rust-lang/libc",
                 ),
-                prelude: true,
-                sysroot: false,
+                name: "libc",
             },
-            Dependency {
-                crate_id: Idx::<CrateData>(4),
-                name: CrateName(
-                    "libc",
+            is_proc_macro: false,
+            proc_macro_cwd: Some(
+                AbsPathBuf(
+                    "$ROOT$.cargo/registry/src/github.com-1ecc6299db9ec823/libc-0.2.98",
                 ),
-                prelude: true,
-                sysroot: false,
-            },
-        ],
-        origin: Local {
-            repo: None,
-            name: Some(
-                "hello-world",
             ),
         },
-        is_proc_macro: false,
-        proc_macro_cwd: Some(
-            AbsPathBuf(
-                "$ROOT$hello-world",
+        extra: ExtraCrateData {
+            version: Some(
+                "0.2.98",
             ),
-        ),
-    },
-    4: CrateData {
-        root_file_id: FileId(
-            5,
-        ),
-        edition: Edition2015,
-        version: Some(
-            "0.2.98",
-        ),
-        display_name: Some(
-            CrateDisplayName {
-                crate_name: CrateName(
-                    "libc",
+            display_name: Some(
+                CrateDisplayName {
+                    crate_name: CrateName(
+                        "libc",
+                    ),
+                    canonical_name: "libc",
+                },
+            ),
+            potential_cfg_options: Some(
+                CfgOptions(
+                    [
+                        "feature=align",
+                        "feature=const-extern-fn",
+                        "feature=default",
+                        "feature=extra_traits",
+                        "feature=rustc-dep-of-std",
+                        "feature=std",
+                        "feature=use_std",
+                        "true",
+                    ],
                 ),
-                canonical_name: "libc",
-            },
-        ),
+            ),
+        },
         cfg_options: CfgOptions(
             [
                 "feature=default",
                 "feature=std",
                 "true",
             ],
-        ),
-        potential_cfg_options: Some(
-            CfgOptions(
-                [
-                    "feature=align",
-                    "feature=const-extern-fn",
-                    "feature=default",
-                    "feature=extra_traits",
-                    "feature=rustc-dep-of-std",
-                    "feature=std",
-                    "feature=use_std",
-                    "true",
-                ],
-            ),
         ),
         env: Env {
             entries: {
@@ -353,18 +410,11 @@
                 "CARGO_PKG_VERSION_PRE": "",
             },
         },
-        dependencies: [],
-        origin: Library {
-            repo: Some(
-                "https://github.com/rust-lang/libc",
+        ws_data: CrateWorkspaceData {
+            data_layout: Err(
+                "target_data_layout not loaded",
             ),
-            name: "libc",
+            toolchain: None,
         },
-        is_proc_macro: false,
-        proc_macro_cwd: Some(
-            AbsPathBuf(
-                "$ROOT$.cargo/registry/src/github.com-1ecc6299db9ec823/libc-0.2.98",
-            ),
-        ),
     },
 }

--- a/crates/project-model/test_data/output/cargo_hello_world_project_model_with_wildcard_overrides.txt
+++ b/crates/project-model/test_data/output/cargo_hello_world_project_model_with_wildcard_overrides.txt
@@ -1,27 +1,53 @@
 {
-    0: CrateData {
-        root_file_id: FileId(
-            1,
-        ),
-        edition: Edition2018,
-        version: Some(
-            "0.1.0",
-        ),
-        display_name: Some(
-            CrateDisplayName {
-                crate_name: CrateName(
-                    "hello_world",
+    0: CrateBuilder {
+        basic: CrateData {
+            root_file_id: FileId(
+                1,
+            ),
+            edition: Edition2018,
+            dependencies: [
+                Dependency {
+                    crate_id: Idx::<CrateBuilder>(4),
+                    name: CrateName(
+                        "libc",
+                    ),
+                    prelude: true,
+                    sysroot: false,
+                },
+            ],
+            origin: Local {
+                repo: None,
+                name: Some(
+                    "hello-world",
                 ),
-                canonical_name: "hello-world",
             },
-        ),
+            is_proc_macro: false,
+            proc_macro_cwd: Some(
+                AbsPathBuf(
+                    "$ROOT$hello-world",
+                ),
+            ),
+        },
+        extra: ExtraCrateData {
+            version: Some(
+                "0.1.0",
+            ),
+            display_name: Some(
+                CrateDisplayName {
+                    crate_name: CrateName(
+                        "hello_world",
+                    ),
+                    canonical_name: "hello-world",
+                },
+            ),
+            potential_cfg_options: None,
+        },
         cfg_options: CfgOptions(
             [
                 "rust_analyzer",
                 "true",
             ],
         ),
-        potential_cfg_options: None,
         env: Env {
             entries: {
                 "CARGO": "$CARGO$",
@@ -43,52 +69,70 @@
                 "CARGO_PKG_VERSION_PRE": "",
             },
         },
-        dependencies: [
-            Dependency {
-                crate_id: Idx::<CrateData>(4),
-                name: CrateName(
-                    "libc",
+        ws_data: CrateWorkspaceData {
+            data_layout: Err(
+                "target_data_layout not loaded",
+            ),
+            toolchain: None,
+        },
+    },
+    1: CrateBuilder {
+        basic: CrateData {
+            root_file_id: FileId(
+                2,
+            ),
+            edition: Edition2018,
+            dependencies: [
+                Dependency {
+                    crate_id: Idx::<CrateBuilder>(0),
+                    name: CrateName(
+                        "hello_world",
+                    ),
+                    prelude: true,
+                    sysroot: false,
+                },
+                Dependency {
+                    crate_id: Idx::<CrateBuilder>(4),
+                    name: CrateName(
+                        "libc",
+                    ),
+                    prelude: true,
+                    sysroot: false,
+                },
+            ],
+            origin: Local {
+                repo: None,
+                name: Some(
+                    "hello-world",
                 ),
-                prelude: true,
-                sysroot: false,
             },
-        ],
-        origin: Local {
-            repo: None,
-            name: Some(
-                "hello-world",
+            is_proc_macro: false,
+            proc_macro_cwd: Some(
+                AbsPathBuf(
+                    "$ROOT$hello-world",
+                ),
             ),
         },
-        is_proc_macro: false,
-        proc_macro_cwd: Some(
-            AbsPathBuf(
-                "$ROOT$hello-world",
+        extra: ExtraCrateData {
+            version: Some(
+                "0.1.0",
             ),
-        ),
-    },
-    1: CrateData {
-        root_file_id: FileId(
-            2,
-        ),
-        edition: Edition2018,
-        version: Some(
-            "0.1.0",
-        ),
-        display_name: Some(
-            CrateDisplayName {
-                crate_name: CrateName(
-                    "hello_world",
-                ),
-                canonical_name: "hello-world",
-            },
-        ),
+            display_name: Some(
+                CrateDisplayName {
+                    crate_name: CrateName(
+                        "hello_world",
+                    ),
+                    canonical_name: "hello-world",
+                },
+            ),
+            potential_cfg_options: None,
+        },
         cfg_options: CfgOptions(
             [
                 "rust_analyzer",
                 "true",
             ],
         ),
-        potential_cfg_options: None,
         env: Env {
             entries: {
                 "CARGO": "$CARGO$",
@@ -110,60 +154,70 @@
                 "CARGO_PKG_VERSION_PRE": "",
             },
         },
-        dependencies: [
-            Dependency {
-                crate_id: Idx::<CrateData>(0),
-                name: CrateName(
-                    "hello_world",
+        ws_data: CrateWorkspaceData {
+            data_layout: Err(
+                "target_data_layout not loaded",
+            ),
+            toolchain: None,
+        },
+    },
+    2: CrateBuilder {
+        basic: CrateData {
+            root_file_id: FileId(
+                3,
+            ),
+            edition: Edition2018,
+            dependencies: [
+                Dependency {
+                    crate_id: Idx::<CrateBuilder>(0),
+                    name: CrateName(
+                        "hello_world",
+                    ),
+                    prelude: true,
+                    sysroot: false,
+                },
+                Dependency {
+                    crate_id: Idx::<CrateBuilder>(4),
+                    name: CrateName(
+                        "libc",
+                    ),
+                    prelude: true,
+                    sysroot: false,
+                },
+            ],
+            origin: Local {
+                repo: None,
+                name: Some(
+                    "hello-world",
                 ),
-                prelude: true,
-                sysroot: false,
             },
-            Dependency {
-                crate_id: Idx::<CrateData>(4),
-                name: CrateName(
-                    "libc",
+            is_proc_macro: false,
+            proc_macro_cwd: Some(
+                AbsPathBuf(
+                    "$ROOT$hello-world",
                 ),
-                prelude: true,
-                sysroot: false,
-            },
-        ],
-        origin: Local {
-            repo: None,
-            name: Some(
-                "hello-world",
             ),
         },
-        is_proc_macro: false,
-        proc_macro_cwd: Some(
-            AbsPathBuf(
-                "$ROOT$hello-world",
+        extra: ExtraCrateData {
+            version: Some(
+                "0.1.0",
             ),
-        ),
-    },
-    2: CrateData {
-        root_file_id: FileId(
-            3,
-        ),
-        edition: Edition2018,
-        version: Some(
-            "0.1.0",
-        ),
-        display_name: Some(
-            CrateDisplayName {
-                crate_name: CrateName(
-                    "an_example",
-                ),
-                canonical_name: "an-example",
-            },
-        ),
+            display_name: Some(
+                CrateDisplayName {
+                    crate_name: CrateName(
+                        "an_example",
+                    ),
+                    canonical_name: "an-example",
+                },
+            ),
+            potential_cfg_options: None,
+        },
         cfg_options: CfgOptions(
             [
                 "rust_analyzer",
                 "true",
             ],
         ),
-        potential_cfg_options: None,
         env: Env {
             entries: {
                 "CARGO": "$CARGO$",
@@ -185,60 +239,70 @@
                 "CARGO_PKG_VERSION_PRE": "",
             },
         },
-        dependencies: [
-            Dependency {
-                crate_id: Idx::<CrateData>(0),
-                name: CrateName(
-                    "hello_world",
+        ws_data: CrateWorkspaceData {
+            data_layout: Err(
+                "target_data_layout not loaded",
+            ),
+            toolchain: None,
+        },
+    },
+    3: CrateBuilder {
+        basic: CrateData {
+            root_file_id: FileId(
+                4,
+            ),
+            edition: Edition2018,
+            dependencies: [
+                Dependency {
+                    crate_id: Idx::<CrateBuilder>(0),
+                    name: CrateName(
+                        "hello_world",
+                    ),
+                    prelude: true,
+                    sysroot: false,
+                },
+                Dependency {
+                    crate_id: Idx::<CrateBuilder>(4),
+                    name: CrateName(
+                        "libc",
+                    ),
+                    prelude: true,
+                    sysroot: false,
+                },
+            ],
+            origin: Local {
+                repo: None,
+                name: Some(
+                    "hello-world",
                 ),
-                prelude: true,
-                sysroot: false,
             },
-            Dependency {
-                crate_id: Idx::<CrateData>(4),
-                name: CrateName(
-                    "libc",
+            is_proc_macro: false,
+            proc_macro_cwd: Some(
+                AbsPathBuf(
+                    "$ROOT$hello-world",
                 ),
-                prelude: true,
-                sysroot: false,
-            },
-        ],
-        origin: Local {
-            repo: None,
-            name: Some(
-                "hello-world",
             ),
         },
-        is_proc_macro: false,
-        proc_macro_cwd: Some(
-            AbsPathBuf(
-                "$ROOT$hello-world",
+        extra: ExtraCrateData {
+            version: Some(
+                "0.1.0",
             ),
-        ),
-    },
-    3: CrateData {
-        root_file_id: FileId(
-            4,
-        ),
-        edition: Edition2018,
-        version: Some(
-            "0.1.0",
-        ),
-        display_name: Some(
-            CrateDisplayName {
-                crate_name: CrateName(
-                    "it",
-                ),
-                canonical_name: "it",
-            },
-        ),
+            display_name: Some(
+                CrateDisplayName {
+                    crate_name: CrateName(
+                        "it",
+                    ),
+                    canonical_name: "it",
+                },
+            ),
+            potential_cfg_options: None,
+        },
         cfg_options: CfgOptions(
             [
                 "rust_analyzer",
                 "true",
             ],
         ),
-        potential_cfg_options: None,
         env: Env {
             entries: {
                 "CARGO": "$CARGO$",
@@ -260,73 +324,66 @@
                 "CARGO_PKG_VERSION_PRE": "",
             },
         },
-        dependencies: [
-            Dependency {
-                crate_id: Idx::<CrateData>(0),
-                name: CrateName(
-                    "hello_world",
+        ws_data: CrateWorkspaceData {
+            data_layout: Err(
+                "target_data_layout not loaded",
+            ),
+            toolchain: None,
+        },
+    },
+    4: CrateBuilder {
+        basic: CrateData {
+            root_file_id: FileId(
+                5,
+            ),
+            edition: Edition2015,
+            dependencies: [],
+            origin: Library {
+                repo: Some(
+                    "https://github.com/rust-lang/libc",
                 ),
-                prelude: true,
-                sysroot: false,
+                name: "libc",
             },
-            Dependency {
-                crate_id: Idx::<CrateData>(4),
-                name: CrateName(
-                    "libc",
+            is_proc_macro: false,
+            proc_macro_cwd: Some(
+                AbsPathBuf(
+                    "$ROOT$.cargo/registry/src/github.com-1ecc6299db9ec823/libc-0.2.98",
                 ),
-                prelude: true,
-                sysroot: false,
-            },
-        ],
-        origin: Local {
-            repo: None,
-            name: Some(
-                "hello-world",
             ),
         },
-        is_proc_macro: false,
-        proc_macro_cwd: Some(
-            AbsPathBuf(
-                "$ROOT$hello-world",
+        extra: ExtraCrateData {
+            version: Some(
+                "0.2.98",
             ),
-        ),
-    },
-    4: CrateData {
-        root_file_id: FileId(
-            5,
-        ),
-        edition: Edition2015,
-        version: Some(
-            "0.2.98",
-        ),
-        display_name: Some(
-            CrateDisplayName {
-                crate_name: CrateName(
-                    "libc",
+            display_name: Some(
+                CrateDisplayName {
+                    crate_name: CrateName(
+                        "libc",
+                    ),
+                    canonical_name: "libc",
+                },
+            ),
+            potential_cfg_options: Some(
+                CfgOptions(
+                    [
+                        "feature=align",
+                        "feature=const-extern-fn",
+                        "feature=default",
+                        "feature=extra_traits",
+                        "feature=rustc-dep-of-std",
+                        "feature=std",
+                        "feature=use_std",
+                        "true",
+                    ],
                 ),
-                canonical_name: "libc",
-            },
-        ),
+            ),
+        },
         cfg_options: CfgOptions(
             [
                 "feature=default",
                 "feature=std",
                 "true",
             ],
-        ),
-        potential_cfg_options: Some(
-            CfgOptions(
-                [
-                    "feature=align",
-                    "feature=const-extern-fn",
-                    "feature=default",
-                    "feature=extra_traits",
-                    "feature=rustc-dep-of-std",
-                    "feature=std",
-                    "feature=use_std",
-                    "true",
-                ],
-            ),
         ),
         env: Env {
             entries: {
@@ -349,18 +406,11 @@
                 "CARGO_PKG_VERSION_PRE": "",
             },
         },
-        dependencies: [],
-        origin: Library {
-            repo: Some(
-                "https://github.com/rust-lang/libc",
+        ws_data: CrateWorkspaceData {
+            data_layout: Err(
+                "target_data_layout not loaded",
             ),
-            name: "libc",
+            toolchain: None,
         },
-        is_proc_macro: false,
-        proc_macro_cwd: Some(
-            AbsPathBuf(
-                "$ROOT$.cargo/registry/src/github.com-1ecc6299db9ec823/libc-0.2.98",
-            ),
-        ),
     },
 }

--- a/crates/project-model/test_data/output/rust_project_cfg_groups.txt
+++ b/crates/project-model/test_data/output/rust_project_cfg_groups.txt
@@ -1,18 +1,38 @@
 {
-    0: CrateData {
-        root_file_id: FileId(
-            1,
-        ),
-        edition: Edition2021,
-        version: None,
-        display_name: Some(
-            CrateDisplayName {
-                crate_name: CrateName(
-                    "alloc",
-                ),
-                canonical_name: "alloc",
-            },
-        ),
+    0: CrateBuilder {
+        basic: CrateData {
+            root_file_id: FileId(
+                1,
+            ),
+            edition: Edition2021,
+            dependencies: [
+                Dependency {
+                    crate_id: Idx::<CrateBuilder>(1),
+                    name: CrateName(
+                        "core",
+                    ),
+                    prelude: true,
+                    sysroot: false,
+                },
+            ],
+            origin: Lang(
+                Alloc,
+            ),
+            is_proc_macro: false,
+            proc_macro_cwd: None,
+        },
+        extra: ExtraCrateData {
+            version: None,
+            display_name: Some(
+                CrateDisplayName {
+                    crate_name: CrateName(
+                        "alloc",
+                    ),
+                    canonical_name: "alloc",
+                },
+            ),
+            potential_cfg_options: None,
+        },
         cfg_options: CfgOptions(
             [
                 "debug_assertions",
@@ -20,40 +40,41 @@
                 "true",
             ],
         ),
-        potential_cfg_options: None,
         env: Env {
             entries: {},
         },
-        dependencies: [
-            Dependency {
-                crate_id: Idx::<CrateData>(1),
-                name: CrateName(
-                    "core",
-                ),
-                prelude: true,
-                sysroot: false,
-            },
-        ],
-        origin: Lang(
-            Alloc,
-        ),
-        is_proc_macro: false,
-        proc_macro_cwd: None,
+        ws_data: CrateWorkspaceData {
+            data_layout: Err(
+                "test has no data layout",
+            ),
+            toolchain: None,
+        },
     },
-    1: CrateData {
-        root_file_id: FileId(
-            2,
-        ),
-        edition: Edition2021,
-        version: None,
-        display_name: Some(
-            CrateDisplayName {
-                crate_name: CrateName(
-                    "core",
-                ),
-                canonical_name: "core",
-            },
-        ),
+    1: CrateBuilder {
+        basic: CrateData {
+            root_file_id: FileId(
+                2,
+            ),
+            edition: Edition2021,
+            dependencies: [],
+            origin: Lang(
+                Core,
+            ),
+            is_proc_macro: false,
+            proc_macro_cwd: None,
+        },
+        extra: ExtraCrateData {
+            version: None,
+            display_name: Some(
+                CrateDisplayName {
+                    crate_name: CrateName(
+                        "core",
+                    ),
+                    canonical_name: "core",
+                },
+            ),
+            potential_cfg_options: None,
+        },
         cfg_options: CfgOptions(
             [
                 "debug_assertions",
@@ -61,31 +82,41 @@
                 "true",
             ],
         ),
-        potential_cfg_options: None,
         env: Env {
             entries: {},
         },
-        dependencies: [],
-        origin: Lang(
-            Core,
-        ),
-        is_proc_macro: false,
-        proc_macro_cwd: None,
+        ws_data: CrateWorkspaceData {
+            data_layout: Err(
+                "test has no data layout",
+            ),
+            toolchain: None,
+        },
     },
-    2: CrateData {
-        root_file_id: FileId(
-            3,
-        ),
-        edition: Edition2021,
-        version: None,
-        display_name: Some(
-            CrateDisplayName {
-                crate_name: CrateName(
-                    "panic_abort",
-                ),
-                canonical_name: "panic_abort",
-            },
-        ),
+    2: CrateBuilder {
+        basic: CrateData {
+            root_file_id: FileId(
+                3,
+            ),
+            edition: Edition2021,
+            dependencies: [],
+            origin: Lang(
+                Other,
+            ),
+            is_proc_macro: false,
+            proc_macro_cwd: None,
+        },
+        extra: ExtraCrateData {
+            version: None,
+            display_name: Some(
+                CrateDisplayName {
+                    crate_name: CrateName(
+                        "panic_abort",
+                    ),
+                    canonical_name: "panic_abort",
+                },
+            ),
+            potential_cfg_options: None,
+        },
         cfg_options: CfgOptions(
             [
                 "debug_assertions",
@@ -93,31 +124,41 @@
                 "true",
             ],
         ),
-        potential_cfg_options: None,
         env: Env {
             entries: {},
         },
-        dependencies: [],
-        origin: Lang(
-            Other,
-        ),
-        is_proc_macro: false,
-        proc_macro_cwd: None,
+        ws_data: CrateWorkspaceData {
+            data_layout: Err(
+                "test has no data layout",
+            ),
+            toolchain: None,
+        },
     },
-    3: CrateData {
-        root_file_id: FileId(
-            4,
-        ),
-        edition: Edition2021,
-        version: None,
-        display_name: Some(
-            CrateDisplayName {
-                crate_name: CrateName(
-                    "panic_unwind",
-                ),
-                canonical_name: "panic_unwind",
-            },
-        ),
+    3: CrateBuilder {
+        basic: CrateData {
+            root_file_id: FileId(
+                4,
+            ),
+            edition: Edition2021,
+            dependencies: [],
+            origin: Lang(
+                Other,
+            ),
+            is_proc_macro: false,
+            proc_macro_cwd: None,
+        },
+        extra: ExtraCrateData {
+            version: None,
+            display_name: Some(
+                CrateDisplayName {
+                    crate_name: CrateName(
+                        "panic_unwind",
+                    ),
+                    canonical_name: "panic_unwind",
+                },
+            ),
+            potential_cfg_options: None,
+        },
         cfg_options: CfgOptions(
             [
                 "debug_assertions",
@@ -125,31 +166,58 @@
                 "true",
             ],
         ),
-        potential_cfg_options: None,
         env: Env {
             entries: {},
         },
-        dependencies: [],
-        origin: Lang(
-            Other,
-        ),
-        is_proc_macro: false,
-        proc_macro_cwd: None,
+        ws_data: CrateWorkspaceData {
+            data_layout: Err(
+                "test has no data layout",
+            ),
+            toolchain: None,
+        },
     },
-    4: CrateData {
-        root_file_id: FileId(
-            5,
-        ),
-        edition: Edition2021,
-        version: None,
-        display_name: Some(
-            CrateDisplayName {
-                crate_name: CrateName(
-                    "proc_macro",
-                ),
-                canonical_name: "proc_macro",
-            },
-        ),
+    4: CrateBuilder {
+        basic: CrateData {
+            root_file_id: FileId(
+                5,
+            ),
+            edition: Edition2021,
+            dependencies: [
+                Dependency {
+                    crate_id: Idx::<CrateBuilder>(6),
+                    name: CrateName(
+                        "std",
+                    ),
+                    prelude: true,
+                    sysroot: false,
+                },
+                Dependency {
+                    crate_id: Idx::<CrateBuilder>(1),
+                    name: CrateName(
+                        "core",
+                    ),
+                    prelude: true,
+                    sysroot: false,
+                },
+            ],
+            origin: Lang(
+                ProcMacro,
+            ),
+            is_proc_macro: false,
+            proc_macro_cwd: None,
+        },
+        extra: ExtraCrateData {
+            version: None,
+            display_name: Some(
+                CrateDisplayName {
+                    crate_name: CrateName(
+                        "proc_macro",
+                    ),
+                    canonical_name: "proc_macro",
+                },
+            ),
+            potential_cfg_options: None,
+        },
         cfg_options: CfgOptions(
             [
                 "debug_assertions",
@@ -157,48 +225,41 @@
                 "true",
             ],
         ),
-        potential_cfg_options: None,
         env: Env {
             entries: {},
         },
-        dependencies: [
-            Dependency {
-                crate_id: Idx::<CrateData>(6),
-                name: CrateName(
-                    "std",
-                ),
-                prelude: true,
-                sysroot: false,
-            },
-            Dependency {
-                crate_id: Idx::<CrateData>(1),
-                name: CrateName(
-                    "core",
-                ),
-                prelude: true,
-                sysroot: false,
-            },
-        ],
-        origin: Lang(
-            ProcMacro,
-        ),
-        is_proc_macro: false,
-        proc_macro_cwd: None,
+        ws_data: CrateWorkspaceData {
+            data_layout: Err(
+                "test has no data layout",
+            ),
+            toolchain: None,
+        },
     },
-    5: CrateData {
-        root_file_id: FileId(
-            6,
-        ),
-        edition: Edition2021,
-        version: None,
-        display_name: Some(
-            CrateDisplayName {
-                crate_name: CrateName(
-                    "profiler_builtins",
-                ),
-                canonical_name: "profiler_builtins",
-            },
-        ),
+    5: CrateBuilder {
+        basic: CrateData {
+            root_file_id: FileId(
+                6,
+            ),
+            edition: Edition2021,
+            dependencies: [],
+            origin: Lang(
+                Other,
+            ),
+            is_proc_macro: false,
+            proc_macro_cwd: None,
+        },
+        extra: ExtraCrateData {
+            version: None,
+            display_name: Some(
+                CrateDisplayName {
+                    crate_name: CrateName(
+                        "profiler_builtins",
+                    ),
+                    canonical_name: "profiler_builtins",
+                },
+            ),
+            potential_cfg_options: None,
+        },
         cfg_options: CfgOptions(
             [
                 "debug_assertions",
@@ -206,31 +267,106 @@
                 "true",
             ],
         ),
-        potential_cfg_options: None,
         env: Env {
             entries: {},
         },
-        dependencies: [],
-        origin: Lang(
-            Other,
-        ),
-        is_proc_macro: false,
-        proc_macro_cwd: None,
+        ws_data: CrateWorkspaceData {
+            data_layout: Err(
+                "test has no data layout",
+            ),
+            toolchain: None,
+        },
     },
-    6: CrateData {
-        root_file_id: FileId(
-            7,
-        ),
-        edition: Edition2021,
-        version: None,
-        display_name: Some(
-            CrateDisplayName {
-                crate_name: CrateName(
-                    "std",
-                ),
-                canonical_name: "std",
-            },
-        ),
+    6: CrateBuilder {
+        basic: CrateData {
+            root_file_id: FileId(
+                7,
+            ),
+            edition: Edition2021,
+            dependencies: [
+                Dependency {
+                    crate_id: Idx::<CrateBuilder>(0),
+                    name: CrateName(
+                        "alloc",
+                    ),
+                    prelude: true,
+                    sysroot: false,
+                },
+                Dependency {
+                    crate_id: Idx::<CrateBuilder>(3),
+                    name: CrateName(
+                        "panic_unwind",
+                    ),
+                    prelude: true,
+                    sysroot: false,
+                },
+                Dependency {
+                    crate_id: Idx::<CrateBuilder>(2),
+                    name: CrateName(
+                        "panic_abort",
+                    ),
+                    prelude: true,
+                    sysroot: false,
+                },
+                Dependency {
+                    crate_id: Idx::<CrateBuilder>(1),
+                    name: CrateName(
+                        "core",
+                    ),
+                    prelude: true,
+                    sysroot: false,
+                },
+                Dependency {
+                    crate_id: Idx::<CrateBuilder>(5),
+                    name: CrateName(
+                        "profiler_builtins",
+                    ),
+                    prelude: true,
+                    sysroot: false,
+                },
+                Dependency {
+                    crate_id: Idx::<CrateBuilder>(9),
+                    name: CrateName(
+                        "unwind",
+                    ),
+                    prelude: true,
+                    sysroot: false,
+                },
+                Dependency {
+                    crate_id: Idx::<CrateBuilder>(7),
+                    name: CrateName(
+                        "std_detect",
+                    ),
+                    prelude: true,
+                    sysroot: false,
+                },
+                Dependency {
+                    crate_id: Idx::<CrateBuilder>(8),
+                    name: CrateName(
+                        "test",
+                    ),
+                    prelude: true,
+                    sysroot: false,
+                },
+            ],
+            origin: Lang(
+                Std,
+            ),
+            is_proc_macro: false,
+            proc_macro_cwd: None,
+        },
+        extra: ExtraCrateData {
+            version: None,
+            display_name: Some(
+                CrateDisplayName {
+                    crate_name: CrateName(
+                        "std",
+                    ),
+                    canonical_name: "std",
+                },
+            ),
+            potential_cfg_options: None,
+        },
         cfg_options: CfgOptions(
             [
                 "debug_assertions",
@@ -238,96 +374,41 @@
                 "true",
             ],
         ),
-        potential_cfg_options: None,
         env: Env {
             entries: {},
         },
-        dependencies: [
-            Dependency {
-                crate_id: Idx::<CrateData>(0),
-                name: CrateName(
-                    "alloc",
-                ),
-                prelude: true,
-                sysroot: false,
-            },
-            Dependency {
-                crate_id: Idx::<CrateData>(3),
-                name: CrateName(
-                    "panic_unwind",
-                ),
-                prelude: true,
-                sysroot: false,
-            },
-            Dependency {
-                crate_id: Idx::<CrateData>(2),
-                name: CrateName(
-                    "panic_abort",
-                ),
-                prelude: true,
-                sysroot: false,
-            },
-            Dependency {
-                crate_id: Idx::<CrateData>(1),
-                name: CrateName(
-                    "core",
-                ),
-                prelude: true,
-                sysroot: false,
-            },
-            Dependency {
-                crate_id: Idx::<CrateData>(5),
-                name: CrateName(
-                    "profiler_builtins",
-                ),
-                prelude: true,
-                sysroot: false,
-            },
-            Dependency {
-                crate_id: Idx::<CrateData>(9),
-                name: CrateName(
-                    "unwind",
-                ),
-                prelude: true,
-                sysroot: false,
-            },
-            Dependency {
-                crate_id: Idx::<CrateData>(7),
-                name: CrateName(
-                    "std_detect",
-                ),
-                prelude: true,
-                sysroot: false,
-            },
-            Dependency {
-                crate_id: Idx::<CrateData>(8),
-                name: CrateName(
-                    "test",
-                ),
-                prelude: true,
-                sysroot: false,
-            },
-        ],
-        origin: Lang(
-            Std,
-        ),
-        is_proc_macro: false,
-        proc_macro_cwd: None,
+        ws_data: CrateWorkspaceData {
+            data_layout: Err(
+                "test has no data layout",
+            ),
+            toolchain: None,
+        },
     },
-    7: CrateData {
-        root_file_id: FileId(
-            8,
-        ),
-        edition: Edition2021,
-        version: None,
-        display_name: Some(
-            CrateDisplayName {
-                crate_name: CrateName(
-                    "std_detect",
-                ),
-                canonical_name: "std_detect",
-            },
-        ),
+    7: CrateBuilder {
+        basic: CrateData {
+            root_file_id: FileId(
+                8,
+            ),
+            edition: Edition2021,
+            dependencies: [],
+            origin: Lang(
+                Other,
+            ),
+            is_proc_macro: false,
+            proc_macro_cwd: None,
+        },
+        extra: ExtraCrateData {
+            version: None,
+            display_name: Some(
+                CrateDisplayName {
+                    crate_name: CrateName(
+                        "std_detect",
+                    ),
+                    canonical_name: "std_detect",
+                },
+            ),
+            potential_cfg_options: None,
+        },
         cfg_options: CfgOptions(
             [
                 "debug_assertions",
@@ -335,31 +416,41 @@
                 "true",
             ],
         ),
-        potential_cfg_options: None,
         env: Env {
             entries: {},
         },
-        dependencies: [],
-        origin: Lang(
-            Other,
-        ),
-        is_proc_macro: false,
-        proc_macro_cwd: None,
+        ws_data: CrateWorkspaceData {
+            data_layout: Err(
+                "test has no data layout",
+            ),
+            toolchain: None,
+        },
     },
-    8: CrateData {
-        root_file_id: FileId(
-            9,
-        ),
-        edition: Edition2021,
-        version: None,
-        display_name: Some(
-            CrateDisplayName {
-                crate_name: CrateName(
-                    "test",
-                ),
-                canonical_name: "test",
-            },
-        ),
+    8: CrateBuilder {
+        basic: CrateData {
+            root_file_id: FileId(
+                9,
+            ),
+            edition: Edition2021,
+            dependencies: [],
+            origin: Lang(
+                Test,
+            ),
+            is_proc_macro: false,
+            proc_macro_cwd: None,
+        },
+        extra: ExtraCrateData {
+            version: None,
+            display_name: Some(
+                CrateDisplayName {
+                    crate_name: CrateName(
+                        "test",
+                    ),
+                    canonical_name: "test",
+                },
+            ),
+            potential_cfg_options: None,
+        },
         cfg_options: CfgOptions(
             [
                 "debug_assertions",
@@ -367,31 +458,41 @@
                 "true",
             ],
         ),
-        potential_cfg_options: None,
         env: Env {
             entries: {},
         },
-        dependencies: [],
-        origin: Lang(
-            Test,
-        ),
-        is_proc_macro: false,
-        proc_macro_cwd: None,
+        ws_data: CrateWorkspaceData {
+            data_layout: Err(
+                "test has no data layout",
+            ),
+            toolchain: None,
+        },
     },
-    9: CrateData {
-        root_file_id: FileId(
-            10,
-        ),
-        edition: Edition2021,
-        version: None,
-        display_name: Some(
-            CrateDisplayName {
-                crate_name: CrateName(
-                    "unwind",
-                ),
-                canonical_name: "unwind",
-            },
-        ),
+    9: CrateBuilder {
+        basic: CrateData {
+            root_file_id: FileId(
+                10,
+            ),
+            edition: Edition2021,
+            dependencies: [],
+            origin: Lang(
+                Other,
+            ),
+            is_proc_macro: false,
+            proc_macro_cwd: None,
+        },
+        extra: ExtraCrateData {
+            version: None,
+            display_name: Some(
+                CrateDisplayName {
+                    crate_name: CrateName(
+                        "unwind",
+                    ),
+                    canonical_name: "unwind",
+                },
+            ),
+            potential_cfg_options: None,
+        },
         cfg_options: CfgOptions(
             [
                 "debug_assertions",
@@ -399,31 +500,85 @@
                 "true",
             ],
         ),
-        potential_cfg_options: None,
         env: Env {
             entries: {},
         },
-        dependencies: [],
-        origin: Lang(
-            Other,
-        ),
-        is_proc_macro: false,
-        proc_macro_cwd: None,
+        ws_data: CrateWorkspaceData {
+            data_layout: Err(
+                "test has no data layout",
+            ),
+            toolchain: None,
+        },
     },
-    10: CrateData {
-        root_file_id: FileId(
-            11,
-        ),
-        edition: Edition2018,
-        version: None,
-        display_name: Some(
-            CrateDisplayName {
-                crate_name: CrateName(
+    10: CrateBuilder {
+        basic: CrateData {
+            root_file_id: FileId(
+                11,
+            ),
+            edition: Edition2018,
+            dependencies: [
+                Dependency {
+                    crate_id: Idx::<CrateBuilder>(1),
+                    name: CrateName(
+                        "core",
+                    ),
+                    prelude: true,
+                    sysroot: true,
+                },
+                Dependency {
+                    crate_id: Idx::<CrateBuilder>(0),
+                    name: CrateName(
+                        "alloc",
+                    ),
+                    prelude: false,
+                    sysroot: true,
+                },
+                Dependency {
+                    crate_id: Idx::<CrateBuilder>(6),
+                    name: CrateName(
+                        "std",
+                    ),
+                    prelude: true,
+                    sysroot: true,
+                },
+                Dependency {
+                    crate_id: Idx::<CrateBuilder>(8),
+                    name: CrateName(
+                        "test",
+                    ),
+                    prelude: false,
+                    sysroot: true,
+                },
+                Dependency {
+                    crate_id: Idx::<CrateBuilder>(4),
+                    name: CrateName(
+                        "proc_macro",
+                    ),
+                    prelude: false,
+                    sysroot: true,
+                },
+            ],
+            origin: Local {
+                repo: None,
+                name: Some(
                     "hello_world",
                 ),
-                canonical_name: "hello_world",
             },
-        ),
+            is_proc_macro: false,
+            proc_macro_cwd: None,
+        },
+        extra: ExtraCrateData {
+            version: None,
+            display_name: Some(
+                CrateDisplayName {
+                    crate_name: CrateName(
+                        "hello_world",
+                    ),
+                    canonical_name: "hello_world",
+                },
+            ),
+            potential_cfg_options: None,
+        },
         cfg_options: CfgOptions(
             [
                 "group1_cfg=some_config",
@@ -434,75 +589,85 @@
                 "true",
             ],
         ),
-        potential_cfg_options: None,
         env: Env {
             entries: {},
         },
-        dependencies: [
-            Dependency {
-                crate_id: Idx::<CrateData>(1),
-                name: CrateName(
-                    "core",
-                ),
-                prelude: true,
-                sysroot: true,
-            },
-            Dependency {
-                crate_id: Idx::<CrateData>(0),
-                name: CrateName(
-                    "alloc",
-                ),
-                prelude: false,
-                sysroot: true,
-            },
-            Dependency {
-                crate_id: Idx::<CrateData>(6),
-                name: CrateName(
-                    "std",
-                ),
-                prelude: true,
-                sysroot: true,
-            },
-            Dependency {
-                crate_id: Idx::<CrateData>(8),
-                name: CrateName(
-                    "test",
-                ),
-                prelude: false,
-                sysroot: true,
-            },
-            Dependency {
-                crate_id: Idx::<CrateData>(4),
-                name: CrateName(
-                    "proc_macro",
-                ),
-                prelude: false,
-                sysroot: true,
-            },
-        ],
-        origin: Local {
-            repo: None,
-            name: Some(
-                "hello_world",
+        ws_data: CrateWorkspaceData {
+            data_layout: Err(
+                "test has no data layout",
             ),
+            toolchain: None,
         },
-        is_proc_macro: false,
-        proc_macro_cwd: None,
     },
-    11: CrateData {
-        root_file_id: FileId(
-            11,
-        ),
-        edition: Edition2018,
-        version: None,
-        display_name: Some(
-            CrateDisplayName {
-                crate_name: CrateName(
+    11: CrateBuilder {
+        basic: CrateData {
+            root_file_id: FileId(
+                11,
+            ),
+            edition: Edition2018,
+            dependencies: [
+                Dependency {
+                    crate_id: Idx::<CrateBuilder>(1),
+                    name: CrateName(
+                        "core",
+                    ),
+                    prelude: true,
+                    sysroot: true,
+                },
+                Dependency {
+                    crate_id: Idx::<CrateBuilder>(0),
+                    name: CrateName(
+                        "alloc",
+                    ),
+                    prelude: false,
+                    sysroot: true,
+                },
+                Dependency {
+                    crate_id: Idx::<CrateBuilder>(6),
+                    name: CrateName(
+                        "std",
+                    ),
+                    prelude: true,
+                    sysroot: true,
+                },
+                Dependency {
+                    crate_id: Idx::<CrateBuilder>(8),
+                    name: CrateName(
+                        "test",
+                    ),
+                    prelude: false,
+                    sysroot: true,
+                },
+                Dependency {
+                    crate_id: Idx::<CrateBuilder>(4),
+                    name: CrateName(
+                        "proc_macro",
+                    ),
+                    prelude: false,
+                    sysroot: true,
+                },
+            ],
+            origin: Local {
+                repo: None,
+                name: Some(
                     "other_crate",
                 ),
-                canonical_name: "other_crate",
             },
-        ),
+            is_proc_macro: false,
+            proc_macro_cwd: None,
+        },
+        extra: ExtraCrateData {
+            version: None,
+            display_name: Some(
+                CrateDisplayName {
+                    crate_name: CrateName(
+                        "other_crate",
+                    ),
+                    canonical_name: "other_crate",
+                },
+            ),
+            potential_cfg_options: None,
+        },
         cfg_options: CfgOptions(
             [
                 "group2_cfg=fourth_config",
@@ -513,59 +678,14 @@
                 "unrelated_cfg",
             ],
         ),
-        potential_cfg_options: None,
         env: Env {
             entries: {},
         },
-        dependencies: [
-            Dependency {
-                crate_id: Idx::<CrateData>(1),
-                name: CrateName(
-                    "core",
-                ),
-                prelude: true,
-                sysroot: true,
-            },
-            Dependency {
-                crate_id: Idx::<CrateData>(0),
-                name: CrateName(
-                    "alloc",
-                ),
-                prelude: false,
-                sysroot: true,
-            },
-            Dependency {
-                crate_id: Idx::<CrateData>(6),
-                name: CrateName(
-                    "std",
-                ),
-                prelude: true,
-                sysroot: true,
-            },
-            Dependency {
-                crate_id: Idx::<CrateData>(8),
-                name: CrateName(
-                    "test",
-                ),
-                prelude: false,
-                sysroot: true,
-            },
-            Dependency {
-                crate_id: Idx::<CrateData>(4),
-                name: CrateName(
-                    "proc_macro",
-                ),
-                prelude: false,
-                sysroot: true,
-            },
-        ],
-        origin: Local {
-            repo: None,
-            name: Some(
-                "other_crate",
+        ws_data: CrateWorkspaceData {
+            data_layout: Err(
+                "test has no data layout",
             ),
+            toolchain: None,
         },
-        is_proc_macro: false,
-        proc_macro_cwd: None,
     },
 }

--- a/crates/project-model/test_data/output/rust_project_hello_world_project_model.txt
+++ b/crates/project-model/test_data/output/rust_project_hello_world_project_model.txt
@@ -1,18 +1,38 @@
 {
-    0: CrateData {
-        root_file_id: FileId(
-            1,
-        ),
-        edition: Edition2021,
-        version: None,
-        display_name: Some(
-            CrateDisplayName {
-                crate_name: CrateName(
-                    "alloc",
-                ),
-                canonical_name: "alloc",
-            },
-        ),
+    0: CrateBuilder {
+        basic: CrateData {
+            root_file_id: FileId(
+                1,
+            ),
+            edition: Edition2021,
+            dependencies: [
+                Dependency {
+                    crate_id: Idx::<CrateBuilder>(1),
+                    name: CrateName(
+                        "core",
+                    ),
+                    prelude: true,
+                    sysroot: false,
+                },
+            ],
+            origin: Lang(
+                Alloc,
+            ),
+            is_proc_macro: false,
+            proc_macro_cwd: None,
+        },
+        extra: ExtraCrateData {
+            version: None,
+            display_name: Some(
+                CrateDisplayName {
+                    crate_name: CrateName(
+                        "alloc",
+                    ),
+                    canonical_name: "alloc",
+                },
+            ),
+            potential_cfg_options: None,
+        },
         cfg_options: CfgOptions(
             [
                 "debug_assertions",
@@ -20,40 +40,41 @@
                 "true",
             ],
         ),
-        potential_cfg_options: None,
         env: Env {
             entries: {},
         },
-        dependencies: [
-            Dependency {
-                crate_id: Idx::<CrateData>(1),
-                name: CrateName(
-                    "core",
-                ),
-                prelude: true,
-                sysroot: false,
-            },
-        ],
-        origin: Lang(
-            Alloc,
-        ),
-        is_proc_macro: false,
-        proc_macro_cwd: None,
+        ws_data: CrateWorkspaceData {
+            data_layout: Err(
+                "test has no data layout",
+            ),
+            toolchain: None,
+        },
     },
-    1: CrateData {
-        root_file_id: FileId(
-            2,
-        ),
-        edition: Edition2021,
-        version: None,
-        display_name: Some(
-            CrateDisplayName {
-                crate_name: CrateName(
-                    "core",
-                ),
-                canonical_name: "core",
-            },
-        ),
+    1: CrateBuilder {
+        basic: CrateData {
+            root_file_id: FileId(
+                2,
+            ),
+            edition: Edition2021,
+            dependencies: [],
+            origin: Lang(
+                Core,
+            ),
+            is_proc_macro: false,
+            proc_macro_cwd: None,
+        },
+        extra: ExtraCrateData {
+            version: None,
+            display_name: Some(
+                CrateDisplayName {
+                    crate_name: CrateName(
+                        "core",
+                    ),
+                    canonical_name: "core",
+                },
+            ),
+            potential_cfg_options: None,
+        },
         cfg_options: CfgOptions(
             [
                 "debug_assertions",
@@ -61,31 +82,41 @@
                 "true",
             ],
         ),
-        potential_cfg_options: None,
         env: Env {
             entries: {},
         },
-        dependencies: [],
-        origin: Lang(
-            Core,
-        ),
-        is_proc_macro: false,
-        proc_macro_cwd: None,
+        ws_data: CrateWorkspaceData {
+            data_layout: Err(
+                "test has no data layout",
+            ),
+            toolchain: None,
+        },
     },
-    2: CrateData {
-        root_file_id: FileId(
-            3,
-        ),
-        edition: Edition2021,
-        version: None,
-        display_name: Some(
-            CrateDisplayName {
-                crate_name: CrateName(
-                    "panic_abort",
-                ),
-                canonical_name: "panic_abort",
-            },
-        ),
+    2: CrateBuilder {
+        basic: CrateData {
+            root_file_id: FileId(
+                3,
+            ),
+            edition: Edition2021,
+            dependencies: [],
+            origin: Lang(
+                Other,
+            ),
+            is_proc_macro: false,
+            proc_macro_cwd: None,
+        },
+        extra: ExtraCrateData {
+            version: None,
+            display_name: Some(
+                CrateDisplayName {
+                    crate_name: CrateName(
+                        "panic_abort",
+                    ),
+                    canonical_name: "panic_abort",
+                },
+            ),
+            potential_cfg_options: None,
+        },
         cfg_options: CfgOptions(
             [
                 "debug_assertions",
@@ -93,31 +124,41 @@
                 "true",
             ],
         ),
-        potential_cfg_options: None,
         env: Env {
             entries: {},
         },
-        dependencies: [],
-        origin: Lang(
-            Other,
-        ),
-        is_proc_macro: false,
-        proc_macro_cwd: None,
+        ws_data: CrateWorkspaceData {
+            data_layout: Err(
+                "test has no data layout",
+            ),
+            toolchain: None,
+        },
     },
-    3: CrateData {
-        root_file_id: FileId(
-            4,
-        ),
-        edition: Edition2021,
-        version: None,
-        display_name: Some(
-            CrateDisplayName {
-                crate_name: CrateName(
-                    "panic_unwind",
-                ),
-                canonical_name: "panic_unwind",
-            },
-        ),
+    3: CrateBuilder {
+        basic: CrateData {
+            root_file_id: FileId(
+                4,
+            ),
+            edition: Edition2021,
+            dependencies: [],
+            origin: Lang(
+                Other,
+            ),
+            is_proc_macro: false,
+            proc_macro_cwd: None,
+        },
+        extra: ExtraCrateData {
+            version: None,
+            display_name: Some(
+                CrateDisplayName {
+                    crate_name: CrateName(
+                        "panic_unwind",
+                    ),
+                    canonical_name: "panic_unwind",
+                },
+            ),
+            potential_cfg_options: None,
+        },
         cfg_options: CfgOptions(
             [
                 "debug_assertions",
@@ -125,31 +166,58 @@
                 "true",
             ],
         ),
-        potential_cfg_options: None,
         env: Env {
             entries: {},
         },
-        dependencies: [],
-        origin: Lang(
-            Other,
-        ),
-        is_proc_macro: false,
-        proc_macro_cwd: None,
+        ws_data: CrateWorkspaceData {
+            data_layout: Err(
+                "test has no data layout",
+            ),
+            toolchain: None,
+        },
     },
-    4: CrateData {
-        root_file_id: FileId(
-            5,
-        ),
-        edition: Edition2021,
-        version: None,
-        display_name: Some(
-            CrateDisplayName {
-                crate_name: CrateName(
-                    "proc_macro",
-                ),
-                canonical_name: "proc_macro",
-            },
-        ),
+    4: CrateBuilder {
+        basic: CrateData {
+            root_file_id: FileId(
+                5,
+            ),
+            edition: Edition2021,
+            dependencies: [
+                Dependency {
+                    crate_id: Idx::<CrateBuilder>(6),
+                    name: CrateName(
+                        "std",
+                    ),
+                    prelude: true,
+                    sysroot: false,
+                },
+                Dependency {
+                    crate_id: Idx::<CrateBuilder>(1),
+                    name: CrateName(
+                        "core",
+                    ),
+                    prelude: true,
+                    sysroot: false,
+                },
+            ],
+            origin: Lang(
+                ProcMacro,
+            ),
+            is_proc_macro: false,
+            proc_macro_cwd: None,
+        },
+        extra: ExtraCrateData {
+            version: None,
+            display_name: Some(
+                CrateDisplayName {
+                    crate_name: CrateName(
+                        "proc_macro",
+                    ),
+                    canonical_name: "proc_macro",
+                },
+            ),
+            potential_cfg_options: None,
+        },
         cfg_options: CfgOptions(
             [
                 "debug_assertions",
@@ -157,48 +225,41 @@
                 "true",
             ],
         ),
-        potential_cfg_options: None,
         env: Env {
             entries: {},
         },
-        dependencies: [
-            Dependency {
-                crate_id: Idx::<CrateData>(6),
-                name: CrateName(
-                    "std",
-                ),
-                prelude: true,
-                sysroot: false,
-            },
-            Dependency {
-                crate_id: Idx::<CrateData>(1),
-                name: CrateName(
-                    "core",
-                ),
-                prelude: true,
-                sysroot: false,
-            },
-        ],
-        origin: Lang(
-            ProcMacro,
-        ),
-        is_proc_macro: false,
-        proc_macro_cwd: None,
+        ws_data: CrateWorkspaceData {
+            data_layout: Err(
+                "test has no data layout",
+            ),
+            toolchain: None,
+        },
     },
-    5: CrateData {
-        root_file_id: FileId(
-            6,
-        ),
-        edition: Edition2021,
-        version: None,
-        display_name: Some(
-            CrateDisplayName {
-                crate_name: CrateName(
-                    "profiler_builtins",
-                ),
-                canonical_name: "profiler_builtins",
-            },
-        ),
+    5: CrateBuilder {
+        basic: CrateData {
+            root_file_id: FileId(
+                6,
+            ),
+            edition: Edition2021,
+            dependencies: [],
+            origin: Lang(
+                Other,
+            ),
+            is_proc_macro: false,
+            proc_macro_cwd: None,
+        },
+        extra: ExtraCrateData {
+            version: None,
+            display_name: Some(
+                CrateDisplayName {
+                    crate_name: CrateName(
+                        "profiler_builtins",
+                    ),
+                    canonical_name: "profiler_builtins",
+                },
+            ),
+            potential_cfg_options: None,
+        },
         cfg_options: CfgOptions(
             [
                 "debug_assertions",
@@ -206,31 +267,106 @@
                 "true",
             ],
         ),
-        potential_cfg_options: None,
         env: Env {
             entries: {},
         },
-        dependencies: [],
-        origin: Lang(
-            Other,
-        ),
-        is_proc_macro: false,
-        proc_macro_cwd: None,
+        ws_data: CrateWorkspaceData {
+            data_layout: Err(
+                "test has no data layout",
+            ),
+            toolchain: None,
+        },
     },
-    6: CrateData {
-        root_file_id: FileId(
-            7,
-        ),
-        edition: Edition2021,
-        version: None,
-        display_name: Some(
-            CrateDisplayName {
-                crate_name: CrateName(
-                    "std",
-                ),
-                canonical_name: "std",
-            },
-        ),
+    6: CrateBuilder {
+        basic: CrateData {
+            root_file_id: FileId(
+                7,
+            ),
+            edition: Edition2021,
+            dependencies: [
+                Dependency {
+                    crate_id: Idx::<CrateBuilder>(0),
+                    name: CrateName(
+                        "alloc",
+                    ),
+                    prelude: true,
+                    sysroot: false,
+                },
+                Dependency {
+                    crate_id: Idx::<CrateBuilder>(3),
+                    name: CrateName(
+                        "panic_unwind",
+                    ),
+                    prelude: true,
+                    sysroot: false,
+                },
+                Dependency {
+                    crate_id: Idx::<CrateBuilder>(2),
+                    name: CrateName(
+                        "panic_abort",
+                    ),
+                    prelude: true,
+                    sysroot: false,
+                },
+                Dependency {
+                    crate_id: Idx::<CrateBuilder>(1),
+                    name: CrateName(
+                        "core",
+                    ),
+                    prelude: true,
+                    sysroot: false,
+                },
+                Dependency {
+                    crate_id: Idx::<CrateBuilder>(5),
+                    name: CrateName(
+                        "profiler_builtins",
+                    ),
+                    prelude: true,
+                    sysroot: false,
+                },
+                Dependency {
+                    crate_id: Idx::<CrateBuilder>(9),
+                    name: CrateName(
+                        "unwind",
+                    ),
+                    prelude: true,
+                    sysroot: false,
+                },
+                Dependency {
+                    crate_id: Idx::<CrateBuilder>(7),
+                    name: CrateName(
+                        "std_detect",
+                    ),
+                    prelude: true,
+                    sysroot: false,
+                },
+                Dependency {
+                    crate_id: Idx::<CrateBuilder>(8),
+                    name: CrateName(
+                        "test",
+                    ),
+                    prelude: true,
+                    sysroot: false,
+                },
+            ],
+            origin: Lang(
+                Std,
+            ),
+            is_proc_macro: false,
+            proc_macro_cwd: None,
+        },
+        extra: ExtraCrateData {
+            version: None,
+            display_name: Some(
+                CrateDisplayName {
+                    crate_name: CrateName(
+                        "std",
+                    ),
+                    canonical_name: "std",
+                },
+            ),
+            potential_cfg_options: None,
+        },
         cfg_options: CfgOptions(
             [
                 "debug_assertions",
@@ -238,96 +374,41 @@
                 "true",
             ],
         ),
-        potential_cfg_options: None,
         env: Env {
             entries: {},
         },
-        dependencies: [
-            Dependency {
-                crate_id: Idx::<CrateData>(0),
-                name: CrateName(
-                    "alloc",
-                ),
-                prelude: true,
-                sysroot: false,
-            },
-            Dependency {
-                crate_id: Idx::<CrateData>(3),
-                name: CrateName(
-                    "panic_unwind",
-                ),
-                prelude: true,
-                sysroot: false,
-            },
-            Dependency {
-                crate_id: Idx::<CrateData>(2),
-                name: CrateName(
-                    "panic_abort",
-                ),
-                prelude: true,
-                sysroot: false,
-            },
-            Dependency {
-                crate_id: Idx::<CrateData>(1),
-                name: CrateName(
-                    "core",
-                ),
-                prelude: true,
-                sysroot: false,
-            },
-            Dependency {
-                crate_id: Idx::<CrateData>(5),
-                name: CrateName(
-                    "profiler_builtins",
-                ),
-                prelude: true,
-                sysroot: false,
-            },
-            Dependency {
-                crate_id: Idx::<CrateData>(9),
-                name: CrateName(
-                    "unwind",
-                ),
-                prelude: true,
-                sysroot: false,
-            },
-            Dependency {
-                crate_id: Idx::<CrateData>(7),
-                name: CrateName(
-                    "std_detect",
-                ),
-                prelude: true,
-                sysroot: false,
-            },
-            Dependency {
-                crate_id: Idx::<CrateData>(8),
-                name: CrateName(
-                    "test",
-                ),
-                prelude: true,
-                sysroot: false,
-            },
-        ],
-        origin: Lang(
-            Std,
-        ),
-        is_proc_macro: false,
-        proc_macro_cwd: None,
+        ws_data: CrateWorkspaceData {
+            data_layout: Err(
+                "test has no data layout",
+            ),
+            toolchain: None,
+        },
     },
-    7: CrateData {
-        root_file_id: FileId(
-            8,
-        ),
-        edition: Edition2021,
-        version: None,
-        display_name: Some(
-            CrateDisplayName {
-                crate_name: CrateName(
-                    "std_detect",
-                ),
-                canonical_name: "std_detect",
-            },
-        ),
+    7: CrateBuilder {
+        basic: CrateData {
+            root_file_id: FileId(
+                8,
+            ),
+            edition: Edition2021,
+            dependencies: [],
+            origin: Lang(
+                Other,
+            ),
+            is_proc_macro: false,
+            proc_macro_cwd: None,
+        },
+        extra: ExtraCrateData {
+            version: None,
+            display_name: Some(
+                CrateDisplayName {
+                    crate_name: CrateName(
+                        "std_detect",
+                    ),
+                    canonical_name: "std_detect",
+                },
+            ),
+            potential_cfg_options: None,
+        },
         cfg_options: CfgOptions(
             [
                 "debug_assertions",
@@ -335,31 +416,41 @@
                 "true",
             ],
         ),
-        potential_cfg_options: None,
         env: Env {
             entries: {},
         },
-        dependencies: [],
-        origin: Lang(
-            Other,
-        ),
-        is_proc_macro: false,
-        proc_macro_cwd: None,
+        ws_data: CrateWorkspaceData {
+            data_layout: Err(
+                "test has no data layout",
+            ),
+            toolchain: None,
+        },
     },
-    8: CrateData {
-        root_file_id: FileId(
-            9,
-        ),
-        edition: Edition2021,
-        version: None,
-        display_name: Some(
-            CrateDisplayName {
-                crate_name: CrateName(
-                    "test",
-                ),
-                canonical_name: "test",
-            },
-        ),
+    8: CrateBuilder {
+        basic: CrateData {
+            root_file_id: FileId(
+                9,
+            ),
+            edition: Edition2021,
+            dependencies: [],
+            origin: Lang(
+                Test,
+            ),
+            is_proc_macro: false,
+            proc_macro_cwd: None,
+        },
+        extra: ExtraCrateData {
+            version: None,
+            display_name: Some(
+                CrateDisplayName {
+                    crate_name: CrateName(
+                        "test",
+                    ),
+                    canonical_name: "test",
+                },
+            ),
+            potential_cfg_options: None,
+        },
         cfg_options: CfgOptions(
             [
                 "debug_assertions",
@@ -367,31 +458,41 @@
                 "true",
             ],
         ),
-        potential_cfg_options: None,
         env: Env {
             entries: {},
         },
-        dependencies: [],
-        origin: Lang(
-            Test,
-        ),
-        is_proc_macro: false,
-        proc_macro_cwd: None,
+        ws_data: CrateWorkspaceData {
+            data_layout: Err(
+                "test has no data layout",
+            ),
+            toolchain: None,
+        },
     },
-    9: CrateData {
-        root_file_id: FileId(
-            10,
-        ),
-        edition: Edition2021,
-        version: None,
-        display_name: Some(
-            CrateDisplayName {
-                crate_name: CrateName(
-                    "unwind",
-                ),
-                canonical_name: "unwind",
-            },
-        ),
+    9: CrateBuilder {
+        basic: CrateData {
+            root_file_id: FileId(
+                10,
+            ),
+            edition: Edition2021,
+            dependencies: [],
+            origin: Lang(
+                Other,
+            ),
+            is_proc_macro: false,
+            proc_macro_cwd: None,
+        },
+        extra: ExtraCrateData {
+            version: None,
+            display_name: Some(
+                CrateDisplayName {
+                    crate_name: CrateName(
+                        "unwind",
+                    ),
+                    canonical_name: "unwind",
+                },
+            ),
+            potential_cfg_options: None,
+        },
         cfg_options: CfgOptions(
             [
                 "debug_assertions",
@@ -399,31 +500,85 @@
                 "true",
             ],
         ),
-        potential_cfg_options: None,
         env: Env {
             entries: {},
         },
-        dependencies: [],
-        origin: Lang(
-            Other,
-        ),
-        is_proc_macro: false,
-        proc_macro_cwd: None,
+        ws_data: CrateWorkspaceData {
+            data_layout: Err(
+                "test has no data layout",
+            ),
+            toolchain: None,
+        },
     },
-    10: CrateData {
-        root_file_id: FileId(
-            11,
-        ),
-        edition: Edition2018,
-        version: None,
-        display_name: Some(
-            CrateDisplayName {
-                crate_name: CrateName(
+    10: CrateBuilder {
+        basic: CrateData {
+            root_file_id: FileId(
+                11,
+            ),
+            edition: Edition2018,
+            dependencies: [
+                Dependency {
+                    crate_id: Idx::<CrateBuilder>(1),
+                    name: CrateName(
+                        "core",
+                    ),
+                    prelude: true,
+                    sysroot: true,
+                },
+                Dependency {
+                    crate_id: Idx::<CrateBuilder>(0),
+                    name: CrateName(
+                        "alloc",
+                    ),
+                    prelude: false,
+                    sysroot: true,
+                },
+                Dependency {
+                    crate_id: Idx::<CrateBuilder>(6),
+                    name: CrateName(
+                        "std",
+                    ),
+                    prelude: true,
+                    sysroot: true,
+                },
+                Dependency {
+                    crate_id: Idx::<CrateBuilder>(8),
+                    name: CrateName(
+                        "test",
+                    ),
+                    prelude: false,
+                    sysroot: true,
+                },
+                Dependency {
+                    crate_id: Idx::<CrateBuilder>(4),
+                    name: CrateName(
+                        "proc_macro",
+                    ),
+                    prelude: false,
+                    sysroot: true,
+                },
+            ],
+            origin: Local {
+                repo: None,
+                name: Some(
                     "hello_world",
                 ),
-                canonical_name: "hello_world",
             },
-        ),
+            is_proc_macro: false,
+            proc_macro_cwd: None,
+        },
+        extra: ExtraCrateData {
+            version: None,
+            display_name: Some(
+                CrateDisplayName {
+                    crate_name: CrateName(
+                        "hello_world",
+                    ),
+                    canonical_name: "hello_world",
+                },
+            ),
+            potential_cfg_options: None,
+        },
         cfg_options: CfgOptions(
             [
                 "rust_analyzer",
@@ -431,59 +586,14 @@
                 "true",
             ],
         ),
-        potential_cfg_options: None,
         env: Env {
             entries: {},
         },
-        dependencies: [
-            Dependency {
-                crate_id: Idx::<CrateData>(1),
-                name: CrateName(
-                    "core",
-                ),
-                prelude: true,
-                sysroot: true,
-            },
-            Dependency {
-                crate_id: Idx::<CrateData>(0),
-                name: CrateName(
-                    "alloc",
-                ),
-                prelude: false,
-                sysroot: true,
-            },
-            Dependency {
-                crate_id: Idx::<CrateData>(6),
-                name: CrateName(
-                    "std",
-                ),
-                prelude: true,
-                sysroot: true,
-            },
-            Dependency {
-                crate_id: Idx::<CrateData>(8),
-                name: CrateName(
-                    "test",
-                ),
-                prelude: false,
-                sysroot: true,
-            },
-            Dependency {
-                crate_id: Idx::<CrateData>(4),
-                name: CrateName(
-                    "proc_macro",
-                ),
-                prelude: false,
-                sysroot: true,
-            },
-        ],
-        origin: Local {
-            repo: None,
-            name: Some(
-                "hello_world",
+        ws_data: CrateWorkspaceData {
+            data_layout: Err(
+                "test has no data layout",
             ),
+            toolchain: None,
         },
-        is_proc_macro: false,
-        proc_macro_cwd: None,
     },
 }

--- a/crates/rust-analyzer/src/global_state.rs
+++ b/crates/rust-analyzer/src/global_state.rs
@@ -8,7 +8,7 @@ use std::{ops::Not as _, time::Instant};
 use crossbeam_channel::{unbounded, Receiver, Sender};
 use hir::ChangeWithProcMacros;
 use ide::{Analysis, AnalysisHost, Cancellable, FileId, SourceRootId};
-use ide_db::base_db::{CrateId, ProcMacroPaths, SourceDatabase};
+use ide_db::base_db::{Crate, ProcMacroPaths, SourceDatabase};
 use itertools::Itertools;
 use load_cargo::SourceRootConfig;
 use lsp_types::{SemanticTokens, Url};
@@ -158,7 +158,7 @@ pub(crate) struct GlobalState {
     // op queues
     pub(crate) fetch_workspaces_queue: OpQueue<FetchWorkspaceRequest, FetchWorkspaceResponse>,
     pub(crate) fetch_build_data_queue: OpQueue<(), FetchBuildDataResponse>,
-    pub(crate) fetch_proc_macros_queue: OpQueue<Vec<ProcMacroPaths>, bool>,
+    pub(crate) fetch_proc_macros_queue: OpQueue<(ChangeWithProcMacros, Vec<ProcMacroPaths>), bool>,
     pub(crate) prime_caches_queue: OpQueue,
     pub(crate) discover_workspace_queue: OpQueue,
 
@@ -714,7 +714,7 @@ impl GlobalStateSnapshot {
         self.vfs_read().file_path(file_id).clone()
     }
 
-    pub(crate) fn target_spec_for_crate(&self, crate_id: CrateId) -> Option<TargetSpec> {
+    pub(crate) fn target_spec_for_crate(&self, crate_id: Crate) -> Option<TargetSpec> {
         let file_id = self.analysis.crate_root(crate_id).ok()?;
         let path = self.vfs_read().file_path(file_id).clone();
         let path = path.as_path()?;

--- a/crates/rust-analyzer/src/main_loop.rs
+++ b/crates/rust-analyzer/src/main_loop.rs
@@ -10,7 +10,7 @@ use std::{
 
 use always_assert::always;
 use crossbeam_channel::{select, Receiver};
-use ide_db::base_db::{RootQueryDb, SourceDatabase, VfsPath};
+use ide_db::base_db::{SourceDatabase, VfsPath};
 use lsp_server::{Connection, Notification, Request};
 use lsp_types::{notification::Notification as _, TextDocumentIdentifier};
 use stdx::thread::ThreadIntent;
@@ -504,8 +504,10 @@ impl GlobalState {
         if !self.fetch_workspaces_queue.op_in_progress() {
             if let Some((cause, ())) = self.fetch_build_data_queue.should_start_op() {
                 self.fetch_build_data(cause);
-            } else if let Some((cause, paths)) = self.fetch_proc_macros_queue.should_start_op() {
-                self.fetch_proc_macros(cause, paths);
+            } else if let Some((cause, (change, paths))) =
+                self.fetch_proc_macros_queue.should_start_op()
+            {
+                self.fetch_proc_macros(cause, change, paths);
             }
         }
 
@@ -804,9 +806,10 @@ impl GlobalState {
                 let (state, msg) = match progress {
                     ProcMacroProgress::Begin => (Some(Progress::Begin), None),
                     ProcMacroProgress::Report(msg) => (Some(Progress::Report), Some(msg)),
-                    ProcMacroProgress::End(proc_macro_load_result) => {
+                    ProcMacroProgress::End(change) => {
                         self.fetch_proc_macros_queue.op_completed(true);
-                        self.set_proc_macros(proc_macro_load_result);
+                        self.analysis_host.apply_change(change);
+                        self.finish_loading_crate_graph();
                         (Some(Progress::End), None)
                     }
                 };
@@ -909,16 +912,15 @@ impl GlobalState {
                 });
             }
             QueuedTask::CheckProcMacroSources(modified_rust_files) => {
-                let crate_graph = self.analysis_host.raw_database().crate_graph();
                 let analysis = AssertUnwindSafe(self.snapshot().analysis);
                 self.task_pool.handle.spawn_with_sender(stdx::thread::ThreadIntent::Worker, {
                     move |sender| {
                         if modified_rust_files.into_iter().any(|file_id| {
                             // FIXME: Check whether these files could be build script related
                             match analysis.crates_for(file_id) {
-                                Ok(crates) => {
-                                    crates.iter().any(|&krate| crate_graph[krate].is_proc_macro)
-                                }
+                                Ok(crates) => crates.iter().any(|&krate| {
+                                    analysis.is_proc_macro_crate(krate).is_ok_and(|it| it)
+                                }),
                                 _ => false,
                             }
                         }) {

--- a/crates/rust-analyzer/src/target_spec.rs
+++ b/crates/rust-analyzer/src/target_spec.rs
@@ -4,7 +4,7 @@ use std::mem;
 
 use cfg::{CfgAtom, CfgExpr};
 use hir::sym;
-use ide::{Cancellable, CrateId, FileId, RunnableKind, TestId};
+use ide::{Cancellable, Crate, FileId, RunnableKind, TestId};
 use project_model::project_json::Runnable;
 use project_model::{CargoFeatures, ManifestPath, TargetKind};
 use rustc_hash::FxHashSet;
@@ -54,7 +54,7 @@ pub(crate) struct CargoTargetSpec {
     pub(crate) package: String,
     pub(crate) target: String,
     pub(crate) target_kind: TargetKind,
-    pub(crate) crate_id: CrateId,
+    pub(crate) crate_id: Crate,
     pub(crate) required_features: Vec<String>,
     pub(crate) features: FxHashSet<String>,
     pub(crate) sysroot_root: Option<vfs::AbsPathBuf>,

--- a/crates/test-fixture/Cargo.toml
+++ b/crates/test-fixture/Cargo.toml
@@ -18,6 +18,7 @@ rustc-hash.workspace = true
 span.workspace = true
 stdx.workspace = true
 intern.workspace = true
+triomphe.workspace = true
 
 [lints]
 workspace = true


### PR DESCRIPTION
I.e. make it not one giant input but multiple, for incrementality and decreased memory usage for Salsa 3 reasons.

This means that changing the metadata of a crate (e.g. adding a dependency) invalidates only it.

Draft for now because I still need to review the after-rebase changes.