### PR TITLE
Guide users to use the new Path and Module System

### DIFF
--- a/crates/ide-diagnostics/src/handlers/unresolved_module.rs
+++ b/crates/ide-diagnostics/src/handlers/unresolved_module.rs
@@ -41,7 +41,10 @@ fn fixes(ctx: &DiagnosticsContext<'_>, d: &hir::UnresolvedModule) -> Option<Vec<
             .map(|candidate| {
                 fix(
                     "create_module",
-                    &format!("Create module at `{candidate}`"),
+                    &format!(
+                        "Create module at `{candidate}` {}",
+                        if candidate.ends_with("mod.rs") { "(old style)" } else { "(recommended)" }
+                    ),
                     FileSystemEdit::CreateFile {
                         dst: AnchoredPathBuf {
                             anchor: d.decl.file_id.original_file(ctx.sema.db).file_id(ctx.sema.db),

--- a/crates/rust-analyzer/tests/slow-tests/main.rs
+++ b/crates/rust-analyzer/tests/slow-tests/main.rs
@@ -757,7 +757,7 @@ fn main() {}
         },
         json!([
             {
-                "title": "Create module at `bar.rs`",
+                "title": "Create module at `bar.rs` (recommended)",
                 "kind": "quickfix",
                 "edit": {
                 "documentChanges": [
@@ -769,7 +769,7 @@ fn main() {}
                 }
             },
             {
-                "title": "Create module at `bar/mod.rs`",
+                "title": "Create module at `bar/mod.rs` (old style)",
                 "kind": "quickfix",
                 "edit": {
                 "documentChanges": [
@@ -840,7 +840,7 @@ fn main() {{}}
         },
         json!([
             {
-                "title": "Create module at `bar.rs`",
+                "title": "Create module at `bar.rs` (recommended)",
                 "kind": "quickfix",
                 "edit": {
                 "documentChanges": [
@@ -852,7 +852,7 @@ fn main() {{}}
                 }
             },
             {
-                "title": "Create module at `bar/mod.rs`",
+                "title": "Create module at `bar/mod.rs` (old style)",
                 "kind": "quickfix",
                 "edit": {
                 "documentChanges": [


### PR DESCRIPTION
According to the [Edition 2018 Guide](https://doc.rust-lang.org/edition-guide/rust-2018/path-changes.html) and [“the book”](https://doc.rust-lang.org/stable/book/ch07-05-separating-modules-into-different-files.html), we should encourage users to adopt the new `Path and Module System`.

My motivation for this stems from a Rust promotional video I made on a Chinese video platform. Surprisingly, many people were unaware of the clearer `Path and Module System` introduced in Edition 2018. I think we should provide some guidance on this matter : )