### PR TITLE
Migrate convert_from_to_tryfrom assist to SyntaxEditor API

### DIFF
--- a/crates/ide-assists/src/handlers/convert_from_to_tryfrom.rs
+++ b/crates/ide-assists/src/handlers/convert_from_to_tryfrom.rs
@@ -1,6 +1,6 @@
 use ide_db::{famous_defs::FamousDefs, traits::resolve_target_trait};
 use syntax::ast::edit::IndentLevel;
-use syntax::ast::{self, AstNode, HasGenericArgs, HasName, make};
+use syntax::ast::{self, AstNode, HasGenericArgs, HasName, syntax_factory::SyntaxFactory};
 use syntax::syntax_editor::{Element, Position};
 
 use crate::{AssistContext, AssistId, Assists};
@@ -74,36 +74,25 @@ pub(crate) fn convert_from_to_tryfrom(acc: &mut Assists, ctx: &AssistContext<'_>
         "Convert From to TryFrom",
         impl_.syntax().text_range(),
         |builder| {
+            let make = SyntaxFactory::with_mappings();
             let mut editor = builder.make_editor(impl_.syntax());
-            editor.replace(
-                trait_ty.syntax(),
-                make::ty(&format!("TryFrom<{from_type}>")).syntax().clone_for_update(),
-            );
+
+            editor.replace(trait_ty.syntax(), make.ty(&format!("TryFrom<{from_type}>")).syntax());
             editor.replace(
                 from_fn_return_type.syntax(),
-                make::ty("Result<Self, Self::Error>").syntax().clone_for_update(),
+                make.ty("Result<Self, Self::Error>").syntax(),
             );
-            editor
-                .replace(from_fn_name.syntax(), make::name("try_from").syntax().clone_for_update());
-            editor.replace(
-                tail_expr.syntax(),
-                wrap_ok(tail_expr.clone()).syntax().clone_for_update(),
-            );
+            editor.replace(from_fn_name.syntax(), make.name("try_from").syntax());
+            editor.replace(tail_expr.syntax(), wrap_ok(&make, tail_expr.clone()).syntax());
 
             for r in return_exprs {
-                let t = r.expr().unwrap_or_else(make::ext::expr_unit);
-                editor.replace(t.syntax(), wrap_ok(t.clone()).syntax().clone_for_update());
+                let t = r.expr().unwrap_or_else(|| make.expr_unit());
+                editor.replace(t.syntax(), wrap_ok(&make, t.clone()).syntax());
             }
 
-            let error_type = ast::AssocItem::TypeAlias(make::ty_alias(
-                None,
-                "Error",
-                None,
-                None,
-                None,
-                Some((make::ty_unit(), None)),
-            ))
-            .clone_for_update();
+            let error_type_alias =
+                make.ty_alias(None, "Error", None, None, None, Some((make.ty("()"), None)));
+            let error_type = ast::AssocItem::TypeAlias(error_type_alias);
 
             if let Some(cap) = ctx.config.snippet_cap
                 && let ast::AssocItem::TypeAlias(type_alias) = &error_type
@@ -117,22 +106,19 @@ pub(crate) fn convert_from_to_tryfrom(acc: &mut Assists, ctx: &AssistContext<'_>
             editor.insert_all(
                 Position::after(associated_l_curly),
                 vec![
-                    make::tokens::whitespace(&format!("\n{indent}")).syntax_element(),
+                    make.whitespace(&format!("\n{indent}")).syntax_element(),
                     error_type.syntax().syntax_element(),
-                    make::tokens::whitespace("\n").syntax_element(),
+                    make.whitespace("\n").syntax_element(),
                 ],
             );
+            editor.add_mappings(make.finish_with_mappings());
             builder.add_file_edits(ctx.vfs_file_id(), editor);
         },
     )
 }
 
-fn wrap_ok(expr: ast::Expr) -> ast::Expr {
-    make::expr_call(
-        make::expr_path(make::ext::ident_path("Ok")),
-        make::arg_list(std::iter::once(expr)),
-    )
-    .into()
+fn wrap_ok(make: &SyntaxFactory, expr: ast::Expr) -> ast::Expr {
+    make.expr_call(make.expr_path(make.path_from_text("Ok")), make.arg_list([expr])).into()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Part of rust-lang/rust-analyzer#18285.

Migrates the [convert_from_to_tryfrom](cci:1://file:///Users/kawkoiharu/code/gsoc/rust-analyzer/crates/ide-assists/src/handlers/convert_from_to_tryfrom.rs:7:0-120:1) assist from mutable syntax tree
editing (`clone_for_update`) to the [SyntaxEditor](cci:2://file:///Users/kawkoiharu/code/gsoc/rust-analyzer/crates/syntax/src/syntax_editor.rs:26:0-31:1) / [SyntaxFactory](cci:2://file:///Users/kawkoiharu/code/gsoc/rust-analyzer/crates/syntax/src/ast/syntax_factory.rs:14:0-17:1) API.

**Changes**

- Create `SyntaxFactory::with_mappings()` named `make` (following the
  migration guide in rust-lang/rust-analyzer#18285)
- Replace `make::ty() + .clone_for_update()` → `make.ty()`
- Replace `make::name() + .clone_for_update()` → `make.name()`
- Replace `make::ty_alias() + .clone_for_update()` → `make.ty_alias()`
- Update [wrap_ok()](cci:1://file:///Users/kawkoiharu/code/gsoc/rust-analyzer/crates/ide-assists/src/handlers/convert_from_to_tryfrom.rs:122:0-128:1) helper to accept `&SyntaxFactory` and use
  `make.expr_call` / `make.arg_list` / `make.expr_path`
- Add `editor.add_mappings(make.finish_with_mappings())`
