### PR TITLE
feat: Implement `textDocument/documentColor`

### DIFF
--- a/crates/ide/src/document_color.rs
+++ b/crates/ide/src/document_color.rs
@@ -1,0 +1,65 @@
+#![allow(warnings)]
+
+use hir::{EditionedFileId, Semantics};
+use ide_db::RootDatabase;
+use span::FileId;
+use syntax::AstNode as _;
+
+pub struct DocumentColor {
+    pub start_line: u32,
+    pub start_char: u32,
+    pub end_char: u32,
+    pub end_line: u32,
+    pub r: f32,
+    pub g: f32,
+    pub b: f32,
+    pub a: f32,
+}
+
+/// Document colors let IDEs annotate regions of source code as having a particular color.
+///
+/// The advantage over `textDocument/documentHighlight` is that IDEs can create virtual text
+/// to show swatches, representing the color.
+///
+/// # Basic Plan
+///
+/// 1. Visit every expression that is known at compile time (is `const`)
+/// 1. If the type `struct` of the expression contains
+///    an attribute `#[rust_analyzer::color::rgb]`, proceed
+/// 1. If there are 3 `f32` fields with attribute `#[rust_analyzer::color::rgb::{r,g,b}]`,
+///    then we have all the necessary information to construct the type itself
+pub(crate) fn document_color(db: &RootDatabase, file_id: FileId) -> Vec<DocumentColor> {
+    let sema = Semantics::new(db);
+    let file_id = sema
+        .attach_first_edition(file_id)
+        .unwrap_or_else(|| EditionedFileId::current_edition(db, file_id));
+
+    let file = sema.parse(file_id);
+    let file = file.syntax();
+
+    for event in file.preorder() {
+        let syntax::WalkEvent::Leave(syntax_node) = event else { continue };
+        let Some(expr) = syntax::ast::Expr::cast(syntax_node) else { continue };
+        dbg!(&expr);
+
+        // `type_of_expr` fails... but why?
+        let Some(ty) = sema.type_of_expr(&expr) else { continue };
+        dbg!(ty);
+    }
+
+    vec![DocumentColor {
+        start_line: 1,
+        start_char: 1,
+        end_char: 1,
+        end_line: 1,
+        r: 1.0,
+        g: 0.0,
+        b: 0.0,
+        a: 1.0,
+    }]
+}
+
+// ^^^^^ INFO: `sema.scope(file)` is NONE
+// let Some(scope) = sema.scope(file) else {
+//     return None;
+// };

--- a/crates/ide/src/lib.rs
+++ b/crates/ide/src/lib.rs
@@ -22,6 +22,7 @@ mod annotations;
 mod call_hierarchy;
 mod child_modules;
 mod doc_links;
+mod document_color;
 mod expand_macro;
 mod extend_selection;
 mod fetch_crates;
@@ -80,6 +81,7 @@ use crate::navigation_target::ToNav;
 pub use crate::{
     annotations::{Annotation, AnnotationConfig, AnnotationKind, AnnotationLocation},
     call_hierarchy::{CallHierarchyConfig, CallItem},
+    document_color::DocumentColor,
     expand_macro::ExpandedMacro,
     file_structure::{StructureNode, StructureNodeKind},
     folding_ranges::{Fold, FoldKind},
@@ -437,6 +439,10 @@ impl Analysis {
 
             file_structure::file_structure(&db.parse(editioned_file_id_wrapper).tree())
         })
+    }
+
+    pub fn document_color(&self, file_id: FileId) -> Cancellable<Vec<DocumentColor>> {
+        self.with_db(|db| document_color::document_color(db, file_id))
     }
 
     /// Returns a list of the places in the file where type hints can be displayed.

--- a/crates/rust-analyzer/src/handlers/request.rs
+++ b/crates/rust-analyzer/src/handlers/request.rs
@@ -1713,6 +1713,21 @@ pub(crate) fn handle_ssr(
     to_proto::workspace_edit(&snap, source_change).map_err(Into::into)
 }
 
+pub(crate) fn handle_document_color(
+    _snap: GlobalStateSnapshot,
+    _params: lsp_types::DocumentColorParams,
+) -> anyhow::Result<Vec<lsp_types::ColorInformation>> {
+    let _p = tracing::info_span!("handle_document_color").entered();
+
+    Ok(vec![lsp_types::ColorInformation {
+        range: Range {
+            start: Position { line: 1, character: 1 },
+            end: Position { line: 1, character: 4 },
+        },
+        color: lsp_types::Color { red: 1.0, green: 1.0, blue: 1.0, alpha: 0.5 },
+    }])
+}
+
 pub(crate) fn handle_inlay_hints(
     snap: GlobalStateSnapshot,
     params: InlayHintParams,

--- a/crates/rust-analyzer/src/handlers/request.rs
+++ b/crates/rust-analyzer/src/handlers/request.rs
@@ -1713,19 +1713,16 @@ pub(crate) fn handle_ssr(
     to_proto::workspace_edit(&snap, source_change).map_err(Into::into)
 }
 
+#[allow(unused)]
 pub(crate) fn handle_document_color(
-    _snap: GlobalStateSnapshot,
-    _params: lsp_types::DocumentColorParams,
+    snap: GlobalStateSnapshot,
+    params: lsp_types::DocumentColorParams,
 ) -> anyhow::Result<Vec<lsp_types::ColorInformation>> {
     let _p = tracing::info_span!("handle_document_color").entered();
 
-    Ok(vec![lsp_types::ColorInformation {
-        range: Range {
-            start: Position { line: 1, character: 1 },
-            end: Position { line: 1, character: 4 },
-        },
-        color: lsp_types::Color { red: 1.0, green: 1.0, blue: 1.0, alpha: 0.5 },
-    }])
+    let file_id = try_default!(from_proto::file_id(&snap, &params.text_document.uri)?);
+
+    Ok(snap.analysis.document_color(file_id)?.into_iter().map(to_proto::document_color).collect())
 }
 
 pub(crate) fn handle_inlay_hints(

--- a/crates/rust-analyzer/src/lsp/capabilities.rs
+++ b/crates/rust-analyzer/src/lsp/capabilities.rs
@@ -91,7 +91,7 @@ pub fn server_capabilities(config: &Config) -> ServerCapabilities {
         })),
         linked_editing_range_provider: None,
         document_link_provider: None,
