### PR TITLE
fix: deduplicate `warnings` lint in completion list

### DIFF
--- a/crates/ide-completion/src/tests/attribute.rs
+++ b/crates/ide-completion/src/tests/attribute.rs
@@ -1372,6 +1372,16 @@ mod lint {
             r#"#[allow(rustdoc::bare_urls struct Test;"#,
         );
     }
+
+    #[test]
+    fn no_duplicate_warnings_lint() {
+        let completions = crate::tests::completion_list(r#"#[allow(w$0)] struct Test;"#);
+        let warning_count = completions.lines().filter(|line| line.contains("warnings")).count();
+        assert_eq!(
+            warning_count, 1,
+            "Expected `warnings` to appear exactly once, but found {warning_count} occurrences:\n{completions}"
+        );
+    }
 }
 
 mod repr {

--- a/crates/ide-db/src/generated/lints.rs
+++ b/crates/ide-db/src/generated/lints.rs
@@ -1608,13 +1608,6 @@ pub const DEFAULT_LINTS: &[Lint] = &[
         warn_since: None,
         deny_since: None,
     },
-    Lint {
-        label: "warnings",
-        description: r##"lint group for: all lints that are set to issue warnings"##,
-        default_severity: Severity::Allow,
-        warn_since: None,
-        deny_since: None,
-    },
 ];
 
 pub const DEFAULT_LINT_GROUPS: &[LintGroup] = &[

--- a/xtask/src/codegen/lints.rs
+++ b/xtask/src/codegen/lints.rs
@@ -352,7 +352,9 @@ fn generate_lint_descriptor(sh: &Shell, buf: &mut String) {
         push_lint_completion(buf, name, lint);
     }
     for (name, (group, _)) in &lint_groups {
-        push_lint_completion(buf, name, group);
+        if !lints.iter().any(|(n, _)| n == name) {
+            push_lint_completion(buf, name, group);
+        }
     }
     buf.push_str("];\n\n");
 
@@ -376,7 +378,9 @@ fn generate_lint_descriptor(sh: &Shell, buf: &mut String) {
         push_lint_completion(buf, name, lint);
     }
     for (name, (group, _)) in &lint_groups_rustdoc {
-        push_lint_completion(buf, name, group);
+        if !lints_rustdoc.iter().any(|(n, _)| n == name) {
+            push_lint_completion(buf, name, group);
+        }
     }
     buf.push_str("];\n\n");
 


### PR DESCRIPTION
Fixes rust-lang/rust-analyzer#21943

`warnings` shows up twice when completing `#[allow(w` because it exists as both a regular lint and a lint group in `rustc -Whelp` output. The codegen in `xtask/src/codegen/lints.rs` writes both into `DEFAULT_LINTS` without deduplication.

**Fix:** When iterating lint groups to append to the combined list, skip any group whose name already appeared in the regular lints. Applied the same check for `RUSTDOC_LINTS`.

Also regenerated `crates/ide-db/src/generated/lints.rs` to remove the existing duplicate, and added a regression test that verifies `warnings` appears exactly once.

**AI disclosure:** Used Claude as a coding assistant. I reviewed and verified all changes.