### PR TITLE
Bump notify from 8.0.0. to 8.2.0

### DIFF
--- a/crates/vfs-notify/Cargo.toml
+++ b/crates/vfs-notify/Cargo.toml
@@ -16,7 +16,7 @@ doctest = false
 tracing.workspace = true
 walkdir = "2.5.0"
 crossbeam-channel.workspace = true
-notify = "8.0.0"
+notify = "8.2.0"
 rayon = "1.10.0"
 
 stdx.workspace = true


### PR DESCRIPTION
 Bump the `notify` dependency for `vfs-notify` from `8.0.0` to `8.2.0`.
 Notice that the lock file already points to the resolved `8.2.0` version.