### PR TITLE
fix: use `ast::TokenTree` in `make::expr_macro`

### DIFF
--- a/crates/ide-assists/src/handlers/destructure_struct_binding.rs
+++ b/crates/ide-assists/src/handlers/destructure_struct_binding.rs
@@ -302,7 +302,12 @@ fn build_usage_edit(
         }),
         None => Some((
             usage.name.syntax().as_node().unwrap().clone(),
-            make.expr_macro(ast::make::ext::ident_path("todo"), make.arg_list([])).syntax().clone(),
+            make.expr_macro(
+                ast::make::ext::ident_path("todo"),
+                make.token_tree(syntax::SyntaxKind::L_PAREN, []),
+            )
+            .syntax()
+            .clone(),
         )),
     }
 }

--- a/crates/ide-assists/src/utils/gen_trait_fn_body.rs
+++ b/crates/ide-assists/src/utils/gen_trait_fn_body.rs
@@ -230,7 +230,9 @@ fn gen_debug_impl(adt: &ast::Adt, func: &ast::Fn) -> Option<()> {
                     }
                     None => {
                         let fmt_string = make::expr_literal(&(format!("\"{name}\""))).into();
-                        let args = make::arg_list([target, fmt_string]);
+                        let args = make::ext::token_tree_from_node(
+                            make::arg_list([target, fmt_string]).syntax(),
+                        );
                         let macro_name = make::ext::ident_path("write");
                         let macro_call = make::expr_macro(macro_name, args);
 

--- a/crates/syntax/src/ast/make.rs
+++ b/crates/syntax/src/ast/make.rs
@@ -32,12 +32,9 @@ pub mod ext {
     use super::*;
 
     pub fn simple_ident_pat(name: ast::Name) -> ast::IdentPat {
-        return from_text(&name.text());
-
-        fn from_text(text: &str) -> ast::IdentPat {
-            ast_from_text(&format!("fn f({text}: ())"))
-        }
+        ast_from_text(&format!("fn f({}: ())", name.text()))
     }
+
     pub fn ident_path(ident: &str) -> ast::Path {
         path_unqualified(path_segment(name_ref(ident)))
     }
@@ -81,7 +78,6 @@ pub mod ext {
     pub fn expr_self() -> ast::Expr {
         expr_from_text("self")
     }
-
     pub fn zero_number() -> ast::Expr {
         expr_from_text("0")
     }
@@ -115,6 +111,10 @@ pub mod ext {
     }
     pub fn ty_result(t: ast::Type, e: ast::Type) -> ast::Type {
         ty_from_text(&format!("Result<{t}, {e}>"))
+    }
+
+    pub fn token_tree_from_node(node: &ast::SyntaxNode) -> ast::TokenTree {
+        ast_from_text(&format!("todo!{node}"))
     }
 }
 
@@ -643,8 +643,8 @@ pub fn expr_method_call(
 ) -> ast::MethodCallExpr {
     expr_from_text(&format!("{receiver}.{method}{arg_list}"))
 }
-pub fn expr_macro(path: ast::Path, arg_list: ast::ArgList) -> ast::MacroExpr {
-    expr_from_text(&format!("{path}!{arg_list}"))
+pub fn expr_macro(path: ast::Path, tt: ast::TokenTree) -> ast::MacroExpr {
+    expr_from_text(&format!("{path}!{tt}"))
 }
 pub fn expr_ref(expr: ast::Expr, exclusive: bool) -> ast::Expr {
     expr_from_text(&if exclusive { format!("&mut {expr}") } else { format!("&{expr}") })
@@ -1226,7 +1226,7 @@ pub fn meta_path(path: ast::Path) -> ast::Meta {
 
 pub fn token_tree(
     delimiter: SyntaxKind,
-    tt: Vec<NodeOrToken<ast::TokenTree, SyntaxToken>>,
+    tt: impl IntoIterator<Item = NodeOrToken<ast::TokenTree, SyntaxToken>>,
 ) -> ast::TokenTree {
     let (l_delimiter, r_delimiter) = match delimiter {
         T!['('] => ('(', ')'),

--- a/crates/syntax/src/ast/syntax_factory/constructors.rs
+++ b/crates/syntax/src/ast/syntax_factory/constructors.rs
@@ -584,15 +584,15 @@ impl SyntaxFactory {
         ast
     }
 
-    pub fn expr_macro(&self, path: ast::Path, args: ast::ArgList) -> ast::MacroExpr {
-        let ast = make::expr_macro(path.clone(), args.clone()).clone_for_update();
+    pub fn expr_macro(&self, path: ast::Path, tt: ast::TokenTree) -> ast::MacroExpr {
+        let ast = make::expr_macro(path.clone(), tt.clone()).clone_for_update();
 
         if let Some(mut mapping) = self.mappings() {
             let macro_call = ast.macro_call().unwrap();
             let mut builder = SyntaxMappingBuilder::new(macro_call.syntax().clone());
             builder.map_node(path.syntax().clone(), macro_call.path().unwrap().syntax().clone());
             builder
-                .map_node(args.syntax().clone(), macro_call.token_tree().unwrap().syntax().clone());
+                .map_node(tt.syntax().clone(), macro_call.token_tree().unwrap().syntax().clone());
             builder.finish(&mut mapping);
         }
 


### PR DESCRIPTION
Fixes rust-lang/rust-analyzer#19584 