### PR TITLE
internal: Configure codecov

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,10 @@
+coverage:
+  range: 40...60
+  status:
+    patch: off
+    project:
+      default:
+        informational: true
+
+# Don't leave comments on PRs
+comment: false

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -1,0 +1,44 @@
+name: Coverage
+
+on: [pull_request, push]
+
+env:
+  CARGO_INCREMENTAL: 0
+  CARGO_NET_RETRY: 10
+  CI: 1
+  RUST_BACKTRACE: short
+  RUSTUP_MAX_RETRIES: 10
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        run: |
+          rustup update --no-self-update nightly
+          rustup default nightly
+          rustup component add --toolchain nightly rust-src rustc-dev rustfmt
+          # We also install a nightly rustfmt, because we use `--file-lines` in
+          # a test.
+          rustup toolchain install nightly --profile minimal --component rustfmt
+
+          rustup toolchain install nightly --component llvm-tools-preview
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+
+      - name: Install nextest
+        uses: taiki-e/install-action@nextest
+
+      - name: Generate code coverage
+        run: cargo llvm-cov --workspace --lcov --output-path lcov.info
+      
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: lcov.info
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
+          verbose: true


### PR DESCRIPTION
It would be wonderful to have test coverage tracking for rust-analyzer. I've added a basic configuration.

This will need adding a token to the secrets on this repository, but this is a good first step.

You can see a coverage report in my fork: https://app.codecov.io/github/Wilfred/rust-analyzer/commit/33f0a8efda0c2418343df02f590b42d08783ea89/tree