### PR TITLE
fix: Incorrect flychecks with multiple workspaces

### DIFF
--- a/crates/rust-analyzer/src/flycheck.rs
+++ b/crates/rust-analyzer/src/flycheck.rs
@@ -1021,7 +1021,7 @@ impl JsonLinesParser<CheckMessage> for CheckParser {
     }
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Debug)]
 #[serde(untagged)]
 enum JsonMessage {
     Cargo(cargo_metadata::Message),

--- a/crates/rust-analyzer/src/handlers/notification.rs
+++ b/crates/rust-analyzer/src/handlers/notification.rs
@@ -295,8 +295,9 @@ pub(crate) fn handle_did_change_watched_files(
     for change in params.changes.iter().unique_by(|&it| &it.uri) {
         if let Ok(path) = from_proto::abs_path(&change.uri) {
             if !trigger_flycheck {
+                // Trigger if no workspaces contain this file.
                 trigger_flycheck =
-                    state.config.workspace_roots().iter().any(|root| !path.starts_with(root));
+                    state.config.workspace_roots().iter().all(|root| !path.starts_with(root));
             }
             state.loader.handle.invalidate(path);
         }


### PR DESCRIPTION
When rust-analyzer receives textDocument/didChangeWatchedFiles, we
want to trigger a flycheck in all workspaces if we can't find which
workspace owns those files.

However, since we used .any() instead of .all(), this behaviour was
always triggered when the user had more than one workspace.

Instead, use .all() so we correctly detect when the file it outside of
all workspaces.

---

For cargo-based projects, this just made rust-analyzer slower. For
projects with a custom check command using $saved_file or
{saved_file}, this introduced a race condition that sometimes
prevented diagnostics.

When we see the following flycheck events in this order:

    // Created by textDocument/didSave.
    RequestStateChange(Restart { ... saved_file: Some("foo.rs") })
    // Created by textDocument/didChangeWatchedFiles
    RequestStateChange(Restart { ... saved_file: None })

Then the flycheck debounce takes the last event, we invoke flycheck
with saved_file: None, and no flycheck occurs (because we require a
value to substitute in $saved_file).

Previously the debounce took the first event (until
rust-lang/rust-analyzer#21666), but that just meant a race condition
when events arrived in the opposite order.