### PR TITLE
Remove the mapping for `expr_underscore` from the syntax factory constructor

### DIFF
--- a/crates/syntax/src/ast/syntax_factory/constructors.rs
+++ b/crates/syntax/src/ast/syntax_factory/constructors.rs
@@ -896,10 +896,6 @@ impl SyntaxFactory {
             unreachable!()
         };
 
-        if let Some(mut mapping) = self.mappings() {
-            SyntaxMappingBuilder::new(ast.syntax().clone()).finish(&mut mapping);
-        }
-
         ast
     }
 


### PR DESCRIPTION
`expr_underscore` method represents a leaf expr with no inputs, the PR remove's the no-op mapping defined in it.


part of https://github.com/rust-lang/rust-analyzer/issues/15710 and https://github.com/rust-lang/rust-analyzer/issues/18285