### PR TITLE
ide-assists: Clarify that generated setters receive `&mut self`

### DIFF
--- a/crates/ide-assists/src/handlers/generate_getter_or_setter.rs
+++ b/crates/ide-assists/src/handlers/generate_getter_or_setter.rs
@@ -13,7 +13,7 @@ use crate::{
 
 // Assist: generate_setter
 //
-// Generate a setter method.
+// Generate a `&mut self` setter method.
 //
 // ```
 // struct Person {
@@ -64,7 +64,7 @@ pub(crate) fn generate_setter(acc: &mut Assists, ctx: &AssistContext<'_>) -> Opt
     acc.add_group(
         &GroupLabel("Generate getter/setter".to_owned()),
         AssistId::generate("generate_setter"),
-        "Generate a setter method",
+        "Generate an `&mut self` setter method",
         target,
         |builder| build_source_change(builder, ctx, info_of_record_fields, setter_info),
     );

--- a/crates/ide-assists/src/tests.rs
+++ b/crates/ide-assists/src/tests.rs
@@ -440,7 +440,10 @@ fn assist_order_field_struct() {
     assert_eq!(assists.next().expect("expected assist").label, "Change visibility to pub(crate)");
     assert_eq!(assists.next().expect("expected assist").label, "Generate a getter method");
     assert_eq!(assists.next().expect("expected assist").label, "Generate a mut getter method");
-    assert_eq!(assists.next().expect("expected assist").label, "Generate a setter method");
+    assert_eq!(
+        assists.next().expect("expected assist").label,
+        "Generate an `&mut self` setter method"
+    );
     assert_eq!(assists.next().expect("expected assist").label, "Add `#[derive]`");
     assert_eq!(assists.next().expect("expected assist").label, "Generate `new`");
     assert_eq!(assists.next().map(|it| it.label.to_string()), None);


### PR DESCRIPTION
This is different from "builder setters", which typically receive an owned `self` and return `Self` as well.

I'd like to implement generation for `fn with_foo(mut self, foo: T) -> Self` methods in the future, but first we should clarify what `rust-analyzer` means by "setter method"s.