### PR TITLE
feat(project-model): provide flag for no deps

### DIFF
--- a/crates/project-model/src/cargo_workspace.rs
+++ b/crates/project-model/src/cargo_workspace.rs
@@ -108,7 +108,10 @@ pub struct CargoConfig {
     pub invocation_strategy: InvocationStrategy,
     /// Optional path to use instead of `target` when building
     pub target_dir: Option<Utf8PathBuf>,
+    /// Gate `#[test]` behind `#[cfg(test)]`
     pub set_test: bool,
+    /// Load the project without any dependencies
+    pub no_deps: bool,
 }
 
 pub type Package = Idx<PackageData>;
@@ -308,6 +311,7 @@ impl CargoWorkspace {
         current_dir: &AbsPath,
         config: &CargoMetadataConfig,
         sysroot: &Sysroot,
+        no_deps: bool,
         locked: bool,
         progress: &dyn Fn(String),
     ) -> anyhow::Result<(cargo_metadata::Metadata, Option<anyhow::Error>)> {
@@ -316,8 +320,8 @@ impl CargoWorkspace {
             current_dir,
             config,
             sysroot,
+            no_deps,
             locked,
-            false,
             progress,
         );
         if let Ok((_, Some(ref e))) = res {
@@ -335,8 +339,8 @@ impl CargoWorkspace {
         current_dir: &AbsPath,
         config: &CargoMetadataConfig,
         sysroot: &Sysroot,
-        locked: bool,
         no_deps: bool,
+        locked: bool,
         progress: &dyn Fn(String),
     ) -> anyhow::Result<(cargo_metadata::Metadata, Option<anyhow::Error>)> {
         let cargo = sysroot.tool(Tool::Cargo, current_dir);

--- a/crates/project-model/src/sysroot.rs
+++ b/crates/project-model/src/sysroot.rs
@@ -300,6 +300,7 @@ impl Sysroot {
             rust_lib_src_dir,
             &cargo_config,
             self,
+            false,
             // Make sure we never attempt to write to the sysroot
             true,
             &|_| (),

--- a/crates/project-model/src/workspace.rs
+++ b/crates/project-model/src/workspace.rs
@@ -220,6 +220,7 @@ impl ProjectWorkspace {
             sysroot,
             sysroot_src,
             target,
+            no_deps,
             ..
         } = config;
         let mut sysroot = match (sysroot, sysroot_src) {
@@ -301,6 +302,7 @@ impl ProjectWorkspace {
                             extra_env: extra_env.clone(),
                         },
                         &sysroot,
+                        *no_deps,
                         false,
                         &|_| (),
                     ) {
@@ -343,6 +345,7 @@ impl ProjectWorkspace {
                         extra_env: extra_env.clone(),
                     },
                     &sysroot,
+                    *no_deps,
                     false,
                     &|_| (),
                 )
@@ -511,6 +514,7 @@ impl ProjectWorkspace {
                 extra_env: config.extra_env.clone(),
             },
             &sysroot,
+            config.no_deps,
             false,
             &|_| (),
         )

--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -609,6 +609,9 @@ config_data! {
         cargo_features: CargoFeaturesDef      = CargoFeaturesDef::Selected(vec![]),
         /// Whether to pass `--no-default-features` to cargo.
         cargo_noDefaultFeatures: bool    = false,
+        /// Whether to skip fetching dependencies. If set to "true", the analysis is performed
+        /// entirely offline, and Cargo metadata for dependencies is not fetched.
+        cargo_noDeps: bool = false,
         /// Relative path to the sysroot, or "discover" to try to automatically find it via
         /// "rustc --print sysroot".
         ///
@@ -2027,6 +2030,7 @@ impl Config {
             extra_env: self.cargo_extraEnv(source_root).clone(),
             target_dir: self.target_dir_from_config(source_root),
             set_test: *self.cfg_setTest(source_root),
+            no_deps: *self.cargo_noDeps(source_root),
         }
     }
 

--- a/docs/book/src/configuration_generated.md
+++ b/docs/book/src/configuration_generated.md
@@ -130,6 +130,12 @@ Set this to `"all"` to pass `--all-features` to cargo.
  Whether to pass `--no-default-features` to cargo.
 
 
+**rust-analyzer.cargo.noDeps** (default: false)
+
+ Whether to skip fetching dependencies. If set to "true", the analysis is performed
+entirely offline, and Cargo metadata for dependencies is not fetched.
+
+
 **rust-analyzer.cargo.sysroot** (default: "discover")
 
  Relative path to the sysroot, or "discover" to try to automatically find it via

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -894,6 +894,16 @@
             {
                 "title": "cargo",
                 "properties": {
+                    "rust-analyzer.cargo.noDeps": {
+                        "markdownDescription": "Whether to skip fetching dependencies. If set to \"true\", the analysis is performed\nentirely offline, and Cargo metadata for dependencies is not fetched.",
+                        "default": false,
+                        "type": "boolean"
+                    }
+                }
+            },
+            {
+                "title": "cargo",
+                "properties": {
                     "rust-analyzer.cargo.sysroot": {
                         "markdownDescription": "Relative path to the sysroot, or \"discover\" to try to automatically find it via\n\"rustc --print sysroot\".\n\nUnsetting this disables sysroot loading.\n\nThis option does not take effect until rust-analyzer is restarted.",
                         "default": "discover",


### PR DESCRIPTION
A Cargo project can now be built without any dependency metadata being fetched. This classifies as a breaking change for the `ra_ap_project_model` public API, since we introduce a new field into the config struct, and a new configuration option for the analyzer.

Fixes #19518 