### PR TITLE
add test for Associated type of super trait not resolved in dyn syntax. #10018

### DIFF
--- a/crates/ide-diagnostics/src/handlers/unresolved_assoc_item.rs
+++ b/crates/ide-diagnostics/src/handlers/unresolved_assoc_item.rs
@@ -49,4 +49,25 @@ fn main() {
 "#,
         );
     }
+
+    #[test]
+    fn dyn_super_trait_assoc_type() {
+        check_diagnostics(
+            r#"
+//- minicore: future, send
+
+use core::{future::Future, marker::Send, pin::Pin};
+
+trait FusedFuture: Future {
+    fn is_terminated(&self) -> bool;
+}
+
+struct Box<T: ?Sized>(*const T);
+
+fn main() {
+    let _fut: Pin<Box<dyn FusedFuture<Output = ()> + Send>> = loop {};
+}
+"#,
+        );
+    }
 }


### PR DESCRIPTION
fix rust-lang/rust-analyzer#10018

Added a regression test mirroring issue rust-lang/rust-analyzer#10018 that builds a `Pin<Box<dyn FusedFuture<Output = ()> + Send>>` and confirms no spurious “no such associated item” diagnostic is emitted for the Output projection when the associated type originates from a super-trait (Future).
