### PR TITLE
fix: handle multi-byte UTF-8 identifiers in `NameGenerator::suggest_name`

### DIFF
--- a/crates/ide-db/src/syntax_helpers/suggest_name.rs
+++ b/crates/ide-db/src/syntax_helpers/suggest_name.rs
@@ -89,6 +89,12 @@ const USELESS_METHODS: &[&str] = &[
 ///
 /// assert_eq!(generator.suggest_name("b2"), "b2");
 /// assert_eq!(generator.suggest_name("b"), "b3");
+///
+/// // Multi-byte UTF-8 identifiers (e.g. CJK) are handled correctly
+/// assert_eq!(generator.suggest_name("日本語"), "日本語");
+/// assert_eq!(generator.suggest_name("日本語"), "日本語1");
+/// assert_eq!(generator.suggest_name("données3"), "données3");
+/// assert_eq!(generator.suggest_name("données"), "données4");
 /// ```
 #[derive(Debug, Default)]
 pub struct NameGenerator {
@@ -262,11 +268,15 @@ impl NameGenerator {
     /// Remove the numeric suffix from the name
     ///
     /// # Examples
-    /// `a1b2c3` -> `a1b2c`
+    /// `a1b2c3` -> (`a1b2c`, Some(3))
     fn split_numeric_suffix(name: &str) -> (&str, Option<usize>) {
         let pos =
             name.rfind(|c: char| !c.is_numeric()).expect("Name cannot be empty or all-numeric");
-        let (prefix, suffix) = name.split_at(pos + 1);
+        // `rfind` returns the byte offset of the matched character, which may be
+        // multi-byte (e.g. CJK identifiers). Use `ceil_char_boundary` to advance
+        // past the full character to the next valid split point.
+        let split = name.ceil_char_boundary(pos + 1);
+        let (prefix, suffix) = name.split_at(split);
         (prefix, suffix.parse().ok())
     }
 }


### PR DESCRIPTION
`split_numeric_suffix` used `rfind` to locate the last non-numeric character and then split at `pos + 1`. Since `rfind` returns a **byte offset**, this panics when the last non-numeric character is multi-byte (e.g. CJK identifiers like `日本語`).

Use `str::ceil_char_boundary` to advance past the full character before splitting.

Added doctests covering CJK and accented Latin identifiers with numeric suffixes.