### PR TITLE
fix: Fix a bug in orphan rules calculation

### DIFF
--- a/crates/ide-diagnostics/src/handlers/trait_impl_orphan.rs
+++ b/crates/ide-diagnostics/src/handlers/trait_impl_orphan.rs
@@ -104,4 +104,17 @@ impl<T> foo::Foo<dyn LocalTrait> for Bar {}
 "#,
         );
     }
+
+    #[test]
+    fn twice_fundamental() {
+        check_diagnostics(
+            r#"
+//- /foo.rs crate:foo
+pub trait Trait {}
+//- /bar.rs crate:bar deps:foo
+struct Foo;
+impl foo::Trait for &&Foo {}
+        "#,
+        );
+    }
 }


### PR DESCRIPTION
Where a fundamental type applied twice wasn't considered local.

We're going to get a full coherence checker for free with the next trait solver, so I don't want to invest in completing the current check, but this fix is simple enough and it can cause annoying red squiggles.