### PR TITLE
Use a more specific error message when talking about the server logs

### DIFF
--- a/crates/rust-analyzer/src/reload.rs
+++ b/crates/rust-analyzer/src/reload.rs
@@ -152,7 +152,9 @@ impl GlobalState {
         if self.fetch_build_data_error().is_err() {
             status.health |= lsp_ext::Health::Warning;
             message.push_str("Failed to run build scripts of some packages.\n\n");
-            message.push_str("Please refer to the logs for more details on the errors.");
+            message.push_str(
+                "Please refer to the language server logs for more details on the errors.",
+            );
         }
         if let Some(err) = &self.config_errors {
             status.health |= lsp_ext::Health::Warning;


### PR DESCRIPTION
When rust-analyzer fails to run a flycheck, it might respond with a status update, something like
```
Language server rust-analyzer:

Failed to run build scripts of some packages.

Please refer to the logs for more details on the errors.
```

The problem is, those messages are shown in the editor's UI and editor's logs, so without specifying what kind of logs to see, it might be somewhat confusing for certain users.

Make it more explicit that the error is located in the language server logs.