### PR TITLE
minor: Rename proc-macro-srv protocol flags

### DIFF
--- a/crates/proc-macro-api/src/process.rs
+++ b/crates/proc-macro-api/src/process.rs
@@ -274,9 +274,9 @@ fn mk_child<'a>(
     #[allow(clippy::disallowed_methods)]
     let mut cmd = Command::new(path);
     if matches!(protocol, Protocol::LegacyJson { .. }) {
-        cmd.args(["--format", "json"]);
+        cmd.args(["--format", "json-legacy"]);
     } else {
-        cmd.args(["--format", "postcard"]);
+        cmd.args(["--format", "postcard-legacy"]);
     }
     for env in extra_env {
         match env {

--- a/crates/proc-macro-srv-cli/src/main.rs
+++ b/crates/proc-macro-srv-cli/src/main.rs
@@ -31,7 +31,7 @@ fn main() -> std::io::Result<()> {
             clap::Arg::new("format")
                 .long("format")
                 .action(clap::ArgAction::Set)
-                .default_value("json")
+                .default_value("json-legacy")
                 .value_parser(clap::builder::EnumValueParser::<ProtocolFormat>::new()),
             clap::Arg::new("version")
                 .long("version")
@@ -50,25 +50,27 @@ fn main() -> std::io::Result<()> {
 
 #[derive(Copy, Clone)]
 enum ProtocolFormat {
-    Json,
-    Postcard,
+    JsonLegacy,
+    PostcardLegacy,
 }
 
 impl ValueEnum for ProtocolFormat {
     fn value_variants<'a>() -> &'a [Self] {
-        &[ProtocolFormat::Json, ProtocolFormat::Postcard]
+        &[ProtocolFormat::JsonLegacy, ProtocolFormat::PostcardLegacy]
     }
 
     fn to_possible_value(&self) -> Option<clap::builder::PossibleValue> {
         match self {
-            ProtocolFormat::Json => Some(clap::builder::PossibleValue::new("json")),
-            ProtocolFormat::Postcard => Some(clap::builder::PossibleValue::new("postcard")),
+            ProtocolFormat::JsonLegacy => Some(clap::builder::PossibleValue::new("json-legacy")),
+            ProtocolFormat::PostcardLegacy => {
+                Some(clap::builder::PossibleValue::new("postcard-legacy"))
+            }
         }
     }
     fn from_str(input: &str, _ignore_case: bool) -> Result<Self, String> {
         match input {
-            "json" => Ok(ProtocolFormat::Json),
-            "postcard" => Ok(ProtocolFormat::Postcard),
+            "json-legacy" => Ok(ProtocolFormat::JsonLegacy),
+            "postcard-legacy" => Ok(ProtocolFormat::PostcardLegacy),
             _ => Err(format!("unknown protocol format: {input}")),
         }
     }


### PR DESCRIPTION
This gives us more flexibility with changing the actual protocol later