### PR TITLE
fix: MIR evaluation of sized &T with recursive const fn

### DIFF
--- a/crates/hir-ty/src/mir/eval.rs
+++ b/crates/hir-ty/src/mir/eval.rs
@@ -2211,10 +2211,10 @@ impl<'db> Evaluator<'db> {
                     match size {
                         Some((size, _)) => {
                             let addr_usize = from_bytes!(usize, bytes);
-                            mm.insert(
-                                addr_usize,
-                                this.read_memory(Address::from_usize(addr_usize), size)?.into(),
-                            )
+                            let bytes =
+                                this.read_memory(Address::from_usize(addr_usize), size)?.to_vec();
+                            mm.insert(addr_usize, bytes.clone().into());
+                            rec(this, &bytes, t, locals, mm, stack_depth_limit - 1)?;
                         }
                         None => {
                             let mut check_inner = None;
@@ -2379,9 +2379,20 @@ impl<'db> Evaluator<'db> {
                 match size {
                     Some(_) => {
                         let current = from_bytes!(usize, self.read_memory(addr, my_size)?);
-                        if let Some(it) = patch_map.get(&current) {
-                            self.write_memory(addr, &it.to_le_bytes())?;
-                        }
+                        let patched = match patch_map.get(&current) {
+                            Some(it) => {
+                                self.write_memory(addr, &it.to_le_bytes())?;
+                                *it
+                            }
+                            None => current,
+                        };
+                        self.patch_addresses(
+                            patch_map,
+                            ty_of_bytes,
+                            Address::from_usize(patched),
+                            t,
+                            locals,
+                        )?;
                     }
                     None => {
                         let current = from_bytes!(usize, self.read_memory(addr, my_size / 2)?);

--- a/crates/ide/src/hover/tests.rs
+++ b/crates/ide/src/hover/tests.rs
@@ -11079,6 +11079,58 @@ impl PublicFlags for NoteDialects {
 }
 
 #[test]
+fn hover_recursive_const_fn() {
+    check(
+        r#"
+//- minicore: option
+enum Child {
+    Static { child: &'static MyEnum },
+}
+
+enum MyEnum {
+    Unit,
+    Array(Child),
+}
+
+impl MyEnum {
+    pub const fn static_array(child: &'static MyEnum) -> Self {
+        MyEnum::Array(Child::Static { child })
+    }
+}
+
+pub trait MyTrait {
+    const MY_CONST: &'static MyEnum;
+}
+
+impl<T> MyTrait for Option<T> where T: MyTrait {
+    const MY_CONST: &'static MyEnum = &MyEnum::static_array(T::MY_CONST);
+}
+
+impl MyTrait for () {
+    const MY_CONST: &'static MyEnum = &MyEnum::Unit;
+}
+
+pub struct Address;
+
+impl MyTrait for Address {
+    const MY_CONST$0: &'static MyEnum = (<Option<()> as MyTrait>::MY_CONST);
+}
+    "#,
+        expect![[r#"
+            *MY_CONST*
+
+            ```rust
+            ra_test_fixture::Address
+            ```
+
+            ```rust
+            const MY_CONST: &'static MyEnum = &Array(Static { child: &Unit })
+            ```
+        "#]],
+    );
+}
+
+#[test]
 fn bounds_from_container_do_not_panic() {
     check(
         r#"


### PR DESCRIPTION
Previously, we didn't recurse in Evaluator::create_memory_map() or Evaluator::patch_addresses() when handling references with a known size.

This caused problems for hover rendering on const values, which would build a memory map for evaluated allocations and then pretty-printed values by following references through that map.

As a result, references in the map still pointed to the original addresses, meaning that the value pretty-printer would see the type parameters before substitution. This could cause stack overflows on well-formed Rust code using recursive const functions.

Add a regression test for hovering on a recursive const fn that previously caused stack overflow.

Fixes rust-lang/rust-analyzer#21503

AI disclosure: I used Codex with GPT 5.4 to investigate the issue and write the initial version of this commit.