### PR TITLE
fix: Prettify AST in `PathTransform` if it's coming from a macro

### DIFF
--- a/crates/hir/src/semantics.rs
+++ b/crates/hir/src/semantics.rs
@@ -2199,6 +2199,10 @@ pub struct SemanticsScope<'db> {
 }
 
 impl<'db> SemanticsScope<'db> {
+    pub fn file_id(&self) -> HirFileId {
+        self.file_id
+    }
+
     pub fn module(&self) -> Module {
         Module { id: self.resolver.module() }
     }

--- a/crates/ide-completion/src/tests/item_list.rs
+++ b/crates/ide-completion/src/tests/item_list.rs
@@ -550,3 +550,30 @@ fn inside_extern_blocks() {
         "#]],
     )
 }
+
+#[test]
+fn tokens_from_macro() {
+    check_edit(
+        "fn as_ref",
+        r#"
+//- proc_macros: identity
+//- minicore: as_ref
+struct Foo;
+
+#[proc_macros::identity]
+impl<'a> AsRef<&'a i32> for Foo {
+    $0
+}
+    "#,
+        r#"
+struct Foo;
+
+#[proc_macros::identity]
+impl<'a> AsRef<&'a i32> for Foo {
+    fn as_ref(&self) -> &&'a i32 {
+    $0
+}
+}
+    "#,
+    );
+}


### PR DESCRIPTION
Fixes rust-lang/rust-analyzer#19972.