### PR TITLE
fix: Correct internal error message for ptr_guaranteed_cmp shim

### DIFF
--- a/crates/hir-ty/src/mir/eval/shim.rs
+++ b/crates/hir-ty/src/mir/eval/shim.rs
@@ -843,7 +843,7 @@ impl<'db> Evaluator<'db> {
                 // cases.
                 let [lhs, rhs] = args else {
                     return Err(MirEvalError::InternalError(
-                        "wrapping_add args are not provided".into(),
+                        "ptr_guaranteed_cmp args are not provided".into(),
                     ));
                 };
                 let ans = lhs.get(self)? == rhs.get(self)?;


### PR DESCRIPTION
## Summary

The `ptr_guaranteed_cmp` intrinsic branch reported `wrapping_add args are not provided` when arguments were missing; align the message with the shim name.

## Notes

Assisted by an AI coding tool (see CONTRIBUTING.md).
