### PR TITLE
Add ide-assist: desugar_self_param

### DIFF
--- a/crates/ide-assists/src/handlers/desugar_self_param.rs
+++ b/crates/ide-assists/src/handlers/desugar_self_param.rs
@@ -1,0 +1,121 @@
+use ide_db::assists::AssistId;
+use syntax::{
+    AstNode,
+    ast::{self, make},
+};
+
+use crate::assist_context::{AssistContext, Assists};
+
+// Assist: desugar_self_param
+//
+// Replaces like `&self` with a `self: &Self` parameter.
+//
+// ```
+// struct Foo;
+// impl Foo {
+//     fn foo(&$0self) {}
+// }
+// ```
+// ->
+// ```
+// struct Foo;
+// impl Foo {
+//     fn foo(self: &Self) {}
+// }
+// ```
+pub(crate) fn desugar_self_param(acc: &mut Assists, ctx: &AssistContext<'_>) -> Option<()> {
+    let param = ctx.find_node_at_offset::<ast::SelfParam>()?;
+
+    if param.colon_token().is_some() {
+        return None;
+    }
+
+    let self_ty =
+        make::ty_path(make::path_unqualified(make::path_segment(make::name_ref_self_ty())));
+    let replace = match param.kind() {
+        ast::SelfParamKind::Owned => self_ty,
+        ast::SelfParamKind::Ref => make::ty_ref(self_ty, false),
+        ast::SelfParamKind::MutRef => make::ty_ref(self_ty, true),
+    };
+
+    let target = param.syntax().text_range();
+    acc.add(
+        AssistId::refactor_rewrite("desugar_self_param"),
+        format!("Replace `{param}` to `self: {replace}`"),
+        target,
+        |edit| {
+            edit.replace(target, format!("self: {replace}"));
+        },
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::tests::{check_assist, check_assist_not_applicable};
+
+    #[test]
+    fn test_desugar_self_param() {
+        check_assist(
+            desugar_self_param,
+            r#"
+                struct Foo;
+                impl Foo {
+                    fn foo(&$0self) {}
+                }
+            "#,
+            r#"
+                struct Foo;
+                impl Foo {
+                    fn foo(self: &Self) {}
+                }
+            "#,
+        );
+
+        check_assist(
+            desugar_self_param,
+            r#"
+                struct Foo;
+                impl Foo {
+                    fn foo(&$0mut self) {}
+                }
+            "#,
+            r#"
+                struct Foo;
+                impl Foo {
+                    fn foo(self: &mut Self) {}
+                }
+            "#,
+        );
+
+        check_assist(
+            desugar_self_param,
+            r#"
+                struct Foo;
+                impl Foo {
+                    fn foo($0self) {}
+                }
+            "#,
+            r#"
+                struct Foo;
+                impl Foo {
+                    fn foo(self: Self) {}
+                }
+            "#,
+        );
+    }
+
+    #[test]
+    fn test_desugar_self_param_not_applicable() {
+        check_assist_not_applicable(
+            desugar_self_param,
+            r#"
+                struct Foo;
+                impl Foo {
+                    fn foo($0self: &Self) {}
+                }
+            "#,
+        );
+    }
+}

--- a/crates/ide-assists/src/lib.rs
+++ b/crates/ide-assists/src/lib.rs
@@ -139,6 +139,7 @@ mod handlers {
     mod destructure_struct_binding;
     mod destructure_tuple_binding;
     mod desugar_doc_comment;
+    mod desugar_self_param;
     mod desugar_try_expr;
     mod expand_glob_import;
     mod expand_rest_pattern;
@@ -273,6 +274,7 @@ mod handlers {
             destructure_struct_binding::destructure_struct_binding,
             destructure_tuple_binding::destructure_tuple_binding,
             desugar_doc_comment::desugar_doc_comment,
+            desugar_self_param::desugar_self_param,
             desugar_try_expr::desugar_try_expr,
             expand_glob_import::expand_glob_import,
             expand_glob_import::expand_glob_reexport,

--- a/crates/ide-assists/src/tests/generated.rs
+++ b/crates/ide-assists/src/tests/generated.rs
@@ -930,6 +930,25 @@ comment"]
 }
 
 #[test]
+fn doctest_desugar_self_param() {
+    check_doc_test(
+        "desugar_self_param",
+        r#####"
+struct Foo;
+impl Foo {
+    fn foo(&$0self) {}
+}
+"#####,
+        r#####"
+struct Foo;
+impl Foo {
+    fn foo(self: &Self) {}
+}
+"#####,
+    )
+}
+
+#[test]
 fn doctest_desugar_try_expr_let_else() {
     check_doc_test(
         "desugar_try_expr_let_else",


### PR DESCRIPTION
Convenient for `&mut self` -> `self: &mut Self` -> `self: Pin<&mut Self>`

```rust
struct Foo;
impl Foo {
    fn foo(&$0self) {}
}
```
->
```rust
struct Foo;
impl Foo {
    fn foo(self: &Self) {}
}
```
