### PR TITLE
feat(hir-ty): add method references_only_ty_error to detect type errors

### DIFF
--- a/crates/hir-ty/src/method_resolution/probe.rs
+++ b/crates/hir-ty/src/method_resolution/probe.rs
@@ -1246,9 +1246,9 @@ impl<'a, 'db, Choice: ProbeChoice<'db>> ProbeContext<'a, 'db, Choice> {
             .filter(|step| step.reachable_via_deref)
             .filter(|step| {
                 debug!("pick_all_method: step={:?}", step);
-                // skip types that are from a type error or that would require dereferencing
-                // a raw pointer
-                !step.self_ty.value.value.references_non_lt_error() && !step.from_unsafe_deref
+                // Skip types with type errors (but not const/lifetime errors, which are
+                // often spurious due to incomplete const evaluation) and raw pointer derefs.
+                !step.self_ty.value.value.references_only_ty_error() && !step.from_unsafe_deref
             })
             .try_for_each(|step| {
                 let InferOk { value: self_ty, obligations: instantiate_self_ty_obligations } = self


### PR DESCRIPTION

Add a new method `references_only_ty_error` to the `Ty` implementation to determine if a type contains only type errors, ignoring const and lifetime errors. Enhance test suite for const generic method resolution.

Fixes: https://github.com/rust-lang/rust-analyzer/issues/21315
 
Before
```
(base) ➜  rust-analyzer git:(master) ✗ cargo test -r -p hir-ty -- regression_21315
   Compiling hir-ty v0.0.0 (/root/ys/rust-analyzer/crates/hir-ty)
    Finished `release` profile [optimized] target(s) in 52.49s
     Running unittests src/lib.rs (target/release/deps/hir_ty-7b27e9f23d18774a)

running 1 test
test tests::regression::new_solver::regression_21315_const_generic_method_resolution ... FAILED

failures:

---- tests::regression::new_solver::regression_21315_const_generic_method_resolution stdout ----


error: expect test failed
   --> crates/hir-ty/src/tests/regression/new_solver.rs:515:9

You can update all `expect!` tests by running:

    env UPDATE_EXPECT=1 cargo test

To update a single test, place the cursor on `expect` token and use `run` feature of rust-analyzer.

Expect:
----
127..131 'self': Between<M, _, T>
133..137 '_sep': &'? str
145..151 '_other': Between<M, _, T>
167..187 '{     ...     }': Between<M, _, T>
177..181 'self': Between<M, _, T>
245..249 'self': Self
287..316 '{     ...     }': Between<M, _, Self>
297..304 'Between': fn Between<M, _, Self>(Self) -> Between<M, _, Self>
297..310 'Between(self)': Between<M, _, Self>
305..309 'self': Self
348..352 'self': Self
377..406 '{     ...     }': Between<0, N, Self>
387..394 'Between': fn Between<0, N, Self>(Self) -> Between<0, N, Self>
387..400 'Between(self)': Between<0, N, Self>
395..399 'self': Self
454..531 '{     ...um); }': ()
464..467 'num': Between<1, _, char>
470..473 ''9'': char
470..489 ''9'.at...:<1>()': Between<1, _, char>
499..503 '_ver': Between<1, _, char>
506..509 'num': Between<1, _, char>
506..528 'num.se..., num)': Between<1, _, char>
519..522 '"."': &'static str
524..527 'num': Between<1, _, char>
551..588 '{     ...>(); }': ()
561..564 'num': Between<0, 1, char>
567..570 ''9'': char
567..585 ''9'.at...:<1>()': Between<0, 1, char>

----

Actual:
----
127..131 'self': Between<M, _, T>
133..137 '_sep': &'? str
145..151 '_other': Between<M, _, T>
167..187 '{     ...     }': Between<M, _, T>
177..181 'self': Between<M, _, T>
245..249 'self': Self
287..316 '{     ...     }': Between<M, _, Self>
297..304 'Between': fn Between<M, _, Self>(Self) -> Between<M, _, Self>
297..310 'Between(self)': Between<M, _, Self>
305..309 'self': Self
348..352 'self': Self
377..406 '{     ...     }': Between<0, N, Self>
387..394 'Between': fn Between<0, N, Self>(Self) -> Between<0, N, Self>
387..400 'Between(self)': Between<0, N, Self>
395..399 'self': Self
454..531 '{     ...um); }': ()
464..467 'num': Between<1, _, char>
470..473 ''9'': char
470..489 ''9'.at...:<1>()': Between<1, _, char>
499..503 '_ver': {unknown}
506..509 'num': Between<1, _, char>
506..528 'num.se..., num)': {unknown}
519..522 '"."': &'static str
524..527 'num': Between<1, _, char>
551..588 '{     ...>(); }': ()
561..564 'num': Between<0, 1, char>
567..570 ''9'': char
567..585 ''9'.at...:<1>()': Between<0, 1, char>

----

Diff:
----
127..131 'self': Between<M, _, T>
133..137 '_sep': &'? str
145..151 '_other': Between<M, _, T>
167..187 '{     ...     }': Between<M, _, T>
177..181 'self': Between<M, _, T>
245..249 'self': Self
287..316 '{     ...     }': Between<M, _, Self>
297..304 'Between': fn Between<M, _, Self>(Self) -> Between<M, _, Self>
297..310 'Between(self)': Between<M, _, Self>
305..309 'self': Self
348..352 'self': Self
377..406 '{     ...     }': Between<0, N, Self>
387..394 'Between': fn Between<0, N, Self>(Self) -> Between<0, N, Self>
387..400 'Between(self)': Between<0, N, Self>
395..399 'self': Self
454..531 '{     ...um); }': ()
464..467 'num': Between<1, _, char>
470..473 ''9'': char
470..489 ''9'.at...:<1>()': Between<1, _, char>
499..503 '_ver': Between<1, _, char>{unknown}
506..509 'num': Between<1, _, char>
506..528 'num.se..., num)': Between<1, _, char>{unknown}
519..522 '"."': &'static str
524..527 'num': Between<1, _, char>
551..588 '{     ...>(); }': ()
561..564 'num': Between<0, 1, char>
567..570 ''9'': char
567..585 ''9'.at...:<1>()': Between<0, 1, char>

----



failures:
    tests::regression::new_solver::regression_21315_const_generic_method_resolution

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 945 filtered out; finished in 0.01s
```

After
````
(base) ➜  rust-analyzer git:(master) cargo test -r -p hir-ty -- regression_21315
   Compiling hir-ty v0.0.0 (/root/ys/rust-analyzer/crates/hir-ty)
    Finished `release` profile [optimized] target(s) in 52.65s
     Running unittests src/lib.rs (target/release/deps/hir_ty-7b27e9f23d18774a)

running 1 test
test tests::regression::new_solver::regression_21315_const_generic_method_resolution ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 945 filtered out; finished in 0.01s

```