### PR TITLE
internal: Remove `TraitEnvironment`

### DIFF
--- a/crates/hir-ty/src/db.rs
+++ b/crates/hir-ty/src/db.rs
@@ -12,13 +12,16 @@ use salsa::plumbing::AsId;
 use triomphe::Arc;
 
 use crate::{
-    ImplTraitId, TraitEnvironment, TyDefId, ValueTyDefId,
+    ImplTraitId, TyDefId, ValueTyDefId,
     consteval::ConstEvalError,
     dyn_compatibility::DynCompatibilityViolation,
     layout::{Layout, LayoutError},
     lower::{Diagnostics, GenericDefaults},
     mir::{BorrowckResult, MirBody, MirLowerError},
-    next_solver::{Const, EarlyBinder, GenericArgs, PolyFnSig, TraitRef, Ty, VariancesOf},
+    next_solver::{
+        Const, EarlyBinder, GenericArgs, ParamEnv, PolyFnSig, TraitRef, Ty, VariancesOf,
+    },
+    traits::ParamEnvAndCrate,
 };
 
 #[query_group::query_group]
@@ -46,7 +49,7 @@ pub trait HirDatabase: DefDatabase + std::fmt::Debug {
         &'db self,
         def: DefWithBodyId,
         subst: GenericArgs<'db>,
-        env: Arc<TraitEnvironment<'db>>,
+        env: ParamEnvAndCrate<'db>,
     ) -> Result<Arc<MirBody<'db>>, MirLowerError<'db>>;
 
     #[salsa::invoke(crate::mir::monomorphized_mir_body_for_closure_query)]
@@ -54,7 +57,7 @@ pub trait HirDatabase: DefDatabase + std::fmt::Debug {
         &'db self,
         def: InternedClosureId,
         subst: GenericArgs<'db>,
-        env: Arc<TraitEnvironment<'db>>,
+        env: ParamEnvAndCrate<'db>,
     ) -> Result<Arc<MirBody<'db>>, MirLowerError<'db>>;
 
     #[salsa::invoke(crate::mir::borrowck_query)]
@@ -70,7 +73,7 @@ pub trait HirDatabase: DefDatabase + std::fmt::Debug {
         &'db self,
         def: ConstId,
         subst: GenericArgs<'db>,
-        trait_env: Option<Arc<TraitEnvironment<'db>>>,
+        trait_env: Option<ParamEnvAndCrate<'db>>,
     ) -> Result<Const<'db>, ConstEvalError<'db>>;
 
     #[salsa::invoke(crate::consteval::const_eval_static_query)]
@@ -88,7 +91,7 @@ pub trait HirDatabase: DefDatabase + std::fmt::Debug {
     #[salsa::transparent]
     fn lookup_impl_method<'db>(
         &'db self,
-        env: Arc<TraitEnvironment<'db>>,
+        env: ParamEnvAndCrate<'db>,
         func: FunctionId,
         fn_subst: GenericArgs<'db>,
     ) -> (FunctionId, GenericArgs<'db>);
@@ -101,7 +104,7 @@ pub trait HirDatabase: DefDatabase + std::fmt::Debug {
         &'db self,
         def: AdtId,
         args: GenericArgs<'db>,
-        trait_env: Arc<TraitEnvironment<'db>>,
+        trait_env: ParamEnvAndCrate<'db>,
     ) -> Result<Arc<Layout>, LayoutError>;
 
     #[salsa::invoke(crate::layout::layout_of_ty_query)]
@@ -109,7 +112,7 @@ pub trait HirDatabase: DefDatabase + std::fmt::Debug {
     fn layout_of_ty<'db>(
         &'db self,
         ty: Ty<'db>,
-        env: Arc<TraitEnvironment<'db>>,
+        env: ParamEnvAndCrate<'db>,
     ) -> Result<Arc<Layout>, LayoutError>;
 
     #[salsa::invoke(crate::layout::target_data_layout_query)]
@@ -186,11 +189,10 @@ pub trait HirDatabase: DefDatabase + std::fmt::Debug {
 
     #[salsa::invoke(crate::lower::trait_environment_for_body_query)]
     #[salsa::transparent]
-    fn trait_environment_for_body<'db>(&'db self, def: DefWithBodyId)
-    -> Arc<TraitEnvironment<'db>>;
+    fn trait_environment_for_body<'db>(&'db self, def: DefWithBodyId) -> ParamEnv<'db>;
 
     #[salsa::invoke(crate::lower::trait_environment_query)]
-    fn trait_environment<'db>(&'db self, def: GenericDefId) -> Arc<TraitEnvironment<'db>>;
+    fn trait_environment<'db>(&'db self, def: GenericDefId) -> ParamEnv<'db>;
 
     #[salsa::invoke(crate::lower::generic_defaults_with_diagnostics_query)]
     #[salsa::cycle(cycle_result = crate::lower::generic_defaults_with_diagnostics_cycle_result)]

