### PR TITLE
Move mutability responsibility from caller to edit_algo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2283,9 +2283,9 @@ checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "rowan"
-version = "0.15.17"
+version = "0.15.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4f1e4a001f863f41ea8d0e6a0c34b356d5b733db50dadab3efef640bafb779b"
+checksum = "62f509095fc8cc0c8c8564016771d458079c11a8d857e65861f045145c0d3208"
 dependencies = [
  "countme",
  "hashbrown 0.14.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,7 +132,7 @@ process-wrap = { version = "8.2.1", features = ["std"] }
 pulldown-cmark-to-cmark = "10.0.4"
 pulldown-cmark = { version = "0.9.6", default-features = false }
 rayon = "1.10.0"
-rowan = "=0.15.17"
+rowan = "=0.15.18"
 # Ideally we'd not enable the macros feature but unfortunately the `tracked` attribute does not work
 # on impls without it
 salsa = { version = "0.25.2", default-features = false, features = [

--- a/crates/ide-assists/src/handlers/inline_type_alias.rs
+++ b/crates/ide-assists/src/handlers/inline_type_alias.rs
@@ -170,7 +170,7 @@ impl Replacement {
             Replacement::Generic { lifetime_map, const_and_type_map } => {
                 create_replacement(lifetime_map, const_and_type_map, concrete_type)
             }
-            Replacement::Plain => concrete_type.syntax().clone_subtree().clone_for_update(),
+            Replacement::Plain => concrete_type.syntax().clone(),
         }
     }
 }
@@ -361,7 +361,7 @@ fn create_replacement(
                     continue;
                 }
 
-                replacements.push((syntax.clone(), new_lifetime.syntax().clone_for_update()));
+                replacements.push((syntax.clone(), new_lifetime.syntax().clone()));
             }
         } else if let Some(name_ref) = ast::NameRef::cast(syntax.clone()) {
             let Some(replacement_syntax) = const_and_type_map.0.get(&name_ref.to_string()) else {
@@ -449,15 +449,12 @@ impl ConstOrTypeGeneric {
     }
 
     fn replacement_value(&self) -> Option<SyntaxNode> {
-        Some(
-            match self {
-                ConstOrTypeGeneric::ConstArg(ca) => ca.expr()?.syntax().clone(),
-                ConstOrTypeGeneric::TypeArg(ta) => ta.syntax().clone(),
-                ConstOrTypeGeneric::ConstParam(cp) => cp.default_val()?.syntax().clone(),
-                ConstOrTypeGeneric::TypeParam(tp) => tp.default_type()?.syntax().clone(),
-            }
-            .clone_for_update(),
-        )
+        Some(match self {
+            ConstOrTypeGeneric::ConstArg(ca) => ca.expr()?.syntax().clone(),
+            ConstOrTypeGeneric::TypeArg(ta) => ta.syntax().clone(),
+            ConstOrTypeGeneric::ConstParam(cp) => cp.default_val()?.syntax().clone(),
+            ConstOrTypeGeneric::TypeParam(tp) => tp.default_type()?.syntax().clone(),
+        })
     }
 }
 

--- a/crates/syntax/src/syntax_editor/edit_algo.rs
+++ b/crates/syntax/src/syntax_editor/edit_algo.rs
@@ -192,11 +192,8 @@ pub(super) fn apply_edits(editor: SyntaxEditor) -> SyntaxEdit {
                     }
                 };
             }
-            Change::Replace(SyntaxElement::Node(target), Some(SyntaxElement::Node(new_target))) => {
+            Change::Replace(SyntaxElement::Node(target), Some(SyntaxElement::Node(_))) => {
                 *target = tree_mutator.make_syntax_mut(target);
-                if new_target.ancestors().any(|node| node == tree_mutator.immutable) {
-                    *new_target = new_target.clone_for_update();
-                }
             }
             Change::Replace(target, _) | Change::ReplaceWithMany(target, _) => {
                 *target = tree_mutator.make_element_mut(target);
@@ -207,6 +204,31 @@ pub(super) fn apply_edits(editor: SyntaxEditor) -> SyntaxEdit {
 
                 *range = start..=end;
             }
+        }
+
+        match &mut changes[index as usize] {
+            Change::Insert(_, SyntaxElement::Node(node))
+            | Change::Replace(_, Some(SyntaxElement::Node(node))) => {
+                if node.parent().is_some() {
+                    *node = node.clone_subtree().clone_for_update();
+                } else if *node == tree_mutator.immutable {
+                    *node = node.clone_for_update();
+                }
+            }
+            Change::InsertAll(_, elements)
+            | Change::ReplaceWithMany(_, elements)
+            | Change::ReplaceAll(_, elements) => {
+                for element in elements {
+                    if let SyntaxElement::Node(node) = element {
+                        if node.parent().is_some() {
+                            *node = node.clone_subtree().clone_for_update();
+                        } else if *node == tree_mutator.immutable {
+                            *node = node.clone_for_update();
+                        }
+                    }
+                }
+            }
+            _ => {}
         }
 
         match &mut changes[index as usize] {

--- a/crates/syntax/src/syntax_editor/edit_algo.rs
+++ b/crates/syntax/src/syntax_editor/edit_algo.rs
@@ -211,7 +211,7 @@ pub(super) fn apply_edits(editor: SyntaxEditor) -> SyntaxEdit {
             | Change::Replace(_, Some(SyntaxElement::Node(node))) => {
                 if node.parent().is_some() {
                     *node = node.clone_subtree().clone_for_update();
-                } else if *node == tree_mutator.immutable {
+                } else if !node.is_mutable() {
                     *node = node.clone_for_update();
                 }
             }
@@ -222,7 +222,7 @@ pub(super) fn apply_edits(editor: SyntaxEditor) -> SyntaxEdit {
                     if let SyntaxElement::Node(node) = element {
                         if node.parent().is_some() {
                             *node = node.clone_subtree().clone_for_update();
-                        } else if *node == tree_mutator.immutable {
+                        } else if !node.is_mutable() {
                             *node = node.clone_for_update();
                         }
                     }


### PR DESCRIPTION
This PR moves responsibility from the caller to the edit pipeline. The goal is to eliminate all `clone_subtree` and `clone_for_update` calls at the caller site and handle them within the pipeline. I may still be overlooking some edge cases, but this approach feels like a more appropriate way to manage mutability.

part of https://github.com/rust-lang/rust-analyzer/issues/15710 and https://github.com/rust-lang/rust-analyzer/issues/18285