### PR TITLE
Fix clippy on master

### DIFF
--- a/xtask/src/codegen/grammar/ast_src.rs
+++ b/xtask/src/codegen/grammar/ast_src.rs
@@ -189,9 +189,9 @@ pub(crate) fn generate_kind_src(
             }
         }
     });
-    PUNCT.iter().zip(used_puncts).filter(|(_, used)| !used).for_each(|((punct, _), _)| {
+    if let Some(punct) = PUNCT.iter().zip(used_puncts).find(|(_, used)| !used) {
         panic!("Punctuation {punct:?} is not used in grammar");
-    });
+    }
     keywords.extend(RESERVED.iter().copied());
     keywords.sort();
     keywords.dedup();


### PR DESCRIPTION
A recent Clippy release breaks the master. More details: https://github.com/rust-lang/rust-analyzer/actions/runs/22743273242/job/65961444987?pr=21734

This PR fixes the issue.