### PR TITLE
Fix "Invariant violation: file emitted multiple times" when doing `scip .`

### DIFF
--- a/crates/ide/src/static_index.rs
+++ b/crates/ide/src/static_index.rs
@@ -325,12 +325,12 @@ impl StaticIndex<'_> {
             };
             let mut visited_files = FxHashSet::default();
             for module in work {
-                let file_id = module.definition_source_file_id(db).original_file(db);
+                let file_id =
+                    module.definition_source_file_id(db).original_file(db).file_id(&analysis.db);
                 if visited_files.contains(&file_id) {
                     continue;
                 }
-                this.add_file(file_id.file_id(&analysis.db));
-                // mark the file
+                this.add_file(file_id);
                 visited_files.insert(file_id);
             }
             this


### PR DESCRIPTION
Summary:

It turns out the small piece of code I'm editing can and does add a file ID multiple times, which results in "Invariant violation: file emitted multiple times" when doing rust-analyzer scip . for some rust projects.

Test Plan:
```
cargo build --bin rust-analyzer --release
rust_analyzer=$(realpath target/release/rust-analyzer)
mytmp=$(mktemp -d)
cd $mytmp
git clone https://github.com/GraphiteEditor/Graphite.git
cd Graphite
$rust_analyzer scip .
```
Before: Some error like "Invariant violation: file emitted multiple times"
After: generates an index.scip as expected