### PR TITLE
Add a lot more db lifetimes

### DIFF
--- a/crates/hir-ty/src/db.rs
+++ b/crates/hir-ty/src/db.rs
@@ -277,7 +277,7 @@ pub trait HirDatabase: DefDatabase + std::fmt::Debug {
 
     // Interned IDs for solver integration
     #[salsa::interned]
-    fn intern_impl_trait_id(&self, id: ImplTraitId<'_>) -> InternedOpaqueTyId;
+    fn intern_impl_trait_id<'db>(&'db self, id: ImplTraitId<'db>) -> InternedOpaqueTyId<'db>;
 
     #[salsa::interned]
     fn intern_closure(&self, id: InternedClosure) -> InternedClosureId;
@@ -319,9 +319,9 @@ pub struct InternedConstParamId {
     pub loc: ConstParamId,
 }
 
-#[salsa_macros::interned(no_lifetime, debug, revisions = usize::MAX)]
+#[salsa_macros::interned(debug, revisions = usize::MAX)]
 #[derive(PartialOrd, Ord)]
-pub struct InternedOpaqueTyId {
+pub struct InternedOpaqueTyId<'db> {
     pub loc: ImplTraitId<'db>,
 }
 

--- a/crates/hir-ty/src/dyn_compatibility.rs
+++ b/crates/hir-ty/src/dyn_compatibility.rs
@@ -495,9 +495,9 @@ fn contains_illegal_impl_trait_in_trait<'db>(
     db: &'db dyn HirDatabase,
     sig: &EarlyBinder<'db, Binder<'db, rustc_type_ir::FnSig<DbInterner<'db>>>>,
 ) -> Option<MethodViolationCode> {
-    struct OpaqueTypeCollector(FxHashSet<InternedOpaqueTyId>);
+    struct OpaqueTypeCollector<'x>(FxHashSet<InternedOpaqueTyId<'x>>);
 
-    impl<'db> rustc_type_ir::TypeVisitor<DbInterner<'db>> for OpaqueTypeCollector {
+    impl<'db> rustc_type_ir::TypeVisitor<DbInterner<'db>> for OpaqueTypeCollector<'db> {
         type Result = ControlFlow<()>;
 
         fn visit_ty(

--- a/crates/hir-ty/src/infer.rs
+++ b/crates/hir-ty/src/infer.rs
@@ -1282,8 +1282,8 @@ impl<'body, 'db> InferenceContext<'body, 'db> {
         struct TypeAliasImplTraitCollector<'a, 'db> {
             db: &'a dyn HirDatabase,
             table: &'a mut InferenceTable<'db>,
-            assocs: FxHashMap<InternedOpaqueTyId, (ImplId, Ty<'db>)>,
-            non_assocs: FxHashMap<InternedOpaqueTyId, Ty<'db>>,
+            assocs: FxHashMap<InternedOpaqueTyId<'db>, (ImplId, Ty<'db>)>,
+            non_assocs: FxHashMap<InternedOpaqueTyId<'db>, Ty<'db>>,
         }
 
         impl<'db> TypeVisitor<DbInterner<'db>> for TypeAliasImplTraitCollector<'_, 'db> {

--- a/crates/hir-ty/src/infer/unify.rs
+++ b/crates/hir-ty/src/infer/unify.rs
@@ -158,7 +158,7 @@ fn could_unify_impl<'db>(
 pub(crate) struct InferenceTable<'db> {
     pub(crate) db: &'db dyn HirDatabase,
     pub(crate) trait_env: Arc<TraitEnvironment<'db>>,
-    pub(crate) tait_coercion_table: Option<FxHashMap<InternedOpaqueTyId, Ty<'db>>>,
+    pub(crate) tait_coercion_table: Option<FxHashMap<InternedOpaqueTyId<'db>, Ty<'db>>>,
     pub(crate) infer_ctxt: InferCtxt<'db>,
     pub(super) fulfillment_cx: FulfillmentCtxt<'db>,
     pub(super) diverging_type_vars: FxHashSet<Ty<'db>>,
@@ -478,14 +478,14 @@ impl<'db> InferenceTable<'db> {
     }
 
     /// Create a `GenericArgs` full of infer vars for `def`.
-    pub(crate) fn fresh_args_for_item(&self, def: SolverDefId) -> GenericArgs<'db> {
+    pub(crate) fn fresh_args_for_item(&self, def: SolverDefId<'db>) -> GenericArgs<'db> {
         self.infer_ctxt.fresh_args_for_item(def)
     }
 
     /// Like `fresh_args_for_item()`, but first uses the args from `first`.
     pub(crate) fn fill_rest_fresh_args(
         &self,
-        def_id: SolverDefId,
+        def_id: SolverDefId<'db>,
         first: impl IntoIterator<Item = GenericArg<'db>>,
     ) -> GenericArgs<'db> {
         self.infer_ctxt.fill_rest_fresh_args(def_id, first)

--- a/crates/hir-ty/src/lower.rs
+++ b/crates/hir-ty/src/lower.rs
@@ -480,7 +480,7 @@ impl<'db, 'a> TyLoweringContext<'db, 'a> {
                             |f| ImplTraitId::ReturnTypeImplTrait(f, Idx::from_raw(idx.into_raw())),
                             |a| ImplTraitId::TypeAliasImplTrait(a, Idx::from_raw(idx.into_raw())),
                         );
-                        let opaque_ty_id: SolverDefId =
+                        let opaque_ty_id: SolverDefId<'db> =
                             self.db.intern_impl_trait_id(impl_trait_id).into();
 
                         // We don't want to lower the bounds inside the binders
@@ -879,7 +879,7 @@ impl<'db, 'a> TyLoweringContext<'db, 'a> {
 
     fn lower_impl_trait(
         &mut self,
-        def_id: SolverDefId,
+        def_id: SolverDefId<'db>,
         bounds: &[TypeBound],
         krate: Crate,
     ) -> ImplTrait<'db> {

--- a/crates/hir-ty/src/next_solver/consts.rs
+++ b/crates/hir-ty/src/next_solver/consts.rs
@@ -397,7 +397,7 @@ impl<'db> rustc_type_ir::inherent::BoundVarLike<DbInterner<'db>> for BoundConst 
         self.var
     }
 
-    fn assert_eq(self, var: BoundVarKind) {
+    fn assert_eq(self, var: BoundVarKind<'db>) {
         var.expect_const()
     }
 }

--- a/crates/hir-ty/src/next_solver/def_id.rs
+++ b/crates/hir-ty/src/next_solver/def_id.rs
@@ -5,7 +5,6 @@ use hir_def::{
     GeneralConstId, GenericDefId, ImplId, StaticId, StructId, TraitId, TypeAliasId, UnionId,
 };
 use rustc_type_ir::inherent;
-use stdx::impl_from;
 
 use crate::db::{InternedClosureId, InternedCoroutineId, InternedOpaqueTyId};
 
@@ -18,7 +17,7 @@ pub enum Ctor {
 }
 
 #[derive(PartialOrd, Ord, Clone, Copy, PartialEq, Eq, Hash, salsa::Supertype)]
-pub enum SolverDefId {
+pub enum SolverDefId<'db> {
     AdtId(AdtId),
     ConstId(ConstId),
     FunctionId(FunctionId),
@@ -28,13 +27,13 @@ pub enum SolverDefId {
     TypeAliasId(TypeAliasId),
     InternedClosureId(InternedClosureId),
     InternedCoroutineId(InternedCoroutineId),
-    InternedOpaqueTyId(InternedOpaqueTyId),
+    InternedOpaqueTyId(InternedOpaqueTyId<'db>),
     EnumVariantId(EnumVariantId),
     // FIXME(next-solver): Do we need the separation of `Ctor`? It duplicates some variants.
     Ctor(Ctor),
 }
 
-impl std::fmt::Debug for SolverDefId {
+impl<'db> std::fmt::Debug for SolverDefId<'db> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let interner = DbInterner::conjure();
         let db = interner.db;
@@ -102,23 +101,83 @@ impl std::fmt::Debug for SolverDefId {
     }
 }
 
-impl_from!(
-    AdtId(StructId, EnumId, UnionId),
-    ConstId,
-    FunctionId,
-    ImplId,
-    StaticId,
-    TraitId,
-    TypeAliasId,
-    InternedClosureId,
-    InternedCoroutineId,
-    InternedOpaqueTyId,
-    EnumVariantId,
-    Ctor
-    for SolverDefId
-);
+impl<'db> From<AdtId> for SolverDefId<'db> {
+    fn from(it: AdtId) -> SolverDefId<'db> {
+        SolverDefId::AdtId(it)
+    }
+}
+impl<'db> From<StructId> for SolverDefId<'db> {
+    fn from(it: StructId) -> SolverDefId<'db> {
+        SolverDefId::AdtId(AdtId::StructId(it))
+    }
+}
+impl<'db> From<EnumId> for SolverDefId<'db> {
+    fn from(it: EnumId) -> SolverDefId<'db> {
+        SolverDefId::AdtId(AdtId::EnumId(it))
+    }
+}
+impl<'db> From<UnionId> for SolverDefId<'db> {
+    fn from(it: UnionId) -> SolverDefId<'db> {
+        SolverDefId::AdtId(AdtId::UnionId(it))
+    }
+}
+impl<'db> From<ConstId> for SolverDefId<'db> {
+    fn from(it: ConstId) -> SolverDefId<'db> {
+        SolverDefId::ConstId(it)
+    }
+}
+impl<'db> From<FunctionId> for SolverDefId<'db> {
+    fn from(it: FunctionId) -> SolverDefId<'db> {
+        SolverDefId::FunctionId(it)
+    }
+}
+impl<'db> From<ImplId> for SolverDefId<'db> {
+    fn from(it: ImplId) -> SolverDefId<'db> {
+        SolverDefId::ImplId(it)
+    }
+}
+impl<'db> From<StaticId> for SolverDefId<'db> {
+    fn from(it: StaticId) -> SolverDefId<'db> {
+        SolverDefId::StaticId(it)
+    }
+}
+impl<'db> From<TraitId> for SolverDefId<'db> {
+    fn from(it: TraitId) -> SolverDefId<'db> {
+        SolverDefId::TraitId(it)
+    }
+}
+impl<'db> From<TypeAliasId> for SolverDefId<'db> {
+    fn from(it: TypeAliasId) -> SolverDefId<'db> {
+        SolverDefId::TypeAliasId(it)
+    }
+}
+impl<'db> From<InternedClosureId> for SolverDefId<'db> {
+    fn from(it: InternedClosureId) -> SolverDefId<'db> {
+        SolverDefId::InternedClosureId(it)
+    }
+}
+impl<'db> From<InternedCoroutineId> for SolverDefId<'db> {
+    fn from(it: InternedCoroutineId) -> SolverDefId<'db> {
+        SolverDefId::InternedCoroutineId(it)
+    }
+}
+impl<'db> From<InternedOpaqueTyId<'db>> for SolverDefId<'db> {
+    fn from(it: InternedOpaqueTyId<'db>) -> SolverDefId<'db> {
+        SolverDefId::InternedOpaqueTyId(it)
+    }
+}
+impl<'db> From<EnumVariantId> for SolverDefId<'db> {
+    fn from(it: EnumVariantId) -> SolverDefId<'db> {
+        SolverDefId::EnumVariantId(it)
+    }
+}
+impl<'db> From<Ctor> for SolverDefId<'db> {
+    fn from(it: Ctor) -> SolverDefId<'db> {
+        SolverDefId::Ctor(it)
+    }
+}
 
