### PR TITLE
fix SCIP panicking due to salsa not attaching

### DIFF
--- a/crates/ide/src/static_index.rs
+++ b/crates/ide/src/static_index.rs
@@ -278,7 +278,7 @@ impl StaticIndex<'_> {
         for token in tokens {
             let range = token.text_range();
             let node = token.parent().unwrap();
-            match get_definitions(&sema, token.clone()) {
+            match salsa::attach(self.db, || get_definitions(&sema, token.clone())) {
                 Some(it) => {
                     for i in it {
                         add_token(i, range, &node);


### PR DESCRIPTION
On main, trying to run `rust-analyzer scip $(pwd) --output $(pwd)/index.scip` (within any repo I've tried) results in the following panic:

```
thread 'main' (1558669) panicked at crates/hir-ty/src/next_solver/interner.rs:295:10:
db is expected to be attached
stack backtrace:
   0: __rustc::rust_begin_unwind
   1: core::panicking::panic_fmt
   2: core::option::expect_failed
   3: hir_ty::next_solver::interner::DbInterner::conjure
   4: hir_ty::traits::TraitEnvironment::empty
   5: hir::Type::new_with_resolver_inner
   6: hir::source_analyzer::SourceAnalyzer::resolve_record_field
   7: hir::semantics::SemanticsImpl::resolve_record_field_with_substitution
   8: ide_db::defs::NameRefClass::classify
   9: ide_db::defs::IdentClass::classify_node
  10: ide_db::defs::IdentClass::classify_token
  11: ide::static_index::StaticIndex::compute
  12: rust_analyzer::cli::scip::<impl rust_analyzer::cli::flags::Scip>::run
  13: rust_analyzer::main
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```

This PR simply attaches the salsa db before calling into any code that needs it (but also after anything else that attaches it so we don't get double-attaching panics).

I also added a test here to make sure we can do a full scip run with the smallest crate in this workspace (`edition`), but that takes a while to run - significantly longer than all other tests (but I feel it's very useful since it would've caught this issue). On my machine, it's much faster to compile & run that specific test with `--release` than without (even including compile time), so maybe that's something that should be done to keep CI passing in a reasonable amount of time if we want to keep this test in?