### PR TITLE
Fix LifetimeParam::lifetime_bounds invalid implement

### DIFF
--- a/crates/syntax/src/ast/node_ext.rs
+++ b/crates/syntax/src/ast/node_ext.rs
@@ -12,8 +12,8 @@ use rowan::{GreenNodeData, GreenTokenData};
 use crate::{
     NodeOrToken, SmolStr, SyntaxElement, SyntaxToken, T, TokenText,
     ast::{
-        self, AstNode, AstToken, HasAttrs, HasGenericArgs, HasGenericParams, HasName, SyntaxNode,
-        support,
+        self, AstNode, AstToken, HasAttrs, HasGenericArgs, HasGenericParams, HasName,
+        HasTypeBounds, SyntaxNode, support,
     },
     ted,
 };
@@ -912,11 +912,10 @@ impl ast::Visibility {
 
 impl ast::LifetimeParam {
     pub fn lifetime_bounds(&self) -> impl Iterator<Item = SyntaxToken> {
-        self.syntax()
-            .children_with_tokens()
-            .filter_map(|it| it.into_token())
-            .skip_while(|x| x.kind() != T![:])
-            .filter(|it| it.kind() == T![lifetime_ident])
+        self.type_bound_list()
+            .into_iter()
+            .flat_map(|it| it.bounds())
+            .filter_map(|it| it.lifetime()?.lifetime_ident_token())
     }
 }
 


### PR DESCRIPTION
Lifetime node example:

```
LIFETIME_PARAM@15..21
  LIFETIME@15..17
    LIFETIME_IDENT@15..17 "'a"
  COLON@17..18 ":"
  WHITESPACE@18..19 " "
  TYPE_BOUND_LIST@19..21
    TYPE_BOUND@19..21
      LIFETIME@19..21
        LIFETIME_IDENT@19..21 "'b"
```
