### PR TITLE
fix: Report correct crates_total in prime caches Done progress

### DIFF
--- a/crates/ide-db/src/prime_caches.rs
+++ b/crates/ide-db/src/prime_caches.rs
@@ -244,7 +244,7 @@ pub fn parallel_prime_caches(
                 cb(ParallelPrimeCachesProgress {
                     crates_currently_indexing: vec![],
                     crates_done: crate_def_maps_done,
-                    crates_total: crate_def_maps_done,
+                    crates_total: crate_def_maps_total,
                     work_type: "Done",
                 });
                 return;


### PR DESCRIPTION
## Summary

When the parallel prime-caches progress channel closed, the final `Done` callback set `crates_total` to `crate_def_maps_done` instead of `crate_def_maps_total`. The total should match the def-map indexing phase (same as other `ParallelPrimeCachesProgress` updates).

## Notes

Assisted by an AI coding tool (see CONTRIBUTING.md).
