### PR TITLE
internal: Ensure tracing is configured in slow tests

### DIFF
--- a/crates/rust-analyzer/tests/slow-tests/support.rs
+++ b/crates/rust-analyzer/tests/slow-tests/support.rs
@@ -173,7 +173,8 @@ impl Project<'_> {
                 chalk_filter: std::env::var("CHALK_DEBUG").ok(),
                 profile_filter: std::env::var("RA_PROFILE").ok(),
                 json_profile_filter: std::env::var("RA_PROFILE_JSON").ok(),
-            };
+            }
+            .init();
         });
 
         let FixtureWithProjectMeta {


### PR DESCRIPTION
rust-lang/rust-analyzer#16394 changed the logging initialisation to create a Config struct, but never did anything with it. Call `.init()` so slow tests have tracing configured.

You can test this by adding a test failure to a slow test, e.g. `test_format_document_2018`, and then running it:

```
$ RA_LOG=trace RUN_SLOW_TESTS=1 cargo t test_format_document_2018
```

Previously this didn't log anything, even though RA_LOG was set.