### PR TITLE
ci: Pin `cargo-workspaces` to `0.3.6`

### DIFF
--- a/.github/workflows/publish-libs.yaml
+++ b/.github/workflows/publish-libs.yaml
@@ -22,7 +22,7 @@ jobs:
         run: rustup update --no-self-update stable
 
       - name: Install cargo-workspaces
-        run: cargo install cargo-workspaces
+        run: cargo install cargo-workspaces --version "0.3.6"
 
       - name: Publish Crates
         env:


### PR DESCRIPTION
Might fix (or not) rust-lang/rust-analyzer#19903

All the other conditions - our workspace structure, cargo or rustc version - are same as before (last release on May 26th) but `cargo-workspaces` has released a new version last week and I think there would be some regression there