### PR TITLE
Fix ignore flag for test attributes with values

### DIFF
--- a/crates/hir-def/src/attrs.rs
+++ b/crates/hir-def/src/attrs.rs
@@ -135,6 +135,7 @@ fn match_attr_flags(attr_flags: &mut AttrFlags, attr: Meta) -> ControlFlow<Infal
     match attr {
         Meta::NamedKeyValue { name: Some(name), value, .. } => match name.text() {
             "deprecated" => attr_flags.insert(AttrFlags::IS_DEPRECATED),
+            "ignore" => attr_flags.insert(AttrFlags::IS_IGNORE),
             "lang" => attr_flags.insert(AttrFlags::LANG_ITEM),
             "path" => attr_flags.insert(AttrFlags::HAS_PATH),
             "unstable" => attr_flags.insert(AttrFlags::IS_UNSTABLE),


### PR DESCRIPTION
See bug report rust-lang/rust-analyzer#21435 for details on what case exactly is fixed.

Before this fix the ignore attribute would be only handled correctly when used like this:
```rust
#[test]
#[ignore]
fn example_a() {}
```
Now it can also handle cases where a an optional reason is specified:
```rust
#[test]
#[ignore = "some reason"]
fn example_b() {}
```