### PR TITLE
internal: Upgrade rustc crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1863,9 +1863,9 @@ dependencies = [
 
 [[package]]
 name = "ra-ap-rustc_abi"
-version = "0.126.0"
+version = "0.128.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6789d94fb3e6e30d62f55e99a321ba63484a8bb3b4ead338687c9ddc282d28"
+checksum = "8da95e732b424802b1f043ab4007c78a0fc515ab249587abbea4634bf5fdce9a"
 dependencies = [
  "bitflags 2.9.1",
  "ra-ap-rustc_hashes",
@@ -1875,24 +1875,24 @@ dependencies = [
 
 [[package]]
 name = "ra-ap-rustc_ast_ir"
-version = "0.126.0"
+version = "0.128.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aaab80bda0f05e9842e3afb7779b0bad0a4b54e0f7ba6deb5705dcf86482811d"
+checksum = "3838d9d7a3a5cdc511cfb6ad78740ce532f75a2366d3fc3b9853ea1b5c872779"
 
 [[package]]
 name = "ra-ap-rustc_hashes"
-version = "0.126.0"
+version = "0.128.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64bd405e538102b5f699241794b2eefee39d5414c0e4bc72435e91430c51f905"
+checksum = "bdc8995d268d3bb4ece910f575ea5a063d6003e193ec155d15703b65882d53fb"
 dependencies = [
  "rustc-stable-hash",
 ]
 
 [[package]]
 name = "ra-ap-rustc_index"
-version = "0.126.0"
+version = "0.128.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521621e271aa03b8433dad5981838278d6cfd7d2d8c9f4eb6d427f1d671f90fc"
+checksum = "ed0ccdf6e5627c6c3e54e571e52ce0bc8b94d5f0b94b7460269ca68a4706be69"
 dependencies = [
  "ra-ap-rustc_index_macros",
  "smallvec",
@@ -1900,9 +1900,9 @@ dependencies = [
 
 [[package]]
 name = "ra-ap-rustc_index_macros"
-version = "0.126.0"
+version = "0.128.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "245e30f2e1fef258913cc548b36f575549c8af31cbc4649929d21deda96ceeb7"
+checksum = "bd28f42362b5c9fb9b8766c3189df02a402b13363600c6885e11027889f03ee6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1911,9 +1911,9 @@ dependencies = [
 
 [[package]]
 name = "ra-ap-rustc_lexer"
-version = "0.126.0"
+version = "0.128.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a82681f924500e888c860e60ed99e9bf702a219a69374f59116c4261525a2157"
+checksum = "f1c31a82f091b910a27ee53a86a9af28a2df10c3484e2f1bbfe70633aa84dee9"
 dependencies = [
  "memchr",
  "unicode-properties",
@@ -1922,9 +1922,9 @@ dependencies = [
 
 [[package]]
 name = "ra-ap-rustc_next_trait_solver"
-version = "0.126.0"
+version = "0.128.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c9ce51f2431fbdc7fabd2d957522b6e27f41f68ec2af74b52a6f4116352ce1a"
+checksum = "f8cac6c2b5a8924209d4ca682cbc507252c58a664911e0ef463c112882ba6f72"
 dependencies = [
  "derive-where",
  "ra-ap-rustc_index",
@@ -1935,9 +1935,9 @@ dependencies = [
 
 [[package]]
 name = "ra-ap-rustc_parse_format"
-version = "0.126.0"
+version = "0.128.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adc85ef3fdb6c084bde84857d8948dc66b752129dc8417a8614ce490e99a143f"
+checksum = "a085a1cf902dcca8abbc537faaef154bbccbbb51850f779ce5484ae3782b5d8f"
 dependencies = [
  "ra-ap-rustc_lexer",
  "rustc-literal-escaper 0.0.5",
@@ -1945,9 +1945,9 @@ dependencies = [
 
 [[package]]
 name = "ra-ap-rustc_pattern_analysis"
-version = "0.126.0"
+version = "0.128.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cd81eccf33d9528905d4e5abaa254b3129a6405d6c5f123fed9b73a3d217f35"
+checksum = "8ba32e3985367bc34856b41c7604133649d4a367eb5d7bdf50623025731459d8"
 dependencies = [
  "ra-ap-rustc_index",
  "rustc-hash 2.1.1",
@@ -1958,10 +1958,11 @@ dependencies = [
 
 [[package]]
 name = "ra-ap-rustc_type_ir"
-version = "0.126.0"
+version = "0.128.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11cb0da02853698d9c89e1d1c01657b9969752befd56365e8899d4310e52b373"
+checksum = "9c9911d72f75d85d21fe88374d7bcec94f2200feffb7234108a24cc3da7c3591"
 dependencies = [
+ "arrayvec",
  "bitflags 2.9.1",
  "derive-where",
  "ena",
@@ -1977,9 +1978,9 @@ dependencies = [
 
 [[package]]
 name = "ra-ap-rustc_type_ir_macros"
-version = "0.126.0"
+version = "0.128.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffc93adeb52c483ede13bee6680466458218243ab479c04fb71bb53925a6e0ff"
+checksum = "22f539b87991683ce17cc52e62600fdf2b4a8af43952db30387edc1a576d3b43"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,14 +89,14 @@ vfs-notify = { path = "./crates/vfs-notify", version = "0.0.0" }
 vfs = { path = "./crates/vfs", version = "0.0.0" }
 edition = { path = "./crates/edition", version = "0.0.0" }
 
-ra-ap-rustc_lexer = { version = "0.126", default-features = false }
-ra-ap-rustc_parse_format = { version = "0.126", default-features = false }
-ra-ap-rustc_index = { version = "0.126", default-features = false }
-ra-ap-rustc_abi = { version = "0.126", default-features = false }
-ra-ap-rustc_pattern_analysis = { version = "0.126", default-features = false }
-ra-ap-rustc_ast_ir = { version = "0.126", default-features = false }
-ra-ap-rustc_type_ir = { version = "0.126", default-features = false }
-ra-ap-rustc_next_trait_solver = { version = "0.126", default-features = false }
+ra-ap-rustc_lexer = { version = "0.128", default-features = false }
+ra-ap-rustc_parse_format = { version = "0.128", default-features = false }
+ra-ap-rustc_index = { version = "0.128", default-features = false }
+ra-ap-rustc_abi = { version = "0.128", default-features = false }
+ra-ap-rustc_pattern_analysis = { version = "0.128", default-features = false }
+ra-ap-rustc_ast_ir = { version = "0.128", default-features = false }
+ra-ap-rustc_type_ir = { version = "0.128", default-features = false }
+ra-ap-rustc_next_trait_solver = { version = "0.128", default-features = false }
 
 # local crates that aren't published to crates.io. These should not have versions.
 

--- a/crates/hir-def/src/lang_item.rs
+++ b/crates/hir-def/src/lang_item.rs
@@ -84,6 +84,15 @@ impl LangItemTarget {
             _ => None,
         }
     }
+
+    pub fn as_adt(self) -> Option<AdtId> {
+        match self {
+            LangItemTarget::Union(it) => Some(it.into()),
+            LangItemTarget::EnumId(it) => Some(it.into()),
+            LangItemTarget::Struct(it) => Some(it.into()),
+            _ => None,
+        }
+    }
 }
 
 /// Salsa query. This will look for lang items in a specific crate.
@@ -287,6 +296,10 @@ impl LangItem {
 
     pub fn resolve_trait(self, db: &dyn DefDatabase, start_crate: Crate) -> Option<TraitId> {
         lang_item(db, start_crate, self).and_then(|t| t.as_trait())
+    }
+
+    pub fn resolve_adt(self, db: &dyn DefDatabase, start_crate: Crate) -> Option<AdtId> {
+        lang_item(db, start_crate, self).and_then(|t| t.as_adt())
     }
 
     pub fn resolve_enum(self, db: &dyn DefDatabase, start_crate: Crate) -> Option<EnumId> {

--- a/crates/hir-ty/src/layout.rs
+++ b/crates/hir-ty/src/layout.rs
@@ -25,7 +25,7 @@ use crate::{
     consteval_nextsolver::try_const_usize,
     db::HirDatabase,
     next_solver::{
-        DbInterner, GenericArgs, ParamEnv, SolverDefId, Ty, TyKind, TypingMode,
+        DbInterner, GenericArgs, ParamEnv, Ty, TyKind, TypingMode,
         infer::{DbInternerInferExt, traits::ObligationCause},
         mapping::{ChalkToNextSolver, convert_args_for_result},
         project::solve_normalize::deeply_normalize,
@@ -323,14 +323,10 @@ pub fn layout_of_ty_query<'db>(
             ptr.valid_range_mut().start = 1;
             Layout::scalar(dl, ptr)
         }
-        TyKind::Closure(c, args) => {
-            let id = match c {
-                SolverDefId::InternedClosureId(id) => id,
-                _ => unreachable!(),
-            };
-            let def = db.lookup_intern_closure(id);
+        TyKind::Closure(id, args) => {
+            let def = db.lookup_intern_closure(id.0);
             let infer = db.infer(def.0);
-            let (captures, _) = infer.closure_info(&id.into());
+            let (captures, _) = infer.closure_info(&id.0.into());
             let fields = captures
                 .iter()
                 .map(|it| {

--- a/crates/hir-ty/src/method_resolution.rs
+++ b/crates/hir-ty/src/method_resolution.rs
@@ -161,10 +161,7 @@ impl TyFingerprint {
                 rustc_ast_ir::Mutability::Mut => TyFingerprint::RawPtr(Mutability::Mut),
                 rustc_ast_ir::Mutability::Not => TyFingerprint::RawPtr(Mutability::Not),
             },
-            TyKind::Foreign(def) => {
-                let SolverDefId::TypeAliasId(def) = def else { unreachable!() };
-                TyFingerprint::ForeignType(crate::to_foreign_def_id(def))
-            }
+            TyKind::Foreign(def) => TyFingerprint::ForeignType(crate::to_foreign_def_id(def.0)),
             TyKind::Dynamic(bounds, _, _) => {
                 let trait_ref = bounds
                     .as_slice()

--- a/crates/hir-ty/src/next_solver/infer/canonical/canonicalizer.rs
+++ b/crates/hir-ty/src/next_solver/infer/canonical/canonicalizer.rs
@@ -400,7 +400,7 @@ impl<'cx, 'db> TypeFolder<DbInterner<'db>> for Canonicalizer<'cx, 'db> {
             TyKind::Infer(IntVar(vid)) => {
                 let nt = self.infcx.opportunistic_resolve_int_var(vid);
                 if nt != t {
-                    return self.fold_ty(nt);
+                    self.fold_ty(nt)
                 } else {
                     self.canonicalize_ty_var(CanonicalVarKind::Int, t)
                 }
@@ -408,7 +408,7 @@ impl<'cx, 'db> TypeFolder<DbInterner<'db>> for Canonicalizer<'cx, 'db> {
             TyKind::Infer(FloatVar(vid)) => {
                 let nt = self.infcx.opportunistic_resolve_float_var(vid);
                 if nt != t {
-                    return self.fold_ty(nt);
+                    self.fold_ty(nt)
                 } else {
                     self.canonicalize_ty_var(CanonicalVarKind::Float, t)
                 }

--- a/crates/hir-ty/src/next_solver/infer/canonical/mod.rs
+++ b/crates/hir-ty/src/next_solver/infer/canonical/mod.rs
@@ -82,9 +82,7 @@ impl<'db> InferCtxt<'db> {
         let var_values = CanonicalVarValues::instantiate(
             self.interner,
             canonical.variables,
-            |var_values, info| {
-                self.instantiate_canonical_var(info, &var_values, |ui| universes[ui])
-            },
+            |var_values, info| self.instantiate_canonical_var(info, var_values, |ui| universes[ui]),
         );
         let result = canonical.instantiate(self.interner, &var_values);
         (result, var_values)

--- a/crates/hir-ty/src/next_solver/infer/canonical/mod.rs
+++ b/crates/hir-ty/src/next_solver/infer/canonical/mod.rs
@@ -32,9 +32,10 @@ use crate::next_solver::{
 };
 use instantiate::CanonicalExt;
 use rustc_index::IndexVec;
+use rustc_type_ir::inherent::IntoKind;
 use rustc_type_ir::{
-    AliasRelationDirection, AliasTyKind, CanonicalTyVarKind, CanonicalVarKind, InferTy,
-    TypeFoldable, UniverseIndex, Upcast, Variance,
+    AliasRelationDirection, AliasTyKind, CanonicalVarKind, InferTy, TypeFoldable, UniverseIndex,
+    Upcast, Variance,
     inherent::{SliceLike, Ty as _},
     relate::{
         Relate, TypeRelation, VarianceDiagInfo,
@@ -78,27 +79,15 @@ impl<'db> InferCtxt<'db> {
             .chain((1..=canonical.max_universe.as_u32()).map(|_| self.create_next_universe()))
             .collect();
 
-        let canonical_inference_vars =
-            self.instantiate_canonical_vars(canonical.variables, |ui| universes[ui]);
-        let result = canonical.instantiate(self.interner, &canonical_inference_vars);
-        (result, canonical_inference_vars)
-    }
-
-    /// Given the "infos" about the canonical variables from some
-    /// canonical, creates fresh variables with the same
-    /// characteristics (see `instantiate_canonical_var` for
-    /// details). You can then use `instantiate` to instantiate the
-    /// canonical variable with these inference variables.
-    fn instantiate_canonical_vars(
-        &self,
-        variables: CanonicalVars<'db>,
-        universe_map: impl Fn(UniverseIndex) -> UniverseIndex,
-    ) -> CanonicalVarValues<'db> {
-        CanonicalVarValues {
-            var_values: self.interner.mk_args_from_iter(
-                variables.iter().map(|info| self.instantiate_canonical_var(info, &universe_map)),
-            ),
-        }
+        let var_values = CanonicalVarValues::instantiate(
+            self.interner,
+            canonical.variables,
+            |var_values, info| {
+                self.instantiate_canonical_var(info, &var_values, |ui| universes[ui])
+            },
+        );
+        let result = canonical.instantiate(self.interner, &var_values);
+        (result, var_values)
     }
 
     /// Given the "info" about a canonical variable, creates a fresh
@@ -112,21 +101,27 @@ impl<'db> InferCtxt<'db> {
     pub fn instantiate_canonical_var(
         &self,
         cv_info: CanonicalVarKind<DbInterner<'db>>,
+        previous_var_values: &[GenericArg<'db>],
         universe_map: impl Fn(UniverseIndex) -> UniverseIndex,
     ) -> GenericArg<'db> {
         match cv_info {
-            CanonicalVarKind::Ty(ty_kind) => {
-                let ty = match ty_kind {
-                    CanonicalTyVarKind::General(ui) => {
-                        self.next_ty_var_in_universe(universe_map(ui))
+            CanonicalVarKind::Ty { ui, sub_root } => {
+                let vid = self.next_ty_var_id_in_universe(universe_map(ui));
+                // If this inference variable is related to an earlier variable
+                // via subtyping, we need to add that info to the inference context.
+                if let Some(prev) = previous_var_values.get(sub_root.as_usize()) {
+                    if let TyKind::Infer(InferTy::TyVar(sub_root)) = prev.expect_ty().kind() {
+                        self.sub_unify_ty_vids_raw(vid, sub_root);
+                    } else {
+                        unreachable!()
                     }
-
-                    CanonicalTyVarKind::Int => self.next_int_var(),
-
-                    CanonicalTyVarKind::Float => self.next_float_var(),
-                };
-                ty.into()
+                }
+                Ty::new_var(self.interner, vid).into()
             }
+
+            CanonicalVarKind::Int => self.next_int_var().into(),
+
+            CanonicalVarKind::Float => self.next_float_var().into(),
 
             CanonicalVarKind::PlaceholderTy(PlaceholderTy { universe, bound }) => {
                 let universe_mapped = universe_map(universe);

--- a/crates/hir-ty/src/next_solver/infer/context.rs
+++ b/crates/hir-ty/src/next_solver/infer/context.rs
@@ -313,4 +313,12 @@ impl<'db> rustc_type_ir::InferCtxtLike for InferCtxt<'db> {
     fn reset_opaque_types(&self) {
         let _ = self.take_opaque_types();
     }
+
+    fn sub_unification_table_root_var(&self, var: rustc_type_ir::TyVid) -> rustc_type_ir::TyVid {
+        self.sub_unification_table_root_var(var)
+    }
+
+    fn sub_unify_ty_vids_raw(&self, a: rustc_type_ir::TyVid, b: rustc_type_ir::TyVid) {
+        self.sub_unify_ty_vids_raw(a, b);
+    }
 }

--- a/crates/hir-ty/src/next_solver/infer/mod.rs
+++ b/crates/hir-ty/src/next_solver/infer/mod.rs
@@ -1019,6 +1019,14 @@ impl<'db> InferCtxt<'db> {
             }
         }
     }
+
+    fn sub_unification_table_root_var(&self, var: rustc_type_ir::TyVid) -> rustc_type_ir::TyVid {
+        self.inner.borrow_mut().type_variables().sub_unification_table_root_var(var)
+    }
+
+    fn sub_unify_ty_vids_raw(&self, a: rustc_type_ir::TyVid, b: rustc_type_ir::TyVid) {
+        self.inner.borrow_mut().type_variables().sub_unify(a, b);
+    }
 }
 
 /// Helper for [InferCtxt::ty_or_const_infer_var_changed] (see comment on that), currently

--- a/crates/hir-ty/src/next_solver/infer/snapshot/undo_log.rs
+++ b/crates/hir-ty/src/next_solver/infer/snapshot/undo_log.rs
@@ -25,7 +25,7 @@ pub struct Snapshot {
 pub(crate) enum UndoLog<'db> {
     DuplicateOpaqueType,
     OpaqueTypes(OpaqueTypeKey<'db>, Option<OpaqueHiddenType<'db>>),
-    TypeVariables(sv::UndoLog<ut::Delegate<type_variable::TyVidEqKey<'db>>>),
+    TypeVariables(type_variable::UndoLog<'db>),
     ConstUnificationTable(sv::UndoLog<ut::Delegate<ConstVidKey<'db>>>),
     IntUnificationTable(sv::UndoLog<ut::Delegate<IntVid>>),
     FloatUnificationTable(sv::UndoLog<ut::Delegate<FloatVid>>),
@@ -51,6 +51,8 @@ impl_from! {
     RegionConstraintCollector(region_constraints::UndoLog<'db>),
 
     TypeVariables(sv::UndoLog<ut::Delegate<type_variable::TyVidEqKey<'db>>>),
+    TypeVariables(sv::UndoLog<ut::Delegate<type_variable::TyVidSubKey>>),
+    TypeVariables(type_variable::UndoLog<'db>),
     IntUnificationTable(sv::UndoLog<ut::Delegate<IntVid>>),
     FloatUnificationTable(sv::UndoLog<ut::Delegate<FloatVid>>),
 

--- a/crates/hir-ty/src/next_solver/infer/type_variable.rs
+++ b/crates/hir-ty/src/next_solver/infer/type_variable.rs
@@ -17,9 +17,45 @@ use crate::next_solver::SolverDefId;
 use crate::next_solver::Ty;
 use crate::next_solver::infer::InferCtxtUndoLogs;
 
+/// Represents a single undo-able action that affects a type inference variable.
+#[derive(Clone)]
+pub(crate) enum UndoLog<'tcx> {
+    EqRelation(sv::UndoLog<ut::Delegate<TyVidEqKey<'tcx>>>),
+    SubRelation(sv::UndoLog<ut::Delegate<TyVidSubKey>>),
+}
+
+/// Convert from a specific kind of undo to the more general UndoLog
+impl<'db> From<sv::UndoLog<ut::Delegate<TyVidEqKey<'db>>>> for UndoLog<'db> {
+    fn from(l: sv::UndoLog<ut::Delegate<TyVidEqKey<'db>>>) -> Self {
+        UndoLog::EqRelation(l)
+    }
+}
+
+/// Convert from a specific kind of undo to the more general UndoLog
+impl<'db> From<sv::UndoLog<ut::Delegate<TyVidSubKey>>> for UndoLog<'db> {
+    fn from(l: sv::UndoLog<ut::Delegate<TyVidSubKey>>) -> Self {
+        UndoLog::SubRelation(l)
+    }
+}
+
 impl<'db> Rollback<sv::UndoLog<ut::Delegate<TyVidEqKey<'db>>>> for TypeVariableStorage<'db> {
     fn reverse(&mut self, undo: sv::UndoLog<ut::Delegate<TyVidEqKey<'db>>>) {
         self.eq_relations.reverse(undo)
+    }
+}
+
+impl<'tcx> Rollback<sv::UndoLog<ut::Delegate<TyVidSubKey>>> for TypeVariableStorage<'tcx> {
+    fn reverse(&mut self, undo: sv::UndoLog<ut::Delegate<TyVidSubKey>>) {
+        self.sub_unification_table.reverse(undo)
+    }
+}
+
+impl<'tcx> Rollback<UndoLog<'tcx>> for TypeVariableStorage<'tcx> {
+    fn reverse(&mut self, undo: UndoLog<'tcx>) {
+        match undo {
+            UndoLog::EqRelation(undo) => self.eq_relations.reverse(undo),
+            UndoLog::SubRelation(undo) => self.sub_unification_table.reverse(undo),
+        }
     }
 }
 
@@ -31,6 +67,25 @@ pub(crate) struct TypeVariableStorage<'db> {
     /// constraint `?X == ?Y`. This table also stores, for each key,
     /// the known value.
     eq_relations: ut::UnificationTableStorage<TyVidEqKey<'db>>,
+    /// Only used by `-Znext-solver` and for diagnostics. Tracks whether
+    /// type variables are related via subtyping at all, ignoring which of
+    /// the two is the subtype.
+    ///
+    /// When reporting ambiguity errors, we sometimes want to
+    /// treat all inference vars which are subtypes of each
+    /// others as if they are equal. For this case we compute
+    /// the transitive closure of our subtype obligations here.
+    ///
+    /// E.g. when encountering ambiguity errors, we want to suggest
+    /// specifying some method argument or to add a type annotation
+    /// to a local variable. Because subtyping cannot change the
+    /// shape of a type, it's fine if the cause of the ambiguity error
+    /// is only related to the suggested variable via subtyping.
+    ///
+    /// Even for something like `let x = returns_arg(); x.method();` the
+    /// type of `x` is only a supertype of the argument of `returns_arg`. We
+    /// still want to suggest specifying the type of the argument.
+    sub_unification_table: ut::UnificationTableStorage<TyVidSubKey>,
 }
 
 pub(crate) struct TypeVariableTable<'a, 'db> {
@@ -112,6 +167,17 @@ impl<'db> TypeVariableTable<'_, 'db> {
         debug_assert!(self.probe(a).is_unknown());
         debug_assert!(self.probe(b).is_unknown());
         self.eq_relations().union(a, b);
+        self.sub_unification_table().union(a, b);
+    }
+
+    /// Records that `a` and `b` are related via subtyping. We don't track
+    /// which of the two is the subtype.
+    ///
+    /// Precondition: neither `a` nor `b` are known.
+    pub(crate) fn sub_unify(&mut self, a: TyVid, b: TyVid) {
+        debug_assert!(self.probe(a).is_unknown());
+        debug_assert!(self.probe(b).is_unknown());
+        self.sub_unification_table().union(a, b);
     }
 
     /// Instantiates `vid` with the type `ty`.
@@ -141,6 +207,10 @@ impl<'db> TypeVariableTable<'_, 'db> {
     ///   for improving error messages.
     pub(crate) fn new_var(&mut self, universe: UniverseIndex, origin: TypeVariableOrigin) -> TyVid {
         let eq_key = self.eq_relations().new_key(TypeVariableValue::Unknown { universe });
+
+        let sub_key = self.sub_unification_table().new_key(());
+        debug_assert_eq!(eq_key.vid, sub_key.vid);
+
         let index = self.storage.values.push(TypeVariableData { origin });
         debug_assert_eq!(eq_key.vid, index);
 
@@ -163,6 +233,18 @@ impl<'db> TypeVariableTable<'_, 'db> {
         self.eq_relations().find(vid).vid
     }
 
+    /// Returns the "root" variable of `vid` in the `sub_unification_table`
+    /// equivalence table. All type variables that have been are related via
+    /// equality or subtyping will yield the same root variable (per the
+    /// union-find algorithm), so `sub_unification_table_root_var(a)
+    /// == sub_unification_table_root_var(b)` implies that:
+    /// ```text
+    /// exists X. (a <: X || X <: a) && (b <: X || X <: b)
+    /// ```
+    pub(crate) fn sub_unification_table_root_var(&mut self, vid: TyVid) -> TyVid {
+        self.sub_unification_table().find(vid).vid
+    }
+
     /// Retrieves the type to which `vid` has been instantiated, if
     /// any.
     pub(crate) fn probe(&mut self, vid: TyVid) -> TypeVariableValue<'db> {
@@ -178,6 +260,11 @@ impl<'db> TypeVariableTable<'_, 'db> {
     #[inline]
     fn eq_relations(&mut self) -> super::UnificationTable<'_, 'db, TyVidEqKey<'db>> {
         self.storage.eq_relations.with_log(self.undo_log)
+    }
+
+    #[inline]
+    fn sub_unification_table(&mut self) -> super::UnificationTable<'_, 'db, TyVidSubKey> {
+        self.storage.sub_unification_table.with_log(self.undo_log)
     }
 
     /// Returns indices of all variables that are not yet
@@ -227,6 +314,36 @@ impl<'db> ut::UnifyKey for TyVidEqKey<'db> {
     }
     fn tag() -> &'static str {
         "TyVidEqKey"
+    }
+    fn order_roots(a: Self, _: &Self::Value, b: Self, _: &Self::Value) -> Option<(Self, Self)> {
+        if a.vid.as_u32() < b.vid.as_u32() { Some((a, b)) } else { Some((b, a)) }
+    }
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub(crate) struct TyVidSubKey {
+    vid: TyVid,
+}
+
+impl From<TyVid> for TyVidSubKey {
+    #[inline] // make this function eligible for inlining - it is quite hot.
+    fn from(vid: TyVid) -> Self {
+        TyVidSubKey { vid }
+    }
+}
+
+impl ut::UnifyKey for TyVidSubKey {
+    type Value = ();
+    #[inline]
+    fn index(&self) -> u32 {
+        self.vid.as_u32()
+    }
+    #[inline]
+    fn from_index(i: u32) -> TyVidSubKey {
+        TyVidSubKey { vid: TyVid::from_u32(i) }
+    }
+    fn tag() -> &'static str {
+        "TyVidSubKey"
     }
 }
 

--- a/crates/hir-ty/src/next_solver/infer/unify_key.rs
+++ b/crates/hir-ty/src/next_solver/infer/unify_key.rs
@@ -139,6 +139,9 @@ impl<'db> UnifyKey for ConstVidKey<'db> {
     fn tag() -> &'static str {
         "ConstVidKey"
     }
+    fn order_roots(a: Self, _: &Self::Value, b: Self, _: &Self::Value) -> Option<(Self, Self)> {
+        if a.vid.as_u32() < b.vid.as_u32() { Some((a, b)) } else { Some((b, a)) }
+    }
 }
 
 impl<'db> UnifyValue for ConstVariableValue<'db> {

--- a/crates/hir-ty/src/next_solver/mapping.rs
+++ b/crates/hir-ty/src/next_solver/mapping.rs
@@ -243,12 +243,10 @@ impl<'db> ChalkToNextSolver<'db, Ty<'db>> for chalk_ir::Ty<Interner> {
                 }
                 chalk_ir::TyKind::FnDef(fn_def_id, substitution) => {
                     let def_id = CallableDefId::from_chalk(interner.db(), *fn_def_id);
-                    let id: SolverDefId = match def_id {
-                        CallableDefId::FunctionId(id) => id.into(),
-                        CallableDefId::StructId(id) => SolverDefId::Ctor(Ctor::Struct(id)),
-                        CallableDefId::EnumVariantId(id) => SolverDefId::Ctor(Ctor::Enum(id)),
-                    };
-                    rustc_type_ir::TyKind::FnDef(id, substitution.to_nextsolver(interner))
+                    rustc_type_ir::TyKind::FnDef(
+                        def_id.into(),
+                        substitution.to_nextsolver(interner),
+                    )
                 }
                 chalk_ir::TyKind::Str => rustc_type_ir::TyKind::Str,
                 chalk_ir::TyKind::Never => rustc_type_ir::TyKind::Never,
@@ -271,7 +269,7 @@ impl<'db> ChalkToNextSolver<'db, Ty<'db>> for chalk_ir::Ty<Interner> {
                     )
                 }
                 chalk_ir::TyKind::Foreign(foreign_def_id) => rustc_type_ir::TyKind::Foreign(
-                    SolverDefId::TypeAliasId(crate::from_foreign_def_id(*foreign_def_id)),
+                    crate::from_foreign_def_id(*foreign_def_id).into(),
                 ),
                 chalk_ir::TyKind::Error => rustc_type_ir::TyKind::Error(ErrorGuaranteed),
                 chalk_ir::TyKind::Dyn(dyn_ty) => {
@@ -1511,13 +1509,7 @@ pub(crate) fn convert_ty_for_result<'db>(interner: DbInterner<'db>, ty: Ty<'db>)
             TyKind::Slice(ty)
         }
 
-        rustc_type_ir::TyKind::Foreign(foreign) => {
-            let def_id = match foreign {
-                SolverDefId::TypeAliasId(id) => id,
-                _ => unreachable!(),
-            };
-            TyKind::Foreign(to_foreign_def_id(def_id))
-        }
+        rustc_type_ir::TyKind::Foreign(foreign) => TyKind::Foreign(to_foreign_def_id(foreign.0)),
         rustc_type_ir::TyKind::Pat(_, _) => unimplemented!(),
         rustc_type_ir::TyKind::RawPtr(ty, mutability) => {
             let mutability = match mutability {
@@ -1528,40 +1520,22 @@ pub(crate) fn convert_ty_for_result<'db>(interner: DbInterner<'db>, ty: Ty<'db>)
             TyKind::Raw(mutability, ty)
         }
         rustc_type_ir::TyKind::FnDef(def_id, args) => {
-            let id = match def_id {
-                SolverDefId::FunctionId(id) => CallableDefId::FunctionId(id),
-                SolverDefId::Ctor(Ctor::Struct(id)) => CallableDefId::StructId(id),
-                SolverDefId::Ctor(Ctor::Enum(id)) => CallableDefId::EnumVariantId(id),
-                _ => unreachable!(),
-            };
             let subst = convert_args_for_result(interner, args.as_slice());
-            TyKind::FnDef(id.to_chalk(interner.db()), subst)
+            TyKind::FnDef(def_id.0.to_chalk(interner.db()), subst)
         }
 
         rustc_type_ir::TyKind::Closure(def_id, args) => {
-            let id = match def_id {
-                SolverDefId::InternedClosureId(id) => id,
-                _ => unreachable!(),
-            };
             let subst = convert_args_for_result(interner, args.as_slice());
-            TyKind::Closure(id.into(), subst)
+            TyKind::Closure(def_id.0.into(), subst)
         }
         rustc_type_ir::TyKind::CoroutineClosure(_, _) => unimplemented!(),
         rustc_type_ir::TyKind::Coroutine(def_id, args) => {
-            let id = match def_id {
-                SolverDefId::InternedCoroutineId(id) => id,
-                _ => unreachable!(),
-            };
             let subst = convert_args_for_result(interner, args.as_slice());
-            TyKind::Coroutine(id.into(), subst)
+            TyKind::Coroutine(def_id.0.into(), subst)
         }
         rustc_type_ir::TyKind::CoroutineWitness(def_id, args) => {
-            let id = match def_id {
-                SolverDefId::InternedCoroutineId(id) => id,
-                _ => unreachable!(),
-            };
             let subst = convert_args_for_result(interner, args.as_slice());
-            TyKind::CoroutineWitness(id.into(), subst)
+            TyKind::CoroutineWitness(def_id.0.into(), subst)
         }
 
         rustc_type_ir::TyKind::UnsafeBinder(_) => unimplemented!(),

--- a/crates/hir-ty/src/next_solver/solver.rs
+++ b/crates/hir-ty/src/next_solver/solver.rs
@@ -9,6 +9,7 @@ use rustc_type_ir::{
     solve::{Certainty, NoSolution},
 };
 
+use crate::next_solver::CanonicalVarKind;
 use crate::next_solver::mapping::NextSolverToChalk;
 use crate::{
     TraitRefExt,
@@ -117,13 +118,14 @@ impl<'db> SolverDelegate for SolverContext<'db> {
         canonical.instantiate(self.cx(), &values)
     }
 
-    fn instantiate_canonical_var_with_infer(
+    fn instantiate_canonical_var(
         &self,
-        cv_info: rustc_type_ir::CanonicalVarKind<Self::Interner>,
-        _span: <Self::Interner as rustc_type_ir::Interner>::Span,
+        kind: CanonicalVarKind<'db>,
+        span: <Self::Interner as Interner>::Span,
+        var_values: &[GenericArg<'db>],
         universe_map: impl Fn(rustc_type_ir::UniverseIndex) -> rustc_type_ir::UniverseIndex,
-    ) -> <Self::Interner as rustc_type_ir::Interner>::GenericArg {
-        self.0.instantiate_canonical_var(cv_info, universe_map)
+    ) -> GenericArg<'db> {
+        self.0.instantiate_canonical_var(kind, var_values, universe_map)
     }
 
     fn add_item_bounds_for_hidden_type(

--- a/crates/hir-ty/src/next_solver/solver.rs
+++ b/crates/hir-ty/src/next_solver/solver.rs
@@ -9,8 +9,8 @@ use rustc_type_ir::{
     solve::{Certainty, NoSolution},
 };
 
-use crate::next_solver::CanonicalVarKind;
 use crate::next_solver::mapping::NextSolverToChalk;
+use crate::next_solver::{CanonicalVarKind, ImplIdWrapper};
 use crate::{
     TraitRefExt,
     db::HirDatabase,
@@ -148,12 +148,8 @@ impl<'db> SolverDelegate for SolverContext<'db> {
         &self,
         goal_trait_ref: rustc_type_ir::TraitRef<Self::Interner>,
         trait_assoc_def_id: <Self::Interner as rustc_type_ir::Interner>::DefId,
-        impl_def_id: <Self::Interner as rustc_type_ir::Interner>::DefId,
+        impl_id: ImplIdWrapper,
     ) -> Result<Option<<Self::Interner as rustc_type_ir::Interner>::DefId>, ErrorGuaranteed> {
-        let impl_id = match impl_def_id {
-            SolverDefId::ImplId(id) => id,
-            _ => panic!("Unexpected SolverDefId"),
-        };
         let trait_assoc_id = match trait_assoc_def_id {
             SolverDefId::TypeAliasId(id) => id,
             _ => panic!("Unexpected SolverDefId"),
@@ -162,7 +158,7 @@ impl<'db> SolverDelegate for SolverContext<'db> {
             .0
             .interner
             .db()
-            .impl_trait(impl_id)
+            .impl_trait(impl_id.0)
             // ImplIds for impls where the trait ref can't be resolved should never reach solver
             .expect("invalid impl passed to next-solver")
             .into_value_and_skipped_binders()
@@ -170,7 +166,7 @@ impl<'db> SolverDelegate for SolverContext<'db> {
         let trait_ = trait_ref.hir_trait_id();
         let trait_data = trait_.trait_items(self.0.interner.db());
         let id =
-            impl_id.impl_items(self.0.interner.db()).items.iter().find_map(|item| -> Option<_> {
+            impl_id.0.impl_items(self.0.interner.db()).items.iter().find_map(|item| -> Option<_> {
                 match item {
                     (_, AssocItemId::TypeAliasId(type_alias)) => {
                         let name = &self.0.interner.db().type_alias_signature(*type_alias).name;

--- a/crates/hir-ty/src/next_solver/ty.rs
+++ b/crates/hir-ty/src/next_solver/ty.rs
@@ -20,7 +20,9 @@ use rustc_type_ir::{
 use salsa::plumbing::{AsId, FromId};
 use smallvec::SmallVec;
 
-use crate::next_solver::GenericArg;
+use crate::next_solver::{
+    CallableIdWrapper, ClosureIdWrapper, CoroutineIdWrapper, GenericArg, TypeAliasIdWrapper,
+};
 use crate::{
     db::HirDatabase,
     interner::InternedWrapperNoDebug,
@@ -599,10 +601,7 @@ impl<'db> rustc_type_ir::inherent::Ty<DbInterner<'db>> for Ty<'db> {
         Ty::new(interner, TyKind::Adt(adt_def, args))
     }
 
-    fn new_foreign(
-        interner: DbInterner<'db>,
-        def_id: <DbInterner<'db> as rustc_type_ir::Interner>::DefId,
-    ) -> Self {
+    fn new_foreign(interner: DbInterner<'db>, def_id: TypeAliasIdWrapper) -> Self {
         Ty::new(interner, TyKind::Foreign(def_id))
     }
 
@@ -617,7 +616,7 @@ impl<'db> rustc_type_ir::inherent::Ty<DbInterner<'db>> for Ty<'db> {
 
     fn new_coroutine(
         interner: DbInterner<'db>,
-        def_id: <DbInterner<'db> as rustc_type_ir::Interner>::DefId,
+        def_id: CoroutineIdWrapper,
         args: <DbInterner<'db> as rustc_type_ir::Interner>::GenericArgs,
     ) -> Self {
         Ty::new(interner, TyKind::Coroutine(def_id, args))
@@ -625,7 +624,7 @@ impl<'db> rustc_type_ir::inherent::Ty<DbInterner<'db>> for Ty<'db> {
 
     fn new_coroutine_closure(
         interner: DbInterner<'db>,
-        def_id: <DbInterner<'db> as rustc_type_ir::Interner>::DefId,
+        def_id: CoroutineIdWrapper,
         args: <DbInterner<'db> as rustc_type_ir::Interner>::GenericArgs,
     ) -> Self {
         Ty::new(interner, TyKind::CoroutineClosure(def_id, args))
@@ -633,7 +632,7 @@ impl<'db> rustc_type_ir::inherent::Ty<DbInterner<'db>> for Ty<'db> {
 
     fn new_closure(
         interner: DbInterner<'db>,
-        def_id: <DbInterner<'db> as rustc_type_ir::Interner>::DefId,
+        def_id: ClosureIdWrapper,
         args: <DbInterner<'db> as rustc_type_ir::Interner>::GenericArgs,
     ) -> Self {
         Ty::new(interner, TyKind::Closure(def_id, args))
@@ -641,7 +640,7 @@ impl<'db> rustc_type_ir::inherent::Ty<DbInterner<'db>> for Ty<'db> {
 
     fn new_coroutine_witness(
         interner: DbInterner<'db>,
-        def_id: <DbInterner<'db> as rustc_type_ir::Interner>::DefId,
+        def_id: CoroutineIdWrapper,
         args: <DbInterner<'db> as rustc_type_ir::Interner>::GenericArgs,
     ) -> Self {
         Ty::new(interner, TyKind::CoroutineWitness(def_id, args))
@@ -649,7 +648,7 @@ impl<'db> rustc_type_ir::inherent::Ty<DbInterner<'db>> for Ty<'db> {
 
     fn new_coroutine_witness_for_coroutine(
         interner: DbInterner<'db>,
-        def_id: <DbInterner<'db> as rustc_type_ir::Interner>::DefId,
+        def_id: CoroutineIdWrapper,
         coroutine_args: <DbInterner<'db> as rustc_type_ir::Interner>::GenericArgs,
     ) -> Self {
         // HACK: Coroutine witness types are lifetime erased, so they
@@ -714,7 +713,7 @@ impl<'db> rustc_type_ir::inherent::Ty<DbInterner<'db>> for Ty<'db> {
 
     fn new_fn_def(
         interner: DbInterner<'db>,
-        def_id: <DbInterner<'db> as rustc_type_ir::Interner>::DefId,
+        def_id: CallableIdWrapper,
         args: <DbInterner<'db> as rustc_type_ir::Interner>::GenericArgs,
     ) -> Self {
         Ty::new(interner, TyKind::FnDef(def_id, args))

--- a/crates/hir-ty/src/next_solver/util.rs
+++ b/crates/hir-ty/src/next_solver/util.rs
@@ -532,17 +532,14 @@ pub(crate) fn mini_canonicalize<'db, T: TypeFoldable<DbInterner<'db>>>(
         max_universe: UniverseIndex::from_u32(1),
         variables: CanonicalVars::new_from_iter(
             context.cx(),
-            vars.iter().map(|(k, v)| match (*k).kind() {
+            vars.iter().enumerate().map(|(idx, (k, v))| match (*k).kind() {
                 GenericArgKind::Type(ty) => match ty.kind() {
-                    TyKind::Int(..) | TyKind::Uint(..) => {
-                        rustc_type_ir::CanonicalVarKind::Ty(rustc_type_ir::CanonicalTyVarKind::Int)
-                    }
-                    TyKind::Float(..) => rustc_type_ir::CanonicalVarKind::Ty(
-                        rustc_type_ir::CanonicalTyVarKind::Float,
-                    ),
-                    _ => rustc_type_ir::CanonicalVarKind::Ty(
-                        rustc_type_ir::CanonicalTyVarKind::General(UniverseIndex::ZERO),
-                    ),
+                    TyKind::Int(..) | TyKind::Uint(..) => rustc_type_ir::CanonicalVarKind::Int,
+                    TyKind::Float(..) => rustc_type_ir::CanonicalVarKind::Float,
+                    _ => rustc_type_ir::CanonicalVarKind::Ty {
+                        ui: UniverseIndex::ZERO,
+                        sub_root: BoundVar::from_usize(idx),
+                    },
                 },
                 GenericArgKind::Lifetime(_) => {
                     rustc_type_ir::CanonicalVarKind::Region(UniverseIndex::ZERO)


### PR DESCRIPTION
The first commit adapts to changes in canonicalization. I really wait for a r-l/r sync so that we won't need to constantly do it manually. (If you can help - see [#t-compiler/help > Dependency of both Chalk and rustc_type_ir fails r-a sync](https://rust-lang.zulipchat.com/#narrow/channel/182449-t-compiler.2Fhelp/topic/Dependency.20of.20both.20Chalk.20and.20rustc_type_ir.20fails.20r-a.20sync/with/538052097)).

The second commit is where the fun is. The upgrade brings even more custom types. Yay for type safety!

@rust-lang/rust-analyzer, @rust-lang/types the remaining source of dynamic ID types are aliases, which are a problem because `TyKind::Alias` may carry either a type alias id or an opaque type id. If you can have an idea how to sort that - that'll make me really happy.