### PR TITLE
fix: use Pattern_White_Space for whitespace handling

### DIFF
--- a/crates/parser/src/frontmatter.rs
+++ b/crates/parser/src/frontmatter.rs
@@ -263,7 +263,7 @@ pub fn strip_ws_lines(input: &str) -> Option<usize> {
 /// True if `c` is considered a whitespace according to Rust language definition.
 /// See [Rust language reference](https://doc.rust-lang.org/reference/whitespace.html)
 /// for definitions of these classes.
-fn is_whitespace(c: char) -> bool {
+pub(crate) fn is_whitespace(c: char) -> bool {
     // This is Pattern_White_Space.
     //
     // Note that this set is stable (ie, it doesn't change with different

--- a/crates/parser/src/lib.rs
+++ b/crates/parser/src/lib.rs
@@ -56,6 +56,13 @@ pub use crate::{
     syntax_kind::SyntaxKind,
 };
 
+/// True if `c` is whitespace in Rust source (Unicode Pattern_White_Space as in the language reference).
+///
+/// See <https://doc.rust-lang.org/reference/whitespace.html>.
+pub fn is_rust_whitespace(c: char) -> bool {
+    frontmatter::is_whitespace(c)
+}
+
 /// Parse the whole of the input as a given syntactic construct.
 ///
 /// This covers two main use-cases:

--- a/crates/rust-analyzer/src/cli/analysis_stats.rs
+++ b/crates/rust-analyzer/src/cli/analysis_stats.rs
@@ -587,8 +587,8 @@ impl flags::AnalysisStats {
                     continue;
                 };
 
-                fn trim(s: &str) -> String {
-                    s.chars().filter(|c| !c.is_whitespace()).collect()
+                fn drop_whitespace(s: &str) -> String {
+                    s.chars().filter(|c| !parser::is_rust_whitespace(*c)).collect()
                 }
 
                 let todo = syntax::ast::make::ext::expr_todo().to_string();
@@ -608,7 +608,8 @@ impl flags::AnalysisStats {
                             display_target,
                         )
                         .unwrap();
-                    syntax_hit_found |= trim(&original_text) == trim(&generated);
+                    syntax_hit_found |=
+                        drop_whitespace(&original_text) == drop_whitespace(&generated);
 
                     // Validate if type-checks
                     let mut txt = file_txt.text(db).to_string();
@@ -662,7 +663,7 @@ impl flags::AnalysisStats {
                 let msg = move || {
                     format!(
                         "processing: {:<50}",
-                        trim(&original_text).chars().take(50).collect::<String>()
+                        drop_whitespace(&original_text).chars().take(50).collect::<String>()
                     )
                 };
                 if verbosity.is_spammy() {
@@ -1646,5 +1647,5 @@ impl fmt::Display for PrettyItemStats {
 // fn syntax_len(node: SyntaxNode) -> usize {
 //     // Macro expanded code doesn't contain whitespace, so erase *all* whitespace
 //     // to make macro and non-macro code comparable.
-//     node.to_string().replace(|it: char| it.is_ascii_whitespace(), "").len()
+//     drop_whitespace(&node.to_string()).len()
 // }


### PR DESCRIPTION
**Description**
This PR fixes incorrect whitespace handling in `analysis_stats.rs` by implementing Rust's definition of whitespace (Pattern_white_space).

**Issue**
Some parts fo code were using `char::is_whitespace` which was missing character like vertical tab ( \u{000B}).

**Fixed**
- Export a parse helper ,`parser::is_rust_whitespace` which follows Rust's `Pattern_White_Space`.
- Updated crates/parser/src/frontmatter.rs to use that shared Rust-whitespace logic.
- Renamed the local helper in analysis_stats.rs from trim to drop_whitespace for clarity.

****Related Issue****
This PR addresses the Outreachy issue : [non-macro code miscompare](https://github.com/rustfoundation/interop-initiative/issues/53)