### PR TITLE
fix: Always coerce in a cast, even when there are unknown types

### DIFF
--- a/crates/hir-ty/src/tests/regression/new_solver.rs
+++ b/crates/hir-ty/src/tests/regression/new_solver.rs
@@ -98,3 +98,21 @@ fn main() {
     "#,
     );
 }
+
+#[test]
+fn cast_error_type() {
+    check_infer(
+        r#"
+fn main() {
+  let foo: [_; _] = [false] as _;
+}
+    "#,
+        expect![[r#"
+            10..47 '{   le...s _; }': ()
+            18..21 'foo': [bool; 1]
+            32..39 '[false]': [bool; 1]
+            32..44 '[false] as _': [bool; 1]
+            33..38 'false': bool
+        "#]],
+    );
+}


### PR DESCRIPTION
This cause the relationships between inference vars to get recorded.

I'm not entirely sure this is the correct thing to do, rustc's cast handling seems much more complicated, but it seems better than the status quo. CC @ShoyuVanilla I think you've inspected the rustc implementation in the past with greater scrutiny.

Fixes rust-lang/rust-analyzer#20644. This issue is unfortunate: when mapping next solver consts to Chalk, Chalk stores the types of the const but the next solver does not, so we stub them with `TyKind::Error`. Unfortunately, that makes Chalk to mark the type as containing errors. I don't see a way around this, we'll probably need to live with spurious error flags in our types for the time being.