### PR TITLE
Avoid relying on `block_def_map()` needlessly

### DIFF
--- a/crates/hir-ty/src/chalk_db.rs
+++ b/crates/hir-ty/src/chalk_db.rs
@@ -553,7 +553,7 @@ impl ChalkContext<'_> {
 
         let block_impls = iter::successors(self.block, |&block_id| {
             cov_mark::hit!(block_local_impls);
-            self.db.block_def_map(block_id).parent().and_then(|module| module.containing_block())
+            block_id.loc(self.db).module.containing_block()
         })
         .inspect(|&block_id| {
             // make sure we don't search the same block twice


### PR DESCRIPTION
We can compute the wanted information from the block's interned data.