### PR TITLE
fix: Fix a panic where an opaque was constrained to an impossible type in method autoderef

### DIFF
--- a/crates/hir-ty/src/method_resolution/probe.rs
+++ b/crates/hir-ty/src/method_resolution/probe.rs
@@ -285,11 +285,15 @@ impl<'a, 'db> MethodResolutionContext<'a, 'db> {
                 let infcx = self.infcx;
                 let (self_ty, var_values) = infcx.instantiate_canonical(&query_input);
                 debug!(?self_ty, ?query_input, "probe_op: Mode::Path");
+                let prev_opaque_entries =
+                    self.infcx.inner.borrow_mut().opaque_types().num_entries();
                 MethodAutoderefStepsResult {
                     steps: smallvec![CandidateStep {
-                        self_ty: self
-                            .infcx
-                            .make_query_response_ignoring_pending_obligations(var_values, self_ty),
+                        self_ty: self.infcx.make_query_response_ignoring_pending_obligations(
+                            var_values,
+                            self_ty,
+                            prev_opaque_entries
+                        ),
                         self_ty_is_opaque: false,
                         autoderefs: 0,
                         from_unsafe_deref: false,
@@ -376,6 +380,8 @@ impl<'a, 'db> MethodResolutionContext<'a, 'db> {
             // infer var is not an opaque.
             let infcx = self.infcx;
             let (self_ty, inference_vars) = infcx.instantiate_canonical(self_ty);
+            let prev_opaque_entries = infcx.inner.borrow_mut().opaque_types().num_entries();
+
             let self_ty_is_opaque = |ty: Ty<'_>| {
                 if let TyKind::Infer(InferTy::TyVar(vid)) = ty.kind() {
                     infcx.has_opaques_with_sub_unified_hidden_type(vid)
@@ -414,6 +420,7 @@ impl<'a, 'db> MethodResolutionContext<'a, 'db> {
                             self_ty: infcx.make_query_response_ignoring_pending_obligations(
                                 inference_vars,
                                 ty,
+                                prev_opaque_entries,
                             ),
                             self_ty_is_opaque: self_ty_is_opaque(ty),
                             autoderefs: d,
@@ -437,6 +444,7 @@ impl<'a, 'db> MethodResolutionContext<'a, 'db> {
                             self_ty: infcx.make_query_response_ignoring_pending_obligations(
                                 inference_vars,
                                 ty,
+                                prev_opaque_entries,
                             ),
                             self_ty_is_opaque: self_ty_is_opaque(ty),
                             autoderefs: d,
@@ -461,13 +469,17 @@ impl<'a, 'db> MethodResolutionContext<'a, 'db> {
                         ty: infcx.make_query_response_ignoring_pending_obligations(
                             inference_vars,
                             final_ty,
+                            prev_opaque_entries,
                         ),
                     })
                 }
                 TyKind::Error(_) => Some(MethodAutoderefBadTy {
                     reached_raw_pointer,
-                    ty: infcx
-                        .make_query_response_ignoring_pending_obligations(inference_vars, final_ty),
+                    ty: infcx.make_query_response_ignoring_pending_obligations(
+                        inference_vars,
+                        final_ty,
+                        prev_opaque_entries,
+                    ),
                 }),
                 TyKind::Array(elem_ty, _) => {
                     let autoderefs = steps.iter().filter(|s| s.reachable_via_deref).count() - 1;
@@ -475,6 +487,7 @@ impl<'a, 'db> MethodResolutionContext<'a, 'db> {
                         self_ty: infcx.make_query_response_ignoring_pending_obligations(
                             inference_vars,
                             Ty::new_slice(infcx.interner, elem_ty),
+                            prev_opaque_entries,
                         ),
                         self_ty_is_opaque: false,
                         autoderefs,

--- a/crates/hir-ty/src/next_solver/infer/canonical/instantiate.rs
+++ b/crates/hir-ty/src/next_solver/infer/canonical/instantiate.rs
@@ -15,6 +15,7 @@ use crate::next_solver::{
     infer::{
         InferCtxt, InferOk, InferResult,
         canonical::{QueryRegionConstraints, QueryResponse, canonicalizer::OriginalQueryValues},
+        opaque_types::table::OpaqueTypeStorageEntries,
         traits::{ObligationCause, PredicateObligations},
     },
 };
@@ -194,6 +195,7 @@ impl<'db> InferCtxt<'db> {
         &self,
         inference_vars: CanonicalVarValues<'db>,
         answer: T,
+        prev_entries: OpaqueTypeStorageEntries,
     ) -> Canonical<'db, QueryResponse<'db, T>>
     where
         T: TypeFoldable<DbInterner<'db>>,
@@ -209,7 +211,7 @@ impl<'db> InferCtxt<'db> {
             .inner
             .borrow_mut()
             .opaque_type_storage
-            .iter_opaque_types()
+            .opaque_types_added_since(prev_entries)
             .map(|(k, v)| (k, v.ty))
             .collect();
 


### PR DESCRIPTION
Fixes rust-lang/rust-analyzer#21455.
Fixes rust-lang/rust-analyzer#21217.

Fix imported from https://github.com/rust-lang/rust/pull/151676.