### PR TITLE
internal: migrate `inline_call` assist to `SyntaxEditor`

### DIFF
--- a/crates/ide-assists/src/handlers/inline_call.rs
+++ b/crates/ide-assists/src/handlers/inline_call.rs
@@ -1,6 +1,5 @@
 use std::collections::BTreeSet;
 
-use ast::make;
 use either::Either;
 use hir::{
     FileRange, PathResolution, Semantics, TypeInfo,
@@ -11,7 +10,6 @@ use ide_db::{
     EditionedFileId, RootDatabase,
     base_db::Crate,
     defs::Definition,
-    imports::insert_use::remove_path_if_in_use_stmt,
     path_transform::PathTransform,
     search::{FileReference, FileReferenceNode, SearchScope},
     source_change::SourceChangeBuilder,
@@ -21,9 +19,11 @@ use itertools::{Itertools, izip};
 use syntax::{
     AstNode, NodeOrToken, SyntaxKind,
     ast::{
-        self, HasArgList, HasGenericArgs, Pat, PathExpr, edit::IndentLevel, edit_in_place::Indent,
+        self, HasArgList, HasGenericArgs, Pat, PathExpr,
+        edit::{AstNodeEdit, IndentLevel},
+        make,
     },
-    ted,
+    syntax_editor::SyntaxEditor,
 };
 
 use crate::{
@@ -108,35 +108,62 @@ pub(crate) fn inline_into_callers(acc: &mut Assists, ctx: &AssistContext<'_>) ->
 
             let mut remove_def = true;
             let mut inline_refs_for_file = |file_id: EditionedFileId, refs: Vec<FileReference>| {
+                use syntax::syntax_editor::Removable;
+
                 let file_id = file_id.file_id(ctx.db());
                 builder.edit_file(file_id);
                 let call_krate = ctx.sema.file_to_module_def(file_id).map(|it| it.krate(ctx.db()));
                 let count = refs.len();
-                // The collects are required as we are otherwise iterating while mutating 🙅‍♀️🙅‍♂️
-                let (name_refs, name_refs_use) = split_refs_and_uses(builder, refs, Some);
+                // Split refs into call-site name refs and use-tree paths
+                let (name_refs, use_trees): (Vec<ast::NameRef>, Vec<ast::UseTree>) = refs
+                    .into_iter()
+                    .filter_map(|file_ref| match file_ref.name {
+                        FileReferenceNode::NameRef(name_ref) => Some(name_ref),
+                        _ => None,
+                    })
+                    .partition_map(|name_ref| {
+                        match name_ref.syntax().ancestors().find_map(ast::UseTree::cast) {
+                            Some(use_tree) => Either::Right(use_tree),
+                            None => Either::Left(name_ref),
+                        }
+                    });
                 let call_infos: Vec<_> = name_refs
                     .into_iter()
                     .filter_map(|it| CallInfo::from_name_ref(it, call_krate?.into()))
                     // FIXME: do not handle callsites in macros' parameters, because
                     // directly inlining into macros may cause errors.
                     .filter(|call_info| !ctx.sema.hir_file_for(call_info.node.syntax()).is_macro())
-                    .map(|call_info| {
-                        let mut_node = builder.make_syntax_mut(call_info.node.syntax().clone());
-                        (call_info, mut_node)
-                    })
                     .collect();
-                let replaced = call_infos
-                    .into_iter()
-                    .map(|(call_info, mut_node)| {
-                        let replacement =
-                            inline(&ctx.sema, def_file, function, &func_body, &params, &call_info);
-                        ted::replace(mut_node, replacement.syntax());
-                    })
-                    .count();
-                if replaced + name_refs_use.len() == count {
-                    // we replaced all usages in this file, so we can remove the imports
-                    name_refs_use.iter().for_each(remove_path_if_in_use_stmt);
-                } else {
+                if let Some(first) = call_infos.first() {
+                    let mut editor = builder.make_editor(first.node.syntax());
+                    let replaced = call_infos
+                        .into_iter()
+                        .map(|call_info| {
+                            let replacement = inline(
+                                &ctx.sema, def_file, function, &func_body, &params, &call_info,
+                            );
+                            editor.replace(call_info.node.syntax(), replacement.syntax());
+                        })
+                        .count();
+                    if replaced + use_trees.len() == count {
+                        // we replaced all usages in this file, so we can remove the imports
+                        for use_tree in &use_trees {
+                            if use_tree.use_tree_list().is_some() || use_tree.star_token().is_some()
+                            {
+                                continue;
+                            }
+                            if let Some(use_) = use_tree.syntax().parent().and_then(ast::Use::cast)
+                            {
+                                use_.remove(&mut editor);
+                            } else {
+                                use_tree.remove(&mut editor);
+                            }
+                        }
+                    } else {
+                        remove_def = false;
+                    }
+                    builder.add_file_edits(file_id, editor);
+                } else if use_trees.len() != count {
                     remove_def = false;
                 }
             };
@@ -148,7 +175,9 @@ pub(crate) fn inline_into_callers(acc: &mut Assists, ctx: &AssistContext<'_>) ->
                 None => builder.edit_file(vfs_def_file),
             }
             if remove_def {
-                builder.delete(ast_func.syntax().text_range());
+                let mut editor = builder.make_editor(ast_func.syntax());
+                editor.delete(ast_func.syntax());
+                builder.add_file_edits(vfs_def_file, editor);
             }
         },
     )
@@ -320,19 +349,28 @@ fn inline(
     CallInfo { node, arguments, generic_arg_list, krate }: &CallInfo,
 ) -> ast::Expr {
     let file_id = sema.hir_file_for(fn_body.syntax());
-    let mut body = if let Some(macro_file) = file_id.macro_file() {
+    let body_to_clone = if let Some(macro_file) = file_id.macro_file() {
         cov_mark::hit!(inline_call_defined_in_macro);
         let span_map = sema.db.expansion_span_map(macro_file);
         let body_prettified =
             prettify_macro_expansion(sema.db, fn_body.syntax().clone(), &span_map, *krate);
-        if let Some(body) = ast::BlockExpr::cast(body_prettified) {
-            body
-        } else {
-            fn_body.clone_for_update()
-        }
+        if let Some(body) = ast::BlockExpr::cast(body_prettified) { body } else { fn_body.clone() }
     } else {
-        fn_body.clone_for_update()
+        fn_body.clone()
     };
+
+    // Capture indent level before SyntaxEditor re-roots via clone_subtree.
+    // For non-macro bodies, body_to_clone still has its parent, so from_node
+    // finds the whitespace before `{` and returns the correct source indent level.
+    // For macro/prettified bodies (already re-rooted at 0), from_node returns 0,
+    // which is also correct since prettify_macro_expansion rebuilds indent from 0.
+    let original_body_indent = IndentLevel::from_node(body_to_clone.syntax());
+
+    // The original body's start offset — needed to adjust FileReference ranges
+    // since SyntaxEditor::with_ast_node re-roots the tree to offset 0
+    let body_offset = body_to_clone.syntax().text_range().start();
+    let (mut editor, body) = SyntaxEditor::with_ast_node(&body_to_clone);
+
     let usages_for_locals = |local| {
         Definition::Local(local)
             .usages(sema)
@@ -355,7 +393,7 @@ fn inline(
                     .map(|FileReference { name, range, .. }| match name {
                         FileReferenceNode::NameRef(_) => body
                             .syntax()
-                            .covering_element(range)
+                            .covering_element(range - body_offset)
                             .ancestors()
                             .nth(3)
                             .and_then(ast::PathExpr::cast),
@@ -368,48 +406,59 @@ fn inline(
         })
         .collect();
 
-    if function.self_param(sema.db).is_some() {
-        let this = || {
-            make::name_ref("this")
-                .syntax()
-                .clone_for_update()
-                .first_token()
-                .expect("NameRef should have had a token.")
-        };
-        if let Some(self_local) = params[0].2.as_local(sema.db) {
-            usages_for_locals(self_local)
-                .filter_map(|FileReference { name, range, .. }| match name {
-                    FileReferenceNode::NameRef(_) => Some(body.syntax().covering_element(range)),
-                    _ => None,
-                })
-                .for_each(|usage| {
-                    ted::replace(usage, this());
-                });
-        }
-    }
+    let has_self_param = function.self_param(sema.db).is_some();
 
-    // We should place the following code after last usage of `usages_for_locals`
-    // because `ted::replace` will change the offset in syntax tree, which makes
-    // `FileReference` incorrect
+    // Collect all self token usages upfront (needed when a let binding is emitted).
+    // When self can be directly inlined, the parameter loop handles those PathExprs;
+    // when a let stmt is needed, we rename all self tokens to `this` here.
+    let self_token_usages: Vec<_> = if has_self_param {
+        params[0]
+            .2
+            .as_local(sema.db)
+            .map(|self_local| {
+                usages_for_locals(self_local)
+                    .filter_map(|FileReference { name, range, .. }| match name {
+                        FileReferenceNode::NameRef(_) => {
+                            Some(body.syntax().covering_element(range - body_offset))
+                        }
+                        _ => None,
+                    })
+                    .collect()
+            })
+            .unwrap_or_default()
+    } else {
+        Vec::new()
+    };
+
+    // Replace `Self` type keywords with the actual impl type
     if let Some(imp) =
         sema.ancestors_with_macros(fn_body.syntax().clone()).find_map(ast::Impl::cast)
         && !node.syntax().ancestors().any(|anc| &anc == imp.syntax())
         && let Some(t) = imp.self_ty()
     {
-        while let Some(self_tok) = body
+        let self_tokens: Vec<_> = body
             .syntax()
             .descendants_with_tokens()
             .filter_map(NodeOrToken::into_token)
-            .find(|tok| tok.kind() == SyntaxKind::SELF_TYPE_KW)
-        {
-            let replace_with = t.clone_subtree().syntax().clone_for_update();
-            if !is_in_type_path(&self_tok)
-                && let Some(ty) = ast::Type::cast(replace_with.clone())
-                && let Some(generic_arg_list) = ty.generic_arg_list()
-            {
-                ted::remove(generic_arg_list.syntax());
+            .filter(|tok| tok.kind() == SyntaxKind::SELF_TYPE_KW)
+            .collect();
+        for self_tok in self_tokens {
+            let mut replace_with = t.clone_subtree().syntax().clone_subtree();
+            if !is_in_type_path(&self_tok) {
+                if let Some(ty) = ast::Type::cast(replace_with.clone()) {
+                    if let Some(generic_arg_list) = ty.generic_arg_list() {
+                        // Build replacement without generics using a sub-editor
+                        let (mut sub_editor, sub_root) = SyntaxEditor::new(replace_with.clone());
+                        let generic_node = sub_root
+                            .descendants()
+                            .find(|n| n.text_range() == generic_arg_list.syntax().text_range())
+                            .unwrap();
+                        sub_editor.delete(generic_node);
+                        replace_with = sub_editor.finish().new_root().clone();
+                    }
+                }
             }
-            ted::replace(self_tok, replace_with);
+            editor.replace(self_tok, replace_with);
         }
     }
 
@@ -428,7 +477,7 @@ fn inline(
         }
     }
 
-    let mut let_stmts = Vec::new();
+    let mut let_stmts: Vec<ast::Stmt> = Vec::new();
 
     // Inline parameter expressions or generate `let` statements depending on whether inlining works or not.
     for ((pat, param_ty, param), usages, expr) in izip!(params, param_use_nodes, arguments) {
@@ -486,30 +535,46 @@ fn inline(
                         }
                     }
                 };
-                let_stmts
-                    .push(make::let_stmt(this_pat.into(), ty, Some(expr)).clone_for_update().into())
+                let_stmts.push(make::let_stmt(this_pat.into(), ty, Some(expr)).into())
             } else {
-                let_stmts.push(
-                    make::let_stmt(pat.clone(), ty, Some(expr.clone())).clone_for_update().into(),
-                );
+                let_stmts.push(make::let_stmt(pat.clone(), ty, Some(expr.clone())).into());
             }
         };
+
+        let is_self_param =
+            has_self_param && param.name(sema.db).is_some_and(|name| name == sym::self_);
 
         // check if there is a local var in the function that conflicts with parameter
         // if it does then emit a let statement and continue
         if func_let_vars.contains(&expr.syntax().text().to_string()) {
+            if is_self_param {
+                for usage in &self_token_usages {
+                    let this_token = make::name_ref("this")
+                        .syntax()
+                        .clone_subtree()
+                        .first_token()
+                        .expect("NameRef should have had a token.");
+                    editor.replace(usage.clone(), this_token);
+                }
+            }
             insert_let_stmt();
             continue;
         }
 
-        let inline_direct = |usage, replacement: &ast::Expr| {
-            if let Some(field) = path_expr_as_record_field(usage) {
-                cov_mark::hit!(inline_call_inline_direct_field);
-                field.replace_expr(replacement.clone_for_update());
-            } else {
-                ted::replace(usage.syntax(), replacement.syntax().clone_for_update());
-            }
-        };
+        let inline_direct =
+            |editor: &mut SyntaxEditor, usage: &PathExpr, replacement: &ast::Expr| {
+                if let Some(field) = path_expr_as_record_field(usage) {
+                    cov_mark::hit!(inline_call_inline_direct_field);
+                    let field_name = field.field_name().unwrap();
+                    let new_field = make::record_expr_field(
+                        make::name_ref(&field_name.text()),
+                        Some(replacement.clone()),
+                    );
+                    editor.replace(field.syntax(), new_field.syntax());
+                } else {
+                    editor.replace(usage.syntax(), replacement.syntax().clone_subtree());
+                }
+            };
 
         match usages {
             // inline single use closure arguments
@@ -519,29 +584,45 @@ fn inline(
             {
                 cov_mark::hit!(inline_call_inline_closure);
                 let expr = make::expr_paren(expr.clone()).into();
-                inline_direct(usage, &expr);
+                inline_direct(&mut editor, usage, &expr);
             }
             // inline single use literals
             [usage] if matches!(expr, ast::Expr::Literal(_)) => {
                 cov_mark::hit!(inline_call_inline_literal);
-                inline_direct(usage, expr);
+                inline_direct(&mut editor, usage, expr);
             }
             // inline direct local arguments
             [_, ..] if expr_as_name_ref(expr).is_some() => {
                 cov_mark::hit!(inline_call_inline_locals);
-                usages.iter().for_each(|usage| inline_direct(usage, expr));
+                usages.iter().for_each(|usage| inline_direct(&mut editor, usage, expr));
             }
             // can't inline, emit a let statement
             _ => {
+                if is_self_param {
+                    // Rename all `self` tokens to `this` so the let binding matches.
+                    for usage in &self_token_usages {
+                        let this_token = make::name_ref("this")
+                            .syntax()
+                            .clone_subtree()
+                            .first_token()
+                            .expect("NameRef should have had a token.");
+                        editor.replace(usage.clone(), this_token);
+                    }
+                }
                 insert_let_stmt();
             }
         }
     }
 
+    // Apply all edits to get the transformed body
+    let edit = editor.finish();
+    let mut body = ast::BlockExpr::cast(edit.new_root().clone())
+        .expect("editor root should still be a BlockExpr");
+
+    // Apply generic substitution (needs immutable tree)
     if let Some(generic_arg_list) = generic_arg_list.clone()
         && let Some((target, source)) = &sema.scope(node.syntax()).zip(sema.scope(fn_body.syntax()))
     {
-        body.reindent_to(IndentLevel(0));
         if let Some(new_body) = ast::BlockExpr::cast(
             PathTransform::function_call(target, source, function, generic_arg_list)
                 .apply(body.syntax()),
@@ -553,31 +634,30 @@ fn inline(
     let is_async_fn = function.is_async(sema.db);
     if is_async_fn {
         cov_mark::hit!(inline_call_async_fn);
-        body = make::async_move_block_expr(body.statements(), body.tail_expr()).clone_for_update();
+        body = make::async_move_block_expr(body.statements(), body.tail_expr());
 
         // Arguments should be evaluated outside the async block, and then moved into it.
         if !let_stmts.is_empty() {
             cov_mark::hit!(inline_call_async_fn_with_let_stmts);
-            body.indent(IndentLevel(1));
-            body = make::block_expr(let_stmts, Some(body.into())).clone_for_update();
+            body = body.indent(IndentLevel(1));
+            body = make::block_expr(let_stmts, Some(body.into()));
         }
-    } else if let Some(stmt_list) = body.stmt_list() {
-        let position = stmt_list.l_curly_token().expect("L_CURLY for StatementList is missing.");
-        let_stmts.into_iter().rev().for_each(|let_stmt| {
-            ted::insert(ted::Position::after(position.clone()), let_stmt.syntax().clone());
-        });
+    } else if !let_stmts.is_empty() {
+        // Prepend let statements to the body's existing statements
+        let stmts: Vec<ast::Stmt> = let_stmts.into_iter().chain(body.statements()).collect();
+        body = make::block_expr(stmts, body.tail_expr());
     }
 
     let original_indentation = match node {
         ast::CallableExpr::Call(it) => it.indent_level(),
         ast::CallableExpr::MethodCall(it) => it.indent_level(),
     };
-    body.reindent_to(original_indentation);
+    body = body.dedent(original_body_indent).indent(original_indentation);
 
     let no_stmts = body.statements().next().is_none();
     match body.tail_expr() {
         Some(expr) if matches!(expr, ast::Expr::ClosureExpr(_)) && no_stmts => {
-            make::expr_paren(expr).clone_for_update().into()
+            make::expr_paren(expr).into()
         }
         Some(expr) if !is_async_fn && no_stmts => expr,
         _ => match node
@@ -587,7 +667,7 @@ fn inline(
             .and_then(|bin_expr| bin_expr.lhs())
         {
             Some(lhs) if lhs.syntax() == node.syntax() => {
-                make::expr_paren(ast::Expr::BlockExpr(body)).clone_for_update().into()
+                make::expr_paren(ast::Expr::BlockExpr(body)).into()
             }
             _ => ast::Expr::BlockExpr(body),
         },

--- a/crates/ide-assists/src/handlers/inline_call.rs
+++ b/crates/ide-assists/src/handlers/inline_call.rs
@@ -17,7 +17,7 @@ use ide_db::{
 };
 use itertools::{Itertools, izip};
 use syntax::{
-    AstNode, NodeOrToken, SyntaxKind,
+    AstNode, NodeOrToken, SyntaxKind, TextRange,
     ast::{
         self, HasArgList, HasGenericArgs, Pat, PathExpr,
         edit::{AstNodeEdit, IndentLevel},
@@ -121,6 +121,18 @@ pub(crate) fn inline_into_callers(acc: &mut Assists, ctx: &AssistContext<'_>) ->
                     // directly inlining into macros may cause errors.
                     .filter(|call_info| !ctx.sema.hir_file_for(call_info.node.syntax()).is_macro())
                     .collect();
+
+                // Skip calls nested inside other calls being inlined to avoid overlapping
+                // edits. Nested calls are implicitly replaced when the outer call is inlined.
+                let all_ranges: Vec<TextRange> =
+                    call_infos.iter().map(|ci| ci.node.syntax().text_range()).collect();
+                let (call_infos, nested_infos): (Vec<_>, Vec<_>) =
+                    call_infos.into_iter().partition(|ci| {
+                        let r = ci.node.syntax().text_range();
+                        !all_ranges.iter().any(|&other| other != r && other.contains_range(r))
+                    });
+                let nested_count = nested_infos.len();
+
                 let anchor = call_infos
                     .first()
                     .map(|ci| ci.node.syntax().clone())
@@ -138,7 +150,7 @@ pub(crate) fn inline_into_callers(acc: &mut Assists, ctx: &AssistContext<'_>) ->
                             editor.replace(call_info.node.syntax(), replacement.syntax());
                         })
                         .count();
-                    if replaced + use_trees.len() == count {
+                    if replaced + nested_count + use_trees.len() == count {
                         // we replaced all usages in this file, so we can remove the imports
                         for use_tree in &use_trees {
                             remove_use_tree_if_simple(use_tree, editor);
@@ -332,7 +344,7 @@ fn inline(
     CallInfo { node, arguments, generic_arg_list, krate }: &CallInfo,
     file_editor: &SyntaxEditor,
 ) -> ast::Expr {
-    let factory = file_editor.make();
+    let make = file_editor.make();
     let file_id = sema.hir_file_for(fn_body.syntax());
     let body_to_clone = if let Some(macro_file) = file_id.macro_file() {
         cov_mark::hit!(inline_call_defined_in_macro);
@@ -433,7 +445,7 @@ fn inline(
                     "",
                     1,
                 );
-                factory.ty(&stripped).syntax().clone()
+                editor.make().ty(&stripped).syntax().clone()
             } else {
                 t.syntax().clone()
             };
@@ -458,8 +470,12 @@ fn inline(
 
     let mut let_stmts: Vec<ast::Stmt> = Vec::new();
 
-    let this_token =
-        factory.name_ref("this").syntax().first_token().expect("NameRef should have had a token.");
+    let this_token = editor
+        .make()
+        .name_ref("this")
+        .syntax()
+        .first_token()
+        .expect("NameRef should have had a token.");
     let rewrite_self_to_this = |editor: &SyntaxEditor| {
         for usage in &self_token_usages {
             editor.replace(usage.clone(), this_token.clone());
@@ -494,7 +510,7 @@ fn inline(
             let is_self = param.name(sema.db).is_some_and(|name| name == sym::self_);
 
             if is_self {
-                let mut this_pat = factory.ident_pat(false, false, factory.name("this"));
+                let mut this_pat = make.ident_pat(false, false, make.name("this"));
                 let mut expr = expr.clone();
                 if let Pat::IdentPat(pat) = pat {
                     match (pat.ref_token(), pat.mut_token()) {
@@ -502,11 +518,11 @@ fn inline(
                         (None, None) => {}
                         // mut self => let mut this = obj
                         (None, Some(_)) => {
-                            this_pat = factory.ident_pat(false, true, factory.name("this"));
+                            this_pat = make.ident_pat(false, true, make.name("this"));
                         }
                         // &self => let this = &obj
                         (Some(_), None) => {
-                            expr = factory.expr_ref(expr, false);
+                            expr = make.expr_ref(expr, false);
                         }
                         // let foo = &mut X; &mut self => let this = &mut obj
                         // let mut foo = X;  &mut self => let this = &mut *obj (reborrow)
@@ -515,16 +531,16 @@ fn inline(
                                 .type_of_expr(&expr)
                                 .map(|ty| ty.original.is_mutable_reference());
                             expr = if let Some(true) = should_reborrow {
-                                factory.expr_reborrow(expr)
+                                make.expr_reborrow(expr)
                             } else {
-                                factory.expr_ref(expr, true)
+                                make.expr_ref(expr, true)
                             };
                         }
                     }
                 };
-                let_stmts.push(factory.let_stmt(this_pat.into(), ty, Some(expr)).into())
+                let_stmts.push(make.let_stmt(this_pat.into(), ty, Some(expr)).into())
             } else {
-                let_stmts.push(factory.let_stmt(pat.clone(), ty, Some(expr.clone())).into());
+                let_stmts.push(make.let_stmt(pat.clone(), ty, Some(expr.clone())).into());
             }
         };
 
@@ -545,8 +561,8 @@ fn inline(
             if let Some(field) = path_expr_as_record_field(usage) {
                 cov_mark::hit!(inline_call_inline_direct_field);
                 let field_name = field.field_name().unwrap();
-                let new_field = factory.record_expr_field(
-                    factory.name_ref(&field_name.text()),
+                let new_field = editor.make().record_expr_field(
+                    editor.make().name_ref(&field_name.text()),
                     Some(replacement.clone()),
                 );
                 editor.replace(field.syntax(), new_field.syntax());
@@ -562,7 +578,7 @@ fn inline(
                     && usage.syntax().parent().and_then(ast::Expr::cast).is_some() =>
             {
                 cov_mark::hit!(inline_call_inline_closure);
-                let expr = factory.expr_paren(expr.clone()).into();
+                let expr = editor.make().expr_paren(expr.clone()).into();
                 inline_direct(&editor, usage, &expr);
             }
             // inline single use literals
@@ -605,18 +621,18 @@ fn inline(
     let is_async_fn = function.is_async(sema.db);
     if is_async_fn {
         cov_mark::hit!(inline_call_async_fn);
-        body = factory.async_move_block_expr(body.statements(), body.tail_expr());
+        body = make.async_move_block_expr(body.statements(), body.tail_expr());
 
         // Arguments should be evaluated outside the async block, and then moved into it.
         if !let_stmts.is_empty() {
             cov_mark::hit!(inline_call_async_fn_with_let_stmts);
             body = body.indent(IndentLevel(1));
-            body = factory.block_expr(let_stmts, Some(body.into()));
+            body = make.block_expr(let_stmts, Some(body.into()));
         }
     } else if !let_stmts.is_empty() {
         // Prepend let statements to the body's existing statements
         let stmts: Vec<ast::Stmt> = let_stmts.into_iter().chain(body.statements()).collect();
-        body = factory.block_expr(stmts, body.tail_expr());
+        body = make.block_expr(stmts, body.tail_expr());
     }
 
     let original_indentation = match node {
@@ -628,7 +644,7 @@ fn inline(
     let no_stmts = body.statements().next().is_none();
     match body.tail_expr() {
         Some(expr) if matches!(expr, ast::Expr::ClosureExpr(_)) && no_stmts => {
-            factory.expr_paren(expr).into()
+            make.expr_paren(expr).into()
         }
         Some(expr) if !is_async_fn && no_stmts => expr,
         _ => match node
@@ -638,7 +654,7 @@ fn inline(
             .and_then(|bin_expr| bin_expr.lhs())
         {
             Some(lhs) if lhs.syntax() == node.syntax() => {
-                factory.expr_paren(ast::Expr::BlockExpr(body)).into()
+                make.expr_paren(ast::Expr::BlockExpr(body)).into()
             }
             _ => ast::Expr::BlockExpr(body),
         },
@@ -1914,6 +1930,28 @@ fn _hash2(self_: &u64, state: &mut u64) {
 }
 "#,
         )
+    }
+
+    #[test]
+    fn inline_callers_nested_calls() {
+        check_assist(
+            inline_into_callers,
+            r#"
+fn id$0(x: u32) -> u32 { x }
+fn main() {
+    let x = id(id(1));
+}
+"#,
+            r#"
+
+fn main() {
+    let x = {
+        let x = id(1);
+        x
+    };
+}
+"#,
+        );
     }
 
     #[test]

--- a/crates/ide-assists/src/handlers/inline_call.rs
+++ b/crates/ide-assists/src/handlers/inline_call.rs
@@ -7,7 +7,7 @@ use hir::{
     sym,
 };
 use ide_db::{
-    EditionedFileId, RootDatabase,
+    EditionedFileId, FileId, FxHashMap, RootDatabase,
     base_db::Crate,
     defs::Definition,
     imports::insert_use::remove_use_tree_if_simple,
@@ -107,6 +107,7 @@ pub(crate) fn inline_into_callers(acc: &mut Assists, ctx: &AssistContext<'_>) ->
             let mut usages = usages.all();
             let current_file_usage = usages.references.remove(&def_file);
 
+            let mut file_editors: FxHashMap<FileId, SyntaxEditor> = FxHashMap::default();
             let mut remove_def = true;
             let mut inline_refs_for_file = |file_id: EditionedFileId, refs: Vec<FileReference>| {
                 let file_id = file_id.file_id(ctx.db());
@@ -126,12 +127,14 @@ pub(crate) fn inline_into_callers(acc: &mut Assists, ctx: &AssistContext<'_>) ->
                     .map(|ci| ci.node.syntax().clone())
                     .or_else(|| use_trees.first().map(|ut| ut.syntax().clone()));
                 if let Some(anchor) = anchor {
-                    let mut editor = builder.make_editor(&anchor);
+                    let editor =
+                        file_editors.entry(file_id).or_insert_with(|| builder.make_editor(&anchor));
                     let replaced = call_infos
                         .into_iter()
                         .map(|call_info| {
                             let replacement = inline(
                                 &ctx.sema, def_file, function, &func_body, &params, &call_info,
+                                editor,
                             );
                             editor.replace(call_info.node.syntax(), replacement.syntax());
                         })
@@ -139,12 +142,11 @@ pub(crate) fn inline_into_callers(acc: &mut Assists, ctx: &AssistContext<'_>) ->
                     if replaced + use_trees.len() == count {
                         // we replaced all usages in this file, so we can remove the imports
                         for use_tree in &use_trees {
-                            remove_use_tree_if_simple(use_tree, &mut editor);
+                            remove_use_tree_if_simple(use_tree, editor);
                         }
                     } else {
                         remove_def = false;
                     }
-                    builder.add_file_edits(file_id, editor);
                 } else if use_trees.len() != count {
                     remove_def = false;
                 }
@@ -157,9 +159,13 @@ pub(crate) fn inline_into_callers(acc: &mut Assists, ctx: &AssistContext<'_>) ->
                 None => builder.edit_file(vfs_def_file),
             }
             if remove_def {
-                let mut editor = builder.make_editor(ast_func.syntax());
+                let editor = file_editors
+                    .entry(vfs_def_file)
+                    .or_insert_with(|| builder.make_editor(ast_func.syntax()));
                 editor.delete(ast_func.syntax());
-                builder.add_file_edits(vfs_def_file, editor);
+            }
+            for (file_id, editor) in file_editors {
+                builder.add_file_edits(file_id, editor);
             }
         },
     )
@@ -245,14 +251,11 @@ pub(crate) fn inline_call(acc: &mut Assists, ctx: &AssistContext<'_>) -> Option<
 
     let syntax = call_info.node.syntax().clone();
     acc.add(AssistId::refactor_inline("inline_call"), label, syntax.text_range(), |builder| {
-        let replacement = inline(&ctx.sema, file_id, function, &fn_body, &params, &call_info);
-        builder.replace_ast(
-            match call_info.node {
-                ast::CallableExpr::Call(it) => ast::Expr::CallExpr(it),
-                ast::CallableExpr::MethodCall(it) => ast::Expr::MethodCallExpr(it),
-            },
-            replacement,
-        );
+        let mut editor = builder.make_editor(call_info.node.syntax());
+        let replacement =
+            inline(&ctx.sema, file_id, function, &fn_body, &params, &call_info, &mut editor);
+        editor.replace(call_info.node.syntax(), replacement.syntax());
+        builder.add_file_edits(ctx.vfs_file_id(), editor);
     })
 }
 
@@ -328,7 +331,9 @@ fn inline(
     fn_body: &ast::BlockExpr,
     params: &[(ast::Pat, Option<ast::Type>, hir::Param<'_>)],
     CallInfo { node, arguments, generic_arg_list, krate }: &CallInfo,
+    file_editor: &mut SyntaxEditor,
 ) -> ast::Expr {
+    let factory = SyntaxFactory::with_mappings();
     let file_id = sema.hir_file_for(fn_body.syntax());
     let body_to_clone = if let Some(macro_file) = file_id.macro_file() {
         cov_mark::hit!(inline_call_defined_in_macro);
@@ -340,15 +345,8 @@ fn inline(
         fn_body.clone()
     };
 
-    // Capture indent level before SyntaxEditor re-roots via clone_subtree.
-    // For non-macro bodies, body_to_clone still has its parent, so from_node
-    // finds the whitespace before `{` and returns the correct source indent level.
-    // For macro/prettified bodies (already re-rooted at 0), from_node returns 0,
-    // which is also correct since prettify_macro_expansion rebuilds indent from 0.
+    // Capture before `with_ast_node` re-roots and loses the source-relative position.
     let original_body_indent = IndentLevel::from_node(body_to_clone.syntax());
-
-    // The original body's start offset — needed to adjust FileReference ranges
-    // since SyntaxEditor::with_ast_node re-roots the tree to offset 0
     let body_offset = body_to_clone.syntax().text_range().start();
     let (mut editor, body) = SyntaxEditor::with_ast_node(&body_to_clone);
 
@@ -424,20 +422,22 @@ fn inline(
             .filter(|tok| tok.kind() == SyntaxKind::SELF_TYPE_KW)
             .collect();
         for self_tok in self_tokens {
-            let mut replace_with = t.syntax().clone_subtree();
-            if !is_in_type_path(&self_tok)
-                && let Some(ty) = ast::Type::cast(replace_with.clone())
-                && let Some(generic_arg_list) = ty.generic_arg_list()
+            let replace_with = if !is_in_type_path(&self_tok)
+                && let Some(generic_arg_list) = t.generic_arg_list()
             {
-                // Build replacement without generics using a sub-editor
-                let (mut sub_editor, sub_root) = SyntaxEditor::new(replace_with.clone());
-                let generic_node = sub_root
-                    .descendants()
-                    .find(|n| n.text_range() == generic_arg_list.syntax().text_range())
-                    .unwrap();
-                sub_editor.delete(generic_node);
-                replace_with = sub_editor.finish().new_root().clone();
-            }
+                // Strip the outer generic arg list and reparse, since turbofish-less
+                // generics aren't valid in expression position. The outermost
+                // `GenericArgList` text is unique within `t`'s text (any inner generics
+                // are nested inside it), so `replacen(.., 1)` is safe.
+                let stripped = t.syntax().text().to_string().replacen(
+                    &generic_arg_list.syntax().text().to_string(),
+                    "",
+                    1,
+                );
+                factory.ty(&stripped).syntax().clone()
+            } else {
+                t.syntax().clone()
+            };
             editor.replace(self_tok, replace_with);
         }
     }
@@ -458,6 +458,14 @@ fn inline(
     }
 
     let mut let_stmts: Vec<ast::Stmt> = Vec::new();
+
+    let this_token =
+        factory.name_ref("this").syntax().first_token().expect("NameRef should have had a token.");
+    let rewrite_self_to_this = |editor: &mut SyntaxEditor| {
+        for usage in &self_token_usages {
+            editor.replace(usage.clone(), this_token.clone());
+        }
+    };
 
     // Inline parameter expressions or generate `let` statements depending on whether inlining works or not.
     for ((pat, param_ty, param), usages, expr) in izip!(params, param_use_nodes, arguments) {
@@ -487,7 +495,7 @@ fn inline(
             let is_self = param.name(sema.db).is_some_and(|name| name == sym::self_);
 
             if is_self {
-                let mut this_pat = make::ident_pat(false, false, make::name("this"));
+                let mut this_pat = factory.ident_pat(false, false, factory.name("this"));
                 let mut expr = expr.clone();
                 if let Pat::IdentPat(pat) = pat {
                     match (pat.ref_token(), pat.mut_token()) {
@@ -495,11 +503,11 @@ fn inline(
                         (None, None) => {}
                         // mut self => let mut this = obj
                         (None, Some(_)) => {
-                            this_pat = make::ident_pat(false, true, make::name("this"));
+                            this_pat = factory.ident_pat(false, true, factory.name("this"));
                         }
                         // &self => let this = &obj
                         (Some(_), None) => {
-                            expr = make::expr_ref(expr, false);
+                            expr = factory.expr_ref(expr, false);
                         }
                         // let foo = &mut X; &mut self => let this = &mut obj
                         // let mut foo = X;  &mut self => let this = &mut *obj (reborrow)
@@ -508,16 +516,16 @@ fn inline(
                                 .type_of_expr(&expr)
                                 .map(|ty| ty.original.is_mutable_reference());
                             expr = if let Some(true) = should_reborrow {
-                                make::expr_reborrow(expr)
+                                factory.expr_reborrow(expr)
                             } else {
-                                make::expr_ref(expr, true)
+                                factory.expr_ref(expr, true)
                             };
                         }
                     }
                 };
-                let_stmts.push(make::let_stmt(this_pat.into(), ty, Some(expr)).into())
+                let_stmts.push(factory.let_stmt(this_pat.into(), ty, Some(expr)).into())
             } else {
-                let_stmts.push(make::let_stmt(pat.clone(), ty, Some(expr.clone())).into());
+                let_stmts.push(factory.let_stmt(pat.clone(), ty, Some(expr.clone())).into());
             }
         };
 
@@ -528,13 +536,7 @@ fn inline(
         // if it does then emit a let statement and continue
         if func_let_vars.contains(&expr.syntax().text().to_string()) {
             if is_self_param {
-                for usage in &self_token_usages {
-                    let this_token = make::name_ref("this")
-                        .syntax()
-                        .first_token()
-                        .expect("NameRef should have had a token.");
-                    editor.replace(usage.clone(), this_token);
-                }
+                rewrite_self_to_this(&mut editor);
             }
             insert_let_stmt();
             continue;
@@ -545,7 +547,6 @@ fn inline(
                 if let Some(field) = path_expr_as_record_field(usage) {
                     cov_mark::hit!(inline_call_inline_direct_field);
                     let field_name = field.field_name().unwrap();
-                    let factory = SyntaxFactory::without_mappings();
                     let new_field = factory.record_expr_field(
                         factory.name_ref(&field_name.text()),
                         Some(replacement.clone()),
@@ -563,7 +564,7 @@ fn inline(
                     && usage.syntax().parent().and_then(ast::Expr::cast).is_some() =>
             {
                 cov_mark::hit!(inline_call_inline_closure);
-                let expr = make::expr_paren(expr.clone()).into();
+                let expr = factory.expr_paren(expr.clone()).into();
                 inline_direct(&mut editor, usage, &expr);
             }
             // inline single use literals
@@ -580,14 +581,7 @@ fn inline(
             _ => {
                 if is_self_param {
                     // Rename all `self` tokens to `this` so the let binding matches.
-                    for usage in &self_token_usages {
-                        let this_token = make::name_ref("this")
-                            .syntax()
-                            .clone_subtree()
-                            .first_token()
-                            .expect("NameRef should have had a token.");
-                        editor.replace(usage.clone(), this_token);
-                    }
+                    rewrite_self_to_this(&mut editor);
                 }
                 insert_let_stmt();
             }
@@ -610,11 +604,10 @@ fn inline(
         body = new_body;
     }
 
-    let factory = SyntaxFactory::without_mappings();
     let is_async_fn = function.is_async(sema.db);
     if is_async_fn {
         cov_mark::hit!(inline_call_async_fn);
-        body = make::async_move_block_expr(body.statements(), body.tail_expr());
+        body = factory.async_move_block_expr(body.statements(), body.tail_expr());
 
         // Arguments should be evaluated outside the async block, and then moved into it.
         if !let_stmts.is_empty() {
@@ -635,7 +628,7 @@ fn inline(
     body = body.dedent(original_body_indent).indent(original_indentation);
 
     let no_stmts = body.statements().next().is_none();
-    match body.tail_expr() {
+    let result = match body.tail_expr() {
         Some(expr) if matches!(expr, ast::Expr::ClosureExpr(_)) && no_stmts => {
             factory.expr_paren(expr).into()
         }
@@ -651,7 +644,9 @@ fn inline(
             }
             _ => ast::Expr::BlockExpr(body),
         },
-    }
+    };
+    file_editor.add_mappings(factory.finish_with_mappings());
+    result
 }
 
 fn is_in_type_path(self_tok: &syntax::SyntaxToken) -> bool {

--- a/crates/ide-assists/src/handlers/inline_call.rs
+++ b/crates/ide-assists/src/handlers/inline_call.rs
@@ -357,7 +357,7 @@ fn inline(
     };
 
     // Capture before `with_ast_node` re-roots and loses the source-relative position.
-    let original_body_indent = IndentLevel::from_node(body_to_clone.syntax());
+    let mut original_body_indent = IndentLevel::from_node(body_to_clone.syntax());
     let body_offset = body_to_clone.syntax().text_range().start();
     let (editor, body) = SyntaxEditor::with_ast_node(&body_to_clone);
 
@@ -628,6 +628,7 @@ fn inline(
         // Prepend let statements to the body's existing statements
         let stmts: Vec<ast::Stmt> = let_stmts.into_iter().chain(body.statements()).collect();
         body = make.block_expr(stmts, body.tail_expr());
+        original_body_indent = IndentLevel(0);
     }
 
     let original_indentation = match node {

--- a/crates/ide-assists/src/handlers/inline_call.rs
+++ b/crates/ide-assists/src/handlers/inline_call.rs
@@ -22,7 +22,6 @@ use syntax::{
         self, HasArgList, HasGenericArgs, Pat, PathExpr,
         edit::{AstNodeEdit, IndentLevel},
         make,
-        syntax_factory::SyntaxFactory,
     },
     syntax_editor::SyntaxEditor,
 };
@@ -251,9 +250,9 @@ pub(crate) fn inline_call(acc: &mut Assists, ctx: &AssistContext<'_>) -> Option<
 
     let syntax = call_info.node.syntax().clone();
     acc.add(AssistId::refactor_inline("inline_call"), label, syntax.text_range(), |builder| {
-        let mut editor = builder.make_editor(call_info.node.syntax());
+        let editor = builder.make_editor(call_info.node.syntax());
         let replacement =
-            inline(&ctx.sema, file_id, function, &fn_body, &params, &call_info, &mut editor);
+            inline(&ctx.sema, file_id, function, &fn_body, &params, &call_info, &editor);
         editor.replace(call_info.node.syntax(), replacement.syntax());
         builder.add_file_edits(ctx.vfs_file_id(), editor);
     })
@@ -331,9 +330,9 @@ fn inline(
     fn_body: &ast::BlockExpr,
     params: &[(ast::Pat, Option<ast::Type>, hir::Param<'_>)],
     CallInfo { node, arguments, generic_arg_list, krate }: &CallInfo,
-    file_editor: &mut SyntaxEditor,
+    file_editor: &SyntaxEditor,
 ) -> ast::Expr {
-    let factory = SyntaxFactory::with_mappings();
+    let factory = file_editor.make();
     let file_id = sema.hir_file_for(fn_body.syntax());
     let body_to_clone = if let Some(macro_file) = file_id.macro_file() {
         cov_mark::hit!(inline_call_defined_in_macro);
@@ -348,7 +347,7 @@ fn inline(
     // Capture before `with_ast_node` re-roots and loses the source-relative position.
     let original_body_indent = IndentLevel::from_node(body_to_clone.syntax());
     let body_offset = body_to_clone.syntax().text_range().start();
-    let (mut editor, body) = SyntaxEditor::with_ast_node(&body_to_clone);
+    let (editor, body) = SyntaxEditor::with_ast_node(&body_to_clone);
 
     let usages_for_locals = |local| {
         Definition::Local(local)
@@ -461,7 +460,7 @@ fn inline(
 
     let this_token =
         factory.name_ref("this").syntax().first_token().expect("NameRef should have had a token.");
-    let rewrite_self_to_this = |editor: &mut SyntaxEditor| {
+    let rewrite_self_to_this = |editor: &SyntaxEditor| {
         for usage in &self_token_usages {
             editor.replace(usage.clone(), this_token.clone());
         }
@@ -536,26 +535,25 @@ fn inline(
         // if it does then emit a let statement and continue
         if func_let_vars.contains(&expr.syntax().text().to_string()) {
             if is_self_param {
-                rewrite_self_to_this(&mut editor);
+                rewrite_self_to_this(&editor);
             }
             insert_let_stmt();
             continue;
         }
 
-        let inline_direct =
-            |editor: &mut SyntaxEditor, usage: &PathExpr, replacement: &ast::Expr| {
-                if let Some(field) = path_expr_as_record_field(usage) {
-                    cov_mark::hit!(inline_call_inline_direct_field);
-                    let field_name = field.field_name().unwrap();
-                    let new_field = factory.record_expr_field(
-                        factory.name_ref(&field_name.text()),
-                        Some(replacement.clone()),
-                    );
-                    editor.replace(field.syntax(), new_field.syntax());
-                } else {
-                    editor.replace(usage.syntax(), replacement.syntax());
-                }
-            };
+        let inline_direct = |editor: &SyntaxEditor, usage: &PathExpr, replacement: &ast::Expr| {
+            if let Some(field) = path_expr_as_record_field(usage) {
+                cov_mark::hit!(inline_call_inline_direct_field);
+                let field_name = field.field_name().unwrap();
+                let new_field = factory.record_expr_field(
+                    factory.name_ref(&field_name.text()),
+                    Some(replacement.clone()),
+                );
+                editor.replace(field.syntax(), new_field.syntax());
+            } else {
+                editor.replace(usage.syntax(), replacement.syntax());
+            }
+        };
 
         match usages {
             // inline single use closure arguments
@@ -565,23 +563,23 @@ fn inline(
             {
                 cov_mark::hit!(inline_call_inline_closure);
                 let expr = factory.expr_paren(expr.clone()).into();
-                inline_direct(&mut editor, usage, &expr);
+                inline_direct(&editor, usage, &expr);
             }
             // inline single use literals
             [usage] if matches!(expr, ast::Expr::Literal(_)) => {
                 cov_mark::hit!(inline_call_inline_literal);
-                inline_direct(&mut editor, usage, expr);
+                inline_direct(&editor, usage, expr);
             }
             // inline direct local arguments
             [_, ..] if expr_as_name_ref(expr).is_some() => {
                 cov_mark::hit!(inline_call_inline_locals);
-                usages.iter().for_each(|usage| inline_direct(&mut editor, usage, expr));
+                usages.iter().for_each(|usage| inline_direct(&editor, usage, expr));
             }
             // can't inline, emit a let statement
             _ => {
                 if is_self_param {
                     // Rename all `self` tokens to `this` so the let binding matches.
-                    rewrite_self_to_this(&mut editor);
+                    rewrite_self_to_this(&editor);
                 }
                 insert_let_stmt();
             }
@@ -628,7 +626,7 @@ fn inline(
     body = body.dedent(original_body_indent).indent(original_indentation);
 
     let no_stmts = body.statements().next().is_none();
-    let result = match body.tail_expr() {
+    match body.tail_expr() {
         Some(expr) if matches!(expr, ast::Expr::ClosureExpr(_)) && no_stmts => {
             factory.expr_paren(expr).into()
         }
@@ -644,9 +642,7 @@ fn inline(
             }
             _ => ast::Expr::BlockExpr(body),
         },
-    };
-    file_editor.add_mappings(factory.finish_with_mappings());
-    result
+    }
 }
 
 fn is_in_type_path(self_tok: &syntax::SyntaxToken) -> bool {

--- a/crates/ide-assists/src/handlers/inline_call.rs
+++ b/crates/ide-assists/src/handlers/inline_call.rs
@@ -560,12 +560,7 @@ fn inline(
         let inline_direct = |editor: &SyntaxEditor, usage: &PathExpr, replacement: &ast::Expr| {
             if let Some(field) = path_expr_as_record_field(usage) {
                 cov_mark::hit!(inline_call_inline_direct_field);
-                let field_name = field.field_name().unwrap();
-                let new_field = editor.make().record_expr_field(
-                    editor.make().name_ref(&field_name.text()),
-                    Some(replacement.clone()),
-                );
-                editor.replace(field.syntax(), new_field.syntax());
+                field.replace_expr_with_editor(editor, replacement.clone());
             } else {
                 editor.replace(usage.syntax(), replacement.syntax());
             }

--- a/crates/ide-assists/src/handlers/inline_call.rs
+++ b/crates/ide-assists/src/handlers/inline_call.rs
@@ -444,19 +444,18 @@ fn inline(
             .collect();
         for self_tok in self_tokens {
             let mut replace_with = t.clone_subtree().syntax().clone_subtree();
-            if !is_in_type_path(&self_tok) {
-                if let Some(ty) = ast::Type::cast(replace_with.clone()) {
-                    if let Some(generic_arg_list) = ty.generic_arg_list() {
-                        // Build replacement without generics using a sub-editor
-                        let (mut sub_editor, sub_root) = SyntaxEditor::new(replace_with.clone());
-                        let generic_node = sub_root
-                            .descendants()
-                            .find(|n| n.text_range() == generic_arg_list.syntax().text_range())
-                            .unwrap();
-                        sub_editor.delete(generic_node);
-                        replace_with = sub_editor.finish().new_root().clone();
-                    }
-                }
+            if !is_in_type_path(&self_tok)
+                && let Some(ty) = ast::Type::cast(replace_with.clone())
+                && let Some(generic_arg_list) = ty.generic_arg_list()
+            {
+                // Build replacement without generics using a sub-editor
+                let (mut sub_editor, sub_root) = SyntaxEditor::new(replace_with.clone());
+                let generic_node = sub_root
+                    .descendants()
+                    .find(|n| n.text_range() == generic_arg_list.syntax().text_range())
+                    .unwrap();
+                sub_editor.delete(generic_node);
+                replace_with = sub_editor.finish().new_root().clone();
             }
             editor.replace(self_tok, replace_with);
         }
@@ -622,13 +621,12 @@ fn inline(
     // Apply generic substitution (needs immutable tree)
     if let Some(generic_arg_list) = generic_arg_list.clone()
         && let Some((target, source)) = &sema.scope(node.syntax()).zip(sema.scope(fn_body.syntax()))
-    {
-        if let Some(new_body) = ast::BlockExpr::cast(
+        && let Some(new_body) = ast::BlockExpr::cast(
             PathTransform::function_call(target, source, function, generic_arg_list)
                 .apply(body.syntax()),
-        ) {
-            body = new_body;
-        }
+        )
+    {
+        body = new_body;
     }
 
     let is_async_fn = function.is_async(sema.db);

--- a/crates/ide-assists/src/handlers/inline_call.rs
+++ b/crates/ide-assists/src/handlers/inline_call.rs
@@ -10,9 +10,9 @@ use ide_db::{
     EditionedFileId, RootDatabase,
     base_db::Crate,
     defs::Definition,
+    imports::insert_use::remove_use_tree_if_simple,
     path_transform::PathTransform,
     search::{FileReference, FileReferenceNode, SearchScope},
-    source_change::SourceChangeBuilder,
     syntax_helpers::{node_ext::expr_as_name_ref, prettify_macro_expansion},
 };
 use itertools::{Itertools, izip};
@@ -22,6 +22,7 @@ use syntax::{
         self, HasArgList, HasGenericArgs, Pat, PathExpr,
         edit::{AstNodeEdit, IndentLevel},
         make,
+        syntax_factory::SyntaxFactory,
     },
     syntax_editor::SyntaxEditor,
 };
@@ -108,25 +109,11 @@ pub(crate) fn inline_into_callers(acc: &mut Assists, ctx: &AssistContext<'_>) ->
 
             let mut remove_def = true;
             let mut inline_refs_for_file = |file_id: EditionedFileId, refs: Vec<FileReference>| {
-                use syntax::syntax_editor::Removable;
-
                 let file_id = file_id.file_id(ctx.db());
                 builder.edit_file(file_id);
                 let call_krate = ctx.sema.file_to_module_def(file_id).map(|it| it.krate(ctx.db()));
                 let count = refs.len();
-                // Split refs into call-site name refs and use-tree paths
-                let (name_refs, use_trees): (Vec<ast::NameRef>, Vec<ast::UseTree>) = refs
-                    .into_iter()
-                    .filter_map(|file_ref| match file_ref.name {
-                        FileReferenceNode::NameRef(name_ref) => Some(name_ref),
-                        _ => None,
-                    })
-                    .partition_map(|name_ref| {
-                        match name_ref.syntax().ancestors().find_map(ast::UseTree::cast) {
-                            Some(use_tree) => Either::Right(use_tree),
-                            None => Either::Left(name_ref),
-                        }
-                    });
+                let (name_refs, use_trees) = split_refs_and_uses(refs, Some);
                 let call_infos: Vec<_> = name_refs
                     .into_iter()
                     .filter_map(|it| CallInfo::from_name_ref(it, call_krate?.into()))
@@ -134,8 +121,12 @@ pub(crate) fn inline_into_callers(acc: &mut Assists, ctx: &AssistContext<'_>) ->
                     // directly inlining into macros may cause errors.
                     .filter(|call_info| !ctx.sema.hir_file_for(call_info.node.syntax()).is_macro())
                     .collect();
-                if let Some(first) = call_infos.first() {
-                    let mut editor = builder.make_editor(first.node.syntax());
+                let anchor = call_infos
+                    .first()
+                    .map(|ci| ci.node.syntax().clone())
+                    .or_else(|| use_trees.first().map(|ut| ut.syntax().clone()));
+                if let Some(anchor) = anchor {
+                    let mut editor = builder.make_editor(&anchor);
                     let replaced = call_infos
                         .into_iter()
                         .map(|call_info| {
@@ -148,16 +139,7 @@ pub(crate) fn inline_into_callers(acc: &mut Assists, ctx: &AssistContext<'_>) ->
                     if replaced + use_trees.len() == count {
                         // we replaced all usages in this file, so we can remove the imports
                         for use_tree in &use_trees {
-                            if use_tree.use_tree_list().is_some() || use_tree.star_token().is_some()
-                            {
-                                continue;
-                            }
-                            if let Some(use_) = use_tree.syntax().parent().and_then(ast::Use::cast)
-                            {
-                                use_.remove(&mut editor);
-                            } else {
-                                use_tree.remove(&mut editor);
-                            }
+                            remove_use_tree_if_simple(use_tree, &mut editor);
                         }
                     } else {
                         remove_def = false;
@@ -184,17 +166,16 @@ pub(crate) fn inline_into_callers(acc: &mut Assists, ctx: &AssistContext<'_>) ->
 }
 
 pub(super) fn split_refs_and_uses<T: ast::AstNode>(
-    builder: &mut SourceChangeBuilder,
     iter: impl IntoIterator<Item = FileReference>,
     mut map_ref: impl FnMut(ast::NameRef) -> Option<T>,
-) -> (Vec<T>, Vec<ast::Path>) {
+) -> (Vec<T>, Vec<ast::UseTree>) {
     iter.into_iter()
         .filter_map(|file_ref| match file_ref.name {
             FileReferenceNode::NameRef(name_ref) => Some(name_ref),
             _ => None,
         })
         .filter_map(|name_ref| match name_ref.syntax().ancestors().find_map(ast::UseTree::cast) {
-            Some(use_tree) => builder.make_mut(use_tree).path().map(Either::Right),
+            Some(use_tree) => Some(Either::Right(use_tree)),
             None => map_ref(name_ref).map(Either::Left),
         })
         .partition_map(|either| either)
@@ -443,7 +424,7 @@ fn inline(
             .filter(|tok| tok.kind() == SyntaxKind::SELF_TYPE_KW)
             .collect();
         for self_tok in self_tokens {
-            let mut replace_with = t.clone_subtree().syntax().clone_subtree();
+            let mut replace_with = t.syntax().clone_subtree();
             if !is_in_type_path(&self_tok)
                 && let Some(ty) = ast::Type::cast(replace_with.clone())
                 && let Some(generic_arg_list) = ty.generic_arg_list()
@@ -550,7 +531,6 @@ fn inline(
                 for usage in &self_token_usages {
                     let this_token = make::name_ref("this")
                         .syntax()
-                        .clone_subtree()
                         .first_token()
                         .expect("NameRef should have had a token.");
                     editor.replace(usage.clone(), this_token);
@@ -565,13 +545,14 @@ fn inline(
                 if let Some(field) = path_expr_as_record_field(usage) {
                     cov_mark::hit!(inline_call_inline_direct_field);
                     let field_name = field.field_name().unwrap();
-                    let new_field = make::record_expr_field(
-                        make::name_ref(&field_name.text()),
+                    let factory = SyntaxFactory::without_mappings();
+                    let new_field = factory.record_expr_field(
+                        factory.name_ref(&field_name.text()),
                         Some(replacement.clone()),
                     );
                     editor.replace(field.syntax(), new_field.syntax());
                 } else {
-                    editor.replace(usage.syntax(), replacement.syntax().clone_subtree());
+                    editor.replace(usage.syntax(), replacement.syntax());
                 }
             };
 
@@ -629,6 +610,7 @@ fn inline(
         body = new_body;
     }
 
+    let factory = SyntaxFactory::without_mappings();
     let is_async_fn = function.is_async(sema.db);
     if is_async_fn {
         cov_mark::hit!(inline_call_async_fn);
@@ -638,12 +620,12 @@ fn inline(
         if !let_stmts.is_empty() {
             cov_mark::hit!(inline_call_async_fn_with_let_stmts);
             body = body.indent(IndentLevel(1));
-            body = make::block_expr(let_stmts, Some(body.into()));
+            body = factory.block_expr(let_stmts, Some(body.into()));
         }
     } else if !let_stmts.is_empty() {
         // Prepend let statements to the body's existing statements
         let stmts: Vec<ast::Stmt> = let_stmts.into_iter().chain(body.statements()).collect();
-        body = make::block_expr(stmts, body.tail_expr());
+        body = factory.block_expr(stmts, body.tail_expr());
     }
 
     let original_indentation = match node {
@@ -655,7 +637,7 @@ fn inline(
     let no_stmts = body.statements().next().is_none();
     match body.tail_expr() {
         Some(expr) if matches!(expr, ast::Expr::ClosureExpr(_)) && no_stmts => {
-            make::expr_paren(expr).into()
+            factory.expr_paren(expr).into()
         }
         Some(expr) if !is_async_fn && no_stmts => expr,
         _ => match node
@@ -665,7 +647,7 @@ fn inline(
             .and_then(|bin_expr| bin_expr.lhs())
         {
             Some(lhs) if lhs.syntax() == node.syntax() => {
-                make::expr_paren(ast::Expr::BlockExpr(body)).into()
+                factory.expr_paren(ast::Expr::BlockExpr(body)).into()
             }
             _ => ast::Expr::BlockExpr(body),
         },

--- a/crates/ide-assists/src/handlers/inline_type_alias.rs
+++ b/crates/ide-assists/src/handlers/inline_type_alias.rs
@@ -5,7 +5,8 @@
 use hir::{HasSource, PathResolution};
 use ide_db::FxHashMap;
 use ide_db::{
-    defs::Definition, imports::insert_use::ast_to_remove_for_path_in_use_stmt,
+    defs::Definition,
+    imports::insert_use::remove_use_tree_if_simple,
     search::FileReference,
 };
 use itertools::Itertools;
@@ -73,13 +74,12 @@ pub(crate) fn inline_type_alias_uses(acc: &mut Assists, ctx: &AssistContext<'_>)
                 let editor = builder.make_editor(source.syntax());
 
                 let (path_types, path_type_uses) =
-                    split_refs_and_uses(builder, refs, |path_type| {
+                    split_refs_and_uses(refs, |path_type| {
                         path_type.syntax().ancestors().nth(3).and_then(ast::PathType::cast)
                     });
                 path_type_uses
                     .iter()
-                    .flat_map(ast_to_remove_for_path_in_use_stmt)
-                    .for_each(|x| editor.delete(x.syntax()));
+                    .for_each(|use_tree| remove_use_tree_if_simple(use_tree, &mut editor));
 
                 for (target, replacement) in path_types.into_iter().filter_map(|path_type| {
                     let replacement =
@@ -1094,7 +1094,6 @@ fn f() -> Vec<&str> {
 }
 
 //- /foo.rs
-
 fn foo() {
     let _: Vec<i8> = Vec::new();
 }
@@ -1123,7 +1122,6 @@ mod foo;
 
 
 //- /foo.rs
-
 fn foo() {
     let _: i32 = 0;
 }

--- a/crates/ide-assists/src/handlers/inline_type_alias.rs
+++ b/crates/ide-assists/src/handlers/inline_type_alias.rs
@@ -5,9 +5,7 @@
 use hir::{HasSource, PathResolution};
 use ide_db::FxHashMap;
 use ide_db::{
-    defs::Definition,
-    imports::insert_use::remove_use_tree_if_simple,
-    search::FileReference,
+    defs::Definition, imports::insert_use::remove_use_tree_if_simple, search::FileReference,
 };
 use itertools::Itertools;
 use syntax::ast::syntax_factory::SyntaxFactory;
@@ -73,10 +71,9 @@ pub(crate) fn inline_type_alias_uses(acc: &mut Assists, ctx: &AssistContext<'_>)
                 let source = ctx.sema.parse(file_id);
                 let editor = builder.make_editor(source.syntax());
 
-                let (path_types, path_type_uses) =
-                    split_refs_and_uses(refs, |path_type| {
-                        path_type.syntax().ancestors().nth(3).and_then(ast::PathType::cast)
-                    });
+                let (path_types, path_type_uses) = split_refs_and_uses(refs, |path_type| {
+                    path_type.syntax().ancestors().nth(3).and_then(ast::PathType::cast)
+                });
                 path_type_uses
                     .iter()
                     .for_each(|use_tree| remove_use_tree_if_simple(use_tree, &mut editor));

--- a/crates/ide-assists/src/handlers/inline_type_alias.rs
+++ b/crates/ide-assists/src/handlers/inline_type_alias.rs
@@ -69,14 +69,14 @@ pub(crate) fn inline_type_alias_uses(acc: &mut Assists, ctx: &AssistContext<'_>)
 
             let mut inline_refs_for_file = |file_id, refs: Vec<FileReference>| {
                 let source = ctx.sema.parse(file_id);
-                let mut editor = builder.make_editor(source.syntax());
+                let editor = builder.make_editor(source.syntax());
 
                 let (path_types, path_type_uses) = split_refs_and_uses(refs, |path_type| {
                     path_type.syntax().ancestors().nth(3).and_then(ast::PathType::cast)
                 });
                 path_type_uses
                     .iter()
-                    .for_each(|use_tree| remove_use_tree_if_simple(use_tree, &mut editor));
+                    .for_each(|use_tree| remove_use_tree_if_simple(use_tree, &editor));
 
                 for (target, replacement) in path_types.into_iter().filter_map(|path_type| {
                     let replacement =

--- a/crates/ide-assists/src/handlers/inline_type_alias.rs
+++ b/crates/ide-assists/src/handlers/inline_type_alias.rs
@@ -69,7 +69,7 @@ pub(crate) fn inline_type_alias_uses(acc: &mut Assists, ctx: &AssistContext<'_>)
 
             let mut inline_refs_for_file = |file_id, refs: Vec<FileReference>| {
                 let source = ctx.sema.parse(file_id);
-                let editor = builder.make_editor(source.syntax());
+                let mut editor = builder.make_editor(source.syntax());
 
                 let (path_types, path_type_uses) = split_refs_and_uses(refs, |path_type| {
                     path_type.syntax().ancestors().nth(3).and_then(ast::PathType::cast)

--- a/crates/ide-db/src/imports/insert_use.rs
+++ b/crates/ide-db/src/imports/insert_use.rs
@@ -347,6 +347,17 @@ pub fn remove_path_if_in_use_stmt(path: &ast::Path) {
     }
 }
 
+pub fn remove_use_tree_if_simple(use_tree: &ast::UseTree, editor: &mut SyntaxEditor) {
+    if use_tree.use_tree_list().is_some() || use_tree.star_token().is_some() {
+        return;
+    }
+    if let Some(use_) = use_tree.syntax().parent().and_then(ast::Use::cast) {
+        syntax::syntax_editor::Removable::remove(&use_, editor);
+    } else {
+        syntax::syntax_editor::Removable::remove(use_tree, editor);
+    }
+}
+
 #[derive(Eq, PartialEq, PartialOrd, Ord)]
 enum ImportGroup {
     // the order here defines the order of new group inserts

--- a/crates/ide-db/src/imports/insert_use.rs
+++ b/crates/ide-db/src/imports/insert_use.rs
@@ -7,10 +7,7 @@ use std::cmp::Ordering;
 use hir::Semantics;
 use syntax::{
     Direction, NodeOrToken, SyntaxKind, SyntaxNode, algo,
-    ast::{
-        self, AstNode, HasAttrs, HasModuleItem, HasVisibility, PathSegmentKind,
-        edit_in_place::Removable, make,
-    },
+    ast::{self, AstNode, HasAttrs, HasModuleItem, HasVisibility, PathSegmentKind, make},
     syntax_editor::{Position, SyntaxEditor},
     ted,
 };
@@ -326,28 +323,7 @@ fn insert_use_with_alias_option_with_editor(
     insert_use_with_editor_(scope, use_item, cfg.group, syntax_editor);
 }
 
-pub fn ast_to_remove_for_path_in_use_stmt(path: &ast::Path) -> Option<Box<dyn Removable>> {
-    // FIXME: improve this
-    if path.parent_path().is_some() {
-        return None;
-    }
-    let use_tree = path.syntax().parent().and_then(ast::UseTree::cast)?;
-    if use_tree.use_tree_list().is_some() || use_tree.star_token().is_some() {
-        return None;
-    }
-    if let Some(use_) = use_tree.syntax().parent().and_then(ast::Use::cast) {
-        return Some(Box::new(use_));
-    }
-    Some(Box::new(use_tree))
-}
-
-pub fn remove_path_if_in_use_stmt(path: &ast::Path) {
-    if let Some(node) = ast_to_remove_for_path_in_use_stmt(path) {
-        node.remove();
-    }
-}
-
-pub fn remove_use_tree_if_simple(use_tree: &ast::UseTree, editor: &mut SyntaxEditor) {
+pub fn remove_use_tree_if_simple(use_tree: &ast::UseTree, editor: &SyntaxEditor) {
     if use_tree.use_tree_list().is_some() || use_tree.star_token().is_some() {
         return;
     }

--- a/crates/syntax/src/ast/edit_in_place.rs
+++ b/crates/syntax/src/ast/edit_in_place.rs
@@ -10,6 +10,7 @@ use crate::{
     SyntaxNode, SyntaxToken,
     algo::{self, neighbor},
     ast::{self, edit::IndentLevel, make},
+    syntax_editor::SyntaxEditor,
     ted,
 };
 
@@ -449,6 +450,24 @@ impl ast::RecordExprField {
                 expr.syntax().clone().into(),
             ];
             ted::insert_all_raw(ted::Position::last_child_of(self.syntax()), children);
+        }
+    }
+
+    /// [`SyntaxEditor`]-based equivalent of [`replace_expr`](Self::replace_expr).
+    pub fn replace_expr_with_editor(&self, editor: &SyntaxEditor, expr: ast::Expr) {
+        if self.name_ref().is_some() {
+            if let Some(prev) = self.expr() {
+                editor.replace(prev.syntax(), expr.syntax());
+            }
+        } else if let Some(ast::Expr::PathExpr(path_expr)) = self.expr()
+            && let Some(path) = path_expr.path()
+            && let Some(name_ref) = path.as_single_name_ref()
+        {
+            // shorthand `{ x }` → expand to `{ x: expr }`
+            let new_field = editor
+                .make()
+                .record_expr_field(editor.make().name_ref(&name_ref.text()), Some(expr));
+            editor.replace(self.syntax(), new_field.syntax());
         }
     }
 }

--- a/crates/syntax/src/ast/syntax_factory/constructors.rs
+++ b/crates/syntax/src/ast/syntax_factory/constructors.rs
@@ -985,6 +985,37 @@ impl SyntaxFactory {
         ast
     }
 
+    pub fn async_move_block_expr(
+        &self,
+        statements: impl IntoIterator<Item = ast::Stmt>,
+        tail_expr: Option<ast::Expr>,
+    ) -> ast::BlockExpr {
+        let (statements, mut input) = iterator_input(statements);
+
+        let ast = make::async_move_block_expr(statements, tail_expr.clone()).clone_for_update();
+
+        if let Some(mut mapping) = self.mappings() {
+            let stmt_list = ast.stmt_list().unwrap();
+            let mut builder = SyntaxMappingBuilder::new(stmt_list.syntax().clone());
+
+            if let Some(input) = tail_expr {
+                builder.map_node(
+                    input.syntax().clone(),
+                    stmt_list.tail_expr().unwrap().syntax().clone(),
+                );
+            } else if let Some(ast_tail) = stmt_list.tail_expr() {
+                let last_stmt = input.pop().unwrap();
+                builder.map_node(last_stmt, ast_tail.syntax().clone());
+            }
+
+            builder.map_children(input, stmt_list.statements().map(|it| it.syntax().clone()));
+
+            builder.finish(&mut mapping);
+        }
+
+        ast
+    }
+
     pub fn expr_empty_block(&self) -> ast::BlockExpr {
         make::expr_empty_block().clone_for_update()
     }
@@ -1129,6 +1160,27 @@ impl SyntaxFactory {
         if let Some(mut mapping) = self.mappings() {
             let mut builder = SyntaxMappingBuilder::new(ast.syntax().clone());
             builder.map_node(expr.syntax().clone(), ast.expr().unwrap().syntax().clone());
+            builder.finish(&mut mapping);
+        }
+
+        ast.into()
+    }
+
+    pub fn expr_reborrow(&self, expr: ast::Expr) -> ast::Expr {
+        let ast::Expr::RefExpr(ast) = make::expr_reborrow(expr.clone()).clone_for_update() else {
+            unreachable!()
+        };
+
+        if let Some(mut mapping) = self.mappings() {
+            // Layout: RefExpr(&mut, PrefixExpr(*, expr)). Map `expr` to the
+            // inner expr inside the synthesized PrefixExpr.
+            let prefix = match ast.expr() {
+                Some(ast::Expr::PrefixExpr(p)) => p,
+                _ => unreachable!("expr_reborrow always produces `&mut *expr`"),
+            };
+            let inner = prefix.expr().unwrap();
+            let mut builder = SyntaxMappingBuilder::new(prefix.syntax().clone());
+            builder.map_node(expr.syntax().clone(), inner.syntax().clone());
             builder.finish(&mut mapping);
         }
 


### PR DESCRIPTION
replace `clone_for_update + ted` mutations with `SyntaxEditor`. `inline()` uses `SyntaxEditor::with_ast_node` on the body clone for all parameter replacements, self-token renaming and Self type substitution. `inline_into_callers` uses `make_editor + add_file_edits`. import removal uses the Removable trait instead of `split_refs_and_uses + make_syntax_mut`.