### PR TITLE
fix: Turn back `TyLoweringContext.store` to self after lowering parent defaults

### DIFF
--- a/crates/hir-ty/src/lower.rs
+++ b/crates/hir-ty/src/lower.rs
@@ -2411,10 +2411,11 @@ pub(crate) fn generic_defaults_with_diagnostics_query(
     }
     let resolver = def.resolver(db);
 
+    let store_for_self = generic_params.store();
     let mut ctx = TyLoweringContext::new(
         db,
         &resolver,
-        generic_params.store(),
+        store_for_self,
         def,
         LifetimeElisionKind::AnonymousReportError,
     )
@@ -2432,6 +2433,7 @@ pub(crate) fn generic_defaults_with_diagnostics_query(
         })
         .collect::<Vec<_>>();
     ctx.diagnostics.clear(); // Don't include diagnostics from the parent.
+    ctx.store = store_for_self;
     defaults.extend(generic_params.iter_self().map(|(_id, p)| {
         let (result, has_default) = handle_generic_param(&mut ctx, idx, p);
         has_any_default |= has_default;

--- a/crates/ide-diagnostics/src/handlers/missing_lifetime.rs
+++ b/crates/ide-diagnostics/src/handlers/missing_lifetime.rs
@@ -115,4 +115,20 @@ struct A<'a, T> {
         "#,
         );
     }
+
+    // FIXME: Ideally, should emit generic default forbidden as well
+    #[test]
+    fn regression_16280() {
+        check_diagnostics(
+            r#"
+trait Traitor<'a, const M: Traitor = Traitor> {
+    fn crash<const Traitor: Traitor = Traitor, const M: Traitor = Traitor>(&self) -> Traitor {
+                         // ^^^^^^^ error: missing lifetime specifier
+                                                     // ^^^^^^^ error: missing lifetime specifier
+        Traitor
+    }
+}
+"#,
+        );
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust-analyzer/issues/16280