### PR TITLE
feat: add test for async-trait type mismatch

### DIFF
--- a/crates/hir-ty/src/tests/regression/new_solver.rs
+++ b/crates/hir-ty/src/tests/regression/new_solver.rs
@@ -557,8 +557,6 @@ where
 fn regression_19957() {
     // This test documents issue #19957: async-trait patterns incorrectly produce
     // type mismatches between Pin<Box<dyn Future>> and Pin<Box<impl Future>>.
-    //
-    // The test currently FAILS (as expected) because the bug is not yet fixed.
     check_no_mismatches(
         r#"
 //- minicore: future, pin, result, error, send, coerce_unsized, dispatch_from_dyn

--- a/crates/test-utils/src/minicore.rs
+++ b/crates/test-utils/src/minicore.rs
@@ -1518,6 +1518,12 @@ pub mod pin {
     {
     }
     // endregion:dispatch_from_dyn
+    // region:coerce_unsized
+    impl<Ptr, U> crate::ops::CoerceUnsized<Pin<U>> for Pin<Ptr> where
+        Ptr: crate::ops::CoerceUnsized<U>
+    {
+    }
+    // endregion:coerce_unsized
 }
 // endregion:pin
 


### PR DESCRIPTION
closes rust-lang/rust-analyzer#19957 (remaining part)

Made a test to verify that issue rust-lang/rust-analyzer#19957 is resolved. The test passes successfully, confirming that the async-trait type mismatch issue has been fixed by the migration to the new trait solver (commit d1288f6353).

### About Test
As we can't directly use `#[async_trait]` in hir-ty tests (it's not available in minicore), the test simulates what the `#[async_trait]` macro expands to.

The test verifies that no type mismatch occurs between the `Pin<Box<dyn Future>>` signature and the `Pin<Box<impl Future>>` returned by the async block.