### PR TITLE
Remove try-normalize-use-tree

### DIFF
--- a/crates/ide-db/src/imports/merge_imports.rs
+++ b/crates/ide-db/src/imports/merge_imports.rs
@@ -256,16 +256,6 @@ pub fn try_normalize_import(use_item: &ast::Use, style: NormalizationStyle) -> O
     Some(use_item)
 }
 
-/// Normalizes a use tree (see [`try_normalize_import`] doc).
-pub fn try_normalize_use_tree(
-    use_tree: &ast::UseTree,
-    style: NormalizationStyle,
-) -> Option<ast::UseTree> {
-    let use_tree = use_tree.clone_subtree().clone_for_update();
-    try_normalize_use_tree_mut(&use_tree, style)?;
-    Some(use_tree)
-}
-
 pub fn try_normalize_use_tree_mut(
     use_tree: &ast::UseTree,
     style: NormalizationStyle,


### PR DESCRIPTION
Removing try-normalize-use-tree method from ide-db as it is unused.