### PR TITLE
fix: Fix invalid signature bitflags

### DIFF
--- a/crates/hir-def/src/expr_store/pretty.rs
+++ b/crates/hir-def/src/expr_store/pretty.rs
@@ -157,7 +157,7 @@ pub(crate) fn print_struct(
             wln!(p, "#[repr(pack({}))]", pack.bytes());
         }
     }
-    if flags.contains(StructFlags::IS_FUNDAMENTAL) {
+    if flags.contains(StructFlags::FUNDAMENTAL) {
         wln!(p, "#[fundamental]");
     }
     w!(p, "struct ");
@@ -202,16 +202,16 @@ pub(crate) fn print_function(
         line_format: LineFormat::Newline,
         edition,
     };
-    if flags.contains(FnFlags::HAS_CONST_KW) {
+    if flags.contains(FnFlags::CONST) {
         w!(p, "const ");
     }
-    if flags.contains(FnFlags::HAS_ASYNC_KW) {
+    if flags.contains(FnFlags::ASYNC) {
         w!(p, "async ");
     }
-    if flags.contains(FnFlags::HAS_UNSAFE_KW) {
+    if flags.contains(FnFlags::UNSAFE) {
         w!(p, "unsafe ");
     }
-    if flags.contains(FnFlags::HAS_SAFE_KW) {
+    if flags.contains(FnFlags::EXPLICIT_SAFE) {
         w!(p, "safe ");
     }
     if let Some(abi) = abi {

--- a/crates/hir-ty/src/chalk_db.rs
+++ b/crates/hir-ty/src/chalk_db.rs
@@ -674,13 +674,13 @@ pub(crate) fn trait_datum_query(
     let generic_params = generics(db, trait_.into());
     let bound_vars = generic_params.bound_vars_subst(db, DebruijnIndex::INNERMOST);
     let flags = rust_ir::TraitFlags {
-        auto: trait_data.flags.contains(TraitFlags::IS_AUTO),
+        auto: trait_data.flags.contains(TraitFlags::AUTO),
         upstream: trait_.lookup(db).container.krate() != krate,
         non_enumerable: true,
         coinductive: false, // only relevant for Chalk testing
         // FIXME: set these flags correctly
         marker: false,
-        fundamental: trait_data.flags.contains(TraitFlags::IS_FUNDAMENTAL),
+        fundamental: trait_data.flags.contains(TraitFlags::FUNDAMENTAL),
     };
     let where_clauses = convert_where_clauses(db, trait_.into(), &bound_vars);
     let associated_ty_ids =
@@ -761,10 +761,7 @@ pub(crate) fn adt_datum_query(
     let (fundamental, phantom_data) = match adt_id {
         hir_def::AdtId::StructId(s) => {
             let flags = db.struct_signature(s).flags;
-            (
-                flags.contains(StructFlags::IS_FUNDAMENTAL),
-                flags.contains(StructFlags::IS_PHANTOM_DATA),
-            )
+            (flags.contains(StructFlags::FUNDAMENTAL), flags.contains(StructFlags::IS_PHANTOM_DATA))
         }
         // FIXME set fundamental flags correctly
         hir_def::AdtId::UnionId(_) => (false, false),
@@ -851,7 +848,7 @@ fn impl_def_datum(db: &dyn HirDatabase, krate: Crate, impl_id: hir_def::ImplId) 
         rust_ir::ImplType::External
     };
     let where_clauses = convert_where_clauses(db, impl_id.into(), &bound_vars);
-    let negative = impl_data.flags.contains(ImplFlags::IS_NEGATIVE);
+    let negative = impl_data.flags.contains(ImplFlags::NEGATIVE);
     let polarity = if negative { rust_ir::Polarity::Negative } else { rust_ir::Polarity::Positive };
 
     let impl_datum_bound = rust_ir::ImplDatumBound { trait_ref, where_clauses };

--- a/crates/hir-ty/src/diagnostics/decl_check.rs
+++ b/crates/hir-ty/src/diagnostics/decl_check.rs
@@ -560,7 +560,7 @@ impl<'a> DeclValidator<'a> {
 
     fn validate_static(&mut self, static_id: StaticId) {
         let data = self.db.static_signature(static_id);
-        if data.flags.contains(StaticFlags::IS_EXTERN) {
+        if data.flags.contains(StaticFlags::EXTERN) {
             cov_mark::hit!(extern_static_incorrect_case_ignored);
             return;
         }

--- a/crates/hir-ty/src/diagnostics/unsafe_check.rs
+++ b/crates/hir-ty/src/diagnostics/unsafe_check.rs
@@ -361,8 +361,8 @@ impl<'a> UnsafeVisitor<'a> {
             let static_data = self.db.static_signature(id);
             if static_data.flags.contains(StaticFlags::MUTABLE) {
                 self.on_unsafe_op(node, UnsafetyReason::MutableStatic);
-            } else if static_data.flags.contains(StaticFlags::IS_EXTERN)
-                && !static_data.flags.contains(StaticFlags::HAS_SAFE)
+            } else if static_data.flags.contains(StaticFlags::EXTERN)
+                && !static_data.flags.contains(StaticFlags::EXPLICIT_SAFE)
             {
                 self.on_unsafe_op(node, UnsafetyReason::ExternStatic);
             }

--- a/crates/hir-ty/src/dyn_compatibility.rs
+++ b/crates/hir-ty/src/dyn_compatibility.rs
@@ -429,7 +429,7 @@ where
         // Allow `impl AutoTrait` predicates
         if let WhereClause::Implemented(TraitRef { trait_id, substitution }) = pred {
             let trait_data = db.trait_signature(from_chalk_trait_id(*trait_id));
-            if trait_data.flags.contains(TraitFlags::IS_AUTO)
+            if trait_data.flags.contains(TraitFlags::AUTO)
                 && substitution
                     .as_slice(Interner)
                     .first()

--- a/crates/hir-ty/src/lower.rs
+++ b/crates/hir-ty/src/lower.rs
@@ -586,13 +586,13 @@ impl<'a> TyLoweringContext<'a> {
                             .db
                             .trait_signature(from_chalk_trait_id(lhs_id))
                             .flags
-                            .contains(TraitFlags::IS_AUTO);
+                            .contains(TraitFlags::AUTO);
                         let rhs_id = rhs.trait_id;
                         let rhs_is_auto = ctx
                             .db
                             .trait_signature(from_chalk_trait_id(rhs_id))
                             .flags
-                            .contains(TraitFlags::IS_AUTO);
+                            .contains(TraitFlags::AUTO);
 
                         if !lhs_is_auto && !rhs_is_auto {
                             multiple_regular_traits = true;

--- a/crates/hir-ty/src/method_resolution.rs
+++ b/crates/hir-ty/src/method_resolution.rs
@@ -386,15 +386,15 @@ pub fn def_crates(db: &dyn HirDatabase, ty: &Ty, cur_crate: Crate) -> Option<Sma
                 hir_def::AdtId::StructId(id) => db
                     .struct_signature(id)
                     .flags
-                    .contains(StructFlags::IS_RUSTC_HAS_INCOHERENT_INHERENT_IMPLS),
+                    .contains(StructFlags::RUSTC_HAS_INCOHERENT_INHERENT_IMPLS),
                 hir_def::AdtId::UnionId(id) => db
                     .union_signature(id)
                     .flags
-                    .contains(StructFlags::IS_RUSTC_HAS_INCOHERENT_INHERENT_IMPLS),
+                    .contains(StructFlags::RUSTC_HAS_INCOHERENT_INHERENT_IMPLS),
                 hir_def::AdtId::EnumId(id) => db
                     .enum_signature(id)
                     .flags
-                    .contains(EnumFlags::IS_RUSTC_HAS_INCOHERENT_INHERENT_IMPLS),
+                    .contains(EnumFlags::RUSTC_HAS_INCOHERENT_INHERENT_IMPLS),
             };
             Some(if rustc_has_incoherent_inherent_impls {
                 db.incoherent_inherent_impl_crates(cur_crate, TyFingerprint::Adt(def_id))
@@ -408,7 +408,7 @@ pub fn def_crates(db: &dyn HirDatabase, ty: &Ty, cur_crate: Crate) -> Option<Sma
                 if db
                     .type_alias_signature(alias)
                     .flags
-                    .contains(TypeAliasFlags::RUSTC_HAS_INCOHERENT_INHERENT_IMPLS)
+                    .contains(TypeAliasFlags::RUSTC_HAS_INCOHERENT_INHERENT_IMPL)
                 {
                     db.incoherent_inherent_impl_crates(cur_crate, TyFingerprint::ForeignType(id))
                 } else {
@@ -831,15 +831,15 @@ fn is_inherent_impl_coherent(
                 hir_def::AdtId::StructId(id) => db
                     .struct_signature(id)
                     .flags
-                    .contains(StructFlags::IS_RUSTC_HAS_INCOHERENT_INHERENT_IMPLS),
+                    .contains(StructFlags::RUSTC_HAS_INCOHERENT_INHERENT_IMPLS),
                 hir_def::AdtId::UnionId(id) => db
                     .union_signature(id)
                     .flags
-                    .contains(StructFlags::IS_RUSTC_HAS_INCOHERENT_INHERENT_IMPLS),
+                    .contains(StructFlags::RUSTC_HAS_INCOHERENT_INHERENT_IMPLS),
                 hir_def::AdtId::EnumId(it) => db
                     .enum_signature(it)
                     .flags
-                    .contains(EnumFlags::IS_RUSTC_HAS_INCOHERENT_INHERENT_IMPLS),
+                    .contains(EnumFlags::RUSTC_HAS_INCOHERENT_INHERENT_IMPLS),
             },
             TyKind::Dyn(it) => it.principal_id().is_some_and(|trait_id| {
                 db.trait_signature(from_chalk_trait_id(trait_id))
@@ -854,7 +854,7 @@ fn is_inherent_impl_coherent(
             && !items.items.is_empty()
             && items.items.iter().all(|&(_, assoc)| match assoc {
                 AssocItemId::FunctionId(it) => {
-                    db.function_signature(it).flags.contains(FnFlags::RUSTC_ALLOW_INCOHERENT_IMPLS)
+                    db.function_signature(it).flags.contains(FnFlags::RUSTC_ALLOW_INCOHERENT_IMPL)
                 }
                 AssocItemId::ConstId(it) => {
                     db.const_signature(it).flags.contains(ConstFlags::RUSTC_ALLOW_INCOHERENT_IMPL)
@@ -862,7 +862,7 @@ fn is_inherent_impl_coherent(
                 AssocItemId::TypeAliasId(it) => db
                     .type_alias_signature(it)
                     .flags
-                    .contains(TypeAliasFlags::RUSTC_ALLOW_INCOHERENT_IMPLS),
+                    .contains(TypeAliasFlags::RUSTC_ALLOW_INCOHERENT_IMPL),
             })
     }
 }
@@ -898,7 +898,7 @@ pub fn check_orphan_rules(db: &dyn HirDatabase, impl_: ImplId) -> bool {
                 TyKind::Ref(_, _, referenced) => ty = referenced.clone(),
                 &TyKind::Adt(AdtId(hir_def::AdtId::StructId(s)), ref subs) => {
                     let struct_signature = db.struct_signature(s);
-                    if struct_signature.flags.contains(StructFlags::IS_FUNDAMENTAL) {
+                    if struct_signature.flags.contains(StructFlags::FUNDAMENTAL) {
                         let next = subs.type_parameters(Interner).next();
                         match next {
                             Some(it) => ty = it,

--- a/crates/hir-ty/src/mir/eval.rs
+++ b/crates/hir-ty/src/mir/eval.rs
@@ -2754,7 +2754,7 @@ impl Evaluator<'_> {
             return Ok(*o);
         };
         let static_data = self.db.static_signature(st);
-        let result = if !static_data.flags.contains(StaticFlags::IS_EXTERN) {
+        let result = if !static_data.flags.contains(StaticFlags::EXTERN) {
             let konst = self.db.const_eval_static(st).map_err(|e| {
                 MirEvalError::ConstEvalError(static_data.name.as_str().to_owned(), Box::new(e))
             })?;

--- a/crates/hir/src/display.rs
+++ b/crates/hir/src/display.rs
@@ -794,10 +794,10 @@ impl HirDisplay for Trait {
 fn write_trait_header(trait_: &Trait, f: &mut HirFormatter<'_>) -> Result<(), HirDisplayError> {
     write_visibility(trait_.module(f.db).id, trait_.visibility(f.db), f)?;
     let data = f.db.trait_signature(trait_.id);
-    if data.flags.contains(TraitFlags::IS_UNSAFE) {
+    if data.flags.contains(TraitFlags::UNSAFE) {
         f.write_str("unsafe ")?;
     }
-    if data.flags.contains(TraitFlags::IS_AUTO) {
+    if data.flags.contains(TraitFlags::AUTO) {
         f.write_str("auto ")?;
     }
     write!(f, "trait {}", data.name.display(f.db, f.edition()))?;

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -2898,11 +2898,11 @@ impl Trait {
     }
 
     pub fn is_auto(self, db: &dyn HirDatabase) -> bool {
-        db.trait_signature(self.id).flags.contains(TraitFlags::IS_AUTO)
+        db.trait_signature(self.id).flags.contains(TraitFlags::AUTO)
     }
 
     pub fn is_unsafe(&self, db: &dyn HirDatabase) -> bool {
-        db.trait_signature(self.id).flags.contains(TraitFlags::IS_UNSAFE)
+        db.trait_signature(self.id).flags.contains(TraitFlags::UNSAFE)
     }
 
     pub fn type_or_const_param_count(
@@ -4454,11 +4454,11 @@ impl Impl {
     }
 
     pub fn is_negative(self, db: &dyn HirDatabase) -> bool {
-        db.impl_signature(self.id).flags.contains(ImplFlags::IS_NEGATIVE)
+        db.impl_signature(self.id).flags.contains(ImplFlags::NEGATIVE)
     }
 
     pub fn is_unsafe(self, db: &dyn HirDatabase) -> bool {
-        db.impl_signature(self.id).flags.contains(ImplFlags::IS_UNSAFE)
+        db.impl_signature(self.id).flags.contains(ImplFlags::UNSAFE)
     }
 
     pub fn module(self, db: &dyn HirDatabase) -> Module {


### PR DESCRIPTION
There was more non-sense in here like the 0th bit being used and some other collisions, also re-orders some flags to use the same bits across differing flag types for the same flags which should give slightly better codegen (though I didn't try too much as its difficult to use the same bits for all of them)