### PR TITLE
fix: Avoid .unwrap() when running the discover command

### DIFF
--- a/crates/rust-analyzer/src/main_loop.rs
+++ b/crates/rust-analyzer/src/main_loop.rs
@@ -783,9 +783,14 @@ impl GlobalState {
                             DiscoverProjectParam::Path(it) => DiscoverArgument::Path(it),
                         };
 
-                        let handle =
-                            discover.spawn(arg, &std::env::current_dir().unwrap()).unwrap();
-                        self.discover_handle = Some(handle);
+                        let handle = discover.spawn(
+                            arg,
+                            &std::env::current_dir()
+                                .expect("Failed to get cwd during project discovery"),
+                        );
+                        self.discover_handle = Some(handle.unwrap_or_else(|e| {
+                            panic!("Failed to spawn project discovery command: {e}")
+                        }));
                     }
                 }
             }


### PR DESCRIPTION
Previously, the following configuration in settings.json:

    "rust-analyzer.workspace.discoverConfig": {
        "command": [
            "oops",
            "develop-json",
            "{arg}"
        ],
        "progressLabel": "rust-analyzer",
        "filesToWatch": [
            "BUCK",
            "TARGETS"
        ]
    },

Would previously cause a crash in rust-analyzer:

    thread 'LspServer' panicked at crates/rust-analyzer/src/main_loop.rs:776:84:
    called `Result::unwrap()` on an `Err` value: Os { code: 2, kind: NotFound, message: "No such file or directory" }

Instead, use more specific panic messages.