### PR TITLE
fix: Fix a bug with predicate lowering of associated items

### DIFF
--- a/crates/ide/src/inlay_hints.rs
+++ b/crates/ide/src/inlay_hints.rs
@@ -1032,4 +1032,23 @@ fn bar() {
         "#,
         );
     }
+
+    #[test]
+    fn regression_19610() {
+        check(
+            r#"
+trait Trait {
+    type Assoc;
+}
+struct Foo<A>(A);
+impl<A: Trait<Assoc = impl Trait>> Foo<A> {
+    fn foo<'a, 'b>(_: &'a [i32], _: &'b [i32]) {}
+}
+
+fn bar() {
+    Foo::foo(&[1], &[2]);
+}
+"#,
+        );
+    }
 }


### PR DESCRIPTION
The essence of the bug is that bounds on `impl Trait` got lowered with incorrect bound vars, as if we were lowering the parent.

Another bug from the item tree rewrite. Kind of expected, I think (I don't blame anyone!)

Fixes rust-lang/rust-analyzer#19610.

Somewhat ironically, finding & fixing the bug was almost less work than creating a test that fails in the previous version... (and understand the bug deeply, which is needed to create such test).