### PR TITLE
fix: Do not require all rename definitions to be renameable

### DIFF
--- a/crates/ide/src/rename.rs
+++ b/crates/ide/src/rename.rs
@@ -35,13 +35,8 @@ pub(crate) fn prepare_rename(
     let syntax = source_file.syntax();
 
     let res = find_definitions(&sema, syntax, position, &Name::new_symbol_root(sym::underscore))?
-        .map(|(frange, kind, def, _, _)| {
-            // ensure all ranges are valid
-
-            if def.range_for_rename(&sema).is_none() {
-                bail!("No references found at position")
-            }
-
+        .filter(|(_, _, def, _, _)| def.range_for_rename(&sema).is_some())
+        .map(|(frange, kind, _, _, _)| {
             always!(
                 frange.range.contains_inclusive(position.offset)
                     && frange.file_id == position.file_id


### PR DESCRIPTION
Might fix https://github.com/rust-lang/rust-analyzer/issues/20332 have not tested it but the logic here seems flawed either way after recent changes to the codebase