### PR TITLE
fix: include trailing underscores when hiding inlay hints

### DIFF
--- a/crates/ide/src/inlay_hints/param_name.rs
+++ b/crates/ide/src/inlay_hints/param_name.rs
@@ -124,12 +124,12 @@ fn should_hide_param_name_hint(
     // hide when:
     // - the parameter name is a suffix of the function's name
     // - the argument is a qualified constructing or call expression where the qualifier is an ADT
-    // - exact argument<->parameter match(ignoring leading underscore) or parameter is a prefix/suffix
-    //   of argument with _ splitting it off
+    // - exact argument<->parameter match(ignoring leading and trailing underscore) or
+    //   parameter is a prefix/suffix of argument with _ splitting it off
     // - param starts with `ra_fixture`
     // - param is a well known name in a unary function
 
-    let param_name = param_name.trim_start_matches('_');
+    let param_name = param_name.trim_matches('_');
     if param_name.is_empty() {
         return true;
     }
@@ -540,6 +540,8 @@ fn enum_matches_param_name(completion_kind: CompletionKind) {}
 fn foo(param: u32) {}
 fn bar(param_eter: u32) {}
 fn baz(a_d_e: u32) {}
+fn far(loop_: u32) {}
+fn faz(r#loop: u32) {}
 
 enum CompletionKind {
     Keyword,
@@ -590,6 +592,9 @@ fn main() {
     let param_eter2 = 0;
     bar(param_eter2);
       //^^^^^^^^^^^ param_eter
+    let loop_level = 0;
+    far(loop_level);
+    faz(loop_level);
 
     non_ident_pat((0, 0));
 


### PR DESCRIPTION
Using suffix underscores to avoid keywords is one of the common skill, and inlayHints hiding should support it

Example
---

**Before this PR**:

```rust
fn far(loop_: u32) {}
fn faz(r#loop: u32) {}

let loop_level = 0;
far(loop_level);
  //^^^^^^^^^^ loop_
faz(loop_level);
```

**After this PR**:

```rust
fn far(loop_: u32) {}
fn faz(r#loop: u32) {}

let loop_level = 0;
far(loop_level);
faz(loop_level);
```
