### PR TITLE
docs: Mention editor-independent configuration

### DIFF
--- a/docs/book/src/configuration.md
+++ b/docs/book/src/configuration.md
@@ -46,6 +46,11 @@ To verify which configuration is actually used by `rust-analyzer`, set
 config-related messages. Logs should show both the JSON that
 `rust-analyzer` sees as well as the updated config.
 
+(Work in progress:) It is also possible to place configuration in a
+`rust-analyzer.toml` file. It should be located in the project root or in your
+user configuration directory (e.g. `~/.config/rust-analyzer/`). This is a work in
+progress, many configuration options aren't supported yet.
+
 This is the list of config options `rust-analyzer` supports:
 
 {{#include configuration_generated.md}}


### PR DESCRIPTION
Motivated by the discussion [here](https://github.com/rust-lang/rust-analyzer/issues/20798#issuecomment-3368962316).