### PR TITLE
internal: Refactor handling of associated type shorthand for type parameters, i.e. `T::AssocType` without specifying the trait

### DIFF
--- a/crates/hir-def/src/hir/generics.rs
+++ b/crates/hir-def/src/hir/generics.rs
@@ -184,7 +184,7 @@ static EMPTY: LazyLock<Arc<GenericParams>> = LazyLock::new(|| {
 
 impl GenericParams {
     /// The index of the self param in the generic of the non-parent definition.
-    pub(crate) const SELF_PARAM_ID_IN_SELF: la_arena::Idx<TypeOrConstParamData> =
+    pub const SELF_PARAM_ID_IN_SELF: la_arena::Idx<TypeOrConstParamData> =
         LocalTypeOrConstParamId::from_raw(RawIdx::from_u32(0));
 
     pub fn new(db: &dyn DefDatabase, def: GenericDefId) -> Arc<GenericParams> {

--- a/crates/hir-def/src/lib.rs
+++ b/crates/hir-def/src/lib.rs
@@ -86,7 +86,7 @@ use crate::{
     builtin_type::BuiltinType,
     db::DefDatabase,
     expr_store::ExpressionStoreSourceMap,
-    hir::generics::{LocalLifetimeParamId, LocalTypeOrConstParamId},
+    hir::generics::{GenericParams, LocalLifetimeParamId, LocalTypeOrConstParamId},
     nameres::{
         LocalDefMap,
         assoc::{ImplItems, TraitItems},
@@ -553,15 +553,25 @@ pub struct TypeOrConstParamId {
 pub struct TypeParamId(TypeOrConstParamId);
 
 impl TypeParamId {
+    #[inline]
     pub fn parent(&self) -> GenericDefId {
         self.0.parent
     }
+
+    #[inline]
     pub fn local_id(&self) -> LocalTypeOrConstParamId {
         self.0.local_id
     }
-}
 
-impl TypeParamId {
+    #[inline]
+    pub fn trait_self(trait_: TraitId) -> TypeParamId {
+        TypeParamId::from_unchecked(TypeOrConstParamId {
+            parent: trait_.into(),
+            local_id: GenericParams::SELF_PARAM_ID_IN_SELF,
+        })
+    }
+
+    #[inline]
     /// Caller should check if this toc id really belongs to a type
     pub fn from_unchecked(it: TypeOrConstParamId) -> Self {
         Self(it)

--- a/crates/hir-ty/src/generics.rs
+++ b/crates/hir-ty/src/generics.rs
@@ -224,22 +224,6 @@ impl Generics {
     }
 }
 
-pub(crate) fn trait_self_param_idx(db: &dyn DefDatabase, def: GenericDefId) -> Option<usize> {
-    match def {
-        GenericDefId::TraitId(_) => {
-            let params = db.generic_params(def);
-            params.trait_self_param().map(|idx| idx.into_raw().into_u32() as usize)
-        }
-        GenericDefId::ImplId(_) => None,
-        _ => {
-            let parent_def = parent_generic_def(db, def)?;
-            let parent_params = db.generic_params(parent_def);
-            let parent_self_idx = parent_params.trait_self_param()?.into_raw().into_u32() as usize;
-            Some(parent_self_idx)
-        }
-    }
-}
-
 pub(crate) fn parent_generic_def(db: &dyn DefDatabase, def: GenericDefId) -> Option<GenericDefId> {
     let container = match def {
         GenericDefId::FunctionId(it) => it.lookup(db).container,

--- a/crates/hir-ty/src/lib.rs
+++ b/crates/hir-ty/src/lib.rs
@@ -57,9 +57,12 @@ mod test_db;
 #[cfg(test)]
 mod tests;
 
-use std::hash::Hash;
+use std::{hash::Hash, ops::ControlFlow};
 
-use hir_def::{CallableDefId, TypeOrConstParamId, type_ref::Rawness};
+use hir_def::{
+    CallableDefId, GenericDefId, TypeAliasId, TypeOrConstParamId, TypeParamId,
+    hir::generics::GenericParams, resolver::TypeNs, type_ref::Rawness,
+};
 use hir_expand::name::Name;
 use indexmap::{IndexMap, map::Entry};
 use intern::{Symbol, sym};
@@ -77,10 +80,11 @@ use crate::{
     db::HirDatabase,
     display::{DisplayTarget, HirDisplay},
     infer::unify::InferenceTable,
+    lower::SupertraitsInfo,
     next_solver::{
         AliasTy, Binder, BoundConst, BoundRegion, BoundRegionKind, BoundTy, BoundTyKind, Canonical,
-        CanonicalVarKind, CanonicalVars, Const, ConstKind, DbInterner, FnSig, GenericArgs,
-        PolyFnSig, Predicate, Region, RegionKind, TraitRef, Ty, TyKind, Tys, abi,
+        CanonicalVarKind, CanonicalVars, ClauseKind, Const, ConstKind, DbInterner, FnSig,
+        GenericArgs, PolyFnSig, Predicate, Region, RegionKind, TraitRef, Ty, TyKind, Tys, abi,
     },
 };
 
@@ -94,7 +98,7 @@ pub use infer::{
 };
 pub use lower::{
     GenericPredicates, ImplTraits, LifetimeElisionKind, TyDefId, TyLoweringContext, ValueTyDefId,
-    associated_type_shorthand_candidates, diagnostics::*,
+    diagnostics::*,
 };
 pub use next_solver::interner::{attach_db, attach_db_allow_change, with_attached_db};
 pub use target_feature::TargetFeatures;
@@ -476,6 +480,55 @@ where
         max_universe: rustc_type_ir::UniverseIndex::ZERO,
         variables: CanonicalVars::new_from_slice(&error_replacer.vars),
     }
+}
+
+/// To be used from `hir` only.
+pub fn associated_type_shorthand_candidates(
+    db: &dyn HirDatabase,
+    def: GenericDefId,
+    res: TypeNs,
+    mut cb: impl FnMut(&Name, TypeAliasId) -> bool,
+) -> Option<TypeAliasId> {
+    let interner = DbInterner::new_no_crate(db);
+    let (def, param) = match res {
+        TypeNs::GenericParam(param) => (def, param),
+        TypeNs::SelfType(impl_) => {
+            let impl_trait = db.impl_trait(impl_)?.skip_binder().def_id.0;
+            let param = TypeParamId::from_unchecked(TypeOrConstParamId {
+                parent: impl_trait.into(),
+                local_id: GenericParams::SELF_PARAM_ID_IN_SELF,
+            });
+            (impl_trait.into(), param)
+        }
+        _ => return None,
+    };
+
+    let mut dedup_map = FxHashSet::default();
+    let param_ty = Ty::new_param(interner, param, param_idx(db, param.into()).unwrap() as u32);
+    // We use the ParamEnv and not the predicates because the ParamEnv elaborates bounds.
+    let param_env = db.trait_environment(def);
+    for clause in param_env.clauses {
+        let ClauseKind::Trait(trait_clause) = clause.kind().skip_binder() else { continue };
+        if trait_clause.self_ty() != param_ty {
+            continue;
+        }
+        let trait_id = trait_clause.def_id().0;
+        dedup_map.extend(
+            SupertraitsInfo::query(db, trait_id)
+                .defined_assoc_types
+                .iter()
+                .map(|(name, id)| (name, *id)),
+        );
+    }
+
+    dedup_map
+        .into_iter()
+        .try_for_each(
+            |(name, id)| {
+                if cb(name, id) { ControlFlow::Break(id) } else { ControlFlow::Continue(()) }
+            },
+        )
+        .break_value()
 }
 
 /// To be used from `hir` only.

--- a/crates/hir-ty/src/lower/path.rs
+++ b/crates/hir-ty/src/lower/path.rs
@@ -2,7 +2,7 @@
 
 use either::Either;
 use hir_def::{
-    GenericDefId, GenericParamId, Lookup, TraitId, TypeAliasId,
+    GenericDefId, GenericParamId, Lookup, TraitId, TypeParamId,
     expr_store::{
         ExpressionStore, HygieneId,
         path::{
@@ -17,7 +17,6 @@ use hir_def::{
     signatures::TraitFlags,
     type_ref::{TypeRef, TypeRefId},
 };
-use hir_expand::name::Name;
 use rustc_type_ir::{
     AliasTerm, AliasTy, AliasTyKind,
     inherent::{GenericArgs as _, Region as _, Ty as _},
@@ -31,13 +30,10 @@ use crate::{
     consteval::{unknown_const, unknown_const_as_generic},
     db::HirDatabase,
     generics::{Generics, generics},
-    lower::{
-        GenericPredicateSource, LifetimeElisionKind, PathDiagnosticCallbackData,
-        named_associated_type_shorthand_candidates,
-    },
+    lower::{GenericPredicateSource, LifetimeElisionKind, PathDiagnosticCallbackData},
     next_solver::{
-        Binder, Clause, Const, DbInterner, ErrorGuaranteed, GenericArg, GenericArgs, Predicate,
-        ProjectionPredicate, Region, TraitRef, Ty,
+        Binder, Clause, Const, DbInterner, EarlyBinder, ErrorGuaranteed, GenericArg, GenericArgs,
+        Predicate, ProjectionPredicate, Region, TraitRef, Ty,
     },
 };
 
@@ -481,43 +477,59 @@ impl<'a, 'b, 'db> PathLoweringContext<'a, 'b, 'db> {
     #[tracing::instrument(skip(self), ret)]
     fn select_associated_type(&mut self, res: Option<TypeNs>, infer_args: bool) -> Ty<'db> {
         let interner = self.ctx.interner;
-        let Some(res) = res else {
-            return Ty::new_error(self.ctx.interner, ErrorGuaranteed);
-        };
+        let db = self.ctx.db;
         let def = self.ctx.def;
         let segment = self.current_or_prev_segment;
         let assoc_name = segment.name;
-        let check_alias = |name: &Name, t: TraitRef<'db>, associated_ty: TypeAliasId| {
-            if name != assoc_name {
-                return None;
+        let error_ty = || Ty::new_error(self.ctx.interner, ErrorGuaranteed);
+        let (assoc_type, trait_args) = match res {
+            Some(TypeNs::GenericParam(param)) => {
+                let Ok(assoc_type) = super::resolve_type_param_assoc_type_shorthand(
+                    db,
+                    def,
+                    param,
+                    assoc_name.clone(),
+                ) else {
+                    return error_ty();
+                };
+                assoc_type
+                    .get_with(|(assoc_type, trait_args)| (*assoc_type, trait_args.as_ref()))
+                    .skip_binder()
             }
-
-            // FIXME: `substs_from_path_segment()` pushes `TyKind::Error` for every parent
-            // generic params. It's inefficient to splice the `Substitution`s, so we may want
-            // that method to optionally take parent `Substitution` as we already know them at
-            // this point (`t.substitution`).
-            let substs =
-                self.substs_from_path_segment(associated_ty.into(), infer_args, None, true);
-
-            let substs = GenericArgs::new_from_iter(
-                interner,
-                t.args.iter().chain(substs.iter().skip(t.args.len())),
-            );
-
-            Some(Ty::new_alias(
-                interner,
-                AliasTyKind::Projection,
-                AliasTy::new_from_args(interner, associated_ty.into(), substs),
-            ))
+            Some(TypeNs::SelfType(impl_)) => {
+                let Some(impl_trait) = db.impl_trait(impl_) else {
+                    return error_ty();
+                };
+                let impl_trait = impl_trait.instantiate_identity();
+                // Searching for `Self::Assoc` in `impl Trait for Type` is like searching for `Self::Assoc` in `Trait`.
+                let Ok(assoc_type) = super::resolve_type_param_assoc_type_shorthand(
+                    db,
+                    impl_trait.def_id.0.into(),
+                    TypeParamId::trait_self(impl_trait.def_id.0),
+                    assoc_name.clone(),
+                ) else {
+                    return error_ty();
+                };
+                let (assoc_type, trait_args) = assoc_type
+                    .get_with(|(assoc_type, trait_args)| (*assoc_type, trait_args.as_ref()))
+                    .skip_binder();
+                (assoc_type, EarlyBinder::bind(trait_args).instantiate(interner, impl_trait.args))
+            }
+            _ => return error_ty(),
         };
-        named_associated_type_shorthand_candidates(
+
+        // FIXME: `substs_from_path_segment()` pushes `TyKind::Error` for every parent
+        // generic params. It's inefficient to splice the `Substitution`s, so we may want
+        // that method to optionally take parent `Substitution` as we already know them at
+        // this point (`t.substitution`).
+        let substs = self.substs_from_path_segment(assoc_type.into(), infer_args, None, true);
+
+        let substs = GenericArgs::new_from_iter(
             interner,
-            def,
-            res,
-            Some(assoc_name.clone()),
-            check_alias,
-        )
-        .unwrap_or_else(|| Ty::new_error(interner, ErrorGuaranteed))
+            trait_args.iter().chain(substs.iter().skip(trait_args.len())),
+        );
+
+        Ty::new_projection_from_args(interner, assoc_type.into(), substs)
     }
 
     fn lower_path_inner(&mut self, typeable: TyDefId, infer_args: bool) -> Ty<'db> {
@@ -862,9 +874,9 @@ impl<'a, 'b, 'db> PathLoweringContext<'a, 'b, 'db> {
                 let found = associated_type_by_name_including_super_traits(
                     self.ctx.db,
                     trait_ref,
-                    &binding.name,
+                    binding.name.clone(),
                 );
-                let (super_trait_ref, associated_ty) = match found {
+                let (associated_ty, super_trait_args) = match found {
                     None => return SmallVec::new(),
                     Some(t) => t,
                 };
@@ -878,7 +890,7 @@ impl<'a, 'b, 'db> PathLoweringContext<'a, 'b, 'db> {
                             binding.args.as_ref(),
                             associated_ty.into(),
                             false, // this is not relevant
-                            Some(super_trait_ref.self_ty()),
+                            Some(super_trait_args.type_at(0)),
                             PathGenericsSource::AssocType {
                                 segment: this.current_segment_u32(),
                                 assoc_type: binding_idx as u32,
@@ -889,7 +901,7 @@ impl<'a, 'b, 'db> PathLoweringContext<'a, 'b, 'db> {
                     });
                 let args = GenericArgs::new_from_iter(
                     interner,
-                    super_trait_ref.args.iter().chain(args.iter().skip(super_trait_ref.args.len())),
+                    super_trait_args.iter().chain(args.iter().skip(super_trait_args.len())),
                 );
                 let projection_term =
                     AliasTerm::new_from_args(interner, associated_ty.into(), args);

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -6167,6 +6167,7 @@ impl<'db> Type<'db> {
         self.autoderef_(db)
             .filter_map(|ty| ty.dyn_trait())
             .flat_map(move |dyn_trait_id| hir_ty::all_super_traits(db, dyn_trait_id))
+            .copied()
             .map(Trait::from)
     }
 
@@ -6184,6 +6185,7 @@ impl<'db> Type<'db> {
                         _ => None,
                     })
                     .flat_map(|t| hir_ty::all_super_traits(db, t))
+                    .copied()
             })
             .map(Trait::from)
     }

--- a/crates/ide/src/signature_help.rs
+++ b/crates/ide/src/signature_help.rs
@@ -1975,8 +1975,8 @@ trait Sub: Super + Super {
 fn f() -> impl Sub<$0
             "#,
             expect![[r#"
-                trait Sub<SuperTy = …, SubTy = …>
-                          ^^^^^^^^^^^  ---------
+                trait Sub<SubTy = …, SuperTy = …>
+                          ^^^^^^^^^  -----------
             "#]],
         );
     }


### PR DESCRIPTION
I believe the new code is both cleaner and more robust, and should fix some edge cases.

rustc does all of this very differently with plenty of queries for various forms of predicate lowering; but we have tight memory constraints so we prefer a different approach.

Fixes rust-lang/rust-analyzer#21592.