### PR TITLE
fix: Sort notable traits in hover

### DIFF
--- a/crates/ide/src/hover.rs
+++ b/crates/ide/src/hover.rs
@@ -505,6 +505,7 @@ fn notable_traits(
                 )
             })
         })
+        .sorted_by_cached_key(|(trait_, _)| trait_.name(db))
         .collect::<Vec<_>>()
 }
 


### PR DESCRIPTION
Previously it was ordered by what accidentally happened to be the crate graph order, which isn't sensible, plus it caused changes when any change was done to salsa IDs.