### PR TITLE
fix: Properly handle directories that are nested within excluded directories

### DIFF
--- a/crates/project-model/src/workspace.rs
+++ b/crates/project-model/src/workspace.rs
@@ -753,7 +753,6 @@ impl ProjectWorkspace {
 
                         let exclude = vec![
                             pkg_root.join(".git"),
-                            pkg_root.join("target"),
                             pkg_root.join("tests"),
                             pkg_root.join("examples"),
                             pkg_root.join("benches"),
@@ -840,8 +839,6 @@ impl ProjectWorkspace {
                         let mut exclude = vec![pkg_root.join(".git")];
                         if is_local {
                             include.extend(self.extra_includes.iter().cloned());
-
-                            exclude.push(pkg_root.join("target"));
                         } else {
                             exclude.push(pkg_root.join("tests"));
                             exclude.push(pkg_root.join("examples"));
@@ -903,8 +900,6 @@ impl ProjectWorkspace {
                         let mut exclude = vec![pkg_root.join(".git")];
                         if is_local {
                             include.extend(self.extra_includes.iter().cloned());
-
-                            exclude.push(pkg_root.join("target"));
                         } else {
                             exclude.push(pkg_root.join("tests"));
                             exclude.push(pkg_root.join("examples"));

--- a/crates/vfs-notify/src/lib.rs
+++ b/crates/vfs-notify/src/lib.rs
@@ -276,9 +276,18 @@ impl NotifyActor {
                                 return false;
                             }
 
-                            // We want to filter out subdirectories that are roots themselves, because they will be visited separately.
-                            dirs.exclude.iter().all(|it| it != path)
-                                && (root == path || dirs.include.iter().all(|it| it != path))
+                            if dirs.exclude.iter().any(|it| path.starts_with(it)) {
+                                // Directly excluded.
+                                false
+                            } else if root == path {
+                                // Needed so that we won't enter the next if.
+                                true
+                            } else if dirs.include.iter().any(|it| it == path) {
+                                // A subdirectory that is a project on its own, exclude it or it will be scanned twice.
+                                false
+                            } else {
+                                true
+                            }
                         });
 
                     let files = walkdir.filter_map(|it| it.ok()).filter_map(|entry| {

--- a/crates/vfs/src/loader.rs
+++ b/crates/vfs/src/loader.rs
@@ -110,11 +110,11 @@ impl Entry {
     /// Entry::Directories(Directories {
     ///     extensions: ["rs"],
     ///     include: [base],
-    ///     exclude: [base/.git, base/target],
+    ///     exclude: [base/.git],
     /// })
     /// ```
     pub fn local_cargo_package(base: AbsPathBuf) -> Entry {
-        Entry::Directories(dirs(base, &[".git", "target"]))
+        Entry::Directories(dirs(base, &[".git"]))
     }
 
     /// Returns:


### PR DESCRIPTION
That is `/excluded` is excluded, and `/excluded/project` is the project.