### PR TITLE
fix: add ident_pat qualifier to fully fn param

### DIFF
--- a/crates/ide-completion/src/completions/fn_param.rs
+++ b/crates/ide-completion/src/completions/fn_param.rs
@@ -30,14 +30,27 @@ pub(crate) fn complete_fn_param(
         _ => return None,
     };
 
+    let qualifier = param_qualifier(param);
     let comma_wrapper = comma_wrapper(ctx);
     let mut add_new_item_to_acc = |label: &str| {
-        let mk_item = |label: &str, range: TextRange| {
-            CompletionItem::new(CompletionItemKind::Binding, range, label, ctx.edition)
+        let label = label.strip_prefix(qualifier.as_str()).unwrap_or(label);
+        let insert = if label.starts_with('#') {
+            // FIXME: `#[attr] it: i32` -> `#[attr] mut it: i32`
+            label.to_smolstr()
+        } else {
+            format_smolstr!("{qualifier}{label}")
+        };
+        let mk_item = |insert_text: &str, range: TextRange| {
+            let mut item =
+                CompletionItem::new(CompletionItemKind::Binding, range, label, ctx.edition);
+            if insert_text != label {
+                item.insert_text(insert_text);
+            }
+            item
         };
         let item = match &comma_wrapper {
-            Some((fmt, range)) => mk_item(&fmt(label), *range),
-            None => mk_item(label, ctx.source_range()),
+            Some((fmt, range)) => mk_item(&fmt(&insert), *range),
+            None => mk_item(&insert, ctx.source_range()),
         };
         // Completion lookup is omitted intentionally here.
         // See the full discussion: https://github.com/rust-lang/rust-analyzer/issues/12073
@@ -213,4 +226,17 @@ fn is_simple_param(param: &ast::Param) -> bool {
     param
         .pat()
         .is_none_or(|pat| matches!(pat, ast::Pat::IdentPat(ident_pat) if ident_pat.pat().is_none()))
+}
+
+fn param_qualifier(param: &ast::Param) -> SmolStr {
+    let mut b = syntax::SmolStrBuilder::new();
+    if let Some(ast::Pat::IdentPat(pat)) = param.pat() {
+        if pat.ref_token().is_some() {
+            b.push_str("ref ");
+        }
+        if pat.mut_token().is_some() {
+            b.push_str("mut ");
+        }
+    }
+    b.finish()
 }

--- a/crates/ide-completion/src/render/function.rs
+++ b/crates/ide-completion/src/render/function.rs
@@ -678,7 +678,7 @@ fn main() {
     fn complete_fn_param() {
         // has mut kw
         check_edit(
-            "mut bar: u32",
+            "bar: u32",
             r#"
 fn f(foo: (), mut bar: u32) {}
 fn g(foo: (), mut ba$0)
@@ -689,9 +689,34 @@ fn g(foo: (), mut bar: u32)
 "#,
         );
 
-        // has type param
+        // has unmatched mut kw
+        check_edit(
+            "bar: u32",
+            r#"
+fn f(foo: (), bar: u32) {}
+fn g(foo: (), mut ba$0)
+"#,
+            r#"
+fn f(foo: (), bar: u32) {}
+fn g(foo: (), mut bar: u32)
+"#,
+        );
+
         check_edit(
             "mut bar: u32",
+            r#"
+fn f(foo: (), mut bar: u32) {}
+fn g(foo: (), ba$0)
+"#,
+            r#"
+fn f(foo: (), mut bar: u32) {}
+fn g(foo: (), mut bar: u32)
+"#,
+        );
+
+        // has type param
+        check_edit(
+            "bar: u32",
             r#"
 fn g(foo: (), mut ba$0: u32)
 fn f(foo: (), mut bar: u32) {}
@@ -707,7 +732,7 @@ fn f(foo: (), mut bar: u32) {}
     fn complete_fn_mut_param_add_comma() {
         // add leading and trailing comma
         check_edit(
-            ", mut bar: u32,",
+            "bar: u32",
             r#"
 fn f(foo: (), mut bar: u32) {}
 fn g(foo: ()mut ba$0 baz: ())
@@ -746,7 +771,7 @@ fn g(foo: (), #[baz = "qux"] mut bar: u32)
         );
 
         check_edit(
-            r#", #[baz = "qux"] mut bar: u32"#,
+            r#"#[baz = "qux"] mut bar: u32"#,
             r#"
 fn f(foo: (), #[baz = "qux"] mut bar: u32) {}
 fn g(foo: ()#[baz = "qux"] mut ba$0)

--- a/crates/ide-completion/src/tests/fn_param.rs
+++ b/crates/ide-completion/src/tests/fn_param.rs
@@ -43,7 +43,7 @@ fn bar(file_id: usize) {}
 fn baz(file$0 id: u32) {}
 "#,
         expect![[r#"
-            bn file_id: usize,
+            bn file_id: usize
             kw mut
             kw ref
         "#]],


### PR DESCRIPTION
- Do not show commas on label

Example
---
```rust
fn f(foo: (), bar: u32) {}
fn g(foo: (), mut ba$0)
```

**Before this PR**

```rust
fn f(foo: (), bar: u32) {}
fn g(foo: (), bar: u32)
```

**After this PR**

```rust
fn f(foo: (), bar: u32) {}
fn g(foo: (), mut bar: u32)
```
