### PR TITLE
fix: Record macro calls for fields in `ChildBySource` impls

### DIFF
--- a/crates/hir/src/semantics/child_by_source.rs
+++ b/crates/hir/src/semantics/child_by_source.rs
@@ -191,6 +191,8 @@ impl ChildBySource for VariantId {
                 Either::Right(source) => res[keys::RECORD_FIELD].insert(AstPtr::new(&source), id),
             }
         }
+        let (_, sm) = db.variant_fields_with_source_map(*self);
+        sm.expansions().for_each(|(ast, &exp_id)| res[keys::MACRO_CALL].insert(ast.value, exp_id));
     }
 }
 
@@ -209,11 +211,10 @@ impl ChildBySource for EnumId {
                 .insert(ast_id_map.get(tree[variant.lookup(db).id.value].ast_id), variant);
         });
         let (_, source_map) = db.enum_signature_with_source_map(*self);
-        source_map.expansions().filter(|(ast, _)| ast.file_id == file_id).for_each(
-            |(ast, &exp_id)| {
-                res[keys::MACRO_CALL].insert(ast.value, exp_id);
-            },
-        );
+        source_map
+            .expansions()
+            .filter(|(ast, _)| ast.file_id == file_id)
+            .for_each(|(ast, &exp_id)| res[keys::MACRO_CALL].insert(ast.value, exp_id));
     }
 }
 
@@ -274,11 +275,10 @@ impl ChildBySource for GenericDefId {
             }
         }
 
-        source_map.expansions().filter(|(ast, _)| ast.file_id == file_id).for_each(
-            |(ast, &exp_id)| {
-                res[keys::MACRO_CALL].insert(ast.value, exp_id);
-            },
-        );
+        source_map
+            .expansions()
+            .filter(|(ast, _)| ast.file_id == file_id)
+            .for_each(|(ast, &exp_id)| res[keys::MACRO_CALL].insert(ast.value, exp_id));
     }
 }
 

--- a/crates/ide/src/expand_macro.rs
+++ b/crates/ide/src/expand_macro.rs
@@ -844,4 +844,21 @@ impl<const C: foo$0!()> Trait for () {}
                 Trait"#]],
         );
     }
+
+    #[test]
+    fn works_in_fields() {
+        check(
+            r#"
+macro_rules! foo {
+    () => { u32 };
+}
+struct S {
+    field: foo$0!(),
+}
+"#,
+            expect![[r#"
+                foo!
+                u32"#]],
+        );
+    }
 }

--- a/crates/rust-analyzer/tests/slow-tests/ratoml.rs
+++ b/crates/rust-analyzer/tests/slow-tests/ratoml.rs
@@ -439,6 +439,7 @@ assist.emitMustUse = true"#,
 }
 
 #[test]
+#[ignore = "flaky test that tends to hang"]
 fn ratoml_inherit_config_from_ws_root() {
     if skip_slow_tests() {
         return;


### PR DESCRIPTION
https://github.com/rust-lang/rust-analyzer/pull/19932#issuecomment-2945342263