### PR TITLE
feat: Properly handle lifetimes when checking generic arguments len

### DIFF
--- a/crates/hir-def/src/hir/type_ref.rs
+++ b/crates/hir-def/src/hir/type_ref.rs
@@ -106,6 +106,14 @@ pub struct FnType {
     pub abi: Option<Symbol>,
 }
 
+impl FnType {
+    #[inline]
+    pub fn split_params_and_ret(&self) -> (&[(Option<Name>, TypeRefId)], TypeRefId) {
+        let (ret, params) = self.params.split_last().expect("should have at least return type");
+        (params, ret.1)
+    }
+}
+
 #[derive(Clone, PartialEq, Eq, Hash, Debug)]
 pub struct ArrayType {
     pub ty: TypeRefId,

--- a/crates/hir-ty/src/chalk_db.rs
+++ b/crates/hir-ty/src/chalk_db.rs
@@ -27,6 +27,7 @@ use crate::{
     db::{HirDatabase, InternedCoroutine},
     from_assoc_type_id, from_chalk_trait_id, from_foreign_def_id,
     generics::generics,
+    lower::LifetimeElisionKind,
     make_binders, make_single_type_binders,
     mapping::{ToChalk, TypeAliasAsValue, from_chalk},
     method_resolution::{ALL_FLOAT_FPS, ALL_INT_FPS, TraitImpls, TyFingerprint},
@@ -632,9 +633,14 @@ pub(crate) fn associated_ty_data_query(
     let type_alias_data = db.type_alias_signature(type_alias);
     let generic_params = generics(db, type_alias.into());
     let resolver = hir_def::resolver::HasResolver::resolver(type_alias, db);
-    let mut ctx =
-        crate::TyLoweringContext::new(db, &resolver, &type_alias_data.store, type_alias.into())
-            .with_type_param_mode(crate::lower::ParamLoweringMode::Variable);
+    let mut ctx = crate::TyLoweringContext::new(
+        db,
+        &resolver,
+        &type_alias_data.store,
+        type_alias.into(),
+        LifetimeElisionKind::AnonymousReportError,
+    )
+    .with_type_param_mode(crate::lower::ParamLoweringMode::Variable);
 
     let trait_subst = TyBuilder::subst_for_def(db, trait_, None)
         .fill_with_bound_vars(crate::DebruijnIndex::INNERMOST, 0)

--- a/crates/hir-ty/src/infer/closure.rs
+++ b/crates/hir-ty/src/infer/closure.rs
@@ -440,6 +440,8 @@ impl InferenceContext<'_> {
         // collect explicitly written argument types
         for arg_type in arg_types.iter() {
             let arg_ty = match arg_type {
+                // FIXME: I think rustc actually lowers closure params with `LifetimeElisionKind::AnonymousCreateParameter`
+                // (but the return type with infer).
                 Some(type_ref) => self.make_body_ty(*type_ref),
                 None => self.table.new_type_var(),
             };

--- a/crates/hir-ty/src/infer/expr.rs
+++ b/crates/hir-ty/src/infer/expr.rs
@@ -37,7 +37,7 @@ use crate::{
     },
     lang_items::lang_items_for_bin_op,
     lower::{
-        GenericArgsPosition, ParamLoweringMode, lower_to_chalk_mutability,
+        LifetimeElisionKind, ParamLoweringMode, lower_to_chalk_mutability,
         path::{GenericArgsLowerer, TypeLikeConst, substs_from_args_and_bindings},
     },
     mapping::{ToChalk, from_chalk},
@@ -2162,6 +2162,23 @@ impl InferenceContext<'_> {
                     }
                 }
             }
+
+            fn report_elided_lifetimes_in_path(
+                &mut self,
+                _def: GenericDefId,
+                _expected_count: u32,
+                _hard_error: bool,
+            ) {
+                unreachable!("we set `LifetimeElisionKind::Infer`")
+            }
+
+            fn report_elision_failure(&mut self, _def: GenericDefId, _expected_count: u32) {
+                unreachable!("we set `LifetimeElisionKind::Infer`")
+            }
+
+            fn report_missing_lifetime(&mut self, _def: GenericDefId, _expected_count: u32) {
+                unreachable!("we set `LifetimeElisionKind::Infer`")
+            }
         }
 
         substs_from_args_and_bindings(
@@ -2170,7 +2187,8 @@ impl InferenceContext<'_> {
             generic_args,
             def,
             true,
-            GenericArgsPosition::MethodCall,
+            LifetimeElisionKind::Infer,
+            false,
             None,
             &mut LowererCtx { ctx: self, expr },
         )

