### PR TITLE
minor: Fix dead link to Cargo.toml in documentation

### DIFF
--- a/docs/book/src/contributing/style.md
+++ b/docs/book/src/contributing/style.md
@@ -101,7 +101,7 @@ Including a description and GIF suitable for the changelog means less work for t
 
 ## Clippy
 
-We use Clippy to improve the code, but if some lints annoy you, allow them in the [Cargo.toml](../../Cargo.toml) [workspace.lints.clippy] section.
+We use Clippy to improve the code, but if some lints annoy you, allow them in the [Cargo.toml](https://github.com/rust-lang/rust-analyzer/blob/master/Cargo.toml) [workspace.lints.clippy] section.
 
 # Code
 


### PR DESCRIPTION
The ['Clippy' section](https://rust-analyzer.github.io/book/contributing/style.html#clippy) of the online style guide contains a dead link to the `Cargo.toml `as it links to `../../Cargo.toml`, which resolves to https://rust-analyzer.github.io/Cargo.toml.

I'm proposing this as a fix, even though I don't love hard-coding hyperlinks. But since it is also done in the [Rationale for Assertions](https://rust-analyzer.github.io/book/contributing/style.html#assertions), I assume it is fine here too!

I would love to contribute to rust-analyzer (even though I lack Rust experience), so I am working through the book now! I'll let you know if I stumble over more dead links like this :)