### PR TITLE
fix: trigger completion inside format strings in VS Code

### DIFF
--- a/crates/rust-analyzer/src/lsp/capabilities.rs
+++ b/crates/rust-analyzer/src/lsp/capabilities.rs
@@ -55,6 +55,7 @@ pub fn server_capabilities(config: &Config) -> ServerCapabilities {
                 ".".to_owned(),
                 "'".to_owned(),
                 "(".to_owned(),
+                "{".to_owned(),
             ]),
             all_commit_characters: None,
             completion_item: config.caps().completion_item(),


### PR DESCRIPTION
Fixes rust-lang/rust-analyzer#22001
This PR adds `"{".to_owned()` to the `trigger_characters` array in the server capabilities (`crates/rust-analyzer/src/caps.rs`). 
This instructs the VS Code client to automatically query the language server for completions the moment a user opens a curly brace.