### PR TITLE
fix: add `else` keyword completion after `let` statements

### DIFF
--- a/crates/ide-completion/src/completions/expr.rs
+++ b/crates/ide-completion/src/completions/expr.rs
@@ -61,6 +61,7 @@ pub(crate) fn complete_expr_path(
         after_if_expr,
         in_condition,
         incomplete_let,
+        after_incomplete_let,
         in_value,
         ref ref_expr_parent,
         after_amp,
@@ -385,8 +386,11 @@ pub(crate) fn complete_expr_path(
                         add_keyword("let", "let $1 = $0;");
                     }
 
-                    if after_if_expr {
+                    if after_if_expr || after_incomplete_let {
                         add_keyword("else", "else {\n    $0\n}");
+                    }
+
+                    if after_if_expr {
                         add_keyword("else if", "else if $1 {\n    $0\n}");
                     }
 

--- a/crates/ide-completion/src/completions/keyword.rs
+++ b/crates/ide-completion/src/completions/keyword.rs
@@ -248,6 +248,46 @@ fn main() {
         );
 
         check_edit(
+            "else",
+            r#"
+fn main() {
+    let x = if true {
+        ()
+    } $0
+    let y = 92;
+}
+"#,
+            r#"
+fn main() {
+    let x = if true {
+        ()
+    } else {
+    $0
+};
+    let y = 92;
+}
+"#,
+        );
+
+        check_edit(
+            "else",
+            r#"
+fn main() {
+    let x = 2 $0
+    let y = 92;
+}
+"#,
+            r#"
+fn main() {
+    let x = 2 else {
+    $0
+};
+    let y = 92;
+}
+"#,
+        );
+
+        check_edit(
             "loop",
             r#"
 fn main() {

--- a/crates/ide-completion/src/context.rs
+++ b/crates/ide-completion/src/context.rs
@@ -147,6 +147,7 @@ pub(crate) struct PathExprCtx<'db> {
     /// Whether this expression is the direct condition of an if or while expression
     pub(crate) in_condition: bool,
     pub(crate) incomplete_let: bool,
+    pub(crate) after_incomplete_let: bool,
     pub(crate) in_value: bool,
     pub(crate) ref_expr_parent: Option<ast::RefExpr>,
     pub(crate) after_amp: bool,

--- a/crates/ide-completion/src/tests/expression.rs
+++ b/crates/ide-completion/src/tests/expression.rs
@@ -451,6 +451,155 @@ fn completes_in_let_initializer() {
 }
 
 #[test]
+fn completes_let_else() {
+    check(
+        r#"fn main() { let _ = 2 $0 }"#,
+        expect![[r#"
+            fn main() fn()
+            bt u32     u32
+            kw async
+            kw const
+            kw crate::
+            kw else
+            kw enum
+            kw extern
+            kw false
+            kw fn
+            kw for
+            kw if
+            kw if let
+            kw impl
+            kw impl for
+            kw let
+            kw letm
+            kw loop
+            kw match
+            kw mod
+            kw return
+            kw self::
+            kw static
+            kw struct
+            kw trait
+            kw true
+            kw type
+            kw union
+            kw unsafe
+            kw use
+            kw while
+            kw while let
+            sn macro_rules
+            sn pd
+            sn ppd
+        "#]],
+    );
+
+    check(
+        r#"fn main() { let _ = 2 el$0 }"#,
+        expect![[r#"
+            fn main() fn()
+            bt u32     u32
+            kw async
+            kw const
+            kw crate::
+            kw else
+            kw enum
+            kw extern
+            kw false
+            kw fn
+            kw for
+            kw if
+            kw if let
+            kw impl
+            kw impl for
+            kw let
+            kw letm
+            kw loop
+            kw match
+            kw mod
+            kw return
+            kw self::
+            kw static
+            kw struct
+            kw trait
+            kw true
+            kw type
+            kw union
+            kw unsafe
+            kw use
+            kw while
+            kw while let
+            sn macro_rules
+            sn pd
+            sn ppd
+        "#]],
+    );
+
+    check_edit(
+        "else",
+        r#"
+fn main() {
+    let _ = 2 $0
+}
+"#,
+        r#"
+fn main() {
+    let _ = 2 else {
+    $0
+};
+}
+"#,
+    );
+
+    check_edit(
+        "else",
+        r#"
+fn main() {
+    let _ = 2 el$0
+}
+"#,
+        r#"
+fn main() {
+    let _ = 2 else {
+    $0
+};
+}
+"#,
+    );
+
+    check_edit(
+        "else",
+        r#"
+fn main() {
+    let _ = 2 $0;
+}
+"#,
+        r#"
+fn main() {
+    let _ = 2 else {
+    $0
+};
+}
+"#,
+    );
+
+    check_edit(
+        "else",
+        r#"
+fn main() {
+    let _ = 2 el$0;
+}
+"#,
+        r#"
+fn main() {
+    let _ = 2 else {
+    $0
+};
+}
+"#,
+    );
+}
+
+#[test]
 fn completes_after_ref_expr() {
     check(
         r#"fn main() { let _ = &$0 }"#,


### PR DESCRIPTION
Example
---
```rust
fn foo() {
    let _ = 2 el$0
}
```
->
```rust
fn foo() {
    let _ = 2 else {
        $0
    };
}
```

---

And fix the no completion semicolon for `else` in incomplete LetStmt of rust-lang/rust-analyzer#20518

```rust
fn foo() {
    let _ = if true {} el$0
}
```

**Before this PR**:

```rust
fn foo() {
    let _ = if true {} else {
        $0
    }
}
```

**After this PR**:

```rust
fn foo() {
    let _ = if true {} else {
        $0
    };
}
```
