### PR TITLE
fix: Skip pattern analysis on type mismatches

### DIFF
--- a/crates/hir-ty/src/diagnostics/expr.rs
+++ b/crates/hir-ty/src/diagnostics/expr.rs
@@ -324,6 +324,9 @@ impl ExprValidator {
             let &Statement::Let { pat, initializer, else_branch: None, .. } = stmt else {
                 continue;
             };
+            if self.infer.type_mismatch_for_pat(pat).is_some() {
+                continue;
+            }
             let Some(initializer) = initializer else { continue };
             let ty = &self.infer[initializer];
             if ty.contains_unknown() {

--- a/crates/ide-diagnostics/src/handlers/type_mismatch.rs
+++ b/crates/ide-diagnostics/src/handlers/type_mismatch.rs
@@ -1243,4 +1243,18 @@ fn foo(v: &Enum) {
     "#,
         );
     }
+
+    #[test]
+    fn regression_19844() {
+        check_diagnostics(
+            r#"
+fn main() {
+    struct S {}
+    enum E { V() }
+    let E::V() = &S {};
+     // ^^^^^^ error: expected S, found E
+}
+"#,
+        );
+    }
 }


### PR DESCRIPTION
Fixes rust-lang/rust-analyzer#19844

Playing with tracings on rustc, I found that it never enters `rustc_pattern_analysis` if there exists any typecheck error inside the given body:

- [Entrypoint for pattern analysis](https://github.com/rust-lang/rust/blob/45f256d9d7cffb66185c0bf1b8a864cba79db90c/compiler/rustc_mir_build/src/thir/pattern/check_match.rs#L52)
- [Short circuit on `tcx.thir_body()?`](https://github.com/rust-lang/rust/blob/45f256d9d7cffb66185c0bf1b8a864cba79db90c/compiler/rustc_mir_build/src/thir/pattern/check_match.rs#L36)
- [`tcx.thir_body()` implementation](https://github.com/rust-lang/rust/blob/45f256d9d7cffb66185c0bf1b8a864cba79db90c/compiler/rustc_mir_build/src/thir/cx/mod.rs#L27-L29)

We've been doing simillar "skip on type-error" things on the following lines:

https://github.com/rust-lang/rust-analyzer/blob/7230ded9c7938b4e8bfc53e6639d67af5e87d632/crates/hir-ty/src/diagnostics/expr.rs#L210-L225

https://github.com/rust-lang/rust-analyzer/blob/7230ded9c7938b4e8bfc53e6639d67af5e87d632/crates/hir-ty/src/diagnostics/expr.rs#L160-L163

But unfortunately not on the line in this PR