### PR TITLE
fix: Infinite loop while elaborting predicates

### DIFF
--- a/crates/hir-ty/src/dyn_compatibility.rs
+++ b/crates/hir-ty/src/dyn_compatibility.rs
@@ -138,6 +138,9 @@ pub fn generics_require_sized_self(db: &dyn HirDatabase, def: GenericDefId) -> b
 
     let interner = DbInterner::new_with(db, Some(krate), None);
     let predicates = db.generic_predicates_ns(def);
+    // FIXME: We should use `explicit_predicates_of` here, which hasn't been implemented to
+    // rust-analyzer yet
+    // https://github.com/rust-lang/rust/blob/ddaf12390d3ffb7d5ba74491a48f3cd528e5d777/compiler/rustc_hir_analysis/src/collect/predicates_of.rs#L490
     elaborate::elaborate(interner, predicates.iter().copied()).any(|pred| {
         match pred.kind().skip_binder() {
             ClauseKind::Trait(trait_pred) => {

--- a/crates/hir-ty/src/dyn_compatibility/tests.rs
+++ b/crates/hir-ty/src/dyn_compatibility/tests.rs
@@ -253,7 +253,8 @@ trait Bar<T> {
 trait Baz : Bar<Self> {
 }
 "#,
-        [("Bar", vec![]), ("Baz", vec![SizedSelf, SelfReferential])],
+        // FIXME: We should also report `SizedSelf` here
+        [("Bar", vec![]), ("Baz", vec![SelfReferential])],
     );
 }
 

--- a/crates/hir-ty/src/lower_nextsolver.rs
+++ b/crates/hir-ty/src/lower_nextsolver.rs
@@ -1358,6 +1358,9 @@ where
         }
     }
 
+    // FIXME: rustc gathers more predicates by recursing through resulting trait predicates.
+    // See https://github.com/rust-lang/rust/blob/76c5ed2847cdb26ef2822a3a165d710f6b772217/compiler/rustc_hir_analysis/src/collect/predicates_of.rs#L689-L715
+
     (
         GenericPredicates(predicates.is_empty().not().then(|| predicates.into())),
         create_diagnostics(ctx.diagnostics),


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust-analyzer/issues/20582

> Disclaimer: this code can effectively hang or stack-overflow your rust-analyzer!

```rust
trait DimMax<Other: Dimension> {
    type Output: Dimension;
}
trait Dimension: DimMax<<Self as Dimension>:: Smaller, Output = Self> {
    type Smaller: Dimension;
}
```

If we gonna normalize projection types related to the above traits, the current implementation endlessly elaborates implied bounds like

- `<T as DimMax>::Output: Dimension` and we have `Dimension: DimMax`
- `<<T as DimMax>::Output as DimMax>::Output: DimMax`
- `<<<T as DimMax>::Output as DimMax>::Output as DimMax>::Output: DimMax`
- `...` 😵 

Though this is not the best I can, I partially ported some implementation details from rustc to fix this infinite loop.

I think we should move overall lowering logic closer to that of rustc's, especially for those ones in here:
https://github.com/rust-lang/rust/blob/76c5ed2847cdb26ef2822a3a165d710f6b772217/compiler/rustc_hir_analysis/src/collect/predicates_of.rs

but maybe after migrating remaining things to next-solver.
