### PR TITLE
fix: recognize sysroot packages in build script output processing

### DIFF
--- a/crates/load-cargo/src/lib.rs
+++ b/crates/load-cargo/src/lib.rs
@@ -65,7 +65,8 @@ pub fn load_workspace_at(
     let mut workspace = ProjectWorkspace::load(root, cargo_config, progress)?;
 
     if load_config.load_out_dirs_from_check {
-        let build_scripts = workspace.run_build_scripts(cargo_config, progress)?;
+        let (build_scripts, sysroot_build_scripts) =
+            workspace.run_build_scripts(cargo_config, progress)?;
         if let Some(error) = build_scripts.error() {
             tracing::debug!(
                 "Errors occurred while running build scripts for {}: {}",
@@ -73,7 +74,7 @@ pub fn load_workspace_at(
                 error
             );
         }
-        workspace.set_build_scripts(build_scripts)
+        workspace.set_build_scripts(build_scripts, sysroot_build_scripts)
     }
 
     load_workspace(workspace, &cargo_config.extra_env, load_config)

--- a/crates/project-model/src/build_dependencies.rs
+++ b/crates/project-model/src/build_dependencies.rs
@@ -24,6 +24,7 @@ use crate::{
     CargoConfig, CargoFeatures, CargoWorkspace, InvocationStrategy, ManifestPath, Package, Sysroot,
     TargetKind,
     cargo_config_file::{LockfileCopy, LockfileUsage, make_lockfile_copy},
+    sysroot::RustLibSrcWorkspace,
     utf8_stdout,
 };
 
@@ -92,7 +93,7 @@ impl WorkspaceBuildScripts {
             sysroot,
             toolchain,
         )?;
-        Self::run_per_ws(cmd, workspace, progress)
+        Self::run_per_ws(cmd, workspace, sysroot, progress)
     }
 
     /// Runs the build scripts by invoking the configured command *once*.
@@ -100,6 +101,7 @@ impl WorkspaceBuildScripts {
     pub(crate) fn run_once(
         config: &CargoConfig,
         workspaces: &[&CargoWorkspace],
+        sysroots: &[&Sysroot],
         progress: &dyn Fn(String),
         working_directory: &AbsPathBuf,
     ) -> io::Result<Vec<WorkspaceBuildScripts>> {
@@ -118,7 +120,8 @@ impl WorkspaceBuildScripts {
         // NB: Cargo.toml could have been modified between `cargo metadata` and
         // `cargo check`. We shouldn't assume that package ids we see here are
         // exactly those from `config`.
-        let mut by_id = FxHashMap::default();
+        // `None` entries mark sysroot packages: recognized but not stored in any workspace output.
+        let mut by_id: FxHashMap<Arc<PackageId>, Option<(Package, usize)>> = FxHashMap::default();
         // some workspaces might depend on the same crates, so we need to duplicate the outputs
         // to those collisions
         let mut collisions = Vec::new();
@@ -132,28 +135,51 @@ impl WorkspaceBuildScripts {
                     if by_id.contains_key(&workspace[package].id) {
                         collisions.push((&workspace[package].id, idx, package));
                     } else {
-                        by_id.insert(workspace[package].id.clone(), (package, idx));
+                        by_id.insert(workspace[package].id.clone(), Some((package, idx)));
                     }
                 }
                 res
             })
             .collect();
 
+        // Insert sysroot package IDs so that messages for stdlib crates emitted when
+        // build-std is enabled are recognized rather than reported as unknown packages.
+        for sysroot in sysroots {
+            if let RustLibSrcWorkspace::Workspace { ws, .. } = sysroot.workspace() {
+                for package in ws.packages() {
+                    by_id.entry(ws[package].id.clone()).or_insert(None);
+                }
+            }
+        }
+
         let errors = Self::run_command(
             cmd,
             |package, cb| {
-                if let Some(&(package, workspace)) = by_id.get(package) {
-                    cb(&workspaces[workspace][package].name, &mut res[workspace].outputs[package]);
-                } else {
-                    tracing::error!("Received compiler message for unknown package: {}", package);
+                match by_id.get(package) {
+                    Some(Some((package, workspace))) => {
+                        cb(
+                            &workspaces[*workspace][*package].name,
+                            &mut res[*workspace].outputs[*package],
+                        );
+                    }
+                    Some(None) => {
+                        // Sysroot package (e.g. core when build-std is enabled);
+                        // its outputs are handled separately.
+                    }
+                    None => {
+                        tracing::error!(
+                            "Received compiler message for unknown package: {}",
+                            package
+                        );
+                    }
                 }
             },
             progress,
         )?;
         res.iter_mut().for_each(|it| it.error.clone_from(&errors));
         collisions.into_iter().for_each(|(id, workspace, package)| {
-            if let Some(&(p, w)) = by_id.get(id) {
-                res[workspace].outputs[package] = res[w].outputs[p].clone();
+            if let Some(Some((p, w))) = by_id.get(id) {
+                res[workspace].outputs[package] = res[*w].outputs[*p].clone();
             }
         });
 
@@ -281,6 +307,7 @@ impl WorkspaceBuildScripts {
     fn run_per_ws(
         cmd: Command,
         workspace: &CargoWorkspace,
+        sysroot: &Sysroot,
         progress: &dyn Fn(String),
     ) -> io::Result<WorkspaceBuildScripts> {
         let mut res = WorkspaceBuildScripts::default();
@@ -288,23 +315,36 @@ impl WorkspaceBuildScripts {
         // NB: Cargo.toml could have been modified between `cargo metadata` and
         // `cargo check`. We shouldn't assume that package ids we see here are
         // exactly those from `config`.
-        let mut by_id: FxHashMap<Arc<PackageId>, Package> = FxHashMap::default();
+        // `None` entries mark sysroot packages: recognized but not stored in the workspace output.
+        let mut by_id: FxHashMap<Arc<PackageId>, Option<Package>> = FxHashMap::default();
         for package in workspace.packages() {
             outputs.insert(package, BuildScriptOutput::default());
-            by_id.insert(workspace[package].id.clone(), package);
+            by_id.insert(workspace[package].id.clone(), Some(package));
+        }
+        // Insert sysroot package IDs so that messages for stdlib crates emitted when
+        // build-std is enabled are recognized rather than reported as unknown packages.
+        if let RustLibSrcWorkspace::Workspace { ws, .. } = sysroot.workspace() {
+            for package in ws.packages() {
+                by_id.entry(ws[package].id.clone()).or_insert(None);
+            }
         }
 
         res.error = Self::run_command(
             cmd,
             |package, cb| {
-                if let Some(&package) = by_id.get(package) {
-                    cb(&workspace[package].name, &mut outputs[package]);
-                } else {
-                    never!(
-                        "Received compiler message for unknown package: {}\n {}",
-                        package,
-                        by_id.keys().join(", ")
-                    );
+                match by_id.get(package) {
+                    Some(Some(package)) => cb(&workspace[*package].name, &mut outputs[*package]),
+                    Some(None) => {
+                        // Sysroot package (e.g. core when build-std is enabled);
+                        // its outputs are handled separately, so discard here.
+                    }
+                    None => {
+                        never!(
+                            "Received compiler message for unknown package: {}\n {}",
+                            package,
+                            by_id.keys().join(", ")
+                        );
+                    }
                 }
             },
             progress,

--- a/crates/project-model/src/build_dependencies.rs
+++ b/crates/project-model/src/build_dependencies.rs
@@ -23,7 +23,7 @@ use triomphe::Arc;
 use crate::{
     CargoConfig, CargoFeatures, CargoWorkspace, InvocationStrategy, ManifestPath, Package, Sysroot,
     TargetKind,
-    cargo_config_file::{LockfileCopy, LockfileUsage, make_lockfile_copy},
+    cargo_config_file::{CargoConfigFile, LockfileCopy, LockfileUsage, make_lockfile_copy},
     sysroot::RustLibSrcWorkspace,
     utf8_stdout,
 };
@@ -73,14 +73,17 @@ impl BuildScriptOutput {
 }
 
 impl WorkspaceBuildScripts {
-    /// Runs the build scripts for the given workspace
+    /// Runs the build scripts for the given workspace.
+    ///
+    /// Returns `(workspace_build_scripts, sysroot_build_scripts)`. The sysroot build scripts are
+    /// populated when build-std is active; otherwise they are empty/default.
     pub(crate) fn run_for_workspace(
         config: &CargoConfig,
         workspace: &CargoWorkspace,
         progress: &dyn Fn(String),
         sysroot: &Sysroot,
         toolchain: Option<&semver::Version>,
-    ) -> io::Result<WorkspaceBuildScripts> {
+    ) -> io::Result<(WorkspaceBuildScripts, WorkspaceBuildScripts)> {
         let current_dir = workspace.workspace_root();
 
         let allowed_features = workspace.workspace_features();
@@ -93,18 +96,26 @@ impl WorkspaceBuildScripts {
             sysroot,
             toolchain,
         )?;
-        Self::run_per_ws(cmd, workspace, sysroot, progress)
+        let build_std =
+            CargoConfigFile::load(workspace.manifest_path(), &config.extra_env, sysroot)
+                .as_ref()
+                .is_some_and(CargoConfigFile::build_std_requested);
+        Self::run_per_ws(cmd, workspace, sysroot, progress, build_std)
     }
 
     /// Runs the build scripts by invoking the configured command *once*.
     /// This populates the outputs for all passed in workspaces.
+    ///
+    /// Returns a `Vec` of `(workspace_build_scripts, sysroot_build_scripts)` pairs, one per
+    /// workspace. The sysroot build scripts are populated when build-std is active for that
+    /// workspace; otherwise they are empty/default.
     pub(crate) fn run_once(
         config: &CargoConfig,
         workspaces: &[&CargoWorkspace],
         sysroots: &[&Sysroot],
         progress: &dyn Fn(String),
         working_directory: &AbsPathBuf,
-    ) -> io::Result<Vec<WorkspaceBuildScripts>> {
+    ) -> io::Result<Vec<(WorkspaceBuildScripts, WorkspaceBuildScripts)>> {
         assert_eq!(config.invocation_strategy, InvocationStrategy::Once);
 
         let (_guard, cmd) = Self::build_command(
@@ -142,12 +153,51 @@ impl WorkspaceBuildScripts {
             })
             .collect();
 
-        // Insert sysroot package IDs so that messages for stdlib crates emitted when
-        // build-std is enabled are recognized rather than reported as unknown packages.
+        // Detect build-std per workspace. For workspaces where build-std is active, we capture
+        // sysroot package outputs; for others, we just recognize and discard them.
+        let build_std_per_ws: Vec<bool> = workspaces
+            .iter()
+            .zip(sysroots.iter())
+            .map(|(ws, sysroot)| {
+                CargoConfigFile::load(ws.manifest_path(), &config.extra_env, sysroot)
+                    .as_ref()
+                    .is_some_and(CargoConfigFile::build_std_requested)
+            })
+            .collect();
+        let any_build_std = build_std_per_ws.iter().any(|&b| b);
+
+        // `None` entries: sysroot packages that are recognized but discarded (non-build-std path).
+        // For build-std workspaces, sysroot packages go into `sysroot_by_id` / `sysroot_res`.
+        let mut sysroot_by_id: FxHashMap<Arc<PackageId>, (Package, usize)> = FxHashMap::default();
+        let mut sysroot_collisions: Vec<(&Arc<PackageId>, usize, Package)> = Vec::new();
+        let sysroot_res: Vec<RefCell<WorkspaceBuildScripts>> = sysroots
+            .iter()
+            .enumerate()
+            .map(|(idx, sysroot)| {
+                let mut sbs = WorkspaceBuildScripts::default();
+                if build_std_per_ws.get(idx).copied().unwrap_or(false) {
+                    if let RustLibSrcWorkspace::Workspace { ws, .. } = sysroot.workspace() {
+                        for package in ws.packages() {
+                            sbs.outputs.insert(package, BuildScriptOutput::default());
+                            if sysroot_by_id.contains_key(&ws[package].id) {
+                                sysroot_collisions.push((&ws[package].id, idx, package));
+                            } else {
+                                sysroot_by_id.insert(ws[package].id.clone(), (package, idx));
+                            }
+                        }
+                    }
+                }
+                RefCell::new(sbs)
+            })
+            .collect();
+
+        // For sysroot packages not covered by build-std, insert as None (silent discard).
         for sysroot in sysroots {
             if let RustLibSrcWorkspace::Workspace { ws, .. } = sysroot.workspace() {
                 for package in ws.packages() {
-                    by_id.entry(ws[package].id.clone()).or_insert(None);
+                    if !sysroot_by_id.contains_key(&ws[package].id) {
+                        by_id.entry(ws[package].id.clone()).or_insert(None);
+                    }
                 }
             }
         }
@@ -163,10 +213,21 @@ impl WorkspaceBuildScripts {
                         );
                     }
                     Some(None) => {
-                        // Sysroot package (e.g. core when build-std is enabled);
-                        // its outputs are handled separately.
+                        // Sysroot package not in build-std mode; discard.
                     }
                     None => {
+                        if any_build_std {
+                            if let Some(&(sysroot_pkg, sysroot_idx)) = sysroot_by_id.get(package) {
+                                let sysroot = sysroots[sysroot_idx];
+                                if let RustLibSrcWorkspace::Workspace { ws, .. } =
+                                    sysroot.workspace()
+                                {
+                                    let mut sr = sysroot_res[sysroot_idx].borrow_mut();
+                                    cb(&ws[sysroot_pkg].name, &mut sr.outputs[sysroot_pkg]);
+                                    return;
+                                }
+                            }
+                        }
                         tracing::error!(
                             "Received compiler message for unknown package: {}",
                             package
@@ -183,6 +244,15 @@ impl WorkspaceBuildScripts {
             }
         });
 
+        let mut sysroot_res: Vec<WorkspaceBuildScripts> =
+            sysroot_res.into_iter().map(|r| r.into_inner()).collect();
+        sysroot_res.iter_mut().for_each(|it| it.error.clone_from(&errors));
+        sysroot_collisions.into_iter().for_each(|(id, sysroot_idx, package)| {
+            if let Some(&(p, w)) = sysroot_by_id.get(id) {
+                sysroot_res[sysroot_idx].outputs[package] = sysroot_res[w].outputs[p].clone();
+            }
+        });
+
         if tracing::enabled!(tracing::Level::INFO) {
             for (idx, workspace) in workspaces.iter().enumerate() {
                 for package in workspace.packages() {
@@ -194,7 +264,7 @@ impl WorkspaceBuildScripts {
             }
         }
 
-        Ok(res)
+        Ok(res.into_iter().zip(sysroot_res).collect())
     }
 
     pub fn error(&self) -> Option<&str> {
@@ -309,23 +379,36 @@ impl WorkspaceBuildScripts {
         workspace: &CargoWorkspace,
         sysroot: &Sysroot,
         progress: &dyn Fn(String),
-    ) -> io::Result<WorkspaceBuildScripts> {
+        build_std: bool,
+    ) -> io::Result<(WorkspaceBuildScripts, WorkspaceBuildScripts)> {
         let mut res = WorkspaceBuildScripts::default();
         let outputs = &mut res.outputs;
         // NB: Cargo.toml could have been modified between `cargo metadata` and
         // `cargo check`. We shouldn't assume that package ids we see here are
         // exactly those from `config`.
-        // `None` entries mark sysroot packages: recognized but not stored in the workspace output.
+        // `None` entries mark sysroot packages: recognized but discarded (non-build-std path).
         let mut by_id: FxHashMap<Arc<PackageId>, Option<Package>> = FxHashMap::default();
         for package in workspace.packages() {
             outputs.insert(package, BuildScriptOutput::default());
             by_id.insert(workspace[package].id.clone(), Some(package));
         }
-        // Insert sysroot package IDs so that messages for stdlib crates emitted when
-        // build-std is enabled are recognized rather than reported as unknown packages.
+
+        // When build-std is NOT active, insert sysroot package IDs as None so that any
+        // unexpected messages for them are silently discarded rather than flagged as unknown.
+        // When build-std IS active, we capture sysroot outputs via `sysroot_by_id` below.
+        let mut sysroot_by_id: FxHashMap<Arc<PackageId>, Package> = FxHashMap::default();
+        let sysroot_res = RefCell::new(WorkspaceBuildScripts::default());
         if let RustLibSrcWorkspace::Workspace { ws, .. } = sysroot.workspace() {
-            for package in ws.packages() {
-                by_id.entry(ws[package].id.clone()).or_insert(None);
+            if build_std {
+                let mut sbs = sysroot_res.borrow_mut();
+                for package in ws.packages() {
+                    sbs.outputs.insert(package, BuildScriptOutput::default());
+                    sysroot_by_id.insert(ws[package].id.clone(), package);
+                }
+            } else {
+                for package in ws.packages() {
+                    by_id.entry(ws[package].id.clone()).or_insert(None);
+                }
             }
         }
 
@@ -335,15 +418,21 @@ impl WorkspaceBuildScripts {
                 match by_id.get(package) {
                     Some(Some(package)) => cb(&workspace[*package].name, &mut outputs[*package]),
                     Some(None) => {
-                        // Sysroot package (e.g. core when build-std is enabled);
-                        // its outputs are handled separately, so discard here.
+                        // Sysroot package not in build-std mode; discard.
                     }
                     None => {
-                        never!(
-                            "Received compiler message for unknown package: {}\n {}",
-                            package,
-                            by_id.keys().join(", ")
-                        );
+                        if let Some(&sysroot_pkg) = sysroot_by_id.get(package) {
+                            if let RustLibSrcWorkspace::Workspace { ws, .. } = sysroot.workspace() {
+                                let mut sr = sysroot_res.borrow_mut();
+                                cb(&ws[sysroot_pkg].name, &mut sr.outputs[sysroot_pkg]);
+                            }
+                        } else {
+                            never!(
+                                "Received compiler message for unknown package: {}\n {}",
+                                package,
+                                by_id.keys().join(", ")
+                            );
+                        }
                     }
                 }
             },
@@ -359,7 +448,7 @@ impl WorkspaceBuildScripts {
             }
         }
 
-        Ok(res)
+        Ok((res, sysroot_res.into_inner()))
     }
 
     fn run_command(

--- a/crates/project-model/src/build_dependencies.rs
+++ b/crates/project-model/src/build_dependencies.rs
@@ -23,7 +23,8 @@ use triomphe::Arc;
 use crate::{
     CargoConfig, CargoFeatures, CargoWorkspace, InvocationStrategy, ManifestPath, Package, Sysroot,
     TargetKind,
-    cargo_config_file::{LockfileCopy, LockfileUsage, make_lockfile_copy},
+    cargo_config_file::{CargoConfigFile, LockfileCopy, LockfileUsage, make_lockfile_copy},
+    sysroot::RustLibSrcWorkspace,
     utf8_stdout,
 };
 
@@ -72,14 +73,17 @@ impl BuildScriptOutput {
 }
 
 impl WorkspaceBuildScripts {
-    /// Runs the build scripts for the given workspace
+    /// Runs the build scripts for the given workspace.
+    ///
+    /// Returns `(workspace_build_scripts, sysroot_build_scripts)`. The sysroot build scripts are
+    /// populated when build-std is active; otherwise they are empty/default.
     pub(crate) fn run_for_workspace(
         config: &CargoConfig,
         workspace: &CargoWorkspace,
         progress: &dyn Fn(String),
         sysroot: &Sysroot,
         toolchain: Option<&semver::Version>,
-    ) -> io::Result<WorkspaceBuildScripts> {
+    ) -> io::Result<(WorkspaceBuildScripts, WorkspaceBuildScripts)> {
         let current_dir = workspace.workspace_root();
 
         let allowed_features = workspace.workspace_features();
@@ -92,17 +96,30 @@ impl WorkspaceBuildScripts {
             sysroot,
             toolchain,
         )?;
-        Self::run_per_ws(cmd, workspace, progress)
+        let build_std = CargoConfigFile::load(
+            workspace.manifest_path(),
+            &config.extra_env,
+            sysroot,
+            config.config_path.as_deref(),
+        )
+        .as_ref()
+        .is_some_and(CargoConfigFile::build_std_requested);
+        Self::run_per_ws(cmd, workspace, sysroot, progress, build_std)
     }
 
     /// Runs the build scripts by invoking the configured command *once*.
     /// This populates the outputs for all passed in workspaces.
+    ///
+    /// Returns a `Vec` of `(workspace_build_scripts, sysroot_build_scripts)` pairs, one per
+    /// workspace. The sysroot build scripts are populated when build-std is active for that
+    /// workspace; otherwise they are empty/default.
     pub(crate) fn run_once(
         config: &CargoConfig,
         workspaces: &[&CargoWorkspace],
+        sysroots: &[&Sysroot],
         progress: &dyn Fn(String),
         working_directory: &AbsPathBuf,
-    ) -> io::Result<Vec<WorkspaceBuildScripts>> {
+    ) -> io::Result<Vec<(WorkspaceBuildScripts, WorkspaceBuildScripts)>> {
         assert_eq!(config.invocation_strategy, InvocationStrategy::Once);
 
         let (_guard, cmd) = Self::build_command(
@@ -118,7 +135,8 @@ impl WorkspaceBuildScripts {
         // NB: Cargo.toml could have been modified between `cargo metadata` and
         // `cargo check`. We shouldn't assume that package ids we see here are
         // exactly those from `config`.
-        let mut by_id = FxHashMap::default();
+        // `None` entries mark sysroot packages: recognized but not stored in any workspace output.
+        let mut by_id: FxHashMap<Arc<PackageId>, Option<(Package, usize)>> = FxHashMap::default();
         // some workspaces might depend on the same crates, so we need to duplicate the outputs
         // to those collisions
         let mut collisions = Vec::new();
@@ -132,28 +150,113 @@ impl WorkspaceBuildScripts {
                     if by_id.contains_key(&workspace[package].id) {
                         collisions.push((&workspace[package].id, idx, package));
                     } else {
-                        by_id.insert(workspace[package].id.clone(), (package, idx));
+                        by_id.insert(workspace[package].id.clone(), Some((package, idx)));
                     }
                 }
                 res
             })
             .collect();
 
+        // Detect build-std per workspace. For workspaces where build-std is active, we capture
+        // sysroot package outputs; for others, we just recognize and discard them.
+        let build_std_per_ws: Vec<bool> = workspaces
+            .iter()
+            .zip(sysroots.iter())
+            .map(|(ws, sysroot)| {
+                CargoConfigFile::load(
+                    ws.manifest_path(),
+                    &config.extra_env,
+                    sysroot,
+                    config.config_path.as_deref(),
+                )
+                .as_ref()
+                .is_some_and(CargoConfigFile::build_std_requested)
+            })
+            .collect();
+        let any_build_std = build_std_per_ws.iter().any(|&b| b);
+
+        // `None` entries: sysroot packages that are recognized but discarded (non-build-std path).
+        // For build-std workspaces, sysroot packages go into `sysroot_by_id` / `sysroot_res`.
+        let mut sysroot_by_id: FxHashMap<Arc<PackageId>, (Package, usize)> = FxHashMap::default();
+        let mut sysroot_collisions: Vec<(&Arc<PackageId>, usize, Package)> = Vec::new();
+        let sysroot_res: Vec<RefCell<WorkspaceBuildScripts>> = sysroots
+            .iter()
+            .enumerate()
+            .map(|(idx, sysroot)| {
+                let mut sbs = WorkspaceBuildScripts::default();
+                if build_std_per_ws.get(idx).copied().unwrap_or(false)
+                    && let RustLibSrcWorkspace::Workspace { ws, .. } = sysroot.workspace()
+                {
+                    for package in ws.packages() {
+                        sbs.outputs.insert(package, BuildScriptOutput::default());
+                        if sysroot_by_id.contains_key(&ws[package].id) {
+                            sysroot_collisions.push((&ws[package].id, idx, package));
+                        } else {
+                            sysroot_by_id.insert(ws[package].id.clone(), (package, idx));
+                        }
+                    }
+                }
+                RefCell::new(sbs)
+            })
+            .collect();
+
+        // For sysroot packages not covered by build-std, insert as None (silent discard).
+        for sysroot in sysroots {
+            if let RustLibSrcWorkspace::Workspace { ws, .. } = sysroot.workspace() {
+                for package in ws.packages() {
+                    if !sysroot_by_id.contains_key(&ws[package].id) {
+                        by_id.entry(ws[package].id.clone()).or_insert(None);
+                    }
+                }
+            }
+        }
+
         let errors = Self::run_command(
             cmd,
             |package, cb| {
-                if let Some(&(package, workspace)) = by_id.get(package) {
-                    cb(&workspaces[workspace][package].name, &mut res[workspace].outputs[package]);
-                } else {
-                    tracing::error!("Received compiler message for unknown package: {}", package);
+                match by_id.get(package) {
+                    Some(Some((package, workspace))) => {
+                        cb(
+                            &workspaces[*workspace][*package].name,
+                            &mut res[*workspace].outputs[*package],
+                        );
+                    }
+                    Some(None) => {
+                        // Sysroot package not in build-std mode; discard.
+                    }
+                    None => {
+                        if any_build_std
+                            && let Some(&(sysroot_pkg, sysroot_idx)) = sysroot_by_id.get(package)
+                        {
+                            let sysroot = sysroots[sysroot_idx];
+                            if let RustLibSrcWorkspace::Workspace { ws, .. } = sysroot.workspace() {
+                                let mut sr = sysroot_res[sysroot_idx].borrow_mut();
+                                cb(&ws[sysroot_pkg].name, &mut sr.outputs[sysroot_pkg]);
+                                return;
+                            }
+                        }
+                        tracing::error!(
+                            "Received compiler message for unknown package: {}",
+                            package
+                        );
+                    }
                 }
             },
             progress,
         )?;
         res.iter_mut().for_each(|it| it.error.clone_from(&errors));
         collisions.into_iter().for_each(|(id, workspace, package)| {
-            if let Some(&(p, w)) = by_id.get(id) {
-                res[workspace].outputs[package] = res[w].outputs[p].clone();
+            if let Some(Some((p, w))) = by_id.get(id) {
+                res[workspace].outputs[package] = res[*w].outputs[*p].clone();
+            }
+        });
+
+        let mut sysroot_res: Vec<WorkspaceBuildScripts> =
+            sysroot_res.into_iter().map(|r| r.into_inner()).collect();
+        sysroot_res.iter_mut().for_each(|it| it.error.clone_from(&errors));
+        sysroot_collisions.into_iter().for_each(|(id, sysroot_idx, package)| {
+            if let Some(&(p, w)) = sysroot_by_id.get(id) {
+                sysroot_res[sysroot_idx].outputs[package] = sysroot_res[w].outputs[p].clone();
             }
         });
 
@@ -168,7 +271,7 @@ impl WorkspaceBuildScripts {
             }
         }
 
-        Ok(res)
+        Ok(res.into_iter().zip(sysroot_res).collect())
     }
 
     pub fn error(&self) -> Option<&str> {
@@ -281,30 +384,63 @@ impl WorkspaceBuildScripts {
     fn run_per_ws(
         cmd: Command,
         workspace: &CargoWorkspace,
+        sysroot: &Sysroot,
         progress: &dyn Fn(String),
-    ) -> io::Result<WorkspaceBuildScripts> {
+        build_std: bool,
+    ) -> io::Result<(WorkspaceBuildScripts, WorkspaceBuildScripts)> {
         let mut res = WorkspaceBuildScripts::default();
         let outputs = &mut res.outputs;
         // NB: Cargo.toml could have been modified between `cargo metadata` and
         // `cargo check`. We shouldn't assume that package ids we see here are
         // exactly those from `config`.
-        let mut by_id: FxHashMap<Arc<PackageId>, Package> = FxHashMap::default();
+        // `None` entries mark sysroot packages: recognized but discarded (non-build-std path).
+        let mut by_id: FxHashMap<Arc<PackageId>, Option<Package>> = FxHashMap::default();
         for package in workspace.packages() {
             outputs.insert(package, BuildScriptOutput::default());
-            by_id.insert(workspace[package].id.clone(), package);
+            by_id.insert(workspace[package].id.clone(), Some(package));
+        }
+
+        // When build-std is NOT active, insert sysroot package IDs as None so that any
+        // unexpected messages for them are silently discarded rather than flagged as unknown.
+        // When build-std IS active, we capture sysroot outputs via `sysroot_by_id` below.
+        let mut sysroot_by_id: FxHashMap<Arc<PackageId>, Package> = FxHashMap::default();
+        let sysroot_res = RefCell::new(WorkspaceBuildScripts::default());
+        if let RustLibSrcWorkspace::Workspace { ws, .. } = sysroot.workspace() {
+            if build_std {
+                let mut sbs = sysroot_res.borrow_mut();
+                for package in ws.packages() {
+                    sbs.outputs.insert(package, BuildScriptOutput::default());
+                    sysroot_by_id.insert(ws[package].id.clone(), package);
+                }
+            } else {
+                for package in ws.packages() {
+                    by_id.entry(ws[package].id.clone()).or_insert(None);
+                }
+            }
         }
 
         res.error = Self::run_command(
             cmd,
             |package, cb| {
-                if let Some(&package) = by_id.get(package) {
-                    cb(&workspace[package].name, &mut outputs[package]);
-                } else {
-                    never!(
-                        "Received compiler message for unknown package: {}\n {}",
-                        package,
-                        by_id.keys().join(", ")
-                    );
+                match by_id.get(package) {
+                    Some(Some(package)) => cb(&workspace[*package].name, &mut outputs[*package]),
+                    Some(None) => {
+                        // Sysroot package not in build-std mode; discard.
+                    }
+                    None => {
+                        if let Some(&sysroot_pkg) = sysroot_by_id.get(package) {
+                            if let RustLibSrcWorkspace::Workspace { ws, .. } = sysroot.workspace() {
+                                let mut sr = sysroot_res.borrow_mut();
+                                cb(&ws[sysroot_pkg].name, &mut sr.outputs[sysroot_pkg]);
+                            }
+                        } else {
+                            never!(
+                                "Received compiler message for unknown package: {}\n {}",
+                                package,
+                                by_id.keys().join(", ")
+                            );
+                        }
+                    }
                 }
             },
             progress,
@@ -319,7 +455,7 @@ impl WorkspaceBuildScripts {
             }
         }
 
-        Ok(res)
+        Ok((res, sysroot_res.into_inner()))
     }
 
     fn run_command(

--- a/crates/project-model/src/cargo_config_file.rs
+++ b/crates/project-model/src/cargo_config_file.rs
@@ -42,6 +42,15 @@ impl CargoConfigFile {
         CargoConfigFileReader::new(&self.0)
     }
 
+    pub(crate) fn build_std_requested(&self) -> bool {
+        let Some(reader) = self.read() else { return false };
+        match reader.get(["unstable", "build-std"]) {
+            Some(DeValue::Array(arr)) => !arr.is_empty(),
+            Some(_) => true,
+            None => false,
+        }
+    }
+
     #[cfg(test)]
     pub(crate) fn from_string_for_test(s: String) -> Self {
         CargoConfigFile(s)

--- a/crates/project-model/src/cargo_config_file.rs
+++ b/crates/project-model/src/cargo_config_file.rs
@@ -46,6 +46,15 @@ impl CargoConfigFile {
         CargoConfigFileReader::new(&self.0)
     }
 
+    pub(crate) fn build_std_requested(&self) -> bool {
+        let Some(reader) = self.read() else { return false };
+        match reader.get(["unstable", "build-std"]) {
+            Some(DeValue::Array(arr)) => !arr.is_empty(),
+            Some(_) => true,
+            None => false,
+        }
+    }
+
     #[cfg(test)]
     pub(crate) fn from_string_for_test(s: String) -> Self {
         CargoConfigFile(s)

--- a/crates/project-model/src/tests.rs
+++ b/crates/project-model/src/tests.rs
@@ -39,6 +39,7 @@ fn load_workspace_from_metadata(file: &str) -> ProjectWorkspace {
         kind: ProjectWorkspaceKind::Cargo {
             cargo: cargo_workspace,
             build_scripts: WorkspaceBuildScripts::default(),
+            sysroot_build_scripts: WorkspaceBuildScripts::default(),
             rustc: Err(None),
             error: None,
         },
@@ -267,6 +268,7 @@ fn smoke_test_real_sysroot_cargo() {
         kind: ProjectWorkspaceKind::Cargo {
             cargo: cargo_workspace,
             build_scripts: WorkspaceBuildScripts::default(),
+            sysroot_build_scripts: WorkspaceBuildScripts::default(),
             rustc: Err(None),
             error: None,
         },

--- a/crates/project-model/src/workspace.rs
+++ b/crates/project-model/src/workspace.rs
@@ -84,6 +84,8 @@ pub enum ProjectWorkspaceKind {
         error: Option<Arc<anyhow::Error>>,
         /// The build script results for the workspace.
         build_scripts: WorkspaceBuildScripts,
+        /// Build script results for sysroot packages (populated when build-std is active).
+        sysroot_build_scripts: WorkspaceBuildScripts,
         /// The rustc workspace loaded for this workspace. An `Err(None)` means loading has been
         /// disabled or was otherwise not requested.
         rustc: Result<Box<(CargoWorkspace, WorkspaceBuildScripts)>, Option<String>>,
@@ -122,7 +124,7 @@ impl fmt::Debug for ProjectWorkspace {
             set_test,
         } = self;
         match kind {
-            ProjectWorkspaceKind::Cargo { cargo, error: _, build_scripts, rustc } => f
+            ProjectWorkspaceKind::Cargo { cargo, error: _, build_scripts, rustc, .. } => f
                 .debug_struct("Cargo")
                 .field("root", &cargo.workspace_root().file_name())
                 .field("n_packages", &cargo.packages().len())
@@ -452,6 +454,7 @@ impl ProjectWorkspace {
             kind: ProjectWorkspaceKind::Cargo {
                 cargo,
                 build_scripts: WorkspaceBuildScripts::default(),
+                sysroot_build_scripts: WorkspaceBuildScripts::default(),
                 rustc,
                 error: error.map(Arc::new),
             },
@@ -618,11 +621,14 @@ impl ProjectWorkspace {
     }
 
     /// Runs the build scripts for this [`ProjectWorkspace`].
+    ///
+    /// Returns `(workspace_build_scripts, sysroot_build_scripts)`. The sysroot build scripts are
+    /// populated when build-std is active; otherwise they are empty/default.
     pub fn run_build_scripts(
         &self,
         config: &CargoConfig,
         progress: &dyn Fn(String),
-    ) -> anyhow::Result<WorkspaceBuildScripts> {
+    ) -> anyhow::Result<(WorkspaceBuildScripts, WorkspaceBuildScripts)> {
         match &self.kind {
             ProjectWorkspaceKind::DetachedFile { cargo: Some((cargo, _, None)), .. }
             | ProjectWorkspaceKind::Cargo { cargo, error: None, .. } => {
@@ -637,18 +643,20 @@ impl ProjectWorkspace {
                     format!("Failed to run build scripts for {}", cargo.workspace_root())
                 })
             }
-            _ => Ok(WorkspaceBuildScripts::default()),
+            _ => Ok((WorkspaceBuildScripts::default(), WorkspaceBuildScripts::default())),
         }
     }
 
     /// Runs the build scripts for the given [`ProjectWorkspace`]s. Depending on the invocation
     /// strategy this may run a single build process for all project workspaces.
+    ///
+    /// Returns a `Vec` of `(workspace_build_scripts, sysroot_build_scripts)` per workspace.
     pub fn run_all_build_scripts(
         workspaces: &[ProjectWorkspace],
         config: &CargoConfig,
         progress: &dyn Fn(String),
         working_directory: &AbsPathBuf,
-    ) -> Vec<anyhow::Result<WorkspaceBuildScripts>> {
+    ) -> Vec<anyhow::Result<(WorkspaceBuildScripts, WorkspaceBuildScripts)>> {
         if matches!(config.invocation_strategy, InvocationStrategy::PerWorkspace)
             || config.run_build_script_command.is_none()
         {
@@ -683,18 +691,29 @@ impl ProjectWorkspace {
                         format!("Failed to run build scripts for {}", cargo.workspace_root())
                     }),
                 },
-                _ => Ok(WorkspaceBuildScripts::default()),
+                _ => Ok((WorkspaceBuildScripts::default(), WorkspaceBuildScripts::default())),
             })
             .collect()
     }
 
-    pub fn set_build_scripts(&mut self, bs: WorkspaceBuildScripts) {
+    pub fn set_build_scripts(
+        &mut self,
+        bs: WorkspaceBuildScripts,
+        sysroot_bs: WorkspaceBuildScripts,
+    ) {
         match &mut self.kind {
-            ProjectWorkspaceKind::Cargo { build_scripts, .. }
-            | ProjectWorkspaceKind::DetachedFile { cargo: Some((_, build_scripts, _)), .. } => {
-                *build_scripts = bs
+            ProjectWorkspaceKind::Cargo { build_scripts, sysroot_build_scripts, .. } => {
+                *build_scripts = bs;
+                *sysroot_build_scripts = sysroot_bs;
             }
-            _ => assert_eq!(bs, WorkspaceBuildScripts::default()),
+            ProjectWorkspaceKind::DetachedFile { cargo: Some((_, build_scripts, _)), .. } => {
+                *build_scripts = bs;
+                assert_eq!(sysroot_bs, WorkspaceBuildScripts::default());
+            }
+            _ => {
+                assert_eq!(bs, WorkspaceBuildScripts::default());
+                assert_eq!(sysroot_bs, WorkspaceBuildScripts::default());
+            }
         }
     }
 
@@ -807,7 +826,7 @@ impl ProjectWorkspace {
                 .into_iter()
                 .chain(mk_sysroot())
                 .collect::<Vec<_>>(),
-            ProjectWorkspaceKind::Cargo { cargo, rustc, build_scripts, error: _ } => {
+            ProjectWorkspaceKind::Cargo { cargo, rustc, build_scripts, error: _, .. } => {
                 cargo
                     .packages()
                     .map(|pkg| {
@@ -966,19 +985,24 @@ impl ProjectWorkspace {
                 false,
                 crate_ws_data,
             ),
-            ProjectWorkspaceKind::Cargo { cargo, rustc, build_scripts, error: _ } => {
-                cargo_to_crate_graph(
-                    load,
-                    rustc.as_ref().map(|a| a.as_ref()).ok(),
-                    cargo,
-                    sysroot,
-                    rustc_cfg.clone(),
-                    cfg_overrides,
-                    build_scripts,
-                    self.set_test,
-                    crate_ws_data,
-                )
-            }
+            ProjectWorkspaceKind::Cargo {
+                cargo,
+                rustc,
+                build_scripts,
+                sysroot_build_scripts,
+                error: _,
+            } => cargo_to_crate_graph(
+                load,
+                rustc.as_ref().map(|a| a.as_ref()).ok(),
+                cargo,
+                sysroot,
+                rustc_cfg.clone(),
+                cfg_overrides,
+                build_scripts,
+                sysroot_build_scripts,
+                self.set_test,
+                crate_ws_data,
+            ),
             ProjectWorkspaceKind::DetachedFile { file, cargo: cargo_script, .. } => {
                 if let Some((cargo, build_scripts, _)) = cargo_script {
                     cargo_to_crate_graph(
@@ -989,6 +1013,7 @@ impl ProjectWorkspace {
                         rustc_cfg.clone(),
                         cfg_overrides,
                         build_scripts,
+                        &WorkspaceBuildScripts::default(),
                         self.set_test,
                         crate_ws_data,
                     )
@@ -1024,13 +1049,8 @@ impl ProjectWorkspace {
         } = other;
         (match (kind, o_kind) {
             (
-                ProjectWorkspaceKind::Cargo { cargo, rustc, build_scripts: _, error: _ },
-                ProjectWorkspaceKind::Cargo {
-                    cargo: o_cargo,
-                    rustc: o_rustc,
-                    build_scripts: _,
-                    error: _,
-                },
+                ProjectWorkspaceKind::Cargo { cargo, rustc, .. },
+                ProjectWorkspaceKind::Cargo { cargo: o_cargo, rustc: o_rustc, .. },
             ) => cargo == o_cargo && rustc == o_rustc,
             (ProjectWorkspaceKind::Json(project), ProjectWorkspaceKind::Json(o_project)) => {
                 project == o_project
@@ -1079,6 +1099,7 @@ fn project_json_to_crate_graph(
         rustc_cfg.clone(),
         load,
         // FIXME: This looks incorrect but I don't think this matters.
+        &WorkspaceBuildScripts::default(),
         crate_ws_data.clone(),
     );
 
@@ -1225,6 +1246,7 @@ fn cargo_to_crate_graph(
     rustc_cfg: Vec<CfgAtom>,
     override_cfg: &CfgOverrides,
     build_scripts: &WorkspaceBuildScripts,
+    sysroot_build_scripts: &WorkspaceBuildScripts,
     set_test: bool,
     crate_ws_data: Arc<CrateWorkspaceData>,
 ) -> (CrateGraphBuilder, ProcMacroPaths) {
@@ -1236,6 +1258,7 @@ fn cargo_to_crate_graph(
         sysroot,
         rustc_cfg.clone(),
         load,
+        sysroot_build_scripts,
         crate_ws_data.clone(),
     );
     let cargo_path = sysroot.tool_path(Tool::Cargo, cargo.workspace_root(), cargo.env());
@@ -1447,6 +1470,7 @@ fn detached_file_to_crate_graph(
         rustc_cfg.clone(),
         load,
         // FIXME: This looks incorrect but I don't think this causes problems.
+        &WorkspaceBuildScripts::default(),
         crate_ws_data.clone(),
     );
 
@@ -1767,6 +1791,7 @@ fn sysroot_to_crate_graph(
     sysroot: &Sysroot,
     rustc_cfg: Vec<CfgAtom>,
     load: FileLoader<'_>,
+    sysroot_build_scripts: &WorkspaceBuildScripts,
     crate_ws_data: Arc<CrateWorkspaceData>,
 ) -> (SysrootPublicDeps, Option<CrateBuilderId>) {
     let _p = tracing::info_span!("sysroot_to_crate_graph").entered();
@@ -1789,6 +1814,7 @@ fn sysroot_to_crate_graph(
                     ),
                     ..Default::default()
                 },
+                sysroot_build_scripts,
                 &WorkspaceBuildScripts::default(),
                 false,
                 crate_ws_data,

--- a/crates/project-model/src/workspace.rs
+++ b/crates/project-model/src/workspace.rs
@@ -655,16 +655,17 @@ impl ProjectWorkspace {
             return workspaces.iter().map(|it| it.run_build_scripts(config, progress)).collect();
         }
 
-        let cargo_ws: Vec<_> = workspaces
+        let (cargo_ws, sysroots): (Vec<_>, Vec<_>) = workspaces
             .iter()
             .filter_map(|it| match &it.kind {
-                ProjectWorkspaceKind::Cargo { cargo, .. } => Some(cargo),
+                ProjectWorkspaceKind::Cargo { cargo, .. } => Some((cargo, &it.sysroot)),
                 _ => None,
             })
-            .collect();
+            .unzip();
         let outputs = &mut match WorkspaceBuildScripts::run_once(
             config,
             &cargo_ws,
+            &sysroots,
             progress,
             working_directory,
         ) {

--- a/crates/project-model/src/workspace.rs
+++ b/crates/project-model/src/workspace.rs
@@ -84,6 +84,8 @@ pub enum ProjectWorkspaceKind {
         error: Option<Arc<anyhow::Error>>,
         /// The build script results for the workspace.
         build_scripts: WorkspaceBuildScripts,
+        /// Build script results for sysroot packages (populated when build-std is active).
+        sysroot_build_scripts: WorkspaceBuildScripts,
         /// The rustc workspace loaded for this workspace. An `Err(None)` means loading has been
         /// disabled or was otherwise not requested.
         rustc: Result<Box<(CargoWorkspace, WorkspaceBuildScripts)>, Option<String>>,
@@ -122,7 +124,7 @@ impl fmt::Debug for ProjectWorkspace {
             set_test,
         } = self;
         match kind {
-            ProjectWorkspaceKind::Cargo { cargo, error: _, build_scripts, rustc } => f
+            ProjectWorkspaceKind::Cargo { cargo, error: _, build_scripts, rustc, .. } => f
                 .debug_struct("Cargo")
                 .field("root", &cargo.workspace_root().file_name())
                 .field("n_packages", &cargo.packages().len())
@@ -456,6 +458,7 @@ impl ProjectWorkspace {
             kind: ProjectWorkspaceKind::Cargo {
                 cargo,
                 build_scripts: WorkspaceBuildScripts::default(),
+                sysroot_build_scripts: WorkspaceBuildScripts::default(),
                 rustc,
                 error: error.map(Arc::new),
             },
@@ -628,11 +631,14 @@ impl ProjectWorkspace {
     }
 
     /// Runs the build scripts for this [`ProjectWorkspace`].
+    ///
+    /// Returns `(workspace_build_scripts, sysroot_build_scripts)`. The sysroot build scripts are
+    /// populated when build-std is active; otherwise they are empty/default.
     pub fn run_build_scripts(
         &self,
         config: &CargoConfig,
         progress: &dyn Fn(String),
-    ) -> anyhow::Result<WorkspaceBuildScripts> {
+    ) -> anyhow::Result<(WorkspaceBuildScripts, WorkspaceBuildScripts)> {
         match &self.kind {
             ProjectWorkspaceKind::DetachedFile { cargo: Some((cargo, _, None)), .. }
             | ProjectWorkspaceKind::Cargo { cargo, error: None, .. } => {
@@ -647,34 +653,37 @@ impl ProjectWorkspace {
                     format!("Failed to run build scripts for {}", cargo.workspace_root())
                 })
             }
-            _ => Ok(WorkspaceBuildScripts::default()),
+            _ => Ok((WorkspaceBuildScripts::default(), WorkspaceBuildScripts::default())),
         }
     }
 
     /// Runs the build scripts for the given [`ProjectWorkspace`]s. Depending on the invocation
     /// strategy this may run a single build process for all project workspaces.
+    ///
+    /// Returns a `Vec` of `(workspace_build_scripts, sysroot_build_scripts)` per workspace.
     pub fn run_all_build_scripts(
         workspaces: &[ProjectWorkspace],
         config: &CargoConfig,
         progress: &dyn Fn(String),
         working_directory: &AbsPathBuf,
-    ) -> Vec<anyhow::Result<WorkspaceBuildScripts>> {
+    ) -> Vec<anyhow::Result<(WorkspaceBuildScripts, WorkspaceBuildScripts)>> {
         if matches!(config.invocation_strategy, InvocationStrategy::PerWorkspace)
             || config.run_build_script_command.is_none()
         {
             return workspaces.iter().map(|it| it.run_build_scripts(config, progress)).collect();
         }
 
-        let cargo_ws: Vec<_> = workspaces
+        let (cargo_ws, sysroots): (Vec<_>, Vec<_>) = workspaces
             .iter()
             .filter_map(|it| match &it.kind {
-                ProjectWorkspaceKind::Cargo { cargo, .. } => Some(cargo),
+                ProjectWorkspaceKind::Cargo { cargo, .. } => Some((cargo, &it.sysroot)),
                 _ => None,
             })
-            .collect();
+            .unzip();
         let outputs = &mut match WorkspaceBuildScripts::run_once(
             config,
             &cargo_ws,
+            &sysroots,
             progress,
             working_directory,
         ) {
@@ -692,18 +701,29 @@ impl ProjectWorkspace {
                         format!("Failed to run build scripts for {}", cargo.workspace_root())
                     }),
                 },
-                _ => Ok(WorkspaceBuildScripts::default()),
+                _ => Ok((WorkspaceBuildScripts::default(), WorkspaceBuildScripts::default())),
             })
             .collect()
     }
 
-    pub fn set_build_scripts(&mut self, bs: WorkspaceBuildScripts) {
+    pub fn set_build_scripts(
+        &mut self,
+        bs: WorkspaceBuildScripts,
+        sysroot_bs: WorkspaceBuildScripts,
+    ) {
         match &mut self.kind {
-            ProjectWorkspaceKind::Cargo { build_scripts, .. }
-            | ProjectWorkspaceKind::DetachedFile { cargo: Some((_, build_scripts, _)), .. } => {
-                *build_scripts = bs
+            ProjectWorkspaceKind::Cargo { build_scripts, sysroot_build_scripts, .. } => {
+                *build_scripts = bs;
+                *sysroot_build_scripts = sysroot_bs;
             }
-            _ => assert_eq!(bs, WorkspaceBuildScripts::default()),
+            ProjectWorkspaceKind::DetachedFile { cargo: Some((_, build_scripts, _)), .. } => {
+                *build_scripts = bs;
+                assert_eq!(sysroot_bs, WorkspaceBuildScripts::default());
+            }
+            _ => {
+                assert_eq!(bs, WorkspaceBuildScripts::default());
+                assert_eq!(sysroot_bs, WorkspaceBuildScripts::default());
+            }
         }
     }
 
@@ -816,7 +836,7 @@ impl ProjectWorkspace {
                 .into_iter()
                 .chain(mk_sysroot())
                 .collect::<Vec<_>>(),
-            ProjectWorkspaceKind::Cargo { cargo, rustc, build_scripts, error: _ } => {
+            ProjectWorkspaceKind::Cargo { cargo, rustc, build_scripts, error: _, .. } => {
                 cargo
                     .packages()
                     .map(|pkg| {
@@ -982,19 +1002,24 @@ impl ProjectWorkspace {
                 false,
                 crate_ws_data,
             ),
-            ProjectWorkspaceKind::Cargo { cargo, rustc, build_scripts, error: _ } => {
-                cargo_to_crate_graph(
-                    load,
-                    rustc.as_ref().map(|a| a.as_ref()).ok(),
-                    cargo,
-                    sysroot,
-                    rustc_cfg.clone(),
-                    cfg_overrides,
-                    build_scripts,
-                    self.set_test,
-                    crate_ws_data,
-                )
-            }
+            ProjectWorkspaceKind::Cargo {
+                cargo,
+                rustc,
+                build_scripts,
+                sysroot_build_scripts,
+                error: _,
+            } => cargo_to_crate_graph(
+                load,
+                rustc.as_ref().map(|a| a.as_ref()).ok(),
+                cargo,
+                sysroot,
+                rustc_cfg.clone(),
+                cfg_overrides,
+                build_scripts,
+                sysroot_build_scripts,
+                self.set_test,
+                crate_ws_data,
+            ),
             ProjectWorkspaceKind::DetachedFile { file, cargo: cargo_script, .. } => {
                 if let Some((cargo, build_scripts, _)) = cargo_script {
                     cargo_to_crate_graph(
@@ -1005,6 +1030,7 @@ impl ProjectWorkspace {
                         rustc_cfg.clone(),
                         cfg_overrides,
                         build_scripts,
+                        &WorkspaceBuildScripts::default(),
                         self.set_test,
                         crate_ws_data,
                     )
@@ -1040,13 +1066,8 @@ impl ProjectWorkspace {
         } = other;
         (match (kind, o_kind) {
             (
-                ProjectWorkspaceKind::Cargo { cargo, rustc, build_scripts: _, error: _ },
-                ProjectWorkspaceKind::Cargo {
-                    cargo: o_cargo,
-                    rustc: o_rustc,
-                    build_scripts: _,
-                    error: _,
-                },
+                ProjectWorkspaceKind::Cargo { cargo, rustc, .. },
+                ProjectWorkspaceKind::Cargo { cargo: o_cargo, rustc: o_rustc, .. },
             ) => cargo == o_cargo && rustc == o_rustc,
             (ProjectWorkspaceKind::Json(project), ProjectWorkspaceKind::Json(o_project)) => {
                 project == o_project
@@ -1095,6 +1116,7 @@ fn project_json_to_crate_graph(
         rustc_cfg.clone(),
         load,
         // FIXME: This looks incorrect but I don't think this matters.
+        &WorkspaceBuildScripts::default(),
         crate_ws_data.clone(),
     );
 
@@ -1241,6 +1263,7 @@ fn cargo_to_crate_graph(
     rustc_cfg: Vec<CfgAtom>,
     override_cfg: &CfgOverrides,
     build_scripts: &WorkspaceBuildScripts,
+    sysroot_build_scripts: &WorkspaceBuildScripts,
     set_test: bool,
     crate_ws_data: Arc<CrateWorkspaceData>,
 ) -> (CrateGraphBuilder, ProcMacroPaths) {
@@ -1252,6 +1275,7 @@ fn cargo_to_crate_graph(
         sysroot,
         rustc_cfg.clone(),
         load,
+        sysroot_build_scripts,
         crate_ws_data.clone(),
     );
     let cargo_path = sysroot.tool_path(Tool::Cargo, cargo.workspace_root(), cargo.env());
@@ -1463,6 +1487,7 @@ fn detached_file_to_crate_graph(
         rustc_cfg.clone(),
         load,
         // FIXME: This looks incorrect but I don't think this causes problems.
+        &WorkspaceBuildScripts::default(),
         crate_ws_data.clone(),
     );
 
@@ -1783,6 +1808,7 @@ fn sysroot_to_crate_graph(
     sysroot: &Sysroot,
     rustc_cfg: Vec<CfgAtom>,
     load: FileLoader<'_>,
+    sysroot_build_scripts: &WorkspaceBuildScripts,
     crate_ws_data: Arc<CrateWorkspaceData>,
 ) -> (SysrootPublicDeps, Option<CrateBuilderId>) {
     let _p = tracing::info_span!("sysroot_to_crate_graph").entered();
@@ -1805,6 +1831,7 @@ fn sysroot_to_crate_graph(
                     ),
                     ..Default::default()
                 },
+                sysroot_build_scripts,
                 &WorkspaceBuildScripts::default(),
                 false,
                 crate_ws_data,

--- a/crates/rust-analyzer/src/cli/analysis_stats.rs
+++ b/crates/rust-analyzer/src/cli/analysis_stats.rs
@@ -99,8 +99,8 @@ impl flags::AnalysisStats {
             None
         } else {
             let mut build_scripts_sw = self.stop_watch();
-            let bs = workspace.run_build_scripts(&cargo_config, no_progress)?;
-            workspace.set_build_scripts(bs);
+            let (bs, sysroot_bs) = workspace.run_build_scripts(&cargo_config, no_progress)?;
+            workspace.set_build_scripts(bs, sysroot_bs);
             Some(build_scripts_sw.elapsed())
         };
 
@@ -619,7 +619,8 @@ impl flags::AnalysisStats {
                     if self.validate_term_search {
                         std::fs::write(path, txt).unwrap();
 
-                        let res = ws.run_build_scripts(&cargo_config, &|_| ()).unwrap();
+                        let (res, _sysroot_bs) =
+                            ws.run_build_scripts(&cargo_config, &|_| ()).unwrap();
                         if let Some(err) = res.error()
                             && err.contains("error: could not compile")
                         {

--- a/crates/rust-analyzer/src/cli/analysis_stats.rs
+++ b/crates/rust-analyzer/src/cli/analysis_stats.rs
@@ -103,8 +103,8 @@ impl flags::AnalysisStats {
             None
         } else {
             let mut build_scripts_sw = self.stop_watch();
-            let bs = workspace.run_build_scripts(&cargo_config, no_progress)?;
-            workspace.set_build_scripts(bs);
+            let (bs, sysroot_bs) = workspace.run_build_scripts(&cargo_config, no_progress)?;
+            workspace.set_build_scripts(bs, sysroot_bs);
             Some(build_scripts_sw.elapsed())
         };
 
@@ -624,7 +624,8 @@ impl flags::AnalysisStats {
                     if self.validate_term_search {
                         std::fs::write(path, txt).unwrap();
 
-                        let res = ws.run_build_scripts(&cargo_config, &|_| ()).unwrap();
+                        let (res, _sysroot_bs) =
+                            ws.run_build_scripts(&cargo_config, &|_| ()).unwrap();
                         if let Some(err) = res.error()
                             && err.contains("error: could not compile")
                         {

--- a/crates/rust-analyzer/src/cli/lsif.rs
+++ b/crates/rust-analyzer/src/cli/lsif.rs
@@ -301,8 +301,9 @@ impl flags::Lsif {
         eprintln!("Generating LSIF for project at {root}");
         let mut workspace = ProjectWorkspace::load(root, cargo_config, no_progress)?;
 
-        let build_scripts = workspace.run_build_scripts(cargo_config, no_progress)?;
-        workspace.set_build_scripts(build_scripts);
+        let (build_scripts, sysroot_build_scripts) =
+            workspace.run_build_scripts(cargo_config, no_progress)?;
+        workspace.set_build_scripts(build_scripts, sysroot_build_scripts);
 
         let (db, vfs, _proc_macro) =
             load_workspace(workspace, &cargo_config.extra_env, &load_cargo_config)?;

--- a/crates/rust-analyzer/src/cli/lsif.rs
+++ b/crates/rust-analyzer/src/cli/lsif.rs
@@ -302,8 +302,9 @@ impl flags::Lsif {
         eprintln!("Generating LSIF for project at {root}");
         let mut workspace = ProjectWorkspace::load(root, cargo_config, no_progress)?;
 
-        let build_scripts = workspace.run_build_scripts(cargo_config, no_progress)?;
-        workspace.set_build_scripts(build_scripts);
+        let (build_scripts, sysroot_build_scripts) =
+            workspace.run_build_scripts(cargo_config, no_progress)?;
+        workspace.set_build_scripts(build_scripts, sysroot_build_scripts);
 
         let (db, vfs, _proc_macro) =
             load_workspace(workspace, &cargo_config.extra_env, &load_cargo_config)?;

--- a/crates/rust-analyzer/src/global_state.rs
+++ b/crates/rust-analyzer/src/global_state.rs
@@ -61,7 +61,7 @@ pub(crate) struct FetchWorkspaceResponse {
 
 pub(crate) struct FetchBuildDataResponse {
     pub(crate) workspaces: Arc<Vec<ProjectWorkspace>>,
-    pub(crate) build_scripts: Vec<anyhow::Result<WorkspaceBuildScripts>>,
+    pub(crate) build_scripts: Vec<anyhow::Result<(WorkspaceBuildScripts, WorkspaceBuildScripts)>>,
 }
 
 // Enforces drop order

--- a/crates/rust-analyzer/src/reload.rs
+++ b/crates/rust-analyzer/src/reload.rs
@@ -55,7 +55,12 @@ pub(crate) enum ProjectWorkspaceProgress {
 pub(crate) enum BuildDataProgress {
     Begin,
     Report(String),
-    End((Arc<Vec<ProjectWorkspace>>, Vec<anyhow::Result<WorkspaceBuildScripts>>)),
+    End(
+        (
+            Arc<Vec<ProjectWorkspace>>,
+            Vec<anyhow::Result<(WorkspaceBuildScripts, WorkspaceBuildScripts)>>,
+        ),
+    ),
 }
 
 #[derive(Debug)]
@@ -514,7 +519,8 @@ impl GlobalState {
                         .cloned()
                         .zip(build_scripts)
                         .map(|(mut ws, bs)| {
-                            ws.set_build_scripts(bs.as_ref().ok().cloned().unwrap_or_default());
+                            let (bs, sysroot_bs) = bs.as_ref().ok().cloned().unwrap_or_default();
+                            ws.set_build_scripts(bs, sysroot_bs);
                             ws
                         })
                         .collect::<Vec<_>>();
@@ -854,7 +860,7 @@ impl GlobalState {
 
         for script in build_scripts {
             match script {
-                Ok(data) => {
+                Ok((data, _sysroot_data)) => {
                     if let Some(stderr) = data.error() {
                         stdx::format_to!(buf, "{:#}\n", stderr)
                     }

--- a/crates/rust-analyzer/src/reload.rs
+++ b/crates/rust-analyzer/src/reload.rs
@@ -55,7 +55,12 @@ pub(crate) enum ProjectWorkspaceProgress {
 pub(crate) enum BuildDataProgress {
     Begin,
     Report(String),
-    End((Arc<Vec<ProjectWorkspace>>, Vec<anyhow::Result<WorkspaceBuildScripts>>)),
+    End(
+        (
+            Arc<Vec<ProjectWorkspace>>,
+            Vec<anyhow::Result<(WorkspaceBuildScripts, WorkspaceBuildScripts)>>,
+        ),
+    ),
 }
 
 #[derive(Debug)]
@@ -507,7 +512,8 @@ impl GlobalState {
                         .cloned()
                         .zip(build_scripts)
                         .map(|(mut ws, bs)| {
-                            ws.set_build_scripts(bs.as_ref().ok().cloned().unwrap_or_default());
+                            let (bs, sysroot_bs) = bs.as_ref().ok().cloned().unwrap_or_default();
+                            ws.set_build_scripts(bs, sysroot_bs);
                             ws
                         })
                         .collect::<Vec<_>>();
@@ -850,7 +856,7 @@ impl GlobalState {
 
         for script in build_scripts {
             match script {
-                Ok(data) => {
+                Ok((data, _sysroot_data)) => {
                     if let Some(stderr) = data.error() {
                         stdx::format_to!(buf, "{:#}\n", stderr)
                     }


### PR DESCRIPTION
This PR fixes issue rust-lang/rust-analyzer#21602 

## Fix

  Insert sysroot package IDs into `by_id` (mapped to `None`) alongside
  user workspace packages (mapped to `Some`). When the build script
  output callback encounters a `None` entry, it silently discards the
  output — sysroot build outputs are already handled separately via
  `rustc_crates()`.