### PR TITLE
Pin nightly for miri workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -206,8 +206,11 @@ jobs:
 
       - name: Install Rust toolchain
         run: |
-          rustup update --no-self-update nightly
-          rustup default nightly
+          # FIXME: Pin nightly due to a regression in miri on nightly-2026-02-12.
+          # See https://github.com/rust-lang/miri/issues/4855.
+          # Revert to plain `nightly` once this is fixed upstream.
+          rustup toolchain install nightly-2026-02-10
+          rustup default nightly-2026-02-10
           rustup component add miri
 
       # - name: Cache Dependencies


### PR DESCRIPTION
Pin Miri to nightly-2026-02-10 due to a regression in nightly-2026-02-12 (rust-lang/miri#4855). This is temporary and should be reverted once the upstream issue is fixed.