### PR TITLE
Fix false positive precedence in `(2 as i32) < 3`

### DIFF
--- a/crates/ide-assists/src/handlers/remove_parentheses.rs
+++ b/crates/ide-assists/src/handlers/remove_parentheses.rs
@@ -322,6 +322,12 @@ mod tests {
     }
 
     #[test]
+    fn remove_parens_conflict_cast_before_l_angle() {
+        check_assist_not_applicable(remove_parentheses, r#"fn f() { _ = $0(1 as u32) << 10; }"#);
+        check_assist_not_applicable(remove_parentheses, r#"fn f() { _ = $0(1 as u32) < 10; }"#);
+    }
+
+    #[test]
     fn remove_parens_double_paren_stmt() {
         check_assist(
             remove_parentheses,


### PR DESCRIPTION
Fixes rust-lang/rust-analyzer#21461

Example
---
```rust
fn f() { _ = $0(1 as u32) << 10; }
```

**Before this PR**

This is syntax error

```rust
fn f() { _ = 1 as u32 << 10; }
```

**After this PR**

Assist not applicable
