### PR TITLE
refactor: Simplify by removing ? operator

### DIFF
--- a/crates/proc-macro-api/src/legacy_protocol/json.rs
+++ b/crates/proc-macro-api/src/legacy_protocol/json.rs
@@ -30,6 +30,5 @@ pub fn write_json(out: &mut impl Write, msg: &str) -> io::Result<()> {
     tracing::debug!("> {}", msg);
     out.write_all(msg.as_bytes())?;
     out.write_all(b"\n")?;
-    out.flush()?;
-    Ok(())
+    out.flush()
 }


### PR DESCRIPTION
`out.flush()` already returns a `io::Result<()>`, so there is no need for `?` operator and `Ok(())`