### PR TITLE
Fix not applicable match inside if for pull_assignment_up

### DIFF
--- a/crates/ide-assists/src/handlers/pull_assignment_up.rs
+++ b/crates/ide-assists/src/handlers/pull_assignment_up.rs
@@ -1,3 +1,4 @@
+use either::Either;
 use syntax::{
     AstNode,
     algo::find_node_at_range,
@@ -52,14 +53,15 @@ pub(crate) fn pull_assignment_up(acc: &mut Assists, ctx: &AssistContext<'_>) -> 
         assignments: Vec::new(),
     };
 
-    let tgt: ast::Expr = if let Some(if_expr) = ctx.find_node_at_offset::<ast::IfExpr>() {
+    let node: Either<ast::IfExpr, ast::MatchExpr> = ctx.find_node_at_offset()?;
+    let tgt: ast::Expr = if let Either::Left(if_expr) = node {
         let if_expr = std::iter::successors(Some(if_expr), |it| {
             it.syntax().parent().and_then(ast::IfExpr::cast)
         })
         .last()?;
         collector.collect_if(&if_expr)?;
         if_expr.into()
-    } else if let Some(match_expr) = ctx.find_node_at_offset::<ast::MatchExpr>() {
+    } else if let Either::Right(match_expr) = node {
         collector.collect_match(&match_expr)?;
         match_expr.into()
     } else {
@@ -307,6 +309,33 @@ fn foo() {
             4
         }
     };
+}"#,
+        );
+    }
+
+    #[test]
+    fn test_pull_assignment_up_match_in_if_expr() {
+        check_assist(
+            pull_assignment_up,
+            r#"
+fn foo() {
+    let x;
+    if true {
+        match true {
+            true => $0x = 2,
+            false => x = 3,
+        }
+    }
+}"#,
+            r#"
+fn foo() {
+    let x;
+    if true {
+        x = match true {
+            true => 2,
+            false => 3,
+        };
+    }
 }"#,
         );
     }


### PR DESCRIPTION
Example
---
```rust
fn foo() {
    let x;
    if true {
        match true {
            true => $0x = 2,
            false => x = 3,
        }
    }
}
```

**Before this PR**:

Assist not applicable

**After this PR**:

```rust
fn foo() {
    let x;
    if true {
        x = match true {
            true => 2,
            false => 3,
        };
    }
}
```
