### PR TITLE
internal: Upgrade rustc crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2025,9 +2025,9 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "ra-ap-rustc_abi"
-version = "0.137.0"
+version = "0.139.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4ce5c9ea794353e02beae390c4674f74ffb23a2ad9de763469fdcef5c1026ef"
+checksum = "ce480c45c05462cf6b700468118201b00132613a968a1849da5f7a555c0f1db9"
 dependencies = [
  "bitflags 2.9.4",
  "ra-ap-rustc_hashes",
@@ -2037,24 +2037,24 @@ dependencies = [
 
 [[package]]
 name = "ra-ap-rustc_ast_ir"
-version = "0.137.0"
+version = "0.139.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1696b77af9bbfe1fcc7a09c907561061c6ef4c8bd6d5f1675b927bc62d349103"
+checksum = "453da2376de406d740ca28412a31ae3d5a6039cd45698c1c2fb01b577dff64ae"
 
 [[package]]
 name = "ra-ap-rustc_hashes"
-version = "0.137.0"
+version = "0.139.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c055d8b0d8a592d8cf9547495189f52c1ee5c691d28df1628253a816214e8521"
+checksum = "bf411a55deaa3ea348594c8273fb2d1200265bf87b881b40c62b32f75caf8323"
 dependencies = [
  "rustc-stable-hash",
 ]
 
 [[package]]
 name = "ra-ap-rustc_index"
-version = "0.137.0"
+version = "0.139.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a08a03e3d4a452144b68f48130eda3a2894d4d79e99ddb44bdb4e0ab8c384e10"
+checksum = "1d0dd4cf1417ea8a809e9e7bf296c6ce6e05b75b043483872d1bd2951a08142c"
 dependencies = [
  "ra-ap-rustc_index_macros",
  "smallvec",
@@ -2062,9 +2062,9 @@ dependencies = [
 
 [[package]]
 name = "ra-ap-rustc_index_macros"
-version = "0.137.0"
+version = "0.139.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1e0446b4d65a8ce19d8fd12826c4bf2365ffa4b8fe0ee94daf5968fe36e920c"
+checksum = "a1b0d218fb91f8969716a962142c722d88b3cd3fd1f7ef03093261bf37e85dfd"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2073,9 +2073,9 @@ dependencies = [
 
 [[package]]
 name = "ra-ap-rustc_lexer"
-version = "0.137.0"
+version = "0.139.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac80365383a3c749f38af567fdcfaeff3fa6ea5df3846852abbce73e943921b9"
+checksum = "5ec7c26e92c44d5433b29cf661faf0027e263b70a411d0f28996bd67e3bdb57e"
 dependencies = [
  "memchr",
  "unicode-properties",
@@ -2084,9 +2084,9 @@ dependencies = [
 
 [[package]]
 name = "ra-ap-rustc_next_trait_solver"
-version = "0.137.0"
+version = "0.139.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a39b419d2d6f7fdec7e0981b7fb7d5beb5dda7140064f1199704ec9dadbb6f73"
+checksum = "029686fdbc8a058cf3d81ad157e1cdc81a37b9de0400289ccb86a62465484313"
 dependencies = [
  "derive-where",
  "ra-ap-rustc_index",
@@ -2097,9 +2097,9 @@ dependencies = [
 
 [[package]]
 name = "ra-ap-rustc_parse_format"
-version = "0.137.0"
+version = "0.139.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b743b0c8f795842e41b1720bbc5af6e896129fb9acf04e9785774bfb0dc5947c"
+checksum = "509d279f1e87acc33476da3fbd05a6054e9ffeb4427cb38ba01b9d2656aec268"
 dependencies = [
  "ra-ap-rustc_lexer",
  "rustc-literal-escaper 0.0.5",
@@ -2107,9 +2107,9 @@ dependencies = [
 
 [[package]]
 name = "ra-ap-rustc_pattern_analysis"
-version = "0.137.0"
+version = "0.139.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf944dce80137195528f89a576f70153c2060a6f8ca49c3fa9f55f9da14ab937"
+checksum = "9bb2c9930854314b03bd7aab060a14bca6f194b76381a4c309e3905ec3a02bbc"
 dependencies = [
  "ra-ap-rustc_index",
  "rustc-hash 2.1.1",
@@ -2120,9 +2120,9 @@ dependencies = [
 
 [[package]]
 name = "ra-ap-rustc_type_ir"
-version = "0.137.0"
+version = "0.139.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfe2722b20bc889a9d7711bd3a1f4f7b082940491241615aa643c17e0deffec"
+checksum = "0e4a92a3e4dbdebb0d4c9caceb52eff45c4df784d21fb2da90dac50e218f95c0"
 dependencies = [
  "arrayvec",
  "bitflags 2.9.4",
@@ -2140,9 +2140,9 @@ dependencies = [
 
 [[package]]
 name = "ra-ap-rustc_type_ir_macros"
-version = "0.137.0"
+version = "0.139.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fad1527df26aaa77367393fae86f42818b33e02b3737a19f3846d1c7671e7f9"
+checksum = "ca368eca2472367f2e6fdfb431c8342e99d848e4ce89cb20dd3b3bdcc43cbc28"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,14 +86,14 @@ vfs-notify = { path = "./crates/vfs-notify", version = "0.0.0" }
 vfs = { path = "./crates/vfs", version = "0.0.0" }
 edition = { path = "./crates/edition", version = "0.0.0" }
 
-ra-ap-rustc_lexer = { version = "0.137", default-features = false }
-ra-ap-rustc_parse_format = { version = "0.137", default-features = false }
-ra-ap-rustc_index = { version = "0.137", default-features = false }
-ra-ap-rustc_abi = { version = "0.137", default-features = false }
-ra-ap-rustc_pattern_analysis = { version = "0.137", default-features = false }
-ra-ap-rustc_ast_ir = { version = "0.137", default-features = false }
-ra-ap-rustc_type_ir = { version = "0.137", default-features = false }
-ra-ap-rustc_next_trait_solver = { version = "0.137", default-features = false }
+ra-ap-rustc_lexer = { version = "0.139", default-features = false }
+ra-ap-rustc_parse_format = { version = "0.139", default-features = false }
+ra-ap-rustc_index = { version = "0.139", default-features = false }
+ra-ap-rustc_abi = { version = "0.139", default-features = false }
+ra-ap-rustc_pattern_analysis = { version = "0.139", default-features = false }
+ra-ap-rustc_ast_ir = { version = "0.139", default-features = false }
+ra-ap-rustc_type_ir = { version = "0.139", default-features = false }
+ra-ap-rustc_next_trait_solver = { version = "0.139", default-features = false }
 
 # local crates that aren't published to crates.io. These should not have versions.
 

--- a/crates/hir-ty/src/display.rs
+++ b/crates/hir-ty/src/display.rs
@@ -10,8 +10,7 @@ use std::{
 use base_db::Crate;
 use either::Either;
 use hir_def::{
-    FindPathConfig, GeneralConstId, GenericDefId, HasModule, LocalFieldId, Lookup, ModuleDefId,
-    ModuleId, TraitId,
+    FindPathConfig, GenericDefId, HasModule, LocalFieldId, Lookup, ModuleDefId, ModuleId, TraitId,
     db::DefDatabase,
     expr_store::{ExpressionStore, path::Path},
     find_path::{self, PrefixKind},
@@ -700,11 +699,7 @@ impl<'db> HirDisplay<'db> for Const<'db> {
                 const_bytes.ty,
             ),
             ConstKind::Unevaluated(unev) => {
-                let c = match unev.def {
-                    SolverDefId::ConstId(id) => GeneralConstId::ConstId(id),
-                    SolverDefId::StaticId(id) => GeneralConstId::StaticId(id),
-                    _ => unreachable!(),
-                };
+                let c = unev.def.0;
                 write!(f, "{}", c.name(f.db))?;
                 hir_fmt_generics(f, unev.args.as_slice(), c.generic_def(f.db), None)?;
                 Ok(())

--- a/crates/hir-ty/src/lower.rs
+++ b/crates/hir-ty/src/lower.rs
@@ -15,9 +15,9 @@ use base_db::Crate;
 use either::Either;
 use hir_def::{
     AdtId, AssocItemId, CallableDefId, ConstId, ConstParamId, DefWithBodyId, EnumId, EnumVariantId,
-    FunctionId, GenericDefId, GenericParamId, HasModule, ImplId, ItemContainerId, LifetimeParamId,
-    LocalFieldId, Lookup, StaticId, StructId, TypeAliasId, TypeOrConstParamId, TypeParamId,
-    UnionId, VariantId,
+    FunctionId, GeneralConstId, GenericDefId, GenericParamId, HasModule, ImplId, ItemContainerId,
+    LifetimeParamId, LocalFieldId, Lookup, StaticId, StructId, TypeAliasId, TypeOrConstParamId,
+    TypeParamId, UnionId, VariantId,
     builtin_type::BuiltinType,
     expr_store::{ExpressionStore, HygieneId, path::Path},
     hir::generics::{
@@ -335,7 +335,7 @@ impl<'db, 'a> TyLoweringContext<'db, 'a> {
                 Some(Const::new(
                     self.interner,
                     rustc_type_ir::ConstKind::Unevaluated(UnevaluatedConst::new(
-                        SolverDefId::ConstId(c),
+                        GeneralConstId::ConstId(c).into(),
                         args,
                     )),
                 ))

--- a/crates/hir-ty/src/mir/eval.rs
+++ b/crates/hir-ty/src/mir/eval.rs
@@ -42,8 +42,8 @@ use crate::{
     layout::{Layout, LayoutError, RustcEnumVariantIdx},
     method_resolution::{is_dyn_method, lookup_impl_const},
     next_solver::{
-        Const, ConstBytes, ConstKind, DbInterner, ErrorGuaranteed, GenericArgs, Region,
-        SolverDefId, Ty, TyKind, TypingMode, UnevaluatedConst, ValueConst,
+        Const, ConstBytes, ConstKind, DbInterner, ErrorGuaranteed, GenericArgs, Region, Ty, TyKind,
+        TypingMode, UnevaluatedConst, ValueConst,
         infer::{DbInternerInferExt, InferCtxt, traits::ObligationCause},
         obligation_ctxt::ObligationCtxt,
     },
@@ -1917,11 +1917,7 @@ impl<'db> Evaluator<'db> {
         let value = match konst.kind() {
             ConstKind::Value(value) => value,
             ConstKind::Unevaluated(UnevaluatedConst { def: const_id, args: subst }) => 'b: {
-                let mut id = match const_id {
-                    SolverDefId::ConstId(it) => GeneralConstId::from(it),
-                    SolverDefId::StaticId(it) => it.into(),
-                    _ => unreachable!("unevaluated consts should be consts or statics"),
-                };
+                let mut id = const_id.0;
                 let mut subst = subst;
                 if let hir_def::GeneralConstId::ConstId(c) = id {
                     let (c, s) = lookup_impl_const(&self.infcx, self.trait_env.clone(), c, subst);

--- a/crates/hir-ty/src/next_solver/def_id.rs
+++ b/crates/hir-ty/src/next_solver/def_id.rs
@@ -335,6 +335,55 @@ declare_id_wrapper!(AdtIdWrapper, AdtId);
 declare_id_wrapper!(ImplIdWrapper, ImplId);
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
+pub struct GeneralConstIdWrapper(pub GeneralConstId);
+
+impl std::fmt::Debug for GeneralConstIdWrapper {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Debug::fmt(&self.0, f)
+    }
+}
+impl From<GeneralConstIdWrapper> for GeneralConstId {
+    #[inline]
+    fn from(value: GeneralConstIdWrapper) -> GeneralConstId {
+        value.0
+    }
+}
+impl From<GeneralConstId> for GeneralConstIdWrapper {
+    #[inline]
+    fn from(value: GeneralConstId) -> GeneralConstIdWrapper {
+        Self(value)
+    }
+}
+impl From<GeneralConstIdWrapper> for SolverDefId {
+    #[inline]
+    fn from(value: GeneralConstIdWrapper) -> SolverDefId {
+        match value.0 {
+            GeneralConstId::ConstId(id) => SolverDefId::ConstId(id),
+            GeneralConstId::StaticId(id) => SolverDefId::StaticId(id),
+        }
+    }
+}
+impl TryFrom<SolverDefId> for GeneralConstIdWrapper {
+    type Error = ();
+    #[inline]
+    fn try_from(value: SolverDefId) -> Result<Self, Self::Error> {
+        match value {
+            SolverDefId::ConstId(it) => Ok(Self(it.into())),
+            SolverDefId::StaticId(it) => Ok(Self(it.into())),
+            _ => Err(()),
+        }
+    }
+}
+impl<'db> inherent::DefId<DbInterner<'db>> for GeneralConstIdWrapper {
+    fn as_local(self) -> Option<SolverDefId> {
+        Some(self.into())
+    }
+    fn is_local(self) -> bool {
+        true
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
 pub struct CallableIdWrapper(pub CallableDefId);
 
 impl std::fmt::Debug for CallableIdWrapper {

--- a/crates/hir-ty/src/next_solver/solver.rs
+++ b/crates/hir-ty/src/next_solver/solver.rs
@@ -1,6 +1,6 @@
 //! Defining `SolverContext` for next-trait-solver.
 
-use hir_def::AssocItemId;
+use hir_def::{AssocItemId, GeneralConstId};
 use rustc_next_trait_solver::delegate::SolverDelegate;
 use rustc_type_ir::{
     AliasTyKind, GenericArgKind, InferCtxtLike, Interner, PredicatePolarity, TypeFlags,
@@ -233,17 +233,16 @@ impl<'db> SolverDelegate for SolverContext<'db> {
         _param_env: ParamEnv<'db>,
         uv: rustc_type_ir::UnevaluatedConst<Self::Interner>,
     ) -> Option<<Self::Interner as rustc_type_ir::Interner>::Const> {
-        match uv.def {
-            SolverDefId::ConstId(c) => {
+        match uv.def.0 {
+            GeneralConstId::ConstId(c) => {
                 let subst = uv.args;
                 let ec = self.cx().db.const_eval(c, subst, None).ok()?;
                 Some(ec)
             }
-            SolverDefId::StaticId(c) => {
+            GeneralConstId::StaticId(c) => {
                 let ec = self.cx().db.const_eval_static(c).ok()?;
                 Some(ec)
             }
-            _ => unreachable!(),
         }
     }
 


### PR DESCRIPTION
Major changes:

 - `GoalSource::InstantiateHigherRanked` was removed.
 - `Interner::UnevaluatedConstId` was introduced, allowing further simplifications due to better typing. Generally we don't represent unevaluated consts like we should, but it's still better.
 - `PatternKind::NotNull` was introduced.