### PR TITLE
Delete support for rustc_intrinsic_must_be_overridden

### DIFF
--- a/crates/hir-expand/src/inert_attr_macro.rs
+++ b/crates/hir-expand/src/inert_attr_macro.rs
@@ -641,11 +641,6 @@ pub const INERT_ATTRIBUTES: &[BuiltinAttribute] = &[
         "#[rustc_no_mir_inline] prevents the MIR inliner from inlining a function while not affecting codegen"
     ),
     rustc_attr!(
-        rustc_intrinsic_must_be_overridden, Normal, template!(Word), ErrorFollowing,
-        "the `#[rustc_intrinsic_must_be_overridden]` attribute is used to declare intrinsics without real bodies",
-    ),
-
-    rustc_attr!(
         rustc_deprecated_safe_2024, Normal, template!(Word), WarnFollowing,
         "the `#[rustc_safe_intrinsic]` marks functions as unsafe in Rust 2024",
     ),

--- a/crates/hir-ty/src/mir/eval/shim.rs
+++ b/crates/hir-ty/src/mir/eval/shim.rs
@@ -83,8 +83,7 @@ impl Evaluator<'_> {
                 destination,
                 locals,
                 span,
-                !function_data.has_body()
-                    || attrs.by_key(sym::rustc_intrinsic_must_be_overridden).exists(),
+                !function_data.has_body(),
             );
         }
         let is_extern_c = match def.lookup(self.db).container {

--- a/crates/ide-db/src/generated/lints.rs
+++ b/crates/ide-db/src/generated/lints.rs
@@ -7027,7 +7027,7 @@ the intrinsic directly when you can.
 
 ## Intrinsics with fallback logic
 
-Many intrinsics can be written in pure rust, albeit inefficiently or without supporting
+Many intrinsics can be written in pure Rust, albeit inefficiently or without supporting
 some features that only exist on some backends. Backends can simply not implement those
 intrinsics without causing any code miscompilations or failures to compile.
 All intrinsic fallback bodies are automatically made cross-crate inlineable (like `#[inline]`)
@@ -7068,55 +7068,12 @@ with any regular function.
 Various intrinsics have native MIR operations that they correspond to. Instead of requiring
 backends to implement both the intrinsic and the MIR operation, the `lower_intrinsics` pass
 will convert the calls to the MIR operation. Backends do not need to know about these intrinsics
-at all. These intrinsics only make sense without a body, and can either be declared as a "rust-intrinsic"
-or as a `#[rustc_intrinsic]`. The body is never used, as calls to the intrinsic do not exist
-anymore after MIR analyses.
+at all. These intrinsics only make sense without a body.  The body is never used, as calls to
+the intrinsic do not exist anymore after MIR analyses.
 
 ## Intrinsics without fallback logic
 
 These must be implemented by all backends.
-
-### `#[rustc_intrinsic]` declarations
-
-These are written like intrinsics with fallback bodies, but the body is irrelevant.
-Use `loop {}` for the body or call the intrinsic recursively and add
-`#[rustc_intrinsic_must_be_overridden]` to the function to ensure that backends don't
-invoke the body.
-
-### Legacy extern ABI based intrinsics
-
-These are imported as if they were FFI functions, with the special
-`rust-intrinsic` ABI. For example, if one was in a freestanding
-context, but wished to be able to `transmute` between types, and
-perform efficient pointer arithmetic, one would import those functions
-via a declaration like
-
-```rust
-#![feature(intrinsics)]
-#![allow(internal_features)]
-# fn main() {}
-
-extern "rust-intrinsic" {
-    fn transmute<T, U>(x: T) -> U;
-
-    fn arith_offset<T>(dst: *const T, offset: isize) -> *const T;
-}
-```
-
-As with any other FFI functions, these are by default always `unsafe` to call.
-You can add `#[rustc_safe_intrinsic]` to the intrinsic to make it safe to call.
-"##,
-        default_severity: Severity::Allow,
-        warn_since: None,
-        deny_since: None,
-    },
-    Lint {
-        label: "io_const_error",
-        description: r##"# `io_const_error`
-
-The tracking issue for this feature is: [#133448]
-
-[#133448]: https://github.com/rust-lang/rust/issues/133448
 
 ------------------------
 "##,

--- a/crates/intern/src/symbol/symbols.rs
+++ b/crates/intern/src/symbol/symbols.rs
@@ -425,7 +425,6 @@ define_symbols! {
     rustc_deallocator,
     rustc_deprecated_safe_2024,
     rustc_has_incoherent_inherent_impls,
-    rustc_intrinsic_must_be_overridden,
     rustc_intrinsic,
     rustc_layout_scalar_valid_range_end,
     rustc_layout_scalar_valid_range_start,


### PR DESCRIPTION
Also `extern "rust-intrinsic"`.

Closes rust-lang/rust-analyzer#19539