### PR TITLE
completions: avoid invalidating `handle_completion_resolve`

### DIFF
--- a/crates/ide-completion/src/lib.rs
+++ b/crates/ide-completion/src/lib.rs
@@ -64,8 +64,8 @@ impl CompletionFieldsToResolve {
         Self {
             resolve_label_details: false,
             resolve_tags: false,
-            resolve_detail: false,
-            resolve_documentation: false,
+            resolve_detail: true,
+            resolve_documentation: true,
             resolve_filter_text: false,
             resolve_text_edit: false,
             resolve_command: false,


### PR DESCRIPTION
(I accidentally pushed this branch to rust-analyzer, not a fork. Sorry about that.)

I [noticed that](https://rust-lang.zulipchat.com/#narrow/channel/185405-t-compiler.2Frust-analyzer/topic/Profiling/near/519455701) `handle_completion_resolve` was taking a longer than I expected, especially immediately after a `handle_completion` on the same completion item. Naively, I'd expect `handle_completion_resolve` to be largely instant, as we rust-analyzer did most of the required work in `handle_completion` completion _already_.

I did some additional digging and realized that—at least, in VS Code—the only differences between the configuration passed to `snap.analysis.completions` was in the `completion_config`/`forced_resolve_completions_config`, specifically, in `CompletionFieldsToResolve`. The former had `resolve_detail`/`resolve_documentation` set to true; the latter set to false.

This set of changes sped up completions on some work-private projects by about ~20% or so.