### PR TITLE
internal: Update supported Rust version to 1.90.0

### DIFF
--- a/crates/rust-analyzer/src/lib.rs
+++ b/crates/rust-analyzer/src/lib.rs
@@ -14,7 +14,7 @@ extern crate ra_ap_rustc_type_ir as rustc_type_ir;
 /// Any toolchain less than this version will likely not work with rust-analyzer built from this revision.
 pub const MINIMUM_SUPPORTED_TOOLCHAIN_VERSION: semver::Version = semver::Version {
     major: 1,
-    minor: 78,
+    minor: 90,
     patch: 0,
     pre: semver::Prerelease::EMPTY,
     build: semver::BuildMetadata::EMPTY,


### PR DESCRIPTION
We no longer work properly with older versions.

Closes https://github.com/rust-lang/rust-analyzer/issues/20487 as per [decision in Zulip](https://rust-lang.zulipchat.com/#narrow/channel/185405-t-compiler.2Frust-analyzer/topic/Supporting.20old.20rustc.20versions/with/562272182).