### PR TITLE
feat: user choice group api

### DIFF
--- a/crates/ide-assists/src/assist_context.rs
+++ b/crates/ide-assists/src/assist_context.rs
@@ -205,6 +205,8 @@ impl Assists {
 
     /// Give user multiple choices, user's choice will be passed to `f` as a list of indices.
     /// The indices are the indices of the choices in the original list.
+    /// TODO(discord9): remove allow(unused) once auto import all use this function
+    #[allow(unused)]
     pub(crate) fn add_choices(
         &mut self,
         group: &Option<GroupLabel>,

--- a/crates/ide-assists/src/assist_context.rs
+++ b/crates/ide-assists/src/assist_context.rs
@@ -1,7 +1,7 @@
 //! See [`AssistContext`].
 
 use hir::{EditionedFileId, FileRange, Semantics};
-use ide_db::source_change::UserChoiceGroup;
+use ide_db::source_change::{UserChoice, UserChoiceGroup};
 use ide_db::{FileId, RootDatabase, label::Label};
 use syntax::Edition;
 use syntax::{
@@ -213,7 +213,7 @@ impl Assists {
         id: AssistId,
         label: impl Into<String>,
         target: TextRange,
-        choices: Vec<Vec<String>>,
+        choices: Vec<(String, Vec<String>)>,
         f: impl FnOnce(&mut SourceChangeBuilder, &[usize]) + Send + 'static,
     ) -> Option<()> {
         if !self.is_allowed(&id) {
@@ -229,7 +229,14 @@ impl Assists {
             target,
             source_change: None,
             command: None,
-            user_choice_group: Some(UserChoiceGroup::new(choices, f)),
+            user_choice_group: Some(UserChoiceGroup::new(
+                choices
+                    .into_iter()
+                    .map(|(title, choices)| UserChoice::new(title, choices))
+                    .collect(),
+                f,
+                self.file,
+            )),
         });
 
         Some(())

--- a/crates/ide-db/src/assists.rs
+++ b/crates/ide-db/src/assists.rs
@@ -9,7 +9,7 @@ use std::str::FromStr;
 
 use syntax::TextRange;
 
-use crate::{label::Label, source_change::SourceChange};
+use crate::{label::Label, source_change::{SourceChange, UserChoiceGroup}};
 
 #[derive(Debug, Clone)]
 pub struct Assist {
@@ -31,6 +31,8 @@ pub struct Assist {
     pub source_change: Option<SourceChange>,
     /// The command to execute after the assist is applied.
     pub command: Option<Command>,
+    /// The group of choices to show to the user when applying the assist.
+    pub user_choice_group: Option<UserChoiceGroup>
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/ide-db/src/source_change.rs
+++ b/crates/ide-db/src/source_change.rs
@@ -3,8 +3,10 @@
 //!
 //! It can be viewed as a dual for `Change`.
 
+use std::sync::{Arc, Mutex};
 use std::{collections::hash_map::Entry, fmt, iter, mem};
 
+use crate::source_change;
 use crate::text_edit::{TextEdit, TextEditBuilder};
 use crate::{SnippetCap, assists::Command, syntax_helpers::tree_diff::diff};
 use base_db::AnchoredPathBuf;
@@ -556,4 +558,99 @@ impl PlaceSnippet {
             }
         }
     }
+}
+
+/// a function that takes a `SourceChangeBuilder` and a slice of indices
+/// which represent the indices of the choices made by the user
+/// which is the choice being made, each one from corrseponding choice list in `Assists::add_choices`
+pub type ChoiceCallback = dyn FnOnce(&mut SourceChangeBuilder, &[usize]) + Send + 'static;
+
+/// Represents a group of choices offered to the user, along with a callback
+/// to be executed based on the user's selection.
+///
+/// This is typically used in scenarios like "assists" or "quick fixes" where
+/// the user needs to pick from several options to proceed with a source code change.
+#[derive(Clone)]
+pub struct UserChoiceGroup {
+    /// A list of choice groups. Each inner vector represents a set of options
+    /// from which the user can make one selection.
+    /// For example, `choices[0]` might be `["Option A", "Option B"]` and
+    /// `choices[1]` might be `["Setting X", "Setting Y"]`.
+    choice_options: Vec<Vec<String>>,
+    /// The callback function to be invoked with the user's selections.
+    /// The `&[usize]` argument to the callback will contain the indices
+    /// of the choices made by the user, corresponding to each group in `choice_options`.
+    callback: Arc<Mutex<Option<Box<ChoiceCallback>>>>,
+    /// The current choices made by the user, represented as a vector of indices.
+    cur_choices: Vec<usize>,
+}
+
+impl std::fmt::Debug for UserChoiceGroup {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("UserChoiceGroup")
+            .field("choice_options", &self.choice_options)
+            .field("callback", &"<ChoiceCallback>")
+            .field("cur_choices", &self.cur_choices)
+            .finish()
+    }
+}
+
+impl UserChoiceGroup {
+    /// Creates a new `UserChoiceGroup`.
+    ///
+    /// # Arguments
+    ///
+    /// * `choice_options`: A vector of vectors of strings, where each inner vector
+    ///   represents a group of choices.
+    /// * `callback`: A function that will be called with the indices of the
+    ///   user's selections after they make their choices.
+    ///
+    pub fn new(
+        choice_options: Vec<Vec<String>>,
+        callback: impl FnOnce(&mut SourceChangeBuilder, &[usize]) + Send + 'static,
+    ) -> Self {
+        Self {
+            cur_choices: vec![],
+            choice_options,
+            callback: Arc::new(Mutex::new(Some(Box::new(callback)))),
+        }
+    }
+
+    /// Returns next question(and it's indices) to be asked to the user.
+    ///
+    pub fn next_question(&self) -> Option<(usize, &Vec<String>)> {
+        if self.cur_choices.len() < self.choice_options.len() {
+            let idx = self.cur_choices.len();
+            let choices = &self.choice_options[idx];
+            Some((idx, choices))
+        } else {
+            None
+        }
+    }
+
+    /// Make the idx-th choice in the group.
+    /// `choice` is the index of the choice in the group(0-based).
+    /// This function will be called when the user makes a choice.
+    pub fn make_choice(&mut self, idx: usize, choice: usize) -> Result<(), String> {
+        if idx < self.choice_options.len() && idx == self.cur_choices.len() {
+            self.cur_choices.push(choice);
+        } else {
+            return Err("Invalid index for choice group".to_string());
+        }
+
+        Ok(())
+    }
+
+    /// Finalizes the choices made by the user and invokes the callback.
+    /// This function should be called when the user has finished making their choices.
+    pub fn finish(self, builder: &mut SourceChangeBuilder) {
+        let mut callback = self.callback.lock().unwrap();
+        let callback = callback.take().expect("Callback already");
+        callback(builder, &self.cur_choices);
+    }
+
+    // Potentially add other methods here, for example:
+    // - To get the number of choice groups.
+    // - To get the options for a specific group.
+    // - To validate selection indices.
 }

--- a/crates/ide-db/src/source_change.rs
+++ b/crates/ide-db/src/source_change.rs
@@ -644,6 +644,11 @@ impl UserChoiceGroup {
         }
     }
 
+    /// Whether the user has finished making their choices.
+    pub fn is_done_asking(&self) -> bool {
+        self.cur_choices.len() == self.choice_options.len()
+    }
+
     /// Make the idx-th choice in the group.
     /// `choice` is the index of the choice in the group(0-based).
     /// This function will be called when the user makes a choice.
@@ -663,6 +668,10 @@ impl UserChoiceGroup {
         let mut callback = self.callback.lock().unwrap();
         let callback = callback.take().expect("Callback already");
         callback(builder, &self.cur_choices);
+    }
+
+    pub fn file_id(&self) -> FileId {
+        self.file
     }
 }
 
