### PR TITLE
feat: offer 'add_braces' on bin-expr assignment

### DIFF
--- a/crates/ide-assists/src/handlers/add_braces.rs
+++ b/crates/ide-assists/src/handlers/add_braces.rs
@@ -84,6 +84,7 @@ fn get_replacement_node(ctx: &AssistContext<'_>) -> Option<(ParentType, ast::Exp
             match parent {
                 ast::LetStmt(it) => it.initializer()?,
                 ast::LetExpr(it) => it.expr()?,
+                ast::BinExpr(it) => it.rhs()?,
                 ast::Static(it) => it.body()?,
                 ast::Const(it) => it.body()?,
                 _ => return None,
@@ -191,6 +192,22 @@ fn foo() {
     x = {
         n + 100
     };
+}
+"#,
+        );
+
+        check_assist(
+            add_braces,
+            r#"
+fn foo() {
+    if let x =$0 n + 100 {}
+}
+"#,
+            r#"
+fn foo() {
+    if let x = {
+        n + 100
+    } {}
 }
 "#,
         );


### PR DESCRIPTION
Close rust-lang/rust-analyzer#21834
Close rust-lang/rust-analyzer#21842
Implement https://github.com/rust-lang/rust-analyzer/pull/21834#discussion_r2955481024

- **ide-assists: add tests for const, static in add_braces**
- **add tests for let-expr in add_braces**

Example
---
```rust
fn foo() {
    let x;
    x =$0 n + 100;
}
```

**Before this PR**

Assist not applicable

**After this PR**

```rust
fn foo() {
    let x;
    x = {
        n + 100
    };
}
```
