### PR TITLE
fix: convert_integer_literal not on selected

### DIFF
--- a/crates/ide-assists/src/handlers/convert_integer_literal.rs
+++ b/crates/ide-assists/src/handlers/convert_integer_literal.rs
@@ -14,6 +14,9 @@ use crate::{AssistContext, AssistId, Assists, GroupLabel};
 // const _: i32 = 0b1010;
 // ```
 pub(crate) fn convert_integer_literal(acc: &mut Assists, ctx: &AssistContext<'_>) -> Option<()> {
+    if !ctx.has_empty_selection() {
+        return None;
+    }
     let literal = ctx.find_node_at_offset::<ast::Literal>()?;
     let literal = match literal.kind() {
         ast::LiteralKind::IntNumber(it) => it,
@@ -264,5 +267,10 @@ mod tests {
         let before = "const _: i32 =
             111111111111111111111111111111111111111111111111111111111111111111111111$0;";
         check_assist_not_applicable(convert_integer_literal, before);
+    }
+
+    #[test]
+    fn convert_non_empty_selection_literal() {
+        check_assist_not_applicable(convert_integer_literal, "const _: i32 = $00b1010$0;");
     }
 }

--- a/crates/ide-assists/src/tests.rs
+++ b/crates/ide-assists/src/tests.rs
@@ -456,7 +456,6 @@ pub fn test_some_range(a: int) -> bool {
     let expected = labels(&assists);
 
     expect![[r#"
-        Convert integer base
         Extract into...
         Replace if let with match
     "#]]
@@ -489,7 +488,6 @@ pub fn test_some_range(a: int) -> bool {
         let expected = labels(&assists);
 
         expect![[r#"
-            Convert integer base
             Extract into...
             Replace if let with match
         "#]]


### PR DESCRIPTION
`convert_integer_literal` can only convert the first literal,
it is not reasonable to apply it when selected

Example
---

```rust
fn main() {
    $01+1$0;
}
```

**Assist old outputs**:

```
Convert 1 to 0b1
Convert 1 to 0o1
Convert 1 to 0x1
Replace arithmetic with call to checked_*
Replace arithmetic with call to saturating_*
Replace arithmetic with call to wrapping_*
Extract into variable
Extract into constant
Extract into static
Extract into function
```

**Assist this PR outputs**:

```
Replace arithmetic with call to checked_*
Replace arithmetic with call to saturating_*
Replace arithmetic with call to wrapping_*
Extract into variable
Extract into constant
Extract into static
Extract into function
```
