### PR TITLE
fix: resolve doc path for module

### DIFF
--- a/crates/hir/src/attrs.rs
+++ b/crates/hir/src/attrs.rs
@@ -116,7 +116,7 @@ fn resolve_doc_path_on_(
     ns: Option<Namespace>,
 ) -> Option<DocLinkDef> {
     let resolver = match attr_id {
-        AttrDefId::ModuleId(it) => it.resolver(db.upcast()),
+        AttrDefId::ModuleId(it) => Module::from(it).parent(db)?.id.resolver(db.upcast()),
         AttrDefId::FieldId(it) => it.parent.resolver(db.upcast()),
         AttrDefId::AdtId(it) => it.resolver(db.upcast()),
         AttrDefId::FunctionId(it) => it.resolver(db.upcast()),

--- a/crates/ide/src/doc_links/tests.rs
+++ b/crates/ide/src/doc_links/tests.rs
@@ -576,6 +576,24 @@ struct S$0(i32);
 }
 
 #[test]
+fn doc_links_module() {
+    check_doc_links(
+        r#"
+/// [`M`]
+/// [`M::f`]
+/// [`M::S`]
+mod M$0 {
+  //^ M
+    pub fn f() {}
+         //^ M::f
+    pub struct S;
+             //^ M::S
+}
+"#,
+    );
+}
+
+#[test]
 fn rewrite_html_root_url() {
     check_rewrite(
         r#"


### PR DESCRIPTION
This PR fixes an issue where links to modules in doc comments don't match the generated documentation.
<img width="328" alt="スクリーンショット 2025-03-28 23 59 58" src="https://github.com/user-attachments/assets/687c6e4f-d81a-4ae0-ad43-c102dcefe103" />

<img width="267" alt="スクリーンショット 2025-03-28 23 54 02" src="https://github.com/user-attachments/assets/33625126-e3d5-4032-a207-593629b4cd07" />

I think links should be resolved starting from the parent module.
<img width="316" alt="スクリーンショット 2025-03-28 23 53 09" src="https://github.com/user-attachments/assets/d4318b39-65fd-4ec5-b265-76d3c07ed123" />