-        color_provider: None,
+        color_provider: Some(lsp_types::ColorProviderCapability::Simple(true)),
         execute_command_provider: None,
         workspace: Some(WorkspaceServerCapabilities {
             workspace_folders: Some(WorkspaceFoldersServerCapabilities {

--- a/crates/rust-analyzer/src/lsp/to_proto.rs
+++ b/crates/rust-analyzer/src/lsp/to_proto.rs
@@ -549,6 +549,16 @@ pub(crate) fn signature_help(
     }
 }
 
+pub(crate) fn document_color(c: ide::DocumentColor) -> lsp_types::ColorInformation {
+    lsp_types::ColorInformation {
+        range: lsp_types::Range {
+            start: lsp_types::Position { line: c.start_line, character: c.start_char },
+            end: lsp_types::Position { line: c.end_line, character: c.end_char },
+        },
+        color: lsp_types::Color { red: c.r, green: c.g, blue: c.b, alpha: c.a },
+    }
+}
+
 pub(crate) fn inlay_hint(
     snap: &GlobalStateSnapshot,
     fields_to_resolve: &InlayFieldsToResolve,

--- a/crates/rust-analyzer/src/main_loop.rs
+++ b/crates/rust-analyzer/src/main_loop.rs
@@ -1160,6 +1160,7 @@ impl GlobalState {
             .on::<NO_RETRY, lsp_request::GotoImplementation>(handlers::handle_goto_implementation)
             .on::<NO_RETRY, lsp_request::GotoTypeDefinition>(handlers::handle_goto_type_definition)
             .on::<NO_RETRY, lsp_request::InlayHintRequest>(handlers::handle_inlay_hints)
+            .on::<NO_RETRY, lsp_request::DocumentColor>(handlers::handle_document_color)
             .on_identity::<NO_RETRY, lsp_request::InlayHintResolveRequest, _>(handlers::handle_inlay_hints_resolve)
             .on::<NO_RETRY, lsp_request::CodeLensRequest>(handlers::handle_code_lens)
             .on_identity::<NO_RETRY, lsp_request::CodeLensResolve, _>(handlers::handle_code_lens_resolve)


### PR DESCRIPTION
Hi, I want to add `textDocument/documentColor` method to rust-analyzer, it will allow libraries with a type like `Color { r: u8, g: u8, b: u8 }` to annotate this type with special attributes `#[rust_analyzer::color::rgb]`.

IDEs can then annotate expressions known at compile time that of type `Color`
with color swatches, similar to how it works for CSS:

![image](https://github.com/user-attachments/assets/bccd7c27-65ef-4724-8c5f-258f28288008)

I added the feature to Helix from the client side (https://github.com/helix-editor/helix/pull/12308) and think it'd be fun to also add it from the server side. 

---

My current plan is to have an API like this:

```
#[rust_analyzer::color::rgb]
struct Color {
    #[rust_analyzer::color::rgb::r]
    red: f32,
    #[rust_analyzer::color::rgb::g]
    green: f32,
    #[rust_analyzer::color::rgb::b]
    blue: f32,
}

// the expression `Color { ... }` will have a red square next to it!
const RED: Color = Color {
    red: 255,
    green: 0,
    blue: 0,
};
```

This is what I want for a MVP:

 1. Visit every expression that is known at compile time (is `const`)
 1. If the type `struct` of the expression contains
    an attribute `#[rust_analyzer::color::rgb]`, proceed
 1. If there are 3 `f32` fields with attribute `#[rust_analyzer::color::rgb::{r,g,b}]`,
    then we have all the necessary information to construct the type itself

Currently, the problem that I face is that I cannot obtain the `Type` of an expression. `type_of_expr` returns `None`:

```rs
for event in file.preorder() {
    let syntax::WalkEvent::Leave(syntax_node) = event else { continue };
    let Some(expr) = syntax::ast::Expr::cast(syntax_node) else { continue };
    dbg!(&expr);

    // `type_of_expr` fails... but why?
    let Some(ty) = sema.type_of_expr(&expr) else { continue };
    dbg!(ty);
}
```

I'm building rust-analyzer with `cargo run --release` then in `.helix/languages.toml` I tell the editor to use the built binary:

```toml
[language-server.rust-analyzer]
command = "/home/e/contrib/rust-analyzer/target/release/rust-analyzer"
```

This works. I get hover information, auto-complete. I get custom logs in Helix's log (`:log-open`).

The current implementation draws a single red square in the file, so I assume the problem isn't with my setup