### PR TITLE
Account for `Generate` actions when filtering the allowed ones

### DIFF
--- a/crates/rust-analyzer/src/lsp/from_proto.rs
+++ b/crates/rust-analyzer/src/lsp/from_proto.rs
@@ -103,6 +103,7 @@ pub(crate) fn file_range_uri(
 
 pub(crate) fn assist_kind(kind: lsp_types::CodeActionKind) -> Option<AssistKind> {
     let assist_kind = match &kind {
+        k if k == &lsp_types::CodeActionKind::EMPTY => AssistKind::Generate,
         k if k == &lsp_types::CodeActionKind::QUICKFIX => AssistKind::QuickFix,
         k if k == &lsp_types::CodeActionKind::REFACTOR => AssistKind::Refactor,
         k if k == &lsp_types::CodeActionKind::REFACTOR_EXTRACT => AssistKind::RefactorExtract,


### PR DESCRIPTION
r-a converts `AssistKind::Generate` into `lsp_types::CodeActionKind::EMPTY`

https://github.com/rust-lang/rust-analyzer/blob/cdd0ac27e350920be0cd535fabfa02ae32b83d37/crates/rust-analyzer/src/lsp/to_proto.rs#L1480

but does not perform the reverse conversion, so whatever `lsp_types::CodeActionKind::EMPTY` comes is converted into `None` here:

https://github.com/rust-lang/rust-analyzer/blob/cdd0ac27e350920be0cd535fabfa02ae32b83d37/crates/rust-analyzer/src/lsp/from_proto.rs#L104-L115

thus always being filtered out when `only` exists in the action request params:

https://github.com/rust-lang/rust-analyzer/blob/cdd0ac27e350920be0cd535fabfa02ae32b83d37/crates/rust-analyzer/src/handlers/request.rs#L1426-L1430

Zed tries to use actions, declared in the server capabilities: 
https://github.com/zed-industries/zed/blob/40c91d5df06b6d3f213c9cfda3ceb243ed0b2f12/crates/project/src/lsp_command.rs#L2474-L2489

which are correctly defined for r-a:
https://github.com/rust-lang/rust-analyzer/blob/cdd0ac27e350920be0cd535fabfa02ae32b83d37/crates/rust-analyzer/src/lsp/capabilities.rs#L260-L267

but without the filtering bit, we miss all the generate actions.

Other editors, e.g. VSCode and Helix, seem to get around this by always sending `None` in the list of filters:
https://github.com/helix-editor/helix/blob/8961ae1dc66633ea6c9f761896cb0d885ae078ed/helix-term/src/commands/lsp.rs#L673

but it does not seem incorrect to do what Zed does too?

Before the fix:
<img width="485" alt="image" src="https://github.com/user-attachments/assets/215f1c55-9afe-4f23-9eef-49c8ac36d155" />

After the fix:
<img width="542" alt="image" src="https://github.com/user-attachments/assets/5e539b97-9522-4da8-9fbf-37a50b616060" />
