### PR TITLE
Improve extract_function name

### DIFF
--- a/crates/ide-assists/src/handlers/extract_function.rs
+++ b/crates/ide-assists/src/handlers/extract_function.rs
@@ -257,7 +257,7 @@ fn make_function_name(
 
     let mut name = body
         .suggest_name()
-        .filter(|name| name.contains('_'))
+        .filter(|name| name.len() > 2)
         .unwrap_or_else(|| default_name.to_owned());
     let mut counter = 0;
     while names_in_scope.contains(&name) {


### PR DESCRIPTION
If the name contains `_`, it is likely to be descriptive

Example
---
```rust
fn foo(kind: i32) {
    let is_complex = $0kind != 0$0;
}
```

**Before this PR**

```rust
fn foo(kind: i32) {
    let is_complex = fun_name(kind);
}

fn fun_name(kind: i32) -> bool {
    kind != 0
}
```

**After this PR**

```rust
fn foo(kind: i32) {
    let is_complex = is_complex(kind);
}

fn is_complex(kind: i32) -> bool {
    kind != 0
}
```
