### PR TITLE
Add ide-assist: merge_nested_else_if

### DIFF
--- a/crates/ide-assists/src/lib.rs
+++ b/crates/ide-assists/src/lib.rs
@@ -322,6 +322,7 @@ mod handlers {
             merge_imports::merge_imports,
             merge_match_arms::merge_match_arms,
             merge_nested_if::merge_nested_if,
+            merge_nested_if::merge_nested_else_if,
             move_bounds::move_bounds_to_where_clause,
             move_const_to_impl::move_const_to_impl,
             move_from_mod_rs::move_from_mod_rs,

--- a/crates/ide-assists/src/tests/generated.rs
+++ b/crates/ide-assists/src/tests/generated.rs
@@ -2477,6 +2477,37 @@ fn handle(action: Action) {
 }
 
 #[test]
+fn doctest_merge_nested_else_if() {
+    check_doc_test(
+        "merge_nested_else_if",
+        r#####"
+fn main() {
+    if x == 3 {
+        true
+    } $0else {
+        if x == 2 {
+            false
+        } else {
+            true
+        }
+    }
+}
+"#####,
+        r#####"
+fn main() {
+    if x == 3 {
+        true
+    } else if x == 2 {
+        false
+    } else {
+        true
+    }
+}
+"#####,
+    )
+}
+
+#[test]
 fn doctest_merge_nested_if() {
     check_doc_test(
         "merge_nested_if",


### PR DESCRIPTION
This transforms `if x {} else { if y {} }` into `if x {} else if y {}`,
This assist can only be applied with the cursor on `else`.

Example
---
```rust
fn main() {
    if x == 3 {
        true
    } $0else {
        if x == 2 {
            false
        } else {
            true
        }
    }
}
```
->
```rust
fn main() {
    if x == 3 {
        true
    } else if x == 2 {
        false
    } else {
        true
    }
}
```
