### PR TITLE
internal: Gate spawning proc-macro-srv with --format on toolchain version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1838,6 +1838,7 @@ dependencies = [
  "postcard",
  "proc-macro-srv",
  "rustc-hash 2.1.1",
+ "semver",
  "serde",
  "serde_derive",
  "serde_json",

--- a/crates/load-cargo/src/lib.rs
+++ b/crates/load-cargo/src/lib.rs
@@ -96,12 +96,13 @@ pub fn load_workspace_into_db(
     tracing::debug!(?load_config, "LoadCargoConfig");
     let proc_macro_server = match &load_config.with_proc_macro_server {
         ProcMacroServerChoice::Sysroot => ws.find_sysroot_proc_macro_srv().map(|it| {
-            it.and_then(|it| ProcMacroClient::spawn(&it, extra_env).map_err(Into::into)).map_err(
-                |e| ProcMacroLoadingError::ProcMacroSrvError(e.to_string().into_boxed_str()),
-            )
+            it.and_then(|it| {
+                ProcMacroClient::spawn(&it, extra_env, ws.toolchain.as_ref()).map_err(Into::into)
+            })
+            .map_err(|e| ProcMacroLoadingError::ProcMacroSrvError(e.to_string().into_boxed_str()))
         }),
         ProcMacroServerChoice::Explicit(path) => {
-            Some(ProcMacroClient::spawn(path, extra_env).map_err(|e| {
+            Some(ProcMacroClient::spawn(path, extra_env, ws.toolchain.as_ref()).map_err(|e| {
                 ProcMacroLoadingError::ProcMacroSrvError(e.to_string().into_boxed_str())
             }))
         }

--- a/crates/proc-macro-api/Cargo.toml
+++ b/crates/proc-macro-api/Cargo.toml
@@ -30,6 +30,7 @@ span = { path = "../span", version = "0.0.0", default-features = false}
 
 intern.workspace = true
 postcard.workspace = true
+semver.workspace = true
 
 [features]
 sysroot-abi = ["proc-macro-srv", "proc-macro-srv/sysroot-abi"]

--- a/crates/proc-macro-api/src/lib.rs
+++ b/crates/proc-macro-api/src/lib.rs
@@ -18,6 +18,7 @@ pub mod legacy_protocol;
 mod process;
 
 use paths::{AbsPath, AbsPathBuf};
+use semver::Version;
 use span::{ErasedFileAstId, FIXUP_ERASED_FILE_AST_ID_MARKER, Span};
 use std::{fmt, io, sync::Arc, time::SystemTime};
 
@@ -125,8 +126,9 @@ impl ProcMacroClient {
         env: impl IntoIterator<
             Item = (impl AsRef<std::ffi::OsStr>, &'a Option<impl 'a + AsRef<std::ffi::OsStr>>),
         > + Clone,
+        version: Option<&Version>,
     ) -> io::Result<ProcMacroClient> {
-        let process = ProcMacroServerProcess::run(process_path, env)?;
+        let process = ProcMacroServerProcess::run(process_path, env, version)?;
         Ok(ProcMacroClient { process: Arc::new(process), path: process_path.to_owned() })
     }
 

--- a/crates/proc-macro-api/src/process.rs
+++ b/crates/proc-macro-api/src/process.rs
@@ -8,6 +8,7 @@ use std::{
 };
 
 use paths::AbsPath;
+use semver::Version;
 use stdx::JodChild;
 
 use crate::{
@@ -30,13 +31,8 @@ pub(crate) struct ProcMacroServerProcess {
 
 #[derive(Debug, Clone)]
 pub(crate) enum Protocol {
-    LegacyJson {
-        mode: SpanMode,
-    },
-    #[expect(dead_code)]
-    Postcard {
-        mode: SpanMode,
-    },
+    LegacyJson { mode: SpanMode },
+    LegacyPostcard { mode: SpanMode },
 }
 
 /// Maintains the state of the proc-macro server process.
@@ -54,50 +50,76 @@ impl ProcMacroServerProcess {
         env: impl IntoIterator<
             Item = (impl AsRef<std::ffi::OsStr>, &'a Option<impl 'a + AsRef<std::ffi::OsStr>>),
         > + Clone,
+        version: Option<&Version>,
     ) -> io::Result<ProcMacroServerProcess> {
-        let create_srv = || {
-            let mut process = Process::run(process_path, env.clone())?;
-            let (stdin, stdout) = process.stdio().expect("couldn't access child stdio");
+        const VERSION: Version = Version::new(1, 93, 0);
+        // we do `>` for nightly as this started working in the middle of the 1.93 nightly release, so we dont want to break on half of the nightlies
+        let has_working_format_flag = version.map_or(false, |v| {
+            if v.pre.as_str() == "nightly" { *v > VERSION } else { *v >= VERSION }
+        });
 
-            io::Result::Ok(ProcMacroServerProcess {
-                state: Mutex::new(ProcessSrvState { process, stdin, stdout }),
-                version: 0,
-                protocol: Protocol::LegacyJson { mode: SpanMode::Id },
-                exited: OnceLock::new(),
-            })
+        let formats: &[_] = if has_working_format_flag {
+            &[
+                (Some("postcard-legacy"), Protocol::LegacyPostcard { mode: SpanMode::Id }),
+                (Some("json-legacy"), Protocol::LegacyJson { mode: SpanMode::Id }),
+            ]
+        } else {
+            &[(None, Protocol::LegacyJson { mode: SpanMode::Id })]
         };
-        let mut srv = create_srv()?;
-        tracing::info!("sending proc-macro server version check");
-        match srv.version_check() {
-            Ok(v) if v > version::CURRENT_API_VERSION => {
-                #[allow(clippy::disallowed_methods)]
-                let process_version = Command::new(process_path)
-                    .arg("--version")
-                    .output()
-                    .map(|output| String::from_utf8_lossy(&output.stdout).trim().to_owned())
-                    .unwrap_or_else(|_| "unknown version".to_owned());
-                Err(io::Error::other(format!(
-                    "Your installed proc-macro server is too new for your rust-analyzer. API version: {}, server version: {process_version}. \
+
+        let mut err = None;
+        for &(format, ref protocol) in formats {
+            let create_srv = || {
+                let mut process = Process::run(process_path, env.clone(), format)?;
+                let (stdin, stdout) = process.stdio().expect("couldn't access child stdio");
+
+                io::Result::Ok(ProcMacroServerProcess {
+                    state: Mutex::new(ProcessSrvState { process, stdin, stdout }),
+                    version: 0,
+                    protocol: protocol.clone(),
+                    exited: OnceLock::new(),
+                })
+            };
+            let mut srv = create_srv()?;
+            tracing::info!("sending proc-macro server version check");
+            match srv.version_check() {
+                Ok(v) if v > version::CURRENT_API_VERSION => {
+                    #[allow(clippy::disallowed_methods)]
+                    let process_version = Command::new(process_path)
+                        .arg("--version")
+                        .output()
+                        .map(|output| String::from_utf8_lossy(&output.stdout).trim().to_owned())
+                        .unwrap_or_else(|_| "unknown version".to_owned());
+                    err = Some(io::Error::other(format!(
+                        "Your installed proc-macro server is too new for your rust-analyzer. API version: {}, server version: {process_version}. \
                         This will prevent proc-macro expansion from working. Please consider updating your rust-analyzer to ensure compatibility with your current toolchain.",
-                    version::CURRENT_API_VERSION
-                )))
-            }
-            Ok(v) => {
-                tracing::info!("Proc-macro server version: {v}");
-                srv.version = v;
-                if srv.version >= version::RUST_ANALYZER_SPAN_SUPPORT
-                    && let Ok(mode) = srv.enable_rust_analyzer_spans()
-                {
-                    srv.protocol = Protocol::LegacyJson { mode };
+                        version::CURRENT_API_VERSION
+                    )));
                 }
-                tracing::info!("Proc-macro server protocol: {:?}", srv.protocol);
-                Ok(srv)
-            }
-            Err(e) => {
-                tracing::info!(%e, "proc-macro version check failed");
-                Err(io::Error::other(format!("proc-macro server version check failed: {e}")))
+                Ok(v) => {
+                    tracing::info!("Proc-macro server version: {v}");
+                    srv.version = v;
+                    if srv.version >= version::RUST_ANALYZER_SPAN_SUPPORT
+                        && let Ok(new_mode) = srv.enable_rust_analyzer_spans()
+                    {
+                        match &mut srv.protocol {
+                            Protocol::LegacyJson { mode } | Protocol::LegacyPostcard { mode } => {
+                                *mode = new_mode
+                            }
+                        }
+                    }
+                    tracing::info!("Proc-macro server protocol: {:?}", srv.protocol);
+                    return Ok(srv);
+                }
+                Err(e) => {
+                    tracing::info!(%e, "proc-macro version check failed");
+                    err = Some(io::Error::other(format!(
+                        "proc-macro server version check failed: {e}"
+                    )))
+                }
             }
         }
+        Err(err.unwrap())
     }
 
     /// Returns the server error if the process has exited.
@@ -106,7 +128,7 @@ impl ProcMacroServerProcess {
     }
 
     pub(crate) fn use_postcard(&self) -> bool {
-        matches!(self.protocol, Protocol::Postcard { .. })
+        matches!(self.protocol, Protocol::LegacyPostcard { .. })
     }
 
     /// Retrieves the API version of the proc-macro server.
@@ -118,7 +140,7 @@ impl ProcMacroServerProcess {
     pub(crate) fn rust_analyzer_spans(&self) -> bool {
         match self.protocol {
             Protocol::LegacyJson { mode } => mode == SpanMode::RustAnalyzer,
-            Protocol::Postcard { mode } => mode == SpanMode::RustAnalyzer,
+            Protocol::LegacyPostcard { mode } => mode == SpanMode::RustAnalyzer,
         }
     }
 
@@ -126,7 +148,7 @@ impl ProcMacroServerProcess {
     fn version_check(&self) -> Result<u32, ServerError> {
         match self.protocol {
             Protocol::LegacyJson { .. } => legacy_protocol::version_check(self),
-            Protocol::Postcard { .. } => legacy_protocol::version_check(self),
+            Protocol::LegacyPostcard { .. } => legacy_protocol::version_check(self),
         }
     }
 
@@ -134,7 +156,7 @@ impl ProcMacroServerProcess {
     fn enable_rust_analyzer_spans(&self) -> Result<SpanMode, ServerError> {
         match self.protocol {
             Protocol::LegacyJson { .. } => legacy_protocol::enable_rust_analyzer_spans(self),
-            Protocol::Postcard { .. } => legacy_protocol::enable_rust_analyzer_spans(self),
+            Protocol::LegacyPostcard { .. } => legacy_protocol::enable_rust_analyzer_spans(self),
         }
     }
 
@@ -145,7 +167,7 @@ impl ProcMacroServerProcess {
     ) -> Result<Result<Vec<(String, ProcMacroKind)>, String>, ServerError> {
         match self.protocol {
             Protocol::LegacyJson { .. } => legacy_protocol::find_proc_macros(self, dylib_path),
-            Protocol::Postcard { .. } => legacy_protocol::find_proc_macros(self, dylib_path),
+            Protocol::LegacyPostcard { .. } => legacy_protocol::find_proc_macros(self, dylib_path),
         }
     }
 
@@ -220,8 +242,9 @@ impl Process {
         env: impl IntoIterator<
             Item = (impl AsRef<std::ffi::OsStr>, &'a Option<impl 'a + AsRef<std::ffi::OsStr>>),
         >,
+        format: Option<&str>,
     ) -> io::Result<Process> {
-        let child = JodChild(mk_child(path, env)?);
+        let child = JodChild(mk_child(path, env, format)?);
         Ok(Process { child })
     }
 
@@ -241,6 +264,7 @@ fn mk_child<'a>(
     extra_env: impl IntoIterator<
         Item = (impl AsRef<std::ffi::OsStr>, &'a Option<impl 'a + AsRef<std::ffi::OsStr>>),
     >,
+    format: Option<&str>,
 ) -> io::Result<Child> {
     #[allow(clippy::disallowed_methods)]
     let mut cmd = Command::new(path);
@@ -249,6 +273,10 @@ fn mk_child<'a>(
             (key, Some(val)) => cmd.env(key, val),
             (key, None) => cmd.env_remove(key),
         };
+    }
+    if let Some(format) = format {
+        cmd.arg("--format");
+        cmd.arg(format);
     }
     cmd.env("RUST_ANALYZER_INTERNALS_DO_NOT_USE", "this is unstable")
         .stdin(Stdio::piped())

--- a/crates/rust-analyzer/src/reload.rs
+++ b/crates/rust-analyzer/src/reload.rs
@@ -700,7 +700,7 @@ impl GlobalState {
                 };
                 info!("Using proc-macro server at {path}");
 
-                Some(ProcMacroClient::spawn(&path, &env).map_err(|err| {
+                Some(ProcMacroClient::spawn(&path, &env, ws.toolchain.as_ref()).map_err(|err| {
                     tracing::error!(
                         "Failed to run proc-macro server from path {path}, error: {err:?}",
                     );


### PR DESCRIPTION
This is assuming that this weeks proc-macro server PRs will land before december 5th which is the next beta branch for 1.93