### PR TITLE
minor: Release a new smol-str minor version with borsh fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2635,7 +2635,7 @@ dependencies = [
 
 [[package]]
 name = "smol_str"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "arbitrary",
  "borsh",

--- a/lib/smol_str/CHANGELOG.md
+++ b/lib/smol_str/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.3.6 - 2026-03-04
+- Fix the `borsh` feature.
+
 ## 0.3.5 - 2026-01-08
 - Optimise `SmolStr::clone` 4-5x speedup inline, 0.5x heap (slow down).
 

--- a/lib/smol_str/Cargo.toml
+++ b/lib/smol_str/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smol_str"
-version = "0.3.5"
+version = "0.3.6"
 description = "small-string optimized string type with O(1) clone"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/rust-analyzer/tree/master/lib/smol_str"


### PR DESCRIPTION
https://github.com/rust-lang/rust-analyzer/pull/21648.