### PR TITLE
fix: rust-analyzer.imports.granularity.group should get a dropdown UI

### DIFF
--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -3566,23 +3566,13 @@ fn field_props(field: &str, ty: &str, doc: &[&str], default: &str) -> serde_json
         },
         "ImportGranularityDef" => set! {
             "type": "string",
-            "anyOf": [
-                {
-                    "enum": ["crate", "module", "item", "one"],
-                    "enumDescriptions": [
-                        "Merge imports from the same crate into a single use statement. Conversely, imports from different crates are split into separate statements.",
-                        "Merge imports from the same module into a single use statement. Conversely, imports from different modules are split into separate statements.",
-                        "Flatten imports so that each has its own use statement.",
-                        "Merge all imports into a single use statement as long as they have the same visibility and attributes."
-                    ],
-                },
-                {
-                    "enum": ["preserve"],
-                    "enumDescriptions": [
-                        "Deprecated - unless `enforceGranularity` is `true`, the style of the current file is preferred over this setting. Behaves like `item`.",
-                    ],
-                    "deprecated": true,
-                }
+            "enum": ["crate", "module", "item", "one", "preserve"],
+            "enumDescriptions": [
+                "Merge imports from the same crate into a single use statement. Conversely, imports from different crates are split into separate statements.",
+                "Merge imports from the same module into a single use statement. Conversely, imports from different modules are split into separate statements.",
+                "Flatten imports so that each has its own use statement.",
+                "Merge all imports into a single use statement as long as they have the same visibility and attributes.",
+                "Deprecated - unless `enforceGranularity` is `true`, the style of the current file is preferred over this setting. Behaves like `item`."
             ],
         },
         "ImportPrefixDef" => set! {

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -2020,30 +2020,19 @@
                         "markdownDescription": "How imports should be grouped into use statements.",
                         "default": "crate",
                         "type": "string",
-                        "anyOf": [
-                            {
-                                "enum": [
-                                    "crate",
-                                    "module",
-                                    "item",
-                                    "one"
-                                ],
-                                "enumDescriptions": [
-                                    "Merge imports from the same crate into a single use statement. Conversely, imports from different crates are split into separate statements.",
-                                    "Merge imports from the same module into a single use statement. Conversely, imports from different modules are split into separate statements.",
-                                    "Flatten imports so that each has its own use statement.",
-                                    "Merge all imports into a single use statement as long as they have the same visibility and attributes."
-                                ]
-                            },
-                            {
-                                "enum": [
-                                    "preserve"
-                                ],
-                                "enumDescriptions": [
-                                    "Deprecated - unless `enforceGranularity` is `true`, the style of the current file is preferred over this setting. Behaves like `item`."
-                                ],
-                                "deprecated": true
-                            }
+                        "enum": [
+                            "crate",
+                            "module",
+                            "item",
+                            "one",
+                            "preserve"
+                        ],
+                        "enumDescriptions": [
+                            "Merge imports from the same crate into a single use statement. Conversely, imports from different crates are split into separate statements.",
+                            "Merge imports from the same module into a single use statement. Conversely, imports from different modules are split into separate statements.",
+                            "Flatten imports so that each has its own use statement.",
+                            "Merge all imports into a single use statement as long as they have the same visibility and attributes.",
+                            "Deprecated - unless `enforceGranularity` is `true`, the style of the current file is preferred over this setting. Behaves like `item`."
                         ]
                     }
                 }


### PR DESCRIPTION
VS Code only offers a dropdown if a the toplevel property description is `enum`. For `anyOf` (a JSON schema feature), we don't get that helpful UI.

Whilst the previous version marked `preserve` as deprecated, the VS Code UI didn't do anything special when users chose that value.

Instead, use an enum so we get the helpful dropdown, and just use the description to highlight the deprecated value.

Relevant docs:

https://code.visualstudio.com/api/references/contribution-points#:~:text=The%20enumDescriptions%20property%20provides%20a,will%20be%20parsed%20as%20Markdown.

https://json-schema.org/draft/2020-12/draft-bhutton-json-schema-01#section-10.2.1.2