### PR TITLE
fix: Expand literals with wrong suffixes into `LitKind::Err`

### DIFF
--- a/crates/ide/src/syntax_highlighting/test_data/regression_20952.html
+++ b/crates/ide/src/syntax_highlighting/test_data/regression_20952.html
@@ -1,0 +1,45 @@
+
+<style>
+body                { margin: 0; }
+pre                 { color: #DCDCCC; background: #3F3F3F; font-size: 22px; padding: 0.4em; }
+
+.lifetime           { color: #DFAF8F; font-style: italic; }
+.label              { color: #DFAF8F; font-style: italic; }
+.comment            { color: #7F9F7F; }
+.documentation      { color: #629755; }
+.intra_doc_link     { font-style: italic; }
+.injected           { opacity: 0.65 ; }
+.struct, .enum      { color: #7CB8BB; }
+.enum_variant       { color: #BDE0F3; }
+.string_literal     { color: #CC9393; }
+.field              { color: #94BFF3; }
+.function           { color: #93E0E3; }
+.parameter          { color: #94BFF3; }
+.text               { color: #DCDCCC; }
+.type               { color: #7CB8BB; }
+.builtin_type       { color: #8CD0D3; }
+.type_param         { color: #DFAF8F; }
+.attribute          { color: #94BFF3; }
+.numeric_literal    { color: #BFEBBF; }
+.bool_literal       { color: #BFE6EB; }
+.macro              { color: #94BFF3; }
+.proc_macro         { color: #94BFF3; text-decoration: underline; }
+.derive             { color: #94BFF3; font-style: italic; }
+.module             { color: #AFD8AF; }
+.value_param        { color: #DCDCCC; }
+.variable           { color: #DCDCCC; }
+.format_specifier   { color: #CC696B; }
+.mutable            { text-decoration: underline; }
+.escape_sequence    { color: #94BFF3; }
+.keyword            { color: #F0DFAF; font-weight: bold; }
+.control            { font-style: italic; }
+.reference          { font-style: italic; font-weight: bold; }
+.const              { font-weight: bolder; }
+.unsafe             { color: #BC8383; }
+
+.invalid_escape_sequence { color: #FC5555; text-decoration: wavy underline; }
+.unresolved_reference    { color: #FC5555; text-decoration: wavy underline; }
+</style>
+<pre><code><span class="keyword">fn</span> <span class="function declaration">main</span><span class="parenthesis">(</span><span class="parenthesis">)</span> <span class="brace">{</span>
+    <span class="macro default_library library">format_args</span><span class="macro_bang">!</span><span class="parenthesis">(</span>"{} {}, {} (подозрение на спам: {:.2}%)"б<span class="parenthesis">)</span><span class="semicolon">;</span>
+<span class="brace">}</span></code></pre>

--- a/crates/ide/src/syntax_highlighting/tests.rs
+++ b/crates/ide/src/syntax_highlighting/tests.rs
@@ -1497,3 +1497,17 @@ fn main() {
         false,
     );
 }
+
+#[test]
+fn regression_20952() {
+    check_highlighting(
+        r#"
+//- minicore: fmt
+fn main() {
+    format_args!("{} {}, {} (подозрение на спам: {:.2}%)"б);
+}
+"#,
+        expect_file!["./test_data/regression_20952.html"],
+        false,
+    );
+}

--- a/crates/proc-macro-srv/src/tests/mod.rs
+++ b/crates/proc-macro-srv/src/tests/mod.rs
@@ -326,7 +326,7 @@ fn test_fn_like_macro_clone_literals() {
               PUNCH   , [alone] 1
               LITERAL Str hello bridge 1
               PUNCH   , [alone] 1
-              LITERAL Str suffixedsuffix 1
+              LITERAL Err(()) "suffixed"suffix 1
               PUNCH   , [alone] 1
               LITERAL StrRaw(2) raw 1
               PUNCH   , [alone] 1
@@ -372,7 +372,7 @@ fn test_fn_like_macro_clone_literals() {
               PUNCH   , [alone] 42:Root[0000, 0]@27..28#ROOT2024
               LITERAL Str hello bridge 42:Root[0000, 0]@29..43#ROOT2024
               PUNCH   , [alone] 42:Root[0000, 0]@43..44#ROOT2024
-              LITERAL Str suffixedsuffix 42:Root[0000, 0]@45..61#ROOT2024
+              LITERAL Err(()) "suffixed"suffix 42:Root[0000, 0]@45..61#ROOT2024
               PUNCH   , [alone] 42:Root[0000, 0]@61..62#ROOT2024
               LITERAL StrRaw(2) raw 42:Root[0000, 0]@63..73#ROOT2024
               PUNCH   , [alone] 42:Root[0000, 0]@73..74#ROOT2024

--- a/crates/tt/src/lib.rs
+++ b/crates/tt/src/lib.rs
@@ -622,6 +622,15 @@ where
     let lit = &lit[start_offset..lit.len() - end_offset];
     let suffix = match suffix {
         "" | "_" => None,
+        // ill-suffixed literals
+        _ if !matches!(kind, LitKind::Integer | LitKind::Float | LitKind::Err(_)) => {
+            return Literal {
+                span,
+                symbol: Symbol::intern(text),
+                kind: LitKind::Err(()),
+                suffix: None,
+            };
+        }
         suffix => Some(Symbol::intern(suffix)),
     };
 


### PR DESCRIPTION
Fixes rust-lang/rust-analyzer#20952 

For ill-suffixed literals like `""б`(Not a number `6` 😅), we pass it as `fmt_snippet` here:

https://github.com/rust-lang/rust-analyzer/blob/00b627daf283b1e90e952dd3fd141c619e6b3aee/crates/hir-def/src/hir/format_args.rs#L197

But in that function the following line panics if the string literal has the suffix ending with a `char::len_utf8() > 1` 
 https://doc.rust-lang.org/1.91.0/nightly-rustc/src/rustc_parse_format/lib.rs.html#319

We might limplement some diagnostics or error recovery upon those ill-suffixed string literals but that's not quite doable without some non-trivial refactoring in our parser/token tree/expansion infra. The simplest fix would be just erroring on those literals