### PR TITLE
Remove incorrect doc comment

### DIFF
--- a/crates/hir-expand/src/proc_macro.rs
+++ b/crates/hir-expand/src/proc_macro.rs
@@ -253,7 +253,6 @@ impl CustomProcMacroExpander {
         self.proc_macro_id == Self::PROC_MACRO_ATTR_DISABLED
     }
 
-    /// The macro is explicitly disabled due to proc-macro attribute expansion being disabled.
     pub fn as_expand_error(&self, def_crate: Crate) -> Option<ExpandErrorKind> {
         match self.proc_macro_id {
             Self::PROC_MACRO_ATTR_DISABLED => Some(ExpandErrorKind::ProcMacroAttrExpansionDisabled),


### PR DESCRIPTION
I just happened to come across this while investigating an error.

It looks like this comment was mistakenly copied from the function right above it. I'm happy to add a better comment if you like, but I think it's fairly clear from the function name and type signature.