### PR TITLE
chore: Cancel analysis-stats job when rust job fails

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -81,6 +81,8 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
+      - run: exit 1
+
       - name: Install Rust toolchain
         run: |
           rustup update --no-self-update stable
@@ -116,6 +118,10 @@ jobs:
       - name: clippy
         if: matrix.os == 'macos-latest'
         run: cargo clippy --all-targets -- -D clippy::disallowed_macros -D clippy::dbg_macro -D clippy::todo -D clippy::print_stdout -D clippy::print_stderr
+
+      - if: failure()
+        run: |
+          curl -X POST -H "Accept: application/vnd.github.v3+json" -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" -H "X-GitHub-Api-Version: 2022-11-28" https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs/analysis-stats/cancel
 
   analysis-stats:
     if: github.repository == 'rust-lang/rust-analyzer'


### PR DESCRIPTION
Tries to do what https://github.com/rust-lang/rust-analyzer/pull/19521/ does but more fine-grained and without an action dependency