### PR TITLE
internal: Use parser expect where possible

### DIFF
--- a/crates/parser/src/grammar/attributes.rs
+++ b/crates/parser/src/grammar/attributes.rs
@@ -24,15 +24,11 @@ fn attr(p: &mut Parser<'_>, inner: bool) {
         p.bump(T![!]);
     }
 
-    if p.eat(T!['[']) {
+    if p.expect(T!['[']) {
         meta(p);
-
-        if !p.eat(T![']']) {
-            p.error("expected `]`");
-        }
-    } else {
-        p.error("expected `[`");
+        p.expect(T![']']);
     }
+
     attr.complete(p, ATTR);
 }
 

--- a/crates/parser/test_data/parser/err/0002_duplicate_shebang.rast
+++ b/crates/parser/test_data/parser/err/0002_duplicate_shebang.rast
@@ -28,7 +28,7 @@ SOURCE_FILE
         NAME_REF
           IDENT "rusti"
   WHITESPACE "\n"
-error 23: expected `[`
+error 23: expected L_BRACK
 error 23: expected an item
 error 27: expected one of `*`, `::`, `{`, `self`, `super` or an identifier
 error 28: expected SEMICOLON

--- a/crates/parser/test_data/parser/err/0005_attribute_recover.rast
+++ b/crates/parser/test_data/parser/err/0005_attribute_recover.rast
@@ -58,5 +58,5 @@ SOURCE_FILE
           R_CURLY "}"
   WHITESPACE "\n"
 error 53: expected R_PAREN
-error 53: expected `]`
+error 53: expected R_BRACK
 error 53: expected an item

--- a/crates/parser/test_data/parser/err/0032_match_arms_inner_attrs.rast
+++ b/crates/parser/test_data/parser/err/0032_match_arms_inner_attrs.rast
@@ -192,14 +192,14 @@ SOURCE_FILE
         WHITESPACE "\n"
         R_CURLY "}"
   WHITESPACE "\n"
-error 52: expected `[`
+error 52: expected L_BRACK
 error 52: expected pattern
 error 53: expected FAT_ARROW
 error 78: expected `,`
-error 161: expected `[`
+error 161: expected L_BRACK
 error 161: expected pattern
 error 162: expected FAT_ARROW
-error 232: expected `[`
+error 232: expected L_BRACK
 error 232: expected pattern
 error 233: expected FAT_ARROW
 error 250: expected `,`


### PR DESCRIPTION
I had this change lying around from more than a year ago when I sent rust-lang/rust-analyzer#16786. Was cleaning up my local and found it.

We should use `p.expect` instead of manually doing `p.error` after `p.eat`.