### PR TITLE
fix: offer on empty else block for 'convert_let_else_to_match'

### DIFF
--- a/crates/ide-assists/src/handlers/convert_let_else_to_match.rs
+++ b/crates/ide-assists/src/handlers/convert_let_else_to_match.rs
@@ -32,8 +32,10 @@ pub(crate) fn convert_let_else_to_match(acc: &mut Assists, ctx: &AssistContext<'
         .or_else(|| ctx.find_token_syntax_at_offset(T![let])?.parent())?;
     let let_stmt = LetStmt::cast(let_stmt)?;
     let else_block = let_stmt.let_else()?.block_expr()?;
-    let else_expr = if else_block.statements().next().is_none() {
-        else_block.tail_expr()?.reset_indent()
+    let else_expr = if else_block.statements().next().is_none()
+        && let Some(tail_expr) = else_block.tail_expr()
+    {
+        tail_expr.reset_indent()
     } else {
         else_block.reset_indent().into()
     };
@@ -293,6 +295,24 @@ fn main() {
     let x = match f() {
         Ok(x) => x,
         _ => continue,
+    };
+}",
+        );
+    }
+
+    #[test]
+    fn convert_let_else_to_match_with_empty_else_block() {
+        check_assist(
+            convert_let_else_to_match,
+            r"
+fn main() {
+    let Ok(x) = f() else$0 {};
+}",
+            r"
+fn main() {
+    let x = match f() {
+        Ok(x) => x,
+        _ => {}
     };
 }",
         );


### PR DESCRIPTION
When editing, there are situations where the else block has not been filled in yet but needs to be converted

Example
---
```rust
fn main() {
    let Ok(x) = f() else$0 {};
}
```

**Before this PR**

Assist not applicable

**After this PR**

```rust
fn main() {
    let x = match f() {
        Ok(x) => x,
        _ => {}
    };
}
```
