### PR TITLE
fix: modify name to avoid duplicate warnings lints

### DIFF
--- a/crates/ide-db/src/generated/lints.rs
+++ b/crates/ide-db/src/generated/lints.rs
@@ -1511,7 +1511,7 @@ pub const DEFAULT_LINTS: &[Lint] = &[
         deny_since: None,
     },
     Lint {
-        label: "warnings",
+        label: "warnings-mass",
         description: r##"mass-change the level for lints which produce warnings"##,
         default_severity: Severity::Warning,
         warn_since: None,


### PR DESCRIPTION
fix rust-lang/rust-analyzer#21943
I think we should rename one of these two 'warnings' lints to avoid confusion.
