### PR TITLE
fix: handle method calls in `apply_demorgan`

### DIFF
--- a/crates/ide-assists/src/handlers/apply_demorgan.rs
+++ b/crates/ide-assists/src/handlers/apply_demorgan.rs
@@ -124,47 +124,37 @@ pub(crate) fn apply_demorgan(acc: &mut Assists, ctx: &AssistContext<'_>) -> Opti
         op_range,
         |builder| {
             let make = SyntaxFactory::with_mappings();
-            let paren_expr = bin_expr.syntax().parent().and_then(ast::ParenExpr::cast);
-            let neg_expr = paren_expr
-                .clone()
+            let (target_node, result_expr) = if let Some(neg_expr) = bin_expr
+                .syntax()
+                .parent()
+                .and_then(ast::ParenExpr::cast)
                 .and_then(|paren_expr| paren_expr.syntax().parent())
                 .and_then(ast::PrefixExpr::cast)
                 .filter(|prefix_expr| matches!(prefix_expr.op_kind(), Some(ast::UnaryOp::Not)))
-                .map(ast::Expr::PrefixExpr);
-
-            let mut editor;
-            if let Some(paren_expr) = paren_expr {
-                if let Some(neg_expr) = neg_expr {
-                    cov_mark::hit!(demorgan_double_negation);
-                    let parent = neg_expr.syntax().parent();
-                    editor = builder.make_editor(neg_expr.syntax());
-
-                    if parent.is_some_and(|parent| {
-                        demorganed.needs_parens_in_place_of(&parent, neg_expr.syntax())
-                    }) {
-                        cov_mark::hit!(demorgan_keep_parens_for_op_precedence2);
-                        editor.replace(neg_expr.syntax(), make.expr_paren(demorganed).syntax());
-                    } else {
-                        editor.replace(neg_expr.syntax(), demorganed.syntax());
-                    };
-                } else {
-                    cov_mark::hit!(demorgan_double_parens);
-                    editor = builder.make_editor(paren_expr.syntax());
-
-                    let new_expr = add_bang_paren(&make, demorganed);
-                    if paren_expr.syntax().parent().is_some_and(|parent| {
-                        new_expr.needs_parens_in_place_of(&parent, paren_expr.syntax())
-                    }) {
-                        editor.replace(paren_expr.syntax(), make.expr_paren(new_expr).syntax());
-                    } else {
-                        editor.replace(paren_expr.syntax(), new_expr.syntax());
-                    }
-                }
+            {
+                cov_mark::hit!(demorgan_double_negation);
+                (ast::Expr::from(neg_expr).syntax().clone(), demorganed)
+            } else if let Some(paren_expr) =
+                bin_expr.syntax().parent().and_then(ast::ParenExpr::cast)
+            {
+                cov_mark::hit!(demorgan_double_parens);
+                (paren_expr.syntax().clone(), add_bang_paren(&make, demorganed))
             } else {
-                editor = builder.make_editor(bin_expr.syntax());
-                editor.replace(bin_expr.syntax(), add_bang_paren(&make, demorganed).syntax());
-            }
+                (bin_expr.syntax().clone(), add_bang_paren(&make, demorganed))
+            };
 
+            let final_expr = if target_node
+                .parent()
+                .is_some_and(|p| result_expr.needs_parens_in_place_of(&p, &target_node))
+            {
+                cov_mark::hit!(demorgan_keep_parens_for_op_precedence2);
+                make.expr_paren(result_expr).into()
+            } else {
+                result_expr
+            };
+
+            let mut editor = builder.make_editor(&target_node);
+            editor.replace(&target_node, final_expr.syntax());
             editor.add_mappings(make.finish_with_mappings());
             builder.add_file_edits(ctx.vfs_file_id(), editor);
         },


### PR DESCRIPTION
Apply De Morgan's law
```rust
fn f() { (x ||$0 !y).then_some(42) }
```
before this PR: 

```rust
fn f() { !(!x && y).then_some(42) } // syntax error
```

after
```rust
fn f() { (!(!x && y)).then_some(42) }
```