@@ -696,10 +705,12 @@ impl UserChoiceHandler {
         self.queue.pop_front()
     }
 
+    /// Whether awaiting for sent request's response.
     pub fn is_awaiting(&self) -> bool {
         self.is_awaiting
     }
 
+    /// Sets the awaiting state.
     pub fn set_awaiting(&mut self, awaiting: bool) {
         self.is_awaiting = awaiting;
     }

--- a/crates/ide-diagnostics/src/handlers/trait_impl_redundant_assoc_item.rs
+++ b/crates/ide-diagnostics/src/handlers/trait_impl_redundant_assoc_item.rs
@@ -106,6 +106,7 @@ fn quickfix_for_redundant_assoc_item(
         target: range,
         source_change: Some(source_change_builder.finish()),
         command: None,
+        user_choice_group: None,
     }])
 }
 

--- a/crates/ide-diagnostics/src/handlers/typed_hole.rs
+++ b/crates/ide-diagnostics/src/handlers/typed_hole.rs
@@ -94,6 +94,7 @@ fn fixes(ctx: &DiagnosticsContext<'_>, d: &hir::TypedHole) -> Option<Vec<Assist>
                 TextEdit::replace(original_range.range, code),
             )),
             command: None,
+            user_choice_group: None,
         })
         .collect();
 

