### PR TITLE
fix: In highlight_related, when on an unsafe block, don't highlight unsafe operations of other unsafe blocks

### DIFF
--- a/crates/hir-ty/src/diagnostics/unsafe_check.rs
+++ b/crates/hir-ty/src/diagnostics/unsafe_check.rs
@@ -119,11 +119,11 @@ pub fn unsafe_operations(
     def: DefWithBodyId,
     body: &Body,
     current: ExprId,
-    callback: &mut dyn FnMut(InsideUnsafeBlock),
+    callback: &mut dyn FnMut(ExprOrPatId, InsideUnsafeBlock),
 ) {
     let mut visitor_callback = |diag| {
-        if let UnsafeDiagnostic::UnsafeOperation { inside_unsafe_block, .. } = diag {
-            callback(inside_unsafe_block);
+        if let UnsafeDiagnostic::UnsafeOperation { inside_unsafe_block, node, .. } = diag {
+            callback(node, inside_unsafe_block);
         }
     };
     let mut visitor = UnsafeVisitor::new(db, infer, body, def, &mut visitor_callback);

--- a/crates/hir/src/source_analyzer.rs
+++ b/crates/hir/src/source_analyzer.rs
@@ -1283,7 +1283,7 @@ impl<'db> SourceAnalyzer<'db> {
         {
             let mut is_unsafe = false;
             let mut walk_expr = |expr_id| {
-                unsafe_operations(db, infer, def, body, expr_id, &mut |inside_unsafe_block| {
+                unsafe_operations(db, infer, def, body, expr_id, &mut |_, inside_unsafe_block| {
                     is_unsafe |= inside_unsafe_block == InsideUnsafeBlock::No
                 })
             };

--- a/crates/ide/src/highlight_related.rs
+++ b/crates/ide/src/highlight_related.rs
@@ -805,10 +805,8 @@ pub(crate) fn highlight_unsafe_points(
         push_to_highlights(unsafe_token_file_id, Some(unsafe_token.text_range()));
 
         // highlight unsafe operations
-        if let Some(block) = block_expr
-            && let Some(body) = sema.body_for(InFile::new(unsafe_token_file_id, block.syntax()))
-        {
-            let unsafe_ops = sema.get_unsafe_ops(body);
+        if let Some(block) = block_expr {
+            let unsafe_ops = sema.get_unsafe_ops_for_unsafe_block(block);
             for unsafe_op in unsafe_ops {
                 push_to_highlights(unsafe_op.file_id, Some(unsafe_op.value.text_range()));
             }
@@ -2533,6 +2531,23 @@ fn foo() {
     };
 }
 "#,
+        );
+    }
+
+    #[test]
+    fn different_unsafe_block() {
+        check(
+            r#"
+fn main() {
+    unsafe$0 {
+ // ^^^^^^
+        *(0 as *const u8)
+     // ^^^^^^^^^^^^^^^^^
+    };
+    unsafe { *(1 as *const u8) };
+    unsafe { *(2 as *const u8) };
+}
+        "#,
         );
     }
 }


### PR DESCRIPTION
Fixes #20546.