### PR TITLE
fix: remove double-nesting of capabilities in minimal_lsp example

### DIFF
--- a/lib/lsp-server/examples/minimal_lsp.rs
+++ b/lib/lsp-server/examples/minimal_lsp.rs
@@ -128,12 +128,7 @@ fn main() -> std::result::Result<(), Box<dyn Error + Sync + Send>> {
         document_formatting_provider: Some(OneOf::Left(true)),
         ..Default::default()
     };
-    let init_value = serde_json::json!({
-        "capabilities": caps,
-        "offsetEncoding": ["utf-8"],
-    });
-
-    let init_params = connection.initialize(init_value)?;
+    let init_params = connection.initialize(serde_json::to_value(caps)?)?;
     main_loop(connection, init_params)?;
     io_thread.join()?;
     log::error!("shutting down server");


### PR DESCRIPTION
## Summary
Fixes the `minimal_lsp.rs` example which was incorrectly double-nesting the `capabilities` property in the `InitializeResult`.

Fixes rust-lang/rust-analyzer#21441

## Problem
The `Connection::initialize()` method already wraps the passed value in `{"capabilities": ...}`, but the example was also wrapping it:

```rust
// Before (incorrect)
let init_value = serde_json::json!({
    "capabilities": caps,  // <-- wrapped here
    "offsetEncoding": ["utf-8"],
});
let init_params = connection.initialize(init_value)?;  // <-- wrapped again
```

This produced invalid LSP output: `{"capabilities": {"capabilities": {...}}}`

## Solution
Pass the `ServerCapabilities` directly to `initialize()`:

```rust
// After (correct)
let init_params = connection.initialize(serde_json::to_value(caps)?)?;
```

## Test plan
- [x] Verified the example compiles successfully
- [ ] Verified the example produces correct LSP InitializeResult

🤖 Generated with [Claude Code](https://claude.ai/code)