### PR TITLE
fix: enable vscode suggest in strings

### DIFF
--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -3296,6 +3296,13 @@
             }
         ],
         "configurationDefaults": {
+            "[rust]": {
+                "editor.quickSuggestions": {
+                    "other": true,
+                    "comments": false,
+                    "strings": true
+                }
+            },
             "explorer.fileNesting.patterns": {
                 "Cargo.toml": "Cargo.lock"
             }


### PR DESCRIPTION
Fixes rust-lang/rust-analyzer#22001

Reference: https://github.com/rust-lang/rust-analyzer/pull/22015#discussion_r3068203795
