### PR TITLE
fix: Fixes for builtin derive expansions

### DIFF
--- a/crates/hir-def/src/builtin_derive.rs
+++ b/crates/hir-def/src/builtin_derive.rs
@@ -8,7 +8,8 @@ use intern::{Symbol, sym};
 use tt::TextRange;
 
 use crate::{
-    AdtId, BuiltinDeriveImplId, BuiltinDeriveImplLoc, FunctionId, HasModule, db::DefDatabase,
+    AdtId, BuiltinDeriveImplId, BuiltinDeriveImplLoc, FunctionId, HasModule, MacroId,
+    db::DefDatabase, lang_item::LangItems,
 };
 
 macro_rules! declare_enum {
@@ -85,6 +86,25 @@ declare_enum!(
     CoerceUnsized => [],
     DispatchFromDyn => [],
 );
+
+impl BuiltinDeriveImplTrait {
+    pub fn derive_macro(self, lang_items: &LangItems) -> Option<MacroId> {
+        match self {
+            BuiltinDeriveImplTrait::Copy => lang_items.CopyDerive,
+            BuiltinDeriveImplTrait::Clone => lang_items.CloneDerive,
+            BuiltinDeriveImplTrait::Default => lang_items.DefaultDerive,
+            BuiltinDeriveImplTrait::Debug => lang_items.DebugDerive,
+            BuiltinDeriveImplTrait::Hash => lang_items.HashDerive,
+            BuiltinDeriveImplTrait::Ord => lang_items.OrdDerive,
+            BuiltinDeriveImplTrait::PartialOrd => lang_items.PartialOrdDerive,
+            BuiltinDeriveImplTrait::Eq => lang_items.EqDerive,
+            BuiltinDeriveImplTrait::PartialEq => lang_items.PartialEqDerive,
+            BuiltinDeriveImplTrait::CoerceUnsized | BuiltinDeriveImplTrait::DispatchFromDyn => {
+                lang_items.CoercePointeeDerive
+            }
+        }
+    }
+}
 
 impl BuiltinDeriveImplMethod {
     pub fn trait_method(

--- a/crates/hir-def/src/dyn_map.rs
+++ b/crates/hir-def/src/dyn_map.rs
@@ -27,14 +27,15 @@
 pub mod keys {
     use std::marker::PhantomData;
 
+    use either::Either;
     use hir_expand::{MacroCallId, attrs::AttrId};
     use rustc_hash::FxHashMap;
     use syntax::{AstNode, AstPtr, ast};
 
     use crate::{
-        BlockId, ConstId, EnumId, EnumVariantId, ExternBlockId, ExternCrateId, FieldId, FunctionId,
-        ImplId, LifetimeParamId, Macro2Id, MacroRulesId, ProcMacroId, StaticId, StructId, TraitId,
-        TypeAliasId, TypeOrConstParamId, UnionId, UseId,
+        BlockId, BuiltinDeriveImplId, ConstId, EnumId, EnumVariantId, ExternBlockId, ExternCrateId,
+        FieldId, FunctionId, ImplId, LifetimeParamId, Macro2Id, MacroRulesId, ProcMacroId,
+        StaticId, StructId, TraitId, TypeAliasId, TypeOrConstParamId, UnionId, UseId,
         dyn_map::{DynMap, Policy},
     };
 
@@ -71,7 +72,8 @@ pub mod keys {
         (
             AttrId,
             /* derive() */ MacroCallId,
-            /* actual derive macros */ Box<[Option<MacroCallId>]>,
+            /* actual derive macros */
+            Box<[Option<Either<MacroCallId, BuiltinDeriveImplId>>]>,
         ),
     > = Key::new();
 

--- a/crates/hir-def/src/nameres.rs
+++ b/crates/hir-def/src/nameres.rs
@@ -61,6 +61,7 @@ mod tests;
 use std::ops::{Deref, DerefMut, Index, IndexMut};
 
 use base_db::Crate;
+use either::Either;
 use hir_expand::{
     EditionedFileId, ErasedAstId, HirFileId, InFile, MacroCallId, mod_path::ModPath, name::Name,
     proc_macro::ProcMacroKind,
@@ -75,8 +76,8 @@ use triomphe::Arc;
 use tt::TextRange;
 
 use crate::{
-    AstId, BlockId, BlockLoc, ExternCrateId, FunctionId, FxIndexMap, Lookup, MacroCallStyles,
-    MacroExpander, MacroId, ModuleId, ModuleIdLt, ProcMacroId, UseId,
+    AstId, BlockId, BlockLoc, BuiltinDeriveImplId, ExternCrateId, FunctionId, FxIndexMap, Lookup,
+    MacroCallStyles, MacroExpander, MacroId, ModuleId, ModuleIdLt, ProcMacroId, UseId,
     db::DefDatabase,
     item_scope::{BuiltinShadowMode, ItemScope},
     item_tree::TreeId,
@@ -192,7 +193,8 @@ pub struct DefMap {
     /// Tracks which custom derives are in scope for an item, to allow resolution of derive helper
     /// attributes.
     // FIXME: Figure out a better way for the IDE layer to resolve these?
-    derive_helpers_in_scope: FxHashMap<AstId<ast::Item>, Vec<(Name, MacroId, MacroCallId)>>,
+    derive_helpers_in_scope:
+        FxHashMap<AstId<ast::Item>, Vec<(Name, MacroId, Either<MacroCallId, BuiltinDeriveImplId>)>>,
     /// A mapping from [`hir_expand::MacroDefId`] to [`crate::MacroId`].
     pub macro_def_to_macro_id: FxHashMap<ErasedAstId, MacroId>,
 
@@ -540,7 +542,7 @@ impl DefMap {
     pub fn derive_helpers_in_scope(
         &self,
         id: AstId<ast::Adt>,
-    ) -> Option<&[(Name, MacroId, MacroCallId)]> {
+    ) -> Option<&[(Name, MacroId, Either<MacroCallId, BuiltinDeriveImplId>)]> {
         self.derive_helpers_in_scope.get(&id.map(|it| it.upcast())).map(Deref::deref)
     }
 

--- a/crates/hir/src/semantics/source_to_def.rs
+++ b/crates/hir/src/semantics/source_to_def.rs
@@ -87,10 +87,10 @@
 
 use either::Either;
 use hir_def::{
-    AdtId, BlockId, ConstId, ConstParamId, DefWithBodyId, EnumId, EnumVariantId, ExternBlockId,
-    ExternCrateId, FieldId, FunctionId, GenericDefId, GenericParamId, ImplId, LifetimeParamId,
-    Lookup, MacroId, ModuleId, StaticId, StructId, TraitId, TypeAliasId, TypeParamId, UnionId,
-    UseId, VariantId,
+    AdtId, BlockId, BuiltinDeriveImplId, ConstId, ConstParamId, DefWithBodyId, EnumId,
+    EnumVariantId, ExternBlockId, ExternCrateId, FieldId, FunctionId, GenericDefId, GenericParamId,
+    ImplId, LifetimeParamId, Lookup, MacroId, ModuleId, StaticId, StructId, TraitId, TypeAliasId,
+    TypeParamId, UnionId, UseId, VariantId,
     dyn_map::{
         DynMap,
         keys::{self, Key},
@@ -394,7 +394,7 @@ impl SourceToDefCtx<'_, '_> {
         &mut self,
         item: InFile<&ast::Adt>,
         src: InFile<ast::Attr>,
-    ) -> Option<(AttrId, MacroCallId, &[Option<MacroCallId>])> {
+    ) -> Option<(AttrId, MacroCallId, &[Option<Either<MacroCallId, BuiltinDeriveImplId>>])> {
         let map = self.dyn_map(item)?;
         map[keys::DERIVE_MACRO_CALL]
             .get(&AstPtr::new(&src.value))
@@ -409,8 +409,11 @@ impl SourceToDefCtx<'_, '_> {
     pub(super) fn derive_macro_calls<'slf>(
         &'slf mut self,
         adt: InFile<&ast::Adt>,
-    ) -> Option<impl Iterator<Item = (AttrId, MacroCallId, &'slf [Option<MacroCallId>])> + use<'slf>>
-    {
+    ) -> Option<
+        impl Iterator<
+            Item = (AttrId, MacroCallId, &'slf [Option<Either<MacroCallId, BuiltinDeriveImplId>>]),
+        > + use<'slf>,
+    > {
         self.dyn_map(adt).as_ref().map(|&map| {
             let dyn_map = &map[keys::DERIVE_MACRO_CALL];
             adt.value

--- a/crates/ide/src/expand_macro.rs
+++ b/crates/ide/src/expand_macro.rs
@@ -583,26 +583,16 @@ fn main() {
     fn macro_expand_derive() {
         check(
             r#"
-//- proc_macros: identity
-//- minicore: clone, derive
+//- proc_macros: identity, derive_identity
+//- minicore: derive
 
 #[proc_macros::identity]
-#[derive(C$0lone)]
+#[derive(proc_macros::DeriveIde$0ntity)]
 struct Foo {}
 "#,
             expect![[r#"
-                Clone
-                impl <>core::clone::Clone for Foo< >where {
-                    fn clone(&self) -> Self {
-                        match self {
-                            Foo{}
-                             => Foo{}
-                            ,
-
-                            }
-                    }
-
-                    }"#]],
+                proc_macros::DeriveIdentity
+                struct Foo{}"#]],
         );
     }
 
@@ -610,15 +600,17 @@ struct Foo {}
     fn macro_expand_derive2() {
         check(
             r#"
-//- minicore: copy, clone, derive
+//- proc_macros: derive_identity
+//- minicore: derive
 
-#[derive(Cop$0y)]
-#[derive(Clone)]
+#[derive(proc_macros::$0DeriveIdentity)]
+#[derive(proc_macros::DeriveIdentity)]
 struct Foo {}
 "#,
             expect![[r#"
-                Copy
-                impl <>core::marker::Copy for Foo< >where{}"#]],
+                proc_macros::DeriveIdentity
+                #[derive(proc_macros::DeriveIdentity)]
+                struct Foo{}"#]],
         );
     }
 
@@ -626,35 +618,27 @@ struct Foo {}
     fn macro_expand_derive_multi() {
         check(
             r#"
-//- minicore: copy, clone, derive
+//- proc_macros: derive_identity
+//- minicore: derive
 
-#[derive(Cop$0y, Clone)]
+#[derive(proc_macros::DeriveIdent$0ity, proc_macros::DeriveIdentity)]
 struct Foo {}
 "#,
             expect![[r#"
-                Copy
-                impl <>core::marker::Copy for Foo< >where{}"#]],
+                proc_macros::DeriveIdentity
+                struct Foo{}"#]],
         );
         check(
             r#"
-//- minicore: copy, clone, derive
+//- proc_macros: derive_identity
+//- minicore: derive
 
-#[derive(Copy, Cl$0one)]
+#[derive(proc_macros::DeriveIdentity, proc_macros::De$0riveIdentity)]
 struct Foo {}
 "#,
             expect![[r#"
-                Clone
-                impl <>core::clone::Clone for Foo< >where {
-                    fn clone(&self) -> Self {
-                        match self {
-                            Foo{}
-                             => Foo{}
-                            ,
-
-                            }
-                    }
-
-                    }"#]],
+                proc_macros::DeriveIdentity
+                struct Foo{}"#]],
         );
     }
 

--- a/crates/intern/src/symbol/symbols.rs
+++ b/crates/intern/src/symbol/symbols.rs
@@ -532,4 +532,5 @@ define_symbols! {
     CoerceUnsized,
     DispatchFromDyn,
     define_opaque,
+    marker,
 }


### PR DESCRIPTION
 - Do not store the `MacroCallId` of the "real" expansion anywhere, so that the IDE layer could not expand it by mistake
 - Fix a stupid bug where we used the directive of the `derive` itself instead of of the macro, leading us to re-expand it again and again.

Fixes rust-lang/rust-analyzer#21382.