### PR TITLE
fix: Don't assume `extern fn`s parameters are patterns

### DIFF
--- a/crates/hir-ty/src/tests/regression.rs
+++ b/crates/hir-ty/src/tests/regression.rs
@@ -2757,3 +2757,16 @@ where
         "#]],
     );
 }
+
+#[test]
+fn extern_fns_cannot_have_param_patterns() {
+    check_no_mismatches(
+        r#"
+pub(crate) struct Builder<'a>(&'a ());
+
+unsafe extern "C"  {
+    pub(crate) fn foo<'a>(Builder: &Builder<'a>);
+}
+    "#,
+    );
+}


### PR DESCRIPTION
Unlike normal fns, they should be bare identifiers.

Fixes rust-lang/rust-analyzer#21621.