### PR TITLE
fix: Use `display_source_code()` in `ReferenceConversion`

### DIFF
--- a/crates/ide-assists/src/handlers/generate_function.rs
+++ b/crates/ide-assists/src/handlers/generate_function.rs
@@ -1147,14 +1147,7 @@ fn fn_arg_type(
         if ty.is_reference() || ty.is_mutable_reference() {
             let famous_defs = &FamousDefs(&ctx.sema, ctx.sema.scope(fn_arg.syntax())?.krate());
             convert_reference_type(ty.strip_references(), ctx.db(), famous_defs)
-                .map(|conversion| {
-                    conversion
-                        .convert_type(
-                            ctx.db(),
-                            target_module.krate(ctx.db()).to_display_target(ctx.db()),
-                        )
-                        .to_string()
-                })
+                .map(|conversion| conversion.convert_type(ctx.db(), target_module).to_string())
                 .or_else(|| ty.display_source_code(ctx.db(), target_module.into(), true).ok())
         } else {
             ty.display_source_code(ctx.db(), target_module.into(), true).ok()
@@ -3187,6 +3180,28 @@ fn main() {
             r#"
 fn main() {
     s.self$0();
+}
+        "#,
+        );
+    }
+
+    #[test]
+    fn regression_21288() {
+        check_assist(
+            generate_function,
+            r#"
+//- minicore: copy
+fn foo() {
+    $0bar(&|x| true)
+}
+        "#,
+            r#"
+fn foo() {
+    bar(&|x| true)
+}
+
+fn bar(arg: impl Fn(_) -> bool) {
+    ${0:todo!()}
 }
         "#,
         );

--- a/crates/ide-assists/src/handlers/generate_getter_or_setter.rs
+++ b/crates/ide-assists/src/handlers/generate_getter_or_setter.rs
@@ -226,15 +226,15 @@ fn generate_getter_from_info(
         )
     } else {
         (|| {
-            let krate = ctx.sema.scope(record_field_info.field_ty.syntax())?.krate();
-            let famous_defs = &FamousDefs(&ctx.sema, krate);
+            let module = ctx.sema.scope(record_field_info.field_ty.syntax())?.module();
+            let famous_defs = &FamousDefs(&ctx.sema, module.krate(ctx.db()));
             ctx.sema
                 .resolve_type(&record_field_info.field_ty)
                 .and_then(|ty| convert_reference_type(ty, ctx.db(), famous_defs))
                 .map(|conversion| {
                     cov_mark::hit!(convert_reference_type);
                     (
-                        conversion.convert_type(ctx.db(), krate.to_display_target(ctx.db())),
+                        conversion.convert_type(ctx.db(), module),
                         conversion.getter(record_field_info.field_name.to_string()),
                     )
                 })


### PR DESCRIPTION
The usage of normal `display()` caused it to emit `{unknown}` which then failed to parse in `make::ty()`.

Really we should not use stringly-typed things here, but that's a change for another day.

Fixes rust-lang/rust-analyzer#21288.