### PR TITLE
feat: add is_mutable_raw_ptr and as_raw_ptr to hir::Type

### DIFF
--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -5818,6 +5818,18 @@ impl<'db> Type<'db> {
         matches!(self.ty.kind(), TyKind::RawPtr(..))
     }
 
+    pub fn is_mutable_raw_ptr(&self) -> bool {
+        // Used outside of rust-analyzer (e.g. by `ra_ap_hir` consumers).
+        matches!(self.ty.kind(), TyKind::RawPtr(.., hir_ty::next_solver::Mutability::Mut))
+    }
+
+    pub fn as_raw_ptr(&self) -> Option<(Type<'db>, Mutability)> {
+        // Used outside of rust-analyzer (e.g. by `ra_ap_hir` consumers).
+        let TyKind::RawPtr(ty, m) = self.ty.kind() else { return None };
+        let m = Mutability::from_mutable(matches!(m, hir_ty::next_solver::Mutability::Mut));
+        Some((self.derived(ty), m))
+    }
+
     pub fn remove_raw_ptr(&self) -> Option<Type<'db>> {
         if let TyKind::RawPtr(ty, _) = self.ty.kind() { Some(self.derived(ty)) } else { None }
     }


### PR DESCRIPTION
## Summary

Add `is_mutable_raw_ptr()` and `as_raw_ptr()` methods to `hir::Type`, closing an API gap where raw pointer mutability (`*mut` vs `*const`) was not queryable through the public API.

## Problem

`hir::Type` provides `is_raw_ptr()` to check if a type is a raw pointer, but there is no way to distinguish `*mut T` from `*const T`. This is asymmetric with references, where both `is_mutable_reference()` and `as_reference() -> Option<(Type, Mutability)>` exist:

```rust
// References — full mutability API:
pub fn is_reference(&self) -> bool;
pub fn is_mutable_reference(&self) -> bool;
pub fn as_reference(&self) -> Option<(Type, Mutability)>;

// Raw pointers — mutability NOT queryable before this PR:
pub fn is_raw_ptr(&self) -> bool;
pub fn remove_raw_ptr(&self) -> Option<Type>;  // discards mutability
```

The internal representation (`TyKind::RawPtr(Ty, Mutability)`) already carries the mutability, but `Type.ty` is `pub(crate)` so external consumers cannot access it. The only workaround was parsing the display string:

```rust
let is_mut = ty.is_raw_ptr() && ty.display(db).to_string().starts_with("*mut ");
```

This feature was asked about on StackOverflow ([How to determine raw pointer mutability from ra_ap_hir::Type?](https://stackoverflow.com/questions/79909384/how-to-determine-raw-pointer-mutability-mut-vs-const-from-ra-ap-hirtype)), where a rust-analyzer team member confirmed this is a gap in the API and encouraged contributing the fix.

## Solution Proposal

Add two methods to `hir::Type`, following the exact same pattern as their reference counterparts:

```rust
pub fn is_mutable_raw_ptr(&self) -> bool {
    matches!(self.ty.kind(), TyKind::RawPtr(.., Mutability::Mut))
}

pub fn as_raw_ptr(&self) -> Option<(Type<'db>, Mutability)> {
    let TyKind::RawPtr(ty, m) = self.ty.kind() else { return None };
    let m = Mutability::from_mutable(matches!(m, Mutability::Mut));
    Some((self.derived(ty), m))
}
```

## Test

Snapshot test covers all five type categories side by side, showing the symmetry between the raw pointer and reference APIs:

```
a (*const u32): is_mutable_raw_ptr: false, as_raw_ptr: Some(Shared)
b (*mut u32):   is_mutable_raw_ptr: true,  as_raw_ptr: Some(Mut)
c (&u32):       is_mutable_reference: false, as_reference: Some(Shared)
d (&mut u32):   is_mutable_reference: true,  as_reference: Some(Mut)
e (u32):        all false/None
```

AI tools were used in the development of this change.
