### PR TITLE
Fix loses label for convert_for_to_while_let

### DIFF
--- a/crates/ide-assists/src/handlers/convert_for_to_while_let.rs
+++ b/crates/ide-assists/src/handlers/convert_for_to_while_let.rs
@@ -1,11 +1,8 @@
-use hir::{
-    Name,
-    sym::{self},
-};
+use hir::{Name, sym};
 use ide_db::{famous_defs::FamousDefs, syntax_helpers::suggest_name};
 use syntax::{
     AstNode,
-    ast::{self, HasLoopBody, edit::IndentLevel, make, syntax_factory::SyntaxFactory},
+    ast::{self, HasAttrs, HasLoopBody, edit::IndentLevel, make, syntax_factory::SyntaxFactory},
     syntax_editor::Position,
 };
 
@@ -82,6 +79,18 @@ pub(crate) fn convert_for_loop_to_while_let(
                 Some(iterable),
             );
             let indent = IndentLevel::from_node(for_loop.syntax());
+
+            if let Some(label) = for_loop.label() {
+                let label = label.syntax().clone_for_update();
+                editor.insert(Position::before(for_loop.syntax()), make.whitespace(" "));
+                editor.insert(Position::before(for_loop.syntax()), label);
+            }
+            crate::utils::insert_attributes(
+                for_loop.syntax(),
+                &mut editor,
+                for_loop.attrs().map(|it| it.clone_for_update()),
+            );
+
             editor.insert(
                 Position::before(for_loop.syntax()),
                 make::tokens::whitespace(format!("\n{indent}").as_str()),
@@ -179,6 +188,56 @@ fn main() {
 fn main() {
     let mut x = vec![1, 2, 3];
     let mut tmp = x.into_iter();
+    while let Some(v) = tmp.next() {
+        v *= 2;
+    };
+}",
+        )
+    }
+
+    #[test]
+    fn each_to_for_with_label() {
+        check_assist(
+            convert_for_loop_to_while_let,
+            r"
+fn main() {
+    let mut x = vec![1, 2, 3];
+    'a: for $0v in x {
+        v *= 2;
+        break 'a;
+    };
+}",
+            r"
+fn main() {
+    let mut x = vec![1, 2, 3];
+    let mut tmp = x.into_iter();
+    'a: while let Some(v) = tmp.next() {
+        v *= 2;
+        break 'a;
+    };
+}",
+        )
+    }
+
+    #[test]
+    fn each_to_for_with_attributes() {
+        check_assist(
+            convert_for_loop_to_while_let,
+            r"
+fn main() {
+    let mut x = vec![1, 2, 3];
+    #[allow(unused)]
+    #[deny(unsafe_code)]
+    for $0v in x {
+        v *= 2;
+    };
+}",
+            r"
+fn main() {
+    let mut x = vec![1, 2, 3];
+    let mut tmp = x.into_iter();
+    #[allow(unused)]
+    #[deny(unsafe_code)]
     while let Some(v) = tmp.next() {
         v *= 2;
     };

--- a/crates/ide-assists/src/utils.rs
+++ b/crates/ide-assists/src/utils.rs
@@ -27,7 +27,7 @@ use syntax::{
         make,
         syntax_factory::SyntaxFactory,
     },
-    syntax_editor::{Removable, SyntaxEditor},
+    syntax_editor::{Element, Removable, SyntaxEditor},
 };
 
 use crate::{
@@ -383,6 +383,28 @@ fn invert_special_case_legacy(expr: &ast::Expr) -> Option<ast::Expr> {
         },
         _ => None,
     }
+}
+
+pub(crate) fn insert_attributes(
+    before: impl Element,
+    edit: &mut SyntaxEditor,
+    attrs: impl IntoIterator<Item = ast::Attr>,
+) {
+    let mut attrs = attrs.into_iter().peekable();
+    if attrs.peek().is_none() {
+        return;
+    }
+    let elem = before.syntax_element();
+    let indent = IndentLevel::from_element(&elem);
+    let whitespace = format!("\n{indent}");
+    edit.insert_all(
+        syntax::syntax_editor::Position::before(elem),
+        attrs
+            .flat_map(|attr| {
+                [attr.syntax().clone().into(), make::tokens::whitespace(&whitespace).into()]
+            })
+            .collect(),
+    );
 }
 
 pub(crate) fn next_prev() -> impl Iterator<Item = Direction> {

--- a/crates/syntax/src/ast/make.rs
+++ b/crates/syntax/src/ast/make.rs
@@ -1355,7 +1355,7 @@ pub mod tokens {
 
     pub(super) static SOURCE_FILE: LazyLock<Parse<SourceFile>> = LazyLock::new(|| {
         SourceFile::parse(
-            "use crate::foo; const C: <()>::Item = ( true && true , true || true , 1 != 1, 2 == 2, 3 < 3, 4 <= 4, 5 > 5, 6 >= 6, !true, *p, &p , &mut p, async { let _ @ [] })\n;\n\nunsafe impl A for B where: {}",
+            "use crate::foo; const C: <()>::Item = ( true && true , true || true , 1 != 1, 2 == 2, 3 < 3, 4 <= 4, 5 > 5, 6 >= 6, !true, *p, &p , &mut p, async { let _ @ [] }, while loop {} {})\n;\n\nunsafe impl A for B where: {}",
             Edition::CURRENT,
         )
     });


### PR DESCRIPTION
Fixes:
- loses label for `convert_while_to_loop` and `convert_for_to_while_let`
- loses attributes for `convert_while_to_loop` and `convert_for_to_while_let`
- bad indent for `convert_while_to_loop`

Examples
---
```rust
fn main() {
    #[allow(unused)]
    #[deny(unsafe_code)]
    'a: while$0 let Some(x) = cond {
        foo();
        break 'a;
    }
}
```

**Before this PR**:

```rust
fn main() {
    loop {
        if let Some(x) = cond {
            foo();
            break 'a;
        } else {
            break;
        }
    }
}
```

**After this PR**:

```rust
fn main() {
    #[allow(unused)]
    #[deny(unsafe_code)]
    'a: loop {
        if let Some(x) = cond {
            foo();
            break 'a;
        } else {
            break;
        }
    }
}
```

---

```rust
fn main() {
    let mut x = vec![1, 2, 3];
    #[allow(unused)]
    #[deny(unsafe_code)]
    'a: for $0v in x {
        v *= 2;
        break 'a;
    };
}
```

**Before this PR**:

```rust
fn main() {
    let mut x = vec![1, 2, 3];
    let mut tmp = x.into_iter();
    while let Some(v) = tmp.next() {
        v *= 2;
        break 'a;
    };
}
```

**After this PR**:

```rust
fn main() {
    let mut x = vec![1, 2, 3];
    let mut tmp = x.into_iter();
    #[allow(unused)]
    #[deny(unsafe_code)]
    'a: while let Some(v) = tmp.next() {
        v *= 2;
        break 'a;
    };
}
```
