### PR TITLE
feat: make dyn inlay hints configurable

### DIFF
--- a/crates/ide/src/inlay_hints.rs
+++ b/crates/ide/src/inlay_hints.rs
@@ -316,6 +316,7 @@ pub struct InlayHintsConfig<'a> {
     pub closure_capture_hints: bool,
     pub binding_mode_hints: bool,
     pub implicit_drop_hints: bool,
+    pub implied_dyn_trait_hints: bool,
     pub lifetime_elision_hints: LifetimeElisionHints,
     pub param_names_for_lifetime_elision_hints: bool,
     pub hide_named_constructor_hints: bool,
@@ -907,6 +908,7 @@ mod tests {
         closing_brace_hints_min_lines: None,
         fields_to_resolve: InlayFieldsToResolve::empty(),
         implicit_drop_hints: false,
+        implied_dyn_trait_hints: false,
         range_exclusive_hints: false,
         minicore: MiniCore::default(),
     };

--- a/crates/ide/src/inlay_hints/implied_dyn_trait.rs
+++ b/crates/ide/src/inlay_hints/implied_dyn_trait.rs
@@ -14,6 +14,10 @@ pub(super) fn hints(
     config: &InlayHintsConfig<'_>,
     path: Either<ast::PathType, ast::DynTraitType>,
 ) -> Option<()> {
+    if !config.implied_dyn_trait_hints {
+        return None;
+    }
+
     let parent = path.syntax().parent()?;
     let range = match path {
         Either::Left(path) => {
@@ -76,7 +80,14 @@ mod tests {
 
     #[track_caller]
     fn check(#[rust_analyzer::rust_fixture] ra_fixture: &str) {
-        check_with_config(InlayHintsConfig { sized_bound: true, ..DISABLED_CONFIG }, ra_fixture);
+        check_with_config(
+            InlayHintsConfig {
+                sized_bound: true,
+                implied_dyn_trait_hints: true,
+                ..DISABLED_CONFIG
+            },
+            ra_fixture,
+        );
     }
 
     #[test]
@@ -125,7 +136,7 @@ fn foo(
     #[test]
     fn edit() {
         check_edit(
-            DISABLED_CONFIG,
+            InlayHintsConfig { implied_dyn_trait_hints: true, ..DISABLED_CONFIG },
             r#"
 trait T {}
 fn foo(

--- a/crates/ide/src/static_index.rs
+++ b/crates/ide/src/static_index.rs
@@ -173,6 +173,7 @@ impl StaticIndex<'_> {
                     adjustment_hints_mode: AdjustmentHintsMode::Prefix,
                     adjustment_hints_hide_outside_unsafe: false,
                     implicit_drop_hints: false,
+                    implied_dyn_trait_hints: false,
                     hide_named_constructor_hints: false,
                     hide_closure_initialization_hints: false,
                     hide_closure_parameter_hints: false,

--- a/crates/rust-analyzer/src/cli/analysis_stats.rs
+++ b/crates/rust-analyzer/src/cli/analysis_stats.rs
@@ -1186,6 +1186,7 @@ impl flags::AnalysisStats {
                     closure_capture_hints: true,
                     binding_mode_hints: true,
                     implicit_drop_hints: true,
+                    implied_dyn_trait_hints: true,
                     lifetime_elision_hints: ide::LifetimeElisionHints::Always,
                     param_names_for_lifetime_elision_hints: true,
                     hide_named_constructor_hints: false,

--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -263,6 +263,9 @@ config_data! {
         /// Show inlay hints for the implied type parameter `Sized` bound.
         inlayHints_implicitSizedBoundHints_enable: bool = false,
 
+        /// Show inlay hints for the implied `dyn` keyword in trait object types.
+        inlayHints_impliedDynTraitHints_enable: bool = true,
+
         /// Show inlay type hints for elided lifetimes in function signatures.
         inlayHints_lifetimeElisionHints_enable: LifetimeElisionDef = LifetimeElisionDef::Never,
 
@@ -1983,6 +1986,7 @@ impl Config {
                 &client_capability_fields,
             ),
             implicit_drop_hints: self.inlayHints_implicitDrops_enable().to_owned(),
+            implied_dyn_trait_hints: self.inlayHints_impliedDynTraitHints_enable().to_owned(),
             range_exclusive_hints: self.inlayHints_rangeExclusiveHints_enable().to_owned(),
             minicore,
         }

--- a/docs/book/src/configuration_generated.md
+++ b/docs/book/src/configuration_generated.md
@@ -1033,6 +1033,13 @@ Default: `false`
 Show inlay hints for the implied type parameter `Sized` bound.
 
 
+## rust-analyzer.inlayHints.impliedDynTraitHints.enable {#inlayHints.impliedDynTraitHints.enable}
+
+Default: `true`
+
+Show inlay hints for the implied `dyn` keyword in trait object types.
+
+
 ## rust-analyzer.inlayHints.lifetimeElisionHints.enable {#inlayHints.lifetimeElisionHints.enable}
 
 Default: `"never"`

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -2346,6 +2346,16 @@
             {
                 "title": "Inlay Hints",
                 "properties": {
+                    "rust-analyzer.inlayHints.impliedDynTraitHints.enable": {
+                        "markdownDescription": "Show inlay hints for the implied `dyn` keyword in trait object types.",
+                        "default": true,
+                        "type": "boolean"
+                    }
+                }
+            },
+            {
+                "title": "Inlay Hints",
+                "properties": {
                     "rust-analyzer.inlayHints.lifetimeElisionHints.enable": {
                         "markdownDescription": "Show inlay type hints for elided lifetimes in function signatures.",
                         "default": "never",


### PR DESCRIPTION
closes rust-lang/rust-analyzer#21058 

Implemented a `implied_dyn_trait_hints`  option to `InlayHintsConfig` struct (default to true, meaning the inlay hints will be shown by default and if we wants to disable them, they can do it by using this option)