### PR TITLE
The rustdoc file prefix for constants is "constant" not "const"

### DIFF
--- a/crates/ide/src/doc_links.rs
+++ b/crates/ide/src/doc_links.rs
@@ -627,7 +627,7 @@ fn filename_and_frag_for_def(
             return Some((def, file, Some(format!("variant.{}", ev.name(db).as_str()))));
         }
         Definition::Const(c) => {
-            format!("const.{}.html", c.name(db)?.as_str())
+            format!("constant.{}.html", c.name(db)?.as_str())
         }
         Definition::Static(s) => {
             format!("static.{}.html", s.name(db).as_str())


### PR DESCRIPTION
equivalent to https://github.com/rust-lang/rust/pull/139405, not sure which one is the source of truth