### PR TITLE
feat: Log flycheck stdout and stderr to files

### DIFF
--- a/crates/rust-analyzer/src/discover.rs
+++ b/crates/rust-analyzer/src/discover.rs
@@ -67,7 +67,7 @@ impl DiscoverCommand {
         cmd.args(args);
 
         Ok(DiscoverHandle {
-            _handle: CommandHandle::spawn(cmd, DiscoverProjectParser, self.sender.clone())?,
+            _handle: CommandHandle::spawn(cmd, DiscoverProjectParser, self.sender.clone(), None)?,
             span: info_span!("discover_command").entered(),
         })
     }

--- a/crates/rust-analyzer/src/test_runner.rs
+++ b/crates/rust-analyzer/src/test_runner.rs
@@ -136,7 +136,12 @@ impl CargoTestHandle {
         }
 
         Ok(Self {
-            _handle: CommandHandle::spawn(cmd, CargoTestOutputParser::new(&test_target), sender)?,
+            _handle: CommandHandle::spawn(
+                cmd,
+                CargoTestOutputParser::new(&test_target),
+                sender,
+                None,
+            )?,
         })
     }
 }


### PR DESCRIPTION
This + fingerprint logging allows for easier figuring out causes of spurious rebuilds