### PR TITLE
Revert "Publish no-server to Code Marketplace and OpenVSX"

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -264,6 +264,8 @@ jobs:
           name: ${{ env.TAG }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      - run: rm dist/rust-analyzer-no-server.vsix
+
       - run: npm ci
         working-directory: ./editors/code
 


### PR DESCRIPTION
Reverts rust-lang/rust-analyzer#21516

It *did* break **everything**. rust-analyzer now fails to activate.