### PR TITLE
fix: transform `return` into `break` when inlining functions

### DIFF
--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -2904,23 +2904,21 @@ impl Function {
         }
     }
 
-    /// Returns the text ranges of `return` keywords in this function's body,
+    /// Returns the `return` expressions in this function's body,
     /// excluding those inside closures or async blocks.
-    pub fn return_points(self, db: &dyn HirDatabase) -> Vec<TextRange> {
+    pub fn return_points(self, db: &dyn HirDatabase) -> Vec<ast::ReturnExpr> {
         let func_id: FunctionId = match self.id {
             AnyFunctionId::FunctionId(id) => id,
             _ => return vec![],
         };
         let (body, source_map) = Body::with_source_map(db, func_id.into());
-        let fn_file_id = func_id.loc(db).id.file_id;
 
         fn collect_returns(
             body: &Body,
             source_map: &hir_def::expr_store::ExpressionStoreSourceMap,
             db: &dyn HirDatabase,
-            fn_file_id: HirFileId,
             expr_id: ExprId,
-            acc: &mut Vec<TextRange>,
+            acc: &mut Vec<ast::ReturnExpr>,
         ) {
             match &body[expr_id] {
                 Expr::Closure { .. } | Expr::Const(_) => return,
@@ -2929,30 +2927,18 @@ impl Function {
                         && let Some(ret_expr) = source.value.cast::<ast::ReturnExpr>()
                     {
                         let root = db.parse_or_expand(source.file_id);
-                        let node = ret_expr.to_node(&root);
-                        if let Some(return_token) = node.return_token() {
-                            let token_range = return_token.text_range();
-                            if source.file_id == fn_file_id {
-                                acc.push(token_range);
-                            } else if let Some((file_range, _)) =
-                                InFile::new(source.file_id, token_range)
-                                    .original_node_file_range_opt(db)
-                                && file_range.file_id == fn_file_id
-                            {
-                                acc.push(file_range.range);
-                            }
-                        }
+                        acc.push(ret_expr.to_node(&root));
                     }
                 }
                 _ => {}
             }
             body.walk_child_exprs(expr_id, |child| {
-                collect_returns(body, source_map, db, fn_file_id, child, acc);
+                collect_returns(body, source_map, db, child, acc);
             });
         }
 
         let mut returns = vec![];
-        collect_returns(body, source_map, db, fn_file_id, body.root_expr(), &mut returns);
+        collect_returns(body, source_map, db, body.root_expr(), &mut returns);
         returns
     }
 

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -2906,7 +2906,7 @@ impl Function {
 
     /// Returns the `return` expressions in this function's body,
     /// excluding those inside closures or async blocks.
-    pub fn return_points(self, db: &dyn HirDatabase) -> Vec<ast::ReturnExpr> {
+    pub fn return_points(self, db: &dyn HirDatabase) -> Vec<InFile<ast::ReturnExpr>> {
         let func_id: FunctionId = match self.id {
             AnyFunctionId::FunctionId(id) => id,
             _ => return vec![],
@@ -2918,7 +2918,7 @@ impl Function {
             source_map: &hir_def::expr_store::ExpressionStoreSourceMap,
             db: &dyn HirDatabase,
             expr_id: ExprId,
-            acc: &mut Vec<ast::ReturnExpr>,
+            acc: &mut Vec<InFile<ast::ReturnExpr>>,
         ) {
             match &body[expr_id] {
                 Expr::Closure { .. } | Expr::Const(_) => return,
@@ -2927,7 +2927,7 @@ impl Function {
                         && let Some(ret_expr) = source.value.cast::<ast::ReturnExpr>()
                     {
                         let root = db.parse_or_expand(source.file_id);
-                        acc.push(ret_expr.to_node(&root));
+                        acc.push(InFile::new(source.file_id, ret_expr.to_node(&root)));
                     }
                 }
                 _ => {}

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -2904,34 +2904,55 @@ impl Function {
         }
     }
 
-    /// Returns the return expressions in this function's body that belong to the
-    /// function itself (not inside closures or async blocks which create their own
-    /// return scope). Uses HIR analysis, which handles returns inside macro expansions.
-    pub fn return_points(self, db: &dyn HirDatabase) -> Vec<InFile<AstPtr<ast::ReturnExpr>>> {
+    /// Returns the text ranges of `return` keywords in this function's body,
+    /// excluding those inside closures or async blocks.
+    pub fn return_points(self, db: &dyn HirDatabase) -> Vec<TextRange> {
         let func_id: FunctionId = match self.id {
             AnyFunctionId::FunctionId(id) => id,
             _ => return vec![],
         };
         let (body, source_map) = Body::with_source_map(db, func_id.into());
-        let mut returns = vec![];
-        let mut to_visit = vec![body.root_expr()];
-        while let Some(expr_id) = to_visit.pop() {
-            let expr = &body[expr_id];
-            // Closures and async blocks create their own return scope
-            // Skip closures, async/gen blocks, and const blocks — each creates
-            // its own return scope so `return` inside them exits that scope, not the function.
-            match expr {
-                Expr::Closure { .. } | Expr::Const(_) => continue,
+        let fn_file_id = func_id.loc(db).id.file_id;
+
+        fn collect_returns(
+            body: &Body,
+            source_map: &hir_def::expr_store::ExpressionStoreSourceMap,
+            db: &dyn HirDatabase,
+            fn_file_id: HirFileId,
+            expr_id: ExprId,
+            acc: &mut Vec<TextRange>,
+        ) {
+            match &body[expr_id] {
+                Expr::Closure { .. } | Expr::Const(_) => return,
+                Expr::Return { .. } => {
+                    if let Ok(source) = source_map.expr_syntax(expr_id)
+                        && let Some(ret_expr) = source.value.cast::<ast::ReturnExpr>()
+                    {
+                        let root = db.parse_or_expand(source.file_id);
+                        let node = ret_expr.to_node(&root);
+                        if let Some(return_token) = node.return_token() {
+                            let token_range = return_token.text_range();
+                            if source.file_id == fn_file_id {
+                                acc.push(token_range);
+                            } else if let Some((file_range, _)) =
+                                InFile::new(source.file_id, token_range)
+                                    .original_node_file_range_opt(db)
+                                && file_range.file_id == fn_file_id
+                            {
+                                acc.push(file_range.range);
+                            }
+                        }
+                    }
+                }
                 _ => {}
             }
-            if matches!(expr, Expr::Return { .. })
-                && let Ok(source) = source_map.expr_syntax(expr_id)
-                && let Some(ptr) = source.value.cast::<ast::ReturnExpr>()
-            {
-                returns.push(InFile::new(source.file_id, ptr));
-            }
-            body.walk_child_exprs(expr_id, |child| to_visit.push(child));
+            body.walk_child_exprs(expr_id, |child| {
+                collect_returns(body, source_map, db, fn_file_id, child, acc);
+            });
         }
+
+        let mut returns = vec![];
+        collect_returns(body, source_map, db, fn_file_id, body.root_expr(), &mut returns);
         returns
     }
 

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -2904,6 +2904,40 @@ impl Function {
         }
     }
 
+    /// Returns the return expressions in this function's body that belong to the
+    /// function itself (not inside closures or async blocks which create their own
+    /// return scope). Uses HIR analysis, which handles returns inside macro expansions.
+    pub fn return_points(
+        self,
+        db: &dyn HirDatabase,
+    ) -> Vec<InFile<AstPtr<ast::ReturnExpr>>> {
+        let func_id: FunctionId = match self.id {
+            AnyFunctionId::FunctionId(id) => id,
+            _ => return vec![],
+        };
+        let (body, source_map) = Body::with_source_map(db, func_id.into());
+        let mut returns = vec![];
+        let mut to_visit = vec![body.root_expr()];
+        while let Some(expr_id) = to_visit.pop() {
+            let expr = &body[expr_id];
+            // Closures and async blocks create their own return scope
+            // Skip closures, async/gen blocks, and const blocks — each creates
+            // its own return scope so `return` inside them exits that scope, not the function.
+            match expr {
+                Expr::Closure { .. } | Expr::Const(_) => continue,
+                _ => {}
+            }
+            if matches!(expr, Expr::Return { .. })
+                && let Ok(source) = source_map.expr_syntax(expr_id)
+                && let Some(ptr) = source.value.cast::<ast::ReturnExpr>()
+            {
+                returns.push(InFile::new(source.file_id, ptr));
+            }
+            body.walk_child_exprs(expr_id, |child| to_visit.push(child));
+        }
+        returns
+    }
+
     pub fn as_proc_macro(self, db: &dyn HirDatabase) -> Option<Macro> {
         let AnyFunctionId::FunctionId(id) = self.id else {
             return None;

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -2907,10 +2907,7 @@ impl Function {
     /// Returns the return expressions in this function's body that belong to the
     /// function itself (not inside closures or async blocks which create their own
     /// return scope). Uses HIR analysis, which handles returns inside macro expansions.
-    pub fn return_points(
-        self,
-        db: &dyn HirDatabase,
-    ) -> Vec<InFile<AstPtr<ast::ReturnExpr>>> {
+    pub fn return_points(self, db: &dyn HirDatabase) -> Vec<InFile<AstPtr<ast::ReturnExpr>>> {
         let func_id: FunctionId = match self.id {
             AnyFunctionId::FunctionId(id) => id,
             _ => return vec![],

--- a/crates/ide-assists/src/handlers/inline_call.rs
+++ b/crates/ide-assists/src/handlers/inline_call.rs
@@ -367,65 +367,11 @@ fn inline(
     let body_offset = body_to_clone.syntax().text_range().start();
     let (editor, body) = SyntaxEditor::with_ast_node(&body_to_clone);
 
-    // Collect return expressions that need to be rewritten to labeled breaks.
-    // Async functions are excluded: their body is later wrapped in `async move { }`,
-    // which preserves return semantics.
+    // Check whether the function has return expressions that need to be transformed
+    // into labeled breaks. Async functions don't need this because the body gets wrapped
+    // in `async move { ... }` which preserves return semantics.
     let is_async_fn = function.is_async(sema.db);
-    let return_nodes: Vec<ast::ReturnExpr> = if is_async_fn {
-        vec![]
-    } else if file_id.is_macro() {
-        // Function defined in a macro — the body was prettified so HIR source map ranges
-        // don't match. Walk the prettified body syntactically instead.
-        body.syntax()
-            .descendants()
-            .filter_map(ast::ReturnExpr::cast)
-            .filter(|ret| {
-                ret.syntax().ancestors().take_while(|it| it != body.syntax()).all(|ancestor| {
-                    match ast::Expr::cast(ancestor) {
-                        Some(ast::Expr::ClosureExpr(_)) => false,
-                        Some(ast::Expr::BlockExpr(block)) => !matches!(
-                            block.modifier(),
-                            Some(
-                                ast::BlockModifier::Async(_)
-                                    | ast::BlockModifier::Const(_)
-                                    | ast::BlockModifier::AsyncGen(_)
-                                    | ast::BlockModifier::Gen(_)
-                            )
-                        ),
-                        _ => true,
-                    }
-                })
-            })
-            .collect()
-    } else {
-        // Use HIR analysis to get the return points. The editor's body is re-rooted so
-        // its ranges are body-relative; subtract body_offset to convert file-relative
-        // ranges from return_points() before looking up nodes.
-        function
-            .return_points(sema.db)
-            .into_iter()
-            .filter_map(|ret| {
-                let root = sema.db.parse_or_expand(ret.file_id);
-                let return_expr = ret.value.to_node(&root);
-                let body_relative_range = return_expr.syntax().text_range() - body_offset;
-                body.syntax()
-                    .covering_element(body_relative_range)
-                    .ancestors()
-                    .find_map(ast::ReturnExpr::cast)
-            })
-            .collect()
-    };
-
-    // Register break replacements in the editor now, before finish().
-    if !return_nodes.is_empty() {
-        let inline_lt = make::lifetime("'inline");
-        for ret_expr in &return_nodes {
-            let break_expr = make::expr_break(Some(inline_lt.clone()), ret_expr.expr());
-            editor.replace(ret_expr.syntax(), break_expr.syntax());
-        }
-    }
-
-
+    let has_early_returns = !is_async_fn && !function.return_points(sema.db).is_empty();
     let usages_for_locals = |local| {
         Definition::Local(local)
             .usages(sema)
@@ -678,6 +624,13 @@ fn inline(
         body = new_body;
     }
 
+    // Walk the cloned body and replace `return X` with `break 'inline X` before the body
+    // is potentially reconstructed with prepended let stmts below. The label is inserted
+    // after reconstruction so it survives a `make.block_expr` reassignment.
+    if has_early_returns {
+        replace_returns_with_breaks(&body);
+    }
+
     if is_async_fn {
         cov_mark::hit!(inline_call_async_fn);
         body = make.async_move_block_expr(body.statements(), body.tail_expr());
@@ -695,10 +648,9 @@ fn inline(
         original_body_indent = IndentLevel(0);
     }
 
-    // Insert the `'inline:` label now that the body is fully assembled.
-    // Break replacements were registered in the editor above; just attach the label.
-    // body is always mutable here (editor.finish() and make.block_expr both produce mutable trees).
-    if !return_nodes.is_empty() {
+    // Insert the 'inline label after the body is fully assembled. Doing this after
+    // the let_stmts reconstruction ensures the label survives a `make.block_expr` swap.
+    if has_early_returns {
         let label = make::label(make::lifetime("'inline")).clone_for_update();
         if let Some(stmt_list) = body.stmt_list() {
             ted::insert(ted::Position::before(stmt_list.syntax()), label.syntax());
@@ -741,6 +693,33 @@ fn is_in_type_path(self_tok: &syntax::SyntaxToken) -> bool {
         .and_then(|it| it.syntax().parent())
         .and_then(ast::PathType::cast)
         .is_some()
+}
+
+/// Replaces `return` / `return expr` with `break 'inline` / `break 'inline expr`
+/// for all `ReturnExpr` nodes that belong directly to the function body
+/// (i.e., not nested inside closures or async blocks).
+fn replace_returns_with_breaks(body: &ast::BlockExpr) {
+    fn walk(node: &syntax::SyntaxNode) {
+        for child in node.children() {
+            if ast::ClosureExpr::can_cast(child.kind()) {
+                continue;
+            }
+            if let Some(block) = ast::BlockExpr::cast(child.clone())
+                && (block.async_token().is_some() || block.const_token().is_some())
+            {
+                continue;
+            }
+            if let Some(return_expr) = ast::ReturnExpr::cast(child.clone()) {
+                let break_expr =
+                    make::expr_break(Some(make::lifetime("'inline")), return_expr.expr())
+                        .clone_for_update();
+                ted::replace(return_expr.syntax(), break_expr.syntax());
+            } else {
+                walk(&child);
+            }
+        }
+    }
+    walk(body.syntax());
 }
 
 fn path_expr_as_record_field(usage: &PathExpr) -> Option<ast::RecordExprField> {

--- a/crates/ide-assists/src/handlers/inline_call.rs
+++ b/crates/ide-assists/src/handlers/inline_call.rs
@@ -684,20 +684,6 @@ fn inline(
     }
 }
 
-fn is_in_type_path(self_tok: &syntax::SyntaxToken) -> bool {
-    self_tok
-        .parent_ancestors()
-        .skip_while(|it| !ast::Path::can_cast(it.kind()))
-        .map_while(ast::Path::cast)
-        .last()
-        .and_then(|it| it.syntax().parent())
-        .and_then(ast::PathType::cast)
-        .is_some()
-}
-
-/// Replaces `return` / `return expr` with `break 'inline` / `break 'inline expr`
-/// for all `ReturnExpr` nodes that belong directly to the function body
-/// (i.e., not nested inside closures or async blocks).
 fn replace_returns_with_breaks(body: &ast::BlockExpr) {
     fn walk(node: &syntax::SyntaxNode) {
         for child in node.children() {
@@ -720,6 +706,17 @@ fn replace_returns_with_breaks(body: &ast::BlockExpr) {
         }
     }
     walk(body.syntax());
+}
+
+fn is_in_type_path(self_tok: &syntax::SyntaxToken) -> bool {
+    self_tok
+        .parent_ancestors()
+        .skip_while(|it| !ast::Path::can_cast(it.kind()))
+        .map_while(ast::Path::cast)
+        .last()
+        .and_then(|it| it.syntax().parent())
+        .and_then(ast::PathType::cast)
+        .is_some()
 }
 
 fn path_expr_as_record_field(usage: &PathExpr) -> Option<ast::RecordExprField> {

--- a/crates/ide-assists/src/handlers/inline_call.rs
+++ b/crates/ide-assists/src/handlers/inline_call.rs
@@ -21,9 +21,11 @@ use syntax::{
     ast::{
         self, HasArgList, HasGenericArgs, Pat, PathExpr,
         edit::{AstNodeEdit, IndentLevel},
+        make,
         syntax_factory::SyntaxFactory,
     },
     syntax_editor::SyntaxEditor,
+    ted,
 };
 
 use crate::{
@@ -365,6 +367,46 @@ fn inline(
     let body_offset = body_to_clone.syntax().text_range().start();
     let (editor, body) = SyntaxEditor::with_ast_node(&body_to_clone);
 
+    // Collect return expressions that need to be rewritten to labeled breaks.
+    // Async functions are excluded: their body is later wrapped in `async move { }`,
+    // which preserves the return semantics.
+    let is_async_fn = function.is_async(sema.db);
+    let return_nodes: Vec<ast::ReturnExpr> = if is_async_fn {
+        vec![]
+    } else {
+        body.syntax()
+            .descendants()
+            .filter_map(ast::ReturnExpr::cast)
+            .filter(|ret| {
+                // Exclude returns inside closures or async/const/gen blocks.
+                ret.syntax().ancestors().take_while(|it| it != body.syntax()).all(|ancestor| {
+                    match ast::Expr::cast(ancestor) {
+                        Some(ast::Expr::ClosureExpr(_)) => false,
+                        Some(ast::Expr::BlockExpr(block)) => !matches!(
+                            block.modifier(),
+                            Some(
+                                ast::BlockModifier::Async(_)
+                                    | ast::BlockModifier::Const(_)
+                                    | ast::BlockModifier::AsyncGen(_)
+                                    | ast::BlockModifier::Gen(_)
+                            )
+                        ),
+                        _ => true,
+                    }
+                })
+            })
+            .collect()
+    };
+
+    // Register break replacements in the editor now, before finish().
+    if !return_nodes.is_empty() {
+        let inline_lt = make::lifetime("'inline");
+        for ret_expr in &return_nodes {
+            let break_expr = make::expr_break(Some(inline_lt.clone()), ret_expr.expr());
+            editor.replace(ret_expr.syntax(), break_expr.syntax());
+        }
+    }
+
     let usages_for_locals = |local| {
         Definition::Local(local)
             .usages(sema)
@@ -617,7 +659,6 @@ fn inline(
         body = new_body;
     }
 
-    let is_async_fn = function.is_async(sema.db);
     if is_async_fn {
         cov_mark::hit!(inline_call_async_fn);
         body = make.async_move_block_expr(body.statements(), body.tail_expr());
@@ -635,18 +676,31 @@ fn inline(
         original_body_indent = IndentLevel(0);
     }
 
+    // Insert the `'inline:` label now that the body is fully assembled.
+    // The break replacements were registered in the editor above; we just need
+    // to attach the label to the outermost block here.
+    // body is always mutable at this point (editor.finish() returns a mutable tree,
+    // and make.block_expr / make.async_move_block_expr also produce mutable trees).
+    if !return_nodes.is_empty() {
+        let label = make::label(make::lifetime("'inline")).clone_for_update();
+        if let Some(stmt_list) = body.stmt_list() {
+            ted::insert(ted::Position::before(stmt_list.syntax()), label.syntax());
+        }
+    }
+
     let original_indentation = match node {
         ast::CallableExpr::Call(it) => it.indent_level(),
         ast::CallableExpr::MethodCall(it) => it.indent_level(),
     };
     body = body.dedent(original_body_indent).indent(original_indentation);
 
+    let has_label = body.label().is_some();
     let no_stmts = body.statements().next().is_none();
     match body.tail_expr() {
-        Some(expr) if matches!(expr, ast::Expr::ClosureExpr(_)) && no_stmts => {
+        Some(expr) if matches!(expr, ast::Expr::ClosureExpr(_)) && no_stmts && !has_label => {
             make.expr_paren(expr).into()
         }
-        Some(expr) if !is_async_fn && no_stmts => expr,
+        Some(expr) if !is_async_fn && no_stmts && !has_label => expr,
         _ => match node
             .syntax()
             .parent()
@@ -1978,6 +2032,250 @@ macro_rules! bar {
 
 fn f() {
     bar!(foo$0());
+}
+"#,
+        );
+    }
+
+    #[test]
+    fn inline_call_with_early_return() {
+        check_assist(
+            inline_call,
+            r#"
+fn early_return() -> Option<()> {
+    return None;
+}
+fn main() -> Option<()> {
+    if early_return$0().is_none() {
+        return Some(());
+    }
+    None
+}
+"#,
+            r#"
+fn early_return() -> Option<()> {
+    return None;
+}
+fn main() -> Option<()> {
+    if 'inline: {
+        break 'inline None;
+    }.is_none() {
+        return Some(());
+    }
+    None
+}
+"#,
+        );
+    }
+
+    #[test]
+    fn inline_call_with_early_return_and_tail_expr() {
+        check_assist(
+            inline_call,
+            r#"
+fn foo(x: i32) -> i32 {
+    if x < 0 {
+        return -1;
+    }
+    x * 2
+}
+fn main() {
+    let result = foo$0(5);
+}
+"#,
+            r#"
+fn foo(x: i32) -> i32 {
+    if x < 0 {
+        return -1;
+    }
+    x * 2
+}
+fn main() {
+    let result = 'inline: {
+        let x = 5;
+        if x < 0 {
+            break 'inline -1;
+        }
+        x * 2
+    };
+}
+"#,
+        );
+    }
+
+    #[test]
+    fn inline_call_with_return_in_closure_not_transformed() {
+        check_assist(
+            inline_call,
+            r#"
+fn foo() -> fn() -> i32 {
+    || return 42
+}
+fn main() {
+    let f = foo$0();
+}
+"#,
+            r#"
+fn foo() -> fn() -> i32 {
+    || return 42
+}
+fn main() {
+    let f = (|| return 42);
+}
+"#,
+        );
+    }
+
+    #[test]
+    fn inline_call_with_multiple_early_returns() {
+        check_assist(
+            inline_call,
+            r#"
+fn classify(x: i32) -> &'static str {
+    if x < 0 {
+        return "negative";
+    }
+    if x == 0 {
+        return "zero";
+    }
+    "positive"
+}
+fn main() {
+    let s = classify$0(1);
+}
+"#,
+            r#"
+fn classify(x: i32) -> &'static str {
+    if x < 0 {
+        return "negative";
+    }
+    if x == 0 {
+        return "zero";
+    }
+    "positive"
+}
+fn main() {
+    let s = 'inline: {
+        let x = 1;
+        if x < 0 {
+            break 'inline "negative";
+        }
+        if x == 0 {
+            break 'inline "zero";
+        }
+        "positive"
+    };
+}
+"#,
+        );
+    }
+
+    #[test]
+    fn inline_call_with_return_in_async_block_not_transformed() {
+        check_assist(
+            inline_call,
+            r#"
+fn foo() -> i32 {
+    let _ = async { return 42; };
+    return 0;
+}
+fn main() {
+    let x = foo$0();
+}
+"#,
+            r#"
+fn foo() -> i32 {
+    let _ = async { return 42; };
+    return 0;
+}
+fn main() {
+    let x = 'inline: {
+        let _ = async { return 42; };
+        break 'inline 0;
+    };
+}
+"#,
+        );
+    }
+
+    #[test]
+    fn inline_call_with_return_no_expr() {
+        check_assist(
+            inline_call,
+            r#"
+fn greet(is_loud: bool) {
+    if !is_loud {
+        return;
+    }
+    println!("HELLO!");
+}
+fn main() {
+    greet$0(true);
+}
+"#,
+            r#"
+fn greet(is_loud: bool) {
+    if !is_loud {
+        return;
+    }
+    println!("HELLO!");
+}
+fn main() {
+    'inline: {
+        if !true {
+            break 'inline;
+        }
+        println!("HELLO!");
+    };
+}
+"#,
+        );
+    }
+
+    #[test]
+    fn inline_into_callers_with_early_return() {
+        check_assist(
+            inline_into_callers,
+            r#"
+fn ear$0ly(x: i32) -> i32 {
+    if x < 0 {
+        return -1;
+    }
+    x * 2
+}
+fn main() {
+    let a = early(1);
+}
+"#,
+            r#"
+
+fn main() {
+    let a = 'inline: {
+        let x = 1;
+        if x < 0 {
+            break 'inline -1;
+        }
+        x * 2
+    };
+}
+"#,
+        );
+    }
+
+    #[test]
+    fn inline_call_with_return_as_tail_expr() {
+        check_assist(
+            inline_call,
+            r#"
+fn foo() -> i32 { return 42 }
+fn main() {
+    let x = foo$0();
+}
+"#,
+            r#"
+fn foo() -> i32 { return 42 }
+fn main() {
+    let x = 'inline: { break 'inline 42 };
 }
 "#,
         );

--- a/crates/ide-assists/src/handlers/inline_call.rs
+++ b/crates/ide-assists/src/handlers/inline_call.rs
@@ -369,16 +369,17 @@ fn inline(
 
     // Collect return expressions that need to be rewritten to labeled breaks.
     // Async functions are excluded: their body is later wrapped in `async move { }`,
-    // which preserves the return semantics.
+    // which preserves return semantics.
     let is_async_fn = function.is_async(sema.db);
     let return_nodes: Vec<ast::ReturnExpr> = if is_async_fn {
         vec![]
-    } else {
+    } else if file_id.is_macro() {
+        // Function defined in a macro — the body was prettified so HIR source map ranges
+        // don't match. Walk the prettified body syntactically instead.
         body.syntax()
             .descendants()
             .filter_map(ast::ReturnExpr::cast)
             .filter(|ret| {
-                // Exclude returns inside closures or async/const/gen blocks.
                 ret.syntax().ancestors().take_while(|it| it != body.syntax()).all(|ancestor| {
                     match ast::Expr::cast(ancestor) {
                         Some(ast::Expr::ClosureExpr(_)) => false,
@@ -396,6 +397,23 @@ fn inline(
                 })
             })
             .collect()
+    } else {
+        // Use HIR analysis to get the return points. The editor's body is re-rooted so
+        // its ranges are body-relative; subtract body_offset to convert file-relative
+        // ranges from return_points() before looking up nodes.
+        function
+            .return_points(sema.db)
+            .into_iter()
+            .filter_map(|ret| {
+                let root = sema.db.parse_or_expand(ret.file_id);
+                let return_expr = ret.value.to_node(&root);
+                let body_relative_range = return_expr.syntax().text_range() - body_offset;
+                body.syntax()
+                    .covering_element(body_relative_range)
+                    .ancestors()
+                    .find_map(ast::ReturnExpr::cast)
+            })
+            .collect()
     };
 
     // Register break replacements in the editor now, before finish().
@@ -406,6 +424,7 @@ fn inline(
             editor.replace(ret_expr.syntax(), break_expr.syntax());
         }
     }
+
 
     let usages_for_locals = |local| {
         Definition::Local(local)
@@ -677,10 +696,8 @@ fn inline(
     }
 
     // Insert the `'inline:` label now that the body is fully assembled.
-    // The break replacements were registered in the editor above; we just need
-    // to attach the label to the outermost block here.
-    // body is always mutable at this point (editor.finish() returns a mutable tree,
-    // and make.block_expr / make.async_move_block_expr also produce mutable trees).
+    // Break replacements were registered in the editor above; just attach the label.
+    // body is always mutable here (editor.finish() and make.block_expr both produce mutable trees).
     if !return_nodes.is_empty() {
         let label = make::label(make::lifetime("'inline")).clone_for_update();
         if let Some(stmt_list) = body.stmt_list() {

--- a/crates/syntax/src/ast/make.rs
+++ b/crates/syntax/src/ast/make.rs
@@ -167,6 +167,10 @@ pub fn lifetime(text: &str) -> ast::Lifetime {
     }
 }
 
+pub fn label(lifetime: ast::Lifetime) -> ast::Label {
+    ast_from_text(&format!("fn f() {{ {lifetime}: loop {{}} }}"))
+}
+
 // FIXME: replace stringly-typed constructor with a family of typed ctors, a-la
 // `expr_xxx`.
 pub fn ty(text: &str) -> ast::Type {


### PR DESCRIPTION
when inlining a function containing `return` expressions the `return` would incorrectly exit the caller rather than the inlined block. wrap the inlined body in a labeled block (`'inline: { ... }`) and rewrite `return <expr>` to `break 'inline <expr>`.

returns inside closures, async, const, and gen blocks are not changed because they have their own return scope.

Closes rust-lang/rust-analyzer#19377