### PR TITLE
fix: Allow never coercions in struct update syntax

### DIFF
--- a/crates/hir-ty/src/infer/expr.rs
+++ b/crates/hir-ty/src/infer/expr.rs
@@ -658,7 +658,7 @@ impl<'db> InferenceContext<'_, 'db> {
                     }
                 }
                 if let RecordSpread::Expr(expr) = *spread {
-                    self.infer_expr(expr, &Expectation::has_type(ty), ExprIsRead::Yes);
+                    self.infer_expr_coerce_never(expr, &Expectation::has_type(ty), ExprIsRead::Yes);
                 }
                 ty
             }

--- a/crates/hir-ty/src/tests/never_type.rs
+++ b/crates/hir-ty/src/tests/never_type.rs
@@ -886,3 +886,18 @@ fn foo() {
         "#]],
     );
 }
+
+#[test]
+fn never_coercion_in_struct_update_syntax() {
+    check_no_mismatches(
+        r#"
+struct Struct {
+    field: i32,
+}
+
+fn example() -> Struct {
+    Struct { ..loop {} }
+}
+    "#,
+    );
+}


### PR DESCRIPTION
Fixes rust-lang/rust-analyzer#21701.