### PR TITLE
internal: Upgrade rustc crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1360,7 +1360,7 @@ dependencies = [
  "expect-test",
  "intern",
  "parser",
- "ra-ap-rustc_lexer 0.123.0",
+ "ra-ap-rustc_lexer",
  "rustc-hash 2.1.1",
  "smallvec",
  "span",
@@ -1596,8 +1596,8 @@ dependencies = [
  "drop_bomb",
  "edition",
  "expect-test",
- "ra-ap-rustc_lexer 0.123.0",
- "rustc-literal-escaper",
+ "ra-ap-rustc_lexer",
+ "rustc-literal-escaper 0.0.4",
  "stdx",
  "tracing",
 ]
@@ -1717,7 +1717,7 @@ dependencies = [
  "object",
  "paths",
  "proc-macro-test",
- "ra-ap-rustc_lexer 0.123.0",
+ "ra-ap-rustc_lexer",
  "span",
  "syntax-bridge",
  "temp-dir",
@@ -1863,9 +1863,9 @@ dependencies = [
 
 [[package]]
 name = "ra-ap-rustc_abi"
-version = "0.123.0"
+version = "0.126.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f18c877575c259d127072e9bfc41d985202262fb4d6bfdae3d1252147c2562c2"
+checksum = "0c6789d94fb3e6e30d62f55e99a321ba63484a8bb3b4ead338687c9ddc282d28"
 dependencies = [
  "bitflags 2.9.1",
  "ra-ap-rustc_hashes",
@@ -1875,24 +1875,24 @@ dependencies = [
 
 [[package]]
 name = "ra-ap-rustc_ast_ir"
-version = "0.123.0"
+version = "0.126.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cc17e8ce797f2a8d03b838fbf166749b876164432ce81e37d283bf69e3cf80"
+checksum = "aaab80bda0f05e9842e3afb7779b0bad0a4b54e0f7ba6deb5705dcf86482811d"
 
 [[package]]
 name = "ra-ap-rustc_hashes"
-version = "0.123.0"
+version = "0.126.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2439ed1df3472443133b66949f81080dff88089b42f825761455463709ee1cad"
+checksum = "64bd405e538102b5f699241794b2eefee39d5414c0e4bc72435e91430c51f905"
 dependencies = [
  "rustc-stable-hash",
 ]
 
 [[package]]
 name = "ra-ap-rustc_index"
-version = "0.123.0"
+version = "0.126.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57a24fe0be21be1f8ebc21dcb40129214fb4cefb0f2753f3d46b6dbe656a1a45"
+checksum = "521621e271aa03b8433dad5981838278d6cfd7d2d8c9f4eb6d427f1d671f90fc"
 dependencies = [
  "ra-ap-rustc_index_macros",
  "smallvec",
@@ -1900,9 +1900,9 @@ dependencies = [
 
 [[package]]
 name = "ra-ap-rustc_index_macros"
-version = "0.123.0"
+version = "0.126.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "844a27ddcad0116facae2df8e741fd788662cf93dc13029cd864f2b8013b81f9"
+checksum = "245e30f2e1fef258913cc548b36f575549c8af31cbc4649929d21deda96ceeb7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1911,20 +1911,9 @@ dependencies = [
 
 [[package]]
 name = "ra-ap-rustc_lexer"
-version = "0.121.0"
+version = "0.126.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22944e31fb91e9b3e75bcbc91e37d958b8c0825a6160927f2856831d2ce83b36"
-dependencies = [
- "memchr",
- "unicode-properties",
- "unicode-xid",
-]
-
-[[package]]
-name = "ra-ap-rustc_lexer"
-version = "0.123.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b734cfcb577d09877799a22742f1bd398be6c00bc428d9de56d48d11ece5771"
+checksum = "a82681f924500e888c860e60ed99e9bf702a219a69374f59116c4261525a2157"
 dependencies = [
  "memchr",
  "unicode-properties",
@@ -1933,9 +1922,9 @@ dependencies = [
 
 [[package]]
 name = "ra-ap-rustc_next_trait_solver"
-version = "0.123.0"
+version = "0.126.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14f7dfbdf1d045ff4e385e1efdfc3799379895e9c3f3b9b379a0bef4cb238441"
+checksum = "0c9ce51f2431fbdc7fabd2d957522b6e27f41f68ec2af74b52a6f4116352ce1a"
 dependencies = [
  "derive-where",
  "ra-ap-rustc_index",
@@ -1946,19 +1935,19 @@ dependencies = [
 
 [[package]]
 name = "ra-ap-rustc_parse_format"
-version = "0.121.0"
+version = "0.126.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81057891bc2063ad9e353f29462fbc47a0f5072560af34428ae9313aaa5e9d97"
+checksum = "adc85ef3fdb6c084bde84857d8948dc66b752129dc8417a8614ce490e99a143f"
 dependencies = [
- "ra-ap-rustc_lexer 0.121.0",
- "rustc-literal-escaper",
+ "ra-ap-rustc_lexer",
+ "rustc-literal-escaper 0.0.5",
 ]
 
 [[package]]
 name = "ra-ap-rustc_pattern_analysis"
-version = "0.123.0"
+version = "0.126.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75b0ee1f059b9dea0818c6c7267478926eee95ba4c7dcf89c8db32fa165d3904"
+checksum = "3cd81eccf33d9528905d4e5abaa254b3129a6405d6c5f123fed9b73a3d217f35"
 dependencies = [
  "ra-ap-rustc_index",
  "rustc-hash 2.1.1",
@@ -1969,9 +1958,9 @@ dependencies = [
 
 [[package]]
 name = "ra-ap-rustc_type_ir"
-version = "0.123.0"
+version = "0.126.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bc59fb10a922c38a24cb8a1494f799b0af30bd041acbea689378d3bf330534b"
+checksum = "11cb0da02853698d9c89e1d1c01657b9969752befd56365e8899d4310e52b373"
 dependencies = [
  "bitflags 2.9.1",
  "derive-where",
@@ -1988,9 +1977,9 @@ dependencies = [
 
 [[package]]
 name = "ra-ap-rustc_type_ir_macros"
-version = "0.123.0"
+version = "0.126.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58878914b6dac7499baeecc8dbb4b9d9dda88030e4ab90cd3b4e87523fbedafe"
+checksum = "ffc93adeb52c483ede13bee6680466458218243ab479c04fb71bb53925a6e0ff"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2139,6 +2128,12 @@ name = "rustc-literal-escaper"
 version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab03008eb631b703dd16978282ae36c73282e7922fe101a4bd072a40ecea7b8b"
+
+[[package]]
+name = "rustc-literal-escaper"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4ee29da77c5a54f42697493cd4c9b9f31b74df666a6c04dfc4fde77abe0438b"
 
 [[package]]
 name = "rustc-stable-hash"
@@ -2445,7 +2440,7 @@ dependencies = [
  "rayon",
  "rowan",
  "rustc-hash 2.1.1",
- "rustc-literal-escaper",
+ "rustc-literal-escaper 0.0.4",
  "rustc_apfloat",
  "smol_str",
  "stdx",
@@ -2773,7 +2768,7 @@ version = "0.0.0"
 dependencies = [
  "arrayvec",
  "intern",
- "ra-ap-rustc_lexer 0.123.0",
+ "ra-ap-rustc_lexer",
  "stdx",
  "text-size",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,14 +89,14 @@ vfs-notify = { path = "./crates/vfs-notify", version = "0.0.0" }
 vfs = { path = "./crates/vfs", version = "0.0.0" }
 edition = { path = "./crates/edition", version = "0.0.0" }
 
-ra-ap-rustc_lexer = { version = "0.123", default-features = false }
-ra-ap-rustc_parse_format = { version = "0.121", default-features = false }
-ra-ap-rustc_index = { version = "0.123", default-features = false }
-ra-ap-rustc_abi = { version = "0.123", default-features = false }
-ra-ap-rustc_pattern_analysis = { version = "0.123", default-features = false }
-ra-ap-rustc_ast_ir = { version = "0.123", default-features = false }
-ra-ap-rustc_type_ir = { version = "0.123", default-features = false }
-ra-ap-rustc_next_trait_solver = { version = "0.123", default-features = false }
+ra-ap-rustc_lexer = { version = "0.126", default-features = false }
+ra-ap-rustc_parse_format = { version = "0.126", default-features = false }
+ra-ap-rustc_index = { version = "0.126", default-features = false }
+ra-ap-rustc_abi = { version = "0.126", default-features = false }
+ra-ap-rustc_pattern_analysis = { version = "0.126", default-features = false }
+ra-ap-rustc_ast_ir = { version = "0.126", default-features = false }
+ra-ap-rustc_type_ir = { version = "0.126", default-features = false }
+ra-ap-rustc_next_trait_solver = { version = "0.126", default-features = false }
 
 # local crates that aren't published to crates.io. These should not have versions.
 

--- a/crates/hir-ty/src/display.rs
+++ b/crates/hir-ty/src/display.rs
@@ -737,7 +737,7 @@ impl<'db> HirDisplay for crate::next_solver::Const<'db> {
         match self.kind() {
             rustc_type_ir::ConstKind::Placeholder(_) => write!(f, "<placeholder>"),
             rustc_type_ir::ConstKind::Bound(db, bound_const) => {
-                write!(f, "?{}.{}", db.as_u32(), bound_const.as_u32())
+                write!(f, "?{}.{}", db.as_u32(), bound_const.var.as_u32())
             }
             rustc_type_ir::ConstKind::Infer(..) => write!(f, "#c#"),
             rustc_type_ir::ConstKind::Param(param) => {
@@ -1208,10 +1208,7 @@ impl<'db> HirDisplay for crate::next_solver::Ty<'db> {
                 let contains_impl_fn_ns = |bounds: &[BoundExistentialPredicate<'_>]| {
                     bounds.iter().any(|bound| match bound.skip_binder() {
                         rustc_type_ir::ExistentialPredicate::Trait(trait_ref) => {
-                            let trait_ = match trait_ref.def_id {
-                                SolverDefId::TraitId(id) => id,
-                                _ => unreachable!(),
-                            };
+                            let trait_ = trait_ref.def_id.0;
                             fn_traits(db, trait_).any(|it| it == trait_)
                         }
                         _ => false,
@@ -2217,10 +2214,7 @@ impl HirDisplay for TraitRef {
 
 impl<'db> HirDisplay for crate::next_solver::TraitRef<'db> {
     fn hir_fmt(&self, f: &mut HirFormatter<'_>) -> Result<(), HirDisplayError> {
-        let trait_ = match self.def_id {
-            SolverDefId::TraitId(id) => id,
-            _ => unreachable!(),
-        };
+        let trait_ = self.def_id.0;
         f.start_location_link(trait_.into());
         write!(f, "{}", f.db.trait_signature(trait_).name.display(f.db, f.edition()))?;
         f.end_location_link();

--- a/crates/hir-ty/src/lower_nextsolver/path.rs
+++ b/crates/hir-ty/src/lower_nextsolver/path.rs
@@ -208,10 +208,7 @@ impl<'a, 'b, 'db> PathLoweringContext<'a, 'b, 'db> {
                         tracing::debug!(?trait_ref);
                         self.skip_resolved_segment();
                         let segment = self.current_or_prev_segment;
-                        let trait_id = match trait_ref.def_id {
-                            SolverDefId::TraitId(id) => id,
-                            _ => unreachable!(),
-                        };
+                        let trait_id = trait_ref.def_id.0;
                         let found =
                             trait_id.trait_items(self.ctx.db).associated_type_by_name(segment.name);
 

--- a/crates/hir-ty/src/method_resolution.rs
+++ b/crates/hir-ty/src/method_resolution.rs
@@ -168,11 +168,7 @@ impl TyFingerprint {
                         _ => None,
                     })
                     .next()?;
-                let trait_id = match trait_ref {
-                    SolverDefId::TraitId(id) => id,
-                    _ => panic!("Bad GenericDefId in trait ref"),
-                };
-                TyFingerprint::Dyn(trait_id)
+                TyFingerprint::Dyn(trait_ref.0)
             }
             TyKind::Ref(_, _, mutability) => match mutability {
                 rustc_ast_ir::Mutability::Mut => TyFingerprint::Ref(Mutability::Mut),

--- a/crates/hir-ty/src/next_solver/def_id.rs
+++ b/crates/hir-ty/src/next_solver/def_id.rs
@@ -88,3 +88,60 @@ impl<'db> inherent::DefId<DbInterner<'db>> for SolverDefId {
         true
     }
 }
+
+macro_rules! declare_id_wrapper {
+    ($name:ident, $wraps:ident) => {
+        #[derive(Clone, Copy, PartialEq, Eq, Hash)]
+        pub struct $name(pub $wraps);
+
+        impl std::fmt::Debug for $name {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                std::fmt::Debug::fmt(&self.0, f)
+            }
+        }
+
+        impl From<$name> for $wraps {
+            #[inline]
+            fn from(value: $name) -> $wraps {
+                value.0
+            }
+        }
+
+        impl From<$wraps> for $name {
+            #[inline]
+            fn from(value: $wraps) -> $name {
+                Self(value)
+            }
+        }
+
+        impl From<$name> for SolverDefId {
+            #[inline]
+            fn from(value: $name) -> SolverDefId {
+                value.0.into()
+            }
+        }
+
+        impl TryFrom<SolverDefId> for $name {
+            type Error = ();
+
+            #[inline]
+            fn try_from(value: SolverDefId) -> Result<Self, Self::Error> {
+                match value {
+                    SolverDefId::$wraps(it) => Ok(Self(it)),
+                    _ => Err(()),
+                }
+            }
+        }
+
+        impl<'db> inherent::DefId<DbInterner<'db>> for $name {
+            fn as_local(self) -> Option<SolverDefId> {
+                Some(self.into())
+            }
+            fn is_local(self) -> bool {
+                true
+            }
+        }
+    };
+}
+
+declare_id_wrapper!(TraitIdWrapper, TraitId);

--- a/crates/hir-ty/src/next_solver/fold.rs
+++ b/crates/hir-ty/src/next_solver/fold.rs
@@ -6,6 +6,8 @@ use rustc_type_ir::{
     inherent::{IntoKind, Region as _},
 };
 
+use crate::next_solver::BoundConst;
+
 use super::{
     Binder, BoundRegion, BoundTy, Const, ConstKind, DbInterner, Predicate, Region, Ty, TyKind,
 };
@@ -18,7 +20,7 @@ use super::{
 pub trait BoundVarReplacerDelegate<'db> {
     fn replace_region(&mut self, br: BoundRegion) -> Region<'db>;
     fn replace_ty(&mut self, bt: BoundTy) -> Ty<'db>;
-    fn replace_const(&mut self, bv: BoundVar) -> Const<'db>;
+    fn replace_const(&mut self, bv: BoundConst) -> Const<'db>;
 }
 
 /// A simple delegate taking 3 mutable functions. The used functions must
@@ -27,7 +29,7 @@ pub trait BoundVarReplacerDelegate<'db> {
 pub struct FnMutDelegate<'db, 'a> {
     pub regions: &'a mut (dyn FnMut(BoundRegion) -> Region<'db> + 'a),
     pub types: &'a mut (dyn FnMut(BoundTy) -> Ty<'db> + 'a),
-    pub consts: &'a mut (dyn FnMut(BoundVar) -> Const<'db> + 'a),
+    pub consts: &'a mut (dyn FnMut(BoundConst) -> Const<'db> + 'a),
 }
 
 impl<'db, 'a> BoundVarReplacerDelegate<'db> for FnMutDelegate<'db, 'a> {
@@ -37,7 +39,7 @@ impl<'db, 'a> BoundVarReplacerDelegate<'db> for FnMutDelegate<'db, 'a> {
     fn replace_ty(&mut self, bt: BoundTy) -> Ty<'db> {
         (self.types)(bt)
     }
-    fn replace_const(&mut self, bv: BoundVar) -> Const<'db> {
+    fn replace_const(&mut self, bv: BoundConst) -> Const<'db> {
         (self.consts)(bv)
     }
 }

--- a/crates/hir-ty/src/next_solver/fulfill.rs
+++ b/crates/hir-ty/src/next_solver/fulfill.rs
@@ -167,7 +167,7 @@ impl<'db> FulfillmentCtxt<'db> {
                 }
 
                 let result = delegate.evaluate_root_goal(goal, Span::dummy(), stalled_on);
-                let GoalEvaluation { certainty, has_changed, stalled_on } = match result {
+                let GoalEvaluation { goal: _, certainty, has_changed, stalled_on } = match result {
                     Ok(result) => result,
                     Err(NoSolution) => {
                         errors.push(NextSolverError::TrueError(obligation));

--- a/crates/hir-ty/src/next_solver/generic_arg.rs
+++ b/crates/hir-ty/src/next_solver/generic_arg.rs
@@ -384,7 +384,6 @@ impl<'db> rustc_type_ir::inherent::GenericArgs<DbInterner<'db>> for GenericArgs<
                 signature_parts_ty: signature_parts_ty.expect_ty(),
                 tupled_upvars_ty: tupled_upvars_ty.expect_ty(),
                 coroutine_captures_by_ref_ty: coroutine_captures_by_ref_ty.expect_ty(),
-                coroutine_witness_ty: coroutine_witness_ty.expect_ty(),
             },
             _ => panic!("GenericArgs were likely not for a CoroutineClosure."),
         }
@@ -400,7 +399,6 @@ impl<'db> rustc_type_ir::inherent::GenericArgs<DbInterner<'db>> for GenericArgs<
                     resume_ty: resume_ty.expect_ty(),
                     yield_ty: yield_ty.expect_ty(),
                     return_ty: return_ty.expect_ty(),
-                    witness: Ty::new_unit(interner),
                     tupled_upvars_ty: Ty::new_unit(interner),
                 }
             }

--- a/crates/hir-ty/src/next_solver/infer/canonical/instantiate.rs
+++ b/crates/hir-ty/src/next_solver/infer/canonical/instantiate.rs
@@ -6,6 +6,7 @@
 //!
 //! [c]: https://rust-lang.github.io/chalk/book/canonical_queries/canonicalization.html
 
+use crate::next_solver::BoundConst;
 use crate::next_solver::{
     AliasTy, Binder, BoundRegion, BoundTy, Canonical, CanonicalVarValues, Const, DbInterner, Goal,
     ParamEnv, Predicate, PredicateKind, Region, Ty, TyKind,
@@ -95,7 +96,7 @@ where
                 GenericArgKind::Type(ty) => ty,
                 r => panic!("{bound_ty:?} is a type but value is {r:?}"),
             },
-            consts: &mut |bound_ct: BoundVar| match var_values[bound_ct].kind() {
+            consts: &mut |bound_ct: BoundConst| match var_values[bound_ct.var].kind() {
                 GenericArgKind::Const(ct) => ct,
                 c => panic!("{bound_ct:?} is a const but value is {c:?}"),
             },

--- a/crates/hir-ty/src/next_solver/infer/mod.rs
+++ b/crates/hir-ty/src/next_solver/infer/mod.rs
@@ -37,7 +37,7 @@ use unify_key::{ConstVariableOrigin, ConstVariableValue, ConstVidKey};
 
 use crate::next_solver::fold::BoundVarReplacerDelegate;
 use crate::next_solver::infer::opaque_types::table::OpaqueTypeStorageEntries;
-use crate::next_solver::{BoundRegion, BoundTy, BoundVarKind};
+use crate::next_solver::{BoundConst, BoundRegion, BoundTy, BoundVarKind};
 
 use super::generics::GenericParamDef;
 use super::{
@@ -864,8 +864,8 @@ impl<'db> InferCtxt<'db> {
             fn replace_ty(&mut self, bt: BoundTy) -> Ty<'db> {
                 self.args[bt.var.index()].expect_ty()
             }
-            fn replace_const(&mut self, bv: BoundVar) -> Const<'db> {
-                self.args[bv.index()].expect_const()
+            fn replace_const(&mut self, bv: BoundConst) -> Const<'db> {
+                self.args[bv.var.index()].expect_const()
             }
         }
         let delegate = ToFreshVars { args };

--- a/crates/hir-ty/src/next_solver/infer/relate/higher_ranked.rs
+++ b/crates/hir-ty/src/next_solver/infer/relate/higher_ranked.rs
@@ -10,8 +10,8 @@ use crate::next_solver::fold::FnMutDelegate;
 use crate::next_solver::infer::InferCtxt;
 use crate::next_solver::infer::snapshot::CombinedSnapshot;
 use crate::next_solver::{
-    Binder, BoundRegion, BoundTy, Const, DbInterner, PlaceholderConst, PlaceholderRegion,
-    PlaceholderTy, Region, Ty,
+    Binder, BoundConst, BoundRegion, BoundTy, Const, DbInterner, PlaceholderConst,
+    PlaceholderRegion, PlaceholderTy, Region, Ty,
 };
 
 impl<'db> InferCtxt<'db> {
@@ -50,10 +50,10 @@ impl<'db> InferCtxt<'db> {
                     PlaceholderTy { universe: next_universe, bound: bound_ty },
                 )
             },
-            consts: &mut |bound_var: BoundVar| {
+            consts: &mut |bound: BoundConst| {
                 Const::new_placeholder(
                     self.interner,
-                    PlaceholderConst { universe: next_universe, bound: bound_var },
+                    PlaceholderConst { universe: next_universe, bound },
                 )
             },
         };

--- a/crates/hir-ty/src/next_solver/ir_print.rs
+++ b/crates/hir-ty/src/next_solver/ir_print.rs
@@ -58,10 +58,7 @@ impl<'db> IrPrint<ty::TraitRef<Self>> for DbInterner<'db> {
 
     fn print_debug(t: &ty::TraitRef<Self>, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         salsa::with_attached_database(|db| {
-            let trait_ = match t.def_id {
-                SolverDefId::TraitId(id) => id,
-                _ => panic!("Expected trait."),
-            };
+            let trait_ = t.def_id.0;
             let self_ty = &t.args.as_slice()[0];
             let trait_args = &t.args.as_slice()[1..];
             if trait_args.is_empty() {
@@ -122,10 +119,7 @@ impl<'db> IrPrint<ty::ExistentialTraitRef<Self>> for DbInterner<'db> {
         fmt: &mut std::fmt::Formatter<'_>,
     ) -> std::fmt::Result {
         salsa::with_attached_database(|db| {
-            let trait_ = match t.def_id {
-                SolverDefId::TraitId(id) => id,
-                _ => panic!("Expected trait."),
-            };
+            let trait_ = t.def_id.0;
             fmt.write_str(&format!(
                 "ExistentialTraitRef({:?}[{:?}])",
                 db.as_view::<dyn HirDatabase>().trait_signature(trait_).name.as_str(),

--- a/crates/hir-ty/src/next_solver/predicate.rs
+++ b/crates/hir-ty/src/next_solver/predicate.rs
@@ -15,6 +15,8 @@ use rustc_type_ir::{
 };
 use smallvec::{SmallVec, smallvec};
 
+use crate::next_solver::TraitIdWrapper;
+
 use super::{Binder, BoundVarKinds, DbInterner, Region, Ty, interned_vec_db};
 
 pub type BoundExistentialPredicate<'db> = Binder<'db, ExistentialPredicate<'db>>;
@@ -72,7 +74,7 @@ interned_vec_db!(BoundExistentialPredicates, BoundExistentialPredicate);
 impl<'db> rustc_type_ir::inherent::BoundExistentialPredicates<DbInterner<'db>>
     for BoundExistentialPredicates<'db>
 {
-    fn principal_def_id(self) -> Option<<DbInterner<'db> as rustc_type_ir::Interner>::DefId> {
+    fn principal_def_id(self) -> Option<TraitIdWrapper> {
         self.principal().map(|trait_ref| trait_ref.skip_binder().def_id)
     }
 
@@ -89,9 +91,7 @@ impl<'db> rustc_type_ir::inherent::BoundExistentialPredicates<DbInterner<'db>>
             .transpose()
     }
 
-    fn auto_traits(
-        self,
-    ) -> impl IntoIterator<Item = <DbInterner<'db> as rustc_type_ir::Interner>::DefId> {
+    fn auto_traits(self) -> impl IntoIterator<Item = TraitIdWrapper> {
         self.iter().filter_map(|predicate| match predicate.skip_binder() {
             ExistentialPredicate::AutoTrait(did) => Some(did),
             _ => None,

--- a/crates/hir-ty/src/next_solver/solver.rs
+++ b/crates/hir-ty/src/next_solver/solver.rs
@@ -2,10 +2,10 @@
 
 use hir_def::{AssocItemId, GeneralConstId, TypeAliasId};
 use rustc_next_trait_solver::delegate::SolverDelegate;
+use rustc_type_ir::lang_items::SolverTraitLangItem;
 use rustc_type_ir::{
     InferCtxtLike, Interner, PredicatePolarity, TypeFlags, TypeVisitableExt, UniverseIndex,
     inherent::{IntoKind, SliceLike, Span as _, Term as _, Ty as _},
-    lang_items::TraitSolverLangItem,
     solve::{Certainty, NoSolution},
 };
 
@@ -225,14 +225,14 @@ impl<'db> SolverDelegate for SolverContext<'db> {
             }
 
             if trait_pred.polarity() == PredicatePolarity::Positive {
-                match self.0.cx().as_lang_item(trait_pred.def_id()) {
-                    Some(TraitSolverLangItem::Sized) | Some(TraitSolverLangItem::MetaSized) => {
+                match self.0.cx().as_trait_lang_item(trait_pred.def_id()) {
+                    Some(SolverTraitLangItem::Sized) | Some(SolverTraitLangItem::MetaSized) => {
                         let predicate = self.resolve_vars_if_possible(goal.predicate);
                         if sizedness_fast_path(self.cx(), predicate, goal.param_env) {
                             return Some(Certainty::Yes);
                         }
                     }
-                    Some(TraitSolverLangItem::Copy | TraitSolverLangItem::Clone) => {
+                    Some(SolverTraitLangItem::Copy | SolverTraitLangItem::Clone) => {
                         let self_ty =
                             self.resolve_vars_if_possible(trait_pred.self_ty().skip_binder());
                         // Unlike `Sized` traits, which always prefer the built-in impl,

--- a/crates/hir-ty/src/utils.rs
+++ b/crates/hir-ty/src/utils.rs
@@ -212,10 +212,7 @@ fn direct_super_trait_refs(db: &dyn HirDatabase, trait_ref: &TraitRef, cb: impl 
                 rustc_type_ir::ClauseKind::Trait(t) => {
                     let t =
                         rustc_type_ir::EarlyBinder::bind(t).instantiate(interner, trait_ref_args);
-                    let trait_id = match t.def_id() {
-                        crate::next_solver::SolverDefId::TraitId(id) => to_chalk_trait_id(id),
-                        _ => unreachable!(),
-                    };
+                    let trait_id = to_chalk_trait_id(t.def_id().0);
 
                     let substitution =
                         convert_args_for_result(interner, t.trait_ref.args.as_slice());


### PR DESCRIPTION
The main changes are (there are some other small changes):

 - Using a specific type for trait IDs in the new solver, allowing us to simplify a lot of code.
 - Add `BoundConst` similar to `BoundTy` and `BoundRegion` (previously consts used `BoundVar` directly), due to a new trait requirement.

This should enable the sync https://github.com/rust-lang/rust/pull/146086 - CC @lnicola.

I prefer to merge this before https://github.com/rust-lang/rust-analyzer/pull/20578, but if you think this will cause rebase pains for you @ShoyuVanilla - please tell.