### PR TITLE
fix external docs for exported macros

### DIFF
--- a/crates/ide/src/doc_links.rs
+++ b/crates/ide/src/doc_links.rs
@@ -390,7 +390,8 @@ fn get_doc_links(
 
     let (mut web_url, mut local_url) = get_doc_base_urls(db, target, target_dir, sysroot);
 
-    if let Some(path) = mod_path_of_def(db, target) {
+    let append_mod = !matches!(def, Definition::Macro(m) if m.is_macro_export(db));
+    if append_mod && let Some(path) = mod_path_of_def(db, target) {
         web_url = join_url(web_url, &path);
         local_url = join_url(local_url, &path);
     }

--- a/crates/ide/src/doc_links/tests.rs
+++ b/crates/ide/src/doc_links/tests.rs
@@ -415,6 +415,30 @@ fn foo() {
 }
 
 #[test]
+fn external_docs_macro_export() {
+    check_external_docs(
+        r#"
+//- /lib.rs crate:foo
+pub mod inner {
+    #[macro_export]
+    macro_rules! my_macro {
+        () => {};
+    }
+}
+
+//- /main.rs crate:bar deps:foo
+fn main() {
+    foo::my_m$0acro!();
+}
+        "#,
+        Some("/home/user/project"),
+        Some(expect![[r#"https://docs.rs/foo/*/foo/macro.my_macro.html"#]]),
+        Some(expect![[r#"file:///home/user/project/doc/foo/macro.my_macro.html"#]]),
+        Some("/sysroot"),
+    );
+}
+
+#[test]
 fn doc_links_items_simple() {
     check_doc_links(
         r#"


### PR DESCRIPTION
macros annotated with `#[macro_export]` are documented at the root of the crate, yet `externalDocs` was returning a path which considered it to be documented at the module it's defined in.  this PR fixes that.

example:
- before: `externalDocs` for `println!` was returning `https://doc.rust-lang.org/nightly/std/macros/macro.println.html`
- after: `externalDocs` for `println!` returns `https://doc.rust-lang.org/nightly/std/macro.println.html`