### PR TITLE
Bug Fix: Auto import has broken for vim-lsp

### DIFF
--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -1549,7 +1549,7 @@ impl Config {
             limit: self.completion_limit(source_root).to_owned(),
             enable_term_search: self.completion_termSearch_enable(source_root).to_owned(),
             term_search_fuel: self.completion_termSearch_fuel(source_root).to_owned() as u64,
-            fields_to_resolve: if self.client_is_neovim() {
+            fields_to_resolve: if self.client_is_neovim() || self.client_is_vim_lsp() {
                 CompletionFieldsToResolve::empty()
             } else {
                 CompletionFieldsToResolve::from_client_capabilities(&client_capability_fields)
@@ -2361,6 +2361,10 @@ impl Config {
 
     pub fn client_is_neovim(&self) -> bool {
         self.client_info.as_ref().map(|it| it.name == "Neovim").unwrap_or_default()
+    }
+
+    pub fn client_is_vim_lsp(&self) -> bool {
+        self.client_info.as_ref().map(|it| it.name == "vim-lsp").unwrap_or_default()
     }
 }
 // Deserialization definitions

--- a/crates/rust-analyzer/src/lsp/capabilities.rs
+++ b/crates/rust-analyzer/src/lsp/capabilities.rs
@@ -41,7 +41,7 @@ pub fn server_capabilities(config: &Config) -> ServerCapabilities {
         })),
         hover_provider: Some(HoverProviderCapability::Simple(true)),
         completion_provider: Some(CompletionOptions {
-            resolve_provider: if config.client_is_neovim() {
+            resolve_provider: if config.client_is_neovim() || config.client_is_vim_lsp() {
                 config.completion_item_edit_resolve().then_some(true)
             } else {
                 Some(config.caps().completions_resolve_provider())


### PR DESCRIPTION
  1. Because of change the in [1], vim-lsp cannot complete the auto import items. May be, it`s better to use the method completion_item_edit_resolve [2] to resovle this problem. Also, maybe this change is only a workaround.

  close the bug rust-lang/rust-analyzer#19401

  [1]: https://github.com/rust-lang/rust-analyzer/blob/master/crates/rust-analyzer/src/lsp/capabilities.rs#L188
  [2]: https://github.com/rust-lang/rust-analyzer/blob/master/crates/rust-analyzer/src/lsp/capabilities.rs#L211