### PR TITLE
fix: Improve newline for make `match`, `if`, `while` etc

### DIFF
--- a/crates/ide-assists/src/handlers/move_guard.rs
+++ b/crates/ide-assists/src/handlers/move_guard.rs
@@ -567,7 +567,8 @@ fn main() {
     match 92 {
         x => if true
             && true
-            && true {
+            && true
+        {
             {
                 false
             }

--- a/crates/ide-assists/src/handlers/replace_if_let_with_match.rs
+++ b/crates/ide-assists/src/handlers/replace_if_let_with_match.rs
@@ -972,7 +972,8 @@ fn main() {
 fn main() {
     if true {
         match path.strip_prefix(root_path)
-            .and(x) {
+            .and(x)
+        {
             Ok(rel_path) => {
                 let rel_path = RelativePathBuf::from_path(rel_path)
                     .ok()?;
@@ -1012,7 +1013,8 @@ fn main() {
 fn main() {
     if true {
         match path.strip_prefix(root_path)
-            .and(x) {
+            .and(x)
+        {
             Ok(rel_path) => {
                 Foo {
                     x: 1
@@ -1046,7 +1048,8 @@ fn main() {
 fn main() {
     if true {
         match true
-            && false {
+            && false
+        {
             true => foo(),
             false => (),
         }
@@ -1925,7 +1928,8 @@ fn main() {
 fn main() {
     if true {
         if let Ok(rel_path) = path.strip_prefix(root_path)
-            .and(x) {
+            .and(x)
+        {
             Foo {
                 x: 2
             }
@@ -1965,7 +1969,8 @@ fn main() {
 fn main() {
     if true {
         if let Ok(rel_path) = path.strip_prefix(root_path)
-            .and(x) {
+            .and(x)
+        {
             let rel_path = RelativePathBuf::from_path(rel_path)
                 .ok()?;
             Some((*id, rel_path))


### PR DESCRIPTION
- Remove unused `ast::make::match_arm_with_guard`

Example
---
```rust
fn main() {
    if true {
        $0if true
            && false
        {
            foo()
        }
    }
}
```

**Before this PR**

```rust
fn main() {
    if true {
        match true
            && false {
            true => foo(),
            false => (),
        }
    }
}
```

**After this PR**

```rust
fn main() {
    if true {
        match true
            && false
        {
            true => foo(),
            false => (),
        }
    }
}
```
