### PR TITLE
Fix trailing newline in tool_path

### DIFF
--- a/crates/project-model/src/sysroot.rs
+++ b/crates/project-model/src/sysroot.rs
@@ -192,8 +192,12 @@ impl Sysroot {
 
                 cmd.arg("which");
                 cmd.arg(tool.name());
-                (|| Some(Utf8PathBuf::from(String::from_utf8(cmd.output().ok()?.stdout).ok()?)))()
-                    .unwrap_or_else(|| Utf8PathBuf::from(tool.name()))
+                (|| {
+                    Some(Utf8PathBuf::from(
+                        String::from_utf8(cmd.output().ok()?.stdout).ok()?.trim_end(),
+                    ))
+                })()
+                .unwrap_or_else(|| Utf8PathBuf::from(tool.name()))
             }
             _ => tool.path(),
         }


### PR DESCRIPTION
Since rust-lang/rust-analyzer#21046 was merged, we're seeing execution errors in proc macros. We can trace this down to the new `tool_path` function that calls `rust-up which`. That in turn returns the correct path but (like all CLI tools) with a trailing newline. That newline makes it into various `Env` structures, which eventually causes issues. This PR fixes that by trimming off whitespace at the end of the output.