### PR TITLE
internal: clarify intro in README and manual

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,21 @@
     alt="rust-analyzer logo">
 </p>
 
-rust-analyzer is a modular compiler frontend for the Rust language.
-It is a part of a larger rls-2.0 effort to create excellent IDE support for Rust.
+rust-analyzer is a language server that provides IDE functionality for
+writing Rust programs. You can use it with any editor that supports
+the [Language Server
+Protocol](https://microsoft.github.io/language-server-protocol/) (VS
+Code, Vim, Emacs, Zed, etc).
+
+rust-analyzer features include go-to-definition, find-all-references,
+refactorings and code completion. rust-analyzer also supports
+integrated formatting (with rustfmt) and integrated diagnostics (with
+rustc and clippy).
+
+Internally, rust-analyzer is structured as a set of libraries for
+analyzing Rust code. See
+[Architecture](https://rust-analyzer.github.io/book/contributing/architecture.html)
+in the manual.
 
 ## Quick Start
 

--- a/docs/book/src/README.md
+++ b/docs/book/src/README.md
@@ -1,13 +1,20 @@
 # rust-analyzer
 
-At its core, rust-analyzer is a **library** for semantic analysis of
-Rust code as it changes over time. This manual focuses on a specific
-usage of the library -- running it as part of a server that implements
+rust-analyzer is a language server that provides IDE functionality for
+writing Rust programs. You can use it with any editor that supports
 the [Language Server
-Protocol](https://microsoft.github.io/language-server-protocol/) (LSP).
-The LSP allows various code editors, like VS Code, Emacs or Vim, to
-implement semantic features like completion or goto definition by
-talking to an external language server process.
+Protocol](https://microsoft.github.io/language-server-protocol/) (VS
+Code, Vim, Emacs, Zed, etc).
+
+rust-analyzer features include go-to-definition, find-all-references,
+refactorings and code completion. rust-analyzer also supports
+integrated formatting (with rustfmt) and integrated diagnostics (with
+rustc and clippy).
+
+Internally, rust-analyzer is structured as a set of libraries for
+analyzing Rust code. See
+[Architecture](https://rust-analyzer.github.io/book/contributing/architecture.html)
+for more details.
 
 To improve this document, send a pull request:
 [https://github.com/rust-lang/rust-analyzer](https://github.com/rust-lang/rust-analyzer/blob/master/docs/book/README.md)


### PR DESCRIPTION
The first sentence a new user should see should ideally answer the questions:

* What is rust-analyzer?
* Why might I want to use it?

The vast majority of users will be interested in using rust-analyzer inside their favourite editor. We should clarify that rust-analyzer is an LSP implementation and that it supports all the classic IDE features.

Whilst it's also true that rust-analyzer is modular and organised into libraries, the first impression should (I think) focus on an overview and the primary use case.