### PR TITLE
fix: don't fire `non_camel_case_types` lint for structs/enums marked with `repr(C)`

### DIFF
--- a/crates/ide-diagnostics/src/handlers/incorrect_case.rs
+++ b/crates/ide-diagnostics/src/handlers/incorrect_case.rs
@@ -1059,4 +1059,19 @@ fn foo(_HelloWorld: ()) {}
         "#,
         );
     }
+
+    #[test]
+    fn allow_with_repr_c() {
+        check_diagnostics(
+            r#"
+#[repr(C)]
+struct FFI_Struct;
+
+#[repr(C)]
+enum FFI_Enum {
+    Field,
+}
+        "#,
+        );
+    }
 }

--- a/crates/ide-diagnostics/src/lib.rs
+++ b/crates/ide-diagnostics/src/lib.rs
@@ -108,7 +108,6 @@ use syntax::{
     ast::{self, AstNode},
 };
 
-// FIXME: Make this an enum
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub enum DiagnosticCode {
     RustcHardError(&'static str),


### PR DESCRIPTION
If a struct/enum is marked with `repr(C)` and it doesn't follow camel case convention, rustc actually ignores this.

See corresponding rustc code:

https://github.com/rust-lang/rust/blob/94f8f4083ef82743d44ccb842c2bb65978efec28/compiler/rustc_lint/src/nonstandard_style.rs#L146-L153

And the original commit: https://github.com/rust-lang/rust/commit/c26cd9f05dc20eb67cf90d2ebb18728807b53022