### PR TITLE
fix: Infer generic args for trait ref and its assoc type

### DIFF
--- a/crates/hir-ty/src/lower/path.rs
+++ b/crates/hir-ty/src/lower/path.rs
@@ -183,7 +183,7 @@ impl<'a, 'b, 'db> PathLoweringContext<'a, 'b, 'db> {
                         let trait_ref = self.lower_trait_ref_from_resolved_path(
                             trait_,
                             Ty::new_error(self.ctx.interner, ErrorGuaranteed),
-                            false,
+                            infer_args,
                         );
                         tracing::debug!(?trait_ref);
                         self.skip_resolved_segment();
@@ -201,7 +201,7 @@ impl<'a, 'b, 'db> PathLoweringContext<'a, 'b, 'db> {
                                 // this point (`trait_ref.substitution`).
                                 let substitution = self.substs_from_path_segment(
                                     associated_ty.into(),
-                                    false,
+                                    infer_args,
                                     None,
                                     true,
                                 );

--- a/crates/ide-diagnostics/src/handlers/incorrect_generics_len.rs
+++ b/crates/ide-diagnostics/src/handlers/incorrect_generics_len.rs
@@ -224,4 +224,21 @@ fn main() {
         "#,
         );
     }
+
+    #[test]
+    fn type_as_trait_does_not_count() {
+        check_diagnostics(
+            r#"
+pub trait Lock<T> {
+    fn new(b: T) -> Self;
+}
+pub trait LockChoice {
+    type Lock<T>: Lock<T>;
+}
+fn f<L: LockChoice>() {
+    <L as LockChoice>::Lock::new(());
+}
+        "#,
+        );
+    }
 }


### PR DESCRIPTION
This was already there before the switch to the new solver, but it was reverted during the switch for some reason.

Fixes rust-lang/rust-analyzer#21816.