### PR TITLE
Build aarch64 builds on CI with PGO

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,10 +43,11 @@ jobs:
             container: quay.io/pypa/manylinux_2_28_x86_64
             code-target: linux-x64
             pgo: clap-rs/clap
-          - os: ubuntu-latest
+          - os: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
-            zig_target: aarch64-unknown-linux-gnu.2.28
+            container: quay.io/pypa/manylinux_2_28_aarch64
             code-target: linux-arm64
+            pgo: clap-rs/clap
           - os: ubuntu-latest
             target: arm-unknown-linux-gnueabihf
             zig_target: arm-unknown-linux-gnueabihf.2.28


### PR DESCRIPTION
Uses the manylinux aarch64 image + a native ARM GitHub runner to compile aarch64 builds with PGO.