### PR TITLE
internal: fix panic in `view_crate_graph`

### DIFF
--- a/crates/ide/src/view_crate_graph.rs
+++ b/crates/ide/src/view_crate_graph.rs
@@ -1,4 +1,5 @@
 use dot::{Id, LabelText};
+use ide_db::base_db::salsa::plumbing::AsId;
 use ide_db::{
     FxHashMap, RootDatabase,
     base_db::{
@@ -78,7 +79,8 @@ impl<'a> dot::Labeller<'a, Crate, Edge<'a>> for DotCrateGraph<'_> {
     }
 
     fn node_id(&'a self, n: &Crate) -> Id<'a> {
-        Id::new(format!("_{:?}", n)).unwrap()
+        let id = n.as_id().as_u32();
+        Id::new(format!("_{:?}", id)).unwrap()
     }
 
     fn node_shape(&'a self, _node: &Crate) -> Option<LabelText<'a>> {


### PR DESCRIPTION
Small fix, but the `dot` crate does not like the default symbols included in `Debug` output like `[`. This fixes a panic.