### PR TITLE
feat: support folding multiline arg list & fn body in one folding range

### DIFF
--- a/crates/ide/src/folding_ranges.rs
+++ b/crates/ide/src/folding_ranges.rs
@@ -361,6 +361,23 @@ mod tests {
     }
 
     #[test]
+    fn test_fold_func_with_multiline_param_list() {
+        check(
+            r#"
+<fold function>fn func<fold arglist>(
+    a: i32,
+    b: i32,
+    c: i32,
+)</fold> <fold block>{
+
+
+
+}</fold></fold>
+"#,
+        );
+    }
+
+    #[test]
     fn test_fold_comments() {
         check(
             r#"
@@ -572,10 +589,10 @@ const _: S = S <fold block>{
     fn fold_multiline_params() {
         check(
             r#"
-fn foo<fold arglist>(
+<fold function>fn foo<fold arglist>(
     x: i32,
     y: String,
-) {}</fold>
+)</fold> {}</fold>
 "#,
         )
     }

--- a/crates/rust-analyzer/src/lsp/to_proto.rs
+++ b/crates/rust-analyzer/src/lsp/to_proto.rs
@@ -911,7 +911,8 @@ pub(crate) fn folding_range(
         | FoldKind::Array
         | FoldKind::TraitAliases
         | FoldKind::ExternCrates
-        | FoldKind::MatchArm => None,
+        | FoldKind::MatchArm
+        | FoldKind::Function => None,
     };
 
     let range = range(line_index, fold.range);


### PR DESCRIPTION
It would be convenient to just one-click fold arg list and func body(TypeScript does). However, this behavior is inconsistent with now, perhaps we need a configurable setting that allows users to customize it?

![PixPin_2025-06-30_17-30-39-20250630173048-rlibom6](https://github.com/user-attachments/assets/0f1918e8-3545-4cd0-839e-fd5c7386f3fc)


close https://github.com/rust-lang/rust-analyzer/issues/19299