### PR TITLE
Add ide-assist: generate_impl_trait for generate_impl

### DIFF
--- a/crates/ide-assists/src/lib.rs
+++ b/crates/ide-assists/src/lib.rs
@@ -301,6 +301,7 @@ mod handlers {
             generate_function::generate_function,
             generate_impl::generate_impl,
             generate_impl::generate_trait_impl,
+            generate_impl::generate_impl_trait,
             generate_is_empty_from_len::generate_is_empty_from_len,
             generate_mut_trait_impl::generate_mut_trait_impl,
             generate_new::generate_new,

--- a/crates/ide-assists/src/tests/generated.rs
+++ b/crates/ide-assists/src/tests/generated.rs
@@ -1895,8 +1895,8 @@ trait Foo {
 }
 
 impl Foo for ${1:_} {
-    $0fn foo(&self) -> i32 {
-        todo!()
+    fn foo(&self) -> i32 {
+        $0todo!()
     }
 }
 "#####,

--- a/crates/ide-assists/src/tests/generated.rs
+++ b/crates/ide-assists/src/tests/generated.rs
@@ -1881,6 +1881,29 @@ impl<T: Clone> Ctx<T> {$0}
 }
 
 #[test]
+fn doctest_generate_impl_trait() {
+    check_doc_test(
+        "generate_impl_trait",
+        r#####"
+trait $0Foo {
+    fn foo(&self) -> i32;
+}
+"#####,
+        r#####"
+trait Foo {
+    fn foo(&self) -> i32;
+}
+
+impl Foo for ${1:_} {
+    $0fn foo(&self) -> i32 {
+        todo!()
+    }
+}
+"#####,
+    )
+}
+
+#[test]
 fn doctest_generate_is_empty_from_len() {
     check_doc_test(
         "generate_is_empty_from_len",


### PR DESCRIPTION
Adds this trait impl for a type.

```rust
trait $0Foo {
    fn foo(&self) -> i32;
}
```
->
```rust
trait Foo {
    fn foo(&self) -> i32;
}

impl Foo for ${1:_} {
    $0fn foo(&self) -> i32 {
        todo!()
    }
}
```
