### PR TITLE
Tidy up drop glue notification

### DIFF
--- a/crates/ide/src/hover/tests.rs
+++ b/crates/ide/src/hover/tests.rs
@@ -567,11 +567,7 @@ fn main() {
 
             ---
 
-            size = 8, align = 4
-
-            ---
-
-            does not contain types with destructors (drop glue)
+            size = 8, align = 4, no Drop
         "#]],
     );
 }
@@ -816,11 +812,7 @@ struct Foo { fiel$0d_a: u8, field_b: i32, field_c: i16 }
 
             ---
 
-            size = 1, align = 1, offset = 6
-
-            ---
-
-            does not contain types with destructors (drop glue)
+            size = 1, align = 1, offset = 6, no Drop
         "#]],
     );
 }
@@ -871,11 +863,7 @@ fn main() {
 
             ---
 
-            size = 4, align = 4, offset = 0
-
-            ---
-
-            does not contain types with destructors (drop glue)
+            size = 4, align = 4, offset = 0, no Drop
         "#]],
     );
 }
@@ -945,11 +933,7 @@ struct Foo$0(pub u32) where u32: Copy;
 
             ---
 
-            size = 4, align = 4
-
-            ---
-
-            does not contain types with destructors (drop glue); doesn't have a destructor
+            size = 4, align = 4, no Drop
         "#]],
     );
 }
@@ -975,11 +959,7 @@ struct Foo$0 { field: u32 }
 
             ---
 
-            size = 4, align = 4
-
-            ---
-
-            does not contain types with destructors (drop glue); doesn't have a destructor
+            size = 4, align = 4, no Drop
         "#]],
     );
     check(
@@ -1004,11 +984,7 @@ struct Foo$0 where u32: Copy { field: u32 }
 
             ---
 
-            size = 4, align = 4
-
-            ---
-
-            does not contain types with destructors (drop glue); doesn't have a destructor
+            size = 4, align = 4, no Drop
         "#]],
     );
 }
