### PR TITLE
Do not perform PGO on Linux CI

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,12 +38,10 @@ jobs:
             target: x86_64-unknown-linux-gnu
             zig_target: x86_64-unknown-linux-gnu.2.28
             code-target: linux-x64
-            pgo: true
           - os: ubuntu-latest
             target: aarch64-unknown-linux-gnu
             zig_target: aarch64-unknown-linux-gnu.2.28
             code-target: linux-arm64
-            pgo: true
           - os: ubuntu-latest
             target: arm-unknown-linux-gnueabihf
             zig_target: arm-unknown-linux-gnueabihf.2.28


### PR DESCRIPTION
Reverts a part of rust-lang/rust-analyzer#19582. PGO does not seem to work with `cargo zigbuild` (https://github.com/rust-lang/rust-analyzer/actions/runs/14448767429/job/40515878851).