### PR TITLE
fix: no unused `tracing/attributes` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -156,7 +156,7 @@ smol_str = "0.3.2"
 temp-dir = "0.1.16"
 text-size = "1.1.1"
 toml = "0.9.8"
-tracing = "0.1.41"
+tracing = { version = "0.1.41", default-features = false, features = ["std"] }
 tracing-tree = "0.4.0"
 tracing-subscriber = { version = "0.3.20", default-features = false, features = [
     "registry",

--- a/crates/hir-def/Cargo.toml
+++ b/crates/hir-def/Cargo.toml
@@ -23,7 +23,7 @@ indexmap.workspace = true
 itertools.workspace = true
 la-arena.workspace = true
 rustc-hash.workspace = true
-tracing.workspace = true
+tracing = { workspace = true, features = ["attributes"] }
 smallvec.workspace = true
 triomphe.workspace = true
 rustc_apfloat = "0.2.3"

--- a/crates/hir-ty/Cargo.toml
+++ b/crates/hir-ty/Cargo.toml
@@ -21,7 +21,7 @@ smallvec.workspace = true
 ena = "0.14.3"
 either.workspace = true
 oorandom = "11.1.5"
-tracing.workspace = true
+tracing = { workspace = true, features = ["attributes"] }
 rustc-hash.workspace = true
 scoped-tls = "1.0.1"
 la-arena.workspace = true

--- a/crates/hir/Cargo.toml
+++ b/crates/hir/Cargo.toml
@@ -18,7 +18,7 @@ either.workspace = true
 arrayvec.workspace = true
 itertools.workspace = true
 smallvec.workspace = true
-tracing.workspace = true
+tracing = { workspace = true, features = ["attributes"] }
 triomphe.workspace = true
 indexmap.workspace = true
 

--- a/crates/ide-assists/Cargo.toml
+++ b/crates/ide-assists/Cargo.toml
@@ -18,7 +18,7 @@ cov-mark = "2.0.0"
 itertools.workspace = true
 either.workspace = true
 smallvec.workspace = true
-tracing.workspace = true
+tracing = { workspace = true, features = ["attributes"] }
 
 # local deps
 stdx.workspace = true

--- a/crates/ide-db/Cargo.toml
+++ b/crates/ide-db/Cargo.toml
@@ -15,7 +15,7 @@ doctest = false
 [dependencies]
 cov-mark = "2.0.0"
 crossbeam-channel.workspace = true
-tracing.workspace = true
+tracing = { workspace = true, features = ["attributes"] }
 rayon.workspace = true
 fst = { version = "0.4.7", default-features = false }
 rustc-hash.workspace = true

--- a/crates/parser/Cargo.toml
+++ b/crates/parser/Cargo.toml
@@ -16,7 +16,7 @@ doctest = false
 drop_bomb = "0.1.5"
 ra-ap-rustc_lexer.workspace = true
 rustc-literal-escaper.workspace = true
-tracing = { workspace = true, optional = true }
+tracing.workspace = true
 
 edition.workspace = true
 winnow = { version = "0.7.13", default-features = false }
@@ -27,7 +27,7 @@ expect-test = "1.5.1"
 stdx.workspace = true
 
 [features]
-default = ["tracing"]
+default = []
 in-rust-tree = []
 
 [lints]

--- a/crates/project-model/Cargo.toml
+++ b/crates/project-model/Cargo.toml
@@ -22,7 +22,7 @@ serde.workspace = true
 serde_derive.workspace = true
 temp-dir.workspace = true
 toml.workspace = true
-tracing.workspace = true
+tracing = { workspace = true, features = ["attributes"] }
 triomphe.workspace = true
 la-arena.workspace = true
 itertools.workspace = true


### PR DESCRIPTION
- Discussed in https://github.com/rust-lang/rust-analyzer/issues/21107
- Avoids activating an `attributes` feature to crates that do not use it
- Updates the 6 crates that use attributes feature to specify it in
  their Cargo.toml: {hir,hir-def,hir-ty,ide-assists,ide-db,project-model}
- Removes the `tracing` (implicitly `dep:tracing`) dependency from the parser crate `default` feature group (which now leaves it empty)