### PR TITLE
internal: Add codecov badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ analyzing Rust code. See
 [Architecture](https://rust-analyzer.github.io/book/contributing/architecture.html)
 in the manual.
 
+[![codecov](https://codecov.io/github/rust-lang/rust-analyzer/graph/badge.svg)](https://app.codecov.io/github/rust-lang/rust-analyzer/tree/master)
+
 ## Quick Start
 
 https://rust-analyzer.github.io/book/installation.html


### PR DESCRIPTION
It's tricky to find the relevant codecov page, so add a badge to the readme showing coverage and linking to the codecov dashboard.