### PR TITLE
Add pipe to `autoClosingPairs`

### DIFF
--- a/editors/code/language-configuration.json
+++ b/editors/code/language-configuration.json
@@ -17,6 +17,7 @@
         { "open": "{", "close": "}", "notIn": ["string"] },
         { "open": "[", "close": "]", "notIn": ["string"] },
         { "open": "(", "close": ")", "notIn": ["string"] },
+        { "open": "|", "close": "|", "notIn": ["string"] },
         { "open": "\"", "close": "\"", "notIn": ["string"] },
         { "open": "/*", "close": " */", "notIn": ["string"] },
         { "open": "`", "close": "`", "notIn": ["string"] },


### PR DESCRIPTION
Issue: https://github.com/rust-lang/rust-analyzer/issues/19682

I keep finding myself expecting the `|` token to auto-close in VS code when writing closures, as it does with brackets, parentheses etc. So this PR adds it to `autoClosingPairs`

It is especially grating because as long as the closing pipe is dangling, syntax doesn't parse at all and editor output can be flooded with transient errors.

As noted in https://github.com/rust-lang/rust-analyzer/issues/11192 , the potential downside is for bitwise OR (and match pattern unions), but I would argue that is much less common and offset by the IMO much bigger benefit with respect to closures. Surprisingly, `|` was previously in `surroundingPairs` (causing undesired behavior) but never in `autoClosingPairs`.

As for (lazy) logical ORs, if you press pipe twice you will get the same thing, so there is no downside.