### PR TITLE
fix: Use -Zlockfile-path on every 1.95 nightly

### DIFF
--- a/crates/project-model/src/cargo_config_file.rs
+++ b/crates/project-model/src/cargo_config_file.rs
@@ -158,14 +158,15 @@ pub(crate) fn make_lockfile_copy(
             build: semver::BuildMetadata::EMPTY,
         };
 
-    const MINIMUM_TOOLCHAIN_VERSION_SUPPORTING_LOCKFILE_PATH_ENV: semver::Version =
-        semver::Version {
-            major: 1,
-            minor: 95,
-            patch: 0,
-            pre: semver::Prerelease::EMPTY,
-            build: semver::BuildMetadata::EMPTY,
-        };
+    // TODO: turn this into a const and remove pre once 1.95 is stable
+    #[allow(non_snake_case)]
+    let MINIMUM_TOOLCHAIN_VERSION_SUPPORTING_LOCKFILE_PATH_ENV: semver::Version = semver::Version {
+        major: 1,
+        minor: 95,
+        patch: 0,
+        pre: semver::Prerelease::new("nightly").unwrap(),
+        build: semver::BuildMetadata::EMPTY,
+    };
 
     let usage = if *toolchain_version >= MINIMUM_TOOLCHAIN_VERSION_SUPPORTING_LOCKFILE_PATH_ENV {
         LockfileUsage::WithEnvVar


### PR DESCRIPTION
Closes rust-lang/rust-analyzer#21715