### PR TITLE
fix: lookup flycheck by ID instead of vector index

### DIFF
--- a/crates/rust-analyzer/src/handlers/notification.rs
+++ b/crates/rust-analyzer/src/handlers/notification.rs
@@ -387,14 +387,21 @@ fn run_flycheck(state: &mut GlobalState, vfs_path: VfsPath) -> bool {
                                         } => false,
                                     });
                                 if let Some(idx) = package_workspace_idx {
-                                    let workspace_deps =
-                                        world.all_workspace_dependencies_for_package(&package);
-                                    world.flycheck[idx].restart_for_package(
-                                        package,
-                                        target,
-                                        workspace_deps,
-                                        saved_file.clone(),
-                                    );
+                                    // flycheck handles are indexed by their ID (which is the workspace index),
+                                    // but not all workspaces have flycheck enabled (e.g., JSON projects without
+                                    // a flycheck template). Find the flycheck handle by its ID.
+                                    if let Some(flycheck) =
+                                        world.flycheck.iter().find(|fc| fc.id() == idx)
+                                    {
+                                        let workspace_deps =
+                                            world.all_workspace_dependencies_for_package(&package);
+                                        flycheck.restart_for_package(
+                                            package,
+                                            target,
+                                            workspace_deps,
+                                            saved_file.clone(),
+                                        );
+                                    }
                                 }
                             }
                         }


### PR DESCRIPTION
After rust-lang/rust-analyzer#18043 introduced per-package flycheck for JSON projects, the code assumed that `world.flycheck` indices matched `world.workspaces` indices. However, not all workspaces have flycheck enabled (e.g., JSON projects without a flycheck template configured), so the flycheck vector can be shorter than the workspaces vector.

This caused an index-out-of-bounds panic when saving a file in a JSON project without flycheck configured:

  thread 'Worker' panicked at notification.rs:
  index out of bounds: the len is 0 but the index is 0

Fix by looking up the flycheck handle by its ID (which is the workspace index set during spawn) rather than using the workspace index directly as a vector index.