### PR TITLE
fix: Ensure cpu_profiler feature compiles on Rust edition 2024

### DIFF
--- a/crates/profile/src/google_cpu_profiler.rs
+++ b/crates/profile/src/google_cpu_profiler.rs
@@ -9,7 +9,7 @@ use std::{
 
 #[link(name = "profiler")]
 #[allow(non_snake_case)]
-extern "C" {
+unsafe extern "C" {
     fn ProfilerStart(fname: *const c_char) -> i32;
     fn ProfilerStop();
 }


### PR DESCRIPTION
Without `unsafe` on this block, this feature didn't compile.

https://doc.rust-lang.org/edition-guide/rust-2024/unsafe-extern.html