### PR TITLE
Configure triagebot to reopen bot PRs

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -28,3 +28,6 @@ labels = ["has-merge-commits", "S-waiting-on-author"]
 
 # Prevents mentions in commits to avoid users being spammed
 [no-mentions]
+
+# Automatically close and reopen PRs made by bots to run CI on them
+[bot-pull-requests]


### PR DESCRIPTION
Needed to unblock https://github.com/rust-lang/rust-analyzer/pull/20321. Sorry, I was thinking about this, but then I completely forgot about it.

Note that the solution isn't perfect, because CI will only run after the PR is opened, not after every push (the bot will force push every few days if the PR isn't merged quickly enough). We're working on improving that.