### PR TITLE
Remove 'notIn' from autoClosingPairs for braces

### DIFF
--- a/editors/code/language-configuration.json
+++ b/editors/code/language-configuration.json
@@ -14,7 +14,7 @@
         ["(", ")"]
     ],
     "autoClosingPairs": [
-        { "open": "{", "close": "}", "notIn": ["string"] },
+        { "open": "{", "close": "}" },
         { "open": "[", "close": "]", "notIn": ["string"] },
         { "open": "(", "close": ")", "notIn": ["string"] },
         { "open": "\"", "close": "\"", "notIn": ["string"] },


### PR DESCRIPTION
I know this was changed in 25c732e eight months ago, but I really think that was a mistake. We always use curly braces in formatted strings, so they should auto-close. Same would happen in JS/TS.