### PR TITLE
minor: Add "msg" and "op" to hidden inlay parameter names

### DIFF
--- a/crates/ide/src/inlay_hints/param_name.rs
+++ b/crates/ide/src/inlay_hints/param_name.rs
@@ -111,7 +111,8 @@ fn get_callable<'db>(
 }
 
 const INSIGNIFICANT_METHOD_NAMES: &[&str] = &["clone", "as_ref", "into"];
-const INSIGNIFICANT_PARAMETER_NAMES: &[&str] = &["predicate", "value", "pat", "rhs", "other"];
+const INSIGNIFICANT_PARAMETER_NAMES: &[&str] =
+    &["predicate", "value", "pat", "rhs", "other", "msg", "op"];
 
 fn should_hide_param_name_hint(
     sema: &Semantics<'_, RootDatabase>,


### PR DESCRIPTION
"msg" adds noise to `expect` and crossbeam's `Sender`. "op" adds noise to `map_err`. There's probably more instance of each, but I noticed these all in one snippet:

<img width="791" height="1090" alt="CleanShot 2025-11-09 at 18 19 52" src="https://github.com/user-attachments/assets/7316925e-0473-4e0b-9424-6d7159b1286b" />
