### PR TITLE
add semantic tokens for deprecated items

### DIFF
--- a/crates/ide/src/syntax_highlighting/highlight.rs
+++ b/crates/ide/src/syntax_highlighting/highlight.rs
@@ -3,7 +3,7 @@
 use std::ops::ControlFlow;
 
 use either::Either;
-use hir::{AsAssocItem, HasVisibility, Semantics};
+use hir::{AsAssocItem, HasAttrs, HasVisibility, Semantics, sym};
 use ide_db::{
     FxHashMap, RootDatabase, SymbolKind,
     defs::{Definition, IdentClass, NameClass, NameRefClass},
@@ -483,20 +483,25 @@ pub(super) fn highlight_def(
     is_ref: bool,
 ) -> Highlight {
     let db = sema.db;
-    let mut h = match def {
-        Definition::Macro(m) => Highlight::new(HlTag::Symbol(m.kind(sema.db).into())),
-        Definition::Field(_) | Definition::TupleField(_) => {
-            Highlight::new(HlTag::Symbol(SymbolKind::Field))
+    let (mut h, attrs) = match def {
+        Definition::Macro(m) => {
+            (Highlight::new(HlTag::Symbol(m.kind(sema.db).into())), Some(m.attrs(sema.db)))
         }
-        Definition::Crate(_) => {
-            Highlight::new(HlTag::Symbol(SymbolKind::Module)) | HlMod::CrateRoot
+        Definition::Field(field) => {
+            (Highlight::new(HlTag::Symbol(SymbolKind::Field)), Some(field.attrs(sema.db)))
         }
+        Definition::TupleField(_) => (Highlight::new(HlTag::Symbol(SymbolKind::Field)), None),
+        Definition::Crate(krate) => (
+            Highlight::new(HlTag::Symbol(SymbolKind::Module)) | HlMod::CrateRoot,
+            Some(krate.attrs(sema.db)),
+        ),
         Definition::Module(module) => {
             let mut h = Highlight::new(HlTag::Symbol(SymbolKind::Module));
             if module.is_crate_root() {
                 h |= HlMod::CrateRoot;
             }
-            h
+
+            (h, Some(module.attrs(sema.db)))
         }
         Definition::Function(func) => {
             let mut h = Highlight::new(HlTag::Symbol(SymbolKind::Function));
@@ -544,7 +549,7 @@ pub(super) fn highlight_def(
                 h |= HlMod::Const;
             }
 
-            h
+            (h, Some(func.attrs(sema.db)))
         }
         Definition::Adt(adt) => {
             let h = match adt {
@@ -553,9 +558,11 @@ pub(super) fn highlight_def(
                 hir::Adt::Union(_) => HlTag::Symbol(SymbolKind::Union),
             };
 
-            Highlight::new(h)
+            (Highlight::new(h), Some(adt.attrs(sema.db)))
         }
-        Definition::Variant(_) => Highlight::new(HlTag::Symbol(SymbolKind::Variant)),
+        Definition::Variant(variant) => {
+            (Highlight::new(HlTag::Symbol(SymbolKind::Variant)), Some(variant.attrs(sema.db)))
+        }
         Definition::Const(konst) => {
             let mut h = Highlight::new(HlTag::Symbol(SymbolKind::Const)) | HlMod::Const;
             if let Some(item) = konst.as_assoc_item(db) {
@@ -573,9 +580,11 @@ pub(super) fn highlight_def(
                 }
             }
 
-            h
+            (h, Some(konst.attrs(sema.db)))
         }
-        Definition::Trait(_) => Highlight::new(HlTag::Symbol(SymbolKind::Trait)),
+        Definition::Trait(trait_) => {
+            (Highlight::new(HlTag::Symbol(SymbolKind::Trait)), Some(trait_.attrs(sema.db)))
+        }
         Definition::TypeAlias(type_) => {
             let mut h = Highlight::new(HlTag::Symbol(SymbolKind::TypeAlias));
 
@@ -594,10 +603,12 @@ pub(super) fn highlight_def(
                 }
             }
 
-            h
+            (h, Some(type_.attrs(sema.db)))
         }
-        Definition::BuiltinType(_) => Highlight::new(HlTag::BuiltinType),
-        Definition::BuiltinLifetime(_) => Highlight::new(HlTag::Symbol(SymbolKind::LifetimeParam)),
+        Definition::BuiltinType(_) => (Highlight::new(HlTag::BuiltinType), None),
+        Definition::BuiltinLifetime(_) => {
+            (Highlight::new(HlTag::Symbol(SymbolKind::LifetimeParam)), None)
+        }
         Definition::Static(s) => {
             let mut h = Highlight::new(HlTag::Symbol(SymbolKind::Static));
 
@@ -608,18 +619,23 @@ pub(super) fn highlight_def(
                 }
             }
 
-            h
+            (h, Some(s.attrs(sema.db)))
         }
-        Definition::SelfType(_) => Highlight::new(HlTag::Symbol(SymbolKind::Impl)),
-        Definition::GenericParam(it) => match it {
-            hir::GenericParam::TypeParam(_) => Highlight::new(HlTag::Symbol(SymbolKind::TypeParam)),
-            hir::GenericParam::ConstParam(_) => {
-                Highlight::new(HlTag::Symbol(SymbolKind::ConstParam)) | HlMod::Const
-            }
-            hir::GenericParam::LifetimeParam(_) => {
-                Highlight::new(HlTag::Symbol(SymbolKind::LifetimeParam))
-            }
-        },
+        Definition::SelfType(_) => (Highlight::new(HlTag::Symbol(SymbolKind::Impl)), None),
+        Definition::GenericParam(it) => (
+            match it {
+                hir::GenericParam::TypeParam(_) => {
+                    Highlight::new(HlTag::Symbol(SymbolKind::TypeParam))
+                }
+                hir::GenericParam::ConstParam(_) => {
+                    Highlight::new(HlTag::Symbol(SymbolKind::ConstParam)) | HlMod::Const
+                }
+                hir::GenericParam::LifetimeParam(_) => {
+                    Highlight::new(HlTag::Symbol(SymbolKind::LifetimeParam))
+                }
+            },
+            None,
+        ),
         Definition::Local(local) => {
             let tag = if local.is_self(db) {
                 HlTag::Symbol(SymbolKind::SelfParam)
@@ -639,7 +655,7 @@ pub(super) fn highlight_def(
             if ty.as_callable(db).is_some() || ty.impls_fnonce(db) {
                 h |= HlMod::Callable;
             }
-            h
+            (h, None)
         }
         Definition::ExternCrateDecl(extern_crate) => {
             let mut highlight =
@@ -647,16 +663,20 @@ pub(super) fn highlight_def(
             if extern_crate.alias(db).is_none() {
                 highlight |= HlMod::Library;
             }
-            highlight
+            (highlight, Some(extern_crate.attrs(sema.db)))
         }
-        Definition::Label(_) => Highlight::new(HlTag::Symbol(SymbolKind::Label)),
-        Definition::BuiltinAttr(_) => Highlight::new(HlTag::Symbol(SymbolKind::BuiltinAttr)),
-        Definition::ToolModule(_) => Highlight::new(HlTag::Symbol(SymbolKind::ToolModule)),
-        Definition::DeriveHelper(_) => Highlight::new(HlTag::Symbol(SymbolKind::DeriveHelper)),
+        Definition::Label(_) => (Highlight::new(HlTag::Symbol(SymbolKind::Label)), None),
+        Definition::BuiltinAttr(_) => {
+            (Highlight::new(HlTag::Symbol(SymbolKind::BuiltinAttr)), None)
+        }
+        Definition::ToolModule(_) => (Highlight::new(HlTag::Symbol(SymbolKind::ToolModule)), None),
+        Definition::DeriveHelper(_) => {
+            (Highlight::new(HlTag::Symbol(SymbolKind::DeriveHelper)), None)
+        }
         Definition::InlineAsmRegOrRegClass(_) => {
-            Highlight::new(HlTag::Symbol(SymbolKind::InlineAsmRegOrRegClass))
+            (Highlight::new(HlTag::Symbol(SymbolKind::InlineAsmRegOrRegClass)), None)
         }
-        Definition::InlineAsmOperand(_) => Highlight::new(HlTag::Symbol(SymbolKind::Local)),
+        Definition::InlineAsmOperand(_) => (Highlight::new(HlTag::Symbol(SymbolKind::Local)), None),
     };
 
     let def_crate = def.krate(db);
@@ -674,6 +694,12 @@ pub(super) fn highlight_def(
 
     if is_from_builtin_crate {
         h |= HlMod::DefaultLibrary;
+    }
+
+    if let Some(attrs) = attrs
+        && attrs.by_key(sym::deprecated).exists()
+    {
+        h |= HlMod::Deprecated;
     }
 
     h
@@ -721,6 +747,7 @@ fn highlight_method_call(
     let is_from_other_crate = krate.as_ref().map_or(false, |krate| def_crate != *krate);
     let is_from_builtin_crate = def_crate.is_builtin(sema.db);
     let is_public = func.visibility(sema.db) == hir::Visibility::Public;
+    let is_deprecated = func.attrs(sema.db).by_key(sym::deprecated).exists();
 
     if is_from_other_crate {
         h |= HlMod::Library;
@@ -730,6 +757,10 @@ fn highlight_method_call(
 
     if is_from_builtin_crate {
         h |= HlMod::DefaultLibrary;
+    }
+
+    if is_deprecated {
+        h |= HlMod::Deprecated;
     }
 
     if let Some(self_param) = func.self_param(sema.db) {

--- a/crates/ide/src/syntax_highlighting/html.rs
+++ b/crates/ide/src/syntax_highlighting/html.rs
@@ -121,6 +121,7 @@ pre                 { color: #DCDCCC; background: #3F3F3F; font-size: 22px; padd
 .reference          { font-style: italic; font-weight: bold; }
 .const              { font-weight: bolder; }
 .unsafe             { color: #BC8383; }
+.deprecated         { text-decoration: line-through; }
 
 .invalid_escape_sequence { color: #FC5555; text-decoration: wavy underline; }
 .unresolved_reference    { color: #FC5555; text-decoration: wavy underline; }

--- a/crates/ide/src/syntax_highlighting/tags.rs
+++ b/crates/ide/src/syntax_highlighting/tags.rs
@@ -67,6 +67,8 @@ pub enum HlMod {
     /// `foo` in `fn foo(x: i32)` is a definition, `foo` in `foo(90 + 2)` is
     /// not.
     Definition,
+    /// Used for things with the `#[deprecated]` attribute.
+    Deprecated,
     /// Doc-strings like this one.
     Documentation,
     /// Highlighting injection like rust code in doc strings or ra_fixture.
@@ -224,6 +226,7 @@ impl HlMod {
         HlMod::CrateRoot,
         HlMod::DefaultLibrary,
         HlMod::Definition,
+        HlMod::Deprecated,
         HlMod::Documentation,
         HlMod::Injected,
         HlMod::IntraDocLink,
@@ -250,6 +253,7 @@ impl HlMod {
             HlMod::CrateRoot => "crate_root",
             HlMod::DefaultLibrary => "default_library",
             HlMod::Definition => "declaration",
+            HlMod::Deprecated => "deprecated",
             HlMod::Documentation => "documentation",
             HlMod::Injected => "injected",
             HlMod::IntraDocLink => "intra_doc_link",

--- a/crates/ide/src/syntax_highlighting/test_data/highlight_asm.html
+++ b/crates/ide/src/syntax_highlighting/test_data/highlight_asm.html
@@ -36,6 +36,7 @@ pre                 { color: #DCDCCC; background: #3F3F3F; font-size: 22px; padd
 .reference          { font-style: italic; font-weight: bold; }
 .const              { font-weight: bolder; }
 .unsafe             { color: #BC8383; }
+.deprecated         { text-decoration: line-through; }
 
 .invalid_escape_sequence { color: #FC5555; text-decoration: wavy underline; }
 .unresolved_reference    { color: #FC5555; text-decoration: wavy underline; }

--- a/crates/ide/src/syntax_highlighting/test_data/highlight_assoc_functions.html
+++ b/crates/ide/src/syntax_highlighting/test_data/highlight_assoc_functions.html
@@ -36,6 +36,7 @@ pre                 { color: #DCDCCC; background: #3F3F3F; font-size: 22px; padd
 .reference          { font-style: italic; font-weight: bold; }
 .const              { font-weight: bolder; }
 .unsafe             { color: #BC8383; }
+.deprecated         { text-decoration: line-through; }
 
 .invalid_escape_sequence { color: #FC5555; text-decoration: wavy underline; }
 .unresolved_reference    { color: #FC5555; text-decoration: wavy underline; }

--- a/crates/ide/src/syntax_highlighting/test_data/highlight_attributes.html
+++ b/crates/ide/src/syntax_highlighting/test_data/highlight_attributes.html
@@ -36,6 +36,7 @@ pre                 { color: #DCDCCC; background: #3F3F3F; font-size: 22px; padd
 .reference          { font-style: italic; font-weight: bold; }
 .const              { font-weight: bolder; }
 .unsafe             { color: #BC8383; }
+.deprecated         { text-decoration: line-through; }
 
 .invalid_escape_sequence { color: #FC5555; text-decoration: wavy underline; }
 .unresolved_reference    { color: #FC5555; text-decoration: wavy underline; }

--- a/crates/ide/src/syntax_highlighting/test_data/highlight_block_mod_items.html
+++ b/crates/ide/src/syntax_highlighting/test_data/highlight_block_mod_items.html
@@ -36,6 +36,7 @@ pre                 { color: #DCDCCC; background: #3F3F3F; font-size: 22px; padd
 .reference          { font-style: italic; font-weight: bold; }
 .const              { font-weight: bolder; }
 .unsafe             { color: #BC8383; }
+.deprecated         { text-decoration: line-through; }
 
 .invalid_escape_sequence { color: #FC5555; text-decoration: wavy underline; }
 .unresolved_reference    { color: #FC5555; text-decoration: wavy underline; }

--- a/crates/ide/src/syntax_highlighting/test_data/highlight_comments_disabled.html
+++ b/crates/ide/src/syntax_highlighting/test_data/highlight_comments_disabled.html
@@ -36,6 +36,7 @@ pre                 { color: #DCDCCC; background: #3F3F3F; font-size: 22px; padd
 .reference          { font-style: italic; font-weight: bold; }
 .const              { font-weight: bolder; }
 .unsafe             { color: #BC8383; }
+.deprecated         { text-decoration: line-through; }
 
 .invalid_escape_sequence { color: #FC5555; text-decoration: wavy underline; }
 .unresolved_reference    { color: #FC5555; text-decoration: wavy underline; }

--- a/crates/ide/src/syntax_highlighting/test_data/highlight_const.html
+++ b/crates/ide/src/syntax_highlighting/test_data/highlight_const.html
@@ -36,6 +36,7 @@ pre                 { color: #DCDCCC; background: #3F3F3F; font-size: 22px; padd
 .reference          { font-style: italic; font-weight: bold; }
 .const              { font-weight: bolder; }
 .unsafe             { color: #BC8383; }
+.deprecated         { text-decoration: line-through; }
 
 .invalid_escape_sequence { color: #FC5555; text-decoration: wavy underline; }
 .unresolved_reference    { color: #FC5555; text-decoration: wavy underline; }

--- a/crates/ide/src/syntax_highlighting/test_data/highlight_crate_root.html
+++ b/crates/ide/src/syntax_highlighting/test_data/highlight_crate_root.html
@@ -36,6 +36,7 @@ pre                 { color: #DCDCCC; background: #3F3F3F; font-size: 22px; padd
 .reference          { font-style: italic; font-weight: bold; }
 .const              { font-weight: bolder; }
 .unsafe             { color: #BC8383; }
+.deprecated         { text-decoration: line-through; }
 
 .invalid_escape_sequence { color: #FC5555; text-decoration: wavy underline; }
 .unresolved_reference    { color: #FC5555; text-decoration: wavy underline; }

--- a/crates/ide/src/syntax_highlighting/test_data/highlight_default_library.html
+++ b/crates/ide/src/syntax_highlighting/test_data/highlight_default_library.html
@@ -36,6 +36,7 @@ pre                 { color: #DCDCCC; background: #3F3F3F; font-size: 22px; padd
 .reference          { font-style: italic; font-weight: bold; }
 .const              { font-weight: bolder; }
 .unsafe             { color: #BC8383; }
+.deprecated         { text-decoration: line-through; }
 
 .invalid_escape_sequence { color: #FC5555; text-decoration: wavy underline; }
 .unresolved_reference    { color: #FC5555; text-decoration: wavy underline; }

--- a/crates/ide/src/syntax_highlighting/test_data/highlight_deprecated.html
+++ b/crates/ide/src/syntax_highlighting/test_data/highlight_deprecated.html
@@ -1,0 +1,71 @@
+
+<style>
+body                { margin: 0; }
+pre                 { color: #DCDCCC; background: #3F3F3F; font-size: 22px; padding: 0.4em; }
+
+.lifetime           { color: #DFAF8F; font-style: italic; }
+.label              { color: #DFAF8F; font-style: italic; }
+.comment            { color: #7F9F7F; }
+.documentation      { color: #629755; }
+.intra_doc_link     { font-style: italic; }
+.injected           { opacity: 0.65 ; }
+.struct, .enum      { color: #7CB8BB; }
+.enum_variant       { color: #BDE0F3; }
+.string_literal     { color: #CC9393; }
+.field              { color: #94BFF3; }
+.function           { color: #93E0E3; }
+.parameter          { color: #94BFF3; }
+.text               { color: #DCDCCC; }
+.type               { color: #7CB8BB; }
+.builtin_type       { color: #8CD0D3; }
+.type_param         { color: #DFAF8F; }
+.attribute          { color: #94BFF3; }
+.numeric_literal    { color: #BFEBBF; }
+.bool_literal       { color: #BFE6EB; }
+.macro              { color: #94BFF3; }
+.proc_macro         { color: #94BFF3; text-decoration: underline; }
+.derive             { color: #94BFF3; font-style: italic; }
+.module             { color: #AFD8AF; }
+.value_param        { color: #DCDCCC; }
+.variable           { color: #DCDCCC; }
+.format_specifier   { color: #CC696B; }
+.mutable            { text-decoration: underline; }
+.escape_sequence    { color: #94BFF3; }
+.keyword            { color: #F0DFAF; font-weight: bold; }
+.control            { font-style: italic; }
+.reference          { font-style: italic; font-weight: bold; }
+.const              { font-weight: bolder; }
+.unsafe             { color: #BC8383; }
+.deprecated         { text-decoration: line-through; }
+
+.invalid_escape_sequence { color: #FC5555; text-decoration: wavy underline; }
+.unresolved_reference    { color: #FC5555; text-decoration: wavy underline; }
+</style>
+<pre><code><span class="attribute_bracket attribute">#</span><span class="attribute_bracket attribute">!</span><span class="attribute_bracket attribute">[</span><span class="builtin_attr attribute">deprecated</span><span class="attribute_bracket attribute">]</span>
+<span class="keyword">use</span> <span class="keyword crate_root deprecated public">crate</span> <span class="keyword">as</span> <span class="punctuation">_</span><span class="semicolon">;</span>
+<span class="attribute_bracket attribute">#</span><span class="attribute_bracket attribute">[</span><span class="builtin_attr attribute">deprecated</span><span class="attribute_bracket attribute">]</span>
+<span class="keyword">macro_rules</span><span class="macro_bang">!</span> <span class="macro declaration deprecated public">macro_</span> <span class="brace">{</span>
+    <span class="parenthesis">(</span><span class="parenthesis">)</span> <span class="operator">=</span><span class="operator">&gt;</span> <span class="brace">{</span><span class="brace">}</span><span class="semicolon">;</span>
+<span class="brace">}</span>
+<span class="attribute_bracket attribute">#</span><span class="attribute_bracket attribute">[</span><span class="builtin_attr attribute">deprecated</span><span class="attribute_bracket attribute">]</span>
+<span class="keyword">mod</span> <span class="module declaration deprecated">mod_</span> <span class="brace">{</span><span class="brace">}</span>
+<span class="attribute_bracket attribute">#</span><span class="attribute_bracket attribute">[</span><span class="builtin_attr attribute">deprecated</span><span class="attribute_bracket attribute">]</span>
+<span class="keyword">fn</span> <span class="function declaration deprecated">func</span><span class="parenthesis">(</span><span class="parenthesis">)</span> <span class="brace">{</span><span class="brace">}</span>
+<span class="attribute_bracket attribute">#</span><span class="attribute_bracket attribute">[</span><span class="builtin_attr attribute">deprecated</span><span class="attribute_bracket attribute">]</span>
+<span class="keyword">struct</span> <span class="struct declaration deprecated">Struct</span> <span class="brace">{</span>
+    <span class="attribute_bracket attribute">#</span><span class="attribute_bracket attribute">[</span><span class="builtin_attr attribute">deprecated</span><span class="attribute_bracket attribute">]</span>
+    <span class="field declaration deprecated">field</span><span class="colon">:</span> <span class="builtin_type">u32</span>
+<span class="brace">}</span>
+<span class="attribute_bracket attribute">#</span><span class="attribute_bracket attribute">[</span><span class="builtin_attr attribute">deprecated</span><span class="attribute_bracket attribute">]</span>
+<span class="keyword">enum</span> <span class="enum declaration deprecated">Enum</span> <span class="brace">{</span>
+    <span class="attribute_bracket attribute">#</span><span class="attribute_bracket attribute">[</span><span class="builtin_attr attribute">deprecated</span><span class="attribute_bracket attribute">]</span>
+    <span class="enum_variant declaration deprecated">Variant</span>
+<span class="brace">}</span>
+<span class="attribute_bracket attribute">#</span><span class="attribute_bracket attribute">[</span><span class="builtin_attr attribute">deprecated</span><span class="attribute_bracket attribute">]</span>
+<span class="keyword const">const</span> <span class="constant const declaration deprecated">CONST</span><span class="colon">:</span> <span class="parenthesis">(</span><span class="parenthesis">)</span> <span class="operator">=</span> <span class="parenthesis">(</span><span class="parenthesis">)</span><span class="semicolon">;</span>
+<span class="attribute_bracket attribute">#</span><span class="attribute_bracket attribute">[</span><span class="builtin_attr attribute">deprecated</span><span class="attribute_bracket attribute">]</span>
+<span class="keyword">trait</span> <span class="trait declaration deprecated">Trait</span> <span class="brace">{</span><span class="brace">}</span>
+<span class="attribute_bracket attribute">#</span><span class="attribute_bracket attribute">[</span><span class="builtin_attr attribute">deprecated</span><span class="attribute_bracket attribute">]</span>
+<span class="keyword">type</span> <span class="type_alias declaration deprecated">Alias</span> <span class="operator">=</span> <span class="parenthesis">(</span><span class="parenthesis">)</span><span class="semicolon">;</span>
+<span class="attribute_bracket attribute">#</span><span class="attribute_bracket attribute">[</span><span class="builtin_attr attribute">deprecated</span><span class="attribute_bracket attribute">]</span>
+<span class="keyword">static</span> <span class="static declaration deprecated">STATIC</span><span class="colon">:</span> <span class="parenthesis">(</span><span class="parenthesis">)</span> <span class="operator">=</span> <span class="parenthesis">(</span><span class="parenthesis">)</span><span class="semicolon">;</span></code></pre>

--- a/crates/ide/src/syntax_highlighting/test_data/highlight_doctest.html
+++ b/crates/ide/src/syntax_highlighting/test_data/highlight_doctest.html
@@ -36,6 +36,7 @@ pre                 { color: #DCDCCC; background: #3F3F3F; font-size: 22px; padd
 .reference          { font-style: italic; font-weight: bold; }
 .const              { font-weight: bolder; }
 .unsafe             { color: #BC8383; }
+.deprecated         { text-decoration: line-through; }
 
 .invalid_escape_sequence { color: #FC5555; text-decoration: wavy underline; }
 .unresolved_reference    { color: #FC5555; text-decoration: wavy underline; }

--- a/crates/ide/src/syntax_highlighting/test_data/highlight_extern_crate.html
+++ b/crates/ide/src/syntax_highlighting/test_data/highlight_extern_crate.html
@@ -36,6 +36,7 @@ pre                 { color: #DCDCCC; background: #3F3F3F; font-size: 22px; padd
 .reference          { font-style: italic; font-weight: bold; }
 .const              { font-weight: bolder; }
 .unsafe             { color: #BC8383; }
+.deprecated         { text-decoration: line-through; }
 
 .invalid_escape_sequence { color: #FC5555; text-decoration: wavy underline; }
 .unresolved_reference    { color: #FC5555; text-decoration: wavy underline; }

--- a/crates/ide/src/syntax_highlighting/test_data/highlight_general.html
+++ b/crates/ide/src/syntax_highlighting/test_data/highlight_general.html
@@ -36,6 +36,7 @@ pre                 { color: #DCDCCC; background: #3F3F3F; font-size: 22px; padd
 .reference          { font-style: italic; font-weight: bold; }
 .const              { font-weight: bolder; }
 .unsafe             { color: #BC8383; }
+.deprecated         { text-decoration: line-through; }
 
 .invalid_escape_sequence { color: #FC5555; text-decoration: wavy underline; }
 .unresolved_reference    { color: #FC5555; text-decoration: wavy underline; }

--- a/crates/ide/src/syntax_highlighting/test_data/highlight_injection.html
+++ b/crates/ide/src/syntax_highlighting/test_data/highlight_injection.html
@@ -36,6 +36,7 @@ pre                 { color: #DCDCCC; background: #3F3F3F; font-size: 22px; padd
 .reference          { font-style: italic; font-weight: bold; }
 .const              { font-weight: bolder; }
 .unsafe             { color: #BC8383; }
+.deprecated         { text-decoration: line-through; }
 
 .invalid_escape_sequence { color: #FC5555; text-decoration: wavy underline; }
 .unresolved_reference    { color: #FC5555; text-decoration: wavy underline; }

--- a/crates/ide/src/syntax_highlighting/test_data/highlight_injection_2.html
+++ b/crates/ide/src/syntax_highlighting/test_data/highlight_injection_2.html
@@ -36,6 +36,7 @@ pre                 { color: #DCDCCC; background: #3F3F3F; font-size: 22px; padd
 .reference          { font-style: italic; font-weight: bold; }
 .const              { font-weight: bolder; }
 .unsafe             { color: #BC8383; }
+.deprecated         { text-decoration: line-through; }
 
 .invalid_escape_sequence { color: #FC5555; text-decoration: wavy underline; }
 .unresolved_reference    { color: #FC5555; text-decoration: wavy underline; }

--- a/crates/ide/src/syntax_highlighting/test_data/highlight_issue_18089.html
+++ b/crates/ide/src/syntax_highlighting/test_data/highlight_issue_18089.html
@@ -36,6 +36,7 @@ pre                 { color: #DCDCCC; background: #3F3F3F; font-size: 22px; padd
 .reference          { font-style: italic; font-weight: bold; }
 .const              { font-weight: bolder; }
 .unsafe             { color: #BC8383; }
+.deprecated         { text-decoration: line-through; }
 
 .invalid_escape_sequence { color: #FC5555; text-decoration: wavy underline; }
 .unresolved_reference    { color: #FC5555; text-decoration: wavy underline; }

--- a/crates/ide/src/syntax_highlighting/test_data/highlight_issue_19357.html
+++ b/crates/ide/src/syntax_highlighting/test_data/highlight_issue_19357.html
@@ -36,6 +36,7 @@ pre                 { color: #DCDCCC; background: #3F3F3F; font-size: 22px; padd
 .reference          { font-style: italic; font-weight: bold; }
 .const              { font-weight: bolder; }
 .unsafe             { color: #BC8383; }
+.deprecated         { text-decoration: line-through; }
 
 .invalid_escape_sequence { color: #FC5555; text-decoration: wavy underline; }
 .unresolved_reference    { color: #FC5555; text-decoration: wavy underline; }

--- a/crates/ide/src/syntax_highlighting/test_data/highlight_keywords_2015.html
+++ b/crates/ide/src/syntax_highlighting/test_data/highlight_keywords_2015.html
@@ -36,6 +36,7 @@ pre                 { color: #DCDCCC; background: #3F3F3F; font-size: 22px; padd
 .reference          { font-style: italic; font-weight: bold; }
 .const              { font-weight: bolder; }
 .unsafe             { color: #BC8383; }
+.deprecated         { text-decoration: line-through; }
 
 .invalid_escape_sequence { color: #FC5555; text-decoration: wavy underline; }
 .unresolved_reference    { color: #FC5555; text-decoration: wavy underline; }

--- a/crates/ide/src/syntax_highlighting/test_data/highlight_keywords_2018.html
+++ b/crates/ide/src/syntax_highlighting/test_data/highlight_keywords_2018.html
@@ -36,6 +36,7 @@ pre                 { color: #DCDCCC; background: #3F3F3F; font-size: 22px; padd
 .reference          { font-style: italic; font-weight: bold; }
 .const              { font-weight: bolder; }
 .unsafe             { color: #BC8383; }
+.deprecated         { text-decoration: line-through; }
 
 .invalid_escape_sequence { color: #FC5555; text-decoration: wavy underline; }
 .unresolved_reference    { color: #FC5555; text-decoration: wavy underline; }

--- a/crates/ide/src/syntax_highlighting/test_data/highlight_keywords_2021.html
+++ b/crates/ide/src/syntax_highlighting/test_data/highlight_keywords_2021.html
@@ -36,6 +36,7 @@ pre                 { color: #DCDCCC; background: #3F3F3F; font-size: 22px; padd
 .reference          { font-style: italic; font-weight: bold; }
 .const              { font-weight: bolder; }
 .unsafe             { color: #BC8383; }
+.deprecated         { text-decoration: line-through; }
 
 .invalid_escape_sequence { color: #FC5555; text-decoration: wavy underline; }
 .unresolved_reference    { color: #FC5555; text-decoration: wavy underline; }

--- a/crates/ide/src/syntax_highlighting/test_data/highlight_keywords_2024.html
+++ b/crates/ide/src/syntax_highlighting/test_data/highlight_keywords_2024.html
@@ -36,6 +36,7 @@ pre                 { color: #DCDCCC; background: #3F3F3F; font-size: 22px; padd
 .reference          { font-style: italic; font-weight: bold; }
 .const              { font-weight: bolder; }
 .unsafe             { color: #BC8383; }
+.deprecated         { text-decoration: line-through; }
 
 .invalid_escape_sequence { color: #FC5555; text-decoration: wavy underline; }
 .unresolved_reference    { color: #FC5555; text-decoration: wavy underline; }

--- a/crates/ide/src/syntax_highlighting/test_data/highlight_keywords_macros.html
+++ b/crates/ide/src/syntax_highlighting/test_data/highlight_keywords_macros.html
@@ -36,6 +36,7 @@ pre                 { color: #DCDCCC; background: #3F3F3F; font-size: 22px; padd
 .reference          { font-style: italic; font-weight: bold; }
 .const              { font-weight: bolder; }
 .unsafe             { color: #BC8383; }
+.deprecated         { text-decoration: line-through; }
 
 .invalid_escape_sequence { color: #FC5555; text-decoration: wavy underline; }
 .unresolved_reference    { color: #FC5555; text-decoration: wavy underline; }

--- a/crates/ide/src/syntax_highlighting/test_data/highlight_lifetimes.html
+++ b/crates/ide/src/syntax_highlighting/test_data/highlight_lifetimes.html
@@ -36,6 +36,7 @@ pre                 { color: #DCDCCC; background: #3F3F3F; font-size: 22px; padd
 .reference          { font-style: italic; font-weight: bold; }
 .const              { font-weight: bolder; }
 .unsafe             { color: #BC8383; }
+.deprecated         { text-decoration: line-through; }
 
 .invalid_escape_sequence { color: #FC5555; text-decoration: wavy underline; }
 .unresolved_reference    { color: #FC5555; text-decoration: wavy underline; }

--- a/crates/ide/src/syntax_highlighting/test_data/highlight_macros.html
+++ b/crates/ide/src/syntax_highlighting/test_data/highlight_macros.html
@@ -36,6 +36,7 @@ pre                 { color: #DCDCCC; background: #3F3F3F; font-size: 22px; padd
 .reference          { font-style: italic; font-weight: bold; }
 .const              { font-weight: bolder; }
 .unsafe             { color: #BC8383; }
+.deprecated         { text-decoration: line-through; }
 
 .invalid_escape_sequence { color: #FC5555; text-decoration: wavy underline; }
 .unresolved_reference    { color: #FC5555; text-decoration: wavy underline; }

--- a/crates/ide/src/syntax_highlighting/test_data/highlight_module_docs_inline.html
+++ b/crates/ide/src/syntax_highlighting/test_data/highlight_module_docs_inline.html
@@ -36,6 +36,7 @@ pre                 { color: #DCDCCC; background: #3F3F3F; font-size: 22px; padd
 .reference          { font-style: italic; font-weight: bold; }
 .const              { font-weight: bolder; }
 .unsafe             { color: #BC8383; }
+.deprecated         { text-decoration: line-through; }
 
 .invalid_escape_sequence { color: #FC5555; text-decoration: wavy underline; }
 .unresolved_reference    { color: #FC5555; text-decoration: wavy underline; }

--- a/crates/ide/src/syntax_highlighting/test_data/highlight_module_docs_outline.html
+++ b/crates/ide/src/syntax_highlighting/test_data/highlight_module_docs_outline.html
@@ -36,6 +36,7 @@ pre                 { color: #DCDCCC; background: #3F3F3F; font-size: 22px; padd
 .reference          { font-style: italic; font-weight: bold; }
 .const              { font-weight: bolder; }
 .unsafe             { color: #BC8383; }
+.deprecated         { text-decoration: line-through; }
 
 .invalid_escape_sequence { color: #FC5555; text-decoration: wavy underline; }
 .unresolved_reference    { color: #FC5555; text-decoration: wavy underline; }

--- a/crates/ide/src/syntax_highlighting/test_data/highlight_operators.html
+++ b/crates/ide/src/syntax_highlighting/test_data/highlight_operators.html
@@ -36,6 +36,7 @@ pre                 { color: #DCDCCC; background: #3F3F3F; font-size: 22px; padd
 .reference          { font-style: italic; font-weight: bold; }
 .const              { font-weight: bolder; }
 .unsafe             { color: #BC8383; }
+.deprecated         { text-decoration: line-through; }
 
 .invalid_escape_sequence { color: #FC5555; text-decoration: wavy underline; }
 .unresolved_reference    { color: #FC5555; text-decoration: wavy underline; }

--- a/crates/ide/src/syntax_highlighting/test_data/highlight_rainbow.html
+++ b/crates/ide/src/syntax_highlighting/test_data/highlight_rainbow.html
@@ -36,6 +36,7 @@ pre                 { color: #DCDCCC; background: #3F3F3F; font-size: 22px; padd
 .reference          { font-style: italic; font-weight: bold; }
 .const              { font-weight: bolder; }
 .unsafe             { color: #BC8383; }
+.deprecated         { text-decoration: line-through; }
 
 .invalid_escape_sequence { color: #FC5555; text-decoration: wavy underline; }
 .unresolved_reference    { color: #FC5555; text-decoration: wavy underline; }

--- a/crates/ide/src/syntax_highlighting/test_data/highlight_strings.html
+++ b/crates/ide/src/syntax_highlighting/test_data/highlight_strings.html
@@ -36,6 +36,7 @@ pre                 { color: #DCDCCC; background: #3F3F3F; font-size: 22px; padd
 .reference          { font-style: italic; font-weight: bold; }
 .const              { font-weight: bolder; }
 .unsafe             { color: #BC8383; }
+.deprecated         { text-decoration: line-through; }
 
 .invalid_escape_sequence { color: #FC5555; text-decoration: wavy underline; }
 .unresolved_reference    { color: #FC5555; text-decoration: wavy underline; }

--- a/crates/ide/src/syntax_highlighting/test_data/highlight_unsafe.html
+++ b/crates/ide/src/syntax_highlighting/test_data/highlight_unsafe.html
@@ -36,6 +36,7 @@ pre                 { color: #DCDCCC; background: #3F3F3F; font-size: 22px; padd
 .reference          { font-style: italic; font-weight: bold; }
 .const              { font-weight: bolder; }
 .unsafe             { color: #BC8383; }
+.deprecated         { text-decoration: line-through; }
 
 .invalid_escape_sequence { color: #FC5555; text-decoration: wavy underline; }
 .unresolved_reference    { color: #FC5555; text-decoration: wavy underline; }

--- a/crates/ide/src/syntax_highlighting/test_data/regression_20952.html
+++ b/crates/ide/src/syntax_highlighting/test_data/regression_20952.html
@@ -36,6 +36,7 @@ pre                 { color: #DCDCCC; background: #3F3F3F; font-size: 22px; padd
 .reference          { font-style: italic; font-weight: bold; }
 .const              { font-weight: bolder; }
 .unsafe             { color: #BC8383; }
+.deprecated         { text-decoration: line-through; }
 
 .invalid_escape_sequence { color: #FC5555; text-decoration: wavy underline; }
 .unresolved_reference    { color: #FC5555; text-decoration: wavy underline; }

--- a/crates/ide/src/syntax_highlighting/tests.rs
+++ b/crates/ide/src/syntax_highlighting/tests.rs
@@ -1511,3 +1511,41 @@ fn main() {
         false,
     );
 }
+
+#[test]
+fn test_deprecated_highlighting() {
+    check_highlighting(
+        r#"
+#![deprecated]
+use crate as _;
+#[deprecated]
+macro_rules! macro_ {
+    () => {};
+}
+#[deprecated]
+mod mod_ {}
+#[deprecated]
+fn func() {}
+#[deprecated]
+struct Struct {
+    #[deprecated]
+    field: u32
+}
+#[deprecated]
+enum Enum {
+    #[deprecated]
+    Variant
+}
+#[deprecated]
+const CONST: () = ();
+#[deprecated]
+trait Trait {}
+#[deprecated]
+type Alias = ();
+#[deprecated]
+static STATIC: () = ();
+        "#,
+        expect_file!["./test_data/highlight_deprecated.html"],
+        false,
+    );
+}

--- a/crates/rust-analyzer/src/lsp/semantic_tokens.rs
+++ b/crates/rust-analyzer/src/lsp/semantic_tokens.rs
@@ -143,6 +143,7 @@ define_semantic_token_modifiers![
         DECLARATION,
         STATIC,
         DEFAULT_LIBRARY,
+        DEPRECATED,
     }
     custom {
         (ASSOCIATED, "associated"),

--- a/crates/rust-analyzer/src/lsp/to_proto.rs
+++ b/crates/rust-analyzer/src/lsp/to_proto.rs
@@ -882,6 +882,7 @@ fn semantic_token_type_and_modifiers(
             HlMod::ControlFlow => mods::CONTROL_FLOW,
             HlMod::CrateRoot => mods::CRATE_ROOT,
             HlMod::DefaultLibrary => mods::DEFAULT_LIBRARY,
+            HlMod::Deprecated => mods::DEPRECATED,
             HlMod::Definition => mods::DECLARATION,
             HlMod::Documentation => mods::DOCUMENTATION,
             HlMod::Injected => mods::INJECTED,


### PR DESCRIPTION
this lets things be rendered with a strikethrough without needing any diagnostics
<img width="141" height="148" alt="image" src="https://github.com/user-attachments/assets/7b0e6c10-670f-43c2-9a2a-763b6a8d47f9" />

it can be set in vscode settings like so
```
    "editor.semanticTokenColorCustomizations": {
        "rules": {
            "*.deprecated": { "fontStyle": "strikethrough" }
        }
    },
```