### PR TITLE
fix: fix duplicate completion item in record update syntax

### DIFF
--- a/crates/ide-completion/src/completions/record.rs
+++ b/crates/ide-completion/src/completions/record.rs
@@ -70,8 +70,11 @@ pub(crate) fn complete_record_expr_fields(
         }
         _ => {
             let missing_fields = ctx.sema.record_literal_missing_fields(record_expr);
+            let update_exists = record_expr
+                .record_expr_field_list()
+                .is_some_and(|list| list.dotdot_token().is_some());
 
-            if !missing_fields.is_empty() {
+            if !missing_fields.is_empty() && !update_exists {
                 cov_mark::hit!(functional_update_field);
                 add_default_update(acc, ctx, ty);
             }

--- a/crates/ide-completion/src/tests/record.rs
+++ b/crates/ide-completion/src/tests/record.rs
@@ -264,6 +264,29 @@ fn main() {
 }
 
 #[test]
+fn functional_update_exist_update() {
+    check(
+        r#"
+//- minicore:default
+struct Foo { foo1: u32, foo2: u32 }
+impl Default for Foo {
+    fn default() -> Self { loop {} }
+}
+
+fn main() {
+    let thing = 1;
+    let foo = Foo { foo1: 0, foo2: 0 };
+    let foo2 = Foo { thing, $0 ..Default::default() }
+}
+"#,
+        expect![[r#"
+            fd foo1 u32
+            fd foo2 u32
+        "#]],
+    );
+}
+
+#[test]
 fn empty_union_literal() {
     check(
         r#"


### PR DESCRIPTION
Example
---
```rust
fn main() {
    let thing = 1;
    let foo = Foo { foo1: 0, foo2: 0 };
    let foo2 = Foo { thing, $0 ..Default::default() }
}
```

**Before this PR**

```text
fd ..Default::default()
fd foo1             u32
fd foo2             u32
```

**After this PR**

```text
fd foo1 u32
fd foo2 u32
```
