### PR TITLE
minor: Remove force-always-assert from xtask/install install_cmd as well

### DIFF
--- a/xtask/src/install.rs
+++ b/xtask/src/install.rs
@@ -44,8 +44,11 @@ pub(crate) struct ServerOpt {
 
 impl ServerOpt {
     fn to_features(&self) -> Vec<&'static str> {
-        let mut features = Vec::new();
-        features.extend(self.malloc.to_features());
+        let malloc_features = self.malloc.to_features();
+        let mut features = Vec::with_capacity(
+            malloc_features.len() + if self.force_always_assert { 2 } else { 0 },
+        );
+        features.extend(malloc_features);
         if self.force_always_assert {
             features.extend(["--features", "force-always-assert"]);
         }
@@ -153,7 +156,7 @@ fn install_server(sh: &Shell, opts: ServerOpt) -> anyhow::Result<()> {
 
     let mut install_cmd = cmd!(
         sh,
-        "cargo install --path crates/rust-analyzer --profile={profile} --locked --force --features force-always-assert {features...}"
+        "cargo install --path crates/rust-analyzer --profile={profile} --locked --force {features...}"
     );
 
     if let Some(train_crate) = opts.pgo {


### PR DESCRIPTION
In rust-lang/rust-analyzer#20852, `force-always-assert` was removed from the default list of features for the install xtask, but it only removed it from the `cargo build` command, not the `cargo install` command. So this just removes it from that command as well (and adds some preallocation to the `to_features` method since it's nice and easy).

Before this change, I was seeing a `query thread panicked: entered unreachable code: inference diagnostic in desugared expr` on every keystroke (in neovim, installed with `cargo xtask install --server --mimalloc --proc-macro-server --pgo tokio-rs/tokio@master`), which panic seemed to cause other issues, but now I don't see the messages or the panics (with this change). Still looking into those issues, but for now I think this is the right thing to do.