### PR TITLE
internal: Improve recursive mbe parsing behavior

### DIFF
--- a/crates/hir-def/src/macro_expansion_tests/mbe/regression.rs
+++ b/crates/hir-def/src/macro_expansion_tests/mbe/regression.rs
@@ -109,6 +109,42 @@ fn main() {
 }
 
 #[test]
+fn ty_fragment_followed_by_expr() {
+    check(
+        r#"
+macro_rules! a {
+    ($t:tt) => {};
+}
+
+macro_rules! b {
+    ($t:ty) => {
+        a!($t);
+    };
+}
+
+fn main() {
+    b!(&'static str);
+}
+"#,
+        expect![[r#"
+macro_rules! a {
+    ($t:tt) => {};
+}
+
+macro_rules! b {
+    ($t:ty) => {
+        a!($t);
+    };
+}
+
+fn main() {
+    a!(&'static str);;
+}
+"#]],
+    );
+}
+
+#[test]
 fn test_winapi_struct() {
     // from https://github.com/retep998/winapi-rs/blob/a7ef2bca086aae76cf6c4ce4c2552988ed9798ad/src/macros.rs#L366
 

--- a/crates/mbe/src/expander.rs
+++ b/crates/mbe/src/expander.rs
@@ -128,7 +128,10 @@ enum Fragment<'a> {
     #[default]
     Empty,
     /// token fragments are just copy-pasted into the output
-    Tokens(tt::TokenTreesView<'a, Span>),
+    Tokens {
+        tree: tt::TokenTreesView<'a, Span>,
+        origin: TokensOrigin,
+    },
     /// Expr ast fragments are surrounded with `()` on transcription to preserve precedence.
     /// Note that this impl is different from the one currently in `rustc` --
     /// `rustc` doesn't translate fragments into token trees at all.
@@ -156,10 +159,16 @@ impl Fragment<'_> {
     fn is_empty(&self) -> bool {
         match self {
             Fragment::Empty => true,
-            Fragment::Tokens(it) => it.len() == 0,
+            Fragment::Tokens { tree, .. } => tree.len() == 0,
             Fragment::Expr(it) => it.len() == 0,
             Fragment::Path(it) => it.len() == 0,
             Fragment::TokensOwned(it) => it.0.is_empty(),
         }
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TokensOrigin {
+    Raw,
+    Ast,
 }


### PR DESCRIPTION
cc rust-lang/rust-analyzer#19168

now tags every Fragment::Tokens with a TokensOrigin (raw token vs parsed AST) so we can keep track of which fragments need to stay wrapped as a single tt chunk during transcription.

records that ty/pat/pat_param/stmt/block/meta/item/vis metavars originate from AST parses while ident/tt/lifetime/literal stay raw, so bindings carry the right origin metadata from the moment they’re matched.

respects the new origin flag: ${concat} handling destructures the updated variant, and expand_var now leaves AST-derived fragments enclosed (preventing the stray 'static token that used to cause expected Expr), while raw fragments keep the previous strip-logic.