### PR TITLE
hir-ty: add incremental tests checking for `infer` invalidation

### DIFF
--- a/crates/hir-ty/src/tests/incremental.rs
+++ b/crates/hir-ty/src/tests/incremental.rs
@@ -106,3 +106,256 @@ fn baz() -> i32 {
         assert_eq!(format!("{events:?}").matches("infer_shim").count(), 1, "{events:#?}")
     }
 }
+
+#[test]
+fn adding_struct_invalidates_infer() {
+    let (mut db, pos) = TestDB::with_position(
+        "
+//- /lib.rs
+fn foo() -> i32 {
+    1 + 1
+}
+
+fn bar() -> f32 {
+    2.0 * 3.0
+}
+$0",
+    );
+    {
+        let events = db.log_executed(|| {
+            let module = db.module_for_file(pos.file_id.file_id(&db));
+            let _crate_def_map = module.def_map(&db);
+            db.trait_impls_in_crate(module.krate());
+        });
+        assert!(format!("{events:?}").contains("trait_impls_in_crate_shim"))
+    }
+
+    let new_text = "
+fn foo() -> i32 {
+    1 + 1
+}
+
+fn bar() -> f32 {
+    2.0 * 3.0
+}
+
+pub struct NewStruct {
+    field: i32,
+}
+";
+
+    db.set_file_text(pos.file_id.file_id(&db), new_text);
+
+    {
+        let actual = db.log_executed(|| {
+            let module = db.module_for_file(pos.file_id.file_id(&db));
+            let _crate_def_map = module.def_map(&db);
+            db.trait_impls_in_crate(module.krate());
+        });
+
+        let expected = vec![
+            "parse_shim".to_owned(),
+            "ast_id_map_shim".to_owned(),
+            "file_item_tree_shim".to_owned(),
+            "real_span_map_shim".to_owned(),
+            "crate_local_def_map".to_owned(),
+            "trait_impls_in_crate_shim".to_owned(),
+        ];
+
+        assert_eq!(expected, actual);
+    }
+}
+
+#[test]
+fn adding_enum_query_log() {
+    let (mut db, pos) = TestDB::with_position(
+        "
+//- /lib.rs
+fn foo() -> i32 {
+    1 + 1
+}
+
+fn bar() -> f32 {
+    2.0 * 3.0
+}
+$0",
+    );
+    {
+        let events = db.log_executed(|| {
+            let module = db.module_for_file(pos.file_id.file_id(&db));
+            let _crate_def_map = module.def_map(&db);
+            db.trait_impls_in_crate(module.krate());
+        });
+        assert!(format!("{events:?}").contains("trait_impls_in_crate_shim"))
+    }
+
+    let new_text = "
+fn foo() -> i32 {
+    1 + 1
+}
+
+fn bar() -> f32 {
+    2.0 * 3.0
+}
+
+pub enum SomeEnum {
+    A,
+    B
+}
+";
+
+    db.set_file_text(pos.file_id.file_id(&db), new_text);
+
+    {
+        let actual = db.log_executed(|| {
+            let module = db.module_for_file(pos.file_id.file_id(&db));
+            let _crate_def_map = module.def_map(&db);
+            db.trait_impls_in_crate(module.krate());
+        });
+
+        let expected = vec![
+            "parse_shim".to_owned(),
+            "ast_id_map_shim".to_owned(),
+            "file_item_tree_shim".to_owned(),
+            "real_span_map_shim".to_owned(),
+            "crate_local_def_map".to_owned(),
+            "trait_impls_in_crate_shim".to_owned(),
+        ];
+
+        assert_eq!(expected, actual);
+    }
+}
+
+#[test]
+fn adding_use_query_log() {
+    let (mut db, pos) = TestDB::with_position(
+        "
+//- /lib.rs
+fn foo() -> i32 {
+    1 + 1
+}
+
+fn bar() -> f32 {
+    2.0 * 3.0
+}
+$0",
+    );
+    {
+        let events = db.log_executed(|| {
+            let module = db.module_for_file(pos.file_id.file_id(&db));
+            let _crate_def_map = module.def_map(&db);
+            db.trait_impls_in_crate(module.krate());
+        });
+        assert!(format!("{events:?}").contains("trait_impls_in_crate_shim"))
+    }
+
+    let new_text = "
+use std::collections::HashMap;
+
+fn foo() -> i32 {
+    1 + 1
+}
+
+fn bar() -> f32 {
+    2.0 * 3.0
+}
+";
+
+    db.set_file_text(pos.file_id.file_id(&db), new_text);
+
+    {
+        let actual = db.log_executed(|| {
+            let module = db.module_for_file(pos.file_id.file_id(&db));
+            let _crate_def_map = module.def_map(&db);
+            db.trait_impls_in_crate(module.krate());
+        });
+
+        let expected = vec![
+            "parse_shim".to_owned(),
+            "ast_id_map_shim".to_owned(),
+            "file_item_tree_shim".to_owned(),
+            "real_span_map_shim".to_owned(),
+            "crate_local_def_map".to_owned(),
+            "trait_impls_in_crate_shim".to_owned(),
+        ];
+
+        assert_eq!(expected, actual);
+    }
+}
+
+#[test]
+fn adding_impl_query_log() {
+    let (mut db, pos) = TestDB::with_position(
+        "
+//- /lib.rs
+fn foo() -> i32 {
+    1 + 1
+}
+
+fn bar() -> f32 {
+    2.0 * 3.0
+}
+
+pub struct SomeStruct {
+    field: i32,
+}
+$0",
+    );
+    {
+        let events = db.log_executed(|| {
+            let module = db.module_for_file(pos.file_id.file_id(&db));
+            let _crate_def_map = module.def_map(&db);
+            db.trait_impls_in_crate(module.krate());
+        });
+        assert!(format!("{events:?}").contains("trait_impls_in_crate_shim"))
+    }
+
+    let new_text = "
+fn foo() -> i32 {
+    1 + 1
+}
+
+fn bar() -> f32 {
+    2.0 * 3.0
+}
+
+pub struct SomeStruct {
+    field: i32,
+}
+
+impl SomeStruct {
+    pub fn new(value: i32) -> Self {
+        Self { field: value }
+    }
+}
+";
+
+    db.set_file_text(pos.file_id.file_id(&db), new_text);
+
+    {
+        let actual = db.log_executed(|| {
+            let module = db.module_for_file(pos.file_id.file_id(&db));
+            let _crate_def_map = module.def_map(&db);
+            db.trait_impls_in_crate(module.krate());
+        });
+
+        let expected = vec![
+            "parse_shim".to_owned(),
+            "ast_id_map_shim".to_owned(),
+            "file_item_tree_shim".to_owned(),
+            "real_span_map_shim".to_owned(),
+            "crate_local_def_map".to_owned(),
+            "trait_impls_in_crate_shim".to_owned(),
+            "attrs_shim".to_owned(),
+            "impl_trait_with_diagnostics_shim".to_owned(),
+            "impl_signature_shim".to_owned(),
+            "impl_signature_with_source_map_shim".to_owned(),
+            "impl_self_ty_with_diagnostics_shim".to_owned(),
+            "struct_signature_shim".to_owned(),
+            "struct_signature_with_source_map_shim".to_owned(),
+            "type_for_adt_tracked".to_owned(),
+        ];
+
+        assert_eq!(expected, actual);
+    }
+}


### PR DESCRIPTION
This PR adds some tests that check that `infer` is invalidated when a DefMap is invalidated. These new tests will need to fixed and renamed https://github.com/rust-lang/rust-analyzer/pull/19837 by:
- renaming tests like `adding_use_statement_invalidates_infer` to `adding_use_statement_should_not_invalidate_infer`.
- Negating the post-edit `events` assertion to `assert!(!format!("{events:?}").contains("infer_shim"), "{events:#?}")`.

(Full disclosure: I used Claude Sonnet 4 to write these tests. I am, of course, responsible for any code I submit for review, but it wasn't half bad at the job. I had to rename a few tests/example code in the tests, however.)