### PR TITLE
minor: Remove `[no-mentions]` handler in our triagebot config

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -25,6 +25,3 @@ labels = ["has-merge-commits", "S-waiting-on-author"]
 
 # Canonicalize issue numbers to avoid closing the wrong issue when upstreaming this subtree
 [canonicalize-issue-links]
-
-# Prevents mentions in commits to avoid users being spammed
-[no-mentions]


### PR DESCRIPTION
This PR removes the `[no-mentions]` handler in our triagebot config as [GitHub is removing notifications for @-mentions in commit messages on December 8th 2025.](https://github.blog/changelog/2025-11-07-removing-notifications-for-mentions-in-commit-messages/)

cf. https://github.com/rust-lang/triagebot/issues/2225