### PR TITLE
make matching brace work when cursor not at bracket

### DIFF
--- a/crates/ide/src/matching_brace.rs
+++ b/crates/ide/src/matching_brace.rs
@@ -17,10 +17,9 @@ use syntax::{
 pub(crate) fn matching_brace(file: &SourceFile, offset: TextSize) -> Option<TextSize> {
     const BRACES: &[SyntaxKind] =
         &[T!['{'], T!['}'], T!['['], T![']'], T!['('], T![')'], T![<], T![>], T![|], T![|]];
-
-    if let Some((brace_token, brace_idx)) = file
-        .syntax()
-        .token_at_offset(offset)
+    let current = file.syntax().token_at_offset(offset);
+    if let Some((brace_token, brace_idx)) = current
+        .clone()
         .filter_map(|node| {
             let idx = BRACES.iter().position(|&brace| brace == node.kind())?;
             Some((node, idx))
@@ -39,10 +38,8 @@ pub(crate) fn matching_brace(file: &SourceFile, offset: TextSize) -> Option<Text
             .find(|node| node.kind() == matching_kind && node != &brace_token)?;
         Some(matching_node.text_range().start())
     } else {
-        // when the offset is not at a brace
-        let thingy = file.syntax().token_at_offset(offset).last()?;
-        // find first parent
-        thingy.parent_ancestors().find_map(|x| {
+        // when the offset is not at a brace, find first parent
+        current.last()?.parent_ancestors().find_map(|x| {
             x.children_with_tokens()
                 .filter_map(|it| it.into_token())
                 // with ending brace
@@ -78,6 +75,14 @@ mod tests {
         do_check(
             "fn func(x) { return (2 * (x + 3)$0) + 5;}",
             "fn func(x) { return $0(2 * (x + 3)) + 5;}",
+        );
+        do_check(
+            "fn func(x) { return (2 * (x $0+ 3)) + 5;}",
+            "fn func(x) { return (2 * (x + 3$0)) + 5;}",
+        );
+        do_check(
+            "fn func(x) { re$0turn (2 * (x + 3)) + 5;}",
+            "fn func(x) { return (2 * (x + 3)) + 5;$0}",
         );
 
         {


### PR DESCRIPTION
by jumping to the parents enclosing bracket.

see [#t-compiler/rust-analyzer > experimental/matching braces when not on a brace @ 💬](https://rust-lang.zulipchat.com/#narrow/channel/185405-t-compiler.2Frust-analyzer/topic/experimental.2Fmatching.20braces.20when.20not.20on.20a.20brace/near/566138066)

this would make the behavior match vscodes go to bracket command.

behavior pictured:

https://github.com/user-attachments/assets/ca6bd28f-48a5-414d-a750-45e0f128b361

