### PR TITLE
fix: is_transmutable always panicking

### DIFF
--- a/crates/hir-ty/src/next_solver/solver.rs
+++ b/crates/hir-ty/src/next_solver/solver.rs
@@ -225,7 +225,9 @@ impl<'db> SolverDelegate for SolverContext<'db> {
         _src: Ty<'db>,
         _assume: <Self::Interner as rustc_type_ir::Interner>::Const,
     ) -> Result<Certainty, NoSolution> {
-        unimplemented!()
+        // It's better to return some value while not fully implement
+        // then panic in the mean time
+        Ok(Certainty::Yes)
     }
 
     fn evaluate_const(


### PR DESCRIPTION
Fixes rust-lang/rust-analyzer#21237

Since the implementation is very large and nightly only. It's better to just return `Ok(Certainty::Yes)`, as per the discussion, on the issue.