### PR TITLE
fix: Fix panicking while resolving callable sigs for `AsyncFnMut`

### DIFF
--- a/crates/hir-ty/src/infer/unify.rs
+++ b/crates/hir-ty/src/infer/unify.rs
@@ -674,10 +674,13 @@ impl<'db> InferenceTable<'db> {
             let args = [ty, arg_ty];
             let trait_ref = TraitRef::new(self.interner(), fn_trait.into(), args);
 
+            let proj_args = self
+                .infer_ctxt
+                .fill_rest_fresh_args(output_assoc_type.into(), args.into_iter().map(Into::into));
             let projection = Ty::new_alias(
                 self.interner(),
                 rustc_type_ir::AliasTyKind::Projection,
-                AliasTy::new(self.interner(), output_assoc_type.into(), args),
+                AliasTy::new(self.interner(), output_assoc_type.into(), proj_args),
             );
 
             let pred = Predicate::upcast_from(trait_ref, self.interner());


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust-analyzer/issues/20951

`AsyncFnMut::CallRefFuture` has a lifetime parameter, so its generic params has length 3(trait self + args tuple + lifetime)