### PR TITLE
fix: Truncate display version of commands consistently

### DIFF
--- a/crates/toolchain/src/lib.rs
+++ b/crates/toolchain/src/lib.rs
@@ -74,9 +74,6 @@ impl Tool {
 // Prevent rustup from automatically installing toolchains, see https://github.com/rust-lang/rust-analyzer/issues/20719.
 pub const NO_RUSTUP_AUTO_INSTALL_ENV: (&str, &str) = ("RUSTUP_AUTO_INSTALL", "0");
 
-// These get ignored when displaying what command is running in LSP status messages.
-pub const DISPLAY_COMMAND_IGNORE_ENVS: &[&str] = &[NO_RUSTUP_AUTO_INSTALL_ENV.0];
-
 #[allow(clippy::disallowed_types)] /* generic parameter allows for FxHashMap */
 pub fn command<H>(
     cmd: impl AsRef<OsStr>,


### PR DESCRIPTION
In rust-lang/rust-analyzer#20327 we started truncating custom check commands so they render nicely in the IDE. This was then accidentally undone in 9c18569d0c87d7f643db50b4806b59642762f1c3, and ended up making the command summary longer (it included full paths).

We ended up with a `Display` implementation and a `display_command` function that both tried to solve the same problem. I've merged and simplified the logic and added tests.