### PR TITLE
 Fix verify_only_whitespaces panicking on vertical tab (\x0B)

### DIFF
--- a/crates/syntax/src/ast/make/quote.rs
+++ b/crates/syntax/src/ast/make/quote.rs
@@ -183,7 +183,7 @@ pub(crate) const fn verify_only_whitespaces(text: &str) {
     let text = text.as_bytes();
     let mut i = 0;
     while i < text.len() {
-        if !text[i].is_ascii_whitespace() {
+        if !text[i].is_ascii_whitespace() && text[i] != 0x0B {
             panic!("non-whitespace found in whitespace token");
         }
         i += 1;
@@ -196,10 +196,10 @@ mod tests {
 
     #[test]
     fn test_verify_only_whitespaces_accepts_rust_lexer_whitespace() {
-        verify_only_whitespaces(" ");    // space
-        verify_only_whitespaces("\t");   // tab
-        verify_only_whitespaces("\n");   // newline
-        verify_only_whitespaces("\r");   // carriage return
+        verify_only_whitespaces(" "); // space
+        verify_only_whitespaces("\t"); // tab
+        verify_only_whitespaces("\n"); // newline
+        verify_only_whitespaces("\r"); // carriage return
         verify_only_whitespaces("\x0C"); // form feed
         verify_only_whitespaces("\x0B"); // vertical tab -- currently panics (bug)
     }

--- a/crates/syntax/src/ast/make/quote.rs
+++ b/crates/syntax/src/ast/make/quote.rs
@@ -189,3 +189,18 @@ pub(crate) const fn verify_only_whitespaces(text: &str) {
         i += 1;
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::verify_only_whitespaces;
+
+    #[test]
+    fn test_verify_only_whitespaces_accepts_rust_lexer_whitespace() {
+        verify_only_whitespaces(" ");    // space
+        verify_only_whitespaces("\t");   // tab
+        verify_only_whitespaces("\n");   // newline
+        verify_only_whitespaces("\r");   // carriage return
+        verify_only_whitespaces("\x0C"); // form feed
+        verify_only_whitespaces("\x0B"); // vertical tab -- currently panics (bug)
+    }
+}


### PR DESCRIPTION
 - `verify_only_whitespaces` used `is_ascii_whitespace()` to validate whitespace tokens, which follows the WHATWG Infra
  standard and excludes vertical tab (\x0B).
  - The Rust lexer treats \x0B as valid whitespace (https://doc.rust-lang.org/reference/whitespace.html), so the
   function incorrectly panicked when encountering it.
  - Fix replaces the check with one that matches Rust's lexer definition exactly: is_ascii_whitespace() || byte == 0x0B.

  Test plan

  - Added a failing test (test_verify_only_whitespaces_accepts_rust_lexer_whitespace) that calls verify_only_whitespaces
   with all 6 Rust lexer whitespace characters, including \x0B
  - Test panicked before the fix, passes after
  - Full test suite passes: cargo test