### PR TITLE
fix: Fix proc macro server handling of strings with minuses

### DIFF
--- a/crates/proc-macro-srv/proc-macro-test/imp/src/lib.rs
+++ b/crates/proc-macro-srv/proc-macro-test/imp/src/lib.rs
@@ -31,6 +31,7 @@ pub fn fn_like_mk_literals(_args: TokenStream) -> TokenStream {
         TokenTree::from(Literal::byte_string(b"byte_string")),
         TokenTree::from(Literal::character('c')),
         TokenTree::from(Literal::string("string")),
+        TokenTree::from(Literal::string("-string")),
         TokenTree::from(Literal::c_string(c"cstring")),
         // as of 2022-07-21, there's no method on `Literal` to build a raw
         // string or a raw byte string

--- a/crates/proc-macro-srv/src/tests/mod.rs
+++ b/crates/proc-macro-srv/src/tests/mod.rs
@@ -244,6 +244,7 @@ fn test_fn_like_mk_literals() {
               LITERAL ByteStr byte_string 1
               LITERAL Char c 1
               LITERAL Str string 1
+              LITERAL Str -string 1
               LITERAL CStr cstring 1
               LITERAL Float 3.14f64 1
               PUNCH   - [alone] 1
@@ -266,6 +267,7 @@ fn test_fn_like_mk_literals() {
               LITERAL ByteStr byte_string 42:2@0..100#ROOT2024
               LITERAL Char c 42:2@0..100#ROOT2024
               LITERAL Str string 42:2@0..100#ROOT2024
+              LITERAL Str -string 42:2@0..100#ROOT2024
               LITERAL CStr cstring 42:2@0..100#ROOT2024
               LITERAL Float 3.14f64 42:2@0..100#ROOT2024
               PUNCH   - [alone] 42:2@0..100#ROOT2024


### PR DESCRIPTION
It used to decompose them thinking they were numbers.

This arose from rust-lang/rust-analyzer#19746.

Fixes rust-lang/rust-analyzer#19965 (I checked it is indeed fixed, but this will have to wait for a sync).