### PR TITLE
fix: Fix a small bug with catastrophic effects

### DIFF
--- a/crates/hir-def/src/signatures.rs
+++ b/crates/hir-def/src/signatures.rs
@@ -503,7 +503,7 @@ bitflags! {
         /// it if needed.
         const HAS_TARGET_FEATURE = 1 << 8;
         const DEPRECATED_SAFE_2024 = 1 << 9;
-        const RUSTC_ALLOW_INCOHERENT_IMPLS = 1 << 9;
+        const RUSTC_ALLOW_INCOHERENT_IMPLS = 1 << 10;
     }
 }
 


### PR DESCRIPTION
The tiny bug was that `FnFlags::DEPRECTAED_SAFE_2024` and `FnFlags::RUSTC_ALLOW_INCOHERENT_IMPLS` were assigned the same value.

The catastrophic effect was that every function marked as `#[rustc_allow_incoherent_impl]` was considered safe-deprecated for edition 2024, which caused it to be considered unsafe to call when called from edition 2024. And that includes `<[_]>::into_vec()`, which is called by the `vec![]` macro. So, catastrophic effect.

This innocent-looking bug probably arose from the item tree rewrite. No review would've catch that!

Fixes #19557.