### PR TITLE
fix: Update VFS when a watched file is deleted

### DIFF
--- a/crates/vfs-notify/src/lib.rs
+++ b/crates/vfs-notify/src/lib.rs
@@ -208,6 +208,22 @@ impl NotifyActor {
                                 )
                             })
                             .filter_map(|path| -> Option<(AbsPathBuf, Option<Vec<u8>>)> {
+                                // Ignore events for files/directories that we're not watching.
+                                if !(self.watched_file_entries.contains(&path)
+                                    || self
+                                        .watched_dir_entries
+                                        .iter()
+                                        .any(|dir| dir.contains_file(&path)))
+                                {
+                                    return None;
+                                }
+
+                                // For removed files, fs::metadata() will return Err, but
+                                // we still want to update the VFS.
+                                if matches!(event.kind, EventKind::Remove(_)) {
+                                    return Some((path, None));
+                                }
+
                                 let meta = fs::metadata(&path).ok()?;
                                 if meta.file_type().is_dir()
                                     && self
@@ -220,15 +236,6 @@ impl NotifyActor {
                                 }
 
                                 if !meta.file_type().is_file() {
-                                    return None;
-                                }
-
-                                if !(self.watched_file_entries.contains(&path)
-                                    || self
-                                        .watched_dir_entries
-                                        .iter()
-                                        .any(|dir| dir.contains_file(&path)))
-                                {
                                     return None;
                                 }
 


### PR DESCRIPTION
When rust-analyzer handles file watching, it previously wouldn't update the VFS on file deletion. We would discard events where fs::metadata() isn't available, and we never have metadata for deleted files.

See also the discussion in rust-lang/rust-analyzer#19907.

AI disclosure: This was partially written with Opus. I rewrote it several times and tested it afterwards.