### PR TITLE
fix: fix parameter info with missing arguments

### DIFF
--- a/crates/ide-completion/src/context/analysis.rs
+++ b/crates/ide-completion/src/context/analysis.rs
@@ -657,7 +657,7 @@ fn expected_type_and_name<'db>(
                     cov_mark::hit!(expected_type_fn_param);
                     ActiveParameter::at_token(
                         sema,
-                       token.clone(),
+                        token.clone(),
                     ).map(|ap| {
                         let name = ap.ident().map(NameOrNameRef::Name);
                         (Some(ap.ty), name)

--- a/crates/ide-completion/src/context/tests.rs
+++ b/crates/ide-completion/src/context/tests.rs
@@ -90,6 +90,20 @@ fn bar(x: u32) {}
 "#,
         expect![[r#"ty: u32, name: x"#]],
     );
+    check_expected_type_and_name(
+        r#"
+fn foo() { bar(, $0); }
+fn bar(x: u32, y: i32) {}
+"#,
+        expect![[r#"ty: i32, name: y"#]],
+    );
+    check_expected_type_and_name(
+        r#"
+fn foo() { bar(, c$0); }
+fn bar(x: u32, y: i32) {}
+"#,
+        expect![[r#"ty: i32, name: y"#]],
+    );
 }
 
 #[test]


### PR DESCRIPTION
Example
---
```rust
fn foo() { bar(, $0); }
fn bar(x: u32, y: i32) {}
```

**Before this PR**

```text
ty: u32, name: x
```

**After this PR**

```text
ty: i32, name: y
```
