### PR TITLE
fix: report `expected type, found {` in parser

### DIFF
--- a/crates/parser/src/grammar/types.rs
+++ b/crates/parser/src/grammar/types.rs
@@ -59,6 +59,9 @@ fn type_with_bounds_cond(p: &mut Parser<'_>, allow_bounds: bool) {
         }
         _ if paths::is_path_start(p) => path_or_macro_type(p, allow_bounds),
         LIFETIME_IDENT if p.nth_at(1, T![+]) => bare_dyn_trait_type(p),
+        T!['{'] => {
+            p.err_recover("expected type, found `{`", TYPE_RECOVERY_SET);
+        }
         _ => {
             p.err_recover("expected type", TYPE_RECOVERY_SET);
         }

--- a/crates/parser/test_data/parser/err/0025_nope.rast
+++ b/crates/parser/test_data/parser/err/0025_nope.rast
@@ -194,7 +194,7 @@ SOURCE_FILE
         WHITESPACE "\n"
         R_CURLY "}"
   WHITESPACE "\n"
-error 95: expected type
+error 95: expected type, found `{`
 error 95: expected COMMA
 error 96: expected field
 error 98: expected field declaration

--- a/crates/parser/test_data/parser/err/0027_incomplete_where_for.rast
+++ b/crates/parser/test_data/parser/err/0027_incomplete_where_for.rast
@@ -26,5 +26,5 @@ SOURCE_FILE
         L_CURLY "{"
         R_CURLY "}"
   WHITESPACE "\n"
-error 26: expected type
+error 26: expected type, found `{`
 error 26: expected colon


### PR DESCRIPTION
Fixes rust-lang/rust-analyzer#19858.

Improves the parse error message when a developer forgets the `->` before a function body block. Added a specific match arm for the `{` token in `type_with_bounds_cond` to report `"expected type, found \`{\`"` instead of the generic `"expected type"` fallback. 