### PR TITLE
fix: Allow duplicate assoc type shorthand resolution if it points to the same assoc type

### DIFF
--- a/crates/hir-ty/src/lower.rs
+++ b/crates/hir-ty/src/lower.rs
@@ -1809,8 +1809,12 @@ fn resolve_type_param_assoc_type_shorthand(
                 return AssocTypeShorthandResolution::Ambiguous {
                     sub_trait_resolution: Some(this_trait_resolution),
                 };
-            } else if supertraits_resolution.is_some() {
-                return AssocTypeShorthandResolution::Ambiguous { sub_trait_resolution: None };
+            } else if let Some(prev_resolution) = &supertraits_resolution {
+                if prev_resolution == lookup_on_bounded_trait {
+                    return AssocTypeShorthandResolution::Ambiguous { sub_trait_resolution: None };
+                } else {
+                    continue;
+                }
             } else {
                 let (assoc_type, args) = assoc_type_and_args
                     .get_with(|(assoc_type, args)| (*assoc_type, args.as_ref()))

--- a/crates/hir-ty/src/tests/regression.rs
+++ b/crates/hir-ty/src/tests/regression.rs
@@ -2815,3 +2815,28 @@ fn contains_0<S: Collection<Item = i32>>(points: &S) {
     "#,
     );
 }
+
+#[test]
+fn regression_21773() {
+    check_no_mismatches(
+        r#"
+trait Neg {
+    type Output;
+}
+
+trait Abs: Neg {
+    fn abs(&self) -> Self::Output;
+}
+
+trait SelfAbs: Abs + Neg
+where
+    Self::Output: Neg<Output = Self::Output> + Abs,
+{
+}
+
+fn wrapped_abs<T: SelfAbs<Output = T>>(v: T) -> T {
+    v.abs()
+}
+    "#,
+    );
+}


### PR DESCRIPTION
And with the same generic args.

Fixes rust-lang/rust-analyzer#21773.