### PR TITLE
feat: implement Go to Assignments for local variables

### DIFF
--- a/crates/ide/src/goto_assignments.rs
+++ b/crates/ide/src/goto_assignments.rs
@@ -1,0 +1,246 @@
+use hir::Semantics;
+use ide_db::{
+    RootDatabase,
+    defs::{Definition, IdentClass},
+    helpers::pick_best_token,
+    search::ReferenceCategory,
+};
+use syntax::{AstNode, SyntaxKind::IDENT};
+
+use crate::{FilePosition, NavigationTarget, RangeInfo, TryToNav};
+
+// Feature: Go to Assignments
+//
+// Navigates to the assignments of an identifier.
+//
+// Returns all locations where the variable is assigned a value, including:
+// - Initial definition sites (let bindings, function parameters, etc.)
+// - Explicit assignment expressions (x = value)
+// - Compound assignment expressions (x += value, x *= value, etc.)
+pub(crate) fn goto_assignments(
+    db: &RootDatabase,
+    position: FilePosition,
+) -> Option<RangeInfo<Vec<NavigationTarget>>> {
+    let sema = &Semantics::new(db);
+
+    let def = find_definition_at_position(sema, position)?;
+
+    let Definition::Local(_) = def else {
+        return None;
+    };
+
+    find_assignments_for_def(sema, def, position)
+}
+
+fn find_definition_at_position(
+    sema: &Semantics<'_, RootDatabase>,
+    position: FilePosition,
+) -> Option<Definition> {
+    let file = sema.parse_guess_edition(position.file_id);
+    let token =
+        pick_best_token(file.syntax().token_at_offset(position.offset), |kind| match kind {
+            IDENT => 1,
+            _ => 0,
+        })?;
+
+    let token = sema.descend_into_macros_no_opaque(token, false).pop()?;
+    let parent = token.value.parent()?;
+
+    IdentClass::classify_node(sema, &parent)?.definitions().pop().map(|(def, _)| def)
+}
+
+fn find_assignments_for_def(
+    sema: &Semantics<'_, RootDatabase>,
+    def: Definition,
+    position: FilePosition,
+) -> Option<RangeInfo<Vec<NavigationTarget>>> {
+    let mut targets = Vec::new();
+
+    if let Some(nav_result) = def.try_to_nav(sema.db) {
+        targets.push(nav_result.call_site);
+    }
+
+    let usages = def.usages(sema).include_self_refs().all();
+
+    targets.extend(usages.iter().flat_map(|(file_id, refs)| {
+        refs.iter().filter(|file_ref| file_ref.category.contains(ReferenceCategory::WRITE)).map(
+            move |file_ref| {
+                NavigationTarget::from_syntax(
+                    file_id.file_id(sema.db),
+                    "assignment".into(),
+                    Some(file_ref.range),
+                    file_ref.range,
+                    ide_db::SymbolKind::Local,
+                )
+            },
+        )
+    }));
+
+    if targets.is_empty() {
+        return None;
+    }
+
+    let range = sema
+        .parse_guess_edition(position.file_id)
+        .syntax()
+        .token_at_offset(position.offset)
+        .next()
+        .map(|token| token.text_range())?;
+
+    Some(RangeInfo::new(range, targets))
+}
+
+#[cfg(test)]
+mod tests {
+    use ide_db::FileRange;
+    use itertools::Itertools;
+
+    use crate::fixture;
+
+    fn check(#[rust_analyzer::rust_fixture] ra_fixture: &str) {
+        let (analysis, position, expected) = fixture::annotations(ra_fixture);
+        let navs = analysis.goto_assignments(position).unwrap().expect("no assignments found").info;
+        if navs.is_empty() {
+            panic!("unresolved reference")
+        }
+
+        let cmp = |&FileRange { file_id, range }: &_| (file_id, range.start());
+        let navs = navs
+            .into_iter()
+            .map(|nav| FileRange { file_id: nav.file_id, range: nav.focus_or_full_range() })
+            .sorted_by_key(cmp)
+            .collect::<Vec<_>>();
+        let expected = expected
+            .into_iter()
+            .map(|(FileRange { file_id, range }, _)| FileRange { file_id, range })
+            .sorted_by_key(cmp)
+            .collect::<Vec<_>>();
+        assert_eq!(expected, navs);
+    }
+
+    #[test]
+    fn goto_assignments_reassignments() {
+        check(
+            r#"
+//- /main.rs
+fn main() {
+    let mut a = 0;
+    let mut x = 1;
+         // ^
+    x$0 = 2;
+ // ^
+    println!("{}", x);
+    x = 3;
+ // ^
+}
+"#,
+        )
+    }
+
+    #[test]
+    fn goto_assignments_compound_operators() {
+        check(
+            r#"
+//- /main.rs
+fn main() {
+    let mut x = 10;
+         // ^
+    x += 5;
+ // ^
+    x$0 *= 2;
+ // ^
+    println!("{}", x);
+}
+"#,
+        )
+    }
+
+    #[test]
+    fn goto_assignments_struct_field_mutation() {
+        check(
+            r#"
+//- /main.rs
+struct Point { x: i32, y: i32 }
+
+fn main() {
+    let mut p = Point { x: 0, y: 0 };
+         // ^
+    p$0 = Point { x: 10, y: 20 };
+ // ^
+    p.x = 5;  // This is not an assignment to `p` itself
+    println!("{:?}", p);
+}
+"#,
+        )
+    }
+
+    #[test]
+    fn goto_assignments_immutable_variable() {
+        // Immutable variables only have the initial definition, no assignments
+        check(
+            r#"
+//- /main.rs
+fn main() {
+    let x$0 = 5;
+     // ^
+    println!("{}", x);
+}
+"#,
+        );
+    }
+
+    #[test]
+    fn goto_assignments_closure_capture() {
+        check(
+            r#"
+//- /main.rs
+fn main() {
+    let mut x = 0;
+         // ^
+    let closure = |mut y: i32| {
+        x$0 = 42;
+     // ^
+        y = 1;  // This is a different variable
+    };
+    closure(0);
+}
+"#,
+        );
+    }
+
+    #[test]
+    fn goto_assignments_loop_variable() {
+        check(
+            r#"
+//- /main.rs
+fn main() {
+    for mut i in 0..3 {
+         // ^
+        if i > 1 {
+            i$0 += 1;
+         // ^
+        }
+    }
+}
+"#,
+        );
+    }
+
+    #[test]
+    fn goto_assignments_shadowing() {
+        // Each `x` is a separate variable, so only assignments to the same binding
+        check(
+            r#"
+//- /main.rs
+fn main() {
+    let mut x = 1;
+    let mut x = 2;  // Different variable (shadowing)
+         // ^
+    x$0 = 3;
+ // ^
+    println!("{}", x);
+}
+"#,
+        );
+    }
+}

