### PR TITLE
remove `pref_align_of` intrinsic handling, rename `{min_=>}align_of{,_val}`

### DIFF
--- a/crates/hir-ty/src/consteval/tests/intrinsics.rs
+++ b/crates/hir-ty/src/consteval/tests/intrinsics.rs
@@ -112,16 +112,16 @@ fn size_of_val() {
 }
 
 #[test]
-fn min_align_of_val() {
+fn align_of_val() {
     check_number(
         r#"
         //- minicore: coerce_unsized
         #[rustc_intrinsic]
-        pub fn min_align_of_val<T: ?Sized>(_: *const T) -> usize;
+        pub fn align_of_val<T: ?Sized>(_: *const T) -> usize;
 
         struct X(i32, u8);
 
-        const GOAL: usize = min_align_of_val(&X(1, 2));
+        const GOAL: usize = align_of_val(&X(1, 2));
         "#,
         4,
     );
@@ -129,11 +129,11 @@ fn min_align_of_val() {
         r#"
         //- minicore: coerce_unsized
         #[rustc_intrinsic]
-        pub fn min_align_of_val<T: ?Sized>(_: *const T) -> usize;
+        pub fn align_of_val<T: ?Sized>(_: *const T) -> usize;
 
         const GOAL: usize = {
             let x: &[i32] = &[1, 2, 3];
-            min_align_of_val(x)
+            align_of_val(x)
         };
         "#,
         4,

--- a/crates/hir-ty/src/mir/eval/shim.rs
+++ b/crates/hir-ty/src/mir/eval/shim.rs
@@ -761,7 +761,9 @@ impl Evaluator<'_> {
                 let size = self.size_of_sized(ty, locals, "size_of arg")?;
                 destination.write_from_bytes(self, &size.to_le_bytes()[0..destination.size])
             }
-            "min_align_of" | "pref_align_of" => {
+            // FIXME: `min_align_of` was renamed to `align_of` in Rust 1.89
+            // (https://github.com/rust-lang/rust/pull/142410)
+            "min_align_of" | "align_of" => {
                 let Some(ty) =
                     generic_args.as_slice(Interner).first().and_then(|it| it.ty(Interner))
                 else {
@@ -793,17 +795,19 @@ impl Evaluator<'_> {
                     destination.write_from_bytes(self, &size.to_le_bytes())
                 }
             }
-            "min_align_of_val" => {
+            // FIXME: `min_align_of_val` was renamed to `align_of_val` in Rust 1.89
+            // (https://github.com/rust-lang/rust/pull/142410)
+            "min_align_of_val" | "align_of_val" => {
                 let Some(ty) =
                     generic_args.as_slice(Interner).first().and_then(|it| it.ty(Interner))
                 else {
                     return Err(MirEvalError::InternalError(
-                        "min_align_of_val generic arg is not provided".into(),
+                        "align_of_val generic arg is not provided".into(),
                     ));
                 };
                 let [arg] = args else {
                     return Err(MirEvalError::InternalError(
-                        "min_align_of_val args are not provided".into(),
+                        "align_of_val args are not provided".into(),
                     ));
                 };
                 if let Some((_, align)) = self.size_align_of(ty, locals)? {


### PR DESCRIPTION
See https://github.com/rust-lang/rust/pull/142410
cc @RalfJung 