### PR TITLE
fix: no complete term expressions on qualified path

### DIFF
--- a/crates/ide-completion/src/completions.rs
+++ b/crates/ide-completion/src/completions.rs
@@ -756,7 +756,7 @@ pub(super) fn complete_name_ref(
             match &path_ctx.kind {
                 PathKind::Expr { expr_ctx } => {
                     expr::complete_expr_path(acc, ctx, path_ctx, expr_ctx);
-                    expr::complete_expr(acc, ctx);
+                    expr::complete_expr(acc, ctx, path_ctx);
 
                     dot::complete_undotted_self(acc, ctx, path_ctx, expr_ctx);
                     item_list::complete_item_list_in_expr(acc, ctx, path_ctx, expr_ctx);

--- a/crates/ide-completion/src/completions/expr.rs
+++ b/crates/ide-completion/src/completions/expr.rs
@@ -451,7 +451,11 @@ pub(crate) fn complete_expr_path(
     }
 }
 
-pub(crate) fn complete_expr(acc: &mut Completions, ctx: &CompletionContext<'_>) {
+pub(crate) fn complete_expr(
+    acc: &mut Completions,
+    ctx: &CompletionContext<'_>,
+    PathCompletionCtx { qualified, .. }: &PathCompletionCtx<'_>,
+) {
     let _p = tracing::info_span!("complete_expr").entered();
 
     if !ctx.config.enable_term_search {
@@ -459,6 +463,10 @@ pub(crate) fn complete_expr(acc: &mut Completions, ctx: &CompletionContext<'_>) 
     }
 
     if !ctx.qualifier_ctx.none() {
+        return;
+    }
+
+    if !matches!(qualified, Qualified::No) {
         return;
     }
 

--- a/crates/ide-completion/src/render.rs
+++ b/crates/ide-completion/src/render.rs
@@ -2211,7 +2211,6 @@ fn bb()-> &'static aa {
 }
 "#,
             expect![[r#"
-                ex bb()  [type]
                 fn from_bytes(…) fn(&[u8]) -> &aa [type_could_unify]
             "#]],
         );

--- a/crates/ide-completion/src/tests/expression.rs
+++ b/crates/ide-completion/src/tests/expression.rs
@@ -1030,8 +1030,6 @@ fn main() {
 "#,
         expect![[r#"
             fn test() fn() -> Zulu
-            ex Zulu
-            ex Zulu::test()
         "#]],
     );
 }

--- a/crates/ide-completion/src/tests/special.rs
+++ b/crates/ide-completion/src/tests/special.rs
@@ -896,9 +896,6 @@ fn bar() -> Bar {
 "#,
         expect![[r#"
             fn foo() (as Foo) fn() -> Self
-            ex Bar
-            ex Bar::foo()
-            ex bar()
         "#]],
     );
 }
@@ -926,9 +923,6 @@ fn bar() -> Bar {
         expect![[r#"
             fn bar()                  fn()
             fn foo() (as Foo) fn() -> Self
-            ex Bar
-            ex Bar::foo()
-            ex bar()
         "#]],
     );
 }
@@ -955,9 +949,6 @@ fn bar() -> Bar {
 "#,
         expect![[r#"
             fn foo() (as Foo) fn() -> Self
-            ex Bar
-            ex Bar::foo()
-            ex bar()
         "#]],
     );
 }


### PR DESCRIPTION
config: `rust-analyzer.completion.termSearch.enable: true`

Example
---
```rust
fn bar() -> Bar {
    <Bar>::$0
}

trait Foo { fn foo() -> Self; }
struct Bar;
impl Bar { fn bar() {} }
impl Foo for Bar {
    fn foo() -> Self { Bar }
}
```

**Before this PR**

```rust
fn bar()                  fn()
fn foo() (as Foo) fn() -> Self
ex Bar
ex Bar::foo()
ex bar()
```

**After this PR**

```rust
fn bar()                  fn()
fn foo() (as Foo) fn() -> Self
```
