### PR TITLE
Add semicolon to use

### DIFF
--- a/crates/ide-completion/src/completions/item_list.rs
+++ b/crates/ide-completion/src/completions/item_list.rs
@@ -142,7 +142,7 @@ fn add_keywords(acc: &mut Completions, ctx: &CompletionContext<'_>, kind: Option
         add_keyword("struct", "struct $0");
         add_keyword("trait", "trait $1 {\n    $0\n}");
         add_keyword("union", "union $1 {\n    $0\n}");
-        add_keyword("use", "use $0");
+        add_keyword("use", "use $0;");
         if no_vis_qualifiers {
             add_keyword("impl", "impl $1 {\n    $0\n}");
             add_keyword("impl for", "impl $1 for $2 {\n    $0\n}");


### PR DESCRIPTION
Fixes rust-lang/rust-analyzer#19601 