### PR TITLE
Do not re-query source roots per crate in analysis-stats

### DIFF
--- a/crates/base-db/src/editioned_file_id.rs
+++ b/crates/base-db/src/editioned_file_id.rs
@@ -1,5 +1,5 @@
 //! Defines [`EditionedFileId`], an interned wrapper around [`span::EditionedFileId`] that
-//! is interned (so queries can take it) and remembers its crate.
+//! is interned (so queries can take it) and stores only the underlying `span::EditionedFileId`.
 
 use std::hash::Hash;
 

--- a/crates/ide/src/typing.rs
+++ b/crates/ide/src/typing.rs
@@ -70,12 +70,11 @@ pub(crate) fn on_char_typed(
     if !TRIGGER_CHARS.contains(&char_typed) {
         return None;
     }
-    let krate = db
+    let edition = db
         .relevant_crates(position.file_id)
         .first()
         .copied()
-        .unwrap_or_else(|| *db.all_crates().first().unwrap());
-    let edition = krate.data(db).edition;
+        .map_or(Edition::CURRENT, |krate| krate.data(db).edition);
     let editioned_file_id_wrapper = EditionedFileId::new(db, position.file_id, edition);
     let file = &db.parse(editioned_file_id_wrapper);
     let char_matches_position =

--- a/crates/rust-analyzer/src/cli/analysis_stats.rs
+++ b/crates/rust-analyzer/src/cli/analysis_stats.rs
@@ -127,7 +127,7 @@ impl flags::AnalysisStats {
             .iter()
             .cloned()
             .map(|krate| (db.file_source_root(krate.root_file(db)).source_root_id(db), krate))
-            .unique();
+            .unique_by(|(source_root_id, _)| *source_root_id);
 
         let mut dep_loc = 0;
         let mut workspace_loc = 0;


### PR DESCRIPTION
Not ideal as we may pick a crate that analysis is not actually using but we do not encode targets in the crate graph so we can't really tell what main library crate will be