### PR TITLE
Add ide-assist: convert_if_let_to_let_else

### DIFF
--- a/crates/ide-assists/src/lib.rs
+++ b/crates/ide-assists/src/lib.rs
@@ -264,6 +264,7 @@ mod handlers {
             convert_iter_for_each_to_for::convert_iter_for_each_to_for,
             convert_let_else_to_match::convert_let_else_to_match,
             convert_match_to_let_else::convert_match_to_let_else,
+            convert_match_to_let_else::convert_if_let_to_let_else,
             convert_named_struct_to_tuple_struct::convert_named_struct_to_tuple_struct,
             convert_nested_function_to_closure::convert_nested_function_to_closure,
             convert_to_guarded_return::convert_to_guarded_return,

--- a/crates/ide-assists/src/tests/generated.rs
+++ b/crates/ide-assists/src/tests/generated.rs
@@ -517,6 +517,30 @@ impl TryFrom<usize> for Thing {
 }
 
 #[test]
+fn doctest_convert_if_let_to_let_else() {
+    check_doc_test(
+        "convert_if_let_to_let_else",
+        r#####"
+//- minicore: option
+fn foo(opt: Option<()>) {
+    let val$0 = if let Some(it) = opt {
+        it
+    } else {
+        return
+    };
+}
+"#####,
+        r#####"
+fn foo(opt: Option<()>) {
+    let Some(val) = opt else {
+        return
+    };
+}
+"#####,
+    )
+}
+
+#[test]
 fn doctest_convert_if_to_bool_then() {
     check_doc_test(
         "convert_if_to_bool_then",


### PR DESCRIPTION
Converts let statement with if-let initializer to let-else statement.

Example
---
```rust
# //- minicore: option
fn foo(opt: Option<()>) {
    let val$0 = if let Some(it) = opt {
        it
    } else {
        return
    };
}
```
->
```rust
fn foo(opt: Option<()>) {
    let Some(val) = opt else {
        return
    };
}
```
