### PR TITLE
Simplify and optimize `ItemTree`

### DIFF
--- a/crates/hir-def/src/attr.rs
+++ b/crates/hir-def/src/attr.rs
@@ -526,7 +526,7 @@ impl AttrsWithOwner {
                     ModuleOrigin::File { definition, declaration_tree_id, declaration, .. } => {
                         let decl_attrs = declaration_tree_id
                             .item_tree(db)
-                            .raw_attrs(AttrOwner::ModItem(declaration.into()))
+                            .raw_attrs(AttrOwner::Item(declaration.erase()))
                             .clone();
                         let tree = db.file_item_tree(definition.into());
                         let def_attrs = tree.raw_attrs(AttrOwner::TopLevel).clone();
@@ -538,7 +538,7 @@ impl AttrsWithOwner {
                     }
                     ModuleOrigin::Inline { definition_tree_id, definition } => definition_tree_id
                         .item_tree(db)
-                        .raw_attrs(AttrOwner::ModItem(definition.into()))
+                        .raw_attrs(AttrOwner::Item(definition.erase()))
                         .clone(),
                     ModuleOrigin::BlockExpr { id, .. } => {
                         let tree = db.block_item_tree(id);

--- a/crates/hir-def/src/attr.rs
+++ b/crates/hir-def/src/attr.rs
@@ -26,6 +26,7 @@ use crate::{
     AdtId, AstIdLoc, AttrDefId, GenericParamId, HasModule, LocalFieldId, Lookup, MacroId,
     VariantId,
     db::DefDatabase,
+    item_tree::block_item_tree_query,
     lang_item::LangItem,
     nameres::{ModuleOrigin, ModuleSource},
     src::{HasChildSource, HasSource},
@@ -539,7 +540,7 @@ impl AttrsWithOwner {
                         definition_tree_id.item_tree(db).raw_attrs(definition.upcast()).clone()
                     }
                     ModuleOrigin::BlockExpr { id, .. } => {
-                        let tree = db.block_item_tree(id);
+                        let tree = block_item_tree_query(db, id);
                         tree.top_level_raw_attrs().clone()
                     }
                 };

--- a/crates/hir-def/src/attr.rs
+++ b/crates/hir-def/src/attr.rs
@@ -523,10 +523,15 @@ impl AttrsWithOwner {
                 let mod_data = &def_map[module.local_id];
 
                 let raw_attrs = match mod_data.origin {
-                    ModuleOrigin::File { definition, declaration_tree_id, .. } => {
+                    ModuleOrigin::File {
+                        definition,
+                        declaration_tree_id,
+                        file_item_tree_id,
+                        ..
+                    } => {
                         let decl_attrs = declaration_tree_id
                             .item_tree(db)
-                            .raw_attrs(AttrOwner::ModItem(declaration_tree_id.value.into()))
+                            .raw_attrs(AttrOwner::ModItem(file_item_tree_id.into()))
                             .clone();
                         let tree = db.file_item_tree(definition.into());
                         let def_attrs = tree.raw_attrs(AttrOwner::TopLevel).clone();
@@ -536,10 +541,12 @@ impl AttrsWithOwner {
                         let tree = db.file_item_tree(definition.into());
                         tree.raw_attrs(AttrOwner::TopLevel).clone()
                     }
-                    ModuleOrigin::Inline { definition_tree_id, .. } => definition_tree_id
-                        .item_tree(db)
-                        .raw_attrs(AttrOwner::ModItem(definition_tree_id.value.into()))
-                        .clone(),
+                    ModuleOrigin::Inline { definition_tree_id, file_item_tree_id, .. } => {
+                        definition_tree_id
+                            .item_tree(db)
+                            .raw_attrs(AttrOwner::ModItem(file_item_tree_id.into()))
+                            .clone()
+                    }
                     ModuleOrigin::BlockExpr { id, .. } => {
                         let tree = db.block_item_tree(id);
                         tree.raw_attrs(AttrOwner::TopLevel).clone()

--- a/crates/hir-def/src/attr.rs
+++ b/crates/hir-def/src/attr.rs
@@ -523,15 +523,10 @@ impl AttrsWithOwner {
                 let mod_data = &def_map[module.local_id];
 
                 let raw_attrs = match mod_data.origin {
-                    ModuleOrigin::File {
-                        definition,
-                        declaration_tree_id,
-                        file_item_tree_id,
-                        ..
-                    } => {
+                    ModuleOrigin::File { definition, declaration_tree_id, declaration, .. } => {
                         let decl_attrs = declaration_tree_id
                             .item_tree(db)
-                            .raw_attrs(AttrOwner::ModItem(file_item_tree_id.into()))
+                            .raw_attrs(AttrOwner::ModItem(declaration.into()))
                             .clone();
                         let tree = db.file_item_tree(definition.into());
                         let def_attrs = tree.raw_attrs(AttrOwner::TopLevel).clone();
@@ -541,12 +536,10 @@ impl AttrsWithOwner {
                         let tree = db.file_item_tree(definition.into());
                         tree.raw_attrs(AttrOwner::TopLevel).clone()
                     }
-                    ModuleOrigin::Inline { definition_tree_id, file_item_tree_id, .. } => {
-                        definition_tree_id
-                            .item_tree(db)
-                            .raw_attrs(AttrOwner::ModItem(file_item_tree_id.into()))
-                            .clone()
-                    }
+                    ModuleOrigin::Inline { definition_tree_id, definition } => definition_tree_id
+                        .item_tree(db)
+                        .raw_attrs(AttrOwner::ModItem(definition.into()))
+                        .clone(),
                     ModuleOrigin::BlockExpr { id, .. } => {
                         let tree = db.block_item_tree(id);
                         tree.raw_attrs(AttrOwner::TopLevel).clone()

--- a/crates/hir-def/src/db.rs
+++ b/crates/hir-def/src/db.rs
@@ -24,7 +24,7 @@ use crate::{
     },
     hir::generics::GenericParams,
     import_map::ImportMap,
-    item_tree::ItemTree,
+    item_tree::{ItemTree, file_item_tree_query},
     lang_item::{self, LangItem},
     nameres::{
         assoc::{ImplItems, TraitItems},
@@ -108,11 +108,9 @@ pub trait DefDatabase: InternDatabase + ExpandDatabase + SourceDatabase {
     fn expand_proc_attr_macros(&self) -> bool;
 
     /// Computes an [`ItemTree`] for the given file or macro expansion.
-    #[salsa::invoke(ItemTree::file_item_tree_query)]
-    fn file_item_tree(&self, file_id: HirFileId) -> Arc<ItemTree>;
-
-    #[salsa::invoke(ItemTree::block_item_tree_query)]
-    fn block_item_tree(&self, block_id: BlockId) -> Arc<ItemTree>;
+    #[salsa::invoke(file_item_tree_query)]
+    #[salsa::transparent]
+    fn file_item_tree(&self, file_id: HirFileId) -> &ItemTree;
 
     /// Turns a MacroId into a MacroDefId, describing the macro's definition post name resolution.
     #[salsa::invoke(macro_def)]

--- a/crates/hir-def/src/db.rs
+++ b/crates/hir-def/src/db.rs
@@ -24,7 +24,7 @@ use crate::{
     },
     hir::generics::GenericParams,
     import_map::ImportMap,
-    item_tree::{AttrOwner, ItemTree},
+    item_tree::ItemTree,
     lang_item::{self, LangItem},
     nameres::{
         assoc::{ImplItems, TraitItems},
@@ -376,7 +376,7 @@ fn include_macro_invoc(
 fn crate_supports_no_std(db: &dyn DefDatabase, crate_id: Crate) -> bool {
     let file = crate_id.data(db).root_file_id(db);
     let item_tree = db.file_item_tree(file.into());
-    let attrs = item_tree.raw_attrs(AttrOwner::TopLevel);
+    let attrs = item_tree.raw_attrs(crate::item_tree::AttrOwner::TopLevel);
     for attr in &**attrs {
         match attr.path().as_ident() {
             Some(ident) if *ident == sym::no_std => return true,

--- a/crates/hir-def/src/db.rs
+++ b/crates/hir-def/src/db.rs
@@ -376,7 +376,7 @@ fn include_macro_invoc(
 fn crate_supports_no_std(db: &dyn DefDatabase, crate_id: Crate) -> bool {
     let file = crate_id.data(db).root_file_id(db);
     let item_tree = db.file_item_tree(file.into());
-    let attrs = item_tree.raw_attrs(crate::item_tree::AttrOwner::TopLevel);
+    let attrs = item_tree.top_level_raw_attrs();
     for attr in &**attrs {
         match attr.path().as_ident() {
             Some(ident) if *ident == sym::no_std => return true,

--- a/crates/hir-def/src/item_tree.rs
+++ b/crates/hir-def/src/item_tree.rs
@@ -404,59 +404,6 @@ impl TreeId {
     }
 }
 
-#[derive(Debug)]
-pub struct ItemTreeId<N> {
-    tree: TreeId,
-    pub value: FileItemTreeId<N>,
-}
-
-impl<N> ItemTreeId<N> {
-    pub fn new(tree: TreeId, idx: FileItemTreeId<N>) -> Self {
-        Self { tree, value: idx }
-    }
-
-    pub fn file_id(self) -> HirFileId {
-        self.tree.file
-    }
-
-    pub fn tree_id(self) -> TreeId {
-        self.tree
-    }
-
-    pub fn item_tree(self, db: &dyn DefDatabase) -> Arc<ItemTree> {
-        self.tree.item_tree(db)
-    }
-
-    pub fn resolved<R>(self, db: &dyn DefDatabase, cb: impl FnOnce(&N) -> R) -> R
-    where
-        ItemTree: Index<FileItemTreeId<N>, Output = N>,
-    {
-        cb(&self.tree.item_tree(db)[self.value])
-    }
-}
-
-impl<N> Copy for ItemTreeId<N> {}
-impl<N> Clone for ItemTreeId<N> {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-
-impl<N> PartialEq for ItemTreeId<N> {
-    fn eq(&self, other: &Self) -> bool {
-        self.tree == other.tree && self.value == other.value
-    }
-}
-
-impl<N> Eq for ItemTreeId<N> {}
-
-impl<N> Hash for ItemTreeId<N> {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.tree.hash(state);
-        self.value.hash(state);
-    }
-}
-
 macro_rules! mod_items {
     ( $( $typ:ident in $fld:ident -> $ast:ty ),+ $(,)? ) => {
         #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]

--- a/crates/hir-def/src/item_tree/lower.rs
+++ b/crates/hir-def/src/item_tree/lower.rs
@@ -168,8 +168,8 @@ impl<'a> Ctx<'a> {
         let name = strukt.name()?.as_name();
         let ast_id = self.source_ast_id_map.ast_id(strukt);
         let shape = adt_shape(strukt.kind());
-        let res = Struct { name, visibility, shape, ast_id };
-        self.tree.big_data.insert(ast_id.upcast(), BigModItem::Struct(res));
+        let res = Struct { name, visibility, shape };
+        self.tree.small_data.insert(ast_id.upcast(), SmallModItem::Struct(res));
 
         Some(ast_id)
     }
@@ -178,7 +178,7 @@ impl<'a> Ctx<'a> {
         let visibility = self.lower_visibility(union);
         let name = union.name()?.as_name();
         let ast_id = self.source_ast_id_map.ast_id(union);
-        let res = Union { name, visibility, ast_id };
+        let res = Union { name, visibility };
         self.tree.small_data.insert(ast_id.upcast(), SmallModItem::Union(res));
         Some(ast_id)
     }
@@ -187,7 +187,7 @@ impl<'a> Ctx<'a> {
         let visibility = self.lower_visibility(enum_);
         let name = enum_.name()?.as_name();
         let ast_id = self.source_ast_id_map.ast_id(enum_);
-        let res = Enum { name, visibility, ast_id };
+        let res = Enum { name, visibility };
         self.tree.small_data.insert(ast_id.upcast(), SmallModItem::Enum(res));
         Some(ast_id)
     }
@@ -198,7 +198,7 @@ impl<'a> Ctx<'a> {
 
         let ast_id = self.source_ast_id_map.ast_id(func);
 
-        let res = Function { name, visibility, ast_id };
+        let res = Function { name, visibility };
 
         self.tree.small_data.insert(ast_id.upcast(), SmallModItem::Function(res));
         Some(ast_id)
@@ -211,7 +211,7 @@ impl<'a> Ctx<'a> {
         let name = type_alias.name()?.as_name();
         let visibility = self.lower_visibility(type_alias);
         let ast_id = self.source_ast_id_map.ast_id(type_alias);
-        let res = TypeAlias { name, visibility, ast_id };
+        let res = TypeAlias { name, visibility };
         self.tree.small_data.insert(ast_id.upcast(), SmallModItem::TypeAlias(res));
         Some(ast_id)
     }
@@ -220,7 +220,7 @@ impl<'a> Ctx<'a> {
         let name = static_.name()?.as_name();
         let visibility = self.lower_visibility(static_);
         let ast_id = self.source_ast_id_map.ast_id(static_);
-        let res = Static { name, visibility, ast_id };
+        let res = Static { name, visibility };
         self.tree.small_data.insert(ast_id.upcast(), SmallModItem::Static(res));
         Some(ast_id)
     }
@@ -229,7 +229,7 @@ impl<'a> Ctx<'a> {
         let name = konst.name().map(|it| it.as_name());
         let visibility = self.lower_visibility(konst);
         let ast_id = self.source_ast_id_map.ast_id(konst);
-        let res = Const { name, visibility, ast_id };
+        let res = Const { name, visibility };
         self.tree.small_data.insert(ast_id.upcast(), SmallModItem::Const(res));
         ast_id
     }
@@ -251,7 +251,7 @@ impl<'a> Ctx<'a> {
             }
         };
         let ast_id = self.source_ast_id_map.ast_id(module);
-        let res = Mod { name, visibility, kind, ast_id };
+        let res = Mod { name, visibility, kind };
         self.tree.big_data.insert(ast_id.upcast(), BigModItem::Mod(res));
         Some(ast_id)
     }
@@ -261,7 +261,7 @@ impl<'a> Ctx<'a> {
         let visibility = self.lower_visibility(trait_def);
         let ast_id = self.source_ast_id_map.ast_id(trait_def);
 
-        let def = Trait { name, visibility, ast_id };
+        let def = Trait { name, visibility };
         self.tree.small_data.insert(ast_id.upcast(), SmallModItem::Trait(def));
         Some(ast_id)
     }
@@ -274,7 +274,7 @@ impl<'a> Ctx<'a> {
         let visibility = self.lower_visibility(trait_alias_def);
         let ast_id = self.source_ast_id_map.ast_id(trait_alias_def);
 
-        let alias = TraitAlias { name, visibility, ast_id };
+        let alias = TraitAlias { name, visibility };
         self.tree.small_data.insert(ast_id.upcast(), SmallModItem::TraitAlias(alias));
         Some(ast_id)
     }
@@ -283,7 +283,7 @@ impl<'a> Ctx<'a> {
         let ast_id = self.source_ast_id_map.ast_id(impl_def);
         // Note that trait impls don't get implicit `Self` unlike traits, because here they are a
         // type alias rather than a type parameter, so this is handled by the resolver.
-        let res = Impl { ast_id };
+        let res = Impl {};
         self.tree.small_data.insert(ast_id.upcast(), SmallModItem::Impl(res));
         ast_id
     }
@@ -295,7 +295,7 @@ impl<'a> Ctx<'a> {
             self.span_map().span_for_range(range).ctx
         })?;
 
-        let res = Use { visibility, ast_id, use_tree };
+        let res = Use { visibility, use_tree };
         self.tree.big_data.insert(ast_id.upcast(), BigModItem::Use(res));
         Some(ast_id)
     }
@@ -311,7 +311,7 @@ impl<'a> Ctx<'a> {
         let visibility = self.lower_visibility(extern_crate);
         let ast_id = self.source_ast_id_map.ast_id(extern_crate);
 
-        let res = ExternCrate { name, alias, visibility, ast_id };
+        let res = ExternCrate { name, alias, visibility };
         self.tree.big_data.insert(ast_id.upcast(), BigModItem::ExternCrate(res));
         Some(ast_id)
     }
@@ -325,8 +325,8 @@ impl<'a> Ctx<'a> {
         })?);
         let ast_id = self.source_ast_id_map.ast_id(m);
         let expand_to = hir_expand::ExpandTo::from_call_site(m);
-        let res = MacroCall { path, ast_id, expand_to, ctxt: span_map.span_for_range(range).ctx };
-        self.tree.big_data.insert(ast_id.upcast(), BigModItem::MacroCall(res));
+        let res = MacroCall { path, expand_to, ctxt: span_map.span_for_range(range).ctx };
+        self.tree.small_data.insert(ast_id.upcast(), SmallModItem::MacroCall(res));
         Some(ast_id)
     }
 
@@ -334,7 +334,7 @@ impl<'a> Ctx<'a> {
         let name = m.name()?;
         let ast_id = self.source_ast_id_map.ast_id(m);
 
-        let res = MacroRules { name: name.as_name(), ast_id };
+        let res = MacroRules { name: name.as_name() };
         self.tree.small_data.insert(ast_id.upcast(), SmallModItem::MacroRules(res));
         Some(ast_id)
     }
@@ -345,7 +345,7 @@ impl<'a> Ctx<'a> {
         let ast_id = self.source_ast_id_map.ast_id(m);
         let visibility = self.lower_visibility(m);
 
-        let res = Macro2 { name: name.as_name(), ast_id, visibility };
+        let res = Macro2 { name: name.as_name(), visibility };
         self.tree.small_data.insert(ast_id.upcast(), SmallModItem::Macro2(res));
         Some(ast_id)
     }
@@ -372,8 +372,8 @@ impl<'a> Ctx<'a> {
                 .collect()
         });
 
-        let res = ExternBlock { ast_id, children };
-        self.tree.big_data.insert(ast_id.upcast(), BigModItem::ExternBlock(res));
+        let res = ExternBlock { children };
+        self.tree.small_data.insert(ast_id.upcast(), SmallModItem::ExternBlock(res));
         ast_id
     }
 

--- a/crates/hir-def/src/item_tree/pretty.rs
+++ b/crates/hir-def/src/item_tree/pretty.rs
@@ -6,10 +6,9 @@ use span::{Edition, ErasedFileAstId};
 
 use crate::{
     item_tree::{
-        AttrOwner, Const, DefDatabase, Enum, ExternBlock, ExternCrate, FieldsShape, Function, Impl,
-        ItemTree, Macro2, MacroCall, MacroRules, Mod, ModItemId, ModKind, RawAttrs,
-        RawVisibilityId, Static, Struct, Trait, TraitAlias, TypeAlias, Union, Use, UseTree,
-        UseTreeKind,
+        Const, DefDatabase, Enum, ExternBlock, ExternCrate, FieldsShape, Function, Impl, ItemTree,
+        Macro2, MacroCall, MacroRules, Mod, ModItemId, ModKind, RawAttrs, RawVisibilityId, Static,
+        Struct, Trait, TraitAlias, TypeAlias, Union, Use, UseTree, UseTreeKind,
     },
     visibility::RawVisibility,
 };
@@ -18,9 +17,7 @@ pub(super) fn print_item_tree(db: &dyn DefDatabase, tree: &ItemTree, edition: Ed
     let mut p =
         Printer { db, tree, buf: String::new(), indent_level: 0, needs_indent: true, edition };
 
-    if let Some(attrs) = tree.attrs.get(&AttrOwner::TopLevel) {
-        p.print_attrs(attrs, true, "\n");
-    }
+    p.print_attrs(&tree.top_attrs, true, "\n");
     p.blank();
 
     for item in tree.top_level_items() {
@@ -102,8 +99,8 @@ impl Printer<'_> {
         }
     }
 
-    fn print_attrs_of(&mut self, of: impl Into<AttrOwner>, separated_by: &str) {
-        if let Some(attrs) = self.tree.attrs.get(&of.into()) {
+    fn print_attrs_of(&mut self, of: ModItemId, separated_by: &str) {
+        if let Some(attrs) = self.tree.attrs.get(&of.ast_id()) {
             self.print_attrs(attrs, false, separated_by);
         }
     }

--- a/crates/hir-def/src/item_tree/pretty.rs
+++ b/crates/hir-def/src/item_tree/pretty.rs
@@ -161,16 +161,16 @@ impl Printer<'_> {
         self.print_attrs_of(item, "\n");
 
         match item {
-            ModItemId::Use(it) => {
-                let Use { visibility, use_tree, ast_id } = &self.tree[it];
+            ModItemId::Use(ast_id) => {
+                let Use { visibility, use_tree } = &self.tree[ast_id];
                 self.print_ast_id(ast_id.erase());
                 self.print_visibility(*visibility);
                 w!(self, "use ");
                 self.print_use_tree(use_tree);
                 wln!(self, ";");
             }
-            ModItemId::ExternCrate(it) => {
-                let ExternCrate { name, alias, visibility, ast_id } = &self.tree[it];
+            ModItemId::ExternCrate(ast_id) => {
+                let ExternCrate { name, alias, visibility } = &self.tree[ast_id];
                 self.print_ast_id(ast_id.erase());
                 self.print_visibility(*visibility);
                 w!(self, "extern crate {}", name.display(self.db, self.edition));
@@ -179,8 +179,8 @@ impl Printer<'_> {
                 }
                 wln!(self, ";");
             }
-            ModItemId::ExternBlock(it) => {
-                let ExternBlock { ast_id, children } = &self.tree[it];
+            ModItemId::ExternBlock(ast_id) => {
+                let ExternBlock { children } = &self.tree[ast_id];
                 self.print_ast_id(ast_id.erase());
                 w!(self, "extern {{");
                 self.indented(|this| {
@@ -190,14 +190,14 @@ impl Printer<'_> {
                 });
                 wln!(self, "}}");
             }
-            ModItemId::Function(it) => {
-                let Function { name, visibility, ast_id } = &self.tree[it];
+            ModItemId::Function(ast_id) => {
+                let Function { name, visibility } = &self.tree[ast_id];
                 self.print_ast_id(ast_id.erase());
                 self.print_visibility(*visibility);
                 wln!(self, "fn {};", name.display(self.db, self.edition));
             }
-            ModItemId::Struct(it) => {
-                let Struct { visibility, name, shape: kind, ast_id } = &self.tree[it];
+            ModItemId::Struct(ast_id) => {
+                let Struct { visibility, name, shape: kind } = &self.tree[ast_id];
                 self.print_ast_id(ast_id.erase());
                 self.print_visibility(*visibility);
                 w!(self, "struct {}", name.display(self.db, self.edition));
@@ -208,22 +208,22 @@ impl Printer<'_> {
                     wln!(self, ";");
                 }
             }
-            ModItemId::Union(it) => {
-                let Union { name, visibility, ast_id } = &self.tree[it];
+            ModItemId::Union(ast_id) => {
+                let Union { name, visibility } = &self.tree[ast_id];
                 self.print_ast_id(ast_id.erase());
                 self.print_visibility(*visibility);
                 w!(self, "union {}", name.display(self.db, self.edition));
                 self.print_fields(FieldsShape::Record);
                 wln!(self);
             }
-            ModItemId::Enum(it) => {
-                let Enum { name, visibility, ast_id } = &self.tree[it];
+            ModItemId::Enum(ast_id) => {
+                let Enum { name, visibility } = &self.tree[ast_id];
                 self.print_ast_id(ast_id.erase());
                 self.print_visibility(*visibility);
                 w!(self, "enum {} {{ ... }}", name.display(self.db, self.edition));
             }
-            ModItemId::Const(it) => {
-                let Const { name, visibility, ast_id } = &self.tree[it];
+            ModItemId::Const(ast_id) => {
+                let Const { name, visibility } = &self.tree[ast_id];
                 self.print_ast_id(ast_id.erase());
                 self.print_visibility(*visibility);
                 w!(self, "const ");
@@ -233,8 +233,8 @@ impl Printer<'_> {
                 }
                 wln!(self, " = _;");
             }
-            ModItemId::Static(it) => {
-                let Static { name, visibility, ast_id } = &self.tree[it];
+            ModItemId::Static(ast_id) => {
+                let Static { name, visibility } = &self.tree[ast_id];
                 self.print_ast_id(ast_id.erase());
                 self.print_visibility(*visibility);
                 w!(self, "static ");
@@ -242,33 +242,33 @@ impl Printer<'_> {
                 w!(self, " = _;");
                 wln!(self);
             }
-            ModItemId::Trait(it) => {
-                let Trait { name, visibility, ast_id } = &self.tree[it];
+            ModItemId::Trait(ast_id) => {
+                let Trait { name, visibility } = &self.tree[ast_id];
                 self.print_ast_id(ast_id.erase());
                 self.print_visibility(*visibility);
                 w!(self, "trait {} {{ ... }}", name.display(self.db, self.edition));
             }
-            ModItemId::TraitAlias(it) => {
-                let TraitAlias { name, visibility, ast_id } = &self.tree[it];
+            ModItemId::TraitAlias(ast_id) => {
+                let TraitAlias { name, visibility } = &self.tree[ast_id];
                 self.print_ast_id(ast_id.erase());
                 self.print_visibility(*visibility);
                 wln!(self, "trait {} = ..;", name.display(self.db, self.edition));
             }
-            ModItemId::Impl(it) => {
-                let Impl { ast_id } = &self.tree[it];
+            ModItemId::Impl(ast_id) => {
+                let Impl {} = &self.tree[ast_id];
                 self.print_ast_id(ast_id.erase());
                 w!(self, "impl {{ ... }}");
             }
-            ModItemId::TypeAlias(it) => {
-                let TypeAlias { name, visibility, ast_id } = &self.tree[it];
+            ModItemId::TypeAlias(ast_id) => {
+                let TypeAlias { name, visibility } = &self.tree[ast_id];
                 self.print_ast_id(ast_id.erase());
                 self.print_visibility(*visibility);
                 w!(self, "type {}", name.display(self.db, self.edition));
                 w!(self, ";");
                 wln!(self);
             }
-            ModItemId::Mod(it) => {
-                let Mod { name, visibility, kind, ast_id } = &self.tree[it];
+            ModItemId::Mod(ast_id) => {
+                let Mod { name, visibility, kind } = &self.tree[ast_id];
                 self.print_ast_id(ast_id.erase());
                 self.print_visibility(*visibility);
                 w!(self, "mod {}", name.display(self.db, self.edition));
@@ -287,8 +287,8 @@ impl Printer<'_> {
                     }
                 }
             }
-            ModItemId::MacroCall(it) => {
-                let MacroCall { path, ast_id, expand_to, ctxt } = &self.tree[it];
+            ModItemId::MacroCall(ast_id) => {
+                let MacroCall { path, expand_to, ctxt } = &self.tree[ast_id];
                 let _ = writeln!(
                     self,
                     "// AstId: {:#?}, SyntaxContextId: {}, ExpandTo: {:?}",
@@ -298,13 +298,13 @@ impl Printer<'_> {
                 );
                 wln!(self, "{}!(...);", path.display(self.db, self.edition));
             }
-            ModItemId::MacroRules(it) => {
-                let MacroRules { name, ast_id } = &self.tree[it];
+            ModItemId::MacroRules(ast_id) => {
+                let MacroRules { name } = &self.tree[ast_id];
                 self.print_ast_id(ast_id.erase());
                 wln!(self, "macro_rules! {} {{ ... }}", name.display(self.db, self.edition));
             }
-            ModItemId::Macro2(it) => {
-                let Macro2 { name, visibility, ast_id } = &self.tree[it];
+            ModItemId::Macro2(ast_id) => {
+                let Macro2 { name, visibility } = &self.tree[ast_id];
                 self.print_ast_id(ast_id.erase());
                 self.print_visibility(*visibility);
                 wln!(self, "macro {} {{ ... }}", name.display(self.db, self.edition));

--- a/crates/hir-def/src/nameres.rs
+++ b/crates/hir-def/src/nameres.rs
@@ -80,7 +80,7 @@ use crate::{
     LocalModuleId, Lookup, MacroExpander, MacroId, ModuleId, ProcMacroId, UseId,
     db::DefDatabase,
     item_scope::{BuiltinShadowMode, ItemScope},
-    item_tree::{ItemTreeId, Mod, TreeId},
+    item_tree::{FileItemTreeId, Mod, TreeId},
     nameres::{diagnostics::DefDiagnostic, path_resolution::ResolveMode},
     per_ns::PerNs,
     visibility::{Visibility, VisibilityExplicitness},
@@ -289,11 +289,13 @@ pub enum ModuleOrigin {
     File {
         is_mod_rs: bool,
         declaration: FileAstId<ast::Module>,
-        declaration_tree_id: ItemTreeId<Mod>,
+        declaration_tree_id: TreeId,
+        file_item_tree_id: FileItemTreeId<Mod>,
         definition: EditionedFileId,
     },
     Inline {
-        definition_tree_id: ItemTreeId<Mod>,
+        definition_tree_id: TreeId,
+        file_item_tree_id: FileItemTreeId<Mod>,
         definition: FileAstId<ast::Module>,
     },
     /// Pseudo-module introduced by a block scope (contains only inner items).
@@ -309,7 +311,7 @@ impl ModuleOrigin {
             &ModuleOrigin::File { declaration, declaration_tree_id, .. } => {
                 Some(AstId::new(declaration_tree_id.file_id(), declaration))
             }
-            &ModuleOrigin::Inline { definition, definition_tree_id } => {
+            &ModuleOrigin::Inline { definition, definition_tree_id, file_item_tree_id: _ } => {
                 Some(AstId::new(definition_tree_id.file_id(), definition))
             }
             ModuleOrigin::CrateRoot { .. } | ModuleOrigin::BlockExpr { .. } => None,
@@ -341,12 +343,14 @@ impl ModuleOrigin {
                 let sf = db.parse(editioned_file_id).tree();
                 InFile::new(editioned_file_id.into(), ModuleSource::SourceFile(sf))
             }
-            &ModuleOrigin::Inline { definition, definition_tree_id } => InFile::new(
-                definition_tree_id.file_id(),
-                ModuleSource::Module(
-                    AstId::new(definition_tree_id.file_id(), definition).to_node(db),
-                ),
-            ),
+            &ModuleOrigin::Inline { definition, definition_tree_id, file_item_tree_id: _ } => {
+                InFile::new(
+                    definition_tree_id.file_id(),
+                    ModuleSource::Module(
+                        AstId::new(definition_tree_id.file_id(), definition).to_node(db),
+                    ),
+                )
+            }
             ModuleOrigin::BlockExpr { block, .. } => {
                 InFile::new(block.file_id, ModuleSource::BlockExpr(block.to_node(db)))
             }
@@ -773,10 +777,12 @@ impl ModuleData {
                     ErasedAstId::new(definition.into(), ROOT_ERASED_FILE_AST_ID).to_range(db),
                 )
             }
-            &ModuleOrigin::Inline { definition, definition_tree_id } => InFile::new(
-                definition_tree_id.file_id(),
-                AstId::new(definition_tree_id.file_id(), definition).to_range(db),
-            ),
+            &ModuleOrigin::Inline { definition, definition_tree_id, file_item_tree_id: _ } => {
+                InFile::new(
+                    definition_tree_id.file_id(),
+                    AstId::new(definition_tree_id.file_id(), definition).to_range(db),
+                )
+            }
             ModuleOrigin::BlockExpr { block, .. } => InFile::new(block.file_id, block.to_range(db)),
         }
     }

--- a/crates/hir-def/src/nameres/collector.rs
+++ b/crates/hir-def/src/nameres/collector.rs
@@ -163,7 +163,7 @@ impl Import {
     ) {
         let it = &tree[item];
         let visibility = &tree[it.visibility];
-        it.use_tree.expand(|idx, path, kind, alias| {
+        it.expand(|idx, path, kind, alias| {
             cb(Self {
                 path,
                 alias,

--- a/crates/hir-def/src/nameres/collector.rs
+++ b/crates/hir-def/src/nameres/collector.rs
@@ -35,8 +35,8 @@ use crate::{
     db::DefDatabase,
     item_scope::{GlobId, ImportId, ImportOrExternCrate, PerNsGlobImports},
     item_tree::{
-        self, FieldsShape, ImportAlias, ImportKind, ItemTree, ItemTreeAstId, ItemTreeNode, Macro2,
-        MacroCall, MacroRules, Mod, ModItemId, ModKind, TreeId, UseTreeKind,
+        self, FieldsShape, ImportAlias, ImportKind, ItemTree, ItemTreeAstId, Macro2, MacroCall,
+        MacroRules, Mod, ModItemId, ModKind, TreeId, UseTreeKind,
     },
     macro_call_as_call_id,
     nameres::{
@@ -1436,9 +1436,9 @@ impl DefCollector<'_> {
 
                         let item_tree = tree.item_tree(self.db);
                         let ast_adt_id: FileAstId<ast::Adt> = match *mod_item {
-                            ModItemId::Struct(strukt) => item_tree[strukt].ast_id().upcast(),
-                            ModItemId::Union(union) => item_tree[union].ast_id().upcast(),
-                            ModItemId::Enum(enum_) => item_tree[enum_].ast_id().upcast(),
+                            ModItemId::Struct(strukt) => item_tree[strukt].ast_id.upcast(),
+                            ModItemId::Union(union) => item_tree[union].ast_id.upcast(),
+                            ModItemId::Enum(enum_) => item_tree[enum_].ast_id.upcast(),
                             _ => {
                                 let diag = DefDiagnostic::invalid_derive_target(
                                     directive.module_id,
@@ -1889,7 +1889,7 @@ impl ModCollector<'_, '_> {
                         if let Some(proc_macro) = attrs.parse_proc_macro_decl(&it.name) {
                             self.def_collector.export_proc_macro(
                                 proc_macro,
-                                InFile::new(self.file_id(), self.item_tree[id].ast_id()),
+                                InFile::new(self.file_id(), self.item_tree[id].ast_id),
                                 fn_id,
                             );
                         }
@@ -2369,7 +2369,7 @@ impl ModCollector<'_, '_> {
         }
         .intern(self.def_collector.db);
         self.def_collector.def_map.macro_def_to_macro_id.insert(
-            InFile::new(self.file_id(), self.item_tree[id].ast_id()).erase(),
+            InFile::new(self.file_id(), self.item_tree[id].ast_id).erase(),
             macro_id.into(),
         );
         self.def_collector.define_macro_rules(
@@ -2437,7 +2437,7 @@ impl ModCollector<'_, '_> {
         }
         .intern(self.def_collector.db);
         self.def_collector.def_map.macro_def_to_macro_id.insert(
-            InFile::new(self.file_id(), self.item_tree[id].ast_id()).erase(),
+            InFile::new(self.file_id(), self.item_tree[id].ast_id).erase(),
             macro_id.into(),
         );
         self.def_collector.define_macro_def(

--- a/crates/hir-def/src/nameres/collector.rs
+++ b/crates/hir-def/src/nameres/collector.rs
@@ -35,8 +35,8 @@ use crate::{
     db::DefDatabase,
     item_scope::{GlobId, ImportId, ImportOrExternCrate, PerNsGlobImports},
     item_tree::{
-        self, AttrOwner, FieldsShape, ImportAlias, ImportKind, ItemTree, ItemTreeAstId,
-        ItemTreeNode, Macro2, MacroCall, MacroRules, Mod, ModItemId, ModKind, TreeId, UseTreeKind,
+        self, FieldsShape, ImportAlias, ImportKind, ItemTree, ItemTreeAstId, ItemTreeNode, Macro2,
+        MacroCall, MacroRules, Mod, ModItemId, ModKind, TreeId, UseTreeKind,
     },
     macro_call_as_call_id,
     nameres::{
@@ -1727,7 +1727,7 @@ impl ModCollector<'_, '_> {
         };
 
         let mut process_mod_item = |item: ModItemId| {
-            let attrs = self.item_tree.attrs(db, krate, item.into());
+            let attrs = self.item_tree.attrs(db, krate, item.ast_id());
             if let Some(cfg) = attrs.cfg() {
                 if !self.is_cfg_enabled(&cfg) {
                     let ast_id = item.ast_id().erase();
@@ -2298,7 +2298,7 @@ impl ModCollector<'_, '_> {
     fn collect_macro_rules(&mut self, id: ItemTreeAstId<MacroRules>, module: ModuleId) {
         let krate = self.def_collector.def_map.krate;
         let mac = &self.item_tree[id];
-        let attrs = self.item_tree.attrs(self.def_collector.db, krate, AttrOwner::Item(id.erase()));
+        let attrs = self.item_tree.attrs(self.def_collector.db, krate, id.upcast());
         let ast_id = InFile::new(self.file_id(), mac.ast_id.upcast());
 
         let export_attr = || attrs.by_key(sym::macro_export);
@@ -2387,7 +2387,7 @@ impl ModCollector<'_, '_> {
 
         // Case 1: builtin macros
         let mut helpers_opt = None;
-        let attrs = self.item_tree.attrs(self.def_collector.db, krate, AttrOwner::Item(id.erase()));
+        let attrs = self.item_tree.attrs(self.def_collector.db, krate, id.upcast());
         let expander = if attrs.by_key(sym::rustc_builtin_macro).exists() {
             if let Some(expander) = find_builtin_macro(&mac.name) {
                 match expander {

--- a/crates/hir-def/src/nameres/collector.rs
+++ b/crates/hir-def/src/nameres/collector.rs
@@ -357,7 +357,7 @@ impl DefCollector<'_> {
             macro_depth: 0,
             module_id: DefMap::ROOT,
             tree_id: TreeId::new(file_id.into(), None),
-            item_tree: &item_tree,
+            item_tree,
             mod_dir: ModDir::root(),
         }
         .collect_in_top_module(item_tree.top_level_items());
@@ -378,7 +378,7 @@ impl DefCollector<'_> {
                 macro_depth: 0,
                 module_id: DefMap::ROOT,
                 tree_id,
-                item_tree: &item_tree,
+                item_tree,
                 mod_dir: ModDir::root(),
             }
             .collect_in_top_module(item_tree.top_level_items());
@@ -1381,7 +1381,7 @@ impl DefCollector<'_> {
                             macro_depth: directive.depth,
                             module_id: directive.module_id,
                             tree_id: *tree,
-                            item_tree: &item_tree,
+                            item_tree,
                             mod_dir,
                         }
                         .collect(&[*mod_item], directive.container);
@@ -1570,7 +1570,7 @@ impl DefCollector<'_> {
             macro_depth: depth,
             tree_id: TreeId::new(file_id, None),
             module_id,
-            item_tree: &item_tree,
+            item_tree,
             mod_dir,
         }
         .collect(item_tree.top_level_items(), container);
@@ -2142,7 +2142,7 @@ impl ModCollector<'_, '_> {
                                     macro_depth: self.macro_depth,
                                     module_id,
                                     tree_id: TreeId::new(file_id.into(), None),
-                                    item_tree: &item_tree,
+                                    item_tree,
                                     mod_dir,
                                 }
                                 .collect_in_top_module(item_tree.top_level_items());

--- a/crates/hir-def/src/nameres/tests/incremental.rs
+++ b/crates/hir-def/src/nameres/tests/incremental.rs
@@ -348,7 +348,7 @@ m!(Z);
             assert_eq!(module_data.scope.resolutions().count(), 4);
         });
         let n_recalculated_item_trees =
-            events.iter().filter(|it| it.contains("file_item_tree_shim")).count();
+            events.iter().filter(|it| it.contains("file_item_tree_query")).count();
         assert_eq!(n_recalculated_item_trees, 6);
         let n_reparsed_macros =
             events.iter().filter(|it| it.contains("parse_macro_expansion_shim")).count();
@@ -370,7 +370,7 @@ m!(Z);
             assert_eq!(module_data.scope.resolutions().count(), 4);
         });
         let n_recalculated_item_trees =
-            events.iter().filter(|it| it.contains("file_item_tree_shim")).count();
+            events.iter().filter(|it| it.contains("file_item_tree_query")).count();
         assert_eq!(n_recalculated_item_trees, 1, "{events:#?}");
         let n_reparsed_macros =
             events.iter().filter(|it| it.contains("parse_macro_expansion_shim")).count();
@@ -405,10 +405,10 @@ pub type Ty = ();
             db.file_item_tree(pos.file_id.into());
         });
         let n_calculated_item_trees =
-            events.iter().filter(|it| it.contains("file_item_tree_shim")).count();
-        assert_eq!(n_calculated_item_trees, 1);
+            events.iter().filter(|it| it.contains("file_item_tree_query")).count();
+        assert_eq!(n_calculated_item_trees, 1, "{events:#?}");
         let n_parsed_files = events.iter().filter(|it| it.contains("parse")).count();
-        assert_eq!(n_parsed_files, 1);
+        assert_eq!(n_parsed_files, 1, "{events:#?}");
     }
 
     // FIXME(salsa-transition): bring this back
@@ -446,6 +446,6 @@ pub type Ty = ();
             }
         });
         let n_reparsed_files = events.iter().filter(|it| it.contains("parse(")).count();
-        assert_eq!(n_reparsed_files, 0);
+        assert_eq!(n_reparsed_files, 0, "{events:?}");
     }
 }

--- a/crates/hir-ty/src/tests/incremental.rs
+++ b/crates/hir-ty/src/tests/incremental.rs
@@ -156,7 +156,7 @@ pub struct NewStruct {
         let expected = vec![
             "parse_shim".to_owned(),
             "ast_id_map_shim".to_owned(),
-            "file_item_tree_shim".to_owned(),
+            "file_item_tree_query".to_owned(),
             "real_span_map_shim".to_owned(),
             "crate_local_def_map".to_owned(),
             "trait_impls_in_crate_shim".to_owned(),
@@ -216,7 +216,7 @@ pub enum SomeEnum {
         let expected = vec![
             "parse_shim".to_owned(),
             "ast_id_map_shim".to_owned(),
-            "file_item_tree_shim".to_owned(),
+            "file_item_tree_query".to_owned(),
             "real_span_map_shim".to_owned(),
             "crate_local_def_map".to_owned(),
             "trait_impls_in_crate_shim".to_owned(),
@@ -273,7 +273,7 @@ fn bar() -> f32 {
         let expected = vec![
             "parse_shim".to_owned(),
             "ast_id_map_shim".to_owned(),
-            "file_item_tree_shim".to_owned(),
+            "file_item_tree_query".to_owned(),
             "real_span_map_shim".to_owned(),
             "crate_local_def_map".to_owned(),
             "trait_impls_in_crate_shim".to_owned(),
@@ -342,7 +342,7 @@ impl SomeStruct {
         let expected = vec![
             "parse_shim".to_owned(),
             "ast_id_map_shim".to_owned(),
-            "file_item_tree_shim".to_owned(),
+            "file_item_tree_query".to_owned(),
             "real_span_map_shim".to_owned(),
             "crate_local_def_map".to_owned(),
             "trait_impls_in_crate_shim".to_owned(),

--- a/crates/intern/src/symbol.rs
+++ b/crates/intern/src/symbol.rs
@@ -112,7 +112,6 @@ impl TaggedArcPtr {
     }
 }
 
-// FIXME: This should have more than one niche
 #[derive(PartialEq, Eq, Hash)]
 pub struct Symbol {
     repr: TaggedArcPtr,

--- a/crates/intern/src/symbol.rs
+++ b/crates/intern/src/symbol.rs
@@ -112,6 +112,7 @@ impl TaggedArcPtr {
     }
 }
 
+// FIXME: This should have more than one niche
 #[derive(PartialEq, Eq, Hash)]
 pub struct Symbol {
     repr: TaggedArcPtr,


### PR DESCRIPTION
Follow up to https://github.com/rust-lang/rust-analyzer/pull/19837, closes https://github.com/rust-lang/rust-analyzer/issues/9023

There is a bunch of things in the item tree we can replace now as item tree ids are superfluous, we can just replace them with an ast id mapping. 
