### PR TITLE
fix: panics in inlay hints that produce empty text edits for closure return types

### DIFF
--- a/crates/ide/src/inlay_hints/bind_pat.rs
+++ b/crates/ide/src/inlay_hints/bind_pat.rs
@@ -87,6 +87,7 @@ pub(super) fn hints(
                 .as_ref()
                 .map_or_else(|| pat.syntax().text_range(), |t| t.text_range())
                 .end(),
+            &|_| (),
             if colon_token.is_some() { "" } else { ": " },
         )
     } else {


### PR DESCRIPTION
fix rust-lang/rust-analyzer#19646.

It's illegal to return `TextEdit::builder().finish()` here.