### PR TITLE
Add tailexpr & -> &mut for generate_mut_trait_impl

### DIFF
--- a/crates/ide-assists/src/tests/generated.rs
+++ b/crates/ide-assists/src/tests/generated.rs
@@ -1933,7 +1933,7 @@ pub enum Axis { X = 0, Y = 1, Z = 2 }
 
 $0impl<T> core::ops::IndexMut<Axis> for [T; 3] {
     fn index_mut(&mut self, index: Axis) -> &mut Self::Output {
-        &self[index as usize]
+        &mut self[index as usize]
     }
 }
 


### PR DESCRIPTION
Implement simple `&` -> `&mut ` on tailexpr for `generate_mut_trait_impl`

https://github.com/rust-lang/rust-analyzer/issues/15581#issuecomment-1791859243

> But there should definitely be a rewrite rule for `&(...)[...]` to `&mut (...)[...]`, and perhaps other common cases. Just because the general problem is impossible doesn't mean the easy cases shouldn't be done; doing the easy cases is what assists are _for_.

