### PR TITLE
internal: don't panic when the crate graph isn't ready

### DIFF
--- a/crates/base-db/src/lib.rs
+++ b/crates/base-db/src/lib.rs
@@ -212,22 +212,21 @@ pub trait RootQueryDb: SourceDatabase + salsa::Database {
 
     /// Returns the crates in topological order.
     ///
-    /// **Warning**: do not use this query in analysis! It kills incrementality across crate metadata modifications.
+    /// **Warning**: do not use this query in `hir-*` crates! It kills incrementality across crate metadata modifications.
     #[salsa::input]
     fn all_crates(&self) -> Arc<Box<[Crate]>>;
 
     /// Returns an iterator over all transitive dependencies of the given crate,
     /// including the crate itself.
     ///
-    /// **Warning**: do not use this query in analysis! It kills incrementality across crate metadata modifications.
-    ///
+    /// **Warning**: do not use this query in `hir-*` crates! It kills incrementality across crate metadata modifications.
     #[salsa::transparent]
     fn transitive_deps(&self, crate_id: Crate) -> FxHashSet<Crate>;
 
     /// Returns all transitive reverse dependencies of the given crate,
     /// including the crate itself.
     ///
-    /// **Warning**: Do not use this query in analysis! It kills incrementality across crate metadata modifications.
+    /// **Warning**: do not use this query in `hir-*` crates! It kills incrementality across crate metadata modifications.
     #[salsa::invoke(input::transitive_rev_deps)]
     #[salsa::transparent]
     fn transitive_rev_deps(&self, of: Crate) -> FxHashSet<Crate>;

--- a/crates/hir-def/src/nameres/tests/macros.rs
+++ b/crates/hir-def/src/nameres/tests/macros.rs
@@ -1095,7 +1095,7 @@ pub fn derive_macro_2(_item: TokenStream) -> TokenStream {
 }
 "#,
     );
-    let krate = *db.all_crates().last().unwrap();
+    let krate = *db.all_crates().last().expect("no crate graph present");
     let def_map = db.crate_def_map(krate);
 
     assert_eq!(def_map.data.exported_derives.len(), 1);
@@ -1445,7 +1445,7 @@ struct TokenStream;
 fn proc_attr(a: TokenStream, b: TokenStream) -> TokenStream { a }
     "#,
     );
-    let krate = *db.all_crates().last().unwrap();
+    let krate = *db.all_crates().last().expect("no crate graph present");
     let def_map = db.crate_def_map(krate);
 
     let root_module = &def_map[DefMap::ROOT].scope;

