### PR TITLE
Add a fix that inserts a missing method

### DIFF
--- a/crates/hir/src/has_source.rs
+++ b/crates/hir/src/has_source.rs
@@ -12,7 +12,7 @@ use syntax::ast;
 use tt::TextRange;
 
 use crate::{
-    Adt, Callee, Const, Enum, ExternCrateDecl, Field, FieldSource, Function, Impl,
+    Adt, AssocItem, Callee, Const, Enum, ExternCrateDecl, Field, FieldSource, Function, Impl,
     InlineAsmOperand, Label, LifetimeParam, LocalSource, Macro, Module, Param, SelfParam, Static,
     Struct, Trait, TraitAlias, TypeAlias, TypeOrConstParam, Union, Variant, VariantDef,
     db::HirDatabase,
@@ -98,6 +98,17 @@ impl HasSource for Field {
             Either::Right(it) => FieldSource::Named(it),
         });
         Some(field_source)
+    }
+}
+impl HasSource for AssocItem {
+    type Ast = ast::AssocItem;
+
+    fn source(self, db: &dyn HirDatabase) -> Option<InFile<Self::Ast>> {
+        match self {
+            AssocItem::Const(c) => Some(c.source(db)?.map(ast::AssocItem::Const)),
+            AssocItem::Function(f) => Some(f.source(db)?.map(ast::AssocItem::Fn)),
+            AssocItem::TypeAlias(t) => Some(t.source(db)?.map(ast::AssocItem::TypeAlias)),
+        }
     }
 }
 impl HasSource for Adt {


### PR DESCRIPTION
## Work in progress! Not ready for review yet.

Often I will call a method even though I know it doesn't exist yet, because I'm planning to add that method.

```rust
struct Dog {}

impl Dog {
  bark(&self) {}
}

fn main() {
  let dog = Dog {};
  dog.bark();
  dog.play_dead();  // errors because the method doesn't exist yet
}
```

This PR adds a fix that inserts a stub for the `play_dead` method.

 - [ ] For now, the receiver type is `&self` but maybe we can figure out whether it should be `self` or `&mut self` instead?
 - [ ] Return type is not added but it could be inferred if the calling code looks like `let lhs: SomeType = dog.play_dead()`
 - [ ] Should the method body be `todo!()` or `unimplemented!()` or something else? What is the most consistent with how r-a does things elsewhere?
 - [ ] Need to do more testing