-impl From<GenericDefId> for SolverDefId {
+impl<'db> From<GenericDefId> for SolverDefId<'db> {
     fn from(value: GenericDefId) -> Self {
         match value {
             GenericDefId::AdtId(adt_id) => SolverDefId::AdtId(adt_id),
@@ -132,7 +191,7 @@ impl From<GenericDefId> for SolverDefId {
     }
 }
 
-impl From<GeneralConstId> for SolverDefId {
+impl<'db> From<GeneralConstId> for SolverDefId<'db> {
     #[inline]
     fn from(value: GeneralConstId) -> Self {
         match value {
@@ -142,7 +201,7 @@ impl From<GeneralConstId> for SolverDefId {
     }
 }
 
-impl From<DefWithBodyId> for SolverDefId {
+impl<'db> From<DefWithBodyId> for SolverDefId<'db> {
     #[inline]
     fn from(value: DefWithBodyId) -> Self {
         match value {
@@ -154,10 +213,10 @@ impl From<DefWithBodyId> for SolverDefId {
     }
 }
 
-impl TryFrom<SolverDefId> for GenericDefId {
+impl<'db> TryFrom<SolverDefId<'db>> for GenericDefId {
     type Error = ();
 
-    fn try_from(value: SolverDefId) -> Result<Self, Self::Error> {
+    fn try_from(value: SolverDefId<'db>) -> Result<Self, Self::Error> {
         Ok(match value {
             SolverDefId::AdtId(adt_id) => GenericDefId::AdtId(adt_id),
             SolverDefId::ConstId(const_id) => GenericDefId::ConstId(const_id),
@@ -175,10 +234,10 @@ impl TryFrom<SolverDefId> for GenericDefId {
     }
 }
 
-impl SolverDefId {
+impl<'db> SolverDefId<'db> {
     #[inline]
     #[track_caller]
-    pub fn expect_opaque_ty(self) -> InternedOpaqueTyId {
+    pub fn expect_opaque_ty(self) -> InternedOpaqueTyId<'db> {
         match self {
             SolverDefId::InternedOpaqueTyId(it) => it,
             _ => panic!("expected opaque type, found {self:?}"),
@@ -195,8 +254,8 @@ impl SolverDefId {
     }
 }
 
-impl<'db> inherent::DefId<DbInterner<'db>> for SolverDefId {
-    fn as_local(self) -> Option<SolverDefId> {
+impl<'db> inherent::DefId<DbInterner<'db>> for SolverDefId<'db> {
+    fn as_local(self) -> Option<SolverDefId<'db>> {
         Some(self)
     }
     fn is_local(self) -> bool {
@@ -229,18 +288,18 @@ macro_rules! declare_id_wrapper {
             }
         }
 
-        impl From<$name> for SolverDefId {
+        impl<'db> From<$name> for SolverDefId<'db> {
             #[inline]
-            fn from(value: $name) -> SolverDefId {
+            fn from(value: $name) -> SolverDefId<'db> {
                 value.0.into()
             }
         }
 
-        impl TryFrom<SolverDefId> for $name {
+        impl<'db> TryFrom<SolverDefId<'db>> for $name {
             type Error = ();
 
             #[inline]
-            fn try_from(value: SolverDefId) -> Result<Self, Self::Error> {
+            fn try_from(value: SolverDefId<'db>) -> Result<Self, Self::Error> {
                 match value {
                     SolverDefId::$wraps(it) => Ok(Self(it)),
                     _ => Err(()),
@@ -249,7 +308,7 @@ macro_rules! declare_id_wrapper {
         }
 
         impl<'db> inherent::DefId<DbInterner<'db>> for $name {
-            fn as_local(self) -> Option<SolverDefId> {
+            fn as_local(self) -> Option<SolverDefId<'db>> {
                 Some(self.into())
             }
             fn is_local(self) -> bool {
@@ -286,9 +345,9 @@ impl From<CallableDefId> for CallableIdWrapper {
         Self(value)
     }
 }
-impl From<CallableIdWrapper> for SolverDefId {
+impl<'db> From<CallableIdWrapper> for SolverDefId<'db> {
     #[inline]
-    fn from(value: CallableIdWrapper) -> SolverDefId {
+    fn from(value: CallableIdWrapper) -> SolverDefId<'db> {
         match value.0 {
             CallableDefId::FunctionId(it) => it.into(),
             CallableDefId::StructId(it) => Ctor::Struct(it).into(),
@@ -296,10 +355,10 @@ impl From<CallableIdWrapper> for SolverDefId {
         }
     }
 }
-impl TryFrom<SolverDefId> for CallableIdWrapper {
+impl<'db> TryFrom<SolverDefId<'db>> for CallableIdWrapper {
     type Error = ();
     #[inline]
-    fn try_from(value: SolverDefId) -> Result<Self, Self::Error> {
+    fn try_from(value: SolverDefId<'db>) -> Result<Self, Self::Error> {
         match value {
             SolverDefId::FunctionId(it) => Ok(Self(it.into())),
             SolverDefId::Ctor(Ctor::Struct(it)) => Ok(Self(it.into())),
@@ -309,7 +368,7 @@ impl TryFrom<SolverDefId> for CallableIdWrapper {
     }
 }
 impl<'db> inherent::DefId<DbInterner<'db>> for CallableIdWrapper {
-    fn as_local(self) -> Option<SolverDefId> {
+    fn as_local(self) -> Option<SolverDefId<'db>> {
         Some(self.into())
     }
     fn is_local(self) -> bool {

--- a/crates/hir-ty/src/next_solver/fold.rs
+++ b/crates/hir-ty/src/next_solver/fold.rs
@@ -17,8 +17,8 @@ use super::{
 /// gets mapped to the same result. `BoundVarReplacer` caches by using
 /// a `DelayedMap` which does not cache the first few types it encounters.
 pub trait BoundVarReplacerDelegate<'db> {
-    fn replace_region(&mut self, br: BoundRegion) -> Region<'db>;
-    fn replace_ty(&mut self, bt: BoundTy) -> Ty<'db>;
+    fn replace_region(&mut self, br: BoundRegion<'db>) -> Region<'db>;
+    fn replace_ty(&mut self, bt: BoundTy<'db>) -> Ty<'db>;
     fn replace_const(&mut self, bv: BoundConst) -> Const<'db>;
 }
 
@@ -26,16 +26,16 @@ pub trait BoundVarReplacerDelegate<'db> {
 /// always return the same result for each bound variable, no matter how
 /// frequently they are called.
 pub struct FnMutDelegate<'db, 'a> {
-    pub regions: &'a mut (dyn FnMut(BoundRegion) -> Region<'db> + 'a),
-    pub types: &'a mut (dyn FnMut(BoundTy) -> Ty<'db> + 'a),
+    pub regions: &'a mut (dyn FnMut(BoundRegion<'db>) -> Region<'db> + 'a),
+    pub types: &'a mut (dyn FnMut(BoundTy<'db>) -> Ty<'db> + 'a),
     pub consts: &'a mut (dyn FnMut(BoundConst) -> Const<'db> + 'a),
 }
 
 impl<'db, 'a> BoundVarReplacerDelegate<'db> for FnMutDelegate<'db, 'a> {
-    fn replace_region(&mut self, br: BoundRegion) -> Region<'db> {
+    fn replace_region(&mut self, br: BoundRegion<'db>) -> Region<'db> {
         (self.regions)(br)
     }
-    fn replace_ty(&mut self, bt: BoundTy) -> Ty<'db> {
+    fn replace_ty(&mut self, bt: BoundTy<'db>) -> Ty<'db> {
         (self.types)(bt)
     }
     fn replace_const(&mut self, bv: BoundConst) -> Const<'db> {

--- a/crates/hir-ty/src/next_solver/fulfill.rs
+++ b/crates/hir-ty/src/next_solver/fulfill.rs
@@ -284,7 +284,7 @@ impl<'db> FulfillmentCtxt<'db> {
 /// This function can be also return false positives, which will lead to poor diagnostics
 /// so we want to keep this visitor *precise* too.
 pub struct StalledOnCoroutines<'a, 'db> {
-    pub stalled_coroutines: &'a [SolverDefId],
+    pub stalled_coroutines: &'a [SolverDefId<'db>],
     pub cache: FxHashSet<Ty<'db>>,
 }
 

--- a/crates/hir-ty/src/next_solver/fulfill/errors.rs
+++ b/crates/hir-ty/src/next_solver/fulfill/errors.rs
@@ -702,7 +702,7 @@ mod wf {
         #[instrument(level = "debug", skip(self))]
         fn nominal_obligations(
             &mut self,
-            def_id: SolverDefId,
+            def_id: SolverDefId<'db>,
             args: GenericArgs<'db>,
         ) -> PredicateObligations<'db> {
             // PERF: `Sized`'s predicates include `MetaSized`, but both are compiler implemented marker

--- a/crates/hir-ty/src/next_solver/generic_arg.rs
+++ b/crates/hir-ty/src/next_solver/generic_arg.rs
@@ -180,7 +180,7 @@ impl<'db> GenericArgs<'db> {
     /// replace defaults of generic parameters.
     pub fn for_item<F>(
         interner: DbInterner<'db>,
-        def_id: SolverDefId,
+        def_id: SolverDefId<'db>,
         mut mk_kind: F,
     ) -> GenericArgs<'db>
     where
@@ -194,7 +194,7 @@ impl<'db> GenericArgs<'db> {
     }
 
     /// Creates an all-error `GenericArgs`.
-    pub fn error_for_item(interner: DbInterner<'db>, def_id: SolverDefId) -> GenericArgs<'db> {
+    pub fn error_for_item(interner: DbInterner<'db>, def_id: SolverDefId<'db>) -> GenericArgs<'db> {
         GenericArgs::for_item(interner, def_id, |_, id, _| GenericArg::error_from_id(interner, id))
     }
 
@@ -217,7 +217,7 @@ impl<'db> GenericArgs<'db> {
     /// Like `for_item()`, but calls first uses the args from `first`.
     pub fn fill_rest<F>(
         interner: DbInterner<'db>,
-        def_id: SolverDefId,
+        def_id: SolverDefId<'db>,
         first: impl IntoIterator<Item = GenericArg<'db>>,
         mut fallback: F,
     ) -> GenericArgs<'db>

--- a/crates/hir-ty/src/next_solver/generics.rs
+++ b/crates/hir-ty/src/next_solver/generics.rs
@@ -14,7 +14,7 @@ use super::SolverDefId;
 
 use super::DbInterner;
 
-pub(crate) fn generics(db: &dyn HirDatabase, def: SolverDefId) -> Generics {
+pub(crate) fn generics<'db>(db: &'db dyn HirDatabase, def: SolverDefId<'db>) -> Generics {
     let mk_lt = |parent, index, local_id| {
         let id = GenericParamId::LifetimeParamId(LifetimeParamId { parent, local_id });
         GenericParamDef { index, id }

--- a/crates/hir-ty/src/next_solver/infer/canonical/instantiate.rs
+++ b/crates/hir-ty/src/next_solver/infer/canonical/instantiate.rs
@@ -79,11 +79,11 @@ where
         value
     } else {
         let delegate = FnMutDelegate {
-            regions: &mut |br: BoundRegion| match var_values[br.var].kind() {
+            regions: &mut |br: BoundRegion<'db>| match var_values[br.var].kind() {
                 GenericArgKind::Lifetime(l) => l,
                 r => panic!("{br:?} is a region but value is {r:?}"),
             },
-            types: &mut |bound_ty: BoundTy| match var_values[bound_ty.var].kind() {
+            types: &mut |bound_ty: BoundTy<'db>| match var_values[bound_ty.var].kind() {
                 GenericArgKind::Type(ty) => ty,
                 r => panic!("{bound_ty:?} is a type but value is {r:?}"),
             },

--- a/crates/hir-ty/src/next_solver/infer/canonical/mod.rs
+++ b/crates/hir-ty/src/next_solver/infer/canonical/mod.rs
@@ -121,7 +121,7 @@ impl<'db> InferCtxt<'db> {
             CanonicalVarKind::PlaceholderRegion(PlaceholderRegion { universe, bound }) => {
                 let universe_mapped = universe_map(universe);
                 let placeholder_mapped: crate::next_solver::Placeholder<
-                    crate::next_solver::BoundRegion,
+                    crate::next_solver::BoundRegion<'db>,
                 > = PlaceholderRegion { universe: universe_mapped, bound };
                 Region::new_placeholder(self.interner, placeholder_mapped).into()
             }

--- a/crates/hir-ty/src/next_solver/infer/context.rs
+++ b/crates/hir-ty/src/next_solver/infer/context.rs
@@ -150,7 +150,7 @@ impl<'db> rustc_type_ir::InferCtxtLike for InferCtxt<'db> {
         self.next_const_var()
     }
 
-    fn fresh_args_for_item(&self, def_id: SolverDefId) -> GenericArgs<'db> {
+    fn fresh_args_for_item(&self, def_id: SolverDefId<'db>) -> GenericArgs<'db> {
         self.fresh_args_for_item(def_id)
     }
 

--- a/crates/hir-ty/src/next_solver/infer/region_constraints/mod.rs
+++ b/crates/hir-ty/src/next_solver/infer/region_constraints/mod.rs
@@ -122,7 +122,7 @@ pub struct Verify<'db> {
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub enum GenericKind<'db> {
     Param(ParamTy),
-    Placeholder(PlaceholderTy),
+    Placeholder(PlaceholderTy<'db>),
     Alias(AliasTy<'db>),
 }
 

--- a/crates/hir-ty/src/next_solver/infer/relate/generalize.rs
+++ b/crates/hir-ty/src/next_solver/infer/relate/generalize.rs
@@ -386,7 +386,7 @@ impl<'db> TypeRelation<DbInterner<'db>> for Generalizer<'_, 'db> {
 
     fn relate_item_args(
         &mut self,
-        item_def_id: SolverDefId,
+        item_def_id: SolverDefId<'db>,
         a_arg: GenericArgs<'db>,
         b_arg: GenericArgs<'db>,
     ) -> RelateResult<'db, GenericArgs<'db>> {

--- a/crates/hir-ty/src/next_solver/infer/relate/higher_ranked.rs
+++ b/crates/hir-ty/src/next_solver/infer/relate/higher_ranked.rs
@@ -35,13 +35,13 @@ impl<'db> InferCtxt<'db> {
         let next_universe = self.create_next_universe();
 
         let delegate = FnMutDelegate {
-            regions: &mut |br: BoundRegion| {
+            regions: &mut |br: BoundRegion<'db>| {
                 Region::new_placeholder(
                     self.interner,
                     PlaceholderRegion { universe: next_universe, bound: br },
                 )
             },
-            types: &mut |bound_ty: BoundTy| {
+            types: &mut |bound_ty: BoundTy<'db>| {
                 Ty::new_placeholder(
                     self.interner,
                     PlaceholderTy { universe: next_universe, bound: bound_ty },

--- a/crates/hir-ty/src/next_solver/infer/select.rs
+++ b/crates/hir-ty/src/next_solver/infer/select.rs
@@ -39,7 +39,7 @@ pub enum SelectionError<'db> {
     /// Computing an opaque type's hidden type caused an error (e.g. a cycle error).
     /// We can thus not know whether the hidden type implements an auto trait, so
     /// we should not presume anything about it.
-    OpaqueTypeAutoTraitLeakageUnknown(InternedOpaqueTyId),
+    OpaqueTypeAutoTraitLeakageUnknown(InternedOpaqueTyId<'db>),
     /// Error for a `ConstArgHasType` goal
     ConstArgHasWrongType { ct: Const<'db>, ct_ty: Ty<'db>, expected_ty: Ty<'db> },
 }

--- a/crates/hir-ty/src/next_solver/infer/snapshot/fudge.rs
+++ b/crates/hir-ty/src/next_solver/infer/snapshot/fudge.rs
@@ -114,7 +114,7 @@ impl<'db> InferCtxt<'db> {
 
     fn fudge_inference<T: TypeFoldable<DbInterner<'db>>>(
         &self,
-        snapshot_vars: SnapshotVarData,
+        snapshot_vars: SnapshotVarData<'db>,
         value: T,
     ) -> T {
         // Micro-optimization: if no variables have been created, then
@@ -127,16 +127,16 @@ impl<'db> InferCtxt<'db> {
     }
 }
 
-struct SnapshotVarData {
+struct SnapshotVarData<'db> {
     region_vars: Range<RegionVid>,
-    type_vars: (Range<TyVid>, Vec<TypeVariableOrigin>),
+    type_vars: (Range<TyVid>, Vec<TypeVariableOrigin<'db>>),
     int_vars: Range<IntVid>,
     float_vars: Range<FloatVid>,
     const_vars: (Range<ConstVid>, Vec<ConstVariableOrigin>),
 }
 
-impl SnapshotVarData {
-    fn new(infcx: &InferCtxt<'_>, vars_pre_snapshot: VariableLengths) -> SnapshotVarData {
+impl<'db> SnapshotVarData<'db> {
+    fn new(infcx: &InferCtxt<'db>, vars_pre_snapshot: VariableLengths) -> SnapshotVarData<'db> {
         let mut inner = infcx.inner.borrow_mut();
         let region_vars = inner
             .unwrap_region_constraints()
@@ -166,7 +166,7 @@ impl SnapshotVarData {
 
 struct InferenceFudger<'a, 'db> {
     infcx: &'a InferCtxt<'db>,
-    snapshot_vars: SnapshotVarData,
+    snapshot_vars: SnapshotVarData<'db>,
 }
 
 impl<'a, 'db> TypeFolder<DbInterner<'db>> for InferenceFudger<'a, 'db> {

--- a/crates/hir-ty/src/next_solver/opaques.rs
+++ b/crates/hir-ty/src/next_solver/opaques.rs
@@ -13,7 +13,7 @@ interned_vec_db!(PredefinedOpaques, PredefinedOpaque);
 pub type ExternalConstraintsData<'db> =
     rustc_type_ir::solve::ExternalConstraintsData<DbInterner<'db>>;
 
-interned_vec_nolifetime_salsa!(SolverDefIds, SolverDefId);
+interned_vec_nolifetime_salsa!(SolverDefIds, SolverDefId<'db>);
 
 #[salsa::interned(constructor = new_, debug)]
 pub struct ExternalConstraints<'db> {

--- a/crates/hir-ty/src/next_solver/solver.rs
+++ b/crates/hir-ty/src/next_solver/solver.rs
@@ -142,9 +142,9 @@ impl<'db> SolverDelegate for SolverContext<'db> {
     fn fetch_eligible_assoc_item(
         &self,
         _goal_trait_ref: rustc_type_ir::TraitRef<Self::Interner>,
-        trait_assoc_def_id: SolverDefId,
+        trait_assoc_def_id: SolverDefId<'db>,
         impl_id: ImplIdWrapper,
-    ) -> Result<Option<SolverDefId>, ErrorGuaranteed> {
+    ) -> Result<Option<SolverDefId<'db>>, ErrorGuaranteed> {
         let impl_items = impl_id.0.impl_items(self.0.interner.db());
         let id = match trait_assoc_def_id {
             SolverDefId::TypeAliasId(trait_assoc_id) => {

--- a/crates/hir-ty/src/next_solver/ty.rs
+++ b/crates/hir-ty/src/next_solver/ty.rs
@@ -83,7 +83,7 @@ impl<'db> Ty<'db> {
         Ty::new(interner, TyKind::Param(ParamTy { id, index }))
     }
 
-    pub fn new_placeholder(interner: DbInterner<'db>, placeholder: PlaceholderTy) -> Self {
+    pub fn new_placeholder(interner: DbInterner<'db>, placeholder: PlaceholderTy<'db>) -> Self {
         Ty::new(interner, TyKind::Placeholder(placeholder))
     }
 
@@ -889,11 +889,11 @@ impl<'db> rustc_type_ir::inherent::Ty<DbInterner<'db>> for Ty<'db> {
         Ty::new(interner, TyKind::Param(param))
     }
 
-    fn new_placeholder(interner: DbInterner<'db>, param: PlaceholderTy) -> Self {
+    fn new_placeholder(interner: DbInterner<'db>, param: PlaceholderTy<'db>) -> Self {
         Ty::new(interner, TyKind::Placeholder(param))
     }
 
-    fn new_bound(interner: DbInterner<'db>, debruijn: DebruijnIndex, var: BoundTy) -> Self {
+    fn new_bound(interner: DbInterner<'db>, debruijn: DebruijnIndex, var: BoundTy<'db>) -> Self {
         Ty::new(interner, TyKind::Bound(BoundVarIndexKind::Bound(debruijn), var))
     }
 
@@ -1195,7 +1195,7 @@ impl<'db> rustc_type_ir::inherent::Tys<DbInterner<'db>> for Tys<'db> {
     }
 }
 
-pub type PlaceholderTy = Placeholder<BoundTy>;
+pub type PlaceholderTy<'db> = Placeholder<BoundTy<'db>>;
 
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
 pub struct ParamTy {
@@ -1219,13 +1219,13 @@ impl std::fmt::Debug for ParamTy {
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
-pub struct BoundTy {
+pub struct BoundTy<'db> {
     pub var: BoundVar,
     // FIXME: This is for diagnostics in rustc, do we really need it?
-    pub kind: BoundTyKind,
+    pub kind: BoundTyKind<'db>,
 }
 
-impl std::fmt::Debug for BoundTy {
+impl<'db> std::fmt::Debug for BoundTy<'db> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self.kind {
             BoundTyKind::Anon => write!(f, "{:?}", self.var),
@@ -1235,9 +1235,9 @@ impl std::fmt::Debug for BoundTy {
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
-pub enum BoundTyKind {
+pub enum BoundTyKind<'db> {
     Anon,
-    Param(SolverDefId),
+    Param(SolverDefId<'db>),
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
@@ -1270,18 +1270,18 @@ impl ParamLike for ParamTy {
     }
 }
 
-impl<'db> BoundVarLike<DbInterner<'db>> for BoundTy {
+impl<'db> BoundVarLike<DbInterner<'db>> for BoundTy<'db> {
     fn var(self) -> BoundVar {
         self.var
     }
 
-    fn assert_eq(self, var: BoundVarKind) {
+    fn assert_eq(self, var: BoundVarKind<'db>) {
         assert_eq!(self.kind, var.expect_ty())
     }
 }
 
-impl<'db> PlaceholderLike<DbInterner<'db>> for PlaceholderTy {
-    type Bound = BoundTy;
+impl<'db> PlaceholderLike<DbInterner<'db>> for PlaceholderTy<'db> {
+    type Bound = BoundTy<'db>;
 
     fn universe(self) -> rustc_type_ir::UniverseIndex {
         self.universe
@@ -1295,7 +1295,7 @@ impl<'db> PlaceholderLike<DbInterner<'db>> for PlaceholderTy {
         Placeholder { universe: ui, bound: self.bound }
     }
 
-    fn new(ui: rustc_type_ir::UniverseIndex, bound: BoundTy) -> Self {
+    fn new(ui: rustc_type_ir::UniverseIndex, bound: BoundTy<'db>) -> Self {
         Placeholder { universe: ui, bound }
     }
 

--- a/crates/hir-ty/src/next_solver/util.rs
+++ b/crates/hir-ty/src/next_solver/util.rs
@@ -499,8 +499,9 @@ pub fn apply_args_to_binder<'db, T: TypeFoldable<DbInterner<'db>>>(
     args: GenericArgs<'db>,
     interner: DbInterner<'db>,
 ) -> T {
-    let types = &mut |ty: BoundTy| args.as_slice()[ty.var.index()].expect_ty();
-    let regions = &mut |region: BoundRegion| args.as_slice()[region.var.index()].expect_region();
+    let types = &mut |ty: BoundTy<'db>| args.as_slice()[ty.var.index()].expect_ty();
+    let regions =
+        &mut |region: BoundRegion<'db>| args.as_slice()[region.var.index()].expect_region();
     let consts = &mut |const_: BoundConst| args.as_slice()[const_.var.index()].expect_const();
     let mut instantiate = BoundVarReplacer::new(interner, FnMutDelegate { types, regions, consts });
     b.skip_binder().fold_with(&mut instantiate)
@@ -508,7 +509,7 @@ pub fn apply_args_to_binder<'db, T: TypeFoldable<DbInterner<'db>>>(
 
 pub fn explicit_item_bounds<'db>(
     interner: DbInterner<'db>,
-    def_id: SolverDefId,
+    def_id: SolverDefId<'db>,
 ) -> EarlyBinder<'db, Clauses<'db>> {
     let db = interner.db();
     match def_id {
@@ -689,8 +690,8 @@ impl<'db> TypeVisitor<DbInterner<'db>> for ContainsTypeErrors {
 /// The inverse of [`BoundVarReplacer`]: replaces placeholders with the bound vars from which they came.
 pub struct PlaceholderReplacer<'a, 'db> {
     infcx: &'a InferCtxt<'db>,
-    mapped_regions: FxIndexMap<PlaceholderRegion, BoundRegion>,
-    mapped_types: FxIndexMap<Placeholder<BoundTy>, BoundTy>,
+    mapped_regions: FxIndexMap<PlaceholderRegion<'db>, BoundRegion<'db>>,
+    mapped_types: FxIndexMap<Placeholder<BoundTy<'db>>, BoundTy<'db>>,
     mapped_consts: FxIndexMap<PlaceholderConst, BoundConst>,
     universe_indices: &'a [Option<UniverseIndex>],
     current_index: DebruijnIndex,
@@ -699,8 +700,8 @@ pub struct PlaceholderReplacer<'a, 'db> {
 impl<'a, 'db> PlaceholderReplacer<'a, 'db> {
     pub fn replace_placeholders<T: TypeFoldable<DbInterner<'db>>>(
         infcx: &'a InferCtxt<'db>,
-        mapped_regions: FxIndexMap<PlaceholderRegion, BoundRegion>,
-        mapped_types: FxIndexMap<Placeholder<BoundTy>, BoundTy>,
+        mapped_regions: FxIndexMap<PlaceholderRegion<'db>, BoundRegion<'db>>,
+        mapped_types: FxIndexMap<Placeholder<BoundTy<'db>>, BoundTy<'db>>,
         mapped_consts: FxIndexMap<PlaceholderConst, BoundConst>,
         universe_indices: &'a [Option<UniverseIndex>],
         value: T,

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -6434,7 +6434,7 @@ fn as_name_opt(name: Option<impl AsName>) -> Name {
 
 fn generic_args_from_tys<'db>(
     interner: DbInterner<'db>,
-    def_id: SolverDefId,
+    def_id: SolverDefId<'db>,
     args: impl IntoIterator<Item = Ty<'db>>,
 ) -> GenericArgs<'db> {
     let mut args = args.into_iter();


### PR DESCRIPTION
As per the request on rust-lang/rust-analyzer#20896, I removed `no_lifetime` and added a 'db to InternedOpaqueTyId. This propagated way farther than I expected, but I followed them all. The macro tweaks were the annoying part, as I had to work around the differences between declaring a type in a signature and calling a method on the type. But it all seems to work.