### PR TITLE
fix: Avoid `--target` option being given twice to `rustc` when invoked through `cargo rustc` while fetching target data layout

### DIFF
--- a/crates/project-model/src/toolchain_info/target_data_layout.rs
+++ b/crates/project-model/src/toolchain_info/target_data_layout.rs
@@ -23,14 +23,11 @@ pub fn get(
         QueryConfig::Cargo(sysroot, cargo_toml, _) => {
             let mut cmd = sysroot.tool(Tool::Cargo, cargo_toml.parent(), extra_env);
             cmd.env("RUSTC_BOOTSTRAP", "1");
-            cmd.args(["rustc", "-Z", "unstable-options"]).args(RUSTC_ARGS).args([
-                "--",
-                "-Z",
-                "unstable-options",
-            ]);
+            cmd.args(["rustc", "-Z", "unstable-options"]).args(RUSTC_ARGS);
             if let Some(target) = target {
                 cmd.args(["--target", target]);
             }
+            cmd.args(["--", "-Z", "unstable-options"]);
             match utf8_stdout(&mut cmd) {
                 Ok(output) => return process(output),
                 Err(e) => {


### PR DESCRIPTION
In `project_model::toolchain_info::target_data_layout::get()`, we are trying to run `rustc --print target-spec-json`.
We first try via `cargo rustc`, and fall back to invoking `rustc` directly in case of failure.

When trying `cargo rustc`, if we have a target string, we add the arguments `["--target", target]` to the very end of the command line, after a `--`. So the target is passed directly to rustc and not interpreted by Cargo.

This becomes an issue when Cargo has also been [given a specific target to use](https://doc.rust-lang.org/cargo/reference/config.html#buildtarget) (e.g. in a `.cargo/config.toml` file), because then Cargo will also add `--target ...` onto its internal invocation of rustc.
Cargo (reasonably) does not inspect the arguments after `--` to check for redundant `--target`, so rustc is invoked with the target option given twice; rustc does not attempt to interpret this and just errors.

If we instead add the target _before_ the `--`, i.e. pass it to Cargo instead of directly to rustc, then Cargo can interpret it as an override to whatever it might see in config files or environment variables, and only pass the option to rustc once.

This is how we do it elsewhere in the codebase, too: https://github.com/rust-lang/rust-analyzer/blob/a271dac5787587e2fa347549e99a41bca79ea6ab/crates/project-model/src/toolchain_info/rustc_cfg.rs#L67-L73