### PR TITLE
Fix missing test update notifications when there are hyphens in the target name and exclude dependencies from `Run All`

### DIFF
--- a/crates/rust-analyzer/src/handlers/request.rs
+++ b/crates/rust-analyzer/src/handlers/request.rs
@@ -203,7 +203,7 @@ pub(crate) fn handle_view_item_tree(
 //   underscores. cargo test requires the real name.
 // - the target kind e.g. bin or lib
 fn find_test_target(namespace_root: &str, cargo: &CargoWorkspace) -> Option<TestTarget> {
-    cargo.packages().find_map(|p| {
+    cargo.packages().filter(|p| cargo[*p].is_member).find_map(|p| {
         let package_name = &cargo[p].name;
         for target in cargo[p].targets.iter() {
             let target_name = &cargo[*target].name;
@@ -222,6 +222,7 @@ fn find_test_target(namespace_root: &str, cargo: &CargoWorkspace) -> Option<Test
 fn get_all_targets(cargo: &CargoWorkspace) -> Vec<TestTarget> {
     cargo
         .packages()
+        .filter(|p| cargo[*p].is_member)
         .flat_map(|p| {
             let package_name = &cargo[p].name;
             cargo[p].targets.iter().map(|target| {

--- a/crates/rust-analyzer/src/handlers/request.rs
+++ b/crates/rust-analyzer/src/handlers/request.rs
@@ -255,7 +255,7 @@ pub(crate) fn handle_run_test(
                         }
                     })
                     .collect_vec(),
-                None => all_test_targets(cargo).into_iter().map(|target| (target, None)).collect(),
+                None => all_test_targets(cargo).map(|target| (target, None)).collect(),
             };
 
             for (target, path) in tests {

--- a/crates/rust-analyzer/src/main_loop.rs
+++ b/crates/rust-analyzer/src/main_loop.rs
@@ -969,7 +969,9 @@ impl GlobalState {
                     TestState::Ok => lsp_ext::TestState::Passed,
                     TestState::Failed { stdout } => lsp_ext::TestState::Failed { message: stdout },
                 };
-                let test_id = format!("{}::{name}", message.target.target);
+
+                // The notification requires the namespace form (with underscores) of the target
+                let test_id = format!("{}::{name}", message.target.target.replace('-', "_"));
 
                 self.send_notification::<lsp_ext::ChangeTestState>(
                     lsp_ext::ChangeTestStateParams { test_id, state },


### PR DESCRIPTION
#19464

Test notifications with targets containing hyphens are failing with the error:

    [error] [Window] [Extension Host] Notification handler 'experimental/changeTestState' failed with message: Cannot read properties of undefined (reading 'id')

The test id expects the namespace form with underscores `tokio_stream` instead of `tokio-stream`.
