### PR TITLE
fix: Cover more cases where we need parentheses in `&(impl Trait1 + Trait2)`

### DIFF
--- a/crates/hir-ty/src/tests/coercion.rs
+++ b/crates/hir-ty/src/tests/coercion.rs
@@ -608,7 +608,7 @@ trait Foo {}
 fn test(f: impl Foo, g: &(impl Foo + ?Sized)) {
     let _: &dyn Foo = &f;
     let _: &dyn Foo = g;
-                    //^ expected &'? (dyn Foo + 'static), got &'? impl Foo + ?Sized
+                    //^ expected &'? (dyn Foo + 'static), got &'? (impl Foo + ?Sized)
 }
         "#,
     );

--- a/crates/hir-ty/src/tests/display_source_code.rs
+++ b/crates/hir-ty/src/tests/display_source_code.rs
@@ -111,7 +111,7 @@ fn test(
     b;
   //^ impl Foo
     c;
-  //^ &impl Foo + ?Sized
+  //^ &(impl Foo + ?Sized)
     d;
   //^ S<impl Foo>
     ref_any;
@@ -192,7 +192,7 @@ fn test(
     b;
   //^ fn(impl Foo) -> impl Foo
     c;
-} //^ fn(&impl Foo + ?Sized) -> &impl Foo + ?Sized
+} //^ fn(&(impl Foo + ?Sized)) -> &(impl Foo + ?Sized)
 "#,
     );
 }

--- a/crates/hir-ty/src/tests/traits.rs
+++ b/crates/hir-ty/src/tests/traits.rs
@@ -4819,7 +4819,7 @@ fn allowed3(baz: impl Baz<Assoc = Qux<impl Foo>>) {}
             431..433 '{}': ()
             447..450 'baz': impl Baz<Assoc = impl Foo>
             480..482 '{}': ()
-            500..503 'baz': impl Baz<Assoc = &'a impl Foo + 'a>
+            500..503 'baz': impl Baz<Assoc = &'a (impl Foo + 'a)>
             544..546 '{}': ()
             560..563 'baz': impl Baz<Assoc = Qux<impl Foo>>
             598..600 '{}': ()

--- a/crates/hir/src/display.rs
+++ b/crates/hir/src/display.rs
@@ -587,6 +587,7 @@ impl<'db> HirDisplay<'db> for TypeParam {
                         Either::Left(ty),
                         &predicates,
                         SizedByDefault::Sized { anchor: krate },
+                        false,
                     );
                 }
             },
@@ -614,6 +615,7 @@ impl<'db> HirDisplay<'db> for TypeParam {
                 Either::Left(ty),
                 &predicates,
                 default_sized,
+                false,
             )?;
         }
         Ok(())

--- a/crates/ide/src/inlay_hints/bind_pat.rs
+++ b/crates/ide/src/inlay_hints/bind_pat.rs
@@ -1382,4 +1382,21 @@ fn f<'a>() {
             "#]],
         );
     }
+
+    #[test]
+    fn ref_multi_trait_impl_trait() {
+        check_with_config(
+            InlayHintsConfig { type_hints: true, ..DISABLED_CONFIG },
+            r#"
+//- minicore: sized
+trait Eq {}
+trait Ord {}
+
+fn foo(argument: &(impl Eq + Ord)) {
+    let x = argument;
+     // ^ &(impl Eq + Ord)
+}
+        "#,
+        );
+    }
 }


### PR DESCRIPTION
And refactor the mechanism to be more maintainable.

Fixes rust-lang/rust-analyzer#21567.