### PR TITLE
feat: show parameter hint for missing arguments

### DIFF
--- a/crates/ide/src/inlay_hints.rs
+++ b/crates/ide/src/inlay_hints.rs
@@ -307,6 +307,7 @@ pub struct InlayHintsConfig<'a> {
     pub sized_bound: bool,
     pub discriminant_hints: DiscriminantHints,
     pub parameter_hints: bool,
+    pub parameter_hints_for_missing_arguments: bool,
     pub generic_parameter_hints: GenericParameterHints,
     pub chaining_hints: bool,
     pub adjustment_hints: AdjustmentHints,
@@ -886,6 +887,7 @@ mod tests {
         render_colons: false,
         type_hints: false,
         parameter_hints: false,
+        parameter_hints_for_missing_arguments: false,
         sized_bound: false,
         generic_parameter_hints: GenericParameterHints {
             type_hints: false,

--- a/crates/ide/src/static_index.rs
+++ b/crates/ide/src/static_index.rs
@@ -169,6 +169,7 @@ impl StaticIndex<'_> {
                     type_hints: true,
                     sized_bound: false,
                     parameter_hints: true,
+                    parameter_hints_for_missing_arguments: false,
                     generic_parameter_hints: crate::GenericParameterHints {
                         type_hints: false,
                         lifetime_hints: false,

--- a/crates/rust-analyzer/src/cli/analysis_stats.rs
+++ b/crates/rust-analyzer/src/cli/analysis_stats.rs
@@ -1205,6 +1205,7 @@ impl flags::AnalysisStats {
                     sized_bound: false,
                     discriminant_hints: ide::DiscriminantHints::Always,
                     parameter_hints: true,
+                    parameter_hints_for_missing_arguments: false,
                     generic_parameter_hints: ide::GenericParameterHints {
                         type_hints: true,
                         lifetime_hints: true,

--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -280,6 +280,9 @@ config_data! {
         /// Show function parameter name inlay hints at the call site.
         inlayHints_parameterHints_enable: bool = true,
 
+        /// Show parameter name inlay hints for missing arguments at the call site.
+        inlayHints_parameterHints_missingArguments_enable: bool = false,
+
         /// Show exclusive range inlay hints.
         inlayHints_rangeExclusiveHints_enable: bool = false,
 
@@ -1916,6 +1919,9 @@ impl Config {
             type_hints: self.inlayHints_typeHints_enable().to_owned(),
             sized_bound: self.inlayHints_implicitSizedBoundHints_enable().to_owned(),
             parameter_hints: self.inlayHints_parameterHints_enable().to_owned(),
+            parameter_hints_for_missing_arguments: self
+                .inlayHints_parameterHints_missingArguments_enable()
+                .to_owned(),
             generic_parameter_hints: GenericParameterHints {
                 type_hints: self.inlayHints_genericParameterHints_type_enable().to_owned(),
                 lifetime_hints: self.inlayHints_genericParameterHints_lifetime_enable().to_owned(),

--- a/docs/book/src/configuration_generated.md
+++ b/docs/book/src/configuration_generated.md
@@ -1070,6 +1070,13 @@ Default: `true`
 Show function parameter name inlay hints at the call site.
 
 
+## rust-analyzer.inlayHints.parameterHints.missingArguments.enable {#inlayHints.parameterHints.missingArguments.enable}
+
+Default: `false`
+
+Show parameter name inlay hints for missing arguments at the call site.
+
+
 ## rust-analyzer.inlayHints.rangeExclusiveHints.enable {#inlayHints.rangeExclusiveHints.enable}
 
 Default: `false`

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -2399,6 +2399,16 @@
             {
                 "title": "Inlay Hints",
                 "properties": {
+                    "rust-analyzer.inlayHints.parameterHints.missingArguments.enable": {
+                        "markdownDescription": "Show parameter name inlay hints for missing arguments at the call site.",
+                        "default": false,
+                        "type": "boolean"
+                    }
+                }
+            },
+            {
+                "title": "Inlay Hints",
+                "properties": {
                     "rust-analyzer.inlayHints.rangeExclusiveHints.enable": {
                         "markdownDescription": "Show exclusive range inlay hints.",
                         "default": false,


### PR DESCRIPTION
Closes rust-lang/rust-analyzer#9486

Adds inlay hint for the next expected parameter when a function call has fewer arguments than parameters. Controlled by the new config option `inlayHints.parameterHints.missingArguments.enable` (default: false).

<img width="911" height="431" alt="Screenshot 2025-12-10 at 5 03 13 PM" src="https://github.com/user-attachments/assets/4f9afe3a-23cb-447f-92a0-3a5dbf459d82" />

<img width="872" height="826" alt="Screenshot 2025-12-10 at 5 20 03 PM" src="https://github.com/user-attachments/assets/04394d23-b1e6-4351-967f-10cd664c2150" />
