### PR TITLE
Add useless prefix `try_into_` for suggest_name

### DIFF
--- a/crates/ide-db/src/syntax_helpers/suggest_name.rs
+++ b/crates/ide-db/src/syntax_helpers/suggest_name.rs
@@ -44,7 +44,7 @@ const SEQUENCE_TYPES: &[&str] = &["Vec", "VecDeque", "LinkedList"];
 /// `vec.as_slice()` -> `slice`
 /// `args.into_config()` -> `config`
 /// `bytes.to_vec()` -> `vec`
-const USELESS_METHOD_PREFIXES: &[&str] = &["into_", "as_", "to_"];
+const USELESS_METHOD_PREFIXES: &[&str] = &["try_into_", "into_", "as_", "to_"];
 
 /// Useless methods that are stripped from expression
 ///


### PR DESCRIPTION
Example
---
```rust
enum Foo {
    Num(i32)
}

impl Foo {
    fn try_into_num(self) -> Result<i32, Self> {
        if let Self::Num(v) = self {
            Ok(v)
        } else {
            Err(self)
        }
    }
}
fn handle(foo: Foo) {
    foo.try_into_num().$0
}
```

**Before this PR**

```rust
fn handle(foo: Foo) {
    if let Ok(${1:try_into_num}) = foo.try_into_num() {
        $0
    }
}
```

**After this PR**

```rust
fn handle(foo: Foo) {
    if let Ok(${1:num}) = foo.try_into_num() {
        $0
    }
}
```
