### PR TITLE
fix: complete `.let` on block tail prefix expression

### DIFF
--- a/crates/ide-completion/src/tests/expression.rs
+++ b/crates/ide-completion/src/tests/expression.rs
@@ -3268,6 +3268,8 @@ fn foo() {
             sn dbg        dbg!(expr)
             sn dbgr      dbg!(&expr)
             sn deref           *expr
+            sn let               let
+            sn letm          let mut
             sn match   match expr {}
             sn ref             &expr
             sn refm        &mut expr


### PR DESCRIPTION
Example
---
```rust
fn main() {
    &baz.l$0
}
```

**Before this PR**

```text
sn if       if expr {}
sn match match expr {}
```

**After this PR**

```text
sn if       if expr {}
sn let             let
sn letm        let mut
sn match match expr {}
```
