### PR TITLE
minor: Bump create-github-app-token

### DIFF
--- a/.github/workflows/gen-lints.yml
+++ b/.github/workflows/gen-lints.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Generate lints/feature flags
         run: cargo codegen lint-definitions
 
-      - uses: actions/create-github-app-token@v2
+      - uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
         id: app-token
         with:
           app-id: ${{ vars.APP_CLIENT_ID }}


### PR DESCRIPTION
Fixes the Node deprecation warning.