### PR TITLE
fix: Fix panic in progress due to splitting unicode incorrectly

### DIFF
--- a/crates/rust-analyzer/src/cli/progress_report.rs
+++ b/crates/rust-analyzer/src/cli/progress_report.rs
@@ -79,8 +79,8 @@ impl<'a> ProgressReport<'a> {
         // Backtrack to the first differing character
         let mut output = String::new();
         output += &'\x08'.to_string().repeat(self.text.len() - common_prefix_length);
-        // Output new suffix
-        output += &text[common_prefix_length..text.len()];
+        // Output new suffix, using chars() iter to ensure unicode compatibility
+        output.extend(text.chars().skip(common_prefix_length));
 
         // If the new text is shorter than the old one: delete overlapping characters
         if let Some(overlap_count) = self.text.len().checked_sub(text.len()) {


### PR DESCRIPTION
In the rare occasion that someone has added unicode characters that are multiple code points, the previous slicing operation could incorrectly split that character, and panic. The fix is to use the `chars()` iterator and just skip the prefix.