### PR TITLE
fix: Set VS Code extension kind explicitly

### DIFF
--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -31,6 +31,9 @@
         "vscode": "^1.93.0"
     },
     "enabledApiProposals": [],
+    "extensionKind": [
+        "workspace"
+    ],
     "scripts": {
         "vscode:prepublish": "npm run build-base -- --minify",
         "package": "vsce package -o rust-analyzer.vsix",


### PR DESCRIPTION
The VS Code extension needs to be a `workspace` extension, because it relies on access to the workspace. The rust-analyzer binary needs to run on the same machine as the checkout of the code it's working on.

https://code.visualstudio.com/api/advanced-topics/remote-extensions#architecture-and-extension-kinds https://code.visualstudio.com/api/advanced-topics/extension-host#preferred-extension-location

If an extension doesn't set extensionKind, VS Code will try to deduce the kind based on the presence of various fields in the package.json, such as a `main`.

https://github.com/microsoft/vscode/blob/fc23f2d26631c6a2c4bf9f69506ea74c90a32804/src/vs/workbench/services/extensions/common/extensionManifestPropertiesService.ts#L222

Instead, mark the extension kind as explicitly `workspace`. This is more explicit and prevents future changes to package.json accidentally making it run in the wrong environment. It's also helpful when debugging startup bugs.