### PR TITLE
fix: strip ANSI escape codes from flycheck messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2048,6 +2048,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "stdx",
+ "strip-ansi-escapes",
  "syntax",
  "syntax-bridge",
  "tenthash",
@@ -2377,6 +2378,15 @@ dependencies = [
  "miow",
  "tracing",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "strip-ansi-escapes"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a8f8038e7e7969abb3f1b7c2a811225e9296da208539e0f79c5251d6cac0025"
+dependencies = [
+ "vte",
 ]
 
 [[package]]
@@ -2838,6 +2848,15 @@ dependencies = [
  "tracing",
  "vfs",
  "walkdir",
+]
+
+[[package]]
+name = "vte"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "231fdcd7ef3037e8330d8e17e61011a2c244126acc0a982f4040ac3f9f0bc077"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -144,6 +144,7 @@ semver = "1.0.26"
 serde = { version = "1.0.219" }
 serde_derive = { version = "1.0.219" }
 serde_json = "1.0.140"
+strip-ansi-escapes = "0.2.1"
 rustc-hash = "2.1.1"
 rustc-literal-escaper = "0.0.4"
 smallvec = { version = "1.15.1", features = [

--- a/crates/rust-analyzer/Cargo.toml
+++ b/crates/rust-analyzer/Cargo.toml
@@ -53,6 +53,7 @@ semver.workspace = true
 memchr = "2.7.5"
 cargo_metadata.workspace = true
 process-wrap.workspace = true
+strip-ansi-escapes.workspace = true
 
 cfg.workspace = true
 hir-def.workspace = true


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust-analyzer/issues/15443

<img width="1774" height="797" alt="image" src="https://github.com/user-attachments/assets/ed06e343-acb7-4ece-9b4f-92b859eb1fc8" />
