### PR TITLE
minor: Emit `WorkspaceDiagnosticRefresh` when flycheck finished

### DIFF
--- a/crates/rust-analyzer/tests/slow-tests/support.rs
+++ b/crates/rust-analyzer/tests/slow-tests/support.rs
@@ -48,6 +48,7 @@ impl Project<'_> {
                         "enable": false,
                     },
                 },
+                "checkOnSave": false,
                 "procMacro": {
                     "enable": false,
                 }


### PR DESCRIPTION
This allows clients to "synchronize"  their pull diagnostics with push diagnostics to some degree at least while its still unclear how to progress with https://github.com/rust-lang/rust-analyzer/issues/18709