### PR TITLE
internal: Remove clone_for_update from flip_range_expr

### DIFF
--- a/crates/ide-assists/src/handlers/flip_binexpr.rs
+++ b/crates/ide-assists/src/handlers/flip_binexpr.rs
@@ -142,11 +142,11 @@ pub(crate) fn flip_range_expr(acc: &mut Assists, ctx: &AssistContext<'_>) -> Opt
                 }
                 (Some(start), None) => {
                     edit.delete(start.syntax());
-                    edit.insert(Position::after(&op), start.syntax().clone_for_update());
+                    edit.insert(Position::after(&op), start.syntax().clone_subtree());
                 }
                 (None, Some(end)) => {
                     edit.delete(end.syntax());
-                    edit.insert(Position::before(&op), end.syntax().clone_for_update());
+                    edit.insert(Position::before(&op), end.syntax().clone_subtree());
                 }
                 (None, None) => (),
             }


### PR DESCRIPTION
This PR removes the use of `.clone_for_update()` in the `flip_range_expr` assist. The `SyntaxEditor` can handle the insertion of the immutable nodes directly, so the mutable clones are no longer necessary.

