### PR TITLE
Add `-Z unstable-options` to `rustc` invocation to make `--target` work

### DIFF
--- a/crates/project-model/src/toolchain_info/rustc_cfg.rs
+++ b/crates/project-model/src/toolchain_info/rustc_cfg.rs
@@ -87,7 +87,7 @@ fn rustc_print_cfg(
     };
 
     let mut cmd = sysroot.tool(Tool::Rustc, current_dir, extra_env);
-    cmd.args(RUSTC_ARGS);
+    cmd.args(["-Z", "unstable-options"]).args(RUSTC_ARGS);
     cmd.arg("-O");
     if let Some(target) = target {
         cmd.args(["--target", target]);


### PR DESCRIPTION
Currently when using a custom target JSON without Cargo, there is the following problem:
```
2026-03-04T13:41:29.078675707Z  WARN failed to get rustc cfgs e=unable to fetch cfgs via `"/.../rustc" "--print" "cfg" "-O" "--target" "/.../custom_target.json"`

Caused by:
    "/.../rustc" "--print" "cfg" "-O" "--target" "/.../custom_target.json" failed, exit status: 1
    stderr:
    error: error loading target specification: custom targets are unstable and require `-Zunstable-options`
      |
      = help: run `rustc --print target-list` for a list of built-in targets
```

Just a few lines above, we already set `-Z unstable-options` in the Cargo branch:
https://github.com/rust-lang/rust-analyzer/blob/2a8f00fb9344cc6701063192fe0aaf66ecf9d337/crates/project-model/src/toolchain_info/rustc_cfg.rs#L69

We should do the same when calling `rustc` directly.