### PR TITLE
fix: support multiple snippet placeholders in VS Code extension

### DIFF
--- a/editors/code/src/snippets.ts
+++ b/editors/code/src/snippets.ts
@@ -53,7 +53,7 @@ export async function applySnippetTextEdits(editor: vscode.TextEditor, edits: vs
 }
 
 function hasSnippet(snip: string): boolean {
-    const m = snip.match(/\$\d+|\{\d+:[^}]*\}/);
+    const m = snip.match(/\$\d+|\$\{\d+:[^}]*\}/);
     return m != null;
 }
 


### PR DESCRIPTION
Fixes rust-lang/rust-analyzer#12312.
Added a missing escaped dollar sign (`\$`) to the regex in `hasSnippet` within `editors/code/src/snippets.ts`. The previous regex `\{\d+:[^}]*\}` failed to match VS Code's official placeholder syntax, which requires a leading dollar sign (e.g., `${1:foo}`). Because of this, assists returning multiple placeholders (like "Generate Documentation") were failing the `hasSnippet` check and being inserted as raw text. 