### PR TITLE
Delay missing-workspace warning until current-config fetch completes

### DIFF
--- a/crates/hir-ty/src/mir/eval.rs
+++ b/crates/hir-ty/src/mir/eval.rs
@@ -1625,7 +1625,7 @@ impl<'db> Evaluator<'db> {
                     };
                     match target_ty {
                         rustc_type_ir::FloatTy::F32 => Owned((value as f32).to_le_bytes().to_vec()),
-                        rustc_type_ir::FloatTy::F64 => Owned((value as f64).to_le_bytes().to_vec()),
+                        rustc_type_ir::FloatTy::F64 => Owned(value.to_le_bytes().to_vec()),
                         rustc_type_ir::FloatTy::F16 | rustc_type_ir::FloatTy::F128 => {
                             not_supported!("unstable floating point type f16 and f128");
                         }

--- a/crates/rust-analyzer/src/handlers/notification.rs
+++ b/crates/rust-analyzer/src/handlers/notification.rs
@@ -183,6 +183,7 @@ pub(crate) fn handle_did_save_text_document(
                     FetchWorkspaceRequest {
                         path: Some(path.to_owned()),
                         force_crate_graph_reload: false,
+                        config_generation: state.config_generation,
                     },
                 );
             } else if state.detached_files.contains(path) {
@@ -191,6 +192,7 @@ pub(crate) fn handle_did_save_text_document(
                     FetchWorkspaceRequest {
                         path: Some(path.to_owned()),
                         force_crate_graph_reload: false,
+                        config_generation: state.config_generation,
                     },
                 );
             }
@@ -278,7 +280,11 @@ pub(crate) fn handle_did_change_workspace_folders(
     if !config.has_linked_projects() && config.detached_files().is_empty() {
         config.rediscover_workspaces();
 
-        let req = FetchWorkspaceRequest { path: None, force_crate_graph_reload: false };
+        let req = FetchWorkspaceRequest {
+            path: None,
+            force_crate_graph_reload: false,
+            config_generation: state.config_generation,
+        };
         state.fetch_workspaces_queue.request_op("client workspaces changed".to_owned(), req);
     }
 

--- a/crates/rust-analyzer/src/handlers/request.rs
+++ b/crates/rust-analyzer/src/handlers/request.rs
@@ -61,7 +61,11 @@ pub(crate) fn handle_workspace_reload(state: &mut GlobalState, _: ()) -> anyhow:
     state.proc_macro_clients = Arc::from_iter([]);
     state.build_deps_changed = false;
 
-    let req = FetchWorkspaceRequest { path: None, force_crate_graph_reload: false };
+    let req = FetchWorkspaceRequest {
+        path: None,
+        force_crate_graph_reload: false,
+        config_generation: state.config_generation,
+    };
     state.fetch_workspaces_queue.request_op("reload workspace request".to_owned(), req);
     Ok(())
 }

--- a/crates/rust-analyzer/src/main_loop.rs
+++ b/crates/rust-analyzer/src/main_loop.rs
@@ -192,12 +192,18 @@ impl GlobalState {
         if self.config.discover_workspace_config().is_none() {
             self.fetch_workspaces_queue.request_op(
                 "startup".to_owned(),
-                FetchWorkspaceRequest { path: None, force_crate_graph_reload: false },
+                FetchWorkspaceRequest {
+                    path: None,
+                    force_crate_graph_reload: false,
+                    config_generation: self.config_generation,
+                },
             );
-            if let Some((cause, FetchWorkspaceRequest { path, force_crate_graph_reload })) =
-                self.fetch_workspaces_queue.should_start_op()
+            if let Some((
+                cause,
+                FetchWorkspaceRequest { path, force_crate_graph_reload, config_generation },
+            )) = self.fetch_workspaces_queue.should_start_op()
             {
-                self.fetch_workspaces(cause, path, force_crate_graph_reload);
+                self.fetch_workspaces(cause, path, force_crate_graph_reload, config_generation);
             }
         }
 
@@ -564,10 +570,12 @@ impl GlobalState {
 
         if (self.config.cargo_autoreload_config(None)
             || self.config.discover_workspace_config().is_some())
-            && let Some((cause, FetchWorkspaceRequest { path, force_crate_graph_reload })) =
-                self.fetch_workspaces_queue.should_start_op()
+            && let Some((
+                cause,
+                FetchWorkspaceRequest { path, force_crate_graph_reload, config_generation },
+            )) = self.fetch_workspaces_queue.should_start_op()
         {
-            self.fetch_workspaces(cause, path, force_crate_graph_reload);
+            self.fetch_workspaces(cause, path, force_crate_graph_reload, config_generation);
         }
 
         if !self.fetch_workspaces_queue.op_in_progress() {
@@ -809,9 +817,14 @@ impl GlobalState {
                 let (state, msg) = match progress {
                     ProjectWorkspaceProgress::Begin => (Progress::Begin, None),
                     ProjectWorkspaceProgress::Report(msg) => (Progress::Report, Some(msg)),
-                    ProjectWorkspaceProgress::End(workspaces, force_crate_graph_reload) => {
+                    ProjectWorkspaceProgress::End(
+                        workspaces,
+                        force_crate_graph_reload,
+                        config_generation,
+                    ) => {
                         let resp = FetchWorkspaceResponse { workspaces, force_crate_graph_reload };
                         self.fetch_workspaces_queue.op_completed(resp);
+                        self.last_workspace_fetch_generation = Some(config_generation);
                         if let Err(e) = self.fetch_workspace_error() {
                             error!("FetchWorkspaceError: {e}");
                         }

--- a/crates/rust-analyzer/src/reload.rs
+++ b/crates/rust-analyzer/src/reload.rs
@@ -975,19 +975,6 @@ impl GlobalState {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::should_warn_missing_workspace;
-
-    #[test]
-    fn missing_workspace_warning_is_gated_by_fetch_completion() {
-        assert!(!should_warn_missing_workspace(false, false, false));
-        assert!(should_warn_missing_workspace(false, false, true));
-        assert!(!should_warn_missing_workspace(true, false, true));
-        assert!(!should_warn_missing_workspace(false, true, true));
-    }
-}
-
 // FIXME: Move this into load-cargo?
 pub fn ws_to_crate_graph(
     workspaces: &[ProjectWorkspace],
@@ -1075,4 +1062,17 @@ fn eq_ignore_underscore(s1: &str, s2: &str) -> bool {
 
         c1 == c2 || (c1_underscore && c2_underscore)
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::should_warn_missing_workspace;
+
+    #[test]
+    fn missing_workspace_warning_is_gated_by_fetch_completion() {
+        assert!(!should_warn_missing_workspace(false, false, false));
+        assert!(should_warn_missing_workspace(false, false, true));
+        assert!(!should_warn_missing_workspace(true, false, true));
+        assert!(!should_warn_missing_workspace(false, true, true));
+    }
 }


### PR DESCRIPTION
Startup could emit “Failed to discover workspace…” before `linkedProjects` from `workspace/didChangeConfiguration` was applied, even when a later fetch succeeded.
Root cause: the initial fetch ran ahead of the config-driven reload, yielding a transient empty workspace and a misleading warning.
Track a lightweight config generation and gate the warning so it only fires after a fetch completes for the current configuration.
Added config_generation and last_workspace_fetch_generation, threaded generation through fetch requests, and recorded completion.
Warning emission is now gated on fetch completion for the current config; fetch flow unchanged.
Fixes rust-lang/rust-analyzer#19567.

Tests:
- Unit: missing_workspace_warning_is_gated_by_fetch_completion
- Slow: cargo test -p rust-analyzer --test slow-tests