### PR TITLE
Migrate `Convert_to_guarded_return` assist to use SyntaxEditor

### DIFF
--- a/crates/ide-assists/src/handlers/convert_to_guarded_return.rs
+++ b/crates/ide-assists/src/handlers/convert_to_guarded_return.rs
@@ -13,7 +13,6 @@ use syntax::{
         edit::{AstNodeEdit, IndentLevel},
         make,
     },
-    ted,
 };
 
 use crate::{
@@ -132,7 +131,6 @@ fn if_expr_to_guarded_return(
         "Convert to guarded return",
         target,
         |edit| {
-            let if_expr = edit.make_mut(if_expr);
             let if_indent_level = IndentLevel::from_node(if_expr.syntax());
             let replacement = match if_let_pat {
                 None => {
@@ -168,8 +166,9 @@ fn if_expr_to_guarded_return(
                         .take_while(|i| *i != end_of_then),
                 )
                 .collect();
-
-            ted::replace_with_many(if_expr.syntax(), then_statements)
+            let mut editor = edit.make_editor(if_expr.syntax());
+            editor.replace_with_many(if_expr.syntax(), then_statements);
+            edit.add_file_edits(ctx.vfs_file_id(), editor);
         },
     )
 }
@@ -214,7 +213,6 @@ fn let_stmt_to_guarded_return(
         "Convert to guarded return",
         target,
         |edit| {
-            let let_stmt = edit.make_mut(let_stmt);
             let let_indent_level = IndentLevel::from_node(let_stmt.syntax());
 
             let replacement = {
@@ -227,8 +225,9 @@ fn let_stmt_to_guarded_return(
                 let let_else_stmt = let_else_stmt.indent(let_indent_level);
                 let_else_stmt.syntax().clone()
             };
-
-            ted::replace(let_stmt.syntax(), replacement)
+            let mut editor = edit.make_editor(let_stmt.syntax());
+            editor.replace(let_stmt.syntax(), replacement);
+            edit.add_file_edits(ctx.vfs_file_id(), editor);
         },
     )
 }


### PR DESCRIPTION
part of https://github.com/rust-lang/rust-analyzer/issues/15710 and https://github.com/rust-lang/rust-analyzer/issues/18285