### PR TITLE
fix a tests that assunes the wrong alignment on s390x

### DIFF
--- a/crates/hir-ty/src/layout/tests.rs
+++ b/crates/hir-ty/src/layout/tests.rs
@@ -379,6 +379,11 @@ struct Goal(Foo<S>);
 
 #[test]
 fn simd_types() {
+    let size = 16;
+    #[cfg(not(target_arch = "s390x"))]
+    let align = 16;
+    #[cfg(target_arch = "s390x")]
+    let align = 8;
     check_size_and_align(
         r#"
             #[repr(simd)]
@@ -386,8 +391,8 @@ fn simd_types() {
             struct Goal(SimdType);
         "#,
         "",
-        16,
-        16,
+        size,
+        align,
     );
 }
 


### PR DESCRIPTION
on s390x vectors are aligned at 8 bytes not 16 or vector length like on x86.