### PR TITLE
Fix not complete after inner-attr in source-file

### DIFF
--- a/crates/ide-completion/src/context/analysis.rs
+++ b/crates/ide-completion/src/context/analysis.rs
@@ -1635,7 +1635,7 @@ fn classify_name_ref<'db>(
                 && let Some(t) = top.first_token()
                 && let Some(prev) =
                     t.prev_token().and_then(|t| syntax::algo::skip_trivia_token(t, Direction::Prev))
-                && ![T![;], T!['}'], T!['{']].contains(&prev.kind())
+                && ![T![;], T!['}'], T!['{'], T![']']].contains(&prev.kind())
             {
                 // This was inferred to be an item position path, but it seems
                 // to be part of some other broken node which leaked into an item

--- a/crates/ide-completion/src/tests/item_list.rs
+++ b/crates/ide-completion/src/tests/item_list.rs
@@ -106,6 +106,40 @@ fn in_item_list_after_attr() {
 }
 
 #[test]
+fn in_item_list_after_inner_attr() {
+    check_with_base_items(
+        r#"#![attr] $0"#,
+        expect![[r#"
+            ma makro!(…) macro_rules! makro
+            md module
+            kw async
+            kw const
+            kw crate::
+            kw enum
+            kw extern
+            kw fn
+            kw impl
+            kw impl for
+            kw mod
+            kw pub
+            kw pub(crate)
+            kw pub(super)
+            kw self::
+            kw static
+            kw struct
+            kw trait
+            kw type
+            kw union
+            kw unsafe
+            kw use
+            sn macro_rules
+            sn tfn (Test function)
+            sn tmod (Test module)
+        "#]],
+    )
+}
+
+#[test]
 fn in_qualified_path() {
     check_with_base_items(
         r#"crate::$0"#,


### PR DESCRIPTION
Fixes rust-lang/rust-analyzer#15748

Example
---
```rust
#![attr] $0
```

**Before this PR**

Empty completion list

**After this PR**

```text
ma makro!(…) macro_rules! makro
md module
kw async
kw const
kw crate::
kw enum
kw extern
kw fn
kw impl
kw impl for
kw mod
kw pub
kw pub(crate)
kw pub(super)
kw self::
kw static
kw struct
kw trait
kw type
kw union
kw unsafe
kw use
sn macro_rules
sn tfn (Test function)
sn tmod (Test module)
```
