### PR TITLE
Add documentation for troubleshooting flatpak permission issues

### DIFF
--- a/docs/book/src/faq.md
+++ b/docs/book/src/faq.md
@@ -5,14 +5,3 @@
 rust-analyzer fails to resolve `None`, and thinks you are binding to a variable
 named `None`. That's usually a sign of a corrupted sysroot. Try removing and re-installing
 it: `rustup component remove rust-src` then `rustup component install rust-src`.
-
-### VSCodium / another IDE cannot resolve cargo files with rust-analyzer
-
-This may be due to a misconfiguration of permissions with flatpak.
-This can be resolved by allowing flatpak to see the cargo binaries in the PATH with the following command:
-```bash
-flatpak --user override com.vscodium.codium  --env=PATH=/app/bin:/usr/bin:/home/$USER/.cargo/bin
-```
-This issue should be resolved in VS Code, if the issue persists with it or another IDE,
-you may substite the flatpak identifier with the appropriate application (EG: `com.visualstudio.code` for VS Code)
-Refer to [Issue #2873](https://github.com/rust-lang/rust-analyzer/issues/2873) and [Issue #20616](https://github.com/rust-lang/rust-analyzer/issues/20616)

--- a/docs/book/src/vs_code.md
+++ b/docs/book/src/vs_code.md
@@ -119,3 +119,10 @@ steps might help:
 A C compiler should already be available via `org.freedesktop.Sdk`. Any
 other tools or libraries you will need to acquire from Flatpak.
 
+If the user has cargo installed and `rust-analyzer` cannot resolve cargo files and fails to initialize,
+you may alternatively override the `PATH` of the specific flatpak to give it permission to see the binaries,
+such as the below command, which applies to the flatpak identifier of VS Codium:
+
+    ```bash
+    flatpak --user override com.vscodium.codium  --env=PATH=/app/bin:/usr/bin:/home/$USER/.cargo/bin
+    ```


### PR DESCRIPTION
Refer to https://github.com/rust-lang/rust-analyzer/issues/2873#issuecomment-1305760775 and my issue https://github.com/rust-lang/rust-analyzer/issues/20616

This change adds documentation to the troubleshooting FAQ for any future users experiencing cargo file resolving errors with rust-analyzer due to their IDE lacking permission to see the cargo binaries.