### PR TITLE
minor: Use 'deferred task' terminology consistently

### DIFF
--- a/crates/rust-analyzer/src/global_state.rs
+++ b/crates/rust-analyzer/src/global_state.rs
@@ -45,7 +45,7 @@ use crate::{
     op_queue::{Cause, OpQueue},
     reload,
     target_spec::{CargoTargetSpec, ProjectJsonTargetSpec, TargetSpec},
-    task_pool::{TaskPool, TaskQueue},
+    task_pool::{DeferredTaskQueue, TaskPool},
     test_runner::{CargoTestHandle, CargoTestMessage},
 };
 
@@ -186,7 +186,8 @@ pub(crate) struct GlobalState {
     /// For certain features, such as [`GlobalState::handle_discover_msg`],
     /// this queue should run only *after* [`GlobalState::process_changes`] has
     /// been called.
-    pub(crate) deferred_task_queue: TaskQueue,
+    pub(crate) deferred_task_queue: DeferredTaskQueue,
+
     /// HACK: Workaround for https://github.com/rust-lang/rust-analyzer/issues/19709
     /// This is marked true if we failed to load a crate root file at crate graph creation,
     /// which will usually end up causing a bunch of incorrect diagnostics on startup.
@@ -241,9 +242,9 @@ impl GlobalState {
         };
         let cancellation_pool = thread::Pool::new(1);
 
-        let task_queue = {
+        let deferred_task_queue = {
             let (sender, receiver) = unbounded();
-            TaskQueue { sender, receiver }
+            DeferredTaskQueue { sender, receiver }
         };
 
         let mut analysis_host = AnalysisHost::new(config.lru_parse_query_capacity());
@@ -314,7 +315,7 @@ impl GlobalState {
             prime_caches_queue: OpQueue::default(),
             discover_workspace_queue: OpQueue::default(),
 
-            deferred_task_queue: task_queue,
+            deferred_task_queue,
             incomplete_crate_graph: false,
 
             minicore: MiniCoreRustAnalyzerInternalOnly::default(),
@@ -540,10 +541,9 @@ impl GlobalState {
         // didn't find anything (to make up for the lack of precision).
         {
             if !matches!(&workspace_structure_change, Some((.., true))) {
-                _ = self
-                    .deferred_task_queue
-                    .sender
-                    .send(crate::main_loop::QueuedTask::CheckProcMacroSources(modified_rust_files));
+                _ = self.deferred_task_queue.sender.send(
+                    crate::main_loop::DeferredTask::CheckProcMacroSources(modified_rust_files),
+                );
             }
             // FIXME: ideally we should only trigger a workspace fetch for non-library changes
             // but something's going wrong with the source root business when we add a new local

--- a/crates/rust-analyzer/src/handlers/notification.rs
+++ b/crates/rust-analyzer/src/handlers/notification.rs
@@ -91,7 +91,7 @@ pub(crate) fn handle_did_open_text_document(
             let _ = state
                 .deferred_task_queue
                 .sender
-                .send(crate::main_loop::QueuedTask::CheckIfIndexed(params.text_document.uri));
+                .send(crate::main_loop::DeferredTask::CheckIfIndexed(params.text_document.uri));
         }
     }
     Ok(())

--- a/crates/rust-analyzer/src/task_pool.rs
+++ b/crates/rust-analyzer/src/task_pool.rs
@@ -6,7 +6,7 @@ use std::panic::UnwindSafe;
 use crossbeam_channel::Sender;
 use stdx::thread::{Pool, ThreadIntent};
 
-use crate::main_loop::QueuedTask;
+use crate::main_loop::DeferredTask;
 
 pub(crate) struct TaskPool<T> {
     sender: Sender<T>,
@@ -45,11 +45,11 @@ impl<T> TaskPool<T> {
     }
 }
 
-/// `TaskQueue`, like its name suggests, queues tasks.
+/// `DeferredTaskQueue` holds deferred tasks.
 ///
-/// This should only be used if a task must run after [`GlobalState::process_changes`]
-/// has been called.
-pub(crate) struct TaskQueue {
-    pub(crate) sender: crossbeam_channel::Sender<QueuedTask>,
-    pub(crate) receiver: crossbeam_channel::Receiver<QueuedTask>,
+/// These are tasks that must be run after
+/// [`GlobalState::process_changes`] has been called.
+pub(crate) struct DeferredTaskQueue {
+    pub(crate) sender: crossbeam_channel::Sender<DeferredTask>,
+    pub(crate) receiver: crossbeam_channel::Receiver<DeferredTask>,
 }


### PR DESCRIPTION
Previously there was a mix of 'queued task' and 'deferred task' terminology. The deferred terminology is more helpful (it provides a hint of which tasks belong there), so standardise on that term.