### PR TITLE
ci: cancel parallel jobs if test fails

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -101,19 +101,31 @@ jobs:
       #       . -> target
       #       ./crates/proc-macro-srv/proc-macro-test/imp -> target
 
-      - uses: taiki-e/install-action@nextest
+      - name: Install nextest
+        uses: taiki-e/install-action@nextest
 
       - name: Codegen checks (rust-analyzer)
         if: matrix.os == 'ubuntu-latest'
         run: cargo codegen --check
 
-      - name: Compile (tests)
+      - name: Compile tests
         run: cargo test --no-run
 
-      - name: Test
+      - name: Run tests
         run: cargo nextest run --no-fail-fast --hide-progress-bar --status-level fail
 
-      - name: clippy
+      - name: Cancel parallel jobs
+        if: failure()
+        run: |
+          # https://docs.github.com/en/rest/actions/workflow-runs?apiVersion=2022-11-28#cancel-a-workflow-run
+          curl -L \
+          -X POST \
+          -H "Accept: application/vnd.github.v3+json" \
+          -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/cancel
+
+      - name: Run Clippy
         if: matrix.os == 'macos-latest'
         run: cargo clippy --all-targets -- -D clippy::disallowed_macros -D clippy::dbg_macro -D clippy::todo -D clippy::print_stdout -D clippy::print_stderr
 


### PR DESCRIPTION
The analysis-stats job takes ~12m to run. This will run even if the tests fail - it's wasted CI minutes. Instead, we can short-circuit the entire workflow if the tests fail.