### PR TITLE
fix: Make lang items query properly filter out overwritten/excluded sysroots

### DIFF
--- a/crates/base-db/src/lib.rs
+++ b/crates/base-db/src/lib.rs
@@ -30,6 +30,8 @@ use triomphe::Arc;
 pub use vfs::{AnchoredPath, AnchoredPathBuf, FileId, VfsPath, file_set::FileSet};
 
 pub type FxIndexSet<T> = indexmap::IndexSet<T, rustc_hash::FxBuildHasher>;
+pub type FxIndexMap<K, V> =
+    indexmap::IndexMap<K, V, std::hash::BuildHasherDefault<rustc_hash::FxHasher>>;
 
 #[macro_export]
 macro_rules! impl_intern_key {

--- a/crates/hir-def/src/lang_item.rs
+++ b/crates/hir-def/src/lang_item.rs
@@ -12,7 +12,7 @@ use crate::{
     StaticId, StructId, TraitId, TypeAliasId, UnionId,
     db::DefDatabase,
     expr_store::path::Path,
-    nameres::{assoc::TraitItems, crate_def_map},
+    nameres::{assoc::TraitItems, crate_def_map, crate_local_def_map},
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -170,7 +170,19 @@ pub fn lang_item(
     {
         return Some(target);
     }
-    start_crate.data(db).dependencies.iter().find_map(|dep| lang_item(db, dep.crate_id, item))
+
+    // Our `CrateGraph` eagerly inserts sysroot dependencies like `core` or `std` into dependencies
+    // even if the target crate has `#![no_std]`, `#![no_core]` or shadowed sysroot dependencies
+    // like `dependencies.std.path = ".."`. So we use `extern_prelude()` instead of
+    // `CrateData.dependencies` here, which has already come through such sysroot complexities
+    // while nameres.
+    //
+    // See https://github.com/rust-lang/rust-analyzer/pull/20475 for details.
+    crate_local_def_map(db, start_crate).local(db).extern_prelude().find_map(|(_, (krate, _))| {
+        // Some crates declares themselves as extern crate like `extern crate self as core`.
+        // Ignore these to prevent cycles.
+        if krate.krate == start_crate { None } else { lang_item(db, krate.krate, item) }
+    })
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Eq)]

--- a/crates/hir-def/src/nameres.rs
+++ b/crates/hir-def/src/nameres.rs
@@ -545,6 +545,10 @@ impl DefMap {
         self.data.no_std || self.data.no_core
     }
 
+    pub fn is_no_core(&self) -> bool {
+        self.data.no_core
+    }
+
     pub fn fn_as_proc_macro(&self, id: FunctionId) -> Option<ProcMacroId> {
         self.data.fn_proc_macro_mapping.get(&id).copied()
     }

--- a/crates/ide-db/src/lib.rs
+++ b/crates/ide-db/src/lib.rs
@@ -66,12 +66,8 @@ pub use rustc_hash::{FxHashMap, FxHashSet, FxHasher};
 pub use ::line_index;
 
 /// `base_db` is normally also needed in places where `ide_db` is used, so this re-export is for convenience.
-pub use base_db;
+pub use base_db::{self, FxIndexMap, FxIndexSet};
 pub use span::{self, FileId};
-
-pub type FxIndexSet<T> = indexmap::IndexSet<T, std::hash::BuildHasherDefault<rustc_hash::FxHasher>>;
-pub type FxIndexMap<K, V> =
-    indexmap::IndexMap<K, V, std::hash::BuildHasherDefault<rustc_hash::FxHasher>>;
 
 pub type FilePosition = FilePositionWrapper<FileId>;
 pub type FileRange = FileRangeWrapper<FileId>;


### PR DESCRIPTION
The panic here: https://github.com/rust-lang/rust-analyzer/issues/20443#issuecomment-3190479593 originates from the "multiple instances" of lang items.

We can verify this running on `analysis-stats` to the following code:

```rust
use std::{ptr, sync::atomic::AtomicPtr};

#[lang = "pointee_trait"]
pub trait Pointee {
    #[lang = "metadata_type"]
    type Metadata;
}

static HOOK: AtomicPtr<()> = AtomicPtr::new(ptr::null_mut())
```

So, depending on the "starting crate" of lang items query, it sometimes resolved as `crate::Pointee::Metadata` but `core::ptr::metadata::Pointee::Metadata` otherwise, and if we try to compare those items, 💥 

This thing is happening in when we are running `analysis-stats` on `std`.
Though `std` has `#![no_std]` and `core` has `#![no_core]`, we always insert sysroots dependencies no matter they are and they are dropped/overwritten on nameless, especially in the following lines

dropping  sysroots on `no_std` or `no_core`:
https://github.com/rust-lang/rust-analyzer/blob/e10fa9393ea2df4067e2258c9b8132244e415964/crates/hir-def/src/nameres/collector.rs#L316-L346

overwriting sysroots when we have `dependencies.std.path = ".."`
https://github.com/rust-lang/rust-analyzer/blob/e10fa9393ea2df4067e2258c9b8132244e415964/crates/hir-def/src/nameres/collector.rs#L73-L77