### PR TITLE
fix(hover): unify horizontal rule formatting to `---`

### DIFF
--- a/crates/ide/src/hover/render.rs
+++ b/crates/ide/src/hover/render.rs
@@ -361,7 +361,7 @@ pub(super) fn try_for_lint(attr: &ast::Attr, token: &SyntaxToken) -> Option<Hove
     let lint =
         lints.binary_search_by_key(&needle, |lint| lint.label).ok().map(|idx| &lints[idx])?;
     Some(HoverResult {
-        markup: Markup::from(format!("```\n{}\n```\n___\n\n{}", lint.label, lint.description)),
+        markup: Markup::from(format!("```\n{}\n```\n---\n\n{}", lint.label, lint.description)),
         ..Default::default()
     })
 }
@@ -912,7 +912,7 @@ pub(super) fn literal(
     };
     let ty = ty.display(sema.db, display_target);
 
-    let mut s = format!("```rust\n{ty}\n```\n___\n\n");
+    let mut s = format!("```rust\n{ty}\n```\n---\n\n");
     match value {
         Ok(value) => {
             let backtick_len = value.chars().filter(|c| *c == '`').count();
@@ -1026,7 +1026,7 @@ fn type_info(
         if let Some(extra) =
             render_notable_trait(db, &notable_traits(db, &original), edition, display_target)
         {
-            desc.push_str("\n___\n");
+            desc.push_str("\n---\n");
             desc.push_str(&extra);
         };
         desc.into()
@@ -1094,7 +1094,7 @@ fn closure_ty(
         |_| None,
         |_| None,
     ) {
-        format_to!(markup, "\n___\n{layout}");
+        format_to!(markup, "\n---\n{layout}");
     }
     format_to!(markup, "{adjusted}\n\n## Captures\n{}", captures_rendered,);
 

--- a/crates/ide/src/hover/tests.rs
+++ b/crates/ide/src/hover/tests.rs
@@ -357,7 +357,7 @@ fn main() {
             ```rust
             impl Fn(i32) -> i32
             ```
-            ___
+            ---
             size = 8, align = 8, niches = 1
 
             ## Captures
@@ -380,7 +380,7 @@ fn main() {
             ```rust
             impl Fn(i32) -> i32
             ```
-            ___
+            ---
             size = 0, align = 1
 
             ## Captures
@@ -414,7 +414,7 @@ fn main() {
             ```rust
             impl FnOnce()
             ```
-            ___
+            ---
             size = 16 (0x10), align = 8, niches = 1
 
             ## Captures
@@ -443,7 +443,7 @@ fn main() {
             ```rust
             impl FnMut()
             ```
-            ___
+            ---
             size = 8, align = 8, niches = 1
 
             ## Captures
@@ -468,7 +468,7 @@ fn main() {
             ```rust
             impl FnOnce() -> S2
             ```
-            ___
+            ---
             size = 8, align = 8, niches = 1
             Coerced to: &impl FnOnce() -> S2
 
@@ -6829,7 +6829,7 @@ fn hover_lint() {
                 ```
                 arithmetic_overflow
                 ```
-                ___
+                ---
 
                 arithmetic operation overflows
             "#]],
@@ -6841,7 +6841,7 @@ fn hover_lint() {
                 ```
                 arithmetic_overflow
                 ```
-                ___
+                ---
 
                 arithmetic operation overflows
             "#]],
@@ -6857,7 +6857,7 @@ fn hover_clippy_lint() {
                 ```
                 clippy::almost_swapped
                 ```
-                ___
+                ---
 
                 Checks for `foo = bar; bar = foo` sequences.
             "#]],
@@ -6869,7 +6869,7 @@ fn hover_clippy_lint() {
                 ```
                 clippy::almost_swapped
                 ```
-                ___
+                ---
 
                 Checks for `foo = bar; bar = foo` sequences.
             "#]],
@@ -8567,7 +8567,7 @@ fn main() {
             ```rust
             &'static str
             ```
-            ___
+            ---
 
             value of literal: ` 🦀🦀\A `
         "#]],
@@ -8583,7 +8583,7 @@ fn main() {
             ```rust
             &'static str
             ```
-            ___
+            ---
 
             value of literal: ` 🦀\u{1f980}\\\x41 `
         "#]],
@@ -8605,7 +8605,7 @@ fsdghs";
             ```rust
             &'static str
             ```
-            ___
+            ---
 
             value of literal (truncated up to newline): ` 🦀\u{1f980}\\\x41 `
         "#]],
@@ -8625,7 +8625,7 @@ fn main() {
             ```rust
             &'static {unknown}
             ```
-            ___
+            ---
 
             value of literal: ` 🦀🦀\A `
         "#]],
@@ -8644,7 +8644,7 @@ fn main() {
             ```rust
             &'static str
             ```
-            ___
+            ---
 
             value of literal: ```` `[^`]*` ````
         "#]],
@@ -8659,7 +8659,7 @@ fn main() {
             ```rust
             &'static str
             ```
-            ___
+            ---
 
             value of literal: `` ` ``
         "#]],
@@ -8674,7 +8674,7 @@ fn main() {
             ```rust
             &'static str
             ```
-            ___
+            ---
 
             value of literal: `    `
         "#]],
@@ -8690,7 +8690,7 @@ fn main() {
             ```rust
             &'static str
             ```
-            ___
+            ---
 
             value of literal: `  Hello World  `
         "#]],
@@ -8710,7 +8710,7 @@ fn main() {
             ```rust
             &'static [u8; 5]
             ```
-            ___
+            ---
 
             value of literal: ` [240, 159, 166, 128, 92] `
         "#]],
@@ -8726,7 +8726,7 @@ fn main() {
             ```rust
             &'static [u8; 18]
             ```
-            ___
+            ---
 
             value of literal: ` [92, 120, 70, 48, 92, 120, 57, 70, 92, 120, 65, 54, 92, 120, 56, 48, 92, 92] `
         "#]],
@@ -8746,7 +8746,7 @@ fn main() {
             ```rust
             u8
             ```
-            ___
+            ---
 
             value of literal: ` 0xF0 `
         "#]],
@@ -8762,7 +8762,7 @@ fn main() {
             ```rust
             u8
             ```
-            ___
+            ---
 
             value of literal: ` 0x5C `
         "#]],
@@ -8782,7 +8782,7 @@ fn main() {
             ```rust
             char
             ```
-            ___
+            ---
 
             value of literal: ` A `
         "#]],
@@ -8798,7 +8798,7 @@ fn main() {
             ```rust
             char
             ```
-            ___
+            ---
 
             value of literal: ` \ `
         "#]],
@@ -8814,7 +8814,7 @@ fn main() {
             ```rust
             char
             ```
-            ___
+            ---
 
             value of literal: ` 🦀 `
         "#]],
@@ -8834,7 +8834,7 @@ fn main() {
             ```rust
             f64
             ```
-            ___
+            ---
 
             value of literal: ` 1 (bits: 0x3FF0000000000000) `
         "#]],
@@ -8850,7 +8850,7 @@ fn main() {
             ```rust
             f16
             ```
-            ___
+            ---
 
             value of literal: ` 1 (bits: 0x3C00) `
         "#]],
@@ -8866,7 +8866,7 @@ fn main() {
             ```rust
             f32
             ```
-            ___
+            ---
 
             value of literal: ` 1 (bits: 0x3F800000) `
         "#]],
@@ -8882,7 +8882,7 @@ fn main() {
             ```rust
             f128
             ```
-            ___
+            ---
 
             value of literal: ` 1 (bits: 0x3FFF0000000000000000000000000000) `
         "#]],
@@ -8898,7 +8898,7 @@ fn main() {
             ```rust
             f64
             ```
-            ___
+            ---
 
             value of literal: ` 134000000000000 (bits: 0x42DE77D399980000) `
         "#]],
@@ -8914,7 +8914,7 @@ fn main() {
             ```rust
             f64
             ```
-            ___
+            ---
 
             value of literal: ` 1523527134274733600000000 (bits: 0x44F429E9249F629B) `
         "#]],
@@ -8930,7 +8930,7 @@ fn main() {
             ```rust
             f64
             ```
-            ___
+            ---
 
             invalid literal: invalid float literal
         "#]],
@@ -8950,7 +8950,7 @@ fn main() {
             ```rust
             i32
             ```
-            ___
+            ---
 
             value of literal: ` 34325236457856836345234 (0x744C659178614489D92|0b111010001001100011001011001000101111000011000010100010010001001110110010010) `
         "#]],
@@ -8966,7 +8966,7 @@ fn main() {
             ```rust
             i32
             ```
-            ___
+            ---
 
             value of literal: ` 13412342421 (0x31F701A95|0b1100011111011100000001101010010101) `
         "#]],
@@ -8982,7 +8982,7 @@ fn main() {
             ```rust
             i32
             ```
-            ___
+            ---
 
             value of literal: ` 306328611 (0x12423423|0b10010010000100011010000100011) `
         "#]],
@@ -8998,7 +8998,7 @@ fn main() {
             ```rust
             i32
             ```
-            ___
+            ---
 
             value of literal: ` 255 (0xFF|0b11111111) `
         "#]],
@@ -9014,7 +9014,7 @@ fn main() {
             ```rust
             i32
             ```
-            ___
+            ---
 
             value of literal: ` 5349 (0x14E5|0b1010011100101) `
         "#]],
@@ -9030,7 +9030,7 @@ fn main() {
             ```rust
             i32
             ```
-            ___
+            ---
 
             invalid literal: number too large to fit in target type
         "#]],
@@ -9186,7 +9186,7 @@ fn main() {
             ```rust
             S
             ```
-            ___
+            ---
             Implements notable traits: `Future<Output = u32>`, `Iterator<Item = S>`, `Notable`"#]],
     );
 }


### PR DESCRIPTION
Currently, hover documentation uses both `___` and `---` as horizontal rule delimiters. While both styles are valid according to the GitHub Flavored Markdown Spec, the mixed usage seems accidental to me.

This PR change all horizontal breaks to `---` because it is less ambiguous and already more common in rust-analyzer than `___`.

I also believe that such consistency makes the code and tests a bit easier to maintain.