### PR TITLE
fix: add missing rest pattern in `convert_named_struct_to_tuple_struct`

### DIFF
--- a/crates/ide-assists/src/handlers/convert_named_struct_to_tuple_struct.rs
+++ b/crates/ide-assists/src/handlers/convert_named_struct_to_tuple_struct.rs
@@ -187,6 +187,7 @@ fn process_struct_name_reference(
         return None;
     }
 
+    // FIXME: Processing RecordPat and RecordExpr for unordered fields, and insert RestPat
     let parent = full_path.syntax().parent()?;
     match_ast! {
         match parent {


### PR DESCRIPTION
Fixes rust-lang/rust-analyzer#20847

Example
---
```rust
struct Inner;
struct A$0 { inner: Inner }
fn foo(A { .. }: A) {}
```

**Before this PR**:

```rust
struct Inner;
struct A(Inner);
fn foo(A(): A) {}
```

**After this PR**:

```rust
struct Inner;
struct A(Inner);
fn foo(A(..): A) {}
```
