### PR TITLE
fix: include all target types with paths outside package root

### DIFF
--- a/crates/project-model/src/workspace.rs
+++ b/crates/project-model/src/workspace.rs
@@ -844,6 +844,8 @@ impl ProjectWorkspace {
                             exclude.push(pkg_root.join("examples"));
                             exclude.push(pkg_root.join("benches"));
                         }
+                        include.sort();
+                        include.dedup();
                         PackageRoot { is_local, include, exclude }
                     })
                     .chain(mk_sysroot())
@@ -905,6 +907,8 @@ impl ProjectWorkspace {
                             exclude.push(pkg_root.join("examples"));
                             exclude.push(pkg_root.join("benches"));
                         }
+                        include.sort();
+                        include.dedup();
                         PackageRoot { is_local, include, exclude }
                     })
                 }))


### PR DESCRIPTION
closes rust-lang/rust-analyzer#21072

The issue was that only the lib targets with custom paths were added to the source root includes. So binary (and other) targets failed when their path was set to a location outside the cargo package directory.

The fix removes the filter that restricted this behavior to only lib, thus allowing all target types (Bin, Example, Test, etc.) with custom paths to have their parent directories included in source roots.