### PR TITLE
Migrate `fix_visibility` assist to SyntaxEditor 

### DIFF
--- a/crates/syntax/src/ast/syntax_factory/constructors.rs
+++ b/crates/syntax/src/ast/syntax_factory/constructors.rs
@@ -79,8 +79,12 @@ impl SyntaxFactory {
         make::path_concat(first, second).clone_for_update()
     }
 
+    pub fn visibility_pub_crate(&self) -> ast::Visibility {
+        make::visibility_pub_crate().clone_for_update()
+    }
+
     pub fn visibility_pub(&self) -> ast::Visibility {
-        make::visibility_pub()
+        make::visibility_pub().clone_for_update()
     }
 
     pub fn struct_(


### PR DESCRIPTION
Changes made in conjunction with Copilot "Ask" agent.

part of https://github.com/rust-lang/rust-analyzer/issues/15710 and https://github.com/rust-lang/rust-analyzer/issues/18285

```
running 14 tests
test handlers::fix_visibility::tests::replaces_pub_crate_with_pub ... ok
test handlers::fix_visibility::tests::fix_visibility_of_reexport ... ok
test handlers::fix_visibility::tests::adds_pub_when_target_is_in_another_crate ... ok
test handlers::fix_visibility::tests::fix_visibility_of_inline_module_in_other_file ... ok
test handlers::fix_visibility::tests::fix_visibility_of_adt_in_other_file ... ok
test handlers::fix_visibility::tests::fix_visibility_of_module_declaration_in_other_file ... ok
test handlers::fix_visibility::tests::fix_visibility_of_static ... ok
test handlers::fix_visibility::tests::fix_visibility_of_type_alias ... ok
test handlers::fix_visibility::tests::fix_visibility_of_const ... ok
test handlers::fix_visibility::tests::fix_visibility_of_fn ... ok
test handlers::fix_visibility::tests::fix_visibility_of_trait ... ok
test handlers::fix_visibility::tests::fix_visibility_of_enum_variant_field ... ok
test handlers::fix_visibility::tests::fix_visibility_of_module ... ok
test handlers::fix_visibility::tests::fix_visibility_of_adt_in_submodule ... ok

test result: ok. 14 passed; 0 failed; 0 ignored; 0 measured; 2675 filtered out; finished in 0.03s
``` 