### PR TITLE
fix: replace TODO placeholders in next-solver IrPrint with proper formatting

### DIFF
--- a/crates/hir-ty/src/next_solver/ir_print.rs
+++ b/crates/hir-ty/src/next_solver/ir_print.rs
@@ -188,7 +188,7 @@ impl<'db> IrPrint<ty::NormalizesTo<Self>> for DbInterner<'db> {
         t: &ty::NormalizesTo<Self>,
         fmt: &mut std::fmt::Formatter<'_>,
     ) -> std::fmt::Result {
-        write!(fmt, "{} -> {:?}", t.alias, t.term)
+        write!(fmt, "NormalizesTo({} -> {:?})", t.alias, t.term)
     }
 }
 impl<'db> IrPrint<ty::SubtypePredicate<Self>> for DbInterner<'db> {
@@ -215,7 +215,7 @@ impl<'db> IrPrint<ty::CoercePredicate<Self>> for DbInterner<'db> {
         t: &ty::CoercePredicate<Self>,
         fmt: &mut std::fmt::Formatter<'_>,
     ) -> std::fmt::Result {
-        write!(fmt, "{:?} -> {:?}", t.a, t.b)
+        write!(fmt, "CoercePredicate({:?} -> {:?})", t.a, t.b)
     }
 }
 impl<'db> IrPrint<ty::FnSig<Self>> for DbInterner<'db> {


### PR DESCRIPTION
seven `IrPrint::print_debug` implementations in the next-solver were placeholder stubs that returned "TODO: <typename>" instead of meaningful output. these are called via the Display impl (and Debug for PatternKind) of these types so any solver trace log containing them was unreadable.

implemented proper formatting for each:
- TraitPredicate      -> "T: Trait" / "!T: Trait"
- HostEffectPredicate -> "const T: Trait" / "[const] T: Trait"
- NormalizesTo        -> "AliasTerm(...) -> Term"
- SubtypePredicate    -> "A <: B"
- CoercePredicate     -> "A -> B"
- FnSig               -> "fn([inputs]) -> output"
- PatternKind         -> "start..=end" / "or([...])" / "!null"

also removed the unused `type_name_of_val` import.