### PR TITLE
fix: Make sense of the mess that were (are) different kind of generics in the solver

### DIFF
--- a/crates/hir-ty/src/chalk_ext.rs
+++ b/crates/hir-ty/src/chalk_ext.rs
@@ -306,7 +306,7 @@ impl TyExt for Ty {
                 predicates.map(|it| it.into_value_and_skipped_binders().0)
             }
             TyKind::Placeholder(idx) => {
-                let id = from_placeholder_idx(db, *idx);
+                let id = from_placeholder_idx(db, *idx).0;
                 let generic_params = db.generic_params(id.parent);
                 let param_data = &generic_params[id.local_id];
                 match param_data {

--- a/crates/hir-ty/src/consteval_nextsolver.rs
+++ b/crates/hir-ty/src/consteval_nextsolver.rs
@@ -49,7 +49,7 @@ pub(crate) fn path_to_const<'a, 'g>(
                 .and_then(|(idx, p)| p.const_param().map(|p| (idx, p.clone())))
             {
                 Some((idx, _param)) => {
-                    Some(Const::new_param(interner, ParamConst { index: idx as u32 }))
+                    Some(Const::new_param(interner, ParamConst { index: idx as u32, id: p }))
                 }
                 None => {
                     never!(

--- a/crates/hir-ty/src/db.rs
+++ b/crates/hir-ty/src/db.rs
@@ -410,13 +410,15 @@ fn hir_database_is_dyn_compatible() {
 #[salsa_macros::interned(no_lifetime, debug, revisions = usize::MAX)]
 #[derive(PartialOrd, Ord)]
 pub struct InternedTypeOrConstParamId {
-    pub loc: TypeOrConstParamId,
+    /// This stores the param and its index.
+    pub loc: (TypeOrConstParamId, u32),
 }
 
 #[salsa_macros::interned(no_lifetime, debug, revisions = usize::MAX)]
 #[derive(PartialOrd, Ord)]
 pub struct InternedLifetimeParamId {
-    pub loc: LifetimeParamId,
+    /// This stores the param and its index.
+    pub loc: (LifetimeParamId, u32),
 }
 
 #[salsa_macros::interned(no_lifetime, debug, revisions = usize::MAX)]

--- a/crates/hir-ty/src/generics.rs
+++ b/crates/hir-ty/src/generics.rs
@@ -256,15 +256,15 @@ impl Generics {
     pub fn placeholder_subst(&self, db: &dyn HirDatabase) -> Substitution {
         Substitution::from_iter(
             Interner,
-            self.iter_id().map(|id| match id {
+            self.iter_id().enumerate().map(|(index, id)| match id {
                 GenericParamId::TypeParamId(id) => {
-                    to_placeholder_idx(db, id.into()).to_ty(Interner).cast(Interner)
+                    to_placeholder_idx(db, id.into(), index as u32).to_ty(Interner).cast(Interner)
                 }
-                GenericParamId::ConstParamId(id) => to_placeholder_idx(db, id.into())
+                GenericParamId::ConstParamId(id) => to_placeholder_idx(db, id.into(), index as u32)
                     .to_const(Interner, db.const_param_ty(id))
                     .cast(Interner),
                 GenericParamId::LifetimeParamId(id) => {
-                    lt_to_placeholder_idx(db, id).to_lifetime(Interner).cast(Interner)
+                    lt_to_placeholder_idx(db, id, index as u32).to_lifetime(Interner).cast(Interner)
                 }
             }),
         )

--- a/crates/hir-ty/src/infer/closure.rs
+++ b/crates/hir-ty/src/infer/closure.rs
@@ -866,7 +866,7 @@ impl CapturedItemWithoutTy {
                     idx: chalk_ir::PlaceholderIndex,
                     outer_binder: DebruijnIndex,
                 ) -> Result<chalk_ir::Const<Interner>, Self::Error> {
-                    let x = from_placeholder_idx(self.db, idx);
+                    let x = from_placeholder_idx(self.db, idx).0;
                     let Some(idx) = self.generics.type_or_const_param_idx(x) else {
                         return Err(());
                     };
@@ -878,7 +878,7 @@ impl CapturedItemWithoutTy {
                     idx: chalk_ir::PlaceholderIndex,
                     outer_binder: DebruijnIndex,
                 ) -> std::result::Result<Ty, Self::Error> {
-                    let x = from_placeholder_idx(self.db, idx);
+                    let x = from_placeholder_idx(self.db, idx).0;
                     let Some(idx) = self.generics.type_or_const_param_idx(x) else {
                         return Err(());
                     };

--- a/crates/hir-ty/src/lib.rs
+++ b/crates/hir-ty/src/lib.rs
@@ -124,7 +124,7 @@ pub use lower_nextsolver::associated_type_shorthand_candidates;
 pub use mapping::{
     ToChalk, from_assoc_type_id, from_chalk_trait_id, from_foreign_def_id, from_placeholder_idx,
     lt_from_placeholder_idx, lt_to_placeholder_idx, to_assoc_type_id, to_chalk_trait_id,
-    to_foreign_def_id, to_placeholder_idx,
+    to_foreign_def_id, to_placeholder_idx, to_placeholder_idx_no_index,
 };
 pub use method_resolution::check_orphan_rules;
 pub use target_feature::TargetFeatures;
@@ -1007,7 +1007,7 @@ struct PlaceholderCollector<'db> {
 
 impl PlaceholderCollector<'_> {
     fn collect(&mut self, idx: PlaceholderIndex) {
-        let id = from_placeholder_idx(self.db, idx);
+        let id = from_placeholder_idx(self.db, idx).0;
         self.placeholders.insert(id);
     }
 }

--- a/crates/hir-ty/src/lower.rs
+++ b/crates/hir-ty/src/lower.rs
@@ -340,7 +340,13 @@ impl<'a> TyLoweringContext<'a> {
                 res = Some(TypeNs::GenericParam(type_param_id));
                 match self.type_param_mode {
                     ParamLoweringMode::Placeholder => {
-                        TyKind::Placeholder(to_placeholder_idx(self.db, type_param_id.into()))
+                        let generics = self.generics();
+                        let idx = generics.type_or_const_param_idx(type_param_id.into()).unwrap();
+                        TyKind::Placeholder(to_placeholder_idx(
+                            self.db,
+                            type_param_id.into(),
+                            idx as u32,
+                        ))
                     }
                     ParamLoweringMode::Variable => {
                         let idx =
@@ -777,7 +783,9 @@ impl<'a> TyLoweringContext<'a> {
                 LifetimeNs::Static => static_lifetime(),
                 LifetimeNs::LifetimeParam(id) => match self.type_param_mode {
                     ParamLoweringMode::Placeholder => {
-                        LifetimeData::Placeholder(lt_to_placeholder_idx(self.db, id))
+                        let generics = self.generics();
+                        let idx = generics.lifetime_idx(id).unwrap();
+                        LifetimeData::Placeholder(lt_to_placeholder_idx(self.db, id, idx as u32))
                     }
                     ParamLoweringMode::Variable => {
                         let idx = match self.generics().lifetime_idx(id) {

--- a/crates/hir-ty/src/lower/path.rs
+++ b/crates/hir-ty/src/lower/path.rs
@@ -222,7 +222,13 @@ impl<'a, 'b> PathLoweringContext<'a, 'b> {
             }
             TypeNs::GenericParam(param_id) => match self.ctx.type_param_mode {
                 ParamLoweringMode::Placeholder => {
-                    TyKind::Placeholder(to_placeholder_idx(self.ctx.db, param_id.into()))
+                    let generics = self.ctx.generics();
+                    let idx = generics.type_or_const_param_idx(param_id.into()).unwrap();
+                    TyKind::Placeholder(to_placeholder_idx(
+                        self.ctx.db,
+                        param_id.into(),
+                        idx as u32,
+                    ))
                 }
                 ParamLoweringMode::Variable => {
                     let idx = match self.ctx.generics().type_or_const_param_idx(param_id.into()) {

--- a/crates/hir-ty/src/lower_nextsolver.rs
+++ b/crates/hir-ty/src/lower_nextsolver.rs
@@ -64,8 +64,7 @@ use crate::{
         AdtDef, AliasTy, Binder, BoundExistentialPredicates, BoundRegionKind, BoundTyKind,
         BoundVarKind, BoundVarKinds, Clause, Clauses, Const, DbInterner, EarlyBinder,
         EarlyParamRegion, ErrorGuaranteed, GenericArgs, PolyFnSig, Predicate, Region, SolverDefId,
-        TraitPredicate, TraitRef, Ty, Tys, abi::Safety, generics::GenericParamDefKind,
-        mapping::ChalkToNextSolver,
+        TraitPredicate, TraitRef, Ty, Tys, abi::Safety, mapping::ChalkToNextSolver,
     },
 };
 
@@ -322,6 +321,7 @@ impl<'db, 'a> TyLoweringContext<'db, 'a> {
                 };
                 Ty::new_param(
                     self.interner,
+                    type_param_id,
                     idx as u32,
                     type_data
                         .name
@@ -866,7 +866,10 @@ impl<'db, 'a> TyLoweringContext<'db, 'a> {
                         None => return Region::error(self.interner),
                         Some(idx) => idx,
                     };
-                    Region::new_early_param(self.interner, EarlyParamRegion { index: idx as u32 })
+                    Region::new_early_param(
+                        self.interner,
+                        EarlyParamRegion { index: idx as u32, id },
+                    )
                 }
             },
             None => Region::error(self.interner),
@@ -1344,11 +1347,11 @@ where
                     {
                         continue;
                     }
-                    let GenericParamDefKind::Type = p.kind else {
+                    let GenericParamId::TypeParamId(param_id) = p.id else {
                         continue;
                     };
                     let idx = idx as u32 + generics.parent_count as u32;
-                    let param_ty = Ty::new_param(interner, idx, p.name.clone());
+                    let param_ty = Ty::new_param(interner, param_id, idx, p.name.clone());
                     if explicitly_unsized_tys.contains(&param_ty) {
                         continue;
                     }

--- a/crates/hir-ty/src/lower_nextsolver/path.rs
+++ b/crates/hir-ty/src/lower_nextsolver/path.rs
@@ -281,6 +281,7 @@ impl<'a, 'b, 'db> PathLoweringContext<'a, 'b, 'db> {
                         };
                         Ty::new_param(
                             self.ctx.interner,
+                            param_id,
                             idx as u32,
                             p.name
                                 .as_ref()
@@ -758,6 +759,7 @@ impl<'a, 'b, 'db> PathLoweringContext<'a, 'b, 'db> {
                     self.ctx.ctx.db.generic_defaults(def).get(preceding_args.len()).map(|default| {
                         convert_binder_to_early_binder(
                             self.ctx.ctx.interner,
+                            def,
                             default.to_nextsolver(self.ctx.ctx.interner),
                         )
                         .instantiate(self.ctx.ctx.interner, preceding_args)

--- a/crates/hir-ty/src/mapping.rs
+++ b/crates/hir-ty/src/mapping.rs
@@ -104,7 +104,10 @@ pub fn from_assoc_type_id(id: AssocTypeId) -> TypeAliasId {
     FromId::from_id(id.0)
 }
 
-pub fn from_placeholder_idx(db: &dyn HirDatabase, idx: PlaceholderIndex) -> TypeOrConstParamId {
+pub fn from_placeholder_idx(
+    db: &dyn HirDatabase,
+    idx: PlaceholderIndex,
+) -> (TypeOrConstParamId, u32) {
     assert_eq!(idx.ui, chalk_ir::UniverseIndex::ROOT);
     // SAFETY: We cannot really encapsulate this unfortunately, so just hope this is sound.
     let interned_id =
@@ -112,15 +115,32 @@ pub fn from_placeholder_idx(db: &dyn HirDatabase, idx: PlaceholderIndex) -> Type
     interned_id.loc(db)
 }
 
-pub fn to_placeholder_idx(db: &dyn HirDatabase, id: TypeOrConstParamId) -> PlaceholderIndex {
-    let interned_id = InternedTypeOrConstParamId::new(db, id);
+pub fn to_placeholder_idx(
+    db: &dyn HirDatabase,
+    id: TypeOrConstParamId,
+    idx: u32,
+) -> PlaceholderIndex {
+    let interned_id = InternedTypeOrConstParamId::new(db, (id, idx));
     PlaceholderIndex {
         ui: chalk_ir::UniverseIndex::ROOT,
         idx: interned_id.as_id().index() as usize,
     }
 }
 
-pub fn lt_from_placeholder_idx(db: &dyn HirDatabase, idx: PlaceholderIndex) -> LifetimeParamId {
+pub fn to_placeholder_idx_no_index(
+    db: &dyn HirDatabase,
+    id: TypeOrConstParamId,
+) -> PlaceholderIndex {
+    let index = crate::generics::generics(db, id.parent)
+        .type_or_const_param_idx(id)
+        .expect("param not found");
+    to_placeholder_idx(db, id, index as u32)
+}
+
+pub fn lt_from_placeholder_idx(
+    db: &dyn HirDatabase,
+    idx: PlaceholderIndex,
+) -> (LifetimeParamId, u32) {
     assert_eq!(idx.ui, chalk_ir::UniverseIndex::ROOT);
     // SAFETY: We cannot really encapsulate this unfortunately, so just hope this is sound.
     let interned_id =
@@ -128,8 +148,12 @@ pub fn lt_from_placeholder_idx(db: &dyn HirDatabase, idx: PlaceholderIndex) -> L
     interned_id.loc(db)
 }
 
-pub fn lt_to_placeholder_idx(db: &dyn HirDatabase, id: LifetimeParamId) -> PlaceholderIndex {
-    let interned_id = InternedLifetimeParamId::new(db, id);
+pub fn lt_to_placeholder_idx(
+    db: &dyn HirDatabase,
+    id: LifetimeParamId,
+    idx: u32,
+) -> PlaceholderIndex {
+    let interned_id = InternedLifetimeParamId::new(db, (id, idx));
     PlaceholderIndex {
         ui: chalk_ir::UniverseIndex::ROOT,
         idx: interned_id.as_id().index() as usize,

--- a/crates/hir-ty/src/mir/monomorphization.rs
+++ b/crates/hir-ty/src/mir/monomorphization.rs
@@ -99,7 +99,7 @@ impl FallibleTypeFolder<Interner> for Filler<'_> {
         idx: chalk_ir::PlaceholderIndex,
         _outer_binder: DebruijnIndex,
     ) -> std::result::Result<chalk_ir::Const<Interner>, Self::Error> {
-        let it = from_placeholder_idx(self.db, idx);
+        let it = from_placeholder_idx(self.db, idx).0;
         let Some(idx) = self.generics.as_ref().and_then(|g| g.type_or_const_param_idx(it)) else {
             not_supported!("missing idx in generics");
         };
@@ -117,7 +117,7 @@ impl FallibleTypeFolder<Interner> for Filler<'_> {
         idx: chalk_ir::PlaceholderIndex,
         _outer_binder: DebruijnIndex,
     ) -> std::result::Result<Ty, Self::Error> {
-        let it = from_placeholder_idx(self.db, idx);
+        let it = from_placeholder_idx(self.db, idx).0;
         let Some(idx) = self.generics.as_ref().and_then(|g| g.type_or_const_param_idx(it)) else {
             not_supported!("missing idx in generics");
         };

--- a/crates/hir-ty/src/next_solver/consts.rs
+++ b/crates/hir-ty/src/next_solver/consts.rs
@@ -2,6 +2,7 @@
 
 use std::hash::Hash;
 
+use hir_def::{ConstParamId, TypeOrConstParamId};
 use intern::{Interned, Symbol};
 use rustc_ast_ir::try_visit;
 use rustc_ast_ir::visit::VisitorResult;
@@ -84,6 +85,8 @@ pub type PlaceholderConst = Placeholder<rustc_type_ir::BoundVar>;
 
 #[derive(Copy, Clone, Hash, Eq, PartialEq)]
 pub struct ParamConst {
+    // FIXME: See `ParamTy`.
+    pub id: ConstParamId,
     pub index: u32,
 }
 

--- a/crates/hir-ty/src/next_solver/infer/mod.rs
+++ b/crates/hir-ty/src/next_solver/infer/mod.rs
@@ -8,6 +8,7 @@ pub use BoundRegionConversionTime::*;
 pub use at::DefineOpaqueTypes;
 use ena::undo_log::UndoLogs;
 use ena::unify as ut;
+use hir_def::GenericParamId;
 use intern::Symbol;
 use opaque_types::{OpaqueHiddenType, OpaqueTypeStorage};
 use region_constraints::{
@@ -38,7 +39,7 @@ use crate::next_solver::fold::BoundVarReplacerDelegate;
 use crate::next_solver::infer::opaque_types::table::OpaqueTypeStorageEntries;
 use crate::next_solver::{BoundRegion, BoundTy, BoundVarKind};
 
-use super::generics::{GenericParamDef, GenericParamDefKind};
+use super::generics::GenericParamDef;
 use super::{
     AliasTerm, Binder, BoundRegionKind, CanonicalQueryInput, CanonicalVarValues, Const, ConstKind,
     DbInterner, ErrorGuaranteed, FxIndexMap, GenericArg, GenericArgs, OpaqueTypeKey, ParamEnv,
@@ -600,14 +601,14 @@ impl<'db> InferCtxt<'db> {
         self.next_region_var_in_universe(universe)
     }
 
-    fn var_for_def(&self, kind: GenericParamDefKind, name: &Symbol) -> GenericArg<'db> {
-        match kind {
-            GenericParamDefKind::Lifetime => {
+    fn var_for_def(&self, id: GenericParamId, name: &Symbol) -> GenericArg<'db> {
+        match id {
+            GenericParamId::LifetimeParamId(_) => {
                 // Create a region inference variable for the given
                 // region parameter definition.
                 self.next_region_var().into()
             }
-            GenericParamDefKind::Type => {
+            GenericParamId::TypeParamId(_) => {
                 // Create a type inference variable for the given
                 // type parameter definition. The generic parameters are
                 // for actual parameters that may be referred to by
@@ -624,7 +625,7 @@ impl<'db> InferCtxt<'db> {
 
                 Ty::new_var(self.interner, ty_var_id).into()
             }
-            GenericParamDefKind::Const => {
+            GenericParamId::ConstParamId(_) => {
                 let origin = ConstVariableOrigin { param_def_id: None };
                 let const_var_id = self
                     .inner

--- a/crates/hir-ty/src/next_solver/region.rs
+++ b/crates/hir-ty/src/next_solver/region.rs
@@ -1,5 +1,6 @@
 //! Things related to regions.
 
+use hir_def::LifetimeParamId;
 use intern::{Interned, Symbol};
 use rustc_type_ir::{
     BoundVar, Flags, INNERMOST, RegionVid, TypeFlags, TypeFoldable, TypeVisitable, VisitorResult,
@@ -110,6 +111,8 @@ pub type PlaceholderRegion = Placeholder<BoundRegion>;
 
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
 pub struct EarlyParamRegion {
+    // FIXME: See `ParamTy`.
+    pub id: LifetimeParamId,
     pub index: u32,
 }
 

--- a/crates/hir-ty/src/variance.rs
+++ b/crates/hir-ty/src/variance.rs
@@ -344,7 +344,7 @@ impl Context<'_> {
 
             // Chalk has no params, so use placeholders for now?
             TyKind::Placeholder(index) => {
-                let idx = crate::from_placeholder_idx(self.db, *index);
+                let idx = crate::from_placeholder_idx(self.db, *index).0;
                 let index = self.generics.type_or_const_param_idx(idx).unwrap();
                 self.constrain(index, variance);
             }
@@ -445,7 +445,7 @@ impl Context<'_> {
         );
         match region.data(Interner) {
             LifetimeData::Placeholder(index) => {
-                let idx = crate::lt_from_placeholder_idx(self.db, *index);
+                let idx = crate::lt_from_placeholder_idx(self.db, *index).0;
                 let inferred = self.generics.lifetime_idx(idx).unwrap();
                 self.constrain(inferred, variance);
             }

--- a/crates/hir/src/display.rs
+++ b/crates/hir/src/display.rs
@@ -474,8 +474,8 @@ impl HirDisplay for TypeParam {
         let param_data = &params[self.id.local_id()];
         let substs = TyBuilder::placeholder_subst(f.db, self.id.parent());
         let krate = self.id.parent().krate(f.db).id;
-        let ty =
-            TyKind::Placeholder(hir_ty::to_placeholder_idx(f.db, self.id.into())).intern(Interner);
+        let ty = TyKind::Placeholder(hir_ty::to_placeholder_idx_no_index(f.db, self.id.into()))
+            .intern(Interner);
         let predicates = f.db.generic_predicates(self.id.parent());
         let predicates = predicates
             .iter()
@@ -528,8 +528,11 @@ impl HirDisplay for TypeParam {
                 f,
                 ":",
                 Either::Left(
-                    &hir_ty::TyKind::Placeholder(hir_ty::to_placeholder_idx(f.db, self.id.into()))
-                        .intern(Interner),
+                    &hir_ty::TyKind::Placeholder(hir_ty::to_placeholder_idx_no_index(
+                        f.db,
+                        self.id.into(),
+                    ))
+                    .intern(Interner),
                 ),
                 &predicates,
                 default_sized,

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -4239,8 +4239,8 @@ impl TypeParam {
 
     pub fn ty(self, db: &dyn HirDatabase) -> Type<'_> {
         let resolver = self.id.parent().resolver(db);
-        let ty =
-            TyKind::Placeholder(hir_ty::to_placeholder_idx(db, self.id.into())).intern(Interner);
+        let ty = TyKind::Placeholder(hir_ty::to_placeholder_idx_no_index(db, self.id.into()))
+            .intern(Interner);
         Type::new_with_resolver_inner(db, &resolver, ty)
     }
 
@@ -5933,7 +5933,7 @@ impl<'db> Type<'db> {
     pub fn as_type_param(&self, db: &'db dyn HirDatabase) -> Option<TypeParam> {
         match self.ty.kind(Interner) {
             TyKind::Placeholder(p) => Some(TypeParam {
-                id: TypeParamId::from_unchecked(hir_ty::from_placeholder_idx(db, *p)),
+                id: TypeParamId::from_unchecked(hir_ty::from_placeholder_idx(db, *p).0),
             }),
             _ => None,
         }


### PR DESCRIPTION
To the extent possible.

Previously they were confused. Sometimes generic params were treated as `Param` and sometimes as `Placeholder`. A completely redundant (in the new solver) mapping of salsa::Id to ints to intern some info where we could just store it uninterned (not in Chalk though, for some weird reason).

Plus fix a cute bug in closure substitution that was caught by the assertions of Chalk but the next solver did not have such assertions. Do we need more assertions?

Should hopefully fix all failures in https://github.com/rust-lang/rust-analyzer/pull/20578.