### PR TITLE
fix: Prevent panics when there is a cyclic dependency between closures

### DIFF
--- a/crates/hir-ty/src/infer/expr.rs
+++ b/crates/hir-ty/src/infer/expr.rs
@@ -1705,9 +1705,7 @@ impl InferenceContext<'_> {
                 if let TyKind::Closure(c, _) =
                     self.table.resolve_completely(callee_ty.clone()).kind(Interner)
                 {
-                    if let Some(par) = self.current_closure {
-                        self.closure_dependencies.entry(par).or_default().push(*c);
-                    }
+                    self.add_current_closure_dependency(*c);
                     self.deferred_closures.entry(*c).or_default().push((
                         derefed_callee.clone(),
                         callee_ty.clone(),

--- a/crates/ide/src/inlay_hints.rs
+++ b/crates/ide/src/inlay_hints.rs
@@ -1004,4 +1004,32 @@ fn foo() {
 "#,
         );
     }
+
+    #[test]
+    fn closure_dependency_cycle_no_panic() {
+        check(
+            r#"
+fn foo() {
+    let closure;
+     // ^^^^^^^ impl Fn()
+    closure = || {
+        closure();
+    };
+}
+
+fn bar() {
+    let closure1;
+     // ^^^^^^^^ impl Fn()
+    let closure2;
+     // ^^^^^^^^ impl Fn()
+    closure1 = || {
+        closure2();
+    };
+    closure2 = || {
+        closure1();
+    };
+}
+        "#,
+        );
+    }
 }


### PR DESCRIPTION
We didn't include them in the sorted closures list, therefore didn't analyze them, then failed to find them.

Fixes rust-lang/rust-analyzer#19577.