### PR TITLE
Support more runnable kinds in project JSON

### DIFF
--- a/crates/project-model/src/project_json.rs
+++ b/crates/project-model/src/project_json.rs
@@ -365,6 +365,21 @@ pub enum RunnableKind {
     /// May include {test_id} which will get the test clicked on by the user.
     TestOne,
 
+    /// Run tests matching a pattern (in RA, usually a path::to::module::of::tests)
+    /// May include {label} which will get the label from the `build` section of a crate.
+    /// May include {test_pattern} which will get the test module clicked on by the user.
+    TestMod,
+
+    /// Run a single doctest
+    /// May include {label} which will get the label from the `build` section of a crate.
+    /// May include {test_id} which will get the doctest clicked on by the user.
+    DocTestOne,
+
+    /// Run a single benchmark
+    /// May include {label} which will get the label from the `build` section of a crate.
+    /// May include {bench_id} which will get the benchmark clicked on by the user.
+    BenchOne,
+
     /// Template for checking a target, emitting rustc JSON diagnostics.
     /// May include {label} which will get the label from the `build` section of a crate.
     Flycheck,
@@ -481,6 +496,9 @@ pub enum RunnableKindData {
     Check,
     Run,
     TestOne,
+    TestMod,
+    DocTestOne,
+    BenchOne,
 
     /// For forwards-compatibility, i.e. old rust-analyzer binary with newer workspace discovery tools
     #[allow(unused)]
@@ -553,6 +571,9 @@ impl From<RunnableKindData> for RunnableKind {
             RunnableKindData::Check => RunnableKind::Check,
             RunnableKindData::Run => RunnableKind::Run,
             RunnableKindData::TestOne => RunnableKind::TestOne,
+            RunnableKindData::TestMod => RunnableKind::TestMod,
+            RunnableKindData::DocTestOne => RunnableKind::DocTestOne,
+            RunnableKindData::BenchOne => RunnableKind::BenchOne,
             RunnableKindData::Flycheck => RunnableKind::Flycheck,
             RunnableKindData::Unknown => RunnableKind::Unknown,
         }

--- a/crates/project-model/src/project_json.rs
+++ b/crates/project-model/src/project_json.rs
@@ -368,6 +368,9 @@ pub enum RunnableKind {
     /// Template for checking a target, emitting rustc JSON diagnostics.
     /// May include {label} which will get the label from the `build` section of a crate.
     Flycheck,
+
+    /// For forwards-compatibility, i.e. old rust-analyzer binary with newer workspace discovery tools
+    Unknown,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
@@ -478,6 +481,11 @@ pub enum RunnableKindData {
     Check,
     Run,
     TestOne,
+
+    /// For forwards-compatibility, i.e. old rust-analyzer binary with newer workspace discovery tools
+    #[allow(unused)]
+    #[serde(other)]
+    Unknown,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
@@ -546,6 +554,7 @@ impl From<RunnableKindData> for RunnableKind {
             RunnableKindData::Run => RunnableKind::Run,
             RunnableKindData::TestOne => RunnableKind::TestOne,
             RunnableKindData::Flycheck => RunnableKind::Flycheck,
+            RunnableKindData::Unknown => RunnableKind::Unknown,
         }
     }
 }

--- a/crates/project-model/src/tests.rs
+++ b/crates/project-model/src/tests.rs
@@ -193,6 +193,12 @@ fn rust_project_hello_world_project_model() {
 }
 
 #[test]
+fn rust_project_labeled_project_model() {
+    // This just needs to parse.
+    _ = load_rust_project("labeled-project.json");
+}
+
+#[test]
 fn rust_project_cfg_groups() {
     let (crate_graph, _proc_macros) = load_rust_project("cfg-groups.json");
     check_crate_graph(crate_graph, expect_file!["../test_data/output/rust_project_cfg_groups.txt"]);

--- a/crates/project-model/test_data/labeled-project.json
+++ b/crates/project-model/test_data/labeled-project.json
@@ -26,6 +26,12 @@
             "program": "$ROOT$custom-flychecker.sh",
             "args": ["{label}"],
             "cwd": "$ROOT$"
+        },
+        {
+            "kind": "we-ignore-unknown-runnable-kinds-for-forwards-compatibility",
+            "program": "abc",
+            "args": ["{label}"],
+            "cwd": "$ROOT$"
         }
     ]
 }

--- a/crates/project-model/test_data/labeled-project.json
+++ b/crates/project-model/test_data/labeled-project.json
@@ -1,0 +1,31 @@
+{
+    "sysroot_src": null,
+    "crates": [
+        {
+            "display_name": "hello_world",
+            "root_module": "$ROOT$src/lib.rs",
+            "edition": "2018",
+            "deps": [],
+            "is_workspace_member": true,
+            "build": {
+                "label": "//:hello_world",
+                "build_file": "$ROOT$BUILD",
+                "target_kind": "bin"
+            }
+        }
+    ],
+    "runnables": [
+        {
+            "kind": "run",
+            "program": "bazel",
+            "args": ["run", "{label}"],
+            "cwd": "$ROOT$"
+        },
+        {
+            "kind": "flycheck",
+            "program": "$ROOT$custom-flychecker.sh",
+            "args": ["{label}"],
+            "cwd": "$ROOT$"
+        }
+    ]
+}

