### PR TITLE
fix: Fix cache problems with lints level

### DIFF
--- a/crates/ide-diagnostics/src/handlers/missing_unsafe.rs
+++ b/crates/ide-diagnostics/src/handlers/missing_unsafe.rs
@@ -915,4 +915,47 @@ fn foo() {
             "#,
         );
     }
+
+    #[test]
+    fn regression_19823() {
+        check_diagnostics(
+            r#"
+pub trait FooTrait {
+    unsafe fn method1();
+    unsafe fn method2();
+}
+
+unsafe fn some_unsafe_fn() {}
+
+macro_rules! impl_foo {
+    () => {
+        unsafe fn method1() {
+            some_unsafe_fn();
+        }
+        unsafe fn method2() {
+            some_unsafe_fn();
+        }
+    };
+}
+
+pub struct S1;
+#[allow(unsafe_op_in_unsafe_fn)]
+impl FooTrait for S1 {
+    unsafe fn method1() {
+        some_unsafe_fn();
+    }
+
+    unsafe fn method2() {
+        some_unsafe_fn();
+    }
+}
+
+pub struct S2;
+#[allow(unsafe_op_in_unsafe_fn)]
+impl FooTrait for S2 {
+    impl_foo!();
+}
+        "#,
+        );
+    }
 }


### PR DESCRIPTION
Fixes rust-lang/rust-analyzer#19823.

I knew this cache will cause us problems.

I question the need for a cache (yep, I authored this code, I know). When there is no cache there are no cache problems. And we all know what the hardest problems in computer science are. This code was just needlessly complex.

Ideally I believe we would have lint levels defined as db queries and query them *before* firing the lints. Unfortunately in rustc lint levels are tied with spans, which can be arbitrary pieces of code, and we can't implement something like that for our hir. So we're stuck with AST-based lint resolution (which isn't *that* bad, actually).