### PR TITLE
minor: add deprecated semantic token for extern crate shorthand

### DIFF
--- a/crates/ide/src/syntax_highlighting/highlight.rs
+++ b/crates/ide/src/syntax_highlighting/highlight.rs
@@ -413,6 +413,10 @@ fn highlight_name_ref(
             if is_from_builtin_crate {
                 h |= HlMod::DefaultLibrary;
             }
+            let is_deprecated = resolved_krate.attrs(sema.db).by_key(sym::deprecated).exists();
+            if is_deprecated {
+                h |= HlMod::Deprecated;
+            }
             h |= HlMod::CrateRoot;
             h
         }

--- a/crates/ide/src/syntax_highlighting/test_data/highlight_deprecated.html
+++ b/crates/ide/src/syntax_highlighting/test_data/highlight_deprecated.html
@@ -43,6 +43,7 @@ pre                 { color: #DCDCCC; background: #3F3F3F; font-size: 22px; padd
 </style>
 <pre><code><span class="attribute_bracket attribute">#</span><span class="attribute_bracket attribute">!</span><span class="attribute_bracket attribute">[</span><span class="builtin_attr attribute">deprecated</span><span class="attribute_bracket attribute">]</span>
 <span class="keyword">use</span> <span class="keyword crate_root deprecated public">crate</span> <span class="keyword">as</span> <span class="punctuation">_</span><span class="semicolon">;</span>
+<span class="keyword">extern</span> <span class="keyword">crate</span> <span class="module crate_root deprecated library">bar</span><span class="semicolon">;</span>
 <span class="attribute_bracket attribute">#</span><span class="attribute_bracket attribute">[</span><span class="builtin_attr attribute">deprecated</span><span class="attribute_bracket attribute">]</span>
 <span class="keyword">macro_rules</span><span class="macro_bang">!</span> <span class="macro declaration deprecated public">macro_</span> <span class="brace">{</span>
     <span class="parenthesis">(</span><span class="parenthesis">)</span> <span class="operator">=</span><span class="operator">&gt;</span> <span class="brace">{</span><span class="brace">}</span><span class="semicolon">;</span>
@@ -68,4 +69,5 @@ pre                 { color: #DCDCCC; background: #3F3F3F; font-size: 22px; padd
 <span class="attribute_bracket attribute">#</span><span class="attribute_bracket attribute">[</span><span class="builtin_attr attribute">deprecated</span><span class="attribute_bracket attribute">]</span>
 <span class="keyword">type</span> <span class="type_alias declaration deprecated">Alias</span> <span class="operator">=</span> <span class="parenthesis">(</span><span class="parenthesis">)</span><span class="semicolon">;</span>
 <span class="attribute_bracket attribute">#</span><span class="attribute_bracket attribute">[</span><span class="builtin_attr attribute">deprecated</span><span class="attribute_bracket attribute">]</span>
-<span class="keyword">static</span> <span class="static declaration deprecated">STATIC</span><span class="colon">:</span> <span class="parenthesis">(</span><span class="parenthesis">)</span> <span class="operator">=</span> <span class="parenthesis">(</span><span class="parenthesis">)</span><span class="semicolon">;</span></code></pre>
+<span class="keyword">static</span> <span class="static declaration deprecated">STATIC</span><span class="colon">:</span> <span class="parenthesis">(</span><span class="parenthesis">)</span> <span class="operator">=</span> <span class="parenthesis">(</span><span class="parenthesis">)</span><span class="semicolon">;</span>
+</code></pre>

--- a/crates/ide/src/syntax_highlighting/tests.rs
+++ b/crates/ide/src/syntax_highlighting/tests.rs
@@ -1516,8 +1516,10 @@ fn main() {
 fn test_deprecated_highlighting() {
     check_highlighting(
         r#"
+//- /foo.rs crate:foo deps:bar
 #![deprecated]
 use crate as _;
+extern crate bar;
 #[deprecated]
 macro_rules! macro_ {
     () => {};
@@ -1544,6 +1546,8 @@ trait Trait {}
 type Alias = ();
 #[deprecated]
 static STATIC: () = ();
+//- /bar.rs crate:bar
+#![deprecated]
         "#,
         expect_file!["./test_data/highlight_deprecated.html"],
         false,


### PR DESCRIPTION
very minor but i missed it in rust-lang/rust-analyzer#21100
did i get everything now? :smile: 