### PR TITLE
Fix complete semicolon in array expression

### DIFF
--- a/crates/ide-completion/src/context.rs
+++ b/crates/ide-completion/src/context.rs
@@ -821,7 +821,10 @@ impl<'db> CompletionContext<'db> {
             CompleteSemicolon::DoNotComplete
         } else if let Some(term_node) =
             sema.token_ancestors_with_macros(token.clone()).find(|node| {
-                matches!(node.kind(), BLOCK_EXPR | MATCH_ARM | CLOSURE_EXPR | ARG_LIST | PAREN_EXPR)
+                matches!(
+                    node.kind(),
+                    BLOCK_EXPR | MATCH_ARM | CLOSURE_EXPR | ARG_LIST | PAREN_EXPR | ARRAY_EXPR
+                )
             })
         {
             let next_token = iter::successors(token.next_token(), |it| it.next_token())

--- a/crates/ide-completion/src/render/function.rs
+++ b/crates/ide-completion/src/render/function.rs
@@ -908,4 +908,23 @@ fn bar() {
 "#,
         );
     }
+
+    #[test]
+    fn no_semicolon_in_array() {
+        check_edit(
+            r#"foo"#,
+            r#"
+fn foo() {}
+fn bar() {
+    let _ = [fo$0];
+}
+"#,
+            r#"
+fn foo() {}
+fn bar() {
+    let _ = [foo()$0];
+}
+"#,
+        );
+    }
 }


### PR DESCRIPTION
Partial of rust-lang/rust-analyzer#21032

Example
---
```rust
fn foo() {}
fn bar() {
    let _ = [fo$0];
}
```

**Before this PR**

```rust
fn foo() {}
fn bar() {
    let _ = [foo();$0];
}
```

**After this PR**

```rust
fn foo() {}
fn bar() {
    let _ = [foo()$0];
}
```
