### PR TITLE
fix: Properly calculate the layouts of tuple ptrs whose last fields are DST

### DIFF
--- a/crates/hir-ty/src/layout.rs
+++ b/crates/hir-ty/src/layout.rs
@@ -388,6 +388,15 @@ fn struct_tail_erasing_lifetimes(db: &dyn HirDatabase, pointee: Ty) -> Ty {
                 None => pointee,
             }
         }
+        TyKind::Tuple(_, subst) => {
+            if let Some(last_field_ty) =
+                subst.iter(Interner).last().and_then(|arg| arg.ty(Interner))
+            {
+                struct_tail_erasing_lifetimes(db, last_field_ty.clone())
+            } else {
+                pointee
+            }
+        }
         _ => pointee,
     }
 }

--- a/crates/hir-ty/src/layout/tests.rs
+++ b/crates/hir-ty/src/layout/tests.rs
@@ -469,6 +469,16 @@ fn tuple() {
 }
 
 #[test]
+fn tuple_ptr_with_dst_tail() {
+    size_and_align!(
+        struct Goal(*const ([u8],));
+    );
+    size_and_align!(
+        struct Goal(*const (u128, [u8]));
+    );
+}
+
+#[test]
 fn non_zero_and_non_null() {
     size_and_align! {
         minicore: non_zero, non_null, option;


### PR DESCRIPTION
Fixes #19399 