### PR TITLE
fix: wrap `Option<>` for desugar_try_expr_let_else

### DIFF
--- a/crates/ide-assists/src/handlers/desugar_try_expr.rs
+++ b/crates/ide-assists/src/handlers/desugar_try_expr.rs
@@ -116,7 +116,7 @@ pub(crate) fn desugar_try_expr(acc: &mut Assists, ctx: &AssistContext<'_>) -> Op
                 let fill_expr = || crate::utils::expr_fill_default(ctx.config);
                 let new_let_stmt = make.let_else_stmt(
                     try_enum.happy_pattern(pat),
-                    let_stmt.ty(),
+                    let_stmt.ty().map(|ty| make.ty_option(ty).into()),
                     expr,
                     make.block_expr(
                         iter::once(
@@ -242,6 +242,27 @@ fn test() {
 fn test() {
     let Ok(pat) = Ok(true) else {
         return Err(todo!());
+    };
+}
+            "#,
+            "Replace try expression with let else",
+        );
+    }
+
+    #[test]
+    fn test_desugar_try_expr_option_let_else_with_type() {
+        check_assist_by_label(
+            desugar_try_expr,
+            r#"
+//- minicore: try, option
+fn test() {
+    let pat: bool = Some(true)$0?;
+}
+            "#,
+            r#"
+fn test() {
+    let Some(pat): Option<bool> = Some(true) else {
+        return None;
     };
 }
             "#,


### PR DESCRIPTION
Example
---
```rust
fn test() {
    let pat: bool = Some(true)$0?;
}
```

**Before this PR**

```rust
fn test() {
    let Some(pat): bool = Some(true) else {
        return None;
    };
}
```

**After this PR**

```rust
fn test() {
    let Some(pat): Option<bool> = Some(true) else {
        return None;
    };
}
```
