### PR TITLE
parse `type const` items

### DIFF
--- a/crates/parser/src/grammar/items.rs
+++ b/crates/parser/src/grammar/items.rs
@@ -235,6 +235,7 @@ pub(super) fn opt_item(p: &mut Parser<'_>, m: Marker, is_in_extern: bool) -> Res
         T![trait] => traits::trait_(p, m),
         T![impl] => traits::impl_(p, m),
 
+        T![type] if p.nth(1) == T![const] => consts::konst(p, m),
         T![type] => type_alias(p, m),
 
         // test extern_block
@@ -266,6 +267,9 @@ fn opt_item_without_modifiers(p: &mut Parser<'_>, m: Marker) -> Result<(), Marke
         T![use] => use_item::use_(p, m),
         T![mod] => mod_item(p, m),
 
+        // test type_const
+        // type const FOO: i32 = 2;
+        T![type] if la == T![const] => consts::konst(p, m),
         T![type] => type_alias(p, m),
         T![struct] => adt::strukt(p, m),
         T![enum] => adt::enum_(p, m),

--- a/crates/parser/src/grammar/items/consts.rs
+++ b/crates/parser/src/grammar/items/consts.rs
@@ -3,6 +3,7 @@ use super::*;
 // test const_item
 // const C: u32 = 92;
 pub(super) fn konst(p: &mut Parser<'_>, m: Marker) {
+    p.eat(T![type]);
     p.bump(T![const]);
     const_or_static(p, m, true);
 }

--- a/crates/parser/test_data/generated/runner.rs
+++ b/crates/parser/test_data/generated/runner.rs
@@ -688,6 +688,8 @@ mod ok {
     #[test]
     fn type_alias() { run_and_expect_no_errors("test_data/parser/inline/ok/type_alias.rs"); }
     #[test]
+    fn type_const() { run_and_expect_no_errors("test_data/parser/inline/ok/type_const.rs"); }
+    #[test]
     fn type_item_type_params() {
         run_and_expect_no_errors("test_data/parser/inline/ok/type_item_type_params.rs");
     }

--- a/crates/parser/test_data/parser/inline/ok/type_const.rast
+++ b/crates/parser/test_data/parser/inline/ok/type_const.rast
@@ -1,0 +1,22 @@
+SOURCE_FILE
+  CONST
+    TYPE_KW "type"
+    WHITESPACE " "
+    CONST_KW "const"
+    WHITESPACE " "
+    NAME
+      IDENT "FOO"
+    COLON ":"
+    WHITESPACE " "
+    PATH_TYPE
+      PATH
+        PATH_SEGMENT
+          NAME_REF
+            IDENT "i32"
+    WHITESPACE " "
+    EQ "="
+    WHITESPACE " "
+    LITERAL
+      INT_NUMBER "2"
+    SEMICOLON ";"
+  WHITESPACE "\n"

--- a/crates/parser/test_data/parser/inline/ok/type_const.rs
+++ b/crates/parser/test_data/parser/inline/ok/type_const.rs
@@ -1,0 +1,1 @@
+type const FOO: i32 = 2;

--- a/crates/syntax/rust.ungram
+++ b/crates/syntax/rust.ungram
@@ -328,6 +328,7 @@ VariantDef =
 Const =
   Attr* Visibility?
   'default'?
+  'type'?
   'const' (Name | '_') GenericParamList? ':' Type
   ('=' body:Expr)?
   WhereClause? ';'

--- a/crates/syntax/src/ast/generated/nodes.rs
+++ b/crates/syntax/src/ast/generated/nodes.rs
@@ -484,6 +484,8 @@ impl Const {
     pub fn const_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![const]) }
     #[inline]
     pub fn default_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![default]) }
+    #[inline]
+    pub fn type_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![type]) }
 }
 pub struct ConstArg {
     pub(crate) syntax: SyntaxNode,


### PR DESCRIPTION
Adds parser support for the unstable `type const` syntax from the
`min_generic_const_args` feature:

```rust
#![feature(min_generic_const_args)]
type const FOO: i32 = 2;
```

Previously rust-analyzer reported 8 syntax errors on this valid (nightly) code.

Closes rust-lang/rust-analyzer#22038.

## Changes

- `rust.ungram`: add optional `'type'?` before `'const'` in the `Const` rule.
- `parser/grammar/items.rs`: dispatch `type` followed by `const` to `consts::konst` in both item match sites (covers `type const FOO` and `default type const FOO`).
- `parser/grammar/items/consts.rs`: `konst` now `p.eat(T![type])` before bumping `const`.
- Inline test `type_const` added; `cargo xtask codegen` regenerated AST nodes and test runner.

## Test plan

- [x] `cargo test -p parser` (including new `type_const` test)
- [x] `cargo test -p syntax`
- [x] Manual end-to-end check via `rust-analyzer parse` on the full issue reproduction — zero errors, correct `CONST` node with `TYPE_KW` + `CONST_KW`.
- [x] Negative case (`type const: i32 = 2;`) still emits errors.

---

Assisted-by: Claude Opus 4.6