### PR TITLE
Use FileId::MAX for id assertion in PathInterner::intern

### DIFF
--- a/crates/vfs/src/path_interner.rs
+++ b/crates/vfs/src/path_interner.rs
@@ -28,7 +28,7 @@ impl PathInterner {
     /// - Else, returns a newly allocated id.
     pub(crate) fn intern(&mut self, path: VfsPath) -> FileId {
         let (id, _added) = self.map.insert_full(path);
-        assert!(id < u32::MAX as usize);
+        assert!(id < FileId::MAX as usize);
         FileId(id as u32)
     }
 


### PR DESCRIPTION
Update PathInterner::intern to use FileId::MAX for id range checks, ensuring FileId MAX invariant.
