### PR TITLE
fix: Remove some deep normalizations from infer

### DIFF
--- a/crates/hir-ty/src/infer/cast.rs
+++ b/crates/hir-ty/src/infer/cast.rs
@@ -110,8 +110,8 @@ impl<'db> CastCheck<'db> {
         &mut self,
         ctx: &mut InferenceContext<'_, 'db>,
     ) -> Result<(), InferenceDiagnostic<'db>> {
-        self.expr_ty = ctx.table.eagerly_normalize_and_resolve_shallow_in(self.expr_ty);
-        self.cast_ty = ctx.table.eagerly_normalize_and_resolve_shallow_in(self.cast_ty);
+        self.expr_ty = ctx.table.try_structurally_resolve_type(self.expr_ty);
+        self.cast_ty = ctx.table.try_structurally_resolve_type(self.cast_ty);
 
         // This should always come first so that we apply the coercion, which impacts infer vars.
         if ctx
@@ -159,7 +159,7 @@ impl<'db> CastCheck<'db> {
                     TyKind::FnDef(..) => {
                         let sig =
                             self.expr_ty.callable_sig(ctx.interner()).expect("FnDef had no sig");
-                        let sig = ctx.table.eagerly_normalize_and_resolve_shallow_in(sig);
+                        let sig = ctx.table.normalize_associated_types_in(sig);
                         let fn_ptr = Ty::new_fn_ptr(ctx.interner(), sig);
                         if ctx
                             .coerce(
@@ -191,7 +191,7 @@ impl<'db> CastCheck<'db> {
                             },
                             // array-ptr-cast
                             CastTy::Ptr(t, m) => {
-                                let t = ctx.table.eagerly_normalize_and_resolve_shallow_in(t);
+                                let t = ctx.table.try_structurally_resolve_type(t);
                                 if !ctx.table.is_sized(t) {
                                     return Err(CastError::IllegalCast);
                                 }
@@ -375,7 +375,7 @@ fn pointer_kind<'db>(
     ty: Ty<'db>,
     ctx: &mut InferenceContext<'_, 'db>,
 ) -> Result<Option<PointerKind<'db>>, ()> {
-    let ty = ctx.table.eagerly_normalize_and_resolve_shallow_in(ty);
+    let ty = ctx.table.try_structurally_resolve_type(ty);
 
     if ctx.table.is_sized(ty) {
         return Ok(Some(PointerKind::Thin));


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust-analyzer/issues/20975

The issue comes from this assertion:
https://github.com/rust-lang/rust-analyzer/blob/4bf516ee5a960c1e2eee9fedd9b1c9e976a19c86/crates/hir-ty/src/next_solver/normalize.rs#L48
The deeply normalization goals returns ambiguous errors with type unspecified integer literal because each integer types are all valid candidates.
Normaly, they should be fallbacked into `i32` but that's done manually in the type inference, not from the trait solving.

This PR removes deep normalizations on `Ty` but there are still two places calling it with `T: TypeFoldable` with non `Ty`. 
I tried to remove the deep normalization entirely from infer, this function.
https://github.com/rust-lang/rust-analyzer/blob/4bf516ee5a960c1e2eee9fedd9b1c9e976a19c86/crates/hir-ty/src/infer/unify.rs#L288-L299
But it caused few regressions especially upon const generic parameters so I left them for now. (Our const evaluation are quite wrong so might need be fixed from there)

I think this is not overlaps with https://github.com/rust-lang/rust-analyzer/pull/20974 but this can be waited and rebased upon it if so 😄 