### PR TITLE
internal: Store closures with "tupled" inputs

### DIFF
--- a/crates/hir-ty/src/infer/closure/analysis.rs
+++ b/crates/hir-ty/src/infer/closure/analysis.rs
@@ -15,7 +15,7 @@ use hir_def::{
 };
 use rustc_ast_ir::Mutability;
 use rustc_hash::{FxHashMap, FxHashSet};
-use rustc_type_ir::inherent::{IntoKind, Ty as _};
+use rustc_type_ir::inherent::{GenericArgs as _, IntoKind, Ty as _};
 use smallvec::{SmallVec, smallvec};
 use stdx::{format_to, never};
 use syntax::utils::is_raw_identifier;
@@ -103,7 +103,7 @@ impl CapturedItem {
 
     pub fn ty<'db>(&self, db: &'db dyn HirDatabase, subst: GenericArgs<'db>) -> Ty<'db> {
         let interner = DbInterner::new_no_crate(db);
-        self.ty.get().instantiate(interner, subst.split_closure_args_untupled().parent_args)
+        self.ty.get().instantiate(interner, subst.as_closure().parent_args())
     }
 
     pub fn kind(&self) -> CaptureKind {

--- a/crates/hir-ty/src/layout.rs
+++ b/crates/hir-ty/src/layout.rs
@@ -14,7 +14,10 @@ use rustc_abi::{
     TargetDataLayout, WrappingRange,
 };
 use rustc_index::IndexVec;
-use rustc_type_ir::{FloatTy, IntTy, UintTy, inherent::IntoKind};
+use rustc_type_ir::{
+    FloatTy, IntTy, UintTy,
+    inherent::{GenericArgs as _, IntoKind},
+};
 use triomphe::Arc;
 
 use crate::{
@@ -335,10 +338,7 @@ pub fn layout_of_ty_query(
             let fields = captures
                 .iter()
                 .map(|it| {
-                    let ty = it
-                        .ty
-                        .get()
-                        .instantiate(interner, args.split_closure_args_untupled().parent_args);
+                    let ty = it.ty.get().instantiate(interner, args.as_closure().parent_args());
                     db.layout_of_ty(ty.store(), trait_env.clone())
                 })
                 .collect::<Result<Vec<_>, _>>()?;

--- a/crates/hir-ty/src/mir/borrowck.rs
+++ b/crates/hir-ty/src/mir/borrowck.rs
@@ -8,6 +8,7 @@ use std::iter;
 use hir_def::{DefWithBodyId, HasModule};
 use la_arena::ArenaMap;
 use rustc_hash::FxHashMap;
+use rustc_type_ir::inherent::GenericArgs as _;
 use stdx::never;
 use triomphe::Arc;
 
@@ -123,7 +124,7 @@ fn make_fetch_closure_field<'db>(
         let InternedClosure(def, _) = db.lookup_intern_closure(c);
         let infer = InferenceResult::for_body(db, def);
         let (captures, _) = infer.closure_info(c);
-        let parent_subst = subst.split_closure_args_untupled().parent_args;
+        let parent_subst = subst.as_closure().parent_args();
         let interner = DbInterner::new_no_crate(db);
         captures.get(f).expect("broken closure field").ty.get().instantiate(interner, parent_subst)
     }

--- a/crates/hir-ty/src/mir/eval.rs
+++ b/crates/hir-ty/src/mir/eval.rs
@@ -27,7 +27,7 @@ use rustc_ast_ir::Mutability;
 use rustc_hash::{FxHashMap, FxHashSet};
 use rustc_type_ir::{
     AliasTyKind,
-    inherent::{AdtDef, IntoKind, Region as _, SliceLike, Ty as _},
+    inherent::{AdtDef, GenericArgs as _, IntoKind, Region as _, SliceLike, Ty as _},
 };
 use span::FileId;
 use stdx::never;
@@ -731,7 +731,7 @@ impl<'db> Evaluator<'db> {
                 let InternedClosure(def, _) = self.db.lookup_intern_closure(c);
                 let infer = InferenceResult::for_body(self.db, def);
                 let (captures, _) = infer.closure_info(c);
-                let parent_subst = subst.split_closure_args_untupled().parent_args;
+                let parent_subst = subst.as_closure().parent_args();
                 captures
                     .get(f)
                     .expect("broken closure field")
@@ -2771,7 +2771,7 @@ impl<'db> Evaluator<'db> {
             TyKind::Closure(closure, subst) => self.exec_closure(
                 closure.0,
                 func_data,
-                GenericArgs::new_from_slice(subst.split_closure_args_untupled().parent_args),
+                GenericArgs::new_from_slice(subst.as_closure().parent_args()),
                 destination,
                 &args[1..],
                 locals,


### PR DESCRIPTION
And remove it when needed, the opposite of what was previously, where we stored without a tuple and tupled for the solver (because it requires that).

Because this is what rustc does, and generally, the closer we follow rustc, the easier our lives become.

The weird name `signature_unclosure()` also comes from rustc.

As an aside: we need to fix our coercion due to https://github.com/rust-lang/rust/pull/148602.