### PR TITLE
Add `expression_types()`, `pattern_types()`, `binding_types()` to `DefWithBody`

### DIFF
--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -2244,6 +2244,39 @@ impl DefWithBody {
             acc.push(diag.into())
         }
     }
+
+    /// Returns an iterator over the inferred types of all expressions in this body.
+    pub fn expression_types<'db>(
+        self,
+        db: &'db dyn HirDatabase,
+    ) -> impl Iterator<Item = Type<'db>> {
+        self.id().into_iter().flat_map(move |def_id| {
+            let infer = InferenceResult::for_body(db, def_id);
+            let resolver = def_id.resolver(db);
+
+            infer.expression_types().map(move |(_, ty)| Type::new_with_resolver(db, &resolver, ty))
+        })
+    }
+
+    /// Returns an iterator over the inferred types of all patterns in this body.
+    pub fn pattern_types<'db>(self, db: &'db dyn HirDatabase) -> impl Iterator<Item = Type<'db>> {
+        self.id().into_iter().flat_map(move |def_id| {
+            let infer = InferenceResult::for_body(db, def_id);
+            let resolver = def_id.resolver(db);
+
+            infer.pattern_types().map(move |(_, ty)| Type::new_with_resolver(db, &resolver, ty))
+        })
+    }
+
+    /// Returns an iterator over the inferred types of all bindings in this body.
+    pub fn binding_types<'db>(self, db: &'db dyn HirDatabase) -> impl Iterator<Item = Type<'db>> {
+        self.id().into_iter().flat_map(move |def_id| {
+            let infer = InferenceResult::for_body(db, def_id);
+            let resolver = def_id.resolver(db);
+
+            infer.binding_types().map(move |(_, ty)| Type::new_with_resolver(db, &resolver, ty))
+        })
+    }
 }
 
 fn expr_store_diagnostics<'db>(


### PR DESCRIPTION
This PR builds upon https://github.com/rust-lang/rust-analyzer/pull/20683, adding corresponding high-level methods, returning `hir::Type<'db>`, as opposed `hir_ty::Ty<'db>`, since the latter are unfortunately sort of unusable from outside of `ra_ap`.

Context: `cargo-modules` has been stuck at `ra_ap` @ 0.0.289 for quite a while now, due to the regression that rust-lang/rust-analyzer#20683 was meant to fix (and due to a lack of time on my part), but that PR turned out to be insufficient, hence this PR with follow-up changes.

cc @ChayimFriedman2, since you reviewed the related PR already.