### PR TITLE
Fix color brackets in string context

### DIFF
--- a/editors/code/language-configuration.json
+++ b/editors/code/language-configuration.json
@@ -14,9 +14,9 @@
         ["(", ")"]
     ],
     "autoClosingPairs": [
-        { "open": "{", "close": "}" },
-        { "open": "[", "close": "]" },
-        { "open": "(", "close": ")" },
+        { "open": "{", "close": "}", "notIn": ["string"] },
+        { "open": "[", "close": "]", "notIn": ["string"] },
+        { "open": "(", "close": ")", "notIn": ["string"] },
         { "open": "\"", "close": "\"", "notIn": ["string"] },
         { "open": "/*", "close": " */", "notIn": ["string"] },
         { "open": "`", "close": "`", "notIn": ["string"] },


### PR DESCRIPTION
before
![image](https://github.com/user-attachments/assets/7ba26f74-9d03-41af-a1ae-8f630d458e41)

after
![image](https://github.com/user-attachments/assets/3adbcb50-ab63-49fb-b101-aeed60bf16a6)
