### PR TITLE
internal: Require Rust 1.85

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["crates/proc-macro-srv/proc-macro-test/imp"]
 resolver = "2"
 
 [workspace.package]
-rust-version = "1.84"
+rust-version = "1.85"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["rust-analyzer team"]


### PR DESCRIPTION
rust-analyzer no longer builds on 1.84:
```
error: failed to compile `rust-analyzer v0.0.0 (/rust-analyzer/crates/rust-analyzer)`, intermediate artifacts can be found at `/rust-analyzer/target`.
To reuse those artifacts with a future compilation, set the environment variable `CARGO_TARGET_DIR` to that path.

Caused by:
  failed to download `ra-ap-rustc_index v0.100.0`

Caused by:
  unable to get packages from source

Caused by:
  failed to parse manifest at `/Users/davidrichey/.cargo/registry/src/index.crates.io-6f17d22bba15001f/ra-ap-rustc_index-0.100.0/Cargo.toml`

Caused by:
  feature `edition2024` is required

  The package requires the Cargo feature called `edition2024`, but that feature is not stabilized in this version of Cargo (1.84.0 (66221abde 2024-11-19)).
  Consider trying a newer version of Cargo (this may require the nightly release).
  See https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#edition-2024 for more information about the status of this feature.
Error: install server

Caused by:
    command exited with non-zero code `cargo install --path crates/rust-analyzer --profile=release --locked --force --features force-always-assert`: 101
```