### PR TITLE
fix: no complete enum variant qualifier in pat

### DIFF
--- a/crates/ide-completion/src/completions/pattern.rs
+++ b/crates/ide-completion/src/completions/pattern.rs
@@ -95,7 +95,7 @@ pub(crate) fn complete_pattern(
                     if refutable || single_variant_enum(variant.parent_enum(ctx.db)) =>
                 {
                     acc.add_variant_pat(ctx, pattern_ctx, None, variant, Some(name.clone()));
-                    true
+                    false
                 }
                 hir::ModuleDef::Adt(hir::Adt::Enum(e)) => refutable || single_variant_enum(e),
                 hir::ModuleDef::Const(..) => refutable,

--- a/crates/ide-completion/src/tests/pattern.rs
+++ b/crates/ide-completion/src/tests/pattern.rs
@@ -122,7 +122,6 @@ fn foo() {
             st Record
             st Tuple
             st Unit
-            ev TupleV
             bn Record {…} Record { field$1 }$0
             bn Tuple(…)            Tuple($1)$0
             bn TupleV(…)          TupleV($1)$0
@@ -159,8 +158,6 @@ fn foo(foo: Foo) { match foo { Foo { x: $0 } } }
         expect![[r#"
             en Bar
             st Foo
-            ev Nil
-            ev Value
             bn Foo {…} Foo { x$1 }$0
             bn Nil             Nil$0
             bn Value         Value$0
@@ -189,7 +186,6 @@ fn foo() {
             st Record
             st Tuple
             st Unit
-            ev Variant
             bn Record {…} Record { field$1 }$0
             bn Tuple(…)            Tuple($1)$0
             bn Variant               Variant$0
@@ -350,6 +346,34 @@ fn func() {
             bn RecordV {…} RecordV { field$1 }$0
             bn TupleV(…)            TupleV($1)$0
             bn UnitV                     UnitV$0
+        "#]],
+    );
+}
+
+#[test]
+fn enum_unqualified() {
+    check_with_base_items(
+        r#"
+use Enum::*;
+fn func() {
+    if let $0 = unknown {}
+}
+"#,
+        expect![[r#"
+            ct CONST
+            en Enum
+            ma makro!(…)      macro_rules! makro
+            md module
+            st Record
+            st Tuple
+            st Unit
+            bn Record {…}   Record { field$1 }$0
+            bn RecordV {…} RecordV { field$1 }$0
+            bn Tuple(…)              Tuple($1)$0
+            bn TupleV(…)            TupleV($1)$0
+            bn UnitV                     UnitV$0
+            kw mut
+            kw ref
         "#]],
     );
 }

--- a/crates/ide-completion/src/tests/record.rs
+++ b/crates/ide-completion/src/tests/record.rs
@@ -61,8 +61,6 @@ fn foo(baz: Baz) {
             en Baz
             en Result
             md core
-            ev Err
-            ev Ok
             bn Baz::Bar Baz::Bar$0
             bn Baz::Foo Baz::Foo$0
             bn Err(…)    Err($1)$0
@@ -89,10 +87,6 @@ fn foo(baz: Baz) {
             en Baz
             en Result
             md core
-            ev Bar
-            ev Err
-            ev Foo
-            ev Ok
             bn Bar        Bar$0
             bn Err(…) Err($1)$0
             bn Foo        Foo$0


### PR DESCRIPTION
Example
---
```rust
enum Enum { TupleV(u32), RecordV { field: u32 }, UnitV }
use Enum::*;
fn func() {
    if let $0 = unknown {}
}
```

**Before this PR**

```text
...
ev RecordV
ev TupleV
ev UnitV
bn RecordV {…} RecordV { field$1 }$0
bn TupleV(…)            TupleV($1)$0
bn UnitV                     UnitV$0
kw mut
kw ref
```

**After this PR**

```text
...
bn RecordV {…} RecordV { field$1 }$0
bn TupleV(…)            TupleV($1)$0
bn UnitV                     UnitV$0
kw mut
kw ref
```
