### PR TITLE
fix: don't make `convert_to_guarded_return` applicable on `let-else`

### DIFF
--- a/crates/ide-assists/src/handlers/convert_to_guarded_return.rs
+++ b/crates/ide-assists/src/handlers/convert_to_guarded_return.rs
@@ -182,7 +182,7 @@ fn let_stmt_to_guarded_return(
     let cursor_in_range =
         let_token_range.cover(let_pattern_range).contains_range(ctx.selection_trimmed());
 
-    if !cursor_in_range {
+    if !cursor_in_range || let_stmt.let_else().is_some() {
         return None;
     }
 
@@ -906,6 +906,19 @@ fn main() {
     } else {
         bar()
     }
+}
+"#,
+        );
+    }
+
+    #[test]
+    fn ignore_let_else_branch() {
+        check_assist_not_applicable(
+            convert_to_guarded_return,
+            r#"
+//- minicore: option
+fn main() {
+    let$0 Some(x) = Some(2) else { return };
 }
 "#,
         );


### PR DESCRIPTION
Example
---
```rust
fn foo() -> bool {
    let$0 Some(x) = Some(2) else { return false };
}
```

**Before this PR**:

```rust
fn foo() -> bool {
    let Some(Some(x)) = Some(2) else { return };
}
```

**After this PR**:

Assist not applicable
