### PR TITLE
minor: Preallocate `parser::Input`

### DIFF
--- a/crates/parser/src/input.rs
+++ b/crates/parser/src/input.rs
@@ -12,7 +12,6 @@ type bits = u64;
 /// `Tokens` doesn't include whitespace and comments. Main input to the parser.
 ///
 /// Struct of arrays internally, but this shouldn't really matter.
-#[derive(Default)]
 pub struct Input {
     kind: Vec<SyntaxKind>,
     joint: Vec<bits>,
@@ -21,6 +20,14 @@ pub struct Input {
 
 /// `pub` impl used by callers to create `Tokens`.
 impl Input {
+    #[inline]
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            kind: Vec::with_capacity(capacity),
+            joint: Vec::with_capacity(capacity / size_of::<bits>()),
+            contextual_kind: Vec::with_capacity(capacity),
+        }
+    }
     #[inline]
     pub fn push(&mut self, kind: SyntaxKind) {
         self.push_impl(kind, SyntaxKind::EOF)

--- a/crates/parser/src/shortcuts.rs
+++ b/crates/parser/src/shortcuts.rs
@@ -27,7 +27,7 @@ pub enum StrStep<'a> {
 impl LexedStr<'_> {
     pub fn to_input(&self, edition: Edition) -> crate::Input {
         let _p = tracing::info_span!("LexedStr::to_input").entered();
-        let mut res = crate::Input::default();
+        let mut res = crate::Input::with_capacity(self.len());
         let mut was_joint = false;
         for i in 0..self.len() {
             let kind = self.kind(i);

--- a/crates/syntax-bridge/src/to_parser_input.rs
+++ b/crates/syntax-bridge/src/to_parser_input.rs
@@ -12,7 +12,7 @@ pub fn to_parser_input<Ctx: Copy + fmt::Debug + PartialEq + Eq + Hash>(
     buffer: tt::TokenTreesView<'_, SpanData<Ctx>>,
     span_to_edition: &mut dyn FnMut(Ctx) -> Edition,
 ) -> parser::Input {
-    let mut res = parser::Input::default();
+    let mut res = parser::Input::with_capacity(buffer.len());
 
     let mut current = buffer.cursor();
     let mut syntax_context_to_edition_cache = FxHashMap::default();


### PR DESCRIPTION
This saves a whole lot 0.127 seconds in `rust-analyzer prime-caches .`!