### PR TITLE
feat: add expected name on simple enum variant

### DIFF
--- a/crates/ide-completion/src/context/analysis.rs
+++ b/crates/ide-completion/src/context/analysis.rs
@@ -827,6 +827,14 @@ fn expected_type_and_name<'db>(
                         .map(|c| (Some(c.return_type()), None))
                         .unwrap_or((None, None))
                 },
+                ast::Variant(it) => {
+                    let is_simple_variant = matches!(
+                        it.field_list(),
+                        Some(ast::FieldList::TupleFieldList(list))
+                        if list.syntax().children_with_tokens().all(|it| it.kind() != T![,])
+                    );
+                    (None, it.name().filter(|_| is_simple_variant).map(NameOrNameRef::Name))
+                },
                 ast::Stmt(_) => (None, None),
                 ast::Item(_) => (None, None),
                 _ => {

--- a/crates/ide-completion/src/render.rs
+++ b/crates/ide-completion/src/render.rs
@@ -3045,6 +3045,41 @@ fn main() {
     }
 
     #[test]
+    fn enum_variant_name_exact_match_is_high_priority() {
+        check_relevance(
+            r#"
+struct Other;
+struct String;
+enum Foo {
+    String($0)
+}
+    "#,
+            expect![[r#"
+                st String String [name]
+                en Foo Foo []
+                st Other Other []
+                sp Self Foo []
+            "#]],
+        );
+
+        check_relevance(
+            r#"
+struct Other;
+struct String;
+enum Foo {
+    String(String, $0)
+}
+    "#,
+            expect![[r#"
+                en Foo Foo []
+                st Other Other []
+                sp Self Foo []
+                st String String []
+            "#]],
+        );
+    }
+
+    #[test]
     fn postfix_inexact_match_is_low_priority() {
         cov_mark::check!(postfix_inexact_match_is_low_priority);
         check_relevance_for_kinds(


### PR DESCRIPTION
Example
---
```rust
struct Other;
struct String;
enum Foo {
    String($0)
}
```

**Before this PR**

```text
en Foo Foo []
st Other Other []
sp Self Foo []
st String String []
```

**After this PR**

```text
st String String [name]
en Foo Foo []
st Other Other []
sp Self Foo []
```
