### PR TITLE
refactor: remove unused code

### DIFF
--- a/editors/code/src/lsp_ext.ts
+++ b/editors/code/src/lsp_ext.ts
@@ -46,9 +46,6 @@ export const rebuildProcMacros = new lc.RequestType0<null, void>("rust-analyzer/
 export const runFlycheck = new lc.NotificationType<{
     textDocument: lc.TextDocumentIdentifier | null;
 }>("rust-analyzer/runFlycheck");
-export const syntaxTree = new lc.RequestType<SyntaxTreeParams, string, void>(
-    "rust-analyzer/syntaxTree",
-);
 export const viewSyntaxTree = new lc.RequestType<ViewSyntaxTreeParams, string, void>(
     "rust-analyzer/viewSyntaxTree",
 );


### PR DESCRIPTION
we have `viewSyntaxTree` so  don't need `syntaxTree` anymore

close https://github.com/rust-lang/rust-analyzer/issues/20992