### PR TITLE
Enable `[canonicalize-issue-links]` and `[no-mentions]` in triagebot

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -21,3 +21,9 @@ exclude_titles = [ # exclude syncs from subtree in rust-lang/rust
 labels = ["has-merge-commits", "S-waiting-on-author"]
 
 [transfer]
+
+# Canonicalize issue numbers to avoid closing the wrong issue when upstreaming this subtree
+[canonicalize-issue-links]
+
+# Prevents mentions in commits to avoid users being spammed
+[no-mentions]


### PR DESCRIPTION
This PR enables two new triagebot feature `[canonicalize-issue-links]` and `[no-mentions]`.

Documentation at https://forge.rust-lang.org/triagebot/canonicalize-issue-links.html and https://forge.rust-lang.org/triagebot/no-mentions.html.