### PR TITLE
internal: Abstract proc-macro-srv and proc-macro-api stdin and stdout away

### DIFF
--- a/crates/proc-macro-api/src/legacy_protocol.rs
+++ b/crates/proc-macro-api/src/legacy_protocol.rs
@@ -162,11 +162,11 @@ fn send_request<P: Codec>(
     req: Request,
     buf: &mut P::Buf,
 ) -> Result<Option<Response>, ServerError> {
-    req.write::<_, P>(&mut writer).map_err(|err| ServerError {
+    req.write::<P>(&mut writer).map_err(|err| ServerError {
         message: "failed to write request".into(),
         io: Some(Arc::new(err)),
     })?;
-    let res = Response::read::<_, P>(&mut reader, buf).map_err(|err| ServerError {
+    let res = Response::read::<P>(&mut reader, buf).map_err(|err| ServerError {
         message: "failed to read response".into(),
         io: Some(Arc::new(err)),
     })?;

--- a/crates/proc-macro-api/src/legacy_protocol/msg.rs
+++ b/crates/proc-macro-api/src/legacy_protocol/msg.rs
@@ -155,13 +155,13 @@ impl ExpnGlobals {
 }
 
 pub trait Message: serde::Serialize + DeserializeOwned {
-    fn read<R: BufRead, C: Codec>(inp: &mut R, buf: &mut C::Buf) -> io::Result<Option<Self>> {
+    fn read<C: Codec>(inp: &mut dyn BufRead, buf: &mut C::Buf) -> io::Result<Option<Self>> {
         Ok(match C::read(inp, buf)? {
             None => None,
             Some(buf) => Some(C::decode(buf)?),
         })
     }
-    fn write<W: Write, C: Codec>(self, out: &mut W) -> io::Result<()> {
+    fn write<C: Codec>(self, out: &mut dyn Write) -> io::Result<()> {
         let value = C::encode(&self)?;
         C::write(out, &value)
     }

--- a/crates/proc-macro-srv-cli/src/main.rs
+++ b/crates/proc-macro-srv-cli/src/main.rs
@@ -45,7 +45,11 @@ fn main() -> std::io::Result<()> {
     }
     let &format =
         matches.get_one::<ProtocolFormat>("format").expect("format value should always be present");
-    run(format)
+
+    let mut stdin = std::io::BufReader::new(std::io::stdin());
+    let mut stdout = std::io::stdout();
+
+    run(&mut stdin, &mut stdout, format)
 }
 
 #[derive(Copy, Clone)]
@@ -88,7 +92,11 @@ impl ValueEnum for ProtocolFormat {
 }
 
 #[cfg(not(feature = "sysroot-abi"))]
-fn run(_: ProtocolFormat) -> std::io::Result<()> {
+fn run(
+    _: &mut std::io::BufReader<std::io::Stdin>,
+    _: &mut std::io::Stdout,
+    _: ProtocolFormat,
+) -> std::io::Result<()> {
     Err(std::io::Error::new(
         std::io::ErrorKind::Unsupported,
         "proc-macro-srv-cli needs to be compiled with the `sysroot-abi` feature to function"


### PR DESCRIPTION
Preparation for landing actual proc-macro server test infra that won't require spinning up rust-analyzer.