### PR TITLE
fix: keep flycheck generations in sync across multiple workspaces

### DIFF
--- a/crates/rust-analyzer/src/flycheck.rs
+++ b/crates/rust-analyzer/src/flycheck.rs
@@ -147,13 +147,13 @@ pub(crate) struct FlycheckHandle {
     sender: Sender<StateChange>,
     _thread: stdx::thread::JoinHandle,
     id: usize,
-    generation: AtomicUsize,
+    generation: Arc<AtomicUsize>,
 }
 
 impl FlycheckHandle {
     pub(crate) fn spawn(
         id: usize,
-        generation: DiagnosticsGeneration,
+        generation: Arc<AtomicUsize>,
         sender: Sender<FlycheckMessage>,
         config: FlycheckConfig,
         sysroot_root: Option<AbsPathBuf>,
@@ -163,7 +163,7 @@ impl FlycheckHandle {
     ) -> FlycheckHandle {
         let actor = FlycheckActor::new(
             id,
-            generation,
+            generation.load(Ordering::Relaxed),
             sender,
             config,
             sysroot_root,
@@ -176,7 +176,7 @@ impl FlycheckHandle {
             stdx::thread::Builder::new(stdx::thread::ThreadIntent::Worker, format!("Flycheck{id}"))
                 .spawn(move || actor.run(receiver))
                 .expect("failed to spawn thread");
-        FlycheckHandle { id, generation: generation.into(), sender, _thread: thread }
+        FlycheckHandle { id, generation, sender, _thread: thread }
     }
 
     /// Schedule a re-start of the cargo check worker to do a workspace wide check.


### PR DESCRIPTION
The diagnostics collection globally tracks the generation for all loaded workspaces as its shared between them, yet the flycheck actors track their own separate generations per workspace. This mismatch could cause flycheck to not work correctly when multiple workspaces were loaded.