### PR TITLE
Distribute x64 and aarch64 Linux builds with PGO optimizations

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,10 +38,12 @@ jobs:
             target: x86_64-unknown-linux-gnu
             zig_target: x86_64-unknown-linux-gnu.2.28
             code-target: linux-x64
+            pgo: true
           - os: ubuntu-latest
             target: aarch64-unknown-linux-gnu
             zig_target: aarch64-unknown-linux-gnu.2.28
             code-target: linux-arm64
+            pgo: true
           - os: ubuntu-latest
             target: arm-unknown-linux-gnueabihf
             zig_target: arm-unknown-linux-gnueabihf.2.28
@@ -74,7 +76,8 @@ jobs:
       - name: Install Rust toolchain
         run: |
           rustup update --no-self-update stable
-          rustup component add rust-src
+          # llvm-tools contain the llvm-profdata tool which is needed for PGO
+          rustup component add rust-src ${{ matrix.pgo && 'llvm-tools' || '' }}
           rustup target add ${{ matrix.target }}
 
       - name: Install Zig toolchain
@@ -87,11 +90,11 @@ jobs:
 
       - name: Dist (plain)
         if: ${{ !matrix.zig_target }}
-        run: cargo xtask dist --client-patch-version ${{ github.run_number }}
+        run: cargo xtask dist --client-patch-version ${{ github.run_number }} ${{ matrix.pgo && '--pgo' || ''}}
 
       - name: Dist (using zigbuild)
         if: ${{ matrix.zig_target }}
-        run: RA_TARGET=${{ matrix.zig_target}} cargo xtask dist --client-patch-version ${{ github.run_number }} --zig
+        run: RA_TARGET=${{ matrix.zig_target}} cargo xtask dist --client-patch-version ${{ github.run_number }} --zig ${{ matrix.pgo && '--pgo' || ''}}
 
       - run: npm ci
         working-directory: editors/code

--- a/xtask/src/flags.rs
+++ b/xtask/src/flags.rs
@@ -59,6 +59,8 @@ xflags::xflags! {
             optional --client-patch-version version: String
             /// Use cargo-zigbuild
             optional --zig
+            /// Apply PGO optimizations
+            optional --pgo
         }
         /// Read a changelog AsciiDoc file and update the GitHub Releases entry in Markdown.
         cmd publish-release-notes {
@@ -147,6 +149,7 @@ pub struct Dist {
     pub jemalloc: bool,
     pub client_patch_version: Option<String>,
     pub zig: bool,
+    pub pgo: bool,
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
Empirically this seems to make the resulting `analysis-stats` command ~20% faster.