### PR TITLE
fix: Fix macro matching of `meta` then `=>` or `==`

### DIFF
--- a/crates/hir-def/src/macro_expansion_tests/mbe/matching.rs
+++ b/crates/hir-def/src/macro_expansion_tests/mbe/matching.rs
@@ -237,3 +237,23 @@ fn test() {
 "#]],
     );
 }
+
+#[test]
+fn meta_fat_arrow() {
+    check(
+        r#"
+macro_rules! m {
+    ( $m:meta => ) => {};
+}
+
+m! { foo => }
+    "#,
+        expect![[r#"
+macro_rules! m {
+    ( $m:meta => ) => {};
+}
+
+
+    "#]],
+    );
+}

--- a/crates/parser/src/grammar/attributes.rs
+++ b/crates/parser/src/grammar/attributes.rs
@@ -70,7 +70,7 @@ pub(super) fn meta(p: &mut Parser<'_>) {
     paths::attr_path(p);
 
     match p.current() {
-        T![=] => {
+        T![=] if !p.at(T![=>]) && !p.at(T![==]) => {
             p.bump(T![=]);
             if expressions::expr(p).is_none() {
                 p.error("expected expression");


### PR DESCRIPTION
The parser declared it was invalid meta because it consumed the lone `=`, which is incorrect.

 Fixes rust-lang/rust-analyzer#21525.