### PR TITLE
fix: Fix a bug in macro-by-example matching

### DIFF
--- a/crates/hir-def/src/macro_expansion_tests/mbe.rs
+++ b/crates/hir-def/src/macro_expansion_tests/mbe.rs
@@ -1979,3 +1979,51 @@ fn f() {
 "#]],
     );
 }
+
+#[test]
+fn foo() {
+    check(
+        r#"
+macro_rules! bug {
+    ($id: expr) => {
+        true
+    };
+    ($id: expr; $($attr: ident),*) => {
+        true
+    };
+    ($id: expr; $($attr: ident),*; $norm: expr) => {
+        true
+    };
+    ($id: expr; $($attr: ident),*;; $print: expr) => {
+        true
+    };
+    ($id: expr; $($attr: ident),*; $norm: expr; $print: expr) => {
+        true
+    };
+}
+
+let _ = bug!(a;;;test);
+    "#,
+        expect![[r#"
+macro_rules! bug {
+    ($id: expr) => {
+        true
+    };
+    ($id: expr; $($attr: ident),*) => {
+        true
+    };
+    ($id: expr; $($attr: ident),*; $norm: expr) => {
+        true
+    };
+    ($id: expr; $($attr: ident),*;; $print: expr) => {
+        true
+    };
+    ($id: expr; $($attr: ident),*; $norm: expr; $print: expr) => {
+        true
+    };
+}
+
+let _ = true;
+    "#]],
+    );
+}

--- a/crates/mbe/src/expander/matcher.rs
+++ b/crates/mbe/src/expander/matcher.rs
@@ -65,7 +65,7 @@ use intern::{Symbol, sym};
 use smallvec::{SmallVec, smallvec};
 use span::{Edition, Span};
 use tt::{
-    DelimSpan,
+    DelimSpan, MAX_GLUED_PUNCT_LEN,
     iter::{TtElement, TtIter},
 };
 
@@ -558,7 +558,7 @@ fn match_loop_inner<'t>(
             }
             OpDelimited::Op(Op::Punct(lhs)) => {
                 let mut fork = src.clone();
-                let error = if let Ok(rhs) = fork.expect_glued_punct() {
+                let error = if let Ok(rhs) = fork.expect_glued_punct(lhs.len()) {
                     let first_is_single_quote = rhs[0].char == '\'';
                     let lhs = lhs.iter().map(|it| it.char);
                     let rhs_ = rhs.iter().map(|it| it.char);
@@ -955,7 +955,7 @@ fn expect_separator<S: Copy>(iter: &mut TtIter<'_, S>, separator: &Separator) ->
             },
             Err(_) => false,
         },
-        Separator::Puncts(lhs) => match fork.expect_glued_punct() {
+        Separator::Puncts(lhs) => match fork.expect_glued_punct(lhs.len()) {
             Ok(rhs) => {
                 let lhs = lhs.iter().map(|it| it.char);
                 let rhs = rhs.iter().map(|it| it.char);
@@ -975,7 +975,7 @@ fn expect_tt<S: Copy>(iter: &mut TtIter<'_, S>) -> Result<(), ()> {
         if punct.char == '\'' {
             expect_lifetime(iter)?;
         } else {
-            iter.expect_glued_punct()?;
+            iter.expect_glued_punct(MAX_GLUED_PUNCT_LEN)?;
         }
     } else {
         iter.next().ok_or(())?;

--- a/crates/mbe/src/parser.rs
+++ b/crates/mbe/src/parser.rs
@@ -6,7 +6,10 @@ use std::sync::Arc;
 use arrayvec::ArrayVec;
 use intern::{Symbol, sym};
 use span::{Edition, Span, SyntaxContext};
-use tt::iter::{TtElement, TtIter};
+use tt::{
+    MAX_GLUED_PUNCT_LEN,
+    iter::{TtElement, TtIter},
+};
 
 use crate::ParseError;
 
@@ -96,7 +99,7 @@ pub(crate) enum Op {
         delimiter: tt::Delimiter<Span>,
     },
     Literal(tt::Literal<Span>),
-    Punct(Box<ArrayVec<tt::Punct<Span>, 3>>),
+    Punct(Box<ArrayVec<tt::Punct<Span>, MAX_GLUED_PUNCT_LEN>>),
     Ident(tt::Ident<Span>),
 }
 
@@ -151,7 +154,7 @@ pub(crate) enum MetaVarKind {
 pub(crate) enum Separator {
     Literal(tt::Literal<Span>),
     Ident(tt::Ident<Span>),
-    Puncts(ArrayVec<tt::Punct<Span>, 3>),
+    Puncts(ArrayVec<tt::Punct<Span>, MAX_GLUED_PUNCT_LEN>),
 }
 
 // Note that when we compare a Separator, we just care about its textual value.
@@ -273,7 +276,7 @@ fn next_op(
 
         TtElement::Leaf(tt::Leaf::Punct(_)) => {
             // There's at least one punct so this shouldn't fail.
-            let puncts = src.expect_glued_punct().unwrap();
+            let puncts = src.expect_glued_punct(MAX_GLUED_PUNCT_LEN).unwrap();
             Op::Punct(Box::new(puncts))
         }
 

--- a/crates/tt/src/lib.rs
+++ b/crates/tt/src/lib.rs
@@ -22,6 +22,8 @@ use stdx::{impl_from, itertools::Itertools as _};
 
 pub use text_size::{TextRange, TextSize};
 
+pub const MAX_GLUED_PUNCT_LEN: usize = 3;
+
 #[derive(Clone, PartialEq, Debug)]
 pub struct Lit {
     pub kind: LitKind,


### PR DESCRIPTION
We always consumed the largest glued punct we could find, even when the template required less than that.

Fixes #19497.