### PR TITLE
Add `all` `any` and `not` attribute completions

### DIFF
--- a/crates/ide-completion/src/tests/attribute.rs
+++ b/crates/ide-completion/src/tests/attribute.rs
@@ -815,7 +815,10 @@ mod cfg {
 #[cfg($0)]
 "#,
             expect![[r#"
+                ba all
+                ba any
                 ba dbg
+                ba not
                 ba opt_level
                 ba test
                 ba true
@@ -827,7 +830,10 @@ mod cfg {
 #[cfg(b$0)]
 "#,
             expect![[r#"
+                ba all
+                ba any
                 ba dbg
+                ba not
                 ba opt_level
                 ba test
                 ba true
@@ -843,7 +849,10 @@ mod cfg {
 #[cfg_attr($0)]
 "#,
             expect![[r#"
+                ba all
+                ba any
                 ba dbg
+                ba not
                 ba opt_level
                 ba test
                 ba true
@@ -855,7 +864,10 @@ mod cfg {
 #[cfg_attr(b$0)]
 "#,
             expect![[r#"
+                ba all
+                ba any
                 ba dbg
+                ba not
                 ba opt_level
                 ba test
                 ba true
@@ -867,7 +879,10 @@ mod cfg {
 #[cfg_attr($0, allow(deprecated))]
 "#,
             expect![[r#"
+                ba all
+                ba any
                 ba dbg
+                ba not
                 ba opt_level
                 ba test
                 ba true
@@ -879,7 +894,10 @@ mod cfg {
 #[cfg_attr(b$0, allow(deprecated))]
 "#,
             expect![[r#"
+                ba all
+                ba any
                 ba dbg
+                ba not
                 ba opt_level
                 ba test
                 ba true
@@ -902,6 +920,20 @@ mod cfg {
                 ba big
                 ba little
             "#]],
+        );
+    }
+
+    #[test]
+    fn inside_conditional() {
+        check_edit(
+            "all",
+            r#"
+//- /main.rs cfg:test,dbg=false,opt_level=2
+#[cfg($0)]
+"#,
+            r#"
+#[cfg(all($0))]
+"#,
         );
     }
 }


### PR DESCRIPTION
Example
---
`#[cfg($0)]` -> `#[cfg(any($0))]`
