### PR TITLE
fix: Server-side file watcher should handle file accesses

### DIFF
--- a/crates/vfs-notify/src/lib.rs
+++ b/crates/vfs-notify/src/lib.rs
@@ -14,7 +14,7 @@ use std::{
 };
 
 use crossbeam_channel::{Receiver, Sender, select, unbounded};
-use notify::{Config, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
+use notify::{Config, EventKind, RecommendedWatcher, RecursiveMode, Watcher, event::AccessKind};
 use paths::{AbsPath, AbsPathBuf, Utf8PathBuf};
 use rayon::iter::{IndexedParallelIterator as _, IntoParallelIterator as _, ParallelIterator};
 use rustc_hash::FxHashSet;
@@ -195,8 +195,10 @@ impl NotifyActor {
                 },
                 Event::NotifyEvent(event) => {
                     if let Some(event) = log_notify_error(event)
-                        && let EventKind::Create(_) | EventKind::Modify(_) | EventKind::Remove(_) =
-                            event.kind
+                        && let EventKind::Create(_)
+                        | EventKind::Access(AccessKind::Open(_))
+                        | EventKind::Modify(_)
+                        | EventKind::Remove(_) = event.kind
                     {
                         let files = event
                             .paths


### PR DESCRIPTION
On some filesystems, particularly FUSE on Linux, we don't get Create(...) events. We do get Access(Open(Any)) events, so handle those consistently with create/modify/remove events.

This fixes missed file notifications when using Sapling SCM with EdenFS, although I believe the problem can occur on other FUSE environments.

## Reproduction:

Commit a change with Sapling that adds a new file foo.rs and references it with `mod foo;` in lib.rs. Configure rust-analyzer as follows:

```
{
    "rust-analyzer.files.watcher": "server",
    "rust-analyzer.server.extraEnv": {
        "RA_LOG": "vfs_notify=debug"
    },
}
```

Go to the previous commit, restart rust-analyzer, then go to the next commit. The logs only show:

```
2026-03-18T07:16:54.211788903-07:00 DEBUG vfs-notify event event=NotifyEvent(Ok(Event { kind: Access(Open(Any)), paths: ["/data/users/wilfred/scratch/src/foo.rs"], attr:tracker: None, attr:flag: None, attr:info: None, attr:source: None }))
2026-03-18T07:16:54.211906733-07:00 DEBUG vfs-notify event event=NotifyEvent(Ok(Event { kind: Access(Open(Any)), paths: ["/data/users/wilfred/scratch/src/foo.rs"], attr:tracker: None, attr:flag: None, attr:info: None, attr:source: None }))
2026-03-18T07:16:54.216467168-07:00 DEBUG vfs-notify event event=NotifyEvent(Ok(Event { kind: Access(Open(Any)), paths: ["/data/users/wilfred/scratch/src/lib.rs"], attr:tracker: None, attr:flag: None, attr:info: None, attr:source: None }))
2026-03-18T07:16:54.216811304-07:00 DEBUG vfs-notify event event=NotifyEvent(Ok(Event { kind: Access(Open(Any)), paths: ["/data/users/wilfred/scratch/src/lib.rs"], attr:tracker: None, attr:flag: None, attr:info: None, attr:source: None }))
```

Observe that `mod foo;` has a red squiggle and shows "unresolved module, can't find module file: foo.rs, or foo/mod.rs". This commit fixes that.