### PR TITLE
internal: Fix test_loading_rust_analyzer when rust-project.json is present

### DIFF
--- a/crates/load-cargo/src/lib.rs
+++ b/crates/load-cargo/src/lib.rs
@@ -744,7 +744,15 @@ mod tests {
 
     #[test]
     fn test_loading_rust_analyzer() {
-        let path = Path::new(env!("CARGO_MANIFEST_DIR")).parent().unwrap().parent().unwrap();
+        let cargo_toml_path = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .unwrap()
+            .parent()
+            .unwrap()
+            .join("Cargo.toml");
+        let cargo_toml_path = AbsPathBuf::assert_utf8(cargo_toml_path);
+        let manifest = ProjectManifest::from_manifest_file(cargo_toml_path).unwrap();
+
         let cargo_config = CargoConfig { set_test: true, ..CargoConfig::default() };
         let load_cargo_config = LoadCargoConfig {
             load_out_dirs_from_check: false,
@@ -752,8 +760,9 @@ mod tests {
             prefill_caches: false,
             proc_macro_processes: 1,
         };
+        let workspace = ProjectWorkspace::load(manifest, &cargo_config, &|_| {}).unwrap();
         let (db, _vfs, _proc_macro) =
-            load_workspace_at(path, &cargo_config, &load_cargo_config, &|_| {}).unwrap();
+            load_workspace(workspace, &cargo_config.extra_env, &load_cargo_config).unwrap();
 
         let n_crates = db.all_crates().len();
         // RA has quite a few crates, but the exact count doesn't matter


### PR DESCRIPTION
load_workspace_at() looks at parent directories. If rust-analyzer is in a directory (e.g. a monorepo) where a parent directory contains a rust-project.json, that configuration wins over the Cargo.toml and the test fails.

One easy way of testing this is deliberately writing an invalid JSON file to the parent directory.

```
$ echo '{' > ../rust-project.json
$ cargo t -p load-cargo
---- tests::test_loading_rust_analyzer stdout ----

thread 'tests::test_loading_rust_analyzer' (38576150) panicked at crates/load-cargo/src/lib.rs:756:81:
called `Result::unwrap()` on an `Err` value: Failed to load the project at /Users/wilfred/src/rust-project.json

Caused by:
    0: Failed to deserialize json file /Users/wilfred/src/rust-project.json
    1: EOF while parsing an object at line 2 column 0
```

Instead, explicitly load the cargo workspace so the presence of a rust-project.json never changes the result of the test.

AI disclosure: Written with help from Claude.