### PR TITLE
feat: offer destructure_struct_binding on self param

### DIFF
--- a/crates/ide-assists/src/handlers/destructure_tuple_binding.rs
+++ b/crates/ide-assists/src/handlers/destructure_tuple_binding.rs
@@ -164,6 +164,7 @@ enum RefType {
     Mutable,
 }
 struct TupleData {
+    // FIXME: After removing ted, it may be possible to reuse destructure_struct_binding::Target
     ident_pat: IdentPat,
     ref_type: Option<RefType>,
     field_names: Vec<String>,


### PR DESCRIPTION
Close rust-lang/rust-analyzer#20869

Example
---
```rust
struct Foo { bar: i32, baz: i32 }

impl Foo {
    fn foo(&mut $0self) {
        self.bar = 5;
    }
}
```

**Before this PR**

Assist not applicable

**After this PR**

```rust
struct Foo { bar: i32, baz: i32 }

impl Foo {
    fn foo(&mut self) {
        let Foo { bar, baz } = self;
        *bar = 5;
    }
}
```
