### PR TITLE
analysis-stats: emit lines of code and item tree counts for workspace; dependencies

### DIFF
--- a/crates/hir-def/src/item_tree.rs
+++ b/crates/hir-def/src/item_tree.rs
@@ -218,6 +218,22 @@ impl ItemTree {
         Attrs::filter(db, krate, self.raw_attrs(of).clone())
     }
 
+    /// Returns a count of a few, expensive items.
+    ///
+    /// For more detail, see [`ItemTreeDataStats`].
+    pub fn item_tree_stats(&self) -> ItemTreeDataStats {
+        match self.data {
+            Some(ref data) => ItemTreeDataStats {
+                traits: data.traits.len(),
+                impls: data.impls.len(),
+                mods: data.mods.len(),
+                macro_calls: data.macro_calls.len(),
+                macro_rules: data.macro_rules.len(),
+            },
+            None => ItemTreeDataStats::default(),
+        }
+    }
+
     pub fn pretty_print(&self, db: &dyn DefDatabase, edition: Edition) -> String {
         pretty::print_item_tree(db, self, edition)
     }
@@ -326,6 +342,15 @@ struct ItemTreeData {
     macro_defs: Arena<Macro2>,
 
     vis: ItemVisibilities,
+}
+
+#[derive(Default, Debug, Eq, PartialEq)]
+pub struct ItemTreeDataStats {
+    pub traits: usize,
+    pub impls: usize,
+    pub mods: usize,
+    pub macro_calls: usize,
+    pub macro_rules: usize,
 }
 
 #[derive(Default, Debug, Eq, PartialEq)]