--- a/crates/hir-ty/src/lib.rs
+++ b/crates/hir-ty/src/lib.rs
@@ -94,8 +94,8 @@ pub use infer::{
 };
 pub use interner::Interner;
 pub use lower::{
-    ImplTraitLoweringMode, ParamLoweringMode, TyDefId, TyLoweringContext, ValueTyDefId,
-    associated_type_shorthand_candidates, diagnostics::*,
+    ImplTraitLoweringMode, LifetimeElisionKind, ParamLoweringMode, TyDefId, TyLoweringContext,
+    ValueTyDefId, associated_type_shorthand_candidates, diagnostics::*,
 };
 pub use mapping::{
     from_assoc_type_id, from_chalk_trait_id, from_foreign_def_id, from_placeholder_idx,
@@ -529,13 +529,13 @@ pub type PolyFnSig = Binders<CallableSig>;
 
 impl CallableSig {
     pub fn from_params_and_return(
-        params: impl ExactSizeIterator<Item = Ty>,
+        params: impl Iterator<Item = Ty>,
         ret: Ty,
         is_varargs: bool,
         safety: Safety,
         abi: FnAbi,
     ) -> CallableSig {
-        let mut params_and_return = Vec::with_capacity(params.len() + 1);
+        let mut params_and_return = Vec::with_capacity(params.size_hint().0 + 1);
         params_and_return.extend(params);
         params_and_return.push(ret);
         CallableSig { params_and_return: params_and_return.into(), is_varargs, safety, abi }

--- a/crates/hir-ty/src/lower/diagnostics.rs
+++ b/crates/hir-ty/src/lower/diagnostics.rs
@@ -63,6 +63,24 @@ pub enum PathLoweringDiagnostic {
         /// Whether the `GenericArgs` contains a `Self` arg.
         has_self_arg: bool,
     },
+    ElidedLifetimesInPath {
+        generics_source: PathGenericsSource,
+        def: GenericDefId,
+        expected_count: u32,
+        hard_error: bool,
+    },
+    /// An elided lifetimes was used (either implicitly, by not specifying lifetimes, or explicitly, by using `'_`),
+    /// but lifetime elision could not find a lifetime to replace it with.
+    ElisionFailure {
+        generics_source: PathGenericsSource,
+        def: GenericDefId,
+        expected_count: u32,
+    },
+    MissingLifetime {
+        generics_source: PathGenericsSource,
+        def: GenericDefId,
+        expected_count: u32,
+    },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/ide-diagnostics/src/handlers/elided_lifetimes_in_path.rs
+++ b/crates/ide-diagnostics/src/handlers/elided_lifetimes_in_path.rs
@@ -1,0 +1,112 @@
+use crate::{Diagnostic, DiagnosticCode, DiagnosticsContext};
+
+// Diagnostic: elided-lifetimes-in-path
+//
+// This diagnostic is triggered when lifetimes are elided in paths. It is a lint only for some cases,
+// and a hard error for others.
+pub(crate) fn elided_lifetimes_in_path(
+    ctx: &DiagnosticsContext<'_>,
+    d: &hir::ElidedLifetimesInPath,
+) -> Diagnostic {
+    if d.hard_error {
+        Diagnostic::new_with_syntax_node_ptr(
+            ctx,
+            DiagnosticCode::RustcHardError("E0726"),
+            "implicit elided lifetime not allowed here",
+            d.generics_or_segment.map(Into::into),
+        )
+        .experimental()
+    } else {
+        Diagnostic::new_with_syntax_node_ptr(
+            ctx,
+            DiagnosticCode::RustcLint("elided_lifetimes_in_paths"),
+            "hidden lifetime parameters in types are deprecated",
+            d.generics_or_segment.map(Into::into),
+        )
+        .experimental()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::tests::check_diagnostics;
+
+    #[test]
+    fn fn_() {
+        check_diagnostics(
+            r#"
+#![warn(elided_lifetimes_in_paths)]
+
+struct Foo<'a>(&'a ());
+
+fn foo(_: Foo) {}
+       // ^^^ warn: hidden lifetime parameters in types are deprecated
+        "#,
+        );
+        check_diagnostics(
+            r#"
+#![warn(elided_lifetimes_in_paths)]
+
+struct Foo<'a>(&'a ());
+
+fn foo(_: Foo<'_>) -> Foo { loop {} }
+                   // ^^^ warn: hidden lifetime parameters in types are deprecated
+        "#,
+        );
+    }
+
+    #[test]
+    fn async_fn() {
+        check_diagnostics(
+            r#"
+struct Foo<'a>(&'a ());
+
+async fn foo(_: Foo) {}
+             // ^^^ error: implicit elided lifetime not allowed here
+        "#,
+        );
+        check_diagnostics(
+            r#"
+#![warn(elided_lifetimes_in_paths)]
+
+struct Foo<'a>(&'a ());
+
+fn foo(_: Foo<'_>) -> Foo { loop {} }
+                   // ^^^ warn: hidden lifetime parameters in types are deprecated
+        "#,
+        );
+    }
+
+    #[test]
+    fn no_error_when_explicitly_elided() {
+        check_diagnostics(
+            r#"
+#![warn(elided_lifetimes_in_paths)]
+
+struct Foo<'a>(&'a ());
+trait Trait<'a> {}
+
+fn foo(_: Foo<'_>) -> Foo<'_> { loop {} }
+async fn bar(_: Foo<'_>) -> Foo<'_> { loop {} }
+impl Foo<'_> {}
+impl Trait<'_> for Foo<'_> {}
+        "#,
+        );
+    }
+
+    #[test]
+    fn impl_() {
+        check_diagnostics(
+            r#"
+struct Foo<'a>(&'a ());
+trait Trait<'a> {}
+
+impl Foo {}
+  // ^^^ error: implicit elided lifetime not allowed here
+
+impl Trait for Foo<'_> {}
+  // ^^^^^ error: implicit elided lifetime not allowed here
+        "#,
+        );
+    }
+}

--- a/crates/ide-diagnostics/src/handlers/missing_lifetime.rs
+++ b/crates/ide-diagnostics/src/handlers/missing_lifetime.rs
@@ -1,0 +1,92 @@
+use crate::{Diagnostic, DiagnosticCode, DiagnosticsContext};
+
+// Diagnostic: missing-lifetime
+//
+// This diagnostic is triggered when a lifetime argument is missing.
+pub(crate) fn missing_lifetime(
+    ctx: &DiagnosticsContext<'_>,
+    d: &hir::MissingLifetime,
+) -> Diagnostic {
+    Diagnostic::new_with_syntax_node_ptr(
+        ctx,
+        DiagnosticCode::RustcHardError("E0106"),
+        "missing lifetime specifier",
+        d.generics_or_segment.map(Into::into),
+    )
+    .experimental()
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::tests::check_diagnostics;
+
+    #[test]
+    fn in_fields() {
+        check_diagnostics(
+            r#"
+struct Foo<'a>(&'a ());
+struct Bar(Foo);
+        // ^^^ error: missing lifetime specifier
+        "#,
+        );
+    }
+
+    #[test]
+    fn bounds() {
+        check_diagnostics(
+            r#"
+struct Foo<'a, T>(&'a T);
+trait Trait<'a> {
+    type Assoc;
+}
+
+fn foo<'a, T: Trait>(
+           // ^^^^^ error: missing lifetime specifier
+    _: impl Trait<'a, Assoc: Trait>,
+                          // ^^^^^ error: missing lifetime specifier
+)
+where
+    Foo<T>: Trait<'a>,
+    // ^^^ error: missing lifetime specifier
+{
+}
+        "#,
+        );
+    }
+
+    #[test]
+    fn generic_defaults() {
+        check_diagnostics(
+            r#"
+struct Foo<'a>(&'a ());
+
+struct Bar<T = Foo>(T);
+            // ^^^ error: missing lifetime specifier
+        "#,
+        );
+    }
+
+    #[test]
+    fn type_alias_type() {
+        check_diagnostics(
+            r#"
+struct Foo<'a>(&'a ());
+
+type Bar = Foo;
+        // ^^^ error: missing lifetime specifier
+        "#,
+        );
+    }
+
+    #[test]
+    fn const_param_ty() {
+        check_diagnostics(
+            r#"
+struct Foo<'a>(&'a ());
+
+fn bar<const F: Foo>() {}
+             // ^^^ error: missing lifetime specifier
+        "#,
+        );
+    }
+}

