### PR TITLE
Add ide-assist: unmerge_to_guarded_arm

### DIFF
--- a/crates/ide-assists/src/lib.rs
+++ b/crates/ide-assists/src/lib.rs
@@ -376,6 +376,7 @@ mod handlers {
             toggle_ignore::toggle_ignore,
             toggle_macro_delimiter::toggle_macro_delimiter,
             unmerge_match_arm::unmerge_match_arm,
+            unmerge_match_arm::unmerge_to_guarded_arm,
             unmerge_imports::unmerge_imports,
             unnecessary_async::unnecessary_async,
             unqualify_method_call::unqualify_method_call,

--- a/crates/ide-assists/src/tests/generated.rs
+++ b/crates/ide-assists/src/tests/generated.rs
@@ -3654,6 +3654,32 @@ fn handle(action: Action) {
 }
 
 #[test]
+fn doctest_unmerge_to_guarded_arm() {
+    check_doc_test(
+        "unmerge_to_guarded_arm",
+        r#####"
+enum Kind { Num(u32) }
+
+fn handle(kind: Kind) {
+    match kind {
+        Kind::Num(n) $0=> foo(n),
+    }
+}
+"#####,
+        r#####"
+enum Kind { Num(u32) }
+
+fn handle(kind: Kind) {
+    match kind {
+        Kind::Num(n) if $0 => foo(n),
+        Kind::Num(n) => foo(n),
+    }
+}
+"#####,
+    )
+}
+
+#[test]
 fn doctest_unnecessary_async() {
     check_doc_test(
         "unnecessary_async",

--- a/crates/syntax/src/ast/make.rs
+++ b/crates/syntax/src/ast/make.rs
@@ -1355,7 +1355,7 @@ pub mod tokens {
 
     pub(super) static SOURCE_FILE: LazyLock<Parse<SourceFile>> = LazyLock::new(|| {
         SourceFile::parse(
-            "use crate::foo; const C: <()>::Item = ( true && true , true || true , 1 != 1, 2 == 2, 3 < 3, 4 <= 4, 5 > 5, 6 >= 6, !true, *p, &p , &mut p, async { let _ @ [] }, while loop {} {})\n;\n\nunsafe impl A for B where: {}",
+            "use crate::foo; const C: <()>::Item = ( true && true , true || true , 1 != 1, 2 == 2, 3 < 3, 4 <= 4, 5 > 5, 6 >= 6, !true, *p, &p , &mut p, async { let _ @ [] }, while loop {} {}, if false { false } else { true })\n;\n\nunsafe impl A for B where: {}",
             Edition::CURRENT,
         )
     });


### PR DESCRIPTION
Unmerge into guarded match arm.

```rust
enum Kind { Num(u32) }

fn handle(kind: Kind) {
    match kind {
        Kind::Num(n) $0=> foo(n),
    }
}
```
->
```rust
enum Kind { Num(u32) }

fn handle(kind: Kind) {
    match kind {
        Kind::Num(n) if $0 => foo(n),
        Kind::Num(n) => foo(n),
    }
}
```