--- a/crates/ide/src/lib.rs
+++ b/crates/ide/src/lib.rs
@@ -27,6 +27,7 @@ mod extend_selection;
 mod fetch_crates;
 mod file_structure;
 mod folding_ranges;
+mod goto_assignments;
 mod goto_declaration;
 mod goto_definition;
 mod goto_implementation;
@@ -516,6 +517,14 @@ impl Analysis {
         position: FilePosition,
     ) -> Cancellable<Option<RangeInfo<Vec<NavigationTarget>>>> {
         self.with_db(|db| goto_type_definition::goto_type_definition(db, position))
+    }
+
+    /// Returns the type definitions for the symbol at `position`.
+    pub fn goto_assignments(
+        &self,
+        position: FilePosition,
+    ) -> Cancellable<Option<RangeInfo<Vec<NavigationTarget>>>> {
+        self.with_db(|db| goto_assignments::goto_assignments(db, position))
     }
 
     pub fn find_all_refs(

--- a/crates/rust-analyzer/src/lsp/ext.rs
+++ b/crates/rust-analyzer/src/lsp/ext.rs
@@ -407,6 +407,40 @@ impl Request for ChildModules {
     const METHOD: &'static str = "experimental/childModules";
 }
 
+pub enum GotoAssignments {}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
+#[serde(untagged)]
+pub enum GotoAssignmentsResponse {
+    Scalar(lsp_types::Location),
+    Array(Vec<lsp_types::Location>),
+    Link(Vec<lsp_types::LocationLink>),
+}
+
+impl From<lsp_types::Location> for GotoAssignmentsResponse {
+    fn from(location: lsp_types::Location) -> Self {
+        GotoAssignmentsResponse::Scalar(location)
+    }
+}
+
+impl From<Vec<lsp_types::Location>> for GotoAssignmentsResponse {
+    fn from(locations: Vec<lsp_types::Location>) -> Self {
+        GotoAssignmentsResponse::Array(locations)
+    }
+}
+
+impl From<Vec<lsp_types::LocationLink>> for GotoAssignmentsResponse {
+    fn from(locations: Vec<lsp_types::LocationLink>) -> Self {
+        GotoAssignmentsResponse::Link(locations)
+    }
+}
+
+impl Request for GotoAssignments {
+    type Params = lsp_types::TextDocumentPositionParams;
+    type Result = Option<GotoAssignmentsResponse>;
+    const METHOD: &'static str = "experimental/gotoAssignments";
+}
+
 pub enum JoinLines {}
 
 impl Request for JoinLines {

--- a/crates/rust-analyzer/src/main_loop.rs
+++ b/crates/rust-analyzer/src/main_loop.rs
@@ -1202,6 +1202,7 @@ impl GlobalState {
             .on::<NO_RETRY, lsp_ext::ExpandMacro>(handlers::handle_expand_macro)
             .on::<NO_RETRY, lsp_ext::ParentModule>(handlers::handle_parent_module)
             .on::<NO_RETRY, lsp_ext::ChildModules>(handlers::handle_child_modules)
+            .on::<NO_RETRY, lsp_ext::GotoAssignments>(handlers::handle_goto_assignments)
             .on::<NO_RETRY, lsp_ext::Runnables>(handlers::handle_runnables)
             .on::<NO_RETRY, lsp_ext::RelatedTests>(handlers::handle_related_tests)
             .on::<NO_RETRY, lsp_ext::CodeActionRequest>(handlers::handle_code_action)

--- a/docs/book/src/contributing/lsp-extensions.md
+++ b/docs/book/src/contributing/lsp-extensions.md
@@ -1,5 +1,5 @@
 <!---
-lsp/ext.rs hash: 78e87a78de8f288e
+lsp/ext.rs hash: 773993a50f921366
 
 If you need to change the above hash to make the test pass, please check if you
 need to adjust this doc as well and ping this issue:

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -176,6 +176,11 @@
                 "category": "rust-analyzer"
             },
             {
+                "command": "rust-analyzer.gotoAssignments",
+                "title": "Go to Assignments",
+                "category": "rust-analyzer"
+            },
+            {
                 "command": "rust-analyzer.joinLines",
                 "title": "Join lines",
                 "category": "rust-analyzer"
@@ -3627,6 +3632,11 @@
                     "command": "rust-analyzer.openDocs",
                     "when": "inRustProject && editorTextFocus && editorLangId == rust",
                     "group": "navigation@1001"
+                },
+                {
+                    "command": "rust-analyzer.gotoAssignments",
+                    "when": "inRustProject && editorTextFocus && editorLangId == rust",
+                    "group": "navigation@1002"
                 }
             ],
             "view/title": [

--- a/editors/code/src/commands.ts
+++ b/editors/code/src/commands.ts
@@ -303,6 +303,43 @@ export function childModules(ctx: CtxInit): Cmd {
     };
 }
 
+export function gotoAssignments(ctx: CtxInit): Cmd {
+    return async () => {
+        const editor = vscode.window.activeTextEditor;
+        if (!editor) return;
+        if (!isRustDocument(editor.document)) return;
+
+        const client = ctx.client;
+
+        const locations = await client.sendRequest(ra.gotoAssignments, {
+            textDocument: client.code2ProtocolConverter.asTextDocumentIdentifier(editor.document),
+            position: client.code2ProtocolConverter.asPosition(editor.selection.active),
+        });
+        if (!locations) return;
+
+        if (locations.length === 1) {
+            const loc = unwrapUndefinable(locations[0]);
+
+            const uri = client.protocol2CodeConverter.asUri(loc.targetUri);
+            const range = client.protocol2CodeConverter.asRange(loc.targetRange);
+
+            const doc = await vscode.workspace.openTextDocument(uri);
+            const e = await vscode.window.showTextDocument(doc);
+            e.selection = new vscode.Selection(range.start, range.start);
+            e.revealRange(range, vscode.TextEditorRevealType.InCenter);
+        } else {
+            const uri = editor.document.uri.toString();
+            const position = client.code2ProtocolConverter.asPosition(editor.selection.active);
+            await showReferencesImpl(
+                client,
+                uri,
+                position,
+                locations.map((loc) => lc.Location.create(loc.targetUri, loc.targetRange)),
+            );
+        }
+    };
+}
+
 export function openCargoToml(ctx: CtxInit): Cmd {
     return async () => {
         const editor = ctx.activeRustEditor;

--- a/editors/code/src/lsp_ext.ts
+++ b/editors/code/src/lsp_ext.ts
@@ -199,6 +199,11 @@ export const childModules = new lc.RequestType<
     lc.LocationLink[] | null,
     void
 >("experimental/childModules");
+export const gotoAssignments = new lc.RequestType<
+    lc.TextDocumentPositionParams,
+    lc.LocationLink[] | null,
+    void
+>("experimental/gotoAssignments");
 export const runnables = new lc.RequestType<RunnablesParams, Runnable[], void>(
     "experimental/runnables",
 );

--- a/editors/code/src/main.ts
+++ b/editors/code/src/main.ts
@@ -159,6 +159,7 @@ function createCommands(): Record<string, CommandFactory> {
         joinLines: { enabled: commands.joinLines },
         parentModule: { enabled: commands.parentModule },
         childModules: { enabled: commands.childModules },
+        gotoAssignments: { enabled: commands.gotoAssignments },
         viewHir: { enabled: commands.viewHir },
         viewMir: { enabled: commands.viewMir },
         interpretFunction: { enabled: commands.interpretFunction },


### PR DESCRIPTION
related: rust-lang/rust-analyzer#18149

## Summary
"Go to Assignments" for local variables as an initial implementation.
New detections like field accesses can be added to crates/ide/src/goto_assignments.rs but I wanted to reduce the diffs for this PR.
I'm gonna add other detections in another PR.

## Evidence
for codes like this,
<img width="613" height="296" alt="スクリーンショット 2025-08-19 0 44 32" src="https://github.com/user-attachments/assets/c3cf72d0-6193-42f9-80a2-fb1d1e30e091" />

we can select "Go to Assignments",
<img width="1023" height="671" alt="スクリーンショット 2025-08-19 0 44 24" src="https://github.com/user-attachments/assets/18a13acc-eba4-400a-b373-786d70396e3e" />

and all assignments, including def, are shown.
The "a" in println() is not shown because it is not an assignment.
<img width="963" height="635" alt="スクリーンショット 2025-08-19 0 44 40" src="https://github.com/user-attachments/assets/0e8ebee8-c364-4c1f-9ca4-c939c7a58adb" />