### PR TITLE
fix: Allow ambiguity in assoc type shorthand if they resolve to the same assoc type, between supertraits this time

### DIFF
--- a/crates/hir-ty/src/lower.rs
+++ b/crates/hir-ty/src/lower.rs
@@ -1869,10 +1869,14 @@ fn resolve_type_param_assoc_type_shorthand(
                 .skip_binder();
             let args = EarlyBinder::bind(args).instantiate(interner, bounded_trait_ref.args);
             let current_result = StoredEarlyBinder::bind((assoc_type, args.store()));
-            if let Some(this_trait_resolution) = this_trait_resolution {
-                return AssocTypeShorthandResolution::Ambiguous {
-                    sub_trait_resolution: Some(this_trait_resolution),
-                };
+            if let Some(this_trait_resolution) = &this_trait_resolution {
+                if *this_trait_resolution == current_result {
+                    continue;
+                } else {
+                    return AssocTypeShorthandResolution::Ambiguous {
+                        sub_trait_resolution: Some(this_trait_resolution.clone()),
+                    };
+                }
             } else if let Some(prev_resolution) = &supertraits_resolution {
                 if let AssocTypeShorthandResolution::Ambiguous {
                     sub_trait_resolution: Some(prev_resolution),

--- a/crates/hir-ty/src/tests/regression.rs
+++ b/crates/hir-ty/src/tests/regression.rs
@@ -2856,3 +2856,31 @@ fn foo<T: B>(v: T::T) {}
     "#,
     );
 }
+
+#[test]
+fn regression_() {
+    check_types(
+        r#"
+//- minicore: fn
+trait Super {
+    type Assoc;
+    fn foo(self) -> Self::Assoc
+    where
+        Self: Sub,
+    { loop {} }
+}
+trait Sub: Super {}
+
+struct Struct;
+impl Super for Struct {
+    type Assoc = u8;
+}
+impl Sub for Struct {}
+
+fn foo() {
+    Struct.foo();
+ // ^^^^^^^^^^^^ u8
+}
+    "#,
+    );
+}


### PR DESCRIPTION
As I said, those rules will never cease to surprise me.

Fixes rust-lang/rust-analyzer#22007. The issue was not const bounds, but that `rposition()` is in `Iterator` and includes `Self: DoubleEndedIterator` and refers to `Self::Item`, similar to the new test.