### PR TITLE
fix(lsp): handle dynamic registration for didSave

### DIFF
--- a/crates/rust-analyzer/src/lsp/capabilities.rs
+++ b/crates/rust-analyzer/src/lsp/capabilities.rs
@@ -37,7 +37,11 @@ pub fn server_capabilities(config: &Config) -> ServerCapabilities {
             change: Some(TextDocumentSyncKind::INCREMENTAL),
             will_save: None,
             will_save_wait_until: None,
-            save: Some(SaveOptions::default().into()),
+            save: if config.caps().did_save_text_document_dynamic_registration() {
+                None
+            } else {
+                Some(SaveOptions::default().into())
+            },
         })),
         hover_provider: Some(HoverProviderCapability::Simple(true)),
         completion_provider: Some(CompletionOptions {


### PR DESCRIPTION
Update server capabilities to set `save` to `None` when the client supports dynamic registration for `didSaveTextDocument`. This prevents redundant static registration and aligns with LSP specification.

https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#client_registerCapability

>If a server wants to support both static and dynamic registration it needs to check the client capability in the initialize request and only register the capability statically if the client doesn’t support dynamic registration for that capability.