### PR TITLE
Fix rustfmt relative custom command

### DIFF
--- a/crates/rust-analyzer/src/handlers/request.rs
+++ b/crates/rust-analyzer/src/handlers/request.rs
@@ -2442,8 +2442,7 @@ fn run_rustfmt(
         }
         RustfmtConfig::CustomCommand { command, args } => {
             let cmd = Utf8PathBuf::from(&command);
-            let target_spec =
-                crates.first().and_then(|&crate_id| snap.target_spec_for_file(file_id, crate_id));
+            let target_spec = TargetSpec::for_file(snap, file_id).ok().flatten();
             let extra_env = snap.config.extra_env(source_root_id);
             let mut cmd = match target_spec {
                 Some(TargetSpec::Cargo(_)) => {


### PR DESCRIPTION
When `rustfmt.overrideCommand` is a relative path, it's joined with the workspace root to make it an absolute path. Without this the command path can't be resolved, especially because rustfmt changes the cwd to make sure rustfmt.toml works correctly.

Currently `run_rustfmt` only does this when it finds a `target_spec` using `target_spec_for_file` which only works for the root file of the target.

This commit changes it to use `TargetSpec::for_file` which works for any file in the crate.