### PR TITLE
internal: Add a regression test for a fixed new trait solver bug

### DIFF
--- a/crates/hir-ty/src/tests/regression/new_solver.rs
+++ b/crates/hir-ty/src/tests/regression/new_solver.rs
@@ -1,6 +1,6 @@
 use expect_test::expect;
 
-use super::check_infer;
+use crate::tests::{check_infer, check_no_mismatches};
 
 #[test]
 fn opaque_generics() {
@@ -48,5 +48,26 @@ fn main() {
             55..65 'Some(1i32)': Option<i32>
             60..64 '1i32': i32
         "#]],
+    );
+}
+
+#[test]
+fn regression_20487() {
+    check_no_mismatches(
+        r#"
+//- minicore: coerce_unsized, dispatch_from_dyn
+trait Foo {
+    fn bar(&self) -> u32 {
+        0xCAFE
+    }
+}
+
+fn debug(_: &dyn Foo) {}
+
+impl Foo for i32 {}
+
+fn main() {
+    debug(&1);
+}"#,
     );
 }


### PR DESCRIPTION
Not sure what exactly fixed it, but why not.

Closes rust-lang/rust-analyzer#20487, closes rust-lang/rust-analyzer#20489.