### PR TITLE
Revert "feat: Implement fine grained client side request cancellation support"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2453,9 +2453,9 @@ checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "salsa"
-version = "0.26.0"
+version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f77debccd43ba198e9cee23efd7f10330ff445e46a98a2b107fed9094a1ee676"
+checksum = "e2e2aa2fca57727371eeafc975acc8e6f4c52f8166a78035543f6ee1c74c2dcc"
 dependencies = [
  "boxcar",
  "crossbeam-queue",
@@ -2478,15 +2478,15 @@ dependencies = [
 
 [[package]]
 name = "salsa-macro-rules"
-version = "0.26.0"
+version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea07adbf42d91cc076b7daf3b38bc8168c19eb362c665964118a89bc55ef19a5"
+checksum = "1bfc2a1e7bf06964105515451d728f2422dedc3a112383324a00b191a5c397a3"
 
 [[package]]
 name = "salsa-macros"
-version = "0.26.0"
+version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16d4d8b66451b9c75ddf740b7fc8399bc7b8ba33e854a5d7526d18708f67b05"
+checksum = "3d844c1aa34946da46af683b5c27ec1088a3d9d84a2b837a108223fd830220e1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,13 +135,13 @@ rayon = "1.10.0"
 rowan = "=0.15.17"
 # Ideally we'd not enable the macros feature but unfortunately the `tracked` attribute does not work
 # on impls without it
-salsa = { version = "0.26", default-features = false, features = [
+salsa = { version = "0.25.2", default-features = false, features = [
     "rayon",
     "salsa_unstable",
     "macros",
     "inventory",
 ] }
-salsa-macros = "0.26"
+salsa-macros = "0.25.2"
 semver = "1.0.26"
 serde = { version = "1.0.219" }
 serde_derive = { version = "1.0.219" }

--- a/crates/base-db/src/editioned_file_id.rs
+++ b/crates/base-db/src/editioned_file_id.rs
@@ -60,7 +60,7 @@ const _: () = {
         }
     }
 
-    impl zalsa_::HashEqLike<WithoutCrate> for EditionedFileIdData {
+    impl zalsa_struct_::HashEqLike<WithoutCrate> for EditionedFileIdData {
         #[inline]
         fn hash<H: Hasher>(&self, state: &mut H) {
             Hash::hash(self, state);

--- a/crates/hir-ty/src/tests/regression.rs
+++ b/crates/hir-ty/src/tests/regression.rs
@@ -2363,7 +2363,6 @@ fn test() {
 }
 "#,
         expect![[r#"
-            46..49 'Foo': Foo<N>
             93..97 'self': Foo<N>
             108..125 '{     ...     }': usize
             118..119 'N': usize

--- a/crates/ide/src/lib.rs
+++ b/crates/ide/src/lib.rs
@@ -67,7 +67,7 @@ use ide_db::{
     FxHashMap, FxIndexSet, LineIndexDatabase,
     base_db::{
         CrateOrigin, CrateWorkspaceData, Env, FileSet, RootQueryDb, SourceDatabase, VfsPath,
-        salsa::{CancellationToken, Cancelled, Database},
+        salsa::{Cancelled, Database},
     },
     prime_caches, symbol_index,
 };
@@ -946,10 +946,6 @@ impl Analysis {
     {
         // We use `attach_db_allow_change()` and not `attach_db()` because fixture injection can change the database.
         hir::attach_db_allow_change(&self.db, || Cancelled::catch(|| f(&self.db)))
-    }
-
-    pub fn cancellation_token(&self) -> CancellationToken {
-        self.db.cancellation_token()
     }
 }
 

--- a/crates/rust-analyzer/src/global_state.rs
+++ b/crates/rust-analyzer/src/global_state.rs
@@ -14,7 +14,7 @@ use hir::ChangeWithProcMacros;
 use ide::{Analysis, AnalysisHost, Cancellable, FileId, SourceRootId};
 use ide_db::{
     MiniCore,
-    base_db::{Crate, ProcMacroPaths, SourceDatabase, salsa::CancellationToken, salsa::Revision},
+    base_db::{Crate, ProcMacroPaths, SourceDatabase, salsa::Revision},
 };
 use itertools::Itertools;
 use load_cargo::SourceRootConfig;
@@ -88,7 +88,6 @@ pub(crate) struct GlobalState {
     pub(crate) task_pool: Handle<TaskPool<Task>, Receiver<Task>>,
     pub(crate) fmt_pool: Handle<TaskPool<Task>, Receiver<Task>>,
     pub(crate) cancellation_pool: thread::Pool,
-    pub(crate) cancellation_tokens: FxHashMap<lsp_server::RequestId, CancellationToken>,
 
     pub(crate) config: Arc<Config>,
     pub(crate) config_errors: Option<ConfigErrors>,
@@ -266,7 +265,6 @@ impl GlobalState {
             task_pool,
             fmt_pool,
             cancellation_pool,
-            cancellation_tokens: Default::default(),
             loader,
             config: Arc::new(config.clone()),
             analysis_host,
@@ -619,7 +617,6 @@ impl GlobalState {
     }
 
     pub(crate) fn respond(&mut self, response: lsp_server::Response) {
-        self.cancellation_tokens.remove(&response.id);
         if let Some((method, start)) = self.req_queue.incoming.complete(&response.id) {
             if let Some(err) = &response.error
                 && err.message.starts_with("server panicked")
@@ -634,9 +631,6 @@ impl GlobalState {
     }
 
     pub(crate) fn cancel(&mut self, request_id: lsp_server::RequestId) {
-        if let Some(token) = self.cancellation_tokens.remove(&request_id) {
-            token.cancel();
-        }
         if let Some(response) = self.req_queue.incoming.cancel(request_id) {
             self.send(response.into());
         }

--- a/crates/rust-analyzer/src/handlers/dispatch.rs
+++ b/crates/rust-analyzer/src/handlers/dispatch.rs
@@ -253,9 +253,6 @@ impl RequestDispatcher<'_> {
         tracing::debug!(?params);
 
         let world = self.global_state.snapshot();
-        self.global_state
-            .cancellation_tokens
-            .insert(req.id.clone(), world.analysis.cancellation_token());
         if RUSTFMT {
             &mut self.global_state.fmt_pool.handle
         } else {
@@ -268,19 +265,7 @@ impl RequestDispatcher<'_> {
             });
             match thread_result_to_response::<R>(req.id.clone(), result) {
                 Ok(response) => Task::Response(response),
-                Err(HandlerCancelledError::Inner(
-                    Cancelled::PendingWrite | Cancelled::PropagatedPanic,
-                )) if ALLOW_RETRYING => Task::Retry(req),
-                // Note: Technically the return value here does not matter as we have already responded to the client with this error.
-                Err(HandlerCancelledError::Inner(Cancelled::Local)) => Task::Response(Response {
-                    id: req.id,
-                    result: None,
-                    error: Some(ResponseError {
-                        code: lsp_server::ErrorCode::RequestCanceled as i32,
-                        message: "canceled by client".to_owned(),
-                        data: None,
-                    }),
-                }),
+                Err(_cancelled) if ALLOW_RETRYING => Task::Retry(req),
                 Err(_cancelled) => {
                     let error = on_cancelled();
                     Task::Response(Response { id: req.id, result: None, error: Some(error) })

--- a/crates/span/src/hygiene.rs
+++ b/crates/span/src/hygiene.rs
@@ -81,24 +81,25 @@ const _: () = {
     #[derive(Hash)]
     struct StructKey<'db, T0, T1, T2, T3>(T0, T1, T2, T3, std::marker::PhantomData<&'db ()>);
 
-    impl<'db, T0, T1, T2, T3> zalsa_::HashEqLike<StructKey<'db, T0, T1, T2, T3>> for SyntaxContextData
+    impl<'db, T0, T1, T2, T3> zalsa_::interned::HashEqLike<StructKey<'db, T0, T1, T2, T3>>
+        for SyntaxContextData
     where
-        Option<MacroCallId>: zalsa_::HashEqLike<T0>,
-        Transparency: zalsa_::HashEqLike<T1>,
-        Edition: zalsa_::HashEqLike<T2>,
-        SyntaxContext: zalsa_::HashEqLike<T3>,
+        Option<MacroCallId>: zalsa_::interned::HashEqLike<T0>,
+        Transparency: zalsa_::interned::HashEqLike<T1>,
+        Edition: zalsa_::interned::HashEqLike<T2>,
+        SyntaxContext: zalsa_::interned::HashEqLike<T3>,
     {
         fn hash<H: std::hash::Hasher>(&self, h: &mut H) {
-            zalsa_::HashEqLike::<T0>::hash(&self.outer_expn, &mut *h);
-            zalsa_::HashEqLike::<T1>::hash(&self.outer_transparency, &mut *h);
-            zalsa_::HashEqLike::<T2>::hash(&self.edition, &mut *h);
-            zalsa_::HashEqLike::<T3>::hash(&self.parent, &mut *h);
+            zalsa_::interned::HashEqLike::<T0>::hash(&self.outer_expn, &mut *h);
+            zalsa_::interned::HashEqLike::<T1>::hash(&self.outer_transparency, &mut *h);
+            zalsa_::interned::HashEqLike::<T2>::hash(&self.edition, &mut *h);
+            zalsa_::interned::HashEqLike::<T3>::hash(&self.parent, &mut *h);
         }
         fn eq(&self, data: &StructKey<'db, T0, T1, T2, T3>) -> bool {
-            zalsa_::HashEqLike::<T0>::eq(&self.outer_expn, &data.0)
-                && zalsa_::HashEqLike::<T1>::eq(&self.outer_transparency, &data.1)
-                && zalsa_::HashEqLike::<T2>::eq(&self.edition, &data.2)
-                && zalsa_::HashEqLike::<T3>::eq(&self.parent, &data.3)
+            zalsa_::interned::HashEqLike::<T0>::eq(&self.outer_expn, &data.0)
+                && zalsa_::interned::HashEqLike::<T1>::eq(&self.outer_transparency, &data.1)
+                && zalsa_::interned::HashEqLike::<T2>::eq(&self.edition, &data.2)
+                && zalsa_::interned::HashEqLike::<T3>::eq(&self.parent, &data.3)
         }
     }
     impl zalsa_struct_::Configuration for SyntaxContext {
@@ -202,10 +203,10 @@ const _: () = {
     impl<'db> SyntaxContext {
         pub fn new<
             Db,
-            T0: zalsa_::Lookup<Option<MacroCallId>> + std::hash::Hash,
-            T1: zalsa_::Lookup<Transparency> + std::hash::Hash,
-            T2: zalsa_::Lookup<Edition> + std::hash::Hash,
-            T3: zalsa_::Lookup<SyntaxContext> + std::hash::Hash,
+            T0: zalsa_::interned::Lookup<Option<MacroCallId>> + std::hash::Hash,
+            T1: zalsa_::interned::Lookup<Transparency> + std::hash::Hash,
+            T2: zalsa_::interned::Lookup<Edition> + std::hash::Hash,
+            T3: zalsa_::interned::Lookup<SyntaxContext> + std::hash::Hash,
         >(
             db: &'db Db,
             outer_expn: T0,
@@ -217,10 +218,10 @@ const _: () = {
         ) -> Self
         where
             Db: ?Sized + salsa::Database,
-            Option<MacroCallId>: zalsa_::HashEqLike<T0>,
-            Transparency: zalsa_::HashEqLike<T1>,
-            Edition: zalsa_::HashEqLike<T2>,
-            SyntaxContext: zalsa_::HashEqLike<T3>,
+            Option<MacroCallId>: zalsa_::interned::HashEqLike<T0>,
+            Transparency: zalsa_::interned::HashEqLike<T1>,
+            Edition: zalsa_::interned::HashEqLike<T2>,
+            SyntaxContext: zalsa_::interned::HashEqLike<T3>,
         {
             let (zalsa, zalsa_local) = db.zalsas();
 
@@ -235,10 +236,10 @@ const _: () = {
                     std::marker::PhantomData,
                 ),
                 |id, data| SyntaxContextData {
-                    outer_expn: zalsa_::Lookup::into_owned(data.0),
-                    outer_transparency: zalsa_::Lookup::into_owned(data.1),
-                    edition: zalsa_::Lookup::into_owned(data.2),
-                    parent: zalsa_::Lookup::into_owned(data.3),
+                    outer_expn: zalsa_::interned::Lookup::into_owned(data.0),
+                    outer_transparency: zalsa_::interned::Lookup::into_owned(data.1),
+                    edition: zalsa_::interned::Lookup::into_owned(data.2),
+                    parent: zalsa_::interned::Lookup::into_owned(data.3),
                     opaque: opaque(zalsa_::FromId::from_id(id)),
                     opaque_and_semiopaque: opaque_and_semiopaque(zalsa_::FromId::from_id(id)),
                 },


### PR DESCRIPTION
Reverts rust-lang/rust-analyzer#21380

I think there is enough evidence that the Salsa upgrade caused huge problems for some people. Ideally we should investigate it but I don't have time for this now and from what I understand r-a is unusable currently for them. So a revert is the only possible option, for now.

r? @Veykril

Should close https://github.com/rust-lang/rust-analyzer/issues/21626, close https://github.com/rust-lang/rust-analyzer/issues/21617, close https://github.com/rust-lang/rust-analyzer/issues/21610.