### PR TITLE
fix: fix spurious `incorrect_generics_len` on generic enum variants used through type aliases

### DIFF
--- a/crates/ide-diagnostics/src/handlers/incorrect_generics_len.rs
+++ b/crates/ide-diagnostics/src/handlers/incorrect_generics_len.rs
@@ -207,4 +207,21 @@ impl WithSignals for Player {
         "#,
         );
     }
+
+    #[test]
+    fn enum_type_alias_default_param() {
+        check_diagnostics(
+            r#"
+//- minicore: result
+
+struct Error;
+
+type Result<T, E = Error> = core::result::Result<T, E>;
+
+fn main() {
+    let _ = Result::<()>::Ok(());
+}
+        "#,
+        );
+    }
 }


### PR DESCRIPTION
Fixes rust-lang/rust-analyzer#20786.