### PR TITLE
gdb pretty printer: fix printing when using Repr::Static

### DIFF
--- a/lib/smol_str/src/gdb_smolstr_printer.py
+++ b/lib/smol_str/src/gdb_smolstr_printer.py
@@ -73,16 +73,14 @@ class SmolStrProvider:
 
         if variant_name == "Static":
             try:
-                data_ptr = variant_val["data_ptr"]
-                length = int(variant_val["length"])
-                mem = gdb.selected_inferior().read_memory(int(data_ptr), length)
-                return _read_utf8(mem)
+                # variant_val["__0"] is &'static str
+                return variant_val["__0"]
             except Exception as e:
                 return f"<SmolStr Static error: {e}>"
 
         if variant_name == "Heap":
             try:
-                # variant_val is an Arc<str>
+                # variant_val["__0"] is an Arc<str>
                 inner = variant_val["__0"]["ptr"]["pointer"]
                 # inner is a fat pointer to ArcInner<str>
                 data_ptr = inner["data_ptr"]


### PR DESCRIPTION
I missed a ["__0"] to access the str in the Static case.

Also, simplify the code to rely on the pretty printer for str rather than accessing data_ptr/length directly. This makes it more robust against changes in str.

Output before: `"<SmolStr Static error: There is no member named data_ptr.>"`
Output after: `"preferred-width"`