### PR TITLE
fix: don't suggest duplicate `const` completions after `raw`

### DIFF
--- a/crates/ide-completion/src/completions/expr.rs
+++ b/crates/ide-completion/src/completions/expr.rs
@@ -352,7 +352,10 @@ pub(crate) fn complete_expr_path(
 
                     if !in_block_expr {
                         add_keyword("unsafe", "unsafe {\n    $0\n}");
-                        add_keyword("const", "const {\n    $0\n}");
+                        if !wants_const_token {
+                            // Avoid having two `const` items in `&raw $0`
+                            add_keyword("const", "const {\n    $0\n}");
+                        }
                     }
                     add_keyword("match", "match $1 {\n    $0\n}");
                     add_keyword("while", "while $1 {\n    $0\n}");

--- a/crates/ide-completion/src/tests/expression.rs
+++ b/crates/ide-completion/src/tests/expression.rs
@@ -628,7 +628,6 @@ fn completes_after_ref_expr() {
             fn main() fn()
             bt u32     u32
             kw const
-            kw const
             kw crate::
             kw false
             kw for


### PR DESCRIPTION
Example
---
```rust
fn main() { let _ = &raw $0 }
```

**Before this PR**

```text
fn main() fn()
bt u32     u32
kw const
kw const
kw crate::
...
```

**After this PR**

```text
fn main() fn()
bt u32     u32
kw const
kw crate::
...
```