@@ -1037,11 +1013,7 @@ fn hover_record_struct_limit() {
 
             ---
 
-            size = 12 (0xC), align = 4
-
-            ---
-
-            does not contain types with destructors (drop glue); doesn't have a destructor
+            size = 12 (0xC), align = 4, no Drop
         "#]],
     );
     check_hover_fields_limit(
@@ -1064,11 +1036,7 @@ fn hover_record_struct_limit() {
 
             ---
 
-            size = 4, align = 4
-
-            ---
-
-            does not contain types with destructors (drop glue); doesn't have a destructor
+            size = 4, align = 4, no Drop
         "#]],
     );
     check_hover_fields_limit(
@@ -1094,11 +1062,7 @@ fn hover_record_struct_limit() {
 
             ---
 
-            size = 16 (0x10), align = 4
-
-            ---
-
-            does not contain types with destructors (drop glue); doesn't have a destructor
+            size = 16 (0x10), align = 4, no Drop
         "#]],
     );
     check_hover_fields_limit(
@@ -1119,11 +1083,7 @@ fn hover_record_struct_limit() {
 
             ---
 
-            size = 12 (0xC), align = 4
-
-            ---
-
-            does not contain types with destructors (drop glue); doesn't have a destructor
+            size = 12 (0xC), align = 4, no Drop
         "#]],
     );
     check_hover_fields_limit(
@@ -1144,11 +1104,7 @@ fn hover_record_struct_limit() {
 
             ---
 
-            size = 12 (0xC), align = 4
-
-            ---
-
-            does not contain types with destructors (drop glue); doesn't have a destructor
+            size = 12 (0xC), align = 4, no Drop
         "#]],
     );
 
@@ -1171,11 +1127,7 @@ fn hover_record_struct_limit() {
 
             ---
 
-            size = 0, align = 1
-
-            ---
-
-            does not contain types with destructors (drop glue); doesn't have a destructor
+            size = 0, align = 1, no Drop
         "#]],
     );
 }
@@ -1200,11 +1152,7 @@ fn hover_record_variant_limit() {
 
             ---
 
-            size = 12 (0xC), align = 4
-
-            ---
-
-            does not contain types with destructors (drop glue)
+            size = 12 (0xC), align = 4, no Drop
         "#]],
     );
     check_hover_fields_limit(
@@ -1225,11 +1173,7 @@ fn hover_record_variant_limit() {
 
             ---
 
-            size = 4, align = 4
-
-            ---
-
-            does not contain types with destructors (drop glue)
+            size = 4, align = 4, no Drop
         "#]],
     );
     check_hover_fields_limit(
@@ -1250,11 +1194,7 @@ fn hover_record_variant_limit() {
 
             ---
 
-            size = 16 (0x10), align = 4
-
-            ---
-
-            does not contain types with destructors (drop glue)
+            size = 16 (0x10), align = 4, no Drop
         "#]],
     );
     check_hover_fields_limit(
@@ -1275,11 +1215,7 @@ fn hover_record_variant_limit() {
 
             ---
 
-            size = 12 (0xC), align = 4
-
-            ---
-
-            does not contain types with destructors (drop glue)
+            size = 12 (0xC), align = 4, no Drop
         "#]],
     );
     check_hover_fields_limit(
@@ -1300,11 +1236,7 @@ fn hover_record_variant_limit() {
 
             ---
 
-            size = 12 (0xC), align = 4
-
-            ---
-
-            does not contain types with destructors (drop glue)
+            size = 12 (0xC), align = 4, no Drop
         "#]],
     );
 }
@@ -1330,11 +1262,7 @@ fn hover_enum_limit() {
 
             ---
 
-            size = 1, align = 1, niches = 254
-
-            ---
-
-            does not contain types with destructors (drop glue); doesn't have a destructor
+            size = 1, align = 1, niches = 254, no Drop
         "#]],
     );
     check_hover_enum_variants_limit(
@@ -1356,11 +1284,7 @@ fn hover_enum_limit() {
 
             ---
 
-            size = 1, align = 1, niches = 254
-
-            ---
-
-            does not contain types with destructors (drop glue); doesn't have a destructor
+            size = 1, align = 1, niches = 254, no Drop
         "#]],
     );
     check_hover_enum_variants_limit(
@@ -1379,11 +1303,7 @@ fn hover_enum_limit() {
 
             ---
 
-            size = 1, align = 1, niches = 254
-
-            ---
-
-            does not contain types with destructors (drop glue); doesn't have a destructor
+            size = 1, align = 1, niches = 254, no Drop
         "#]],
     );
     check_hover_enum_variants_limit(
@@ -1402,11 +1322,7 @@ fn hover_enum_limit() {
 
             ---
 
-            size = 1, align = 1, niches = 254
-
-            ---
-
-            does not contain types with destructors (drop glue); doesn't have a destructor
+            size = 1, align = 1, niches = 254, no Drop
         "#]],
     );
     check_hover_enum_variants_limit(
@@ -1443,11 +1359,7 @@ fn hover_enum_limit() {
 
             ---
 
-            size = 12 (0xC), align = 4, niches = a lot
-
-            ---
-
-            does not contain types with destructors (drop glue); doesn't have a destructor
+            size = 12 (0xC), align = 4, niches = a lot, no Drop
         "#]],
     );
 }
@@ -1473,11 +1385,7 @@ fn hover_union_limit() {
 
             ---
 
-            size = 4, align = 4
-
-            ---
-
-            does not contain types with destructors (drop glue); doesn't have a destructor
+            size = 4, align = 4, no Drop
         "#]],
     );
     check_hover_fields_limit(
@@ -1499,11 +1407,7 @@ fn hover_union_limit() {
 
             ---
 
-            size = 4, align = 4
-
-            ---
-
-            does not contain types with destructors (drop glue); doesn't have a destructor
+            size = 4, align = 4, no Drop
         "#]],
     );
     check_hover_fields_limit(
@@ -1522,11 +1426,7 @@ fn hover_union_limit() {
 
             ---
 
-            size = 4, align = 4
-
-            ---
-
-            does not contain types with destructors (drop glue); doesn't have a destructor
+            size = 4, align = 4, no Drop
         "#]],
     );
     check_hover_fields_limit(
@@ -1545,11 +1445,7 @@ fn hover_union_limit() {
 
             ---
 
-            size = 4, align = 4
-
-            ---
-
-            does not contain types with destructors (drop glue); doesn't have a destructor
+            size = 4, align = 4, no Drop
         "#]],
     );
 }
@@ -1575,11 +1471,7 @@ struct Foo$0 where u32: Copy;
 
             ---
 
-            size = 0, align = 1
-
-            ---
-
-            does not contain types with destructors (drop glue); doesn't have a destructor
+            size = 0, align = 1, no Drop
         "#]],
     );
 }
@@ -1605,7 +1497,7 @@ type Fo$0o: Trait = S where T: Trait;
 
             ---
 
-            does not contain types with destructors (drop glue)
+            no Drop
         "#]],
     );
 }
@@ -1754,11 +1646,7 @@ fn main() {
 
             ---
 
-            size = 8, align = 4
-
-            ---
-
-            does not contain types with destructors (drop glue)
+            size = 8, align = 4, no Drop
         "#]],
     );
     check_hover_range(
@@ -1813,11 +1701,7 @@ fn main() { let b$0ar = Some(12); }
 
             ---
 
-            size = 4, align = 4
-
-            ---
-
-            does not contain types with destructors (drop glue)
+            size = 4, align = 4, no Drop
         "#]],
     );
 }
@@ -1845,7 +1729,7 @@ enum Option<T> {
 
             ---
 
-            does not contain types with destructors (drop glue)
+            no Drop
 
             ---
 
@@ -1908,11 +1792,7 @@ fn hover_for_local_variable_pat() {
 
             ---
 
-            size = 4, align = 4
-
-            ---
-
-            does not contain types with destructors (drop glue)
+            size = 4, align = 4, no Drop
         "#]],
     )
 }
@@ -1944,11 +1824,7 @@ fn hover_for_param_edge() {
 
             ---
 
-            size = 4, align = 4
-
-            ---
-
-            does not contain types with destructors (drop glue)
+            size = 4, align = 4, no Drop
         "#]],
     )
 }
@@ -1974,7 +1850,7 @@ fn hover_for_param_with_multiple_traits() {
 
             ---
 
-            may contain types with destructors (drop glue) depending on type parameters
+            type param may need Drop
         "#]],
     )
 }
@@ -2000,11 +1876,7 @@ fn main() { let foo_$0test = Thing::new(); }
 
             ---
 
-            size = 4, align = 4
-
-            ---
-
-            does not contain types with destructors (drop glue)
+            size = 4, align = 4, no Drop
         "#]],
     )
 }
@@ -2257,11 +2129,7 @@ where
 
             ---
 
-            size = 0, align = 1
-
-            ---
-
-            does not contain types with destructors (drop glue); doesn't have a destructor
+            size = 0, align = 1, no Drop
         "#]],
     );
 }
