### PR TITLE
refactor: Turn `LifetimeRef` into an enum

### DIFF
--- a/crates/hir-def/src/expr_store/lower/generics.rs
+++ b/crates/hir-def/src/expr_store/lower/generics.rs
@@ -123,12 +123,14 @@ impl<'db, 'c> GenericParamsCollector<'db, 'c> {
                 ast::GenericParam::LifetimeParam(lifetime_param) => {
                     let lifetime_ref =
                         self.expr_collector.lower_lifetime_ref_opt(lifetime_param.lifetime());
-                    let param = LifetimeParamData { name: lifetime_ref.name.clone() };
-                    let _idx = self.lifetimes.alloc(param);
-                    self.lower_bounds(
-                        lifetime_param.type_bound_list(),
-                        Either::Right(lifetime_ref),
-                    );
+                    if let LifetimeRef::Named(name) = &lifetime_ref {
+                        let param = LifetimeParamData { name: name.clone() };
+                        let _idx = self.lifetimes.alloc(param);
+                        self.lower_bounds(
+                            lifetime_param.type_bound_list(),
+                            Either::Right(lifetime_ref),
+                        );
+                    }
                 }
             }
         }
@@ -151,7 +153,7 @@ impl<'db, 'c> GenericParamsCollector<'db, 'c> {
                     .map(|lifetime_param| {
                         lifetime_param
                             .lifetime()
-                            .map_or_else(Name::missing, |lt| Name::new_lifetime(&lt))
+                            .map_or_else(Name::missing, |lt| Name::new_lifetime(&lt.text()))
                     })
                     .collect()
             });

--- a/crates/hir-def/src/hir/type_ref.rs
+++ b/crates/hir-def/src/hir/type_ref.rs
@@ -6,7 +6,6 @@ use std::fmt::Write;
 use hir_expand::name::Name;
 use intern::Symbol;
 use la_arena::Idx;
-use syntax::ast;
 use thin_vec::ThinVec;
 
 use crate::{
@@ -145,18 +144,11 @@ const _: () = assert!(size_of::<TypeRef>() == 16);
 pub type TypeRefId = Idx<TypeRef>;
 
 #[derive(Clone, PartialEq, Eq, Hash, Debug)]
-pub struct LifetimeRef {
-    pub name: Name,
-}
-
-impl LifetimeRef {
-    pub(crate) fn new(lifetime: &ast::Lifetime) -> Self {
-        LifetimeRef { name: Name::new_lifetime(lifetime) }
-    }
-
-    pub fn missing() -> LifetimeRef {
-        LifetimeRef { name: Name::missing() }
-    }
+pub enum LifetimeRef {
+    Named(Name),
+    Static,
+    Placeholder,
+    Error,
 }
 
 #[derive(Clone, PartialEq, Eq, Hash, Debug)]

--- a/crates/hir-def/src/resolver.rs
+++ b/crates/hir-def/src/resolver.rs
@@ -501,16 +501,16 @@ impl Resolver {
     }
 
     pub fn resolve_lifetime(&self, lifetime: &LifetimeRef) -> Option<LifetimeNs> {
-        if lifetime.name == sym::tick_static.clone() {
-            return Some(LifetimeNs::Static);
+        match lifetime {
+            LifetimeRef::Static => Some(LifetimeNs::Static),
+            LifetimeRef::Named(name) => self.scopes().find_map(|scope| match scope {
+                Scope::GenericParams { def, params } => {
+                    params.find_lifetime_by_name(name, *def).map(LifetimeNs::LifetimeParam)
+                }
+                _ => None,
+            }),
+            LifetimeRef::Placeholder | LifetimeRef::Error => None,
         }
-
-        self.scopes().find_map(|scope| match scope {
-            Scope::GenericParams { def, params } => {
-                params.find_lifetime_by_name(&lifetime.name, *def).map(LifetimeNs::LifetimeParam)
-            }
-            _ => None,
-        })
     }
 
     /// Returns a set of names available in the current scope.

--- a/crates/hir-expand/src/name.rs
+++ b/crates/hir-expand/src/name.rs
@@ -114,11 +114,10 @@ impl Name {
         Name { symbol, ctx: () }
     }
 
-    pub fn new_lifetime(lt: &ast::Lifetime) -> Name {
-        let text = lt.text();
-        match text.strip_prefix("'r#") {
-            Some(text) => Self::new_text(&format_smolstr!("'{text}")),
-            None => Self::new_text(text.as_str()),
+    pub fn new_lifetime(lt: &str) -> Name {
+        match lt.strip_prefix("'r#") {
+            Some(lt) => Self::new_text(&format_smolstr!("'{lt}")),
+            None => Self::new_text(lt),
         }
     }
 

--- a/crates/hir/src/display.rs
+++ b/crates/hir/src/display.rs
@@ -213,7 +213,8 @@ impl HirDisplay for SelfParam {
             {
                 f.write_char('&')?;
                 if let Some(lifetime) = &ref_.lifetime {
-                    write!(f, "{} ", lifetime.name.display(f.db.upcast(), f.edition()))?;
+                    lifetime.hir_fmt(f, &data.store)?;
+                    f.write_char(' ')?;
                 }
                 if let hir_def::type_ref::Mutability::Mut = ref_.mutability {
                     f.write_str("mut ")?;
@@ -685,9 +686,9 @@ fn write_where_predicates(
                 bound.hir_fmt(f, store)?;
             }
             Lifetime { target, bound } => {
-                let target = target.name.display(f.db.upcast(), f.edition());
-                let bound = bound.name.display(f.db.upcast(), f.edition());
-                write!(f, "{target}: {bound}")?;
+                target.hir_fmt(f, store)?;
+                write!(f, ": ")?;
+                bound.hir_fmt(f, store)?;
             }
             ForLifetime { lifetimes, target, bound } => {
                 let lifetimes =
@@ -703,9 +704,7 @@ fn write_where_predicates(
             f.write_str(" + ")?;
             match nxt {
                 TypeBound { bound, .. } | ForLifetime { bound, .. } => bound.hir_fmt(f, store)?,
-                Lifetime { bound, .. } => {
-                    write!(f, "{}", bound.name.display(f.db.upcast(), f.edition()))?
-                }
+                Lifetime { bound, .. } => bound.hir_fmt(f, store)?,
             }
         }
         f.write_str(",")?;


### PR DESCRIPTION
This makes things more structured