### PR TITLE
internal: Run clippy as a separate CI step

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -96,7 +96,7 @@ jobs:
         run: |
           rustup update --no-self-update stable
           rustup default stable
-          rustup component add --toolchain stable rust-src clippy rustfmt
+          rustup component add --toolchain stable rust-src rustfmt
           # We also install a nightly rustfmt, because we use `--file-lines` in
           # a test.
           rustup toolchain install nightly --profile minimal --component rustfmt
@@ -127,10 +127,6 @@ jobs:
 
       - name: Run cargo-machete
         run: cargo machete
-
-      - name: Run Clippy
-        if: matrix.os == 'macos-latest'
-        run: cargo clippy --all-targets -- -D clippy::disallowed_macros -D clippy::dbg_macro -D clippy::todo -D clippy::print_stdout -D clippy::print_stderr
 
   analysis-stats:
     if: github.repository == 'rust-lang/rust-analyzer'
@@ -177,6 +173,28 @@ jobs:
           rustup component add rustfmt
 
       - run: cargo fmt -- --check
+
+  clippy:
+    if: github.repository == 'rust-lang/rust-analyzer'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # Note that clippy output is currently dependent on whether rust-src is installed,
+      # https://github.com/rust-lang/rust-clippy/issues/14625
+      - name: Install Rust toolchain
+        run: |
+          rustup update --no-self-update stable
+          rustup default stable
+          rustup component add --toolchain stable rust-src clippy
+
+      # https://github.com/actions-rust-lang/setup-rust-toolchain/blob/main/rust.json
+      - name: Install Rust Problem Matcher
+        run: echo "::add-matcher::.github/rust.json"
+
+      - run: cargo clippy --all-targets -- -D clippy::disallowed_macros -D clippy::dbg_macro -D clippy::todo -D clippy::print_stdout -D clippy::print_stderr
 
   miri:
     if: github.repository == 'rust-lang/rust-analyzer'
@@ -309,7 +327,7 @@ jobs:
         run: typos
 
   conclusion:
-    needs: [rust, rust-cross, typescript, typo-check, proc-macro-srv, miri, rustfmt, analysis-stats]
+    needs: [rust, rust-cross, typescript, typo-check, proc-macro-srv, miri, rustfmt, clippy, analysis-stats]
     # We need to ensure this job does *not* get skipped if its dependencies fail,
     # because a skipped job is considered a success by GitHub. So we have to
     # overwrite `if:`. We use `!cancelled()` to ensure the job does still not get run

--- a/crates/hir-ty/src/mir/eval.rs
+++ b/crates/hir-ty/src/mir/eval.rs
@@ -1625,7 +1625,7 @@ impl<'db> Evaluator<'db> {
                     };
                     match target_ty {
                         rustc_type_ir::FloatTy::F32 => Owned((value as f32).to_le_bytes().to_vec()),
-                        rustc_type_ir::FloatTy::F64 => Owned((value as f64).to_le_bytes().to_vec()),
+                        rustc_type_ir::FloatTy::F64 => Owned(value.to_le_bytes().to_vec()),
                         rustc_type_ir::FloatTy::F16 | rustc_type_ir::FloatTy::F128 => {
                             not_supported!("unstable floating point type f16 and f128");
                         }


### PR DESCRIPTION
Currently clippy is run in CI as part of the macOS build. This is a little confusing, because clippy failures just show as "Rust (macos-latest)" which make it look like a macOS build failure.

Instead, treat clippy as a separate build step, like miri and rustfmt.

This should also make CI a little faster, because it reduces macOS runner usage (which tend to be slower than Linux on GitHub actions), and it reduces the number of steps where we need to install clippy.