### PR TITLE
Enable Assist edit for tuple<->named struct for the struct and visiblity keywords

### DIFF
--- a/crates/ide-assists/src/utils.rs
+++ b/crates/ide-assists/src/utils.rs
@@ -1,5 +1,7 @@
 //! Assorted functions shared by several assists.
 
+use either::Either;
+
 pub(crate) use gen_trait_fn_body::gen_trait_fn_body;
 use hir::{
     DisplayTarget, HasAttrs as HirHasAttrs, HirDisplay, InFile, ModuleDef, PathResolution,
@@ -1146,3 +1148,24 @@ pub fn is_body_const(sema: &Semantics<'_, RootDatabase>, expr: &ast::Expr) -> bo
     });
     is_const
 }
+
+/// Gets the struct definition from a context
+pub(crate) fn find_struct_definition_from_cursor(ctx: &AssistContext<'_>)
+-> Option<Either<ast::Struct, ast::Variant>>
+{
+    ctx.find_node_at_offset::<ast::Name>().and_then(|name| name.syntax().parent())
+        .or(find_struct_keyword(ctx).and_then(|kw| kw.parent()))
+        .or(ctx.find_node_at_offset::<ast::Visibility>().and_then(|visibility| visibility.syntax().parent()))
+        .and_then(<Either<ast::Struct, ast::Variant>>::cast)
+}
+
+fn find_struct_keyword(ctx: &AssistContext<'_>) -> Option<SyntaxToken> {
+    // Attempt to find the token at the current cursor offset
+    ctx
+    .token_at_offset()
+    .find(|leaf| match leaf.kind() {
+        STRUCT_KW => true,
+        _ => false,
+    })
+}
+


### PR DESCRIPTION
I was looking for an issue to do my first contribution to this repo.  In the discussion for the issue #19666 , a suggestion was made to expand when the code action for converting between named/tuple structs is triggered to include the struct and visibility keywords, so I've added these too.

Maybe the approach of targetting specific keywords is not that nice and it should be any kind of node who parent is a struct but not the inner part of a struct?

PS. I'm new to rust and this repo, so please feel free to nitpick the code