### PR TITLE
fix: Masquerade as nightly cargo when invoking flycheck with `-Zscript`

### DIFF
--- a/crates/rust-analyzer/src/flycheck.rs
+++ b/crates/rust-analyzer/src/flycheck.rs
@@ -588,6 +588,7 @@ impl FlycheckActor {
                     cmd.arg("--manifest-path");
                     cmd.arg(manifest_path);
                     if manifest_path.extension() == Some("rs") {
+                        cmd.env("__CARGO_TEST_CHANNEL_OVERRIDE_DO_NOT_USE_THIS", "nightly");
                         cmd.arg("-Zscript");
                     }
                 }


### PR DESCRIPTION
cc https://github.com/rust-lang/rust-analyzer/issues/20515