### PR TITLE
fix: Don't allow a package to depend on itself

### DIFF
--- a/crates/project-model/src/workspace.rs
+++ b/crates/project-model/src/workspace.rs
@@ -1357,6 +1357,22 @@ fn cargo_to_crate_graph(
     // target of downstream.
     for pkg in cargo.packages() {
         for dep in &cargo[pkg].dependencies {
+            // A package shouldn't depend on itself in the r-a crate graph. This is rare
+            // but legal in Rust.
+            //
+            // One use case is a package depending on itself in dev-dependencies, to
+            // enable additional features when testing. The cfg crate in r-a does this.
+            //
+            // <https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#development-dependencies>
+            //
+            // Another use case is the 'semver trick', where a crate depends on itself to
+            // reduce the number of breaking changes.
+            //
+            // <https://github.com/dtolnay/semver-trick>
+            if dep.pkg == pkg {
+                continue;
+            }
+
             let Some(&to) = pkg_to_lib_crate.get(&dep.pkg) else { continue };
             let Some(targets) = pkg_crates.get(&pkg) else { continue };
 


### PR DESCRIPTION
I've noticed that generating SCIP on rust-analyzer itself produces the following warning:

```
$ cargo run --bin rust-analyzer --release -- scip .
2026-03-12T18:40:33.824092Z  WARN cyclic deps: cfg(Idx::<CrateBuilder>(21)) -> cfg(Idx::<CrateBuilder>(21)), alternative path: cfg(Idx::<CrateBuilder>(21))
```

This seems to be because `cfg` depends on itself in `cfg/Cargo.toml` to enable the `tt` feature.

Considering this was already generating a warning, I think it's worth fixing.

(There are a bunch of other errors and warnings when generating SCIP for r-a, this is just the first one.)

AI disclosure: The initial implementation was written by Claude, but all the comments were written by me and I've reviewed the change.