### PR TITLE
Support else-branch for move_guard

### DIFF
--- a/crates/ide-assists/src/handlers/move_guard.rs
+++ b/crates/ide-assists/src/handlers/move_guard.rs
@@ -440,6 +440,32 @@ fn main() {
             r#"
 fn main() {
     match 92 {
+        x @ 0..30 if x % 3 == 0 => false,
+        x @ 0..30 $0if x % 2 == 0$0 => true,
+        x @ 0..30 => false,
+        _ => true
+    }
+}
+"#,
+            r#"
+fn main() {
+    match 92 {
+        x @ 0..30 if x % 3 == 0 => false,
+        x @ 0..30 => if x % 2 == 0 {
+            true
+        },
+        x @ 0..30 => false,
+        _ => true
+    }
+}
+"#,
+        );
+
+        check_assist(
+            move_guard_to_arm_body,
+            r#"
+fn main() {
+    match 92 {
         x @ 0..30 $0if x % 3 == 0 => false,
         x @ 0..30 $0if x % 2 == 0 => true,
         x @ 0..30 => false,


### PR DESCRIPTION
Example
---
```rust
fn main() {
    match 92 {
        x @ 0..30 $0if x % 3 == 0 => false,
        x @ 0..30 if x % 2 == 0 => true,
        _ => false
    }
}
```

**Before this PR**

```rust
fn main() {
    match 92 {
        x @ 0..30 => if x % 3 == 0 {
            false
        },
        x @ 0..30 if x % 2 == 0 => true,
        _ => false
    }
}
```

**After this PR**

```rust
fn main() {
    match 92 {
        x @ 0..30 => if x % 3 == 0 {
            false
        } else if x % 2 == 0 {
            true
        },
        _ => false
    }
}
```
