### PR TITLE
fix: prevent premature UnresolvedField diagnostic on type variables

### DIFF
--- a/crates/hir-ty/src/infer/expr.rs
+++ b/crates/hir-ty/src/infer/expr.rs
@@ -1702,12 +1702,14 @@ impl<'db> InferenceContext<'_, 'db> {
                     receiver,
                     tgt_expr,
                 );
-                self.push_diagnostic(InferenceDiagnostic::UnresolvedField {
-                    expr: tgt_expr,
-                    receiver: receiver_ty.store(),
-                    name: name.clone(),
-                    method_with_same_name_exists: resolved.is_ok(),
-                });
+                if !receiver_ty.is_ty_var() {
+                    self.push_diagnostic(InferenceDiagnostic::UnresolvedField {
+                        expr: tgt_expr,
+                        receiver: receiver_ty.store(),
+                        name: name.clone(),
+                        method_with_same_name_exists: resolved.is_ok(),
+                    });
+                }
                 match resolved {
                     Ok((func, _is_visible)) => {
                         self.check_method_call(tgt_expr, &[], func.sig, expected)

--- a/crates/ide-diagnostics/src/handlers/unresolved_field.rs
+++ b/crates/ide-diagnostics/src/handlers/unresolved_field.rs
@@ -554,4 +554,20 @@ impl S {
         "#,
         );
     }
+
+    #[test]
+    fn closure_param_field_access() {
+        check_diagnostics(
+            r#"
+struct S {
+    field: (),
+}
+fn f(_: impl FnOnce(S)) {}
+fn main() {
+    let cb = |s| _ = s.field;
+    f(cb)
+}
+"#,
+        );
+    }
 }


### PR DESCRIPTION
Fixes rust-lang/rust-analyzer#18872.
Added a `!receiver_ty.is_ty_var()` guard in `infer_field_access` to prevent premature `UnresolvedField` diagnostics when the closure parameter type isn't known yet. Added a regression test.