### PR TITLE
fix: rustc cfg crash when directory is deleted

### DIFF
--- a/crates/project-model/src/toolchain_info/rustc_cfg.rs
+++ b/crates/project-model/src/toolchain_info/rustc_cfg.rs
@@ -62,7 +62,7 @@ fn rustc_print_cfg(
     config: QueryConfig<'_>,
 ) -> anyhow::Result<String> {
     const RUSTC_ARGS: [&str; 2] = ["--print", "cfg"];
-    let (sysroot, current_dir) = match config {
+    let (sysroot, mut current_dir) = match config {
         QueryConfig::Cargo(sysroot, cargo_toml, _) => {
             let mut cmd = sysroot.tool(Tool::Cargo, cargo_toml.parent(), extra_env);
             cmd.env("__CARGO_TEST_CHANNEL_OVERRIDE_DO_NOT_USE_THIS", "nightly");
@@ -85,6 +85,14 @@ fn rustc_print_cfg(
         }
         QueryConfig::Rustc(sysroot, current_dir) => (sysroot, current_dir),
     };
+
+    let temp_dir = std::env::temp_dir();
+    if !current_dir.exists() {
+        // It doesn't matter which directory we run `rustc --print cfg` in, but we
+        // want a directory that exists. Use the system temporary directory so we
+        // have a portable directory that should always exist.
+        current_dir = &temp_dir;
+    }
 
     let mut cmd = sysroot.tool(Tool::Rustc, current_dir, extra_env);
     cmd.args(RUSTC_ARGS);


### PR DESCRIPTION
`rustc --print cfg` can be run in any directory, but the command will error if the directory does not exist.

This is more noticeable when working on a large monorepo with a rust-project.json, but it can occur in cargo projects too.

I haven't been able to reproduce this many times, but it seems to be due to switching commits before/after a directory is created.

The rust-analyzer log looks like this:

```
2026-03-13T06:43:13.1075102-07:00  WARN failed to get rustc cfgs e=unable to fetch cfgs via `cd "/home/wilfred/monorepo/old_dir/foo/" && RUSTUP_AUTO_INSTALL="0" "/home/wilfred/.cache/dotslash/obj/cas/35/b8b890939206aaabc7b768fd66ad4d2c/extract/tar.zst/bin/rustc" "--print" "cfg" "-O"`

Caused by:
 0: cd "/home/wilfred/monorepo/old_dir/foo/" && RUSTUP_AUTO_INSTALL="0" "/home/wilfred/.cache/dotslash/obj/cas/35/b8b890939206aaabc7b768fd66ad4d2c/extract/tar.zst/bin/rustc" "--print" "cfg" "-O" failed
```