### PR TITLE
internal: Build x86_64-apple-darwin binaries on macos-14

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,7 @@ env:
   RUSTFLAGS: "-D warnings -W unreachable-pub"
   RUSTUP_MAX_RETRIES: 10
   FETCH_DEPTH: 0 # pull in the tags for the version string
-  MACOSX_DEPLOYMENT_TARGET: 13.0
+  MACOSX_DEPLOYMENT_TARGET: 14.0
   ZIG_VERSION: 0.13.0
   ZIGBUILD_VERSION: 0.19.8
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -52,7 +52,7 @@ jobs:
             target: arm-unknown-linux-gnueabihf
             zig_target: arm-unknown-linux-gnueabihf.2.28
             code-target: linux-armhf
-          - os: macos-13
+          - os: macos-14
             target: x86_64-apple-darwin
             code-target: darwin-x64
             pgo: clap-rs/clap@v4.5.36


### PR DESCRIPTION
and bump `MACOSX_DEPLOYMENT_TARGET` to 14.0.

https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/