### PR TITLE
internal: Utilize `cargo check --compile-time-deps`

### DIFF
--- a/crates/project-model/src/build_dependencies.rs
+++ b/crates/project-model/src/build_dependencies.rs
@@ -20,7 +20,9 @@ use toolchain::Tool;
 
 use crate::{
     CargoConfig, CargoFeatures, CargoWorkspace, InvocationStrategy, ManifestPath, Package, Sysroot,
-    TargetKind, utf8_stdout,
+    TargetKind,
+    toolchain_info::{QueryConfig, version},
+    utf8_stdout,
 };
 
 /// Output of the build script and proc-macro building steps for a workspace.
@@ -446,10 +448,30 @@ impl WorkspaceBuildScripts {
             }
         };
 
-        if config.wrap_rustc_in_build_scripts {
+        // If [`--compile-time-deps` flag](https://github.com/rust-lang/cargo/issues/14434) is
+        // available in current toolchain's cargo, use it to build compile time deps only.
+        const COMP_TIME_DEPS_MIN_TOOLCHAIN_VERSION: semver::Version = semver::Version {
+            major: 1,
+            minor: 90,
+            patch: 0,
+            pre: semver::Prerelease::EMPTY,
+            build: semver::BuildMetadata::EMPTY,
+        };
+
+        let query_config = QueryConfig::Cargo(sysroot, manifest_path);
+        let toolchain = version::get(query_config, &config.extra_env).ok().flatten();
+        let cargo_comp_time_deps_available =
+            toolchain.is_some_and(|v| v >= COMP_TIME_DEPS_MIN_TOOLCHAIN_VERSION);
+
+        if cargo_comp_time_deps_available {
+            cmd.env("__CARGO_TEST_CHANNEL_OVERRIDE_DO_NOT_USE_THIS", "nightly");
+            cmd.arg("-Zunstable-options");
+            cmd.arg("--compile-time-deps");
+        } else if config.wrap_rustc_in_build_scripts {
             // Setup RUSTC_WRAPPER to point to `rust-analyzer` binary itself. We use
             // that to compile only proc macros and build scripts during the initial
             // `cargo check`.
+            // We don't need this if we are using `--compile-time-deps` flag.
             let myself = std::env::current_exe()?;
             cmd.env("RUSTC_WRAPPER", myself);
             cmd.env("RA_RUSTC_WRAPPER", "1");


### PR DESCRIPTION
rust-lang/cargo#15674 has been merged and I guess it would be available in toolchain `1.90.0`

I've tested this on rust-analyzer itself with cargo binary built from current master with the following my rust-analyzer branch
https://github.com/ShoyuVanilla/rust-analyzer/tree/comp-time-deps-test
and these are the results (I had run `cargo clean` before each run and modified the code a bit to use `--compile-time-deps` with injected cargo binary path iff env var `$CARGO_BIN_FOR_TEST` is set)

## With `--compile-time-deps`

![image](https://github.com/user-attachments/assets/fd78bb77-ce07-4a7d-a839-4c359d61a215)
 
## Without `--compile-time-deps`

![image](https://github.com/user-attachments/assets/aca4b103-6fd5-403b-b1d0-82f57a6659e2)


## Comparison

|   | **`analysis-stat` results** | **Time** | **`target` dir size** |
| - | - | - | - |
| **`--compile-time-deps`**  | Identical | 2m 25s | 347 M |
| **default**  | Identical | 2m 55s | 1.4 G |

## System Information

![image](https://github.com/user-attachments/assets/7a9535a5-ae6c-49e4-bf5c-5ee82d125f7e)
