### PR TITLE
Add `fn parent(self, db) -> GenericDef` to `hir::TypeParam`

### DIFF
--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -4150,6 +4150,10 @@ impl TypeParam {
         self.merge().name(db)
     }
 
+    pub fn parent(self, _db: &dyn HirDatabase) -> GenericDef {
+        self.id.parent().into()
+    }
+
     pub fn module(self, db: &dyn HirDatabase) -> Module {
         self.id.parent().module(db).into()
     }


### PR DESCRIPTION
Currently you have to do `param.merge().parent(db)` for `TypeParam`, which slightly less ergonomic, but most importantly it requires you to be aware of the available detour via `TypeOrConstParam`.

With its sibling `ConstParam` you can already do `param.parent(db)`. Now with `TypeParam` you can, too.