### PR TITLE
fix: Fix typo in config

### DIFF
--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -2832,7 +2832,7 @@ enum ReborrowHintsDef {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "snake_case")]
 enum AdjustmentHintsDef {
-    #[serde(alias = "Reborrow")]
+    #[serde(alias = "reborrow")]
     Borrows,
     #[serde(with = "true_or_always")]
     #[serde(untagged)]


### PR DESCRIPTION
To make it backwards-compatible.

See https://github.com/rust-lang/rust-analyzer/pull/20520#discussion_r2321357436.