### PR TITLE
minor: Add regression tests for some fixed `A-ty` issues

### DIFF
--- a/crates/ide-diagnostics/src/handlers/mismatched_arg_count.rs
+++ b/crates/ide-diagnostics/src/handlers/mismatched_arg_count.rs
@@ -488,4 +488,27 @@ fn foo((): (), (): ()) {
 "#,
         );
     }
+
+    #[test]
+    fn regression_17233() {
+        check_diagnostics(
+            r#"
+pub trait A {
+    type X: B;
+}
+pub trait B: A {
+    fn confused_name(self, _: i32);
+}
+
+pub struct Foo;
+impl Foo {
+    pub fn confused_name(&self) {}
+}
+
+pub fn repro<T: A>() {
+    Foo.confused_name();
+}
+"#,
+        );
+    }
 }


### PR DESCRIPTION
closes rust-lang/rust-analyzer#16282 
closes rust-lang/rust-analyzer#17233 
closes rust-lang/rust-analyzer#18692
closes rust-lang/rust-analyzer#20038