### PR TITLE
internal: Prepare for compressing spans to save memory

### DIFF
--- a/crates/cfg/src/cfg_expr.rs
+++ b/crates/cfg/src/cfg_expr.rs
@@ -157,7 +157,7 @@ fn next_cfg_expr_from_ast(
                     },
                     ctx: span::SyntaxContext::root(span::Edition::Edition2015),
                 };
-                let literal = tt::token_to_literal(literal.text(), dummy_span).symbol;
+                let literal = tt::token_to_literal(literal.text(), dummy_span).leaf.symbol;
                 it.next();
                 CfgAtom::KeyValue { key: name, value: literal.clone() }.into()
             } else {
@@ -193,12 +193,12 @@ fn next_cfg_expr(it: &mut tt::iter::TtIter<'_>) -> Option<CfgExpr> {
 
     let name = match it.next() {
         None => return None,
-        Some(TtElement::Leaf(tt::Leaf::Ident(ident))) => ident.sym.clone(),
+        Some(TtElement::Leaf(tt::SpannedLeafKind::Ident(ident))) => ident.sym.clone(),
         Some(_) => return Some(CfgExpr::Invalid),
     };
 
     let ret = match it.peek() {
-        Some(TtElement::Leaf(tt::Leaf::Punct(punct)))
+        Some(TtElement::Leaf(tt::SpannedLeafKind::Punct(punct)))
             // Don't consume on e.g. `=>`.
             if punct.char == '='
                 && (punct.spacing == tt::Spacing::Alone
@@ -231,7 +231,7 @@ fn next_cfg_expr(it: &mut tt::iter::TtIter<'_>) -> Option<CfgExpr> {
     };
 
     // Eat comma separator
-    if let Some(TtElement::Leaf(tt::Leaf::Punct(punct))) = it.peek()
+    if let Some(TtElement::Leaf(tt::SpannedLeafKind::Punct(punct))) = it.peek()
         && punct.char == ','
     {
         it.next();

--- a/crates/hir-def/src/macro_expansion_tests/mod.rs
+++ b/crates/hir-def/src/macro_expansion_tests/mod.rs
@@ -424,9 +424,9 @@ fn regression_20171() {
         },
         ctx: SyntaxContext::root(Edition::CURRENT),
     };
-    let close_brace = tt::Punct { char: '}', spacing: tt::Spacing::Alone, span };
-    let dotdot1 = tt::Punct { char: '.', spacing: tt::Spacing::Joint, span };
-    let dotdot2 = tt::Punct { char: '.', spacing: tt::Spacing::Alone, span };
+    let close_brace = tt::Punct::new('}', tt::Spacing::Alone, span);
+    let dotdot1 = tt::Punct::new('.', tt::Spacing::Joint, span);
+    let dotdot2 = tt::Punct::new('.', tt::Spacing::Alone, span);
     let dollar_crate = sym::dollar_crate;
     let tt = quote! {
             span => {

--- a/crates/hir-def/src/nameres/attr_resolution.rs
+++ b/crates/hir-def/src/nameres/attr_resolution.rs
@@ -114,7 +114,7 @@ pub(super) fn attr_macro_as_call_id(
     let arg = match macro_attr.input.as_deref() {
         Some(AttrInput::TokenTree(tt)) => {
             let mut tt = tt.clone();
-            tt.top_subtree_delimiter_mut().kind = tt::DelimiterKind::Invisible;
+            tt.set_top_subtree_delimiter_kind(tt::DelimiterKind::Invisible);
             Some(tt)
         }
 

--- a/crates/hir-def/src/nameres/collector.rs
+++ b/crates/hir-def/src/nameres/collector.rs
@@ -2447,7 +2447,9 @@ impl ModCollector<'_, '_> {
         let is_export = export_attr().exists();
         let local_inner = if is_export {
             export_attr().tt_values().flat_map(|it| it.iter()).any(|it| match it {
-                tt::TtElement::Leaf(tt::Leaf::Ident(ident)) => ident.sym == sym::local_inner_macros,
+                tt::TtElement::Leaf(tt::SpannedLeafKind::Ident(ident)) => {
+                    ident.sym == sym::local_inner_macros
+                }
                 _ => false,
             })
         } else {

--- a/crates/hir-def/src/nameres/proc_macro.rs
+++ b/crates/hir-def/src/nameres/proc_macro.rs
@@ -78,11 +78,13 @@ pub(crate) fn parse_macro_name_and_helper_attrs(tt: &TopSubtree) -> Option<(Name
             ..
         ] if comma.char == ',' && attributes.sym == sym::attributes =>
         {
-            let helpers = tt::TokenTreesView::new(&tt.token_trees().flat_tokens()[3..]).try_into_subtree()?;
+            let mut iter = tt.iter();
+            iter.nth(2);
+            let helpers = iter.remaining().try_into_subtree()?;
             let helpers = helpers
                 .iter()
                 .filter_map(|tt| match tt {
-                    TtElement::Leaf(Leaf::Ident(helper)) => Some(helper.as_name()),
+                    TtElement::Leaf(tt::SpannedLeafKind::Ident(helper)) => Some(helper.as_name()),
                     _ => None,
                 })
                 .collect::<Box<[_]>>();

--- a/crates/hir-expand/src/builtin/attr_macro.rs
+++ b/crates/hir-expand/src/builtin/attr_macro.rs
@@ -142,13 +142,15 @@ pub fn pseudo_derive_attr_expansion(
     args: &tt::TopSubtree,
     call_site: Span,
 ) -> ExpandResult<tt::TopSubtree> {
-    let mk_leaf =
-        |char| tt::Leaf::Punct(tt::Punct { char, spacing: tt::Spacing::Alone, span: call_site });
+    let mk_leaf = |char| tt::Punct::new(char, tt::Spacing::Alone, call_site).map(tt::Leaf::Punct);
 
-    let mut token_trees = tt::TopSubtreeBuilder::new(args.top_subtree().delimiter);
-    let iter = args.token_trees().split(|tt| {
-        matches!(tt, tt::TtElement::Leaf(tt::Leaf::Punct(tt::Punct { char: ',', .. })))
-    });
+    let mut token_trees = tt::TopSubtreeBuilder::new(
+        args.top_subtree().delimiter.kind,
+        args.top_subtree().delim_span(),
+    );
+    let iter = args.token_trees().split(
+        |tt| matches!(tt, tt::TtElement::Leaf(tt::SpannedLeafKind::Punct(p)) if p.char == ','),
+    );
     for tts in iter {
         token_trees.extend([mk_leaf('#'), mk_leaf('!')]);
         token_trees.open(tt::DelimiterKind::Bracket, call_site);

--- a/crates/hir-expand/src/declarative.rs
+++ b/crates/hir-expand/src/declarative.rs
@@ -48,9 +48,10 @@ impl DeclarativeMacroExpander {
                 .expand(
                     db,
                     &tt,
-                    |s| {
+                    |mut s| {
                         s.ctx =
-                            apply_mark(db, s.ctx, call_id.into(), self.transparency, self.edition)
+                            apply_mark(db, s.ctx, call_id.into(), self.transparency, self.edition);
+                        s
                     },
                     loc.kind.call_style(),
                     span,
@@ -73,7 +74,7 @@ impl DeclarativeMacroExpander {
             ),
             None => self
                 .mac
-                .expand(db, &tt, |_| (), call_style, call_site)
+                .expand(db, &tt, |span| span, call_style, call_site)
                 .map(TupleExt::head)
                 .map_err(Into::into),
         }

--- a/crates/hir-expand/src/eager.rs
+++ b/crates/hir-expand/src/eager.rs
@@ -96,7 +96,7 @@ pub fn expand_eager_macro_input(
         DocCommentDesugarMode::Mbe,
     );
 
-    subtree.top_subtree_delimiter_mut().kind = crate::tt::DelimiterKind::Invisible;
+    subtree.set_top_subtree_delimiter_kind(tt::DelimiterKind::Invisible);
 
     let loc = MacroCallLoc {
         def,

--- a/crates/mbe/src/expander.rs
+++ b/crates/mbe/src/expander.rs
@@ -18,7 +18,7 @@ pub(crate) fn expand_rules(
     db: &dyn salsa::Database,
     rules: &[crate::Rule],
     input: &tt::TopSubtree,
-    marker: impl Fn(&mut Span) + Copy,
+    marker: impl Fn(Span) -> Span + Copy,
     call_style: MacroCallStyle,
     call_site: Span,
 ) -> ExpandResult<(tt::TopSubtree, MatchedArmIndex)> {
@@ -162,7 +162,7 @@ impl Fragment<'_> {
             Fragment::Tokens { tree, .. } => tree.len() == 0,
             Fragment::Expr(it) => it.len() == 0,
             Fragment::Path(it) => it.len() == 0,
-            Fragment::TokensOwned(it) => it.0.is_empty(),
+            Fragment::TokensOwned(_) => false, // A `TopSubtree` is never empty
         }
     }
 }

--- a/crates/mbe/src/lib.rs
+++ b/crates/mbe/src/lib.rs
@@ -277,7 +277,7 @@ impl DeclarativeMacro {
         &self,
         db: &dyn salsa::Database,
         tt: &tt::TopSubtree,
-        marker: impl Fn(&mut Span) + Copy,
+        marker: impl Fn(Span) -> Span + Copy,
         call_style: MacroCallStyle,
         call_site: Span,
     ) -> ExpandResult<(tt::TopSubtree, MatchedArmIndex)> {

--- a/crates/mbe/src/tests.rs
+++ b/crates/mbe/src/tests.rs
@@ -52,7 +52,7 @@ fn check_(
     let res = mac.expand(
         &db,
         &arg_tt,
-        |_| (),
+        |span| span,
         crate::MacroCallStyle::FnLike,
         Span {
             range: TextRange::up_to(TextSize::of(arg)),

--- a/crates/proc-macro-api/src/legacy_protocol/msg.rs
+++ b/crates/proc-macro-api/src/legacy_protocol/msg.rs
@@ -176,10 +176,7 @@ mod tests {
     use span::{
         Edition, ROOT_ERASED_FILE_AST_ID, Span, SpanAnchor, SyntaxContext, TextRange, TextSize,
     };
-    use tt::{
-        Delimiter, DelimiterKind, Ident, Leaf, Literal, Punct, Spacing, TopSubtree,
-        TopSubtreeBuilder,
-    };
+    use tt::{DelimiterKind, Ident, Literal, Punct, Spacing, TopSubtree, TopSubtreeBuilder};
 
     use crate::version;
 
@@ -194,63 +191,59 @@ mod tests {
             ast_id: ROOT_ERASED_FILE_AST_ID,
         };
 
-        let mut builder = TopSubtreeBuilder::new(Delimiter {
-            open: Span {
-                range: TextRange::empty(TextSize::new(0)),
-                anchor,
-                ctx: SyntaxContext::root(Edition::CURRENT),
+        let mut builder = TopSubtreeBuilder::new(
+            DelimiterKind::Invisible,
+            tt::DelimSpan {
+                open: Span {
+                    range: TextRange::empty(TextSize::new(0)),
+                    anchor,
+                    ctx: SyntaxContext::root(Edition::CURRENT),
+                },
+                close: Span {
+                    range: TextRange::empty(TextSize::new(0)),
+                    anchor,
+                    ctx: SyntaxContext::root(Edition::CURRENT),
+                },
             },
-            close: Span {
-                range: TextRange::empty(TextSize::new(0)),
-                anchor,
-                ctx: SyntaxContext::root(Edition::CURRENT),
-            },
-            kind: DelimiterKind::Invisible,
-        });
+        );
 
-        builder.push(
-            Ident {
-                sym: Symbol::intern("struct"),
-                span: Span {
-                    range: TextRange::at(TextSize::new(0), TextSize::of("struct")),
-                    anchor,
-                    ctx: SyntaxContext::root(Edition::CURRENT),
-                },
-                is_raw: tt::IdentIsRaw::No,
-            }
-            .into(),
-        );
-        builder.push(
-            Ident {
-                sym: Symbol::intern("Foo"),
-                span: Span {
-                    range: TextRange::at(TextSize::new(5), TextSize::of("r#Foo")),
-                    anchor,
-                    ctx: SyntaxContext::root(Edition::CURRENT),
-                },
-                is_raw: tt::IdentIsRaw::Yes,
-            }
-            .into(),
-        );
-        builder.push(Leaf::Literal(Literal {
-            symbol: Symbol::intern("Foo"),
-            span: Span {
+        builder.push(Ident::new_sym(
+            Symbol::intern("struct"),
+            tt::IdentIsRaw::No,
+            Span {
+                range: TextRange::at(TextSize::new(0), TextSize::of("struct")),
+                anchor,
+                ctx: SyntaxContext::root(Edition::CURRENT),
+            },
+        ));
+        builder.push(Ident::new_sym(
+            Symbol::intern("Foo"),
+            tt::IdentIsRaw::Yes,
+            Span {
+                range: TextRange::at(TextSize::new(5), TextSize::of("r#Foo")),
+                anchor,
+                ctx: SyntaxContext::root(Edition::CURRENT),
+            },
+        ));
+        builder.push(Literal::new(
+            Symbol::intern("Foo"),
+            Span {
                 range: TextRange::at(TextSize::new(10), TextSize::of("\"Foo\"")),
                 anchor,
                 ctx: SyntaxContext::root(Edition::CURRENT),
             },
-            kind: tt::LitKind::Str,
-            suffix: None,
-        }));
-        builder.push(Leaf::Punct(Punct {
-            char: '@',
-            span: Span {
+            tt::LitKind::Str,
+            None,
+        ));
+        builder.push(Punct::new(
+            '@',
+            Spacing::Joint,
+            Span {
                 range: TextRange::at(TextSize::new(13), TextSize::of('@')),
                 anchor,
                 ctx: SyntaxContext::root(Edition::CURRENT),
             },
-            spacing: Spacing::Joint,
-        }));
+        ));
         builder.open(
             DelimiterKind::Brace,
             Span {
@@ -267,16 +260,16 @@ mod tests {
                 ctx: SyntaxContext::root(Edition::CURRENT),
             },
         );
-        builder.push(Leaf::Literal(Literal {
-            symbol: sym::INTEGER_0,
-            span: Span {
+        builder.push(Literal::new(
+            sym::INTEGER_0,
+            Span {
                 range: TextRange::at(TextSize::new(16), TextSize::of("0u32")),
                 anchor,
                 ctx: SyntaxContext::root(Edition::CURRENT),
             },
-            kind: tt::LitKind::Integer,
-            suffix: Some(sym::u32),
-        }));
+            tt::LitKind::Integer,
+            Some(sym::u32),
+        ));
         builder.close(Span {
             range: TextRange::at(TextSize::new(20), TextSize::of(']')),
             anchor,
@@ -301,19 +294,21 @@ mod tests {
             ast_id: ROOT_ERASED_FILE_AST_ID,
         };
 
-        let builder = TopSubtreeBuilder::new(Delimiter {
-            open: Span {
-                range: TextRange::empty(TextSize::new(0)),
-                anchor,
-                ctx: SyntaxContext::root(Edition::CURRENT),
+        let builder = TopSubtreeBuilder::new(
+            DelimiterKind::Invisible,
+            tt::DelimSpan {
+                open: Span {
+                    range: TextRange::empty(TextSize::new(0)),
+                    anchor,
+                    ctx: SyntaxContext::root(Edition::CURRENT),
+                },
+                close: Span {
+                    range: TextRange::empty(TextSize::new(0)),
+                    anchor,
+                    ctx: SyntaxContext::root(Edition::CURRENT),
+                },
             },
-            close: Span {
-                range: TextRange::empty(TextSize::new(0)),
-                anchor,
-                ctx: SyntaxContext::root(Edition::CURRENT),
-            },
-            kind: DelimiterKind::Invisible,
-        });
+        );
 
         builder.build()
     }
@@ -327,19 +322,21 @@ mod tests {
             ast_id: ROOT_ERASED_FILE_AST_ID,
         };
 
-        let builder = TopSubtreeBuilder::new(Delimiter {
-            open: Span {
-                range: TextRange::empty(TextSize::new(0)),
-                anchor,
-                ctx: SyntaxContext::root(Edition::CURRENT),
+        let builder = TopSubtreeBuilder::new(
+            DelimiterKind::Brace,
+            tt::DelimSpan {
+                open: Span {
+                    range: TextRange::empty(TextSize::new(0)),
+                    anchor,
+                    ctx: SyntaxContext::root(Edition::CURRENT),
+                },
+                close: Span {
+                    range: TextRange::empty(TextSize::new(0)),
+                    anchor,
+                    ctx: SyntaxContext::root(Edition::CURRENT),
+                },
             },
-            close: Span {
-                range: TextRange::empty(TextSize::new(0)),
-                anchor,
-                ctx: SyntaxContext::root(Edition::CURRENT),
-            },
-            kind: DelimiterKind::Brace,
-        });
+        );
 
         builder.build()
     }

--- a/crates/syntax-bridge/src/tests.rs
+++ b/crates/syntax-bridge/src/tests.rs
@@ -1,8 +1,7 @@
 use rustc_hash::FxHashMap;
-use span::Span;
 use syntax::{AstNode, ast};
 use test_utils::extract_annotations;
-use tt::{Leaf, Punct, Spacing, buffer::Cursor};
+use tt::{Punct, Spacing, buffer::Cursor};
 
 use crate::{
     DocCommentDesugarMode,
@@ -30,13 +29,13 @@ fn check_punct_spacing(fixture: &str) {
         })
         .collect();
 
-    let mut cursor = Cursor::new(&subtree.0);
+    let mut cursor = Cursor::new(subtree.as_token_trees());
     while !cursor.eof() {
         while let Some(token_tree) = cursor.token_tree() {
-            if let tt::TokenTree::Leaf(Leaf::Punct(Punct {
-                spacing, span: Span { range, .. }, ..
-            })) = token_tree
-                && let Some(expected) = annotations.remove(range)
+            if let tt::SpannedTokenTree::Leaf(tt::SpannedLeafKind::Punct(leaf)) = token_tree
+                && let Punct { spacing, .. } = *leaf
+                && let range = leaf.span().range
+                && let Some(expected) = annotations.remove(&range)
             {
                 assert_eq!(expected, *spacing);
             }

--- a/crates/tt/src/iter.rs
+++ b/crates/tt/src/iter.rs
@@ -7,7 +7,10 @@ use arrayvec::ArrayVec;
 use intern::sym;
 use span::Span;
 
-use crate::{Ident, Leaf, MAX_GLUED_PUNCT_LEN, Punct, Spacing, Subtree, TokenTree, TokenTreesView};
+use crate::{
+    Ident, Leaf, MAX_GLUED_PUNCT_LEN, Punct, Spacing, SpannedLeaf, SpannedLeafKind, SpannedSubtree,
+    TokenTree, TokenTreesView,
+};
 
 #[derive(Clone)]
 pub struct TtIter<'a> {
@@ -36,28 +39,32 @@ impl<'a> TtIter<'a> {
 
     pub fn expect_char(&mut self, char: char) -> Result<(), ()> {
         match self.next() {
-            Some(TtElement::Leaf(&Leaf::Punct(Punct { char: c, .. }))) if c == char => Ok(()),
+            Some(TtElement::Leaf(SpannedLeafKind::Punct(SpannedLeaf {
+                leaf: &Punct { char: c, .. },
+                ..
+            }))) if c == char => Ok(()),
             _ => Err(()),
         }
     }
 
     pub fn expect_any_char(&mut self, chars: &[char]) -> Result<(), ()> {
         match self.next() {
-            Some(TtElement::Leaf(Leaf::Punct(Punct { char: c, .. }))) if chars.contains(c) => {
-                Ok(())
-            }
+            Some(TtElement::Leaf(SpannedLeafKind::Punct(SpannedLeaf {
+                leaf: Punct { char: c, .. },
+                ..
+            }))) if chars.contains(c) => Ok(()),
             _ => Err(()),
         }
     }
 
-    pub fn expect_subtree(&mut self) -> Result<(&'a Subtree, TtIter<'a>), ()> {
+    pub fn expect_subtree(&mut self) -> Result<(SpannedSubtree<'a>, TtIter<'a>), ()> {
         match self.next() {
             Some(TtElement::Subtree(subtree, iter)) => Ok((subtree, iter)),
             _ => Err(()),
         }
     }
 
-    pub fn expect_leaf(&mut self) -> Result<&'a Leaf, ()> {
+    pub fn expect_leaf(&mut self) -> Result<SpannedLeafKind<'a>, ()> {
         match self.next() {
             Some(TtElement::Leaf(it)) => Ok(it),
             _ => Err(()),
@@ -66,44 +73,48 @@ impl<'a> TtIter<'a> {
 
     pub fn expect_dollar(&mut self) -> Result<(), ()> {
         match self.expect_leaf()? {
-            Leaf::Punct(Punct { char: '$', .. }) => Ok(()),
+            SpannedLeafKind::Punct(SpannedLeaf { leaf: Punct { char: '$', .. }, .. }) => Ok(()),
             _ => Err(()),
         }
     }
 
     pub fn expect_comma(&mut self) -> Result<(), ()> {
         match self.expect_leaf()? {
-            Leaf::Punct(Punct { char: ',', .. }) => Ok(()),
+            SpannedLeafKind::Punct(SpannedLeaf { leaf: Punct { char: ',', .. }, .. }) => Ok(()),
             _ => Err(()),
         }
     }
 
-    pub fn expect_ident(&mut self) -> Result<&'a Ident, ()> {
+    pub fn expect_ident(&mut self) -> Result<SpannedLeaf<&'a Ident>, ()> {
         match self.expect_leaf()? {
-            Leaf::Ident(it) if it.sym != sym::underscore => Ok(it),
+            SpannedLeafKind::Ident(it) if it.sym != sym::underscore => Ok(it),
             _ => Err(()),
         }
     }
 
-    pub fn expect_ident_or_underscore(&mut self) -> Result<&'a Ident, ()> {
+    pub fn expect_ident_or_underscore(&mut self) -> Result<SpannedLeaf<&'a Ident>, ()> {
         match self.expect_leaf()? {
-            Leaf::Ident(it) => Ok(it),
+            SpannedLeafKind::Ident(it) => Ok(it),
             _ => Err(()),
         }
     }
 
-    pub fn expect_literal(&mut self) -> Result<&'a Leaf, ()> {
-        let it = self.expect_leaf()?;
-        match it {
-            Leaf::Literal(_) => Ok(it),
-            Leaf::Ident(ident) if ident.sym == sym::true_ || ident.sym == sym::false_ => Ok(it),
+    pub fn expect_literal(&mut self) -> Result<SpannedLeafKind<'a>, ()> {
+        let leaf = self.expect_leaf()?;
+        match leaf {
+            SpannedLeafKind::Literal(_) => Ok(leaf),
+            SpannedLeafKind::Ident(ident)
+                if ident.sym == sym::true_ || ident.sym == sym::false_ =>
+            {
+                Ok(leaf)
+            }
             _ => Err(()),
         }
     }
 
-    pub fn expect_single_punct(&mut self) -> Result<&'a Punct, ()> {
+    pub fn expect_single_punct(&mut self) -> Result<SpannedLeaf<&'a Punct>, ()> {
         match self.expect_leaf()? {
-            Leaf::Punct(it) => Ok(it),
+            SpannedLeafKind::Punct(it) => Ok(it),
             _ => Err(()),
         }
     }
@@ -112,10 +123,13 @@ impl<'a> TtIter<'a> {
     ///
     /// This method currently may return a single quotation, which is part of lifetime ident and
     /// conceptually not a punct in the context of mbe. Callers should handle this.
-    pub fn expect_glued_punct(&mut self) -> Result<ArrayVec<Punct, MAX_GLUED_PUNCT_LEN>, ()> {
-        let TtElement::Leaf(&Leaf::Punct(first)) = self.next().ok_or(())? else {
+    pub fn expect_glued_punct(
+        &mut self,
+    ) -> Result<ArrayVec<SpannedLeaf<Punct>, MAX_GLUED_PUNCT_LEN>, ()> {
+        let TtElement::Leaf(SpannedLeafKind::Punct(first)) = self.next().ok_or(())? else {
             return Err(());
         };
+        let first = first.cloned();
 
         let mut res = ArrayVec::new();
         if first.spacing == Spacing::Alone {
@@ -141,8 +155,8 @@ impl<'a> TtIter<'a> {
                 let _ = self.next().unwrap();
                 let _ = self.next().unwrap();
                 res.push(first);
-                res.push(*second);
-                res.push(*third.unwrap());
+                res.push(SpannedLeaf { leaf: *second, _span: () });
+                res.push(SpannedLeaf { leaf: *third.unwrap(), _span: () });
             }
             ('-' | '!' | '*' | '/' | '&' | '%' | '^' | '+' | '<' | '=' | '>' | '|', '=', _)
             | ('-' | '=' | '>', '>', _)
@@ -154,7 +168,7 @@ impl<'a> TtIter<'a> {
             | ('|', '|', _) => {
                 let _ = self.next().unwrap();
                 res.push(first);
-                res.push(*second);
+                res.push(SpannedLeaf { leaf: *second, _span: () });
             }
             _ => res.push(first),
         }
@@ -168,11 +182,14 @@ impl<'a> TtIter<'a> {
 
     pub fn peek(&self) -> Option<TtElement<'a>> {
         match self.inner.as_slice().first()? {
-            TokenTree::Leaf(leaf) => Some(TtElement::Leaf(leaf)),
+            TokenTree::Leaf(leaf) => Some(TtElement::Leaf(SpannedLeaf { _span: (), leaf }.kind())),
             TokenTree::Subtree(subtree) => {
                 let nested_iter =
                     TtIter { inner: self.inner.as_slice()[1..][..subtree.usize_len()].iter() };
-                Some(TtElement::Subtree(subtree, nested_iter))
+                Some(TtElement::Subtree(
+                    SpannedSubtree { _open_span: (), _close_span: (), subtree },
+                    nested_iter,
+                ))
             }
         }
     }
@@ -183,7 +200,10 @@ impl<'a> TtIter<'a> {
     }
 
     pub fn next_span(&self) -> Option<Span> {
-        Some(self.inner.as_slice().first()?.first_span())
+        Some(match self.peek()? {
+            TtElement::Leaf(it) => it.span(),
+            TtElement::Subtree(it, _) => it.open_span(),
+        })
     }
 
     pub fn remaining(&self) -> TokenTreesView<'a> {
@@ -214,8 +234,8 @@ impl<'a> TtIter<'a> {
 
 #[derive(Clone)]
 pub enum TtElement<'a> {
-    Leaf(&'a Leaf),
-    Subtree(&'a Subtree, TtIter<'a>),
+    Leaf(SpannedLeafKind<'a>),
+    Subtree(SpannedSubtree<'a>, TtIter<'a>),
 }
 
 impl fmt::Debug for TtElement<'_> {
@@ -233,7 +253,7 @@ impl TtElement<'_> {
     #[inline]
     pub fn first_span(&self) -> Span {
         match self {
-            TtElement::Leaf(it) => *it.span(),
+            TtElement::Leaf(it) => it.span(),
             TtElement::Subtree(it, _) => it.delimiter.open,
         }
     }
@@ -243,12 +263,15 @@ impl<'a> Iterator for TtIter<'a> {
     type Item = TtElement<'a>;
     fn next(&mut self) -> Option<Self::Item> {
         match self.inner.next()? {
-            TokenTree::Leaf(leaf) => Some(TtElement::Leaf(leaf)),
+            TokenTree::Leaf(leaf) => Some(TtElement::Leaf(SpannedLeaf { _span: (), leaf }.kind())),
             TokenTree::Subtree(subtree) => {
                 let nested_iter =
                     TtIter { inner: self.inner.as_slice()[..subtree.usize_len()].iter() };
                 self.inner = self.inner.as_slice()[subtree.usize_len()..].iter();
-                Some(TtElement::Subtree(subtree, nested_iter))
+                Some(TtElement::Subtree(
+                    SpannedSubtree { _open_span: (), _close_span: (), subtree },
+                    nested_iter,
+                ))
             }
         }
     }

--- a/crates/tt/src/lib.rs
+++ b/crates/tt/src/lib.rs
@@ -2,6 +2,10 @@
 //! input and output) of macros.
 //!
 //! The `TokenTree` is semantically a tree, but for performance reasons it is stored as a flat structure.
+//!
+//! A token tree piece has spans, but it does not carry them alone (well, it does, but it won't in the future).
+//! so you always work with the `Spanned` variants: [`SpannedLeaf`], [`SpannedSubtree`], [`SpannedTokenTree`]
+//! and [`SpannedLeafKind`]. They reconstruct the span from its pieces.
 
 #![cfg_attr(feature = "in-rust-tree", feature(rustc_private))]
 
@@ -16,7 +20,7 @@ extern crate rustc_lexer;
 pub mod buffer;
 pub mod iter;
 
-use std::fmt;
+use std::{fmt, ops::Deref};
 
 use buffer::Cursor;
 use intern::Symbol;
@@ -84,14 +88,6 @@ pub enum TokenTree {
     Subtree(Subtree),
 }
 impl_from!(Leaf, Subtree for TokenTree);
-impl TokenTree {
-    pub fn first_span(&self) -> Span {
-        match self {
-            TokenTree::Leaf(l) => *l.span(),
-            TokenTree::Subtree(s) => s.delimiter.open,
-        }
-    }
-}
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Leaf {
@@ -100,15 +96,6 @@ pub enum Leaf {
     Ident(Ident),
 }
 
-impl Leaf {
-    pub fn span(&self) -> &Span {
-        match self {
-            Leaf::Literal(it) => &it.span,
-            Leaf::Punct(it) => &it.span,
-            Leaf::Ident(it) => &it.span,
-        }
-    }
-}
 impl_from!(Literal, Punct, Ident for Leaf);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -119,36 +106,69 @@ pub struct Subtree {
 }
 
 impl Subtree {
+    #[inline]
     pub fn usize_len(&self) -> usize {
         self.len as usize
     }
 }
 
 #[derive(Clone, PartialEq, Eq, Hash)]
-pub struct TopSubtree(pub Box<[TokenTree]>);
+pub struct TopSubtree(Box<[TokenTree]>);
 
 impl TopSubtree {
     pub fn empty(span: DelimSpan) -> Self {
         Self(Box::new([TokenTree::Subtree(Subtree {
-            delimiter: Delimiter::invisible_delim_spanned(span),
+            delimiter: Delimiter {
+                open: span.open,
+                close: span.close,
+                kind: DelimiterKind::Invisible,
+            },
             len: 0,
         })]))
     }
 
-    pub fn invisible_from_leaves<const N: usize>(delim_span: Span, leaves: [Leaf; N]) -> Self {
-        let mut builder = TopSubtreeBuilder::new(Delimiter::invisible_spanned(delim_span));
+    pub fn invisible_from_leaves<const N: usize>(
+        delim_span: Span,
+        leaves: [SpannedLeaf<impl Into<Leaf>>; N],
+    ) -> Self {
+        let mut builder =
+            TopSubtreeBuilder::new(DelimiterKind::Invisible, DelimSpan::from_single(delim_span));
         builder.extend(leaves);
         builder.build()
     }
 
-    pub fn from_token_trees(delimiter: Delimiter, token_trees: TokenTreesView<'_>) -> Self {
-        let mut builder = TopSubtreeBuilder::new(delimiter);
+    pub fn from_token_trees(
+        delimiter_kind: DelimiterKind,
+        delimiter_span: DelimSpan,
+        token_trees: TokenTreesView<'_>,
+    ) -> Self {
+        let mut builder = TopSubtreeBuilder::new(delimiter_kind, delimiter_span);
         builder.extend_with_tt(token_trees);
         builder.build()
     }
 
     pub fn from_subtree(subtree: SubtreeView<'_>) -> Self {
         Self(subtree.0.into())
+    }
+
+    pub fn from_serialized(tt: impl IntoIterator<Item = SerializedTokenTree>) -> Self {
+        Self(
+            tt.into_iter()
+                .map(|tt| match tt {
+                    SerializedTokenTree::Subtree { delimiter, len } => {
+                        TokenTree::Subtree(Subtree {
+                            delimiter: Delimiter {
+                                open: delimiter.open,
+                                close: delimiter.close,
+                                kind: delimiter.kind,
+                            },
+                            len,
+                        })
+                    }
+                    SerializedTokenTree::Leaf(leaf) => TokenTree::Leaf(leaf.leaf),
+                })
+                .collect(),
+        )
     }
 
     pub fn view(&self) -> SubtreeView<'_> {
@@ -159,19 +179,59 @@ impl TopSubtree {
         self.view().iter()
     }
 
-    pub fn top_subtree(&self) -> &Subtree {
+    pub fn top_subtree(&self) -> SpannedSubtree<'_> {
         self.view().top_subtree()
     }
 
-    pub fn top_subtree_delimiter_mut(&mut self) -> &mut Delimiter {
+    pub fn set_top_subtree_delimiter(&mut self, kind: DelimiterKind, span: DelimSpan) {
+        self.top_subtree_mut().delimiter = Delimiter { open: span.open, close: span.close, kind };
+    }
+
+    pub fn set_top_subtree_delimiter_kind(&mut self, kind: DelimiterKind) {
+        self.top_subtree_mut().delimiter.kind = kind;
+    }
+
+    fn top_subtree_mut(&mut self) -> &mut Subtree {
         let TokenTree::Subtree(subtree) = &mut self.0[0] else {
             unreachable!("the first token tree is always the top subtree");
         };
-        &mut subtree.delimiter
+        subtree
+    }
+
+    pub fn flat_tokens_mut(&mut self) -> &mut [TokenTree] {
+        &mut self.0
     }
 
     pub fn token_trees(&self) -> TokenTreesView<'_> {
         self.view().token_trees()
+    }
+
+    pub fn as_token_trees(&self) -> TokenTreesView<'_> {
+        self.view().as_token_trees()
+    }
+
+    pub fn change_every_ast_id(&mut self, mut callback: impl FnMut(&mut span::ErasedFileAstId)) {
+        for tt in &mut self.0 {
+            match tt {
+                TokenTree::Leaf(Leaf::Ident(Ident { span, .. }))
+                | TokenTree::Leaf(Leaf::Literal(Literal { span, .. }))
+                | TokenTree::Leaf(Leaf::Punct(Punct { span, .. })) => {
+                    callback(&mut span.anchor.ast_id);
+                }
+                TokenTree::Subtree(subtree) => {
+                    callback(&mut subtree.delimiter.open.anchor.ast_id);
+                    callback(&mut subtree.delimiter.close.anchor.ast_id);
+                }
+            }
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn iter_mut_dangerous(&mut self) -> impl Iterator<Item = &mut TokenTree> {
+        self.0.iter_mut()
     }
 }
 
@@ -183,13 +243,20 @@ pub struct TopSubtreeBuilder {
 }
 
 impl TopSubtreeBuilder {
-    pub fn new(top_delimiter: Delimiter) -> Self {
+    pub fn new(top_delimiter_kind: DelimiterKind, top_delimiter_span: DelimSpan) -> Self {
         let mut result = Self {
             unclosed_subtree_indices: Vec::new(),
             token_trees: Vec::new(),
             last_closed_subtree: None,
         };
-        let top_subtree = TokenTree::Subtree(Subtree { delimiter: top_delimiter, len: 0 });
+        let top_subtree = TokenTree::Subtree(Subtree {
+            delimiter: Delimiter {
+                open: top_delimiter_span.open,
+                close: top_delimiter_span.close,
+                kind: top_delimiter_kind,
+            },
+            len: 0,
+        });
         result.token_trees.push(top_subtree);
         result
     }
@@ -233,17 +300,12 @@ impl TopSubtreeBuilder {
         }
     }
 
-    pub fn push(&mut self, leaf: Leaf) {
-        self.token_trees.push(TokenTree::Leaf(leaf));
+    pub fn push(&mut self, leaf: SpannedLeaf<impl Into<Leaf>>) {
+        self.token_trees.push(TokenTree::Leaf(leaf.leaf.into()));
     }
 
-    pub fn extend(&mut self, leaves: impl IntoIterator<Item = Leaf>) {
-        self.token_trees.extend(leaves.into_iter().map(TokenTree::Leaf));
-    }
-
-    /// This does not check the token trees are valid, beware!
-    pub fn extend_tt_dangerous(&mut self, tt: impl IntoIterator<Item = TokenTree>) {
-        self.token_trees.extend(tt);
+    pub fn extend(&mut self, leaves: impl IntoIterator<Item = SpannedLeaf<impl Into<Leaf>>>) {
+        self.token_trees.extend(leaves.into_iter().map(|leaf| TokenTree::Leaf(leaf.leaf.into())));
     }
 
     pub fn extend_with_tt(&mut self, tt: TokenTreesView<'_>) {
@@ -330,7 +392,13 @@ pub struct SubtreeBuilderRestorePoint {
 pub struct TokenTreesView<'a>(&'a [TokenTree]);
 
 impl<'a> TokenTreesView<'a> {
-    pub fn new(tts: &'a [TokenTree]) -> Self {
+    #[inline]
+    pub fn empty() -> Self {
+        Self(&[])
+    }
+
+    #[inline]
+    fn new(tts: &'a [TokenTree]) -> Self {
         if cfg!(debug_assertions) {
             tts.iter().enumerate().for_each(|(idx, tt)| {
                 if let TokenTree::Subtree(tt) = &tt {
@@ -350,7 +418,7 @@ impl<'a> TokenTreesView<'a> {
     }
 
     pub fn cursor(&self) -> Cursor<'a> {
-        Cursor::new(self.0)
+        Cursor::new(*self)
     }
 
     pub fn len(&self) -> usize {
@@ -406,6 +474,22 @@ impl<'a> TokenTreesView<'a> {
             Some(result)
         })
     }
+
+    #[inline]
+    pub fn first_span(&self) -> Option<Span> {
+        Some(match self.0.first()? {
+            TokenTree::Leaf(leaf) => leaf.span(),
+            TokenTree::Subtree(subtree) => subtree.delimiter.open,
+        })
+    }
+
+    #[inline]
+    pub fn last_span(&self) -> Option<Span> {
+        Some(match self.0.last()? {
+            TokenTree::Leaf(leaf) => leaf.span(),
+            TokenTree::Subtree(subtree) => subtree.delimiter.close,
+        })
+    }
 }
 
 impl fmt::Debug for TokenTreesView<'_> {
@@ -451,13 +535,14 @@ impl fmt::Display for TokenTreesView<'_> {
                 needs_space = true;
 
                 match child {
-                    TtElement::Leaf(Leaf::Punct(p)) => {
+                    TtElement::Leaf(SpannedLeafKind::Punct(p)) => {
                         needs_space = p.spacing == Spacing::Alone;
-                        fmt::Display::fmt(p, f)?;
+                        fmt::Display::fmt(*p, f)?;
                     }
-                    TtElement::Leaf(leaf) => fmt::Display::fmt(leaf, f)?,
+                    TtElement::Leaf(SpannedLeafKind::Literal(leaf)) => fmt::Display::fmt(*leaf, f)?,
+                    TtElement::Leaf(SpannedLeafKind::Ident(leaf)) => fmt::Display::fmt(*leaf, f)?,
                     TtElement::Subtree(subtree, subtree_iter) => {
-                        subtree_display(subtree, f, subtree_iter)?
+                        subtree_display(&subtree, f, subtree_iter)?
                     }
                 }
             }
@@ -471,7 +556,7 @@ impl fmt::Display for TokenTreesView<'_> {
 pub struct SubtreeView<'a>(&'a [TokenTree]);
 
 impl<'a> SubtreeView<'a> {
-    pub fn new(tts: &'a [TokenTree]) -> Self {
+    fn new(tts: &'a [TokenTree]) -> Self {
         if cfg!(debug_assertions) {
             let TokenTree::Subtree(subtree) = &tts[0] else {
                 panic!("first token tree must be a subtree in `SubtreeView`");
@@ -493,11 +578,11 @@ impl<'a> SubtreeView<'a> {
         TtIter::new(&self.0[1..])
     }
 
-    pub fn top_subtree(&self) -> &'a Subtree {
+    pub fn top_subtree(&self) -> SpannedSubtree<'a> {
         let TokenTree::Subtree(subtree) = &self.0[0] else {
             unreachable!("the first token tree is always the top subtree");
         };
-        subtree
+        SpannedSubtree { _open_span: (), _close_span: (), subtree }
     }
 
     pub fn strip_invisible(&self) -> TokenTreesView<'a> {
@@ -540,20 +625,28 @@ impl DelimSpan {
         DelimSpan { open, close }
     }
 }
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct Delimiter {
+    open: Span,
+    close: Span,
+    pub kind: DelimiterKind,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct SpannedDelimiter {
     pub open: Span,
     pub close: Span,
     pub kind: DelimiterKind,
 }
 
-impl Delimiter {
+impl SpannedDelimiter {
     pub const fn invisible_spanned(span: Span) -> Self {
-        Delimiter { open: span, close: span, kind: DelimiterKind::Invisible }
+        SpannedDelimiter { open: span, close: span, kind: DelimiterKind::Invisible }
     }
 
     pub const fn invisible_delim_spanned(span: DelimSpan) -> Self {
-        Delimiter { open: span.open, close: span.close, kind: DelimiterKind::Invisible }
+        SpannedDelimiter { open: span.open, close: span.close, kind: DelimiterKind::Invisible }
     }
 
     pub fn delim_span(&self) -> DelimSpan {
@@ -573,15 +666,24 @@ pub enum DelimiterKind {
 pub struct Literal {
     // escaped
     pub symbol: Symbol,
-    pub span: Span,
+    span: Span,
     pub kind: LitKind,
     pub suffix: Option<Symbol>,
 }
 
-pub fn token_to_literal(text: &str, span: Span) -> Literal
-where
-    Span: Copy,
-{
+impl Literal {
+    #[inline]
+    pub fn new(
+        symbol: Symbol,
+        span: Span,
+        kind: LitKind,
+        suffix: Option<Symbol>,
+    ) -> SpannedLeaf<Self> {
+        SpannedLeaf { _span: (), leaf: Self { symbol, span, kind, suffix } }
+    }
+}
+
+pub fn token_to_literal(text: &str, span: Span) -> SpannedLeaf<Literal> {
     use rustc_lexer::LiteralKind;
 
     let token = rustc_lexer::tokenize(text, rustc_lexer::FrontmatterAllowed::No).next_tuple();
@@ -590,12 +692,7 @@ where
         ..
     },)) = token
     else {
-        return Literal {
-            span,
-            symbol: Symbol::intern(text),
-            kind: LitKind::Err(()),
-            suffix: None,
-        };
+        return Literal::new(Symbol::intern(text), span, LitKind::Err(()), None);
     };
 
     let (kind, start_offset, end_offset) = match kind {
@@ -629,24 +726,26 @@ where
         "" | "_" => None,
         // ill-suffixed literals
         _ if !matches!(kind, LitKind::Integer | LitKind::Float | LitKind::Err(_)) => {
-            return Literal {
-                span,
-                symbol: Symbol::intern(text),
-                kind: LitKind::Err(()),
-                suffix: None,
-            };
+            return Literal::new(Symbol::intern(text), span, LitKind::Err(()), None);
         }
         suffix => Some(Symbol::intern(suffix)),
     };
 
-    Literal { span, symbol: Symbol::intern(lit), kind, suffix }
+    Literal::new(Symbol::intern(lit), span, kind, suffix)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Punct {
     pub char: char,
     pub spacing: Spacing,
-    pub span: Span,
+    span: Span,
+}
+
+impl Punct {
+    #[inline]
+    pub fn new(char: char, spacing: Spacing, span: Span) -> SpannedLeaf<Self> {
+        SpannedLeaf { _span: (), leaf: Self { char, spacing, span } }
+    }
 }
 
 /// Indicates whether a token can join with the following token to form a
@@ -713,15 +812,20 @@ pub enum Spacing {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Ident {
     pub sym: Symbol,
-    pub span: Span,
+    span: Span,
     pub is_raw: IdentIsRaw,
 }
 
 impl Ident {
-    pub fn new(text: &str, span: Span) -> Self {
+    pub fn new(text: &str, span: Span) -> SpannedLeaf<Self> {
         // let raw_stripped = IdentIsRaw::split_from_symbol(text.as_ref());
         let (is_raw, text) = IdentIsRaw::split_from_symbol(text);
-        Ident { sym: Symbol::intern(text), span, is_raw }
+        Ident::new_sym(Symbol::intern(text), is_raw, span)
+    }
+
+    #[inline]
+    pub fn new_sym(sym: Symbol, is_raw: IdentIsRaw, span: Span) -> SpannedLeaf<Self> {
+        SpannedLeaf { _span: (), leaf: Self { sym, span, is_raw } }
     }
 }
 
@@ -758,7 +862,7 @@ fn print_debug_token(f: &mut fmt::Formatter<'_>, level: usize, tt: TtElement<'_>
 
     match tt {
         TtElement::Leaf(leaf) => match leaf {
-            Leaf::Literal(lit) => {
+            SpannedLeafKind::Literal(lit) => {
                 write!(
                     f,
                     "{}LITERAL {:?} {}{} {:#?}",
@@ -769,7 +873,7 @@ fn print_debug_token(f: &mut fmt::Formatter<'_>, level: usize, tt: TtElement<'_>
                     lit.span
                 )?;
             }
-            Leaf::Punct(punct) => {
+            SpannedLeafKind::Punct(punct) => {
                 write!(
                     f,
                     "{}PUNCH   {} [{}] {:#?}",
@@ -779,7 +883,7 @@ fn print_debug_token(f: &mut fmt::Formatter<'_>, level: usize, tt: TtElement<'_>
                     punct.span
                 )?;
             }
-            Leaf::Ident(ident) => {
+            SpannedLeafKind::Ident(ident) => {
                 write!(
                     f,
                     "{}IDENT   {}{} {:#?}",
@@ -791,7 +895,7 @@ fn print_debug_token(f: &mut fmt::Formatter<'_>, level: usize, tt: TtElement<'_>
             }
         },
         TtElement::Subtree(subtree, subtree_iter) => {
-            print_debug_subtree(f, subtree, level, subtree_iter)?;
+            print_debug_subtree(f, &subtree, level, subtree_iter)?;
         }
     }
 
@@ -882,6 +986,256 @@ impl Subtree {
     pub fn count(&self) -> usize {
         self.usize_len()
     }
+}
+
+pub trait HasLeafSpan {
+    #[doc(hidden)]
+    fn span(&self) -> Span;
+}
+
+impl<T: HasLeafSpan> HasLeafSpan for &T {
+    #[inline]
+    fn span(&self) -> Span {
+        T::span(*self)
+    }
+}
+
+impl HasLeafSpan for Literal {
+    #[inline]
+    fn span(&self) -> Span {
+        self.span
+    }
+}
+
+impl HasLeafSpan for Punct {
+    #[inline]
+    fn span(&self) -> Span {
+        self.span
+    }
+}
+
+impl HasLeafSpan for Ident {
+    #[inline]
+    fn span(&self) -> Span {
+        self.span
+    }
+}
+
+impl HasLeafSpan for Leaf {
+    #[inline]
+    fn span(&self) -> Span {
+        match self {
+            Leaf::Literal(it) => it.span,
+            Leaf::Punct(it) => it.span,
+            Leaf::Ident(it) => it.span,
+        }
+    }
+}
+
+/// A leaf (parameterized by the generic parameter), but with its full span.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[expect(clippy::manual_non_exhaustive, reason = "those are placeholders for compressed spans")]
+pub struct SpannedLeaf<T> {
+    _span: (),
+    pub leaf: T,
+}
+
+impl<T: HasLeafSpan> SpannedLeaf<T> {
+    #[inline]
+    pub fn span(&self) -> Span {
+        self.leaf.span()
+    }
+
+    #[inline]
+    pub fn as_ref(&self) -> SpannedLeaf<&T> {
+        SpannedLeaf { _span: self._span, leaf: &self.leaf }
+    }
+
+    #[inline]
+    pub fn map<U>(self, f: impl FnOnce(T) -> U) -> SpannedLeaf<U> {
+        SpannedLeaf { _span: self._span, leaf: f(self.leaf) }
+    }
+}
+
+impl<T: Clone> SpannedLeaf<&T> {
+    #[inline]
+    pub fn cloned(self) -> SpannedLeaf<T> {
+        SpannedLeaf { _span: self._span, leaf: self.leaf.clone() }
+    }
+}
+
+impl<T> Deref for SpannedLeaf<T> {
+    type Target = T;
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        &self.leaf
+    }
+}
+
+pub trait HasOwnedLeafSpan {
+    #[doc(hidden)]
+    fn set_span(&mut self, span: Span);
+}
+
+impl HasOwnedLeafSpan for Literal {
+    #[inline]
+    fn set_span(&mut self, span: Span) {
+        self.span = span;
+    }
+}
+
+impl HasOwnedLeafSpan for Punct {
+    #[inline]
+    fn set_span(&mut self, span: Span) {
+        self.span = span;
+    }
+}
+
+impl HasOwnedLeafSpan for Ident {
+    #[inline]
+    fn set_span(&mut self, span: Span) {
+        self.span = span;
+    }
+}
+
+impl HasOwnedLeafSpan for Leaf {
+    #[inline]
+    fn set_span(&mut self, span: Span) {
+        match self {
+            Leaf::Literal(it) => it.span = span,
+            Leaf::Punct(it) => it.span = span,
+            Leaf::Ident(it) => it.span = span,
+        }
+    }
+}
+
+impl<T: HasOwnedLeafSpan> SpannedLeaf<T> {
+    #[inline]
+    pub fn set_span(&mut self, span: Span) {
+        self.leaf.set_span(span);
+    }
+}
+
+impl<'a> SpannedLeaf<&'a Leaf> {
+    #[inline]
+    pub fn kind(&self) -> SpannedLeafKind<'a> {
+        match **self {
+            Leaf::Literal(leaf) => SpannedLeafKind::Literal(SpannedLeaf { _span: (), leaf }),
+            Leaf::Punct(leaf) => SpannedLeafKind::Punct(SpannedLeaf { _span: (), leaf }),
+            Leaf::Ident(leaf) => SpannedLeafKind::Ident(SpannedLeaf { _span: (), leaf }),
+        }
+    }
+}
+
+impl From<SpannedLeaf<Literal>> for SpannedLeaf<Leaf> {
+    #[inline]
+    fn from(value: SpannedLeaf<Literal>) -> Self {
+        value.map(Leaf::Literal)
+    }
+}
+
+impl From<SpannedLeaf<Punct>> for SpannedLeaf<Leaf> {
+    #[inline]
+    fn from(value: SpannedLeaf<Punct>) -> Self {
+        value.map(Leaf::Punct)
+    }
+}
+
+impl From<SpannedLeaf<Ident>> for SpannedLeaf<Leaf> {
+    #[inline]
+    fn from(value: SpannedLeaf<Ident>) -> Self {
+        value.map(Leaf::Ident)
+    }
+}
+
+impl<T: fmt::Display> fmt::Display for SpannedLeaf<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.leaf, f)
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum SpannedLeafKind<'a> {
+    Literal(SpannedLeaf<&'a Literal>),
+    Punct(SpannedLeaf<&'a Punct>),
+    Ident(SpannedLeaf<&'a Ident>),
+}
+
+impl SpannedLeafKind<'_> {
+    #[inline]
+    pub fn span(&self) -> Span {
+        match self {
+            SpannedLeafKind::Literal(it) => it.span(),
+            SpannedLeafKind::Punct(it) => it.span(),
+            SpannedLeafKind::Ident(it) => it.span(),
+        }
+    }
+}
+
+/// A leaf (parameterized by the generic parameter), but with its full span.
+#[derive(Debug, Clone, Copy)]
+pub struct SpannedSubtree<'a> {
+    _open_span: (),
+    _close_span: (),
+    subtree: &'a Subtree,
+}
+
+impl SpannedSubtree<'_> {
+    #[inline]
+    pub fn open_span(&self) -> Span {
+        self.subtree.delimiter.open
+    }
+
+    #[inline]
+    pub fn close_span(&self) -> Span {
+        self.subtree.delimiter.close
+    }
+
+    #[inline]
+    pub fn delim_span(&self) -> DelimSpan {
+        DelimSpan { open: self.open_span(), close: self.close_span() }
+    }
+
+    #[inline]
+    pub fn delimiter(&self) -> SpannedDelimiter {
+        SpannedDelimiter {
+            open: self.open_span(),
+            close: self.close_span(),
+            kind: self.delimiter.kind,
+        }
+    }
+}
+
+impl Deref for SpannedSubtree<'_> {
+    type Target = Subtree;
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        self.subtree
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum SpannedTokenTree<'a> {
+    Subtree(SpannedSubtree<'a>),
+    Leaf(SpannedLeafKind<'a>),
+}
+
+impl SpannedTokenTree<'_> {
+    #[inline]
+    pub fn first_span(&self) -> Span {
+        match self {
+            SpannedTokenTree::Leaf(l) => l.span(),
+            SpannedTokenTree::Subtree(s) => s.open_span(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum SerializedTokenTree {
+    Subtree { delimiter: SpannedDelimiter, len: u32 },
+    Leaf(SpannedLeaf<Leaf>),
 }
 
 impl TopSubtree {
@@ -993,4 +1347,88 @@ pub fn pretty(mut tkns: &[TokenTree]) -> String {
         }
     }
     last
+}
+
+#[derive(Debug)]
+pub enum TransformTtAction<'a> {
+    Keep,
+    ReplaceWith(TokenTreesView<'a>),
+}
+
+impl TransformTtAction<'_> {
+    #[inline]
+    pub fn remove() -> Self {
+        Self::ReplaceWith(TokenTreesView::empty())
+    }
+}
+
+/// This function takes a token tree, and calls `callback` with each token tree in it.
+/// Then it does what the callback says: keeps the tt or replaces it with a (possibly empty)
+/// tts view.
+pub fn transform_tt<'b>(
+    tt: &mut TopSubtree,
+    mut callback: impl FnMut(SpannedTokenTree<'_>) -> TransformTtAction<'b>,
+) {
+    let mut tt_vec = std::mem::take(&mut tt.0).into_vec();
+
+    // We need to keep a stack of the currently open subtrees, because we need to update
+    // them if we change the number of items in them.
+    let mut subtrees_stack = Vec::new();
+    let mut i = 0;
+    while i < tt_vec.len() {
+        'pop_finished_subtrees: while let Some(&subtree_idx) = subtrees_stack.last() {
+            let TokenTree::Subtree(subtree) = &tt_vec[subtree_idx] else {
+                unreachable!("non-subtree on subtrees stack");
+            };
+            if i >= subtree_idx + 1 + subtree.usize_len() {
+                subtrees_stack.pop();
+            } else {
+                break 'pop_finished_subtrees;
+            }
+        }
+
+        let current = match &tt_vec[i] {
+            TokenTree::Leaf(leaf) => SpannedTokenTree::Leaf(match leaf {
+                Leaf::Literal(leaf) => SpannedLeafKind::Literal(SpannedLeaf { _span: (), leaf }),
+                Leaf::Punct(leaf) => SpannedLeafKind::Punct(SpannedLeaf { _span: (), leaf }),
+                Leaf::Ident(leaf) => SpannedLeafKind::Ident(SpannedLeaf { _span: (), leaf }),
+            }),
+            TokenTree::Subtree(subtree) => SpannedTokenTree::Subtree(SpannedSubtree {
+                _open_span: (),
+                _close_span: (),
+                subtree,
+            }),
+        };
+        let action = callback(current);
+        match action {
+            TransformTtAction::Keep => {
+                // This cannot be shared with the replaced case, because then we may push the same subtree
+                // twice, and will update it twice which will lead to errors.
+                if let TokenTree::Subtree(_) = &tt_vec[i] {
+                    subtrees_stack.push(i);
+                }
+
+                i += 1;
+            }
+            TransformTtAction::ReplaceWith(replacement) => {
+                let old_len = 1 + match &tt_vec[i] {
+                    TokenTree::Leaf(_) => 0,
+                    TokenTree::Subtree(subtree) => subtree.usize_len(),
+                };
+                let len_diff = replacement.len() as i64 - old_len as i64;
+                tt_vec.splice(i..i + old_len, replacement.flat_tokens().iter().cloned());
+                // Skip the newly inserted replacement, we don't want to visit it.
+                i += replacement.len();
+
+                for &subtree_idx in &subtrees_stack {
+                    let TokenTree::Subtree(subtree) = &mut tt_vec[subtree_idx] else {
+                        unreachable!("non-subtree on subtrees stack");
+                    };
+                    subtree.len = (i64::from(subtree.len) + len_diff).try_into().unwrap();
+                }
+            }
+        }
+    }
+
+    tt.0 = tt_vec.into_boxed_slice();
 }


### PR DESCRIPTION
By making token trees span completely opaque outside the `tt` crate: that is, outside it, you cannot get the `span` of a token tree piece anymore, instead you get a `SpannedX` wrapperr that provides a `span()` method (or `open_span()` and `close_span()` for subtrees).

For now these are just markers, but in the future the span will be split and parts of it will be stored compressed in the parent `TopSubtree`. The current change will allow us to do it while only changing the `tt` crate.

I've learnt my lesson from my huge PRs, and this time I'm splitting span compression into multiple PRs carefully 😅