### PR TITLE
fix "Run Doctest" lens shows up on compile_fail tests #19103

### DIFF
--- a/crates/rust-analyzer/src/target_spec.rs
+++ b/crates/rust-analyzer/src/target_spec.rs
@@ -116,7 +116,7 @@ impl CargoTargetSpec {
         cfg: &Option<CfgExpr>,
     ) -> (Vec<String>, Vec<String>) {
         let config = snap.config.runnables(None);
-        let mut extra_test_binary_args = config.extra_test_binary_args;
+        let extra_test_binary_args = config.extra_test_binary_args;
 
         let mut cargo_args = Vec::new();
         let mut executable_args = Vec::new();
@@ -146,13 +146,10 @@ impl CargoTargetSpec {
                 }
                 executable_args.extend(extra_test_binary_args);
             }
-            RunnableKind::DocTest { test_id, has_compile_fail } => {
+            RunnableKind::DocTest { test_id } => {
                 cargo_args.push("test".to_owned());
                 cargo_args.push("--doc".to_owned());
                 executable_args.push(test_id.to_string());
-                if *has_compile_fail {
-                    extra_test_binary_args.retain(|arg| arg != "--nocapture");
-                }
                 executable_args.extend(extra_test_binary_args);
             }
             RunnableKind::Bin => {


### PR DESCRIPTION
fix rust-lang/rust-analyzer#19103

Added a has_compile_fail flag to RunnableKind::DocTest so we remember when a runnable’s docs include compile-fail snippets; the doc parser now scans every fenced block (handling indentation and both comma/whitespace separators) to capture that metadata while still allowing edition tags such as 2024.

When building Cargo commands we drop the default --nocapture argument for doc tests that have compile‑fail snippets, preventing cargo test output from showing expected compiler errors as if the test failed.

Added a regression test that confirms compile‑fail doctests are still exposed as runnables and that the new flag is set.
