### PR TITLE
fix: Fix `format_args` lowering using wrong integer suffix

### DIFF
--- a/crates/hir-def/src/expr_store/lower.rs
+++ b/crates/hir-def/src/expr_store/lower.rs
@@ -2400,7 +2400,8 @@ impl ExprCollector<'_> {
             Some(FormatCount::Literal(n)) => {
                 let args = self.alloc_expr_desugared(Expr::Literal(Literal::Uint(
                     *n as u128,
-                    Some(BuiltinUint::Usize),
+                    // FIXME: Change this to Some(BuiltinUint::U16) once we drop support for toolchains < 1.88
+                    None,
                 )));
                 let count_is = match LangItem::FormatCount.ty_rel_path(
                     self.db,

--- a/crates/hir-def/src/expr_store/tests.rs
+++ b/crates/hir-def/src/expr_store/tests.rs
@@ -216,7 +216,7 @@ fn main() {
                         8u32,
                         builtin#lang(Count::Implied),
                         builtin#lang(Count::Is)(
-                            2usize,
+                            2,
                         ),
                     ), builtin#lang(Placeholder::new)(
                         1usize,


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust-analyzer/issues/19456