### PR TITLE
fix: Disable `unused_variables` and `unused_mut` warnings

### DIFF
--- a/crates/ide-diagnostics/src/handlers/mutability_errors.rs
+++ b/crates/ide-diagnostics/src/handlers/mutability_errors.rs
@@ -1,3 +1,5 @@
+#![expect(unused, reason = "diagnostics is temporarily disabled due to too many false positives")]
+
 use hir::db::ExpandDatabase;
 use ide_db::source_change::SourceChange;
 use ide_db::text_edit::TextEdit;
@@ -88,16 +90,17 @@ pub(crate) fn unused_mut(ctx: &DiagnosticsContext<'_>, d: &hir::UnusedMut) -> Op
         )])
     })();
     let ast = d.local.primary_source(ctx.sema.db).syntax_ptr();
-    Some(
-        Diagnostic::new_with_syntax_node_ptr(
-            ctx,
-            DiagnosticCode::RustcLint("unused_mut"),
-            "variable does not need to be mutable",
-            ast,
-        )
-        // Not supporting `#[allow(unused_mut)]` in proc macros leads to false positive, hence not stable.
-        .with_fixes(fixes),
-    )
+    // Some(
+    //     Diagnostic::new_with_syntax_node_ptr(
+    //         ctx,
+    //         DiagnosticCode::RustcLint("unused_mut"),
+    //         "variable does not need to be mutable",
+    //         ast,
+    //     )
+    //     // Not supporting `#[allow(unused_mut)]` in proc macros leads to false positive, hence not stable.
+    //     .with_fixes(fixes),
+    // )
+    None
 }
 
 pub(super) fn token(parent: &SyntaxNode, kind: SyntaxKind) -> Option<SyntaxToken> {
@@ -105,6 +108,7 @@ pub(super) fn token(parent: &SyntaxNode, kind: SyntaxKind) -> Option<SyntaxToken
 }
 
 #[cfg(test)]
+#[cfg(false)] // Diagnostic temporarily disabled
 mod tests {
     use crate::tests::{check_diagnostics, check_diagnostics_with_disabled, check_fix};
 

--- a/crates/ide-diagnostics/src/handlers/unused_variables.rs
+++ b/crates/ide-diagnostics/src/handlers/unused_variables.rs
@@ -1,3 +1,5 @@
+#![expect(unused, reason = "diagnostics is temporarily disabled due to too many false positives")]
+
 use hir::Name;
 use ide_db::text_edit::TextEdit;
 use ide_db::{
@@ -40,25 +42,26 @@ pub(crate) fn unused_variables(
         .and_then(syntax::ast::RecordPatField::cast)
         .is_some_and(|field| field.colon_token().is_none());
     let var_name = d.local.name(ctx.sema.db);
-    Some(
-        Diagnostic::new_with_syntax_node_ptr(
-            ctx,
-            DiagnosticCode::RustcLint("unused_variables"),
-            "unused variable",
-            ast,
-        )
-        .with_fixes(name_range.and_then(|it| {
-            fixes(
-                ctx.sema.db,
-                var_name,
-                it.range,
-                diagnostic_range,
-                ast.file_id.is_macro(),
-                is_shorthand_field,
-                ctx.edition,
-            )
-        })),
-    )
+    // Some(
+    //     Diagnostic::new_with_syntax_node_ptr(
+    //         ctx,
+    //         DiagnosticCode::RustcLint("unused_variables"),
+    //         "unused variable",
+    //         ast,
+    //     )
+    //     .with_fixes(name_range.and_then(|it| {
+    //         fixes(
+    //             ctx.sema.db,
+    //             var_name,
+    //             it.range,
+    //             diagnostic_range,
+    //             ast.file_id.is_macro(),
+    //             is_shorthand_field,
+    //             ctx.edition,
+    //         )
+    //     })),
+    // )
+    None
 }
 
 fn fixes(
@@ -91,6 +94,7 @@ fn fixes(
 }
 
 #[cfg(test)]
+#[cfg(false)] // Diagnostic temporarily disabled
 mod tests {
     use crate::tests::{check_diagnostics, check_fix};
 


### PR DESCRIPTION
They suffer from an unacceptable amount of false positives after rust-lang/rust-analyzer#21209.

Another option to disable them is to include them in `rust-analyzer.diagnostics.disable` by default, but that will mean users could override that.

Closes https://github.com/rust-lang/rust-analyzer/issues/21386.

Probably closes rust-lang/rust-analyzer#21384.