### PR TITLE
Fix typo

### DIFF
--- a/crates/hir-ty/src/next_solver.rs
+++ b/crates/hir-ty/src/next_solver.rs
@@ -47,7 +47,7 @@ pub type TypeError<'db> = rustc_type_ir::error::TypeError<DbInterner<'db>>;
 pub type QueryResult<'db> = rustc_type_ir::solve::QueryResult<DbInterner<'db>>;
 
 #[cfg(feature = "in-rust-tree")]
-use rustc_data_structure::sorted_map::index_map as indexmap;
+use rustc_data_structures::sorted_map::index_map as indexmap;
 
 pub type FxIndexMap<K, V> =
     indexmap::IndexMap<K, V, std::hash::BuildHasherDefault<rustc_hash::FxHasher>>;


### PR DESCRIPTION
I have no Idea why did it succeed in my machine 🤔 maybe I just fixed thing in in-tree rust-analyzer and had mistake while moving the changes into r-a. Sorry.