### PR TITLE
fix: Correctly set the span of the proc_macro crate's Group delimiters

### DIFF
--- a/crates/proc-macro-srv/src/server_impl/rust_analyzer_span.rs
+++ b/crates/proc-macro-srv/src/server_impl/rust_analyzer_span.rs
@@ -258,7 +258,9 @@ impl server::TokenStream for RaSpanServer {
         &mut self,
         stream: Self::TokenStream,
     ) -> Vec<bridge::TokenTree<Self::TokenStream, Self::Span, Self::Symbol>> {
-        stream.into_bridge()
+        stream.into_bridge(&mut |first, second| {
+            server::Span::join(self, first, second).unwrap_or(first)
+        })
     }
 }
 

--- a/crates/proc-macro-srv/src/server_impl/token_id.rs
+++ b/crates/proc-macro-srv/src/server_impl/token_id.rs
@@ -238,7 +238,8 @@ impl server::TokenStream for TokenIdServer {
         &mut self,
         stream: Self::TokenStream,
     ) -> Vec<bridge::TokenTree<Self::TokenStream, Self::Span, Self::Symbol>> {
-        stream.into_bridge()
+        // Can't join with `TokenId`.
+        stream.into_bridge(&mut |first, _second| first)
     }
 }
 

--- a/crates/proc-macro-srv/src/server_impl/token_stream.rs
+++ b/crates/proc-macro-srv/src/server_impl/token_stream.rs
@@ -56,7 +56,10 @@ impl<S: Copy> TokenStream<S> {
         self.token_trees.is_empty()
     }
 
-    pub(crate) fn into_bridge(self) -> Vec<bridge::TokenTree<Self, S, intern::Symbol>> {
+    pub(crate) fn into_bridge(
+        self,
+        join_spans: &mut dyn FnMut(S, S) -> S,
+    ) -> Vec<bridge::TokenTree<Self, S, intern::Symbol>> {
         let mut result = Vec::new();
         let mut iter = self.token_trees.into_iter();
         while let Some(tree) = iter.next() {
@@ -98,7 +101,11 @@ impl<S: Copy> TokenStream<S> {
                                 token_trees: iter.by_ref().take(subtree.usize_len()).collect(),
                             })
                         },
-                        span: bridge::DelimSpan::from_single(subtree.delimiter.open),
+                        span: bridge::DelimSpan {
+                            open: subtree.delimiter.open,
+                            close: subtree.delimiter.close,
+                            entire: join_spans(subtree.delimiter.open, subtree.delimiter.close),
+                        },
                     }))
                 }
             }

--- a/crates/proc-macro-srv/src/tests/mod.rs
+++ b/crates/proc-macro-srv/src/tests/mod.rs
@@ -144,7 +144,7 @@ fn test_fn_like_macro_clone_ident_subtree() {
             SUBTREE $$ 42:2@0..100#ROOT2024 42:2@0..100#ROOT2024
               IDENT   ident 42:2@0..5#ROOT2024
               PUNCH   , [alone] 42:2@5..6#ROOT2024
-              SUBTREE [] 42:2@7..8#ROOT2024 42:2@7..8#ROOT2024"#]],
+              SUBTREE [] 42:2@7..9#ROOT2024 42:2@7..9#ROOT2024"#]],
     );
 }
 


### PR DESCRIPTION
Previously only the open delimiter's span was set, and this caused... weird problems.

Probably fixes (don't close!) rust-lang/rust-analyzer#18471, and possibly also rust-lang/rust-analyzer#19834. The problem is that we only had the span of the closing parentheses of the call, and for descending attributes we look at the first and last token, but we couldn't find the last token (the closing paren) in the macro. However, there could be other problems too, so I don't want to close them yet before we verify it works (it's hard to test proc macro server changes).

Perhaps it's worth reconsidering our strategy for descending into attribute macros, especially given that when users create their own `Group`s they have no way of setting each delimiter span separately, only for both.