### PR TITLE
Include operator overload occurrences in SCIP index

### DIFF
--- a/crates/ide/src/static_index.rs
+++ b/crates/ide/src/static_index.rs
@@ -10,7 +10,7 @@ use ide_db::{
     documentation::Documentation,
     famous_defs::FamousDefs,
 };
-use syntax::{AstNode, SyntaxKind::*, SyntaxNode, SyntaxToken, T, TextRange};
+use syntax::{AstNode, SyntaxNode, SyntaxToken, TextRange};
 
 use crate::navigation_target::UpmappingResult;
 use crate::{
@@ -136,12 +136,12 @@ fn documentation_for_definition(
 }
 
 // FIXME: This is a weird function
-fn get_definitions(
-    sema: &Semantics<'_, RootDatabase>,
+fn get_definitions<'db>(
+    sema: &Semantics<'db, RootDatabase>,
     token: SyntaxToken,
-) -> Option<ArrayVec<Definition, 2>> {
+) -> Option<ArrayVec<(Definition, Option<hir::GenericSubstitution<'db>>), 2>> {
     for token in sema.descend_into_macros_exact(token) {
-        let def = IdentClass::classify_token(sema, &token).map(IdentClass::definitions_no_ops);
+        let def = IdentClass::classify_token(sema, &token).map(IdentClass::definitions);
         if let Some(defs) = def
             && !defs.is_empty()
         {
@@ -225,12 +225,6 @@ impl StaticIndex<'_> {
             show_drop_glue: true,
             minicore: MiniCore::default(),
         };
-        let tokens = tokens.filter(|token| {
-            matches!(
-                token.kind(),
-                IDENT | INT_NUMBER | LIFETIME_IDENT | T![self] | T![super] | T![crate] | T![Self]
-            )
-        });
         let mut result = StaticIndexedFile { file_id, inlay_hints, folds, tokens: vec![] };
 
         let mut add_token = |def: Definition, range: TextRange, scope_node: &SyntaxNode| {
@@ -290,9 +284,9 @@ impl StaticIndex<'_> {
             let range = token.text_range();
             let node = token.parent().unwrap();
             match hir::attach_db(self.db, || get_definitions(&sema, token.clone())) {
-                Some(it) => {
-                    for i in it {
-                        add_token(i, range, &node);
+                Some(defs) => {
+                    for (def, _) in defs {
+                        add_token(def, range, &node);
                     }
                 }
                 None => continue,

--- a/crates/rust-analyzer/src/cli/scip.rs
+++ b/crates/rust-analyzer/src/cli/scip.rs
@@ -604,6 +604,29 @@ pub mod example_mod {
     }
 
     #[test]
+    fn operator_overload() {
+        check_symbol(
+            r#"
+//- minicore: add
+//- /workspace/lib.rs crate:main
+use core::ops::AddAssign;
+
+struct S;
+
+impl AddAssign for S {
+    fn add_assign(&mut self, _rhs: Self) {}
+}
+
+fn main() {
+    let mut s = S;
+    s +=$0 S;
+}
+"#,
+            "rust-analyzer cargo main . impl#[S][`AddAssign<Self>`]add_assign().",
+        );
+    }
+
+    #[test]
     fn symbol_for_trait() {
         check_symbol(
             r#"


### PR DESCRIPTION
Operators were explicitly filtered out, both when filtering tokens to search definitions for and when searching for actual definitions.

Fixes rust-lang/rust-analyzer#21127