### PR TITLE
Fix: align `is_rust()` with rustc by correcting constructor ABI in next solver

### DIFF
--- a/crates/hir-ty/src/lower.rs
+++ b/crates/hir-ty/src/lower.rs
@@ -2468,7 +2468,7 @@ fn fn_sig_for_struct_constructor(
     let inputs_and_output =
         Tys::new_from_iter(DbInterner::new_no_crate(db), params.chain(Some(ret.as_ref())));
     StoredEarlyBinder::bind(StoredPolyFnSig::new(Binder::dummy(FnSig {
-        abi: FnAbi::RustCall,
+        abi: FnAbi::Rust,
         c_variadic: false,
         safety: Safety::Safe,
         inputs_and_output,
@@ -2487,7 +2487,7 @@ fn fn_sig_for_enum_variant_constructor(
     let inputs_and_output =
         Tys::new_from_iter(DbInterner::new_no_crate(db), params.chain(Some(ret.as_ref())));
     StoredEarlyBinder::bind(StoredPolyFnSig::new(Binder::dummy(FnSig {
-        abi: FnAbi::RustCall,
+        abi: FnAbi::Rust,
         c_variadic: false,
         safety: Safety::Safe,
         inputs_and_output,

--- a/crates/hir-ty/src/next_solver/abi.rs
+++ b/crates/hir-ty/src/next_solver/abi.rs
@@ -62,7 +62,6 @@ impl<'db> rustc_type_ir::inherent::Abi<DbInterner<'db>> for FnAbi {
     }
 
     fn is_rust(self) -> bool {
-        // TODO: rustc does not consider `RustCall` to be true here, but Chalk does
-        matches!(self, FnAbi::Rust | FnAbi::RustCall)
+        matches!(self, FnAbi::Rust)
     }
 }

--- a/crates/hir-ty/src/tests/traits.rs
+++ b/crates/hir-ty/src/tests/traits.rs
@@ -2218,6 +2218,40 @@ fn test() {
 }
 
 #[test]
+fn tuple_struct_constructor_as_fn_trait() {
+    check_types(
+        r#"
+//- minicore: fn
+struct S(u32, u64);
+
+fn takes_fn<F: Fn(u32, u64) -> S>(f: F) -> S { f(1, 2) }
+
+fn test() {
+    takes_fn(S);
+  //^^^^^^^^^^^ S
+}
+"#,
+    );
+}
+
+#[test]
+fn enum_variant_constructor_as_fn_trait() {
+    check_types(
+        r#"
+//- minicore: fn
+enum E { A(u32) }
+
+fn takes_fn<F: Fn(u32) -> E>(f: F) -> E { f(1) }
+
+fn test() {
+    takes_fn(E::A);
+  //^^^^^^^^^^^^^^ E
+}
+"#,
+    );
+}
+
+#[test]
 fn fn_item_fn_trait() {
     check_types(
         r#"


### PR DESCRIPTION
resolves a TODO in `crates/hir-ty/src/next_solver/abi.rs` .

TODO: rustc does not consider `RustCall` to be true here but chalk does the `rustc_type_ir::inherent::Abi` trait documents `is_rust()` as * "if this ABI is `extern "Rust"`"*. `RustCall` is `extern "rust-call"` a specific ABI used internally for the closure calling convention so returning `true` for it violates the trait contract and diverges from rustcs behavior.

cause:  `fn_sig_for_struct_constructor` and `fn_sig_for_enum_variant_constructor` in `lower.rs` were assigning `FnAbi::RustCall` to tuple struct and enum variant constructors a holdover from the chalk era. in rustc these constructors have `extern "Rust"` ABI. because of this `is_rust()` was forced to include `RustCall` so that constructors would still pass the `is_fn_trait_compatible()` check in the next solver (used at 5 call sites in `rustc_next_trait_solver::solve::assembly::structural_traits` to gate `Fn`/`FnMut`/`FnOnce` impl resolution for `FnDef` and `FnPtr` types).

fix:
- change struct and enum variant constructor signatures to use `FnAbi::Rust`
- change `is_rust()` to `matches!(self, FnAbi::Rust)`, matching rustc's semantics

added two tests comfirming tuple struct and enum variant constructors correctly implement `Fn` traits through the next solver after this change.