### PR TITLE
minor: Fix Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3103,6 +3103,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "stdx",
+ "time",
  "ungrammar",
  "write-json",
  "xflags",


### PR DESCRIPTION
The dependency of `xtask` on `time` was mistakenly removed.