### PR TITLE
remove `add_attr()` from edit_in_place.rs because it use `ted`.

### DIFF
--- a/crates/ide-assists/src/handlers/convert_bool_to_enum.rs
+++ b/crates/ide-assists/src/handlers/convert_bool_to_enum.rs
@@ -13,12 +13,7 @@ use ide_db::{
 use itertools::Itertools;
 use syntax::{
     AstNode, NodeOrToken, SyntaxKind, SyntaxNode, T,
-    ast::{
-        self, HasName,
-        edit::IndentLevel,
-        edit_in_place::{AttrsOwnerEdit, Indent},
-        make,
-    },
+    ast::{self, HasName, edit::IndentLevel, edit_in_place::Indent, make},
 };
 
 use crate::{
@@ -506,18 +501,6 @@ fn node_to_insert_before(target_node: SyntaxNode) -> SyntaxNode {
 }
 
 fn make_bool_enum(make_pub: bool) -> ast::Enum {
-    let enum_def = make::enum_(
-        if make_pub { Some(make::visibility_pub()) } else { None },
-        make::name("Bool"),
-        None,
-        None,
-        make::variant_list(vec![
-            make::variant(None, make::name("True"), None, None),
-            make::variant(None, make::name("False"), None, None),
-        ]),
-    )
-    .clone_for_update();
-
     let derive_eq = make::attr_outer(make::meta_token_tree(
         make::ext::ident_path("derive"),
         make::token_tree(
@@ -529,11 +512,19 @@ fn make_bool_enum(make_pub: bool) -> ast::Enum {
                 NodeOrToken::Token(make::tokens::ident("Eq")),
             ],
         ),
-    ))
-    .clone_for_update();
-    enum_def.add_attr(derive_eq);
-
-    enum_def
+    ));
+    make::enum_(
+        [derive_eq],
+        if make_pub { Some(make::visibility_pub()) } else { None },
+        make::name("Bool"),
+        None,
+        None,
+        make::variant_list(vec![
+            make::variant(None, make::name("True"), None, None),
+            make::variant(None, make::name("False"), None, None),
+        ]),
+    )
+    .clone_for_update()
 }
 
 #[cfg(test)]

