### PR TITLE
fix: complete derive helpers on empty nameref

### DIFF
--- a/crates/ide-completion/src/context/analysis.rs
+++ b/crates/ide-completion/src/context/analysis.rs
@@ -1501,7 +1501,7 @@ fn classify_name_ref<'db>(
                         | SyntaxKind::RECORD_FIELD
                 )
             })
-            .and_then(|_| nameref.as_ref()?.syntax().ancestors().find_map(ast::Adt::cast))
+            .and_then(|_| find_node_at_offset::<ast::Adt>(original_file, original_offset))
             .and_then(|adt| sema.derive_helpers_in_scope(&adt))
             .unwrap_or_default();
         Some(PathKind::Attr { attr_ctx: AttrCtx { kind, annotated_item_kind, derive_helpers } })

--- a/crates/ide-completion/src/tests/attribute.rs
+++ b/crates/ide-completion/src/tests/attribute.rs
@@ -68,7 +68,71 @@ pub struct Foo(#[m$0] i32);
             kw crate::
             kw self::
         "#]],
-    )
+    );
+    check(
+        r#"
+//- /mac.rs crate:mac
+#![crate_type = "proc-macro"]
+
+#[proc_macro_derive(MyDerive, attributes(my_cool_helper_attribute))]
+pub fn my_derive() {}
+
+//- /lib.rs crate:lib deps:mac
+#[rustc_builtin_macro]
+pub macro derive($item:item) {}
+
+#[derive(mac::MyDerive)]
+pub struct Foo(#[$0] i32);
+"#,
+        expect![[r#"
+            at allow(…)
+            at automatically_derived
+            at cfg(…)
+            at cfg_attr(…)
+            at cold
+            at deny(…)
+            at deprecated
+            at derive                                  macro derive
+            at derive(…)
+            at diagnostic::do_not_recommend
+            at diagnostic::on_unimplemented
+            at doc = "…"
+            at doc = include_str!("…")
+            at doc(alias = "…")
+            at doc(hidden)
+            at expect(…)
+            at export_name = "…"
+            at forbid(…)
+            at global_allocator
+            at ignore = "…"
+            at inline
+            at link
+            at link_name = "…"
+            at link_section = "…"
+            at macro_export
+            at macro_use
+            at must_use
+            at my_cool_helper_attribute derive helper of `MyDerive`
+            at no_mangle
+            at non_exhaustive
+            at panic_handler
+            at path = "…"
+            at proc_macro
+            at proc_macro_attribute
+            at proc_macro_derive(…)
+            at repr(…)
+            at should_panic
+            at target_feature(enable = "…")
+            at test
+            at track_caller
+            at unsafe(…)
+            at used
+            at warn(…)
+            md mac
+            kw crate::
+            kw self::
+        "#]],
+    );
 }
 
 #[test]


### PR DESCRIPTION
Example
---
```rust
//- /mac.rs crate:mac

pub fn my_derive() {}

//- /lib.rs crate:lib deps:mac
pub struct Foo(#[$0] i32);
```

**Before this PR**

```text
...
at must_use
at no_mangle
...
```

**After this PR**

```text
...
at must_use
at my_cool_helper_attribute derive helper of `MyDerive`
at no_mangle
...
```
