### PR TITLE
internal: rename `children_modules` to `child_modules`

### DIFF
--- a/crates/ide/src/child_modules.rs
+++ b/crates/ide/src/child_modules.rs
@@ -7,16 +7,16 @@ use syntax::{
 
 use crate::NavigationTarget;
 
-// Feature: Children Modules
+// Feature: Child Modules
 //
-// Navigates to the children modules of the current module.
+// Navigates to the child modules of the current module.
 //
 // | Editor  | Action Name |
 // |---------|-------------|
-// | VS Code | **rust-analyzer: Locate children modules** |
+// | VS Code | **rust-analyzer: Locate child modules** |
 
 /// This returns `Vec` because a module may be included from several places.
-pub(crate) fn children_modules(db: &RootDatabase, position: FilePosition) -> Vec<NavigationTarget> {
+pub(crate) fn child_modules(db: &RootDatabase, position: FilePosition) -> Vec<NavigationTarget> {
     let sema = Semantics::new(db);
     let source_file = sema.parse_guess_edition(position.file_id);
     // First go to the parent module which contains the cursor
@@ -24,7 +24,7 @@ pub(crate) fn children_modules(db: &RootDatabase, position: FilePosition) -> Vec
 
     match module {
         Some(module) => {
-            // Return all the children module inside the ItemList of the parent module
+            // Return all child modules inside the ItemList of the parent module
             sema.to_def(&module)
                 .into_iter()
                 .flat_map(|module| module.children(db))
@@ -32,7 +32,7 @@ pub(crate) fn children_modules(db: &RootDatabase, position: FilePosition) -> Vec
                 .collect()
         }
         None => {
-            // Return all the children module inside the source file
+            // Return all the child modules inside the source file
             sema.file_to_module_defs(position.file_id)
                 .flat_map(|module| module.children(db))
                 .map(|module| NavigationTarget::from_module_to_decl(db, module).call_site())
@@ -47,9 +47,9 @@ mod tests {
 
     use crate::fixture;
 
-    fn check_children_module(#[rust_analyzer::rust_fixture] ra_fixture: &str) {
+    fn check_child_module(#[rust_analyzer::rust_fixture] ra_fixture: &str) {
         let (analysis, position, expected) = fixture::annotations(ra_fixture);
-        let navs = analysis.children_modules(position).unwrap();
+        let navs = analysis.child_modules(position).unwrap();
         let navs = navs
             .iter()
             .map(|nav| FileRange { file_id: nav.file_id, range: nav.focus_or_full_range() })
@@ -58,8 +58,8 @@ mod tests {
     }
 
     #[test]
-    fn test_resolve_children_module() {
-        check_children_module(
+    fn test_resolve_child_module() {
+        check_child_module(
             r#"
 //- /lib.rs
 $0
@@ -73,8 +73,8 @@ mod foo;
     }
 
     #[test]
-    fn test_resolve_children_module_on_module_decl() {
-        check_children_module(
+    fn test_resolve_child_module_on_module_decl() {
+        check_child_module(
             r#"
 //- /lib.rs
 mod $0foo;
@@ -89,8 +89,8 @@ mod bar;
     }
 
     #[test]
-    fn test_resolve_children_module_for_inline() {
-        check_children_module(
+    fn test_resolve_child_module_for_inline() {
+        check_child_module(
             r#"
 //- /lib.rs
 mod foo {
@@ -104,7 +104,7 @@ mod foo {
 
     #[test]
     fn test_resolve_multi_child_module() {
-        check_children_module(
+        check_child_module(
             r#"
 //- /main.rs
 $0

--- a/crates/ide/src/lib.rs
+++ b/crates/ide/src/lib.rs
@@ -20,7 +20,7 @@ mod navigation_target;
 
 mod annotations;
 mod call_hierarchy;
-mod children_modules;
+mod child_modules;
 mod doc_links;
 mod expand_macro;
 mod extend_selection;
@@ -607,8 +607,8 @@ impl Analysis {
     }
 
     /// Returns vec of `mod name;` declaration which are created by the current module.
-    pub fn children_modules(&self, position: FilePosition) -> Cancellable<Vec<NavigationTarget>> {
-        self.with_db(|db| children_modules::children_modules(db, position))
+    pub fn child_modules(&self, position: FilePosition) -> Cancellable<Vec<NavigationTarget>> {
+        self.with_db(|db| child_modules::child_modules(db, position))
     }
 
     /// Returns crates that this file belongs to.

--- a/crates/rust-analyzer/src/handlers/request.rs
+++ b/crates/rust-analyzer/src/handlers/request.rs
@@ -943,14 +943,14 @@ pub(crate) fn handle_parent_module(
     Ok(Some(res))
 }
 
-pub(crate) fn handle_children_modules(
+pub(crate) fn handle_child_modules(
     snap: GlobalStateSnapshot,
     params: lsp_types::TextDocumentPositionParams,
 ) -> anyhow::Result<Option<lsp_types::GotoDefinitionResponse>> {
-    let _p = tracing::info_span!("handle_children_module").entered();
-    // locate children module by semantics
+    let _p = tracing::info_span!("handle_child_modules").entered();
+    // locate child module by semantics
     let position = try_default!(from_proto::file_position(&snap, params)?);
-    let navs = snap.analysis.children_modules(position)?;
+    let navs = snap.analysis.child_modules(position)?;
     let res = to_proto::goto_definition_response(&snap, None, navs)?;
     Ok(Some(res))
 }

--- a/crates/rust-analyzer/src/lsp/capabilities.rs
+++ b/crates/rust-analyzer/src/lsp/capabilities.rs
@@ -157,7 +157,7 @@ pub fn server_capabilities(config: &Config) -> ServerCapabilities {
             "onEnter": true,
             "openCargoToml": true,
             "parentModule": true,
-            "childrenModules": true,
+            "childModules": true,
             "runnables": {
                 "kinds": [ "cargo" ],
             },

--- a/crates/rust-analyzer/src/lsp/ext.rs
+++ b/crates/rust-analyzer/src/lsp/ext.rs
@@ -399,12 +399,12 @@ impl Request for ParentModule {
     const METHOD: &'static str = "experimental/parentModule";
 }
 
-pub enum ChildrenModules {}
+pub enum ChildModules {}
 
-impl Request for ChildrenModules {
+impl Request for ChildModules {
     type Params = lsp_types::TextDocumentPositionParams;
     type Result = Option<lsp_types::GotoDefinitionResponse>;
-    const METHOD: &'static str = "experimental/childrenModule";
+    const METHOD: &'static str = "experimental/childModules";
 }
 
 pub enum JoinLines {}

--- a/crates/rust-analyzer/src/main_loop.rs
+++ b/crates/rust-analyzer/src/main_loop.rs
@@ -1172,7 +1172,7 @@ impl GlobalState {
             .on::<NO_RETRY, lsp_ext::InterpretFunction>(handlers::handle_interpret_function)
             .on::<NO_RETRY, lsp_ext::ExpandMacro>(handlers::handle_expand_macro)
             .on::<NO_RETRY, lsp_ext::ParentModule>(handlers::handle_parent_module)
-            .on::<NO_RETRY, lsp_ext::ChildrenModules>(handlers::handle_children_modules)
+            .on::<NO_RETRY, lsp_ext::ChildModules>(handlers::handle_child_modules)
             .on::<NO_RETRY, lsp_ext::Runnables>(handlers::handle_runnables)
             .on::<NO_RETRY, lsp_ext::RelatedTests>(handlers::handle_related_tests)
             .on::<NO_RETRY, lsp_ext::CodeActionRequest>(handlers::handle_code_action)

--- a/docs/book/src/contributing/lsp-extensions.md
+++ b/docs/book/src/contributing/lsp-extensions.md
@@ -1,5 +1,5 @@
 <!---
-lsp/ext.rs hash: 300b4be5841cee6f
+lsp/ext.rs hash: 78e87a78de8f288e
 
 If you need to change the above hash to make the test pass, please check if you
 need to adjust this doc as well and ping this issue:

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -171,8 +171,8 @@
                 "category": "rust-analyzer"
             },
             {
-                "command": "rust-analyzer.childrenModules",
-                "title": "Locate children modules",
+                "command": "rust-analyzer.childModules",
+                "title": "Locate child modules",
                 "category": "rust-analyzer"
             },
             {
@@ -3379,7 +3379,7 @@
                     "when": "inRustProject"
                 },
                 {
-                    "command": "rust-analyzer.childrenModule",
+                    "command": "rust-analyzer.childModules",
                     "when": "inRustProject"
                 },
                 {

--- a/editors/code/src/commands.ts
+++ b/editors/code/src/commands.ts
@@ -266,7 +266,7 @@ export function parentModule(ctx: CtxInit): Cmd {
     };
 }
 
-export function childrenModules(ctx: CtxInit): Cmd {
+export function childModules(ctx: CtxInit): Cmd {
     return async () => {
         const editor = vscode.window.activeTextEditor;
         if (!editor) return;
@@ -274,7 +274,7 @@ export function childrenModules(ctx: CtxInit): Cmd {
 
         const client = ctx.client;
 
-        const locations = await client.sendRequest(ra.childrenModules, {
+        const locations = await client.sendRequest(ra.childModules, {
             textDocument: client.code2ProtocolConverter.asTextDocumentIdentifier(editor.document),
             position: client.code2ProtocolConverter.asPosition(editor.selection.active),
         });

--- a/editors/code/src/lsp_ext.ts
+++ b/editors/code/src/lsp_ext.ts
@@ -194,11 +194,11 @@ export const parentModule = new lc.RequestType<
     lc.LocationLink[] | null,
     void
 >("experimental/parentModule");
-export const childrenModules = new lc.RequestType<
+export const childModules = new lc.RequestType<
     lc.TextDocumentPositionParams,
     lc.LocationLink[] | null,
     void
->("experimental/childrenModule");
+>("experimental/childModules");
 export const runnables = new lc.RequestType<RunnablesParams, Runnable[], void>(
     "experimental/runnables",
 );

--- a/editors/code/src/main.ts
+++ b/editors/code/src/main.ts
@@ -158,7 +158,7 @@ function createCommands(): Record<string, CommandFactory> {
         matchingBrace: { enabled: commands.matchingBrace },
         joinLines: { enabled: commands.joinLines },
         parentModule: { enabled: commands.parentModule },
-        childrenModules: { enabled: commands.childrenModules },
+        childModules: { enabled: commands.childModules },
         viewHir: { enabled: commands.viewHir },
         viewMir: { enabled: commands.viewMir },
         interpretFunction: { enabled: commands.interpretFunction },
@@ -188,7 +188,9 @@ function createCommands(): Record<string, CommandFactory> {
         openWalkthrough: { enabled: commands.openWalkthrough },
         // Internal commands which are invoked by the server.
         applyActionGroup: { enabled: commands.applyActionGroup },
-        applySnippetWorkspaceEdit: { enabled: commands.applySnippetWorkspaceEditCommand },
+        applySnippetWorkspaceEdit: {
+            enabled: commands.applySnippetWorkspaceEditCommand,
+        },
         debugSingle: { enabled: commands.debugSingle },
         gotoLocation: { enabled: commands.gotoLocation },
         hoverRefCommandProxy: { enabled: commands.hoverRefCommandProxy },
@@ -201,8 +203,12 @@ function createCommands(): Record<string, CommandFactory> {
         revealDependency: { enabled: commands.revealDependency },
         syntaxTreeReveal: { enabled: commands.syntaxTreeReveal },
         syntaxTreeCopy: { enabled: commands.syntaxTreeCopy },
-        syntaxTreeHideWhitespace: { enabled: commands.syntaxTreeHideWhitespace },
-        syntaxTreeShowWhitespace: { enabled: commands.syntaxTreeShowWhitespace },
+        syntaxTreeHideWhitespace: {
+            enabled: commands.syntaxTreeHideWhitespace,
+        },
+        syntaxTreeShowWhitespace: {
+            enabled: commands.syntaxTreeShowWhitespace,
+        },
     };
 }
 


### PR DESCRIPTION
I think that "child modules" reads a bit more nicely than "children modules".