### PR TITLE
internal: add special `ErasedFileAstId` used for bypassing downmapping

### DIFF
--- a/crates/hir-expand/src/lib.rs
+++ b/crates/hir-expand/src/lib.rs
@@ -37,7 +37,9 @@ use std::{hash::Hash, ops};
 
 use base_db::Crate;
 use either::Either;
-use span::{Edition, ErasedFileAstId, FileAstId, Span, SyntaxContext};
+use span::{
+    Edition, ErasedFileAstId, FileAstId, NO_DOWNMAP_ERASED_FILE_AST_ID_MARKER, Span, SyntaxContext,
+};
 use syntax::{
     SyntaxNode, SyntaxToken, TextRange, TextSize,
     ast::{self, AstNode},
@@ -854,6 +856,10 @@ impl ExpansionInfo {
         &self,
         span: Span,
     ) -> Option<InMacroFile<impl Iterator<Item = (SyntaxToken, SyntaxContext)> + '_>> {
+        if span.anchor.ast_id == NO_DOWNMAP_ERASED_FILE_AST_ID_MARKER {
+            return None;
+        }
+
         let tokens = self.exp_map.ranges_with_span_exact(span).flat_map(move |(range, ctx)| {
             self.expanded.value.covering_element(range).into_token().zip(Some(ctx))
         });
@@ -869,6 +875,10 @@ impl ExpansionInfo {
         &self,
         span: Span,
     ) -> Option<InMacroFile<impl Iterator<Item = (SyntaxToken, SyntaxContext)> + '_>> {
+        if span.anchor.ast_id == NO_DOWNMAP_ERASED_FILE_AST_ID_MARKER {
+            return None;
+        }
+
         let tokens = self.exp_map.ranges_with_span(span).flat_map(move |(range, ctx)| {
             self.expanded.value.covering_element(range).into_token().zip(Some(ctx))
         });

--- a/crates/span/src/ast_id.rs
+++ b/crates/span/src/ast_id.rs
@@ -48,6 +48,11 @@ pub const ROOT_ERASED_FILE_AST_ID: ErasedFileAstId =
 pub const FIXUP_ERASED_FILE_AST_ID_MARKER: ErasedFileAstId =
     ErasedFileAstId(pack_hash_index_and_kind(0, 0, ErasedFileAstIdKind::Fixup as u32));
 
+/// [`ErasedFileAstId`] used as the span for syntax nodes that should not be mapped down to
+/// macro expansion. Any `Span` containing this file id is to be considered fake.
+pub const NO_DOWNMAP_ERASED_FILE_AST_ID_MARKER: ErasedFileAstId =
+    ErasedFileAstId(pack_hash_index_and_kind(0, 0, ErasedFileAstIdKind::NoDownmap as u32));
+
 /// This is a type erased FileAstId.
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
 pub struct ErasedFileAstId(u32);
@@ -95,6 +100,7 @@ impl fmt::Debug for ErasedFileAstId {
             BlockExpr,
             AsmExpr,
             Fixup,
+            NoDownmap,
         );
         if f.alternate() {
             write!(f, "{kind}[{:04X}, {}]", self.hash_value(), self.index())
@@ -150,6 +156,9 @@ enum ErasedFileAstIdKind {
     // because incrementality is not a problem, they will always be the only item in the macro file,
     // and memory usage also not because they're rare.
     AsmExpr,
+    /// Represents a fake [`ErasedFileAstId`] that should not be mapped down to macro expansion
+    /// result.
+    NoDownmap,
     /// Keep this last.
     Root,
 }

--- a/crates/span/src/lib.rs
+++ b/crates/span/src/lib.rs
@@ -14,7 +14,7 @@ mod map;
 pub use self::{
     ast_id::{
         AstIdMap, AstIdNode, ErasedFileAstId, FIXUP_ERASED_FILE_AST_ID_MARKER, FileAstId,
-        ROOT_ERASED_FILE_AST_ID,
+        NO_DOWNMAP_ERASED_FILE_AST_ID_MARKER, ROOT_ERASED_FILE_AST_ID,
     },
     hygiene::{SyntaxContext, Transparency},
     map::{RealSpanMap, SpanMap},


### PR DESCRIPTION
Introduce `NO_DOWNMAP_ERASED_FILE_AST_ID_MARKER`, which prevents `Span`s from being mapped down into macro expansions.

This is a preparatory step for adding a new field to the `rust-project.json` format that can inject crate-level attributes. `Span`s for those attributes will be marked with
`NO_DOWNMAP_ERASED_FILE_AST_ID_MARKER`, indicating that they should not be mapped down into macro expansions.