### PR TITLE
Always error when failed to parse DiscoverProjectMessage

### DIFF
--- a/crates/rust-analyzer/src/discover.rs
+++ b/crates/rust-analyzer/src/discover.rs
@@ -7,7 +7,6 @@ use ide_db::FxHashMap;
 use paths::{AbsPathBuf, Utf8Path, Utf8PathBuf};
 use project_model::ProjectJsonData;
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
 use tracing::{info_span, span::EnteredSpan};
 
 use crate::command::{CargoParser, CommandHandle};
@@ -121,18 +120,19 @@ struct DiscoverProjectParser;
 
 impl CargoParser<DiscoverProjectMessage> for DiscoverProjectParser {
     fn from_line(&self, line: &str, _error: &mut String) -> Option<DiscoverProjectMessage> {
-        // can the line even be deserialized as JSON?
-        let Ok(data) = serde_json::from_str::<Value>(line) else {
-            let err = DiscoverProjectData::Error { error: line.to_owned(), source: None };
-            return Some(DiscoverProjectMessage::new(err));
-        };
-
-        let Ok(data) = serde_json::from_value::<DiscoverProjectData>(data) else {
-            return None;
-        };
-
-        let msg = DiscoverProjectMessage::new(data);
-        Some(msg)
+        match serde_json::from_str::<DiscoverProjectData>(line) {
+            Ok(data) => {
+                let msg = DiscoverProjectMessage::new(data);
+                Some(msg)
+            }
+            Err(err) => {
+                let err = DiscoverProjectData::Error {
+                    error: format!("{:#?}\n{}", err, line),
+                    source: None,
+                };
+                Some(DiscoverProjectMessage::new(err))
+            }
+        }
     }
 
     fn from_eof(&self) -> Option<DiscoverProjectMessage> {


### PR DESCRIPTION
Currently we silently fail if the line can be parsed as json but not as `DiscoverProjectData`. That means if the discover command emits a malformed `DiscoverProjectData`, project discovery will never finish, and rust-analyzer becomes unusable. Instead, return an error if the line isn't a valid `DiscoverProjectData` so the discovery process fails and the error is correctly reported.