### PR TITLE
fix: Enhance remove_parentheses assist to handle return expressions

### DIFF
--- a/crates/ide-assists/src/handlers/remove_parentheses.rs
+++ b/crates/ide-assists/src/handlers/remove_parentheses.rs
@@ -163,17 +163,18 @@ mod tests {
     }
 
     #[test]
-    fn remove_parens_prefix_with_return_no_value() {
-        // removing `()` from !(return) would make `!return` which is invalid syntax
-        check_assist_not_applicable(
+    fn remove_parens_prefix_with_ret_like_prefix() {
+        check_assist(remove_parentheses, r#"fn f() { !$0(return) }"#, r#"fn f() { !return }"#);
+        // `break`, `continue` behave the same under prefix operators
+        check_assist(remove_parentheses, r#"fn f() { !$0(break) }"#, r#"fn f() { !break }"#);
+        check_assist(remove_parentheses, r#"fn f() { !$0(continue) }"#, r#"fn f() { !continue }"#);
+        check_assist(
             remove_parentheses,
-            r#"fn main() { let _x = true && !$0(return) || true; }"#,
+            r#"fn f() { !$0(return false) }"#,
+            r#"fn f() { !return false }"#,
         );
-        check_assist_not_applicable(remove_parentheses, r#"fn f() { !$0(return) }"#);
-        check_assist_not_applicable(remove_parentheses, r#"fn f() { !$0(break) }"#);
-        check_assist_not_applicable(remove_parentheses, r#"fn f() { !$0(continue) }"#);
 
-        // Binary operators should still allow removal
+        // Binary operators should still allow removal unless a ret-like expression is immediately followed by `||` or `&&`.
         check_assist(
             remove_parentheses,
             r#"fn f() { true || $0(return) }"#,
@@ -244,6 +245,79 @@ mod tests {
             remove_parentheses,
             r#"fn f() { &$0(return ()) }"#,
             r#"fn f() { &return () }"#,
+        );
+    }
+
+    #[test]
+    fn remove_parens_return_in_unary_not() {
+        check_assist(
+            remove_parentheses,
+            r#"fn f() { cond && !$0(return) }"#,
+            r#"fn f() { cond && !return }"#,
+        );
+        check_assist(
+            remove_parentheses,
+            r#"fn f() { cond && !$0(return false) }"#,
+            r#"fn f() { cond && !return false }"#,
+        );
+    }
+
+    #[test]
+    fn remove_parens_return_in_disjunction_with_closure_risk() {
+        // `return` may only be blocked when it would form `return ||` or `return &&`
+        check_assist_not_applicable(
+            remove_parentheses,
+            r#"fn f() { let _x = true && $0(return) || true; }"#,
+        );
+        check_assist_not_applicable(
+            remove_parentheses,
+            r#"fn f() { let _x = true && !$0(return) || true; }"#,
+        );
+        check_assist_not_applicable(
+            remove_parentheses,
+            r#"fn f() { let _x = true && $0(return false) || true; }"#,
+        );
+        check_assist_not_applicable(
+            remove_parentheses,
+            r#"fn f() { let _x = true && !$0(return false) || true; }"#,
+        );
+        check_assist_not_applicable(
+            remove_parentheses,
+            r#"fn f() { let _x = true && $0(return) && true; }"#,
+        );
+        check_assist_not_applicable(
+            remove_parentheses,
+            r#"fn f() { let _x = true && !$0(return) && true; }"#,
+        );
+        check_assist_not_applicable(
+            remove_parentheses,
+            r#"fn f() { let _x = true && $0(return false) && true; }"#,
+        );
+        check_assist_not_applicable(
+            remove_parentheses,
+            r#"fn f() { let _x = true && !$0(return false) && true; }"#,
+        );
+        check_assist_not_applicable(
+            remove_parentheses,
+            r#"fn f() { let _x = $0(return) || true; }"#,
+        );
+        check_assist_not_applicable(
+            remove_parentheses,
+            r#"fn f() { let _x = $0(return) && true; }"#,
+        );
+    }
+
+    #[test]
+    fn remove_parens_return_in_disjunction_is_ok() {
+        check_assist(
+            remove_parentheses,
+            r#"fn f() { let _x = true || $0(return); }"#,
+            r#"fn f() { let _x = true || return; }"#,
+        );
+        check_assist(
+            remove_parentheses,
+            r#"fn f() { let _x = true && $0(return); }"#,
+            r#"fn f() { let _x = true && return; }"#,
         );
     }
 


### PR DESCRIPTION
close rust-lang/rust-analyzer#21063

## Summary

This PR refines the `remove_parentheses` assist’s handling of `return`-like control-flow expressions, based on the discussion in rust-lang/rust-analyzer#21092.

The assist now applies the following rules:

1. Prevent producing `return || …`
    - Parentheses around `return` are not removed when doing so would create `return ||`


2. Allow removal under prefix operators
    - Parentheses around `return`, `return <expr>`, `break`, and `continue` are removed when used under prefix operators like `!`
   (e.g., `!(return)` → `!return`, `!(return false)` → `!return false`).

## Tests

This PR adds comprehensive tests covering:

- All prohibited cases that would form `return || …` (with and without values, with or without a prefix operator).
- Valid prefix cases (`!(return)`, `!(return false)`, `!(break)`, `!(continue)`).
- Valid binary-operator cases (`true || (return)` → `true || return`).
