### PR TITLE
fix: Detect E0804 when casting raw ptr-to-dyn adds auto traits

### DIFF
--- a/crates/hir-ty/src/infer/cast.rs
+++ b/crates/hir-ty/src/infer/cast.rs
@@ -328,11 +328,7 @@ impl<'db> CastCheck<'db> {
                     //
                     // Note that trait upcasting goes through a different mechanism (`coerce_unsized`)
                     // and is unaffected by this check.
-                    (Some(src_principal), Some(dst_principal)) => {
-                        if src_principal == dst_principal {
-                            return Ok(());
-                        }
-
+                    (Some(src_principal), Some(_)) => {
                         // We need to reconstruct trait object types.
                         // `m_src` and `m_dst` won't work for us here because they will potentially
                         // contain wrappers, which we do not care about.

--- a/crates/ide-diagnostics/src/handlers/invalid_cast.rs
+++ b/crates/ide-diagnostics/src/handlers/invalid_cast.rs
@@ -517,11 +517,13 @@ trait Trait<'a> {}
 
 fn add_auto<'a>(x: *mut dyn Trait<'a>) -> *mut (dyn Trait<'a> + Send) {
     x as _
+  //^^^^^^ error: cannot add auto trait to dyn bound via pointer cast
 }
 
 // (to test diagnostic list formatting)
 fn add_multiple_auto<'a>(x: *mut dyn Trait<'a>) -> *mut (dyn Trait<'a> + Send + Sync + Unpin) {
     x as _
+  //^^^^^^ error: cannot add auto trait to dyn bound via pointer cast
 }
 "#,
         );


### PR DESCRIPTION
the `check_ptr_ptr_cast` function had an early return when the source and destination dyn trait objects shared the same principal trait def id:

    if src_principal == dst_principal {
        return Ok(());
    }

this bypassed all three remaining checks that the code comment explicitly listed as required: generic argument equality, projection equality and the auto-trait superset check. as a resultcasts like `*mut dyn Trait as *mut (dyn Trait + Send)` were silently accepted instead of emitting e0804.

the fix removes the early return. `CastError::PtrPtrAddingAutoTraits` and its diagnostic were already implemented they just couldnt be reached. the supertrait case (`trait Trait: Send`) continues to work correctly because the auto trait check already accounts for implied auto traits via supertrait elaboration.