### PR TITLE
chore: Replace some `invoke`s with `invoke_actual` in hir-ty

### DIFF
--- a/crates/hir-ty/src/dyn_compatibility.rs
+++ b/crates/hir-ty/src/dyn_compatibility.rs
@@ -22,7 +22,7 @@ use crate::{
     from_assoc_type_id, from_chalk_trait_id,
     generics::{generics, trait_self_param_idx},
     lower::callable_item_sig,
-    to_assoc_type_id, to_chalk_trait_id,
+    to_chalk_trait_id,
     utils::elaborate_clause_supertraits,
 };
 
@@ -171,8 +171,7 @@ fn bounds_reference_self(db: &dyn HirDatabase, trait_: TraitId) -> bool {
         .iter()
         .filter_map(|(_, it)| match *it {
             AssocItemId::TypeAliasId(id) => {
-                let assoc_ty_id = to_assoc_type_id(id);
-                let assoc_ty_data = db.associated_ty_data(assoc_ty_id);
+                let assoc_ty_data = db.associated_ty_data(id);
                 Some(assoc_ty_data)
             }
             _ => None,

--- a/crates/hir-ty/src/infer/closure.rs
+++ b/crates/hir-ty/src/infer/closure.rs
@@ -31,7 +31,7 @@ use crate::{
     DynTyExt, FnAbi, FnPointer, FnSig, Interner, OpaqueTy, ProjectionTyExt, Substitution, Ty,
     TyExt, WhereClause,
     db::{HirDatabase, InternedClosure},
-    error_lifetime, from_chalk_trait_id, from_placeholder_idx,
+    error_lifetime, from_assoc_type_id, from_chalk_trait_id, from_placeholder_idx,
     generics::Generics,
     infer::coerce::CoerceNever,
     make_binders,
@@ -153,7 +153,8 @@ impl InferenceContext<'_> {
             if let WhereClause::AliasEq(AliasEq { alias: AliasTy::Projection(projection), ty }) =
                 bound.skip_binders()
             {
-                let assoc_data = self.db.associated_ty_data(projection.associated_ty_id);
+                let assoc_data =
+                    self.db.associated_ty_data(from_assoc_type_id(projection.associated_ty_id));
                 if !fn_traits.contains(&assoc_data.trait_id) {
                     return None;
                 }

--- a/crates/hir-ty/src/mir/borrowck.rs
+++ b/crates/hir-ty/src/mir/borrowck.rs
@@ -71,7 +71,7 @@ fn all_mir_bodies(
         c: ClosureId,
         cb: &mut impl FnMut(Arc<MirBody>),
     ) -> Result<(), MirLowerError> {
-        match db.mir_body_for_closure(c) {
+        match db.mir_body_for_closure(c.into()) {
             Ok(body) => {
                 cb(body.clone());
                 body.closures.iter().try_for_each(|&it| for_closure(db, it, cb))

--- a/crates/hir-ty/src/mir/eval.rs
+++ b/crates/hir-ty/src/mir/eval.rs
@@ -2452,7 +2452,7 @@ impl Evaluator<'_> {
         let mir_body = self
             .db
             .monomorphized_mir_body_for_closure(
-                closure,
+                closure.into(),
                 generic_args.clone(),
                 self.trait_env.clone(),
             )

--- a/crates/hir-ty/src/mir/monomorphization.rs
+++ b/crates/hir-ty/src/mir/monomorphization.rs
@@ -17,9 +17,9 @@ use hir_def::DefWithBodyId;
 use triomphe::Arc;
 
 use crate::{
-    ClosureId, Const, Interner, ProjectionTy, Substitution, TraitEnvironment, Ty, TyKind,
+    Const, Interner, ProjectionTy, Substitution, TraitEnvironment, Ty, TyKind,
     consteval::{intern_const_scalar, unknown_const},
-    db::{HirDatabase, HirDatabaseData, InternedClosure},
+    db::{HirDatabase, HirDatabaseData, InternedClosure, InternedClosureId},
     from_placeholder_idx,
     generics::{Generics, generics},
     infer::normalize,
@@ -326,11 +326,11 @@ pub(crate) fn monomorphized_mir_body_recover(
 
 pub fn monomorphized_mir_body_for_closure_query(
     db: &dyn HirDatabase,
-    closure: ClosureId,
+    closure: InternedClosureId,
     subst: Substitution,
     trait_env: Arc<crate::TraitEnvironment>,
 ) -> Result<Arc<MirBody>, MirLowerError> {
-    let InternedClosure(owner, _) = db.lookup_intern_closure(closure.into());
+    let InternedClosure(owner, _) = db.lookup_intern_closure(closure);
     let generics = owner.as_generic_def_id(db.upcast()).map(|g_def| generics(db.upcast(), g_def));
     let filler = &mut Filler { db, subst: &subst, trait_env, generics, owner };
     let body = db.mir_body_for_closure(closure)?;

--- a/crates/hir-ty/src/mir/pretty.rs
+++ b/crates/hir-ty/src/mir/pretty.rs
@@ -154,7 +154,7 @@ impl<'a> MirPrettyCtx<'a> {
     }
 
     fn for_closure(&mut self, closure: ClosureId) {
-        let body = match self.db.mir_body_for_closure(closure) {
+        let body = match self.db.mir_body_for_closure(closure.into()) {
             Ok(it) => it,
             Err(e) => {
                 wln!(self, "// error in {closure:?}: {e:?}");


### PR DESCRIPTION
None of these require to be interned to be re-exposed as salsa structs