--- a/crates/hir-ty/src/consteval/tests.rs
+++ b/crates/hir-ty/src/consteval/tests.rs
@@ -101,7 +101,8 @@ fn check_answer(
 fn pretty_print_err(e: ConstEvalError, db: TestDB) -> String {
     let mut err = String::new();
     let span_formatter = |file, range| format!("{file:?} {range:?}");
-    let display_target = DisplayTarget::from_crate(&db, *db.all_crates().last().unwrap());
+    let display_target =
+        DisplayTarget::from_crate(&db, *db.all_crates().last().expect("no crate graph present"));
     match e {
         ConstEvalError::MirLowerError(e) => {
             e.pretty_print(&mut err, &db, span_formatter, display_target)

--- a/crates/hir/src/semantics.rs
+++ b/crates/hir/src/semantics.rs
@@ -314,11 +314,11 @@ impl<'db> SemanticsImpl<'db> {
         tree
     }
 
-    /// If not crate is found for the file, returns the last crate in topological order.
-    pub fn first_crate_or_default(&self, file: FileId) -> Crate {
+    /// If not crate is found for the file, try to return the last crate in topological order.
+    pub fn first_crate(&self, file: FileId) -> Option<Crate> {
         match self.file_to_module_defs(file).next() {
-            Some(module) => module.krate(),
-            None => (*self.db.all_crates().last().unwrap()).into(),
+            Some(module) => Some(module.krate()),
+            None => self.db.all_crates().last().copied().map(Into::into),
         }
     }
 

--- a/crates/hir/src/symbols.rs
+++ b/crates/hir/src/symbols.rs
@@ -77,7 +77,10 @@ impl<'a> SymbolCollector<'a> {
             symbols: Default::default(),
             work: Default::default(),
             current_container_name: None,
-            display_target: DisplayTarget::from_crate(db, *db.all_crates().last().unwrap()),
+            display_target: DisplayTarget::from_crate(
+                db,
+                *db.all_crates().last().expect("no crate graph present"),
+            ),
         }
     }
 

--- a/crates/ide-diagnostics/src/lib.rs
+++ b/crates/ide-diagnostics/src/lib.rs
@@ -389,9 +389,17 @@ pub fn semantic_diagnostics(
         module.and_then(|m| db.toolchain_channel(m.krate().into())),
         Some(ReleaseChannel::Nightly) | None
     );
-    let krate = module
-        .map(|module| module.krate())
-        .unwrap_or_else(|| (*db.all_crates().last().unwrap()).into());
+
+    let krate = match module {
+        Some(module) => module.krate(),
+        None => {
+            match db.all_crates().last() {
+                Some(last) => (*last).into(),
+                // short-circuit, return an empty vec of diagnostics
+                None => return vec![],
+            }
+        }
+    };
     let display_target = krate.to_display_target(db);
     let ctx = DiagnosticsContext { config, sema, resolve, edition, is_nightly, display_target };
 

--- a/crates/ide-ssr/src/matching.rs
+++ b/crates/ide-ssr/src/matching.rs
@@ -626,11 +626,9 @@ impl<'db, 'sema> Matcher<'db, 'sema> {
                 match_error!("Failed to get receiver type for `{}`", expr.syntax().text())
             })?
             .original;
-        let krate = self
-            .sema
-            .scope(expr.syntax())
-            .map(|it| it.krate())
-            .unwrap_or_else(|| hir::Crate::from(*self.sema.db.all_crates().last().unwrap()));
+        let krate = self.sema.scope(expr.syntax()).map(|it| it.krate()).unwrap_or_else(|| {
+            hir::Crate::from(*self.sema.db.all_crates().last().expect("no crate graph present"))
+        });
         let res = code_type
             .autoderef(self.sema.db)
             .enumerate()

--- a/crates/ide/src/hover.rs
+++ b/crates/ide/src/hover.rs
@@ -130,7 +130,7 @@ pub(crate) fn hover(
     let file = sema.parse_guess_edition(file_id).syntax().clone();
     let edition =
         sema.attach_first_edition(file_id).map(|it| it.edition()).unwrap_or(Edition::CURRENT);
-    let display_target = sema.first_crate_or_default(file_id).to_display_target(db);
+    let display_target = sema.first_crate(file_id)?.to_display_target(db);
     let mut res = if range.is_empty() {
         hover_offset(
             sema,

--- a/crates/ide/src/inlay_hints.rs
+++ b/crates/ide/src/inlay_hints.rs
@@ -211,7 +211,10 @@ fn hints(
     file_id: EditionedFileId,
     node: SyntaxNode,
 ) {
-    let display_target = sema.first_crate_or_default(file_id.file_id()).to_display_target(sema.db);
+    let Some(krate) = sema.first_crate(file_id.file_id()) else {
+        return;
+    };
+    let display_target = krate.to_display_target(sema.db);
     closing_brace::hints(hints, sema, config, file_id, display_target, node.clone());
     if let Some(any_has_generic_args) = ast::AnyHasGenericArgs::cast(node.clone()) {
         generic_param::hints(hints, famous_defs, config, any_has_generic_args);

--- a/crates/ide/src/runnables.rs
+++ b/crates/ide/src/runnables.rs
@@ -498,8 +498,9 @@ fn module_def_doctest(db: &RootDatabase, def: Definition) -> Option<Runnable> {
     };
     let krate = def.krate(db);
     let edition = krate.map(|it| it.edition(db)).unwrap_or(Edition::CURRENT);
-    let display_target =
-        krate.unwrap_or_else(|| (*db.all_crates().last().unwrap()).into()).to_display_target(db);
+    let display_target = krate
+        .unwrap_or_else(|| (*db.all_crates().last().expect("no crate graph present")).into())
+        .to_display_target(db);
     if !has_runnable_doc_test(&attrs) {
         return None;
     }

--- a/crates/ide/src/signature_help.rs
+++ b/crates/ide/src/signature_help.rs
@@ -84,7 +84,7 @@ pub(crate) fn signature_help(
     let token = sema.descend_into_macros_single_exact(token);
     let edition =
         sema.attach_first_edition(file_id).map(|it| it.edition()).unwrap_or(Edition::CURRENT);
-    let display_target = sema.first_crate_or_default(file_id).to_display_target(db);
+    let display_target = sema.first_crate(file_id)?.to_display_target(db);
 
     for node in token.parent_ancestors() {
         match_ast! {

--- a/crates/ide/src/view_memory_layout.rs
+++ b/crates/ide/src/view_memory_layout.rs
@@ -83,7 +83,7 @@ pub(crate) fn view_memory_layout(
 ) -> Option<RecursiveMemoryLayout> {
     let sema = Semantics::new(db);
     let file = sema.parse_guess_edition(position.file_id);
-    let display_target = sema.first_crate_or_default(position.file_id).to_display_target(db);
+    let display_target = sema.first_crate(position.file_id)?.to_display_target(db);
     let token =
         pick_best_token(file.syntax().token_at_offset(position.offset), |kind| match kind {
             SyntaxKind::IDENT => 3,

--- a/crates/rust-analyzer/src/cli/analysis_stats.rs
+++ b/crates/rust-analyzer/src/cli/analysis_stats.rs
@@ -384,8 +384,10 @@ impl flags::AnalysisStats {
 
         for &file_id in &file_ids {
             let sema = hir::Semantics::new(db);
-            let display_target =
-                sema.first_crate_or_default(file_id.file_id()).to_display_target(db);
+            let display_target = match sema.first_crate(file_id.file_id()) {
+                Some(krate) => krate.to_display_target(sema.db),
+                None => continue,
+            };
 
             let parse = sema.parse_guess_edition(file_id.into());
             let file_txt = db.file_text(file_id.into());


### PR DESCRIPTION
This comes up when using rust-analyzer with the project discovery functionality (e.g., with Buck or Bazel), as rust-analyzer has *started*, but the crate graph isn't populated yet. I chose to return with an empty set of diagnostics instead of panicking.

@ChayimFriedman2: I think this qualifies as `RootQueryDb::all_crates` being used in query analysis?