### PR TITLE
fix: fix indent in `add_braces`

### DIFF
--- a/crates/ide-assists/src/handlers/add_braces.rs
+++ b/crates/ide-assists/src/handlers/add_braces.rs
@@ -1,7 +1,7 @@
 use either::Either;
 use syntax::{
     AstNode,
-    ast::{self, edit_in_place::Indent, syntax_factory::SyntaxFactory},
+    ast::{self, edit::AstNodeEdit, syntax_factory::SyntaxFactory},
 };
 
 use crate::{AssistContext, AssistId, Assists};
@@ -43,10 +43,10 @@ pub(crate) fn add_braces(acc: &mut Assists, ctx: &AssistContext<'_>) -> Option<(
             let make = SyntaxFactory::with_mappings();
             let mut editor = builder.make_editor(expr.syntax());
 
-            let block_expr = make.block_expr(None, Some(expr.clone()));
-            block_expr.indent(expr.indent_level());
+            let new_expr = expr.reset_indent().indent(1.into());
+            let block_expr = make.block_expr(None, Some(new_expr));
 
-            editor.replace(expr.syntax(), block_expr.syntax());
+            editor.replace(expr.syntax(), block_expr.indent(expr.indent_level()).syntax());
 
             editor.add_mappings(make.finish_with_mappings());
             builder.add_file_edits(ctx.vfs_file_id(), editor);
@@ -166,6 +166,41 @@ fn foo() {
         },
         _ => ()
     };
+}
+"#,
+        );
+    }
+
+    #[test]
+    fn multiple_indent() {
+        check_assist(
+            add_braces,
+            r#"
+fn foo() {
+    {
+        match n {
+            Some(n) $0=> foo(
+                29,
+                30,
+            ),
+            _ => ()
+        };
+    }
+}
+"#,
+            r#"
+fn foo() {
+    {
+        match n {
+            Some(n) => {
+                foo(
+                    29,
+                    30,
+                )
+            },
+            _ => ()
+        };
+    }
 }
 "#,
         );


### PR DESCRIPTION
- And fix indent

Example
---
```rust
fn foo() {
    {
        match n {
            Some(n) $0=> foo(
                29,
                30,
            ),
            _ => ()
        };
    }
}
```

**Before this PR**:

```rust
fn main() {
    {
        match n {
            Some(n) => {
                foo(
                            29,
                            30,
                        )
            },
            _ => ()
        };
    }
}
```

**After this PR**:

```rust
fn foo() {
    {
        match n {
            Some(n) => {
                foo(
                    29,
                    30,
                )
            },
            _ => ()
        };
    }
}
```
