### PR TITLE
 fix: Skip cfg attributes in macro input attribute stripping

### DIFF
--- a/crates/hir-def/src/macro_expansion_tests/proc_macros.rs
+++ b/crates/hir-def/src/macro_expansion_tests/proc_macros.rs
@@ -341,3 +341,22 @@ struct Foo;
 #[helper_should_be_ignored] struct Foo;"#]],
     );
 }
+
+#[test]
+fn attribute_macro_stripping_with_cfg() {
+    check(
+        r#"
+//- proc_macros: generate_suffixed_type
+#[cfg(all())]
+#[proc_macros::generate_suffixed_type]
+struct S;
+"#,
+        expect![[r#"
+#[cfg(all())]
+#[proc_macros::generate_suffixed_type]
+struct S;
+
+struct S;
+struct SSuffix;"#]],
+    );
+}

--- a/crates/hir-expand/src/cfg_process.rs
+++ b/crates/hir-expand/src/cfg_process.rs
@@ -162,24 +162,18 @@ fn macro_input_callback(
                                     }
                                 }
                                 Meta::TokenTree { path, tt } => {
-                                    if path.segments.len() != 1
+                                    if path.is1("cfg") {
+                                        let cfg_expr = CfgExpr::parse_from_ast(
+                                            &mut TokenTreeChildren::new(&tt).peekable(),
+                                        );
+                                        if cfg_options().check(&cfg_expr) == Some(false) {
+                                            return ControlFlow::Break(ItemIsCfgedOut);
+                                        }
+                                        strip_current_attr = true;
+                                    } else if path.segments.len() != 1
                                         || !is_item_tree_filtered_attr(path.segments[0].text())
                                     {
                                         strip_current_attr = should_strip_attr();
-                                    }
-
-                                    if path.segments.len() == 1 {
-                                        let name = path.segments[0].text();
-
-                                        if name == "cfg" {
-                                            let cfg_expr = CfgExpr::parse_from_ast(
-                                                &mut TokenTreeChildren::new(&tt).peekable(),
-                                            );
-                                            if cfg_options().check(&cfg_expr) == Some(false) {
-                                                return ControlFlow::Break(ItemIsCfgedOut);
-                                            }
-                                            strip_current_attr = true;
-                                        }
                                     }
                                 }
                                 Meta::Path { path } => {


### PR DESCRIPTION
  ## Description:
 This fixes a regression introduced in commit f0e372c3b6 ("Rewrite attribute handling"), where cfg attributes
     were incorrectly counted during macro input stripping. 
  ## Problem




   When using attribute macros like [maybe-async-cfg](https://github.com/nvksv/maybe-async-cfg), if cfg attributes are present on the item, rust-analyzer may
   fail to strip the macro attribute itself from the input. This results in the macro being expanded recursively
   (e.g., `TestStruct` -> `TestStructAsync`(Correct) -> `TestStructAsyncAsync`(Wrong)).

<img width="1660" height="1122" alt="522373810-313be124-ff2d-42d1-9dd0-fae782897561" src="https://github.com/user-attachments/assets/f84377e5-9564-430b-832d-d138db8996ac" />


<img width="1526" height="1168" alt="522374103-e62f4dcf-f545-4c56-9ae6-8dceb8efb09e" src="https://github.com/user-attachments/assets/45c48e68-ac7a-4b7d-a57c-7fdeb2447f9b" />

   ## Cause

   The `macro_input_callback` function in `crates/hir-expand/src/cfg_process.rs` uses a counter (`item_tree_attr_id`)
   to identify which attribute to strip. This counter was being incremented for cfg attributes.

   However, `collect_item_tree_attrs` (which assigns the attribute IDs) filters out cfg attributes. This caused the
   counter in `macro_input_callbac`k to desynchronize with the actual attribute IDs, leading to the macro attribute
   not being identified and stripped.

## Fix

   Explicitly skip cfg attributes when determining whether to call `should_strip_attr()` in `macro_input_callback`.
   This ensures the attribute counter remains in sync with the item tree.
<img width="1855" height="967" alt="image" src="https://github.com/user-attachments/assets/e733f6df-76db-4906-8039-de90b8906c7c" />
## Repro


```rust
#[maybe_async_cfg::maybe(sync(keep_self), async(feature = "async"))]
#[derive(Debug)]
pub struct TestStruct {
    pub value: u32,
}

#[cfg(feature = "async")]
pub fn test_async_only() {
    let _x = TestStructAsync { value: 42 };
}
#[cfg(not(feature = "async"))]
pub fn test_sync_only() {
    let _y = TestStruct { value: 1 };
}
pub fn test_both_exist() {
    let _a = TestStruct { value: 1 };

    let _b = TestStructAsync { value: 2 };
}
```
```toml
[package]
name = "test-maybe-async"
version = "0.1.0"
edition = "2024"

[dependencies]
maybe-async-cfg = "=0.2.4"

[features]
async = []
```