### PR TITLE
internal: Fix rustdoc quoting

### DIFF
--- a/crates/ide-completion/src/context.rs
+++ b/crates/ide-completion/src/context.rs
@@ -411,7 +411,7 @@ pub(crate) enum CompletionAnalysis<'db> {
         fake_attribute_under_caret: Option<ast::TokenTreeMeta>,
         extern_crate: Option<ast::ExternCrate>,
     },
-    /// Set if we are inside the predicate of a #[cfg] or #[cfg_attr].
+    /// Set if we are inside the predicate of a `#[cfg]` or `#[cfg_attr]`.
     CfgPredicate,
     MacroSegment,
 }


### PR DESCRIPTION
GitHub actions are currently failing with:

    error: unresolved link to `cfg_attr`
       --> crates/ide-completion/src/context.rs:414:61
        |
    414 |     /// Set if we are inside the predicate of a #[cfg] or #[cfg_attr].
        |                                                             ^^^^^^^^ no item named `cfg_attr` in scope
        |
        = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
        = note: `-D rustdoc::broken-intra-doc-links` implied by `-D warnings`
        = help: to override `-D warnings` add `#[allow(rustdoc::broken_intra_doc_links)]`

     Documenting ide v0.0.0 (/home/runner/work/rust-analyzer/rust-analyzer/crates/ide)
    error: could not document `ide-completion`

Use backticks to fix this.

AI disclosure: written with Claude Opus because it was marginally faster.