### PR TITLE
fix: respect rustc's lint attribute application order

### DIFF
--- a/crates/hir/src/semantics.rs
+++ b/crates/hir/src/semantics.rs
@@ -267,7 +267,7 @@ impl<DB: HirDatabase + ?Sized> Semantics<'_, DB> {
         &self,
         krate: Crate,
         item: ast::AnyHasAttrs,
-    ) -> impl Iterator<Item = (LintAttr, SmolStr)> {
+    ) -> impl DoubleEndedIterator<Item = (LintAttr, SmolStr)> {
         let mut cfg_options = None;
         let cfg_options = || *cfg_options.get_or_insert_with(|| krate.id.cfg_options(self.db));
         let mut result = Vec::new();

--- a/crates/ide-diagnostics/src/handlers/incorrect_case.rs
+++ b/crates/ide-diagnostics/src/handlers/incorrect_case.rs
@@ -1000,7 +1000,8 @@ mod OtherBadCase;
  // ^^^^^^^^^^^^ 💡 error: Module `OtherBadCase` should have snake_case name, e.g. `other_bad_case`
 
 //- /BAD_CASE/OtherBadCase.rs
-#![deny(non_snake_case)]
+#![allow(non_snake_case)]
+#![deny(non_snake_case)] // The lint level has been overridden.
 
 fn FOO() {}
 // ^^^ 💡 error: Function `FOO` should have snake_case name, e.g. `foo`

--- a/crates/ide-diagnostics/src/handlers/unused_variables.rs
+++ b/crates/ide-diagnostics/src/handlers/unused_variables.rs
@@ -183,6 +183,61 @@ fn main2() {
     }
 
     #[test]
+    fn apply_last_lint_attribute_when_multiple_are_present() {
+        check_diagnostics(
+            r#"
+#![allow(unused_variables)]
+#![warn(unused_variables)]
+#![deny(unused_variables)]
+
+fn main() {
+    let x = 2;
+      //^ 💡 error: unused variable
+
+    #[deny(unused_variables)]
+    #[warn(unused_variables)]
+    #[allow(unused_variables)]
+    let y = 0;
+}
+"#,
+        );
+    }
+
+    #[test]
+    fn prefer_closest_ancestor_lint_attribute() {
+        check_diagnostics(
+            r#"
+#![allow(unused_variables)]
+
+fn main() {
+    #![warn(unused_variables)]
+
+    #[deny(unused_variables)]
+    let x = 2;
+      //^ 💡 error: unused variable
+}
+
+#[warn(unused_variables)]
+fn main2() {
+    #[deny(unused_variables)]
+    let x = 2;
+      //^ 💡 error: unused variable
+}
+
+#[warn(unused_variables)]
+fn main3() {
+    let x = 2;
+      //^ 💡 warn: unused variable
+}
+
+fn main4() {
+    let x = 2;
+}
+"#,
+        );
+    }
+
+    #[test]
     fn fix_unused_variable() {
         check_fix(
             r#"

--- a/crates/ide-diagnostics/src/lib.rs
+++ b/crates/ide-diagnostics/src/lib.rs
@@ -643,19 +643,13 @@ fn find_outline_mod_lint_severity(
 
     let mod_def = sema.to_module_def(&mod_node)?;
     let module_source_file = sema.module_definition_node(mod_def);
-    let mut result = None;
     let lint_groups = lint_groups(&diag.code, edition);
     lint_attrs(
         sema,
         krate,
         ast::AnyHasAttrs::cast(module_source_file.value).expect("SourceFile always has attrs"),
     )
-    .for_each(|(lint, severity)| {
-        if lint_groups.contains(&lint) {
-            result = Some(severity);
-        }
-    });
-    result
+    .find_map(|(lint, severity)| lint_groups.contains(&lint).then_some(severity))
 }
 
 fn lint_severity_at(
@@ -682,7 +676,7 @@ fn lint_attrs(
     krate: hir::Crate,
     ancestor: ast::AnyHasAttrs,
 ) -> impl Iterator<Item = (SmolStr, Severity)> {
-    sema.lint_attrs(krate, ancestor).map(|(lint_attr, lint)| {
+    sema.lint_attrs(krate, ancestor).rev().map(|(lint_attr, lint)| {
         let severity = match lint_attr {
             hir::LintAttr::Allow | hir::LintAttr::Expect => Severity::Allow,
             hir::LintAttr::Warn => Severity::Warning,


### PR DESCRIPTION
# Description

Reverse the order of returned lint attributes for a `SyntaxNode` to match rustc's behavior.

When multiple lint attributes are present, rustc overrides earlier ones with the last defined attribute. The previous iteration order was incorrect, causing earlier attributes to override the later ones.

## Before this PR

<img width="2000" height="1214" alt="image" src="https://github.com/user-attachments/assets/417dbcd6-696d-491f-a1a0-94d8c439cfdb" />

## After this PR

<img width="2000" height="1214" alt="image" src="https://github.com/user-attachments/assets/1cf8d64a-a508-48ed-b105-0f2df5d02e72" />

## Is it worthwhile?

Generally, no one wants to specify same lints with different levels in a row. However, it is technically possible for users to use `-Zcrate-attr` to inject crate-level lint attributes at the top of the crate root file. This means any overlapping lints passed by `-Zcrate-attr` should not override the corresponding ones specified in the source file.

If we're trying to mimic the behavior of `-Zcrate-attr` when [introducing a new field in the `rust-project.json` format that can inject crate-level attributes](https://rust-lang.zulipchat.com/#narrow/channel/185405-t-compiler.2Frust-analyzer/topic/Primitive.20type.20inherent.20method.20lookup.20fails/with/562983853), it would need to handle lint attributes in a similar fashion.

Overall, I'm not sure this is truly worthwhile, since neither scenario seems to be a common use case (even the decision to support lint attributes hasn't been made yet). That said, I don't see a good reason to leave it as-is, especially since the fix isn't difficult to implement.

## Reference setup for reproduction

`main.rs`
```rs
#![allow(unused)]
#![deny(unused)]

fn main() {
    let should_be_denied = 0;

    #[warn(unused)]
    #[allow(unused)]
    let should_be_allowed = 0;
}
```

`rust-project.json`
```json
{
    "sysroot": "/usr/local/rustup/toolchains/1.91.1-aarch64-unknown-linux-gnu",
    "sysroot_src": "/usr/local/rustup/toolchains/1.91.1-aarch64-unknown-linux-gnu/lib/rustlib/src/rust/library",
    "crates": [
        {
            "cfg": [],
            "deps": [],
            "edition": "2024",
            "is_proc_macro": false,
            "root_module": "/root/workspace/lint-attr-order/main.rs"
        }
    ]
}
```

`.vscode/settings.json`
```json
{
    "rust-analyzer.diagnostics.experimental.enable": true
}
```