### PR TITLE
Add support for type-erased `Semantics<'db, dyn HirDatabase>`, by use of `DB: ?Sized`

### DIFF
--- a/crates/hir/src/semantics.rs
+++ b/crates/hir/src/semantics.rs
@@ -147,7 +147,7 @@ impl TypeInfo {
 }
 
 /// Primary API to get semantic information, like types, from syntax trees.
-pub struct Semantics<'db, DB> {
+pub struct Semantics<'db, DB: ?Sized> {
     pub db: &'db DB,
     imp: SemanticsImpl<'db>,
 }


### PR DESCRIPTION
The `Semantics<'db, DB>` type is currently defined like this:

```rust
pub struct Semantics<'db, DB> {
    pub db: &'db DB,
    imp: SemanticsImpl<'db>,
}
```

I was surprised to find that `Semantics<'db, DB>` never actually accesses `self.db` (nor does any other code in `ra_ap_hir`). So I removed the `pub` from `db` to see who (if anybody) was actually using that field: Turns out the only crates that actually access `sema.db` are `ra_ap_ide`/`ra_ap_ide_db`/`rust_analyzer`.

As such it is rather unfortunate for all those useful methods on `Semantics<'db, DB>`, of which none actually need access to the type `Db`, are inaccessible in contexts where only `db: &dyn HirDatabase` is available (e.g. in salsa's tracked functions).

I would thus like to propose a refactoring of `Semantics<'db, Db>`, extracting the `dyn`-compatible logic into `DynSemantics<'db>` (with a plea to try to prefer the latter where applicable):

```rust
pub struct DynSemantics<'db> {
    imp: SemanticsImpl<'db>,
}

pub struct Semantics<'db, Db> {
    pub db: &'db DB,
    sema: DynSemantics<'db>,
}
```

The motivation behind this change is to make the resolution logic of `Semantics<'db, DB>` available in `dyn` contexts and to provide `DynSemantics<'db>` as an alternative to the tightly coupled `Semantics<'db, DB>`.

(the PR is motivated by an outside use of the `ra_ap_hir` crate that would benefit from being able to access `Semantics<'db, Db>` in `dyn` contexts)