### PR TITLE
fix: Handle `Self::EnumVariant` and `Self` on traits in doclinks

### DIFF
--- a/crates/ide/src/hover/tests.rs
+++ b/crates/ide/src/hover/tests.rs
@@ -11239,3 +11239,75 @@ impl<T> Foo<i32, u64> for T {
         "#]],
     );
 }
+
+#[test]
+fn doc_link_enum_self_variant() {
+    check(
+        r#"
+/// - [`VariantOne$0`](Self::One)
+pub enum MyEnum {
+    One,
+    Two,
+}
+    "#,
+        expect![[r#"
+            *[`VariantOne`](Self::One)*
+
+            ```rust
+            ra_test_fixture::MyEnum
+            ```
+
+            ```rust
+            One = 0
+            ```
+        "#]],
+    );
+}
+
+#[test]
+fn doc_link_trait_self() {
+    check(
+        r#"
+/// - [`do_something$0`](Self::do_something)
+pub trait MyTrait {
+    fn do_something(&self);
+}
+    "#,
+        expect![[r#"
+            *[`do_something`](Self::do_something)*
+
+            ```rust
+            ra_test_fixture::MyTrait
+            ```
+
+            ```rust
+            pub trait MyTrait
+            pub fn do_something(&self)
+            ```
+        "#]],
+    );
+    check(
+        r#"
+pub trait MyTrait {
+    /// - [`do_something$0`](Self::do_something)
+    fn do_something(&self);
+}
+    "#,
+        expect![[r#"
+            *[`do_something`](Self::do_something)*
+
+            ```rust
+            ra_test_fixture::MyTrait
+            ```
+
+            ```rust
+            pub trait MyTrait
+            pub fn do_something(&self)
+            ```
+
+            ---
+
+            * [`do_something`](https://docs.rs/ra_test_fixture/*/ra_test_fixture/trait.MyTrait.html#tymethod.do_something)
+        "#]],
+    );
+}


### PR DESCRIPTION
Fixes rust-lang/rust-analyzer#21515.