### PR TITLE
Add ide-assist: convert_attr_cfg_to_if

### DIFF
--- a/crates/ide-assists/src/lib.rs
+++ b/crates/ide-assists/src/lib.rs
@@ -256,6 +256,7 @@ mod handlers {
             convert_bool_to_enum::convert_bool_to_enum,
             convert_closure_to_fn::convert_closure_to_fn,
             convert_attr_cfg_to_if::convert_attr_cfg_to_if,
+            convert_attr_cfg_to_if::convert_if_cfg_to_attr,
             convert_comment_block::convert_comment_block,
             convert_comment_from_or_to_doc::convert_comment_from_or_to_doc,
             convert_for_to_while_let::convert_for_loop_to_while_let,

--- a/crates/ide-assists/src/tests/generated.rs
+++ b/crates/ide-assists/src/tests/generated.rs
@@ -539,6 +539,28 @@ impl TryFrom<usize> for Thing {
 }
 
 #[test]
+fn doctest_convert_if_cfg_to_attr() {
+    check_doc_test(
+        "convert_if_cfg_to_attr",
+        r#####"
+fn foo() {
+    if $0cfg!(feature = "foo") {
+        let _x = 2;
+    }
+}
+"#####,
+        r#####"
+fn foo() {
+    #[cfg(feature = "foo")]
+    {
+        let _x = 2;
+    }
+}
+"#####,
+    )
+}
+
+#[test]
 fn doctest_convert_if_to_bool_then() {
     check_doc_test(
         "convert_if_to_bool_then",


### PR DESCRIPTION
Close rust-lang/rust-analyzer#20274

Convert `#[cfg(...)] {}` to `if cfg!(...) {}`.

```rust
fn foo() {
    $0#[cfg(feature = "foo")]
    {
        let _x = 2;
    }
}
```
->
```rust
fn foo() {
    if cfg!(feature = "foo") {
        let _x = 2;
    }
}
```

Convert `if cfg!(...) {}` to `#[cfg(...)] {}`.

```rust
fn foo() {
    $0if cfg!(feature = "foo") {
        let _x = 2;
    }
}
```
->
```rust
fn foo() {
    #[cfg(feature = "foo")]
    {
        let _x = 2;
    }
}
```
