### PR TITLE
fix: Fix stale `Building CrateGraph` report

### DIFF
--- a/crates/rust-analyzer/src/reload.rs
+++ b/crates/rust-analyzer/src/reload.rs
@@ -754,13 +754,11 @@ impl GlobalState {
             self.analysis_host.apply_change(change);
 
             self.finish_loading_crate_graph();
-            return;
+        } else {
+            change.set_crate_graph(crate_graph);
+            self.fetch_proc_macros_queue.request_op(cause, (change, proc_macro_paths));
         }
-        change.set_crate_graph(crate_graph);
-        self.fetch_proc_macros_queue.request_op(cause, (change, proc_macro_paths));
-    }
 
-    pub(crate) fn finish_loading_crate_graph(&mut self) {
         self.report_progress(
             "Building CrateGraph",
             crate::lsp::utils::Progress::End,
@@ -768,7 +766,9 @@ impl GlobalState {
             None,
             None,
         );
+    }
 
+    pub(crate) fn finish_loading_crate_graph(&mut self) {
         self.process_changes();
         self.reload_flycheck();
     }


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust-analyzer/issues/19380

I believe the issue could occur if we trigger a `recreate_crate_graph` before finishing the proc-macro loading resulting in us only finishing the last report.

We should look into rewriting the workspace loading stuff here soon, it is really convoluted and difficult to reason about