@@ -2807,11 +2675,7 @@ fn test_hover_function_pointer_show_identifiers() {
 
             ---
 
-            size = 8, align = 8, niches = 1
-
-            ---
-
-            does not contain types with destructors (drop glue)
+            size = 8, align = 8, niches = 1, no Drop
         "#]],
     );
 }
@@ -2833,11 +2697,7 @@ fn test_hover_function_pointer_no_identifier() {
 
             ---
 
-            size = 8, align = 8, niches = 1
-
-            ---
-
-            does not contain types with destructors (drop glue)
+            size = 8, align = 8, niches = 1, no Drop
         "#]],
     );
 }
@@ -3080,11 +2940,7 @@ pub struct B$0ar
 
             ---
 
-            size = 0, align = 1
-
-            ---
-
-            does not contain types with destructors (drop glue); doesn't have a destructor
+            size = 0, align = 1, no Drop
 
             ---
 
@@ -3115,11 +2971,7 @@ pub struct B$0ar
 
             ---
 
-            size = 0, align = 1
-
-            ---
-
-            does not contain types with destructors (drop glue); doesn't have a destructor
+            size = 0, align = 1, no Drop
 
             ---
 
@@ -3212,11 +3064,7 @@ fn test_hover_layout_of_variant() {
 
             ---
 
-            size = 4, align = 2
-
-            ---
-
-            does not contain types with destructors (drop glue)
+            size = 4, align = 2, no Drop
         "#]],
     );
 }
@@ -3241,7 +3089,7 @@ fn test_hover_layout_of_variant_generic() {
 
             ---
 
-            does not contain types with destructors (drop glue)
+            no Drop
         "#]],
     );
 }
@@ -3266,11 +3114,7 @@ struct S$0<T>(core::marker::PhantomData<T>);
 
             ---
 
-            size = 0, align = 1
-
-            ---
-
-            does not contain types with destructors (drop glue); doesn't have a destructor
+            size = 0, align = 1, no Drop
         "#]],
     );
 }