--- a/crates/ide-assists/src/handlers/convert_closure_to_fn.rs
+++ b/crates/ide-assists/src/handlers/convert_closure_to_fn.rs
@@ -236,6 +236,7 @@ pub(crate) fn convert_closure_to_fn(acc: &mut Assists, ctx: &AssistContext<'_>) 
             };
             let mut fn_ = make::fn_(
                 None,
+                None,
                 closure_name_or_default.clone(),
                 closure_type_params,
                 closure_where_clause,

--- a/crates/ide-assists/src/handlers/convert_from_to_tryfrom.rs
+++ b/crates/ide-assists/src/handlers/convert_from_to_tryfrom.rs
@@ -96,6 +96,7 @@ pub(crate) fn convert_from_to_tryfrom(acc: &mut Assists, ctx: &AssistContext<'_>
             }
 
             let error_type = ast::AssocItem::TypeAlias(make::ty_alias(
+                None,
                 "Error",
                 None,
                 None,

--- a/crates/ide-assists/src/handlers/extract_function.rs
+++ b/crates/ide-assists/src/handlers/extract_function.rs
@@ -1642,6 +1642,7 @@ fn format_function(
 
     make::fn_(
         None,
+        None,
         fun_name,
         generic_params,
         where_clause,

--- a/crates/ide-assists/src/handlers/extract_module.rs
+++ b/crates/ide-assists/src/handlers/extract_module.rs
@@ -586,6 +586,7 @@ impl Module {
             if (def_out_sel || !is_item) && use_stmt_not_in_sel {
                 let use_ = make::use_(
                     None,
+                    None,
                     make::use_tree(make::join_paths(use_tree_paths), None, None, false),
                 );
                 self.use_items.insert(0, ast::Item::from(use_));
@@ -599,6 +600,7 @@ impl Module {
         let super_path = make::ext::ident_path("super");
         let node_path = make::ext::ident_path(&node_syntax.to_string());
         let use_ = make::use_(
+            None,
             None,
             make::use_tree(make::join_paths(vec![super_path, node_path]), None, None, false),
         );

--- a/crates/ide-assists/src/handlers/extract_type_alias.rs
+++ b/crates/ide-assists/src/handlers/extract_type_alias.rs
@@ -69,8 +69,9 @@ pub(crate) fn extract_type_alias(acc: &mut Assists, ctx: &AssistContext<'_>) -> 
             edit.replace(ty.syntax(), new_ty.syntax());
 
             // Insert new alias
-            let ty_alias = make::ty_alias("Type", generic_params, None, None, Some((ty, None)))
-                .clone_for_update();
+            let ty_alias =
+                make::ty_alias(None, "Type", generic_params, None, None, Some((ty, None)))
+                    .clone_for_update();
 
             if let Some(cap) = ctx.config.snippet_cap
                 && let Some(name) = ty_alias.name()

--- a/crates/ide-assists/src/handlers/extract_variable.rs
+++ b/crates/ide-assists/src/handlers/extract_variable.rs
@@ -200,7 +200,7 @@ pub(crate) fn extract_variable(acc: &mut Assists, ctx: &AssistContext<'_>) -> Op
                     }
                     ExtractionKind::Constant => {
                         let ast_ty = make.ty(&ty_string);
-                        ast::Item::Const(make.item_const(None, pat_name, ast_ty, initializer))
+                        ast::Item::Const(make.item_const(None, None, pat_name, ast_ty, initializer))
                             .into()
                     }
                     ExtractionKind::Static => {

--- a/crates/ide-assists/src/handlers/generate_delegate_methods.rs
+++ b/crates/ide-assists/src/handlers/generate_delegate_methods.rs
@@ -155,6 +155,7 @@ pub(crate) fn generate_delegate_methods(acc: &mut Assists, ctx: &AssistContext<'
                 let ret_type = method_source.ret_type();
 
                 let f = make::fn_(
+                    None,
                     vis,
                     fn_name,
                     type_params,
@@ -195,6 +196,7 @@ pub(crate) fn generate_delegate_methods(acc: &mut Assists, ctx: &AssistContext<'
                         let assoc_item_list = make::assoc_item_list(Some(vec![item]));
 
                         let impl_def = make::impl_(
+                            None,
                             ty_params,
                             ty_args,
                             make::ty_path(make::ext::ident_path(name)),

--- a/crates/ide-assists/src/handlers/generate_fn_type_alias.rs
+++ b/crates/ide-assists/src/handlers/generate_fn_type_alias.rs
@@ -94,6 +94,7 @@ pub(crate) fn generate_fn_type_alias(acc: &mut Assists, ctx: &AssistContext<'_>)
 
                 // Insert new alias
                 let ty_alias = make::ty_alias(
+                    None,
                     &alias_name,
                     generic_params,
                     None,

--- a/crates/ide-assists/src/handlers/generate_function.rs
+++ b/crates/ide-assists/src/handlers/generate_function.rs
@@ -189,7 +189,7 @@ fn add_func_to_accumulator(
             )));
 
             // FIXME: adt may have generic params.
-            let impl_ = make::impl_(None, None, name, None, None).clone_for_update();
+            let impl_ = make::impl_(None, None, None, name, None, None).clone_for_update();
 
             func.indent(IndentLevel(1));
             impl_.get_or_create_assoc_item_list().add_item(func.into());
@@ -365,6 +365,7 @@ impl FunctionBuilder {
             Visibility::Pub => Some(make::visibility_pub()),
         };
         let fn_def = make::fn_(
+            None,
             visibility,
             self.fn_name,
             self.generic_param_list,

--- a/crates/ide-assists/src/handlers/generate_getter_or_setter.rs
+++ b/crates/ide-assists/src/handlers/generate_getter_or_setter.rs
@@ -263,6 +263,7 @@ fn generate_getter_from_info(
     let body = make::block_expr([], Some(body));
 
     make::fn_(
+        None,
         strukt.visibility(),
         fn_name,
         None,
@@ -299,6 +300,7 @@ fn generate_setter_from_info(info: &AssistInfo, record_field_info: &RecordFieldI
 
     // Make the setter fn
     make::fn_(
+        None,
         strukt.visibility(),
         fn_name,
         None,

--- a/crates/ide-assists/src/handlers/generate_impl.rs
+++ b/crates/ide-assists/src/handlers/generate_impl.rs
@@ -174,6 +174,7 @@ pub(crate) fn generate_impl_trait(acc: &mut Assists, ctx: &AssistContext<'_>) ->
 
             let make_impl_ = |body| {
                 make::impl_trait(
+                    None,
                     trait_.unsafe_token().is_some(),
                     None,
                     trait_gen_args.clone(),

--- a/crates/ide-assists/src/handlers/generate_new.rs
+++ b/crates/ide-assists/src/handlers/generate_new.rs
@@ -134,6 +134,7 @@ pub(crate) fn generate_new(acc: &mut Assists, ctx: &AssistContext<'_>) -> Option
         let ret_type = make::ret_type(make::ty_path(make::ext::ident_path("Self")));
 
         let fn_ = make::fn_(
+            None,
             strukt.visibility(),
             make::name("new"),
             None,

--- a/crates/ide-assists/src/handlers/promote_local_to_const.rs
+++ b/crates/ide-assists/src/handlers/promote_local_to_const.rs
@@ -88,7 +88,7 @@ pub(crate) fn promote_local_to_const(acc: &mut Assists, ctx: &AssistContext<'_>)
                 }
             }
 
-            let item = make.item_const(None, make.name(&name), make.ty(&ty), initializer);
+            let item = make.item_const(None, None, make.name(&name), make.ty(&ty), initializer);
 
             if let Some((cap, name)) = ctx.config.snippet_cap.zip(item.name()) {
                 let tabstop = edit.make_tabstop_before(cap);

--- a/crates/ide-assists/src/handlers/unmerge_imports.rs
+++ b/crates/ide-assists/src/handlers/unmerge_imports.rs
@@ -1,9 +1,6 @@
 use syntax::{
     AstNode, SyntaxKind,
-    ast::{
-        self, HasAttrs, HasVisibility, edit::IndentLevel, edit_in_place::AttrsOwnerEdit, make,
-        syntax_factory::SyntaxFactory,
-    },
+    ast::{self, HasAttrs, HasVisibility, edit::IndentLevel, make, syntax_factory::SyntaxFactory},
     syntax_editor::{Element, Position, Removable},
 };
 
@@ -46,13 +43,10 @@ pub(crate) fn unmerge_imports(acc: &mut Assists, ctx: &AssistContext<'_>) -> Opt
     acc.add(AssistId::refactor_rewrite("unmerge_imports"), label, target, |builder| {
         let make = SyntaxFactory::with_mappings();
         let new_use = make.use_(
+            use_.attrs(),
             use_.visibility(),
             make.use_tree(path, tree.use_tree_list(), tree.rename(), tree.star_token().is_some()),
         );
-        // Add any attributes that are present on the use tree
-        use_.attrs().for_each(|attr| {
-            new_use.add_attr(attr.clone_for_update());
-        });
 
         let mut editor = builder.make_editor(use_.syntax());
         // Remove the use tree from the current use item

--- a/crates/ide-assists/src/utils.rs
+++ b/crates/ide-assists/src/utils.rs
@@ -736,8 +736,11 @@ fn generate_impl_inner(
         generic_params.as_ref().map(|params| params.to_generic_args().clone_for_update());
     let ty = make::ty_path(make::ext::ident_path(&adt.name().unwrap().text()));
 
-    let impl_ = match trait_ {
+    let cfg_attrs =
+        adt.attrs().filter(|attr| attr.as_simple_call().is_some_and(|(name, _arg)| name == "cfg"));
+    match trait_ {
         Some(trait_) => make::impl_trait(
+            cfg_attrs,
             is_unsafe,
             None,
             None,
@@ -750,26 +753,9 @@ fn generate_impl_inner(
             adt.where_clause(),
             body,
         ),
-        None => make::impl_(generic_params, generic_args, ty, adt.where_clause(), body),
+        None => make::impl_(cfg_attrs, generic_params, generic_args, ty, adt.where_clause(), body),
     }
-    .clone_for_update();
-
-    // Copy any cfg attrs from the original adt
-    add_cfg_attrs_to(adt, &impl_);
-
-    impl_
-}
-
-pub(crate) fn add_cfg_attrs_to<T, U>(from: &T, to: &U)
-where
-    T: HasAttrs,
-    U: AttrsOwnerEdit,
-{
-    let cfg_attrs =
-        from.attrs().filter(|attr| attr.as_simple_call().is_some_and(|(name, _arg)| name == "cfg"));
-    for attr in cfg_attrs {
-        to.add_attr(attr.clone_for_update());
-    }
+    .clone_for_update()
 }
 
 pub(crate) fn add_method_to_adt(

--- a/crates/ide-db/src/imports/insert_use.rs
+++ b/crates/ide-db/src/imports/insert_use.rs
@@ -194,7 +194,7 @@ fn insert_use_with_alias_option(
         use_tree = use_tree.clone_for_update();
         use_tree.wrap_in_tree_list();
     }
-    let use_item = make::use_(None, use_tree).clone_for_update();
+    let use_item = make::use_(None, None, use_tree).clone_for_update();
     for attr in
         scope.required_cfgs.iter().map(|attr| attr.syntax().clone_subtree().clone_for_update())
     {

--- a/crates/syntax/src/ast/edit_in_place.rs
+++ b/crates/syntax/src/ast/edit_in_place.rs
@@ -273,28 +273,6 @@ pub trait AttrsOwnerEdit: ast::HasAttrs {
             }
         }
     }
-
-    fn add_attr(&self, attr: ast::Attr) {
-        add_attr(self.syntax(), attr);
-
-        fn add_attr(node: &SyntaxNode, attr: ast::Attr) {
-            let indent = IndentLevel::from_node(node);
-            attr.reindent_to(indent);
-
-            let after_attrs_and_comments = node
-                .children_with_tokens()
-                .find(|it| !matches!(it.kind(), WHITESPACE | COMMENT | ATTR))
-                .map_or(Position::first_child_of(node), Position::before);
-
-            ted::insert_all(
-                after_attrs_and_comments,
-                vec![
-                    attr.syntax().clone().into(),
-                    make::tokens::whitespace(&format!("\n{indent}")).into(),
-                ],
-            )
-        }
-    }
 }
 
 impl<T: ast::HasAttrs> AttrsOwnerEdit for T {}

--- a/crates/syntax/src/ast/make.rs
+++ b/crates/syntax/src/ast/make.rs
@@ -190,6 +190,7 @@ fn ty_from_text(text: &str) -> ast::Type {
 }
 
 pub fn ty_alias(
+    attrs: impl IntoIterator<Item = ast::Attr>,
     ident: &str,
     generic_param_list: Option<ast::GenericParamList>,
     type_param_bounds: Option<ast::TypeParam>,
@@ -200,6 +201,7 @@ pub fn ty_alias(
     let assignment_where = assignment_where.flatten();
     quote! {
         TypeAlias {
+            #(#attrs "\n")*
             [type] " "
                 Name { [IDENT ident] }
                 #generic_param_list
@@ -277,12 +279,16 @@ fn merge_where_clause(
 }
 
 pub fn impl_(
+    attrs: impl IntoIterator<Item = ast::Attr>,
     generic_params: Option<ast::GenericParamList>,
     generic_args: Option<ast::GenericArgList>,
     path_type: ast::Type,
     where_clause: Option<ast::WhereClause>,
     body: Option<ast::AssocItemList>,
 ) -> ast::Impl {
+    let attrs =
+        attrs.into_iter().fold(String::new(), |mut acc, attr| format_to_acc!(acc, "{}\n", attr));
+
     let gen_args = generic_args.map_or_else(String::new, |it| it.to_string());
 
     let gen_params = generic_params.map_or_else(String::new, |it| it.to_string());
@@ -295,10 +301,11 @@ pub fn impl_(
     };
 
     let body = body.map_or_else(|| format!("{{{body_newline}}}"), |it| it.to_string());
-    ast_from_text(&format!("impl{gen_params} {path_type}{gen_args}{where_clause}{body}"))
+    ast_from_text(&format!("{attrs}impl{gen_params} {path_type}{gen_args}{where_clause}{body}"))
 }
 
 pub fn impl_trait(
+    attrs: impl IntoIterator<Item = ast::Attr>,
     is_unsafe: bool,
     trait_gen_params: Option<ast::GenericParamList>,
     trait_gen_args: Option<ast::GenericArgList>,
@@ -311,6 +318,8 @@ pub fn impl_trait(
     ty_where_clause: Option<ast::WhereClause>,
     body: Option<ast::AssocItemList>,
 ) -> ast::Impl {
+    let attrs =
+        attrs.into_iter().fold(String::new(), |mut acc, attr| format_to_acc!(acc, "{}\n", attr));
     let is_unsafe = if is_unsafe { "unsafe " } else { "" };
 
     let trait_gen_args = trait_gen_args.map(|args| args.to_string()).unwrap_or_default();
@@ -334,7 +343,7 @@ pub fn impl_trait(
     let body = body.map_or_else(|| format!("{{{body_newline}}}"), |it| it.to_string());
 
     ast_from_text(&format!(
-        "{is_unsafe}impl{gen_params} {is_negative}{path_type}{trait_gen_args} for {ty}{type_gen_args}{where_clause}{body}"
+        "{attrs}{is_unsafe}impl{gen_params} {is_negative}{path_type}{trait_gen_args} for {ty}{type_gen_args}{where_clause}{body}"
     ))
 }
 
@@ -452,12 +461,18 @@ pub fn use_tree_list(use_trees: impl IntoIterator<Item = ast::UseTree>) -> ast::
     ast_from_text(&format!("use {{{use_trees}}};"))
 }
 
-pub fn use_(visibility: Option<ast::Visibility>, use_tree: ast::UseTree) -> ast::Use {
+pub fn use_(
+    attrs: impl IntoIterator<Item = ast::Attr>,
+    visibility: Option<ast::Visibility>,
+    use_tree: ast::UseTree,
+) -> ast::Use {
+    let attrs =
+        attrs.into_iter().fold(String::new(), |mut acc, attr| format_to_acc!(acc, "{}\n", attr));
     let visibility = match visibility {
         None => String::new(),
         Some(it) => format!("{it} "),
     };
-    ast_from_text(&format!("{visibility}use {use_tree};"))
+    ast_from_text(&format!("{attrs}{visibility}use {use_tree};"))
 }
 
 pub fn record_expr(path: ast::Path, fields: ast::RecordExprFieldList) -> ast::RecordExpr {
@@ -946,16 +961,19 @@ pub fn expr_stmt(expr: ast::Expr) -> ast::ExprStmt {
 }
 
 pub fn item_const(
+    attrs: impl IntoIterator<Item = ast::Attr>,
     visibility: Option<ast::Visibility>,
     name: ast::Name,
     ty: ast::Type,
     expr: ast::Expr,
 ) -> ast::Const {
+    let attrs =
+        attrs.into_iter().fold(String::new(), |mut acc, attr| format_to_acc!(acc, "{}\n", attr));
     let visibility = match visibility {
         None => String::new(),
         Some(it) => format!("{it} "),
     };
-    ast_from_text(&format!("{visibility}const {name}: {ty} = {expr};"))
+    ast_from_text(&format!("{attrs}{visibility}const {name}: {ty} = {expr};"))
 }
 
 pub fn item_static(
@@ -1162,6 +1180,7 @@ pub fn variant(
 }
 
 pub fn fn_(
+    attrs: impl IntoIterator<Item = ast::Attr>,
     visibility: Option<ast::Visibility>,
     fn_name: ast::Name,
     type_params: Option<ast::GenericParamList>,
@@ -1174,6 +1193,8 @@ pub fn fn_(
     is_unsafe: bool,
     is_gen: bool,
 ) -> ast::Fn {
+    let attrs =
+        attrs.into_iter().fold(String::new(), |mut acc, attr| format_to_acc!(acc, "{}\n", attr));
     let type_params = match type_params {
         Some(type_params) => format!("{type_params}"),
         None => "".into(),
@@ -1197,7 +1218,7 @@ pub fn fn_(
     let gen_literal = if is_gen { "gen " } else { "" };
 
     ast_from_text(&format!(
-        "{visibility}{const_literal}{async_literal}{gen_literal}{unsafe_literal}fn {fn_name}{type_params}{params} {ret_type}{where_clause}{body}",
+        "{attrs}{visibility}{const_literal}{async_literal}{gen_literal}{unsafe_literal}fn {fn_name}{type_params}{params} {ret_type}{where_clause}{body}",
     ))
 }
 pub fn struct_(
@@ -1217,12 +1238,15 @@ pub fn struct_(
 }
 
 pub fn enum_(
+    attrs: impl IntoIterator<Item = ast::Attr>,
     visibility: Option<ast::Visibility>,
     enum_name: ast::Name,
     generic_param_list: Option<ast::GenericParamList>,
     where_clause: Option<ast::WhereClause>,
     variant_list: ast::VariantList,
 ) -> ast::Enum {
+    let attrs =
+        attrs.into_iter().fold(String::new(), |mut acc, attr| format_to_acc!(acc, "{}\n", attr));
     let visibility = match visibility {
         None => String::new(),
         Some(it) => format!("{it} "),
@@ -1232,7 +1256,7 @@ pub fn enum_(
     let where_clause = where_clause.map(|it| format!(" {it}")).unwrap_or_default();
 
     ast_from_text(&format!(
-        "{visibility}enum {enum_name}{generic_params}{where_clause} {variant_list}"
+        "{attrs}{visibility}enum {enum_name}{generic_params}{where_clause} {variant_list}"
     ))
 }
 

--- a/crates/syntax/src/syntax_editor.rs
+++ b/crates/syntax/src/syntax_editor.rs
@@ -619,6 +619,7 @@ mod tests {
     fn test_replace_token_in_parent() {
         let parent_fn = make::fn_(
             None,
+            None,
             make::name("it"),
             None,
             None,


### PR DESCRIPTION
part of https://github.com/rust-lang/rust-analyzer/issues/15710 and https://github.com/rust-lang/rust-analyzer/issues/18285

I set attrs when I use `make::`.
I remove [add_attr()](https://github.com/rust-lang/rust/blob/e1b9081e699065badfc1a9419ec9566e5c8615c4/src/tools/rust-analyzer/crates/syntax/src/ast/edit_in_place.rs#L277)