### PR TITLE
fix: Correct type_or_const param index bound in debug_assert

### DIFF
--- a/crates/hir-ty/src/generics.rs
+++ b/crates/hir-ty/src/generics.rs
@@ -185,7 +185,7 @@ impl Generics {
         if param.parent == self.def {
             let idx = param.local_id.into_raw().into_u32() as usize;
             debug_assert!(
-                idx <= self.params.len_type_or_consts(),
+                idx < self.params.len_type_or_consts(),
                 "idx: {} len: {}",
                 idx,
                 self.params.len_type_or_consts()


### PR DESCRIPTION
## Summary

In `find_type_or_const_param`, `param.local_id` is interpreted as an index into type/const parameters. Valid indices are `0..len_type_or_consts()`. The `debug_assert` used `<=`, which incorrectly allowed `idx == len`.

## Notes

Assisted by an AI coding tool (see CONTRIBUTING.md).