--- a/crates/rust-analyzer/src/cli/analysis_stats.rs
+++ b/crates/rust-analyzer/src/cli/analysis_stats.rs
@@ -167,19 +167,12 @@ impl flags::AnalysisStats {
         eprintln!("  item trees: {workspace_item_trees}");
         let item_tree_time = item_tree_sw.elapsed();
 
-        eprintln!("Source stats:");
         eprintln!(
             "  dependency lines of code: {}, item trees: {}",
             UsizeWithUnderscore(dep_loc),
             UsizeWithUnderscore(dep_item_trees),
         );
         eprintln!("  dependency item stats: {}", dep_item_stats);
-        eprintln!(
-            "  workspace lines of code: {}, item trees: {}",
-            UsizeWithUnderscore(workspace_loc),
-            UsizeWithUnderscore(workspace_item_trees),
-        );
-        eprintln!("  workspace stats: {}", workspace_item_stats);
 
         // FIXME(salsa-transition): bring back stats for ParseQuery (file size)
         // and ParseMacroExpansionQuery (macro expansion "file") size whenever we implement
@@ -197,8 +190,9 @@ impl flags::AnalysisStats {
         // }
         // eprintln!("source files: {total_file_size}, macro files: {total_macro_file_size}");
 
-        eprintln!("{:<20} {}", "Item Tree Collection (workspace):", item_tree_time);
+        eprintln!("{:<20} {}", "Item Tree Collection:", item_tree_time);
         report_metric("item tree time", item_tree_time.time.as_millis() as u64, "ms");
+        eprintln!("  Total Statistics:");
 
         let mut crate_def_map_sw = self.stop_watch();
         let mut num_crates = 0;
@@ -221,7 +215,7 @@ impl flags::AnalysisStats {
             shuffle(&mut rng, &mut visit_queue);
         }
 
-        eprint!("  crates: {num_crates}");
+        eprint!("    crates: {num_crates}");
         let mut num_decls = 0;
         let mut bodies = Vec::new();
         let mut adts = Vec::new();
@@ -279,7 +273,7 @@ impl flags::AnalysisStats {
             }
         }
         eprintln!(
-            ", mods: {}, decls: {num_decls}, bodies: {}, adts: {}, consts: {},",
+            ", mods: {}, decls: {num_decls}, bodies: {}, adts: {}, consts: {}",
             visited_modules.len(),
             bodies.len(),
             adts.len(),
@@ -288,7 +282,25 @@ impl flags::AnalysisStats {
                 .filter(|it| matches!(it, DefWithBody::Const(_) | DefWithBody::Static(_)))
                 .count(),
         );
-        eprintln!("  traits: {num_traits}, macro_rules macros: {num_macro_rules_macros}, proc_macros: {num_proc_macros}");
+
+        eprintln!("  Workspace:");
+        eprintln!(
+            "    traits: {num_traits}, macro_rules macros: {num_macro_rules_macros}, proc_macros: {num_proc_macros}"
+        );
+        eprintln!(
+            "    lines of code: {}, item trees: {}",
+            UsizeWithUnderscore(workspace_loc),
+            UsizeWithUnderscore(workspace_item_trees),
+        );
+        eprintln!("    usages: {}", workspace_item_stats);
+
+        eprintln!("  Dependencies:");
+        eprintln!(
+            "    lines of code: {}, item trees: {}",
+            UsizeWithUnderscore(dep_loc),
+            UsizeWithUnderscore(dep_item_trees),
+        );
+        eprintln!("    declarations: {}", dep_item_stats);
 
         let crate_def_map_time = crate_def_map_sw.elapsed();
         eprintln!("{:<20} {}", "Item Collection:", crate_def_map_time);

--- a/crates/rust-analyzer/src/cli/analysis_stats.rs
+++ b/crates/rust-analyzer/src/cli/analysis_stats.rs
@@ -141,7 +141,7 @@ impl flags::AnalysisStats {
 
                             workspace_loc += length;
                             workspace_item_trees += 1;
-                        } else if self.source_stats {
+                        } else {
                             let length = db.file_text(file_id).text(db).lines().count();
                             db.file_item_tree(EditionedFileId::current_edition(file_id).into());
 
@@ -155,29 +155,25 @@ impl flags::AnalysisStats {
         eprintln!("  item trees: {workspace_item_trees}");
         let item_tree_time = item_tree_sw.elapsed();
 
-        if self.source_stats {
-            eprintln!("Source stats:");
-            eprintln!("  dependency lines of code: {dep_loc}, item trees: {deps_item_trees}");
-            eprintln!(
-                "  workspace lines of code: {workspace_loc}, item trees: {workspace_item_trees}"
-            );
+        eprintln!("Source stats:");
+        eprintln!("  dependency lines of code: {dep_loc}, item trees: {deps_item_trees}");
+        eprintln!("  workspace lines of code: {workspace_loc}, item trees: {workspace_item_trees}");
 
-            // FIXME(salsa-transition): bring back stats for ParseQuery (file size)
-            // and ParseMacroExpansionQuery (mcaro expansion "file") size whenever we implement
-            // Salsa's memory usage tracking works with tracked functions.
+        // FIXME(salsa-transition): bring back stats for ParseQuery (file size)
+        // and ParseMacroExpansionQuery (mcaro expansion "file") size whenever we implement
+        // Salsa's memory usage tracking works with tracked functions.
 
-            // let mut total_file_size = Bytes::default();
-            // for e in ide_db::base_db::ParseQuery.in_db(db).entries::<Vec<_>>() {
-            //     total_file_size += syntax_len(db.parse(e.key).syntax_node())
-            // }
+        // let mut total_file_size = Bytes::default();
+        // for e in ide_db::base_db::ParseQuery.in_db(db).entries::<Vec<_>>() {
+        //     total_file_size += syntax_len(db.parse(e.key).syntax_node())
+        // }
 
-            // let mut total_macro_file_size = Bytes::default();
-            // for e in hir::db::ParseMacroExpansionQuery.in_db(db).entries::<Vec<_>>() {
-            //     let val = db.parse_macro_expansion(e.key).value.0;
-            //     total_macro_file_size += syntax_len(val.syntax_node())
-            // }
-            // eprintln!("source files: {total_file_size}, macro files: {total_macro_file_size}");
-        }
+        // let mut total_macro_file_size = Bytes::default();
+        // for e in hir::db::ParseMacroExpansionQuery.in_db(db).entries::<Vec<_>>() {
+        //     let val = db.parse_macro_expansion(e.key).value.0;
+        //     total_macro_file_size += syntax_len(val.syntax_node())
+        // }
+        // eprintln!("source files: {total_file_size}, macro files: {total_macro_file_size}");
 
         eprintln!("{:<20} {}", "Item Tree Collection:", item_tree_time);
         report_metric("item tree time", item_tree_time.time.as_millis() as u64, "ms");
@@ -261,7 +257,7 @@ impl flags::AnalysisStats {
             }
         }
         eprintln!(
-            ", mods: {}, decls: {num_decls}, bodies: {}, adts: {}, consts: {}",
+            ", mods: {}, decls: {num_decls}, bodies: {}, adts: {}, consts: {},",
             visited_modules.len(),
             bodies.len(),
             adts.len(),

--- a/crates/rust-analyzer/src/cli/analysis_stats.rs
+++ b/crates/rust-analyzer/src/cli/analysis_stats.rs
@@ -2,7 +2,7 @@
 //! errors.
 
 use std::{
-    env,
+    env, fmt,
     time::{SystemTime, UNIX_EPOCH},
 };
 
@@ -156,6 +156,11 @@ impl flags::AnalysisStats {
         let item_tree_time = item_tree_sw.elapsed();
 
         eprintln!("Source stats:");
+        let dep_loc = UsizeWithUnderscore(dep_loc);
+        let deps_item_trees = UsizeWithUnderscore(deps_item_trees);
+        let workspace_loc = UsizeWithUnderscore(workspace_loc);
+        let workspace_item_trees = UsizeWithUnderscore(workspace_item_trees);
+
         eprintln!("  dependency lines of code: {dep_loc}, item trees: {deps_item_trees}");
         eprintln!("  workspace lines of code: {workspace_loc}, item trees: {workspace_item_trees}");
 
@@ -1248,6 +1253,30 @@ fn shuffle<T>(rng: &mut Rand32, slice: &mut [T]) {
 
 fn percentage(n: u64, total: u64) -> u64 {
     (n * 100).checked_div(total).unwrap_or(100)
+}
+
+struct UsizeWithUnderscore(usize);
+
+impl fmt::Display for UsizeWithUnderscore {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let num_str = self.0.to_string();
+
+        if num_str.len() <= 3 {
+            return write!(f, "{}", num_str);
+        }
+
+        let mut result = String::new();
+
+        for (count, ch) in num_str.chars().rev().enumerate() {
+            if count > 0 && count % 3 == 0 {
+                result.push('_');
+            }
+            result.push(ch);
+        }
+
+        let result = result.chars().rev().collect::<String>();
+        write!(f, "{}", result)
+    }
 }
 
 // FIXME(salsa-transition): bring this back whenever we implement

--- a/crates/rust-analyzer/src/cli/analysis_stats.rs
+++ b/crates/rust-analyzer/src/cli/analysis_stats.rs
@@ -126,7 +126,7 @@ impl flags::AnalysisStats {
 
         let mut dep_loc = 0;
         let mut workspace_loc = 0;
-        let mut deps_item_trees = 0;
+        let mut dep_item_trees = 0;
         let mut workspace_item_trees = 0;
 
         for source_root_id in source_roots {
@@ -146,7 +146,7 @@ impl flags::AnalysisStats {
                             db.file_item_tree(EditionedFileId::current_edition(file_id).into());
 
                             dep_loc += length;
-                            deps_item_trees += 1
+                            dep_item_trees += 1
                         }
                     }
                 }
@@ -156,16 +156,19 @@ impl flags::AnalysisStats {
         let item_tree_time = item_tree_sw.elapsed();
 
         eprintln!("Source stats:");
-        let dep_loc = UsizeWithUnderscore(dep_loc);
-        let deps_item_trees = UsizeWithUnderscore(deps_item_trees);
-        let workspace_loc = UsizeWithUnderscore(workspace_loc);
-        let workspace_item_trees = UsizeWithUnderscore(workspace_item_trees);
-
-        eprintln!("  dependency lines of code: {dep_loc}, item trees: {deps_item_trees}");
-        eprintln!("  workspace lines of code: {workspace_loc}, item trees: {workspace_item_trees}");
+        eprintln!(
+            "  dependency lines of code: {}, item trees: {}",
+            UsizeWithUnderscore(dep_loc),
+            UsizeWithUnderscore(dep_item_trees),
+        );
+        eprintln!(
+            "  workspace lines of code: {}, item trees: {}",
+            UsizeWithUnderscore(workspace_loc),
+            UsizeWithUnderscore(workspace_item_trees),
+        );
 
         // FIXME(salsa-transition): bring back stats for ParseQuery (file size)
-        // and ParseMacroExpansionQuery (mcaro expansion "file") size whenever we implement
+        // and ParseMacroExpansionQuery (macro expansion "file") size whenever we implement
         // Salsa's memory usage tracking works with tracked functions.
 
         // let mut total_file_size = Bytes::default();
@@ -180,7 +183,7 @@ impl flags::AnalysisStats {
         // }
         // eprintln!("source files: {total_file_size}, macro files: {total_macro_file_size}");
 
-        eprintln!("{:<20} {}", "Item Tree Collection:", item_tree_time);
+        eprintln!("{:<20} {}", "Item Tree Collection (workspace):", item_tree_time);
         report_metric("item tree time", item_tree_time.time.as_millis() as u64, "ms");
 
         let mut crate_def_map_sw = self.stop_watch();

--- a/crates/rust-analyzer/src/cli/flags.rs
+++ b/crates/rust-analyzer/src/cli/flags.rs
@@ -62,8 +62,6 @@ xflags::xflags! {
             optional --randomize
             /// Run type inference in parallel.
             optional --parallel
-            /// Print the total length of all source and macro files (whitespace is not counted).
-            optional --source-stats
 
             /// Only analyze items matching this path.
             optional -o, --only path: String
@@ -231,7 +229,6 @@ pub struct AnalysisStats {
     pub output: Option<OutputFormat>,
     pub randomize: bool,
     pub parallel: bool,
-    pub source_stats: bool,
     pub only: Option<String>,
     pub with_deps: bool,
     pub no_sysroot: bool,


### PR DESCRIPTION
Realized that we don't have a good measure for how many lines of code rust-analyzer is processing, so I decided to fix this. When `analysis-stats` is run, it'll now default to including a section titled "Source Stats" under "Database Loaded". See below for an example of me running `analysis-stats` on Salsa:

```
❯ ~/.cargo/bin/rust-analyzer analysis-stats .
Database loaded:     4.17s, 123mb (metadata 556.26ms, 2513kb; build 2.69s, 47kb)
  item trees: 207
  dependency lines of code: 2_588_498, item trees: 5_039
  dependency item stats: traits: 1_562, impl: 23_087, mods: 5_955, macro calls: 9_136, macro rules: 2_175
Item Tree Collection: 4.23s, 934mb
  Total Statistics:
    crates: 90, mods: 235, decls: 5294, bodies: 4116, adts: 865, consts: 486
  Workspace:
    traits: 190, macro_rules macros: 14, proc_macros: 7
    lines of code: 24_128, item trees: 207
    usages: traits: 46, impl: 334, mods: 148, macro calls: 32, macro rules: 20
  Dependencies:
    lines of code: 2_588_498, item trees: 5_039
    declarations: traits: 1_562, impl: 23_087, mods: 5_955, macro calls: 9_136, macro rules: 2_175
Item Collection:     4.04s, 829mb
Body lowering:       614.41ms, 164mb
  exprs: 83892, ??ty: 114 (0%), ?ty: 99 (0%), !ty: 1
  pats: 17244, ??ty: 33 (0%), ?ty: 2 (0%), !ty: 0
Inference:           4.20s, 334mb
MIR lowering:        1.79s, 111mb
Mir failed bodies: 21 (0%)
Data layouts:        23.66ms, 6mb
Failed data layouts: 2 (0%)
Const evaluation:    7.10ms, 1571kb
Failed const evals: 0 (0%)
Total:               15.29s, 1134mb
```