### PR TITLE
Add function to fetch runnable at cursor position

### DIFF
--- a/editors/code/src/commands.ts
+++ b/editors/code/src/commands.ts
@@ -14,6 +14,7 @@ import {
     selectRunnable,
     createTaskFromRunnable,
     createCargoArgs,
+    selectRunnableAtCursor,
 } from "./run";
 import {
     isRustDocument,
@@ -1209,6 +1210,13 @@ export function debug(ctx: CtxInit): Cmd {
 export function debugSingle(ctx: CtxInit): Cmd {
     return async (config: ra.Runnable) => {
         await startDebugSession(ctx, config);
+    };
+}
+
+export function fetchRunnableAtCursor(ctx: CtxInit): Cmd {
+    return async () => {
+        const editor = ctx.activeRustEditor ?? ctx.activeCargoTomlEditor;
+        return await selectRunnableAtCursor(ctx, editor, undefined);
     };
 }
 

--- a/editors/code/src/commands.ts
+++ b/editors/code/src/commands.ts
@@ -1216,6 +1216,7 @@ export function debugSingle(ctx: CtxInit): Cmd {
 export function fetchRunnableAtCursor(ctx: CtxInit): Cmd {
     return async () => {
         const editor = ctx.activeRustEditor ?? ctx.activeCargoTomlEditor;
+        if (!editor) return;
         return await selectRunnableAtCursor(ctx, editor, undefined);
     };
 }

--- a/editors/code/src/main.ts
+++ b/editors/code/src/main.ts
@@ -177,7 +177,7 @@ function createCommands(): Record<string, CommandFactory> {
         copyRunCommandLine: { enabled: commands.copyRunCommandLine },
         debug: { enabled: commands.debug },
         newDebugConfig: { enabled: commands.newDebugConfig },
-        fetchRunnableAtCursor : { enabled: commands.fetchRunnableAtCursor },
+        fetchRunnableAtCursor: { enabled: commands.fetchRunnableAtCursor },
         openDocs: { enabled: commands.openDocs },
         openExternalDocs: { enabled: commands.openExternalDocs },
         openCargoToml: { enabled: commands.openCargoToml },

--- a/editors/code/src/main.ts
+++ b/editors/code/src/main.ts
@@ -177,6 +177,7 @@ function createCommands(): Record<string, CommandFactory> {
         copyRunCommandLine: { enabled: commands.copyRunCommandLine },
         debug: { enabled: commands.debug },
         newDebugConfig: { enabled: commands.newDebugConfig },
+        fetchRunnableAtCursor : { enabled: commands.fetchRunnableAtCursor },
         openDocs: { enabled: commands.openDocs },
         openExternalDocs: { enabled: commands.openExternalDocs },
         openCargoToml: { enabled: commands.openCargoToml },

--- a/editors/code/src/run.ts
+++ b/editors/code/src/run.ts
@@ -59,7 +59,7 @@ export async function selectRunnable(
     );
 }
 
-async function selectRunnableAtCursor(
+export async function selectRunnableAtCursor(
     ctx: CtxInit,
     editor: RustEditor,
     prevRunnable?: RunnableQuickPick,


### PR DESCRIPTION
Expose a command in the extension that provides an interface for fetching a specific Runnable from the LSP. This lets the user select a Runnable directly instead of using the debug command, which currently prompts them to choose between multiple runnables. The fetched Runnable can then be used to call the debugSingle command directly.

Open to suggestions if there’s existing functionality that already provides this.

Here’s an example of the behavior I’m trying to address::
<img width="867" height="427" alt="Screenshot 2025-11-06 at 11 31 36" src="https://github.com/user-attachments/assets/134b34b9-ec9d-4bb1-a332-c4e367da0181" />
