### PR TITLE
fix: Fix postfix snippets duplicating derefs

### DIFF
--- a/crates/ide-completion/src/tests/expression.rs
+++ b/crates/ide-completion/src/tests/expression.rs
@@ -2174,3 +2174,22 @@ fn bar() {
     "#,
     );
 }
+
+#[test]
+fn dbg_too_many_asterisks() {
+    check_edit(
+        "dbg",
+        r#"
+fn main() {
+    let x = &42;
+    let y = *x.$0;
+}
+    "#,
+        r#"
+fn main() {
+    let x = &42;
+    let y = dbg!(*x);
+}
+    "#,
+    );
+}


### PR DESCRIPTION
Fixes rust-lang/rust-analyzer#19758.

I'm not entirely sure the `found_ref_or_deref` check is correct - I think maybe we should remove it - but removing it makes `let` postfix completions no longer appear (although I suspect this is because we check the grandparent instead of the parent).