### PR TITLE
fix negative const generic integer literals

### DIFF
--- a/crates/hir-ty/src/lower_nextsolver.rs
+++ b/crates/hir-ty/src/lower_nextsolver.rs
@@ -285,6 +285,29 @@ impl<'db, 'a> TyLoweringContext<'db, 'a> {
                 const_type,
                 self.resolver.krate(),
             ),
+            hir_def::hir::Expr::UnaryOp { expr: inner_expr, op: hir_def::hir::UnaryOp::Neg } => {
+                if let hir_def::hir::Expr::Literal(literal) = &self.store[*inner_expr] {
+                    // Only handle negation for signed integers and floats
+                    match literal {
+                        hir_def::hir::Literal::Int(_, _) | hir_def::hir::Literal::Float(_, _) => {
+                            if let Some(negated_literal) = literal.clone().negate() {
+                                intern_const_ref(
+                                    self.db,
+                                    &negated_literal.into(),
+                                    const_type,
+                                    self.resolver.krate(),
+                                )
+                            } else {
+                                unknown_const(const_type)
+                            }
+                        }
+                        // For unsigned integers, chars, bools, etc., negation is not meaningful
+                        _ => unknown_const(const_type),
+                    }
+                } else {
+                    unknown_const(const_type)
+                }
+            }
             _ => unknown_const(const_type),
         }
     }

--- a/crates/ide/src/hover/tests.rs
+++ b/crates/ide/src/hover/tests.rs
@@ -4738,7 +4738,7 @@ fn main() {
             *value*
 
             ```rust
-            let value: Const<_>
+            let value: Const<-1>
             ```
 
             ---


### PR DESCRIPTION
https://github.com/rust-lang/rust-analyzer/issues/20696

openly admit this was AI-assisted, but it seemed like a sufficiently small/straightforward issue to be a good idea to attempt