### PR TITLE
internal: Remove the block from `DbInterner`

### DIFF
--- a/crates/hir-ty/src/autoderef.rs
+++ b/crates/hir-ty/src/autoderef.rs
@@ -38,7 +38,7 @@ pub fn autoderef<'db>(
     env: Arc<TraitEnvironment<'db>>,
     ty: Canonical<'db, Ty<'db>>,
 ) -> impl Iterator<Item = Ty<'db>> + use<'db> {
-    let interner = DbInterner::new_with(db, env.krate, env.block);
+    let interner = DbInterner::new_with(db, env.krate);
     let infcx = interner.infer_ctxt().build(TypingMode::PostAnalysis);
     let (ty, _) = infcx.instantiate_canonical(&ty);
     let autoderef = Autoderef::new(&infcx, &env, ty);

--- a/crates/hir-ty/src/diagnostics/expr.rs
+++ b/crates/hir-ty/src/diagnostics/expr.rs
@@ -79,7 +79,7 @@ impl BodyValidationDiagnostic {
         let infer = InferenceResult::for_body(db, owner);
         let body = db.body(owner);
         let env = db.trait_environment_for_body(owner);
-        let interner = DbInterner::new_with(db, env.krate, env.block);
+        let interner = DbInterner::new_with(db, env.krate);
         let infcx =
             interner.infer_ctxt().build(TypingMode::typeck_for_body(interner, owner.into()));
         let mut validator = ExprValidator {

--- a/crates/hir-ty/src/display.rs
+++ b/crates/hir-ty/src/display.rs
@@ -309,7 +309,7 @@ pub trait HirDisplay<'db> {
         allow_opaque: bool,
     ) -> Result<String, DisplaySourceCodeError> {
         let mut result = String::new();
-        let interner = DbInterner::new_with(db, module_id.krate(), module_id.containing_block());
+        let interner = DbInterner::new_with(db, module_id.krate());
         match self.hir_fmt(&mut HirFormatter {
             db,
             interner,
@@ -544,11 +544,7 @@ pub enum ClosureStyle {
 impl<'db, T: HirDisplay<'db>> HirDisplayWrapper<'_, 'db, T> {
     pub fn write_to<F: HirWrite>(&self, f: &mut F) -> Result<(), HirDisplayError> {
         let krate = self.display_target.krate;
-        let block = match self.display_kind {
-            DisplayKind::SourceCode { target_module_id, .. } => target_module_id.containing_block(),
-            DisplayKind::Diagnostics | DisplayKind::Test => None,
-        };
-        let interner = DbInterner::new_with(self.db, krate, block);
+        let interner = DbInterner::new_with(self.db, krate);
         self.t.hir_fmt(&mut HirFormatter {
             db: self.db,
             interner,

--- a/crates/hir-ty/src/dyn_compatibility.rs
+++ b/crates/hir-ty/src/dyn_compatibility.rs
@@ -131,7 +131,7 @@ pub fn dyn_compatibility_of_trait_query(
 
 pub fn generics_require_sized_self(db: &dyn HirDatabase, def: GenericDefId) -> bool {
     let krate = def.module(db).krate();
-    let interner = DbInterner::new_with(db, krate, None);
+    let interner = DbInterner::new_with(db, krate);
     let Some(sized) = interner.lang_items().Sized else {
         return false;
     };
@@ -402,7 +402,7 @@ fn receiver_is_dispatchable<'db>(
     let sig = sig.instantiate_identity();
 
     let module = trait_.module(db);
-    let interner = DbInterner::new_with(db, module.krate(), module.containing_block());
+    let interner = DbInterner::new_with(db, module.krate());
     let self_param_id = TypeParamId::from_unchecked(TypeOrConstParamId {
         parent: trait_.into(),
         local_id: LocalTypeOrConstParamId::from_raw(la_arena::RawIdx::from_u32(0)),

--- a/crates/hir-ty/src/infer/coerce.rs
+++ b/crates/hir-ty/src/infer/coerce.rs
@@ -1576,7 +1576,7 @@ fn coerce<'db>(
     env: Arc<TraitEnvironment<'db>>,
     tys: &Canonical<'db, (Ty<'db>, Ty<'db>)>,
 ) -> Result<(Vec<Adjustment<'db>>, Ty<'db>), TypeError<DbInterner<'db>>> {
-    let interner = DbInterner::new_with(db, env.krate, env.block);
+    let interner = DbInterner::new_with(db, env.krate);
     let infcx = interner.infer_ctxt().build(TypingMode::PostAnalysis);
     let ((ty1_with_vars, ty2_with_vars), vars) = infcx.instantiate_canonical(tys);
 

--- a/crates/hir-ty/src/infer/expr.rs
+++ b/crates/hir-ty/src/infer/expr.rs
@@ -1455,11 +1455,10 @@ impl<'db> InferenceContext<'_, 'db> {
     ) -> Ty<'db> {
         let coerce_ty = expected.coercion_target_type(&mut self.table);
         let g = self.resolver.update_to_inner_scope(self.db, self.owner, expr);
-        let prev_state = block_id.map(|block_id| {
+        let prev_env = block_id.map(|block_id| {
             let prev_env = self.table.trait_env.clone();
             TraitEnvironment::with_block(&mut self.table.trait_env, block_id);
-            let prev_block = self.table.infer_ctxt.interner.block.replace(block_id);
-            (prev_env, prev_block)
+            prev_env
         });
 
         let (break_ty, ty) =
@@ -1567,9 +1566,8 @@ impl<'db> InferenceContext<'_, 'db> {
                 }
             });
         self.resolver.reset_to_guard(g);
-        if let Some((prev_env, prev_block)) = prev_state {
+        if let Some(prev_env) = prev_env {
             self.table.trait_env = prev_env;
-            self.table.infer_ctxt.interner.block = prev_block;
         }
 
         break_ty.unwrap_or(ty)

--- a/crates/hir-ty/src/infer/unify.rs
+++ b/crates/hir-ty/src/infer/unify.rs
@@ -113,7 +113,7 @@ fn could_unify_impl<'db>(
     tys: &Canonical<'db, (Ty<'db>, Ty<'db>)>,
     select: for<'a> fn(&mut ObligationCtxt<'a, 'db>) -> Vec<NextSolverError<'db>>,
 ) -> bool {
-    let interner = DbInterner::new_with(db, env.krate, env.block);
+    let interner = DbInterner::new_with(db, env.krate);
     let infcx = interner.infer_ctxt().build(TypingMode::PostAnalysis);
     let cause = ObligationCause::dummy();
     let at = infcx.at(&cause, env.env);
@@ -148,7 +148,7 @@ impl<'db> InferenceTable<'db> {
         trait_env: Arc<TraitEnvironment<'db>>,
         owner: Option<DefWithBodyId>,
     ) -> Self {
-        let interner = DbInterner::new_with(db, trait_env.krate, trait_env.block);
+        let interner = DbInterner::new_with(db, trait_env.krate);
         let typing_mode = match owner {
             Some(owner) => TypingMode::typeck_for_body(interner, owner.into()),
             // IDE things wants to reveal opaque types.

--- a/crates/hir-ty/src/layout.rs
+++ b/crates/hir-ty/src/layout.rs
@@ -162,7 +162,7 @@ pub fn layout_of_ty_query<'db>(
     trait_env: Arc<TraitEnvironment<'db>>,
 ) -> Result<Arc<Layout>, LayoutError> {
     let krate = trait_env.krate;
-    let interner = DbInterner::new_with(db, krate, trait_env.block);
+    let interner = DbInterner::new_with(db, krate);
     let Ok(target) = db.target_data_layout(krate) else {
         return Err(LayoutError::TargetLayoutNotAvailable);
     };

--- a/crates/hir-ty/src/lower.rs
+++ b/crates/hir-ty/src/lower.rs
@@ -194,7 +194,7 @@ impl<'db, 'a> TyLoweringContext<'db, 'a> {
     ) -> Self {
         let impl_trait_mode = ImplTraitLoweringState::new(ImplTraitLoweringMode::Disallowed);
         let in_binders = DebruijnIndex::ZERO;
-        let interner = DbInterner::new_with(db, resolver.krate(), None);
+        let interner = DbInterner::new_with(db, resolver.krate());
         Self {
             db,
             // Can provide no block since we don't use it for trait solving.
@@ -1756,7 +1756,7 @@ pub(crate) fn trait_environment_query<'db>(
     def: GenericDefId,
 ) -> Arc<TraitEnvironment<'db>> {
     let module = def.module(db);
-    let interner = DbInterner::new_with(db, module.krate(), module.containing_block());
+    let interner = DbInterner::new_with(db, module.krate());
     let predicates = GenericPredicates::query_all(db, def);
     let traits_in_scope = predicates
         .iter_identity_copied()
@@ -2289,7 +2289,7 @@ pub(crate) fn associated_type_by_name_including_super_traits<'db>(
     name: &Name,
 ) -> Option<(TraitRef<'db>, TypeAliasId)> {
     let module = trait_ref.def_id.0.module(db);
-    let interner = DbInterner::new_with(db, module.krate(), module.containing_block());
+    let interner = DbInterner::new_with(db, module.krate());
     rustc_type_ir::elaborate::supertraits(interner, Binder::dummy(trait_ref)).find_map(|t| {
         let trait_id = t.as_ref().skip_binder().def_id.0;
         let assoc_type = trait_id.trait_items(db).associated_type_by_name(name)?;

--- a/crates/hir-ty/src/method_resolution.rs
+++ b/crates/hir-ty/src/method_resolution.rs
@@ -419,7 +419,7 @@ pub(crate) fn lookup_impl_method_query<'db>(
     func: FunctionId,
     fn_subst: GenericArgs<'db>,
 ) -> (FunctionId, GenericArgs<'db>) {
-    let interner = DbInterner::new_with(db, env.krate, env.block);
+    let interner = DbInterner::new_with(db, env.krate);
     let infcx = interner.infer_ctxt().build(TypingMode::PostAnalysis);
 
     let ItemContainerId::TraitId(trait_id) = func.loc(db).container else {

--- a/crates/hir-ty/src/mir/borrowck.rs
+++ b/crates/hir-ty/src/mir/borrowck.rs
@@ -97,7 +97,7 @@ pub fn borrowck_query<'db>(
 ) -> Result<Arc<[BorrowckResult<'db>]>, MirLowerError<'db>> {
     let _p = tracing::info_span!("borrowck_query").entered();
     let module = def.module(db);
-    let interner = DbInterner::new_with(db, module.krate(), module.containing_block());
+    let interner = DbInterner::new_with(db, module.krate());
     let env = db.trait_environment_for_body(def);
     let mut res = vec![];
     // This calculates opaques defining scope which is a bit costly therefore is put outside `all_mir_bodies()`.

--- a/crates/hir-ty/src/mir/eval.rs
+++ b/crates/hir-ty/src/mir/eval.rs
@@ -641,7 +641,7 @@ impl<'db> Evaluator<'db> {
             Err(e) => return Err(MirEvalError::TargetDataLayoutNotAvailable(e)),
         };
         let cached_ptr_size = target_data_layout.pointer_size().bytes_usize();
-        let interner = DbInterner::new_with(db, crate_id, module.containing_block());
+        let interner = DbInterner::new_with(db, crate_id);
         let infcx = interner.infer_ctxt().build(TypingMode::PostAnalysis);
         let lang_items = interner.lang_items();
         Ok(Evaluator {

--- a/crates/hir-ty/src/mir/lower.rs
+++ b/crates/hir-ty/src/mir/lower.rs
@@ -302,7 +302,7 @@ impl<'a, 'db> MirLowerCtx<'a, 'db> {
         };
         let resolver = owner.resolver(db);
         let env = db.trait_environment_for_body(owner);
-        let interner = DbInterner::new_with(db, env.krate, env.block);
+        let interner = DbInterner::new_with(db, env.krate);
         // FIXME(next-solver): Is `non_body_analysis()` correct here? Don't we want to reveal opaque types defined by this body?
         let infcx = interner.infer_ctxt().build(TypingMode::non_body_analysis());
 

--- a/crates/hir-ty/src/mir/monomorphization.rs
+++ b/crates/hir-ty/src/mir/monomorphization.rs
@@ -98,7 +98,7 @@ impl<'db> Filler<'db> {
         env: Arc<TraitEnvironment<'db>>,
         subst: GenericArgs<'db>,
     ) -> Self {
-        let interner = DbInterner::new_with(db, env.krate, env.block);
+        let interner = DbInterner::new_with(db, env.krate);
         let infcx = interner.infer_ctxt().build(TypingMode::PostAnalysis);
         Self { infcx, trait_env: env, subst }
     }

--- a/crates/hir-ty/src/opaques.rs
+++ b/crates/hir-ty/src/opaques.rs
@@ -118,7 +118,7 @@ pub(crate) fn tait_hidden_types<'db>(
 
     let loc = type_alias.loc(db);
     let module = loc.module(db);
-    let interner = DbInterner::new_with(db, module.krate(), module.containing_block());
+    let interner = DbInterner::new_with(db, module.krate());
     let infcx = interner.infer_ctxt().build(TypingMode::non_body_analysis());
     let mut ocx = ObligationCtxt::new(&infcx);
     let cause = ObligationCause::dummy();

--- a/crates/hir-ty/src/specialization.rs
+++ b/crates/hir-ty/src/specialization.rs
@@ -46,7 +46,7 @@ fn specializes_query(
     parent_impl_def_id: ImplId,
 ) -> bool {
     let trait_env = db.trait_environment(specializing_impl_def_id.into());
-    let interner = DbInterner::new_with(db, trait_env.krate, trait_env.block);
+    let interner = DbInterner::new_with(db, trait_env.krate);
 
     let specializing_impl_signature = db.impl_signature(specializing_impl_def_id);
     let parent_impl_signature = db.impl_signature(parent_impl_def_id);

--- a/crates/hir-ty/src/traits.rs
+++ b/crates/hir-ty/src/traits.rs
@@ -216,7 +216,7 @@ fn implements_trait_unique_impl<'db>(
     trait_: TraitId,
     create_args: &mut dyn FnMut(&InferCtxt<'db>) -> GenericArgs<'db>,
 ) -> bool {
-    let interner = DbInterner::new_with(db, env.krate, env.block);
+    let interner = DbInterner::new_with(db, env.krate);
     // FIXME(next-solver): I believe this should be `PostAnalysis`.
     let infcx = interner.infer_ctxt().build(TypingMode::non_body_analysis());
 

--- a/crates/hir/src/attrs.rs
+++ b/crates/hir/src/attrs.rs
@@ -421,7 +421,7 @@ fn resolve_impl_trait_item<'db>(
     // attributes here. Use path resolution directly instead.
     //
     // FIXME: resolve type aliases (which are not yielded by iterate_path_candidates)
-    let interner = DbInterner::new_with(db, environment.krate, environment.block);
+    let interner = DbInterner::new_with(db, environment.krate);
     let infcx = interner.infer_ctxt().build(TypingMode::PostAnalysis);
     let unstable_features =
         MethodResolutionUnstableFeatures::from_def_map(resolver.top_level_def_map());

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -765,7 +765,7 @@ impl Module {
         }
         self.legacy_macros(db).into_iter().for_each(|m| emit_macro_def_diagnostics(db, acc, m));
 
-        let interner = DbInterner::new_with(db, self.id.krate(), self.id.containing_block());
+        let interner = DbInterner::new_with(db, self.id.krate());
         let infcx = interner.infer_ctxt().build(TypingMode::non_body_analysis());
 
         let mut impl_assoc_items_scratch = vec![];
@@ -5130,7 +5130,7 @@ impl<'db> Type<'db> {
         args: &[Type<'db>],
         alias: TypeAlias,
     ) -> Option<Type<'db>> {
-        let interner = DbInterner::new_with(db, self.env.krate, self.env.block);
+        let interner = DbInterner::new_with(db, self.env.krate);
         let args = generic_args_from_tys(
             interner,
             alias.id.into(),
@@ -5473,7 +5473,7 @@ impl<'db> Type<'db> {
         f: impl FnOnce(&MethodResolutionContext<'_, 'db>) -> R,
     ) -> R {
         let module = resolver.module();
-        let interner = DbInterner::new_with(db, module.krate(), module.containing_block());
+        let interner = DbInterner::new_with(db, module.krate());
         let infcx = interner.infer_ctxt().build(TypingMode::PostAnalysis);
         let unstable_features =
             MethodResolutionUnstableFeatures::from_def_map(resolver.top_level_def_map());
@@ -5812,7 +5812,7 @@ impl<'db> Type<'db> {
     }
 
     pub fn drop_glue(&self, db: &'db dyn HirDatabase) -> DropGlue {
-        let interner = DbInterner::new_with(db, self.env.krate, self.env.block);
+        let interner = DbInterner::new_with(db, self.env.krate);
         let infcx = interner.infer_ctxt().build(TypingMode::PostAnalysis);
         hir_ty::drop::has_drop_glue(&infcx, self.ty, self.env.clone())
     }

--- a/crates/hir/src/source_analyzer.rs
+++ b/crates/hir/src/source_analyzer.rs
@@ -821,7 +821,7 @@ impl<'db> SourceAnalyzer<'db> {
 
         let trait_env = container.env;
 
-        let interner = DbInterner::new_with(db, trait_env.krate, trait_env.block);
+        let interner = DbInterner::new_with(db, trait_env.krate);
         let infcx = interner.infer_ctxt().build(TypingMode::PostAnalysis);
 
         let mut container = Either::Right(container.ty);
@@ -1427,7 +1427,7 @@ impl<'db> SourceAnalyzer<'db> {
             None => return (const_id, subs),
         };
         let env = db.trait_environment_for_body(owner);
-        let interner = DbInterner::new_with(db, env.krate, env.block);
+        let interner = DbInterner::new_with(db, env.krate);
         let infcx = interner.infer_ctxt().build(TypingMode::PostAnalysis);
         method_resolution::lookup_impl_const(&infcx, env, const_id, subs)
     }

--- a/crates/ide-assists/src/handlers/generate_from_impl_for_enum.rs
+++ b/crates/ide-assists/src/handlers/generate_from_impl_for_enum.rs
@@ -123,7 +123,7 @@ fn existing_from_impl(
     let variant = sema.to_def(variant)?;
     let krate = variant.module(db).krate();
     let from_trait = FamousDefs(sema, krate).core_convert_From()?;
-    let interner = DbInterner::new_with(db, krate.base(), None);
+    let interner = DbInterner::new_with(db, krate.base());
     use hir::next_solver::infer::DbInternerInferExt;
     let infcx = interner.infer_ctxt().build(TypingMode::non_body_analysis());
 

--- a/crates/ide-assists/src/handlers/generate_single_field_struct_from.rs
+++ b/crates/ide-assists/src/handlers/generate_single_field_struct_from.rs
@@ -220,7 +220,7 @@ fn from_impl_exists(
     let strukt = sema.to_def(strukt)?;
     let krate = strukt.krate(db);
     let from_trait = FamousDefs(sema, krate).core_convert_From()?;
-    let interner = DbInterner::new_with(db, krate.base(), None);
+    let interner = DbInterner::new_with(db, krate.base());
     use hir::next_solver::infer::DbInternerInferExt;
     let infcx = interner.infer_ctxt().build(TypingMode::non_body_analysis());
 


### PR DESCRIPTION
Turns out we're not using it anymore.

That was mostly search & replace.