### PR TITLE
minor: drop `rustc_hashes` dependency, add `syn` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,7 +85,6 @@ vfs-notify = { path = "./crates/vfs-notify", version = "0.0.0" }
 vfs = { path = "./crates/vfs", version = "0.0.0" }
 edition = { path = "./crates/edition", version = "0.0.0" }
 
-ra-ap-rustc_hashes = { version = "0.100", default-features = false }
 ra-ap-rustc_lexer = { version = "0.100", default-features = false }
 ra-ap-rustc_parse_format = { version = "0.100", default-features = false }
 ra-ap-rustc_index = { version = "0.100", default-features = false }

--- a/crates/hir-def/src/lib.rs
+++ b/crates/hir-def/src/lib.rs
@@ -18,9 +18,6 @@ extern crate ra_ap_rustc_parse_format as rustc_parse_format;
 #[cfg(feature = "in-rust-tree")]
 extern crate rustc_abi;
 
-#[cfg(feature = "in-rust-tree")]
-extern crate rustc_hashes;
-
 #[cfg(not(feature = "in-rust-tree"))]
 extern crate ra_ap_rustc_abi as rustc_abi;
 

--- a/crates/query-group-macro/Cargo.toml
+++ b/crates/query-group-macro/Cargo.toml
@@ -15,7 +15,7 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1.0"
 quote = "1.0"
-syn = { version = "2.0", features = ["full", "extra-traits"] }
+syn = { version = "2.0", features = ["full", "extra-traits", "visit-mut"] }
 
 [dev-dependencies]
 expect-test = "1.5.0"


### PR DESCRIPTION
One is a leftover from #19416, the other fixes auto-publishing.