### PR TITLE
fix: File watcher should watch directories recursively

### DIFF
--- a/crates/vfs-notify/src/lib.rs
+++ b/crates/vfs-notify/src/lib.rs
@@ -317,7 +317,7 @@ impl NotifyActor {
 
     fn watch(&mut self, path: &Path) {
         if let Some((watcher, _)) = &mut self.watcher {
-            log_notify_error(watcher.watch(path, RecursiveMode::NonRecursive));
+            log_notify_error(watcher.watch(path, RecursiveMode::Recursive));
         }
     }
 


### PR DESCRIPTION
Currently rust-analyzer only watches the directory itself, and doesn't consider children recursively.

This is a problem when the directory itself is deleted and recreated (e.g. if you're creating all of `mycrate/src/` with a code generating script). The obvious solution is to configure rust-analyzer to watch the parent directory (assuming rust-project.json), but that requires recursive watching.

This problem probably also occurs when switching between git commits.

Instead, watch directories recursively so we can use the file watcher with parent directories.

See also discussion on rust-lang/rust-analyzer#19907.

I've tested on some decent sized projects (several hundred transitive dependencies) and performance seemed fine.