### PR TITLE
Clarify text for add_braces assist

### DIFF
--- a/crates/ide-assists/src/handlers/add_braces.rs
+++ b/crates/ide-assists/src/handlers/add_braces.rs
@@ -7,7 +7,7 @@ use crate::{AssistContext, AssistId, Assists};
 
 // Assist: add_braces
 //
-// Adds braces to lambda and match arm expressions.
+// Adds braces to closure bodies and match arm expressions.
 //
 // ```
 // fn foo(n: i32) -> i32 {
@@ -34,8 +34,8 @@ pub(crate) fn add_braces(acc: &mut Assists, ctx: &AssistContext<'_>) -> Option<(
     acc.add(
         AssistId::refactor_rewrite("add_braces"),
         match expr_type {
-            ParentType::ClosureExpr => "Add braces to closure body",
-            ParentType::MatchArmExpr => "Add braces to arm expression",
+            ParentType::ClosureExpr => "Add braces to this closure body",
+            ParentType::MatchArmExpr => "Add braces to this match arm expression",
         },
         expr.syntax().text_range(),
         |builder| {


### PR DESCRIPTION
"to arm expression" is hard to parse, because "arm" can be a verb. Not all Rust users may know that "arm" refers to a `match` expression either.

Tweak the wording to make the sentence easier to parse, and clarify that this assist refers to `match`. Use the same wording style for the closure version too.