### PR TITLE
minor: Fix overlapping cfg attributes for wasm32-unknown-emscripten target

### DIFF
--- a/crates/stdx/src/process.rs
+++ b/crates/stdx/src/process.rs
@@ -76,7 +76,7 @@ pub fn spawn_with_streaming_output(
     Ok(Output { status, stdout, stderr })
 }
 
-#[cfg(unix)]
+#[cfg(all(unix, not(target_arch = "wasm32")))]
 mod imp {
     use std::{
         io::{self, prelude::*},


### PR DESCRIPTION
The `wasm32-unknown-emscripten` target sets both `cfg(unix)` and `cfg(target_arch = "wasm32")`, causing the `mod imp` definitions in `process.rs` to overlap and fail to compile:

```
$ rustup target add wasm32-unknown-emscripten
$ cargo build -p stdx --target wasm32-unknown-emscripten
error[E0428]: the name `imp` is defined multiple times
   --> crates/stdx/src/process.rs:260:1
    |
 80 | mod imp {
    | ------- previous definition of the module `imp` here
...
260 | mod imp {
    | ^^^^^^^ `imp` redefined here
    |
    = note: `imp` must be defined only once in the type namespace of this module

For more information about this error, try `rustc --explain E0428`.
```

This PR ensures the three platform-specific implementations are mutually exclusive.
Before this fix, the above command fails with duplicate `mod imp` definitions. After this fix, it compiles successfully.