### PR TITLE
internal: Clarify error messages when proc-macro-srv changes working directory

### DIFF
--- a/crates/proc-macro-srv/src/lib.rs
+++ b/crates/proc-macro-srv/src/lib.rs
@@ -328,7 +328,7 @@ impl<'snap> EnvChange<'snap> {
                 let prev_working_dir = std::env::current_dir().ok();
                 if let Err(err) = std::env::set_current_dir(dir) {
                     eprintln!(
-                        "Failed to set the current working dir to {}. Error: {err:?}",
+                        "Failed to change the current working dir to {}. Error: {err:?}",
                         dir.display()
                     )
                 }
@@ -370,7 +370,7 @@ impl Drop for EnvChange<'_> {
             && let Err(err) = std::env::set_current_dir(dir)
         {
             eprintln!(
-                "Failed to set the current working dir to {}. Error: {:?}",
+                "Failed to change the current working dir back to {}. Error: {:?}",
                 dir.display(),
                 err
             )


### PR DESCRIPTION
I'm investigating issues where users see a load of logs of the form:

```
Failed to set the current working dir to /redacted/path. Error: Os { code: 2, kind: NotFound, message: "No such file or directory" }
```

This is tricky to debug because there's two different code paths that write exactly the same error message. Ensure they're unique.