### PR TITLE
fix: Suppress false positive missing assoc item diag on specialization

### DIFF
--- a/crates/ide-diagnostics/src/handlers/trait_impl_missing_assoc_item.rs
+++ b/crates/ide-diagnostics/src/handlers/trait_impl_missing_assoc_item.rs
@@ -156,4 +156,22 @@ impl Trait for dyn OtherTrait {}
  "#,
         )
     }
+
+    #[test]
+    fn no_false_positive_on_specialization() {
+        check_diagnostics(
+            r#"
+#![feature(specialization)]
+
+pub trait Foo {
+    fn foo();
+}
+
+impl<T> Foo for T {
+    default fn foo() {}
+}
+impl Foo for bool {}
+"#,
+        );
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust-analyzer/issues/21378