### PR TITLE
completions: Add rudimentary support for closure completions

### DIFF
--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -6384,6 +6384,7 @@ enum Callee<'db> {
     BuiltinDeriveImplMethod { method: BuiltinDeriveImplMethod, impl_: BuiltinDeriveImplId },
 }
 
+#[derive(Debug)]
 pub enum CallableKind<'db> {
     Function(Function),
     TupleStruct(Struct),

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -6464,7 +6464,7 @@ impl<'db> Callable<'db> {
     }
 
     /// Returns the generic substitution for this callable, if it is a function.
-    pub fn substitution(&self, db: &'db dyn HirDatabase) -> Option<GenericSubstitution<'db>> {
+    pub fn substitution(&self) -> Option<GenericSubstitution<'db>> {
         let fun = self.as_function()?;
         match self.ty.ty.kind() {
             TyKind::FnDef(_, substs) => GenericSubstitution::new_from_fn(fun, substs, self.ty.env),

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -6462,6 +6462,15 @@ impl<'db> Callable<'db> {
     pub fn ty(&self) -> &Type<'db> {
         &self.ty
     }
+
+    /// Returns the generic substitution for this callable, if it is a function.
+    pub fn substitution(&self, db: &'db dyn HirDatabase) -> Option<GenericSubstitution<'db>> {
+        let fun = self.as_function()?;
+        match self.ty.ty.kind() {
+            TyKind::FnDef(_, substs) => GenericSubstitution::new_from_fn(fun, substs, self.ty.env),
+            _ => None,
+        }
+    }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/crates/ide-completion/src/completions/fn_param.rs
+++ b/crates/ide-completion/src/completions/fn_param.rs
@@ -256,9 +256,6 @@ pub(crate) fn complete_closure_within_param(
 
     let fn_callable = generic_param_ty.as_callable(ctx.db)?;
     let closure_params = fn_callable.params();
-    if closure_params.is_empty() {
-        return None;
-    }
 
     let module = ctx.scope.module().into();
     let source_range = ctx.source_range();

--- a/crates/ide-completion/src/completions/fn_param.rs
+++ b/crates/ide-completion/src/completions/fn_param.rs
@@ -261,7 +261,7 @@ pub(crate) fn complete_closure_within_param(
     // (via turbofish or inference from other arguments). If a substituted
     // type is concrete (not unknown), the corresponding param is resolved.
     let resolved_param_names: FxHashSet<_> = callable
-        .substitution(ctx.db)
+        .substitution()
         .map(|subst| {
             subst
                 .types(ctx.db)

--- a/crates/ide-completion/src/tests.rs
+++ b/crates/ide-completion/src/tests.rs
@@ -242,10 +242,32 @@ pub(crate) fn check_edit_with_config(
     ra_fixture_before: &str,
     ra_fixture_after: &str,
 ) {
+    check_edit_impl(config, what, ra_fixture_before, ra_fixture_after, None)
+}
+
+#[track_caller]
+pub(crate) fn check_edit_with_trigger_character(
+    what: &str,
+    #[rust_analyzer::rust_fixture] ra_fixture_before: &str,
+    #[rust_analyzer::rust_fixture] ra_fixture_after: &str,
+    trigger_character: Option<char>,
+) {
+    check_edit_impl(TEST_CONFIG, what, ra_fixture_before, ra_fixture_after, trigger_character)
+}
+
+#[track_caller]
+fn check_edit_impl(
+    config: CompletionConfig<'_>,
+    what: &str,
+    ra_fixture_before: &str,
+    ra_fixture_after: &str,
+    trigger_character: Option<char>,
+) {
     let ra_fixture_after = trim_indent(ra_fixture_after);
     let (db, position) = position(ra_fixture_before);
-    let completions: Vec<CompletionItem> =
-        hir::attach_db(&db, || crate::completions(&db, &config, position, None).unwrap());
+    let completions: Vec<CompletionItem> = hir::attach_db(&db, || {
+        crate::completions(&db, &config, position, trigger_character).unwrap()
+    });
     let Some((completion,)) = completions.iter().filter(|it| it.lookup() == what).collect_tuple()
     else {
         panic!("can't find {what:?} completion in {completions:#?}")

--- a/crates/ide-completion/src/tests/fn_param.rs
+++ b/crates/ide-completion/src/tests/fn_param.rs
@@ -622,3 +622,66 @@ fn main() {
         Some('|'),
     );
 }
+
+#[test]
+fn closure_within_param_generic_resolved_by_turbofish() {
+    check_edit_with_trigger_character(
+        "|_| ",
+        r#"
+//- minicore: fn
+fn foo<T>(f: impl Fn(T)) {}
+fn main() {
+    foo::<u32>(|$0);
+}
+"#,
+        r#"
+fn foo<T>(f: impl Fn(T)) {}
+fn main() {
+    foo::<u32>(|${1:_}| $0);
+}
+"#,
+        Some('|'),
+    );
+}
+
+#[test]
+fn closure_within_param_generic_resolved_by_inference() {
+    check_edit_with_trigger_character(
+        "|_| ",
+        r#"
+//- minicore: fn
+fn foo<T>(x: T, f: impl Fn(T)) {}
+fn main() {
+    foo(42u32, |$0);
+}
+"#,
+        r#"
+fn foo<T>(x: T, f: impl Fn(T)) {}
+fn main() {
+    foo(42u32, |${1:_}| $0);
+}
+"#,
+        Some('|'),
+    );
+}
+
+#[test]
+fn closure_within_param_generic_partially_resolved() {
+    check_edit_with_trigger_character(
+        "|_, _: U| ",
+        r#"
+//- minicore: fn
+fn foo<T, U>(x: T, f: impl Fn(T, U)) {}
+fn main() {
+    foo(42u32, |$0);
+}
+"#,
+        r#"
+fn foo<T, U>(x: T, f: impl Fn(T, U)) {}
+fn main() {
+    foo(42u32, |${1:_}, ${2:_}: ${3:U}| $0);
+}
+"#,
+        Some('|'),
+    );
+}

--- a/crates/ide-completion/src/tests/fn_param.rs
+++ b/crates/ide-completion/src/tests/fn_param.rs
@@ -601,3 +601,24 @@ fn main() {
         Some('|'),
     );
 }
+
+#[test]
+fn closure_within_param_no_args() {
+    check_edit_with_trigger_character(
+        "|| ",
+        r#"
+//- minicore: fn
+fn foo(f: impl Fn()) {}
+fn main() {
+    foo(|$0);
+}
+"#,
+        r#"
+fn foo(f: impl Fn()) {}
+fn main() {
+    foo(|| $0);
+}
+"#,
+        Some('|'),
+    );
+}

--- a/crates/ide-completion/src/tests/fn_param.rs
+++ b/crates/ide-completion/src/tests/fn_param.rs
@@ -1,6 +1,6 @@
 use expect_test::expect;
 
-use crate::tests::{check, check_with_trigger_character};
+use crate::tests::{check, check_edit_with_trigger_character, check_with_trigger_character};
 
 #[test]
 fn only_param() {
@@ -357,4 +357,247 @@ fn g(foo: (), #[baz = "qux"] mut ba$0)
             bn #[baz = "qux"] mut bar: u32
         "##]],
     )
+}
+
+#[test]
+fn closure_within_param_fn_single() {
+    check_edit_with_trigger_character(
+        "|_| ",
+        r#"
+//- minicore: fn
+fn foo(f: impl Fn(u32)) {}
+fn main() {
+    foo(|$0);
+}
+"#,
+        r#"
+fn foo(f: impl Fn(u32)) {}
+fn main() {
+    foo(|${1:_}| $0);
+}
+"#,
+        Some('|'),
+    );
+}
+
+#[test]
+fn closure_within_param_fn_multiple() {
+    check_edit_with_trigger_character(
+        "|_, _| ",
+        r#"
+//- minicore: fn
+fn foo(f: impl Fn(u32, i64) -> bool) {}
+fn main() {
+    foo(|$0);
+}
+"#,
+        r#"
+fn foo(f: impl Fn(u32, i64) -> bool) {}
+fn main() {
+    foo(|${1:_}, ${2:_}| $0);
+}
+"#,
+        Some('|'),
+    );
+}
+
+#[test]
+fn closure_within_param_fn_mut() {
+    check_edit_with_trigger_character(
+        "|_| ",
+        r#"
+//- minicore: fn
+fn foo(f: impl FnMut(u32)) {}
+fn main() {
+    foo(|$0);
+}
+"#,
+        r#"
+fn foo(f: impl FnMut(u32)) {}
+fn main() {
+    foo(|${1:_}| $0);
+}
+"#,
+        Some('|'),
+    );
+}
+
+#[test]
+fn closure_within_param_fn_once() {
+    check_edit_with_trigger_character(
+        "|_| ",
+        r#"
+//- minicore: fn
+fn foo(f: impl FnOnce(String) -> String) {}
+fn main() {
+    foo(|$0);
+}
+"#,
+        r#"
+fn foo(f: impl FnOnce(String) -> String) {}
+fn main() {
+    foo(|${1:_}| $0);
+}
+"#,
+        Some('|'),
+    );
+}
+
+#[test]
+fn closure_within_param_second_arg() {
+    check_edit_with_trigger_character(
+        "|_| ",
+        r#"
+//- minicore: fn
+fn foo(x: u32, f: impl Fn(bool) -> bool) {}
+fn main() {
+    foo(0, |$0);
+}
+"#,
+        r#"
+fn foo(x: u32, f: impl Fn(bool) -> bool) {}
+fn main() {
+    foo(0, |${1:_}| $0);
+}
+"#,
+        Some('|'),
+    );
+}
+
+#[test]
+fn closure_within_param_method_call() {
+    check_edit_with_trigger_character(
+        "|_| ",
+        r#"
+//- minicore: fn
+struct S;
+impl S {
+    fn foo(&self, f: impl FnOnce(u32) -> bool) {}
+}
+fn main() {
+    S.foo(|$0);
+}
+"#,
+        r#"
+struct S;
+impl S {
+    fn foo(&self, f: impl FnOnce(u32) -> bool) {}
+}
+fn main() {
+    S.foo(|${1:_}| $0);
+}
+"#,
+        Some('|'),
+    );
+}
+
+#[test]
+fn closure_within_param_method_second_closure_arg() {
+    check_edit_with_trigger_character(
+        "|_, _| ",
+        r#"
+//- minicore: fn
+struct S;
+impl S {
+    fn foo(&self, a: impl Fn(u32), b: impl Fn(bool, i64)) {}
+}
+fn main() {
+    S.foo(|_| {}, |$0);
+}
+"#,
+        r#"
+struct S;
+impl S {
+    fn foo(&self, a: impl Fn(u32), b: impl Fn(bool, i64)) {}
+}
+fn main() {
+    S.foo(|_| {}, |${1:_}, ${2:_}| $0);
+}
+"#,
+        Some('|'),
+    );
+}
+
+#[test]
+fn closure_within_param_where_clause() {
+    check_edit_with_trigger_character(
+        "|_, _| ",
+        r#"
+//- minicore: fn
+fn foo<F>(f: F) where F: Fn(u32, bool) -> bool {}
+fn main() {
+    foo(|$0);
+}
+"#,
+        r#"
+fn foo<F>(f: F) where F: Fn(u32, bool) -> bool {}
+fn main() {
+    foo(|${1:_}, ${2:_}| $0);
+}
+"#,
+        Some('|'),
+    );
+}
+
+#[test]
+fn closure_within_param_generic_single() {
+    check_edit_with_trigger_character(
+        "|_: T| ",
+        r#"
+//- minicore: fn
+fn foo<T>(f: impl Fn(T) -> T) {}
+fn main() {
+    foo(|$0);
+}
+"#,
+        r#"
+fn foo<T>(f: impl Fn(T) -> T) {}
+fn main() {
+    foo(|${1:_}: ${2:T}| $0);
+}
+"#,
+        Some('|'),
+    );
+}
+
+#[test]
+fn closure_within_param_generic_mixed() {
+    check_edit_with_trigger_character(
+        "|_, _: T| ",
+        r#"
+//- minicore: fn
+fn foo<T>(f: impl Fn(u32, T) -> bool) {}
+fn main() {
+    foo(|$0);
+}
+"#,
+        r#"
+fn foo<T>(f: impl Fn(u32, T) -> bool) {}
+fn main() {
+    foo(|${1:_}, ${2:_}: ${3:T}| $0);
+}
+"#,
+        Some('|'),
+    );
+}
+
+#[test]
+fn closure_within_param_generic_multiple() {
+    check_edit_with_trigger_character(
+        "|_: T, _: U| ",
+        r#"
+//- minicore: fn
+fn foo<T, U>(f: impl Fn(T, U)) {}
+fn main() {
+    foo(|$0);
+}
+"#,
+        r#"
+fn foo<T, U>(f: impl Fn(T, U)) {}
+fn main() {
+    foo(|${1:_}: ${2:T}, ${3:_}: ${4:U}| $0);
+}
+"#,
+        Some('|'),
+    );
 }

--- a/crates/rust-analyzer/src/handlers/request.rs
+++ b/crates/rust-analyzer/src/handlers/request.rs
@@ -1145,7 +1145,7 @@ pub(crate) fn handle_completion(
         None => return Ok(None),
         Some(items) => items,
     };
-
+    tracing::error!("{:?}", &items);
     let items = to_proto::completion_items(
         &snap.config,
         &completion_config.fields_to_resolve,

--- a/crates/rust-analyzer/src/lsp/capabilities.rs
+++ b/crates/rust-analyzer/src/lsp/capabilities.rs
@@ -55,6 +55,7 @@ pub fn server_capabilities(config: &Config) -> ServerCapabilities {
                 ".".to_owned(),
                 "'".to_owned(),
                 "(".to_owned(),
+                "|".to_owned(),
             ]),
             all_commit_characters: None,
             completion_item: config.caps().completion_item(),


### PR DESCRIPTION
Related to https://github.com/rust-lang/rust-analyzer/issues/8676
Related to https://github.com/rust-lang/rust-analyzer/issues/9444

https://github.com/user-attachments/assets/2797fee1-ecf1-4566-91a5-a775c68cbecc

Closure parameter names are a bit wacky, but they've been that way even before this PR; we should probably filter out suggestions for patterns that cannot actually be destructured.

