### PR TITLE
Bump perf-event from 0.4.7. to 0.4.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1731,9 +1731,9 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perf-event"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5396562cd2eaa828445d6d34258ae21ee1eb9d40fe626ca7f51c8dccb4af9d66"
+checksum = "b4d6393d9238342159080d79b78cb59c67399a8e7ecfa5d410bd614169e4e823"
 dependencies = [
  "libc",
  "perf-event-open-sys",
@@ -1741,9 +1741,9 @@ dependencies = [
 
 [[package]]
 name = "perf-event-open-sys"
-version = "1.0.1"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce9bedf5da2c234fdf2391ede2b90fabf585355f33100689bc364a3ea558561a"
+checksum = "7c44fb1c7651a45a3652c4afc6e754e40b3d6e6556f1487e2b230bfc4f33c2a8"
 dependencies = [
  "libc",
 ]

--- a/crates/profile/Cargo.toml
+++ b/crates/profile/Cargo.toml
@@ -16,8 +16,8 @@ doctest = false
 cfg-if = "1.0.1"
 jemalloc-ctl = { version = "0.5.4", package = "tikv-jemalloc-ctl", optional = true }
 
-[target.'cfg(all(target_os = "linux", not(target_env = "ohos")))'.dependencies]
-perf-event = "=0.4.7"
+[target.'cfg(all(target_os = "linux", not(target_env = "ohos"), any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64")))'.dependencies]
+perf-event = "=0.4.8"
 
 [target.'cfg(all(target_os = "linux", target_env = "gnu"))'.dependencies]
 libc.workspace = true

--- a/crates/profile/src/stop_watch.rs
+++ b/crates/profile/src/stop_watch.rs
@@ -11,7 +11,11 @@ use crate::MemoryUsage;
 
 pub struct StopWatch {
     time: Instant,
-    #[cfg(all(target_os = "linux", not(target_env = "ohos")))]
+    #[cfg(all(
+        target_os = "linux",
+        not(target_env = "ohos"),
+        any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64")
+    ))]
     counter: Option<perf_event::Counter>,
     memory: MemoryUsage,
 }
@@ -24,7 +28,11 @@ pub struct StopWatchSpan {
 
 impl StopWatch {
     pub fn start() -> StopWatch {
-        #[cfg(all(target_os = "linux", not(target_env = "ohos")))]
+        #[cfg(all(
+            target_os = "linux",
+            not(target_env = "ohos"),
+            any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64")
+        ))]
         let counter = {
             // When debugging rust-analyzer using rr, the perf-related syscalls cause it to abort.
             // We allow disabling perf by setting the env var `RA_DISABLE_PERF`.
@@ -51,7 +59,11 @@ impl StopWatch {
         let time = Instant::now();
         StopWatch {
             time,
-            #[cfg(all(target_os = "linux", not(target_env = "ohos")))]
+            #[cfg(all(
+                target_os = "linux",
+                not(target_env = "ohos"),
+                any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64")
+            ))]
             counter,
             memory,
         }
@@ -60,13 +72,19 @@ impl StopWatch {
     pub fn elapsed(&mut self) -> StopWatchSpan {
         let time = self.time.elapsed();
 
-        #[cfg(all(target_os = "linux", not(target_env = "ohos")))]
+        #[cfg(all(
+            target_os = "linux",
+            not(target_env = "ohos"),
+            any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64")
+        ))]
         let instructions = self.counter.as_mut().and_then(|it| {
             it.read().map_err(|err| eprintln!("Failed to read perf counter: {err}")).ok()
         });
-        #[cfg(all(target_os = "linux", target_env = "ohos"))]
-        let instructions = None;
-        #[cfg(not(target_os = "linux"))]
+        #[cfg(not(all(
+            target_os = "linux",
+            not(target_env = "ohos"),
+            any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64")
+        )))]
         let instructions = None;
 
         let memory = MemoryUsage::now() - self.memory;


### PR DESCRIPTION
The dependency is only used as part of the `profile` functionality. Bump it to the latest available version.

The build was failing after the bump for certain architectures. These seems due to the false sense of cross-platform support in the previous version of the `perf-event-open-sys` dependency. The new version refuses to compile on unsupported platforms, where the perf structs would be incorrect. Therefore I am also restricting compilation to the supported architectures.