### PR TITLE
fix: Fix opaque generics

### DIFF
--- a/crates/hir-ty/src/next_solver/util.rs
+++ b/crates/hir-ty/src/next_solver/util.rs
@@ -685,7 +685,6 @@ pub fn explicit_item_bounds<'db>(
                 LifetimeElisionKind::AnonymousReportError,
             );
 
-            let trait_args = GenericArgs::identity_for_item(interner, trait_.into());
             let item_args = GenericArgs::identity_for_item(interner, def_id);
             let interner_ty = Ty::new_projection_from_args(interner, def_id, item_args);
 

--- a/crates/hir-ty/src/tests/regression.rs
+++ b/crates/hir-ty/src/tests/regression.rs
@@ -1,3 +1,5 @@
+mod new_solver;
+
 use expect_test::expect;
 
 use super::{check_infer, check_no_mismatches, check_types};

--- a/crates/hir-ty/src/tests/regression/new_solver.rs
+++ b/crates/hir-ty/src/tests/regression/new_solver.rs
@@ -1,0 +1,26 @@
+use expect_test::expect;
+
+use super::check_infer;
+
+#[test]
+fn opaque_generics() {
+    check_infer(
+        r#"
+//- minicore: iterator
+pub struct Grid {}
+
+impl<'a> IntoIterator for &'a Grid {
+    type Item = &'a ();
+
+    type IntoIter = impl Iterator<Item = &'a ()>;
+
+    fn into_iter(self) -> Self::IntoIter {
+    }
+}
+    "#,
+        expect![[r#"
+            150..154 'self': &'a Grid
+            174..181 '{     }': impl Iterator<Item = &'a ()>
+        "#]],
+    );
+}


### PR DESCRIPTION
The parent generics were incorrectly not considered for TAIT.

I'm not convinced we should follow rustc here, also there are items (opaques) with more than 1 parent (opaque -> fn/type alias -> impl/trait) and I'm not sure we properly account for that in all places, but for now I left it as-is.

Also fix a bug where lifetimes' indices were incorrect when there is a self param (they started from 0 instead of 1).

That was the reason for https://github.com/rust-lang/rust-analyzer/issues/20443#issuecomment-3217182201.