@@ -3298,11 +3142,7 @@ fn test_hover_layout_of_enum() {
 
             ---
 
-            size = 16 (0x10), align = 8, niches = 254
-
-            ---
-
-            does not contain types with destructors (drop glue); doesn't have a destructor
+            size = 16 (0x10), align = 8, niches = 254, no Drop
         "#]],
     );
 }
@@ -3324,7 +3164,7 @@ fn test_hover_no_memory_layout() {
 
             ---
 
-            does not contain types with destructors (drop glue)
+            no Drop
         "#]],
     );
 
@@ -4632,11 +4472,7 @@ fn main() {
 
             ---
 
-            size = 8, align = 8, niches = 1
-
-            ---
-
-            does not contain types with destructors (drop glue)
+            size = 8, align = 8, niches = 1, no Drop
 
             ---
 
@@ -4650,11 +4486,7 @@ fn main() {
 
             ---
 
-            size = 4, align = 4, offset = 0
-
-            ---
-
-            does not contain types with destructors (drop glue)
+            size = 4, align = 4, offset = 0, no Drop
         "#]],
     );
 }
@@ -4679,11 +4511,7 @@ struct S$0T<const C: usize = 1, T = Foo>(T);
 
             ---
 
-            size = 0, align = 1
-
-            ---
-
-            may contain types with destructors (drop glue) depending on type parameters; doesn't have a destructor
+            size = 0, align = 1, type param may need Drop
         "#]],
     );
 }
@@ -4708,11 +4536,7 @@ struct S$0T<const C: usize = {40 + 2}, T = Foo>(T);
 
             ---
 
-            size = 0, align = 1
-
-            ---
-
-            may contain types with destructors (drop glue) depending on type parameters; doesn't have a destructor
+            size = 0, align = 1, type param may need Drop
         "#]],
     );
 }
@@ -4738,11 +4562,7 @@ struct S$0T<const C: usize = VAL, T = Foo>(T);
 
             ---
 
-            size = 0, align = 1
-
-            ---
-
-            may contain types with destructors (drop glue) depending on type parameters; doesn't have a destructor
+            size = 0, align = 1, type param may need Drop
         "#]],
     );
 }
@@ -4766,11 +4586,7 @@ fn main() {
 
             ---
 
-            size = 0, align = 1
-
-            ---
-
-            does not contain types with destructors (drop glue)
+            size = 0, align = 1, no Drop
         "#]],
     );
 }
@@ -4794,11 +4610,7 @@ fn main() {
 
             ---
 
-            size = 0, align = 1
-
-            ---
-
-            does not contain types with destructors (drop glue)
+            size = 0, align = 1, no Drop
         "#]],
     );
 }
@@ -4822,11 +4634,7 @@ fn main() {
 
             ---
 
-            size = 0, align = 1
-
-            ---
-
-            does not contain types with destructors (drop glue)
+            size = 0, align = 1, no Drop
         "#]],
     );
 }
@@ -4850,11 +4658,7 @@ fn main() {
 
             ---
 
-            size = 0, align = 1
-
-            ---
-
-            does not contain types with destructors (drop glue)
+            size = 0, align = 1, no Drop
         "#]],
     );
 }
@@ -4878,11 +4682,7 @@ fn main() {
 
             ---
 
-            size = 0, align = 1
-
-            ---
-
-            does not contain types with destructors (drop glue)
+            size = 0, align = 1, no Drop
         "#]],
     );
 }
@@ -4905,11 +4705,7 @@ impl Foo {
 
             ---
 
-            size = 8, align = 8, niches = 1
-
-            ---
-
-            does not contain types with destructors (drop glue)
+            size = 8, align = 8, niches = 1, no Drop
         "#]],
     );
 }
@@ -4933,11 +4729,7 @@ impl Foo {
 
             ---
 
-            size = 0, align = 1
-
-            ---
-
-            does not contain types with destructors (drop glue)
+            size = 0, align = 1, no Drop
         "#]],
     );
 }
@@ -5427,11 +5219,7 @@ type Fo$0o2 = Foo<2>;
 
             ---
 
-            size = 0, align = 1
-
-            ---
-
-            does not contain types with destructors (drop glue)
+            size = 0, align = 1, no Drop
         "#]],
     );
 }
