### PR TITLE
Fix extra semicolon before else in let-stmt

### DIFF
--- a/crates/ide-completion/src/completions/keyword.rs
+++ b/crates/ide-completion/src/completions/keyword.rs
@@ -270,6 +270,46 @@ fn main() {
         );
 
         check_edit(
+            "else if",
+            r#"
+fn main() {
+    let x = if true {
+        ()
+    } $0 else {};
+}
+"#,
+            r#"
+fn main() {
+    let x = if true {
+        ()
+    } else if $1 {
+    $0
+} else {};
+}
+"#,
+        );
+
+        check_edit(
+            "else if",
+            r#"
+fn main() {
+    let x = if true {
+        ()
+    } $0 else if true {};
+}
+"#,
+            r#"
+fn main() {
+    let x = if true {
+        ()
+    } else if $1 {
+    $0
+} else if true {};
+}
+"#,
+        );
+
+        check_edit(
             "else",
             r#"
 fn main() {


### PR DESCRIPTION
Fixes rust-lang/rust-analyzer#20620

Example
---
```rust
fn main() {
    let x = if true {
        ()
    } $0 else {};
}
```

**Before this PR**:

```rust
fn main() {
    let x = if true {
        ()
    } else if $1 {
        $0
    }; else {};
}
```

**After this PR**:

```rust
fn main() {
    let x = if true {
        ()
    } else if $1 {
        $0
    } else {};
}
```
