### PR TITLE
internal: Ensure rustdoc GitHub action runs on PRs

### DIFF
--- a/.github/workflows/rustdoc.yaml
+++ b/.github/workflows/rustdoc.yaml
@@ -3,6 +3,8 @@ on:
   push:
     branches:
       - master
+  pull_request:
+  merge_group:
 
 env:
   CARGO_INCREMENTAL: 0
@@ -28,6 +30,7 @@ jobs:
         run: cargo doc --all --no-deps --document-private-items
 
       - name: Deploy Docs
+        if: github.event_name == 'push' && github.repository == 'rust-lang/rust-analyzer' && github.ref == 'refs/heads/master'
         uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/crates/hir-expand/src/attrs.rs
+++ b/crates/hir-expand/src/attrs.rs
@@ -92,7 +92,7 @@ impl AstKeyValueMetaExt for ast::KeyValueMeta {
 }
 
 /// The callback is passed the attribute and the outermost `ast::Attr`.
-/// Note that one node may map to multiple [`Meta`]s due to `cfg_attr`.
+/// Note that one node may map to multiple [`ast::Meta`]s due to `cfg_attr`.
 ///
 /// `unsafe(attr)` are passed the inner attribute for now.
 #[inline]


### PR DESCRIPTION
We want to complain on PRs that generate rustdoc warnings, but only deploy the generate HTML on the master branch.

Also fix the existing rustdoc warning.

AI disclosure: Some Claude Opus usage.