### PR TITLE
fix: update format_like doc and GIF

### DIFF
--- a/crates/ide-completion/src/completions/postfix/format_like.rs
+++ b/crates/ide-completion/src/completions/postfix/format_like.rs
@@ -1,6 +1,6 @@
 // Feature: Format String Completion
 //
-// `"Result {result} is {2 + 2}"` is expanded to the `"Result {} is {}", result, 2 + 2`.
+// `"Result {result} is {2 + 2}"` is expanded to the `"Result {result} is {}", 2 + 2`.
 //
 // The following postfix snippets are available:
 //


### PR DESCRIPTION
## Description

Fixes https://github.com/rust-lang/rust-analyzer/issues/21852
![output2](https://github.com/user-attachments/assets/cc981640-a05b-4744-a6a6-557cc7f80ca6)


**TODO**: I still need to upload the attached GIF (somewhere, I don't know where yet), to make sure we can use this as a demo link in `format_like.rs`. I'll figure this out.