### PR TITLE
fix: Handle multiple `#[repr(..)]` attrs correctly

### DIFF
--- a/crates/hir-def/src/lib.rs
+++ b/crates/hir-def/src/lib.rs
@@ -24,9 +24,6 @@ extern crate rustc_hashes;
 #[cfg(not(feature = "in-rust-tree"))]
 extern crate ra_ap_rustc_abi as rustc_abi;
 
-#[cfg(not(feature = "in-rust-tree"))]
-extern crate ra_ap_rustc_hashes as rustc_hashes;
-
 pub mod db;
 
 pub mod attr;

--- a/crates/hir-ty/src/layout/tests.rs
+++ b/crates/hir-ty/src/layout/tests.rs
@@ -285,6 +285,18 @@ fn repr_packed() {
 }
 
 #[test]
+fn multiple_repr_attrs() {
+    size_and_align!(
+        #[repr(C)]
+        #[repr(packed)]
+        struct Goal {
+            id: i32,
+            u: u8,
+        }
+    )
+}
+
+#[test]
 fn generic() {
     size_and_align! {
         struct Pair<A, B>(A, B);


### PR DESCRIPTION
Fixes #15037

In codes like the following cases:

```rust
#[repr(X)]
#[repr(Y)]
#[repr(Z)]
struct Foo { .. }
```

we've been using only the first `#[repr(X)]` attribute on struct, but we should handle them like `#[repr(X, Y, Z)]`