### PR TITLE
fix: Normalize all types when finishing inference

### DIFF
--- a/crates/hir-ty/src/infer/unify.rs
+++ b/crates/hir-ty/src/infer/unify.rs
@@ -621,6 +621,9 @@ impl<'a> InferenceTable<'a> {
     where
         T: HasInterner<Interner = Interner> + TypeFoldable<Interner>,
     {
+        let t = self.resolve_with_fallback(t, &|_, _, d, _| d);
+        let t = self.normalize_associated_types_in(t);
+        // Resolve again, because maybe normalization inserted infer vars.
         self.resolve_with_fallback(t, &|_, _, d, _| d)
     }
 

--- a/crates/hir-ty/src/next_solver/mapping.rs
+++ b/crates/hir-ty/src/next_solver/mapping.rs
@@ -808,14 +808,24 @@ impl<'db> ChalkToNextSolver<'db, PredicateKind<'db>> for chalk_ir::DomainGoal<In
                     _ => unimplemented!(),
                 };
                 let args: GenericArgs<'db> = proj_ty.substitution.to_nextsolver(interner);
-                let alias = rustc_type_ir::AliasTerm::new(
+                let alias = Ty::new(
                     interner,
-                    from_assoc_type_id(proj_ty.associated_ty_id).into(),
-                    args,
-                );
+                    rustc_type_ir::TyKind::Alias(
+                        rustc_type_ir::AliasTyKind::Projection,
+                        rustc_type_ir::AliasTy::new(
+                            interner,
+                            from_assoc_type_id(proj_ty.associated_ty_id).into(),
+                            args,
+                        ),
+                    ),
+                )
+                .into();
                 let term = normalize.ty.to_nextsolver(interner).into();
-                let normalizes_to = rustc_type_ir::NormalizesTo { alias, term };
-                PredicateKind::NormalizesTo(normalizes_to)
+                PredicateKind::AliasRelate(
+                    alias,
+                    term,
+                    rustc_type_ir::AliasRelationDirection::Equate,
+                )
             }
             chalk_ir::DomainGoal::WellFormed(well_formed) => {
                 let term = match well_formed {

--- a/crates/hir-ty/src/tests/regression/new_solver.rs
+++ b/crates/hir-ty/src/tests/regression/new_solver.rs
@@ -24,3 +24,29 @@ impl<'a> IntoIterator for &'a Grid {
         "#]],
     );
 }
+
+#[test]
+fn normalization() {
+    check_infer(
+        r#"
+//- minicore: iterator, iterators
+fn main() {
+    _ = [0i32].into_iter().filter_map(|_n| Some(1i32));
+}
+    "#,
+        expect![[r#"
+            10..69 '{     ...2)); }': ()
+            16..17 '_': FilterMap<IntoIter<i32, 1>, impl FnMut(i32) -> Option<i32>>
+            16..66 '_ = [0...1i32))': ()
+            20..26 '[0i32]': [i32; 1]
+            20..38 '[0i32]...iter()': IntoIter<i32, 1>
+            20..66 '[0i32]...1i32))': FilterMap<IntoIter<i32, 1>, impl FnMut(i32) -> Option<i32>>
+            21..25 '0i32': i32
+            50..65 '|_n| Some(1i32)': impl FnMut(i32) -> Option<i32>
+            51..53 '_n': i32
+            55..59 'Some': fn Some<i32>(i32) -> Option<i32>
+            55..65 'Some(1i32)': Option<i32>
+            60..64 '1i32': i32
+        "#]],
+    );
+}


### PR DESCRIPTION
The new solver does not eagerly normalize, but things after inference expect types to be normalized. rustc does the same.

Also, I'm afraid other things in r-a don't expect results of the solver to be unnormalized. We'll need to handle that.

Fixes rust-lang/rust-analyzer#20536.