### PR TITLE
SmolStr: DerefPure

### DIFF
--- a/lib/smol_str/Cargo.toml
+++ b/lib/smol_str/Cargo.toml
@@ -28,6 +28,7 @@ rand = "0.9.2"
 default = ["std"]
 std = ["serde_core?/std", "borsh?/std"]
 serde = ["dep:serde_core"]
+nightly = []
 
 [[bench]]
 name = "bench"

--- a/lib/smol_str/src/lib.rs
+++ b/lib/smol_str/src/lib.rs
@@ -1,5 +1,6 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(feature = "nightly", feature(deref_pure_trait))]
 #![debugger_visualizer(gdb_script_file = "gdb_smolstr_printer.py")]
 
 extern crate alloc;
@@ -123,6 +124,9 @@ impl SmolStr {
         SmolStr::new(unsafe { core::str::from_utf8_unchecked(bytes) })
     }
 }
+
+#[cfg(feature = "nightly")]
+unsafe impl std::ops::DerefPure for SmolStr {}
 
 impl Clone for SmolStr {
     #[inline]


### PR DESCRIPTION
enables matching on smolstrs directly.

before:
```rs
match Some(smolstr) {
   Some(x) if x == "y" => {},
   _ => {}
}
```
after:
```rs
match Some(smolstr) {
   Some("y") => {},
   _ => {}
}
```