### PR TITLE
feat: Add two new diagnostics: one for mismatch in generic arguments count, and another for mismatch in their kind

### DIFF
--- a/crates/hir-def/src/expr_store.rs
+++ b/crates/hir-def/src/expr_store.rs
@@ -35,7 +35,9 @@ use crate::{
 };
 
 pub use self::body::{Body, BodySourceMap};
-pub use self::lower::hir_segment_to_ast_segment;
+pub use self::lower::{
+    hir_assoc_type_binding_to_ast, hir_generic_arg_to_ast, hir_segment_to_ast_segment,
+};
 
 /// A wrapper around [`span::SyntaxContextId`] that is intended only for comparisons.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]

--- a/crates/hir-def/src/expr_store/lower/path.rs
+++ b/crates/hir-def/src/expr_store/lower/path.rs
@@ -152,10 +152,8 @@ pub(super) fn lower_path(
                                 args: iter::once(self_type)
                                     .chain(it.args.iter().cloned())
                                     .collect(),
-
                                 has_self_type: true,
-                                bindings: it.bindings.clone(),
-                                parenthesized: it.parenthesized,
+                                ..it
                             },
                             None => GenericArgs {
                                 args: Box::new([self_type]),

--- a/crates/hir-def/src/hir/generics.rs
+++ b/crates/hir-def/src/hir/generics.rs
@@ -138,6 +138,7 @@ impl GenericParamData {
 
 impl_from!(TypeParamData, ConstParamData, LifetimeParamData for GenericParamData);
 
+#[derive(Debug, Clone, Copy)]
 pub enum GenericParamDataRef<'a> {
     TypeParamData(&'a TypeParamData),
     ConstParamData(&'a ConstParamData),

--- a/crates/hir-ty/src/db.rs
+++ b/crates/hir-ty/src/db.rs
@@ -200,6 +200,9 @@ pub trait HirDatabase: DefDatabase + std::fmt::Debug {
         def: GenericDefId,
     ) -> (GenericDefaults, Diagnostics);
 
+    /// This returns an empty list if no parameter has default.
+    ///
+    /// The binders of the returned defaults are only up to (not including) this parameter.
     #[salsa::invoke(crate::lower::generic_defaults_query)]
     #[salsa::transparent]
     fn generic_defaults(&self, def: GenericDefId) -> GenericDefaults;

--- a/crates/hir-ty/src/display.rs
+++ b/crates/hir-ty/src/display.rs
@@ -1640,7 +1640,7 @@ fn generic_args_sans_defaults<'ga>(
                         Some(default_parameter) => {
                             // !is_err(default_parameter.skip_binders())
                             // &&
-                            arg != &default_parameter.clone().substitute(Interner, &parameters)
+                            arg != &default_parameter.clone().substitute(Interner, &parameters[..i])
                         }
                     }
                 };

--- a/crates/hir-ty/src/infer/diagnostics.rs
+++ b/crates/hir-ty/src/infer/diagnostics.rs
@@ -12,6 +12,7 @@ use hir_def::expr_store::path::Path;
 use hir_def::{hir::ExprOrPatId, resolver::Resolver};
 use la_arena::{Idx, RawIdx};
 
+use crate::lower::GenericArgsPosition;
 use crate::{
     InferenceDiagnostic, InferenceTyDiagnosticSource, TyLoweringContext, TyLoweringDiagnostic,
     db::HirDatabase,
@@ -74,6 +75,7 @@ impl<'a> InferenceTyLoweringContext<'a> {
         &'b mut self,
         path: &'b Path,
         node: ExprOrPatId,
+        position: GenericArgsPosition,
     ) -> PathLoweringContext<'b, 'a> {
         let on_diagnostic = PathDiagnosticCallback {
             data: Either::Right(PathDiagnosticCallbackData { diagnostics: self.diagnostics, node }),
@@ -83,13 +85,14 @@ impl<'a> InferenceTyLoweringContext<'a> {
                     .push(InferenceDiagnostic::PathDiagnostic { node: data.node, diag });
             },
         };
-        PathLoweringContext::new(&mut self.ctx, on_diagnostic, path)
+        PathLoweringContext::new(&mut self.ctx, on_diagnostic, path, position)
     }
 
     #[inline]
     pub(super) fn at_path_forget_diagnostics<'b>(
         &'b mut self,
         path: &'b Path,
+        position: GenericArgsPosition,
     ) -> PathLoweringContext<'b, 'a> {
         let on_diagnostic = PathDiagnosticCallback {
             data: Either::Right(PathDiagnosticCallbackData {
@@ -98,7 +101,7 @@ impl<'a> InferenceTyLoweringContext<'a> {
             }),
             callback: |_data, _, _diag| {},
         };
-        PathLoweringContext::new(&mut self.ctx, on_diagnostic, path)
+        PathLoweringContext::new(&mut self.ctx, on_diagnostic, path, position)
     }
 
     #[inline]

--- a/crates/hir-ty/src/infer/path.rs
+++ b/crates/hir-ty/src/infer/path.rs
@@ -16,6 +16,7 @@ use crate::{
     consteval, error_lifetime,
     generics::generics,
     infer::diagnostics::InferenceTyLoweringContext as TyLoweringContext,
+    lower::GenericArgsPosition,
     method_resolution::{self, VisibleFromModule},
     to_chalk_trait_id,
 };
@@ -95,7 +96,7 @@ impl InferenceContext<'_> {
         };
 
         let substs = self.with_body_ty_lowering(|ctx| {
-            let mut path_ctx = ctx.at_path(path, id);
+            let mut path_ctx = ctx.at_path(path, id, GenericArgsPosition::Value);
             let last_segment = path.segments().len().checked_sub(1);
             if let Some(last_segment) = last_segment {
                 path_ctx.set_current_segment(last_segment)
@@ -163,9 +164,9 @@ impl InferenceContext<'_> {
             self.generic_def,
         );
         let mut path_ctx = if no_diagnostics {
-            ctx.at_path_forget_diagnostics(path)
+            ctx.at_path_forget_diagnostics(path, GenericArgsPosition::Value)
         } else {
-            ctx.at_path(path, id)
+            ctx.at_path(path, id, GenericArgsPosition::Value)
         };
         let (value, self_subst) = if let Some(type_ref) = path.type_anchor() {
             let last = path.segments().last()?;

--- a/crates/hir-ty/src/lib.rs
+++ b/crates/hir-ty/src/lib.rs
@@ -347,20 +347,24 @@ pub(crate) fn make_binders<T: HasInterner<Interner = Interner>>(
     generics: &Generics,
     value: T,
 ) -> Binders<T> {
-    Binders::new(
-        VariableKinds::from_iter(
-            Interner,
-            generics.iter_id().map(|x| match x {
-                hir_def::GenericParamId::ConstParamId(id) => {
-                    chalk_ir::VariableKind::Const(db.const_param_ty(id))
-                }
-                hir_def::GenericParamId::TypeParamId(_) => {
-                    chalk_ir::VariableKind::Ty(chalk_ir::TyVariableKind::General)
-                }
-                hir_def::GenericParamId::LifetimeParamId(_) => chalk_ir::VariableKind::Lifetime,
-            }),
-        ),
-        value,
+    Binders::new(variable_kinds_from_iter(db, generics.iter_id()), value)
+}
+
+pub(crate) fn variable_kinds_from_iter(
+    db: &dyn HirDatabase,
+    iter: impl Iterator<Item = hir_def::GenericParamId>,
+) -> VariableKinds {
+    VariableKinds::from_iter(
+        Interner,
+        iter.map(|x| match x {
+            hir_def::GenericParamId::ConstParamId(id) => {
+                chalk_ir::VariableKind::Const(db.const_param_ty(id))
+            }
+            hir_def::GenericParamId::TypeParamId(_) => {
+                chalk_ir::VariableKind::Ty(chalk_ir::TyVariableKind::General)
+            }
+            hir_def::GenericParamId::LifetimeParamId(_) => chalk_ir::VariableKind::Lifetime,
+        }),
     )
 }
 

--- a/crates/hir-ty/src/lower/diagnostics.rs
+++ b/crates/hir-ty/src/lower/diagnostics.rs
@@ -1,6 +1,7 @@
 //! This files contains the declaration of diagnostics kinds for ty and path lowering.
 
 use hir_def::type_ref::TypeRefId;
+use hir_def::{GenericDefId, GenericParamId};
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct TyLoweringDiagnostic {
@@ -21,13 +22,51 @@ pub enum GenericArgsProhibitedReason {
     PrimitiveTy,
     Const,
     Static,
+    LocalVariable,
     /// When there is a generic enum, within the expression `Enum::Variant`,
     /// either `Enum` or `Variant` are allowed to have generic arguments, but not both.
     EnumVariant,
 }
 
+/// A path can have many generic arguments: each segment may have one associated with the
+/// segment, and in addition, each associated type binding may have generic arguments. This
+/// enum abstracts over both.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PathGenericsSource {
+    /// Generic arguments directly on the segment.
+    Segment(u32),
+    /// Generic arguments on an associated type, e.g. `Foo<Assoc<A, B> = C>` or `Foo<Assoc<A, B>: Bound>`.
+    AssocType { segment: u32, assoc_type: u32 },
+}
+
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum PathLoweringDiagnostic {
-    GenericArgsProhibited { segment: u32, reason: GenericArgsProhibitedReason },
-    ParenthesizedGenericArgsWithoutFnTrait { segment: u32 },
+    GenericArgsProhibited {
+        segment: u32,
+        reason: GenericArgsProhibitedReason,
+    },
+    ParenthesizedGenericArgsWithoutFnTrait {
+        segment: u32,
+    },
+    /// The expected lifetimes & types and consts counts can be found by inspecting the `GenericDefId`.
+    IncorrectGenericsLen {
+        generics_source: PathGenericsSource,
+        provided_count: u32,
+        expected_count: u32,
+        kind: IncorrectGenericsLenKind,
+        def: GenericDefId,
+    },
+    IncorrectGenericsOrder {
+        generics_source: PathGenericsSource,
+        param_id: GenericParamId,
+        arg_idx: u32,
+        /// Whether the `GenericArgs` contains a `Self` arg.
+        has_self_arg: bool,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IncorrectGenericsLenKind {
+    Lifetimes,
+    TypesAndConsts,
 }

--- a/crates/ide-diagnostics/src/handlers/incorrect_generics_len.rs
+++ b/crates/ide-diagnostics/src/handlers/incorrect_generics_len.rs
@@ -1,0 +1,172 @@
+use crate::{Diagnostic, DiagnosticCode, DiagnosticsContext};
+use hir::IncorrectGenericsLenKind;
+
+// Diagnostic: incorrect-generics-len
+//
+// This diagnostic is triggered if the number of generic arguments does not match their declaration.
+pub(crate) fn incorrect_generics_len(
+    ctx: &DiagnosticsContext<'_>,
+    d: &hir::IncorrectGenericsLen,
+) -> Diagnostic {
+    let owner_description = d.def.description();
+    let expected = d.expected;
+    let provided = d.provided;
+    let kind_description = match d.kind {
+        IncorrectGenericsLenKind::Lifetimes => "lifetime",
+        IncorrectGenericsLenKind::TypesAndConsts => "generic",
+    };
+    let message = format!(
+        "this {owner_description} takes {expected} {kind_description} argument{} \
+            but {provided} {kind_description} argument{} {} supplied",
+        if expected == 1 { "" } else { "s" },
+        if provided == 1 { "" } else { "s" },
+        if provided == 1 { "was" } else { "were" },
+    );
+    Diagnostic::new_with_syntax_node_ptr(
+        ctx,
+        DiagnosticCode::RustcHardError("E0107"),
+        message,
+        d.generics_or_segment.map(Into::into),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::tests::check_diagnostics;
+
+    #[test]
+    fn partially_specified_generics() {
+        check_diagnostics(
+            r#"
+struct Bar<T, U>(T, U);
+
+fn foo() {
+    let _ = Bar::<()>;
+            // ^^^^^^ error: this struct takes 2 generic arguments but 1 generic argument was supplied
+}
+
+        "#,
+        );
+    }
+
+    #[test]
+    fn enum_variant() {
+        check_diagnostics(
+            r#"
+enum Enum<T, U> {
+    Variant(T, U),
+}
+
+fn foo() {
+    let _ = Enum::<()>::Variant;
+             // ^^^^^^ error: this enum takes 2 generic arguments but 1 generic argument was supplied
+    let _ = Enum::Variant::<()>;
+                      // ^^^^^^ error: this enum takes 2 generic arguments but 1 generic argument was supplied
+}
+
+        "#,
+        );
+    }
+
+    #[test]
+    fn lifetimes() {
+        check_diagnostics(
+            r#"
+struct Foo<'a, 'b>(&'a &'b ());
+struct Bar<'a>(&'a ());
+
+fn foo() -> Foo {
+    let _ = Foo;
+    let _ = Foo::<>;
+    let _ = Foo::<'static>;
+            // ^^^^^^^^^^^ error: this struct takes 2 lifetime arguments but 1 lifetime argument was supplied
+    loop {}
+}
+
+fn bar(_v: Bar) -> Foo { loop {} }
+        "#,
+        );
+    }
+
+    #[test]
+    fn no_error_for_elided_lifetimes() {
+        check_diagnostics(
+            r#"
+struct Foo<'a>(&'a ());
+
+fn foo(_v: &()) -> Foo { loop {} }
+        "#,
+        );
+    }
+
+    #[test]
+    fn errs_for_elided_lifetimes_if_lifetimes_are_explicitly_provided() {
+        check_diagnostics(
+            r#"
+struct Foo<'a, 'b>(&'a &'b ());
+
+fn foo(_v: Foo<'_>
+           // ^^^^ error: this struct takes 2 lifetime arguments but 1 lifetime argument was supplied
+) -> Foo<'static> { loop {} }
+     // ^^^^^^^^^ error: this struct takes 2 lifetime arguments but 1 lifetime argument was supplied
+        "#,
+        );
+    }
+
+    #[test]
+    fn types_and_consts() {
+        check_diagnostics(
+            r#"
+struct Foo<'a, T>(&'a T);
+fn foo(_v: Foo) {}
+        // ^^^ error: this struct takes 1 generic argument but 0 generic arguments were supplied
+
+struct Bar<T, const N: usize>(T);
+fn bar() {
+    let _ = Bar::<()>;
+            // ^^^^^^ error: this struct takes 2 generic arguments but 1 generic argument was supplied
+}
+        "#,
+        );
+    }
+
+    #[test]
+    fn respects_defaults() {
+        check_diagnostics(
+            r#"
+struct Foo<T = (), const N: usize = 0>(T);
+fn foo(_v: Foo) {}
+
+struct Bar<T, const N: usize = 0>(T);
+fn bar(_v: Bar<()>) {}
+        "#,
+        );
+    }
+
+    #[test]
+    fn constant() {
+        check_diagnostics(
+            r#"
+const CONST: i32 = 0;
+fn baz() {
+    let _ = CONST::<()>;
+              // ^^^^^^ error: this constant takes 0 generic arguments but 1 generic argument was supplied
+}
+        "#,
+        );
+    }
+
+    #[test]
+    fn assoc_type() {
+        check_diagnostics(
+            r#"
+trait Trait {
+    type Assoc;
+}
+
+fn foo<T: Trait<Assoc<i32> = bool>>() {}
+                  // ^^^^^ error: this type alias takes 0 generic arguments but 1 generic argument was supplied
+        "#,
+        );
+    }
+}

--- a/crates/ide-diagnostics/src/handlers/incorrect_generics_order.rs
+++ b/crates/ide-diagnostics/src/handlers/incorrect_generics_order.rs
@@ -1,0 +1,80 @@
+use crate::{Diagnostic, DiagnosticCode, DiagnosticsContext};
+use hir::GenericArgKind;
+use syntax::SyntaxKind;
+
+// Diagnostic: incorrect-generics-order
+//
+// This diagnostic is triggered the order of provided generic arguments does not match their declaration.
+pub(crate) fn incorrect_generics_order(
+    ctx: &DiagnosticsContext<'_>,
+    d: &hir::IncorrectGenericsOrder,
+) -> Diagnostic {
+    let provided_description = match d.provided_arg.value.kind() {
+        SyntaxKind::CONST_ARG => "constant",
+        SyntaxKind::LIFETIME_ARG => "lifetime",
+        SyntaxKind::TYPE_ARG => "type",
+        _ => panic!("non-generic-arg passed to `incorrect_generics_order()`"),
+    };
+    let expected_description = match d.expected_kind {
+        GenericArgKind::Lifetime => "lifetime",
+        GenericArgKind::Type => "type",
+        GenericArgKind::Const => "constant",
+    };
+    let message =
+        format!("{provided_description} provided when a {expected_description} was expected");
+    Diagnostic::new_with_syntax_node_ptr(
+        ctx,
+        DiagnosticCode::RustcHardError("E0747"),
+        message,
+        d.provided_arg.map(Into::into),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::tests::check_diagnostics;
+
+    #[test]
+    fn lifetime_out_of_order() {
+        check_diagnostics(
+            r#"
+struct Foo<'a, T>(&'a T);
+
+fn bar(_v: Foo<(), 'static>) {}
+            // ^^ error: type provided when a lifetime was expected
+        "#,
+        );
+    }
+
+    #[test]
+    fn types_and_consts() {
+        check_diagnostics(
+            r#"
+struct Foo<T>(T);
+fn foo1(_v: Foo<1>) {}
+             // ^ error: constant provided when a type was expected
+fn foo2(_v: Foo<{ (1, 2) }>) {}
+             // ^^^^^^^^^^ error: constant provided when a type was expected
+
+struct Bar<const N: usize>;
+fn bar(_v: Bar<()>) {}
+            // ^^ error: type provided when a constant was expected
+
+struct Baz<T, const N: usize>(T);
+fn baz(_v: Baz<1, ()>) {}
+            // ^ error: constant provided when a type was expected
+        "#,
+        );
+    }
+
+    #[test]
+    fn no_error_when_num_incorrect() {
+        check_diagnostics(
+            r#"
+struct Baz<T, U>(T, U);
+fn baz(_v: Baz<1>) {}
+           // ^^^ error: this struct takes 2 generic arguments but 1 generic argument was supplied
+        "#,
+        );
+    }
+}

--- a/crates/ide-diagnostics/src/lib.rs
+++ b/crates/ide-diagnostics/src/lib.rs
@@ -32,6 +32,8 @@ mod handlers {
     pub(crate) mod inactive_code;
     pub(crate) mod incoherent_impl;
     pub(crate) mod incorrect_case;
+    pub(crate) mod incorrect_generics_len;
+    pub(crate) mod incorrect_generics_order;
     pub(crate) mod invalid_cast;
     pub(crate) mod invalid_derive_target;
     pub(crate) mod macro_error;
@@ -499,6 +501,8 @@ pub fn semantic_diagnostics(
                 handlers::parenthesized_generic_args_without_fn_trait::parenthesized_generic_args_without_fn_trait(&ctx, &d)
             }
             AnyDiagnostic::BadRtn(d) => handlers::bad_rtn::bad_rtn(&ctx, &d),
+            AnyDiagnostic::IncorrectGenericsLen(d) => handlers::incorrect_generics_len::incorrect_generics_len(&ctx, &d),
+            AnyDiagnostic::IncorrectGenericsOrder(d) => handlers::incorrect_generics_order::incorrect_generics_order(&ctx, &d),
         };
         res.push(d)
     }

--- a/crates/test-utils/src/minicore.rs
+++ b/crates/test-utils/src/minicore.rs
@@ -1063,7 +1063,7 @@ pub mod cmp {
 // region:fmt
 pub mod fmt {
     pub struct Error;
-    pub type Result = Result<(), Error>;
+    pub type Result = crate::result::Result<(), Error>;
     pub struct Formatter<'a>;
     pub struct DebugTuple;
     pub struct DebugStruct;


### PR DESCRIPTION
Also known as E0747 and E0107.

And by the way, rewrite how we lower generic arguments and deduplicate it between paths and method calls. The new version is taken almost straight from rustc.

This commit also changes the binders of `generic_defaults()`, to only include the binders of the arguments up to (and not including) the current argument. This make it easier to handle it in the rewritten lowering of generic args. It's also how rustc does it.

This is a step towards https://github.com/rust-lang/rust-analyzer/issues/17590, the next step will be to add a quickfix to the count mismatch diagnostic that adds new parameters. Since this became somewhat big I separated the steps.