### PR TITLE
internal: Switch to Rust 1.86.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["crates/proc-macro-srv/proc-macro-test/imp"]
 resolver = "2"
 
 [workspace.package]
-rust-version = "1.85"
+rust-version = "1.86"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["rust-analyzer team"]

--- a/crates/base-db/src/lib.rs
+++ b/crates/base-db/src/lib.rs
@@ -43,10 +43,6 @@ macro_rules! impl_intern_key {
     };
 }
 
-pub trait Upcast<T: ?Sized> {
-    fn upcast(&self) -> &T;
-}
-
 pub const DEFAULT_FILE_TEXT_LRU_CAP: u16 = 16;
 pub const DEFAULT_PARSE_LRU_CAP: u16 = 128;
 pub const DEFAULT_BORROWCK_LRU_CAP: u16 = 2024;

--- a/crates/hir-def/src/attr.rs
+++ b/crates/hir-def/src/attr.rs
@@ -46,7 +46,7 @@ impl Attrs {
     }
 
     pub(crate) fn filter(db: &dyn DefDatabase, krate: Crate, raw_attrs: RawAttrs) -> Attrs {
-        Attrs(raw_attrs.filter(db.upcast(), krate))
+        Attrs(raw_attrs.filter(db, krate))
     }
 }
 
