### PR TITLE
fix: Use `ROOT` hygiene for `args` inside new `format_args!` expansion

### DIFF
--- a/crates/hir-def/src/expr_store/lower.rs
+++ b/crates/hir-def/src/expr_store/lower.rs
@@ -2825,14 +2825,7 @@ impl ExprCollector<'_> {
         let use_format_args_since_1_89_0 = fmt_args().is_some() && fmt_unsafe_arg().is_none();
 
         let idx = if use_format_args_since_1_89_0 {
-            self.collect_format_args_impl(
-                syntax_ptr,
-                fmt,
-                hygiene,
-                argmap,
-                lit_pieces,
-                format_options,
-            )
+            self.collect_format_args_impl(syntax_ptr, fmt, argmap, lit_pieces, format_options)
         } else {
             self.collect_format_args_before_1_89_0_impl(
                 syntax_ptr,
@@ -2962,7 +2955,6 @@ impl ExprCollector<'_> {
         &mut self,
         syntax_ptr: AstPtr<ast::Expr>,
         fmt: FormatArgs,
-        hygiene: HygieneId,
         argmap: FxIndexSet<(usize, ArgumentType)>,
         lit_pieces: ExprId,
         format_options: ExprId,
@@ -2997,8 +2989,11 @@ impl ExprCollector<'_> {
             let args =
                 self.alloc_expr_desugared(Expr::Array(Array::ElementList { elements: args }));
             let args_name = Name::new_symbol_root(sym::args);
-            let args_binding =
-                self.alloc_binding(args_name.clone(), BindingAnnotation::Unannotated, hygiene);
+            let args_binding = self.alloc_binding(
+                args_name.clone(),
+                BindingAnnotation::Unannotated,
+                HygieneId::ROOT,
+            );
             let args_pat = self.alloc_pat_desugared(Pat::Bind { id: args_binding, subpat: None });
             self.add_definition_to_binding(args_binding, args_pat);
             // TODO: We don't have `super let` yet.
@@ -3008,13 +3003,16 @@ impl ExprCollector<'_> {
                 initializer: Some(args),
                 else_branch: None,
             };
-            (vec![let_stmt], self.alloc_expr_desugared(Expr::Path(Path::from(args_name))))
+            (vec![let_stmt], self.alloc_expr_desugared(Expr::Path(args_name.into())))
         } else {
             // Generate:
             //     super let args = (&arg0, &arg1, &...);
             let args_name = Name::new_symbol_root(sym::args);
-            let args_binding =
-                self.alloc_binding(args_name.clone(), BindingAnnotation::Unannotated, hygiene);
+            let args_binding = self.alloc_binding(
+                args_name.clone(),
+                BindingAnnotation::Unannotated,
+                HygieneId::ROOT,
+            );
             let args_pat = self.alloc_pat_desugared(Pat::Bind { id: args_binding, subpat: None });
             self.add_definition_to_binding(args_binding, args_pat);
             let elements = arguments
@@ -3057,8 +3055,11 @@ impl ExprCollector<'_> {
                 .collect();
             let array =
                 self.alloc_expr_desugared(Expr::Array(Array::ElementList { elements: args }));
-            let args_binding =
-                self.alloc_binding(args_name.clone(), BindingAnnotation::Unannotated, hygiene);
+            let args_binding = self.alloc_binding(
+                args_name.clone(),
+                BindingAnnotation::Unannotated,
+                HygieneId::ROOT,
+            );
             let args_pat = self.alloc_pat_desugared(Pat::Bind { id: args_binding, subpat: None });
             self.add_definition_to_binding(args_binding, args_pat);
             let let_stmt2 = Statement::Let {

--- a/crates/hir-ty/src/mir/eval/tests.rs
+++ b/crates/hir-ty/src/mir/eval/tests.rs
@@ -984,3 +984,17 @@ fn main<'a, T: Foo + Bar + Baz>(
         |e| matches!(e, MirEvalError::MirLowerError(_, MirLowerError::GenericArgNotProvided(..))),
     );
 }
+
+#[test]
+fn format_args_pass() {
+    check_pass(
+        r#"
+//- minicore: fmt
+fn main() {
+    let x1 = format_args!("");
+    let x2 = format_args!("{}", x1);
+    let x3 = format_args!("{} {}", x1, x2);
+}
+"#,
+    );
+}

--- a/crates/ide-assists/src/handlers/term_search.rs
+++ b/crates/ide-assists/src/handlers/term_search.rs
@@ -100,9 +100,7 @@ fn f() { let a: u128 = 1; let b: u128 = todo$0!() }"#,
     fn test_complete_todo_with_msg() {
         check_assist(
             term_search,
-            // FIXME: Since we are lacking of `super let`, term search fails due to borrowck failure.
-            // Should implement super let and remove `fmt_before_1_89_0`
-            r#"//- minicore: todo, unimplemented, fmt_before_1_89_0
+            r#"//- minicore: todo, unimplemented
 fn f() { let a: u128 = 1; let b: u128 = todo$0!("asd") }"#,
             r#"fn f() { let a: u128 = 1; let b: u128 = a }"#,
         )
@@ -112,10 +110,8 @@ fn f() { let a: u128 = 1; let b: u128 = todo$0!("asd") }"#,
     fn test_complete_unimplemented_with_msg() {
         check_assist(
             term_search,
-            // FIXME: Since we are lacking of `super let`, term search fails due to borrowck failure.
-            // Should implement super let and remove `fmt_before_1_89_0`
-            r#"//- minicore: todo, unimplemented, fmt_before_1_89_0
-fn f() { let a: u128 = 1; let b: u128 = todo$0!("asd") }"#,
+            r#"//- minicore: todo, unimplemented
+fn f() { let a: u128 = 1; let b: u128 = unimplemented$0!("asd") }"#,
             r#"fn f() { let a: u128 = 1; let b: u128 = a }"#,
         )
     }
@@ -124,10 +120,8 @@ fn f() { let a: u128 = 1; let b: u128 = todo$0!("asd") }"#,
     fn test_complete_unimplemented() {
         check_assist(
             term_search,
-            // FIXME: Since we are lacking of `super let`, term search fails due to borrowck failure.
-            // Should implement super let and remove `fmt_before_1_89_0`
-            r#"//- minicore: todo, unimplemented, fmt_before_1_89_0
-fn f() { let a: u128 = 1; let b: u128 = todo$0!("asd") }"#,
+            r#"//- minicore: todo, unimplemented
+fn f() { let a: u128 = 1; let b: u128 = unimplemented$0!() }"#,
             r#"fn f() { let a: u128 = 1; let b: u128 = a }"#,
         )
     }


### PR DESCRIPTION
I thought that [this](https://github.com/rust-lang/rust-analyzer/pull/20056#discussion_r2160217300) was because we don't have `super let` but it was definitely my mistake in rust-lang/rust-analyzer#20056 😅 