### PR TITLE
fix: no imports on type anchor qualified path

### DIFF
--- a/crates/ide-completion/src/completions/flyimport.rs
+++ b/crates/ide-completion/src/completions/flyimport.rs
@@ -133,7 +133,8 @@ pub(crate) fn import_on_the_fly_path(
     let potential_import_name = import_name(ctx);
     let qualifier = match qualified {
         Qualified::With { path, .. } => Some(path.clone()),
-        _ => None,
+        Qualified::TypeAnchor { .. } => return None,
+        Qualified::No | Qualified::Absolute => None,
     };
     let import_assets = import_assets_for_path(
         ctx,

--- a/crates/ide-completion/src/tests/flyimport.rs
+++ b/crates/ide-completion/src/tests/flyimport.rs
@@ -1243,6 +1243,39 @@ impl Bar for Foo {
 }
 
 #[test]
+fn no_flyimports_type_anchor() {
+    check(
+        r#"
+mod m {
+    pub fn foo() {}
+}
+struct Bar;
+trait Foo {}
+impl Foo for Bar {}
+fn main() {
+    <Bar as Foo>::foo$0
+}
+    "#,
+        expect![[r#""#]],
+    );
+
+    check(
+        r#"
+mod m {
+    pub fn foo() {}
+}
+struct Bar;
+trait Foo {}
+impl Foo for Bar {}
+fn main() {
+    <Bar>::foo$0
+}
+    "#,
+        expect![[r#""#]],
+    );
+}
+
+#[test]
 fn no_inherent_candidates_proposed() {
     check(
         r#"


### PR DESCRIPTION
Fixes rust-lang/rust-analyzer#22006

Example
---
```rust
fn main() {
    <Bar as Foo>::foo$0
}
mod m {
    pub fn foo() {}
}
struct Bar;
trait Foo {}
impl Foo for Bar {}
```

**Before this PR**

```
fn foo() (use m::foo) fn()
```

**After this PR**

no any imports
