### PR TITLE
refactor: Use MEDIUM durability for crate-graph changes, high for library source files

### DIFF
--- a/crates/base-db/src/change.rs
+++ b/crates/base-db/src/change.rs
@@ -55,7 +55,7 @@ impl FileChange {
         if let Some(roots) = self.roots {
             for (idx, root) in roots.into_iter().enumerate() {
                 let root_id = SourceRootId(idx as u32);
-                let durability = durability(&root);
+                let durability = source_root_durability(&root);
                 for file_id in root.iter() {
                     db.set_file_source_root_with_durability(file_id, root_id, durability);
                 }
@@ -68,7 +68,7 @@ impl FileChange {
             let source_root_id = db.file_source_root(file_id);
             let source_root = db.source_root(source_root_id.source_root_id(db));
 
-            let durability = durability(&source_root.source_root(db));
+            let durability = file_text_durability(&source_root.source_root(db));
             // XXX: can't actually remove the file, just reset the text
             let text = text.unwrap_or_default();
             db.set_file_text_with_durability(file_id, &text, durability)
@@ -81,6 +81,10 @@ impl FileChange {
     }
 }
 
-fn durability(source_root: &SourceRoot) -> Durability {
+fn source_root_durability(source_root: &SourceRoot) -> Durability {
+    if source_root.is_library { Durability::MEDIUM } else { Durability::LOW }
+}
+
+fn file_text_durability(source_root: &SourceRoot) -> Durability {
     if source_root.is_library { Durability::HIGH } else { Durability::LOW }
 }

--- a/crates/base-db/src/input.rs
+++ b/crates/base-db/src/input.rs
@@ -491,7 +491,7 @@ impl CrateGraphBuilder {
         if **old_all_crates != *all_crates {
             db.set_all_crates_with_durability(
                 Arc::new(all_crates.into_boxed_slice()),
-                Durability::HIGH,
+                Durability::MEDIUM,
             );
         }
 
@@ -549,30 +549,30 @@ impl CrateGraphBuilder {
                 Entry::Occupied(entry) => {
                     let old_crate = *entry.get();
                     if crate_data != *old_crate.data(db) {
-                        old_crate.set_data(db).with_durability(Durability::HIGH).to(crate_data);
+                        old_crate.set_data(db).with_durability(Durability::MEDIUM).to(crate_data);
                     }
                     if krate.extra != *old_crate.extra_data(db) {
                         old_crate
                             .set_extra_data(db)
-                            .with_durability(Durability::HIGH)
+                            .with_durability(Durability::MEDIUM)
                             .to(krate.extra.clone());
                     }
                     if krate.cfg_options != *old_crate.cfg_options(db) {
                         old_crate
                             .set_cfg_options(db)
-                            .with_durability(Durability::HIGH)
+                            .with_durability(Durability::MEDIUM)
                             .to(krate.cfg_options.clone());
                     }
                     if krate.env != *old_crate.env(db) {
                         old_crate
                             .set_env(db)
-                            .with_durability(Durability::HIGH)
+                            .with_durability(Durability::MEDIUM)
                             .to(krate.env.clone());
                     }
                     if krate.ws_data != *old_crate.workspace_data(db) {
                         old_crate
                             .set_workspace_data(db)
-                            .with_durability(Durability::HIGH)
+                            .with_durability(Durability::MEDIUM)
                             .to(krate.ws_data.clone());
                     }
                     old_crate
@@ -585,7 +585,7 @@ impl CrateGraphBuilder {
                         krate.cfg_options.clone(),
                         krate.env.clone(),
                     )
-                    .durability(Durability::HIGH)
+                    .durability(Durability::MEDIUM)
                     .new(db);
                     entry.insert(input);
                     input

--- a/crates/ide-db/src/apply_change.rs
+++ b/crates/ide-db/src/apply_change.rs
@@ -29,8 +29,8 @@ impl RootDatabase {
                     local_roots.insert(root_id);
                 }
             }
-            self.set_local_roots_with_durability(Arc::new(local_roots), Durability::HIGH);
-            self.set_library_roots_with_durability(Arc::new(library_roots), Durability::HIGH);
+            self.set_local_roots_with_durability(Arc::new(local_roots), Durability::MEDIUM);
+            self.set_library_roots_with_durability(Arc::new(library_roots), Durability::MEDIUM);
         }
         change.apply(self);
     }

--- a/crates/ide-db/src/lib.rs
+++ b/crates/ide-db/src/lib.rs
@@ -220,9 +220,9 @@ impl RootDatabase {
         // This needs to be here otherwise `CrateGraphBuilder` will panic.
         db.set_all_crates(Arc::new(Box::new([])));
         CrateGraphBuilder::default().set_in_db(&mut db);
-        db.set_proc_macros_with_durability(Default::default(), Durability::HIGH);
-        db.set_local_roots_with_durability(Default::default(), Durability::HIGH);
-        db.set_library_roots_with_durability(Default::default(), Durability::HIGH);
+        db.set_proc_macros_with_durability(Default::default(), Durability::MEDIUM);
+        db.set_local_roots_with_durability(Default::default(), Durability::MEDIUM);
+        db.set_library_roots_with_durability(Default::default(), Durability::MEDIUM);
         db.set_expand_proc_attr_macros_with_durability(false, Durability::HIGH);
         db.update_base_query_lru_capacities(lru_capacity);
         db


### PR DESCRIPTION


The idea here is that the crate graph may change over time, but library source file contents *never* will (or really never should). Disconnecting the two means that queries that depend on library sources will not need to re-validatewhen the crate graph changes (unless they depend on the crate graph in some capacity).