### PR TITLE
Use PGO on Linux x64 builds

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,6 +42,7 @@ jobs:
             # Zig is not used because it doesn't work with PGO
             container: quay.io/pypa/manylinux_2_28_x86_64
             code-target: linux-x64
+            pgo: clap-rs/clap
           - os: ubuntu-latest
             target: aarch64-unknown-linux-gnu
             zig_target: aarch64-unknown-linux-gnu.2.28


### PR DESCRIPTION
After https://github.com/rust-lang/rust-analyzer/pull/19586 it should be possible to do PGO on Linux.