### PR TITLE
fix: use `cmark_with_options` to write shortcuts links to the output

### DIFF
--- a/crates/ide/src/doc_links.rs
+++ b/crates/ide/src/doc_links.rs
@@ -8,7 +8,7 @@ mod intra_doc_links;
 use std::ops::Range;
 
 use pulldown_cmark::{BrokenLink, CowStr, Event, InlineStr, LinkType, Options, Parser, Tag};
-use pulldown_cmark_to_cmark::{Options as CMarkOptions, cmark_resume_with_options};
+use pulldown_cmark_to_cmark::{Options as CMarkOptions, cmark_with_options};
 use stdx::format_to;
 use url::Url;
 
@@ -89,10 +89,9 @@ pub(crate) fn rewrite_links(
         }
     });
     let mut out = String::new();
-    cmark_resume_with_options(
+    cmark_with_options(
         doc,
         &mut out,
-        None,
         CMarkOptions { code_block_token_count: 3, ..Default::default() },
     )
     .ok();
@@ -125,10 +124,9 @@ pub(crate) fn remove_links(markdown: &str) -> String {
     });
 
     let mut out = String::new();
-    cmark_resume_with_options(
+    cmark_with_options(
         doc,
         &mut out,
-        None,
         CMarkOptions { code_block_token_count: 3, ..Default::default() },
     )
     .ok();

--- a/crates/ide/src/doc_links/tests.rs
+++ b/crates/ide/src/doc_links/tests.rs
@@ -724,7 +724,10 @@ pub struct $0Foo;
 /// [`foo`]: Foo
 pub struct $0Foo;
 "#,
-        expect![["[`foo`]"]],
+        expect![[r#"
+            [`foo`]
+
+            [`foo`]: https://docs.rs/foo/*/foo/struct.Foo.html"#]],
     );
 }
 


### PR DESCRIPTION
fixes: rust-lang/rust-analyzer#21214