### PR TITLE
minor: Fix grammar in "Use of AI tools" section

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,6 +38,6 @@ considered accepted feel free to just drop a comment and ask!
 
 AI tool use is not discouraged on the rust-analyzer codebase, as long as it meets our quality standards.
 We kindly ask you to disclose usage of AI tools in your contributions.
-If you used them without disclosing it, we may reject your contribution on that basis alone due to the assumption that you likely not reviewed your own submission (so why should we?).
+If you used them without disclosing it, we may reject your contribution on that basis alone due to the assumption that you have, most likely, not reviewed your own submission (so why should we?).
 
 We may still reject AI-assisted contributions if we deem the quality of the contribution to be unsatisfactory as to reduce impact on the team's review budget.


### PR DESCRIPTION
cc rust-lang/rust-analyzer#21314

Full disclosure: I made use of an LLM to make sure that the original wording is grammatically incorrect 🤣, but the rewording is my own.