### PR TITLE
fix: Not suggest name in nested type in variant

### DIFF
--- a/crates/ide-completion/src/context/analysis.rs
+++ b/crates/ide-completion/src/context/analysis.rs
@@ -828,10 +828,15 @@ fn expected_type_and_name<'db>(
                         .unwrap_or((None, None))
                 },
                 ast::Variant(it) => {
+                    let is_simple_field = |field: ast::TupleField| {
+                        let Some(ty) = field.ty() else { return true };
+                        matches!(ty, ast::Type::PathType(_)) && ty.generic_arg_list().is_none()
+                    };
                     let is_simple_variant = matches!(
                         it.field_list(),
                         Some(ast::FieldList::TupleFieldList(list))
                         if list.syntax().children_with_tokens().all(|it| it.kind() != T![,])
+                            && list.fields().next().is_none_or(is_simple_field)
                     );
                     (None, it.name().filter(|_| is_simple_variant).map(NameOrNameRef::Name))
                 },

--- a/crates/ide-completion/src/render.rs
+++ b/crates/ide-completion/src/render.rs
@@ -3077,6 +3077,22 @@ enum Foo {
                 st String String []
             "#]],
         );
+
+        check_relevance(
+            r#"
+struct Other;
+struct Vec<T>(T);
+enum Foo {
+    Vec(Vec<$0>)
+}
+    "#,
+            expect![[r#"
+                en Foo Foo []
+                st Other Other []
+                sp Self Foo []
+                st Vec<…> Vec<{unknown}> []
+            "#]],
+        );
     }
 
     #[test]


### PR DESCRIPTION
Partial of rust-lang/rust-analyzer#21892

Example
---
```rust
struct Other;
struct Vec<T>(T);
enum Foo {
    Vec(Vec<$0>)
}
```

**Before this PR**

```text
st Vec<…> Vec<{unknown}> [name]
en Foo Foo []
st Other Other []
sp Self Foo []
```

**After this PR**

```text
en Foo Foo []
st Other Other []
sp Self Foo []
st Vec<…> Vec<{unknown}> []
```
