### PR TITLE
Edition::EditionFuture for forwards compatibility

### DIFF
--- a/crates/edition/src/lib.rs
+++ b/crates/edition/src/lib.rs
@@ -10,6 +10,8 @@ pub enum Edition {
     Edition2018,
     Edition2021,
     Edition2024,
+    /// For forwards-compatibility, i.e. old rust-analyzer with newer rustc
+    EditionFuture,
 }
 
 impl Edition {
@@ -21,10 +23,12 @@ impl Edition {
 
     pub fn from_u32(u32: u32) -> Edition {
         match u32 {
+            // Match enum order. EditionFuture should stay at the bottom and be updated to latest+1.
             0 => Edition::Edition2015,
             1 => Edition::Edition2018,
             2 => Edition::Edition2021,
             3 => Edition::Edition2024,
+            4 => Edition::EditionFuture,
             _ => panic!("invalid edition"),
         }
     }
@@ -41,15 +45,25 @@ impl Edition {
         self >= Edition::Edition2018
     }
 
+    /// Replaces EditionFuture with the latest known edition.
+    pub fn or_latest(self) -> Edition {
+        match self {
+            Edition::EditionFuture => Edition::LATEST,
+            _ => self,
+        }
+    }
+
     pub fn number(&self) -> usize {
         match self {
             Edition::Edition2015 => 2015,
             Edition::Edition2018 => 2018,
             Edition::Edition2021 => 2021,
             Edition::Edition2024 => 2024,
+            Edition::EditionFuture => 9999,
         }
     }
 
+    /// Iterate the known editions. Excludes EditionFuture
     pub fn iter() -> impl Iterator<Item = Edition> {
         [Edition::Edition2015, Edition::Edition2018, Edition::Edition2021, Edition::Edition2024]
             .iter()
@@ -91,6 +105,7 @@ impl fmt::Display for Edition {
             Edition::Edition2018 => "2018",
             Edition::Edition2021 => "2021",
             Edition::Edition2024 => "2024",
+            Edition::EditionFuture => "future",
         })
     }
 }

--- a/crates/hir-def/src/nameres/collector.rs
+++ b/crates/hir-def/src/nameres/collector.rs
@@ -545,14 +545,16 @@ impl<'db> DefCollector<'db> {
             Name::new_symbol_root(sym::core)
         };
 
-        let edition = match self.def_map.data.edition {
+        let edition_or_latest = self.def_map.data.edition.or_latest();
+        let edition = match edition_or_latest {
             Edition::Edition2015 => Name::new_symbol_root(sym::rust_2015),
             Edition::Edition2018 => Name::new_symbol_root(sym::rust_2018),
             Edition::Edition2021 => Name::new_symbol_root(sym::rust_2021),
             Edition::Edition2024 => Name::new_symbol_root(sym::rust_2024),
+            Edition::EditionFuture => unreachable!("Replaced with latest"),
         };
 
-        let path_kind = match self.def_map.data.edition {
+        let path_kind = match edition_or_latest {
             Edition::Edition2015 => PathKind::Plain,
             _ => PathKind::Abs,
         };

--- a/crates/project-model/src/project_json.rs
+++ b/crates/project-model/src/project_json.rs
@@ -454,6 +454,8 @@ enum EditionData {
     Edition2021,
     #[serde(rename = "2024")]
     Edition2024,
+    #[serde(other)]
+    EditionFuture,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
@@ -529,6 +531,7 @@ impl From<EditionData> for Edition {
             EditionData::Edition2018 => Edition::Edition2018,
             EditionData::Edition2021 => Edition::Edition2021,
             EditionData::Edition2024 => Edition::Edition2024,
+            EditionData::EditionFuture => Edition::EditionFuture,
         }
     }
 }


### PR DESCRIPTION
Like rust-lang/rust-analyzer#21423 but for editions.

I would like it so that RA is not necessarily bricked as soon as a new edition comes out. Usually a new edition means RA will have to update (new syntax, new keywords, new trait stuff, etc) but we should allow it to lurch on a little longer if that is not bothering a given user. I have been forced to upgrade because of this and it would have been nice at the time to do that the following month instead of in a mega-upgrade of rustc, 100 crates, rust-analyzer, and buck2 all at once.

I'm not sure if this is the exact right approach. Maybe we just assume all editions will be years and parse the string to a number? Then we can at least inject the prelude using a non-interned symbol to construct a `use ::std::prelude::rust_xxxx::*` import, rather than falling back to the latest edition and probably missing some symbols.