### PR TITLE
Improve tmp iterator variable name for convert_for_to_while_let

### DIFF
--- a/crates/ide-assists/src/handlers/convert_for_to_while_let.rs
+++ b/crates/ide-assists/src/handlers/convert_for_to_while_let.rs
@@ -24,8 +24,8 @@ use crate::{AssistContext, AssistId, Assists};
 // ```
 // fn main() {
 //     let x = vec![1, 2, 3];
-//     let mut tmp = x.into_iter();
-//     while let Some(v) = tmp.next() {
+//     let mut iter = x.into_iter();
+//     while let Some(v) = iter.next() {
 //         let y = v * 2;
 //     };
 // }
@@ -71,7 +71,7 @@ pub(crate) fn convert_for_loop_to_while_let(
             let mut new_name = suggest_name::NameGenerator::new_from_scope_locals(
                 ctx.sema.scope(for_loop.syntax()),
             );
-            let tmp_var = new_name.suggest_name("tmp");
+            let tmp_var = new_name.suggest_name("iter");
 
             let mut_expr = make.let_stmt(
                 make.ident_pat(false, true, make.name(&tmp_var)).into(),
@@ -188,8 +188,8 @@ fn main() {
             r"
 fn main() {
     let mut x = vec![1, 2, 3];
-    let mut tmp = x.into_iter();
-    while let Some(v) = tmp.next() {
+    let mut iter = x.into_iter();
+    while let Some(v) = iter.next() {
         v *= 2;
     };
 }",
@@ -211,8 +211,8 @@ fn main() {
             r"
 fn main() {
     let mut x = vec![1, 2, 3];
-    let mut tmp = x.into_iter();
-    'a: while let Some(v) = tmp.next() {
+    let mut iter = x.into_iter();
+    'a: while let Some(v) = iter.next() {
         v *= 2;
         break 'a;
     };
@@ -236,10 +236,10 @@ fn main() {
             r"
 fn main() {
     let mut x = vec![1, 2, 3];
-    let mut tmp = x.into_iter();
+    let mut iter = x.into_iter();
     #[allow(unused)]
     #[deny(unsafe_code)]
-    while let Some(v) = tmp.next() {
+    while let Some(v) = iter.next() {
         v *= 2;
     };
 }",
@@ -275,8 +275,8 @@ impl<T> core::iter::Iterator for core::ops::Range<T> {
 }
 
 fn main() {
-    let mut tmp = 0..92;
-    while let Some(x) = tmp.next() {
+    let mut iter = 0..92;
+    while let Some(x) = iter.next() {
         print!("{}", x);
     }
 }"#,
@@ -330,8 +330,8 @@ impl S {
 
 fn main() {
     let x = S;
-    let mut tmp = x.iter();
-    while let Some(v) = tmp.next() {
+    let mut iter = x.iter();
+    while let Some(v) = iter.next() {
         let a = v * 2;
     }
 }
@@ -356,8 +356,8 @@ fn main() {
 struct NoIterMethod;
 fn main() {
     let x = NoIterMethod;
-    let mut tmp = (&x).into_iter();
-    while let Some(v) = tmp.next() {
+    let mut iter = (&x).into_iter();
+    while let Some(v) = iter.next() {
         let a = v * 2;
     }
 }
@@ -382,8 +382,8 @@ fn main() {
 struct NoIterMethod;
 fn main() {
     let x = NoIterMethod;
-    let mut tmp = (&mut x).into_iter();
-    while let Some(v) = tmp.next() {
+    let mut iter = (&mut x).into_iter();
+    while let Some(v) = iter.next() {
         let a = v * 2;
     }
 }
@@ -423,8 +423,8 @@ impl S {
 
 fn main() {
     let x = S;
-    let mut tmp = x.iter_mut();
-    while let Some(v) = tmp.next() {
+    let mut iter = x.iter_mut();
+    while let Some(v) = iter.next() {
         let a = v * 2;
     }
 }
@@ -448,8 +448,8 @@ fn main() {
 fn main() {
     let mut x = vec![1, 2, 3];
     let y = &mut x;
-    let mut tmp = y.into_iter();
-    while let Some(v) = tmp.next() {
+    let mut iter = y.into_iter();
+    while let Some(v) = iter.next() {
         *v *= 2;
     }
 }",
@@ -471,8 +471,8 @@ fn main() {
 "#,
             r#"
 fn main() {
-    let mut tmp = core::iter::repeat(92).take(1);
-    while let Some(a) = tmp.next() {
+    let mut iter = core::iter::repeat(92).take(1);
+    while let Some(a) = iter.next() {
         println!("{}", a);
     }
 }

--- a/crates/ide-assists/src/tests/generated.rs
+++ b/crates/ide-assists/src/tests/generated.rs
@@ -507,8 +507,8 @@ fn main() {
         r#####"
 fn main() {
     let x = vec![1, 2, 3];
-    let mut tmp = x.into_iter();
-    while let Some(v) = tmp.next() {
+    let mut iter = x.into_iter();
+    while let Some(v) = iter.next() {
         let y = v * 2;
     };
 }


### PR DESCRIPTION
Example
---
```rust
fn main() {
    let x = vec![1, 2, 3];
    for$0 v in x {
        let y = v * 2;
    };
}
```

**Before this PR**

```rust
fn main() {
    let x = vec![1, 2, 3];
    let mut tmp = x.into_iter();
    while let Some(v) = tmp.next() {
        let y = v * 2;
    };
}
```

**After this PR**

```rust
fn main() {
    let x = vec![1, 2, 3];
    let mut iter = x.into_iter();
    while let Some(v) = iter.next() {
        let y = v * 2;
    };
}
```
