### PR TITLE
[WIP] Allow overriding paths to rust component binaries

### DIFF
--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -1602,6 +1602,66 @@
                 }
             },
             {
+                "title": "Environment",
+                "properties": {
+                    "rust-analyzer.environment.cargoPath": {
+                        "markdownDescription": "The absolute path to the `cargo` binary. Leave null to search the PATH.",
+                        "default": null,
+                        "anyOf": [
+                            {
+                                "type": "null"
+                            },
+                            {
+                                "type": "boolean"
+                            },
+                            {
+                                "type": "string"
+                            }
+                        ]
+                    }
+                }
+            },
+            {
+                "title": "Environment",
+                "properties": {
+                    "rust-analyzer.environment.rustcPath": {
+                        "markdownDescription": "The absolute path to the `rustc` binary. Leave null to search the PATH.",
+                        "default": null,
+                        "anyOf": [
+                            {
+                                "type": "null"
+                            },
+                            {
+                                "type": "boolean"
+                            },
+                            {
+                                "type": "string"
+                            }
+                        ]
+                    }
+                }
+            },
+            {
+                "title": "Environment",
+                "properties": {
+                    "rust-analyzer.environment.rustupPath": {
+                        "markdownDescription": "The absolute path to the `rustup` binary. Leave null to search the PATH.",
+                        "default": null,
+                        "anyOf": [
+                            {
+                                "type": "null"
+                            },
+                            {
+                                "type": "boolean"
+                            },
+                            {
+                                "type": "string"
+                            }
+                        ]
+                    }
+                }
+            },
+            {
                 "title": "Files",
                 "properties": {
                     "rust-analyzer.files.exclude": {

--- a/editors/code/src/config.ts
+++ b/editors/code/src/config.ts
@@ -302,6 +302,10 @@ export class Config {
         return this.get<boolean>("checkOnSave") ?? false;
     }
 
+    configuredExecutablePath(executableName: "cargo" | "rustc" | "rustup"): null | string {
+        return this.get<null | string>(`environment.${executableName}Path`);
+    }
+
     async toggleCheckOnSave() {
         const config = this.rawCfg.inspect<boolean>("checkOnSave") ?? { key: "checkOnSave" };
         let overrideInLanguage;

--- a/editors/code/src/debug.ts
+++ b/editors/code/src/debug.ts
@@ -145,6 +145,7 @@ async function getDebugConfiguration(
     }
 
     const executable = await getDebugExecutable(
+        config,
         runnableArgs,
         prepareEnv(true, {}, config.runnablesExtraEnv(runnable.label)),
     );
@@ -308,8 +309,8 @@ const knownEngines: {
     },
 };
 
-async function getDebugExecutable(runnableArgs: ra.CargoRunnableArgs, env: Env): Promise<string> {
-    const cargo = new Cargo(runnableArgs.workspaceRoot || ".", env);
+async function getDebugExecutable(config: Config, runnableArgs: ra.CargoRunnableArgs, env: Env): Promise<string> {
+    const cargo = new Cargo(config, runnableArgs.workspaceRoot || ".", env);
     const executable = await cargo.executableFromArgs(runnableArgs);
 
     // if we are here, there were no compilation errors.

--- a/editors/code/src/tasks.ts
+++ b/editors/code/src/tasks.ts
@@ -52,7 +52,7 @@ class RustTaskProvider implements vscode.TaskProvider {
         ];
 
         // FIXME: The server should provide this
-        const cargo = await toolchain.cargoPath();
+        const cargo = await toolchain.cargoPath(this.config);
 
         const tasks: vscode.Task[] = [];
         for (const workspaceTarget of vscode.workspace.workspaceFolders) {
@@ -126,7 +126,7 @@ export async function targetToExecution(
     let command, args;
     if (isCargoTask(definition)) {
         // FIXME: The server should provide cargo
-        command = cargo || (await toolchain.cargoPath(options?.env));
+        command = cargo || (await toolchain.cargoPath(this.config, options?.env));
         args = [definition.command].concat(definition.args || []);
     } else {
         command = definition.command;


### PR DESCRIPTION
My setup means that `cargo`, `rustup`, etc... are not usually in the path. This means I can't use the `rust-analyzer` extension since it assumes they are. This adds a few options to allow setting the absolute path to the binaries, like how the R language extension does it.