### PR TITLE
internal: migrate `expand_record_rest_pattern` assist to `SyntaxEditor`

### DIFF
--- a/crates/ide-assists/src/tests/generated.rs
+++ b/crates/ide-assists/src/tests/generated.rs
@@ -1035,7 +1035,7 @@ fn foo(bar: Bar) {
 struct Bar { y: Y, z: Z }
 
 fn foo(bar: Bar) {
-    let Bar { y, z  } = bar;
+    let Bar { y, z } = bar;
 }
 "#####,
     )


### PR DESCRIPTION
Because `add_field` uses `ted`
