### PR TITLE
minor: Fix "cannot insert `true` or `false` to cfg" error in fixtures

### DIFF
--- a/crates/cfg/src/lib.rs
+++ b/crates/cfg/src/lib.rs
@@ -115,6 +115,13 @@ impl CfgOptions {
     pub fn shrink_to_fit(&mut self) {
         self.enabled.shrink_to_fit();
     }
+
+    pub fn append(&mut self, other: CfgOptions) {
+        // Do not call `insert_any_atom()`, as it'll check for `true` and `false`, but this is not
+        // needed since we already checked for that when constructing `other`. Furthermore, this
+        // will always err, as `other` inevitably contains `true` (just as we do).
+        self.enabled.extend(other.enabled);
+    }
 }
 
 impl Extend<CfgAtom> for CfgOptions {

--- a/crates/test-fixture/src/lib.rs
+++ b/crates/test-fixture/src/lib.rs
@@ -252,7 +252,7 @@ impl ChangeFixture {
                 assert!(default_crate_root.is_none());
                 default_crate_root = Some(file_id);
                 default_edition = meta.edition;
-                default_cfg.extend(meta.cfg.into_iter());
+                default_cfg.append(meta.cfg);
                 default_env.extend_from_other(&meta.env);
             }
 


### PR DESCRIPTION
I do wonder though whether it's better to just not care about `true` and `false` in cfg insertion and instead treat them in checking specifically...