### PR TITLE
fix: fix type completion with nested patterns

### DIFF
--- a/crates/ide-completion/src/render/pattern.rs
+++ b/crates/ide-completion/src/render/pattern.rs
@@ -163,6 +163,7 @@ fn render_pat(
         PatternContext {
             param_ctx: Some(ParamContext { kind: ParamKind::Function(_), .. }),
             has_type_ascription: false,
+            parent_pat: None,
             ..
         }
     );

--- a/crates/ide-completion/src/tests/pattern.rs
+++ b/crates/ide-completion/src/tests/pattern.rs
@@ -399,6 +399,25 @@ fn foo($0) {}
 }
 
 #[test]
+fn completes_in_fn_param_in_nested_pattern() {
+    check(
+        r#"
+struct Foo { num: u32 }
+struct Bar(Foo);
+fn foo(Bar($0)) {}
+"#,
+        expect![[r#"
+            st Bar
+            st Foo
+            bn Bar(…)        Bar($1)$0
+            bn Foo {…} Foo { num$1 }$0
+            kw mut
+            kw ref
+        "#]],
+    )
+}
+
+#[test]
 fn completes_in_closure_param() {
     check(
         r#"


### PR DESCRIPTION
Fixes rust-lang/rust-analyzer#17525

Example
---
```rust
struct Foo { num: u32 }
struct Bar(Foo);
fn foo(Bar($0)) {}
```

**Before this PR**:

```rust
struct Foo { num: u32 }
struct Bar(Foo);
fn foo(Bar(Foo { num$1 }: Foo$0)) {}
```

**After this PR**:

```rust
struct Foo { num: u32 }
struct Bar(Foo);
fn foo(Bar(Foo { num$1 }$0)) {}
```
