### PR TITLE
minor: Fix one more thing in `in-rust-tree`

### DIFF
--- a/crates/hir-ty/src/next_solver/inspect.rs
+++ b/crates/hir-ty/src/next_solver/inspect.rs
@@ -1,4 +1,4 @@
-pub use ra_ap_rustc_next_trait_solver::solve::inspect::*;
+pub use rustc_next_trait_solver::solve::inspect::*;
 
 use rustc_ast_ir::try_visit;
 use rustc_next_trait_solver::{


### PR DESCRIPTION
I guess this is the last thing for the errors like `Foo and Foo have similar names, but are actually distinct types` 🙃 

We might need CI that runs cargo check with `in-rust-tree` feature and check whether we are using `ra_ap_*` things