--- a/crates/rust-analyzer/src/target_spec.rs
+++ b/crates/rust-analyzer/src/target_spec.rs
@@ -103,9 +103,20 @@ impl ProjectJsonTargetSpec {
                     arg.replace("{label}", &this.label).replace("{test_id}", &test_id.to_string())
                 })
             }
-            RunnableKind::TestMod { .. } => None,
-            RunnableKind::Bench { .. } => None,
-            RunnableKind::DocTest { .. } => None,
+            RunnableKind::TestMod { path } => self
+                .find_replace_runnable(project_json::RunnableKind::TestMod, &|this, arg| {
+                    arg.replace("{label}", &this.label).replace("{test_pattern}", path)
+                }),
+            RunnableKind::Bench { test_id } => {
+                self.find_replace_runnable(project_json::RunnableKind::BenchOne, &|this, arg| {
+                    arg.replace("{label}", &this.label).replace("{bench_id}", &test_id.to_string())
+                })
+            }
+            RunnableKind::DocTest { test_id } => {
+                self.find_replace_runnable(project_json::RunnableKind::DocTestOne, &|this, arg| {
+                    arg.replace("{label}", &this.label).replace("{test_id}", &test_id.to_string())
+                })
+            }
         }
     }
 }

--- a/crates/rust-analyzer/src/target_spec.rs
+++ b/crates/rust-analyzer/src/target_spec.rs
@@ -6,7 +6,7 @@ use cargo_metadata::PackageId;
 use cfg::{CfgAtom, CfgExpr};
 use hir::sym;
 use ide::{Cancellable, Crate, FileId, RunnableKind, TestId};
-use project_model::project_json::Runnable;
+use project_model::project_json::{self, Runnable};
 use project_model::{CargoFeatures, ManifestPath, TargetKind};
 use rustc_hash::FxHashSet;
 use triomphe::Arc;
@@ -72,44 +72,36 @@ pub(crate) struct ProjectJsonTargetSpec {
 }
 
 impl ProjectJsonTargetSpec {
+    fn find_replace_runnable(
+        &self,
+        kind: project_json::RunnableKind,
+        replacer: &dyn Fn(&Self, &str) -> String,
+    ) -> Option<Runnable> {
+        for runnable in &self.shell_runnables {
+            if runnable.kind == kind {
+                let mut runnable = runnable.clone();
+
+                let replaced_args: Vec<_> =
+                    runnable.args.iter().map(|arg| replacer(self, arg)).collect();
+                runnable.args = replaced_args;
+
+                return Some(runnable);
+            }
+        }
+
+        None
+    }
+
     pub(crate) fn runnable_args(&self, kind: &RunnableKind) -> Option<Runnable> {
         match kind {
-            RunnableKind::Bin => {
-                for runnable in &self.shell_runnables {
-                    if matches!(runnable.kind, project_model::project_json::RunnableKind::Run) {
-                        let mut runnable = runnable.clone();
-
-                        let replaced_args: Vec<_> = runnable
-                            .args
-                            .iter()
-                            .map(|arg| arg.replace("{label}", &self.label))
-                            .collect();
-                        runnable.args = replaced_args;
-
-                        return Some(runnable);
-                    }
-                }
-
-                None
-            }
+            RunnableKind::Bin => self
+                .find_replace_runnable(project_json::RunnableKind::Run, &|this, arg| {
+                    arg.replace("{label}", &this.label)
+                }),
             RunnableKind::Test { test_id, .. } => {
-                for runnable in &self.shell_runnables {
-                    if matches!(runnable.kind, project_model::project_json::RunnableKind::TestOne) {
-                        let mut runnable = runnable.clone();
-
-                        let replaced_args: Vec<_> = runnable
-                            .args
-                            .iter()
-                            .map(|arg| arg.replace("{test_id}", &test_id.to_string()))
-                            .map(|arg| arg.replace("{label}", &self.label))
-                            .collect();
-                        runnable.args = replaced_args;
-
-                        return Some(runnable);
-                    }
-                }
-
-                None
+                self.find_replace_runnable(project_json::RunnableKind::Run, &|this, arg| {
+                    arg.replace("{label}", &this.label).replace("{test_id}", &test_id.to_string())
+                })
             }
             RunnableKind::TestMod { .. } => None,
             RunnableKind::Bench { .. } => None,


### PR DESCRIPTION
Adds support for benchmarks, whole modules of tests, doctests.

Fixes rust-lang/rust-analyzer#20359 but you will have to update your tooling that generates the JSON to include such runnables, e.g. `testMod`, `doctestOne`, `benchOne`.

TODO

- [ ] Resolve rust-lang/rust-analyzer#21423 one way or another, as this PR includes part of it, so as not to conflict.
- [ ] update the public-facing docs as well