### PR TITLE
minor: Decrease minimal toolchain version for `comp-time-deps` to `1.89.0`

### DIFF
--- a/crates/project-model/src/build_dependencies.rs
+++ b/crates/project-model/src/build_dependencies.rs
@@ -452,7 +452,7 @@ impl WorkspaceBuildScripts {
         // available in current toolchain's cargo, use it to build compile time deps only.
         const COMP_TIME_DEPS_MIN_TOOLCHAIN_VERSION: semver::Version = semver::Version {
             major: 1,
-            minor: 90,
+            minor: 89,
             patch: 0,
             pre: semver::Prerelease::EMPTY,
             build: semver::BuildMetadata::EMPTY,


### PR DESCRIPTION
I originally thought that new `cargo` with `--compile-time-deps` is coming with toolchain version `1.90.0`, as `rust-lang/rust`'s `cargo` submodule hasn't been updated to that version by the date written [here](https://releases.rs/docs/1.89.0/):
![image](https://github.com/user-attachments/assets/d9869d87-6b86-42a3-bdcc-bd4c64eefa5c)

But surprisingly, [it has been included to `1.89.0` milestone and beta branch](https://github.com/rust-lang/rust/pull/142898)
