### PR TITLE
fix: Support spans with proc macro servers from before the ast id changes

### DIFF
--- a/crates/proc-macro-api/src/legacy_protocol/msg.rs
+++ b/crates/proc-macro-api/src/legacy_protocol/msg.rs
@@ -55,7 +55,7 @@ pub enum SpanMode {
     Id,
 
     /// Rust Analyzer-specific span handling mode.
-    RustAnalyzer { fixup_ast_id: u32 },
+    RustAnalyzer,
 }
 
 /// Represents responses sent from the proc-macro-srv to the client.
@@ -308,7 +308,7 @@ mod tests {
     #[test]
     fn test_proc_macro_rpc_works() {
         let tt = fixture_token_tree();
-        for v in HASHED_AST_ID..=CURRENT_API_VERSION {
+        for v in RUST_ANALYZER_SPAN_SUPPORT..=CURRENT_API_VERSION {
             let mut span_data_table = Default::default();
             let task = ExpandMacro {
                 data: ExpandMacroData {

--- a/crates/proc-macro-srv-cli/src/main_loop.rs
+++ b/crates/proc-macro-srv-cli/src/main_loop.rs
@@ -26,7 +26,7 @@ pub(crate) fn run() -> io::Result<()> {
     let write_response = |msg: msg::Response| msg.write(write_json, &mut io::stdout().lock());
 
     let env = EnvSnapshot::default();
-    let mut srv = proc_macro_srv::ProcMacroSrv::new(&env);
+    let srv = proc_macro_srv::ProcMacroSrv::new(&env);
 
     let mut span_mode = SpanMode::Id;
 
@@ -78,7 +78,7 @@ pub(crate) fn run() -> io::Result<()> {
                         })
                         .map_err(msg::PanicMessage)
                     }),
-                    SpanMode::RustAnalyzer { .. } => msg::Response::ExpandMacroExtended({
+                    SpanMode::RustAnalyzer => msg::Response::ExpandMacroExtended({
                         let mut span_data_table = deserialize_span_data_index_map(&span_data_table);
 
                         let def_site = span_data_table[def_site];
@@ -122,9 +122,6 @@ pub(crate) fn run() -> io::Result<()> {
             msg::Request::ApiVersionCheck {} => msg::Response::ApiVersionCheck(CURRENT_API_VERSION),
             msg::Request::SetConfig(config) => {
                 span_mode = config.span_mode;
-                if let SpanMode::RustAnalyzer { fixup_ast_id } = span_mode {
-                    srv.set_fixup_ast_id(fixup_ast_id);
-                }
                 msg::Response::SetConfig(config)
             }
         };

--- a/crates/proc-macro-srv/src/dylib.rs
+++ b/crates/proc-macro-srv/src/dylib.rs
@@ -3,7 +3,6 @@
 mod version;
 
 use proc_macro::bridge;
-use span::ErasedFileAstId;
 use std::{fmt, fs, io, time::SystemTime};
 
 use libloading::Library;
@@ -162,20 +161,14 @@ impl Expander {
         def_site: S,
         call_site: S,
         mixed_site: S,
-        fixup_ast_id: ErasedFileAstId,
     ) -> Result<TopSubtree<S>, String>
     where
         <S::Server as bridge::server::Types>::TokenStream: Default,
     {
-        let result = self.inner.proc_macros.expand(
-            macro_name,
-            macro_body,
-            attributes,
-            def_site,
-            call_site,
-            mixed_site,
-            fixup_ast_id,
-        );
+        let result = self
+            .inner
+            .proc_macros
+            .expand(macro_name, macro_body, attributes, def_site, call_site, mixed_site);
         result.map_err(|e| e.into_string().unwrap_or_default())
     }
 

--- a/crates/proc-macro-srv/src/lib.rs
+++ b/crates/proc-macro-srv/src/lib.rs
@@ -41,7 +41,7 @@ use std::{
 };
 
 use paths::{Utf8Path, Utf8PathBuf};
-use span::{ErasedFileAstId, FIXUP_ERASED_FILE_AST_ID_MARKER, Span, TokenId};
+use span::{Span, TokenId};
 
 use crate::server_impl::TokenStream;
 
@@ -57,16 +57,11 @@ pub const RUSTC_VERSION_STRING: &str = env!("RUSTC_VERSION");
 pub struct ProcMacroSrv<'env> {
     expanders: Mutex<HashMap<Utf8PathBuf, Arc<dylib::Expander>>>,
     env: &'env EnvSnapshot,
-    fixup_ast_id: ErasedFileAstId,
 }
 
 impl<'env> ProcMacroSrv<'env> {
     pub fn new(env: &'env EnvSnapshot) -> Self {
-        Self { expanders: Default::default(), env, fixup_ast_id: FIXUP_ERASED_FILE_AST_ID_MARKER }
-    }
-
-    pub fn set_fixup_ast_id(&mut self, fixup_ast_id: u32) {
-        self.fixup_ast_id = ErasedFileAstId::from_raw(fixup_ast_id);
+        Self { expanders: Default::default(), env }
     }
 }
 
@@ -106,7 +101,6 @@ impl ProcMacroSrv<'_> {
                             def_site,
                             call_site,
                             mixed_site,
-                            self.fixup_ast_id,
                         )
                         .map(|tt| tt.0)
                 });
@@ -162,41 +156,25 @@ impl ProcMacroSrv<'_> {
 
 pub trait ProcMacroSrvSpan: Copy + Send {
     type Server: proc_macro::bridge::server::Server<TokenStream = TokenStream<Self>>;
-    fn make_server(
-        call_site: Self,
-        def_site: Self,
-        mixed_site: Self,
-        fixup_ast_id: ErasedFileAstId,
-    ) -> Self::Server;
+    fn make_server(call_site: Self, def_site: Self, mixed_site: Self) -> Self::Server;
 }
 
 impl ProcMacroSrvSpan for TokenId {
     type Server = server_impl::token_id::TokenIdServer;
 
-    fn make_server(
-        call_site: Self,
-        def_site: Self,
-        mixed_site: Self,
-        _fixup_ast_id: ErasedFileAstId,
-    ) -> Self::Server {
+    fn make_server(call_site: Self, def_site: Self, mixed_site: Self) -> Self::Server {
         Self::Server { call_site, def_site, mixed_site }
     }
 }
 impl ProcMacroSrvSpan for Span {
     type Server = server_impl::rust_analyzer_span::RaSpanServer;
-    fn make_server(
-        call_site: Self,
-        def_site: Self,
-        mixed_site: Self,
-        fixup_ast_id: ErasedFileAstId,
-    ) -> Self::Server {
+    fn make_server(call_site: Self, def_site: Self, mixed_site: Self) -> Self::Server {
         Self::Server {
             call_site,
             def_site,
             mixed_site,
             tracked_env_vars: Default::default(),
             tracked_paths: Default::default(),
-            fixup_ast_id,
         }
     }
 }

--- a/crates/proc-macro-srv/src/proc_macros.rs
+++ b/crates/proc-macro-srv/src/proc_macros.rs
@@ -1,7 +1,6 @@
 //! Proc macro ABI
 
 use proc_macro::bridge;
-use span::ErasedFileAstId;
 
 use crate::{ProcMacroKind, ProcMacroSrvSpan, server_impl::TopSubtree};
 
@@ -23,7 +22,6 @@ impl ProcMacros {
         def_site: S,
         call_site: S,
         mixed_site: S,
-        fixup_ast_id: ErasedFileAstId,
     ) -> Result<TopSubtree<S>, crate::PanicMessage> {
         let parsed_body = crate::server_impl::TokenStream::with_subtree(macro_body);
 
@@ -39,7 +37,7 @@ impl ProcMacros {
                 {
                     let res = client.run(
                         &bridge::server::SameThread,
-                        S::make_server(call_site, def_site, mixed_site, fixup_ast_id),
+                        S::make_server(call_site, def_site, mixed_site),
                         parsed_body,
                         cfg!(debug_assertions),
                     );
@@ -50,7 +48,7 @@ impl ProcMacros {
                 bridge::client::ProcMacro::Bang { name, client } if *name == macro_name => {
                     let res = client.run(
                         &bridge::server::SameThread,
-                        S::make_server(call_site, def_site, mixed_site, fixup_ast_id),
+                        S::make_server(call_site, def_site, mixed_site),
                         parsed_body,
                         cfg!(debug_assertions),
                     );
@@ -61,7 +59,7 @@ impl ProcMacros {
                 bridge::client::ProcMacro::Attr { name, client } if *name == macro_name => {
                     let res = client.run(
                         &bridge::server::SameThread,
-                        S::make_server(call_site, def_site, mixed_site, fixup_ast_id),
+                        S::make_server(call_site, def_site, mixed_site),
                         parsed_attributes,
                         parsed_body,
                         cfg!(debug_assertions),

--- a/crates/proc-macro-srv/src/tests/utils.rs
+++ b/crates/proc-macro-srv/src/tests/utils.rs
@@ -2,8 +2,7 @@
 
 use expect_test::Expect;
 use span::{
-    EditionedFileId, FIXUP_ERASED_FILE_AST_ID_MARKER, FileId, ROOT_ERASED_FILE_AST_ID, Span,
-    SpanAnchor, SyntaxContext, TokenId,
+    EditionedFileId, FileId, ROOT_ERASED_FILE_AST_ID, Span, SpanAnchor, SyntaxContext, TokenId,
 };
 use tt::TextRange;
 
@@ -68,17 +67,8 @@ fn assert_expand_impl(
     let input_ts_string = format!("{input_ts:?}");
     let attr_ts_string = attr_ts.as_ref().map(|it| format!("{it:?}"));
 
-    let res = expander
-        .expand(
-            macro_name,
-            input_ts,
-            attr_ts,
-            def_site,
-            call_site,
-            mixed_site,
-            FIXUP_ERASED_FILE_AST_ID_MARKER,
-        )
-        .unwrap();
+    let res =
+        expander.expand(macro_name, input_ts, attr_ts, def_site, call_site, mixed_site).unwrap();
     expect.assert_eq(&format!(
         "{input_ts_string}\n\n{}\n\n{res:?}",
         attr_ts_string.unwrap_or_default()
@@ -110,17 +100,7 @@ fn assert_expand_impl(
     let fixture_string = format!("{fixture:?}");
     let attr_string = attr.as_ref().map(|it| format!("{it:?}"));
 
-    let res = expander
-        .expand(
-            macro_name,
-            fixture,
-            attr,
-            def_site,
-            call_site,
-            mixed_site,
-            FIXUP_ERASED_FILE_AST_ID_MARKER,
-        )
-        .unwrap();
+    let res = expander.expand(macro_name, fixture, attr, def_site, call_site, mixed_site).unwrap();
     expect_spanned
         .assert_eq(&format!("{fixture_string}\n\n{}\n\n{res:#?}", attr_string.unwrap_or_default()));
 }

--- a/crates/span/src/ast_id.rs
+++ b/crates/span/src/ast_id.rs
@@ -108,7 +108,8 @@ impl fmt::Debug for ErasedFileAstId {
 
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
 enum ErasedFileAstIdKind {
-    Root,
+    /// This needs to not change because it's depended upon by the proc macro server.
+    Fixup,
     // The following are associated with `ErasedHasNameFileAstId`.
     Enum,
     Struct,
@@ -143,7 +144,7 @@ enum ErasedFileAstIdKind {
     /// Associated with [`BlockExprFileAstId`].
     BlockExpr,
     /// Keep this last.
-    Fixup,
+    Root,
 }
 
 // First hash, then index, then kind.
@@ -218,7 +219,7 @@ impl ErasedFileAstId {
     }
 
     #[inline]
-    pub fn from_raw(v: u32) -> Self {
+    pub const fn from_raw(v: u32) -> Self {
         Self(v)
     }
 }


### PR DESCRIPTION
The only thing changed is the value of the fixup ast id, so we just swap it.

As @Veykril suggested in rust-lang/rust-analyzer#19837.

This brings unknown types back to normal.