### PR TITLE
fix: Prevent inlay hints from flickering while typing

### DIFF
--- a/crates/rust-analyzer/src/main_loop.rs
+++ b/crates/rust-analyzer/src/main_loop.rs
@@ -505,17 +505,17 @@ impl GlobalState {
                     self.send_request::<lsp_types::request::CodeLensRefresh>((), |_, _| ());
                 }
 
-                // Refresh inlay hints if the client supports it.
-                if self.config.inlay_hints_refresh() {
-                    self.send_request::<lsp_types::request::InlayHintRefreshRequest>((), |_, _| ());
-                }
-
                 if self.config.diagnostics_refresh() {
                     self.send_request::<lsp_types::request::WorkspaceDiagnosticRefresh>(
                         (),
                         |_, _| (),
                     );
                 }
+            }
+
+            // Refresh inlay hints only when quiescent to avoid flickering during typing.
+            if became_quiescent && self.config.inlay_hints_refresh() {
+                self.send_request::<lsp_types::request::InlayHintRefreshRequest>((), |_, _| ());
             }
 
             let project_or_mem_docs_changed =


### PR DESCRIPTION
closes rust-lang/rust-analyzer#21091

Inlay hints were rapidly appearing and hiding while typing, making code unable to read.  I moved the inlay hint refresh logic to trigger when the system becomes quiescent.