### PR TITLE
Allow defining inline structs in `diagnostics!`

### DIFF
--- a/crates/hir/src/diagnostics.rs
+++ b/crates/hir/src/diagnostics.rs
@@ -445,7 +445,7 @@ diagnostics![AnyDiagnostic<'db> ->
 
     ;
 
-    // IncorrectCase,
+    IncorrectCase,
 ];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]


### PR DESCRIPTION
Just a random TODO comment I thought I'd implement. I have some doubts about this though:
- is this still desired?
- is removing `pub` and `struct` really worth it? I feel like one'd write them almost instinctively and be surprised when it doesn't work. Maybe I could adjust the macro to look for `$($($vis:vis)? strukt:ident)?` instead?
- the macro definition ended up being _somewhat_ cursed
- formatting is completely broken

Also, the diff is pretty hard to review, sorry about that. I found that commenting out `IncorrectCase` helped a _little_ bit, hence the second commit that uncomments it.