### PR TITLE
Reorder add_return_type assist

### DIFF
--- a/crates/ide-assists/src/lib.rs
+++ b/crates/ide-assists/src/lib.rs
@@ -247,7 +247,6 @@ mod handlers {
             add_label_to_loop::add_label_to_loop,
             add_lifetime_to_type::add_lifetime_to_type,
             add_missing_match_arms::add_missing_match_arms,
-            add_return_type::add_return_type,
             add_turbo_fish::add_turbo_fish,
             apply_demorgan::apply_demorgan_iterator,
             apply_demorgan::apply_demorgan,
@@ -392,6 +391,7 @@ mod handlers {
             // used as a tie-breaker.
             add_missing_impl_members::add_missing_impl_members,
             add_missing_impl_members::add_missing_default_members,
+            add_return_type::add_return_type,
             //
             replace_string_with_char::replace_string_with_char,
             replace_string_with_char::replace_char_with_string,


### PR DESCRIPTION
This assist is often before inline and is very inconvenient

Usually, incomplete expression statements are written at the tail of the block, but they are not the return value of the block

```rust
fn foo() {
    Some(2).$0and(optb)
}
```

```text
1. Add this function's return type
2. Inline `and`
3. Qualify `and` method call
4. Replace and with and_then
```
