### PR TITLE
Build rust-analyzer with `--target` for install/pgo xtask

### DIFF
--- a/xtask/src/install.rs
+++ b/xtask/src/install.rs
@@ -145,12 +145,12 @@ fn install_server(sh: &Shell, opts: ServerOpt) -> anyhow::Result<()> {
     );
 
     if let Some(train_crate) = opts.pgo {
+        let target = detect_target(sh);
         let build_cmd = cmd!(
             sh,
-            "cargo build --manifest-path ./crates/rust-analyzer/Cargo.toml --bin rust-analyzer --profile={profile} --locked --features force-always-assert {features...}"
+            "cargo build --manifest-path ./crates/rust-analyzer/Cargo.toml --bin rust-analyzer --target {target} --profile={profile} --locked --features force-always-assert {features...}"
         );
 
-        let target = detect_target(sh);
         let profile = crate::pgo::gather_pgo_profile(sh, build_cmd, &target, train_crate)?;
         install_cmd = crate::pgo::apply_pgo_to_cmd(install_cmd, &profile);
     }


### PR DESCRIPTION
The pgo xtask expects to find the recently-compiled version of rust-analyzer at `/target/$target/release/rust-analyzer`, but the `install` xtask builds it without the `--target $target` flag, thus placing it at `/target/release/rust-analyzer`.

This PR adds the `--target $target` argument to the compilation of rust-analyzer in the `install` xtask so it works as expected.

It also checks to make sure pgo actually generates files, and fails with a more actionable error (instead of the previous misleading `Do you have the rustup llvm-tools component installed?` suggestion) when no files are generated.