### PR TITLE
display varargs in completion detail

### DIFF
--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -2374,6 +2374,10 @@ impl Function {
         db.function_data(self.id).is_async()
     }
 
+    pub fn is_varargs(self, db: &dyn HirDatabase) -> bool {
+        db.function_data(self.id).is_varargs()
+    }
+
     pub fn extern_block(self, db: &dyn HirDatabase) -> Option<ExternBlock> {
         match self.id.lookup(db.upcast()).container {
             ItemContainerId::ExternBlockId(id) => Some(ExternBlock { id }),

--- a/crates/ide-completion/src/render.rs
+++ b/crates/ide-completion/src/render.rs
@@ -1277,6 +1277,53 @@ fn main() { fo$0 }
     }
 
     #[test]
+    fn fn_detail_includes_variadics() {
+        check(
+            r#"
+unsafe extern "C" fn foo(a: u32, b: u32, ...) {}
+
+fn main() { fo$0 }
+"#,
+            SymbolKind::Function,
+            expect![[r#"
+                [
+                    CompletionItem {
+                        label: "foo(…)",
+                        detail_left: None,
+                        detail_right: Some(
+                            "unsafe fn(u32, u32, ...)",
+                        ),
+                        source_range: 62..64,
+                        delete: 62..64,
+                        insert: "foo(${1:a}, ${2:b});$0",
+                        kind: SymbolKind(
+                            Function,
+                        ),
+                        lookup: "foo",
+                        detail: "unsafe fn(u32, u32, ...)",
+                        trigger_call_info: true,
+                    },
+                    CompletionItem {
+                        label: "main()",
+                        detail_left: None,
+                        detail_right: Some(
+                            "fn()",
+                        ),
+                        source_range: 62..64,
+                        delete: 62..64,
+                        insert: "main();$0",
+                        kind: SymbolKind(
+                            Function,
+                        ),
+                        lookup: "main",
+                        detail: "fn()",
+                    },
+                ]
+            "#]],
+        );
+    }
+
+    #[test]
     fn enum_detail_just_name_for_unit() {
         check(
             r#"

--- a/crates/ide-completion/src/render/function.rs
+++ b/crates/ide-completion/src/render/function.rs
@@ -347,7 +347,7 @@ fn detail_full(ctx: &CompletionContext<'_>, func: hir::Function) -> String {
 }
 
 fn params_display(ctx: &CompletionContext<'_>, func: hir::Function) -> String {
-    if let Some(self_param) = func.self_param(ctx.db) {
+    let mut params = if let Some(self_param) = func.self_param(ctx.db) {
         let assoc_fn_params = func.assoc_fn_params(ctx.db);
         let params = assoc_fn_params
             .iter()
@@ -364,7 +364,13 @@ fn params_display(ctx: &CompletionContext<'_>, func: hir::Function) -> String {
     } else {
         let assoc_fn_params = func.assoc_fn_params(ctx.db);
         assoc_fn_params.iter().map(|p| p.ty().display(ctx.db, ctx.display_target)).join(", ")
+    };
+
+    if func.is_varargs(ctx.db) {
+        params.push_str(", ...");
     }
+
+    params
 }
 
 fn params(


### PR DESCRIPTION
Currently the varargs are ignored, making the function signatures misleading.