### PR TITLE
Support undotted-self for `this` param closure

### DIFF
--- a/crates/ide-completion/src/context.rs
+++ b/crates/ide-completion/src/context.rs
@@ -157,7 +157,7 @@ pub(crate) struct PathExprCtx<'db> {
     pub(crate) after_amp: bool,
     /// The surrounding RecordExpression we are completing a functional update
     pub(crate) is_func_update: Option<ast::RecordExpr>,
-    pub(crate) self_param: Option<hir::SelfParam>,
+    pub(crate) self_param: Option<Either<hir::SelfParam, hir::Param<'db>>>,
     pub(crate) innermost_ret_ty: Option<hir::Type<'db>>,
     pub(crate) innermost_breakable_ty: Option<hir::Type<'db>>,
     pub(crate) impl_: Option<ast::Impl>,

--- a/crates/ide-completion/src/context/analysis.rs
+++ b/crates/ide-completion/src/context/analysis.rs
@@ -1286,10 +1286,26 @@ fn classify_name_ref<'db>(
                     )
                 }
             };
-            let find_fn_self_param = |it| match it {
-                ast::Item::Fn(fn_) => Some(sema.to_def(&fn_).and_then(|it| it.self_param(sema.db))),
-                ast::Item::MacroCall(_) => None,
-                _ => Some(None),
+            let fn_self_param =
+                |fn_: ast::Fn| sema.to_def(&fn_).and_then(|it| it.self_param(sema.db));
+            let closure_this_param = |closure: ast::ClosureExpr| {
+                if closure.param_list()?.params().next()?.pat()?.syntax().text() != "this" {
+                    return None;
+                }
+                sema.type_of_expr(&closure.into())
+                    .and_then(|it| it.original.as_callable(sema.db))
+                    .and_then(|it| it.params().into_iter().next())
+            };
+            let find_fn_self_param = |it: SyntaxNode| {
+                match_ast! {
+                    match it {
+                        ast::Fn(fn_) => Some(fn_self_param(fn_).map(Either::Left)),
+                        ast::ClosureExpr(f) => closure_this_param(f).map(Either::Right).map(Some),
+                        ast::MacroCall(_) => None,
+                        ast::Item(_) => Some(None),
+                        _ => None,
+                    }
+                }
             };
 
             match find_node_in_file_compensated(sema, original_file, &expr) {
@@ -1302,7 +1318,6 @@ fn classify_name_ref<'db>(
 
                     let self_param = sema
                         .ancestors_with_macros(it.syntax().clone())
-                        .filter_map(ast::Item::cast)
                         .find_map(find_fn_self_param)
                         .flatten();
                     (innermost_ret_ty, self_param)

--- a/crates/ide-completion/src/render.rs
+++ b/crates/ide-completion/src/render.rs
@@ -3240,6 +3240,48 @@ impl S {
     }
 
     #[test]
+    fn field_access_includes_closure_this_param() {
+        check_edit(
+            "length",
+            r#"
+//- minicore: fn
+struct S {
+    length: i32
+}
+
+impl S {
+    fn pack(&mut self, f: impl FnOnce(&mut Self, i32)) {
+        self.length += 1;
+        f(self, 3);
+        self.length -= 1;
+    }
+
+    fn some_fn(&mut self) {
+        self.pack(|this, n| len$0);
+    }
+}
+"#,
+            r#"
+struct S {
+    length: i32
+}
+
+impl S {
+    fn pack(&mut self, f: impl FnOnce(&mut Self, i32)) {
+        self.length += 1;
+        f(self, 3);
+        self.length -= 1;
+    }
+
+    fn some_fn(&mut self) {
+        self.pack(|this, n| this.length);
+    }
+}
+"#,
+        )
+    }
+
+    #[test]
     fn notable_traits_method_relevance() {
         check_kinds(
             r#"


### PR DESCRIPTION
Using `this` instead of `self` in a closure is a common pattern

Example
---
```rust
struct Foo { field: i32 }
impl Foo {
    fn foo(&mut self) {
        let f: fn(&mut Self) = |this| { $0 };
        f(self)
    }
}
```

**Before this PR**

```text
fd self.field           i32
me self.foo() fn(&mut self)
lc self            &mut Foo
lc this            &mut Foo
md core
sp Self                 Foo
st Foo                  Foo
tt Fn
tt FnMut
tt FnOnce
bt u32                  u32
```

**After this PR**

```text
fd this.field           i32
me this.foo() fn(&mut self)
lc self            &mut Foo
lc this            &mut Foo
md core
sp Self                 Foo
st Foo                  Foo
tt Fn
tt FnMut
tt FnOnce
bt u32                  u32
```
