### PR TITLE
Fix not complete type alias in pattern

### DIFF
--- a/crates/ide-completion/src/completions/pattern.rs
+++ b/crates/ide-completion/src/completions/pattern.rs
@@ -101,6 +101,7 @@ pub(crate) fn complete_pattern(
                 hir::ModuleDef::Const(..) => refutable,
                 hir::ModuleDef::Module(..) => true,
                 hir::ModuleDef::Macro(mac) => mac.is_fn_like(ctx.db),
+                hir::ModuleDef::TypeAlias(_) => true,
                 _ => false,
             },
             hir::ScopeDef::ImplSelfType(impl_) => match impl_.self_ty(ctx.db).as_adt() {

--- a/crates/ide-completion/src/tests/pattern.rs
+++ b/crates/ide-completion/src/tests/pattern.rs
@@ -783,6 +783,37 @@ fn f(x: EnumAlias<u8>) {
 }
 
 #[test]
+fn through_alias_it_self() {
+    check(
+        r#"
+enum Enum<T> {
+    Unit,
+    Tuple(T),
+}
+
+type EnumAlias<T> = Enum<T>;
+
+fn f(x: EnumAlias<u8>) {
+    match x {
+        $0 => (),
+        _ => (),
+    }
+
+}
+
+"#,
+        expect![[r#"
+            en Enum
+            ta EnumAlias
+            bn Enum::Tuple(…) Enum::Tuple($1)$0
+            bn Enum::Unit          Enum::Unit$0
+            kw mut
+            kw ref
+        "#]],
+    );
+}
+
+#[test]
 fn pat_no_unstable_item_on_stable() {
     check(
         r#"


### PR DESCRIPTION
Example
---
```rust
enum Enum<T> {
    Unit,
    Tuple(T),
}

type EnumAlias<T> = Enum<T>;

fn f(x: EnumAlias<u8>) {
    match x {
        $0 => (),
        _ => (),
    }

}
```

**Before this PR**

```text
en Enum
bn Enum::Tuple(…) Enum::Tuple($1)$0
bn Enum::Unit          Enum::Unit$0
kw mut
kw ref
```

**After this PR**

```text
en Enum
ta EnumAlias
bn Enum::Tuple(…) Enum::Tuple($1)$0
bn Enum::Unit          Enum::Unit$0
kw mut
kw ref
```
