### PR TITLE
internal: Remove mdbook-toc usage

### DIFF
--- a/docs/book/README.md
+++ b/docs/book/README.md
@@ -8,7 +8,6 @@ To run the documentation site locally:
 
 ```shell
 cargo install mdbook
-cargo install mdbook-toc
 cargo xtask codegen
 cd docs/book
 mdbook serve

--- a/docs/book/book.toml
+++ b/docs/book/book.toml
@@ -33,8 +33,3 @@ use-boolean-and = true
 [output.html.fold]
 enable = true
 level = 3
-
-[preprocessor.toc]
-command = "mdbook-toc"
-renderer = ["html"]
-max-level = 3

--- a/docs/book/src/contributing/README.md
+++ b/docs/book/src/contributing/README.md
@@ -26,8 +26,6 @@ Discussion happens in this Zulip stream:
 
 <https://rust-lang.zulipchat.com/#narrow/stream/185405-t-compiler.2Frust-analyzer>
 
-<!-- toc -->
-
 # Issue Labels
 
 * [good-first-issue](https://github.com/rust-lang/rust-analyzer/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22good%20first%20issue%22)

--- a/docs/book/src/contributing/architecture.md
+++ b/docs/book/src/contributing/architecture.md
@@ -20,8 +20,6 @@ For older, by now mostly outdated stuff, see the [guide](./guide.md) and [anothe
 
 ![](https://user-images.githubusercontent.com/4789492/107129398-0ab70f00-687a-11eb-9bfc-d4eb023aec06.png)
 
-<!-- toc -->
-
 On the highest level, rust-analyzer is a thing which accepts input source code from the client and produces a structured semantic model of the code.
 
 More specifically, input data consists of a set of test files (`(PathBuf, String)` pairs) and information about project structure, captured in the so called `CrateGraph`.

--- a/docs/book/src/contributing/guide.md
+++ b/docs/book/src/contributing/guide.md
@@ -12,8 +12,6 @@ however, it's based on an older 2019-01-20 release (git tag [guide-2019-01]):
 [guide-2019-01]: https://github.com/rust-lang/rust-analyzer/tree/guide-2019-01
 [2024-01-01]: https://github.com/rust-lang/rust-analyzer/tree/2024-01-01
 
-<!-- toc -->
-
 ## The big picture
 
 On the highest possible level, rust-analyzer is a stateful component. A client may

--- a/docs/book/src/contributing/lsp-extensions.md
+++ b/docs/book/src/contributing/lsp-extensions.md
@@ -19,8 +19,6 @@ Requests, which are likely to always remain specific to `rust-analyzer` are unde
 
 If you want to be notified about the changes to this document, subscribe to [#4604](https://github.com/rust-lang/rust-analyzer/issues/4604).
 
-<!-- toc -->
-
 ## Configuration in `initializationOptions`
 
 **Upstream Issue:** <https://github.com/microsoft/language-server-protocol/issues/567>

--- a/docs/book/src/other_editors.md
+++ b/docs/book/src/other_editors.md
@@ -6,8 +6,6 @@ Protocol](https://microsoft.github.io/language-server-protocol/).
 This page assumes that you have already [installed the rust-analyzer
 binary](./rust_analyzer_binary.html).
 
-<!-- toc -->
-
 ## Emacs
 
 To use `rust-analyzer`, you need to install and enable one of the two


### PR DESCRIPTION
Now that there's a table of contents rendered in the left sidebar, there doesn't seem to be much value in rendering a table of contents on the page too.

The sidebar TOC was added in mdbook 0.5:
https://github.com/rust-lang/mdBook/blob/master/CHANGELOG.md#05-migration-guide