### PR TITLE
fix: adjust the priority of code actions

### DIFF
--- a/editors/code/src/client.ts
+++ b/editors/code/src/client.ts
@@ -267,6 +267,12 @@ export async function createClient(
                     }
                     result.push(primary);
                 }
+
+                result.sort((a, b) => {
+                    const priorityA = getActionPriority(a);
+                    const priorityB = getActionPriority(b);
+                    return priorityA - priorityB;
+                });
                 return result;
             };
             return client
@@ -420,3 +426,17 @@ function renderHoverActions(actions: ra.CommandLinkGroup[]): vscode.MarkdownStri
     result.isTrusted = true;
     return result;
 }
+
+const getActionPriority = (action: vscode.CodeAction | vscode.Command): number => {
+    // rust-analyzer diagnostic > rust-analyzer assist > rustc diagnostic > other
+    if (!(action instanceof vscode.CodeAction)) {
+        return 3;
+    }
+
+    if (action.edit && action.edit.size > 0) return 2;
+    const command = action.command?.command;
+    if (command === "rust-analyzer.resolveCodeAction") return 0;
+    if (command === "rust-analyzer.applyActionGroup") return 1;
+
+    return 3;
+};


### PR DESCRIPTION
Closed: https://github.com/rust-lang/rust-analyzer/issues/3903

---

Example:
```rust
mod a {
    pub const POLY_SUBPIXEL_SHIFT: u32 = 8;
    pub const POLY_SUBPIXEL_SCALE: u32 = (1 << POLY_SUBPIXEL_SHIFT) - 1;
    pub fn lerp_u8() {}
    pub fn prelerp_u8() {}
}

pub mod my_module {
    pub struct HashMap;
    pub const POLY_SUBPIXEL_SCALE: i32 = 256;
}

use a::{POLY_SUBPIXEL_SHIFT, lerp_u8};

fn main() {
    println!("SCALE= {}", POLY_SUBPIXEL_SCALE);
    prelerp_u8();
    let value = POLY_SUBPIXEL_SCALE;
}

```

                 Before               |           After             
<img  height="200" alt="image" src="https://github.com/user-attachments/assets/6ec1c88d-e6ff-477a-8465-2de9ba92e162" />

<img  height="200" alt="image" src="https://github.com/user-attachments/assets/ceb82d68-5228-4e5e-b41f-a16e6a1fa3f4" />

<img  height="200" alt="image" src="https://github.com/user-attachments/assets/d8b7fc65-2035-4d07-ba96-77a7758515b2" />

---

### Why choose reordering over adjusting the push order of CodeActions from the backend/frontend?

Initially, following the guidance in https://github.com/rust-lang/rust-analyzer/issues/3903, I attempted to adjust the push order in the backend but found it ineffective. 

Then I tried reordering them after the push was complete, and noticed the final presentation seemed to be sorted in segments. For example, we could make `Qualify` rank higher than `Import`, but it could never surpass `similar name`. 

I realized this was likely a frontend issue, and eventually located the relevant code here:

https://github.com/rust-lang/rust-analyzer/blob/d26e4b24d8021f856b3149b882201484ce9d3015/editors/code/src/client.ts#L176-L178


> I'm not very familiar with TS; the subsequent work relied heavily on Sonnet 4.5 : )


<img width="800" alt="image" src="https://github.com/user-attachments/assets/5c9b16cd-2797-4cd8-9338-8f473f883b81" />

Based on the inserted logs, the issue is indeed determined by the frontend.
However, judging from the code logic, it doesn't seem possible to change the final presentation order by altering the processing sequence, so I decided to sort them after all processing was complete.

---

The order is based on matklad's idea, namely `ra diagnostic > ra assist > rustc diagnostic`
<img width="500" alt="image" src="https://github.com/user-attachments/assets/961f1be9-43db-4d2c-b67a-8acaf1aa8c46" />

As for the criteria for determining priority, it might not be perfectly precise, but `it works :)`

---
The frontend testing framework seems relatively basic; I'm not sure where to write tests or how to write them.