### PR TITLE
fix: Infer the expected len in `include_bytes!()`, to avoid mismatches

### DIFF
--- a/crates/hir-expand/src/builtin/fn_macro.rs
+++ b/crates/hir-expand/src/builtin/fn_macro.rs
@@ -830,15 +830,18 @@ fn include_bytes_expand(
     span: Span,
 ) -> ExpandResult<tt::TopSubtree> {
     // FIXME: actually read the file here if the user asked for macro expansion
-    let res = tt::TopSubtree::invisible_from_leaves(
+    let underscore = sym::underscore;
+    let zero = tt::Literal {
+        text_and_suffix: sym::_0_u8,
         span,
-        [tt::Leaf::Literal(tt::Literal {
-            text_and_suffix: Symbol::empty(),
-            span,
-            kind: tt::LitKind::ByteStrRaw(1),
-            suffix_len: 0,
-        })],
-    );
+        kind: tt::LitKind::Integer,
+        suffix_len: 3,
+    };
+    // We don't use a real length since we can't know the file length, so we use an underscore
+    // to infer it.
+    let res = quote! {span =>
+        &[#zero; #underscore]
+    };
     ExpandResult::ok(res)
 }
 

--- a/crates/hir-ty/src/tests/simple.rs
+++ b/crates/hir-ty/src/tests/simple.rs
@@ -4056,3 +4056,13 @@ fn foo() {
         "#]],
     );
 }
+
+#[test]
+fn include_bytes_len_mismatch() {
+    check_no_mismatches(
+        r#"
+//- minicore: include_bytes
+static S: &[u8; 158] = include_bytes!("/foo/bar/baz.txt");
+    "#,
+    );
+}

--- a/crates/intern/src/symbol/symbols.rs
+++ b/crates/intern/src/symbol/symbols.rs
@@ -110,6 +110,7 @@ define_symbols! {
     win64_dash_unwind = "win64-unwind",
     x86_dash_interrupt = "x86-interrupt",
     rust_dash_preserve_dash_none = "preserve-none",
+    _0_u8 = "0_u8",
 
     @PLAIN:
     __ra_fixup,

--- a/crates/test-utils/src/minicore.rs
+++ b/crates/test-utils/src/minicore.rs
@@ -43,6 +43,7 @@
 //!     dispatch_from_dyn: unsize, pin
 //!     hash: sized
 //!     include:
+//!     include_bytes:
 //!     index: sized
 //!     infallible:
 //!     int_impl: size_of, transmute
@@ -2039,6 +2040,14 @@ mod macros {
         ($file:expr $(,)?) => {{ /* compiler built-in */ }};
     }
     // endregion:include
+
+    // region:include_bytes
+    #[rustc_builtin_macro]
+    #[macro_export]
+    macro_rules! include_bytes {
+        ($file:expr $(,)?) => {{ /* compiler built-in */ }};
+    }
+    // endregion:include_bytes
 
     // region:concat
     #[rustc_builtin_macro]


### PR DESCRIPTION
Since we can't read the real file size.

CC https://github.com/rust-lang/rust-analyzer/issues/21552#issuecomment-3834227801.