--- a/crates/ide-diagnostics/src/lib.rs
+++ b/crates/ide-diagnostics/src/lib.rs
@@ -27,6 +27,7 @@ mod handlers {
     pub(crate) mod await_outside_of_async;
     pub(crate) mod bad_rtn;
     pub(crate) mod break_outside_of_loop;
+    pub(crate) mod elided_lifetimes_in_path;
     pub(crate) mod expected_function;
     pub(crate) mod generic_args_prohibited;
     pub(crate) mod inactive_code;
@@ -40,6 +41,7 @@ mod handlers {
     pub(crate) mod malformed_derive;
     pub(crate) mod mismatched_arg_count;
     pub(crate) mod missing_fields;
+    pub(crate) mod missing_lifetime;
     pub(crate) mod missing_match_arms;
     pub(crate) mod missing_unsafe;
     pub(crate) mod moved_out_of_ref;
@@ -503,6 +505,8 @@ pub fn semantic_diagnostics(
             AnyDiagnostic::BadRtn(d) => handlers::bad_rtn::bad_rtn(&ctx, &d),
             AnyDiagnostic::IncorrectGenericsLen(d) => handlers::incorrect_generics_len::incorrect_generics_len(&ctx, &d),
             AnyDiagnostic::IncorrectGenericsOrder(d) => handlers::incorrect_generics_order::incorrect_generics_order(&ctx, &d),
+            AnyDiagnostic::MissingLifetime(d) => handlers::missing_lifetime::missing_lifetime(&ctx, &d),
+            AnyDiagnostic::ElidedLifetimesInPath(d) => handlers::elided_lifetimes_in_path::elided_lifetimes_in_path(&ctx, &d),
         };
         res.push(d)
     }


### PR DESCRIPTION
And also, prepare for correct lowering of lifetime. We still don't handle most lifetimes correctly, but a bit more of the foundation to lifetime elision is now implemented.

This is the "proper" fix for rust-lang/rust-analyzer#19668. rust-lang/rust-analyzer#19672 fixed it in the "quick-and-dirty" way.

rustc does this all differently by inserting the lifetimes in late resolution (which is why my code originally did not work correctly). We can't do this. But I did follow rustc's late resolve closely when implementing this.

This also adds two new diagnostics.