### PR TITLE
fix: Fix IDE resolution of item macros

### DIFF
--- a/crates/hir-def/src/db.rs
+++ b/crates/hir-def/src/db.rs
@@ -422,6 +422,7 @@ fn macro_def(db: &dyn DefDatabase, id: MacroId) -> MacroDefId {
             let makro = &item_tree[loc.id.value];
             MacroDefId {
                 krate: loc.container.krate,
+                block: loc.container.block.map(|block| salsa::plumbing::AsId::as_id(&block)),
                 kind: kind(loc.expander, loc.id.file_id(), makro.ast_id.upcast()),
                 local_inner: false,
                 allow_internal_unsafe: loc.allow_internal_unsafe,
@@ -435,6 +436,7 @@ fn macro_def(db: &dyn DefDatabase, id: MacroId) -> MacroDefId {
             let makro = &item_tree[loc.id.value];
             MacroDefId {
                 krate: loc.container.krate,
+                block: loc.container.block.map(|block| salsa::plumbing::AsId::as_id(&block)),
                 kind: kind(loc.expander, loc.id.file_id(), makro.ast_id.upcast()),
                 local_inner: loc.flags.contains(MacroRulesLocFlags::LOCAL_INNER),
                 allow_internal_unsafe: loc
@@ -450,6 +452,7 @@ fn macro_def(db: &dyn DefDatabase, id: MacroId) -> MacroDefId {
             let makro = &item_tree[loc.id.value];
             MacroDefId {
                 krate: loc.container.krate,
+                block: None,
                 kind: MacroDefKind::ProcMacro(
                     InFile::new(loc.id.file_id(), makro.ast_id),
                     loc.expander,

--- a/crates/hir-def/src/resolver.rs
+++ b/crates/hir-def/src/resolver.rs
@@ -696,6 +696,15 @@ impl<'db> Resolver<'db> {
         &def_map[local_id].scope
     }
 
+    pub fn item_scopes(&self) -> impl Iterator<Item = &ItemScope> {
+        self.scopes()
+            .filter_map(move |scope| match scope {
+                Scope::BlockScope(m) => Some(&m.def_map[m.module_id].scope),
+                _ => None,
+            })
+            .chain(std::iter::once(&self.module_scope.def_map[self.module_scope.module_id].scope))
+    }
+
     pub fn krate(&self) -> Crate {
         self.module_scope.def_map.krate()
     }

--- a/crates/hir-expand/src/lib.rs
+++ b/crates/hir-expand/src/lib.rs
@@ -258,6 +258,8 @@ pub struct MacroCallLoc {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct MacroDefId {
     pub krate: Crate,
+    // FIXME: In `hir-expand` we can't refer to `BlockId`.
+    pub block: Option<salsa::Id>,
     pub edition: Edition,
     pub kind: MacroDefKind,
     pub local_inner: bool,

--- a/crates/hir/src/semantics.rs
+++ b/crates/hir/src/semantics.rs
@@ -411,7 +411,7 @@ impl<'db> SemanticsImpl<'db> {
         let sa = self.analyze_no_infer(macro_call.syntax())?;
 
         let macro_call = InFile::new(sa.file_id, macro_call);
-        let file_id = sa.expand(self.db, macro_call)?;
+        let file_id = sa.expansion(self.db, macro_call)?;
 
         let node = self.parse_or_expand(file_id.into());
         Some(node)
@@ -437,7 +437,7 @@ impl<'db> SemanticsImpl<'db> {
         let sa = self.analyze_no_infer(macro_call.syntax())?;
 
         let macro_call = InFile::new(sa.file_id, macro_call);
-        let file_id = sa.expand(self.db, macro_call)?;
+        let file_id = sa.expansion(self.db, macro_call)?;
         let macro_call = self.db.lookup_intern_macro_call(file_id);
 
         let skip = matches!(
@@ -576,7 +576,7 @@ impl<'db> SemanticsImpl<'db> {
     ) -> Option<(SyntaxNode, Vec<(SyntaxToken, u8)>)> {
         let analyzer = self.analyze_no_infer(actual_macro_call.syntax())?;
         let macro_call = InFile::new(analyzer.file_id, actual_macro_call);
-        let macro_file = analyzer.expansion(macro_call)?;
+        let macro_file = analyzer.expansion(self.db, macro_call)?;
         hir_expand::db::expand_speculative(
             self.db,
             macro_file,
@@ -1120,7 +1120,7 @@ impl<'db> SemanticsImpl<'db> {
                                                 false,
                                             )
                                         })?
-                                        .expand(self.db, mcall.as_ref())?;
+                                        .expansion(self.db, mcall.as_ref())?;
                                     m_cache.insert(mcall, it);
                                     it
                                 }
@@ -1579,7 +1579,7 @@ impl<'db> SemanticsImpl<'db> {
         let sa = self.analyze(macro_call.syntax())?;
         self.db
             .parse_macro_expansion(
-                sa.expand(self.db, self.wrap_node_infile(macro_call.clone()).as_ref())?,
+                sa.expansion(self.db, self.wrap_node_infile(macro_call.clone()).as_ref())?,
             )
             .value
             .1

--- a/crates/ide-completion/src/tests/item.rs
+++ b/crates/ide-completion/src/tests/item.rs
@@ -4,7 +4,7 @@
 //! in [crate::completions::mod_].
 use expect_test::expect;
 
-use crate::tests::{check_edit, check_with_base_items};
+use crate::tests::{check, check_edit, check_with_base_items};
 
 #[test]
 fn target_type_or_trait_in_impl_block() {
@@ -305,6 +305,42 @@ fn bar() {
             sn macro_rules
             sn pd
             sn ppd
+        "#]],
+    );
+}
+
+#[test]
+fn expression_in_item_macro() {
+    check(
+        r#"
+fn foo() -> u8 { 0 }
+
+macro_rules! foo {
+    ($expr:expr) => {
+        const BAR: u8 = $expr;
+    };
+}
+
+foo!(f$0);
+    "#,
+        expect![[r#"
+            ct BAR                   u8
+            fn foo()         fn() -> u8
+            ma foo!(…) macro_rules! foo
+            bt u32                  u32
+            kw const
+            kw crate::
+            kw false
+            kw for
+            kw if
+            kw if let
+            kw loop
+            kw match
+            kw self::
+            kw true
+            kw unsafe
+            kw while
+            kw while let
         "#]],
     );
 }


### PR DESCRIPTION
It wasn't inside the source map, because there was no source map.

Fixes rust-lang/rust-analyzer#19860.

This regressed in the item tree refactor. I'm not sure why it switched to the code to lookup in maps instead of relower the macro but I preserved that (CC @Veykril).