### PR TITLE
feat: supports minus to underscore rename

### DIFF
--- a/crates/ide-db/src/rename.rs
+++ b/crates/ide-db/src/rename.rs
@@ -701,6 +701,7 @@ pub enum IdentifierKind {
 
 impl IdentifierKind {
     pub fn classify(edition: Edition, new_name: &str) -> Result<(Name, IdentifierKind)> {
+        let new_name = &new_name.replace('-', "_");
         match parser::LexedStr::single_token(edition, new_name) {
             Some(res) => match res {
                 (SyntaxKind::IDENT, _) => Ok((Name::new_root(new_name), IdentifierKind::Ident)),
@@ -710,7 +711,7 @@ impl IdentifierKind {
                 (SyntaxKind::LIFETIME_IDENT, _) if new_name != "'static" && new_name != "'_" => {
                     Ok((Name::new_lifetime(new_name), IdentifierKind::Lifetime))
                 }
-                _ if SyntaxKind::from_keyword(new_name, edition).is_some() => match new_name {
+                _ if SyntaxKind::from_keyword(new_name, edition).is_some() => match &**new_name {
                     "self" => Ok((Name::new_root(new_name), IdentifierKind::LowercaseSelf)),
                     "crate" | "super" | "Self" => {
                         bail!("Invalid name `{}`: cannot rename to a keyword", new_name)

--- a/crates/ide/src/rename.rs
+++ b/crates/ide/src/rename.rs
@@ -1037,8 +1037,9 @@ impl Foo {
     }
 
     #[test]
-    fn test_rename_to_underscore() {
-        check("_", r#"fn main() { let i$0 = 1; }"#, r#"fn main() { let _ = 1; }"#);
+    fn test_rename_minus_to_underscore() {
+        check("-", r#"fn main() { let i$0 = 1; }"#, r#"fn main() { let _ = 1; }"#);
+        check("a-b", r#"fn main() { let i$0 = 1; }"#, r#"fn main() { let a_b = 1; }"#);
     }
 
     #[test]


### PR DESCRIPTION
Typing minus is usually much more convenient than typing underscore

Example
---
Rename to `"a-b"`
```rust
fn main() { let i$0 = 1; }
```

**Before this PR**

Invalid name `a-b`: not an identifier

**After this PR**

```rust
fn main() { let a_b = 1; }
```
