### PR TITLE
minor: Fix compile error in `crates/cfg` tests due to `tt` feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -235,6 +235,7 @@ name = "cfg"
 version = "0.0.0"
 dependencies = [
  "arbitrary",
+ "cfg",
  "expect-test",
  "intern",
  "oorandom",

--- a/crates/cfg/Cargo.toml
+++ b/crates/cfg/Cargo.toml
@@ -29,5 +29,8 @@ arbitrary = { version = "1.4.1", features = ["derive"] }
 syntax-bridge.workspace = true
 syntax.workspace = true
 
+# tt is needed for testing
+cfg = { path = ".", default-features = false, features = ["tt"] }
+
 [lints]
 workspace = true


### PR DESCRIPTION
# Issue
The tests in [`crates/cfg/src/tests.rs`](https://github.com/rust-lang/rust-analyzer/blob/c5181dbbe33af6f21b9d83e02fdb6fda298a3b65/crates/cfg/src/tests.rs) depend on the `tt` feature of that crate, but are not feature-gated behind it.

When tests are run from the workspace root, there is no error because the workspace enables the `tt` feature:
https://github.com/rust-lang/rust-analyzer/blob/c5181dbbe33af6f21b9d83e02fdb6fda298a3b65/Cargo.toml#L57

But there are compile errors when trying to run that specific crate's tests via `cargo test --package cfg` or `cd crates/cfg && cargo test`. This also affects running tests via the VSCode "Run Test" inlay buttons or Test Explorer panel.

# Fix
~In this PR, I just made `tt` a required dependency of `cfg`, removing the feature.~

~I looked at all the places where this `cfg` crate is used, and it seems everywhere inherits the dependency spec from the workspace, and so enables the `tt` feature.~

~If it turns out having `tt` as an optional dependency is important, I'm up for making all the tests conditionally compiled, or potentially applying [a workaround](https://github.com/rust-lang/cargo/issues/2911#issuecomment-1483256987) to enable the `tt` feature when compiling tests.~

Having `tt` as an optional dependency ***is*** important, so instead this PR will enable the `tt` feature when compiling tests. There is not direct support in Cargo for doing this, so this is done by depending on ourselves by path with the feature enabled in the `dev-dependencies` section.