### PR TITLE
Fix nested expr missing semicolon in incomplete-let

### DIFF
--- a/crates/ide-completion/src/completions/keyword.rs
+++ b/crates/ide-completion/src/completions/keyword.rs
@@ -344,6 +344,60 @@ fn main() {
 }
 "#,
         );
+
+        check_edit(
+            "loop",
+            r#"
+fn main() {
+    let x = &$0
+    bar();
+}
+"#,
+            r#"
+fn main() {
+    let x = &loop {
+    $0
+};
+    bar();
+}
+"#,
+        );
+
+        check_edit(
+            "loop",
+            r#"
+fn main() {
+    let x = -$0
+    bar();
+}
+"#,
+            r#"
+fn main() {
+    let x = -loop {
+    $0
+};
+    bar();
+}
+"#,
+        );
+
+        check_edit(
+            "loop",
+            r#"
+fn main() {
+    let x = 2 + $0
+    bar();
+}
+"#,
+            r#"
+fn main() {
+    let x = 2 + loop {
+    $0
+};
+    bar();
+}
+"#,
+        );
     }
 
     #[test]

--- a/crates/ide-completion/src/context/analysis.rs
+++ b/crates/ide-completion/src/context/analysis.rs
@@ -1321,9 +1321,8 @@ fn classify_name_ref<'db>(
         let incomplete_expr_stmt =
             it.parent().and_then(ast::ExprStmt::cast).map(|it| it.semicolon_token().is_none());
         let before_else_kw = before_else_kw(it);
-        let incomplete_let = it
-            .parent()
-            .and_then(ast::LetStmt::cast)
+        let incomplete_let = left_ancestors(it.parent())
+            .find_map(ast::LetStmt::cast)
             .is_some_and(|it| it.semicolon_token().is_none())
             || after_incomplete_let && incomplete_expr_stmt.unwrap_or(true) && !before_else_kw;
         let in_value = is_in_value(it);
@@ -1880,6 +1879,13 @@ fn path_or_use_tree_qualifier(path: &ast::Path) -> Option<(ast::Path, bool)> {
     let use_tree_list = path.syntax().ancestors().find_map(ast::UseTreeList::cast)?;
     let use_tree = use_tree_list.syntax().parent().and_then(ast::UseTree::cast)?;
     Some((use_tree.path()?, true))
+}
+
+fn left_ancestors(node: Option<SyntaxNode>) -> impl Iterator<Item = SyntaxNode> {
+    node.into_iter().flat_map(|node| {
+        let end = node.text_range().end();
+        node.ancestors().take_while(move |it| it.text_range().end() == end)
+    })
 }
 
 fn is_in_token_of_for_loop(path: &ast::Path) -> bool {


### PR DESCRIPTION
Example
---
```rust
fn main() {
    let x = &$0
}
```

**Before this PR**

```rust
fn main() {
    let x = &loop {
        $0
    }
}
```

**After this PR**

```rust
fn main() {
    let x = &loop {
        $0
    };
}
```
