### PR TITLE
Fix ide-assist: generate Deref transitive

### DIFF
--- a/crates/ide-assists/src/handlers/generate_deref.rs
+++ b/crates/ide-assists/src/handlers/generate_deref.rs
@@ -10,7 +10,7 @@ use syntax::{
 use crate::{
     AssistId,
     assist_context::{AssistContext, Assists, SourceChangeBuilder},
-    utils::generate_trait_impl_text,
+    utils::generate_trait_impl_text_intransitive,
 };
 
 // Assist: generate_deref
@@ -150,7 +150,7 @@ fn generate_edit(
         ),
     };
     let strukt_adt = ast::Adt::Struct(strukt);
-    let deref_impl = generate_trait_impl_text(
+    let deref_impl = generate_trait_impl_text_intransitive(
         &strukt_adt,
         &trait_path.display(db, edition).to_string(),
         &impl_code,
@@ -224,6 +224,28 @@ impl core::ops::Deref for B {
         &self.a
     }
 }"#,
+        );
+    }
+
+    #[test]
+    fn test_generate_record_deref_with_generic() {
+        check_assist(
+            generate_deref,
+            r#"
+//- minicore: deref
+struct A<T>($0T);
+"#,
+            r#"
+struct A<T>(T);
+
+impl<T> core::ops::Deref for A<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+"#,
         );
     }
 

--- a/crates/ide-assists/src/utils.rs
+++ b/crates/ide-assists/src/utils.rs
@@ -567,6 +567,7 @@ pub(crate) fn generate_impl_text(adt: &ast::Adt, code: &str) -> String {
 ///
 /// This is useful for traits like `PartialEq`, since `impl<T> PartialEq for U<T>` often requires `T: PartialEq`.
 // FIXME: migrate remaining uses to `generate_trait_impl`
+#[allow(dead_code)]
 pub(crate) fn generate_trait_impl_text(adt: &ast::Adt, trait_text: &str, code: &str) -> String {
     generate_impl_text_inner(adt, Some(trait_text), true, code)
 }


### PR DESCRIPTION
# Example

```rust
struct Foo<T>($0T);
```

Current output:

```rust
struct Foo<T>(T);

impl<T: std::ops::Deref> std::ops::Deref for Foo<T> {
    type Target = T;

    fn deref(&self) -> &Self::Target {
        &self.0
    }
}
```

This PR fixed output:

```rust
struct Foo<T>(T);

impl<T> std::ops::Deref for Foo<T> {
    type Target = T;

    fn deref(&self) -> &Self::Target {
        &self.0
    }
}
```
