### PR TITLE
fix: Use the official npm mirror for all VS Code dependencies

### DIFF
--- a/editors/code/package-lock.json
+++ b/editors/code/package-lock.json
@@ -257,7 +257,7 @@
         },
         "node_modules/@emnapi/core": {
             "version": "1.9.1",
-            "resolved": "https://registry.npmmirror.com/@emnapi/core/-/core-1.9.1.tgz",
+            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.1.tgz",
             "integrity": "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==",
             "dev": true,
             "license": "MIT",
@@ -269,7 +269,7 @@
         },
         "node_modules/@emnapi/runtime": {
             "version": "1.9.1",
-            "resolved": "https://registry.npmmirror.com/@emnapi/runtime/-/runtime-1.9.1.tgz",
+            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.1.tgz",
             "integrity": "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==",
             "dev": true,
             "license": "MIT",
@@ -280,7 +280,7 @@
         },
         "node_modules/@emnapi/wasi-threads": {
             "version": "1.2.0",
-            "resolved": "https://registry.npmmirror.com/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
+            "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
             "integrity": "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==",
             "dev": true,
             "license": "MIT",
@@ -940,7 +940,7 @@
         },
         "node_modules/@napi-rs/wasm-runtime": {
             "version": "0.2.12",
-            "resolved": "https://registry.npmmirror.com/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
+            "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
             "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
             "dev": true,
             "license": "MIT",
@@ -953,7 +953,7 @@
         },
         "node_modules/@node-rs/crc32": {
             "version": "1.10.6",
-            "resolved": "https://registry.npmmirror.com/@node-rs/crc32/-/crc32-1.10.6.tgz",
+            "resolved": "https://registry.npmjs.org/@node-rs/crc32/-/crc32-1.10.6.tgz",
             "integrity": "sha512-+llXfqt+UzgoDzT9of5vPQPGqTAVCohU74I9zIBkNo5TH6s2P31DFJOGsJQKN207f0GHnYv5pV3wh3BCY/un/A==",
             "dev": true,
             "license": "MIT",
@@ -983,7 +983,7 @@
         },
         "node_modules/@node-rs/crc32-android-arm-eabi": {
             "version": "1.10.6",
-            "resolved": "https://registry.npmmirror.com/@node-rs/crc32-android-arm-eabi/-/crc32-android-arm-eabi-1.10.6.tgz",
+            "resolved": "https://registry.npmjs.org/@node-rs/crc32-android-arm-eabi/-/crc32-android-arm-eabi-1.10.6.tgz",
             "integrity": "sha512-vZAMuJXm3TpWPOkkhxdrofWDv+Q+I2oO7ucLRbXyAPmXFNDhHtBxbO1rk9Qzz+M3eep8ieS4/+jCL1Q0zacNMQ==",
             "cpu": [
                 "arm"
@@ -1000,7 +1000,7 @@
         },
         "node_modules/@node-rs/crc32-android-arm64": {
             "version": "1.10.6",
-            "resolved": "https://registry.npmmirror.com/@node-rs/crc32-android-arm64/-/crc32-android-arm64-1.10.6.tgz",
+            "resolved": "https://registry.npmjs.org/@node-rs/crc32-android-arm64/-/crc32-android-arm64-1.10.6.tgz",
             "integrity": "sha512-Vl/JbjCinCw/H9gEpZveWCMjxjcEChDcDBM8S4hKay5yyoRCUHJPuKr4sjVDBeOm+1nwU3oOm6Ca8dyblwp4/w==",
             "cpu": [
                 "arm64"
@@ -1017,7 +1017,7 @@
         },
         "node_modules/@node-rs/crc32-darwin-arm64": {
             "version": "1.10.6",
-            "resolved": "https://registry.npmmirror.com/@node-rs/crc32-darwin-arm64/-/crc32-darwin-arm64-1.10.6.tgz",
+            "resolved": "https://registry.npmjs.org/@node-rs/crc32-darwin-arm64/-/crc32-darwin-arm64-1.10.6.tgz",
             "integrity": "sha512-kARYANp5GnmsQiViA5Qu74weYQ3phOHSYQf0G+U5wB3NB5JmBHnZcOc46Ig21tTypWtdv7u63TaltJQE41noyg==",
             "cpu": [
                 "arm64"
@@ -1034,7 +1034,7 @@
         },
         "node_modules/@node-rs/crc32-darwin-x64": {
             "version": "1.10.6",
-            "resolved": "https://registry.npmmirror.com/@node-rs/crc32-darwin-x64/-/crc32-darwin-x64-1.10.6.tgz",
+            "resolved": "https://registry.npmjs.org/@node-rs/crc32-darwin-x64/-/crc32-darwin-x64-1.10.6.tgz",
             "integrity": "sha512-Q99bevJVMfLTISpkpKBlXgtPUItrvTWKFyiqoKH5IvscZmLV++NH4V13Pa17GTBmv9n18OwzgQY4/SRq6PQNVA==",
             "cpu": [
                 "x64"
@@ -1051,7 +1051,7 @@
         },
         "node_modules/@node-rs/crc32-freebsd-x64": {
             "version": "1.10.6",
-            "resolved": "https://registry.npmmirror.com/@node-rs/crc32-freebsd-x64/-/crc32-freebsd-x64-1.10.6.tgz",
+            "resolved": "https://registry.npmjs.org/@node-rs/crc32-freebsd-x64/-/crc32-freebsd-x64-1.10.6.tgz",
             "integrity": "sha512-66hpawbNjrgnS9EDMErta/lpaqOMrL6a6ee+nlI2viduVOmRZWm9Rg9XdGTK/+c4bQLdtC6jOd+Kp4EyGRYkAg==",
             "cpu": [
                 "x64"
@@ -1068,7 +1068,7 @@
         },
         "node_modules/@node-rs/crc32-linux-arm-gnueabihf": {
             "version": "1.10.6",
-            "resolved": "https://registry.npmmirror.com/@node-rs/crc32-linux-arm-gnueabihf/-/crc32-linux-arm-gnueabihf-1.10.6.tgz",
+            "resolved": "https://registry.npmjs.org/@node-rs/crc32-linux-arm-gnueabihf/-/crc32-linux-arm-gnueabihf-1.10.6.tgz",
             "integrity": "sha512-E8Z0WChH7X6ankbVm8J/Yym19Cq3otx6l4NFPS6JW/cWdjv7iw+Sps2huSug+TBprjbcEA+s4TvEwfDI1KScjg==",
             "cpu": [
                 "arm"
@@ -1085,7 +1085,7 @@
         },
         "node_modules/@node-rs/crc32-linux-arm64-gnu": {
             "version": "1.10.6",
-            "resolved": "https://registry.npmmirror.com/@node-rs/crc32-linux-arm64-gnu/-/crc32-linux-arm64-gnu-1.10.6.tgz",
+            "resolved": "https://registry.npmjs.org/@node-rs/crc32-linux-arm64-gnu/-/crc32-linux-arm64-gnu-1.10.6.tgz",
             "integrity": "sha512-LmWcfDbqAvypX0bQjQVPmQGazh4dLiVklkgHxpV4P0TcQ1DT86H/SWpMBMs/ncF8DGuCQ05cNyMv1iddUDugoQ==",
             "cpu": [
                 "arm64"
@@ -1102,7 +1102,7 @@
         },
         "node_modules/@node-rs/crc32-linux-arm64-musl": {
             "version": "1.10.6",
-            "resolved": "https://registry.npmmirror.com/@node-rs/crc32-linux-arm64-musl/-/crc32-linux-arm64-musl-1.10.6.tgz",
+            "resolved": "https://registry.npmjs.org/@node-rs/crc32-linux-arm64-musl/-/crc32-linux-arm64-musl-1.10.6.tgz",
             "integrity": "sha512-k8ra/bmg0hwRrIEE8JL1p32WfaN9gDlUUpQRWsbxd1WhjqvXea7kKO6K4DwVxyxlPhBS9Gkb5Urq7Y4mXANzaw==",
             "cpu": [
                 "arm64"
@@ -1119,7 +1119,7 @@
         },
         "node_modules/@node-rs/crc32-linux-x64-gnu": {
             "version": "1.10.6",
-            "resolved": "https://registry.npmmirror.com/@node-rs/crc32-linux-x64-gnu/-/crc32-linux-x64-gnu-1.10.6.tgz",
+            "resolved": "https://registry.npmjs.org/@node-rs/crc32-linux-x64-gnu/-/crc32-linux-x64-gnu-1.10.6.tgz",
             "integrity": "sha512-IfjtqcuFK7JrSZ9mlAFhb83xgium30PguvRjIMI45C3FJwu18bnLk1oR619IYb/zetQT82MObgmqfKOtgemEKw==",
             "cpu": [
                 "x64"
@@ -1136,7 +1136,7 @@
         },
         "node_modules/@node-rs/crc32-linux-x64-musl": {
             "version": "1.10.6",
-            "resolved": "https://registry.npmmirror.com/@node-rs/crc32-linux-x64-musl/-/crc32-linux-x64-musl-1.10.6.tgz",
+            "resolved": "https://registry.npmjs.org/@node-rs/crc32-linux-x64-musl/-/crc32-linux-x64-musl-1.10.6.tgz",
             "integrity": "sha512-LbFYsA5M9pNunOweSt6uhxenYQF94v3bHDAQRPTQ3rnjn+mK6IC7YTAYoBjvoJP8lVzcvk9hRj8wp4Jyh6Y80g==",
             "cpu": [
                 "x64"
@@ -1153,7 +1153,7 @@
         },
         "node_modules/@node-rs/crc32-wasm32-wasi": {
             "version": "1.10.6",
-            "resolved": "https://registry.npmmirror.com/@node-rs/crc32-wasm32-wasi/-/crc32-wasm32-wasi-1.10.6.tgz",
+            "resolved": "https://registry.npmjs.org/@node-rs/crc32-wasm32-wasi/-/crc32-wasm32-wasi-1.10.6.tgz",
             "integrity": "sha512-KaejdLgHMPsRaxnM+OG9L9XdWL2TabNx80HLdsCOoX9BVhEkfh39OeahBo8lBmidylKbLGMQoGfIKDjq0YMStw==",
             "cpu": [
                 "wasm32"
@@ -1170,7 +1170,7 @@
         },
         "node_modules/@node-rs/crc32-win32-arm64-msvc": {
             "version": "1.10.6",
-            "resolved": "https://registry.npmmirror.com/@node-rs/crc32-win32-arm64-msvc/-/crc32-win32-arm64-msvc-1.10.6.tgz",
+            "resolved": "https://registry.npmjs.org/@node-rs/crc32-win32-arm64-msvc/-/crc32-win32-arm64-msvc-1.10.6.tgz",
             "integrity": "sha512-x50AXiSxn5Ccn+dCjLf1T7ZpdBiV1Sp5aC+H2ijhJO4alwznvXgWbopPRVhbp2nj0i+Gb6kkDUEyU+508KAdGQ==",
             "cpu": [
                 "arm64"
@@ -1187,7 +1187,7 @@
         },
         "node_modules/@node-rs/crc32-win32-ia32-msvc": {
             "version": "1.10.6",
-            "resolved": "https://registry.npmmirror.com/@node-rs/crc32-win32-ia32-msvc/-/crc32-win32-ia32-msvc-1.10.6.tgz",
+            "resolved": "https://registry.npmjs.org/@node-rs/crc32-win32-ia32-msvc/-/crc32-win32-ia32-msvc-1.10.6.tgz",
             "integrity": "sha512-DpDxQLaErJF9l36aghe1Mx+cOnYLKYo6qVPqPL9ukJ5rAGLtCdU0C+Zoi3gs9ySm8zmbFgazq/LvmsZYU42aBw==",
             "cpu": [
                 "ia32"
@@ -1204,7 +1204,7 @@
         },
         "node_modules/@node-rs/crc32-win32-x64-msvc": {
             "version": "1.10.6",
-            "resolved": "https://registry.npmmirror.com/@node-rs/crc32-win32-x64-msvc/-/crc32-win32-x64-msvc-1.10.6.tgz",
+            "resolved": "https://registry.npmjs.org/@node-rs/crc32-win32-x64-msvc/-/crc32-win32-x64-msvc-1.10.6.tgz",
             "integrity": "sha512-5B1vXosIIBw1m2Rcnw62IIfH7W9s9f7H7Ma0rRuhT8HR4Xh8QCgw6NJSI2S2MCngsGktYnAhyUvs81b7efTyQw==",
             "cpu": [
                 "x64"
@@ -1676,7 +1676,7 @@
         },
         "node_modules/@tybys/wasm-util": {
             "version": "0.10.1",
-            "resolved": "https://registry.npmmirror.com/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+            "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
             "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
             "dev": true,
             "license": "MIT",
@@ -2006,7 +2006,7 @@
         },
         "node_modules/@vscode/vsce": {
             "version": "3.7.1",
-            "resolved": "https://registry.npmmirror.com/@vscode/vsce/-/vsce-3.7.1.tgz",
+            "resolved": "https://registry.npmjs.org/@vscode/vsce/-/vsce-3.7.1.tgz",
             "integrity": "sha512-OTm2XdMt2YkpSn2Nx7z2EJtSuhRHsTPYsSK59hr3v8jRArK+2UEoju4Jumn1CmpgoBLGI6ReHLJ/czYltNUW3g==",
             "dev": true,
             "license": "MIT",
@@ -3354,7 +3354,7 @@
         },
         "node_modules/define-data-property": {
             "version": "1.1.4",
-            "resolved": "https://registry.npmmirror.com/define-data-property/-/define-data-property-1.1.4.tgz",
+            "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
             "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
             "dev": true,
             "license": "MIT",
@@ -3385,7 +3385,7 @@
         },
         "node_modules/define-properties": {
             "version": "1.2.1",
-            "resolved": "https://registry.npmmirror.com/define-properties/-/define-properties-1.2.1.tgz",
+            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
             "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
             "dev": true,
             "license": "MIT",
@@ -4319,7 +4319,7 @@
         },
         "node_modules/globalthis": {
             "version": "1.0.4",
-            "resolved": "https://registry.npmmirror.com/globalthis/-/globalthis-1.0.4.tgz",
+            "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
             "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
             "dev": true,
             "license": "MIT",
@@ -4397,7 +4397,7 @@
         },
         "node_modules/has-property-descriptors": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmmirror.com/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+            "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
             "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
             "dev": true,
             "license": "MIT",
@@ -4703,7 +4703,7 @@
         },
         "node_modules/is-it-type": {
             "version": "5.1.3",
-            "resolved": "https://registry.npmmirror.com/is-it-type/-/is-it-type-5.1.3.tgz",
+            "resolved": "https://registry.npmjs.org/is-it-type/-/is-it-type-5.1.3.tgz",
             "integrity": "sha512-AX2uU0HW+TxagTgQXOJY7+2fbFHemC7YFBwN1XqD8qQMKdtfbOC8OC3fUb4s5NU59a3662Dzwto8tWDdZYRXxg==",
             "dev": true,
             "license": "MIT",
@@ -5483,7 +5483,7 @@
         },
         "node_modules/object-keys": {
             "version": "1.1.1",
-            "resolved": "https://registry.npmmirror.com/object-keys/-/object-keys-1.1.1.tgz",
+            "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
             "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
             "dev": true,
             "license": "MIT",
@@ -5619,7 +5619,7 @@
         },
         "node_modules/ovsx": {
             "version": "0.10.10",
-            "resolved": "https://registry.npmmirror.com/ovsx/-/ovsx-0.10.10.tgz",
+            "resolved": "https://registry.npmjs.org/ovsx/-/ovsx-0.10.10.tgz",
             "integrity": "sha512-/X5J4VLKPUGGaMynW9hgvsGg9jmwsK/3RhODeA2yzdeDbb8PUSNcg5GQ9aPDJW/znlqNvAwQcXAyE+Cq0RRvAQ==",
             "dev": true,
             "license": "EPL-2.0",
@@ -6465,7 +6465,7 @@
         },
         "node_modules/simple-invariant": {
             "version": "2.0.1",
-            "resolved": "https://registry.npmmirror.com/simple-invariant/-/simple-invariant-2.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/simple-invariant/-/simple-invariant-2.0.1.tgz",
             "integrity": "sha512-1sbhsxqI+I2tqlmjbz99GXNmZtr6tKIyEgGGnJw/MKGblalqk/XoOYYFJlBzTKZCxx8kLaD3FD5s9BEEjx5Pyg==",
             "dev": true,
             "license": "MIT",
@@ -7544,7 +7544,7 @@
         },
         "node_modules/yauzl-promise": {
             "version": "4.0.0",
-            "resolved": "https://registry.npmmirror.com/yauzl-promise/-/yauzl-promise-4.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/yauzl-promise/-/yauzl-promise-4.0.0.tgz",
             "integrity": "sha512-/HCXpyHXJQQHvFq9noqrjfa/WpQC2XYs3vI7tBiAi4QiIU1knvYhZGaO1QPjwIVMdqflxbmwgMXtYeaRiAE0CA==",
             "dev": true,
             "license": "MIT",


### PR DESCRIPTION
c420e48547e444e1f978be9dbf045d459936b0d5 changed a few packages to be installed from npmmirror.com rather than npmjs.org. This is harmless (there's a SHA512 hash to confirm integrity) but it prevents building the VS Code extension in locked down environments that only permit official package repositories.

It looks like npmmirror.com is an unofficial mirror run by Taobao (it replaced npm.taobao.org) and it can lag behind the official npm repository.