### PR TITLE
fix: offer `toggle_macro_delimiter` in nested macro

### DIFF
--- a/crates/ide-assists/src/handlers/toggle_macro_delimiter.rs
+++ b/crates/ide-assists/src/handlers/toggle_macro_delimiter.rs
@@ -415,7 +415,6 @@ prt!{(3 + 5)}
         )
     }
 
-    // FIXME @alibektas : Inner macro_call is not seen as such. So this doesn't work.
     #[test]
     fn test_nested_macros() {
         check_assist(


### PR DESCRIPTION
Example
---
```rust
prt!{abc!$0(3 + 5)};
```

**Before this PR**

Assist not applicable

**After this PR**

```rust
prt!{abc!{3 + 5}};
```
