### PR TITLE
diagnostics: show closure signatures in type mismatch messages

### DIFF
--- a/crates/ide-diagnostics/src/handlers/type_mismatch.rs
+++ b/crates/ide-diagnostics/src/handlers/type_mismatch.rs
@@ -45,10 +45,10 @@ pub(crate) fn type_mismatch(ctx: &DiagnosticsContext<'_>, d: &hir::TypeMismatch<
             "expected {}, found {}",
             d.expected
                 .display(ctx.sema.db, ctx.display_target)
-                .with_closure_style(ClosureStyle::ClosureWithId),
+                .with_closure_style(ClosureStyle::ImplFn),
             d.actual
                 .display(ctx.sema.db, ctx.display_target)
-                .with_closure_style(ClosureStyle::ClosureWithId),
+                .with_closure_style(ClosureStyle::ImplFn),
         ),
         display_range,
     )
@@ -1249,6 +1249,17 @@ fn main() {
     enum E { V() }
     let E::V() = &S {};
      // ^^^^^^ error: expected S, found E
+}
+"#,
+        );
+    }
+    #[test]
+    fn shows_closure_signatures_in_mismatch() {
+        check_diagnostics(
+            r#"//- minicore: fn
+fn main() {
+    let _: bool = || { 0u8 };
+     //           ^^^^^^^^^^ error: expected bool, found impl Fn() -> u8
 }
 "#,
         );


### PR DESCRIPTION
Type-mismatch diagnostics currently print opaque closure IDs like `{closure#…}`, which hides parameter and return types. This change renders closures as callable signatures in those messages.

- In `crates/ide-diagnostics/src/handlers/type_mismatch.rs`, switch:
  ```rust
  .with_closure_style(ClosureStyle::ClosureWithId)
  ```
  to:
  ```rust
  .with_closure_style(ClosureStyle::ImplFn)
  ```
- Add a regression test `shows_closure_signatures_in_mismatch` to assert the new rendering.

#### Before / After

#### Example 1
**Code**
```rust
fn main() {
    let _: bool = || { 0u8 };
}
```

**Before**
```text
error: expected bool, found {closure#12345}
```

**After**
```text
error: expected bool, found impl Fn() -> u8
```

---

#### Example 2
**Code**
```rust
fn needs_f(_: impl FnMut(&i32) -> bool) {}
fn main() {
    let g = |_x: &u32| -> bool { true };
    needs_f(g);
}
```

**Before**
```text
error: expected {closure#…}, found {closure#…}
```

**After**
```text
error: expected impl FnMut(&i32) -> bool, found impl FnMut(&u32) -> bool
```

Readable signatures make mismatches clear and actionable. Opaque IDs do not convey what the closure accepts or returns.


**Targeted test**
```bash
cargo test -p ide-diagnostics handlers::type_mismatch::tests::shows_closure_signatures_in_mismatch -- --nocapture
```

## Notes
- If the preferred style is pipe notation (`|…| -> …`), switching to `ClosureStyle::RANotation` is a one-word change.

Refs #20555
