### PR TITLE
Fix assoc type where clause position

### DIFF
--- a/crates/ide-completion/src/tests/item_list.rs
+++ b/crates/ide-completion/src/tests/item_list.rs
@@ -458,6 +458,33 @@ type O = $0;
         r"
 struct A;
 trait B {
+type O<'a>
+where
+Self: 'a;
+}
+impl B for A {
+$0
+}
+",
+        r#"
+struct A;
+trait B {
+type O<'a>
+where
+Self: 'a;
+}
+impl B for A {
+type O<'a> = $0
+where
+Self: 'a;
+}
+"#,
+    );
+    check_edit(
+        "type O",
+        r"
+struct A;
+trait B {
 type O: ?Sized = u32;
 }
 impl B for A {


### PR DESCRIPTION
**Code**:

```rust
trait Foo {
    type X<'a> where Self: 'a;
}
impl Foo for () {
    $0
}
```

**Current**:

```rust
trait Foo {
    type X<'a> where Self: 'a;
}
impl Foo for () {
    type X<'a> where Self: 'a = $0;
}
```

**This pr fixed**:

```rust
trait Foo {
    type X<'a> where Self: 'a;
}
impl Foo for () {
    type X<'a> = $0 where Self: 'a;
}
```