### PR TITLE
fix: Implement mut to const ptr cast for method resolution

### DIFF
--- a/crates/hir-ty/src/tests/method_resolution.rs
+++ b/crates/hir-ty/src/tests/method_resolution.rs
@@ -2170,3 +2170,26 @@ fn main() {
 "#,
     );
 }
+
+#[test]
+fn mut_to_const_pointer() {
+    check(
+        r#"
+pub trait X {
+    fn perform(self) -> u64;
+}
+
+impl X for *const u8 {
+    fn perform(self) -> u64 {
+        42
+    }
+}
+
+fn test(x: *mut u8) {
+    let _v = x.perform();
+     //      ^ adjustments: Pointer(MutToConstPointer)
+     //      ^^^^^^^^^^^ type: u64
+}
+"#,
+    );
+}


### PR DESCRIPTION
Fixes rust-lang/rust-analyzer#19724 

Mimicked part of the method resolution logic of rustc and I think that we should move r-a's closer to rustc's (Maybe I'll do it later)