### PR TITLE
feat: add option to set lower priority for flycheck

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2311,6 +2311,7 @@ dependencies = [
  "ide-ssr",
  "indexmap",
  "itertools 0.14.0",
+ "libc",
  "load-cargo",
  "lsp-server 0.7.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "lsp-types",

--- a/crates/rust-analyzer/Cargo.toml
+++ b/crates/rust-analyzer/Cargo.toml
@@ -51,6 +51,7 @@ toml.workspace = true
 walkdir = "2.5.0"
 semver.workspace = true
 memchr = "2.7.5"
+libc.workspace = true
 cargo_metadata.workspace = true
 process-wrap.workspace = true
 dhat = { version = "0.3.3", optional = true }

--- a/docs/book/src/configuration_generated.md
+++ b/docs/book/src/configuration_generated.md
@@ -338,6 +338,16 @@ Note: The option must be specified as an array of command line arguments, with
 the first argument being the name of the command to run.
 
 
+## rust-analyzer.check.priority {#check.priority}
+
+Default: `"normal"`
+
+Set the priority of the check command.
+
+On Unix, this will use `nice` to set the priority.
+On Windows, this will use `BELOW_NORMAL_PRIORITY_CLASS`.
+
+
 ## rust-analyzer.check.targets {#check.targets}
 
 Default: `null`

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -1228,6 +1228,24 @@
             {
                 "title": "Check",
                 "properties": {
+                    "rust-analyzer.check.priority": {
+                        "markdownDescription": "Set the priority of the check command.\n\nOn Unix, this will use `nice` to set the priority.\nOn Windows, this will use `BELOW_NORMAL_PRIORITY_CLASS`.",
+                        "default": "normal",
+                        "type": "string",
+                        "enum": [
+                            "normal",
+                            "low"
+                        ],
+                        "enumDescriptions": [
+                            "Run with normal priority.",
+                            "Run with low priority (e.g., nice on Unix)."
+                        ]
+                    }
+                }
+            },
+            {
+                "title": "Check",
+                "properties": {
                     "rust-analyzer.check.targets": {
                         "markdownDescription": "Check for specific targets. Defaults to `#rust-analyzer.cargo.target#` if empty.\n\nCan be a single target, e.g. `\"x86_64-unknown-linux-gnu\"` or a list of targets, e.g.\n`[\"aarch64-apple-darwin\", \"x86_64-apple-darwin\"]`.\n\nAliased as `\"checkOnSave.targets\"`.",
                         "default": null,


### PR DESCRIPTION
 allowing users to set a lower process priority for the `cargo check` process

Verified that the code compiles on Linux.
`cargo test -p rust-analyzer --lib config::tests` to ensure `package.json` and docs are up to date.

Fixes: rust-lang/rust-analyzer#11352