### PR TITLE
feat: pretty print attributes up to `cfg(false)`

### DIFF
--- a/crates/cfg/src/cfg_expr.rs
+++ b/crates/cfg/src/cfg_expr.rs
@@ -56,6 +56,36 @@ pub enum CfgExpr {
     Not(Box<CfgExpr>),
 }
 
+impl fmt::Display for CfgExpr {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            CfgExpr::Atom(atom) => atom.fmt(f),
+            CfgExpr::All(exprs) => {
+                write!(f, "all(")?;
+                for (i, expr) in exprs.iter().enumerate() {
+                    if i > 0 {
+                        write!(f, ", ")?;
+                    }
+                    expr.fmt(f)?;
+                }
+                write!(f, ")")
+            }
+            CfgExpr::Any(exprs) => {
+                write!(f, "any(")?;
+                for (i, expr) in exprs.iter().enumerate() {
+                    if i > 0 {
+                        write!(f, ", ")?;
+                    }
+                    expr.fmt(f)?;
+                }
+                write!(f, ")")
+            }
+            CfgExpr::Not(expr) => write!(f, "not({})", expr),
+            CfgExpr::Invalid => write!(f, "invalid"),
+        }
+    }
+}
+
 impl From<CfgAtom> for CfgExpr {
     fn from(atom: CfgAtom) -> Self {
         CfgExpr::Atom(atom)

--- a/crates/hir-def/src/item_tree/pretty.rs
+++ b/crates/hir-def/src/item_tree/pretty.rs
@@ -86,9 +86,9 @@ impl Printer<'_> {
     }
 
     fn print_attrs(&mut self, attrs: &AttrsOrCfg, inner: bool, separated_by: &str) {
-        let AttrsOrCfg::Enabled { attrs } = attrs else {
-            w!(self, "#[cfg(false)]{separated_by}");
-            return;
+        let (cfg_disabled_expr, attrs) = match attrs {
+            AttrsOrCfg::Enabled { attrs } => (None, attrs),
+            AttrsOrCfg::CfgDisabled(inner_box) => (Some(&inner_box.0), &inner_box.1),
         };
         let inner = if inner { "!" } else { "" };
         for attr in &*attrs.as_ref() {
@@ -100,6 +100,9 @@ impl Printer<'_> {
                 attr.input.as_ref().map(|it| it.to_string()).unwrap_or_default(),
                 separated_by,
             );
+        }
+        if let Some(expr) = cfg_disabled_expr {
+            w!(self, "#{inner}[cfg({expr})]{separated_by}");
         }
     }
 


### PR DESCRIPTION
Extend ItemTree pretty-printing to include attributes even when a cfg expression evaluates to false, emitting explicit `cfg(cfg_expr)` marker after the attributes.

This improves testability of ItemTree attribute handling by exposing more information in pretty-printed output.