### PR TITLE
feat: Add destructure_enum assist

### DIFF
--- a/crates/ide-assists/src/handlers/add_missing_match_arms.rs
+++ b/crates/ide-assists/src/handlers/add_missing_match_arms.rs
@@ -388,20 +388,20 @@ fn does_pat_match_variant(pat: &Pat, var: &Pat) -> bool {
 }
 
 #[derive(Eq, PartialEq, Clone)]
-enum ExtendedEnum {
+pub(crate) enum ExtendedEnum {
     Bool,
     Enum { enum_: hir::Enum, use_self: bool },
 }
 
 #[derive(Eq, PartialEq, Clone, Copy, Debug)]
-enum ExtendedVariant {
+pub(crate) enum ExtendedVariant {
     True,
     False,
     Variant { variant: hir::Variant, use_self: bool },
 }
 
 impl ExtendedVariant {
-    fn should_be_hidden(self, db: &RootDatabase, krate: Crate) -> bool {
+    pub(crate) fn should_be_hidden(self, db: &RootDatabase, krate: Crate) -> bool {
         match self {
             ExtendedVariant::Variant { variant: var, .. } => {
                 var.attrs(db).is_doc_hidden() && var.module(db).krate(db) != krate
@@ -412,7 +412,7 @@ impl ExtendedVariant {
 }
 
 impl ExtendedEnum {
-    fn enum_(
+    pub(crate) fn enum_(
         db: &RootDatabase,
         enum_: hir::Enum,
         enum_ty: &hir::Type<'_>,
@@ -424,7 +424,7 @@ impl ExtendedEnum {
         }
     }
 
-    fn is_non_exhaustive(&self, db: &RootDatabase, krate: Crate) -> bool {
+    pub(crate) fn is_non_exhaustive(&self, db: &RootDatabase, krate: Crate) -> bool {
         match self {
             ExtendedEnum::Enum { enum_: e, .. } => {
                 e.attrs(db).is_non_exhaustive() && e.module(db).krate(db) != krate
@@ -433,7 +433,7 @@ impl ExtendedEnum {
         }
     }
 
-    fn variants(&self, db: &RootDatabase) -> Vec<ExtendedVariant> {
+    pub(crate) fn variants(&self, db: &RootDatabase) -> Vec<ExtendedVariant> {
         match *self {
             ExtendedEnum::Enum { enum_: e, use_self } => e
                 .variants(db)
@@ -447,7 +447,7 @@ impl ExtendedEnum {
     }
 }
 
-fn resolve_enum_def(
+pub(crate) fn resolve_enum_def(
     sema: &Semantics<'_, RootDatabase>,
     expr: &ast::Expr,
     self_ty: Option<&hir::Type<'_>>,
@@ -495,7 +495,7 @@ fn resolve_array_of_enum_def(
     })
 }
 
-fn build_pat(
+pub(crate) fn build_pat(
     ctx: &AssistContext<'_>,
     make: &SyntaxFactory,
     module: hir::Module,

--- a/crates/ide-assists/src/handlers/destructure_enum.rs
+++ b/crates/ide-assists/src/handlers/destructure_enum.rs
@@ -1,0 +1,134 @@
+use ide_db::famous_defs::FamousDefs;
+use syntax::ast::{
+    self, AstNode, Expr, edit::AstNodeEdit, edit::IndentLevel, make, syntax_factory::SyntaxFactory,
+};
+
+use crate::handlers::add_missing_match_arms::{ExtendedEnum, build_pat, resolve_enum_def};
+use crate::{AssistContext, AssistId, Assists};
+
+// Assist: destructure_enum
+//
+// Destructures an enum value to a match expression.
+//
+// ```
+// enum Action { Move { distance: u32 }, Stop }
+//
+// fn handle(action: Action) {
+//     action$0
+// }
+// ```
+// ->
+// ```
+// enum Action { Move { distance: u32 }, Stop }
+//
+// fn handle(action: Action) {
+//     match action {
+//         Action::Move { distance } => ${1:{}}
+//         Action::Stop => ${2:{}}$0
+//     }
+// }
+// ```
+//
+// When matching on an Option, Some is offered first.
+//
+// ```
+// # //- minicore: option
+// fn handle(i: Option<i32>) {
+//     i$0
+// }
+// ```
+// ->
+// ```
+// fn handle(i: Option<i32>) {
+//     match i {
+//         Some(_) => ${1:{}}
+//         None => ${2:{}}$0
+//     }
+// }
+// ```
+pub(crate) fn destructure_enum(acc: &mut Assists, ctx: &AssistContext<'_>) -> Option<()> {
+    let expr = ctx.find_node_at_offset::<Expr>()?;
+    let enum_def = resolve_enum_def(&ctx.sema, &expr, None)?;
+
+    let scope = ctx.sema.scope(expr.syntax())?;
+    let module = scope.module();
+    let krate = module.krate(ctx.db());
+    let cfg = ctx.config.find_path_config(ctx.sema.is_nightly(scope.krate()));
+
+    // Handle Option specially.
+    let option_enum = FamousDefs(&ctx.sema, krate).core_option_Option();
+    let is_option =
+        matches!(&enum_def, ExtendedEnum::Enum { enum_, .. } if option_enum == Some(*enum_));
+
+    // Check if we need a catch-all `_ => {}` arm.
+    let has_hidden_variants =
+        enum_def.variants(ctx.db()).iter().any(|v| v.should_be_hidden(ctx.db(), krate));
+    let needs_catch_all_arm = enum_def.is_non_exhaustive(ctx.db(), krate) || has_hidden_variants;
+
+    acc.add(
+        AssistId::refactor_rewrite("destructure_enum"),
+        "Destructure enum with match",
+        expr.syntax().text_range(),
+        |builder| {
+            let make = SyntaxFactory::with_mappings();
+
+            let mut arms: Vec<ast::MatchArm> = enum_def
+                .variants(ctx.db())
+                .into_iter()
+                .filter(|v| !v.should_be_hidden(ctx.db(), krate))
+                .filter_map(|variant| {
+                    let pat = build_pat(ctx, &make, module, variant, cfg)?;
+                    Some(make.match_arm(pat, None, make::expr_empty_block().into()))
+                })
+                .collect();
+
+            // Option puts None before Some, but users expect Some first.
+            if is_option {
+                arms.reverse();
+            }
+
+            if needs_catch_all_arm {
+                let wildcard = make.match_arm(
+                    make.wildcard_pat().into(),
+                    None,
+                    make::expr_empty_block().into(),
+                );
+                arms.push(wildcard);
+            }
+
+            if arms.is_empty() {
+                return;
+            }
+
+            let match_arm_list = make.match_arm_list(arms.clone());
+            let match_expr = make.expr_match(expr.clone(), match_arm_list);
+            let indent = IndentLevel::from_node(expr.syntax());
+            let match_expr = match_expr.indent(indent);
+
+            // Get the match arm list from the indented expression for annotations
+            let match_arm_list = match_expr.match_arm_list().unwrap();
+
+            let mut editor = builder.make_editor(expr.syntax());
+            editor.replace(expr.syntax(), match_expr.syntax());
+
+            // Add snippet placeholders if the LSP client supports it.
+            if let Some(cap) = ctx.config.snippet_cap {
+                for arm in match_arm_list.arms() {
+                    if let Some(arm_expr) = arm.expr() {
+                        editor.add_annotation(
+                            arm_expr.syntax(),
+                            builder.make_placeholder_snippet(cap),
+                        );
+                    }
+                }
+
+                if let Some(last_arm) = match_arm_list.arms().last() {
+                    editor.add_annotation(last_arm.syntax(), builder.make_tabstop_after(cap));
+                }
+            }
+
+            editor.add_mappings(make.finish_with_mappings());
+            builder.add_file_edits(ctx.vfs_file_id(), editor);
+        },
+    )
+}

--- a/crates/ide-assists/src/lib.rs
+++ b/crates/ide-assists/src/lib.rs
@@ -139,6 +139,7 @@ mod handlers {
     mod convert_tuple_struct_to_named_struct;
     mod convert_two_arm_bool_match_to_matches_macro;
     mod convert_while_to_loop;
+    mod destructure_enum;
     mod destructure_struct_binding;
     mod destructure_tuple_binding;
     mod desugar_doc_comment;
@@ -278,6 +279,7 @@ mod handlers {
             convert_tuple_struct_to_named_struct::convert_tuple_struct_to_named_struct,
             convert_two_arm_bool_match_to_matches_macro::convert_two_arm_bool_match_to_matches_macro,
             convert_while_to_loop::convert_while_to_loop,
+            destructure_enum::destructure_enum,
             destructure_struct_binding::destructure_struct_binding,
             destructure_tuple_binding::destructure_tuple_binding,
             desugar_doc_comment::desugar_doc_comment,

--- a/crates/ide-assists/src/tests/generated.rs
+++ b/crates/ide-assists/src/tests/generated.rs
@@ -945,6 +945,51 @@ fn main() {
 }
 
 #[test]
+fn doctest_destructure_enum() {
+    check_doc_test(
+        "destructure_enum",
+        r#####"
+enum Action { Move { distance: u32 }, Stop }
+
+fn handle(action: Action) {
+    action$0
+}
+"#####,
+        r#####"
+enum Action { Move { distance: u32 }, Stop }
+
+fn handle(action: Action) {
+    match action {
+        Action::Move { distance } => ${1:{}}
+        Action::Stop => ${2:{}}$0
+    }
+}
+"#####,
+    )
+}
+
+#[test]
+fn doctest_destructure_enum_1() {
+    check_doc_test(
+        "destructure_enum",
+        r#####"
+//- minicore: option
+fn handle(i: Option<i32>) {
+    i$0
+}
+"#####,
+        r#####"
+fn handle(i: Option<i32>) {
+    match i {
+        Some(_) => ${1:{}}
+        None => ${2:{}}$0
+    }
+}
+"#####,
+    )
+}
+
+#[test]
 fn doctest_destructure_struct_binding() {
     check_doc_test(
         "destructure_struct_binding",


### PR DESCRIPTION
r-a already has the ability to fill in match arms as part of the add_missing_match_arms assist. However, there's currently no way to go from `flavor` to `match flavor { Apple => {} ... }`.

If a user does want the IDE to fill in match arms, they have to write the `match` and `{}` themselves. Other language LSPs supporting pattern matching (e.g. merlin for OCaml) support writing the whole match statement.

Whilst I'm aware there's a freeze on new assists, this assist is just a generalisation of add_missing_match_arms and reuses the existing logic there (which has great test coverage). I think it's a really compelling feature and hopefully a small ask.

AI disclosure: Written with a little bit of help from Claude in a few places.