### PR TITLE
internal: Skip rustfmt test if nightly toolchain is missing

### DIFF
--- a/crates/rust-analyzer/tests/slow-tests/main.rs
+++ b/crates/rust-analyzer/tests/slow-tests/main.rs
@@ -22,6 +22,7 @@ mod testdir;
 
 use std::{collections::HashMap, path::PathBuf, time::Instant};
 
+use ide_db::FxHashMap;
 use lsp_types::{
     CodeActionContext, CodeActionParams, CompletionParams, DidOpenTextDocumentParams,
     DocumentFormattingParams, DocumentRangeFormattingParams, FileRename, FormattingOptions,
@@ -670,6 +671,17 @@ fn main() {}
 #[test]
 fn test_format_document_range() {
     if skip_slow_tests() {
+        return;
+    }
+
+    // This test requires a nightly toolchain, so skip if it's not available.
+    let cwd = std::env::current_dir().unwrap_or_default();
+    let has_nightly_rustfmt = toolchain::command("rustfmt", cwd, &FxHashMap::default())
+        .args(["+nightly", "--version"])
+        .output()
+        .is_ok_and(|out| out.status.success());
+    if !has_nightly_rustfmt {
+        tracing::warn!("skipping test_format_document_range: nightly rustfmt not available");
         return;
     }
 


### PR DESCRIPTION
Currently the rustfmt slow test fails if you don't have a nightly toolchain installed. We install a nightly toolchain on CI, but it's a little confusing that tests can fail on a fresh checkout on a new laptop.

Instead, skip this test if there's no nightly toolchain.

AI disclosure: Written with a little help from Claude.