@@ -5481,11 +5269,7 @@ enum E {
 
             ---
 
-            size = 1, align = 1
-
-            ---
-
-            does not contain types with destructors (drop glue)
+            size = 1, align = 1, no Drop
 
             ---
 
@@ -5514,11 +5298,7 @@ enum E {
 
             ---
 
-            size = 1, align = 1
-
-            ---
-
-            does not contain types with destructors (drop glue)
+            size = 1, align = 1, no Drop
 
             ---
 
@@ -5548,11 +5328,7 @@ enum E {
 
             ---
 
-            size = 1, align = 1
-
-            ---
-
-            does not contain types with destructors (drop glue)
+            size = 1, align = 1, no Drop
 
             ---
 
@@ -5582,11 +5358,7 @@ enum E {
 
             ---
 
-            size = 1, align = 1
-
-            ---
-
-            does not contain types with destructors (drop glue)
+            size = 1, align = 1, no Drop
 
             ---
 
@@ -6517,11 +6289,7 @@ fn main() {
 
             ---
 
-            size = 32 (0x20), align = 4
-
-            ---
-
-            does not contain types with destructors (drop glue)
+            size = 32 (0x20), align = 4, no Drop
         "#]],
     );
 }
@@ -7820,11 +7588,7 @@ enum Enum {
 
             ---
 
-            size = 4, align = 4
-
-            ---
-
-            does not contain types with destructors (drop glue)
+            size = 4, align = 4, no Drop
         "#]],
     );
 }
@@ -7850,11 +7614,7 @@ enum Enum {
 
             ---
 
-            size = 4, align = 4
-
-            ---
-
-            does not contain types with destructors (drop glue)
+            size = 4, align = 4, no Drop
         "#]],
     );
 }
@@ -8524,11 +8284,7 @@ fn test() {
 
             ---
 
-            size = 0, align = 1
-
-            ---
-
-            does not contain types with destructors (drop glue)
+            size = 0, align = 1, no Drop
         "#]],
     );
 }
@@ -9177,11 +8933,7 @@ fn main(notable$0: u32) {}
 
             ---
 
-            size = 4, align = 4
-
-            ---
-
-            does not contain types with destructors (drop glue)
+            size = 4, align = 4, no Drop
         "#]],
     );
 }
@@ -9273,11 +9025,7 @@ extern "C" {
 
             ---
 
-            size = 0, align = 1
-
-            ---
-
-            does not contain types with destructors (drop glue)
+            size = 0, align = 1, no Drop
         "#]],
     );
 }
@@ -9423,11 +9171,7 @@ struct Pedro$0<'a> {
 
             ---
 
-            size = 16 (0x10), align = 8, niches = 1
-
-            ---
-
-            does not contain types with destructors (drop glue); doesn't have a destructor
+            size = 16 (0x10), align = 8, niches = 1, no Drop
         "#]],
     )
 }
@@ -9448,7 +9192,7 @@ fn main(a$0: impl T) {}
 
             ---
 
-            may contain types with destructors (drop glue) depending on type parameters
+            type param may need Drop
         "#]],
     );
 }
@@ -9469,11 +9213,7 @@ fn main(a$0: T) {}
 
             ---
 
-            size = 0, align = 1
-
-            ---
-
-            does not contain types with destructors (drop glue)
+            size = 0, align = 1, no Drop
         "#]],
     );
 }
@@ -9526,11 +9266,7 @@ fn main() {
 
             ---
 
-            size = 0, align = 1
-
-            ---
-
-            does not contain types with destructors (drop glue)
+            size = 0, align = 1, no Drop
         "#]],
     );
 }
@@ -9864,11 +9600,7 @@ type A$0 = B;
 
             ---
 
-            size = 0, align = 1
-
-            ---
-
-            does not contain types with destructors (drop glue)
+            size = 0, align = 1, no Drop
 
             ---
 
@@ -9901,11 +9633,7 @@ type A$0 = B;
 
             ---
 
-            size = 0, align = 1
-
-            ---
-
-            does not contain types with destructors (drop glue)
+            size = 0, align = 1, no Drop
 
             ---
 
@@ -9939,11 +9667,7 @@ type A$0 = B;
 
             ---
 
-            size = 0, align = 1
-
-            ---
-
-            does not contain types with destructors (drop glue)
+            size = 0, align = 1, no Drop
 
             ---
 
@@ -9975,11 +9699,7 @@ type A$0 = B;
 
             ---
 
-            size = 0, align = 1
-
-            ---
-
-            does not contain types with destructors (drop glue)
+            size = 0, align = 1, no Drop
         "#]],
     );
 
