### PR TITLE
Fix hit incorrect_case on no_mangle static items

### DIFF
--- a/crates/hir-ty/src/diagnostics/decl_check.rs
+++ b/crates/hir-ty/src/diagnostics/decl_check.rs
@@ -563,6 +563,10 @@ impl<'a> DeclValidator<'a> {
             cov_mark::hit!(extern_static_incorrect_case_ignored);
             return;
         }
+        if self.db.attrs(static_id.into()).by_key(sym::no_mangle).exists() {
+            cov_mark::hit!(no_mangle_static_incorrect_case_ignored);
+            return;
+        }
 
         self.create_incorrect_case_diagnostic_for_item_name(
             static_id,

--- a/crates/ide-diagnostics/src/handlers/incorrect_case.rs
+++ b/crates/ide-diagnostics/src/handlers/incorrect_case.rs
@@ -439,10 +439,27 @@ fn f((_O): u8) {}
     #[test]
     fn ignores_no_mangle_items() {
         cov_mark::check!(extern_func_no_mangle_ignored);
+        cov_mark::check!(no_mangle_static_incorrect_case_ignored);
         check_diagnostics(
             r#"
 #[no_mangle]
 extern "C" fn NonSnakeCaseName(some_var: u8) -> u8;
+#[no_mangle]
+static lower_case: () = ();
+            "#,
+        );
+    }
+
+    #[test]
+    fn ignores_unsafe_no_mangle_items() {
+        cov_mark::check!(extern_func_no_mangle_ignored);
+        cov_mark::check!(no_mangle_static_incorrect_case_ignored);
+        check_diagnostics(
+            r#"
+#[unsafe(no_mangle)]
+extern "C" fn NonSnakeCaseName(some_var: u8) -> u8;
+#[unsafe(no_mangle)]
+static lower_case: () = ();
             "#,
         );
     }


### PR DESCRIPTION
Fixes rust-lang/rust-analyzer#21045

Example
---
```rust
#[no_mangle]
static lower_case: () = ();
```

**Before this PR**

```text
non_upper_case_globals
```

**After this PR**

No diagnostics
