### PR TITLE
fix(ide-assists): remove `AssistKind::None`

### DIFF
--- a/crates/ide-assists/src/handlers/toggle_ignore.rs
+++ b/crates/ide-assists/src/handlers/toggle_ignore.rs
@@ -30,13 +30,13 @@ pub(crate) fn toggle_ignore(acc: &mut Assists, ctx: &AssistContext<'_>) -> Optio
 
     match has_ignore_attribute(&func) {
         None => acc.add(
-            AssistId::none("toggle_ignore"),
+            AssistId::refactor("toggle_ignore"),
             "Ignore this test",
             attr.syntax().text_range(),
             |builder| builder.insert(attr.syntax().text_range().end(), "\n#[ignore]"),
         ),
         Some(ignore_attr) => acc.add(
-            AssistId::none("toggle_ignore"),
+            AssistId::refactor("toggle_ignore"),
             "Re-enable this test",
             ignore_attr.syntax().text_range(),
             |builder| {

--- a/crates/ide-db/src/assists.rs
+++ b/crates/ide-db/src/assists.rs
@@ -43,9 +43,6 @@ pub enum Command {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AssistKind {
-    // FIXME: does the None variant make sense? Probably not.
-    None,
-
     QuickFix,
     Generate,
     Refactor,
@@ -61,7 +58,7 @@ impl AssistKind {
         }
 
         match self {
-            AssistKind::None | AssistKind::Generate => true,
+            AssistKind::Generate => true,
             AssistKind::Refactor => matches!(
                 other,
                 AssistKind::RefactorExtract
@@ -74,7 +71,6 @@ impl AssistKind {
 
     pub fn name(&self) -> &str {
         match self {
-            AssistKind::None => "None",
             AssistKind::QuickFix => "QuickFix",
             AssistKind::Generate => "Generate",
             AssistKind::Refactor => "Refactor",
@@ -90,7 +86,6 @@ impl FromStr for AssistKind {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            "None" => Ok(AssistKind::None),
             "QuickFix" => Ok(AssistKind::QuickFix),
             "Generate" => Ok(AssistKind::Generate),
             "Refactor" => Ok(AssistKind::Refactor),
@@ -108,10 +103,6 @@ impl FromStr for AssistKind {
 pub struct AssistId(pub &'static str, pub AssistKind, pub Option<usize>);
 
 impl AssistId {
-    pub fn none(id: &'static str) -> AssistId {
-        AssistId(id, AssistKind::None, None)
-    }
-
     pub fn quick_fix(id: &'static str) -> AssistId {
         AssistId(id, AssistKind::QuickFix, None)
     }

--- a/crates/ide/src/lib.rs
+++ b/crates/ide/src/lib.rs
@@ -753,7 +753,7 @@ impl Analysis {
         frange: FileRange,
     ) -> Cancellable<Vec<Assist>> {
         let include_fixes = match &assist_config.allowed {
-            Some(it) => it.iter().any(|&it| it == AssistKind::None || it == AssistKind::QuickFix),
+            Some(it) => it.iter().any(|&it| it == AssistKind::QuickFix),
             None => true,
         };
 

--- a/crates/rust-analyzer/src/lsp/from_proto.rs
+++ b/crates/rust-analyzer/src/lsp/from_proto.rs
@@ -103,7 +103,6 @@ pub(crate) fn file_range_uri(
 
 pub(crate) fn assist_kind(kind: lsp_types::CodeActionKind) -> Option<AssistKind> {
     let assist_kind = match &kind {
-        k if k == &lsp_types::CodeActionKind::EMPTY => AssistKind::None,
         k if k == &lsp_types::CodeActionKind::QUICKFIX => AssistKind::QuickFix,
         k if k == &lsp_types::CodeActionKind::REFACTOR => AssistKind::Refactor,
         k if k == &lsp_types::CodeActionKind::REFACTOR_EXTRACT => AssistKind::RefactorExtract,

--- a/crates/rust-analyzer/src/lsp/to_proto.rs
+++ b/crates/rust-analyzer/src/lsp/to_proto.rs
@@ -1477,7 +1477,7 @@ pub(crate) fn call_hierarchy_item(
 
 pub(crate) fn code_action_kind(kind: AssistKind) -> lsp_types::CodeActionKind {
     match kind {
-        AssistKind::None | AssistKind::Generate => lsp_types::CodeActionKind::EMPTY,
+        AssistKind::Generate => lsp_types::CodeActionKind::EMPTY,
         AssistKind::QuickFix => lsp_types::CodeActionKind::QUICKFIX,
         AssistKind::Refactor => lsp_types::CodeActionKind::REFACTOR,
         AssistKind::RefactorExtract => lsp_types::CodeActionKind::REFACTOR_EXTRACT,


### PR DESCRIPTION
This was being used by a single assist, which qualifies under the "refactor" kind. The variant has been removed, and all usages updated accordingly.