### PR TITLE
Document sysroot_project field in rust-project.json

### DIFF
--- a/docs/book/src/non_cargo_based_projects.md
+++ b/docs/book/src/non_cargo_based_projects.md
@@ -40,6 +40,9 @@ interface ProjectJson {
     /// several different "sysroots" in one graph of
     /// crates.
     sysroot_src?: string;
+    /// A ProjectJson describing the crates of the sysroot.
+    sysroot_project?: ProjectJson;
+
     /// List of groups of common cfg values, to allow
     /// sharing them between crates.
     ///


### PR DESCRIPTION
This was added in rust-lang/rust-analyzer#19096 but the corresponding docs page didn't mention this field.