### PR TITLE
fix: complete variants of hidden enums through public aliases

### DIFF
--- a/crates/ide-completion/src/completions.rs
+++ b/crates/ide-completion/src/completions.rs
@@ -276,9 +276,6 @@ impl Completions {
         path_ctx: &PathCompletionCtx<'_>,
         e: hir::Enum,
     ) {
-        if !ctx.check_stability_and_hidden(e) {
-            return;
-        }
         e.variants(ctx.db)
             .into_iter()
             .for_each(|variant| self.add_enum_variant(ctx, path_ctx, variant, None));

--- a/crates/ide-completion/src/tests/item.rs
+++ b/crates/ide-completion/src/tests/item.rs
@@ -380,3 +380,23 @@ foo!(f$0);
         "#]],
     );
 }
+
+#[test]
+fn completes_variant_through_hidden_enum_alias() {
+    check(
+        r#"
+//- /lib.rs crate:dep
+#[doc(hidden)]
+pub enum Foo { Variant }
+pub type Bar = Foo;
+
+//- /main.rs crate:main deps:dep
+fn main() {
+    let x = dep::Bar::V$0;
+}
+"#,
+        expect![[r#"
+            ev Variant Variant
+        "#]],
+    );
+}


### PR DESCRIPTION
Fixes rust-lang/rust-analyzer#21891.

Previously, the completion engine would aggressively bail out if the parent enum was marked . This pushes the visibility check down to the individual variants so they can be properly completed when accessed via a public type alias.