### PR TITLE
minor: Impl `std::error::Error` for `SyntaxError`

### DIFF
--- a/crates/syntax/src/syntax_error.rs
+++ b/crates/syntax/src/syntax_error.rs
@@ -42,3 +42,5 @@ impl fmt::Display for SyntaxError {
         self.0.fmt(f)
     }
 }
+
+impl std::error::Error for SyntaxError {}


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust-analyzer/issues/11465. Because it's fun to close years-old minor issue :)