### PR TITLE
Fix incorrect dyn hint in `impl Trait for`

### DIFF
--- a/crates/ide/src/inlay_hints/implied_dyn_trait.rs
+++ b/crates/ide/src/inlay_hints/implied_dyn_trait.rs
@@ -105,6 +105,7 @@ impl T {}
   // ^ dyn
 impl T for (T) {}
          // ^ dyn
+impl T for {}
 impl T
 "#,
         );


### PR DESCRIPTION
Example
---
```rust
trait T {}
impl T for {}
```

**Before this PR**

```rust
trait T {}
impl T for {}
  // ^ dyn
```

**After this PR**

```rust
trait T {}
impl T for {}
```