@@ -10103,11 +9823,7 @@ fn main() {
 
             ---
 
-            size = 0, align = 1
-
-            ---
-
-            does not contain types with destructors (drop glue)
+            size = 0, align = 1, no Drop
         "#]],
     );
 
@@ -10135,11 +9851,7 @@ fn main() {
 
             ---
 
-            size = 0, align = 1
-
-            ---
-
-            does not contain types with destructors (drop glue)
+            size = 0, align = 1, no Drop
         "#]],
     );
 
@@ -10174,11 +9886,7 @@ fn main() {
 
             ---
 
-            size = 0, align = 1
-
-            ---
-
-            does not contain types with destructors (drop glue)
+            size = 0, align = 1, no Drop
         "#]],
     );
 }
@@ -10497,11 +10205,7 @@ fn bar() {
 
             ---
 
-            size = 4, align = 4
-
-            ---
-
-            does not contain types with destructors (drop glue)
+            size = 4, align = 4, no Drop
 
             ---
 
@@ -10515,7 +10219,7 @@ fn bar() {
 
             ---
 
-            may contain types with destructors (drop glue) depending on type parameters
+            type param may need Drop
 
             ---
 
@@ -10748,11 +10452,7 @@ struct NoDrop$0;
 
             ---
 
-            size = 0, align = 1
-
-            ---
-
-            does not contain types with destructors (drop glue); doesn't have a destructor
+            size = 0, align = 1, no Drop
         "#]],
     );
     check(
@@ -10776,11 +10476,7 @@ impl Drop for NeedsDrop {
 
             ---
 
-            size = 0, align = 1
-
-            ---
-
-            does not contain types with destructors (drop glue); has a destructor
+            size = 0, align = 1, impl Drop
         "#]],
     );
     check(
@@ -10805,11 +10501,7 @@ type NoDrop$0 = core::mem::ManuallyDrop<NeedsDrop>;
 
             ---
 
-            size = 0, align = 1
-
-            ---
-
-            does not contain types with destructors (drop glue)
+            size = 0, align = 1, no Drop
         "#]],
     );
     check(
@@ -10840,11 +10532,7 @@ struct DropField$0 {
 
             ---
 
-            size = 4, align = 4
-
-            ---
-
-            contain types with destructors (drop glue); doesn't have a destructor
+            size = 4, align = 4, needs Drop
         "#]],
     );
     check(
@@ -10865,7 +10553,7 @@ type Foo$0 = impl Sized;
 
             ---
 
-            contain types with destructors (drop glue)
+            needs Drop
         "#]],
     );
     check(
@@ -10893,11 +10581,7 @@ enum Enum {
 
             ---
 
-            size = 16 (0x10), align = 8, niches = 1
-
-            ---
-
-            does not contain types with destructors (drop glue)
+            size = 16 (0x10), align = 8, niches = 1, no Drop
         "#]],
     );
     check(
@@ -10917,7 +10601,7 @@ struct Foo$0<T>(T);
 
             ---
 
-            may contain types with destructors (drop glue) depending on type parameters; doesn't have a destructor
+            type param may need Drop
         "#]],
     );
     check(
@@ -10940,7 +10624,7 @@ struct Foo$0<T: Copy>(T);
 
             ---
 
-            does not contain types with destructors (drop glue); doesn't have a destructor
+            no Drop
         "#]],
     );
     check(
@@ -10966,7 +10650,7 @@ struct Foo$0<T: Trait>(T::Assoc);
 
             ---
 
-            does not contain types with destructors (drop glue); doesn't have a destructor
+            no Drop
         "#]],
     );
     check(
@@ -10997,7 +10681,7 @@ pub struct ManuallyDrop$0<T: ?Sized> {
 
             ---
 
-            does not contain types with destructors (drop glue); doesn't have a destructor
+            no Drop
         "#]],
     );
 }


### PR DESCRIPTION
The current notifications are quite verbose (as discussed in #19410), which
causes some arguably more useful information (like the documentation) to be
harder to see.

One option would just be to disable the option by default, but as proposed
there, it seems like a reasonable middle ground would be to show it but
significantly less verbosely.

This change reduces the amount of information shown (a direct `Drop` impl is
rendered the same way as the drop glue that calls `Drop` impls transitively),
but I don't know of a scenario where the difference is meaningful.

Closes #19410
