### PR TITLE
Fix nested if-let for merge_nested_if

### DIFF
--- a/crates/ide-assists/src/handlers/merge_nested_if.rs
+++ b/crates/ide-assists/src/handlers/merge_nested_if.rs
@@ -1,4 +1,3 @@
-use ide_db::syntax_helpers::node_ext::is_pattern_cond;
 use syntax::{
     T,
     ast::{self, AstNode, BinaryOp},
@@ -39,10 +38,6 @@ pub(crate) fn merge_nested_if(acc: &mut Assists, ctx: &AssistContext<'_>) -> Opt
     }
 
     let cond = expr.condition()?;
-    //should not apply for if-let
-    if is_pattern_cond(cond.clone()) {
-        return None;
-    }
 
     let cond_range = cond.syntax().text_range();
 
@@ -62,9 +57,6 @@ pub(crate) fn merge_nested_if(acc: &mut Assists, ctx: &AssistContext<'_>) -> Opt
         return None;
     }
     let nested_if_cond = nested_if_to_merge.condition()?;
-    if is_pattern_cond(nested_if_cond.clone()) {
-        return None;
-    }
 
     let nested_if_then_branch = nested_if_to_merge.then_branch()?;
     let then_branch_range = then_branch.syntax().text_range();
@@ -172,6 +164,24 @@ mod tests {
     }
 
     #[test]
+    fn merge_nested_if_test8() {
+        check_assist(
+            merge_nested_if,
+            "fn f() { i$0f let Some(x) = y { if x == 4 { 1 } } }",
+            "fn f() { if let Some(x) = y && x == 4 { 1 } }",
+        )
+    }
+
+    #[test]
+    fn merge_nested_if_test9() {
+        check_assist(
+            merge_nested_if,
+            "fn f() { i$0f y == 0 { if let Some(x) = y { 1 } } }",
+            "fn f() { if y == 0 && let Some(x) = y { 1 } }",
+        )
+    }
+
+    #[test]
     fn merge_nested_if_do_not_apply_to_if_with_else_branch() {
         check_assist_not_applicable(
             merge_nested_if,
@@ -184,22 +194,6 @@ mod tests {
         check_assist_not_applicable(
             merge_nested_if,
             "fn f() { i$0f x == 3 { if y == 4 { 1 } else { 2 } } }",
-        )
-    }
-
-    #[test]
-    fn merge_nested_if_do_not_apply_to_if_let() {
-        check_assist_not_applicable(
-            merge_nested_if,
-            "fn f() { i$0f let Some(x) = y { if x == 4 { 1 } } }",
-        )
-    }
-
-    #[test]
-    fn merge_nested_if_do_not_apply_to_nested_if_let() {
-        check_assist_not_applicable(
-            merge_nested_if,
-            "fn f() { i$0f y == 0 { if let Some(x) = y { 1 } } }",
         )
     }
 


### PR DESCRIPTION
```rust
fn f() { $0if let Some(x) = y { if x == 4 { 1 } } }
```
->
```rust
fn f() { if let Some(x) = y && x == 4 { 1 } }
```
