### PR TITLE
SmolStrBuilder: move rather than alloc + copy on finish

### DIFF
--- a/lib/smol_str/src/lib.rs
+++ b/lib/smol_str/src/lib.rs
@@ -875,9 +875,9 @@ impl SmolStrBuilder {
 
     /// Builds a [`SmolStr`] from `self`.
     #[must_use]
-    pub fn finish(&self) -> SmolStr {
-        SmolStr(match &self.0 {
-            &SmolStrBuilderRepr::Inline { len, buf } => {
+    pub fn finish(self) -> SmolStr {
+        SmolStr(match self.0 {
+            SmolStrBuilderRepr::Inline { len, buf } => {
                 debug_assert!(len <= INLINE_CAP);
                 Repr::Inline {
                     // SAFETY: We know that `value.len` is less than or equal to the maximum value of `InlineSize`
@@ -885,7 +885,7 @@ impl SmolStrBuilder {
                     buf,
                 }
             }
-            SmolStrBuilderRepr::Heap(heap) => Repr::new(heap),
+            SmolStrBuilderRepr::Heap(heap) => Repr::Heap(Arc::from(heap.into_boxed_str())),
         })
     }
 


### PR DESCRIPTION
Removing unnessecary len checks as well as 1 redundant alloc + copy on finishing a Builder into a SmolStr.

Browsing the old repo for smolstr i came about an issue that mentioned a redundant alloc + copy when finishing a SmolStrBuilder (https://github.com/rust-analyzer/smol_str/issues/94) by @alexheretic. 

The solution passes all tests and skips the conditional tests in the Repr::new(), and as long as the internal String has not too much unused capacity the will skip a reallocation + copy. (into_boxed_str() uses shrink_to_fit)

NOTE: It does change the finish function signature. finish() took a &self so far. This is contrary to what a user would understand from the word finish, imo.

Someone with merging power needs to decide if this change of signature is acceptable.