### PR TITLE
fix: generate function by indet token

### DIFF
--- a/crates/ide-assists/src/handlers/generate_function.rs
+++ b/crates/ide-assists/src/handlers/generate_function.rs
@@ -316,7 +316,7 @@ impl FunctionBuilder {
         let current_module = ctx.sema.scope(call.syntax())?.module();
         let visibility = calculate_necessary_visibility(current_module, target_module, ctx);
 
-        let fn_name = make::name(&name.text());
+        let fn_name = make::name(name.ident_token()?.text());
         let mut necessary_generic_params = FxHashSet::default();
         necessary_generic_params.extend(receiver_ty.generic_params(ctx.db()));
         let params = fn_args(
@@ -3130,5 +3130,33 @@ fn main() {
 }
         "#,
         )
+    }
+
+    #[test]
+    fn no_generate_method_by_keyword() {
+        check_assist_not_applicable(
+            generate_function,
+            r#"
+fn main() {
+    s.super$0();
+}
+        "#,
+        );
+        check_assist_not_applicable(
+            generate_function,
+            r#"
+fn main() {
+    s.Self$0();
+}
+        "#,
+        );
+        check_assist_not_applicable(
+            generate_function,
+            r#"
+fn main() {
+    s.self$0();
+}
+        "#,
+        );
     }
 }


### PR DESCRIPTION
close rust-lang/rust-analyzer#20398 
`ast::NameRef` can have keyword like `Self`, `super`, but `ast::Name` can't have keyword.

