### PR TITLE
internal: ensure a Salsa-ified crate graph works with project discovery

### DIFF
--- a/crates/hir-expand/src/lib.rs
+++ b/crates/hir-expand/src/lib.rs
@@ -208,7 +208,8 @@ impl ExpandErrorKind {
                     },
                     None => RenderedExpandError {
                         message: format!(
-                            "internal error: proc-macro map is missing error entry for crate {def_crate:?}"
+                            "internal error: proc-macro map is missing error entry for crate {:?}",
+                            def_crate
                         ),
                         error: true,
                         kind: RenderedExpandError::GENERAL_KIND,


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust-analyzer/issues/19489.

The main part of this this change is going from a `self.proc_macro_clients.is_empty()` check to a `self.proc_macro_clients.len() < self.workspaces.len()`. I also rewrote some iterator combinators in favor of two `for`  loops and two `match` statements because I had difficulty understanding the code.