@@ -507,7 +507,7 @@ impl AttrsWithOwner {
                     // FIXME: We should be never getting `None` here.
                     match src.value.get(it.local_id()) {
                         Some(val) => RawAttrs::from_attrs_owner(
-                            db.upcast(),
+                            db,
                             src.with_value(val),
                             db.span_map(src.file_id).as_ref(),
                         ),
@@ -519,7 +519,7 @@ impl AttrsWithOwner {
                     // FIXME: We should be never getting `None` here.
                     match src.value.get(it.local_id()) {
                         Some(val) => RawAttrs::from_attrs_owner(
-                            db.upcast(),
+                            db,
                             src.with_value(val),
                             db.span_map(src.file_id).as_ref(),
                         ),
@@ -531,7 +531,7 @@ impl AttrsWithOwner {
                     // FIXME: We should be never getting `None` here.
                     match src.value.get(it.local_id) {
                         Some(val) => RawAttrs::from_attrs_owner(
-                            db.upcast(),
+                            db,
                             src.with_value(val),
                             db.span_map(src.file_id).as_ref(),
                         ),
@@ -544,7 +544,7 @@ impl AttrsWithOwner {
             AttrDefId::UseId(it) => attrs_from_item_tree_loc(db, it),
         };
 
-        let attrs = raw_attrs.filter(db.upcast(), def.krate(db));
+        let attrs = raw_attrs.filter(db, def.krate(db));
         Attrs(attrs)
     }
 

--- a/crates/hir-def/src/db.rs
+++ b/crates/hir-def/src/db.rs
@@ -1,5 +1,5 @@
 //! Defines database & queries for name resolution.
-use base_db::{Crate, RootQueryDb, SourceDatabase, Upcast};
+use base_db::{Crate, RootQueryDb, SourceDatabase};
 use either::Either;
 use hir_expand::{HirFileId, MacroDefId, db::ExpandDatabase};
 use intern::sym;
@@ -100,13 +100,7 @@ pub trait InternDatabase: RootQueryDb {
 }
 
 #[query_group::query_group]
-pub trait DefDatabase:
-    InternDatabase
-    + ExpandDatabase
-    + SourceDatabase
-    + Upcast<dyn ExpandDatabase>
-    + Upcast<dyn RootQueryDb>
-{
+pub trait DefDatabase: InternDatabase + ExpandDatabase + SourceDatabase {
     /// Whether to expand procedural macros during name resolution.
     #[salsa::input]
     fn expand_proc_attr_macros(&self) -> bool;
@@ -381,7 +375,7 @@ fn include_macro_invoc(
         .flat_map(|m| m.scope.iter_macro_invoc())
         .filter_map(|invoc| {
             db.lookup_intern_macro_call(*invoc.1)
-                .include_file_id(db.upcast(), *invoc.1)
+                .include_file_id(db, *invoc.1)
                 .map(|x| (*invoc.1, x))
         })
         .collect()

--- a/crates/hir-def/src/expr_store/expander.rs
+++ b/crates/hir-def/src/expr_store/expander.rs
@@ -72,7 +72,7 @@ impl Expander {
         krate: Crate,
         has_attrs: &dyn HasAttrs,
     ) -> Attrs {
-        Attrs::filter(db, krate, RawAttrs::new(db.upcast(), has_attrs, self.span_map.as_ref()))
+        Attrs::filter(db, krate, RawAttrs::new(db, has_attrs, self.span_map.as_ref()))
     }
 
     pub(super) fn is_cfg_enabled(
@@ -103,7 +103,7 @@ impl Expander {
         let result = self.within_limit(db, |this| {
             let macro_call = this.in_file(&macro_call);
             match macro_call.as_call_id_with_errors(
-                db.upcast(),
+                db,
                 krate,
                 |path| resolver(path).map(|it| db.macro_def(it)),
                 eager_callback,
@@ -178,7 +178,7 @@ impl Expander {
             self.recursion_depth = u32::MAX;
             cov_mark::hit!(your_stack_belongs_to_me);
             return ExpandResult::only_err(ExpandError::new(
-                db.macro_arg_considering_derives(call_id, &call_id.lookup(db.upcast()).kind).2,
+                db.macro_arg_considering_derives(call_id, &call_id.lookup(db).kind).2,
                 ExpandErrorKind::RecursionOverflow,
             ));
         }

--- a/crates/hir-def/src/expr_store/lower/path.rs
+++ b/crates/hir-def/src/expr_store/lower/path.rs
@@ -78,7 +78,7 @@ pub(super) fn lower_path(
                         return None;
                     }
                     break kind = resolve_crate_root(
-                        collector.db.upcast(),
+                        collector.db,
                         collector.expander.ctx_for_range(name_ref.syntax().text_range()),
                     )
                     .map(PathKind::DollarCrate)
@@ -216,7 +216,7 @@ pub(super) fn lower_path(
             let syn_ctxt = collector.expander.ctx_for_range(path.segment()?.syntax().text_range());
             if let Some(macro_call_id) = syn_ctxt.outer_expn(collector.db) {
                 if collector.db.lookup_intern_macro_call(macro_call_id).def.local_inner {
-                    kind = match resolve_crate_root(collector.db.upcast(), syn_ctxt) {
+                    kind = match resolve_crate_root(collector.db, syn_ctxt) {
                         Some(crate_root) => PathKind::DollarCrate(crate_root),
                         None => PathKind::Crate,
                     }

--- a/crates/hir-def/src/import_map.rs
+++ b/crates/hir-def/src/import_map.rs
@@ -68,12 +68,7 @@ impl ImportMap {
         for (k, v) in self.item_to_info_map.iter() {
             format_to!(out, "{:?} ({:?}) -> ", k, v.1);
             for v in &v.0 {
-                format_to!(
-                    out,
-                    "{}:{:?}, ",
-                    v.name.display(db.upcast(), Edition::CURRENT),
-                    v.container
-                );
+                format_to!(out, "{}:{:?}, ", v.name.display(db, Edition::CURRENT), v.container);
             }
             format_to!(out, "\n");
         }
@@ -483,7 +478,7 @@ fn search_maps(
 
 #[cfg(test)]
 mod tests {
-    use base_db::{RootQueryDb, Upcast};
+    use base_db::RootQueryDb;
     use expect_test::{Expect, expect};
     use test_fixture::WithFixture;
 
@@ -533,10 +528,10 @@ mod tests {
             })
             .expect("could not find crate");
 
-        let actual = search_dependencies(db.upcast(), krate, &query)
+        let actual = search_dependencies(&db, krate, &query)
             .into_iter()
             .filter_map(|(dependency, _)| {
-                let dependency_krate = dependency.krate(db.upcast())?;
+                let dependency_krate = dependency.krate(&db)?;
                 let dependency_imports = db.import_map(dependency_krate);
 
                 let (path, mark) = match assoc_item_path(&db, &dependency_imports, dependency) {
@@ -594,7 +589,7 @@ mod tests {
         Some(format!(
             "{}::{}",
             render_path(db, &trait_info[0]),
-            assoc_item_name.display(db.upcast(), Edition::CURRENT)
+            assoc_item_name.display(db, Edition::CURRENT)
         ))
     }
 
@@ -611,7 +606,7 @@ mod tests {
 
                 let map = db.import_map(krate);
 
-                Some(format!("{name}:\n{}\n", map.fmt_for_test(db.upcast())))
+                Some(format!("{name}:\n{}\n", map.fmt_for_test(&db)))
             })
             .sorted()
             .collect::<String>();
@@ -634,7 +629,7 @@ mod tests {
             module = parent;
         }
 
-        segments.iter().rev().map(|it| it.display(db.upcast(), Edition::CURRENT)).join("::")
+        segments.iter().rev().map(|it| it.display(db, Edition::CURRENT)).join("::")
     }
 
     #[test]

--- a/crates/hir-def/src/item_tree.rs
+++ b/crates/hir-def/src/item_tree.rs
@@ -105,7 +105,7 @@ impl ItemTree {
         let mut item_tree = match_ast! {
             match syntax {
                 ast::SourceFile(file) => {
-                    top_attrs = Some(RawAttrs::new(db.upcast(), &file, ctx.span_map()));
+                    top_attrs = Some(RawAttrs::new(db, &file, ctx.span_map()));
                     ctx.lower_module_items(&file)
                 },
                 ast::MacroItems(items) => {
@@ -150,7 +150,7 @@ impl ItemTree {
         static EMPTY: OnceLock<Arc<ItemTree>> = OnceLock::new();
 
         let loc = block.lookup(db);
-        let block = loc.ast_id.to_node(db.upcast());
+        let block = loc.ast_id.to_node(db);
 
         let ctx = lower::Ctx::new(db, loc.ast_id.file_id);
         let mut item_tree = ctx.lower_block(&block);
@@ -885,7 +885,7 @@ impl Use {
     ) -> ast::UseTree {
         // Re-lower the AST item and get the source map.
         // Note: The AST unwraps are fine, since if they fail we should have never obtained `index`.
-        let ast = InFile::new(file_id, self.ast_id).to_node(db.upcast());
+        let ast = InFile::new(file_id, self.ast_id).to_node(db);
         let ast_use_tree = ast.use_tree().expect("missing `use_tree`");
         let (_, source_map) = lower::lower_use_tree(db, ast_use_tree, &mut |range| {
             db.span_map(file_id).span_for_range(range).ctx
@@ -902,7 +902,7 @@ impl Use {
     ) -> Arena<ast::UseTree> {
         // Re-lower the AST item and get the source map.
         // Note: The AST unwraps are fine, since if they fail we should have never obtained `index`.
-        let ast = InFile::new(file_id, self.ast_id).to_node(db.upcast());
+        let ast = InFile::new(file_id, self.ast_id).to_node(db);
         let ast_use_tree = ast.use_tree().expect("missing `use_tree`");
         lower::lower_use_tree(db, ast_use_tree, &mut |range| {
             db.span_map(file_id).span_for_range(range).ctx

--- a/crates/hir-def/src/item_tree/pretty.rs
+++ b/crates/hir-def/src/item_tree/pretty.rs
@@ -96,7 +96,7 @@ impl Printer<'_> {
                 self,
                 "#{}[{}{}]{}",
                 inner,
-                attr.path.display(self.db.upcast(), self.edition),
+                attr.path.display(self.db, self.edition),
                 attr.input.as_ref().map(|it| it.to_string()).unwrap_or_default(),
                 separated_by,
             );
@@ -112,7 +112,7 @@ impl Printer<'_> {
     fn print_visibility(&mut self, vis: RawVisibilityId) {
         match &self.tree[vis] {
             RawVisibility::Module(path, _expl) => {
-                w!(self, "pub({}) ", path.display(self.db.upcast(), self.edition))
+                w!(self, "pub({}) ", path.display(self.db, self.edition))
             }
             RawVisibility::Public => w!(self, "pub "),
         };
@@ -135,7 +135,7 @@ impl Printer<'_> {
                             w!(this, "unsafe ");
                         }
 
-                        wln!(this, "{},", name.display(self.db.upcast(), edition));
+                        wln!(this, "{},", name.display(self.db, edition));
                     }
                 });
                 w!(self, "}}");
@@ -152,7 +152,7 @@ impl Printer<'_> {
                         if *is_unsafe {
                             w!(this, "unsafe ");
                         }
-                        wln!(this, "{},", name.display(self.db.upcast(), edition));
+                        wln!(this, "{},", name.display(self.db, edition));
                     }
                 });
                 w!(self, ")");
@@ -164,20 +164,20 @@ impl Printer<'_> {
     fn print_use_tree(&mut self, use_tree: &UseTree) {
         match &use_tree.kind {
             UseTreeKind::Single { path, alias } => {
-                w!(self, "{}", path.display(self.db.upcast(), self.edition));
+                w!(self, "{}", path.display(self.db, self.edition));
                 if let Some(alias) = alias {
                     w!(self, " as {}", alias.display(self.edition));
                 }
             }
             UseTreeKind::Glob { path } => {
                 if let Some(path) = path {
-                    w!(self, "{}::", path.display(self.db.upcast(), self.edition));
+                    w!(self, "{}::", path.display(self.db, self.edition));
                 }
                 w!(self, "*");
             }
             UseTreeKind::Prefixed { prefix, list } => {
                 if let Some(prefix) = prefix {
-                    w!(self, "{}::", prefix.display(self.db.upcast(), self.edition));
+                    w!(self, "{}::", prefix.display(self.db, self.edition));
                 }
                 w!(self, "{{");
                 for (i, tree) in list.iter().enumerate() {
@@ -207,7 +207,7 @@ impl Printer<'_> {
                 let ExternCrate { name, alias, visibility, ast_id } = &self.tree[it];
                 self.print_ast_id(ast_id.erase());
                 self.print_visibility(*visibility);
-                w!(self, "extern crate {}", name.display(self.db.upcast(), self.edition));
+                w!(self, "extern crate {}", name.display(self.db, self.edition));
                 if let Some(alias) = alias {
                     w!(self, " as {}", alias.display(self.edition));
                 }
@@ -232,13 +232,13 @@ impl Printer<'_> {
                 let Function { name, visibility, ast_id } = &self.tree[it];
                 self.print_ast_id(ast_id.erase());
                 self.print_visibility(*visibility);
-                wln!(self, "fn {};", name.display(self.db.upcast(), self.edition));
+                wln!(self, "fn {};", name.display(self.db, self.edition));
             }
             ModItem::Struct(it) => {
                 let Struct { visibility, name, fields, shape: kind, ast_id } = &self.tree[it];
                 self.print_ast_id(ast_id.erase());
                 self.print_visibility(*visibility);
-                w!(self, "struct {}", name.display(self.db.upcast(), self.edition));
+                w!(self, "struct {}", name.display(self.db, self.edition));
                 self.print_fields(FieldParent::Struct(it), *kind, fields);
                 if matches!(kind, FieldsShape::Record) {
                     wln!(self);
@@ -250,7 +250,7 @@ impl Printer<'_> {
                 let Union { name, visibility, fields, ast_id } = &self.tree[it];
                 self.print_ast_id(ast_id.erase());
                 self.print_visibility(*visibility);
-                w!(self, "union {}", name.display(self.db.upcast(), self.edition));
+                w!(self, "union {}", name.display(self.db, self.edition));
                 self.print_fields(FieldParent::Union(it), FieldsShape::Record, fields);
                 wln!(self);
             }
@@ -258,14 +258,14 @@ impl Printer<'_> {
                 let Enum { name, visibility, variants, ast_id } = &self.tree[it];
                 self.print_ast_id(ast_id.erase());
                 self.print_visibility(*visibility);
-                w!(self, "enum {}", name.display(self.db.upcast(), self.edition));
+                w!(self, "enum {}", name.display(self.db, self.edition));
                 let edition = self.edition;
                 self.indented(|this| {
                     for variant in FileItemTreeId::range_iter(variants.clone()) {
                         let Variant { name, fields, shape: kind, ast_id } = &this.tree[variant];
                         this.print_ast_id(ast_id.erase());
                         this.print_attrs_of(variant, "\n");
-                        w!(this, "{}", name.display(self.db.upcast(), edition));
+                        w!(this, "{}", name.display(self.db, edition));
                         this.print_fields(FieldParent::EnumVariant(variant), *kind, fields);
                         wln!(this, ",");
                     }
@@ -278,7 +278,7 @@ impl Printer<'_> {
                 self.print_visibility(*visibility);
                 w!(self, "const ");
                 match name {
-                    Some(name) => w!(self, "{}", name.display(self.db.upcast(), self.edition)),
+                    Some(name) => w!(self, "{}", name.display(self.db, self.edition)),
                     None => w!(self, "_"),
                 }
                 wln!(self, " = _;");
@@ -288,7 +288,7 @@ impl Printer<'_> {
                 self.print_ast_id(ast_id.erase());
                 self.print_visibility(*visibility);
                 w!(self, "static ");
-                w!(self, "{}", name.display(self.db.upcast(), self.edition));
+                w!(self, "{}", name.display(self.db, self.edition));
                 w!(self, " = _;");
                 wln!(self);
             }
@@ -296,7 +296,7 @@ impl Printer<'_> {
                 let Trait { name, visibility, items, ast_id } = &self.tree[it];
                 self.print_ast_id(ast_id.erase());
                 self.print_visibility(*visibility);
-                w!(self, "trait {} {{", name.display(self.db.upcast(), self.edition));
+                w!(self, "trait {} {{", name.display(self.db, self.edition));
                 self.indented(|this| {
                     for item in &**items {
                         this.print_mod_item((*item).into());
@@ -308,7 +308,7 @@ impl Printer<'_> {
                 let TraitAlias { name, visibility, ast_id } = &self.tree[it];
                 self.print_ast_id(ast_id.erase());
                 self.print_visibility(*visibility);
-                wln!(self, "trait {} = ..;", name.display(self.db.upcast(), self.edition));
+                wln!(self, "trait {} = ..;", name.display(self.db, self.edition));
             }
             ModItem::Impl(it) => {
                 let Impl { items, ast_id } = &self.tree[it];
@@ -325,7 +325,7 @@ impl Printer<'_> {
                 let TypeAlias { name, visibility, ast_id } = &self.tree[it];
                 self.print_ast_id(ast_id.erase());
                 self.print_visibility(*visibility);
-                w!(self, "type {}", name.display(self.db.upcast(), self.edition));
+                w!(self, "type {}", name.display(self.db, self.edition));
                 w!(self, ";");
                 wln!(self);
             }
@@ -333,7 +333,7 @@ impl Printer<'_> {
                 let Mod { name, visibility, kind, ast_id } = &self.tree[it];
                 self.print_ast_id(ast_id.erase());
                 self.print_visibility(*visibility);
-                w!(self, "mod {}", name.display(self.db.upcast(), self.edition));
+                w!(self, "mod {}", name.display(self.db, self.edition));
                 match kind {
                     ModKind::Inline { items } => {
                         w!(self, " {{");
@@ -358,22 +358,18 @@ impl Printer<'_> {
                     ctxt,
                     expand_to
                 );
-                wln!(self, "{}!(...);", path.display(self.db.upcast(), self.edition));
+                wln!(self, "{}!(...);", path.display(self.db, self.edition));
             }
             ModItem::MacroRules(it) => {
                 let MacroRules { name, ast_id } = &self.tree[it];
                 self.print_ast_id(ast_id.erase());
-                wln!(
-                    self,
-                    "macro_rules! {} {{ ... }}",
-                    name.display(self.db.upcast(), self.edition)
-                );
+                wln!(self, "macro_rules! {} {{ ... }}", name.display(self.db, self.edition));
             }
             ModItem::Macro2(it) => {
                 let Macro2 { name, visibility, ast_id } = &self.tree[it];
                 self.print_ast_id(ast_id.erase());
                 self.print_visibility(*visibility);
-                wln!(self, "macro {} {{ ... }}", name.display(self.db.upcast(), self.edition));
+                wln!(self, "macro {} {{ ... }}", name.display(self.db, self.edition));
             }
         }
 

--- a/crates/hir-def/src/lib.rs
+++ b/crates/hir-def/src/lib.rs
@@ -640,7 +640,7 @@ impl GeneralConstId {
             GeneralConstId::StaticId(it) => {
                 let loc = it.lookup(db);
                 let tree = loc.item_tree_id().item_tree(db);
-                let name = tree[loc.id.value].name.display(db.upcast(), Edition::CURRENT);
+                let name = tree[loc.id.value].name.display(db, Edition::CURRENT);
                 name.to_string()
             }
             GeneralConstId::ConstId(const_id) => {
@@ -648,7 +648,7 @@ impl GeneralConstId {
                 let tree = loc.item_tree_id().item_tree(db);
                 tree[loc.id.value].name.as_ref().map_or_else(
                     || "_".to_owned(),
-                    |name| name.display(db.upcast(), Edition::CURRENT).to_string(),
+                    |name| name.display(db, Edition::CURRENT).to_string(),
                 )
             }
         }

--- a/crates/hir-def/src/nameres.rs
+++ b/crates/hir-def/src/nameres.rs
@@ -336,11 +336,11 @@ impl ModuleOrigin {
             &ModuleOrigin::Inline { definition, definition_tree_id } => InFile::new(
                 definition_tree_id.file_id(),
                 ModuleSource::Module(
-                    AstId::new(definition_tree_id.file_id(), definition).to_node(db.upcast()),
+                    AstId::new(definition_tree_id.file_id(), definition).to_node(db),
                 ),
             ),
             ModuleOrigin::BlockExpr { block, .. } => {
-                InFile::new(block.file_id, ModuleSource::BlockExpr(block.to_node(db.upcast())))
+                InFile::new(block.file_id, ModuleSource::BlockExpr(block.to_node(db)))
             }
         }
     }
@@ -607,12 +607,12 @@ impl DefMap {
         ) {
             format_to!(buf, "{}\n", path);
 
-            map.modules[module].scope.dump(db.upcast(), buf);
+            map.modules[module].scope.dump(db, buf);
 
             for (name, child) in
                 map.modules[module].children.iter().sorted_by(|a, b| Ord::cmp(&a.0, &b.0))
             {
-                let path = format!("{path}::{}", name.display(db.upcast(), Edition::LATEST));
+                let path = format!("{path}::{}", name.display(db, Edition::LATEST));
                 buf.push('\n');
                 go(buf, db, map, &path, *child);
             }
@@ -748,17 +748,14 @@ impl ModuleData {
             &ModuleOrigin::File { definition, .. } | &ModuleOrigin::CrateRoot { definition } => {
                 InFile::new(
                     definition.into(),
-                    ErasedAstId::new(definition.into(), ROOT_ERASED_FILE_AST_ID)
-                        .to_range(db.upcast()),
+                    ErasedAstId::new(definition.into(), ROOT_ERASED_FILE_AST_ID).to_range(db),
                 )
             }
             &ModuleOrigin::Inline { definition, definition_tree_id } => InFile::new(
                 definition_tree_id.file_id(),
-                AstId::new(definition_tree_id.file_id(), definition).to_range(db.upcast()),
+                AstId::new(definition_tree_id.file_id(), definition).to_range(db),
             ),
-            ModuleOrigin::BlockExpr { block, .. } => {
-                InFile::new(block.file_id, block.to_range(db.upcast()))
-            }
+            ModuleOrigin::BlockExpr { block, .. } => InFile::new(block.file_id, block.to_range(db)),
         }
     }
 
@@ -766,7 +763,7 @@ impl ModuleData {
     /// `None` for the crate root or block.
     pub fn declaration_source(&self, db: &dyn DefDatabase) -> Option<InFile<ast::Module>> {
         let decl = self.origin.declaration()?;
-        let value = decl.to_node(db.upcast());
+        let value = decl.to_node(db);
         Some(InFile { file_id: decl.file_id, value })
     }
 
@@ -774,7 +771,7 @@ impl ModuleData {
     /// `None` for the crate root or block.
     pub fn declaration_source_range(&self, db: &dyn DefDatabase) -> Option<InFile<TextRange>> {
         let decl = self.origin.declaration()?;
-        Some(InFile { file_id: decl.file_id, value: decl.to_range(db.upcast()) })
+        Some(InFile { file_id: decl.file_id, value: decl.to_range(db) })
     }
 }
 

--- a/crates/hir-def/src/nameres/assoc.rs
+++ b/crates/hir-def/src/nameres/assoc.rs
@@ -259,7 +259,7 @@ impl<'a> AssocItemCollector<'a> {
                         .map(|it| self.db.macro_def(it))
                 };
                 match macro_call_as_call_id(
-                    self.db.upcast(),
+                    self.db,
                     &AstIdWithPath::new(tree_id.file_id(), ast_id, Clone::clone(path)),
                     ctxt,
                     expand_to,

--- a/crates/hir-def/src/nameres/attr_resolution.rs
+++ b/crates/hir-def/src/nameres/attr_resolution.rs
@@ -121,7 +121,7 @@ pub(super) fn attr_macro_as_call_id(
     };
 
     def.make_call(
-        db.upcast(),
+        db,
         krate,
         MacroCallKind::Attr {
             ast_id: item_attr.ast_id,
@@ -146,7 +146,7 @@ pub(super) fn derive_macro_as_call_id(
         .filter(|(_, def_id)| def_id.is_derive())
         .ok_or_else(|| UnresolvedMacro { path: item_attr.path.as_ref().clone() })?;
     let call_id = def_id.make_call(
-        db.upcast(),
+        db,
         krate,
         MacroCallKind::Derive {
             ast_id: item_attr.ast_id,

--- a/crates/hir-def/src/nameres/mod_resolution.rs
+++ b/crates/hir-def/src/nameres/mod_resolution.rs
@@ -1,6 +1,6 @@
 //! This module resolves `mod foo;` declaration to file.
 use arrayvec::ArrayVec;
-use base_db::{AnchoredPath, RootQueryDb};
+use base_db::AnchoredPath;
 use hir_expand::{HirFileIdExt, name::Name};
 use span::EditionedFileId;
 
@@ -77,11 +77,10 @@ impl ModDir {
             }
         };
 
-        let orig_file_id = file_id.original_file_respecting_includes(db.upcast());
+        let orig_file_id = file_id.original_file_respecting_includes(db);
         for candidate in candidate_files.iter() {
             let path = AnchoredPath { anchor: orig_file_id.file_id(), path: candidate.as_str() };
-            if let Some(file_id) = base_db::Upcast::<dyn RootQueryDb>::upcast(db).resolve_path(path)
-            {
+            if let Some(file_id) = db.resolve_path(path) {
                 let is_mod_rs = candidate.ends_with("/mod.rs");
 
                 let root_dir_owner = is_mod_rs || attr_path.is_some();

--- a/crates/hir-ty/src/builder.rs
+++ b/crates/hir-ty/src/builder.rs
@@ -209,12 +209,12 @@ impl TyBuilder<()> {
     }
 
     pub fn placeholder_subst(db: &dyn HirDatabase, def: impl Into<GenericDefId>) -> Substitution {
-        let params = generics(db.upcast(), def.into());
+        let params = generics(db, def.into());
         params.placeholder_subst(db)
     }
 
     pub fn unknown_subst(db: &dyn HirDatabase, def: impl Into<GenericDefId>) -> Substitution {
-        let params = generics(db.upcast(), def.into());
+        let params = generics(db, def.into());
         Substitution::from_iter(
             Interner,
             params.iter_id().map(|id| match id {
@@ -233,7 +233,7 @@ impl TyBuilder<()> {
         def: impl Into<GenericDefId>,
         parent_subst: Option<Substitution>,
     ) -> TyBuilder<()> {
-        let generics = generics(db.upcast(), def.into());
+        let generics = generics(db, def.into());
         assert!(generics.parent_generics().is_some() == parent_subst.is_some());
         let params = generics
             .iter_self()
@@ -259,9 +259,8 @@ impl TyBuilder<()> {
     /// This method prepopulates the builder with placeholder substitution of `parent`, so you
     /// should only push exactly 3 `GenericArg`s before building.
     pub fn subst_for_coroutine(db: &dyn HirDatabase, parent: DefWithBodyId) -> TyBuilder<()> {
-        let parent_subst = parent
-            .as_generic_def_id(db.upcast())
-            .map(|p| generics(db.upcast(), p).placeholder_subst(db));
+        let parent_subst =
+            parent.as_generic_def_id(db).map(|p| generics(db, p).placeholder_subst(db));
         // These represent resume type, yield type, and return type of coroutine.
         let params = std::iter::repeat_n(ParamKind::Type, 3).collect();
         TyBuilder::new((), params, parent_subst)
@@ -274,13 +273,13 @@ impl TyBuilder<()> {
     ) -> Substitution {
         let sig_ty = sig_ty.cast(Interner);
         let self_subst = iter::once(&sig_ty);
-        let Some(parent) = parent.as_generic_def_id(db.upcast()) else {
+        let Some(parent) = parent.as_generic_def_id(db) else {
             return Substitution::from_iter(Interner, self_subst);
         };
         Substitution::from_iter(
             Interner,
             self_subst
-                .chain(generics(db.upcast(), parent).placeholder_subst(db).iter(Interner))
+                .chain(generics(db, parent).placeholder_subst(db).iter(Interner))
                 .cloned()
                 .collect::<Vec<_>>(),
         )

--- a/crates/hir-ty/src/consteval.rs
+++ b/crates/hir-ty/src/consteval.rs
@@ -104,7 +104,7 @@ pub(crate) fn path_to_const<'g>(
     debruijn: DebruijnIndex,
     expected_ty: Ty,
 ) -> Option<Const> {
-    match resolver.resolve_path_in_value_ns_fully(db.upcast(), path, HygieneId::ROOT) {
+    match resolver.resolve_path_in_value_ns_fully(db, path, HygieneId::ROOT) {
         Some(ValueNs::GenericParam(p)) => {
             let ty = db.const_param_ty(p);
             let value = match mode {
@@ -263,7 +263,7 @@ pub(crate) fn const_eval_query(
             db.monomorphized_mir_body(c.into(), subst, db.trait_environment(c.into()))?
         }
         GeneralConstId::StaticId(s) => {
-            let krate = s.module(db.upcast()).krate();
+            let krate = s.module(db).krate();
             db.monomorphized_mir_body(s.into(), subst, TraitEnvironment::empty(krate))?
         }
     };
@@ -290,7 +290,7 @@ pub(crate) fn const_eval_discriminant_variant(
 ) -> Result<i128, ConstEvalError> {
     let def = variant_id.into();
     let body = db.body(def);
-    let loc = variant_id.lookup(db.upcast());
+    let loc = variant_id.lookup(db);
     if body.exprs[body.body_expr] == Expr::Missing {
         let prev_idx = loc.index.checked_sub(1);
         let value = match prev_idx {

--- a/crates/hir-ty/src/db.rs
+++ b/crates/hir-ty/src/db.rs
@@ -3,7 +3,7 @@
 
 use std::sync;
 
-use base_db::{Crate, Upcast, impl_intern_key};
+use base_db::{Crate, impl_intern_key};
 use hir_def::{
     AdtId, BlockId, CallableDefId, ConstParamId, DefWithBodyId, EnumVariantId, FunctionId,
     GeneralConstId, GenericDefId, ImplId, LifetimeParamId, LocalFieldId, StaticId, TraitId,
@@ -29,7 +29,7 @@ use crate::{
 };
 
 #[query_group::query_group]
-pub trait HirDatabase: DefDatabase + Upcast<dyn DefDatabase> + std::fmt::Debug {
+pub trait HirDatabase: DefDatabase + std::fmt::Debug {
     #[salsa::invoke_actual(crate::infer::infer_query)]
     fn infer(&self, def: DefWithBodyId) -> Arc<InferenceResult>;
 

--- a/crates/hir-ty/src/infer/cast.rs
+++ b/crates/hir-ty/src/infer/cast.rs
@@ -44,11 +44,7 @@ impl CastTy {
                     return None;
                 };
                 let enum_data = table.db.enum_variants(id);
-                if enum_data.is_payload_free(table.db.upcast()) {
-                    Some(Self::Int(Int::CEnum))
-                } else {
-                    None
-                }
+                if enum_data.is_payload_free(table.db) { Some(Self::Int(Int::CEnum)) } else { None }
             }
             TyKind::Raw(m, ty) => Some(Self::Ptr(ty.clone(), *m)),
             TyKind::Function(_) => Some(Self::FnPtr),

--- a/crates/hir-ty/src/infer/pat.rs
+++ b/crates/hir-ty/src/infer/pat.rs
@@ -38,7 +38,7 @@ impl InferenceContext<'_> {
         decl: Option<DeclContext>,
     ) -> Ty {
         let (ty, def) = self.resolve_variant(id.into(), path, true);
-        let var_data = def.map(|it| it.variant_data(self.db.upcast()));
+        let var_data = def.map(|it| it.variant_data(self.db));
         if let Some(variant) = def {
             self.write_variant_resolution(id.into(), variant);
         }
@@ -60,7 +60,7 @@ impl InferenceContext<'_> {
             _ if subs.is_empty() => {}
             Some(def) => {
                 let field_types = self.db.field_types(def);
-                let variant_data = def.variant_data(self.db.upcast());
+                let variant_data = def.variant_data(self.db);
                 let visibilities = self.db.field_visibilities(def);
 
                 let (pre, post) = match ellipsis {
@@ -79,7 +79,7 @@ impl InferenceContext<'_> {
                         match variant_data.field(&Name::new_tuple_field(i)) {
                             Some(local_id) => {
                                 if !visibilities[local_id]
-                                    .is_visible_from(self.db.upcast(), self.resolver.module())
+                                    .is_visible_from(self.db, self.resolver.module())
                                 {
                                     // FIXME(DIAGNOSE): private tuple field
                                 }
@@ -129,7 +129,7 @@ impl InferenceContext<'_> {
             _ if subs.len() == 0 => {}
             Some(def) => {
                 let field_types = self.db.field_types(def);
-                let variant_data = def.variant_data(self.db.upcast());
+                let variant_data = def.variant_data(self.db);
                 let visibilities = self.db.field_visibilities(def);
 
                 let substs = ty.as_adt().map(TupleExt::tail);
@@ -139,7 +139,7 @@ impl InferenceContext<'_> {
                         match variant_data.field(&name) {
                             Some(local_id) => {
                                 if !visibilities[local_id]
-                                    .is_visible_from(self.db.upcast(), self.resolver.module())
+                                    .is_visible_from(self.db, self.resolver.module())
                                 {
                                     self.push_diagnostic(InferenceDiagnostic::NoSuchField {
                                         field: inner.into(),
@@ -594,8 +594,7 @@ impl InferenceContext<'_> {
         }
 
         let len = before.len() + suffix.len();
-        let size =
-            consteval::usize_const(self.db, Some(len as u128), self.owner.krate(self.db.upcast()));
+        let size = consteval::usize_const(self.db, Some(len as u128), self.owner.krate(self.db));
 
         let elem_ty = self.table.new_type_var();
         let array_ty = TyKind::Array(elem_ty.clone(), size).intern(Interner);

--- a/crates/hir-ty/src/inhabitedness.rs
+++ b/crates/hir-ty/src/inhabitedness.rs
@@ -139,7 +139,7 @@ impl UninhabitedFrom<'_> {
         ty: &Binders<Ty>,
         subst: &Substitution,
     ) -> ControlFlow<VisiblyUninhabited> {
-        if vis.is_none_or(|it| it.is_visible_from(self.db.upcast(), self.target_mod)) {
+        if vis.is_none_or(|it| it.is_visible_from(self.db, self.target_mod)) {
             let ty = ty.clone().substitute(Interner, subst);
             ty.visit_with(self, DebruijnIndex::INNERMOST)
         } else {

--- a/crates/hir-ty/src/lib.rs
+++ b/crates/hir-ty/src/lib.rs
@@ -301,7 +301,7 @@ impl Hash for ConstScalar {
 
 /// Return an index of a parameter in the generic type parameter list by it's id.
 pub fn param_idx(db: &dyn HirDatabase, id: TypeOrConstParamId) -> Option<usize> {
-    generics::generics(db.upcast(), id.parent).type_or_const_param_idx(id)
+    generics::generics(db, id.parent).type_or_const_param_idx(id)
 }
 
 pub(crate) fn wrap_empty_binders<T>(value: T) -> Binders<T>

--- a/crates/hir-ty/src/lower/path.rs
+++ b/crates/hir-ty/src/lower/path.rs
@@ -185,7 +185,7 @@ impl<'a, 'b> PathLoweringContext<'a, 'b> {
                                     None,
                                 );
                                 let len_self =
-                                    generics(self.ctx.db.upcast(), associated_ty.into()).len_self();
+                                    generics(self.ctx.db, associated_ty.into()).len_self();
                                 let substitution = Substitution::from_iter(
                                     Interner,
                                     substitution
@@ -265,7 +265,7 @@ impl<'a, 'b> PathLoweringContext<'a, 'b> {
                 }
             }
             TypeNs::AdtSelfType(adt) => {
-                let generics = generics(self.ctx.db.upcast(), adt.into());
+                let generics = generics(self.ctx.db, adt.into());
                 let substs = match self.ctx.type_param_mode {
                     ParamLoweringMode::Placeholder => generics.placeholder_subst(self.ctx.db),
                     ParamLoweringMode::Variable => {
@@ -327,10 +327,8 @@ impl<'a, 'b> PathLoweringContext<'a, 'b> {
     }
 
     pub(crate) fn resolve_path_in_type_ns(&mut self) -> Option<(TypeNs, Option<usize>)> {
-        let (resolution, remaining_index, _, prefix_info) = self
-            .ctx
-            .resolver
-            .resolve_path_in_type_ns_with_prefix_info(self.ctx.db.upcast(), self.path)?;
+        let (resolution, remaining_index, _, prefix_info) =
+            self.ctx.resolver.resolve_path_in_type_ns_with_prefix_info(self.ctx.db, self.path)?;
 
         let segments = self.segments;
         if segments.is_empty() || matches!(self.path, Path::LangItem(..)) {
@@ -385,7 +383,7 @@ impl<'a, 'b> PathLoweringContext<'a, 'b> {
         hygiene_id: HygieneId,
     ) -> Option<ResolveValueResult> {
         let (res, prefix_info) = self.ctx.resolver.resolve_path_in_value_ns_with_prefix_info(
-            self.ctx.db.upcast(),
+            self.ctx.db,
             self.path,
             hygiene_id,
         )?;
@@ -510,8 +508,7 @@ impl<'a, 'b> PathLoweringContext<'a, 'b> {
                 let substs = self.substs_from_path_segment(associated_ty.into(), false, None);
 
                 let len_self =
-                    crate::generics::generics(self.ctx.db.upcast(), associated_ty.into())
-                        .len_self();
+                    crate::generics::generics(self.ctx.db, associated_ty.into()).len_self();
 
                 let substs = Substitution::from_iter(
                     Interner,
@@ -583,7 +580,7 @@ impl<'a, 'b> PathLoweringContext<'a, 'b> {
                         self.current_or_prev_segment = penultimate;
                     }
                 }
-                var.lookup(self.ctx.db.upcast()).parent.into()
+                var.lookup(self.ctx.db).parent.into()
             }
         };
         let result = self.substs_from_path_segment(generic_def, infer_args, None);
@@ -639,7 +636,7 @@ impl<'a, 'b> PathLoweringContext<'a, 'b> {
         // - Lifetime parameters
         // - Type or Const parameters
         // - Parent parameters
-        let def_generics = generics(self.ctx.db.upcast(), def);
+        let def_generics = generics(self.ctx.db, def);
         let (
             parent_params,
             self_param,
@@ -742,7 +739,7 @@ impl<'a, 'b> PathLoweringContext<'a, 'b> {
         // ignore them.
         let is_assoc_ty = || match def {
             GenericDefId::TypeAliasId(id) => {
-                matches!(id.lookup(self.ctx.db.upcast()).container, ItemContainerId::TraitId(_))
+                matches!(id.lookup(self.ctx.db).container, ItemContainerId::TraitId(_))
             }
             _ => false,
         };
@@ -816,7 +813,7 @@ impl<'a, 'b> PathLoweringContext<'a, 'b> {
                     false, // this is not relevant
                     Some(super_trait_ref.self_type_parameter(Interner)),
                 );
-                let generics = generics(self.ctx.db.upcast(), associated_ty.into());
+                let generics = generics(self.ctx.db, associated_ty.into());
                 let self_params = generics.len_self();
                 let substitution = Substitution::from_iter(
                     Interner,

--- a/crates/hir-ty/src/mir/borrowck.rs
+++ b/crates/hir-ty/src/mir/borrowck.rs
@@ -132,7 +132,7 @@ fn moved_out_of_ref(db: &dyn HirDatabase, body: &MirBody) -> Vec<MovedOutOfRef> 
                     ty,
                     db,
                     make_fetch_closure_field(db),
-                    body.owner.module(db.upcast()).krate(),
+                    body.owner.module(db).krate(),
                 );
             }
             if is_dereference_of_ref
@@ -223,7 +223,7 @@ fn partially_moved(db: &dyn HirDatabase, body: &MirBody) -> Vec<PartiallyMoved> 
                     ty,
                     db,
                     make_fetch_closure_field(db),
-                    body.owner.module(db.upcast()).krate(),
+                    body.owner.module(db).krate(),
                 );
             }
             if !ty.clone().is_copy(db, body.owner)
@@ -369,12 +369,7 @@ fn place_case(db: &dyn HirDatabase, body: &MirBody, lvalue: &Place) -> Projectio
             }
             ProjectionElem::OpaqueCast(_) => (),
         }
-        ty = proj.projected_ty(
-            ty,
-            db,
-            make_fetch_closure_field(db),
-            body.owner.module(db.upcast()).krate(),
-        );
+        ty = proj.projected_ty(ty, db, make_fetch_closure_field(db), body.owner.module(db).krate());
     }
     if is_part_of { ProjectionCase::DirectPart } else { ProjectionCase::Direct }
 }
@@ -419,10 +414,7 @@ fn ever_initialized_map(
             let Some(terminator) = &block.terminator else {
                 never!(
                     "Terminator should be none only in construction.\nThe body:\n{}",
-                    body.pretty_print(
-                        db,
-                        DisplayTarget::from_crate(db, body.owner.krate(db.upcast()))
-                    )
+                    body.pretty_print(db, DisplayTarget::from_crate(db, body.owner.krate(db)))
                 );
                 return;
             };

--- a/crates/hir-ty/src/mir/eval/shim.rs
+++ b/crates/hir-ty/src/mir/eval/shim.rs
@@ -63,10 +63,10 @@ impl Evaluator<'_> {
             // Keep this around for a bit until extern "rustc-intrinsic" abis are no longer used
             || (match &function_data.abi {
                 Some(abi) => *abi == sym::rust_dash_intrinsic,
-                None => match def.lookup(self.db.upcast()).container {
+                None => match def.lookup(self.db).container {
                     hir_def::ItemContainerId::ExternBlockId(block) => {
-                        let id = block.lookup(self.db.upcast()).id;
-                        id.item_tree(self.db.upcast())[id.value].abi.as_ref()
+                        let id = block.lookup(self.db).id;
+                        id.item_tree(self.db)[id.value].abi.as_ref()
                             == Some(&sym::rust_dash_intrinsic)
                     }
                     _ => false,
@@ -85,10 +85,10 @@ impl Evaluator<'_> {
                     || attrs.by_key(&sym::rustc_intrinsic_must_be_overridden).exists(),
             );
         }
-        let is_extern_c = match def.lookup(self.db.upcast()).container {
+        let is_extern_c = match def.lookup(self.db).container {
             hir_def::ItemContainerId::ExternBlockId(block) => {
-                let id = block.lookup(self.db.upcast()).id;
-                id.item_tree(self.db.upcast())[id.value].abi.as_ref() == Some(&sym::C)
+                let id = block.lookup(self.db).id;
+                id.item_tree(self.db)[id.value].abi.as_ref() == Some(&sym::C)
             }
             _ => false,
         };
@@ -124,7 +124,7 @@ impl Evaluator<'_> {
             destination.write_from_bytes(self, &result)?;
             return Ok(true);
         }
-        if let ItemContainerId::TraitId(t) = def.lookup(self.db.upcast()).container {
+        if let ItemContainerId::TraitId(t) = def.lookup(self.db).container {
             if self.db.lang_attr(t.into()) == Some(LangItem::Clone) {
                 let [self_ty] = generic_args.as_slice(Interner) else {
                     not_supported!("wrong generic arg count for clone");
@@ -154,8 +154,7 @@ impl Evaluator<'_> {
     ) -> Result<Option<FunctionId>> {
         // `PanicFmt` is redirected to `ConstPanicFmt`
         if let Some(LangItem::PanicFmt) = self.db.lang_attr(def.into()) {
-            let resolver =
-                self.db.crate_def_map(self.crate_id).crate_root().resolver(self.db.upcast());
+            let resolver = self.db.crate_def_map(self.crate_id).crate_root().resolver(self.db);
 
             let Some(hir_def::lang_item::LangItemTarget::Function(const_panic_fmt)) =
                 self.db.lang_item(resolver.krate(), LangItem::ConstPanicFmt)
@@ -828,14 +827,14 @@ impl Evaluator<'_> {
                 };
                 let ty_name = match ty.display_source_code(
                     self.db,
-                    locals.body.owner.module(self.db.upcast()),
+                    locals.body.owner.module(self.db),
                     true,
                 ) {
                     Ok(ty_name) => ty_name,
                     // Fallback to human readable display in case of `Err`. Ideally we want to use `display_source_code` to
                     // render full paths.
                     Err(_) => {
-                        let krate = locals.body.owner.krate(self.db.upcast());
+                        let krate = locals.body.owner.krate(self.db);
                         ty.display(self.db, DisplayTarget::from_crate(self.db, krate)).to_string()
                     }
                 };

--- a/crates/hir-ty/src/mir/lower/as_place.rs
+++ b/crates/hir-ty/src/mir/lower/as_place.rs
@@ -136,10 +136,9 @@ impl MirLowerCtx<'_> {
         match &self.body.exprs[expr_id] {
             Expr::Path(p) => {
                 let resolver_guard =
-                    self.resolver.update_to_inner_scope(self.db.upcast(), self.owner, expr_id);
+                    self.resolver.update_to_inner_scope(self.db, self.owner, expr_id);
                 let hygiene = self.body.expr_path_hygiene(expr_id);
-                let resolved =
-                    self.resolver.resolve_path_in_value_ns_fully(self.db.upcast(), p, hygiene);
+                let resolved = self.resolver.resolve_path_in_value_ns_fully(self.db, p, hygiene);
                 self.resolver.reset_to_guard(resolver_guard);
                 let Some(pr) = resolved else {
                     return try_rvalue(self);

--- a/crates/hir-ty/src/mir/lower/pattern_matching.rs
+++ b/crates/hir-ty/src/mir/lower/pattern_matching.rs
@@ -355,7 +355,7 @@ impl MirLowerCtx<'_> {
                     let hygiene = self.body.pat_path_hygiene(pattern);
                     let pr = self
                         .resolver
-                        .resolve_path_in_value_ns(self.db.upcast(), p, hygiene)
+                        .resolve_path_in_value_ns(self.db, p, hygiene)
                         .ok_or_else(unresolved_name)?;
 
                     if let (

--- a/crates/hir-ty/src/mir/monomorphization.rs
+++ b/crates/hir-ty/src/mir/monomorphization.rs
@@ -77,7 +77,7 @@ impl FallibleTypeFolder<Interner> for Filler<'_> {
                             owner: self.owner,
                             trait_env: self.trait_env.clone(),
                             subst: &subst,
-                            generics: Some(generics(self.db.upcast(), func.into())),
+                            generics: Some(generics(self.db, func.into())),
                         };
                         filler.try_fold_ty(infer.type_of_rpit[idx].clone(), outer_binder)
                     }
@@ -305,7 +305,7 @@ pub fn monomorphized_mir_body_query(
     subst: Substitution,
     trait_env: Arc<crate::TraitEnvironment>,
 ) -> Result<Arc<MirBody>, MirLowerError> {
-    let generics = owner.as_generic_def_id(db.upcast()).map(|g_def| generics(db.upcast(), g_def));
+    let generics = owner.as_generic_def_id(db).map(|g_def| generics(db, g_def));
     let filler = &mut Filler { db, subst: &subst, trait_env, generics, owner };
     let body = db.mir_body(owner)?;
     let mut body = (*body).clone();
@@ -331,7 +331,7 @@ pub fn monomorphized_mir_body_for_closure_query(
     trait_env: Arc<crate::TraitEnvironment>,
 ) -> Result<Arc<MirBody>, MirLowerError> {
     let InternedClosure(owner, _) = db.lookup_intern_closure(closure);
-    let generics = owner.as_generic_def_id(db.upcast()).map(|g_def| generics(db.upcast(), g_def));
+    let generics = owner.as_generic_def_id(db).map(|g_def| generics(db, g_def));
     let filler = &mut Filler { db, subst: &subst, trait_env, generics, owner };
     let body = db.mir_body_for_closure(closure)?;
     let mut body = (*body).clone();
@@ -347,7 +347,7 @@ pub fn monomorphize_mir_body_bad(
     trait_env: Arc<crate::TraitEnvironment>,
 ) -> Result<MirBody, MirLowerError> {
     let owner = body.owner;
-    let generics = owner.as_generic_def_id(db.upcast()).map(|g_def| generics(db.upcast(), g_def));
+    let generics = owner.as_generic_def_id(db).map(|g_def| generics(db, g_def));
     let filler = &mut Filler { db, subst: &subst, trait_env, generics, owner };
     filler.fill_body(&mut body)?;
     Ok(body)

--- a/crates/hir-ty/src/mir/pretty.rs
+++ b/crates/hir-ty/src/mir/pretty.rs
@@ -44,15 +44,11 @@ impl MirBody {
         ctx.for_body(|this| match ctx.body.owner {
             hir_def::DefWithBodyId::FunctionId(id) => {
                 let data = db.function_signature(id);
-                w!(this, "fn {}() ", data.name.display(db.upcast(), this.display_target.edition));
+                w!(this, "fn {}() ", data.name.display(db, this.display_target.edition));
             }
             hir_def::DefWithBodyId::StaticId(id) => {
                 let data = db.static_signature(id);
-                w!(
-                    this,
-                    "static {}: _ = ",
-                    data.name.display(db.upcast(), this.display_target.edition)
-                );
+                w!(this, "static {}: _ = ", data.name.display(db, this.display_target.edition));
             }
             hir_def::DefWithBodyId::ConstId(id) => {
                 let data = db.const_signature(id);
@@ -62,21 +58,21 @@ impl MirBody {
                     data.name
                         .as_ref()
                         .unwrap_or(&Name::missing())
-                        .display(db.upcast(), this.display_target.edition)
+                        .display(db, this.display_target.edition)
                 );
             }
             hir_def::DefWithBodyId::VariantId(id) => {
-                let loc = id.lookup(db.upcast());
-                let enum_loc = loc.parent.lookup(db.upcast());
+                let loc = id.lookup(db);
+                let enum_loc = loc.parent.lookup(db);
                 w!(
                     this,
                     "enum {}::{} = ",
-                    enum_loc.id.item_tree(db.upcast())[enum_loc.id.value]
+                    enum_loc.id.item_tree(db)[enum_loc.id.value]
                         .name
-                        .display(db.upcast(), this.display_target.edition),
-                    loc.id.item_tree(db.upcast())[loc.id.value]
+                        .display(db, this.display_target.edition),
+                    loc.id.item_tree(db)[loc.id.value]
                         .name
-                        .display(db.upcast(), this.display_target.edition),
+                        .display(db, this.display_target.edition),
                 )
             }
         });
@@ -131,7 +127,7 @@ impl HirDisplay for LocalName {
         match self {
             LocalName::Unknown(l) => write!(f, "_{}", u32::from(l.into_raw())),
             LocalName::Binding(n, l) => {
-                write!(f, "{}_{}", n.display(f.db.upcast(), f.edition()), u32::from(l.into_raw()))
+                write!(f, "{}_{}", n.display(f.db, f.edition()), u32::from(l.into_raw()))
             }
         }
     }
@@ -336,23 +332,19 @@ impl<'a> MirPrettyCtx<'a> {
                         hir_def::VariantId::EnumVariantId(e) => {
                             w!(this, "(");
                             f(this, local, head);
-                            let loc = e.lookup(this.db.upcast());
+                            let loc = e.lookup(this.db);
                             w!(
                                 this,
                                 " as {}).{}",
                                 this.db.enum_variants(loc.parent).variants[loc.index as usize]
                                     .1
-                                    .display(this.db.upcast(), this.display_target.edition),
-                                name.display(this.db.upcast(), this.display_target.edition)
+                                    .display(this.db, this.display_target.edition),
+                                name.display(this.db, this.display_target.edition)
                             );
                         }
                         hir_def::VariantId::StructId(_) | hir_def::VariantId::UnionId(_) => {
                             f(this, local, head);
-                            w!(
-                                this,
-                                ".{}",
-                                name.display(this.db.upcast(), this.display_target.edition)
-                            );
+                            w!(this, ".{}", name.display(this.db, this.display_target.edition));
                         }
                     }
                 }

--- a/crates/hir-ty/src/test_db.rs
+++ b/crates/hir-ty/src/test_db.rs
@@ -4,11 +4,10 @@ use std::{fmt, panic, sync::Mutex};
 
 use base_db::{
     CrateGraphBuilder, CratesMap, FileSourceRootInput, FileText, RootQueryDb, SourceDatabase,
-    SourceRoot, SourceRootId, SourceRootInput, Upcast,
+    SourceRoot, SourceRootId, SourceRootInput,
 };
 
 use hir_def::{ModuleId, db::DefDatabase};
-use hir_expand::db::ExpandDatabase;
 use rustc_hash::FxHashMap;
 use salsa::{AsDynDatabase, Durability};
 use span::{EditionedFileId, FileId};
@@ -44,30 +43,6 @@ impl Default for TestDB {
 impl fmt::Debug for TestDB {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("TestDB").finish()
-    }
-}
-
-impl Upcast<dyn ExpandDatabase> for TestDB {
-    fn upcast(&self) -> &(dyn ExpandDatabase + 'static) {
-        self
-    }
-}
-
-impl Upcast<dyn DefDatabase> for TestDB {
-    fn upcast(&self) -> &(dyn DefDatabase + 'static) {
-        self
-    }
-}
-
-impl Upcast<dyn RootQueryDb> for TestDB {
-    fn upcast(&self) -> &(dyn RootQueryDb + 'static) {
-        self
-    }
-}
-
-impl Upcast<dyn SourceDatabase> for TestDB {
-    fn upcast(&self) -> &(dyn SourceDatabase + 'static) {
-        self
     }
 }
 

--- a/crates/hir-ty/src/tls.rs
+++ b/crates/hir-ty/src/tls.rs
@@ -25,7 +25,7 @@ impl DebugContext<'_> {
             AdtId::UnionId(it) => self.0.union_signature(it).name.clone(),
             AdtId::EnumId(it) => self.0.enum_signature(it).name.clone(),
         };
-        name.display(self.0.upcast(), Edition::LATEST).fmt(f)?;
+        name.display(self.0, Edition::LATEST).fmt(f)?;
         Ok(())
     }
 
@@ -36,7 +36,7 @@ impl DebugContext<'_> {
     ) -> Result<(), fmt::Error> {
         let trait_: hir_def::TraitId = from_chalk_trait_id(id);
         let trait_data = self.0.trait_signature(trait_);
-        trait_data.name.display(self.0.upcast(), Edition::LATEST).fmt(f)?;
+        trait_data.name.display(self.0, Edition::LATEST).fmt(f)?;
         Ok(())
     }
 
@@ -47,7 +47,7 @@ impl DebugContext<'_> {
     ) -> Result<(), fmt::Error> {
         let type_alias: TypeAliasId = from_assoc_type_id(id);
         let type_alias_data = self.0.type_alias_signature(type_alias);
-        let trait_ = match type_alias.lookup(self.0.upcast()).container {
+        let trait_ = match type_alias.lookup(self.0).container {
             ItemContainerId::TraitId(t) => t,
             _ => panic!("associated type not in trait"),
         };
@@ -55,8 +55,8 @@ impl DebugContext<'_> {
         write!(
             fmt,
             "{}::{}",
-            trait_data.name.display(self.0.upcast(), Edition::LATEST),
-            type_alias_data.name.display(self.0.upcast(), Edition::LATEST)
+            trait_data.name.display(self.0, Edition::LATEST),
+            type_alias_data.name.display(self.0, Edition::LATEST)
         )?;
         Ok(())
     }
@@ -68,7 +68,7 @@ impl DebugContext<'_> {
     ) -> Result<(), fmt::Error> {
         let type_alias = from_assoc_type_id(projection_ty.associated_ty_id);
         let type_alias_data = self.0.type_alias_signature(type_alias);
-        let trait_ = match type_alias.lookup(self.0.upcast()).container {
+        let trait_ = match type_alias.lookup(self.0).container {
             ItemContainerId::TraitId(t) => t,
             _ => panic!("associated type not in trait"),
         };
@@ -76,7 +76,7 @@ impl DebugContext<'_> {
         let trait_ref = projection_ty.trait_ref(self.0);
         let trait_params = trait_ref.substitution.as_slice(Interner);
         let self_ty = trait_ref.self_type_parameter(Interner);
-        write!(fmt, "<{self_ty:?} as {}", trait_name.display(self.0.upcast(), Edition::LATEST))?;
+        write!(fmt, "<{self_ty:?} as {}", trait_name.display(self.0, Edition::LATEST))?;
         if trait_params.len() > 1 {
             write!(
                 fmt,
@@ -84,7 +84,7 @@ impl DebugContext<'_> {
                 trait_params[1..].iter().format_with(", ", |x, f| f(&format_args!("{x:?}"))),
             )?;
         }
-        write!(fmt, ">::{}", type_alias_data.name.display(self.0.upcast(), Edition::LATEST))?;
+        write!(fmt, ">::{}", type_alias_data.name.display(self.0, Edition::LATEST))?;
 
         let proj_params_count = projection_ty.substitution.len(Interner) - trait_params.len();
         let proj_params = &projection_ty.substitution.as_slice(Interner)[..proj_params_count];
@@ -109,16 +109,16 @@ impl DebugContext<'_> {
             CallableDefId::FunctionId(ff) => self.0.function_signature(ff).name.clone(),
             CallableDefId::StructId(s) => self.0.struct_signature(s).name.clone(),
             CallableDefId::EnumVariantId(e) => {
-                let loc = e.lookup(self.0.upcast());
+                let loc = e.lookup(self.0);
                 self.0.enum_variants(loc.parent).variants[loc.index as usize].1.clone()
             }
         };
         match def {
             CallableDefId::FunctionId(_) => {
-                write!(fmt, "{{fn {}}}", name.display(self.0.upcast(), Edition::LATEST))
+                write!(fmt, "{{fn {}}}", name.display(self.0, Edition::LATEST))
             }
             CallableDefId::StructId(_) | CallableDefId::EnumVariantId(_) => {
-                write!(fmt, "{{ctor {}}}", name.display(self.0.upcast(), Edition::LATEST))
+                write!(fmt, "{{ctor {}}}", name.display(self.0, Edition::LATEST))
             }
         }
     }

--- a/crates/hir-ty/src/traits.rs
+++ b/crates/hir-ty/src/traits.rs
@@ -117,7 +117,7 @@ pub(crate) fn trait_solve_query(
         GoalData::DomainGoal(DomainGoal::Holds(WhereClause::Implemented(it))) => db
             .trait_signature(it.hir_trait_id())
             .name
-            .display(db.upcast(), Edition::LATEST)
+            .display(db, Edition::LATEST)
             .to_string(),
         GoalData::DomainGoal(DomainGoal::Holds(WhereClause::AliasEq(_))) => "alias_eq".to_owned(),
         _ => "??".to_owned(),

--- a/crates/hir-ty/src/utils.rs
+++ b/crates/hir-ty/src/utils.rs
@@ -296,12 +296,12 @@ pub fn is_fn_unsafe_to_call(
         }
     }
 
-    let loc = func.lookup(db.upcast());
+    let loc = func.lookup(db);
     match loc.container {
         hir_def::ItemContainerId::ExternBlockId(block) => {
-            let id = block.lookup(db.upcast()).id;
+            let id = block.lookup(db).id;
             let is_intrinsic_block =
-                id.item_tree(db.upcast())[id.value].abi.as_ref() == Some(&sym::rust_dash_intrinsic);
+                id.item_tree(db)[id.value].abi.as_ref() == Some(&sym::rust_dash_intrinsic);
             if is_intrinsic_block {
                 // legacy intrinsics
                 // extern "rust-intrinsic" intrinsics are unsafe unless they have the rustc_safe_intrinsic attribute

--- a/crates/hir-ty/src/variance.rs
+++ b/crates/hir-ty/src/variance.rs
@@ -45,7 +45,7 @@ pub(crate) fn variances_of(db: &dyn HirDatabase, def: GenericDefId) -> Option<Ar
         _ => return None,
     }
 
-    let generics = generics(db.upcast(), def);
+    let generics = generics(db, def);
     let count = generics.len();
     if count == 0 {
         return None;
@@ -60,7 +60,7 @@ pub(crate) fn variances_of_cycle(
     _cycle: &Cycle,
     def: GenericDefId,
 ) -> Option<Arc<[Variance]>> {
-    let generics = generics(db.upcast(), def);
+    let generics = generics(db, def);
     let count = generics.len();
 
     if count == 0 {

--- a/crates/hir/src/attrs.rs
+++ b/crates/hir/src/attrs.rs
@@ -33,7 +33,7 @@ macro_rules! impl_has_attrs {
         impl HasAttrs for $def {
             fn attrs(self, db: &dyn HirDatabase) -> AttrsWithOwner {
                 let def = AttrDefId::$def_id(self.into());
-                AttrsWithOwner::new(db.upcast(), def)
+                AttrsWithOwner::new(db, def)
             }
             fn attr_id(self) -> AttrDefId {
                 AttrDefId::$def_id(self.into())
@@ -95,7 +95,7 @@ impl HasAttrs for AssocItem {
 impl HasAttrs for crate::Crate {
     fn attrs(self, db: &dyn HirDatabase) -> AttrsWithOwner {
         let def = AttrDefId::ModuleId(self.root_module().id);
-        AttrsWithOwner::new(db.upcast(), def)
+        AttrsWithOwner::new(db, def)
     }
     fn attr_id(self) -> AttrDefId {
         AttrDefId::ModuleId(self.root_module().id)
@@ -119,27 +119,27 @@ fn resolve_doc_path_on_(
     ns: Option<Namespace>,
 ) -> Option<DocLinkDef> {
     let resolver = match attr_id {
-        AttrDefId::ModuleId(it) => it.resolver(db.upcast()),
-        AttrDefId::FieldId(it) => it.parent.resolver(db.upcast()),
-        AttrDefId::AdtId(it) => it.resolver(db.upcast()),
-        AttrDefId::FunctionId(it) => it.resolver(db.upcast()),
-        AttrDefId::EnumVariantId(it) => it.resolver(db.upcast()),
-        AttrDefId::StaticId(it) => it.resolver(db.upcast()),
-        AttrDefId::ConstId(it) => it.resolver(db.upcast()),
-        AttrDefId::TraitId(it) => it.resolver(db.upcast()),
-        AttrDefId::TraitAliasId(it) => it.resolver(db.upcast()),
-        AttrDefId::TypeAliasId(it) => it.resolver(db.upcast()),
-        AttrDefId::ImplId(it) => it.resolver(db.upcast()),
-        AttrDefId::ExternBlockId(it) => it.resolver(db.upcast()),
-        AttrDefId::UseId(it) => it.resolver(db.upcast()),
-        AttrDefId::MacroId(it) => it.resolver(db.upcast()),
-        AttrDefId::ExternCrateId(it) => it.resolver(db.upcast()),
+        AttrDefId::ModuleId(it) => it.resolver(db),
+        AttrDefId::FieldId(it) => it.parent.resolver(db),
+        AttrDefId::AdtId(it) => it.resolver(db),
+        AttrDefId::FunctionId(it) => it.resolver(db),
+        AttrDefId::EnumVariantId(it) => it.resolver(db),
+        AttrDefId::StaticId(it) => it.resolver(db),
+        AttrDefId::ConstId(it) => it.resolver(db),
+        AttrDefId::TraitId(it) => it.resolver(db),
+        AttrDefId::TraitAliasId(it) => it.resolver(db),
+        AttrDefId::TypeAliasId(it) => it.resolver(db),
+        AttrDefId::ImplId(it) => it.resolver(db),
+        AttrDefId::ExternBlockId(it) => it.resolver(db),
+        AttrDefId::UseId(it) => it.resolver(db),
+        AttrDefId::MacroId(it) => it.resolver(db),
+        AttrDefId::ExternCrateId(it) => it.resolver(db),
         AttrDefId::GenericParamId(_) => return None,
     };
 
     let mut modpath = doc_modpath_from_str(link)?;
 
-    let resolved = resolver.resolve_module_path_in_items(db.upcast(), &modpath);
+    let resolved = resolver.resolve_module_path_in_items(db, &modpath);
     if resolved.is_none() {
         let last_name = modpath.pop_segment()?;
         resolve_assoc_or_field(db, resolver, modpath, last_name, ns)
@@ -168,7 +168,7 @@ fn resolve_assoc_or_field(
     let path = Path::from_known_path_with_no_generic(path);
     // FIXME: This does not handle `Self` on trait definitions, which we should resolve to the
     // trait itself.
-    let base_def = resolver.resolve_path_in_type_ns_fully(db.upcast(), &path)?;
+    let base_def = resolver.resolve_path_in_type_ns_fully(db, &path)?;
 
     let ty = match base_def {
         TypeNs::SelfType(id) => Impl::from(id).self_ty(db),
@@ -255,7 +255,7 @@ fn resolve_impl_trait_item(
     let environment = resolver
         .generic_def()
         .map_or_else(|| crate::TraitEnvironment::empty(krate.id), |d| db.trait_environment(d));
-    let traits_in_scope = resolver.traits_in_scope(db.upcast());
+    let traits_in_scope = resolver.traits_in_scope(db);
 
     let mut result = None;
 

--- a/crates/hir/src/diagnostics.rs
+++ b/crates/hir/src/diagnostics.rs
@@ -433,7 +433,7 @@ impl AnyDiagnostic {
     ) -> Option<AnyDiagnostic> {
         match diagnostic {
             BodyValidationDiagnostic::RecordMissingFields { record, variant, missed_fields } => {
-                let variant_data = variant.variant_data(db.upcast());
+                let variant_data = variant.variant_data(db);
                 let missed_fields = missed_fields
                     .into_iter()
                     .map(|idx| variant_data.fields()[idx].name.clone())
@@ -444,7 +444,7 @@ impl AnyDiagnostic {
                     Either::Right(record_pat) => source_map.pat_syntax(record_pat).ok()?,
                 };
                 let file = record.file_id;
-                let root = record.file_syntax(db.upcast());
+                let root = record.file_syntax(db);
                 match record.value.to_node(&root) {
                     Either::Left(ast::Expr::RecordExpr(record_expr)) => {
                         if record_expr.record_expr_field_list().is_some() {
@@ -493,7 +493,7 @@ impl AnyDiagnostic {
             BodyValidationDiagnostic::MissingMatchArms { match_expr, uncovered_patterns } => {
                 match source_map.expr_syntax(match_expr) {
                     Ok(source_ptr) => {
-                        let root = source_ptr.file_syntax(db.upcast());
+                        let root = source_ptr.file_syntax(db);
                         if let Either::Left(ast::Expr::MatchExpr(match_expr)) =
                             &source_ptr.value.to_node(&root)
                         {

--- a/crates/hir/src/display.rs
+++ b/crates/hir/src/display.rs
@@ -88,7 +88,7 @@ impl HirDisplay for Function {
         if let Some(abi) = &data.abi {
             write!(f, "extern \"{}\" ", abi.as_str())?;
         }
-        write!(f, "fn {}", data.name.display(f.db.upcast(), f.edition()))?;
+        write!(f, "fn {}", data.name.display(f.db, f.edition()))?;
 
         write_generic_params(GenericDefId::FunctionId(self.id), f)?;
 
@@ -112,8 +112,7 @@ impl HirDisplay for Function {
             }
 
             let pat_id = body.params[param.idx - body.self_param.is_some() as usize];
-            let pat_str =
-                body.pretty_print_pat(db.upcast(), self.id.into(), pat_id, true, f.edition());
+            let pat_str = body.pretty_print_pat(db, self.id.into(), pat_id, true, f.edition());
             f.write_str(&pat_str)?;
 
             f.write_str(": ")?;
@@ -194,7 +193,7 @@ fn write_impl_header(impl_: &Impl, f: &mut HirFormatter<'_>) -> Result<(), HirDi
 
     if let Some(trait_) = impl_.trait_(db) {
         let trait_data = db.trait_signature(trait_.id);
-        write!(f, " {} for", trait_data.name.display(db.upcast(), f.edition()))?;
+        write!(f, " {} for", trait_data.name.display(db, f.edition()))?;
     }
 
     f.write_char(' ')?;
@@ -245,7 +244,7 @@ impl HirDisplay for Struct {
         // FIXME: Render repr if its set explicitly?
         write_visibility(module_id, self.visibility(f.db), f)?;
         f.write_str("struct ")?;
-        write!(f, "{}", self.name(f.db).display(f.db.upcast(), f.edition()))?;
+        write!(f, "{}", self.name(f.db).display(f.db, f.edition()))?;
         let def_id = GenericDefId::AdtId(AdtId::StructId(self.id));
         write_generic_params(def_id, f)?;
 
@@ -284,7 +283,7 @@ impl HirDisplay for Enum {
     fn hir_fmt(&self, f: &mut HirFormatter<'_>) -> Result<(), HirDisplayError> {
         write_visibility(self.module(f.db).id, self.visibility(f.db), f)?;
         f.write_str("enum ")?;
-        write!(f, "{}", self.name(f.db).display(f.db.upcast(), f.edition()))?;
+        write!(f, "{}", self.name(f.db).display(f.db, f.edition()))?;
         let def_id = GenericDefId::AdtId(AdtId::EnumId(self.id));
         write_generic_params(def_id, f)?;
 
@@ -301,7 +300,7 @@ impl HirDisplay for Union {
     fn hir_fmt(&self, f: &mut HirFormatter<'_>) -> Result<(), HirDisplayError> {
         write_visibility(self.module(f.db).id, self.visibility(f.db), f)?;
         f.write_str("union ")?;
-        write!(f, "{}", self.name(f.db).display(f.db.upcast(), f.edition()))?;
+        write!(f, "{}", self.name(f.db).display(f.db, f.edition()))?;
         let def_id = GenericDefId::AdtId(AdtId::UnionId(self.id));
         write_generic_params(def_id, f)?;
 
@@ -361,7 +360,7 @@ fn write_variants(
     } else {
         f.write_str("{\n")?;
         for variant in &variants[..count] {
-            write!(f, "    {}", variant.name(f.db).display(f.db.upcast(), f.edition()))?;
+            write!(f, "    {}", variant.name(f.db).display(f.db, f.edition()))?;
             match variant.kind(f.db) {
                 StructKind::Tuple => {
                     let fields_str =
@@ -390,21 +389,21 @@ fn write_variants(
 impl HirDisplay for Field {
     fn hir_fmt(&self, f: &mut HirFormatter<'_>) -> Result<(), HirDisplayError> {
         write_visibility(self.parent.module(f.db).id, self.visibility(f.db), f)?;
-        write!(f, "{}: ", self.name(f.db).display(f.db.upcast(), f.edition()))?;
+        write!(f, "{}: ", self.name(f.db).display(f.db, f.edition()))?;
         self.ty(f.db).hir_fmt(f)
     }
 }
 
 impl HirDisplay for TupleField {
     fn hir_fmt(&self, f: &mut HirFormatter<'_>) -> Result<(), HirDisplayError> {
-        write!(f, "pub {}: ", self.name().display(f.db.upcast(), f.edition()))?;
+        write!(f, "pub {}: ", self.name().display(f.db, f.edition()))?;
         self.ty(f.db).hir_fmt(f)
     }
 }
 
 impl HirDisplay for Variant {
     fn hir_fmt(&self, f: &mut HirFormatter<'_>) -> Result<(), HirDisplayError> {
-        write!(f, "{}", self.name(f.db).display(f.db.upcast(), f.edition()))?;
+        write!(f, "{}", self.name(f.db).display(f.db, f.edition()))?;
         let data = f.db.variant_fields(self.id.into());
         match data.shape {
             FieldsShape::Unit => {}
@@ -442,7 +441,7 @@ impl HirDisplay for ExternCrateDecl {
     fn hir_fmt(&self, f: &mut HirFormatter<'_>) -> Result<(), HirDisplayError> {
         write_visibility(self.module(f.db).id, self.visibility(f.db), f)?;
         f.write_str("extern crate ")?;
-        write!(f, "{}", self.name(f.db).display(f.db.upcast(), f.edition()))?;
+        write!(f, "{}", self.name(f.db).display(f.db, f.edition()))?;
         if let Some(alias) = self.alias(f.db) {
             write!(f, " as {}", alias.display(f.edition()))?;
         }
@@ -496,7 +495,7 @@ impl HirDisplay for TypeParam {
         match param_data {
             TypeOrConstParamData::TypeParamData(p) => match p.provenance {
                 TypeParamProvenance::TypeParamList | TypeParamProvenance::TraitSelf => {
-                    write!(f, "{}", p.name.clone().unwrap().display(f.db.upcast(), f.edition()))?
+                    write!(f, "{}", p.name.clone().unwrap().display(f.db, f.edition()))?
                 }
                 TypeParamProvenance::ArgumentImplTrait => {
                     return write_bounds_like_dyn_trait_with_prefix(
@@ -509,7 +508,7 @@ impl HirDisplay for TypeParam {
                 }
             },
             TypeOrConstParamData::ConstParamData(p) => {
-                write!(f, "{}", p.name.display(f.db.upcast(), f.edition()))?;
+                write!(f, "{}", p.name.display(f.db, f.edition()))?;
             }
         }
 
@@ -543,13 +542,13 @@ impl HirDisplay for TypeParam {
 
 impl HirDisplay for LifetimeParam {
     fn hir_fmt(&self, f: &mut HirFormatter<'_>) -> Result<(), HirDisplayError> {
-        write!(f, "{}", self.name(f.db).display(f.db.upcast(), f.edition()))
+        write!(f, "{}", self.name(f.db).display(f.db, f.edition()))
     }
 }
 
 impl HirDisplay for ConstParam {
     fn hir_fmt(&self, f: &mut HirFormatter<'_>) -> Result<(), HirDisplayError> {
-        write!(f, "const {}: ", self.name(f.db).display(f.db.upcast(), f.edition()))?;
+        write!(f, "const {}: ", self.name(f.db).display(f.db, f.edition()))?;
         self.ty(f.db).hir_fmt(f)
     }
 }
@@ -581,7 +580,7 @@ fn write_generic_params(
     };
     for (_, lifetime) in params.iter_lt() {
         delim(f)?;
-        write!(f, "{}", lifetime.name.display(f.db.upcast(), f.edition()))?;
+        write!(f, "{}", lifetime.name.display(f.db, f.edition()))?;
     }
     for (_, ty) in params.iter_type_or_consts() {
         if let Some(name) = &ty.name() {
@@ -591,7 +590,7 @@ fn write_generic_params(
                         continue;
                     }
                     delim(f)?;
-                    write!(f, "{}", name.display(f.db.upcast(), f.edition()))?;
+                    write!(f, "{}", name.display(f.db, f.edition()))?;
                     if let Some(default) = &ty.default {
                         f.write_str(" = ")?;
                         default.hir_fmt(f, &store)?;
@@ -599,7 +598,7 @@ fn write_generic_params(
                 }
                 TypeOrConstParamData::ConstParamData(c) => {
                     delim(f)?;
-                    write!(f, "const {}: ", name.display(f.db.upcast(), f.edition()))?;
+                    write!(f, "const {}: ", name.display(f.db, f.edition()))?;
                     c.ty.hir_fmt(f, &store)?;
 
                     if let Some(default) = &c.default {
@@ -657,7 +656,7 @@ fn write_where_predicates(
     let write_target = |target: &WherePredicateTypeTarget, f: &mut HirFormatter<'_>| match target {
         WherePredicateTypeTarget::TypeRef(ty) => ty.hir_fmt(f, store),
         WherePredicateTypeTarget::TypeOrConstParam(id) => match params[*id].name() {
-            Some(name) => write!(f, "{}", name.display(f.db.upcast(), f.edition())),
+            Some(name) => write!(f, "{}", name.display(f.db, f.edition())),
             None => f.write_str("{unnamed}"),
         },
     };
@@ -691,8 +690,7 @@ fn write_where_predicates(
                 bound.hir_fmt(f, store)?;
             }
             ForLifetime { lifetimes, target, bound } => {
-                let lifetimes =
-                    lifetimes.iter().map(|it| it.display(f.db.upcast(), f.edition())).join(", ");
+                let lifetimes = lifetimes.iter().map(|it| it.display(f.db, f.edition())).join(", ");
                 write!(f, "for<{lifetimes}> ")?;
                 write_target(target, f)?;
                 f.write_str(": ")?;
@@ -726,7 +724,7 @@ impl HirDisplay for Const {
         let data = db.const_signature(self.id);
         f.write_str("const ")?;
         match &data.name {
-            Some(name) => write!(f, "{}: ", name.display(f.db.upcast(), f.edition()))?,
+            Some(name) => write!(f, "{}: ", name.display(f.db, f.edition()))?,
             None => f.write_str("_: ")?,
         }
         data.type_ref.hir_fmt(f, &data.store)?;
@@ -742,7 +740,7 @@ impl HirDisplay for Static {
         if data.flags.contains(StaticFlags::MUTABLE) {
             f.write_str("mut ")?;
         }
-        write!(f, "{}: ", data.name.display(f.db.upcast(), f.edition()))?;
+        write!(f, "{}: ", data.name.display(f.db, f.edition()))?;
         data.type_ref.hir_fmt(f, &data.store)?;
         Ok(())
     }
@@ -802,7 +800,7 @@ fn write_trait_header(trait_: &Trait, f: &mut HirFormatter<'_>) -> Result<(), Hi
     if data.flags.contains(TraitFlags::IS_AUTO) {
         f.write_str("auto ")?;
     }
-    write!(f, "trait {}", data.name.display(f.db.upcast(), f.edition()))?;
+    write!(f, "trait {}", data.name.display(f.db, f.edition()))?;
     write_generic_params(GenericDefId::TraitId(trait_.id), f)?;
     Ok(())
 }
@@ -811,7 +809,7 @@ impl HirDisplay for TraitAlias {
     fn hir_fmt(&self, f: &mut HirFormatter<'_>) -> Result<(), HirDisplayError> {
         write_visibility(self.module(f.db).id, self.visibility(f.db), f)?;
         let data = f.db.trait_alias_signature(self.id);
-        write!(f, "trait {}", data.name.display(f.db.upcast(), f.edition()))?;
+        write!(f, "trait {}", data.name.display(f.db, f.edition()))?;
         let def_id = GenericDefId::TraitAliasId(self.id);
         write_generic_params(def_id, f)?;
         f.write_str(" = ")?;
@@ -827,7 +825,7 @@ impl HirDisplay for TypeAlias {
     fn hir_fmt(&self, f: &mut HirFormatter<'_>) -> Result<(), HirDisplayError> {
         write_visibility(self.module(f.db).id, self.visibility(f.db), f)?;
         let data = f.db.type_alias_signature(self.id);
-        write!(f, "type {}", data.name.display(f.db.upcast(), f.edition()))?;
+        write!(f, "type {}", data.name.display(f.db, f.edition()))?;
         let def_id = GenericDefId::TypeAliasId(self.id);
         write_generic_params(def_id, f)?;
         if !data.bounds.is_empty() {
@@ -858,7 +856,7 @@ impl HirDisplay for Module {
             }
         }
         match self.name(f.db) {
-            Some(name) => write!(f, "mod {}", name.display(f.db.upcast(), f.edition())),
+            Some(name) => write!(f, "mod {}", name.display(f.db, f.edition())),
             None => f.write_str("mod {unknown}"),
         }
     }
@@ -880,6 +878,6 @@ impl HirDisplay for Macro {
             hir_def::MacroId::MacroRulesId(_) => f.write_str("macro_rules!"),
             hir_def::MacroId::ProcMacroId(_) => f.write_str("proc_macro"),
         }?;
-        write!(f, " {}", self.name(f.db).display(f.db.upcast(), f.edition()))
+        write!(f, " {}", self.name(f.db).display(f.db, f.edition()))
     }
 }

--- a/crates/hir/src/has_source.rs
+++ b/crates/hir/src/has_source.rs
@@ -36,23 +36,23 @@ pub trait HasSource {
 impl Module {
     /// Returns a node which defines this module. That is, a file or a `mod foo {}` with items.
     pub fn definition_source(self, db: &dyn HirDatabase) -> InFile<ModuleSource> {
-        let def_map = self.id.def_map(db.upcast());
-        def_map[self.id.local_id].definition_source(db.upcast())
+        let def_map = self.id.def_map(db);
+        def_map[self.id.local_id].definition_source(db)
     }
 
     /// Returns a node which defines this module. That is, a file or a `mod foo {}` with items.
     pub fn definition_source_range(self, db: &dyn HirDatabase) -> InFile<TextRange> {
-        let def_map = self.id.def_map(db.upcast());
-        def_map[self.id.local_id].definition_source_range(db.upcast())
+        let def_map = self.id.def_map(db);
+        def_map[self.id.local_id].definition_source_range(db)
     }
 
     pub fn definition_source_file_id(self, db: &dyn HirDatabase) -> HirFileId {
-        let def_map = self.id.def_map(db.upcast());
+        let def_map = self.id.def_map(db);
         def_map[self.id.local_id].definition_source_file_id()
     }
 
     pub fn is_mod_rs(self, db: &dyn HirDatabase) -> bool {
-        let def_map = self.id.def_map(db.upcast());
+        let def_map = self.id.def_map(db);
         match def_map[self.id.local_id].origin {
             ModuleOrigin::File { is_mod_rs, .. } => is_mod_rs,
             _ => false,
@@ -60,7 +60,7 @@ impl Module {
     }
 
     pub fn as_source_file_id(self, db: &dyn HirDatabase) -> Option<EditionedFileId> {
-        let def_map = self.id.def_map(db.upcast());
+        let def_map = self.id.def_map(db);
         match def_map[self.id.local_id].origin {
             ModuleOrigin::File { definition, .. } | ModuleOrigin::CrateRoot { definition, .. } => {
                 Some(definition)
@@ -70,22 +70,22 @@ impl Module {
     }
 
     pub fn is_inline(self, db: &dyn HirDatabase) -> bool {
-        let def_map = self.id.def_map(db.upcast());
+        let def_map = self.id.def_map(db);
         def_map[self.id.local_id].origin.is_inline()
     }
 
     /// Returns a node which declares this module, either a `mod foo;` or a `mod foo {}`.
     /// `None` for the crate root.
     pub fn declaration_source(self, db: &dyn HirDatabase) -> Option<InFile<ast::Module>> {
-        let def_map = self.id.def_map(db.upcast());
-        def_map[self.id.local_id].declaration_source(db.upcast())
+        let def_map = self.id.def_map(db);
+        def_map[self.id.local_id].declaration_source(db)
     }
 
     /// Returns a text range which declares this module, either a `mod foo;` or a `mod foo {}`.
     /// `None` for the crate root.
     pub fn declaration_source_range(self, db: &dyn HirDatabase) -> Option<InFile<TextRange>> {
-        let def_map = self.id.def_map(db.upcast());
-        def_map[self.id.local_id].declaration_source_range(db.upcast())
+        let def_map = self.id.def_map(db);
+        def_map[self.id.local_id].declaration_source_range(db)
     }
 }
 
@@ -93,7 +93,7 @@ impl HasSource for Field {
     type Ast = FieldSource;
     fn source(self, db: &dyn HirDatabase) -> Option<InFile<Self::Ast>> {
         let var = VariantId::from(self.parent);
-        let src = var.child_source(db.upcast());
+        let src = var.child_source(db);
         let field_source = src.map(|it| match it[self.id].clone() {
             Either::Left(it) => FieldSource::Pos(it),
             Either::Right(it) => FieldSource::Named(it),
@@ -124,96 +124,88 @@ impl HasSource for VariantDef {
 impl HasSource for Struct {
     type Ast = ast::Struct;
     fn source(self, db: &dyn HirDatabase) -> Option<InFile<Self::Ast>> {
-        Some(self.id.lookup(db.upcast()).source(db.upcast()))
+        Some(self.id.lookup(db).source(db))
     }
 }
 impl HasSource for Union {
     type Ast = ast::Union;
     fn source(self, db: &dyn HirDatabase) -> Option<InFile<Self::Ast>> {
-        Some(self.id.lookup(db.upcast()).source(db.upcast()))
+        Some(self.id.lookup(db).source(db))
     }
 }
 impl HasSource for Enum {
     type Ast = ast::Enum;
     fn source(self, db: &dyn HirDatabase) -> Option<InFile<Self::Ast>> {
-        Some(self.id.lookup(db.upcast()).source(db.upcast()))
+        Some(self.id.lookup(db).source(db))
     }
 }
 impl HasSource for Variant {
     type Ast = ast::Variant;
     fn source(self, db: &dyn HirDatabase) -> Option<InFile<ast::Variant>> {
-        Some(self.id.lookup(db.upcast()).source(db.upcast()))
+        Some(self.id.lookup(db).source(db))
     }
 }
 impl HasSource for Function {
     type Ast = ast::Fn;
     fn source(self, db: &dyn HirDatabase) -> Option<InFile<Self::Ast>> {
-        Some(self.id.lookup(db.upcast()).source(db.upcast()))
+        Some(self.id.lookup(db).source(db))
     }
 }
 impl HasSource for Const {
     type Ast = ast::Const;
     fn source(self, db: &dyn HirDatabase) -> Option<InFile<Self::Ast>> {
-        Some(self.id.lookup(db.upcast()).source(db.upcast()))
+        Some(self.id.lookup(db).source(db))
     }
 }
 impl HasSource for Static {
     type Ast = ast::Static;
     fn source(self, db: &dyn HirDatabase) -> Option<InFile<Self::Ast>> {
-        Some(self.id.lookup(db.upcast()).source(db.upcast()))
+        Some(self.id.lookup(db).source(db))
     }
 }
 impl HasSource for Trait {
     type Ast = ast::Trait;
     fn source(self, db: &dyn HirDatabase) -> Option<InFile<Self::Ast>> {
-        Some(self.id.lookup(db.upcast()).source(db.upcast()))
+        Some(self.id.lookup(db).source(db))
     }
 }
 impl HasSource for TraitAlias {
     type Ast = ast::TraitAlias;
     fn source(self, db: &dyn HirDatabase) -> Option<InFile<Self::Ast>> {
-        Some(self.id.lookup(db.upcast()).source(db.upcast()))
+        Some(self.id.lookup(db).source(db))
     }
 }
 impl HasSource for TypeAlias {
     type Ast = ast::TypeAlias;
     fn source(self, db: &dyn HirDatabase) -> Option<InFile<Self::Ast>> {
-        Some(self.id.lookup(db.upcast()).source(db.upcast()))
+        Some(self.id.lookup(db).source(db))
     }
 }
 impl HasSource for Macro {
     type Ast = Either<ast::Macro, ast::Fn>;
     fn source(self, db: &dyn HirDatabase) -> Option<InFile<Self::Ast>> {
         match self.id {
-            MacroId::Macro2Id(it) => Some(
-                it.lookup(db.upcast())
-                    .source(db.upcast())
-                    .map(ast::Macro::MacroDef)
-                    .map(Either::Left),
-            ),
-            MacroId::MacroRulesId(it) => Some(
-                it.lookup(db.upcast())
-                    .source(db.upcast())
-                    .map(ast::Macro::MacroRules)
-                    .map(Either::Left),
-            ),
-            MacroId::ProcMacroId(it) => {
-                Some(it.lookup(db.upcast()).source(db.upcast()).map(Either::Right))
+            MacroId::Macro2Id(it) => {
+                Some(it.lookup(db).source(db).map(ast::Macro::MacroDef).map(Either::Left))
             }
+            MacroId::MacroRulesId(it) => {
+                Some(it.lookup(db).source(db).map(ast::Macro::MacroRules).map(Either::Left))
+            }
+            MacroId::ProcMacroId(it) => Some(it.lookup(db).source(db).map(Either::Right)),
         }
     }
 }
 impl HasSource for Impl {
     type Ast = ast::Impl;
     fn source(self, db: &dyn HirDatabase) -> Option<InFile<Self::Ast>> {
-        Some(self.id.lookup(db.upcast()).source(db.upcast()))
+        Some(self.id.lookup(db).source(db))
     }
 }
 
 impl HasSource for TypeOrConstParam {
     type Ast = Either<ast::TypeOrConstParam, ast::TraitOrAlias>;
     fn source(self, db: &dyn HirDatabase) -> Option<InFile<Self::Ast>> {
-        let child_source = self.id.parent.child_source(db.upcast());
+        let child_source = self.id.parent.child_source(db);
         child_source.map(|it| it.get(self.id.local_id).cloned()).transpose()
     }
 }
@@ -221,7 +213,7 @@ impl HasSource for TypeOrConstParam {
 impl HasSource for LifetimeParam {
     type Ast = ast::LifetimeParam;
     fn source(self, db: &dyn HirDatabase) -> Option<InFile<Self::Ast>> {
-        let child_source = self.id.parent.child_source(db.upcast());
+        let child_source = self.id.parent.child_source(db);
         child_source.map(|it| it.get(self.id.local_id).cloned()).transpose()
     }
 }
@@ -291,7 +283,7 @@ impl HasSource for Label {
     fn source(self, db: &dyn HirDatabase) -> Option<InFile<Self::Ast>> {
         let (_body, source_map) = db.body_with_source_map(self.parent);
         let src = source_map.label_syntax(self.label_id);
-        let root = src.file_syntax(db.upcast());
+        let root = src.file_syntax(db);
         Some(src.map(|ast| ast.to_node(&root)))
     }
 }
@@ -300,7 +292,7 @@ impl HasSource for ExternCrateDecl {
     type Ast = ast::ExternCrate;
 
     fn source(self, db: &dyn HirDatabase) -> Option<InFile<Self::Ast>> {
-        Some(self.id.lookup(db.upcast()).source(db.upcast()))
+        Some(self.id.lookup(db).source(db))
     }
 }
 
@@ -309,7 +301,7 @@ impl HasSource for InlineAsmOperand {
     fn source(self, db: &dyn HirDatabase) -> Option<InFile<Self::Ast>> {
         let source_map = db.body_with_source_map(self.owner).1;
         if let Ok(src) = source_map.expr_syntax(self.expr) {
-            let root = src.file_syntax(db.upcast());
+            let root = src.file_syntax(db);
             return src
                 .map(|ast| match ast.to_node(&root) {
                     Either::Left(ast::Expr::AsmExpr(asm)) => asm

--- a/crates/hir/src/semantics/child_by_source.rs
+++ b/crates/hir/src/semantics/child_by_source.rs
@@ -38,7 +38,7 @@ impl ChildBySource for TraitId {
 
         data.attribute_calls().filter(|(ast_id, _)| ast_id.file_id == file_id).for_each(
             |(ast_id, call_id)| {
-                res[keys::ATTR_MACRO_CALL].insert(ast_id.to_ptr(db.upcast()), call_id);
+                res[keys::ATTR_MACRO_CALL].insert(ast_id.to_ptr(db), call_id);
             },
         );
         data.items.iter().for_each(|&(_, item)| {
@@ -53,7 +53,7 @@ impl ChildBySource for ImplId {
         // FIXME: Macro calls
         data.attribute_calls().filter(|(ast_id, _)| ast_id.file_id == file_id).for_each(
             |(ast_id, call_id)| {
-                res[keys::ATTR_MACRO_CALL].insert(ast_id.to_ptr(db.upcast()), call_id);
+                res[keys::ATTR_MACRO_CALL].insert(ast_id.to_ptr(db), call_id);
             },
         );
         data.items.iter().for_each(|&(_, item)| {
@@ -84,7 +84,7 @@ impl ChildBySource for ItemScope {
             .for_each(|konst| insert_item_loc(db, res, file_id, konst, keys::CONST));
         self.attr_macro_invocs().filter(|(id, _)| id.file_id == file_id).for_each(
             |(ast_id, call_id)| {
-                res[keys::ATTR_MACRO_CALL].insert(ast_id.to_ptr(db.upcast()), call_id);
+                res[keys::ATTR_MACRO_CALL].insert(ast_id.to_ptr(db), call_id);
             },
         );
         self.legacy_macros().for_each(|(_, ids)| {
@@ -99,7 +99,7 @@ impl ChildBySource for ItemScope {
         });
         self.derive_macro_invocs().filter(|(id, _)| id.file_id == file_id).for_each(
             |(ast_id, calls)| {
-                let adt = ast_id.to_node(db.upcast());
+                let adt = ast_id.to_node(db);
                 calls.for_each(|(attr_id, call_id, calls)| {
                     if let Some((_, Either::Left(attr))) =
                         collect_attrs(&adt).nth(attr_id.ast_index())
@@ -112,7 +112,7 @@ impl ChildBySource for ItemScope {
         );
         self.iter_macro_invoc().filter(|(id, _)| id.file_id == file_id).for_each(
             |(ast_id, &call)| {
-                let ast = ast_id.to_ptr(db.upcast());
+                let ast = ast_id.to_ptr(db);
                 res[keys::MACRO_CALL].insert(ast, call);
             },
         );
@@ -204,7 +204,7 @@ impl ChildBySource for DefWithBodyId {
             // All block expressions are merged into the same map, because they logically all add
             // inner items to the containing `DefWithBodyId`.
             def_map[DefMap::ROOT].scope.child_by_source_to(db, res, file_id);
-            res[keys::BLOCK].insert(block.lookup(db).ast_id.to_ptr(db.upcast()), block);
+            res[keys::BLOCK].insert(block.lookup(db).ast_id.to_ptr(db), block);
         }
     }
 }

--- a/crates/hir/src/term_search/expr.rs
+++ b/crates/hir/src/term_search/expr.rs
@@ -22,7 +22,7 @@ fn mod_item_path(
 ) -> Option<ModPath> {
     let db = sema_scope.db;
     let m = sema_scope.module();
-    m.find_path(db.upcast(), *def, cfg)
+    m.find_path(db, *def, cfg)
 }
 
 /// Helper function to get path to `ModuleDef` as string
@@ -33,7 +33,7 @@ fn mod_item_path_str(
     edition: Edition,
 ) -> Result<String, DisplaySourceCodeError> {
     let path = mod_item_path(sema_scope, def, cfg);
-    path.map(|it| it.display(sema_scope.db.upcast(), edition).to_string())
+    path.map(|it| it.display(sema_scope.db, edition).to_string())
         .ok_or(DisplaySourceCodeError::PathNotFound)
 }
 
@@ -111,15 +111,15 @@ impl Expr {
                         container_name(container, sema_scope, cfg, edition, display_target)?;
                     let const_name = it
                         .name(db)
-                        .map(|c| c.display(db.upcast(), edition).to_string())
+                        .map(|c| c.display(db, edition).to_string())
                         .unwrap_or(String::new());
                     Ok(format!("{container_name}::{const_name}"))
                 }
                 None => mod_item_path_str(sema_scope, &ModuleDef::Const(*it)),
             },
             Expr::Static(it) => mod_item_path_str(sema_scope, &ModuleDef::Static(*it)),
-            Expr::Local(it) => Ok(it.name(db).display(db.upcast(), edition).to_string()),
-            Expr::ConstParam(it) => Ok(it.name(db).display(db.upcast(), edition).to_string()),
+            Expr::Local(it) => Ok(it.name(db).display(db, edition).to_string()),
+            Expr::ConstParam(it) => Ok(it.name(db).display(db, edition).to_string()),
             Expr::FamousType { value, .. } => Ok(value.to_string()),
             Expr::Function { func, params, .. } => {
                 let args = params
@@ -133,7 +133,7 @@ impl Expr {
                     Some(container) => {
                         let container_name =
                             container_name(container, sema_scope, cfg, edition, display_target)?;
-                        let fn_name = func.name(db).display(db.upcast(), edition).to_string();
+                        let fn_name = func.name(db).display(db, edition).to_string();
                         Ok(format!("{container_name}::{fn_name}({args})"))
                     }
                     None => {
@@ -147,7 +147,7 @@ impl Expr {
                     return Ok(many_formatter(&target.ty(db)));
                 }
 
-                let func_name = func.name(db).display(db.upcast(), edition).to_string();
+                let func_name = func.name(db).display(db, edition).to_string();
                 let self_param = func.self_param(db).unwrap();
                 let target_str =
                     target.gen_source_code(sema_scope, many_formatter, cfg, display_target)?;
@@ -199,7 +199,7 @@ impl Expr {
                             .map(|(a, f)| {
                                 let tmp = format!(
                                     "{}: {}",
-                                    f.name(db).display(db.upcast(), edition),
+                                    f.name(db).display(db, edition),
                                     a.gen_source_code(
                                         sema_scope,
                                         many_formatter,
@@ -241,7 +241,7 @@ impl Expr {
                             .map(|(a, f)| {
                                 let tmp = format!(
                                     "{}: {}",
-                                    f.name(db).display(db.upcast(), edition),
+                                    f.name(db).display(db, edition),
                                     a.gen_source_code(
                                         sema_scope,
                                         many_formatter,
@@ -279,7 +279,7 @@ impl Expr {
 
                 let strukt =
                     expr.gen_source_code(sema_scope, many_formatter, cfg, display_target)?;
-                let field = field.name(db).display(db.upcast(), edition).to_string();
+                let field = field.name(db).display(db, edition).to_string();
                 Ok(format!("{strukt}.{field}"))
             }
             Expr::Reference(expr) => {
@@ -387,7 +387,7 @@ fn container_name(
             let self_ty = imp.self_ty(sema_scope.db);
             // Should it be guaranteed that `mod_item_path` always exists?
             match self_ty.as_adt().and_then(|adt| mod_item_path(sema_scope, &adt.into(), cfg)) {
-                Some(path) => path.display(sema_scope.db.upcast(), edition).to_string(),
+                Some(path) => path.display(sema_scope.db, edition).to_string(),
                 None => self_ty.display(sema_scope.db, display_target).to_string(),
             }
         }

--- a/crates/ide-assists/src/handlers/extract_function.rs
+++ b/crates/ide-assists/src/handlers/extract_function.rs
@@ -248,11 +248,8 @@ fn make_function_name(semantics_scope: &hir::SemanticsScope<'_>) -> ast::NameRef
     let mut names_in_scope = vec![];
     semantics_scope.process_all_names(&mut |name, _| {
         names_in_scope.push(
-            name.display(
-                semantics_scope.db.upcast(),
-                semantics_scope.krate().edition(semantics_scope.db),
-            )
-            .to_string(),
+            name.display(semantics_scope.db, semantics_scope.krate().edition(semantics_scope.db))
+                .to_string(),
         )
     });
 

--- a/crates/ide-assists/src/handlers/fix_visibility.rs
+++ b/crates/ide-assists/src/handlers/fix_visibility.rs
@@ -159,11 +159,7 @@ fn target_data_for_def(
         let in_file_syntax = source.syntax();
         let file_id = in_file_syntax.file_id;
         let range = in_file_syntax.value.text_range();
-        Some((
-            ast::AnyHasVisibility::new(source.value),
-            range,
-            file_id.original_file(db.upcast()).file_id(),
-        ))
+        Some((ast::AnyHasVisibility::new(source.value), range, file_id.original_file(db).file_id()))
     }
 
     let target_name;
@@ -203,7 +199,7 @@ fn target_data_for_def(
         hir::ModuleDef::Module(m) => {
             target_name = m.name(db);
             let in_file_source = m.declaration_source(db)?;
-            let file_id = in_file_source.file_id.original_file(db.upcast());
+            let file_id = in_file_source.file_id.original_file(db);
             let range = in_file_source.value.syntax().text_range();
             (ast::AnyHasVisibility::new(in_file_source.value), range, file_id.file_id())
         }

--- a/crates/ide-assists/src/handlers/generate_constant.rs
+++ b/crates/ide-assists/src/handlers/generate_constant.rs
@@ -3,7 +3,6 @@ use hir::{HasVisibility, HirDisplay, HirFileIdExt, Module};
 use ide_db::{
     FileId,
     assists::AssistId,
-    base_db::Upcast,
     defs::{Definition, NameRefClass},
 };
 use syntax::{
@@ -123,7 +122,7 @@ fn target_data_for_generate_constant(
         return None;
     }
     let in_file_source = current_module.definition_source(ctx.sema.db);
-    let file_id = in_file_source.file_id.original_file(ctx.sema.db.upcast());
+    let file_id = in_file_source.file_id.original_file(ctx.sema.db);
     match in_file_source.value {
         hir::ModuleSource::Module(module_node) => {
             let indent = IndentLevel::from_node(module_node.syntax());

--- a/crates/ide-assists/src/handlers/generate_function.rs
+++ b/crates/ide-assists/src/handlers/generate_function.rs
@@ -1166,7 +1166,7 @@ fn next_space_for_fn_in_module(
     target_module: hir::Module,
 ) -> (FileId, GeneratedFunctionTarget) {
     let module_source = target_module.definition_source(db);
-    let file = module_source.file_id.original_file(db.upcast());
+    let file = module_source.file_id.original_file(db);
     let assist_item = match &module_source.value {
         hir::ModuleSource::SourceFile(it) => match it.items().last() {
             Some(last_item) => GeneratedFunctionTarget::AfterItem(last_item.syntax().clone()),

--- a/crates/ide-completion/src/render/pattern.rs
+++ b/crates/ide-completion/src/render/pattern.rs
@@ -191,7 +191,7 @@ fn render_record_as_pat(
             format!(
                 "{name} {{ {}{} }}",
                 fields.enumerate().format_with(", ", |(idx, field), f| {
-                    f(&format_args!("{}${}", field.name(db).display(db.upcast(), edition), idx + 1))
+                    f(&format_args!("{}${}", field.name(db).display(db, edition), idx + 1))
                 }),
                 if fields_omitted { ", .." } else { "" },
                 name = name

--- a/crates/ide-db/src/lib.rs
+++ b/crates/ide-db/src/lib.rs
@@ -52,11 +52,11 @@ use std::{fmt, mem::ManuallyDrop};
 
 use base_db::{
     CrateGraphBuilder, CratesMap, FileSourceRootInput, FileText, Files, RootQueryDb,
-    SourceDatabase, SourceRoot, SourceRootId, SourceRootInput, Upcast, query_group,
+    SourceDatabase, SourceRoot, SourceRootId, SourceRootInput, query_group,
 };
 use hir::{
     FilePositionWrapper, FileRangeWrapper,
-    db::{DefDatabase, ExpandDatabase, HirDatabase},
+    db::{DefDatabase, ExpandDatabase},
 };
 use triomphe::Arc;
 
@@ -113,39 +113,6 @@ impl Clone for RootDatabase {
 impl fmt::Debug for RootDatabase {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("RootDatabase").finish()
-    }
-}
-
-impl Upcast<dyn ExpandDatabase> for RootDatabase {
-    #[inline]
-    fn upcast(&self) -> &(dyn ExpandDatabase + 'static) {
-        self
-    }
-}
-
-impl Upcast<dyn DefDatabase> for RootDatabase {
-    #[inline]
-    fn upcast(&self) -> &(dyn DefDatabase + 'static) {
-        self
-    }
-}
-
-impl Upcast<dyn HirDatabase> for RootDatabase {
-    #[inline]
-    fn upcast(&self) -> &(dyn HirDatabase + 'static) {
-        self
-    }
-}
-
-impl Upcast<dyn RootQueryDb> for RootDatabase {
-    fn upcast(&self) -> &(dyn RootQueryDb + 'static) {
-        self
-    }
-}
-
-impl Upcast<dyn SourceDatabase> for RootDatabase {
-    fn upcast(&self) -> &(dyn SourceDatabase + 'static) {
-        self
     }
 }
 

--- a/crates/ide-db/src/path_transform.rs
+++ b/crates/ide-db/src/path_transform.rs
@@ -210,7 +210,7 @@ impl<'a> PathTransform<'a> {
             .flat_map(|it| it.lifetime_params(db))
             .zip(self.substs.lifetimes.clone())
             .filter_map(|(k, v)| {
-                Some((k.name(db).display(db.upcast(), target_edition).to_string(), v.lifetime()?))
+                Some((k.name(db).display(db, target_edition).to_string(), v.lifetime()?))
             })
             .collect();
         let ctx = Ctx {
@@ -325,7 +325,7 @@ impl Ctx<'_> {
                                 allow_unstable: true,
                             };
                             let found_path = self.target_module.find_path(
-                                self.source_scope.db.upcast(),
+                                self.source_scope.db,
                                 hir::ModuleDef::Trait(trait_ref),
                                 cfg,
                             )?;
@@ -384,8 +384,7 @@ impl Ctx<'_> {
                     prefer_absolute: false,
                     allow_unstable: true,
                 };
-                let found_path =
-                    self.target_module.find_path(self.source_scope.db.upcast(), def, cfg)?;
+                let found_path = self.target_module.find_path(self.source_scope.db, def, cfg)?;
                 let res = mod_path_to_ast(&found_path, self.target_edition).clone_for_update();
                 if let Some(args) = path.segment().and_then(|it| it.generic_arg_list()) {
                     if let Some(segment) = res.segment() {
@@ -425,7 +424,7 @@ impl Ctx<'_> {
                             allow_unstable: true,
                         };
                         let found_path = self.target_module.find_path(
-                            self.source_scope.db.upcast(),
+                            self.source_scope.db,
                             ModuleDef::from(adt),
                             cfg,
                         )?;

--- a/crates/ide-db/src/symbol_index.rs
+++ b/crates/ide-db/src/symbol_index.rs
@@ -27,7 +27,7 @@ use std::{
     ops::ControlFlow,
 };
 
-use base_db::{RootQueryDb, SourceDatabase, SourceRootId, Upcast};
+use base_db::{RootQueryDb, SourceDatabase, SourceRootId};
 use fst::{Automaton, Streamer, raw::IndexedValue};
 use hir::{
     Crate, Module,
@@ -97,7 +97,7 @@ impl Query {
 }
 
 #[query_group::query_group]
-pub trait SymbolsDatabase: HirDatabase + SourceDatabase + Upcast<dyn HirDatabase> {
+pub trait SymbolsDatabase: HirDatabase + SourceDatabase {
     /// The symbol index for a given module. These modules should only be in source roots that
     /// are inside local_roots.
     fn module_symbols(&self, module: Module) -> Arc<SymbolIndex>;
@@ -123,11 +123,11 @@ pub trait SymbolsDatabase: HirDatabase + SourceDatabase + Upcast<dyn HirDatabase
 fn library_symbols(db: &dyn SymbolsDatabase, source_root_id: SourceRootId) -> Arc<SymbolIndex> {
     let _p = tracing::info_span!("library_symbols").entered();
 
-    let mut symbol_collector = SymbolCollector::new(db.upcast());
+    let mut symbol_collector = SymbolCollector::new(db);
 
     db.source_root_crates(source_root_id)
         .iter()
-        .flat_map(|&krate| Crate::from(krate).modules(db.upcast()))
+        .flat_map(|&krate| Crate::from(krate).modules(db))
         // we specifically avoid calling other SymbolsDatabase queries here, even though they do the same thing,
         // as the index for a library is not going to really ever change, and we do not want to store each
         // the module or crate indices for those in salsa unless we need to.
@@ -139,12 +139,12 @@ fn library_symbols(db: &dyn SymbolsDatabase, source_root_id: SourceRootId) -> Ar
 fn module_symbols(db: &dyn SymbolsDatabase, module: Module) -> Arc<SymbolIndex> {
     let _p = tracing::info_span!("module_symbols").entered();
 
-    Arc::new(SymbolIndex::new(SymbolCollector::new_module(db.upcast(), module)))
+    Arc::new(SymbolIndex::new(SymbolCollector::new_module(db, module)))
 }
 
 pub fn crate_symbols(db: &dyn SymbolsDatabase, krate: Crate) -> Box<[Arc<SymbolIndex>]> {
     let _p = tracing::info_span!("crate_symbols").entered();
-    krate.modules(db.upcast()).into_iter().map(|module| db.module_symbols(module)).collect()
+    krate.modules(db).into_iter().map(|module| db.module_symbols(module)).collect()
 }
 
 // Feature: Workspace Symbol

--- a/crates/ide-diagnostics/src/handlers/missing_fields.rs
+++ b/crates/ide-diagnostics/src/handlers/missing_fields.rs
@@ -175,7 +175,7 @@ fn make_ty(
     edition: Edition,
 ) -> ast::Type {
     let ty_str = match ty.as_adt() {
-        Some(adt) => adt.name(db).display(db.upcast(), edition).to_string(),
+        Some(adt) => adt.name(db).display(db, edition).to_string(),
         None => {
             ty.display_source_code(db, module.into(), false).ok().unwrap_or_else(|| "_".to_owned())
         }

--- a/crates/ide-diagnostics/src/handlers/unlinked_file.rs
+++ b/crates/ide-diagnostics/src/handlers/unlinked_file.rs
@@ -6,9 +6,7 @@ use hir::{DefMap, InFile, ModuleSource, db::DefDatabase};
 use ide_db::base_db::RootQueryDb;
 use ide_db::text_edit::TextEdit;
 use ide_db::{
-    FileId, FileRange, LineIndexDatabase,
-    base_db::{SourceDatabase, Upcast},
-    source_change::SourceChange,
+    FileId, FileRange, LineIndexDatabase, base_db::SourceDatabase, source_change::SourceChange,
 };
 use paths::Utf8Component;
 use syntax::{
@@ -101,7 +99,7 @@ fn fixes(
     };
 
     // check crate roots, i.e. main.rs, lib.rs, ...
-    let relevant_crates = Upcast::<dyn RootQueryDb>::upcast(db).relevant_crates(file_id);
+    let relevant_crates = db.relevant_crates(file_id);
     'crates: for &krate in &*relevant_crates {
         let crate_def_map = ctx.sema.db.crate_def_map(krate);
 
@@ -150,7 +148,7 @@ fn fixes(
             paths.into_iter().find_map(|path| source_root.file_for_path(&path))
         })?;
     stack.pop();
-    let relevant_crates = Upcast::<dyn RootQueryDb>::upcast(db).relevant_crates(parent_id);
+    let relevant_crates = db.relevant_crates(parent_id);
     'crates: for &krate in relevant_crates.iter() {
         let crate_def_map = ctx.sema.db.crate_def_map(krate);
         let Some((_, module)) = crate_def_map.modules().find(|(_, module)| {

--- a/crates/ide/src/expand_macro.rs
+++ b/crates/ide/src/expand_macro.rs
@@ -234,6 +234,8 @@ fn _format(
     file_id: FileId,
     expansion: &str,
 ) -> Option<String> {
+    use ide_db::base_db::RootQueryDb;
+
     // hack until we get hygiene working (same character amount to preserve formatting as much as possible)
     const DOLLAR_CRATE_REPLACE: &str = "__r_a_";
     const BUILTIN_REPLACE: &str = "builtin__POUND";
@@ -247,9 +249,8 @@ fn _format(
     };
     let expansion = format!("{prefix}{expansion}{suffix}");
 
-    let upcast_db = ide_db::base_db::Upcast::<dyn ide_db::base_db::RootQueryDb>::upcast(db);
-    let &crate_id = upcast_db.relevant_crates(file_id).iter().next()?;
-    let edition = crate_id.data(upcast_db).edition;
+    let &crate_id = db.relevant_crates(file_id).iter().next()?;
+    let edition = crate_id.data(db).edition;
 
     #[allow(clippy::disallowed_methods)]
     let mut cmd = std::process::Command::new(toolchain::Tool::Rustfmt.path());

--- a/crates/ide/src/goto_definition.rs
+++ b/crates/ide/src/goto_definition.rs
@@ -11,7 +11,7 @@ use hir::{
 };
 use ide_db::{
     RootDatabase, SymbolKind,
-    base_db::{AnchoredPath, RootQueryDb, SourceDatabase, Upcast},
+    base_db::{AnchoredPath, SourceDatabase},
     defs::{Definition, IdentClass},
     famous_defs::FamousDefs,
     helpers::pick_best_token,
@@ -222,8 +222,7 @@ fn try_lookup_include_path(
     }
     let path = token.value.value().ok()?;
 
-    let file_id = Upcast::<dyn RootQueryDb>::upcast(sema.db)
-        .resolve_path(AnchoredPath { anchor: file_id, path: &path })?;
+    let file_id = sema.db.resolve_path(AnchoredPath { anchor: file_id, path: &path })?;
     let size = sema.db.file_text(file_id).text(sema.db).len().try_into().ok()?;
     Some(NavigationTarget {
         file_id,

--- a/crates/ide/src/goto_type_definition.rs
+++ b/crates/ide/src/goto_type_definition.rs
@@ -1,5 +1,5 @@
 use hir::GenericParam;
-use ide_db::{RootDatabase, base_db::Upcast, defs::Definition, helpers::pick_best_token};
+use ide_db::{RootDatabase, defs::Definition, helpers::pick_best_token};
 use syntax::{AstNode, SyntaxKind::*, SyntaxToken, T, ast, match_ast};
 
 use crate::{FilePosition, NavigationTarget, RangeInfo, TryToNav};
@@ -87,7 +87,7 @@ pub(crate) fn goto_type_definition(
                             ast::Pat(it) => sema.type_of_pat(&it)?.original,
                             ast::SelfParam(it) => sema.type_of_self(&it)?,
                             ast::Type(it) => sema.resolve_type(&it)?,
-                            ast::RecordField(it) => sema.to_def(&it)?.ty(db.upcast()),
+                            ast::RecordField(it) => sema.to_def(&it)?.ty(db),
                             // can't match on RecordExprField directly as `ast::Expr` will match an iteration too early otherwise
                             ast::NameRef(it) => {
                                 if let Some(record_field) = ast::RecordExprField::for_name_ref(&it) {

--- a/crates/ide/src/lib.rs
+++ b/crates/ide/src/lib.rs
@@ -66,8 +66,7 @@ use hir::{ChangeWithProcMacros, sym};
 use ide_db::{
     FxHashMap, FxIndexSet, LineIndexDatabase,
     base_db::{
-        CrateOrigin, CrateWorkspaceData, Env, FileSet, RootQueryDb, SourceDatabase, Upcast,
-        VfsPath,
+        CrateOrigin, CrateWorkspaceData, Env, FileSet, RootQueryDb, SourceDatabase, VfsPath,
         salsa::{AsDynDatabase, Cancelled},
     },
     prime_caches, symbol_index,
@@ -623,10 +622,7 @@ impl Analysis {
 
     /// Returns crates that this file *might* belong to.
     pub fn relevant_crates_for(&self, file_id: FileId) -> Cancellable<Vec<Crate>> {
-        self.with_db(|db| {
-            let db = Upcast::<dyn RootQueryDb>::upcast(db);
-            db.relevant_crates(file_id).iter().copied().collect()
-        })
+        self.with_db(|db| db.relevant_crates(file_id).iter().copied().collect())
     }
 
     /// Returns the edition of the given crate.

--- a/crates/ide/src/parent_module.rs
+++ b/crates/ide/src/parent_module.rs
@@ -1,7 +1,7 @@
 use hir::{Semantics, db::DefDatabase};
 use ide_db::{
     FileId, FilePosition, RootDatabase,
-    base_db::{Crate, RootQueryDb, Upcast},
+    base_db::{Crate, RootQueryDb},
 };
 use itertools::Itertools;
 use syntax::{
@@ -54,9 +54,7 @@ pub(crate) fn parent_module(db: &RootDatabase, position: FilePosition) -> Vec<Na
 
 /// This returns `Vec` because a module may be included from several places.
 pub(crate) fn crates_for(db: &RootDatabase, file_id: FileId) -> Vec<Crate> {
-    let root_db = Upcast::<dyn RootQueryDb>::upcast(db);
-    root_db
-        .relevant_crates(file_id)
+    db.relevant_crates(file_id)
         .iter()
         .copied()
         .filter(|&crate_id| db.crate_def_map(crate_id).modules_for_file(file_id).next().is_some())

--- a/crates/rust-analyzer/src/cli.rs
+++ b/crates/rust-analyzer/src/cli.rs
@@ -86,6 +86,6 @@ fn full_name_of_item(db: &dyn HirDatabase, module: Module, name: Name) -> String
         .rev()
         .filter_map(|it| it.name(db))
         .chain(Some(name))
-        .map(|it| it.display(db.upcast(), Edition::LATEST).to_string())
+        .map(|it| it.display(db, Edition::LATEST).to_string())
         .join("::")
 }


### PR DESCRIPTION
This PR is very big, but the vast majority of it is find & replace of `.upcast()` with empty replacement. Few manual adjustments were needed, and removal of the `Upcast` trait. I don't think it needs more than a skim review.