### PR TITLE
fix: generate method assist uses enclosing impl block instead of first found

### DIFF
--- a/crates/ide-assists/src/handlers/generate_function.rs
+++ b/crates/ide-assists/src/handlers/generate_function.rs
@@ -146,7 +146,7 @@ fn gen_method(acc: &mut Assists, ctx: &AssistContext<'_>) -> Option<()> {
     if !is_editable_crate(target_module.krate(ctx.db()), ctx.db()) {
         return None;
     }
-    //Change
+
     let enclosing_impl = ctx.find_node_at_offset::<ast::Impl>();
     let cursor_impl = enclosing_impl.filter(|impl_| {
         ctx.sema.to_def(impl_).map_or(false, |def| def.self_ty(ctx.sema.db).as_adt() == Some(adt))
@@ -158,7 +158,7 @@ fn gen_method(acc: &mut Assists, ctx: &AssistContext<'_>) -> Option<()> {
         get_adt_source(ctx, &adt, fn_name.text().as_str())?
     };
     let target = get_method_target(ctx, &impl_, &adt)?;
-    //change
+
     let function_builder = FunctionBuilder::from_method_call(
         ctx,
         &call,


### PR DESCRIPTION
Fixes rust-lang/rust-analyzer#21550

## Problem
When using the "Generate method" assist from inside an impl block, 
the generated method was always appended to the first impl block 
found for that type, instead of the impl block where the cursor is.

For example, given:
```rust
struct Foo;

impl Foo {
    fn new() -> Self { Foo }
}

impl Foo {
    fn method1(&self) {
        self.method2(42) // cursor here
    }
}
```

The generated `method2` was incorrectly inserted into the first 
`impl Foo` block instead of the one containing the cursor.

## Fix
In `gen_method`, before falling back to `get_adt_source`, we now 
check if the cursor is already inside an impl block for the target 
type. If so, we use that impl block as the insertion target.

## Test
Added a test case `generate_method_uses_current_impl_block` that 
reproduces the issue and verifies the fix.