### PR TITLE
fix: Fix method resolution for incoherent impls when there are two sysroots in the crate graph

### DIFF
--- a/crates/base-db/src/input.rs
+++ b/crates/base-db/src/input.rs
@@ -465,7 +465,7 @@ impl Crate {
     /// including the crate itself.
     ///
     /// **Warning**: do not use this query in `hir-*` crates! It kills incrementality across crate metadata modifications.
-    pub fn transitive_deps(self, db: &dyn salsa::Database) -> Box<[Crate]> {
+    pub fn transitive_deps(self, db: &dyn salsa::Database) -> Vec<Crate> {
         // There is a bit of duplication here and in `CrateGraphBuilder` in the same method, but it's not terrible
         // and removing that is a bit difficult.
         let mut worklist = vec![self];
@@ -480,7 +480,7 @@ impl Crate {
 
             worklist.extend(krate.data(db).dependencies.iter().map(|dep| dep.crate_id));
         }
-        deps.into_boxed_slice()
+        deps
     }
 
     /// Returns all transitive reverse dependencies of the given crate,

--- a/crates/hir-ty/src/method_resolution.rs
+++ b/crates/hir-ty/src/method_resolution.rs
@@ -505,13 +505,19 @@ pub(crate) fn find_matching_impl<'db>(
 }
 
 #[salsa::tracked(returns(ref))]
-fn crates_containing_incoherent_inherent_impls(db: &dyn HirDatabase) -> Box<[Crate]> {
+fn crates_containing_incoherent_inherent_impls(db: &dyn HirDatabase, krate: Crate) -> Box<[Crate]> {
+    let _p = tracing::info_span!("crates_containing_incoherent_inherent_impls").entered();
     // We assume that only sysroot crates contain `#[rustc_has_incoherent_inherent_impls]`
     // impls, since this is an internal feature and only std uses it.
-    db.all_crates().iter().copied().filter(|krate| krate.data(db).origin.is_lang()).collect()
+    krate.transitive_deps(db).into_iter().filter(|krate| krate.data(db).origin.is_lang()).collect()
 }
 
-pub fn incoherent_inherent_impls(db: &dyn HirDatabase, self_ty: SimplifiedType) -> &[ImplId] {
+pub fn with_incoherent_inherent_impls(
+    db: &dyn HirDatabase,
+    krate: Crate,
+    self_ty: &SimplifiedType,
+    mut callback: impl FnMut(&[ImplId]),
+) {
     let has_incoherent_impls = match self_ty.def() {
         Some(def_id) => match def_id.try_into() {
             Ok(def_id) => AttrFlags::query(db, def_id)
@@ -520,26 +526,14 @@ pub fn incoherent_inherent_impls(db: &dyn HirDatabase, self_ty: SimplifiedType) 
         },
         _ => true,
     };
-    return if !has_incoherent_impls {
-        &[]
-    } else {
-        incoherent_inherent_impls_query(db, (), self_ty)
-    };
-
-    #[salsa::tracked(returns(ref))]
-    fn incoherent_inherent_impls_query(
-        db: &dyn HirDatabase,
-        _force_query_input_to_be_interned: (),
-        self_ty: SimplifiedType,
-    ) -> Box<[ImplId]> {
-        let _p = tracing::info_span!("incoherent_inherent_impl_crates").entered();
-
-        let mut result = Vec::new();
-        for &krate in crates_containing_incoherent_inherent_impls(db) {
-            let impls = InherentImpls::for_crate(db, krate);
-            result.extend_from_slice(impls.for_self_ty(&self_ty));
-        }
-        result.into_boxed_slice()
+    if !has_incoherent_impls {
+        return;
+    }
+    let _p = tracing::info_span!("incoherent_inherent_impls").entered();
+    let crates = crates_containing_incoherent_inherent_impls(db, krate);
+    for &krate in crates {
+        let impls = InherentImpls::for_crate(db, krate);
+        callback(impls.for_self_ty(self_ty));
     }
 }
 


### PR DESCRIPTION
Which can happen when two workspaces are opened, by only considering impls from dependencies of this crate.

I have no idea how to construct a test for this, but I tested it manually and it works.

Fixes rust-lang/rust-analyzer#21267.