### PR TITLE
feat: When autoimporting a segment followed by other segments, only consider items that will resolve with the after segments

### DIFF
--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -6064,11 +6064,7 @@ impl<'db> Type<'db> {
 
             match name {
                 Some(name) => {
-                    match ctx.probe_for_name(
-                        method_resolution::Mode::MethodCall,
-                        name.clone(),
-                        self_ty,
-                    ) {
+                    match ctx.probe_for_name(method_resolution::Mode::Path, name.clone(), self_ty) {
                         Ok(candidate)
                         | Err(method_resolution::MethodError::PrivateMatch(candidate)) => {
                             let id = candidate.item.into();

--- a/crates/ide-assists/src/handlers/auto_import.rs
+++ b/crates/ide-assists/src/handlers/auto_import.rs
@@ -351,7 +351,7 @@ mod tests {
         let config = TEST_CONFIG;
         let ctx = AssistContext::new(sema, &config, frange);
         let mut acc = Assists::new(&ctx, AssistResolveStrategy::All);
-        auto_import(&mut acc, &ctx);
+        hir::attach_db(&db, || auto_import(&mut acc, &ctx));
         let assists = acc.finish();
 
         let labels = assists.iter().map(|assist| assist.label.to_string()).collect::<Vec<_>>();
@@ -1895,5 +1895,36 @@ mod m {
 fn foo(_: S) {}
 "#,
         );
+    }
+
+    #[test]
+    fn with_after_segments() {
+        let before = r#"
+mod foo {
+    pub mod wanted {
+        pub fn abc() {}
+    }
+}
+
+mod bar {
+    pub mod wanted {}
+}
+
+mod baz {
+    pub fn wanted() {}
+}
+
+mod quux {
+    pub struct wanted;
+}
+impl quux::wanted {
+    fn abc() {}
+}
+
+fn f() {
+    wanted$0::abc;
+}
+        "#;
+        check_auto_import_order(before, &["Import `foo::wanted`", "Import `quux::wanted`"]);
     }
 }


### PR DESCRIPTION
Closes rust-lang/rust-analyzer#21519.