### PR TITLE
Add text edit support for return type hints on non-block body closures

### DIFF
--- a/crates/ide/src/inlay_hints/bind_pat.rs
+++ b/crates/ide/src/inlay_hints/bind_pat.rs
@@ -1140,12 +1140,11 @@ fn test() {
 
     #[test]
     fn no_edit_for_closure_return_without_body_block() {
-        // We can lift this limitation; see FIXME in closure_ret module.
         let config = InlayHintsConfig {
             closure_return_type_hints: ClosureReturnTypeHints::Always,
             ..TEST_CONFIG
         };
-        check_no_edit(
+        check_edit(
             config,
             r#"
 struct S<T>(T);
@@ -1154,6 +1153,13 @@ fn test() {
     let f = |a: S<usize>| S(a);
 }
 "#,
+            expect![[r#"
+            struct S<T>(T);
+            fn test() {
+                let f = || -> i32 { 3 };
+                let f = |a: S<usize>| -> S<S<usize>> { S(a) };
+            }
+            "#]],
         );
     }
 

--- a/crates/ide/src/inlay_hints/closure_ret.rs
+++ b/crates/ide/src/inlay_hints/closure_ret.rs
@@ -61,10 +61,9 @@ pub(super) fn hints(
             if arrow.is_none() { " -> " } else { "" },
         )
     } else {
-        let body = closure.body()?;
-        let body_range = body.syntax().text_range();
-
         Some(config.lazy_text_edit(|| {
+            let body = closure.body();
+            let body_range = body.expect("Closure must have a body").syntax().text_range();
             let mut builder = TextEdit::builder();
             let insert_pos = param_list.syntax().text_range().end();
 

--- a/crates/ide/src/inlay_hints/closure_ret.rs
+++ b/crates/ide/src/inlay_hints/closure_ret.rs
@@ -48,7 +48,6 @@ pub(super) fn hints(
     if arrow.is_none() {
         label.prepend_str(" -> ");
     }
-    // FIXME?: We could provide text edit to insert braces for closures with non-block body.
     let text_edit = if has_block_body {
         ty_to_text_edit(
             sema,

--- a/crates/ide/src/inlay_hints/closure_ret.rs
+++ b/crates/ide/src/inlay_hints/closure_ret.rs
@@ -63,7 +63,10 @@ pub(super) fn hints(
     } else {
         Some(config.lazy_text_edit(|| {
             let body = closure.body();
-            let body_range = body.expect("Closure must have a body").syntax().text_range();
+            let body_range = match body {
+                Some(body) => body.syntax().text_range(),
+                None => return TextEdit::builder().finish(),
+            };
             let mut builder = TextEdit::builder();
             let insert_pos = param_list.syntax().text_range().end();
 


### PR DESCRIPTION
This PR fixes the FIXME in `closure_ret` by adding text edit functionality for closures with non-block bodies. When a user activates the return type hint for a closure without a block body (e.g., `|x| x + 1`), the edit now properly inserts both the return type annotation and the necessary braces around the body expression. This makes the return type hint feature work consistently for all types of closures.