### PR TITLE
fix: When mapping next-solver's `dyn` type, add `Self` (aka. bound var ^1.0) to auto traits' substitutions

### DIFF
--- a/crates/hir-ty/src/mir/lower.rs
+++ b/crates/hir-ty/src/mir/lower.rs
@@ -53,6 +53,8 @@ use super::OperandKind;
 
 mod as_place;
 mod pattern_matching;
+#[cfg(test)]
+mod tests;
 
 #[derive(Debug, Clone)]
 struct LoopBlocks {

--- a/crates/hir-ty/src/mir/lower/tests.rs
+++ b/crates/hir-ty/src/mir/lower/tests.rs
@@ -1,0 +1,64 @@
+use hir_def::db::DefDatabase;
+use rustc_hash::FxHashMap;
+use span::Edition;
+use test_fixture::WithFixture;
+use triomphe::Arc;
+
+use crate::{
+    db::HirDatabase,
+    mir::{MirBody, MirLowerError},
+    setup_tracing,
+    test_db::TestDB,
+};
+
+fn lower_mir(
+    #[rust_analyzer::rust_fixture] ra_fixture: &str,
+) -> FxHashMap<String, Result<Arc<MirBody>, MirLowerError>> {
+    let _tracing = setup_tracing();
+    let (db, file_ids) = TestDB::with_many_files(ra_fixture);
+    let file_id = *file_ids.last().unwrap();
+    let module_id = db.module_for_file(file_id.file_id(&db));
+    let def_map = module_id.def_map(&db);
+    let scope = &def_map[module_id.local_id].scope;
+    let funcs = scope.declarations().filter_map(|x| match x {
+        hir_def::ModuleDefId::FunctionId(it) => Some(it),
+        _ => None,
+    });
+    funcs
+        .map(|func| {
+            let name = db.function_signature(func).name.display(&db, Edition::CURRENT).to_string();
+            let mir = db.mir_body(func.into());
+            (name, mir)
+        })
+        .collect()
+}
+
+#[test]
+fn dyn_projection_with_auto_traits_regression_next_solver() {
+    lower_mir(
+        r#"
+//- minicore: sized, send
+pub trait Deserializer {}
+
+pub trait Strictest {
+    type Object: ?Sized;
+}
+
+impl Strictest for dyn CustomValue {
+    type Object = dyn CustomValue + Send;
+}
+
+pub trait CustomValue: Send {}
+
+impl CustomValue for () {}
+
+struct Box<T: ?Sized>;
+
+type DeserializeFn<T> = fn(&mut dyn Deserializer) -> Box<T>;
+
+fn foo() {
+    (|deserializer| Box::new(())) as DeserializeFn<<dyn CustomValue as Strictest>::Object>;
+}
+    "#,
+    );
+}

--- a/crates/hir-ty/src/next_solver/mapping.rs
+++ b/crates/hir-ty/src/next_solver/mapping.rs
@@ -1207,7 +1207,10 @@ pub(crate) fn convert_ty_for_result<'db>(interner: DbInterner<'db>, ty: Ty<'db>)
                                 SolverDefId::TraitId(id) => to_chalk_trait_id(id),
                                 _ => unreachable!(),
                             };
-                            let substitution = chalk_ir::Substitution::empty(Interner);
+                            let substitution = chalk_ir::Substitution::from1(
+                                Interner,
+                                convert_ty_for_result(interner, self_ty),
+                            );
                             let trait_ref = chalk_ir::TraitRef { trait_id, substitution };
                             chalk_ir::WhereClause::Implemented(trait_ref)
                         }


### PR DESCRIPTION
Chalk represents dyn types as a list of predicate, the self type should be there. The next solver represents them quite differently. The `Self` was forgotten for the auto trait case.

Should mitigate https://github.com/rust-lang/rust-analyzer/issues/20443#issuecomment-3227557481 and https://github.com/rust-lang/rust-analyzer/issues/20443#issuecomment-3231928006. The panic is when we try to display the type (it happens to be in MIR lowering) and Chalk expects the `TraitRef` to have a self type. The actual error is way earlier, in inference, when we normalize the type. I chose to write the test at the panic site because it's easy to reproduce the issue there.