### PR TITLE
Fix "sync-from-ra" for `rust-lang/rust`

### DIFF
--- a/crates/hir-ty/src/lib.rs
+++ b/crates/hir-ty/src/lib.rs
@@ -39,6 +39,9 @@ extern crate rustc_next_trait_solver;
 #[cfg(not(feature = "in-rust-tree"))]
 extern crate ra_ap_rustc_next_trait_solver as rustc_next_trait_solver;
 
+#[cfg(feature = "in-rust-tree")]
+extern crate rustc_data_structures as ena;
+
 mod builder;
 mod chalk_db;
 mod chalk_ext;

--- a/crates/hir-ty/src/next_solver.rs
+++ b/crates/hir-ty/src/next_solver.rs
@@ -40,5 +40,8 @@ pub type AliasTy<'db> = rustc_type_ir::AliasTy<DbInterner<'db>>;
 pub type PolyFnSig<'db> = Binder<'db, rustc_type_ir::FnSig<DbInterner<'db>>>;
 pub type TypingMode<'db> = rustc_type_ir::TypingMode<DbInterner<'db>>;
 
+#[cfg(feature = "in-rust-tree")]
+use rustc_data_structure::sorted_map::index_map as indexmap;
+
 pub type FxIndexMap<K, V> =
     indexmap::IndexMap<K, V, std::hash::BuildHasherDefault<rustc_hash::FxHasher>>;


### PR DESCRIPTION
cc [#t-compiler/rust-analyzer > New Trait Solver feedback @ 💬](https://rust-lang.zulipchat.com/#narrow/channel/185405-t-compiler.2Frust-analyzer/topic/New.20Trait.20Solver.20feedback/near/539818036)

Fortunately, `rustc_data_structure` re-exports things in `ena` and `indexmap` so I could fix those "there are multiple different versions of crate" things this time 😌 (there were 93 occurences of it)