### PR TITLE
internal: Use a generated name in old format_args lowering, instead of `args`

### DIFF
--- a/crates/hir-def/src/expr_store/lower/format_args.rs
+++ b/crates/hir-def/src/expr_store/lower/format_args.rs
@@ -655,7 +655,7 @@ impl<'db> ExprCollector<'db> {
                 .collect();
             let args =
                 self.alloc_expr_desugared(Expr::Array(Array::ElementList { elements: args }));
-            let args_name = Name::new_symbol_root(sym::args);
+            let args_name = self.generate_new_name();
             let args_binding = self.alloc_binding(
                 args_name.clone(),
                 BindingAnnotation::Unannotated,
@@ -674,7 +674,7 @@ impl<'db> ExprCollector<'db> {
         } else {
             // Generate:
             //     super let args = (&arg0, &arg1, &...);
-            let args_name = Name::new_symbol_root(sym::args);
+            let args_name = self.generate_new_name();
             let args_binding = self.alloc_binding(
                 args_name.clone(),
                 BindingAnnotation::Unannotated,

--- a/crates/hir-def/src/expr_store/tests/body.rs
+++ b/crates/hir-def/src/expr_store/tests/body.rs
@@ -278,16 +278,16 @@ fn main() {
             let are = "are";
             let count = 10;
             {
-                let args = (&"fancy", &(), &"!", &count, &are, );
-                let args = [
+                let <ra@gennew>0 = (&"fancy", &(), &"!", &count, &are, );
+                let <ra@gennew>0 = [
                     builtin#lang(Argument::new_display)(
-                        args.3,
+                        <ra@gennew>0.3,
                     ), builtin#lang(Argument::new_display)(
-                        args.0,
+                        <ra@gennew>0.0,
                     ), builtin#lang(Argument::new_debug)(
-                        args.4,
+                        <ra@gennew>0.4,
                     ), builtin#lang(Argument::new_display)(
-                        args.2,
+                        <ra@gennew>0.2,
                     ),
                 ];
                 unsafe {
@@ -295,7 +295,7 @@ fn main() {
                         &[
                             "\u{1b}hello ", " ", " friends, we ", " ", "",
                         ],
-                        &args,
+                        &<ra@gennew>0,
                         &[
                             builtin#lang(Placeholder::new)(
                                 0usize,


### PR DESCRIPTION
To prevent it from clashing with other names.