### PR TITLE
Add pretty number for add_explicit_enum_discriminant

### DIFF
--- a/crates/ide-assists/src/handlers/number_representation.rs
+++ b/crates/ide-assists/src/handlers/number_representation.rs
@@ -1,6 +1,6 @@
 use syntax::{AstToken, ast, ast::Radix};
 
-use crate::{AssistContext, AssistId, Assists, GroupLabel};
+use crate::{AssistContext, AssistId, Assists, GroupLabel, utils::add_group_separators};
 
 const MIN_NUMBER_OF_DIGITS_TO_FORMAT: usize = 5;
 
@@ -68,18 +68,6 @@ const fn group_size(r: Radix) -> usize {
         Radix::Decimal => 3,
         Radix::Hexadecimal => 4,
     }
-}
-
-fn add_group_separators(s: &str, group_size: usize) -> String {
-    let mut chars = Vec::new();
-    for (i, ch) in s.chars().filter(|&ch| ch != '_').rev().enumerate() {
-        if i > 0 && i % group_size == 0 {
-            chars.push('_');
-        }
-        chars.push(ch);
-    }
-
-    chars.into_iter().rev().collect()
 }
 
 #[cfg(test)]

--- a/crates/ide-assists/src/utils.rs
+++ b/crates/ide-assists/src/utils.rs
@@ -1080,6 +1080,18 @@ fn test_string_prefix() {
     assert_eq!(Some("r"), string_prefix(r##"r#""#"##));
 }
 
+pub(crate) fn add_group_separators(s: &str, group_size: usize) -> String {
+    let mut chars = Vec::new();
+    for (i, ch) in s.chars().filter(|&ch| ch != '_').rev().enumerate() {
+        if i > 0 && i % group_size == 0 && ch != '-' {
+            chars.push('_');
+        }
+        chars.push(ch);
+    }
+
+    chars.into_iter().rev().collect()
+}
+
 /// Replaces the record expression, handling field shorthands including inside macros.
 pub(crate) fn replace_record_field_expr(
     ctx: &AssistContext<'_>,


### PR DESCRIPTION
Example
---

**Input**:

```rust
#[repr(i64)]
enum TheEnum {
    Foo = 1 << 63,
    Bar,
    Baz$0 = 0x7fff_ffff_ffff_fffe,
    Quux,
}
```

**Before this PR**:

```rust
#[repr(i64)]
enum TheEnum {
    Foo = 1 << 63,
    Bar = -9223372036854775807,
    Baz = 0x7fff_ffff_ffff_fffe,
    Quux = 9223372036854775807,
}
```

**After this PR**:

```rust
#[repr(i64)]
enum TheEnum {
    Foo = 1 << 63,
    Bar = -9_223372_036854_775807,
    Baz = 0x7fff_ffff_ffff_fffe,
    Quux = 0x7fff_ffff_ffff_ffff,
}
```
