### PR TITLE
internal: Upgrade Salsa

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2445,9 +2445,9 @@ checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "salsa"
-version = "0.24.0"
+version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27956164373aeec733ac24ff1736de8541234e3a8e7e6f916b28175b5752af3b"
+checksum = "e2e2aa2fca57727371eeafc975acc8e6f4c52f8166a78035543f6ee1c74c2dcc"
 dependencies = [
  "boxcar",
  "crossbeam-queue",
@@ -2470,15 +2470,15 @@ dependencies = [
 
 [[package]]
 name = "salsa-macro-rules"
-version = "0.24.0"
+version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ca3b9d6e47c08b5de4b218e0c5f7ec910b51bce6314e651c8e7b9d154d174da"
+checksum = "1bfc2a1e7bf06964105515451d728f2422dedc3a112383324a00b191a5c397a3"
 
 [[package]]
 name = "salsa-macros"
-version = "0.24.0"
+version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6337b62f2968be6b8afa30017d7564ecbde6832ada47ed2261fb14d0fd402ff4"
+checksum = "3d844c1aa34946da46af683b5c27ec1088a3d9d84a2b837a108223fd830220e1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,13 +135,13 @@ rayon = "1.10.0"
 rowan = "=0.15.17"
 # Ideally we'd not enable the macros feature but unfortunately the `tracked` attribute does not work
 # on impls without it
-salsa = { version = "0.24.0", default-features = false, features = [
+salsa = { version = "0.25.2", default-features = false, features = [
     "rayon",
     "salsa_unstable",
     "macros",
     "inventory",
 ] }
-salsa-macros = "0.24.0"
+salsa-macros = "0.25.2"
 semver = "1.0.26"
 serde = { version = "1.0.219" }
 serde_derive = { version = "1.0.219" }

--- a/crates/hir-ty/src/consteval.rs
+++ b/crates/hir-ty/src/consteval.rs
@@ -257,6 +257,7 @@ pub(crate) fn eval_to_const<'db>(expr: ExprId, ctx: &mut InferenceContext<'_, 'd
 
 pub(crate) fn const_eval_cycle_result<'db>(
     _: &'db dyn HirDatabase,
+    _: salsa::Id,
     _: ConstId,
     _: GenericArgs<'db>,
     _: Option<ParamEnvAndCrate<'db>>,
@@ -266,6 +267,7 @@ pub(crate) fn const_eval_cycle_result<'db>(
 
 pub(crate) fn const_eval_static_cycle_result<'db>(
     _: &'db dyn HirDatabase,
+    _: salsa::Id,
     _: StaticId,
 ) -> Result<Const<'db>, ConstEvalError<'db>> {
     Err(ConstEvalError::MirLowerError(MirLowerError::Loop))
@@ -273,6 +275,7 @@ pub(crate) fn const_eval_static_cycle_result<'db>(
 
 pub(crate) fn const_eval_discriminant_cycle_result<'db>(
     _: &'db dyn HirDatabase,
+    _: salsa::Id,
     _: EnumVariantId,
 ) -> Result<i128, ConstEvalError<'db>> {
     Err(ConstEvalError::MirLowerError(MirLowerError::Loop))

--- a/crates/hir-ty/src/db.rs
+++ b/crates/hir-ty/src/db.rs
@@ -245,7 +245,7 @@ pub struct InternedConstParamId {
     pub loc: ConstParamId,
 }
 
-#[salsa_macros::interned(no_lifetime, debug, revisions = usize::MAX)]
+#[salsa_macros::interned(no_lifetime, debug, revisions = usize::MAX, unsafe(non_update_types))]
 #[derive(PartialOrd, Ord)]
 pub struct InternedOpaqueTyId {
     pub loc: ImplTraitId<'db>,

--- a/crates/hir-ty/src/infer.rs
+++ b/crates/hir-ty/src/infer.rs
@@ -162,7 +162,7 @@ fn infer_query(db: &dyn HirDatabase, def: DefWithBodyId) -> InferenceResult<'_> 
     ctx.resolve_all()
 }
 
-fn infer_cycle_result(db: &dyn HirDatabase, _: DefWithBodyId) -> InferenceResult<'_> {
+fn infer_cycle_result(db: &dyn HirDatabase, _: salsa::Id, _: DefWithBodyId) -> InferenceResult<'_> {
     InferenceResult {
         has_errors: true,
         ..InferenceResult::new(Ty::new_error(DbInterner::new_no_crate(db), ErrorGuaranteed))
@@ -547,7 +547,7 @@ pub struct InferenceResult<'db> {
 
 #[salsa::tracked]
 impl<'db> InferenceResult<'db> {
-    #[salsa::tracked(returns(ref), cycle_result = infer_cycle_result)]
+    #[salsa::tracked(returns(ref), cycle_result = infer_cycle_result, unsafe(non_update_types))]
     pub fn for_body(db: &'db dyn HirDatabase, def: DefWithBodyId) -> InferenceResult<'db> {
         infer_query(db, def)
     }

--- a/crates/hir-ty/src/layout.rs
+++ b/crates/hir-ty/src/layout.rs
@@ -359,6 +359,7 @@ pub fn layout_of_ty_query<'db>(
 
 pub(crate) fn layout_of_ty_cycle_result<'db>(
     _: &dyn HirDatabase,
+    _: salsa::Id,
     _: Ty<'db>,
     _: ParamEnvAndCrate<'db>,
 ) -> Result<Arc<Layout>, LayoutError> {

--- a/crates/hir-ty/src/layout/adt.rs
+++ b/crates/hir-ty/src/layout/adt.rs
@@ -97,6 +97,7 @@ pub fn layout_of_adt_query<'db>(
 
 pub(crate) fn layout_of_adt_cycle_result<'db>(
     _: &'db dyn HirDatabase,
+    _: salsa::Id,
     _def: AdtId,
     _args: GenericArgs<'db>,
     _trait_env: ParamEnvAndCrate<'db>,

--- a/crates/hir-ty/src/lower.rs
+++ b/crates/hir-ty/src/lower.rs
@@ -1137,7 +1137,7 @@ impl InternedOpaqueTyId {
 
 #[salsa::tracked]
 impl<'db> ImplTraits<'db> {
-    #[salsa::tracked(returns(ref), unsafe(non_update_return_type))]
+    #[salsa::tracked(returns(ref), unsafe(non_update_types))]
     pub(crate) fn return_type_impl_traits(
         db: &'db dyn HirDatabase,
         def: hir_def::FunctionId,
@@ -1166,7 +1166,7 @@ impl<'db> ImplTraits<'db> {
         }
     }
 
-    #[salsa::tracked(returns(ref), unsafe(non_update_return_type))]
+    #[salsa::tracked(returns(ref), unsafe(non_update_types))]
     pub(crate) fn type_alias_impl_traits(
         db: &'db dyn HirDatabase,
         def: hir_def::TypeAliasId,
@@ -1373,6 +1373,7 @@ pub(crate) fn type_for_type_alias_with_diagnostics_query<'db>(
 
 pub(crate) fn type_for_type_alias_with_diagnostics_cycle_result<'db>(
     db: &'db dyn HirDatabase,
+    _: salsa::Id,
     _adt: TypeAliasId,
 ) -> (EarlyBinder<'db, Ty<'db>>, Diagnostics) {
     (EarlyBinder::bind(Ty::new_error(DbInterner::new_no_crate(db), ErrorGuaranteed)), None)
@@ -1406,6 +1407,7 @@ pub(crate) fn impl_self_ty_with_diagnostics_query<'db>(
 
 pub(crate) fn impl_self_ty_with_diagnostics_cycle_result(
     db: &dyn HirDatabase,
+    _: salsa::Id,
     _impl_id: ImplId,
 ) -> (EarlyBinder<'_, Ty<'_>>, Diagnostics) {
     (EarlyBinder::bind(Ty::new_error(DbInterner::new_no_crate(db), ErrorGuaranteed)), None)
@@ -1443,6 +1445,7 @@ pub(crate) fn const_param_ty_with_diagnostics_query<'db>(
 
 pub(crate) fn const_param_ty_with_diagnostics_cycle_result<'db>(
     db: &'db dyn HirDatabase,
+    _: salsa::Id,
     _: crate::db::HirDatabaseData,
     _def: ConstParamId,
 ) -> (Ty<'db>, Diagnostics) {
@@ -1496,7 +1499,7 @@ pub(crate) fn field_types_with_diagnostics_query<'db>(
 /// following bounds are disallowed: `T: Foo<U::Item>, U: Foo<T::Item>`, but
 /// these are fine: `T: Foo<U::Item>, U: Foo<()>`.
 #[tracing::instrument(skip(db), ret)]
-#[salsa::tracked(returns(ref), unsafe(non_update_return_type), cycle_result = generic_predicates_for_param_cycle_result)]
+#[salsa::tracked(returns(ref), unsafe(non_update_types), cycle_result = generic_predicates_for_param_cycle_result)]
 pub(crate) fn generic_predicates_for_param<'db>(
     db: &'db dyn HirDatabase,
     def: GenericDefId,
@@ -1609,6 +1612,7 @@ pub(crate) fn generic_predicates_for_param<'db>(
 
 pub(crate) fn generic_predicates_for_param_cycle_result<'db>(
     _db: &'db dyn HirDatabase,
+    _: salsa::Id,
     _def: GenericDefId,
     _param_id: TypeOrConstParamId,
     _assoc_name: Option<Name>,
@@ -1624,7 +1628,7 @@ pub(crate) fn type_alias_bounds<'db>(
     type_alias_bounds_with_diagnostics(db, type_alias).0.as_ref().map_bound(|it| &**it)
 }
 
-#[salsa::tracked(returns(ref), unsafe(non_update_return_type))]
+#[salsa::tracked(returns(ref), unsafe(non_update_types))]
 pub fn type_alias_bounds_with_diagnostics<'db>(
     db: &'db dyn HirDatabase,
     type_alias: TypeAliasId,
@@ -1682,7 +1686,7 @@ impl<'db> GenericPredicates<'db> {
     /// Resolve the where clause(s) of an item with generics.
     ///
     /// Diagnostics are computed only for this item's predicates, not for parents.
-    #[salsa::tracked(returns(ref), unsafe(non_update_return_type))]
+    #[salsa::tracked(returns(ref), unsafe(non_update_types))]
     pub fn query_with_diagnostics(
         db: &'db dyn HirDatabase,
         def: GenericDefId,
@@ -2090,6 +2094,7 @@ pub(crate) fn generic_defaults_with_diagnostics_query(
 
 pub(crate) fn generic_defaults_with_diagnostics_cycle_result(
     _db: &dyn HirDatabase,
+    _: salsa::Id,
     _def: GenericDefId,
 ) -> (GenericDefaults<'_>, Diagnostics) {
     (GenericDefaults(None), None)

--- a/crates/hir-ty/src/mir/lower.rs
+++ b/crates/hir-ty/src/mir/lower.rs
@@ -2261,6 +2261,7 @@ pub fn mir_body_query<'db>(
 
 pub(crate) fn mir_body_cycle_result<'db>(
     _db: &'db dyn HirDatabase,
+    _: salsa::Id,
     _def: DefWithBodyId,
 ) -> Result<'db, Arc<MirBody<'db>>> {
     Err(MirLowerError::Loop)

--- a/crates/hir-ty/src/mir/monomorphization.rs
+++ b/crates/hir-ty/src/mir/monomorphization.rs
@@ -223,6 +223,7 @@ pub fn monomorphized_mir_body_query<'db>(
 
 pub(crate) fn monomorphized_mir_body_cycle_result<'db>(
     _db: &'db dyn HirDatabase,
+    _: salsa::Id,
     _: DefWithBodyId,
     _: GenericArgs<'db>,
     _: ParamEnvAndCrate<'db>,

--- a/crates/hir-ty/src/next_solver/consts.rs
+++ b/crates/hir-ty/src/next_solver/consts.rs
@@ -23,7 +23,7 @@ use super::{BoundVarKind, DbInterner, ErrorGuaranteed, GenericArgs, Placeholder,
 pub type ConstKind<'db> = rustc_type_ir::ConstKind<DbInterner<'db>>;
 pub type UnevaluatedConst<'db> = rustc_type_ir::UnevaluatedConst<DbInterner<'db>>;
 
-#[salsa::interned(constructor = new_)]
+#[salsa::interned(constructor = new_, unsafe(non_update_types))]
 pub struct Const<'db> {
     #[returns(ref)]
     kind_: InternedWrapperNoDebug<WithCachedTypeInfo<ConstKind<'db>>>,
@@ -202,7 +202,7 @@ impl Hash for ConstBytes<'_> {
     }
 }
 
-#[salsa::interned(constructor = new_, debug)]
+#[salsa::interned(constructor = new_, debug, unsafe(non_update_types))]
 pub struct Valtree<'db> {
     #[returns(ref)]
     bytes_: ConstBytes<'db>,

--- a/crates/hir-ty/src/next_solver/interner.rs
+++ b/crates/hir-ty/src/next_solver/interner.rs
@@ -202,7 +202,7 @@ macro_rules! _interned_vec_db {
         }
     };
     ($name:ident, $ty:ident, nofold) => {
-        #[salsa::interned(constructor = new_)]
+        #[salsa::interned(constructor = new_, unsafe(non_update_types))]
         pub struct $name<'db> {
             #[returns(ref)]
             inner_: smallvec::SmallVec<[$ty<'db>; 2]>,
@@ -762,7 +762,7 @@ impl std::ops::Deref for UnsizingParams {
 
 pub type PatternKind<'db> = rustc_type_ir::PatternKind<DbInterner<'db>>;
 
-#[salsa::interned(constructor = new_, debug)]
+#[salsa::interned(constructor = new_, debug, unsafe(non_update_types))]
 pub struct Pattern<'db> {
     #[returns(ref)]
     kind_: InternedWrapperNoDebug<PatternKind<'db>>,

--- a/crates/hir-ty/src/next_solver/opaques.rs
+++ b/crates/hir-ty/src/next_solver/opaques.rs
@@ -15,7 +15,7 @@ pub type ExternalConstraintsData<'db> =
 
 interned_vec_nolifetime_salsa!(SolverDefIds, SolverDefId);
 
-#[salsa::interned(constructor = new_, debug)]
+#[salsa::interned(constructor = new_, debug, unsafe(non_update_types))]
 pub struct ExternalConstraints<'db> {
     #[returns(ref)]
     kind_: rustc_type_ir::solve::ExternalConstraintsData<DbInterner<'db>>,

--- a/crates/hir-ty/src/next_solver/predicate.rs
+++ b/crates/hir-ty/src/next_solver/predicate.rs
@@ -172,7 +172,7 @@ impl<'db> rustc_type_ir::relate::Relate<DbInterner<'db>> for BoundExistentialPre
     }
 }
 
-#[salsa::interned(constructor = new_)]
+#[salsa::interned(constructor = new_, unsafe(non_update_types))]
 pub struct Predicate<'db> {
     #[returns(ref)]
     kind_: InternedWrapperNoDebug<WithCachedTypeInfo<Binder<'db, PredicateKind<'db>>>>,
@@ -278,7 +278,7 @@ impl<'db> std::hash::Hash for InternedClausesWrapper<'db> {
     }
 }
 
-#[salsa::interned(constructor = new_)]
+#[salsa::interned(constructor = new_, unsafe(non_update_types))]
 pub struct Clauses<'db> {
     #[returns(ref)]
     inner_: InternedClausesWrapper<'db>,

--- a/crates/hir-ty/src/next_solver/region.rs
+++ b/crates/hir-ty/src/next_solver/region.rs
@@ -18,7 +18,7 @@ use super::{
 
 pub type RegionKind<'db> = rustc_type_ir::RegionKind<DbInterner<'db>>;
 
-#[salsa::interned(constructor = new_)]
+#[salsa::interned(constructor = new_, unsafe(non_update_types))]
 pub struct Region<'db> {
     #[returns(ref)]
     kind_: RegionKind<'db>,

--- a/crates/hir-ty/src/next_solver/ty.rs
+++ b/crates/hir-ty/src/next_solver/ty.rs
@@ -44,7 +44,7 @@ pub type SimplifiedType = rustc_type_ir::fast_reject::SimplifiedType<SolverDefId
 pub type TyKind<'db> = rustc_type_ir::TyKind<DbInterner<'db>>;
 pub type FnHeader<'db> = rustc_type_ir::FnHeader<DbInterner<'db>>;
 
-#[salsa::interned(constructor = new_)]
+#[salsa::interned(constructor = new_, unsafe(non_update_types))]
 pub struct Ty<'db> {
     #[returns(ref)]
     kind_: InternedWrapperNoDebug<WithCachedTypeInfo<TyKind<'db>>>,

--- a/crates/hir-ty/src/opaques.rs
+++ b/crates/hir-ty/src/opaques.rs
@@ -89,7 +89,7 @@ pub(crate) fn opaque_types_defined_by(
 
 // These are firewall queries to prevent drawing dependencies between infers:
 
-#[salsa::tracked(returns(ref), unsafe(non_update_return_type))]
+#[salsa::tracked(returns(ref), unsafe(non_update_types))]
 pub(crate) fn rpit_hidden_types<'db>(
     db: &'db dyn HirDatabase,
     function: FunctionId,
@@ -103,7 +103,7 @@ pub(crate) fn rpit_hidden_types<'db>(
     result
 }
 
-#[salsa::tracked(returns(ref), unsafe(non_update_return_type))]
+#[salsa::tracked(returns(ref), unsafe(non_update_types))]
 pub(crate) fn tait_hidden_types<'db>(
     db: &'db dyn HirDatabase,
     type_alias: TypeAliasId,

--- a/crates/hir-ty/src/specialization.rs
+++ b/crates/hir-ty/src/specialization.rs
@@ -22,6 +22,7 @@ use crate::{
 // cannot create a cycle, but a cycle handler is required nevertheless.
 fn specializes_query_cycle(
     _db: &dyn HirDatabase,
+    _: salsa::Id,
     _specializing_impl_def_id: ImplId,
     _parent_impl_def_id: ImplId,
 ) -> bool {

--- a/crates/hir-ty/src/variance.rs
+++ b/crates/hir-ty/src/variance.rs
@@ -105,6 +105,7 @@ fn glb(v1: Variance, v2: Variance) -> Variance {
 
 pub(crate) fn variances_of_cycle_initial(
     db: &dyn HirDatabase,
+    _: salsa::Id,
     def: GenericDefId,
 ) -> VariancesOf<'_> {
     let interner = DbInterner::new_no_crate(db);

--- a/crates/query-group-macro/src/queries.rs
+++ b/crates/query-group-macro/src/queries.rs
@@ -49,7 +49,7 @@ impl ToTokens for TrackedQuery {
             })
             .into_iter()
             .chain(self.lru.map(|lru| quote!(lru = #lru)))
-            .chain(Some(quote!(unsafe(non_update_return_type))));
+            .chain(Some(quote!(unsafe(non_update_types))));
         let annotation = quote!(#[salsa_macros::tracked( #(#options),* )]);
 
         let pat_and_tys = &self.pat_and_tys;


### PR DESCRIPTION
The new version gives an additional `salsa::Id` to cycle handlers, and renames `non_update_return_type` to `non_update_types`.

Doing it separately to shrink my eventual GC PR, which is already huge.