### PR TITLE
minor: Remove outdated SyntaxErrorKind FIXME comment

### DIFF
--- a/crates/syntax/src/syntax_error.rs
+++ b/crates/syntax/src/syntax_error.rs
@@ -9,16 +9,6 @@ use crate::{TextRange, TextSize};
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct SyntaxError(String, TextRange);
 
-// FIXME: there was an unused SyntaxErrorKind previously (before this enum was removed)
-// It was introduced in this PR: https://github.com/rust-lang/rust-analyzer/pull/846/files#diff-827da9b03b8f9faa1bade5cdd44d5dafR95
-// but it was not removed by a mistake.
-//
-// So, we need to find a place where to stick validation for attributes in match clauses.
-// Code before refactor:
-// InvalidMatchInnerAttr => {
-//    write!(f, "Inner attributes are only allowed directly after the opening brace of the match expression")
-// }
-
 impl SyntaxError {
     pub fn new(message: impl Into<String>, range: TextRange) -> Self {
         Self(message.into(), range)


### PR DESCRIPTION
Removes a stale FIXME comment that references deleted code.