### PR TITLE
fix: Closure capturing for let exprs

### DIFF
--- a/crates/hir-ty/src/infer/closure.rs
+++ b/crates/hir-ty/src/infer/closure.rs
@@ -1230,11 +1230,15 @@ impl InferenceContext<'_> {
                     self.select_from_expr(*expr);
                 }
             }
+            Expr::Let { pat: _, expr } => {
+                self.walk_expr(*expr);
+                let place = self.place_of_expr(*expr);
+                self.ref_expr(*expr, place);
+            }
             Expr::UnaryOp { expr, op: _ }
             | Expr::Array(Array::Repeat { initializer: expr, repeat: _ })
             | Expr::Await { expr }
             | Expr::Loop { body: expr, label: _ }
-            | Expr::Let { pat: _, expr }
             | Expr::Box { expr }
             | Expr::Cast { expr, type_ref: _ } => {
                 self.consume_expr(*expr);

--- a/crates/hir-ty/src/tests/closure_captures.rs
+++ b/crates/hir-ty/src/tests/closure_captures.rs
@@ -444,3 +444,22 @@ fn main() {
         expect!["99..165;49..54;120..121,133..134 ByRef(Mut { kind: Default }) a &'? mut A"],
     );
 }
+
+#[test]
+fn let_binding_is_a_ref_capture() {
+    check_closure_captures(
+        r#"
+//- minicore:copy
+struct S;
+fn main() {
+    let mut s = S;
+    let s_ref = &mut s;
+    let closure = || {
+        if let ref cb = s_ref {
+        }
+    };
+}
+"#,
+        expect!["83..135;49..54;112..117 ByRef(Shared) s_ref &'? &'? mut S"],
+    );
+}

--- a/crates/ide-diagnostics/src/handlers/moved_out_of_ref.rs
+++ b/crates/ide-diagnostics/src/handlers/moved_out_of_ref.rs
@@ -220,4 +220,23 @@ fn test() {
             "#,
         )
     }
+
+    #[test]
+    fn regression_18201() {
+        check_diagnostics(
+            r#"
+//- minicore: copy
+struct NotCopy;
+struct S(NotCopy);
+impl S {
+    fn f(&mut self) {
+        || {
+            if let ref mut _cb = self.0 {
+            }
+        };
+    }
+}
+"#,
+        )
+    }
 }


### PR DESCRIPTION
Fixes rust-lang/rust-analyzer#18201

We have been handling closure captures for let expressions in a wrong way: 

Here,
https://github.com/rust-lang/rust-analyzer/blob/6807f60ccd74f341f6e7c830ab5d9d0c27ae9dc2/crates/hir-ty/src/infer/closure.rs#L1237-L1241

which ends up as a capture by value if the captured target is not `Copy`
https://github.com/rust-lang/rust-analyzer/blob/6807f60ccd74f341f6e7c830ab5d9d0c27ae9dc2/crates/hir-ty/src/infer/closure.rs#L1034-L1051

But rustc handles this as a capture by ref(immutable, in most cases) in the following lines:

https://github.com/rust-lang/rust/blob/6f935a044d1ddeb6160494a6320d008d7c311aef/compiler/rustc_hir_typeck/src/expr_use_visitor.rs#L452-L454
https://github.com/rust-lang/rust/blob/6f935a044d1ddeb6160494a6320d008d7c311aef/compiler/rustc_hir_typeck/src/upvar.rs#L2093-L2114

Of course, rustc's capturing logic is more sophiscated than my modification here and we lack many details of them but at least, this one is at least more precise than the present, I think 😅 

I think that we should move our capturing logic closer to that of rustc, but after next-gen solver migration