--- a/crates/ide-diagnostics/src/handlers/unresolved_field.rs
+++ b/crates/ide-diagnostics/src/handlers/unresolved_field.rs
@@ -127,6 +127,7 @@ fn add_variant_to_union(
         target: error_range.range,
         source_change: Some(src_change_builder.finish()),
         command: None,
+        user_choice_group: None,
     })
 }
 
@@ -176,6 +177,7 @@ fn add_field_to_struct_fix(
                 target: error_range.range,
                 source_change: Some(src_change_builder.finish()),
                 command: None,
+                user_choice_group: None,
             })
         }
         None => {
@@ -213,6 +215,7 @@ fn add_field_to_struct_fix(
                 target: error_range.range,
                 source_change: Some(src_change_builder.finish()),
                 command: None,
+                user_choice_group: None,
             })
         }
         Some(FieldList::TupleFieldList(_tuple)) => {
@@ -275,6 +278,7 @@ fn method_fix(
             TextEdit::insert(range.end(), "()".to_owned()),
         )),
         command: None,
+        user_choice_group: None,
     })
 }
 #[cfg(test)]

--- a/crates/ide-diagnostics/src/handlers/unresolved_method.rs
+++ b/crates/ide-diagnostics/src/handlers/unresolved_method.rs
@@ -104,6 +104,7 @@ fn field_fix(
             (file_id.file_id(ctx.sema.db), TextEdit::insert(range.end(), ")".to_owned())),
         ])),
         command: None,
+        user_choice_group: None,
     })
 }
 
@@ -185,6 +186,7 @@ fn assoc_func_fix(ctx: &DiagnosticsContext<'_>, d: &hir::UnresolvedMethodCall) -
                 TextEdit::replace(range, assoc_func_call_expr_string),
             )),
             command: None,
+            user_choice_group: None,
         })
     } else {
         None

--- a/crates/ide-diagnostics/src/handlers/unused_variables.rs
+++ b/crates/ide-diagnostics/src/handlers/unused_variables.rs
@@ -80,6 +80,7 @@ fn fixes(
             TextEdit::replace(name_range, format!("_{}", var_name.display(db, edition))),
         )),
         command: None,
+        user_choice_group: None,
     }])
 }
 

--- a/crates/ide-diagnostics/src/lib.rs
+++ b/crates/ide-diagnostics/src/lib.rs
@@ -983,6 +983,7 @@ fn unresolved_fix(id: &'static str, label: &str, target: TextRange) -> Assist {
         target,
         source_change: None,
         command: None,
+        user_choice_group: None,
     }
 }
 

--- a/crates/ide/src/ssr.rs
+++ b/crates/ide/src/ssr.rs
@@ -46,6 +46,7 @@ pub(crate) fn ssr_assists(
             target: comment_range,
             source_change,
             command: None,
+            user_choice_group: None,
         };
 
         ssr_assists.push(assist);

--- a/crates/rust-analyzer/src/handlers/request.rs
+++ b/crates/rust-analyzer/src/handlers/request.rs
@@ -1443,7 +1443,10 @@ pub(crate) fn handle_code_action(
         resolve,
         frange,
     )?;
