### PR TITLE
Optimise `SmolStr::clone` 4-5x speedup inline, 0.5x heap (slow down)

### DIFF
--- a/lib/smol_str/CHANGELOG.md
+++ b/lib/smol_str/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Optimise `SmolStr::clone` 4-5x speedup inline, 0.5x heap (slow down).
 
 ## 0.3.4 - 2025-10-23
 


### PR DESCRIPTION
This is an interesting performance trade-off. We can significantly improve inline `SmolStr::clone` performance at the expense of heap performance if we use `#[cold]` & `#[inline(never)]` hints against the latter.

This is a better result for users that care most about inline variant performance. If we think that represents most users it may be worth it.

## Benchmarks
* inline clones 4.1ns -> 0.8ns :slightly_smiling_face: 
* heap clones 2.8ns -> 5.8ns :slightly_frowning_face: 

```
group                      master                  pr
-----                      ------                  --
SmolStr::clone len=12      4.86      4.1±0.00ns    1.00      0.8±0.00ns
SmolStr::clone len=50      1.00      2.8±0.02ns    2.05      5.8±0.01ns
SmolStr::clone len=1000    1.00      2.8±0.01ns    2.04      5.8±0.02ns
```