### PR TITLE
minor: Drop unused `ungrammar` import

### DIFF
--- a/lib/ungrammar/src/parser.rs
+++ b/lib/ungrammar/src/parser.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 
 use crate::{
     Grammar, Node, NodeData, Rule, Token, TokenData,
-    error::{Result, bail, format_err},
+    error::{Result, format_err},
     lexer::{self, TokenKind},
 };
 


### PR DESCRIPTION
Hopefully will unblock the syncs