-    for (index, assist) in assists.into_iter().enumerate() {
+    for (index, mut assist) in assists.into_iter().enumerate() {
+        if let Some(user_choice_group) = assist.user_choice_group.take() {
+            snap.user_choice_handler.lock().add_choice_group(user_choice_group);
+        }
         let resolve_data = if code_action_resolve_cap {
             Some((index, params.clone(), snap.file_version(file_id)))
         } else {

--- a/crates/rust-analyzer/src/main_loop.rs
+++ b/crates/rust-analyzer/src/main_loop.rs
@@ -11,7 +11,10 @@ use std::{
 use crossbeam_channel::{Receiver, select};
 use ide_db::base_db::{SourceDatabase, VfsPath, salsa::Database as _};
 use lsp_server::{Connection, Notification, Request};
-use lsp_types::{TextDocumentIdentifier, notification::Notification as _};
+use lsp_types::{
+    ShowMessageRequestParams, TextDocumentIdentifier, notification::Notification as _,
+    request::Request as _, request::ShowMessageRequest,
+};
 use stdx::thread::ThreadIntent;
 use tracing::{Level, error, span};
 use vfs::{AbsPathBuf, FileId, loader::LoadingProgress};
@@ -515,6 +518,7 @@ impl GlobalState {
         }
 
         self.update_status_or_notify();
+        self.ask_for_choice();
 
         let loop_duration = loop_start.elapsed();
         if loop_duration > Duration::from_millis(100) && was_quiescent {
@@ -710,6 +714,108 @@ impl GlobalState {
                     open_log_button,
                 );
             }
+        }
+    }
+
+    /// Ask for user choice by sending ShowMessageRequest
+    fn ask_for_choice(&mut self) {
+        let params = {
+            let mut handler = self.user_choice_handler.lock();
+            if handler.is_awaiting() {
+                // already sent a request, do nothing
+                return;
+            }
+            let params = if let Some(choice_group) = handler.first_mut_choice_group() {
+                if let Some((_idx, choice)) = choice_group.get_cur_question() {
+                    Some(ShowMessageRequestParams {
+                        typ: lsp_types::MessageType::INFO,
+                        message: choice.title.clone(),
+                        actions: Some(
+                            choice
+                                .actions
+                                .clone()
+                                .into_iter()
+                                .map(|action| lsp_types::MessageActionItem {
+                                    title: action,
+                                    properties: Default::default(),
+                                })
+                                .collect(),
+                        ),
+                    })
+                } else {
+                    // TODO: handle finished choice
+                    // spawn a new task to handle the finished choice, in case of panic
+                    None
+                }
+            } else {
+                None
+            };
+            if params.is_some() {
+                handler.set_awaiting(true);
+            }
+            params
+        };
+
+        // send ShowMessageRequest to the client, and handle the response
+        if let Some(params) = params {
+            self.send_request::<ShowMessageRequest>(params, |state, response| {
+                let lsp_server::Response { error: None, result: Some(result), .. } = response
+                else {
+                    return;
+                };
+                let choice = match crate::from_json::<
+                    <lsp_types::request::ShowMessageRequest as lsp_types::request::Request>::Result,
+                >(
+                    lsp_types::request::ShowMessageRequest::METHOD, &result
+                ) {
+                    Ok(Some(item)) => Some(item.title.clone()),
+                    Err(err) => {
+                        tracing::error!("Failed to deserialize ShowMessageRequest result: {err}");
+                        None
+                    }
+                    // user made no choice
+                    Ok(None) => None,
+                };
+                let mut do_pop = false;
+                let mut handler = state.user_choice_handler.lock();
+                match (handler.first_mut_choice_group(), choice) {
+                    (Some(choice_group), Some(choice)) => {
+                        let Some((question_idx, user_choices)) = choice_group.get_cur_question()
+                        else {
+                            tracing::error!("No question found for user choice");
+                            return;
+                        };
+                        let choice_idx = user_choices
+                            .actions
+                            .iter()
+                            .position(|it| *it == choice)
+                            .unwrap_or(user_choices.actions.len());
+                        if let Err(err) = choice_group.make_choice(question_idx, choice_idx) {
+                            tracing::error!("Failed to make choice: {err}");
+                        }
+                    }
+                    (None, Some(choice)) => {
+                        tracing::error!("No ongoing choice group found for user choice: {choice}");
+                    }
+                    (Some(_), None) => {
+                        // user made no choice, pop&drop current choice group
+                        do_pop = true;
+                    }
+                    _ => (),
+                }
+
+                if do_pop {
+                    let group = handler.pop_choice_group();
+                    tracing::error!(
+                        "User made no choice, dropping current choice group: {group:?}"
+                    );
+                }
+                handler.set_awaiting(false);
+                drop(handler);
+
+                // recursively call handle_choice to handle the next question
+                state.ask_for_choice();
+            });
         }
     }
 


### PR DESCRIPTION
## overview

Added a API for asking user multiple questions and get answers, useful for quick fix that need to ask multiple question and get user choice(i.e. import all missing item, choose multiple import crates etc.) 

## details
Use [ShowMessageRequest](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#window_showMessage) to send message to user, and get `MessageAction` in return.

The major impl is in `ask_for_choice` function and is somewhere twisted as writing async code using callback is certainly very uncomfortable. `ask_for_choice` send with a empty request id as can't determine what request id it should belong to.

On the `Assists` side, developer basically provide a callback with signature of `dyn FnOnce(&mut SourceChangeBuilder, &[usize]) + Send + 'static` to handle what to do after get user choices results, so it's similar to `add_group` method

## todo
test this with a integration test