### PR TITLE
refactor: Remove `WherePredicateTypeTarget`

### DIFF
--- a/crates/hir-def/src/expr_store/lower/asm.rs
+++ b/crates/hir-def/src/expr_store/lower/asm.rs
@@ -11,7 +11,6 @@ use tt::TextRange;
 use crate::{
     expr_store::lower::{ExprCollector, FxIndexSet},
     hir::{AsmOperand, AsmOptions, Expr, ExprId, InlineAsm, InlineAsmRegOrRegClass},
-    type_ref::TypeRef,
 };
 
 impl ExprCollector<'_> {
@@ -159,10 +158,12 @@ impl ExprCollector<'_> {
                                 AsmOperand::Const(self.collect_expr_opt(c.expr()))
                             }
                             ast::AsmOperand::AsmSym(s) => {
-                                let Some(path) = s
-                                    .path()
-                                    .and_then(|p| self.lower_path(p, &mut |_| TypeRef::Error))
-                                else {
+                                let Some(path) = s.path().and_then(|p| {
+                                    self.lower_path(
+                                        p,
+                                        &mut ExprCollector::impl_trait_error_allocator,
+                                    )
+                                }) else {
                                     continue;
                                 };
                                 AsmOperand::Sym(path)

--- a/crates/hir-def/src/expr_store/lower/generics.rs
+++ b/crates/hir-def/src/expr_store/lower/generics.rs
@@ -227,7 +227,7 @@ impl GenericParamsCollector {
             (_, TypeBound::Error | TypeBound::Use(_)) => return,
             (Either::Left(type_ref), bound) => match hrtb_lifetimes {
                 Some(hrtb_lifetimes) => WherePredicate::ForLifetime {
-                    lifetimes: hrtb_lifetimes.to_vec().into_boxed_slice(),
+                    lifetimes: ThinVec::from_iter(hrtb_lifetimes.iter().cloned()),
                     target: type_ref,
                     bound,
                 },

--- a/crates/hir-def/src/expr_store/lower/generics.rs
+++ b/crates/hir-def/src/expr_store/lower/generics.rs
@@ -15,205 +15,67 @@ use triomphe::Arc;
 
 use crate::{
     GenericDefId, TypeOrConstParamId, TypeParamId,
-    expr_store::lower::ExprCollector,
+    expr_store::{TypePtr, lower::ExprCollector},
     hir::generics::{
         ConstParamData, GenericParams, LifetimeParamData, TypeOrConstParamData, TypeParamData,
-        TypeParamProvenance, WherePredicate, WherePredicateTypeTarget,
+        TypeParamProvenance, WherePredicate,
     },
     type_ref::{LifetimeRef, TypeBound, TypeRef, TypeRefId},
 };
 
-pub(crate) struct GenericParamsCollector<'db, 'c> {
-    expr_collector: &'c mut ExprCollector<'db>,
+pub(crate) type ImplTraitLowerFn<'l> = &'l mut dyn for<'ec, 'db> FnMut(
+    &'ec mut ExprCollector<'db>,
+    TypePtr,
+    ThinVec<TypeBound>,
+) -> TypeRefId;
+
+pub(crate) struct GenericParamsCollector {
     type_or_consts: Arena<TypeOrConstParamData>,
     lifetimes: Arena<LifetimeParamData>,
     where_predicates: Vec<WherePredicate>,
     parent: GenericDefId,
 }
 
-impl<'db, 'c> GenericParamsCollector<'db, 'c> {
-    pub(crate) fn new(expr_collector: &'c mut ExprCollector<'db>, parent: GenericDefId) -> Self {
+impl GenericParamsCollector {
+    pub(crate) fn new(parent: GenericDefId) -> Self {
         Self {
-            expr_collector,
             type_or_consts: Default::default(),
             lifetimes: Default::default(),
             where_predicates: Default::default(),
             parent,
         }
     }
-
-    pub(crate) fn fill_self_param(&mut self, bounds: Option<ast::TypeBoundList>) {
-        let self_ = Name::new_symbol_root(sym::Self_);
-        let idx = self.type_or_consts.alloc(
-            TypeParamData {
-                name: Some(self_.clone()),
-                default: None,
-                provenance: TypeParamProvenance::TraitSelf,
-            }
-            .into(),
-        );
-        let type_ref = TypeRef::TypeParam(TypeParamId::from_unchecked(TypeOrConstParamId {
-            parent: self.parent,
-            local_id: idx,
-        }));
-        let self_ = self.expr_collector.alloc_type_ref_desugared(type_ref);
-        if let Some(bounds) = bounds {
-            self.lower_bounds(Some(bounds), Either::Left(self_));
-        }
+    pub(crate) fn with_self_param(
+        ec: &mut ExprCollector<'_>,
+        parent: GenericDefId,
+        bounds: Option<ast::TypeBoundList>,
+    ) -> Self {
+        let mut this = Self::new(parent);
+        this.fill_self_param(ec, bounds);
+        this
     }
 
     pub(crate) fn lower(
         &mut self,
+        ec: &mut ExprCollector<'_>,
         generic_param_list: Option<ast::GenericParamList>,
         where_clause: Option<ast::WhereClause>,
     ) {
         if let Some(params) = generic_param_list {
-            self.lower_param_list(params)
+            self.lower_param_list(ec, params)
         }
         if let Some(where_clause) = where_clause {
-            self.lower_where_predicates(where_clause);
+            self.lower_where_predicates(ec, where_clause);
         }
-    }
-
-    fn lower_param_list(&mut self, params: ast::GenericParamList) {
-        for generic_param in params.generic_params() {
-            let enabled = self.expr_collector.expander.is_cfg_enabled(
-                self.expr_collector.db,
-                self.expr_collector.module.krate(),
-                &generic_param,
-            );
-            if !enabled {
-                continue;
-            }
-
-            match generic_param {
-                ast::GenericParam::TypeParam(type_param) => {
-                    let name = type_param.name().map_or_else(Name::missing, |it| it.as_name());
-                    let default = type_param
-                        .default_type()
-                        .map(|it| self.expr_collector.lower_type_ref(it, &mut |_| TypeRef::Error));
-                    let param = TypeParamData {
-                        name: Some(name.clone()),
-                        default,
-                        provenance: TypeParamProvenance::TypeParamList,
-                    };
-                    let idx = self.type_or_consts.alloc(param.into());
-                    let type_ref =
-                        TypeRef::TypeParam(TypeParamId::from_unchecked(TypeOrConstParamId {
-                            parent: self.parent,
-                            local_id: idx,
-                        }));
-                    let type_ref = self.expr_collector.alloc_type_ref_desugared(type_ref);
-                    self.lower_bounds(type_param.type_bound_list(), Either::Left(type_ref));
-                }
-                ast::GenericParam::ConstParam(const_param) => {
-                    let name = const_param.name().map_or_else(Name::missing, |it| it.as_name());
-                    let ty = self
-                        .expr_collector
-                        .lower_type_ref_opt(const_param.ty(), &mut |_| TypeRef::Error);
-                    let param = ConstParamData {
-                        name,
-                        ty,
-                        default: const_param
-                            .default_val()
-                            .map(|it| self.expr_collector.lower_const_arg(it)),
-                    };
-                    let _idx = self.type_or_consts.alloc(param.into());
-                }
-                ast::GenericParam::LifetimeParam(lifetime_param) => {
-                    let lifetime_ref =
-                        self.expr_collector.lower_lifetime_ref_opt(lifetime_param.lifetime());
-                    if let LifetimeRef::Named(name) = &lifetime_ref {
-                        let param = LifetimeParamData { name: name.clone() };
-                        let _idx = self.lifetimes.alloc(param);
-                        self.lower_bounds(
-                            lifetime_param.type_bound_list(),
-                            Either::Right(lifetime_ref),
-                        );
-                    }
-                }
-            }
-        }
-    }
-
-    fn lower_where_predicates(&mut self, where_clause: ast::WhereClause) {
-        for pred in where_clause.predicates() {
-            let target = if let Some(type_ref) = pred.ty() {
-                Either::Left(self.expr_collector.lower_type_ref(type_ref, &mut |_| TypeRef::Error))
-            } else if let Some(lifetime) = pred.lifetime() {
-                Either::Right(self.expr_collector.lower_lifetime_ref(lifetime))
-            } else {
-                continue;
-            };
-
-            let lifetimes: Option<Box<_>> = pred.generic_param_list().map(|param_list| {
-                // Higher-Ranked Trait Bounds
-                param_list
-                    .lifetime_params()
-                    .map(|lifetime_param| {
-                        lifetime_param
-                            .lifetime()
-                            .map_or_else(Name::missing, |lt| Name::new_lifetime(&lt.text()))
-                    })
-                    .collect()
-            });
-            for bound in pred.type_bound_list().iter().flat_map(|l| l.bounds()) {
-                self.lower_type_bound_as_predicate(bound, lifetimes.as_deref(), target.clone());
-            }
-        }
-    }
-
-    fn lower_bounds(
-        &mut self,
-        type_bounds: Option<ast::TypeBoundList>,
-        target: Either<TypeRefId, LifetimeRef>,
-    ) {
-        for bound in type_bounds.iter().flat_map(|type_bound_list| type_bound_list.bounds()) {
-            self.lower_type_bound_as_predicate(bound, None, target.clone());
-        }
-    }
-
-    fn lower_type_bound_as_predicate(
-        &mut self,
-        bound: ast::TypeBound,
-        hrtb_lifetimes: Option<&[Name]>,
-        target: Either<TypeRefId, LifetimeRef>,
-    ) {
-        let bound = self.expr_collector.lower_type_bound(
-            bound,
-            &mut Self::lower_argument_impl_trait(
-                &mut self.type_or_consts,
-                &mut self.where_predicates,
-                self.parent,
-            ),
-        );
-        let predicate = match (target, bound) {
-            (_, TypeBound::Error | TypeBound::Use(_)) => return,
-            (Either::Left(type_ref), bound) => match hrtb_lifetimes {
-                Some(hrtb_lifetimes) => WherePredicate::ForLifetime {
-                    lifetimes: hrtb_lifetimes.to_vec().into_boxed_slice(),
-                    target: WherePredicateTypeTarget::TypeRef(type_ref),
-                    bound,
-                },
-                None => WherePredicate::TypeBound {
-                    target: WherePredicateTypeTarget::TypeRef(type_ref),
-                    bound,
-                },
-            },
-            (Either::Right(lifetime), TypeBound::Lifetime(bound)) => {
-                WherePredicate::Lifetime { target: lifetime, bound }
-            }
-            (Either::Right(_), TypeBound::ForLifetime(..) | TypeBound::Path(..)) => return,
-        };
-        self.where_predicates.push(predicate);
     }
 
     pub(crate) fn collect_impl_trait<R>(
         &mut self,
-        cb: impl FnOnce(&mut ExprCollector<'_>, &mut dyn FnMut(ThinVec<TypeBound>) -> TypeRef) -> R,
+        ec: &mut ExprCollector<'_>,
+        cb: impl FnOnce(&mut ExprCollector<'_>, ImplTraitLowerFn<'_>) -> R,
     ) -> R {
         cb(
-            self.expr_collector,
+            ec,
             &mut Self::lower_argument_impl_trait(
                 &mut self.type_or_consts,
                 &mut self.where_predicates,
@@ -222,39 +84,8 @@ impl<'db, 'c> GenericParamsCollector<'db, 'c> {
         )
     }
 
-    fn lower_argument_impl_trait(
-        type_or_consts: &mut Arena<TypeOrConstParamData>,
-        where_predicates: &mut Vec<WherePredicate>,
-        parent: GenericDefId,
-    ) -> impl FnMut(ThinVec<TypeBound>) -> TypeRef {
-        move |impl_trait_bounds| {
-            let param = TypeParamData {
-                name: None,
-                default: None,
-                provenance: TypeParamProvenance::ArgumentImplTrait,
-            };
-            let param_id = type_or_consts.alloc(param.into());
-            for bound in impl_trait_bounds {
-                where_predicates.push(WherePredicate::TypeBound {
-                    target: WherePredicateTypeTarget::TypeOrConstParam(param_id),
-                    bound: bound.clone(),
-                });
-            }
-            TypeRef::TypeParam(TypeParamId::from_unchecked(TypeOrConstParamId {
-                parent,
-                local_id: param_id,
-            }))
-        }
-    }
-
     pub(crate) fn finish(self) -> Arc<GenericParams> {
-        let Self {
-            mut lifetimes,
-            mut type_or_consts,
-            mut where_predicates,
-            expr_collector: _,
-            parent: _,
-        } = self;
+        let Self { mut lifetimes, mut type_or_consts, mut where_predicates, parent: _ } = self;
 
         if lifetimes.is_empty() && type_or_consts.is_empty() && where_predicates.is_empty() {
             static EMPTY: LazyLock<Arc<GenericParams>> = LazyLock::new(|| {
@@ -275,5 +106,184 @@ impl<'db, 'c> GenericParamsCollector<'db, 'c> {
             lifetimes,
             where_predicates: where_predicates.into_boxed_slice(),
         })
+    }
+
+    fn lower_param_list(&mut self, ec: &mut ExprCollector<'_>, params: ast::GenericParamList) {
+        for generic_param in params.generic_params() {
+            let enabled = ec.expander.is_cfg_enabled(ec.db, ec.module.krate(), &generic_param);
+            if !enabled {
+                continue;
+            }
+
+            match generic_param {
+                ast::GenericParam::TypeParam(type_param) => {
+                    let name = type_param.name().map_or_else(Name::missing, |it| it.as_name());
+                    let default = type_param.default_type().map(|it| {
+                        ec.lower_type_ref(it, &mut ExprCollector::impl_trait_error_allocator)
+                    });
+                    let param = TypeParamData {
+                        name: Some(name.clone()),
+                        default,
+                        provenance: TypeParamProvenance::TypeParamList,
+                    };
+                    let idx = self.type_or_consts.alloc(param.into());
+                    let type_ref =
+                        TypeRef::TypeParam(TypeParamId::from_unchecked(TypeOrConstParamId {
+                            parent: self.parent,
+                            local_id: idx,
+                        }));
+                    let type_ref = ec.alloc_type_ref_desugared(type_ref);
+                    self.lower_bounds(ec, type_param.type_bound_list(), Either::Left(type_ref));
+                }
+                ast::GenericParam::ConstParam(const_param) => {
+                    let name = const_param.name().map_or_else(Name::missing, |it| it.as_name());
+                    let ty = ec.lower_type_ref_opt(
+                        const_param.ty(),
+                        &mut ExprCollector::impl_trait_error_allocator,
+                    );
+                    let param = ConstParamData {
+                        name,
+                        ty,
+                        default: const_param.default_val().map(|it| ec.lower_const_arg(it)),
+                    };
+                    let _idx = self.type_or_consts.alloc(param.into());
+                }
+                ast::GenericParam::LifetimeParam(lifetime_param) => {
+                    let lifetime_ref = ec.lower_lifetime_ref_opt(lifetime_param.lifetime());
+                    if let LifetimeRef::Named(name) = &lifetime_ref {
+                        let param = LifetimeParamData { name: name.clone() };
+                        let _idx = self.lifetimes.alloc(param);
+                        self.lower_bounds(
+                            ec,
+                            lifetime_param.type_bound_list(),
+                            Either::Right(lifetime_ref),
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    fn lower_where_predicates(
+        &mut self,
+        ec: &mut ExprCollector<'_>,
+        where_clause: ast::WhereClause,
+    ) {
+        for pred in where_clause.predicates() {
+            let target = if let Some(type_ref) = pred.ty() {
+                Either::Left(
+                    ec.lower_type_ref(type_ref, &mut ExprCollector::impl_trait_error_allocator),
+                )
+            } else if let Some(lifetime) = pred.lifetime() {
+                Either::Right(ec.lower_lifetime_ref(lifetime))
+            } else {
+                continue;
+            };
+
+            let lifetimes: Option<Box<_>> = pred.generic_param_list().map(|param_list| {
+                // Higher-Ranked Trait Bounds
+                param_list
+                    .lifetime_params()
+                    .map(|lifetime_param| {
+                        lifetime_param
+                            .lifetime()
+                            .map_or_else(Name::missing, |lt| Name::new_lifetime(&lt.text()))
+                    })
+                    .collect()
+            });
+            for bound in pred.type_bound_list().iter().flat_map(|l| l.bounds()) {
+                self.lower_type_bound_as_predicate(ec, bound, lifetimes.as_deref(), target.clone());
+            }
+        }
+    }
+
+    fn lower_bounds(
+        &mut self,
+        ec: &mut ExprCollector<'_>,
+        type_bounds: Option<ast::TypeBoundList>,
+        target: Either<TypeRefId, LifetimeRef>,
+    ) {
+        for bound in type_bounds.iter().flat_map(|type_bound_list| type_bound_list.bounds()) {
+            self.lower_type_bound_as_predicate(ec, bound, None, target.clone());
+        }
+    }
+
+    fn lower_type_bound_as_predicate(
+        &mut self,
+        ec: &mut ExprCollector<'_>,
+        bound: ast::TypeBound,
+        hrtb_lifetimes: Option<&[Name]>,
+        target: Either<TypeRefId, LifetimeRef>,
+    ) {
+        let bound = ec.lower_type_bound(
+            bound,
+            &mut Self::lower_argument_impl_trait(
+                &mut self.type_or_consts,
+                &mut self.where_predicates,
+                self.parent,
+            ),
+        );
+        let predicate = match (target, bound) {
+            (_, TypeBound::Error | TypeBound::Use(_)) => return,
+            (Either::Left(type_ref), bound) => match hrtb_lifetimes {
+                Some(hrtb_lifetimes) => WherePredicate::ForLifetime {
+                    lifetimes: hrtb_lifetimes.to_vec().into_boxed_slice(),
+                    target: type_ref,
+                    bound,
+                },
+                None => WherePredicate::TypeBound { target: type_ref, bound },
+            },
+            (Either::Right(lifetime), TypeBound::Lifetime(bound)) => {
+                WherePredicate::Lifetime { target: lifetime, bound }
+            }
+            (Either::Right(_), TypeBound::ForLifetime(..) | TypeBound::Path(..)) => return,
+        };
+        self.where_predicates.push(predicate);
+    }
+
+    fn lower_argument_impl_trait(
+        type_or_consts: &mut Arena<TypeOrConstParamData>,
+        where_predicates: &mut Vec<WherePredicate>,
+        parent: GenericDefId,
+    ) -> impl for<'ec, 'db> FnMut(&'ec mut ExprCollector<'db>, TypePtr, ThinVec<TypeBound>) -> TypeRefId
+    {
+        move |ec, ptr, impl_trait_bounds| {
+            let param = TypeParamData {
+                name: None,
+                default: None,
+                provenance: TypeParamProvenance::ArgumentImplTrait,
+            };
+            let param_id = TypeRef::TypeParam(TypeParamId::from_unchecked(TypeOrConstParamId {
+                parent,
+                local_id: type_or_consts.alloc(param.into()),
+            }));
+            let type_ref = ec.alloc_type_ref(param_id, ptr);
+            for bound in impl_trait_bounds {
+                where_predicates
+                    .push(WherePredicate::TypeBound { target: type_ref, bound: bound.clone() });
+            }
+            type_ref
+        }
+    }
+
+    fn fill_self_param(&mut self, ec: &mut ExprCollector<'_>, bounds: Option<ast::TypeBoundList>) {
+        let self_ = Name::new_symbol_root(sym::Self_);
+        let idx = self.type_or_consts.alloc(
+            TypeParamData {
+                name: Some(self_.clone()),
+                default: None,
+                provenance: TypeParamProvenance::TraitSelf,
+            }
+            .into(),
+        );
+        debug_assert_eq!(idx, GenericParams::SELF_PARAM_ID_IN_SELF);
+        let type_ref = TypeRef::TypeParam(TypeParamId::from_unchecked(TypeOrConstParamId {
+            parent: self.parent,
+            local_id: idx,
+        }));
+        let self_ = ec.alloc_type_ref_desugared(type_ref);
+        if let Some(bounds) = bounds {
+            self.lower_bounds(ec, Some(bounds), Either::Left(self_));
+        }
     }
 }

--- a/crates/hir-def/src/expr_store/lower/path.rs
+++ b/crates/hir-def/src/expr_store/lower/path.rs
@@ -5,7 +5,10 @@ mod tests;
 
 use std::iter;
 
-use crate::expr_store::{lower::ExprCollector, path::NormalPath};
+use crate::expr_store::{
+    lower::{ExprCollector, generics::ImplTraitLowerFn},
+    path::NormalPath,
+};
 
 use hir_expand::{
     mod_path::{ModPath, PathKind, resolve_crate_root},
@@ -16,11 +19,10 @@ use syntax::{
     AstPtr,
     ast::{self, AstNode, HasGenericArgs},
 };
-use thin_vec::ThinVec;
 
 use crate::{
     expr_store::path::{GenericArg, GenericArgs, Path},
-    type_ref::{TypeBound, TypeRef},
+    type_ref::TypeRef,
 };
 
 #[cfg(test)]
@@ -36,7 +38,7 @@ thread_local! {
 pub(super) fn lower_path(
     collector: &mut ExprCollector<'_>,
     mut path: ast::Path,
-    impl_trait_lower_fn: &mut impl FnMut(ThinVec<TypeBound>) -> TypeRef,
+    impl_trait_lower_fn: ImplTraitLowerFn<'_>,
 ) -> Option<Path> {
     let mut kind = PathKind::Plain;
     let mut type_anchor = None;

--- a/crates/hir-def/src/expr_store/lower/path/tests.rs
+++ b/crates/hir-def/src/expr_store/lower/path/tests.rs
@@ -15,14 +15,13 @@ use crate::{
         pretty,
     },
     test_db::TestDB,
-    type_ref::TypeRef,
 };
 
 fn lower_path(path: ast::Path) -> (TestDB, ExpressionStore, Option<Path>) {
     let (db, file_id) = TestDB::with_single_file("");
     let krate = db.fetch_test_crate();
     let mut ctx = ExprCollector::new(&db, db.crate_def_map(krate).root_module_id(), file_id.into());
-    let lowered_path = ctx.lower_path(path, &mut TypeRef::ImplTrait);
+    let lowered_path = ctx.lower_path(path, &mut ExprCollector::impl_trait_allocator);
     let store = ctx.store.finish();
     (db, store, lowered_path)
 }

--- a/crates/hir-def/src/expr_store/pretty.rs
+++ b/crates/hir-def/src/expr_store/pretty.rs
@@ -16,7 +16,7 @@ use crate::{
     expr_store::path::{GenericArg, GenericArgs},
     hir::{
         Array, BindingAnnotation, CaptureBy, ClosureKind, Literal, Movability, Statement,
-        generics::{GenericParams, WherePredicate, WherePredicateTypeTarget},
+        generics::{GenericParams, WherePredicate},
     },
     lang_item::LangItemTarget,
     signatures::{FnFlags, FunctionSignature, StructSignature},
@@ -336,21 +336,11 @@ fn print_where_clauses(db: &dyn DefDatabase, generic_params: &GenericParams, p: 
                     w!(p, ",\n");
                 }
                 match pred {
-                    WherePredicate::TypeBound { target, bound } => match target {
-                        &WherePredicateTypeTarget::TypeRef(idx) => {
-                            p.print_type_ref(idx);
-                            w!(p, ": ");
-                            p.print_type_bounds(std::slice::from_ref(bound));
-                        }
-                        WherePredicateTypeTarget::TypeOrConstParam(idx) => {
-                            match generic_params[*idx].name() {
-                                Some(name) => w!(p, "{}", name.display(db, p.edition)),
-                                None => w!(p, "Param[{}]", idx.into_raw()),
-                            }
-                            w!(p, ": ");
-                            p.print_type_bounds(std::slice::from_ref(bound));
-                        }
-                    },
+                    WherePredicate::TypeBound { target, bound } => {
+                        p.print_type_ref(*target);
+                        w!(p, ": ");
+                        p.print_type_bounds(std::slice::from_ref(bound));
+                    }
                     WherePredicate::Lifetime { target, bound } => {
                         p.print_lifetime_ref(target);
                         w!(p, ": ");
@@ -365,21 +355,9 @@ fn print_where_clauses(db: &dyn DefDatabase, generic_params: &GenericParams, p: 
                             w!(p, "{}", lifetime.display(db, p.edition));
                         }
                         w!(p, "> ");
-                        match target {
-                            WherePredicateTypeTarget::TypeRef(idx) => {
-                                p.print_type_ref(*idx);
-                                w!(p, ": ");
-                                p.print_type_bounds(std::slice::from_ref(bound));
-                            }
-                            WherePredicateTypeTarget::TypeOrConstParam(idx) => {
-                                match generic_params[*idx].name() {
-                                    Some(name) => w!(p, "{}", name.display(db, p.edition)),
-                                    None => w!(p, "Param[{}]", idx.into_raw()),
-                                }
-                                w!(p, ": ");
-                                p.print_type_bounds(std::slice::from_ref(bound));
-                            }
-                        }
+                        p.print_type_ref(*target);
+                        w!(p, ": ");
+                        p.print_type_bounds(std::slice::from_ref(bound));
                     }
                 }
             }

--- a/crates/hir-def/src/hir/generics.rs
+++ b/crates/hir-def/src/hir/generics.rs
@@ -4,6 +4,7 @@ use std::{ops, sync::LazyLock};
 use hir_expand::name::Name;
 use la_arena::{Arena, Idx, RawIdx};
 use stdx::impl_from;
+use thin_vec::ThinVec;
 use triomphe::Arc;
 
 use crate::{
@@ -171,7 +172,7 @@ impl ops::Index<LocalLifetimeParamId> for GenericParams {
 pub enum WherePredicate {
     TypeBound { target: TypeRefId, bound: TypeBound },
     Lifetime { target: LifetimeRef, bound: LifetimeRef },
-    ForLifetime { lifetimes: Box<[Name]>, target: TypeRefId, bound: TypeBound },
+    ForLifetime { lifetimes: ThinVec<Name>, target: TypeRefId, bound: TypeBound },
 }
 
 static EMPTY: LazyLock<Arc<GenericParams>> = LazyLock::new(|| {

--- a/crates/hir-def/src/hir/generics.rs
+++ b/crates/hir-def/src/hir/generics.rs
@@ -13,10 +13,6 @@ use crate::{
     type_ref::{ConstRef, LifetimeRef, TypeBound, TypeRefId},
 };
 
-/// The index of the self param in the generic of the non-parent definition.
-const SELF_PARAM_ID_IN_SELF: la_arena::Idx<TypeOrConstParamData> =
-    LocalTypeOrConstParamId::from_raw(RawIdx::from_u32(0));
-
 pub type LocalTypeOrConstParamId = Idx<TypeOrConstParamData>;
 pub type LocalLifetimeParamId = Idx<LifetimeParamData>;
 
@@ -173,17 +169,9 @@ impl ops::Index<LocalLifetimeParamId> for GenericParams {
 /// associated type bindings like `Iterator<Item = u32>`.
 #[derive(Clone, PartialEq, Eq, Debug, Hash)]
 pub enum WherePredicate {
-    TypeBound { target: WherePredicateTypeTarget, bound: TypeBound },
+    TypeBound { target: TypeRefId, bound: TypeBound },
     Lifetime { target: LifetimeRef, bound: LifetimeRef },
-    ForLifetime { lifetimes: Box<[Name]>, target: WherePredicateTypeTarget, bound: TypeBound },
-}
-
-#[derive(Clone, PartialEq, Eq, Debug, Hash)]
-pub enum WherePredicateTypeTarget {
-    TypeRef(TypeRefId),
-    // FIXME: This can be folded into the above now that `TypeRef` can refer to `TypeParam`?
-    /// For desugared where predicates that can directly refer to a type param.
-    TypeOrConstParam(LocalTypeOrConstParamId),
+    ForLifetime { lifetimes: Box<[Name]>, target: TypeRefId, bound: TypeBound },
 }
 
 static EMPTY: LazyLock<Arc<GenericParams>> = LazyLock::new(|| {
@@ -193,7 +181,12 @@ static EMPTY: LazyLock<Arc<GenericParams>> = LazyLock::new(|| {
         where_predicates: Box::default(),
     })
 });
+
 impl GenericParams {
+    /// The index of the self param in the generic of the non-parent definition.
+    pub(crate) const SELF_PARAM_ID_IN_SELF: la_arena::Idx<TypeOrConstParamData> =
+        LocalTypeOrConstParamId::from_raw(RawIdx::from_u32(0));
+
     pub fn new(db: &dyn DefDatabase, def: GenericDefId) -> Arc<GenericParams> {
         match def {
             GenericDefId::AdtId(AdtId::EnumId(it)) => db.enum_signature(it).generic_params.clone(),
@@ -388,13 +381,13 @@ impl GenericParams {
             return None;
         }
         matches!(
-            self.type_or_consts[SELF_PARAM_ID_IN_SELF],
+            self.type_or_consts[Self::SELF_PARAM_ID_IN_SELF],
             TypeOrConstParamData::TypeParamData(TypeParamData {
                 provenance: TypeParamProvenance::TraitSelf,
                 ..
             })
         )
-        .then(|| SELF_PARAM_ID_IN_SELF)
+        .then(|| Self::SELF_PARAM_ID_IN_SELF)
     }
 
     pub fn find_lifetime_by_name(

--- a/crates/hir-def/src/signatures.rs
+++ b/crates/hir-def/src/signatures.rs
@@ -34,7 +34,7 @@ use crate::{
     },
     lang_item::LangItem,
     src::HasSource,
-    type_ref::{TraitRef, TypeBound, TypeRef, TypeRefId},
+    type_ref::{TraitRef, TypeBound, TypeRefId},
 };
 
 #[derive(Debug, PartialEq, Eq)]
@@ -877,7 +877,8 @@ fn lower_fields<'a>(
         if attrs.is_cfg_enabled(cfg_options) {
             arena.alloc(FieldData {
                 name: field.name.clone(),
-                type_ref: col.lower_type_ref_opt(ty, &mut |_| TypeRef::Error),
+                type_ref: col
+                    .lower_type_ref_opt(ty, &mut ExprCollector::impl_trait_error_allocator),
                 visibility: item_tree[override_visibility.unwrap_or(field.visibility)].clone(),
                 is_unsafe: field.is_unsafe,
             });

--- a/crates/hir-ty/src/display.rs
+++ b/crates/hir-ty/src/display.rs
@@ -16,9 +16,7 @@ use hir_def::{
     db::DefDatabase,
     expr_store::{ExpressionStore, path::Path},
     find_path::{self, PrefixKind},
-    hir::generics::{
-        TypeOrConstParamData, TypeParamProvenance, WherePredicate, WherePredicateTypeTarget,
-    },
+    hir::generics::{TypeOrConstParamData, TypeParamProvenance, WherePredicate},
     item_scope::ItemInNs,
     item_tree::FieldsShape,
     lang_item::{LangItem, LangItemTarget},
@@ -2119,15 +2117,15 @@ impl HirDisplayWithExpressionStore for TypeRefId {
                             generic_params
                                 .where_predicates()
                                 .filter_map(|it| match it {
-                                    WherePredicate::TypeBound {
-                                        target: WherePredicateTypeTarget::TypeOrConstParam(p),
-                                        bound,
+                                    WherePredicate::TypeBound { target, bound }
+                                    | WherePredicate::ForLifetime { lifetimes: _, target, bound }
+                                        if matches!(
+                                            store[*target],
+                                            TypeRef::TypeParam(t) if t == *param
+                                        ) =>
+                                    {
+                                        Some(bound)
                                     }
-                                    | WherePredicate::ForLifetime {
-                                        lifetimes: _,
-                                        target: WherePredicateTypeTarget::TypeOrConstParam(p),
-                                        bound,
-                                    } if *p == param.local_id() => Some(bound),
                                     _ => None,
                                 })
                                 .map(ExpressionStoreAdapter::wrap(store)),

--- a/crates/hir-ty/src/utils.rs
+++ b/crates/hir-ty/src/utils.rs
@@ -11,7 +11,7 @@ use chalk_ir::{
 use hir_def::{
     EnumId, EnumVariantId, FunctionId, Lookup, TraitId, TypeAliasId, TypeOrConstParamId,
     db::DefDatabase,
-    hir::generics::{WherePredicate, WherePredicateTypeTarget},
+    hir::generics::WherePredicate,
     lang_item::LangItem,
     resolver::{HasResolver, TypeNs},
     type_ref::{TraitBoundModifier, TypeRef},
@@ -170,15 +170,10 @@ fn direct_super_traits_cb(db: &dyn DefDatabase, trait_: TraitId, cb: impl FnMut(
         .filter_map(|pred| match pred {
             WherePredicate::ForLifetime { target, bound, .. }
             | WherePredicate::TypeBound { target, bound } => {
-                let is_trait = match *target {
-                    WherePredicateTypeTarget::TypeRef(type_ref) => match &store[type_ref] {
-                        TypeRef::Path(p) => p.is_self_type(),
-                        TypeRef::TypeParam(p) => Some(p.local_id()) == trait_self,
-                        _ => false,
-                    },
-                    WherePredicateTypeTarget::TypeOrConstParam(local_id) => {
-                        Some(local_id) == trait_self
-                    }
+                let is_trait = match &store[*target] {
+                    TypeRef::Path(p) => p.is_self_type(),
+                    TypeRef::TypeParam(p) => Some(p.local_id()) == trait_self,
+                    _ => false,
                 };
                 match is_trait {
                     true => bound.as_path(&store),

--- a/crates/hir/src/source_analyzer.rs
+++ b/crates/hir/src/source_analyzer.rs
@@ -26,7 +26,7 @@ use hir_def::{
     lang_item::LangItem,
     nameres::MacroSubNs,
     resolver::{HasResolver, Resolver, TypeNs, ValueNs, resolver_for_scope},
-    type_ref::{Mutability, TypeRef, TypeRefId},
+    type_ref::{Mutability, TypeRefId},
 };
 use hir_expand::{
     HirFileId, InFile, MacroCallId,
@@ -1004,9 +1004,11 @@ impl SourceAnalyzer {
 
         // FIXME: collectiong here shouldnt be necessary?
         let mut collector = ExprCollector::new(db, self.resolver.module(), self.file_id);
-        let hir_path = collector.lower_path(path.clone(), &mut |_| TypeRef::Error)?;
-        let parent_hir_path =
-            path.parent_path().and_then(|p| collector.lower_path(p, &mut |_| TypeRef::Error));
+        let hir_path =
+            collector.lower_path(path.clone(), &mut ExprCollector::impl_trait_error_allocator)?;
+        let parent_hir_path = path
+            .parent_path()
+            .and_then(|p| collector.lower_path(p, &mut ExprCollector::impl_trait_error_allocator));
         let store = collector.store.finish();
 
         // Case where path is a qualifier of a use tree, e.g. foo::bar::{Baz, Qux} where we are


### PR DESCRIPTION
Also cleans up the impl triat handling a bit, should allow making diagnostics for it easier in the future I think