### PR TITLE
internal: Fix hir-ty implicit serde derive feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -903,6 +903,7 @@ dependencies = [
  "salsa",
  "salsa-macros",
  "serde",
+ "serde_derive",
  "smallvec",
  "span",
  "stdx",

--- a/crates/hir-ty/Cargo.toml
+++ b/crates/hir-ty/Cargo.toml
@@ -19,6 +19,7 @@ arrayvec.workspace = true
 smallvec.workspace = true
 ena = "0.14.3"
 serde.workspace = true
+serde_derive.workspace = true
 either.workspace = true
 oorandom = "11.1.5"
 tracing = { workspace = true, features = ["attributes"] }

--- a/crates/hir-ty/src/next_solver/format_proof_tree.rs
+++ b/crates/hir-ty/src/next_solver/format_proof_tree.rs
@@ -1,5 +1,5 @@
 use rustc_type_ir::{solve::GoalSource, solve::inspect::GoalEvaluation};
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 
 use crate::next_solver::infer::InferCtxt;
 use crate::next_solver::inspect::{InspectCandidate, InspectGoal};


### PR DESCRIPTION
bad commit: 0dd3fe029a532c6c5fa3b0bdd7c4eb57843bb156 (rust-lang/rust-analyzer#21309)
cwd: crates/hir-ty
cmd: cargo check
output: error: cannot find derive macro `Serialize` in this scope
