### PR TITLE
fix: Register `define_opaque` builtin attribute macro

### DIFF
--- a/crates/hir-expand/src/builtin/attr_macro.rs
+++ b/crates/hir-expand/src/builtin/attr_macro.rs
@@ -7,7 +7,7 @@ use crate::{ExpandResult, MacroCallId, MacroCallKind, db::ExpandDatabase, name, 
 use super::quote;
 
 macro_rules! register_builtin {
-    ($(($name:ident, $variant:ident) => $expand:ident),* ) => {
+    ($(($name:ident, $variant:ident) => $expand:ident),* $(,)? ) => {
         #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
         pub enum BuiltinAttrExpander {
             $($variant),*
@@ -65,7 +65,8 @@ register_builtin! {
     (derive_const, DeriveConst) => derive_expand,
     (global_allocator, GlobalAllocator) => dummy_attr_expand,
     (test, Test) => dummy_gate_test_expand,
-    (test_case, TestCase) => dummy_gate_test_expand
+    (test_case, TestCase) => dummy_gate_test_expand,
+    (define_opaque, DefineOpaque) => dummy_attr_expand,
 }
 
 pub fn find_builtin_attr(ident: &name::Name) -> Option<BuiltinAttrExpander> {

--- a/crates/ide-completion/src/tests/attribute.rs
+++ b/crates/ide-completion/src/tests/attribute.rs
@@ -1508,3 +1508,55 @@ extern crate dep;
         )
     }
 }
+
+#[test]
+fn builtin_macro_completed_only_as_its_kind() {
+    check(
+        r#"
+#[rustc_builtin_macro]
+pub macro define_opaque($($tt:tt)*) {
+    /* compiler built-in */
+}
+
+fn foo() {
+    def$0
+}
+    "#,
+        expect![[r#"
+            fn foo()  fn()
+            bt u32     u32
+            kw async
+            kw const
+            kw crate::
+            kw enum
+            kw extern
+            kw false
+            kw fn
+            kw for
+            kw if
+            kw if let
+            kw impl
+            kw impl for
+            kw let
+            kw letm
+            kw loop
+            kw match
+            kw mod
+            kw return
+            kw self::
+            kw static
+            kw struct
+            kw trait
+            kw true
+            kw type
+            kw union
+            kw unsafe
+            kw use
+            kw while
+            kw while let
+            sn macro_rules
+            sn pd
+            sn ppd
+        "#]],
+    );
+}

--- a/crates/intern/src/symbol/symbols.rs
+++ b/crates/intern/src/symbol/symbols.rs
@@ -524,4 +524,5 @@ define_symbols! {
     arbitrary_self_types,
     arbitrary_self_types_pointers,
     supertrait_item_shadowing,
+    define_opaque,
 }


### PR DESCRIPTION
So that we'll correctly treat it as an attribute.

I don't like that we have to register every builtin macro even if we don't need it, but that's what we got.

Fixes rust-lang/rust-analyzer#21142.