### PR TITLE
Fix panic when using analysis-stats

### DIFF
--- a/crates/rust-analyzer/src/cli/analysis_stats.rs
+++ b/crates/rust-analyzer/src/cli/analysis_stats.rs
@@ -335,15 +335,15 @@ impl flags::AnalysisStats {
             if !self.skip_const_eval {
                 self.run_const_eval(db, &bodies, verbosity);
             }
-
-            if self.run_all_ide_things {
-                self.run_ide_things(host.analysis(), file_ids.clone(), db, &vfs, verbosity);
-            }
-
-            if self.run_term_search {
-                self.run_term_search(&workspace, db, &vfs, file_ids, verbosity);
-            }
         });
+
+        if self.run_all_ide_things {
+            self.run_ide_things(host.analysis(), file_ids.clone(), db, &vfs, verbosity);
+        }
+
+        if self.run_term_search {
+            self.run_term_search(&workspace, db, &vfs, file_ids, verbosity);
+        }
 
         let db = host.raw_database_mut();
         db.trigger_lru_eviction();


### PR DESCRIPTION
On main, trying to run `cargo xtask install --pgo crate@version` panics due to some code paths trying to re-attach to the salsa database when it's already attached. To resolve that, I changed some parts of the code to not attach to the database when we already know we're attached.

I'm not sure if this is the "correct" approach, but it seems to do the job for me. After this change, I was able to do all the following just fine:

1. `cargo nextest run`
2. `cargo build --release --features mimalloc --target $(rustc --print host-tuple) && cargo xtask install --server --mimalloc --proc-macro-server --pgo apache/datafusion@50.0.0` (as an example crate)
3. Using my ide with the version of rust-analyzer installed in the previous step and jumping around, using suggestions, etc.

This PR is also probably better viewed without the whitespace changes - there's a good bit of indentation changes.