--- a/crates/hir-ty/src/diagnostics/match_check/pat_analysis.rs
+++ b/crates/hir-ty/src/diagnostics/match_check/pat_analysis.rs
@@ -14,14 +14,12 @@ use rustc_pattern_analysis::{
 use rustc_type_ir::inherent::{AdtDef, IntoKind, SliceLike};
 use smallvec::{SmallVec, smallvec};
 use stdx::never;
-use triomphe::Arc;
 
 use crate::{
-    TraitEnvironment,
     db::HirDatabase,
     inhabitedness::{is_enum_variant_uninhabited_from, is_ty_uninhabited_from},
     next_solver::{
-        Ty, TyKind,
+        ParamEnv, Ty, TyKind,
         infer::{InferCtxt, traits::ObligationCause},
     },
 };
@@ -76,16 +74,12 @@ pub(crate) struct MatchCheckCtx<'a, 'db> {
     module: ModuleId,
     pub(crate) db: &'db dyn HirDatabase,
     exhaustive_patterns: bool,
-    env: Arc<TraitEnvironment<'db>>,
+    env: ParamEnv<'db>,
     infcx: &'a InferCtxt<'db>,
 }
 
 impl<'a, 'db> MatchCheckCtx<'a, 'db> {
-    pub(crate) fn new(
-        module: ModuleId,
-        infcx: &'a InferCtxt<'db>,
-        env: Arc<TraitEnvironment<'db>>,
-    ) -> Self {
+    pub(crate) fn new(module: ModuleId, infcx: &'a InferCtxt<'db>, env: ParamEnv<'db>) -> Self {
         let db = infcx.interner.db;
         let def_map = module.crate_def_map(db);
         let exhaustive_patterns = def_map.is_unstable_feature_enabled(&sym::exhaustive_patterns);
@@ -114,7 +108,7 @@ impl<'a, 'db> MatchCheckCtx<'a, 'db> {
     }
 
     fn is_uninhabited(&self, ty: Ty<'db>) -> bool {
-        is_ty_uninhabited_from(self.infcx, ty, self.module, self.env.clone())
+        is_ty_uninhabited_from(self.infcx, ty, self.module, self.env)
     }
 
     /// Returns whether the given ADT is from another crate declared `#[non_exhaustive]`.
@@ -159,7 +153,7 @@ impl<'a, 'db> MatchCheckCtx<'a, 'db> {
             let ty = field_tys[fid].instantiate(self.infcx.interner, substs);
             let ty = self
                 .infcx
-                .at(&ObligationCause::dummy(), self.env.env)
+                .at(&ObligationCause::dummy(), self.env)
                 .deeply_normalize(ty)
                 .unwrap_or(ty);
             (fid, ty)
@@ -446,11 +440,7 @@ impl<'a, 'db> PatCx for MatchCheckCtx<'a, 'db> {
                             let mut variants = IndexVec::with_capacity(enum_data.variants.len());
                             for &(variant, _, _) in enum_data.variants.iter() {
                                 let is_uninhabited = is_enum_variant_uninhabited_from(
-                                    cx.infcx,
-                                    variant,
-                                    subst,
-                                    cx.module,
-                                    self.env.clone(),
+                                    cx.infcx, variant, subst, cx.module, self.env,
                                 );
                                 let visibility = if is_uninhabited {
                                     VariantVisibility::Empty

--- a/crates/hir-ty/src/infer.rs
+++ b/crates/hir-ty/src/infer.rs
@@ -944,7 +944,7 @@ impl<'body, 'db> InferenceContext<'body, 'db> {
         resolver: Resolver<'db>,
     ) -> Self {
         let trait_env = db.trait_environment_for_body(owner);
-        let table = unify::InferenceTable::new(db, trait_env, Some(owner));
+        let table = unify::InferenceTable::new(db, trait_env, resolver.krate(), Some(owner));
         let types = InternedStandardTypes::new(table.interner());
         InferenceContext {
             result: InferenceResult::new(types.error),

--- a/crates/hir-ty/src/infer/autoderef.rs
+++ b/crates/hir-ty/src/infer/autoderef.rs
@@ -16,11 +16,11 @@ use crate::{
 
 impl<'db> InferenceTable<'db> {
     pub(crate) fn autoderef(&self, base_ty: Ty<'db>) -> Autoderef<'_, 'db, usize> {
-        Autoderef::new(&self.infer_ctxt, &self.trait_env, base_ty)
+        Autoderef::new(&self.infer_ctxt, self.param_env, base_ty)
     }
 
     pub(crate) fn autoderef_with_tracking(&self, base_ty: Ty<'db>) -> Autoderef<'_, 'db> {
-        Autoderef::new_with_tracking(&self.infer_ctxt, &self.trait_env, base_ty)
+        Autoderef::new_with_tracking(&self.infer_ctxt, self.param_env, base_ty)
     }
 }
 

--- a/crates/hir-ty/src/infer/closure.rs
+++ b/crates/hir-ty/src/infer/closure.rs
@@ -367,7 +367,7 @@ impl<'db> InferenceContext<'_, 'db> {
                     _ = self
                         .table
                         .infer_ctxt
-                        .at(&ObligationCause::new(), self.table.trait_env.env)
+                        .at(&ObligationCause::new(), self.table.param_env)
                         .eq(inferred_fnptr_sig, generalized_fnptr_sig)
                         .map(|infer_ok| self.table.register_infer_ok(infer_ok));
 
@@ -749,19 +749,18 @@ impl<'db> InferenceContext<'_, 'db> {
             {
                 // Check that E' = S'.
                 let cause = ObligationCause::new();
-                let InferOk { value: (), obligations } = table
-                    .infer_ctxt
-                    .at(&cause, table.trait_env.env)
-                    .eq(expected_ty, supplied_ty)?;
+                let InferOk { value: (), obligations } =
+                    table.infer_ctxt.at(&cause, table.param_env).eq(expected_ty, supplied_ty)?;
                 all_obligations.extend(obligations);
             }
 
             let supplied_output_ty = supplied_sig.output();
             let cause = ObligationCause::new();
-            let InferOk { value: (), obligations } = table
-                .infer_ctxt
-                .at(&cause, table.trait_env.env)
-                .eq(expected_sigs.liberated_sig.output(), supplied_output_ty)?;
+            let InferOk { value: (), obligations } =
+                table
+                    .infer_ctxt
+                    .at(&cause, table.param_env)
+                    .eq(expected_sigs.liberated_sig.output(), supplied_output_ty)?;
             all_obligations.extend(obligations);
 
             let inputs = supplied_sig

--- a/crates/hir-ty/src/infer/op.rs
+++ b/crates/hir-ty/src/infer/op.rs
@@ -343,7 +343,7 @@ impl<'a, 'db> InferenceContext<'a, 'db> {
                 let obligation = Obligation::new(
                     self.interner(),
                     cause,
-                    self.table.trait_env.env,
+                    self.table.param_env,
                     TraitRef::new_from_args(self.interner(), trait_did.into(), args),
                 );
                 let mut ocx = ObligationCtxt::new(self.infcx());

--- a/crates/hir-ty/src/infer/opaques.rs
+++ b/crates/hir-ty/src/infer/opaques.rs
@@ -136,7 +136,7 @@ impl<'db> InferenceContext<'_, 'db> {
         }
 
         let cause = ObligationCause::new();
-        let at = self.table.infer_ctxt.at(&cause, self.table.trait_env.env);
+        let at = self.table.infer_ctxt.at(&cause, self.table.param_env);
         let hidden_type = match at.deeply_normalize(hidden_type) {
             Ok(hidden_type) => hidden_type,
             Err(_errors) => OpaqueHiddenType { ty: self.types.error },

--- a/crates/hir-ty/src/infer/path.rs
+++ b/crates/hir-ty/src/infer/path.rs
@@ -224,7 +224,7 @@ impl<'db> InferenceContext<'_, 'db> {
     ) {
         let interner = self.interner();
         let predicates = GenericPredicates::query_all(self.db, def);
-        let param_env = self.table.trait_env.env;
+        let param_env = self.table.param_env;
         self.table.register_predicates(clauses_as_obligations(
             predicates.iter_instantiated_copied(interner, subst.as_slice()),
             ObligationCause::new(),
@@ -343,7 +343,7 @@ impl<'db> InferenceContext<'_, 'db> {
                 self.table.register_predicate(Obligation::new(
                     self.interner(),
                     ObligationCause::new(),
-                    self.table.trait_env.env,
+                    self.table.param_env,
                     trait_ref,
                 ));
                 args

--- a/crates/hir-ty/src/infer/place_op.rs
+++ b/crates/hir-ty/src/infer/place_op.rs
@@ -124,7 +124,7 @@ impl<'a, 'db> InferenceContext<'a, 'db> {
                     ctx.table.register_predicate(Obligation::new(
                         ctx.interner(),
                         ObligationCause::new(),
-                        ctx.table.trait_env.env,
+                        ctx.table.param_env,
                         ClauseKind::ConstArgHasType(ct, ctx.types.usize),
                     ));
                     self_ty = Ty::new_slice(ctx.interner(), element_ty);

--- a/crates/hir-ty/src/infer/unify.rs
+++ b/crates/hir-ty/src/infer/unify.rs
@@ -2,6 +2,7 @@
 
 use std::fmt;
 
+use base_db::Crate;
 use hir_def::{AdtId, DefWithBodyId, GenericParamId};
 use hir_expand::name::Name;
 use intern::sym;
@@ -12,15 +13,13 @@ use rustc_type_ir::{
     solve::Certainty,
 };
 use smallvec::SmallVec;
-use triomphe::Arc;
 
 use crate::{
-    TraitEnvironment,
     db::HirDatabase,
     next_solver::{
         AliasTy, Canonical, ClauseKind, Const, DbInterner, ErrorGuaranteed, GenericArg,
-        GenericArgs, Goal, Predicate, PredicateKind, Region, SolverDefId, Term, TraitRef, Ty,
-        TyKind, TypingMode,
+        GenericArgs, Goal, ParamEnv, Predicate, PredicateKind, Region, SolverDefId, Term, TraitRef,
+        Ty, TyKind, TypingMode,
         fulfill::{FulfillmentCtxt, NextSolverError},
         infer::{
             DbInternerInferExt, InferCtxt, InferOk, InferResult,
@@ -32,7 +31,8 @@ use crate::{
         obligation_ctxt::ObligationCtxt,
     },
     traits::{
-        FnTrait, NextTraitSolveResult, next_trait_solve_canonical_in_ctxt, next_trait_solve_in_ctxt,
+        FnTrait, NextTraitSolveResult, ParamEnvAndCrate, next_trait_solve_canonical_in_ctxt,
+        next_trait_solve_in_ctxt,
     },
 };
 
@@ -89,7 +89,7 @@ impl<'a, 'db> ProofTreeVisitor<'db> for NestedObligationsForSelfTy<'a, 'db> {
 /// unresolved goal `T = U`.
 pub fn could_unify<'db>(
     db: &'db dyn HirDatabase,
-    env: Arc<TraitEnvironment<'db>>,
+    env: ParamEnvAndCrate<'db>,
     tys: &Canonical<'db, (Ty<'db>, Ty<'db>)>,
 ) -> bool {
     could_unify_impl(db, env, tys, |ctxt| ctxt.try_evaluate_obligations())
@@ -101,7 +101,7 @@ pub fn could_unify<'db>(
 /// them. For example `Option<T>` and `Option<U>` do not unify as we cannot show that `T = U`
 pub fn could_unify_deeply<'db>(
     db: &'db dyn HirDatabase,
-    env: Arc<TraitEnvironment<'db>>,
+    env: ParamEnvAndCrate<'db>,
     tys: &Canonical<'db, (Ty<'db>, Ty<'db>)>,
 ) -> bool {
     could_unify_impl(db, env, tys, |ctxt| ctxt.evaluate_obligations_error_on_ambiguity())
@@ -109,14 +109,14 @@ pub fn could_unify_deeply<'db>(
 
 fn could_unify_impl<'db>(
     db: &'db dyn HirDatabase,
-    env: Arc<TraitEnvironment<'db>>,
+    env: ParamEnvAndCrate<'db>,
     tys: &Canonical<'db, (Ty<'db>, Ty<'db>)>,
     select: for<'a> fn(&mut ObligationCtxt<'a, 'db>) -> Vec<NextSolverError<'db>>,
 ) -> bool {
     let interner = DbInterner::new_with(db, env.krate);
     let infcx = interner.infer_ctxt().build(TypingMode::PostAnalysis);
     let cause = ObligationCause::dummy();
-    let at = infcx.at(&cause, env.env);
+    let at = infcx.at(&cause, env.param_env);
     let ((ty1_with_vars, ty2_with_vars), _) = infcx.instantiate_canonical(tys);
     let mut ctxt = ObligationCtxt::new(&infcx);
     let can_unify = at
@@ -129,7 +129,7 @@ fn could_unify_impl<'db>(
 #[derive(Clone)]
 pub(crate) struct InferenceTable<'db> {
     pub(crate) db: &'db dyn HirDatabase,
-    pub(crate) trait_env: Arc<TraitEnvironment<'db>>,
+    pub(crate) param_env: ParamEnv<'db>,
     pub(crate) infer_ctxt: InferCtxt<'db>,
     pub(super) fulfillment_cx: FulfillmentCtxt<'db>,
     pub(super) diverging_type_vars: FxHashSet<Ty<'db>>,
@@ -145,10 +145,11 @@ impl<'db> InferenceTable<'db> {
     /// Outside it, always pass `owner = None`.
     pub(crate) fn new(
         db: &'db dyn HirDatabase,
-        trait_env: Arc<TraitEnvironment<'db>>,
+        trait_env: ParamEnv<'db>,
+        krate: Crate,
         owner: Option<DefWithBodyId>,
     ) -> Self {
-        let interner = DbInterner::new_with(db, trait_env.krate);
+        let interner = DbInterner::new_with(db, krate);
         let typing_mode = match owner {
             Some(owner) => TypingMode::typeck_for_body(interner, owner.into()),
             // IDE things wants to reveal opaque types.
@@ -157,7 +158,7 @@ impl<'db> InferenceTable<'db> {
         let infer_ctxt = interner.infer_ctxt().build(typing_mode);
         InferenceTable {
             db,
-            trait_env,
+            param_env: trait_env,
             fulfillment_cx: FulfillmentCtxt::new(&infer_ctxt),
             infer_ctxt,
             diverging_type_vars: FxHashSet::default(),
@@ -170,7 +171,7 @@ impl<'db> InferenceTable<'db> {
     }
 
     pub(crate) fn type_is_copy_modulo_regions(&self, ty: Ty<'db>) -> bool {
-        self.infer_ctxt.type_is_copy_modulo_regions(self.trait_env.env, ty)
+        self.infer_ctxt.type_is_copy_modulo_regions(self.param_env, ty)
     }
 
     pub(crate) fn type_var_is_sized(&self, self_ty: TyVid) -> bool {
@@ -272,7 +273,7 @@ impl<'db> InferenceTable<'db> {
 
     pub(crate) fn normalize_alias_ty(&mut self, alias: Ty<'db>) -> Ty<'db> {
         self.infer_ctxt
-            .at(&ObligationCause::new(), self.trait_env.env)
+            .at(&ObligationCause::new(), self.param_env)
             .structurally_normalize_ty(alias, &mut self.fulfillment_cx)
             .unwrap_or(alias)
     }
@@ -332,7 +333,7 @@ impl<'db> InferenceTable<'db> {
     }
 
     pub(crate) fn at<'a>(&'a self, cause: &'a ObligationCause) -> At<'a, 'db> {
-        self.infer_ctxt.at(cause, self.trait_env.env)
+        self.infer_ctxt.at(cause, self.param_env)
     }
 
     pub(crate) fn shallow_resolve(&self, ty: Ty<'db>) -> Ty<'db> {
@@ -374,7 +375,7 @@ impl<'db> InferenceTable<'db> {
             // in a reentrant borrow, causing an ICE.
             let result = self
                 .infer_ctxt
-                .at(&ObligationCause::misc(), self.trait_env.env)
+                .at(&ObligationCause::misc(), self.param_env)
                 .structurally_normalize_ty(ty, &mut self.fulfillment_cx);
             match result {
                 Ok(normalized_ty) => normalized_ty,
@@ -422,14 +423,14 @@ impl<'db> InferenceTable<'db> {
     /// choice (during e.g. method resolution or deref).
     #[tracing::instrument(level = "debug", skip(self))]
     pub(crate) fn try_obligation(&mut self, predicate: Predicate<'db>) -> NextTraitSolveResult {
-        let goal = Goal { param_env: self.trait_env.env, predicate };
+        let goal = Goal { param_env: self.param_env, predicate };
         let canonicalized = self.canonicalize(goal);
 
         next_trait_solve_canonical_in_ctxt(&self.infer_ctxt, canonicalized)
     }
 
     pub(crate) fn register_obligation(&mut self, predicate: Predicate<'db>) {
-        let goal = Goal { param_env: self.trait_env.env, predicate };
+        let goal = Goal { param_env: self.param_env, predicate };
         self.register_obligation_in_env(goal)
     }
 
@@ -486,7 +487,7 @@ impl<'db> InferenceTable<'db> {
         self.register_predicate(Obligation::new(
             self.interner(),
             cause,
-            self.trait_env.env,
+            self.param_env,
             ClauseKind::WellFormed(term),
         ));
     }

--- a/crates/hir-ty/src/layout/adt.rs
+++ b/crates/hir-ty/src/layout/adt.rs
@@ -13,7 +13,7 @@ use smallvec::SmallVec;
 use triomphe::Arc;
 
 use crate::{
-    TraitEnvironment,
+    ParamEnvAndCrate,
     db::HirDatabase,
     layout::{Layout, LayoutCx, LayoutError, field_ty},
     next_solver::GenericArgs,
@@ -23,7 +23,7 @@ pub fn layout_of_adt_query<'db>(
     db: &'db dyn HirDatabase,
     def: AdtId,
     args: GenericArgs<'db>,
-    trait_env: Arc<TraitEnvironment<'db>>,
+    trait_env: ParamEnvAndCrate<'db>,
 ) -> Result<Arc<Layout>, LayoutError> {
     let krate = trait_env.krate;
     let Ok(target) = db.target_data_layout(krate) else {
@@ -34,7 +34,7 @@ pub fn layout_of_adt_query<'db>(
     let handle_variant = |def: VariantId, var: &VariantFields| {
         var.fields()
             .iter()
-            .map(|(fd, _)| db.layout_of_ty(field_ty(db, def, fd, &args), trait_env.clone()))
+            .map(|(fd, _)| db.layout_of_ty(field_ty(db, def, fd, &args), trait_env))
             .collect::<Result<Vec<_>, _>>()
     };
     let (variants, repr, is_special_no_niche) = match def {
@@ -99,7 +99,7 @@ pub(crate) fn layout_of_adt_cycle_result<'db>(
     _: &'db dyn HirDatabase,
     _def: AdtId,
     _args: GenericArgs<'db>,
-    _trait_env: Arc<TraitEnvironment<'db>>,
+    _trait_env: ParamEnvAndCrate<'db>,
 ) -> Result<Arc<Layout>, LayoutError> {
     Err(LayoutError::RecursiveTypeWithoutIndirection)
 }

--- a/crates/hir-ty/src/layout/tests.rs
+++ b/crates/hir-ty/src/layout/tests.rs
@@ -1,6 +1,6 @@
 use base_db::target::TargetData;
 use either::Either;
-use hir_def::db::DefDatabase;
+use hir_def::{HasModule, db::DefDatabase};
 use project_model::{Sysroot, toolchain_info::QueryConfig};
 use rustc_hash::FxHashMap;
 use rustc_type_ir::inherent::GenericArgs as _;
@@ -9,7 +9,7 @@ use test_fixture::WithFixture;
 use triomphe::Arc;
 
 use crate::{
-    InferenceResult,
+    InferenceResult, ParamEnvAndCrate,
     db::HirDatabase,
     layout::{Layout, LayoutError},
     next_solver::{DbInterner, GenericArgs},
@@ -90,13 +90,15 @@ fn eval_goal(
             ),
             Either::Right(ty_id) => db.ty(ty_id.into()).instantiate_identity(),
         };
-        db.layout_of_ty(
-            goal_ty,
-            db.trait_environment(match adt_or_type_alias_id {
-                Either::Left(adt) => hir_def::GenericDefId::AdtId(adt),
-                Either::Right(ty) => hir_def::GenericDefId::TypeAliasId(ty),
-            }),
-        )
+        let param_env = db.trait_environment(match adt_or_type_alias_id {
+            Either::Left(adt) => hir_def::GenericDefId::AdtId(adt),
+            Either::Right(ty) => hir_def::GenericDefId::TypeAliasId(ty),
+        });
+        let krate = match adt_or_type_alias_id {
+            Either::Left(it) => it.krate(&db),
+            Either::Right(it) => it.krate(&db),
+        };
+        db.layout_of_ty(goal_ty, ParamEnvAndCrate { param_env, krate })
     })
 }
 
@@ -139,7 +141,9 @@ fn eval_expr(
             .0;
         let infer = InferenceResult::for_body(&db, function_id.into());
         let goal_ty = infer.type_of_binding[b];
-        db.layout_of_ty(goal_ty, db.trait_environment(function_id.into()))
+        let param_env = db.trait_environment(function_id.into());
+        let krate = function_id.krate(&db);
+        db.layout_of_ty(goal_ty, ParamEnvAndCrate { param_env, krate })
     })
 }
 

--- a/crates/hir-ty/src/lib.rs
+++ b/crates/hir-ty/src/lib.rs
@@ -67,7 +67,6 @@ use rustc_type_ir::{
 };
 use syntax::ast::{ConstArg, make};
 use traits::FnTrait;
-use triomphe::Arc;
 
 use crate::{
     db::HirDatabase,
@@ -94,7 +93,7 @@ pub use lower::{
 };
 pub use next_solver::interner::{attach_db, attach_db_allow_change, with_attached_db};
 pub use target_feature::TargetFeatures;
-pub use traits::{TraitEnvironment, check_orphan_rules};
+pub use traits::{ParamEnvAndCrate, check_orphan_rules};
 pub use utils::{
     TargetFeatureIsSafeInTarget, Unsafety, all_super_traits, direct_super_traits,
     is_fn_unsafe_to_call, target_feature_is_safe_in_target,
@@ -474,10 +473,10 @@ where
 /// To be used from `hir` only.
 pub fn callable_sig_from_fn_trait<'db>(
     self_ty: Ty<'db>,
-    trait_env: Arc<TraitEnvironment<'db>>,
+    trait_env: ParamEnvAndCrate<'db>,
     db: &'db dyn HirDatabase,
 ) -> Option<(FnTrait, PolyFnSig<'db>)> {
-    let mut table = InferenceTable::new(db, trait_env.clone(), None);
+    let mut table = InferenceTable::new(db, trait_env.param_env, trait_env.krate, None);
     let lang_items = table.interner().lang_items();
 
     let fn_once_trait = FnTrait::FnOnce.get_id(lang_items)?;

--- a/crates/hir-ty/src/method_resolution/confirm.rs
+++ b/crates/hir-ty/src/method_resolution/confirm.rs
@@ -507,7 +507,7 @@ impl<'a, 'b, 'db> ConfirmContext<'a, 'b, 'db> {
             GenericPredicates::query_all(self.db(), def_id.into())
                 .iter_instantiated_copied(self.interner(), all_args),
             ObligationCause::new(),
-            self.ctx.table.trait_env.env,
+            self.ctx.table.param_env,
         );
 
         let sig =

--- a/crates/hir-ty/src/method_resolution/probe.rs
+++ b/crates/hir-ty/src/method_resolution/probe.rs
@@ -334,7 +334,7 @@ impl<'a, 'db> MethodResolutionContext<'a, 'db> {
                     .infcx
                     .instantiate_query_response_and_region_obligations(
                         &ObligationCause::new(),
-                        self.env.env,
+                        self.param_env,
                         &orig_values,
                         ty,
                     )
@@ -394,7 +394,7 @@ impl<'a, 'db> MethodResolutionContext<'a, 'db> {
             // converted to, in order to find out which of those methods might actually
             // be callable.
             let mut autoderef_via_deref =
-                Autoderef::new(infcx, self.env, self_ty).include_raw_pointers();
+                Autoderef::new(infcx, self.param_env, self_ty).include_raw_pointers();
 
             let mut reached_raw_pointer = false;
             let arbitrary_self_types_enabled = self.unstable_features.arbitrary_self_types
@@ -403,7 +403,7 @@ impl<'a, 'db> MethodResolutionContext<'a, 'db> {
                 let reachable_via_deref =
                     autoderef_via_deref.by_ref().map(|_| true).chain(std::iter::repeat(false));
 
-                let mut autoderef_via_receiver = Autoderef::new(infcx, self.env, self_ty)
+                let mut autoderef_via_receiver = Autoderef::new(infcx, self.param_env, self_ty)
                     .include_raw_pointers()
                     .use_receiver_trait();
                 let steps = autoderef_via_receiver
@@ -835,7 +835,7 @@ impl<'a, 'db, Choice: ProbeChoice<'db>> ProbeContext<'a, 'db, Choice> {
 
     #[inline]
     fn param_env(&self) -> ParamEnv<'db> {
-        self.ctx.env.env
+        self.ctx.param_env
     }
 
     /// When we're looking up a method by path (UFCS), we relate the receiver

--- a/crates/hir-ty/src/mir/eval/shim.rs
+++ b/crates/hir-ty/src/mir/eval/shim.rs
@@ -840,7 +840,7 @@ impl<'db> Evaluator<'db> {
                         "size_of generic arg is not provided".into(),
                     ));
                 };
-                let result = match has_drop_glue(&self.infcx, ty, self.trait_env.clone()) {
+                let result = match has_drop_glue(&self.infcx, ty, self.param_env.param_env) {
                     DropGlue::HasDropGlue => true,
                     DropGlue::None => false,
                     DropGlue::DependOnParams => {

--- a/crates/hir-ty/src/mir/eval/tests.rs
+++ b/crates/hir-ty/src/mir/eval/tests.rs
@@ -1,4 +1,4 @@
-use hir_def::db::DefDatabase;
+use hir_def::{HasModule, db::DefDatabase};
 use hir_expand::EditionedFileId;
 use span::Edition;
 use syntax::{TextRange, TextSize};
@@ -40,7 +40,10 @@ fn eval_main(db: &TestDB, file_id: EditionedFileId) -> Result<(String, String), 
             .monomorphized_mir_body(
                 func_id.into(),
                 GenericArgs::new_from_iter(interner, []),
-                db.trait_environment(func_id.into()),
+                crate::ParamEnvAndCrate {
+                    param_env: db.trait_environment(func_id.into()),
+                    krate: func_id.krate(db),
+                },
             )
             .map_err(|e| MirEvalError::MirLowerError(func_id, e))?;
 

--- a/crates/hir-ty/src/mir/monomorphization.rs
+++ b/crates/hir-ty/src/mir/monomorphization.rs
@@ -14,9 +14,11 @@ use rustc_type_ir::{
 };
 use triomphe::Arc;
 
-use crate::next_solver::{Const, ConstKind, Region, RegionKind};
 use crate::{
-    TraitEnvironment,
+    ParamEnvAndCrate,
+    next_solver::{Const, ConstKind, Region, RegionKind},
+};
+use crate::{
     db::{HirDatabase, InternedClosureId},
     next_solver::{
         DbInterner, GenericArgs, Ty, TyKind, TypingMode,
@@ -30,7 +32,7 @@ use super::{MirBody, MirLowerError, Operand, OperandKind, Rvalue, StatementKind,
 
 struct Filler<'db> {
     infcx: InferCtxt<'db>,
-    trait_env: Arc<TraitEnvironment<'db>>,
+    trait_env: ParamEnvAndCrate<'db>,
     subst: GenericArgs<'db>,
 }
 
@@ -53,7 +55,11 @@ impl<'db> FallibleTypeFolder<DbInterner<'db>> for Filler<'db> {
 
                 let mut ocx = ObligationCtxt::new(&self.infcx);
                 let ty = ocx
-                    .structurally_normalize_ty(&ObligationCause::dummy(), self.trait_env.env, ty)
+                    .structurally_normalize_ty(
+                        &ObligationCause::dummy(),
+                        self.trait_env.param_env,
+                        ty,
+                    )
                     .map_err(|_| MirLowerError::NotSupported("can't normalize alias".to_owned()))?;
                 ty.try_super_fold_with(self)
             }
@@ -93,11 +99,7 @@ impl<'db> FallibleTypeFolder<DbInterner<'db>> for Filler<'db> {
 }
 
 impl<'db> Filler<'db> {
-    fn new(
-        db: &'db dyn HirDatabase,
-        env: Arc<TraitEnvironment<'db>>,
-        subst: GenericArgs<'db>,
-    ) -> Self {
+    fn new(db: &'db dyn HirDatabase, env: ParamEnvAndCrate<'db>, subst: GenericArgs<'db>) -> Self {
         let interner = DbInterner::new_with(db, env.krate);
         let infcx = interner.infer_ctxt().build(TypingMode::PostAnalysis);
         Self { infcx, trait_env: env, subst }
@@ -210,7 +212,7 @@ pub fn monomorphized_mir_body_query<'db>(
     db: &'db dyn HirDatabase,
     owner: DefWithBodyId,
     subst: GenericArgs<'db>,
-    trait_env: Arc<crate::TraitEnvironment<'db>>,
+    trait_env: ParamEnvAndCrate<'db>,
 ) -> Result<Arc<MirBody<'db>>, MirLowerError<'db>> {
     let mut filler = Filler::new(db, trait_env, subst);
     let body = db.mir_body(owner)?;
@@ -223,7 +225,7 @@ pub(crate) fn monomorphized_mir_body_cycle_result<'db>(
     _db: &'db dyn HirDatabase,
     _: DefWithBodyId,
     _: GenericArgs<'db>,
-    _: Arc<crate::TraitEnvironment<'db>>,
+    _: ParamEnvAndCrate<'db>,
 ) -> Result<Arc<MirBody<'db>>, MirLowerError<'db>> {
     Err(MirLowerError::Loop)
 }
@@ -232,7 +234,7 @@ pub fn monomorphized_mir_body_for_closure_query<'db>(
     db: &'db dyn HirDatabase,
     closure: InternedClosureId,
     subst: GenericArgs<'db>,
-    trait_env: Arc<crate::TraitEnvironment<'db>>,
+    trait_env: ParamEnvAndCrate<'db>,
 ) -> Result<Arc<MirBody<'db>>, MirLowerError<'db>> {
     let mut filler = Filler::new(db, trait_env, subst);
     let body = db.mir_body_for_closure(closure)?;

--- a/crates/hir-ty/src/next_solver/predicate.rs
+++ b/crates/hir-ty/src/next_solver/predicate.rs
@@ -427,6 +427,10 @@ impl<'db> ParamEnv<'db> {
     pub fn empty() -> Self {
         ParamEnv { clauses: Clauses::new_from_iter(DbInterner::conjure(), []) }
     }
+
+    pub fn clauses(self) -> Clauses<'db> {
+        self.clauses
+    }
 }
 
 impl<'db> rustc_type_ir::inherent::ParamEnv<DbInterner<'db>> for ParamEnv<'db> {

--- a/crates/hir-ty/src/opaques.rs
+++ b/crates/hir-ty/src/opaques.rs
@@ -122,7 +122,7 @@ pub(crate) fn tait_hidden_types<'db>(
     let infcx = interner.infer_ctxt().build(TypingMode::non_body_analysis());
     let mut ocx = ObligationCtxt::new(&infcx);
     let cause = ObligationCause::dummy();
-    let param_env = db.trait_environment(type_alias.into()).env;
+    let param_env = db.trait_environment(type_alias.into());
 
     let defining_bodies = tait_defining_bodies(db, &loc);
 

--- a/crates/hir-ty/src/specialization.rs
+++ b/crates/hir-ty/src/specialization.rs
@@ -1,6 +1,6 @@
 //! Impl specialization related things
 
-use hir_def::{ImplId, nameres::crate_def_map};
+use hir_def::{HasModule, ImplId, nameres::crate_def_map};
 use intern::sym;
 use rustc_type_ir::inherent::SliceLike;
 use tracing::debug;
@@ -46,7 +46,7 @@ fn specializes_query(
     parent_impl_def_id: ImplId,
 ) -> bool {
     let trait_env = db.trait_environment(specializing_impl_def_id.into());
-    let interner = DbInterner::new_with(db, trait_env.krate);
+    let interner = DbInterner::new_with(db, specializing_impl_def_id.krate(db));
 
     let specializing_impl_signature = db.impl_signature(specializing_impl_def_id);
     let parent_impl_signature = db.impl_signature(parent_impl_def_id);
@@ -70,7 +70,7 @@ fn specializes_query(
 
     // create a parameter environment corresponding to an identity instantiation of the specializing impl,
     // i.e. the most generic instantiation of the specializing impl.
-    let param_env = trait_env.env;
+    let param_env = trait_env;
 
     // Create an infcx, taking the predicates of the specializing impl as assumptions:
     let infcx = interner.infer_ctxt().build(TypingMode::non_body_analysis());

--- a/crates/hir-ty/src/traits.rs
+++ b/crates/hir-ty/src/traits.rs
@@ -4,7 +4,7 @@ use std::hash::Hash;
 
 use base_db::Crate;
 use hir_def::{
-    AdtId, AssocItemId, BlockId, HasModule, ImplId, Lookup, TraitId,
+    AdtId, AssocItemId, HasModule, ImplId, Lookup, TraitId,
     lang_item::LangItems,
     nameres::DefMap,
     signatures::{ConstFlags, EnumFlags, FnFlags, StructFlags, TraitFlags, TypeAliasFlags},
@@ -17,7 +17,6 @@ use rustc_type_ir::{
     inherent::{AdtDef, BoundExistentialPredicates, IntoKind, Span as _},
     solve::Certainty,
 };
-use triomphe::Arc;
 
 use crate::{
     db::HirDatabase,
@@ -29,60 +28,22 @@ use crate::{
     },
 };
 
-/// A set of clauses that we assume to be true. E.g. if we are inside this function:
-/// ```rust
-/// fn foo<T: Default>(t: T) {}
-/// ```
-/// we assume that `T: Default`.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct TraitEnvironment<'db> {
+/// Type for `hir`, because commonly we want both param env and a crate in an exported API.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct ParamEnvAndCrate<'db> {
+    pub param_env: ParamEnv<'db>,
     pub krate: Crate,
-    pub block: Option<BlockId>,
-    // FIXME make this a BTreeMap
-    traits_from_clauses: Box<[(Ty<'db>, TraitId)]>,
-    pub env: ParamEnv<'db>,
-}
-
-impl<'db> TraitEnvironment<'db> {
-    pub fn empty(krate: Crate) -> Arc<Self> {
-        Arc::new(TraitEnvironment {
-            krate,
-            block: None,
-            traits_from_clauses: Box::default(),
-            env: ParamEnv::empty(),
-        })
-    }
-
-    pub fn new(
-        krate: Crate,
-        block: Option<BlockId>,
-        traits_from_clauses: Box<[(Ty<'db>, TraitId)]>,
-        env: ParamEnv<'db>,
-    ) -> Arc<Self> {
-        Arc::new(TraitEnvironment { krate, block, traits_from_clauses, env })
-    }
-
-    // pub fn with_block(self: &mut Arc<Self>, block: BlockId) {
-    pub fn with_block(this: &mut Arc<Self>, block: BlockId) {
-        Arc::make_mut(this).block = Some(block);
-    }
-
-    pub fn traits_in_scope_from_clauses(&self, ty: Ty<'db>) -> impl Iterator<Item = TraitId> + '_ {
-        self.traits_from_clauses
-            .iter()
-            .filter_map(move |(self_ty, trait_id)| (*self_ty == ty).then_some(*trait_id))
-    }
 }
 
 /// This should be used in `hir` only.
 pub fn structurally_normalize_ty<'db>(
     infcx: &InferCtxt<'db>,
     ty: Ty<'db>,
-    env: Arc<TraitEnvironment<'db>>,
+    env: ParamEnv<'db>,
 ) -> Ty<'db> {
     let TyKind::Alias(..) = ty.kind() else { return ty };
     let mut ocx = ObligationCtxt::new(infcx);
-    let ty = ocx.structurally_normalize_ty(&ObligationCause::dummy(), env.env, ty).unwrap_or(ty);
+    let ty = ocx.structurally_normalize_ty(&ObligationCause::dummy(), env, ty).unwrap_or(ty);
     ty.replace_infer_with_error(infcx.interner)
 }
 
@@ -192,7 +153,7 @@ impl FnTrait {
 pub fn implements_trait_unique<'db>(
     ty: Ty<'db>,
     db: &'db dyn HirDatabase,
-    env: Arc<TraitEnvironment<'db>>,
+    env: ParamEnvAndCrate<'db>,
     trait_: TraitId,
 ) -> bool {
     implements_trait_unique_impl(db, env, trait_, &mut |infcx| {
@@ -203,7 +164,7 @@ pub fn implements_trait_unique<'db>(
 /// This should not be used in `hir-ty`, only in `hir`.
 pub fn implements_trait_unique_with_args<'db>(
     db: &'db dyn HirDatabase,
-    env: Arc<TraitEnvironment<'db>>,
+    env: ParamEnvAndCrate<'db>,
     trait_: TraitId,
     args: GenericArgs<'db>,
 ) -> bool {
@@ -212,7 +173,7 @@ pub fn implements_trait_unique_with_args<'db>(
 
 fn implements_trait_unique_impl<'db>(
     db: &'db dyn HirDatabase,
-    env: Arc<TraitEnvironment<'db>>,
+    env: ParamEnvAndCrate<'db>,
     trait_: TraitId,
     create_args: &mut dyn FnMut(&InferCtxt<'db>) -> GenericArgs<'db>,
 ) -> bool {
@@ -222,7 +183,7 @@ fn implements_trait_unique_impl<'db>(
 
     let args = create_args(&infcx);
     let trait_ref = rustc_type_ir::TraitRef::new_from_args(interner, trait_.into(), args);
-    let goal = Goal::new(interner, env.env, trait_ref);
+    let goal = Goal::new(interner, env.param_env, trait_ref);
 
     let result = crate::traits::next_trait_solve_in_ctxt(&infcx, goal);
     matches!(result, Ok((_, Certainty::Yes)))

--- a/crates/hir/src/attrs.rs
+++ b/crates/hir/src/attrs.rs
@@ -412,9 +412,7 @@ fn resolve_impl_trait_item<'db>(
     ns: Option<Namespace>,
 ) -> Option<DocLinkDef> {
     let krate = ty.krate(db);
-    let environment = resolver
-        .generic_def()
-        .map_or_else(|| crate::TraitEnvironment::empty(krate.id), |d| db.trait_environment(d));
+    let environment = crate::param_env_from_resolver(db, &resolver);
     let traits_in_scope = resolver.traits_in_scope(db);
 
     // `ty.iterate_path_candidates()` require a scope, which is not available when resolving
@@ -428,7 +426,7 @@ fn resolve_impl_trait_item<'db>(
     let ctx = MethodResolutionContext {
         infcx: &infcx,
         resolver: &resolver,
-        env: &environment,
+        param_env: environment.param_env,
         traits_in_scope: &traits_in_scope,
         edition: krate.edition(db),
         unstable_features: &unstable_features,

--- a/crates/rust-analyzer/src/cli/analysis_stats.rs
+++ b/crates/rust-analyzer/src/cli/analysis_stats.rs
@@ -10,8 +10,8 @@ use std::{
 
 use cfg::{CfgAtom, CfgDiff};
 use hir::{
-    Adt, AssocItem, Crate, DefWithBody, FindPathConfig, HasSource, HirDisplay, ModuleDef, Name,
-    crate_lang_items,
+    Adt, AssocItem, Crate, DefWithBody, FindPathConfig, HasCrate, HasSource, HirDisplay, ModuleDef,
+    Name, crate_lang_items,
     db::{DefDatabase, ExpandDatabase, HirDatabase},
     next_solver::{DbInterner, GenericArgs},
 };
@@ -391,7 +391,10 @@ impl flags::AnalysisStats {
             let Err(e) = db.layout_of_adt(
                 hir_def::AdtId::from(a),
                 GenericArgs::new_from_iter(interner, []),
-                db.trait_environment(a.into()),
+                hir_ty::ParamEnvAndCrate {
+                    param_env: db.trait_environment(a.into()),
+                    krate: a.krate(db).into(),
+                },
             ) else {
                 continue;
             };


### PR DESCRIPTION
We don't need it anymore; `ParamEnv` is enough.

A lot of code relied on getting the crate from the `TraitEnvironment`. Some had it readily available from other sources, some changed to take a new struct `ParamEnvAndCrate`.

I believe some of the code that used to take a `TraitEnvironment`, now taking `ParamEnvAndCrate`, e.g. layout and mir eval, only needs the crate - but I'm not entirely sure and this is not for this PR.