### PR TITLE
refactor: Remove fields from `ItemTree`

### DIFF
--- a/crates/hir-def/src/item_tree/tests.rs
+++ b/crates/hir-def/src/item_tree/tests.rs
@@ -1,5 +1,4 @@
 use expect_test::{Expect, expect};
-use span::Edition;
 use test_fixture::WithFixture;
 
 use crate::{db::DefDatabase, test_db::TestDB};
@@ -7,7 +6,7 @@ use crate::{db::DefDatabase, test_db::TestDB};
 fn check(#[rust_analyzer::rust_fixture] ra_fixture: &str, expect: Expect) {
     let (db, file_id) = TestDB::with_single_file(ra_fixture);
     let item_tree = db.file_item_tree(file_id.into());
-    let pretty = item_tree.pretty_print(&db, Edition::CURRENT);
+    let pretty = item_tree.pretty_print(&db, file_id);
     expect.assert_eq(&pretty);
 }
 

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -52,7 +52,7 @@ use hir_def::{
         BindingAnnotation, BindingId, Expr, ExprId, ExprOrPatId, LabelId, Pat,
         generics::{LifetimeParamData, TypeOrConstParamData, TypeParamProvenance},
     },
-    item_tree::{AttrOwner, FieldParent, ImportAlias, ItemTreeFieldId, ItemTreeNode},
+    item_tree::{AttrOwner, FieldParent, ImportAlias, ItemTreeNode},
     layout::{self, ReprOptions, TargetDataLayout},
     nameres::{self, diagnostics::DefDiagnostic},
     per_ns::PerNs,
@@ -1060,15 +1060,14 @@ fn emit_def_diagnostic_(
             // FIXME: This parses... We could probably store relative ranges for the children things
             // here in the item tree?
             (|| {
-                let process_field_list =
-                    |field_list: Option<_>, idx: ItemTreeFieldId| match field_list? {
-                        ast::FieldList::RecordFieldList(it) => Some(SyntaxNodePtr::new(
-                            it.fields().nth(idx.into_raw().into_u32() as usize)?.syntax(),
-                        )),
-                        ast::FieldList::TupleFieldList(it) => Some(SyntaxNodePtr::new(
-                            it.fields().nth(idx.into_raw().into_u32() as usize)?.syntax(),
-                        )),
-                    };
+                let process_field_list = |field_list: Option<_>, idx: usize| match field_list? {
+                    ast::FieldList::RecordFieldList(it) => {
+                        Some(SyntaxNodePtr::new(it.fields().nth(idx)?.syntax()))
+                    }
+                    ast::FieldList::TupleFieldList(it) => {
+                        Some(SyntaxNodePtr::new(it.fields().nth(idx)?.syntax()))
+                    }
+                };
                 let ptr = match *item {
                     AttrOwner::ModItem(it) => {
                         ast_id_map.get(it.ast_id(&item_tree)).syntax_node_ptr()
@@ -1097,7 +1096,7 @@ fn emit_def_diagnostic_(
                             .to_node(&db.parse_or_expand(tree.file_id()))
                             .record_field_list()?
                             .fields()
-                            .nth(idx.into_raw().into_u32() as usize)?
+                            .nth(idx)?
                             .syntax(),
                     ),
                 };

--- a/crates/ide/src/view_item_tree.rs
+++ b/crates/ide/src/view_item_tree.rs
@@ -13,5 +13,5 @@ pub(crate) fn view_item_tree(db: &RootDatabase, file_id: FileId) -> String {
     let file_id = sema
         .attach_first_edition(file_id)
         .unwrap_or_else(|| EditionedFileId::current_edition(db, file_id));
-    db.file_item_tree(file_id.into()).pretty_print(db, file_id.edition(db))
+    db.file_item_tree(file_id.into()).pretty_print(db, file_id)
 }


### PR DESCRIPTION
Resolves rust-lang/rust-analyzer#19549