### PR TITLE
add `SyntaxEditor::delete_all` to migrate utils.rs `add_trait_assoc_items_to_impl`

### DIFF
--- a/crates/syntax/src/syntax_editor.rs
+++ b/crates/syntax/src/syntax_editor.rs
@@ -83,6 +83,16 @@ impl SyntaxEditor {
         self.changes.push(Change::Replace(element.syntax_element(), None));
     }
 
+    pub fn delete_all(&mut self, range: RangeInclusive<SyntaxElement>) {
+        if range.start() == range.end() {
+            self.delete(range.start());
+            return;
+        }
+
+        debug_assert!(is_ancestor_or_self_of_element(range.start(), &self.root));
+        self.changes.push(Change::ReplaceAll(range, Vec::new()))
+    }
+
     pub fn replace(&mut self, old: impl Element, new: impl Element) {
         let old = old.syntax_element();
         debug_assert!(is_ancestor_or_self_of_element(&old, &self.root));


### PR DESCRIPTION
part of https://github.com/rust-lang/rust-analyzer/issues/15710 and https://github.com/rust-lang/rust-analyzer/issues/18285

I add `delete_all` instead of [`ted::remove_all`.](https://github.com/rust-lang/rust-analyzer/blob/8611b714597c89b092f3d4874f14acd3f72f44fd/crates/syntax/src/ted.rs#L116)

`delete_all` was called from syntax_editor/edit.rs `ast::TypeBoundList{ fn remove}` like as `ted::remove_all`  in [`ast::TypeBoundList{ fn remove}`](https://github.com/rust-lang/rust-analyzer/blob/8611b714597c89b092f3d4874f14acd3f72f44fd/crates/syntax/src/ast/edit_in_place.rs#L413C1-L420C2) of edit_in_place.rs
