### PR TITLE
Move syntax factory inside syntax editor

### DIFF
--- a/crates/hir-expand/src/builtin/derive_macro.rs
+++ b/crates/hir-expand/src/builtin/derive_macro.rs
@@ -1294,8 +1294,8 @@ fn coerce_pointee_expand(
         ));
     }
 
-    let (mut editor, strukt) = SyntaxEditor::with_ast_node(strukt);
-    strukt.get_or_create_where_clause(&mut editor, new_predicates.into_iter());
+    let (editor, strukt) = SyntaxEditor::with_ast_node(strukt);
+    strukt.get_or_create_where_clause(&editor, new_predicates.into_iter());
     let edit = editor.finish();
     let strukt = ast::Struct::cast(edit.new_root().clone()).unwrap();
     let adt = ast::Adt::Struct(strukt.clone());

--- a/crates/hir-expand/src/builtin/derive_macro.rs
+++ b/crates/hir-expand/src/builtin/derive_macro.rs
@@ -22,7 +22,7 @@ use crate::{
 use syntax::{
     ast::{
         self, AstNode, FieldList, HasAttrs, HasGenericArgs, HasGenericParams, HasModuleItem,
-        HasName, HasTypeBounds, make, syntax_factory::SyntaxFactory,
+        HasName, HasTypeBounds, make,
     },
     syntax_editor::{GetOrCreateWhereClause, SyntaxEditor},
     ted,
@@ -1295,9 +1295,7 @@ fn coerce_pointee_expand(
     }
 
     let (mut editor, strukt) = SyntaxEditor::with_ast_node(strukt);
-    let make = SyntaxFactory::with_mappings();
-    strukt.get_or_create_where_clause(&mut editor, &make, new_predicates.into_iter());
-    editor.add_mappings(make.finish_with_mappings());
+    strukt.get_or_create_where_clause(&mut editor, new_predicates.into_iter());
     let edit = editor.finish();
     let strukt = ast::Struct::cast(edit.new_root().clone()).unwrap();
     let adt = ast::Adt::Struct(strukt.clone());

--- a/crates/ide-assists/src/handlers/add_braces.rs
+++ b/crates/ide-assists/src/handlers/add_braces.rs
@@ -1,7 +1,7 @@
 use either::Either;
 use syntax::{
     AstNode, T,
-    ast::{self, edit::AstNodeEdit, syntax_factory::SyntaxFactory},
+    ast::{self, edit::AstNodeEdit},
     match_ast,
 };
 
@@ -56,15 +56,12 @@ pub(crate) fn add_braces(acc: &mut Assists, ctx: &AssistContext<'_>) -> Option<(
         },
         expr.syntax().text_range(),
         |builder| {
-            let make = SyntaxFactory::with_mappings();
             let mut editor = builder.make_editor(expr.syntax());
 
             let new_expr = expr.reset_indent().indent(1.into());
-            let block_expr = make.block_expr(None, Some(new_expr));
+            let block_expr = editor.make().block_expr(None, Some(new_expr));
 
             editor.replace(expr.syntax(), block_expr.indent(expr.indent_level()).syntax());
-
-            editor.add_mappings(make.finish_with_mappings());
             builder.add_file_edits(ctx.vfs_file_id(), editor);
         },
     )

--- a/crates/ide-assists/src/handlers/add_braces.rs
+++ b/crates/ide-assists/src/handlers/add_braces.rs
@@ -56,10 +56,11 @@ pub(crate) fn add_braces(acc: &mut Assists, ctx: &AssistContext<'_>) -> Option<(
         },
         expr.syntax().text_range(),
         |builder| {
-            let mut editor = builder.make_editor(expr.syntax());
+            let editor = builder.make_editor(expr.syntax());
+            let make = editor.make();
 
             let new_expr = expr.reset_indent().indent(1.into());
-            let block_expr = editor.make().block_expr(None, Some(new_expr));
+            let block_expr = make.block_expr(None, Some(new_expr));
 
             editor.replace(expr.syntax(), block_expr.indent(expr.indent_level()).syntax());
             builder.add_file_edits(ctx.vfs_file_id(), editor);

--- a/crates/ide-assists/src/handlers/add_explicit_dot_deref.rs
+++ b/crates/ide-assists/src/handlers/add_explicit_dot_deref.rs
@@ -53,18 +53,17 @@ pub(crate) fn add_explicit_method_call_deref(
         "Insert explicit method call derefs",
         dot_token.text_range(),
         |builder| {
-            let mut edit = builder.make_editor(method_call_expr.syntax());
-            let make = SyntaxFactory::without_mappings();
+            let mut editor = builder.make_editor(method_call_expr.syntax());
             let mut expr = receiver.clone();
 
             for adjust_kind in adjustments {
-                expr = adjust_kind.wrap_expr(expr, &make);
+                expr = adjust_kind.wrap_expr(expr, editor.make());
             }
 
-            expr = make.expr_paren(expr).into();
-            edit.replace(receiver.syntax(), expr.syntax());
+            expr = editor.make().expr_paren(expr).into();
+            editor.replace(receiver.syntax(), expr.syntax());
 
-            builder.add_file_edits(ctx.vfs_file_id(), edit);
+            builder.add_file_edits(ctx.vfs_file_id(), editor);
         },
     )
 }

--- a/crates/ide-assists/src/handlers/add_explicit_dot_deref.rs
+++ b/crates/ide-assists/src/handlers/add_explicit_dot_deref.rs
@@ -53,14 +53,15 @@ pub(crate) fn add_explicit_method_call_deref(
         "Insert explicit method call derefs",
         dot_token.text_range(),
         |builder| {
-            let mut editor = builder.make_editor(method_call_expr.syntax());
+            let editor = builder.make_editor(method_call_expr.syntax());
+            let make = editor.make();
             let mut expr = receiver.clone();
 
             for adjust_kind in adjustments {
-                expr = adjust_kind.wrap_expr(expr, editor.make());
+                expr = adjust_kind.wrap_expr(expr, make);
             }
 
-            expr = editor.make().expr_paren(expr).into();
+            expr = make.expr_paren(expr).into();
             editor.replace(receiver.syntax(), expr.syntax());
 
             builder.add_file_edits(ctx.vfs_file_id(), editor);

--- a/crates/ide-assists/src/handlers/add_label_to_loop.rs
+++ b/crates/ide-assists/src/handlers/add_label_to_loop.rs
@@ -3,7 +3,7 @@ use ide_db::{
 };
 use syntax::{
     SyntaxToken, T,
-    ast::{self, AstNode, HasLoopBody, syntax_factory::SyntaxFactory},
+    ast::{self, AstNode, HasLoopBody},
     syntax_editor::{Position, SyntaxEditor},
 };
 
@@ -42,14 +42,13 @@ pub(crate) fn add_label_to_loop(acc: &mut Assists, ctx: &AssistContext<'_>) -> O
         "Add Label",
         loop_expr.syntax().text_range(),
         |builder| {
-            let make = SyntaxFactory::with_mappings();
             let mut editor = builder.make_editor(loop_expr.syntax());
 
-            let label = make.lifetime("'l");
+            let label = editor.make().lifetime("'l");
             let elements = vec![
                 label.syntax().clone().into(),
-                make.token(T![:]).into(),
-                make.whitespace(" ").into(),
+                editor.make().token(T![:]).into(),
+                editor.make().whitespace(" ").into(),
             ];
             editor.insert_all(Position::before(&loop_kw), elements);
 
@@ -65,11 +64,10 @@ pub(crate) fn add_label_to_loop(acc: &mut Assists, ctx: &AssistContext<'_>) -> O
                     _ => return,
                 };
                 if let Some(token) = token {
-                    insert_label_after_token(&mut editor, &make, &token, ctx, builder);
+                    insert_label_after_token(&mut editor, &token, ctx, builder);
                 }
             });
 
-            editor.add_mappings(make.finish_with_mappings());
             builder.add_file_edits(ctx.vfs_file_id(), editor);
             builder.rename();
         },
@@ -86,13 +84,12 @@ fn loop_token(loop_expr: &ast::AnyHasLoopBody) -> Option<syntax::SyntaxToken> {
 
 fn insert_label_after_token(
     editor: &mut SyntaxEditor,
-    make: &SyntaxFactory,
     token: &SyntaxToken,
     ctx: &AssistContext<'_>,
     builder: &mut SourceChangeBuilder,
 ) {
-    let label = make.lifetime("'l");
-    let elements = vec![make.whitespace(" ").into(), label.syntax().clone().into()];
+    let label = editor.make().lifetime("'l");
+    let elements = vec![editor.make().whitespace(" ").into(), label.syntax().clone().into()];
     editor.insert_all(Position::after(token), elements);
 
     if let Some(cap) = ctx.config.snippet_cap {

--- a/crates/ide-assists/src/handlers/add_label_to_loop.rs
+++ b/crates/ide-assists/src/handlers/add_label_to_loop.rs
@@ -42,13 +42,14 @@ pub(crate) fn add_label_to_loop(acc: &mut Assists, ctx: &AssistContext<'_>) -> O
         "Add Label",
         loop_expr.syntax().text_range(),
         |builder| {
-            let mut editor = builder.make_editor(loop_expr.syntax());
+            let editor = builder.make_editor(loop_expr.syntax());
+            let make = editor.make();
 
-            let label = editor.make().lifetime("'l");
+            let label = make.lifetime("'l");
             let elements = vec![
                 label.syntax().clone().into(),
-                editor.make().token(T![:]).into(),
-                editor.make().whitespace(" ").into(),
+                make.token(T![:]).into(),
+                make.whitespace(" ").into(),
             ];
             editor.insert_all(Position::before(&loop_kw), elements);
 
@@ -64,7 +65,7 @@ pub(crate) fn add_label_to_loop(acc: &mut Assists, ctx: &AssistContext<'_>) -> O
                     _ => return,
                 };
                 if let Some(token) = token {
-                    insert_label_after_token(&mut editor, &token, ctx, builder);
+                    insert_label_after_token(&editor, &token, ctx, builder);
                 }
             });
 
@@ -83,13 +84,14 @@ fn loop_token(loop_expr: &ast::AnyHasLoopBody) -> Option<syntax::SyntaxToken> {
 }
 
 fn insert_label_after_token(
-    editor: &mut SyntaxEditor,
+    editor: &SyntaxEditor,
     token: &SyntaxToken,
     ctx: &AssistContext<'_>,
     builder: &mut SourceChangeBuilder,
 ) {
-    let label = editor.make().lifetime("'l");
-    let elements = vec![editor.make().whitespace(" ").into(), label.syntax().clone().into()];
+    let make = editor.make();
+    let label = make.lifetime("'l");
+    let elements = vec![make.whitespace(" ").into(), label.syntax().clone().into()];
     editor.insert_all(Position::after(token), elements);
 
     if let Some(cap) = ctx.config.snippet_cap {

--- a/crates/ide-assists/src/handlers/add_missing_impl_members.rs
+++ b/crates/ide-assists/src/handlers/add_missing_impl_members.rs
@@ -148,9 +148,10 @@ fn add_missing_impl_members_inner(
 
     let target = impl_def.syntax().text_range();
     acc.add(AssistId::quick_fix(assist_id), label, target, |edit| {
-        let mut editor = edit.make_editor(impl_def.syntax());
+        let editor = edit.make_editor(impl_def.syntax());
+        let make = editor.make();
         let new_item = add_trait_assoc_items_to_impl(
-            editor.make(),
+            make,
             &ctx.sema,
             ctx.config,
             &missing_items,
@@ -166,7 +167,7 @@ fn add_missing_impl_members_inner(
         let mut first_new_item = if let DefaultMethods::No = mode
             && let ast::AssocItem::Fn(func) = &first_new_item
             && let Some(body) = try_gen_trait_body(
-                editor.make(),
+                make,
                 ctx,
                 func,
                 trait_ref,
@@ -175,7 +176,7 @@ fn add_missing_impl_members_inner(
             )
             && let Some(func_body) = func.body()
         {
-            let (mut func_editor, _) = SyntaxEditor::new(first_new_item.syntax().clone());
+            let (func_editor, _) = SyntaxEditor::new(first_new_item.syntax().clone());
             func_editor.replace(func_body.syntax(), body.syntax());
             ast::AssocItem::cast(func_editor.finish().new_root().clone())
         } else {
@@ -189,12 +190,12 @@ fn add_missing_impl_members_inner(
             .collect::<Vec<_>>();
 
         if let Some(assoc_item_list) = impl_def.assoc_item_list() {
-            assoc_item_list.add_items(&mut editor, new_assoc_items);
+            assoc_item_list.add_items(&editor, new_assoc_items);
         } else {
-            let assoc_item_list = editor.make().assoc_item_list(new_assoc_items);
+            let assoc_item_list = make.assoc_item_list(new_assoc_items);
             editor.insert_all(
                 Position::after(impl_def.syntax()),
-                vec![editor.make().whitespace(" ").into(), assoc_item_list.syntax().clone().into()],
+                vec![make.whitespace(" ").into(), assoc_item_list.syntax().clone().into()],
             );
             first_new_item = assoc_item_list.assoc_items().next();
         }

--- a/crates/ide-assists/src/handlers/add_missing_impl_members.rs
+++ b/crates/ide-assists/src/handlers/add_missing_impl_members.rs
@@ -148,9 +148,9 @@ fn add_missing_impl_members_inner(
 
     let target = impl_def.syntax().text_range();
     acc.add(AssistId::quick_fix(assist_id), label, target, |edit| {
-        let make = SyntaxFactory::with_mappings();
+        let mut editor = edit.make_editor(impl_def.syntax());
         let new_item = add_trait_assoc_items_to_impl(
-            &make,
+            editor.make(),
             &ctx.sema,
             ctx.config,
             &missing_items,
@@ -166,7 +166,7 @@ fn add_missing_impl_members_inner(
         let mut first_new_item = if let DefaultMethods::No = mode
             && let ast::AssocItem::Fn(func) = &first_new_item
             && let Some(body) = try_gen_trait_body(
-                &make,
+                editor.make(),
                 ctx,
                 func,
                 trait_ref,
@@ -188,14 +188,13 @@ fn add_missing_impl_members_inner(
             .chain(other_items.iter().cloned())
             .collect::<Vec<_>>();
 
-        let mut editor = edit.make_editor(impl_def.syntax());
         if let Some(assoc_item_list) = impl_def.assoc_item_list() {
             assoc_item_list.add_items(&mut editor, new_assoc_items);
         } else {
-            let assoc_item_list = make.assoc_item_list(new_assoc_items);
+            let assoc_item_list = editor.make().assoc_item_list(new_assoc_items);
             editor.insert_all(
                 Position::after(impl_def.syntax()),
-                vec![make.whitespace(" ").into(), assoc_item_list.syntax().clone().into()],
+                vec![editor.make().whitespace(" ").into(), assoc_item_list.syntax().clone().into()],
             );
             first_new_item = assoc_item_list.assoc_items().next();
         }
@@ -218,7 +217,6 @@ fn add_missing_impl_members_inner(
                 editor.add_annotation(first_new_item.syntax(), tabstop);
             };
         };
-        editor.add_mappings(make.finish_with_mappings());
         edit.add_file_edits(ctx.vfs_file_id(), editor);
     })
 }

--- a/crates/ide-assists/src/handlers/add_missing_match_arms.rs
+++ b/crates/ide-assists/src/handlers/add_missing_match_arms.rs
@@ -74,7 +74,7 @@ pub(crate) fn add_missing_match_arms(acc: &mut Assists, ctx: &AssistContext<'_>)
         .filter(|pat| !matches!(pat, Pat::WildcardPat(_)))
         .collect();
 
-    let make = SyntaxFactory::with_mappings();
+    let make = SyntaxFactory::without_mappings();
 
     let scope = ctx.sema.scope(expr.syntax())?;
     let module = scope.module();
@@ -297,7 +297,6 @@ pub(crate) fn add_missing_match_arms(acc: &mut Assists, ctx: &AssistContext<'_>)
                 }
             }
 
-            editor.add_mappings(make.take());
             builder.add_file_edits(ctx.vfs_file_id(), editor);
         },
     )

--- a/crates/ide-assists/src/handlers/add_missing_match_arms.rs
+++ b/crates/ide-assists/src/handlers/add_missing_match_arms.rs
@@ -271,12 +271,12 @@ pub(crate) fn add_missing_match_arms(acc: &mut Assists, ctx: &AssistContext<'_>)
                 }
             };
 
-            let mut editor = builder.make_editor(&old_place);
+            let editor = builder.make_editor(&old_place);
             let mut arms_edit = ArmsEdit { match_arm_list, place: old_place, last_arm: None };
 
-            arms_edit.remove_wildcard_arms(ctx, &mut editor);
-            arms_edit.add_comma_after_last_arm(ctx, &make, &mut editor);
-            arms_edit.append_arms(&missing_arms, &make, &mut editor);
+            arms_edit.remove_wildcard_arms(ctx, &editor);
+            arms_edit.add_comma_after_last_arm(ctx, &make, &editor);
+            arms_edit.append_arms(&missing_arms, &make, &editor);
 
             if let Some(cap) = ctx.config.snippet_cap {
                 if let Some(it) = missing_arms
@@ -357,7 +357,7 @@ struct ArmsEdit {
 }
 
 impl ArmsEdit {
-    fn remove_wildcard_arms(&mut self, ctx: &AssistContext<'_>, editor: &mut SyntaxEditor) {
+    fn remove_wildcard_arms(&mut self, ctx: &AssistContext<'_>, editor: &SyntaxEditor) {
         for arm in self.match_arm_list.arms() {
             if !matches!(arm.pat(), Some(Pat::WildcardPat(_))) {
                 self.last_arm = Some(arm);
@@ -386,7 +386,7 @@ impl ArmsEdit {
         }
     }
 
-    fn append_arms(&self, arms: &[ast::MatchArm], make: &SyntaxFactory, editor: &mut SyntaxEditor) {
+    fn append_arms(&self, arms: &[ast::MatchArm], make: &SyntaxFactory, editor: &SyntaxEditor) {
         let Some(mut before) = self.place.last_token() else {
             stdx::never!("match arm list not contain any token");
             return;
@@ -419,7 +419,7 @@ impl ArmsEdit {
         &self,
         ctx: &AssistContext<'_>,
         make: &SyntaxFactory,
-        editor: &mut SyntaxEditor,
+        editor: &SyntaxEditor,
     ) {
         if let Some(last_arm) = &self.last_arm
             && last_arm.comma_token().is_none()

--- a/crates/ide-assists/src/handlers/add_turbo_fish.rs
+++ b/crates/ide-assists/src/handlers/add_turbo_fish.rs
@@ -94,21 +94,20 @@ pub(crate) fn add_turbo_fish(acc: &mut Assists, ctx: &AssistContext<'_>) -> Opti
                 ident.text_range(),
                 |builder| {
                     let mut editor = builder.make_editor(let_stmt.syntax());
-                    let make = SyntaxFactory::without_mappings();
 
                     if let_stmt.semicolon_token().is_none() {
                         editor.insert(
                             Position::last_child_of(let_stmt.syntax()),
-                            make.token(syntax::SyntaxKind::SEMICOLON),
+                            editor.make().token(syntax::SyntaxKind::SEMICOLON),
                         );
                     }
 
-                    let placeholder_ty = make.ty_placeholder();
+                    let placeholder_ty = editor.make().ty_placeholder();
 
                     if let Some(pat) = let_stmt.pat() {
                         let elements = vec![
-                            make.token(syntax::SyntaxKind::COLON).into(),
-                            make.whitespace(" ").into(),
+                            editor.make().token(syntax::SyntaxKind::COLON).into(),
+                            editor.make().whitespace(" ").into(),
                             placeholder_ty.syntax().clone().into(),
                         ];
                         editor.insert_all(Position::after(pat.syntax()), elements);
@@ -141,14 +140,12 @@ pub(crate) fn add_turbo_fish(acc: &mut Assists, ctx: &AssistContext<'_>) -> Opti
         ident.text_range(),
         |builder| {
             builder.trigger_parameter_hints();
-
-            let make = SyntaxFactory::with_mappings();
             let mut editor = match &turbofish_target {
                 Either::Left(it) => builder.make_editor(it.syntax()),
                 Either::Right(it) => builder.make_editor(it.syntax()),
             };
 
-            let fish_head = get_fish_head(&make, number_of_arguments);
+            let fish_head = get_fish_head(editor.make(), number_of_arguments);
 
             match turbofish_target {
                 Either::Left(path_segment) => {
@@ -180,8 +177,6 @@ pub(crate) fn add_turbo_fish(acc: &mut Assists, ctx: &AssistContext<'_>) -> Opti
                     editor.add_annotation(arg.syntax(), builder.make_placeholder_snippet(cap));
                 }
             }
-
-            editor.add_mappings(make.finish_with_mappings());
             builder.add_file_edits(ctx.vfs_file_id(), editor);
         },
     )

--- a/crates/ide-assists/src/handlers/add_turbo_fish.rs
+++ b/crates/ide-assists/src/handlers/add_turbo_fish.rs
@@ -93,21 +93,23 @@ pub(crate) fn add_turbo_fish(acc: &mut Assists, ctx: &AssistContext<'_>) -> Opti
                 "Add `: _` before assignment operator",
                 ident.text_range(),
                 |builder| {
-                    let mut editor = builder.make_editor(let_stmt.syntax());
+                    let editor = builder.make_editor(let_stmt.syntax());
+                    let make = editor.make();
 
                     if let_stmt.semicolon_token().is_none() {
                         editor.insert(
                             Position::last_child_of(let_stmt.syntax()),
-                            editor.make().token(syntax::SyntaxKind::SEMICOLON),
+                            make.token(syntax::SyntaxKind::SEMICOLON),
                         );
                     }
 
-                    let placeholder_ty = editor.make().ty_placeholder();
+                    let make = editor.make();
+                    let placeholder_ty = make.ty_placeholder();
 
                     if let Some(pat) = let_stmt.pat() {
                         let elements = vec![
-                            editor.make().token(syntax::SyntaxKind::COLON).into(),
-                            editor.make().whitespace(" ").into(),
+                            make.token(syntax::SyntaxKind::COLON).into(),
+                            make.whitespace(" ").into(),
                             placeholder_ty.syntax().clone().into(),
                         ];
                         editor.insert_all(Position::after(pat.syntax()), elements);
@@ -140,7 +142,7 @@ pub(crate) fn add_turbo_fish(acc: &mut Assists, ctx: &AssistContext<'_>) -> Opti
         ident.text_range(),
         |builder| {
             builder.trigger_parameter_hints();
-            let mut editor = match &turbofish_target {
+            let editor = match &turbofish_target {
                 Either::Left(it) => builder.make_editor(it.syntax()),
                 Either::Right(it) => builder.make_editor(it.syntax()),
             };

--- a/crates/ide-assists/src/handlers/apply_demorgan.rs
+++ b/crates/ide-assists/src/handlers/apply_demorgan.rs
@@ -80,8 +80,9 @@ pub(crate) fn apply_demorgan(acc: &mut Assists, ctx: &AssistContext<'_>) -> Opti
         _ => return None,
     };
 
-    let (mut editor, demorganed) = SyntaxEditor::with_ast_node(&bin_expr);
-    editor.replace(demorganed.op_token()?, editor.make().token(inv_token));
+    let (editor, demorganed) = SyntaxEditor::with_ast_node(&bin_expr);
+    let make = editor.make();
+    editor.replace(demorganed.op_token()?, make.token(inv_token));
 
     let mut exprs = VecDeque::from([
         (bin_expr.lhs()?, demorganed.lhs()?, prec),
@@ -92,13 +93,13 @@ pub(crate) fn apply_demorgan(acc: &mut Assists, ctx: &AssistContext<'_>) -> Opti
         if let BinExpr(bin_expr) = &expr {
             if let BinExpr(cbin_expr) = &demorganed {
                 if op == bin_expr.op_kind()? {
-                    editor.replace(cbin_expr.op_token()?, editor.make().token(inv_token));
+                    editor.replace(cbin_expr.op_token()?, make.token(inv_token));
                     exprs.push_back((bin_expr.lhs()?, cbin_expr.lhs()?, prec));
                     exprs.push_back((bin_expr.rhs()?, cbin_expr.rhs()?, prec));
                 } else {
-                    let mut inv = invert_boolean_expression(editor.make(), expr);
+                    let mut inv = invert_boolean_expression(make, expr);
                     if precedence(&inv).needs_parentheses_in(prec) {
-                        inv = editor.make().expr_paren(inv).into();
+                        inv = make.expr_paren(inv).into();
                     }
                     editor.replace(demorganed.syntax(), inv.syntax());
                 }
@@ -106,9 +107,9 @@ pub(crate) fn apply_demorgan(acc: &mut Assists, ctx: &AssistContext<'_>) -> Opti
                 return None;
             }
         } else {
-            let mut inv = invert_boolean_expression(editor.make(), demorganed.clone());
+            let mut inv = invert_boolean_expression(make, demorganed.clone());
             if precedence(&inv).needs_parentheses_in(prec) {
-                inv = editor.make().expr_paren(inv).into();
+                inv = make.expr_paren(inv).into();
             }
             editor.replace(demorganed.syntax(), inv.syntax());
         }
@@ -123,7 +124,8 @@ pub(crate) fn apply_demorgan(acc: &mut Assists, ctx: &AssistContext<'_>) -> Opti
         "Apply De Morgan's law",
         op_range,
         |builder| {
-            let mut editor = builder.make_editor(bin_expr.syntax());
+            let editor = builder.make_editor(bin_expr.syntax());
+            let make = editor.make();
 
             let (target_node, result_expr) = if let Some(neg_expr) = bin_expr
                 .syntax()
@@ -139,9 +141,9 @@ pub(crate) fn apply_demorgan(acc: &mut Assists, ctx: &AssistContext<'_>) -> Opti
                 bin_expr.syntax().parent().and_then(ast::ParenExpr::cast)
             {
                 cov_mark::hit!(demorgan_double_parens);
-                (paren_expr.syntax().clone(), add_bang_paren(editor.make(), demorganed))
+                (paren_expr.syntax().clone(), add_bang_paren(make, demorganed))
             } else {
-                (bin_expr.syntax().clone(), add_bang_paren(editor.make(), demorganed))
+                (bin_expr.syntax().clone(), add_bang_paren(make, demorganed))
             };
 
             let final_expr = if target_node
@@ -149,7 +151,7 @@ pub(crate) fn apply_demorgan(acc: &mut Assists, ctx: &AssistContext<'_>) -> Opti
                 .is_some_and(|p| result_expr.needs_parens_in_place_of(&p, &target_node))
             {
                 cov_mark::hit!(demorgan_keep_parens_for_op_precedence2);
-                editor.make().expr_paren(result_expr).into()
+                make.expr_paren(result_expr).into()
             } else {
                 result_expr
             };
@@ -202,17 +204,18 @@ pub(crate) fn apply_demorgan_iterator(acc: &mut Assists, ctx: &AssistContext<'_>
         label,
         op_range,
         |builder| {
-            let mut editor = builder.make_editor(method_call.syntax());
+            let editor = builder.make_editor(method_call.syntax());
+            let make = editor.make();
             // replace the method name
             let new_name = match name.text().as_str() {
-                "all" => editor.make().name_ref("any"),
-                "any" => editor.make().name_ref("all"),
+                "all" => make.name_ref("any"),
+                "any" => make.name_ref("all"),
                 _ => unreachable!(),
             };
             editor.replace(name.syntax(), new_name.syntax());
 
             // negate all tail expressions in the closure body
-            let tail_cb = &mut |e: &_| tail_cb_impl(&mut editor, e);
+            let tail_cb = &mut |e: &_| tail_cb_impl(&editor, e);
             walk_expr(&closure_body, &mut |expr| {
                 if let ast::Expr::ReturnExpr(ret_expr) = expr
                     && let Some(ret_expr_arg) = &ret_expr.expr()
@@ -233,10 +236,7 @@ pub(crate) fn apply_demorgan_iterator(acc: &mut Assists, ctx: &AssistContext<'_>
                     prefix_expr.op_token().expect("prefix expression always has an operator"),
                 );
             } else {
-                editor.insert(
-                    Position::before(method_call.syntax()),
-                    editor.make().token(SyntaxKind::BANG),
-                );
+                editor.insert(Position::before(method_call.syntax()), make.token(SyntaxKind::BANG));
             }
             builder.add_file_edits(ctx.vfs_file_id(), editor);
         },
@@ -265,7 +265,7 @@ fn validate_method_call_expr(
     it_type.impls_trait(sema.db, iter_trait, &[]).then_some((name_ref, arg_expr))
 }
 
-fn tail_cb_impl(editor: &mut SyntaxEditor, e: &ast::Expr) {
+fn tail_cb_impl(editor: &SyntaxEditor, e: &ast::Expr) {
     match e {
         ast::Expr::BreakExpr(break_expr) => {
             if let Some(break_expr_arg) = break_expr.expr() {

--- a/crates/ide-assists/src/handlers/apply_demorgan.rs
+++ b/crates/ide-assists/src/handlers/apply_demorgan.rs
@@ -80,10 +80,8 @@ pub(crate) fn apply_demorgan(acc: &mut Assists, ctx: &AssistContext<'_>) -> Opti
         _ => return None,
     };
 
-    let make = SyntaxFactory::with_mappings();
-
     let (mut editor, demorganed) = SyntaxEditor::with_ast_node(&bin_expr);
-    editor.replace(demorganed.op_token()?, make.token(inv_token));
+    editor.replace(demorganed.op_token()?, editor.make().token(inv_token));
 
     let mut exprs = VecDeque::from([
         (bin_expr.lhs()?, demorganed.lhs()?, prec),
@@ -94,13 +92,13 @@ pub(crate) fn apply_demorgan(acc: &mut Assists, ctx: &AssistContext<'_>) -> Opti
         if let BinExpr(bin_expr) = &expr {
             if let BinExpr(cbin_expr) = &demorganed {
                 if op == bin_expr.op_kind()? {
-                    editor.replace(cbin_expr.op_token()?, make.token(inv_token));
+                    editor.replace(cbin_expr.op_token()?, editor.make().token(inv_token));
                     exprs.push_back((bin_expr.lhs()?, cbin_expr.lhs()?, prec));
                     exprs.push_back((bin_expr.rhs()?, cbin_expr.rhs()?, prec));
                 } else {
-                    let mut inv = invert_boolean_expression(&make, expr);
+                    let mut inv = invert_boolean_expression(editor.make(), expr);
                     if precedence(&inv).needs_parentheses_in(prec) {
-                        inv = make.expr_paren(inv).into();
+                        inv = editor.make().expr_paren(inv).into();
                     }
                     editor.replace(demorganed.syntax(), inv.syntax());
                 }
@@ -108,15 +106,14 @@ pub(crate) fn apply_demorgan(acc: &mut Assists, ctx: &AssistContext<'_>) -> Opti
                 return None;
             }
         } else {
-            let mut inv = invert_boolean_expression(&make, demorganed.clone());
+            let mut inv = invert_boolean_expression(editor.make(), demorganed.clone());
             if precedence(&inv).needs_parentheses_in(prec) {
-                inv = make.expr_paren(inv).into();
+                inv = editor.make().expr_paren(inv).into();
             }
             editor.replace(demorganed.syntax(), inv.syntax());
         }
     }
 
-    editor.add_mappings(make.finish_with_mappings());
     let edit = editor.finish();
     let demorganed = ast::Expr::cast(edit.new_root().clone())?;
 
@@ -126,7 +123,8 @@ pub(crate) fn apply_demorgan(acc: &mut Assists, ctx: &AssistContext<'_>) -> Opti
         "Apply De Morgan's law",
         op_range,
         |builder| {
-            let make = SyntaxFactory::with_mappings();
+            let mut editor = builder.make_editor(bin_expr.syntax());
+
             let (target_node, result_expr) = if let Some(neg_expr) = bin_expr
                 .syntax()
                 .parent()
@@ -141,9 +139,9 @@ pub(crate) fn apply_demorgan(acc: &mut Assists, ctx: &AssistContext<'_>) -> Opti
                 bin_expr.syntax().parent().and_then(ast::ParenExpr::cast)
             {
                 cov_mark::hit!(demorgan_double_parens);
-                (paren_expr.syntax().clone(), add_bang_paren(&make, demorganed))
+                (paren_expr.syntax().clone(), add_bang_paren(editor.make(), demorganed))
             } else {
-                (bin_expr.syntax().clone(), add_bang_paren(&make, demorganed))
+                (bin_expr.syntax().clone(), add_bang_paren(editor.make(), demorganed))
             };
 
             let final_expr = if target_node
@@ -151,14 +149,12 @@ pub(crate) fn apply_demorgan(acc: &mut Assists, ctx: &AssistContext<'_>) -> Opti
                 .is_some_and(|p| result_expr.needs_parens_in_place_of(&p, &target_node))
             {
                 cov_mark::hit!(demorgan_keep_parens_for_op_precedence2);
-                make.expr_paren(result_expr).into()
+                editor.make().expr_paren(result_expr).into()
             } else {
                 result_expr
             };
 
-            let mut editor = builder.make_editor(&target_node);
             editor.replace(&target_node, final_expr.syntax());
-            editor.add_mappings(make.finish_with_mappings());
             builder.add_file_edits(ctx.vfs_file_id(), editor);
         },
     )
@@ -206,18 +202,17 @@ pub(crate) fn apply_demorgan_iterator(acc: &mut Assists, ctx: &AssistContext<'_>
         label,
         op_range,
         |builder| {
-            let make = SyntaxFactory::with_mappings();
             let mut editor = builder.make_editor(method_call.syntax());
             // replace the method name
             let new_name = match name.text().as_str() {
-                "all" => make.name_ref("any"),
-                "any" => make.name_ref("all"),
+                "all" => editor.make().name_ref("any"),
+                "any" => editor.make().name_ref("all"),
                 _ => unreachable!(),
             };
             editor.replace(name.syntax(), new_name.syntax());
 
             // negate all tail expressions in the closure body
-            let tail_cb = &mut |e: &_| tail_cb_impl(&mut editor, &make, e);
+            let tail_cb = &mut |e: &_| tail_cb_impl(&mut editor, e);
             walk_expr(&closure_body, &mut |expr| {
                 if let ast::Expr::ReturnExpr(ret_expr) = expr
                     && let Some(ret_expr_arg) = &ret_expr.expr()
@@ -238,10 +233,11 @@ pub(crate) fn apply_demorgan_iterator(acc: &mut Assists, ctx: &AssistContext<'_>
                     prefix_expr.op_token().expect("prefix expression always has an operator"),
                 );
             } else {
-                editor.insert(Position::before(method_call.syntax()), make.token(SyntaxKind::BANG));
+                editor.insert(
+                    Position::before(method_call.syntax()),
+                    editor.make().token(SyntaxKind::BANG),
+                );
             }
-
-            editor.add_mappings(make.finish_with_mappings());
             builder.add_file_edits(ctx.vfs_file_id(), editor);
         },
     )
@@ -269,18 +265,18 @@ fn validate_method_call_expr(
     it_type.impls_trait(sema.db, iter_trait, &[]).then_some((name_ref, arg_expr))
 }
 
-fn tail_cb_impl(editor: &mut SyntaxEditor, make: &SyntaxFactory, e: &ast::Expr) {
+fn tail_cb_impl(editor: &mut SyntaxEditor, e: &ast::Expr) {
     match e {
         ast::Expr::BreakExpr(break_expr) => {
             if let Some(break_expr_arg) = break_expr.expr() {
-                for_each_tail_expr(&break_expr_arg, &mut |e| tail_cb_impl(editor, make, e))
+                for_each_tail_expr(&break_expr_arg, &mut |e| tail_cb_impl(editor, e))
             }
         }
         ast::Expr::ReturnExpr(_) => {
             // all return expressions have already been handled by the walk loop
         }
         e => {
-            let inverted_body = invert_boolean_expression(make, e.clone());
+            let inverted_body = invert_boolean_expression(editor.make(), e.clone());
             editor.replace(e.syntax(), inverted_body.syntax());
         }
     }

--- a/crates/ide-assists/src/handlers/convert_bool_then.rs
+++ b/crates/ide-assists/src/handlers/convert_bool_then.rs
@@ -96,12 +96,12 @@ pub(crate) fn convert_if_to_bool_then(acc: &mut Assists, ctx: &AssistContext<'_>
             let closure_body = ast::Expr::cast(edit.new_root().clone()).unwrap();
 
             let mut editor = builder.make_editor(expr.syntax());
-            let make = SyntaxFactory::with_mappings();
             let closure_body = match closure_body {
                 ast::Expr::BlockExpr(block) => unwrap_trivial_block(block),
                 e => e,
             };
-            let cond = if invert_cond { invert_boolean_expression(&make, cond) } else { cond };
+            let cond =
+                if invert_cond { invert_boolean_expression(editor.make(), cond) } else { cond };
 
             let parenthesize = matches!(
                 cond,
@@ -124,12 +124,12 @@ pub(crate) fn convert_if_to_bool_then(acc: &mut Assists, ctx: &AssistContext<'_>
                     | ast::Expr::YieldExpr(_)
             );
 
-            let cond = if parenthesize { make.expr_paren(cond).into() } else { cond };
-            let arg_list = make.arg_list(Some(make.expr_closure(None, closure_body).into()));
-            let mcall = make.expr_method_call(cond, make.name_ref("then"), arg_list);
+            let cond = if parenthesize { editor.make().expr_paren(cond).into() } else { cond };
+            let arg_list =
+                editor.make().arg_list(Some(editor.make().expr_closure(None, closure_body).into()));
+            let mcall =
+                editor.make().expr_method_call(cond, editor.make().name_ref("then"), arg_list);
             editor.replace(expr.syntax(), mcall.syntax());
-
-            editor.add_mappings(make.finish_with_mappings());
             builder.add_file_edits(ctx.vfs_file_id(), editor);
         },
     )
@@ -211,22 +211,20 @@ pub(crate) fn convert_bool_then_to_if(acc: &mut Assists, ctx: &AssistContext<'_>
             let closure_body = ast::BlockExpr::cast(edit.new_root().clone()).unwrap();
 
             let mut editor = builder.make_editor(mcall.syntax());
-            let make = SyntaxFactory::with_mappings();
 
             let cond = match &receiver {
                 ast::Expr::ParenExpr(expr) => expr.expr().unwrap_or(receiver),
                 _ => receiver,
             };
-            let if_expr = make
+            let if_expr = editor
+                .make()
                 .expr_if(
                     cond,
                     closure_body,
-                    Some(ast::ElseBranch::Block(make.block_expr(None, Some(none_path)))),
+                    Some(ast::ElseBranch::Block(editor.make().block_expr(None, Some(none_path)))),
                 )
                 .indent(mcall.indent_level());
             editor.replace(mcall.syntax().clone(), if_expr.syntax().clone());
-
-            editor.add_mappings(make.finish_with_mappings());
             builder.add_file_edits(ctx.vfs_file_id(), editor);
         },
     )

--- a/crates/ide-assists/src/handlers/convert_bool_then.rs
+++ b/crates/ide-assists/src/handlers/convert_bool_then.rs
@@ -77,7 +77,7 @@ pub(crate) fn convert_if_to_bool_then(acc: &mut Assists, ctx: &AssistContext<'_>
         "Convert `if` expression to `bool::then` call",
         target,
         |builder| {
-            let (mut editor, closure_body) = SyntaxEditor::with_ast_node(&closure_body);
+            let (editor, closure_body) = SyntaxEditor::with_ast_node(&closure_body);
             // Rewrite all `Some(e)` in tail position to `e`
             for_each_tail_expr(&closure_body, &mut |e| {
                 let e = match e {
@@ -95,13 +95,13 @@ pub(crate) fn convert_if_to_bool_then(acc: &mut Assists, ctx: &AssistContext<'_>
             let edit = editor.finish();
             let closure_body = ast::Expr::cast(edit.new_root().clone()).unwrap();
 
-            let mut editor = builder.make_editor(expr.syntax());
+            let editor = builder.make_editor(expr.syntax());
+            let make = editor.make();
             let closure_body = match closure_body {
                 ast::Expr::BlockExpr(block) => unwrap_trivial_block(block),
                 e => e,
             };
-            let cond =
-                if invert_cond { invert_boolean_expression(editor.make(), cond) } else { cond };
+            let cond = if invert_cond { invert_boolean_expression(make, cond) } else { cond };
 
             let parenthesize = matches!(
                 cond,
@@ -124,11 +124,9 @@ pub(crate) fn convert_if_to_bool_then(acc: &mut Assists, ctx: &AssistContext<'_>
                     | ast::Expr::YieldExpr(_)
             );
 
-            let cond = if parenthesize { editor.make().expr_paren(cond).into() } else { cond };
-            let arg_list =
-                editor.make().arg_list(Some(editor.make().expr_closure(None, closure_body).into()));
-            let mcall =
-                editor.make().expr_method_call(cond, editor.make().name_ref("then"), arg_list);
+            let cond = if parenthesize { make.expr_paren(cond).into() } else { cond };
+            let arg_list = make.arg_list(Some(make.expr_closure(None, closure_body).into()));
+            let mcall = make.expr_method_call(cond, make.name_ref("then"), arg_list);
             editor.replace(expr.syntax(), mcall.syntax());
             builder.add_file_edits(ctx.vfs_file_id(), editor);
         },
@@ -187,7 +185,7 @@ pub(crate) fn convert_bool_then_to_if(acc: &mut Assists, ctx: &AssistContext<'_>
                 e => mapless_make.block_expr(None, Some(e)),
             };
 
-            let (mut editor, closure_body) = SyntaxEditor::with_ast_node(&closure_body);
+            let (editor, closure_body) = SyntaxEditor::with_ast_node(&closure_body);
             // Wrap all tails in `Some(...)`
             let none_path = mapless_make.expr_path(mapless_make.ident_path("None"));
             let some_path = mapless_make.expr_path(mapless_make.ident_path("Some"));
@@ -210,7 +208,8 @@ pub(crate) fn convert_bool_then_to_if(acc: &mut Assists, ctx: &AssistContext<'_>
             let edit = editor.finish();
             let closure_body = ast::BlockExpr::cast(edit.new_root().clone()).unwrap();
 
-            let mut editor = builder.make_editor(mcall.syntax());
+            let editor = builder.make_editor(mcall.syntax());
+            let make = editor.make();
 
             let cond = match &receiver {
                 ast::Expr::ParenExpr(expr) => expr.expr().unwrap_or(receiver),
@@ -221,7 +220,7 @@ pub(crate) fn convert_bool_then_to_if(acc: &mut Assists, ctx: &AssistContext<'_>
                 .expr_if(
                     cond,
                     closure_body,
-                    Some(ast::ElseBranch::Block(editor.make().block_expr(None, Some(none_path)))),
+                    Some(ast::ElseBranch::Block(make.block_expr(None, Some(none_path)))),
                 )
                 .indent(mcall.indent_level());
             editor.replace(mcall.syntax().clone(), if_expr.syntax().clone());

--- a/crates/ide-assists/src/handlers/convert_for_to_while_let.rs
+++ b/crates/ide-assists/src/handlers/convert_for_to_while_let.rs
@@ -2,7 +2,7 @@ use hir::{Name, sym};
 use ide_db::{famous_defs::FamousDefs, syntax_helpers::suggest_name};
 use syntax::{
     AstNode,
-    ast::{self, HasAttrs, HasLoopBody, edit::IndentLevel, syntax_factory::SyntaxFactory},
+    ast::{self, HasAttrs, HasLoopBody, edit::IndentLevel},
     syntax_editor::Position,
 };
 
@@ -48,22 +48,24 @@ pub(crate) fn convert_for_loop_to_while_let(
         "Replace this for loop with `while let`",
         for_loop.syntax().text_range(),
         |builder| {
-            let make = SyntaxFactory::with_mappings();
             let mut editor = builder.make_editor(for_loop.syntax());
 
             let (iterable, method) = if impls_core_iter(&ctx.sema, &iterable) {
                 (iterable, None)
             } else if let Some((expr, method)) = is_ref_and_impls_iter_method(&ctx.sema, &iterable)
             {
-                (expr, Some(make.name_ref(method.as_str())))
+                (expr, Some(editor.make().name_ref(method.as_str())))
             } else if let ast::Expr::RefExpr(_) = iterable {
-                (make.expr_paren(iterable).into(), Some(make.name_ref("into_iter")))
+                (
+                    editor.make().expr_paren(iterable).into(),
+                    Some(editor.make().name_ref("into_iter")),
+                )
             } else {
-                (iterable, Some(make.name_ref("into_iter")))
+                (iterable, Some(editor.make().name_ref("into_iter")))
             };
 
             let iterable = if let Some(method) = method {
-                make.expr_method_call(iterable, method, make.arg_list([])).into()
+                editor.make().expr_method_call(iterable, method, editor.make().arg_list([])).into()
             } else {
                 iterable
             };
@@ -73,8 +75,8 @@ pub(crate) fn convert_for_loop_to_while_let(
             );
             let tmp_var = new_name.suggest_name("iter");
 
-            let mut_expr = make.let_stmt(
-                make.ident_pat(false, true, make.name(&tmp_var)).into(),
+            let mut_expr = editor.make().let_stmt(
+                editor.make().ident_pat(false, true, editor.make().name(&tmp_var)).into(),
                 None,
                 Some(iterable),
             );
@@ -82,35 +84,29 @@ pub(crate) fn convert_for_loop_to_while_let(
 
             if let Some(label) = for_loop.label() {
                 let label = label.syntax();
-                editor.insert(Position::before(for_loop.syntax()), make.whitespace(" "));
+                editor.insert(Position::before(for_loop.syntax()), editor.make().whitespace(" "));
                 editor.insert(Position::before(for_loop.syntax()), label);
             }
-            crate::utils::insert_attributes(
-                for_loop.syntax(),
-                &mut editor,
-                for_loop.attrs(),
-                &make,
-            );
+            crate::utils::insert_attributes(for_loop.syntax(), &mut editor, for_loop.attrs());
 
             editor.insert(
                 Position::before(for_loop.syntax()),
-                make.whitespace(format!("\n{indent}").as_str()),
+                editor.make().whitespace(format!("\n{indent}").as_str()),
             );
             editor.insert(Position::before(for_loop.syntax()), mut_expr.syntax());
 
-            let opt_pat = make.tuple_struct_pat(make.ident_path("Some"), [pat]);
-            let iter_next_expr = make.expr_method_call(
-                make.expr_path(make.ident_path(&tmp_var)),
-                make.name_ref("next"),
-                make.arg_list([]),
+            let opt_pat = editor.make().tuple_struct_pat(editor.make().ident_path("Some"), [pat]);
+            let iter_next_expr = editor.make().expr_method_call(
+                editor.make().expr_path(editor.make().ident_path(&tmp_var)),
+                editor.make().name_ref("next"),
+                editor.make().arg_list([]),
             );
-            let cond = make.expr_let(opt_pat.into(), iter_next_expr.into());
+            let cond = editor.make().expr_let(opt_pat.into(), iter_next_expr.into());
 
-            let while_loop = make.expr_while_loop(cond.into(), body);
+            let while_loop = editor.make().expr_while_loop(cond.into(), body);
 
             editor.replace(for_loop.syntax(), while_loop.syntax());
 
-            editor.add_mappings(make.finish_with_mappings());
             builder.add_file_edits(ctx.vfs_file_id(), editor);
         },
     )

--- a/crates/ide-assists/src/handlers/convert_for_to_while_let.rs
+++ b/crates/ide-assists/src/handlers/convert_for_to_while_let.rs
@@ -48,24 +48,22 @@ pub(crate) fn convert_for_loop_to_while_let(
         "Replace this for loop with `while let`",
         for_loop.syntax().text_range(),
         |builder| {
-            let mut editor = builder.make_editor(for_loop.syntax());
+            let editor = builder.make_editor(for_loop.syntax());
+            let make = editor.make();
 
             let (iterable, method) = if impls_core_iter(&ctx.sema, &iterable) {
                 (iterable, None)
             } else if let Some((expr, method)) = is_ref_and_impls_iter_method(&ctx.sema, &iterable)
             {
-                (expr, Some(editor.make().name_ref(method.as_str())))
+                (expr, Some(make.name_ref(method.as_str())))
             } else if let ast::Expr::RefExpr(_) = iterable {
-                (
-                    editor.make().expr_paren(iterable).into(),
-                    Some(editor.make().name_ref("into_iter")),
-                )
+                (make.expr_paren(iterable).into(), Some(make.name_ref("into_iter")))
             } else {
-                (iterable, Some(editor.make().name_ref("into_iter")))
+                (iterable, Some(make.name_ref("into_iter")))
             };
 
             let iterable = if let Some(method) = method {
-                editor.make().expr_method_call(iterable, method, editor.make().arg_list([])).into()
+                make.expr_method_call(iterable, method, make.arg_list([])).into()
             } else {
                 iterable
             };
@@ -75,8 +73,8 @@ pub(crate) fn convert_for_loop_to_while_let(
             );
             let tmp_var = new_name.suggest_name("iter");
 
-            let mut_expr = editor.make().let_stmt(
-                editor.make().ident_pat(false, true, editor.make().name(&tmp_var)).into(),
+            let mut_expr = make.let_stmt(
+                make.ident_pat(false, true, make.name(&tmp_var)).into(),
                 None,
                 Some(iterable),
             );
@@ -84,26 +82,26 @@ pub(crate) fn convert_for_loop_to_while_let(
 
             if let Some(label) = for_loop.label() {
                 let label = label.syntax();
-                editor.insert(Position::before(for_loop.syntax()), editor.make().whitespace(" "));
+                editor.insert(Position::before(for_loop.syntax()), make.whitespace(" "));
                 editor.insert(Position::before(for_loop.syntax()), label);
             }
-            crate::utils::insert_attributes(for_loop.syntax(), &mut editor, for_loop.attrs());
+            crate::utils::insert_attributes(for_loop.syntax(), &editor, for_loop.attrs());
 
             editor.insert(
                 Position::before(for_loop.syntax()),
-                editor.make().whitespace(format!("\n{indent}").as_str()),
+                make.whitespace(format!("\n{indent}").as_str()),
             );
             editor.insert(Position::before(for_loop.syntax()), mut_expr.syntax());
 
-            let opt_pat = editor.make().tuple_struct_pat(editor.make().ident_path("Some"), [pat]);
-            let iter_next_expr = editor.make().expr_method_call(
-                editor.make().expr_path(editor.make().ident_path(&tmp_var)),
-                editor.make().name_ref("next"),
-                editor.make().arg_list([]),
+            let opt_pat = make.tuple_struct_pat(make.ident_path("Some"), [pat]);
+            let iter_next_expr = make.expr_method_call(
+                make.expr_path(make.ident_path(&tmp_var)),
+                make.name_ref("next"),
+                make.arg_list([]),
             );
-            let cond = editor.make().expr_let(opt_pat.into(), iter_next_expr.into());
+            let cond = make.expr_let(opt_pat.into(), iter_next_expr.into());
 
-            let while_loop = editor.make().expr_while_loop(cond.into(), body);
+            let while_loop = make.expr_while_loop(cond.into(), body);
 
             editor.replace(for_loop.syntax(), while_loop.syntax());
 

--- a/crates/ide-assists/src/handlers/convert_from_to_tryfrom.rs
+++ b/crates/ide-assists/src/handlers/convert_from_to_tryfrom.rs
@@ -74,32 +74,24 @@ pub(crate) fn convert_from_to_tryfrom(acc: &mut Assists, ctx: &AssistContext<'_>
         "Convert From to TryFrom",
         impl_.syntax().text_range(),
         |builder| {
-            let mut editor = builder.make_editor(impl_.syntax());
+            let editor = builder.make_editor(impl_.syntax());
+            let make = editor.make();
 
-            editor.replace(
-                trait_ty.syntax(),
-                editor.make().ty(&format!("TryFrom<{from_type}>")).syntax(),
-            );
+            editor.replace(trait_ty.syntax(), make.ty(&format!("TryFrom<{from_type}>")).syntax());
             editor.replace(
                 from_fn_return_type.syntax(),
-                editor.make().ty("Result<Self, Self::Error>").syntax(),
+                make.ty("Result<Self, Self::Error>").syntax(),
             );
-            editor.replace(from_fn_name.syntax(), editor.make().name("try_from").syntax());
-            editor.replace(tail_expr.syntax(), wrap_ok(editor.make(), tail_expr.clone()).syntax());
+            editor.replace(from_fn_name.syntax(), make.name("try_from").syntax());
+            editor.replace(tail_expr.syntax(), wrap_ok(make, tail_expr.clone()).syntax());
 
             for r in return_exprs {
-                let t = r.expr().unwrap_or_else(|| editor.make().expr_unit());
-                editor.replace(t.syntax(), wrap_ok(editor.make(), t.clone()).syntax());
+                let t = r.expr().unwrap_or_else(|| make.expr_unit());
+                editor.replace(t.syntax(), wrap_ok(make, t.clone()).syntax());
             }
 
-            let error_type_alias = editor.make().ty_alias(
-                None,
-                "Error",
-                None,
-                None,
-                None,
-                Some((editor.make().ty("()"), None)),
-            );
+            let error_type_alias =
+                make.ty_alias(None, "Error", None, None, None, Some((make.ty("()"), None)));
             let error_type = ast::AssocItem::TypeAlias(error_type_alias);
 
             if let Some(cap) = ctx.config.snippet_cap
@@ -114,9 +106,9 @@ pub(crate) fn convert_from_to_tryfrom(acc: &mut Assists, ctx: &AssistContext<'_>
             editor.insert_all(
                 Position::after(associated_l_curly),
                 vec![
-                    editor.make().whitespace(&format!("\n{indent}")).syntax_element(),
+                    make.whitespace(&format!("\n{indent}")).syntax_element(),
                     error_type.syntax().syntax_element(),
-                    editor.make().whitespace("\n").syntax_element(),
+                    make.whitespace("\n").syntax_element(),
                 ],
             );
             builder.add_file_edits(ctx.vfs_file_id(), editor);

--- a/crates/ide-assists/src/handlers/convert_from_to_tryfrom.rs
+++ b/crates/ide-assists/src/handlers/convert_from_to_tryfrom.rs
@@ -74,24 +74,32 @@ pub(crate) fn convert_from_to_tryfrom(acc: &mut Assists, ctx: &AssistContext<'_>
         "Convert From to TryFrom",
         impl_.syntax().text_range(),
         |builder| {
-            let make = SyntaxFactory::with_mappings();
             let mut editor = builder.make_editor(impl_.syntax());
 
-            editor.replace(trait_ty.syntax(), make.ty(&format!("TryFrom<{from_type}>")).syntax());
+            editor.replace(
+                trait_ty.syntax(),
+                editor.make().ty(&format!("TryFrom<{from_type}>")).syntax(),
+            );
             editor.replace(
                 from_fn_return_type.syntax(),
-                make.ty("Result<Self, Self::Error>").syntax(),
+                editor.make().ty("Result<Self, Self::Error>").syntax(),
             );
-            editor.replace(from_fn_name.syntax(), make.name("try_from").syntax());
-            editor.replace(tail_expr.syntax(), wrap_ok(&make, tail_expr.clone()).syntax());
+            editor.replace(from_fn_name.syntax(), editor.make().name("try_from").syntax());
+            editor.replace(tail_expr.syntax(), wrap_ok(editor.make(), tail_expr.clone()).syntax());
 
             for r in return_exprs {
-                let t = r.expr().unwrap_or_else(|| make.expr_unit());
-                editor.replace(t.syntax(), wrap_ok(&make, t.clone()).syntax());
+                let t = r.expr().unwrap_or_else(|| editor.make().expr_unit());
+                editor.replace(t.syntax(), wrap_ok(editor.make(), t.clone()).syntax());
             }
 
-            let error_type_alias =
-                make.ty_alias(None, "Error", None, None, None, Some((make.ty("()"), None)));
+            let error_type_alias = editor.make().ty_alias(
+                None,
+                "Error",
+                None,
+                None,
+                None,
+                Some((editor.make().ty("()"), None)),
+            );
             let error_type = ast::AssocItem::TypeAlias(error_type_alias);
 
             if let Some(cap) = ctx.config.snippet_cap
@@ -106,12 +114,11 @@ pub(crate) fn convert_from_to_tryfrom(acc: &mut Assists, ctx: &AssistContext<'_>
             editor.insert_all(
                 Position::after(associated_l_curly),
                 vec![
-                    make.whitespace(&format!("\n{indent}")).syntax_element(),
+                    editor.make().whitespace(&format!("\n{indent}")).syntax_element(),
                     error_type.syntax().syntax_element(),
-                    make.whitespace("\n").syntax_element(),
+                    editor.make().whitespace("\n").syntax_element(),
                 ],
             );
-            editor.add_mappings(make.finish_with_mappings());
             builder.add_file_edits(ctx.vfs_file_id(), editor);
         },
     )

--- a/crates/ide-assists/src/handlers/convert_iter_for_each_to_for.rs
+++ b/crates/ide-assists/src/handlers/convert_iter_for_each_to_for.rs
@@ -58,19 +58,18 @@ pub(crate) fn convert_iter_for_each_to_for(
         range,
         |builder| {
             let target_node = stmt.as_ref().map_or(method.syntax(), AstNode::syntax);
-            let mut editor = builder.make_editor(target_node);
+            let editor = builder.make_editor(target_node);
+            let make = editor.make();
             let indent =
                 stmt.as_ref().map_or_else(|| method.indent_level(), ast::ExprStmt::indent_level);
 
             let block = match body {
                 ast::Expr::BlockExpr(block) => block.reset_indent(),
-                _ => {
-                    editor.make().block_expr(Vec::new(), Some(body.reset_indent().indent(1.into())))
-                }
+                _ => make.block_expr(Vec::new(), Some(body.reset_indent().indent(1.into()))),
             }
             .indent(indent);
 
-            let expr_for_loop = editor.make().expr_for_loop(param, receiver, block);
+            let expr_for_loop = make.expr_for_loop(param, receiver, block);
             editor.replace(target_node, expr_for_loop.syntax());
             builder.add_file_edits(ctx.vfs_file_id(), editor);
         },

--- a/crates/ide-assists/src/handlers/convert_iter_for_each_to_for.rs
+++ b/crates/ide-assists/src/handlers/convert_iter_for_each_to_for.rs
@@ -3,7 +3,7 @@ use ide_db::famous_defs::FamousDefs;
 use stdx::format_to;
 use syntax::{
     AstNode,
-    ast::{self, HasArgList, HasLoopBody, edit::AstNodeEdit, syntax_factory::SyntaxFactory},
+    ast::{self, HasArgList, HasLoopBody, edit::AstNodeEdit},
 };
 
 use crate::{AssistContext, AssistId, Assists};
@@ -57,20 +57,20 @@ pub(crate) fn convert_iter_for_each_to_for(
         "Replace this `Iterator::for_each` with a for loop",
         range,
         |builder| {
-            let make = SyntaxFactory::with_mappings();
+            let target_node = stmt.as_ref().map_or(method.syntax(), AstNode::syntax);
+            let mut editor = builder.make_editor(target_node);
             let indent =
                 stmt.as_ref().map_or_else(|| method.indent_level(), ast::ExprStmt::indent_level);
 
             let block = match body {
                 ast::Expr::BlockExpr(block) => block.reset_indent(),
-                _ => make.block_expr(Vec::new(), Some(body.reset_indent().indent(1.into()))),
+                _ => {
+                    editor.make().block_expr(Vec::new(), Some(body.reset_indent().indent(1.into())))
+                }
             }
             .indent(indent);
 
-            let expr_for_loop = make.expr_for_loop(param, receiver, block);
-
-            let target_node = stmt.as_ref().map_or(method.syntax(), AstNode::syntax);
-            let mut editor = builder.make_editor(target_node);
+            let expr_for_loop = editor.make().expr_for_loop(param, receiver, block);
             editor.replace(target_node, expr_for_loop.syntax());
             builder.add_file_edits(ctx.vfs_file_id(), editor);
         },

--- a/crates/ide-assists/src/handlers/convert_let_else_to_match.rs
+++ b/crates/ide-assists/src/handlers/convert_let_else_to_match.rs
@@ -25,7 +25,7 @@ use crate::{AssistContext, AssistId, Assists};
 // }
 // ```
 pub(crate) fn convert_let_else_to_match(acc: &mut Assists, ctx: &AssistContext<'_>) -> Option<()> {
-    let (mut editor, _) = SyntaxEditor::new(ctx.source_file().syntax().clone());
+    let (editor, _) = SyntaxEditor::new(ctx.source_file().syntax().clone());
     // Should focus on the `else` token to trigger
     let let_stmt = ctx
         .find_token_syntax_at_offset(T![else])
@@ -47,7 +47,7 @@ pub(crate) fn convert_let_else_to_match(acc: &mut Assists, ctx: &AssistContext<'
     }
     let pat = let_stmt.pat()?;
     let mut idents = Vec::default();
-    let pat_without_mut = remove_mut_and_collect_idents(&mut editor, &pat, &mut idents)?;
+    let pat_without_mut = remove_mut_and_collect_idents(&editor, &pat, &mut idents)?;
     let bindings = idents
         .into_iter()
         .filter_map(|ref pat| {
@@ -69,14 +69,13 @@ pub(crate) fn convert_let_else_to_match(acc: &mut Assists, ctx: &AssistContext<'
         },
         let_stmt.syntax().text_range(),
         |builder| {
+            let make = editor.make();
             let binding_paths = bindings
                 .iter()
-                .map(|(name, _)| {
-                    editor.make().expr_path(editor.make().ident_path(&name.to_string()))
-                })
+                .map(|(name, _)| make.expr_path(make.ident_path(&name.to_string())))
                 .collect::<Vec<_>>();
 
-            let binding_arm = editor.make().match_arm(
+            let binding_arm = make.match_arm(
                 pat_without_mut,
                 None,
                 // There are three possible cases:
@@ -85,16 +84,15 @@ pub(crate) fn convert_let_else_to_match(acc: &mut Assists, ctx: &AssistContext<'
                 // - Single binding: `Some(it) => it`
                 // - Multiple bindings: `Foo::Bar { a, b, .. } => (a, b)`
                 match binding_paths.len() {
-                    0 => editor.make().expr_empty_block().into(),
+                    0 => make.expr_empty_block().into(),
 
                     1 => binding_paths[0].clone(),
-                    _ => editor.make().expr_tuple(binding_paths).into(),
+                    _ => make.expr_tuple(binding_paths).into(),
                 },
             );
-            let else_arm =
-                editor.make().match_arm(editor.make().wildcard_pat().into(), None, else_expr);
+            let else_arm = make.match_arm(make.wildcard_pat().into(), None, else_expr);
             let arms = [binding_arm, else_arm].map(|arm| arm.indent(1.into()));
-            let match_ = editor.make().expr_match(init, editor.make().match_arm_list(arms));
+            let match_ = make.expr_match(init, make.match_arm_list(arms));
             let match_ = match_.indent(let_stmt.indent_level());
 
             if bindings.is_empty() {
@@ -102,13 +100,13 @@ pub(crate) fn convert_let_else_to_match(acc: &mut Assists, ctx: &AssistContext<'
             } else {
                 let ident_pats = bindings
                     .into_iter()
-                    .map(|(name, is_mut)| editor.make().ident_pat(false, is_mut, name).into())
+                    .map(|(name, is_mut)| make.ident_pat(false, is_mut, name).into())
                     .collect::<Vec<Pat>>();
-                let new_let_stmt = editor.make().let_stmt(
+                let new_let_stmt = make.let_stmt(
                     if ident_pats.len() == 1 {
                         ident_pats[0].clone()
                     } else {
-                        editor.make().tuple_pat(ident_pats).into()
+                        make.tuple_pat(ident_pats).into()
                     },
                     None,
                     Some(match_.into()),
@@ -121,14 +119,15 @@ pub(crate) fn convert_let_else_to_match(acc: &mut Assists, ctx: &AssistContext<'
 }
 
 fn remove_mut_and_collect_idents(
-    editor: &mut SyntaxEditor,
+    editor: &SyntaxEditor,
     pat: &ast::Pat,
     acc: &mut Vec<ast::IdentPat>,
 ) -> Option<ast::Pat> {
+    let make = editor.make();
     Some(match pat {
         ast::Pat::IdentPat(p) => {
             acc.push(p.clone());
-            let non_mut_pat = editor.make().ident_pat(
+            let non_mut_pat = make.ident_pat(
                 p.ref_token().is_some(),
                 p.ref_token().is_some() && p.mut_token().is_some(),
                 p.name()?,
@@ -142,18 +141,18 @@ fn remove_mut_and_collect_idents(
         }
         ast::Pat::BoxPat(p) => {
             let pat = remove_mut_and_collect_idents(editor, &p.pat()?, acc)?;
-            editor.make().box_pat(pat).into()
+            make.box_pat(pat).into()
         }
         ast::Pat::OrPat(p) => {
             let pats = p
                 .pats()
                 .map(|pat| remove_mut_and_collect_idents(editor, &pat, acc))
                 .collect::<Option<Vec<_>>>()?;
-            editor.make().or_pat(pats, p.leading_pipe().is_some()).into()
+            make.or_pat(pats, p.leading_pipe().is_some()).into()
         }
         ast::Pat::ParenPat(p) => {
             let pat = remove_mut_and_collect_idents(editor, &p.pat()?, acc)?;
-            editor.make().paren_pat(pat).into()
+            make.paren_pat(pat).into()
         }
         ast::Pat::RangePat(p) => {
             let start = if let Some(start) = p.start() {
@@ -166,7 +165,7 @@ fn remove_mut_and_collect_idents(
             } else {
                 None
             };
-            editor.make().range_pat(start, end).into()
+            make.range_pat(start, end).into()
         }
         ast::Pat::RecordPat(p) => {
             let fields = p
@@ -175,9 +174,9 @@ fn remove_mut_and_collect_idents(
                 .map(|field| {
                     remove_mut_and_collect_idents(editor, &field.pat()?, acc).map(|pat| {
                         if let Some(name_ref) = field.name_ref() {
-                            editor.make().record_pat_field(name_ref, pat)
+                            make.record_pat_field(name_ref, pat)
                         } else {
-                            editor.make().record_pat_field_shorthand(pat)
+                            make.record_pat_field_shorthand(pat)
                         }
                     })
                 })
@@ -199,7 +198,7 @@ fn remove_mut_and_collect_idents(
                 p.clone().into()
             } else {
                 let pat = remove_mut_and_collect_idents(editor, &inner, acc)?;
-                editor.make().ref_pat(pat).into()
+                make.ref_pat(pat).into()
             }
         }
         ast::Pat::SlicePat(p) => {
@@ -207,21 +206,21 @@ fn remove_mut_and_collect_idents(
                 .pats()
                 .map(|pat| remove_mut_and_collect_idents(editor, &pat, acc))
                 .collect::<Option<Vec<_>>>()?;
-            editor.make().slice_pat(pats).into()
+            make.slice_pat(pats).into()
         }
         ast::Pat::TuplePat(p) => {
             let pats = p
                 .fields()
                 .map(|field| remove_mut_and_collect_idents(editor, &field, acc))
                 .collect::<Option<Vec<_>>>()?;
-            editor.make().tuple_pat(pats).into()
+            make.tuple_pat(pats).into()
         }
         ast::Pat::TupleStructPat(p) => {
             let fields = p
                 .fields()
                 .map(|field| remove_mut_and_collect_idents(editor, &field, acc))
                 .collect::<Option<Vec<_>>>()?;
-            editor.make().tuple_struct_pat(p.path()?, fields).into()
+            make.tuple_struct_pat(p.path()?, fields).into()
         }
         ast::Pat::RestPat(_)
         | ast::Pat::LiteralPat(_)

--- a/crates/ide-assists/src/handlers/convert_let_else_to_match.rs
+++ b/crates/ide-assists/src/handlers/convert_let_else_to_match.rs
@@ -1,7 +1,6 @@
 use syntax::T;
 use syntax::ast::RangeItem;
 use syntax::ast::edit::AstNodeEdit;
-use syntax::ast::syntax_factory::SyntaxFactory;
 use syntax::ast::{self, AstNode, HasName, LetStmt, Pat};
 use syntax::syntax_editor::SyntaxEditor;
 
@@ -26,15 +25,13 @@ use crate::{AssistContext, AssistId, Assists};
 // }
 // ```
 pub(crate) fn convert_let_else_to_match(acc: &mut Assists, ctx: &AssistContext<'_>) -> Option<()> {
-    let root = ctx.source_file().syntax().clone();
-    let (mut editor, _) = SyntaxEditor::new(root);
+    let (mut editor, _) = SyntaxEditor::new(ctx.source_file().syntax().clone());
     // Should focus on the `else` token to trigger
     let let_stmt = ctx
         .find_token_syntax_at_offset(T![else])
         .and_then(|it| it.parent()?.parent())
         .or_else(|| ctx.find_token_syntax_at_offset(T![let])?.parent())?;
     let let_stmt = LetStmt::cast(let_stmt)?;
-    let make = SyntaxFactory::with_mappings();
     let else_block = let_stmt.let_else()?.block_expr()?;
     let else_expr = if else_block.statements().next().is_none()
         && let Some(tail_expr) = else_block.tail_expr()
@@ -50,7 +47,7 @@ pub(crate) fn convert_let_else_to_match(acc: &mut Assists, ctx: &AssistContext<'
     }
     let pat = let_stmt.pat()?;
     let mut idents = Vec::default();
-    let pat_without_mut = remove_mut_and_collect_idents(&make, &mut editor, &pat, &mut idents)?;
+    let pat_without_mut = remove_mut_and_collect_idents(&mut editor, &pat, &mut idents)?;
     let bindings = idents
         .into_iter()
         .filter_map(|ref pat| {
@@ -72,14 +69,14 @@ pub(crate) fn convert_let_else_to_match(acc: &mut Assists, ctx: &AssistContext<'
         },
         let_stmt.syntax().text_range(),
         |builder| {
-            // let mut editor = builder.make_editor(let_stmt.syntax());
-
             let binding_paths = bindings
                 .iter()
-                .map(|(name, _)| make.expr_path(make.ident_path(&name.to_string())))
+                .map(|(name, _)| {
+                    editor.make().expr_path(editor.make().ident_path(&name.to_string()))
+                })
                 .collect::<Vec<_>>();
 
-            let binding_arm = make.match_arm(
+            let binding_arm = editor.make().match_arm(
                 pat_without_mut,
                 None,
                 // There are three possible cases:
@@ -88,15 +85,16 @@ pub(crate) fn convert_let_else_to_match(acc: &mut Assists, ctx: &AssistContext<'
                 // - Single binding: `Some(it) => it`
                 // - Multiple bindings: `Foo::Bar { a, b, .. } => (a, b)`
                 match binding_paths.len() {
-                    0 => make.expr_empty_block().into(),
+                    0 => editor.make().expr_empty_block().into(),
 
                     1 => binding_paths[0].clone(),
-                    _ => make.expr_tuple(binding_paths).into(),
+                    _ => editor.make().expr_tuple(binding_paths).into(),
                 },
             );
-            let else_arm = make.match_arm(make.wildcard_pat().into(), None, else_expr);
+            let else_arm =
+                editor.make().match_arm(editor.make().wildcard_pat().into(), None, else_expr);
             let arms = [binding_arm, else_arm].map(|arm| arm.indent(1.into()));
-            let match_ = make.expr_match(init, make.match_arm_list(arms));
+            let match_ = editor.make().expr_match(init, editor.make().match_arm_list(arms));
             let match_ = match_.indent(let_stmt.indent_level());
 
             if bindings.is_empty() {
@@ -104,28 +102,25 @@ pub(crate) fn convert_let_else_to_match(acc: &mut Assists, ctx: &AssistContext<'
             } else {
                 let ident_pats = bindings
                     .into_iter()
-                    .map(|(name, is_mut)| make.ident_pat(false, is_mut, name).into())
+                    .map(|(name, is_mut)| editor.make().ident_pat(false, is_mut, name).into())
                     .collect::<Vec<Pat>>();
-                let new_let_stmt = make.let_stmt(
+                let new_let_stmt = editor.make().let_stmt(
                     if ident_pats.len() == 1 {
                         ident_pats[0].clone()
                     } else {
-                        make.tuple_pat(ident_pats).into()
+                        editor.make().tuple_pat(ident_pats).into()
                     },
                     None,
                     Some(match_.into()),
                 );
                 editor.replace(let_stmt.syntax(), new_let_stmt.syntax());
             }
-
-            editor.add_mappings(make.finish_with_mappings());
             builder.add_file_edits(ctx.vfs_file_id(), editor);
         },
     )
 }
 
 fn remove_mut_and_collect_idents(
-    make: &SyntaxFactory,
     editor: &mut SyntaxEditor,
     pat: &ast::Pat,
     acc: &mut Vec<ast::IdentPat>,
@@ -133,103 +128,101 @@ fn remove_mut_and_collect_idents(
     Some(match pat {
         ast::Pat::IdentPat(p) => {
             acc.push(p.clone());
-            let non_mut_pat = make.ident_pat(
+            let non_mut_pat = editor.make().ident_pat(
                 p.ref_token().is_some(),
                 p.ref_token().is_some() && p.mut_token().is_some(),
                 p.name()?,
             );
             let non_mut_pat = if let Some(inner) = p.pat() {
-                non_mut_pat.set_pat(
-                    remove_mut_and_collect_idents(make, editor, &inner, acc),
-                    editor,
-                    make,
-                )
+                non_mut_pat.set_pat(remove_mut_and_collect_idents(editor, &inner, acc), editor)
             } else {
                 non_mut_pat
             };
             non_mut_pat.into()
         }
         ast::Pat::BoxPat(p) => {
-            make.box_pat(remove_mut_and_collect_idents(make, editor, &p.pat()?, acc)?).into()
+            let pat = remove_mut_and_collect_idents(editor, &p.pat()?, acc)?;
+            editor.make().box_pat(pat).into()
         }
-        ast::Pat::OrPat(p) => make
-            .or_pat(
-                p.pats()
-                    .map(|pat| remove_mut_and_collect_idents(make, editor, &pat, acc))
-                    .collect::<Option<Vec<_>>>()?,
-                p.leading_pipe().is_some(),
-            )
-            .into(),
+        ast::Pat::OrPat(p) => {
+            let pats = p
+                .pats()
+                .map(|pat| remove_mut_and_collect_idents(editor, &pat, acc))
+                .collect::<Option<Vec<_>>>()?;
+            editor.make().or_pat(pats, p.leading_pipe().is_some()).into()
+        }
         ast::Pat::ParenPat(p) => {
-            make.paren_pat(remove_mut_and_collect_idents(make, editor, &p.pat()?, acc)?).into()
+            let pat = remove_mut_and_collect_idents(editor, &p.pat()?, acc)?;
+            editor.make().paren_pat(pat).into()
         }
-        ast::Pat::RangePat(p) => make
-            .range_pat(
-                if let Some(start) = p.start() {
-                    Some(remove_mut_and_collect_idents(make, editor, &start, acc)?)
-                } else {
-                    None
-                },
-                if let Some(end) = p.end() {
-                    Some(remove_mut_and_collect_idents(make, editor, &end, acc)?)
-                } else {
-                    None
-                },
-            )
-            .into(),
-        ast::Pat::RecordPat(p) => make
-            .record_pat_with_fields(
-                p.path()?,
-                make.record_pat_field_list(
-                    p.record_pat_field_list()?
-                        .fields()
-                        .map(|field| {
-                            remove_mut_and_collect_idents(make, editor, &field.pat()?, acc).map(
-                                |pat| {
-                                    if let Some(name_ref) = field.name_ref() {
-                                        make.record_pat_field(name_ref, pat)
-                                    } else {
-                                        make.record_pat_field_shorthand(pat)
-                                    }
-                                },
-                            )
-                        })
-                        .collect::<Option<Vec<_>>>()?,
-                    p.record_pat_field_list()?.rest_pat(),
-                ),
-            )
-            .into(),
+        ast::Pat::RangePat(p) => {
+            let start = if let Some(start) = p.start() {
+                Some(remove_mut_and_collect_idents(editor, &start, acc)?)
+            } else {
+                None
+            };
+            let end = if let Some(end) = p.end() {
+                Some(remove_mut_and_collect_idents(editor, &end, acc)?)
+            } else {
+                None
+            };
+            editor.make().range_pat(start, end).into()
+        }
+        ast::Pat::RecordPat(p) => {
+            let fields = p
+                .record_pat_field_list()?
+                .fields()
+                .map(|field| {
+                    remove_mut_and_collect_idents(editor, &field.pat()?, acc).map(|pat| {
+                        if let Some(name_ref) = field.name_ref() {
+                            editor.make().record_pat_field(name_ref, pat)
+                        } else {
+                            editor.make().record_pat_field_shorthand(pat)
+                        }
+                    })
+                })
+                .collect::<Option<Vec<_>>>()?;
+            editor
+                .make()
+                .record_pat_with_fields(
+                    p.path()?,
+                    editor
+                        .make()
+                        .record_pat_field_list(fields, p.record_pat_field_list()?.rest_pat()),
+                )
+                .into()
+        }
         ast::Pat::RefPat(p) => {
             let inner = p.pat()?;
             if let ast::Pat::IdentPat(ident) = inner {
                 acc.push(ident);
                 p.clone().into()
             } else {
-                make.ref_pat(remove_mut_and_collect_idents(make, editor, &inner, acc)?).into()
+                let pat = remove_mut_and_collect_idents(editor, &inner, acc)?;
+                editor.make().ref_pat(pat).into()
             }
         }
-        ast::Pat::SlicePat(p) => make
-            .slice_pat(
-                p.pats()
-                    .map(|pat| remove_mut_and_collect_idents(make, editor, &pat, acc))
-                    .collect::<Option<Vec<_>>>()?,
-            )
-            .into(),
-        ast::Pat::TuplePat(p) => make
-            .tuple_pat(
-                p.fields()
-                    .map(|field| remove_mut_and_collect_idents(make, editor, &field, acc))
-                    .collect::<Option<Vec<_>>>()?,
-            )
-            .into(),
-        ast::Pat::TupleStructPat(p) => make
-            .tuple_struct_pat(
-                p.path()?,
-                p.fields()
-                    .map(|field| remove_mut_and_collect_idents(make, editor, &field, acc))
-                    .collect::<Option<Vec<_>>>()?,
-            )
-            .into(),
+        ast::Pat::SlicePat(p) => {
+            let pats = p
+                .pats()
+                .map(|pat| remove_mut_and_collect_idents(editor, &pat, acc))
+                .collect::<Option<Vec<_>>>()?;
+            editor.make().slice_pat(pats).into()
+        }
+        ast::Pat::TuplePat(p) => {
+            let pats = p
+                .fields()
+                .map(|field| remove_mut_and_collect_idents(editor, &field, acc))
+                .collect::<Option<Vec<_>>>()?;
+            editor.make().tuple_pat(pats).into()
+        }
+        ast::Pat::TupleStructPat(p) => {
+            let fields = p
+                .fields()
+                .map(|field| remove_mut_and_collect_idents(editor, &field, acc))
+                .collect::<Option<Vec<_>>>()?;
+            editor.make().tuple_struct_pat(p.path()?, fields).into()
+        }
         ast::Pat::RestPat(_)
         | ast::Pat::LiteralPat(_)
         | ast::Pat::PathPat(_)

--- a/crates/ide-assists/src/handlers/convert_match_to_let_else.rs
+++ b/crates/ide-assists/src/handlers/convert_match_to_let_else.rs
@@ -121,7 +121,8 @@ fn find_extracted_variable(ctx: &AssistContext<'_>, arm: &ast::MatchArm) -> Opti
 
 // Rename `extracted` with `binding` in `pat`.
 fn rename_variable(pat: &ast::Pat, extracted: &[Name], binding: ast::Pat) -> SyntaxNode {
-    let (mut editor, syntax) = SyntaxEditor::new(pat.syntax().clone());
+    let (editor, syntax) = SyntaxEditor::new(pat.syntax().clone());
+    let make = editor.make();
     let extracted = extracted
         .iter()
         .map(|e| e.syntax().text_range() - pat.syntax().text_range().start())
@@ -138,7 +139,7 @@ fn rename_variable(pat: &ast::Pat, extracted: &[Name], binding: ast::Pat) -> Syn
                     record_pat_field.syntax(),
                     editor
                         .make()
-                        .record_pat_field(editor.make().name_ref(&name_ref.text()), binding.clone())
+                        .record_pat_field(make.name_ref(&name_ref.text()), binding.clone())
                         .syntax(),
                 );
             }

--- a/crates/ide-assists/src/handlers/convert_match_to_let_else.rs
+++ b/crates/ide-assists/src/handlers/convert_match_to_let_else.rs
@@ -1,7 +1,7 @@
 use ide_db::defs::{Definition, NameRefClass};
 use syntax::{
     AstNode, SyntaxNode,
-    ast::{self, HasName, Name, edit::AstNodeEdit, syntax_factory::SyntaxFactory},
+    ast::{self, HasName, Name, edit::AstNodeEdit},
     syntax_editor::SyntaxEditor,
 };
 
@@ -122,7 +122,6 @@ fn find_extracted_variable(ctx: &AssistContext<'_>, arm: &ast::MatchArm) -> Opti
 // Rename `extracted` with `binding` in `pat`.
 fn rename_variable(pat: &ast::Pat, extracted: &[Name], binding: ast::Pat) -> SyntaxNode {
     let (mut editor, syntax) = SyntaxEditor::new(pat.syntax().clone());
-    let make = SyntaxFactory::with_mappings();
     let extracted = extracted
         .iter()
         .map(|e| e.syntax().text_range() - pat.syntax().text_range().start())
@@ -137,7 +136,9 @@ fn rename_variable(pat: &ast::Pat, extracted: &[Name], binding: ast::Pat) -> Syn
             if let Some(name_ref) = record_pat_field.field_name() {
                 editor.replace(
                     record_pat_field.syntax(),
-                    make.record_pat_field(make.name_ref(&name_ref.text()), binding.clone())
+                    editor
+                        .make()
+                        .record_pat_field(editor.make().name_ref(&name_ref.text()), binding.clone())
                         .syntax(),
                 );
             }
@@ -145,7 +146,6 @@ fn rename_variable(pat: &ast::Pat, extracted: &[Name], binding: ast::Pat) -> Syn
             editor.replace(extracted_syntax, binding.syntax());
         }
     }
-    editor.add_mappings(make.finish_with_mappings());
     let new_node = editor.finish().new_root().clone();
     if let Some(pat) = ast::Pat::cast(new_node.clone()) {
         pat.dedent(1.into()).syntax().clone()

--- a/crates/ide-assists/src/handlers/convert_named_struct_to_tuple_struct.rs
+++ b/crates/ide-assists/src/handlers/convert_named_struct_to_tuple_struct.rs
@@ -3,9 +3,7 @@ use ide_db::{defs::Definition, search::FileReference};
 use syntax::{
     NodeOrToken, SyntaxKind, SyntaxNode, T,
     algo::next_non_trivia_token,
-    ast::{
-        self, AstNode, HasAttrs, HasGenericParams, HasVisibility, syntax_factory::SyntaxFactory,
-    },
+    ast::{self, AstNode, HasAttrs, HasGenericParams, HasVisibility},
     match_ast,
     syntax_editor::{Element, Position, SyntaxEditor},
 };
@@ -113,21 +111,20 @@ fn edit_struct_def(
         Some(field)
     });
 
-    let make = SyntaxFactory::without_mappings();
-    let mut edit = builder.make_editor(strukt.syntax());
+    let mut editor = builder.make_editor(strukt.syntax());
 
-    let tuple_fields = make.tuple_field_list(tuple_fields);
+    let tuple_fields = editor.make().tuple_field_list(tuple_fields);
 
     let mut elements = vec![tuple_fields.syntax().clone().into()];
     if let Either::Left(strukt) = strukt {
         if let Some(w) = strukt.where_clause() {
-            edit.delete(w.syntax());
+            editor.delete(w.syntax());
 
             elements.extend([
-                make.whitespace("\n").into(),
+                editor.make().whitespace("\n").into(),
                 remove_trailing_comma(w).into(),
-                make.token(T![;]).into(),
-                make.whitespace("\n").into(),
+                editor.make().token(T![;]).into(),
+                editor.make().whitespace("\n").into(),
             ]);
 
             if let Some(tok) = strukt
@@ -136,23 +133,23 @@ fn edit_struct_def(
                 .and_then(|tok| tok.next_token())
                 .filter(|tok| tok.kind() == SyntaxKind::WHITESPACE)
             {
-                edit.delete(tok);
+                editor.delete(tok);
             }
         } else {
-            elements.push(make.token(T![;]).into());
+            elements.push(editor.make().token(T![;]).into());
         }
     }
-    edit.replace_with_many(record_fields.syntax(), elements);
+    editor.replace_with_many(record_fields.syntax(), elements);
 
     if let Some(tok) = record_fields
         .l_curly_token()
         .and_then(|tok| tok.prev_token())
         .filter(|tok| tok.kind() == SyntaxKind::WHITESPACE)
     {
-        edit.delete(tok)
+        editor.delete(tok)
     }
 
-    builder.add_file_edits(ctx.vfs_file_id(), edit);
+    builder.add_file_edits(ctx.vfs_file_id(), editor);
 }
 
 fn edit_struct_references(
@@ -232,7 +229,7 @@ fn process_struct_name_reference(
 fn record_to_tuple_struct_like<T, I>(
     ctx: &AssistContext<'_>,
     source: &ast::SourceFile,
-    edit: &mut SyntaxEditor,
+    editor: &mut SyntaxEditor,
     field_list: T,
     fields: impl FnOnce(&T) -> I,
 ) -> Option<()>
@@ -240,7 +237,6 @@ where
     T: AstNode,
     I: IntoIterator<Item = ast::NameRef>,
 {
-    let make = SyntaxFactory::without_mappings();
     let orig = ctx.sema.original_range_opt(field_list.syntax())?;
     let list_range = cover_edit_range(source.syntax(), orig.range);
 
@@ -254,13 +250,13 @@ where
     };
 
     if l_curly.kind() == T!['{'] {
-        delete_whitespace(edit, l_curly.prev_token());
-        delete_whitespace(edit, l_curly.next_token());
-        edit.replace(l_curly, make.token(T!['(']));
+        delete_whitespace(editor, l_curly.prev_token());
+        delete_whitespace(editor, l_curly.next_token());
+        editor.replace(l_curly, editor.make().token(T!['(']));
     }
     if r_curly.kind() == T!['}'] {
-        delete_whitespace(edit, r_curly.prev_token());
-        edit.replace(r_curly, make.token(T![')']));
+        delete_whitespace(editor, r_curly.prev_token());
+        editor.replace(r_curly, editor.make().token(T![')']));
     }
 
     for name_ref in fields(&field_list) {
@@ -270,14 +266,14 @@ where
         if let Some(colon) = next_non_trivia_token(name_range.end().clone())
             && colon.kind() == T![:]
         {
-            edit.delete(&colon);
-            edit.delete_all(name_range);
+            editor.delete(&colon);
+            editor.delete_all(name_range);
 
             if let Some(next) = next_non_trivia_token(colon.clone())
                 && next.kind() != T!['}']
             {
                 // Avoid overlapping delete whitespace on `{ field: }`
-                delete_whitespace(edit, colon.next_token());
+                delete_whitespace(editor, colon.next_token());
             }
         }
     }
@@ -289,7 +285,6 @@ fn edit_field_references(
     builder: &mut SourceChangeBuilder,
     fields: impl Iterator<Item = ast::RecordField>,
 ) {
-    let make = SyntaxFactory::without_mappings();
     for (index, field) in fields.enumerate() {
         let field = match ctx.sema.to_def(&field) {
             Some(it) => it,
@@ -299,21 +294,23 @@ fn edit_field_references(
         let usages = def.usages(&ctx.sema).all();
         for (file_id, refs) in usages {
             let source = ctx.sema.parse(file_id);
-            let mut edit = builder.make_editor(source.syntax());
+            let mut editor = builder.make_editor(source.syntax());
 
             for r in refs {
                 if let Some(name_ref) = r.name.as_name_ref() {
                     // Only edit the field reference if it's part of a `.field` access
                     if name_ref.syntax().parent().and_then(ast::FieldExpr::cast).is_some() {
-                        edit.replace_all(
+                        editor.replace_all(
                             cover_edit_range(source.syntax(), r.range),
-                            vec![make.name_ref(&index.to_string()).syntax().clone().into()],
+                            vec![
+                                editor.make().name_ref(&index.to_string()).syntax().clone().into(),
+                            ],
                         );
                     }
                 }
             }
 
-            builder.add_file_edits(file_id.file_id(ctx.db()), edit);
+            builder.add_file_edits(file_id.file_id(ctx.db()), editor);
         }
     }
 }

--- a/crates/ide-assists/src/handlers/convert_named_struct_to_tuple_struct.rs
+++ b/crates/ide-assists/src/handlers/convert_named_struct_to_tuple_struct.rs
@@ -100,7 +100,7 @@ fn edit_struct_def(
     // Note that we don't need to consider macro files in this function because this is
     // currently not triggered for struct definitions inside macro calls.
     let tuple_fields = record_fields.fields().filter_map(|f| {
-        let (mut editor, field) =
+        let (editor, field) =
             SyntaxEditor::with_ast_node(&ast::make::tuple_field(f.visibility(), f.ty()?));
         editor.insert_all(
             Position::first_child_of(field.syntax()),
@@ -111,9 +111,10 @@ fn edit_struct_def(
         Some(field)
     });
 
-    let mut editor = builder.make_editor(strukt.syntax());
+    let editor = builder.make_editor(strukt.syntax());
+    let make = editor.make();
 
-    let tuple_fields = editor.make().tuple_field_list(tuple_fields);
+    let tuple_fields = make.tuple_field_list(tuple_fields);
 
     let mut elements = vec![tuple_fields.syntax().clone().into()];
     if let Either::Left(strukt) = strukt {
@@ -121,10 +122,10 @@ fn edit_struct_def(
             editor.delete(w.syntax());
 
             elements.extend([
-                editor.make().whitespace("\n").into(),
+                make.whitespace("\n").into(),
                 remove_trailing_comma(w).into(),
-                editor.make().token(T![;]).into(),
-                editor.make().whitespace("\n").into(),
+                make.token(T![;]).into(),
+                make.whitespace("\n").into(),
             ]);
 
             if let Some(tok) = strukt
@@ -136,7 +137,7 @@ fn edit_struct_def(
                 editor.delete(tok);
             }
         } else {
-            elements.push(editor.make().token(T![;]).into());
+            elements.push(make.token(T![;]).into());
         }
     }
     editor.replace_with_many(record_fields.syntax(), elements);
@@ -165,18 +166,18 @@ fn edit_struct_references(
 
     for (file_id, refs) in usages {
         let source = ctx.sema.parse(file_id);
-        let mut edit = builder.make_editor(source.syntax());
+        let editor = builder.make_editor(source.syntax());
         for r in refs {
-            process_struct_name_reference(ctx, r, &mut edit, &source);
+            process_struct_name_reference(ctx, r, &editor, &source);
         }
-        builder.add_file_edits(file_id.file_id(ctx.db()), edit);
+        builder.add_file_edits(file_id.file_id(ctx.db()), editor);
     }
 }
 
 fn process_struct_name_reference(
     ctx: &AssistContext<'_>,
     r: FileReference,
-    edit: &mut SyntaxEditor,
+    edit: &SyntaxEditor,
     source: &ast::SourceFile,
 ) -> Option<()> {
     // First check if it's the last semgnet of a path that directly belongs to a record
@@ -229,7 +230,7 @@ fn process_struct_name_reference(
 fn record_to_tuple_struct_like<T, I>(
     ctx: &AssistContext<'_>,
     source: &ast::SourceFile,
-    editor: &mut SyntaxEditor,
+    editor: &SyntaxEditor,
     field_list: T,
     fields: impl FnOnce(&T) -> I,
 ) -> Option<()>
@@ -237,6 +238,7 @@ where
     T: AstNode,
     I: IntoIterator<Item = ast::NameRef>,
 {
+    let make = editor.make();
     let orig = ctx.sema.original_range_opt(field_list.syntax())?;
     let list_range = cover_edit_range(source.syntax(), orig.range);
 
@@ -252,11 +254,11 @@ where
     if l_curly.kind() == T!['{'] {
         delete_whitespace(editor, l_curly.prev_token());
         delete_whitespace(editor, l_curly.next_token());
-        editor.replace(l_curly, editor.make().token(T!['(']));
+        editor.replace(l_curly, make.token(T!['(']));
     }
     if r_curly.kind() == T!['}'] {
         delete_whitespace(editor, r_curly.prev_token());
-        editor.replace(r_curly, editor.make().token(T![')']));
+        editor.replace(r_curly, make.token(T![')']));
     }
 
     for name_ref in fields(&field_list) {
@@ -294,7 +296,8 @@ fn edit_field_references(
         let usages = def.usages(&ctx.sema).all();
         for (file_id, refs) in usages {
             let source = ctx.sema.parse(file_id);
-            let mut editor = builder.make_editor(source.syntax());
+            let editor = builder.make_editor(source.syntax());
+            let make = editor.make();
 
             for r in refs {
                 if let Some(name_ref) = r.name.as_name_ref() {
@@ -302,9 +305,7 @@ fn edit_field_references(
                     if name_ref.syntax().parent().and_then(ast::FieldExpr::cast).is_some() {
                         editor.replace_all(
                             cover_edit_range(source.syntax(), r.range),
-                            vec![
-                                editor.make().name_ref(&index.to_string()).syntax().clone().into(),
-                            ],
+                            vec![make.name_ref(&index.to_string()).syntax().clone().into()],
                         );
                     }
                 }
@@ -315,7 +316,7 @@ fn edit_field_references(
     }
 }
 
-fn delete_whitespace(edit: &mut SyntaxEditor, whitespace: Option<impl Element>) {
+fn delete_whitespace(edit: &SyntaxEditor, whitespace: Option<impl Element>) {
     let Some(whitespace) = whitespace else { return };
     let NodeOrToken::Token(token) = whitespace.syntax_element() else { return };
 
@@ -325,7 +326,7 @@ fn delete_whitespace(edit: &mut SyntaxEditor, whitespace: Option<impl Element>) 
 }
 
 fn remove_trailing_comma(w: ast::WhereClause) -> SyntaxNode {
-    let (mut editor, w) = SyntaxEditor::new(w.syntax().clone());
+    let (editor, w) = SyntaxEditor::new(w.syntax().clone());
     if let Some(last) = w.last_child_or_token()
         && last.kind() == T![,]
     {

--- a/crates/ide-assists/src/handlers/convert_range_for_to_while.rs
+++ b/crates/ide-assists/src/handlers/convert_range_for_to_while.rs
@@ -5,10 +5,7 @@ use syntax::{
     SyntaxKind::WHITESPACE,
     T,
     algo::previous_non_trivia_token,
-    ast::{
-        self, HasArgList, HasLoopBody, HasName, RangeItem, edit::AstNodeEdit, make,
-        syntax_factory::SyntaxFactory,
-    },
+    ast::{self, HasArgList, HasLoopBody, HasName, RangeItem, edit::AstNodeEdit, make},
     syntax_editor::{Element, Position, SyntaxEditor},
 };
 
@@ -55,56 +52,49 @@ pub(crate) fn convert_range_for_to_while(acc: &mut Assists, ctx: &AssistContext<
         description,
         for_.syntax().text_range(),
         |builder| {
-            let mut edit = builder.make_editor(for_.syntax());
-            let make = SyntaxFactory::with_mappings();
+            let mut editor = builder.make_editor(for_.syntax());
 
             let indent = for_.indent_level();
-            let pat = make.ident_pat(pat.ref_token().is_some(), true, name.clone());
-            let let_stmt = make.let_stmt(pat.into(), None, Some(start));
-            edit.insert_all(
+            let pat = editor.make().ident_pat(pat.ref_token().is_some(), true, name.clone());
+            let let_stmt = editor.make().let_stmt(pat.into(), None, Some(start));
+            editor.insert_all(
                 Position::before(for_.syntax()),
                 vec![
                     let_stmt.syntax().syntax_element(),
-                    make.whitespace(&format!("\n{}", indent)).syntax_element(),
+                    editor.make().whitespace(&format!("\n{}", indent)).syntax_element(),
                 ],
             );
 
             let mut elements = vec![];
 
-            let var_expr = make.expr_path(make.ident_path(&name.text()));
+            let var_expr = editor.make().expr_path(editor.make().ident_path(&name.text()));
             let op = ast::BinaryOp::CmpOp(ast::CmpOp::Ord {
                 ordering: ast::Ordering::Less,
                 strict: !inclusive,
             });
             if let Some(end) = end {
                 elements.extend([
-                    make.token(T![while]).syntax_element(),
-                    make.whitespace(" ").syntax_element(),
-                    make.expr_bin(var_expr.clone(), op, end).syntax().syntax_element(),
+                    editor.make().token(T![while]).syntax_element(),
+                    editor.make().whitespace(" ").syntax_element(),
+                    editor.make().expr_bin(var_expr.clone(), op, end).syntax().syntax_element(),
                 ]);
             } else {
-                elements.push(make.token(T![loop]).syntax_element());
+                elements.push(editor.make().token(T![loop]).syntax_element());
             }
 
-            edit.replace_all(
+            editor.replace_all(
                 for_kw.syntax_element()..=iterable.syntax().syntax_element(),
                 elements,
             );
 
             let op = ast::BinaryOp::Assignment { op: Some(ast::ArithOp::Add) };
-            process_loop_body(
-                body,
-                label,
-                &mut edit,
-                vec![
-                    make.whitespace(&format!("\n{}", indent + 1)).syntax_element(),
-                    make.expr_bin(var_expr, op, step).syntax().syntax_element(),
-                    make.token(T![;]).syntax_element(),
-                ],
-            );
-
-            edit.add_mappings(make.finish_with_mappings());
-            builder.add_file_edits(ctx.vfs_file_id(), edit);
+            let incrementer = vec![
+                editor.make().whitespace(&format!("\n{}", indent + 1)).syntax_element(),
+                editor.make().expr_bin(var_expr, op, step).syntax().syntax_element(),
+                editor.make().token(T![;]).syntax_element(),
+            ];
+            process_loop_body(body, label, &mut editor, incrementer);
+            builder.add_file_edits(ctx.vfs_file_id(), editor);
         },
     )
 }

--- a/crates/ide-assists/src/handlers/convert_range_for_to_while.rs
+++ b/crates/ide-assists/src/handlers/convert_range_for_to_while.rs
@@ -52,34 +52,35 @@ pub(crate) fn convert_range_for_to_while(acc: &mut Assists, ctx: &AssistContext<
         description,
         for_.syntax().text_range(),
         |builder| {
-            let mut editor = builder.make_editor(for_.syntax());
+            let editor = builder.make_editor(for_.syntax());
+            let make = editor.make();
 
             let indent = for_.indent_level();
-            let pat = editor.make().ident_pat(pat.ref_token().is_some(), true, name.clone());
-            let let_stmt = editor.make().let_stmt(pat.into(), None, Some(start));
+            let pat = make.ident_pat(pat.ref_token().is_some(), true, name.clone());
+            let let_stmt = make.let_stmt(pat.into(), None, Some(start));
             editor.insert_all(
                 Position::before(for_.syntax()),
                 vec![
                     let_stmt.syntax().syntax_element(),
-                    editor.make().whitespace(&format!("\n{}", indent)).syntax_element(),
+                    make.whitespace(&format!("\n{}", indent)).syntax_element(),
                 ],
             );
 
             let mut elements = vec![];
 
-            let var_expr = editor.make().expr_path(editor.make().ident_path(&name.text()));
+            let var_expr = make.expr_path(make.ident_path(&name.text()));
             let op = ast::BinaryOp::CmpOp(ast::CmpOp::Ord {
                 ordering: ast::Ordering::Less,
                 strict: !inclusive,
             });
             if let Some(end) = end {
                 elements.extend([
-                    editor.make().token(T![while]).syntax_element(),
-                    editor.make().whitespace(" ").syntax_element(),
-                    editor.make().expr_bin(var_expr.clone(), op, end).syntax().syntax_element(),
+                    make.token(T![while]).syntax_element(),
+                    make.whitespace(" ").syntax_element(),
+                    make.expr_bin(var_expr.clone(), op, end).syntax().syntax_element(),
                 ]);
             } else {
-                elements.push(editor.make().token(T![loop]).syntax_element());
+                elements.push(make.token(T![loop]).syntax_element());
             }
 
             editor.replace_all(
@@ -89,11 +90,11 @@ pub(crate) fn convert_range_for_to_while(acc: &mut Assists, ctx: &AssistContext<
 
             let op = ast::BinaryOp::Assignment { op: Some(ast::ArithOp::Add) };
             let incrementer = vec![
-                editor.make().whitespace(&format!("\n{}", indent + 1)).syntax_element(),
-                editor.make().expr_bin(var_expr, op, step).syntax().syntax_element(),
-                editor.make().token(T![;]).syntax_element(),
+                make.whitespace(&format!("\n{}", indent + 1)).syntax_element(),
+                make.expr_bin(var_expr, op, step).syntax().syntax_element(),
+                make.token(T![;]).syntax_element(),
             ];
-            process_loop_body(body, label, &mut editor, incrementer);
+            process_loop_body(body, label, &editor, incrementer);
             builder.add_file_edits(ctx.vfs_file_id(), editor);
         },
     )
@@ -118,7 +119,7 @@ fn extract_range(iterable: &ast::Expr) -> Option<(ast::Expr, Option<ast::Expr>, 
 fn process_loop_body(
     body: ast::StmtList,
     label: Option<ast::Label>,
-    edit: &mut SyntaxEditor,
+    edit: &SyntaxEditor,
     incrementer: Vec<SyntaxElement>,
 ) -> Option<()> {
     let last = previous_non_trivia_token(body.r_curly_token()?)?.syntax_element();
@@ -146,7 +147,7 @@ fn process_loop_body(
 
     let continue_label = make::lifetime("'cont");
     let break_expr = make::expr_break(Some(continue_label.clone()), None);
-    let (mut new_edit, _) = SyntaxEditor::new(new_body.syntax().clone());
+    let (new_edit, _) = SyntaxEditor::new(new_body.syntax().clone());
     for continue_expr in &continues {
         new_edit.replace(continue_expr.syntax(), break_expr.syntax());
     }

--- a/crates/ide-assists/src/handlers/convert_to_guarded_return.rs
+++ b/crates/ide-assists/src/handlers/convert_to_guarded_return.rs
@@ -130,9 +130,10 @@ fn if_expr_to_guarded_return(
         "Convert to guarded return",
         target,
         |edit| {
-            let mut editor = edit.make_editor(if_expr.syntax());
+            let editor = edit.make_editor(if_expr.syntax());
+            let make = editor.make();
             let if_indent_level = IndentLevel::from_node(if_expr.syntax());
-            let early_expression = else_block.make_early_block(&ctx.sema, &make);
+            let early_expression = else_block.make_early_block(&ctx.sema, make);
             let replacement = let_chains.into_iter().map(|expr| {
                 if let ast::Expr::LetExpr(let_expr) = &expr
                     && let (Some(pat), Some(expr)) = (let_expr.pat(), let_expr.expr())
@@ -145,8 +146,8 @@ fn if_expr_to_guarded_return(
                 } else {
                     // If.
                     let new_expr = {
-                        let then_branch = clean_stmt_block(&early_expression, &make);
-                        let cond = invert_boolean_expression(&make, expr);
+                        let then_branch = clean_stmt_block(&early_expression, make);
+                        let cond = invert_boolean_expression(make, expr);
                         make.expr_if(cond, then_branch, None).indent(if_indent_level)
                     };
                     new_expr.syntax().clone()
@@ -208,15 +209,16 @@ fn let_stmt_to_guarded_return(
         "Convert to guarded return",
         target,
         |edit| {
-            let mut editor = edit.make_editor(let_stmt.syntax());
+            let editor = edit.make_editor(let_stmt.syntax());
+            let make = editor.make();
             let let_indent_level = IndentLevel::from_node(let_stmt.syntax());
 
             let replacement = {
-                let let_else_stmt = editor.make().let_else_stmt(
+                let let_else_stmt = make.let_else_stmt(
                     happy_pattern,
                     let_stmt.ty(),
                     expr.reset_indent(),
-                    else_block.make_early_block(&ctx.sema, editor.make()),
+                    else_block.make_early_block(&ctx.sema, make),
                 );
                 let let_else_stmt = let_else_stmt.indent(let_indent_level);
                 let_else_stmt.syntax().clone()
@@ -265,7 +267,8 @@ impl<'db> ElseBlock<'db> {
             return block_expr.reset_indent();
         }
 
-        let (mut edit, block_expr) = SyntaxEditor::with_ast_node(&block_expr.reset_indent());
+        let (editor, block_expr) = SyntaxEditor::with_ast_node(&block_expr.reset_indent());
+        let make = editor.make();
 
         let last_stmt = block_expr.statements().last().map(|it| it.syntax().clone());
         let tail_expr = block_expr.tail_expr().map(|it| it.syntax().clone());
@@ -278,7 +281,7 @@ impl<'db> ElseBlock<'db> {
             && !self.kind.is_unit()
         {
             let early_expr = self.kind.make_early_expr(sema, make, Some(tail_expr.clone()));
-            edit.replace(tail_expr.syntax(), early_expr.syntax());
+            editor.replace(tail_expr.syntax(), early_expr.syntax());
         } else {
             let last_stmt = match block_expr.tail_expr() {
                 Some(expr) => make.expr_stmt(expr).syntax().clone(),
@@ -287,13 +290,13 @@ impl<'db> ElseBlock<'db> {
             let whitespace =
                 make.whitespace(&whitespace.map_or(String::new(), |it| it.to_string()));
             let early_expr = self.kind.make_early_expr(sema, make, None).syntax().clone().into();
-            edit.replace_with_many(
+            editor.replace_with_many(
                 last_element,
                 vec![last_stmt.into(), whitespace.into(), early_expr],
             );
         }
 
-        ast::BlockExpr::cast(edit.finish().new_root().clone()).unwrap()
+        ast::BlockExpr::cast(editor.finish().new_root().clone()).unwrap()
     }
 }
 

--- a/crates/ide-assists/src/handlers/convert_to_guarded_return.rs
+++ b/crates/ide-assists/src/handlers/convert_to_guarded_return.rs
@@ -130,7 +130,7 @@ fn if_expr_to_guarded_return(
         "Convert to guarded return",
         target,
         |edit| {
-            let make = SyntaxFactory::without_mappings();
+            let mut editor = edit.make_editor(if_expr.syntax());
             let if_indent_level = IndentLevel::from_node(if_expr.syntax());
             let early_expression = else_block.make_early_block(&ctx.sema, &make);
             let replacement = let_chains.into_iter().map(|expr| {
@@ -170,7 +170,6 @@ fn if_expr_to_guarded_return(
                         .take_while(|i| *i != end_of_then),
                 )
                 .collect();
-            let mut editor = edit.make_editor(if_expr.syntax());
             editor.replace_with_many(if_expr.syntax(), then_statements);
             edit.add_file_edits(ctx.vfs_file_id(), editor);
         },
@@ -209,22 +208,20 @@ fn let_stmt_to_guarded_return(
         "Convert to guarded return",
         target,
         |edit| {
+            let mut editor = edit.make_editor(let_stmt.syntax());
             let let_indent_level = IndentLevel::from_node(let_stmt.syntax());
-            let make = SyntaxFactory::without_mappings();
 
             let replacement = {
-                let let_else_stmt = make.let_else_stmt(
+                let let_else_stmt = editor.make().let_else_stmt(
                     happy_pattern,
                     let_stmt.ty(),
                     expr.reset_indent(),
-                    else_block.make_early_block(&ctx.sema, &make),
+                    else_block.make_early_block(&ctx.sema, editor.make()),
                 );
                 let let_else_stmt = let_else_stmt.indent(let_indent_level);
                 let_else_stmt.syntax().clone()
             };
-            let mut editor = edit.make_editor(let_stmt.syntax());
             editor.replace(let_stmt.syntax(), replacement);
-            editor.add_mappings(make.finish_with_mappings());
             edit.add_file_edits(ctx.vfs_file_id(), editor);
         },
     )
@@ -277,12 +274,10 @@ impl<'db> ElseBlock<'db> {
         };
         let whitespace = last_element.prev_sibling_or_token().filter(|it| it.kind() == WHITESPACE);
 
-        let make = SyntaxFactory::without_mappings();
-
         if let Some(tail_expr) = block_expr.tail_expr()
             && !self.kind.is_unit()
         {
-            let early_expr = self.kind.make_early_expr(sema, &make, Some(tail_expr.clone()));
+            let early_expr = self.kind.make_early_expr(sema, make, Some(tail_expr.clone()));
             edit.replace(tail_expr.syntax(), early_expr.syntax());
         } else {
             let last_stmt = match block_expr.tail_expr() {
@@ -291,7 +286,7 @@ impl<'db> ElseBlock<'db> {
             };
             let whitespace =
                 make.whitespace(&whitespace.map_or(String::new(), |it| it.to_string()));
-            let early_expr = self.kind.make_early_expr(sema, &make, None).syntax().clone().into();
+            let early_expr = self.kind.make_early_expr(sema, make, None).syntax().clone().into();
             edit.replace_with_many(
                 last_element,
                 vec![last_stmt.into(), whitespace.into(), early_expr],

--- a/crates/ide-assists/src/handlers/convert_tuple_return_type_to_struct.rs
+++ b/crates/ide-assists/src/handlers/convert_tuple_return_type_to_struct.rs
@@ -72,15 +72,14 @@ pub(crate) fn convert_tuple_return_type_to_struct(
         "Convert tuple return type to tuple struct",
         target,
         move |edit| {
-            let mut syntax_editor = edit.make_editor(ret_type.syntax());
-            let syntax_factory = SyntaxFactory::with_mappings();
+            let mut editor = edit.make_editor(ret_type.syntax());
 
             let usages = Definition::Function(fn_def).usages(&ctx.sema).all();
             let struct_name = format!("{}Result", stdx::to_camel_case(&fn_name.to_string()));
             let parent = fn_.syntax().ancestors().find_map(<Either<ast::Impl, ast::Trait>>::cast);
             add_tuple_struct_def(
                 edit,
-                &syntax_factory,
+                editor.make(),
                 ctx,
                 &usages,
                 parent.as_ref().map(|it| it.syntax()).unwrap_or(fn_.syntax()),
@@ -89,22 +88,19 @@ pub(crate) fn convert_tuple_return_type_to_struct(
                 &target_module,
             );
 
-            syntax_editor.replace(
+            editor.replace(
                 ret_type.syntax(),
-                syntax_factory.ret_type(syntax_factory.ty(&struct_name)).syntax(),
+                editor.make().ret_type(editor.make().ty(&struct_name)).syntax(),
             );
 
             if let Some(fn_body) = fn_.body() {
                 replace_body_return_values(
-                    &mut syntax_editor,
-                    &syntax_factory,
+                    &mut editor,
                     ast::Expr::BlockExpr(fn_body),
                     &struct_name,
                 );
             }
-
-            syntax_editor.add_mappings(syntax_factory.finish_with_mappings());
-            edit.add_file_edits(ctx.vfs_file_id(), syntax_editor);
+            edit.add_file_edits(ctx.vfs_file_id(), editor);
 
             replace_usages(edit, ctx, &usages, &struct_name, &target_module);
         },
@@ -123,10 +119,9 @@ fn replace_usages(
         let Some(first_ref) = references.first() else { continue };
 
         let mut editor = edit.make_editor(first_ref.name.syntax().as_node().unwrap());
-        let syntax_factory = SyntaxFactory::with_mappings();
 
         let refs_with_imports = augment_references_with_imports(
-            &syntax_factory,
+            editor.make(),
             ctx,
             references,
             struct_name,
@@ -140,14 +135,13 @@ fn replace_usages(
                 if let Some(ret_type) = fn_.ret_type() {
                     editor.replace(
                         ret_type.syntax(),
-                        syntax_factory.ret_type(syntax_factory.ty(struct_name)).syntax(),
+                        editor.make().ret_type(editor.make().ty(struct_name)).syntax(),
                     );
                 }
 
                 if let Some(fn_body) = fn_.body() {
                     replace_body_return_values(
                         &mut editor,
-                        &syntax_factory,
                         ast::Expr::BlockExpr(fn_body),
                         struct_name,
                     );
@@ -172,9 +166,10 @@ fn replace_usages(
                 for tuple_pat in tuple_pats {
                     editor.replace(
                         tuple_pat.syntax(),
-                        syntax_factory
+                        editor
+                            .make()
                             .tuple_struct_pat(
-                                syntax_factory.path_from_text(struct_name),
+                                editor.make().path_from_text(struct_name),
                                 tuple_pat.fields(),
                             )
                             .syntax(),
@@ -182,17 +177,9 @@ fn replace_usages(
                 }
             }
             if let Some((import_scope, path)) = import_data {
-                insert_use_with_editor(
-                    &import_scope,
-                    path,
-                    &ctx.config.insert_use,
-                    &mut editor,
-                    &syntax_factory,
-                );
+                insert_use_with_editor(&import_scope, path, &ctx.config.insert_use, &mut editor);
             }
         });
-
-        editor.add_mappings(syntax_factory.finish_with_mappings());
         edit.add_file_edits(file_id.file_id(ctx.db()), editor);
     }
 }
@@ -298,7 +285,6 @@ fn add_tuple_struct_def(
 /// Replaces each returned tuple in `body` with the constructor of the tuple struct named `struct_name`.
 fn replace_body_return_values(
     syntax_editor: &mut SyntaxEditor,
-    syntax_factory: &SyntaxFactory,
     body: ast::Expr,
     struct_name: &str,
 ) {
@@ -316,9 +302,9 @@ fn replace_body_return_values(
 
     for ret_expr in exprs_to_wrap {
         if let ast::Expr::TupleExpr(tuple_expr) = &ret_expr {
-            let struct_constructor = syntax_factory.expr_call(
-                syntax_factory.expr_path(syntax_factory.ident_path(struct_name)),
-                syntax_factory.arg_list(tuple_expr.fields()),
+            let struct_constructor = syntax_editor.make().expr_call(
+                syntax_editor.make().expr_path(syntax_editor.make().ident_path(struct_name)),
+                syntax_editor.make().arg_list(tuple_expr.fields()),
             );
             syntax_editor.replace(ret_expr.syntax(), struct_constructor.syntax());
         }

--- a/crates/ide-assists/src/handlers/convert_tuple_return_type_to_struct.rs
+++ b/crates/ide-assists/src/handlers/convert_tuple_return_type_to_struct.rs
@@ -72,14 +72,15 @@ pub(crate) fn convert_tuple_return_type_to_struct(
         "Convert tuple return type to tuple struct",
         target,
         move |edit| {
-            let mut editor = edit.make_editor(ret_type.syntax());
+            let editor = edit.make_editor(ret_type.syntax());
+            let make = editor.make();
 
             let usages = Definition::Function(fn_def).usages(&ctx.sema).all();
             let struct_name = format!("{}Result", stdx::to_camel_case(&fn_name.to_string()));
             let parent = fn_.syntax().ancestors().find_map(<Either<ast::Impl, ast::Trait>>::cast);
             add_tuple_struct_def(
                 edit,
-                editor.make(),
+                make,
                 ctx,
                 &usages,
                 parent.as_ref().map(|it| it.syntax()).unwrap_or(fn_.syntax()),
@@ -88,17 +89,10 @@ pub(crate) fn convert_tuple_return_type_to_struct(
                 &target_module,
             );
 
-            editor.replace(
-                ret_type.syntax(),
-                editor.make().ret_type(editor.make().ty(&struct_name)).syntax(),
-            );
+            editor.replace(ret_type.syntax(), make.ret_type(make.ty(&struct_name)).syntax());
 
             if let Some(fn_body) = fn_.body() {
-                replace_body_return_values(
-                    &mut editor,
-                    ast::Expr::BlockExpr(fn_body),
-                    &struct_name,
-                );
+                replace_body_return_values(&editor, ast::Expr::BlockExpr(fn_body), &struct_name);
             }
             edit.add_file_edits(ctx.vfs_file_id(), editor);
 
@@ -118,33 +112,22 @@ fn replace_usages(
     for (file_id, references) in usages.iter() {
         let Some(first_ref) = references.first() else { continue };
 
-        let mut editor = edit.make_editor(first_ref.name.syntax().as_node().unwrap());
+        let editor = edit.make_editor(first_ref.name.syntax().as_node().unwrap());
+        let make = editor.make();
 
-        let refs_with_imports = augment_references_with_imports(
-            editor.make(),
-            ctx,
-            references,
-            struct_name,
-            target_module,
-        );
+        let refs_with_imports =
+            augment_references_with_imports(make, ctx, references, struct_name, target_module);
 
         refs_with_imports.into_iter().rev().for_each(|(name, import_data)| {
             if let Some(fn_) = name.syntax().parent().and_then(ast::Fn::cast) {
                 cov_mark::hit!(replace_trait_impl_fns);
 
                 if let Some(ret_type) = fn_.ret_type() {
-                    editor.replace(
-                        ret_type.syntax(),
-                        editor.make().ret_type(editor.make().ty(struct_name)).syntax(),
-                    );
+                    editor.replace(ret_type.syntax(), make.ret_type(make.ty(struct_name)).syntax());
                 }
 
                 if let Some(fn_body) = fn_.body() {
-                    replace_body_return_values(
-                        &mut editor,
-                        ast::Expr::BlockExpr(fn_body),
-                        struct_name,
-                    );
+                    replace_body_return_values(&editor, ast::Expr::BlockExpr(fn_body), struct_name);
                 }
             } else {
                 // replace tuple patterns
@@ -168,16 +151,13 @@ fn replace_usages(
                         tuple_pat.syntax(),
                         editor
                             .make()
-                            .tuple_struct_pat(
-                                editor.make().path_from_text(struct_name),
-                                tuple_pat.fields(),
-                            )
+                            .tuple_struct_pat(make.path_from_text(struct_name), tuple_pat.fields())
                             .syntax(),
                     );
                 }
             }
             if let Some((import_scope, path)) = import_data {
-                insert_use_with_editor(&import_scope, path, &ctx.config.insert_use, &mut editor);
+                insert_use_with_editor(&import_scope, path, &ctx.config.insert_use, &editor);
             }
         });
         edit.add_file_edits(file_id.file_id(ctx.db()), editor);
@@ -283,11 +263,8 @@ fn add_tuple_struct_def(
 }
 
 /// Replaces each returned tuple in `body` with the constructor of the tuple struct named `struct_name`.
-fn replace_body_return_values(
-    syntax_editor: &mut SyntaxEditor,
-    body: ast::Expr,
-    struct_name: &str,
-) {
+fn replace_body_return_values(editor: &SyntaxEditor, body: ast::Expr, struct_name: &str) {
+    let make = editor.make();
     let mut exprs_to_wrap = Vec::new();
 
     let tail_cb = &mut |e: &_| tail_cb_impl(&mut exprs_to_wrap, e);
@@ -302,11 +279,11 @@ fn replace_body_return_values(
 
     for ret_expr in exprs_to_wrap {
         if let ast::Expr::TupleExpr(tuple_expr) = &ret_expr {
-            let struct_constructor = syntax_editor.make().expr_call(
-                syntax_editor.make().expr_path(syntax_editor.make().ident_path(struct_name)),
-                syntax_editor.make().arg_list(tuple_expr.fields()),
+            let struct_constructor = make.expr_call(
+                make.expr_path(make.ident_path(struct_name)),
+                make.arg_list(tuple_expr.fields()),
             );
-            syntax_editor.replace(ret_expr.syntax(), struct_constructor.syntax());
+            editor.replace(ret_expr.syntax(), struct_constructor.syntax());
         }
     }
 }

--- a/crates/ide-assists/src/handlers/convert_tuple_struct_to_named_struct.rs
+++ b/crates/ide-assists/src/handlers/convert_tuple_struct_to_named_struct.rs
@@ -86,9 +86,9 @@ pub(crate) fn convert_tuple_struct_to_named_struct(
         "Convert to named struct",
         target,
         |edit| {
-            let names = generate_names(tuple_fields.fields());
-            edit_field_references(ctx, edit, tuple_fields.fields(), &names);
             let mut editor = edit.make_editor(syntax);
+            let names = generate_names(tuple_fields.fields(), editor.make());
+            edit_field_references(ctx, edit, tuple_fields.fields(), &names);
             edit_struct_references(ctx, edit, strukt_def, &names);
             edit_struct_def(&mut editor, &strukt_or_variant, tuple_fields, names);
             edit.add_file_edits(ctx.vfs_file_id(), editor);
@@ -111,8 +111,7 @@ fn edit_struct_def(
         );
         ast::RecordField::cast(field_editor.finish().new_root().clone())
     });
-    let make = SyntaxFactory::without_mappings();
-    let record_fields = make.record_field_list(record_fields);
+    let record_fields = editor.make().record_field_list(record_fields);
     let tuple_fields_before = Position::before(tuple_fields.syntax());
 
     if let Either::Left(strukt) = strukt {
@@ -171,7 +170,6 @@ fn process_struct_name_reference(
     strukt_def: &Definition,
     names: &[ast::Name],
 ) -> Option<()> {
-    let make = SyntaxFactory::without_mappings();
     let name_ref = r.name.as_name_ref()?;
     let path_segment = name_ref.syntax().parent().and_then(ast::PathSegment::cast)?;
     let full_path = path_segment.syntax().parent().and_then(ast::Path::cast)?.top_path();
@@ -187,7 +185,7 @@ fn process_struct_name_reference(
         match parent {
             ast::TupleStructPat(tuple_struct_pat) => {
                 let range = ctx.sema.original_range_opt(tuple_struct_pat.syntax())?.range;
-                let new = make.record_pat_with_fields(
+                let new = editor.make().record_pat_with_fields(
                     full_path,
                     generate_record_pat_list(&tuple_struct_pat, names),
                 );
@@ -209,9 +207,9 @@ fn process_struct_name_reference(
                     let range = ctx.sema.original_range_opt(expr.syntax())?.range;
                     let place = cover_edit_range(source.syntax(), range);
                     let elements = vec![
-                        make.name_ref(&name.text()).syntax().clone().into(),
-                        make.token(T![:]).into(),
-                        make.whitespace(" ").into(),
+                        editor.make().name_ref(&name.text()).syntax().clone().into(),
+                        editor.make().token(T![:]).into(),
+                        editor.make().whitespace(" ").into(),
                     ];
                     if first_insert.is_empty() {
                         // XXX: SyntaxEditor cannot insert after deleted element
@@ -247,14 +245,13 @@ fn process_delimiter(
         syntax::NodeOrToken::Token(t) => Some(t.clone()),
     };
 
-    let make = SyntaxFactory::without_mappings();
     if let Some(l_paren) = l_paren
         && l_paren.kind() == T!['(']
     {
         let mut open_delim = vec![
-            make.whitespace(" ").into(),
-            make.token(T!['{']).into(),
-            make.whitespace(" ").into(),
+            editor.make().whitespace(" ").into(),
+            editor.make().token(T!['{']).into(),
+            editor.make().whitespace(" ").into(),
         ];
         open_delim.extend(first_insert);
         editor.replace_with_many(l_paren, open_delim);
@@ -264,7 +261,7 @@ fn process_delimiter(
     {
         editor.replace_with_many(
             r_paren,
-            vec![make.whitespace(" ").into(), make.token(T!['}']).into()],
+            vec![editor.make().whitespace(" ").into(), editor.make().token(T!['}']).into()],
         );
     }
 }
@@ -300,8 +297,10 @@ fn edit_field_references(
     }
 }
 
-fn generate_names(fields: impl Iterator<Item = ast::TupleField>) -> Vec<ast::Name> {
-    let make = SyntaxFactory::without_mappings();
+fn generate_names(
+    fields: impl Iterator<Item = ast::TupleField>,
+    make: &SyntaxFactory,
+) -> Vec<ast::Name> {
     fields
         .enumerate()
         .map(|(i, _)| {

--- a/crates/ide-assists/src/handlers/convert_tuple_struct_to_named_struct.rs
+++ b/crates/ide-assists/src/handlers/convert_tuple_struct_to_named_struct.rs
@@ -86,24 +86,25 @@ pub(crate) fn convert_tuple_struct_to_named_struct(
         "Convert to named struct",
         target,
         |edit| {
-            let mut editor = edit.make_editor(syntax);
+            let editor = edit.make_editor(syntax);
             let names = generate_names(tuple_fields.fields(), editor.make());
             edit_field_references(ctx, edit, tuple_fields.fields(), &names);
             edit_struct_references(ctx, edit, strukt_def, &names);
-            edit_struct_def(&mut editor, &strukt_or_variant, tuple_fields, names);
+            edit_struct_def(&editor, &strukt_or_variant, tuple_fields, names);
             edit.add_file_edits(ctx.vfs_file_id(), editor);
         },
     )
 }
 
 fn edit_struct_def(
-    editor: &mut SyntaxEditor,
+    editor: &SyntaxEditor,
     strukt: &Either<ast::Struct, ast::Variant>,
     tuple_fields: ast::TupleFieldList,
     names: Vec<ast::Name>,
 ) {
+    let make = editor.make();
     let record_fields = tuple_fields.fields().zip(names).filter_map(|(f, name)| {
-        let (mut field_editor, field) =
+        let (field_editor, field) =
             SyntaxEditor::with_ast_node(&ast::make::record_field(f.visibility(), name, f.ty()?));
         field_editor.insert_all(
             Position::first_child_of(field.syntax()),
@@ -111,7 +112,7 @@ fn edit_struct_def(
         );
         ast::RecordField::cast(field_editor.finish().new_root().clone())
     });
-    let record_fields = editor.make().record_field_list(record_fields);
+    let record_fields = make.record_field_list(record_fields);
     let tuple_fields_before = Position::before(tuple_fields.syntax());
 
     if let Either::Left(strukt) = strukt {
@@ -152,10 +153,10 @@ fn edit_struct_references(
 
     for (file_id, refs) in usages {
         let source = ctx.sema.parse(file_id);
-        let mut editor = edit.make_editor(source.syntax());
+        let editor = edit.make_editor(source.syntax());
 
         for r in refs {
-            process_struct_name_reference(ctx, r, &mut editor, &source, &strukt_def, names);
+            process_struct_name_reference(ctx, r, &editor, &source, &strukt_def, names);
         }
 
         edit.add_file_edits(file_id.file_id(ctx.db()), editor);
@@ -165,11 +166,12 @@ fn edit_struct_references(
 fn process_struct_name_reference(
     ctx: &AssistContext<'_>,
     r: FileReference,
-    editor: &mut SyntaxEditor,
+    editor: &SyntaxEditor,
     source: &ast::SourceFile,
     strukt_def: &Definition,
     names: &[ast::Name],
 ) -> Option<()> {
+    let make = editor.make();
     let name_ref = r.name.as_name_ref()?;
     let path_segment = name_ref.syntax().parent().and_then(ast::PathSegment::cast)?;
     let full_path = path_segment.syntax().parent().and_then(ast::Path::cast)?.top_path();
@@ -185,7 +187,7 @@ fn process_struct_name_reference(
         match parent {
             ast::TupleStructPat(tuple_struct_pat) => {
                 let range = ctx.sema.original_range_opt(tuple_struct_pat.syntax())?.range;
-                let new = editor.make().record_pat_with_fields(
+                let new = make.record_pat_with_fields(
                     full_path,
                     generate_record_pat_list(&tuple_struct_pat, names),
                 );
@@ -207,9 +209,9 @@ fn process_struct_name_reference(
                     let range = ctx.sema.original_range_opt(expr.syntax())?.range;
                     let place = cover_edit_range(source.syntax(), range);
                     let elements = vec![
-                        editor.make().name_ref(&name.text()).syntax().clone().into(),
-                        editor.make().token(T![:]).into(),
-                        editor.make().whitespace(" ").into(),
+                        make.name_ref(&name.text()).syntax().clone().into(),
+                        make.token(T![:]).into(),
+                        make.whitespace(" ").into(),
                     ];
                     if first_insert.is_empty() {
                         // XXX: SyntaxEditor cannot insert after deleted element
@@ -229,10 +231,11 @@ fn process_struct_name_reference(
 fn process_delimiter(
     ctx: &AssistContext<'_>,
     source: &ast::SourceFile,
-    editor: &mut SyntaxEditor,
+    editor: &SyntaxEditor,
     list: &impl AstNode,
     first_insert: Vec<syntax::SyntaxElement>,
 ) {
+    let make = editor.make();
     let Some(range) = ctx.sema.original_range_opt(list.syntax()) else { return };
     let place = cover_edit_range(source.syntax(), range.range);
 
@@ -249,9 +252,9 @@ fn process_delimiter(
         && l_paren.kind() == T!['(']
     {
         let mut open_delim = vec![
-            editor.make().whitespace(" ").into(),
-            editor.make().token(T!['{']).into(),
-            editor.make().whitespace(" ").into(),
+            make.whitespace(" ").into(),
+            make.token(T!['{']).into(),
+            make.whitespace(" ").into(),
         ];
         open_delim.extend(first_insert);
         editor.replace_with_many(l_paren, open_delim);
@@ -261,7 +264,7 @@ fn process_delimiter(
     {
         editor.replace_with_many(
             r_paren,
-            vec![editor.make().whitespace(" ").into(), editor.make().token(T!['}']).into()],
+            vec![make.whitespace(" ").into(), make.token(T!['}']).into()],
         );
     }
 }
@@ -281,7 +284,7 @@ fn edit_field_references(
         let usages = def.usages(&ctx.sema).all();
         for (file_id, refs) in usages {
             let source = ctx.sema.parse(file_id);
-            let mut editor = edit.make_editor(source.syntax());
+            let editor = edit.make_editor(source.syntax());
             for r in refs {
                 if let Some(name_ref) = r.name.as_name_ref()
                     && let Some(original) = ctx.sema.original_range_opt(name_ref.syntax())

--- a/crates/ide-assists/src/handlers/convert_while_to_loop.rs
+++ b/crates/ide-assists/src/handlers/convert_while_to_loop.rs
@@ -6,7 +6,6 @@ use syntax::{
     ast::{
         self, HasLoopBody,
         edit::{AstNodeEdit, IndentLevel},
-        syntax_factory::SyntaxFactory,
     },
     syntax_editor::{Element, Position},
 };
@@ -52,48 +51,50 @@ pub(crate) fn convert_while_to_loop(acc: &mut Assists, ctx: &AssistContext<'_>) 
         "Convert while to loop",
         target,
         |builder| {
-            let make = SyntaxFactory::without_mappings();
-            let mut edit = builder.make_editor(while_expr.syntax());
+            let mut editor = builder.make_editor(while_expr.syntax());
             let while_indent_level = IndentLevel::from_node(while_expr.syntax());
 
-            let break_block = make
+            let break_block = editor
+                .make()
                 .block_expr(
-                    iter::once(make.expr_stmt(make.expr_break(None, None).into()).into()),
+                    iter::once(
+                        editor.make().expr_stmt(editor.make().expr_break(None, None).into()).into(),
+                    ),
                     None,
                 )
                 .indent(IndentLevel(1));
 
-            edit.replace_all(
+            editor.replace_all(
                 while_kw.syntax_element()..=while_cond.syntax().syntax_element(),
-                vec![make.token(T![loop]).syntax_element()],
+                vec![editor.make().token(T![loop]).syntax_element()],
             );
 
             if is_pattern_cond(while_cond.clone()) {
                 let then_branch = while_body.reset_indent().indent(IndentLevel(1));
-                let if_expr = make.expr_if(while_cond, then_branch, Some(break_block.into()));
-                let stmts = iter::once(make.expr_stmt(if_expr.into()).into());
-                let block_expr = make.block_expr(stmts, None);
-                edit.replace(while_body.syntax(), block_expr.indent(while_indent_level).syntax());
+                let if_expr =
+                    editor.make().expr_if(while_cond, then_branch, Some(break_block.into()));
+                let stmts = iter::once(editor.make().expr_stmt(if_expr.into()).into());
+                let block_expr = editor.make().block_expr(stmts, None);
+                editor.replace(while_body.syntax(), block_expr.indent(while_indent_level).syntax());
             } else {
-                let if_cond = invert_boolean_expression(&make, while_cond);
-                let if_expr = make.expr_if(if_cond, break_block, None).indent(while_indent_level);
+                let if_cond = invert_boolean_expression(editor.make(), while_cond);
+                let if_expr =
+                    editor.make().expr_if(if_cond, break_block, None).indent(while_indent_level);
                 if !while_body.syntax().text().contains_char('\n') {
-                    edit.insert(
+                    editor.insert(
                         Position::after(&l_curly),
-                        make.whitespace(&format!("\n{while_indent_level}")),
+                        editor.make().whitespace(&format!("\n{while_indent_level}")),
                     );
                 }
-                edit.insert_all(
+                editor.insert_all(
                     Position::after(&l_curly),
                     vec![
-                        make.whitespace(&format!("\n{}", while_indent_level + 1)).into(),
+                        editor.make().whitespace(&format!("\n{}", while_indent_level + 1)).into(),
                         if_expr.syntax().syntax_element(),
                     ],
                 );
             };
-
-            edit.add_mappings(make.finish_with_mappings());
-            builder.add_file_edits(ctx.vfs_file_id(), edit);
+            builder.add_file_edits(ctx.vfs_file_id(), editor);
         },
     )
 }

--- a/crates/ide-assists/src/handlers/convert_while_to_loop.rs
+++ b/crates/ide-assists/src/handlers/convert_while_to_loop.rs
@@ -51,45 +51,42 @@ pub(crate) fn convert_while_to_loop(acc: &mut Assists, ctx: &AssistContext<'_>) 
         "Convert while to loop",
         target,
         |builder| {
-            let mut editor = builder.make_editor(while_expr.syntax());
+            let editor = builder.make_editor(while_expr.syntax());
+            let make = editor.make();
             let while_indent_level = IndentLevel::from_node(while_expr.syntax());
 
             let break_block = editor
                 .make()
                 .block_expr(
-                    iter::once(
-                        editor.make().expr_stmt(editor.make().expr_break(None, None).into()).into(),
-                    ),
+                    iter::once(make.expr_stmt(make.expr_break(None, None).into()).into()),
                     None,
                 )
                 .indent(IndentLevel(1));
 
             editor.replace_all(
                 while_kw.syntax_element()..=while_cond.syntax().syntax_element(),
-                vec![editor.make().token(T![loop]).syntax_element()],
+                vec![make.token(T![loop]).syntax_element()],
             );
 
             if is_pattern_cond(while_cond.clone()) {
                 let then_branch = while_body.reset_indent().indent(IndentLevel(1));
-                let if_expr =
-                    editor.make().expr_if(while_cond, then_branch, Some(break_block.into()));
-                let stmts = iter::once(editor.make().expr_stmt(if_expr.into()).into());
-                let block_expr = editor.make().block_expr(stmts, None);
+                let if_expr = make.expr_if(while_cond, then_branch, Some(break_block.into()));
+                let stmts = iter::once(make.expr_stmt(if_expr.into()).into());
+                let block_expr = make.block_expr(stmts, None);
                 editor.replace(while_body.syntax(), block_expr.indent(while_indent_level).syntax());
             } else {
-                let if_cond = invert_boolean_expression(editor.make(), while_cond);
-                let if_expr =
-                    editor.make().expr_if(if_cond, break_block, None).indent(while_indent_level);
+                let if_cond = invert_boolean_expression(make, while_cond);
+                let if_expr = make.expr_if(if_cond, break_block, None).indent(while_indent_level);
                 if !while_body.syntax().text().contains_char('\n') {
                     editor.insert(
                         Position::after(&l_curly),
-                        editor.make().whitespace(&format!("\n{while_indent_level}")),
+                        make.whitespace(&format!("\n{while_indent_level}")),
                     );
                 }
                 editor.insert_all(
                     Position::after(&l_curly),
                     vec![
-                        editor.make().whitespace(&format!("\n{}", while_indent_level + 1)).into(),
+                        make.whitespace(&format!("\n{}", while_indent_level + 1)).into(),
                         if_expr.syntax().syntax_element(),
                     ],
                 );

--- a/crates/ide-assists/src/handlers/destructure_struct_binding.rs
+++ b/crates/ide-assists/src/handlers/destructure_struct_binding.rs
@@ -124,9 +124,9 @@ fn destructure_struct_binding_impl(
     data: &StructEditData,
 ) {
     let field_names = generate_field_names(ctx, data);
-    let mut editor = builder.make_editor(data.target.syntax());
-    destructure_pat(ctx, &mut editor, data, &field_names);
-    update_usages(ctx, &mut editor, data, &field_names.into_iter().collect());
+    let editor = builder.make_editor(data.target.syntax());
+    destructure_pat(ctx, &editor, data, &field_names);
+    update_usages(ctx, &editor, data, &field_names.into_iter().collect());
     builder.add_file_edits(ctx.vfs_file_id(), editor);
 }
 
@@ -145,7 +145,8 @@ struct StructEditData {
 }
 
 impl StructEditData {
-    fn apply_to_destruct(&self, new_pat: ast::Pat, editor: &mut SyntaxEditor) {
+    fn apply_to_destruct(&self, new_pat: ast::Pat, editor: &SyntaxEditor) {
+        let make = editor.make();
         match &self.target {
             Target::IdentPat(pat) => {
                 // If the binding is nested inside a record, we need to wrap the new
@@ -153,7 +154,7 @@ impl StructEditData {
                 if self.need_record_field_name {
                     let new_pat = editor
                         .make()
-                        .record_pat_field(editor.make().name_ref(&self.name.to_string()), new_pat);
+                        .record_pat_field(make.name_ref(&self.name.to_string()), new_pat);
                     editor.replace(pat.syntax(), new_pat.syntax())
                 } else {
                     editor.replace(pat.syntax(), new_pat.syntax())
@@ -161,9 +162,9 @@ impl StructEditData {
             }
             Target::SelfParam { insert_after, .. } => {
                 let indent = IndentLevel::from_token(insert_after) + 1;
-                let newline = editor.make().whitespace(&format!("\n{indent}"));
-                let initializer = editor.make().expr_path(editor.make().ident_path("self"));
-                let let_stmt = editor.make().let_stmt(new_pat, None, Some(initializer));
+                let newline = make.whitespace(&format!("\n{indent}"));
+                let initializer = make.expr_path(make.ident_path("self"));
+                let let_stmt = make.let_stmt(new_pat, None, Some(initializer));
                 editor.insert_all(
                     Position::after(insert_after),
                     vec![newline.into(), let_stmt.syntax().clone().into()],
@@ -271,10 +272,11 @@ fn get_names_in_scope(
 
 fn destructure_pat(
     _ctx: &AssistContext<'_>,
-    editor: &mut SyntaxEditor,
+    editor: &SyntaxEditor,
     data: &StructEditData,
     field_names: &[(SmolStr, SmolStr)],
 ) {
+    let make = editor.make();
     let struct_path = mod_path_to_ast(&data.struct_def_path, data.edition);
     let is_ref = data.target.is_ref();
     let is_mut = data.target.is_mut();
@@ -282,40 +284,31 @@ fn destructure_pat(
     let new_pat = match data.kind {
         hir::StructKind::Tuple => {
             let ident_pats = field_names.iter().map(|(_, new_name)| {
-                let name = editor.make().name(new_name);
-                ast::Pat::from(editor.make().ident_pat(is_ref, is_mut, name))
+                let name = make.name(new_name);
+                ast::Pat::from(make.ident_pat(is_ref, is_mut, name))
             });
-            ast::Pat::TupleStructPat(editor.make().tuple_struct_pat(struct_path, ident_pats))
+            ast::Pat::TupleStructPat(make.tuple_struct_pat(struct_path, ident_pats))
         }
         hir::StructKind::Record => {
             let fields = field_names.iter().map(|(old_name, new_name)| {
                 // Use shorthand syntax if possible
                 if old_name == new_name {
-                    editor.make().record_pat_field_shorthand(
-                        editor
-                            .make()
-                            .ident_pat(is_ref, is_mut, editor.make().name(old_name))
-                            .into(),
+                    make.record_pat_field_shorthand(
+                        editor.make().ident_pat(is_ref, is_mut, make.name(old_name)).into(),
                     )
                 } else {
-                    editor.make().record_pat_field(
-                        editor.make().name_ref(old_name),
-                        ast::Pat::IdentPat(editor.make().ident_pat(
-                            is_ref,
-                            is_mut,
-                            editor.make().name(new_name),
-                        )),
+                    make.record_pat_field(
+                        make.name_ref(old_name),
+                        ast::Pat::IdentPat(make.ident_pat(is_ref, is_mut, make.name(new_name))),
                     )
                 }
             });
-            let field_list = editor.make().record_pat_field_list(
-                fields,
-                data.has_private_members.then_some(editor.make().rest_pat()),
-            );
+            let field_list = make
+                .record_pat_field_list(fields, data.has_private_members.then_some(make.rest_pat()));
 
-            ast::Pat::RecordPat(editor.make().record_pat_with_fields(struct_path, field_list))
+            ast::Pat::RecordPat(make.record_pat_with_fields(struct_path, field_list))
         }
-        hir::StructKind::Unit => editor.make().path_pat(struct_path),
+        hir::StructKind::Unit => make.path_pat(struct_path),
     };
 
     data.apply_to_destruct(new_pat, editor);
@@ -357,7 +350,7 @@ fn new_field_name(base_name: SmolStr, names_in_scope: &FxHashSet<SmolStr>) -> Sm
 
 fn update_usages(
     ctx: &AssistContext<'_>,
-    editor: &mut SyntaxEditor,
+    editor: &SyntaxEditor,
     data: &StructEditData,
     field_names: &FxHashMap<SmolStr, SmolStr>,
 ) {

--- a/crates/ide-assists/src/handlers/destructure_struct_binding.rs
+++ b/crates/ide-assists/src/handlers/destructure_struct_binding.rs
@@ -145,19 +145,15 @@ struct StructEditData {
 }
 
 impl StructEditData {
-    fn apply_to_destruct(
-        &self,
-        new_pat: ast::Pat,
-        editor: &mut SyntaxEditor,
-        make: &SyntaxFactory,
-    ) {
+    fn apply_to_destruct(&self, new_pat: ast::Pat, editor: &mut SyntaxEditor) {
         match &self.target {
             Target::IdentPat(pat) => {
                 // If the binding is nested inside a record, we need to wrap the new
                 // destructured pattern in a non-shorthand record field
                 if self.need_record_field_name {
-                    let new_pat =
-                        make.record_pat_field(make.name_ref(&self.name.to_string()), new_pat);
+                    let new_pat = editor
+                        .make()
+                        .record_pat_field(editor.make().name_ref(&self.name.to_string()), new_pat);
                     editor.replace(pat.syntax(), new_pat.syntax())
                 } else {
                     editor.replace(pat.syntax(), new_pat.syntax())
@@ -165,9 +161,9 @@ impl StructEditData {
             }
             Target::SelfParam { insert_after, .. } => {
                 let indent = IndentLevel::from_token(insert_after) + 1;
-                let newline = make.whitespace(&format!("\n{indent}"));
-                let initializer = make.expr_path(make.ident_path("self"));
-                let let_stmt = make.let_stmt(new_pat, None, Some(initializer));
+                let newline = editor.make().whitespace(&format!("\n{indent}"));
+                let initializer = editor.make().expr_path(editor.make().ident_path("self"));
+                let let_stmt = editor.make().let_stmt(new_pat, None, Some(initializer));
                 editor.insert_all(
                     Position::after(insert_after),
                     vec![newline.into(), let_stmt.syntax().clone().into()],
@@ -283,39 +279,46 @@ fn destructure_pat(
     let is_ref = data.target.is_ref();
     let is_mut = data.target.is_mut();
 
-    let make = SyntaxFactory::with_mappings();
     let new_pat = match data.kind {
         hir::StructKind::Tuple => {
             let ident_pats = field_names.iter().map(|(_, new_name)| {
-                let name = make.name(new_name);
-                ast::Pat::from(make.ident_pat(is_ref, is_mut, name))
+                let name = editor.make().name(new_name);
+                ast::Pat::from(editor.make().ident_pat(is_ref, is_mut, name))
             });
-            ast::Pat::TupleStructPat(make.tuple_struct_pat(struct_path, ident_pats))
+            ast::Pat::TupleStructPat(editor.make().tuple_struct_pat(struct_path, ident_pats))
         }
         hir::StructKind::Record => {
             let fields = field_names.iter().map(|(old_name, new_name)| {
                 // Use shorthand syntax if possible
                 if old_name == new_name {
-                    make.record_pat_field_shorthand(
-                        make.ident_pat(is_ref, is_mut, make.name(old_name)).into(),
+                    editor.make().record_pat_field_shorthand(
+                        editor
+                            .make()
+                            .ident_pat(is_ref, is_mut, editor.make().name(old_name))
+                            .into(),
                     )
                 } else {
-                    make.record_pat_field(
-                        make.name_ref(old_name),
-                        ast::Pat::IdentPat(make.ident_pat(is_ref, is_mut, make.name(new_name))),
+                    editor.make().record_pat_field(
+                        editor.make().name_ref(old_name),
+                        ast::Pat::IdentPat(editor.make().ident_pat(
+                            is_ref,
+                            is_mut,
+                            editor.make().name(new_name),
+                        )),
                     )
                 }
             });
-            let field_list = make
-                .record_pat_field_list(fields, data.has_private_members.then_some(make.rest_pat()));
+            let field_list = editor.make().record_pat_field_list(
+                fields,
+                data.has_private_members.then_some(editor.make().rest_pat()),
+            );
 
-            ast::Pat::RecordPat(make.record_pat_with_fields(struct_path, field_list))
+            ast::Pat::RecordPat(editor.make().record_pat_with_fields(struct_path, field_list))
         }
-        hir::StructKind::Unit => make.path_pat(struct_path),
+        hir::StructKind::Unit => editor.make().path_pat(struct_path),
     };
 
-    data.apply_to_destruct(new_pat, editor, &make);
-    editor.add_mappings(make.finish_with_mappings());
+    data.apply_to_destruct(new_pat, editor);
 }
 
 fn generate_field_names(ctx: &AssistContext<'_>, data: &StructEditData) -> Vec<(SmolStr, SmolStr)> {
@@ -359,13 +362,11 @@ fn update_usages(
     field_names: &FxHashMap<SmolStr, SmolStr>,
 ) {
     let source = ctx.source_file().syntax();
-    let make = SyntaxFactory::with_mappings();
     let edits = data
         .usages
         .iter()
-        .filter_map(|r| build_usage_edit(ctx, &make, data, r, field_names))
+        .filter_map(|r| build_usage_edit(ctx, editor.make(), data, r, field_names))
         .collect_vec();
-    editor.add_mappings(make.finish_with_mappings());
     for (old, new) in edits {
         if let Some(range) = ctx.sema.original_range_opt(&old) {
             editor.replace_all(cover_edit_range(source, range.range), vec![new.into()]);

--- a/crates/ide-assists/src/handlers/destructure_tuple_binding.rs
+++ b/crates/ide-assists/src/handlers/destructure_tuple_binding.rs
@@ -90,20 +90,18 @@ fn destructure_tuple_edit_impl(
     in_sub_pattern: bool,
 ) {
     let mut syntax_editor = edit.make_editor(data.ident_pat.syntax());
-    let syntax_factory = SyntaxFactory::with_mappings();
 
     let assignment_edit =
-        edit_tuple_assignment(ctx, edit, &mut syntax_editor, &syntax_factory, data, in_sub_pattern);
-    let current_file_usages_edit = edit_tuple_usages(data, ctx, &syntax_factory, in_sub_pattern);
+        edit_tuple_assignment(ctx, edit, &mut syntax_editor, data, in_sub_pattern);
+    let current_file_usages_edit =
+        edit_tuple_usages(data, ctx, syntax_editor.make(), in_sub_pattern);
 
-    assignment_edit.apply(&mut syntax_editor, &syntax_factory);
+    assignment_edit.apply(&mut syntax_editor);
     if let Some(usages_edit) = current_file_usages_edit {
         usages_edit
             .into_iter()
             .for_each(|usage_edit| usage_edit.apply(ctx, edit, &mut syntax_editor))
     }
-
-    syntax_editor.add_mappings(syntax_factory.finish_with_mappings());
     edit.add_file_edits(ctx.vfs_file_id(), syntax_editor);
 }
 
@@ -176,7 +174,6 @@ fn edit_tuple_assignment(
     ctx: &AssistContext<'_>,
     edit: &mut SourceChangeBuilder,
     editor: &mut SyntaxEditor,
-    make: &SyntaxFactory,
     data: &TupleData,
     in_sub_pattern: bool,
 ) -> AssignmentEdit {
@@ -184,11 +181,10 @@ fn edit_tuple_assignment(
         let original = &data.ident_pat;
         let is_ref = original.ref_token().is_some();
         let is_mut = original.mut_token().is_some();
-        let fields = data
-            .field_names
-            .iter()
-            .map(|name| ast::Pat::from(make.ident_pat(is_ref, is_mut, make.name(name))));
-        make.tuple_pat(fields)
+        let fields = data.field_names.iter().map(|name| {
+            ast::Pat::from(editor.make().ident_pat(is_ref, is_mut, editor.make().name(name)))
+        });
+        editor.make().tuple_pat(fields)
     };
     let is_shorthand_field = data
         .ident_pat
@@ -223,16 +219,20 @@ struct AssignmentEdit {
 }
 
 impl AssignmentEdit {
-    fn apply(self, syntax_editor: &mut SyntaxEditor, syntax_mapping: &SyntaxFactory) {
+    fn apply(self, syntax_editor: &mut SyntaxEditor) {
         // with sub_pattern: keep original tuple and add subpattern: `tup @ (_0, _1)`
         if self.in_sub_pattern {
-            self.ident_pat.set_pat(Some(self.tuple_pat.into()), syntax_editor, syntax_mapping);
+            self.ident_pat.set_pat(Some(self.tuple_pat.into()), syntax_editor);
         } else if self.is_shorthand_field {
             syntax_editor.insert(Position::after(self.ident_pat.syntax()), self.tuple_pat.syntax());
-            syntax_editor
-                .insert(Position::after(self.ident_pat.syntax()), syntax_mapping.whitespace(" "));
-            syntax_editor
-                .insert(Position::after(self.ident_pat.syntax()), syntax_mapping.token(T![:]));
+            syntax_editor.insert(
+                Position::after(self.ident_pat.syntax()),
+                syntax_editor.make().whitespace(" "),
+            );
+            syntax_editor.insert(
+                Position::after(self.ident_pat.syntax()),
+                syntax_editor.make().token(T![:]),
+            );
         } else {
             syntax_editor.replace(self.ident_pat.syntax(), self.tuple_pat.syntax())
         }

--- a/crates/ide-assists/src/handlers/destructure_tuple_binding.rs
+++ b/crates/ide-assists/src/handlers/destructure_tuple_binding.rs
@@ -89,20 +89,17 @@ fn destructure_tuple_edit_impl(
     data: &TupleData,
     in_sub_pattern: bool,
 ) {
-    let mut syntax_editor = edit.make_editor(data.ident_pat.syntax());
+    let editor = edit.make_editor(data.ident_pat.syntax());
+    let make = editor.make();
 
-    let assignment_edit =
-        edit_tuple_assignment(ctx, edit, &mut syntax_editor, data, in_sub_pattern);
-    let current_file_usages_edit =
-        edit_tuple_usages(data, ctx, syntax_editor.make(), in_sub_pattern);
+    let assignment_edit = edit_tuple_assignment(ctx, edit, &editor, data, in_sub_pattern);
+    let current_file_usages_edit = edit_tuple_usages(data, ctx, make, in_sub_pattern);
 
-    assignment_edit.apply(&mut syntax_editor);
+    assignment_edit.apply(&editor);
     if let Some(usages_edit) = current_file_usages_edit {
-        usages_edit
-            .into_iter()
-            .for_each(|usage_edit| usage_edit.apply(ctx, edit, &mut syntax_editor))
+        usages_edit.into_iter().for_each(|usage_edit| usage_edit.apply(ctx, edit, &editor))
     }
-    edit.add_file_edits(ctx.vfs_file_id(), syntax_editor);
+    edit.add_file_edits(ctx.vfs_file_id(), editor);
 }
 
 fn collect_data(ident_pat: IdentPat, ctx: &AssistContext<'_>) -> Option<TupleData> {
@@ -173,18 +170,20 @@ struct TupleData {
 fn edit_tuple_assignment(
     ctx: &AssistContext<'_>,
     edit: &mut SourceChangeBuilder,
-    editor: &mut SyntaxEditor,
+    editor: &SyntaxEditor,
     data: &TupleData,
     in_sub_pattern: bool,
 ) -> AssignmentEdit {
+    let make = editor.make();
     let tuple_pat = {
         let original = &data.ident_pat;
         let is_ref = original.ref_token().is_some();
         let is_mut = original.mut_token().is_some();
-        let fields = data.field_names.iter().map(|name| {
-            ast::Pat::from(editor.make().ident_pat(is_ref, is_mut, editor.make().name(name)))
-        });
-        editor.make().tuple_pat(fields)
+        let fields = data
+            .field_names
+            .iter()
+            .map(|name| ast::Pat::from(make.ident_pat(is_ref, is_mut, make.name(name))));
+        make.tuple_pat(fields)
     };
     let is_shorthand_field = data
         .ident_pat
@@ -219,22 +218,17 @@ struct AssignmentEdit {
 }
 
 impl AssignmentEdit {
-    fn apply(self, syntax_editor: &mut SyntaxEditor) {
+    fn apply(self, editor: &SyntaxEditor) {
+        let make = editor.make();
         // with sub_pattern: keep original tuple and add subpattern: `tup @ (_0, _1)`
         if self.in_sub_pattern {
-            self.ident_pat.set_pat(Some(self.tuple_pat.into()), syntax_editor);
+            self.ident_pat.set_pat(Some(self.tuple_pat.into()), editor);
         } else if self.is_shorthand_field {
-            syntax_editor.insert(Position::after(self.ident_pat.syntax()), self.tuple_pat.syntax());
-            syntax_editor.insert(
-                Position::after(self.ident_pat.syntax()),
-                syntax_editor.make().whitespace(" "),
-            );
-            syntax_editor.insert(
-                Position::after(self.ident_pat.syntax()),
-                syntax_editor.make().token(T![:]),
-            );
+            editor.insert(Position::after(self.ident_pat.syntax()), self.tuple_pat.syntax());
+            editor.insert(Position::after(self.ident_pat.syntax()), make.whitespace(" "));
+            editor.insert(Position::after(self.ident_pat.syntax()), make.token(T![:]));
         } else {
-            syntax_editor.replace(self.ident_pat.syntax(), self.tuple_pat.syntax())
+            editor.replace(self.ident_pat.syntax(), self.tuple_pat.syntax())
         }
     }
 }
@@ -313,7 +307,7 @@ impl EditTupleUsage {
         self,
         ctx: &AssistContext<'_>,
         edit: &mut SourceChangeBuilder,
-        syntax_editor: &mut SyntaxEditor,
+        syntax_editor: &SyntaxEditor,
     ) {
         match self {
             EditTupleUsage::NoIndex(range) => {

--- a/crates/ide-assists/src/handlers/desugar_try_expr.rs
+++ b/crates/ide-assists/src/handlers/desugar_try_expr.rs
@@ -65,33 +65,30 @@ pub(crate) fn desugar_try_expr(acc: &mut Assists, ctx: &AssistContext<'_>) -> Op
         "Replace try expression with match",
         target,
         |builder| {
-            let mut editor = builder.make_editor(try_expr.syntax());
-
+            let editor = builder.make_editor(try_expr.syntax());
+            let make = editor.make();
             let sad_pat = match try_enum {
-                TryEnum::Option => editor.make().path_pat(editor.make().ident_path("None")),
+                TryEnum::Option => make.path_pat(make.ident_path("None")),
                 TryEnum::Result => editor
                     .make()
                     .tuple_struct_pat(
-                        editor.make().ident_path("Err"),
-                        iter::once(editor.make().path_pat(editor.make().ident_path("err"))),
+                        make.ident_path("Err"),
+                        iter::once(make.path_pat(make.ident_path("err"))),
                     )
                     .into(),
             };
-            let sad_expr =
-                editor.make().expr_return(Some(sad_expr(try_enum, editor.make(), || {
-                    editor.make().expr_path(editor.make().ident_path("err"))
-                })));
+            let sad_expr = make.expr_return(Some(sad_expr(try_enum, make, || {
+                make.expr_path(make.ident_path("err"))
+            })));
 
-            let happy_arm = editor.make().match_arm(
-                try_enum.happy_pattern(
-                    editor.make().ident_pat(false, false, editor.make().name("it")).into(),
-                ),
+            let happy_arm = make.match_arm(
+                try_enum.happy_pattern(make.ident_pat(false, false, make.name("it")).into()),
                 None,
-                editor.make().expr_path(editor.make().ident_path("it")),
+                make.expr_path(make.ident_path("it")),
             );
-            let sad_arm = editor.make().match_arm(sad_pat, None, sad_expr.into());
+            let sad_arm = make.match_arm(sad_pat, None, sad_expr.into());
 
-            let match_arm_list = editor.make().match_arm_list([happy_arm, sad_arm]);
+            let match_arm_list = make.match_arm_list([happy_arm, sad_arm]);
 
             let expr_match = editor
                 .make()
@@ -112,17 +109,16 @@ pub(crate) fn desugar_try_expr(acc: &mut Assists, ctx: &AssistContext<'_>) -> Op
             "Replace try expression with let else",
             target,
             |builder| {
-                let mut editor = builder.make_editor(let_stmt.syntax());
+                let editor = builder.make_editor(let_stmt.syntax());
+                let make = editor.make();
 
                 let indent_level = IndentLevel::from_node(let_stmt.syntax());
                 let fill_expr = || crate::utils::expr_fill_default(ctx.config);
-                let new_let_stmt = editor.make().let_else_stmt(
+                let new_let_stmt = make.let_else_stmt(
                     try_enum.happy_pattern(pat),
                     let_stmt.ty().map(|ty| match try_enum {
-                        TryEnum::Option => editor.make().ty_option(ty).into(),
-                        TryEnum::Result => {
-                            editor.make().ty_result(ty, editor.make().ty_infer().into()).into()
-                        }
+                        TryEnum::Option => make.ty_option(ty).into(),
+                        TryEnum::Result => make.ty_result(ty, make.ty_infer().into()).into(),
                     }),
                     expr,
                     editor
@@ -134,11 +130,7 @@ pub(crate) fn desugar_try_expr(acc: &mut Assists, ctx: &AssistContext<'_>) -> Op
                                     .expr_stmt(
                                         editor
                                             .make()
-                                            .expr_return(Some(sad_expr(
-                                                try_enum,
-                                                editor.make(),
-                                                fill_expr,
-                                            )))
+                                            .expr_return(Some(sad_expr(try_enum, make, fill_expr)))
                                             .into(),
                                     )
                                     .into(),

--- a/crates/ide-assists/src/handlers/desugar_try_expr.rs
+++ b/crates/ide-assists/src/handlers/desugar_try_expr.rs
@@ -65,37 +65,40 @@ pub(crate) fn desugar_try_expr(acc: &mut Assists, ctx: &AssistContext<'_>) -> Op
         "Replace try expression with match",
         target,
         |builder| {
-            let make = SyntaxFactory::with_mappings();
             let mut editor = builder.make_editor(try_expr.syntax());
 
             let sad_pat = match try_enum {
-                TryEnum::Option => make.path_pat(make.ident_path("None")),
-                TryEnum::Result => make
+                TryEnum::Option => editor.make().path_pat(editor.make().ident_path("None")),
+                TryEnum::Result => editor
+                    .make()
                     .tuple_struct_pat(
-                        make.ident_path("Err"),
-                        iter::once(make.path_pat(make.ident_path("err"))),
+                        editor.make().ident_path("Err"),
+                        iter::once(editor.make().path_pat(editor.make().ident_path("err"))),
                     )
                     .into(),
             };
-            let sad_expr = make.expr_return(Some(sad_expr(try_enum, &make, || {
-                make.expr_path(make.ident_path("err"))
-            })));
+            let sad_expr =
+                editor.make().expr_return(Some(sad_expr(try_enum, editor.make(), || {
+                    editor.make().expr_path(editor.make().ident_path("err"))
+                })));
 
-            let happy_arm = make.match_arm(
-                try_enum.happy_pattern(make.ident_pat(false, false, make.name("it")).into()),
+            let happy_arm = editor.make().match_arm(
+                try_enum.happy_pattern(
+                    editor.make().ident_pat(false, false, editor.make().name("it")).into(),
+                ),
                 None,
-                make.expr_path(make.ident_path("it")),
+                editor.make().expr_path(editor.make().ident_path("it")),
             );
-            let sad_arm = make.match_arm(sad_pat, None, sad_expr.into());
+            let sad_arm = editor.make().match_arm(sad_pat, None, sad_expr.into());
 
-            let match_arm_list = make.match_arm_list([happy_arm, sad_arm]);
+            let match_arm_list = editor.make().match_arm_list([happy_arm, sad_arm]);
 
-            let expr_match = make
+            let expr_match = editor
+                .make()
                 .expr_match(expr.clone(), match_arm_list)
                 .indent(IndentLevel::from_node(try_expr.syntax()));
 
             editor.replace(try_expr.syntax(), expr_match.syntax());
-            editor.add_mappings(make.finish_with_mappings());
             builder.add_file_edits(ctx.vfs_file_id(), editor);
         },
     );
@@ -109,31 +112,42 @@ pub(crate) fn desugar_try_expr(acc: &mut Assists, ctx: &AssistContext<'_>) -> Op
             "Replace try expression with let else",
             target,
             |builder| {
-                let make = SyntaxFactory::with_mappings();
                 let mut editor = builder.make_editor(let_stmt.syntax());
 
                 let indent_level = IndentLevel::from_node(let_stmt.syntax());
                 let fill_expr = || crate::utils::expr_fill_default(ctx.config);
-                let new_let_stmt = make.let_else_stmt(
+                let new_let_stmt = editor.make().let_else_stmt(
                     try_enum.happy_pattern(pat),
                     let_stmt.ty().map(|ty| match try_enum {
-                        TryEnum::Option => make.ty_option(ty).into(),
-                        TryEnum::Result => make.ty_result(ty, make.ty_infer().into()).into(),
+                        TryEnum::Option => editor.make().ty_option(ty).into(),
+                        TryEnum::Result => {
+                            editor.make().ty_result(ty, editor.make().ty_infer().into()).into()
+                        }
                     }),
                     expr,
-                    make.block_expr(
-                        iter::once(
-                            make.expr_stmt(
-                                make.expr_return(Some(sad_expr(try_enum, &make, fill_expr))).into(),
-                            )
-                            .into(),
-                        ),
-                        None,
-                    )
-                    .indent(indent_level),
+                    editor
+                        .make()
+                        .block_expr(
+                            iter::once(
+                                editor
+                                    .make()
+                                    .expr_stmt(
+                                        editor
+                                            .make()
+                                            .expr_return(Some(sad_expr(
+                                                try_enum,
+                                                editor.make(),
+                                                fill_expr,
+                                            )))
+                                            .into(),
+                                    )
+                                    .into(),
+                            ),
+                            None,
+                        )
+                        .indent(indent_level),
                 );
                 editor.replace(let_stmt.syntax(), new_let_stmt.syntax());
-                editor.add_mappings(make.finish_with_mappings());
                 builder.add_file_edits(ctx.vfs_file_id(), editor);
             },
         );

--- a/crates/ide-assists/src/handlers/expand_glob_import.rs
+++ b/crates/ide-assists/src/handlers/expand_glob_import.rs
@@ -148,7 +148,8 @@ fn build_expanded_import(
     current_module: Module,
     reexport_public_items: bool,
 ) {
-    let mut editor = builder.make_editor(use_tree.syntax());
+    let editor = builder.make_editor(use_tree.syntax());
+    let make = editor.make();
     let (must_be_pub, visible_from) = if !reexport_public_items {
         (false, current_module)
     } else {
@@ -168,11 +169,11 @@ fn build_expanded_import(
         if reexport_public_items { refs_in_target } else { refs_in_target.used_refs(ctx) };
 
     let names_to_import = find_names_to_import(filtered_defs, imported_defs);
-    let expanded = editor.make().use_tree_list(names_to_import.iter().map(|n| {
-        let path = editor.make().ident_path(
+    let expanded = make.use_tree_list(names_to_import.iter().map(|n| {
+        let path = make.ident_path(
             &n.display(ctx.db(), current_module.krate(ctx.db()).edition(ctx.db())).to_string(),
         );
-        editor.make().use_tree(path, None, None, false)
+        make.use_tree(path, None, None, false)
     }));
 
     match use_tree.star_token() {

--- a/crates/ide-assists/src/handlers/expand_glob_import.rs
+++ b/crates/ide-assists/src/handlers/expand_glob_import.rs
@@ -8,7 +8,7 @@ use ide_db::{
 use stdx::never;
 use syntax::{
     AstNode, Direction, SyntaxNode, SyntaxToken, T,
-    ast::{self, Use, UseTree, VisibilityKind, syntax_factory::SyntaxFactory},
+    ast::{self, Use, UseTree, VisibilityKind},
 };
 
 use crate::{
@@ -148,7 +148,6 @@ fn build_expanded_import(
     current_module: Module,
     reexport_public_items: bool,
 ) {
-    let make = SyntaxFactory::with_mappings();
     let mut editor = builder.make_editor(use_tree.syntax());
     let (must_be_pub, visible_from) = if !reexport_public_items {
         (false, current_module)
@@ -169,11 +168,11 @@ fn build_expanded_import(
         if reexport_public_items { refs_in_target } else { refs_in_target.used_refs(ctx) };
 
     let names_to_import = find_names_to_import(filtered_defs, imported_defs);
-    let expanded = make.use_tree_list(names_to_import.iter().map(|n| {
-        let path = make.ident_path(
+    let expanded = editor.make().use_tree_list(names_to_import.iter().map(|n| {
+        let path = editor.make().ident_path(
             &n.display(ctx.db(), current_module.krate(ctx.db()).edition(ctx.db())).to_string(),
         );
-        make.use_tree(path, None, None, false)
+        editor.make().use_tree(path, None, None, false)
     }));
 
     match use_tree.star_token() {
@@ -192,7 +191,6 @@ fn build_expanded_import(
         }
         None => never!(),
     }
-    editor.add_mappings(make.finish_with_mappings());
     builder.add_file_edits(ctx.vfs_file_id(), editor);
 }
 

--- a/crates/ide-assists/src/handlers/expand_rest_pattern.rs
+++ b/crates/ide-assists/src/handlers/expand_rest_pattern.rs
@@ -51,9 +51,10 @@ fn expand_record_rest_pattern(
         "Fill struct fields",
         rest_pat.syntax().text_range(),
         |builder| {
-            let mut editor = builder.make_editor(rest_pat.syntax());
+            let editor = builder.make_editor(rest_pat.syntax());
+            let make = editor.make();
             let new_fields = old_field_list.fields().chain(matched_fields.iter().map(|(f, _)| {
-                editor.make().record_pat_field_shorthand(
+                make.record_pat_field_shorthand(
                     editor
                         .make()
                         .ident_pat(
@@ -66,7 +67,7 @@ fn expand_record_rest_pattern(
                         .into(),
                 )
             }));
-            let new_field_list = editor.make().record_pat_field_list(new_fields, None);
+            let new_field_list = make.record_pat_field_list(new_fields, None);
 
             editor.replace(old_field_list.syntax(), new_field_list.syntax());
             builder.add_file_edits(ctx.vfs_file_id(), editor);
@@ -131,17 +132,18 @@ fn expand_tuple_struct_rest_pattern(
         "Fill tuple struct fields",
         rest_pat.syntax().text_range(),
         |builder| {
-            let mut editor = builder.make_editor(rest_pat.syntax());
+            let editor = builder.make_editor(rest_pat.syntax());
+            let make = editor.make();
 
             let mut name_gen = NameGenerator::new_from_scope_locals(ctx.sema.scope(pat.syntax()));
-            let new_pat = editor.make().tuple_struct_pat(
+            let new_pat = make.tuple_struct_pat(
                 path,
                 pat.fields()
                     .take(prefix_count)
                     .chain(fields[prefix_count..fields.len() - suffix_count].iter().map(|f| {
                         gen_unnamed_pat(
                             ctx,
-                            editor.make(),
+                            make,
                             &mut name_gen,
                             &f.ty(ctx.db()).to_type(ctx.sema.db),
                             f.index(),
@@ -198,21 +200,15 @@ fn expand_tuple_rest_pattern(
         "Fill tuple fields",
         rest_pat.syntax().text_range(),
         |builder| {
-            let mut editor = builder.make_editor(rest_pat.syntax());
-
+            let editor = builder.make_editor(rest_pat.syntax());
+            let make = editor.make();
             let mut name_gen = NameGenerator::new_from_scope_locals(ctx.sema.scope(pat.syntax()));
-            let new_pat = editor.make().tuple_pat(
+            let new_pat = make.tuple_pat(
                 pat.fields()
                     .take(prefix_count)
                     .chain(fields[prefix_count..len - suffix_count].iter().enumerate().map(
                         |(index, ty)| {
-                            gen_unnamed_pat(
-                                ctx,
-                                editor.make(),
-                                &mut name_gen,
-                                ty,
-                                prefix_count + index,
-                            )
+                            gen_unnamed_pat(ctx, make, &mut name_gen, ty, prefix_count + index)
                         },
                     ))
                     .chain(pat.fields().skip(prefix_count + 1)),
@@ -265,15 +261,17 @@ fn expand_slice_rest_pattern(
         "Fill slice fields",
         rest_pat.syntax().text_range(),
         |builder| {
-            let mut editor = builder.make_editor(rest_pat.syntax());
+            let editor = builder.make_editor(rest_pat.syntax());
+            let make = editor.make();
 
             let mut name_gen = NameGenerator::new_from_scope_locals(ctx.sema.scope(pat.syntax()));
-            let new_pat = editor.make().slice_pat(
+            let new_pat = make.slice_pat(
                 pat.pats()
                     .take(prefix_count)
-                    .chain((prefix_count..len - suffix_count).map(|index| {
-                        gen_unnamed_pat(ctx, editor.make(), &mut name_gen, &ty, index)
-                    }))
+                    .chain(
+                        (prefix_count..len - suffix_count)
+                            .map(|index| gen_unnamed_pat(ctx, make, &mut name_gen, &ty, index)),
+                    )
                     .chain(pat.pats().skip(prefix_count + 1)),
             );
 

--- a/crates/ide-assists/src/handlers/expand_rest_pattern.rs
+++ b/crates/ide-assists/src/handlers/expand_rest_pattern.rs
@@ -51,23 +51,24 @@ fn expand_record_rest_pattern(
         "Fill struct fields",
         rest_pat.syntax().text_range(),
         |builder| {
-            let make = SyntaxFactory::with_mappings();
             let mut editor = builder.make_editor(rest_pat.syntax());
             let new_fields = old_field_list.fields().chain(matched_fields.iter().map(|(f, _)| {
-                make.record_pat_field_shorthand(
-                    make.ident_pat(
-                        false,
-                        false,
-                        make.name(&f.name(ctx.sema.db).display_no_db(edition).to_smolstr()),
-                    )
-                    .into(),
+                editor.make().record_pat_field_shorthand(
+                    editor
+                        .make()
+                        .ident_pat(
+                            false,
+                            false,
+                            editor
+                                .make()
+                                .name(&f.name(ctx.sema.db).display_no_db(edition).to_smolstr()),
+                        )
+                        .into(),
                 )
             }));
-            let new_field_list = make.record_pat_field_list(new_fields, None);
+            let new_field_list = editor.make().record_pat_field_list(new_fields, None);
 
             editor.replace(old_field_list.syntax(), new_field_list.syntax());
-
-            editor.add_mappings(make.finish_with_mappings());
             builder.add_file_edits(ctx.vfs_file_id(), editor);
         },
     )
@@ -130,18 +131,17 @@ fn expand_tuple_struct_rest_pattern(
         "Fill tuple struct fields",
         rest_pat.syntax().text_range(),
         |builder| {
-            let make = SyntaxFactory::with_mappings();
             let mut editor = builder.make_editor(rest_pat.syntax());
 
             let mut name_gen = NameGenerator::new_from_scope_locals(ctx.sema.scope(pat.syntax()));
-            let new_pat = make.tuple_struct_pat(
+            let new_pat = editor.make().tuple_struct_pat(
                 path,
                 pat.fields()
                     .take(prefix_count)
                     .chain(fields[prefix_count..fields.len() - suffix_count].iter().map(|f| {
                         gen_unnamed_pat(
                             ctx,
-                            &make,
+                            editor.make(),
                             &mut name_gen,
                             &f.ty(ctx.db()).to_type(ctx.sema.db),
                             f.index(),
@@ -151,8 +151,6 @@ fn expand_tuple_struct_rest_pattern(
             );
 
             editor.replace(pat.syntax(), new_pat.syntax());
-
-            editor.add_mappings(make.finish_with_mappings());
             builder.add_file_edits(ctx.vfs_file_id(), editor);
         },
     )
@@ -200,24 +198,27 @@ fn expand_tuple_rest_pattern(
         "Fill tuple fields",
         rest_pat.syntax().text_range(),
         |builder| {
-            let make = SyntaxFactory::with_mappings();
             let mut editor = builder.make_editor(rest_pat.syntax());
 
             let mut name_gen = NameGenerator::new_from_scope_locals(ctx.sema.scope(pat.syntax()));
-            let new_pat = make.tuple_pat(
+            let new_pat = editor.make().tuple_pat(
                 pat.fields()
                     .take(prefix_count)
                     .chain(fields[prefix_count..len - suffix_count].iter().enumerate().map(
                         |(index, ty)| {
-                            gen_unnamed_pat(ctx, &make, &mut name_gen, ty, prefix_count + index)
+                            gen_unnamed_pat(
+                                ctx,
+                                editor.make(),
+                                &mut name_gen,
+                                ty,
+                                prefix_count + index,
+                            )
                         },
                     ))
                     .chain(pat.fields().skip(prefix_count + 1)),
             );
 
             editor.replace(pat.syntax(), new_pat.syntax());
-
-            editor.add_mappings(make.finish_with_mappings());
             builder.add_file_edits(ctx.vfs_file_id(), editor);
         },
     )
@@ -264,23 +265,19 @@ fn expand_slice_rest_pattern(
         "Fill slice fields",
         rest_pat.syntax().text_range(),
         |builder| {
-            let make = SyntaxFactory::with_mappings();
             let mut editor = builder.make_editor(rest_pat.syntax());
 
             let mut name_gen = NameGenerator::new_from_scope_locals(ctx.sema.scope(pat.syntax()));
-            let new_pat = make.slice_pat(
+            let new_pat = editor.make().slice_pat(
                 pat.pats()
                     .take(prefix_count)
-                    .chain(
-                        (prefix_count..len - suffix_count)
-                            .map(|index| gen_unnamed_pat(ctx, &make, &mut name_gen, &ty, index)),
-                    )
+                    .chain((prefix_count..len - suffix_count).map(|index| {
+                        gen_unnamed_pat(ctx, editor.make(), &mut name_gen, &ty, index)
+                    }))
                     .chain(pat.pats().skip(prefix_count + 1)),
             );
 
             editor.replace(pat.syntax(), new_pat.syntax());
-
-            editor.add_mappings(make.finish_with_mappings());
             builder.add_file_edits(ctx.vfs_file_id(), editor);
         },
     )

--- a/crates/ide-assists/src/handlers/extract_expressions_from_format_string.rs
+++ b/crates/ide-assists/src/handlers/extract_expressions_from_format_string.rs
@@ -8,7 +8,7 @@ use syntax::{
     AstNode, AstToken, NodeOrToken,
     SyntaxKind::WHITESPACE,
     SyntaxToken, T,
-    ast::{self, TokenTree, syntax_factory::SyntaxFactory},
+    ast::{self, TokenTree},
 };
 
 // Assist: extract_expressions_from_format_string
@@ -57,7 +57,7 @@ pub(crate) fn extract_expressions_from_format_string(
         "Extract format expressions",
         tt.syntax().text_range(),
         |edit| {
-            let make = SyntaxFactory::without_mappings();
+            let mut editor = edit.make_editor(tt.syntax());
             // Extract existing arguments in macro
             let mut raw_tokens = tt.token_trees_and_tokens().skip(1).collect_vec();
             let format_string_index = format_str_index(&raw_tokens, &fmt_string);
@@ -95,14 +95,15 @@ pub(crate) fn extract_expressions_from_format_string(
             let mut new_tt_bits = raw_tokens;
             let mut placeholder_indexes = vec![];
 
-            new_tt_bits.push(NodeOrToken::Token(make.expr_literal(&new_fmt).token().clone()));
+            new_tt_bits
+                .push(NodeOrToken::Token(editor.make().expr_literal(&new_fmt).token().clone()));
 
             for arg in extracted_args {
                 if matches!(arg, Arg::Expr(_) | Arg::Placeholder) {
                     // insert ", " before each arg
                     new_tt_bits.extend_from_slice(&[
-                        NodeOrToken::Token(make.token(T![,])),
-                        NodeOrToken::Token(make.whitespace(" ")),
+                        NodeOrToken::Token(editor.make().token(T![,])),
+                        NodeOrToken::Token(editor.make().whitespace(" ")),
                     ]);
                 }
 
@@ -110,7 +111,7 @@ pub(crate) fn extract_expressions_from_format_string(
                     Arg::Expr(s) => {
                         // insert arg
                         let expr = ast::Expr::parse(&s, ctx.edition()).syntax_node();
-                        let mut expr_tt = utils::tt_from_syntax(expr, &make);
+                        let mut expr_tt = utils::tt_from_syntax(expr, editor.make());
                         new_tt_bits.append(&mut expr_tt);
                     }
                     Arg::Placeholder => {
@@ -121,7 +122,7 @@ pub(crate) fn extract_expressions_from_format_string(
                             }
                             None => {
                                 placeholder_indexes.push(new_tt_bits.len());
-                                new_tt_bits.push(NodeOrToken::Token(make.token(T![_])));
+                                new_tt_bits.push(NodeOrToken::Token(editor.make().token(T![_])));
                             }
                         }
                     }
@@ -130,8 +131,7 @@ pub(crate) fn extract_expressions_from_format_string(
             }
 
             // Insert new args
-            let new_tt = make.token_tree(tt_delimiter, new_tt_bits);
-            let mut editor = edit.make_editor(tt.syntax());
+            let new_tt = editor.make().token_tree(tt_delimiter, new_tt_bits);
             editor.replace(tt.syntax(), new_tt.syntax());
 
             if let Some(cap) = ctx.config.snippet_cap {
@@ -158,7 +158,6 @@ pub(crate) fn extract_expressions_from_format_string(
                     editor.add_annotation(literal, annotation);
                 }
             }
-            editor.add_mappings(make.finish_with_mappings());
             edit.add_file_edits(ctx.vfs_file_id(), editor);
         },
     );

--- a/crates/ide-assists/src/handlers/extract_expressions_from_format_string.rs
+++ b/crates/ide-assists/src/handlers/extract_expressions_from_format_string.rs
@@ -57,7 +57,8 @@ pub(crate) fn extract_expressions_from_format_string(
         "Extract format expressions",
         tt.syntax().text_range(),
         |edit| {
-            let mut editor = edit.make_editor(tt.syntax());
+            let editor = edit.make_editor(tt.syntax());
+            let make = editor.make();
             // Extract existing arguments in macro
             let mut raw_tokens = tt.token_trees_and_tokens().skip(1).collect_vec();
             let format_string_index = format_str_index(&raw_tokens, &fmt_string);
@@ -95,15 +96,14 @@ pub(crate) fn extract_expressions_from_format_string(
             let mut new_tt_bits = raw_tokens;
             let mut placeholder_indexes = vec![];
 
-            new_tt_bits
-                .push(NodeOrToken::Token(editor.make().expr_literal(&new_fmt).token().clone()));
+            new_tt_bits.push(NodeOrToken::Token(make.expr_literal(&new_fmt).token().clone()));
 
             for arg in extracted_args {
                 if matches!(arg, Arg::Expr(_) | Arg::Placeholder) {
                     // insert ", " before each arg
                     new_tt_bits.extend_from_slice(&[
-                        NodeOrToken::Token(editor.make().token(T![,])),
-                        NodeOrToken::Token(editor.make().whitespace(" ")),
+                        NodeOrToken::Token(make.token(T![,])),
+                        NodeOrToken::Token(make.whitespace(" ")),
                     ]);
                 }
 
@@ -111,7 +111,7 @@ pub(crate) fn extract_expressions_from_format_string(
                     Arg::Expr(s) => {
                         // insert arg
                         let expr = ast::Expr::parse(&s, ctx.edition()).syntax_node();
-                        let mut expr_tt = utils::tt_from_syntax(expr, editor.make());
+                        let mut expr_tt = utils::tt_from_syntax(expr, make);
                         new_tt_bits.append(&mut expr_tt);
                     }
                     Arg::Placeholder => {
@@ -122,7 +122,7 @@ pub(crate) fn extract_expressions_from_format_string(
                             }
                             None => {
                                 placeholder_indexes.push(new_tt_bits.len());
-                                new_tt_bits.push(NodeOrToken::Token(editor.make().token(T![_])));
+                                new_tt_bits.push(NodeOrToken::Token(make.token(T![_])));
                             }
                         }
                     }
@@ -131,7 +131,7 @@ pub(crate) fn extract_expressions_from_format_string(
             }
 
             // Insert new args
-            let new_tt = editor.make().token_tree(tt_delimiter, new_tt_bits);
+            let new_tt = make.token_tree(tt_delimiter, new_tt_bits);
             editor.replace(tt.syntax(), new_tt.syntax());
 
             if let Some(cap) = ctx.config.snippet_cap {

--- a/crates/ide-assists/src/handlers/extract_struct_from_enum_variant.rs
+++ b/crates/ide-assists/src/handlers/extract_struct_from_enum_variant.rs
@@ -60,7 +60,8 @@ pub(crate) fn extract_struct_from_enum_variant(
         "Extract struct from enum variant",
         target,
         |builder| {
-            let mut editor = builder.make_editor(variant.syntax());
+            let editor = builder.make_editor(variant.syntax());
+            let make = editor.make();
             let edition = enum_hir.krate(ctx.db()).edition(ctx.db());
             let variant_hir_name = variant_hir.name(ctx.db());
             let enum_module_def = ModuleDef::from(enum_hir);
@@ -86,7 +87,7 @@ pub(crate) fn extract_struct_from_enum_variant(
                 if processed.is_empty() {
                     continue;
                 }
-                let mut file_editor = builder.make_editor(processed[0].0.syntax());
+                let file_editor = builder.make_editor(processed[0].0.syntax());
                 processed.into_iter().for_each(|(path, node, import)| {
                     apply_references(
                         ctx.config.insert_use,
@@ -94,7 +95,7 @@ pub(crate) fn extract_struct_from_enum_variant(
                         node,
                         import,
                         edition,
-                        &mut file_editor,
+                        &file_editor,
                     )
                 });
                 builder.add_file_edits(file_id.file_id(ctx.db()), file_editor);
@@ -109,19 +110,12 @@ pub(crate) fn extract_struct_from_enum_variant(
                     references,
                 );
                 processed.into_iter().for_each(|(path, node, import)| {
-                    apply_references(
-                        ctx.config.insert_use,
-                        path,
-                        node,
-                        import,
-                        edition,
-                        &mut editor,
-                    )
+                    apply_references(ctx.config.insert_use, path, node, import, edition, &editor)
                 });
             }
 
             let generic_params = enum_ast.generic_param_list().and_then(|known_generics| {
-                extract_generic_params(editor.make(), &known_generics, &field_list)
+                extract_generic_params(make, &known_generics, &field_list)
             });
 
             // resolve GenericArg in field_list to actual type
@@ -144,13 +138,13 @@ pub(crate) fn extract_struct_from_enum_variant(
             };
 
             let (comments_for_struct, comments_to_delete) =
-                collect_variant_comments(editor.make(), variant.syntax());
+                collect_variant_comments(make, variant.syntax());
             for element in &comments_to_delete {
                 editor.delete(element.clone());
             }
 
             let def = create_struct_def(
-                editor.make(),
+                make,
                 variant_name.clone(),
                 &field_list,
                 generic_params.clone(),
@@ -164,14 +158,14 @@ pub(crate) fn extract_struct_from_enum_variant(
             let mut insert_items: Vec<SyntaxElement> = Vec::new();
             for attr in enum_ast.attrs() {
                 insert_items.push(attr.syntax().clone().into());
-                insert_items.push(editor.make().whitespace("\n").into());
+                insert_items.push(make.whitespace("\n").into());
             }
             insert_items.extend(comments_for_struct);
             insert_items.push(def.syntax().clone().into());
-            insert_items.push(editor.make().whitespace(&format!("\n\n{indent}")).into());
+            insert_items.push(make.whitespace(&format!("\n\n{indent}")).into());
             editor.insert_all_with_whitespace(Position::before(enum_ast.syntax()), insert_items);
 
-            update_variant(&mut editor, &variant, generic_params);
+            update_variant(&editor, &variant, generic_params);
 
             builder.add_file_edits(ctx.vfs_file_id(), editor);
         },
@@ -331,23 +325,24 @@ fn create_struct_def(
 }
 
 fn update_variant(
-    editor: &mut SyntaxEditor,
+    editor: &SyntaxEditor,
     variant: &ast::Variant,
     generics: Option<ast::GenericParamList>,
 ) -> Option<()> {
+    let make = editor.make();
     let name = variant.name()?;
     let generic_args = generics
         .filter(|generics| generics.generic_params().count() > 0)
         .map(|generics| generics.to_generic_args());
     // FIXME: replace with a `ast::make` constructor
     let ty = match generic_args {
-        Some(generic_args) => editor.make().ty(&format!("{name}{generic_args}")),
-        None => editor.make().ty(&name.text()),
+        Some(generic_args) => make.ty(&format!("{name}{generic_args}")),
+        None => make.ty(&name.text()),
     };
 
     // change from a record to a tuple field list
-    let tuple_field = editor.make().tuple_field(None, ty);
-    let field_list = editor.make().tuple_field_list(iter::once(tuple_field));
+    let tuple_field = make.tuple_field(None, ty);
+    let field_list = make.tuple_field_list(iter::once(tuple_field));
     editor.replace(variant.field_list()?.syntax(), field_list.syntax());
 
     // remove any ws after the name
@@ -397,16 +392,17 @@ fn apply_references(
     node: SyntaxNode,
     import: Option<(ImportScope, hir::ModPath)>,
     edition: Edition,
-    editor: &mut SyntaxEditor,
+    editor: &SyntaxEditor,
 ) {
+    let make = editor.make();
     if let Some((scope, path)) = import {
         insert_use_with_editor(&scope, mod_path_to_ast(&path, edition), &insert_use_cfg, editor);
     }
     // deep clone to prevent cycle
-    let path = editor.make().path_from_segments(iter::once(segment.clone()), false);
-    editor.insert(Position::before(segment.syntax()), editor.make().token(T!['(']));
+    let path = make.path_from_segments(iter::once(segment.clone()), false);
+    editor.insert(Position::before(segment.syntax()), make.token(T!['(']));
     editor.insert(Position::before(segment.syntax()), path.syntax());
-    editor.insert(Position::after(&node), editor.make().token(T![')']));
+    editor.insert(Position::after(&node), make.token(T![')']));
 }
 
 fn process_references(

--- a/crates/ide-assists/src/handlers/extract_struct_from_enum_variant.rs
+++ b/crates/ide-assists/src/handlers/extract_struct_from_enum_variant.rs
@@ -60,7 +60,6 @@ pub(crate) fn extract_struct_from_enum_variant(
         "Extract struct from enum variant",
         target,
         |builder| {
-            let make = SyntaxFactory::with_mappings();
             let mut editor = builder.make_editor(variant.syntax());
             let edition = enum_hir.krate(ctx.db()).edition(ctx.db());
             let variant_hir_name = variant_hir.name(ctx.db());
@@ -96,10 +95,8 @@ pub(crate) fn extract_struct_from_enum_variant(
                         import,
                         edition,
                         &mut file_editor,
-                        &make,
                     )
                 });
-                file_editor.add_mappings(make.take());
                 builder.add_file_edits(file_id.file_id(ctx.db()), file_editor);
             }
 
@@ -119,13 +116,12 @@ pub(crate) fn extract_struct_from_enum_variant(
                         import,
                         edition,
                         &mut editor,
-                        &make,
                     )
                 });
             }
 
             let generic_params = enum_ast.generic_param_list().and_then(|known_generics| {
-                extract_generic_params(&make, &known_generics, &field_list)
+                extract_generic_params(editor.make(), &known_generics, &field_list)
             });
 
             // resolve GenericArg in field_list to actual type
@@ -148,13 +144,13 @@ pub(crate) fn extract_struct_from_enum_variant(
             };
 
             let (comments_for_struct, comments_to_delete) =
-                collect_variant_comments(&make, variant.syntax());
+                collect_variant_comments(editor.make(), variant.syntax());
             for element in &comments_to_delete {
                 editor.delete(element.clone());
             }
 
             let def = create_struct_def(
-                &make,
+                editor.make(),
                 variant_name.clone(),
                 &field_list,
                 generic_params.clone(),
@@ -168,20 +164,15 @@ pub(crate) fn extract_struct_from_enum_variant(
             let mut insert_items: Vec<SyntaxElement> = Vec::new();
             for attr in enum_ast.attrs() {
                 insert_items.push(attr.syntax().clone().into());
-                insert_items.push(make.whitespace("\n").into());
+                insert_items.push(editor.make().whitespace("\n").into());
             }
             insert_items.extend(comments_for_struct);
             insert_items.push(def.syntax().clone().into());
-            insert_items.push(make.whitespace(&format!("\n\n{indent}")).into());
-            editor.insert_all_with_whitespace(
-                Position::before(enum_ast.syntax()),
-                insert_items,
-                &make,
-            );
+            insert_items.push(editor.make().whitespace(&format!("\n\n{indent}")).into());
+            editor.insert_all_with_whitespace(Position::before(enum_ast.syntax()), insert_items);
 
-            update_variant(&make, &mut editor, &variant, generic_params);
+            update_variant(&mut editor, &variant, generic_params);
 
-            editor.add_mappings(make.finish_with_mappings());
             builder.add_file_edits(ctx.vfs_file_id(), editor);
         },
     )
@@ -340,7 +331,6 @@ fn create_struct_def(
 }
 
 fn update_variant(
-    make: &SyntaxFactory,
     editor: &mut SyntaxEditor,
     variant: &ast::Variant,
     generics: Option<ast::GenericParamList>,
@@ -351,13 +341,13 @@ fn update_variant(
         .map(|generics| generics.to_generic_args());
     // FIXME: replace with a `ast::make` constructor
     let ty = match generic_args {
-        Some(generic_args) => make.ty(&format!("{name}{generic_args}")),
-        None => make.ty(&name.text()),
+        Some(generic_args) => editor.make().ty(&format!("{name}{generic_args}")),
+        None => editor.make().ty(&name.text()),
     };
 
     // change from a record to a tuple field list
-    let tuple_field = make.tuple_field(None, ty);
-    let field_list = make.tuple_field_list(iter::once(tuple_field));
+    let tuple_field = editor.make().tuple_field(None, ty);
+    let field_list = editor.make().tuple_field_list(iter::once(tuple_field));
     editor.replace(variant.field_list()?.syntax(), field_list.syntax());
 
     // remove any ws after the name
@@ -408,22 +398,15 @@ fn apply_references(
     import: Option<(ImportScope, hir::ModPath)>,
     edition: Edition,
     editor: &mut SyntaxEditor,
-    make: &SyntaxFactory,
 ) {
     if let Some((scope, path)) = import {
-        insert_use_with_editor(
-            &scope,
-            mod_path_to_ast(&path, edition),
-            &insert_use_cfg,
-            editor,
-            make,
-        );
+        insert_use_with_editor(&scope, mod_path_to_ast(&path, edition), &insert_use_cfg, editor);
     }
     // deep clone to prevent cycle
-    let path = make.path_from_segments(iter::once(segment.clone()), false);
-    editor.insert(Position::before(segment.syntax()), make.token(T!['(']));
+    let path = editor.make().path_from_segments(iter::once(segment.clone()), false);
+    editor.insert(Position::before(segment.syntax()), editor.make().token(T!['(']));
     editor.insert(Position::before(segment.syntax()), path.syntax());
-    editor.insert(Position::after(&node), make.token(T![')']));
+    editor.insert(Position::after(&node), editor.make().token(T![')']));
 }
 
 fn process_references(

--- a/crates/ide-assists/src/handlers/extract_type_alias.rs
+++ b/crates/ide-assists/src/handlers/extract_type_alias.rs
@@ -2,10 +2,7 @@ use either::Either;
 use hir::HirDisplay;
 use ide_db::syntax_helpers::node_ext::walk_ty;
 use syntax::{
-    ast::{
-        self, AstNode, HasGenericArgs, HasGenericParams, HasName, edit::IndentLevel,
-        syntax_factory::SyntaxFactory,
-    },
+    ast::{self, AstNode, HasGenericArgs, HasGenericParams, HasName, edit::IndentLevel},
     syntax_editor,
 };
 
@@ -56,10 +53,9 @@ pub(crate) fn extract_type_alias(acc: &mut Assists, ctx: &AssistContext<'_>) -> 
         "Extract type as type alias",
         target,
         |builder| {
-            let mut edit = builder.make_editor(node);
-            let make = SyntaxFactory::without_mappings();
+            let mut editor = builder.make_editor(node);
 
-            let resolved_ty = make.ty(&resolved_ty);
+            let resolved_ty = editor.make().ty(&resolved_ty);
 
             let mut known_generics = match item.generic_param_list() {
                 Some(it) => it.generic_params().collect(),
@@ -73,37 +69,43 @@ pub(crate) fn extract_type_alias(acc: &mut Assists, ctx: &AssistContext<'_>) -> 
             }
             let generics = collect_used_generics(&ty, &known_generics);
             let generic_params =
-                generics.map(|it| make.generic_param_list(it.into_iter().cloned()));
+                generics.map(|it| editor.make().generic_param_list(it.into_iter().cloned()));
 
             // Replace original type with the alias
             let ty_args = generic_params.as_ref().map(|it| it.to_generic_args().generic_args());
             let new_ty = if let Some(ty_args) = ty_args {
-                make.generic_ty_path_segment(make.name_ref("Type"), ty_args)
+                editor.make().generic_ty_path_segment(editor.make().name_ref("Type"), ty_args)
             } else {
-                make.path_segment(make.name_ref("Type"))
+                editor.make().path_segment(editor.make().name_ref("Type"))
             };
-            edit.replace(ty.syntax(), new_ty.syntax());
+            editor.replace(ty.syntax(), new_ty.syntax());
 
             // Insert new alias
-            let ty_alias =
-                make.ty_alias(None, "Type", generic_params, None, None, Some((resolved_ty, None)));
+            let ty_alias = editor.make().ty_alias(
+                None,
+                "Type",
+                generic_params,
+                None,
+                None,
+                Some((resolved_ty, None)),
+            );
 
             if let Some(cap) = ctx.config.snippet_cap
                 && let Some(name) = ty_alias.name()
             {
-                edit.add_annotation(name.syntax(), builder.make_tabstop_before(cap));
+                editor.add_annotation(name.syntax(), builder.make_tabstop_before(cap));
             }
 
             let indent = IndentLevel::from_node(node);
-            edit.insert_all(
+            editor.insert_all(
                 syntax_editor::Position::before(node),
                 vec![
                     ty_alias.syntax().clone().into(),
-                    make.whitespace(&format!("\n\n{indent}")).into(),
+                    editor.make().whitespace(&format!("\n\n{indent}")).into(),
                 ],
             );
 
-            builder.add_file_edits(ctx.vfs_file_id(), edit);
+            builder.add_file_edits(ctx.vfs_file_id(), editor);
         },
     )
 }

--- a/crates/ide-assists/src/handlers/extract_type_alias.rs
+++ b/crates/ide-assists/src/handlers/extract_type_alias.rs
@@ -53,9 +53,10 @@ pub(crate) fn extract_type_alias(acc: &mut Assists, ctx: &AssistContext<'_>) -> 
         "Extract type as type alias",
         target,
         |builder| {
-            let mut editor = builder.make_editor(node);
+            let editor = builder.make_editor(node);
+            let make = editor.make();
 
-            let resolved_ty = editor.make().ty(&resolved_ty);
+            let resolved_ty = make.ty(&resolved_ty);
 
             let mut known_generics = match item.generic_param_list() {
                 Some(it) => it.generic_params().collect(),
@@ -69,26 +70,20 @@ pub(crate) fn extract_type_alias(acc: &mut Assists, ctx: &AssistContext<'_>) -> 
             }
             let generics = collect_used_generics(&ty, &known_generics);
             let generic_params =
-                generics.map(|it| editor.make().generic_param_list(it.into_iter().cloned()));
+                generics.map(|it| make.generic_param_list(it.into_iter().cloned()));
 
             // Replace original type with the alias
             let ty_args = generic_params.as_ref().map(|it| it.to_generic_args().generic_args());
             let new_ty = if let Some(ty_args) = ty_args {
-                editor.make().generic_ty_path_segment(editor.make().name_ref("Type"), ty_args)
+                make.generic_ty_path_segment(make.name_ref("Type"), ty_args)
             } else {
-                editor.make().path_segment(editor.make().name_ref("Type"))
+                make.path_segment(make.name_ref("Type"))
             };
             editor.replace(ty.syntax(), new_ty.syntax());
 
             // Insert new alias
-            let ty_alias = editor.make().ty_alias(
-                None,
-                "Type",
-                generic_params,
-                None,
-                None,
-                Some((resolved_ty, None)),
-            );
+            let ty_alias =
+                make.ty_alias(None, "Type", generic_params, None, None, Some((resolved_ty, None)));
 
             if let Some(cap) = ctx.config.snippet_cap
                 && let Some(name) = ty_alias.name()
@@ -101,7 +96,7 @@ pub(crate) fn extract_type_alias(acc: &mut Assists, ctx: &AssistContext<'_>) -> 
                 syntax_editor::Position::before(node),
                 vec![
                     ty_alias.syntax().clone().into(),
-                    editor.make().whitespace(&format!("\n\n{indent}")).into(),
+                    make.whitespace(&format!("\n\n{indent}")).into(),
                 ],
             );
 

--- a/crates/ide-assists/src/handlers/extract_variable.rs
+++ b/crates/ide-assists/src/handlers/extract_variable.rs
@@ -205,10 +205,11 @@ pub(crate) fn extract_variable(acc: &mut Assists, ctx: &AssistContext<'_>) -> Op
                         to_replace.clone()
                     };
 
-                let mut editor = edit.make_editor(&place);
+                let editor = edit.make_editor(&place);
+                let make = editor.make();
 
-                let pat_name = editor.make().name(&var_name);
-                let name_expr = editor.make().expr_path(editor.make().ident_path(&var_name));
+                let pat_name = make.name(&var_name);
+                let name_expr = make.expr_path(make.ident_path(&var_name));
 
                 if let Some(cap) = ctx.config.snippet_cap {
                     let tabstop = edit.make_tabstop_before(cap);
@@ -217,33 +218,27 @@ pub(crate) fn extract_variable(acc: &mut Assists, ctx: &AssistContext<'_>) -> Op
 
                 let initializer = match ty.as_ref().filter(|_| needs_ref) {
                     Some(receiver_type) if receiver_type.is_mutable_reference() => {
-                        editor.make().expr_ref(to_extract_no_ref.clone(), true)
+                        make.expr_ref(to_extract_no_ref.clone(), true)
                     }
                     Some(receiver_type) if receiver_type.is_reference() => {
-                        editor.make().expr_ref(to_extract_no_ref.clone(), false)
+                        make.expr_ref(to_extract_no_ref.clone(), false)
                     }
                     _ => to_extract_no_ref.clone(),
                 };
 
                 let new_stmt: ast::Stmt = match kind {
                     ExtractionKind::Variable => {
-                        let ident_pat = editor.make().ident_pat(false, needs_mut, pat_name);
-                        editor.make().let_stmt(ident_pat.into(), None, Some(initializer)).into()
+                        let ident_pat = make.ident_pat(false, needs_mut, pat_name);
+                        make.let_stmt(ident_pat.into(), None, Some(initializer)).into()
                     }
                     ExtractionKind::Constant => {
-                        let ast_ty = editor.make().ty(&ty_string);
-                        ast::Item::Const(editor.make().item_const(
-                            None,
-                            None,
-                            pat_name,
-                            ast_ty,
-                            initializer,
-                        ))
-                        .into()
+                        let ast_ty = make.ty(&ty_string);
+                        ast::Item::Const(make.item_const(None, None, pat_name, ast_ty, initializer))
+                            .into()
                     }
                     ExtractionKind::Static => {
-                        let ast_ty = editor.make().ty(&ty_string);
-                        ast::Item::Static(editor.make().item_static(
+                        let ast_ty = make.ty(&ty_string);
+                        ast::Item::Static(make.item_static(
                             None,
                             false,
                             false,
@@ -271,7 +266,7 @@ pub(crate) fn extract_variable(acc: &mut Assists, ctx: &AssistContext<'_>) -> Op
                             Position::before(place),
                             vec![
                                 new_stmt.syntax().clone().into(),
-                                editor.make().whitespace(&trailing_ws).into(),
+                                make.whitespace(&trailing_ws).into(),
                             ],
                         );
 
@@ -288,15 +283,15 @@ pub(crate) fn extract_variable(acc: &mut Assists, ctx: &AssistContext<'_>) -> Op
                         let block = if to_wrap.syntax() == &expr_replace {
                             // Since `expr_replace` is the same that needs to be wrapped in a block,
                             // we can just directly replace it with a block
-                            editor.make().block_expr([new_stmt], Some(name_expr))
+                            make.block_expr([new_stmt], Some(name_expr))
                         } else {
                             // `expr_replace` is a descendant of `to_wrap`, so we just replace it with `name_expr`.
                             editor
                                 .replace_all(to_replace, vec![name_expr.syntax().syntax_element()]);
-                            editor.make().block_expr([new_stmt], Some(to_wrap.clone()))
+                            make.block_expr([new_stmt], Some(to_wrap.clone()))
                         }
                         // fixup indentation of block
-                        .indent_with_mapping(indent_to, editor.make());
+                        .indent_with_mapping(indent_to, make);
 
                         editor.replace(to_wrap.syntax(), block.syntax());
                     }

--- a/crates/ide-assists/src/handlers/extract_variable.rs
+++ b/crates/ide-assists/src/handlers/extract_variable.rs
@@ -9,7 +9,6 @@ use syntax::{
     ast::{
         self, AstNode,
         edit::{AstNodeEdit, IndentLevel},
-        syntax_factory::SyntaxFactory,
     },
     syntax_editor::{Element, Position},
 };
@@ -206,11 +205,10 @@ pub(crate) fn extract_variable(acc: &mut Assists, ctx: &AssistContext<'_>) -> Op
                         to_replace.clone()
                     };
 
-                let make = SyntaxFactory::with_mappings();
                 let mut editor = edit.make_editor(&place);
 
-                let pat_name = make.name(&var_name);
-                let name_expr = make.expr_path(make.ident_path(&var_name));
+                let pat_name = editor.make().name(&var_name);
+                let name_expr = editor.make().expr_path(editor.make().ident_path(&var_name));
 
                 if let Some(cap) = ctx.config.snippet_cap {
                     let tabstop = edit.make_tabstop_before(cap);
@@ -219,27 +217,33 @@ pub(crate) fn extract_variable(acc: &mut Assists, ctx: &AssistContext<'_>) -> Op
 
                 let initializer = match ty.as_ref().filter(|_| needs_ref) {
                     Some(receiver_type) if receiver_type.is_mutable_reference() => {
-                        make.expr_ref(to_extract_no_ref.clone(), true)
+                        editor.make().expr_ref(to_extract_no_ref.clone(), true)
                     }
                     Some(receiver_type) if receiver_type.is_reference() => {
-                        make.expr_ref(to_extract_no_ref.clone(), false)
+                        editor.make().expr_ref(to_extract_no_ref.clone(), false)
                     }
                     _ => to_extract_no_ref.clone(),
                 };
 
                 let new_stmt: ast::Stmt = match kind {
                     ExtractionKind::Variable => {
-                        let ident_pat = make.ident_pat(false, needs_mut, pat_name);
-                        make.let_stmt(ident_pat.into(), None, Some(initializer)).into()
+                        let ident_pat = editor.make().ident_pat(false, needs_mut, pat_name);
+                        editor.make().let_stmt(ident_pat.into(), None, Some(initializer)).into()
                     }
                     ExtractionKind::Constant => {
-                        let ast_ty = make.ty(&ty_string);
-                        ast::Item::Const(make.item_const(None, None, pat_name, ast_ty, initializer))
-                            .into()
+                        let ast_ty = editor.make().ty(&ty_string);
+                        ast::Item::Const(editor.make().item_const(
+                            None,
+                            None,
+                            pat_name,
+                            ast_ty,
+                            initializer,
+                        ))
+                        .into()
                     }
                     ExtractionKind::Static => {
-                        let ast_ty = make.ty(&ty_string);
-                        ast::Item::Static(make.item_static(
+                        let ast_ty = editor.make().ty(&ty_string);
+                        ast::Item::Static(editor.make().item_static(
                             None,
                             false,
                             false,
@@ -267,7 +271,7 @@ pub(crate) fn extract_variable(acc: &mut Assists, ctx: &AssistContext<'_>) -> Op
                             Position::before(place),
                             vec![
                                 new_stmt.syntax().clone().into(),
-                                make.whitespace(&trailing_ws).into(),
+                                editor.make().whitespace(&trailing_ws).into(),
                             ],
                         );
 
@@ -284,21 +288,19 @@ pub(crate) fn extract_variable(acc: &mut Assists, ctx: &AssistContext<'_>) -> Op
                         let block = if to_wrap.syntax() == &expr_replace {
                             // Since `expr_replace` is the same that needs to be wrapped in a block,
                             // we can just directly replace it with a block
-                            make.block_expr([new_stmt], Some(name_expr))
+                            editor.make().block_expr([new_stmt], Some(name_expr))
                         } else {
                             // `expr_replace` is a descendant of `to_wrap`, so we just replace it with `name_expr`.
                             editor
                                 .replace_all(to_replace, vec![name_expr.syntax().syntax_element()]);
-                            make.block_expr([new_stmt], Some(to_wrap.clone()))
+                            editor.make().block_expr([new_stmt], Some(to_wrap.clone()))
                         }
                         // fixup indentation of block
-                        .indent_with_mapping(indent_to, &make);
+                        .indent_with_mapping(indent_to, editor.make());
 
                         editor.replace(to_wrap.syntax(), block.syntax());
                     }
                 }
-
-                editor.add_mappings(make.finish_with_mappings());
                 edit.add_file_edits(ctx.vfs_file_id(), editor);
                 edit.rename();
             },

--- a/crates/ide-assists/src/handlers/fix_visibility.rs
+++ b/crates/ide-assists/src/handlers/fix_visibility.rs
@@ -78,7 +78,7 @@ fn add_vis_to_referenced_module_def(acc: &mut Assists, ctx: &AssistContext<'_>) 
     };
 
     acc.add(AssistId::quick_fix("fix_visibility"), assist_label, target, |builder| {
-        let mut editor = builder.make_editor(vis_owner.syntax());
+        let editor = builder.make_editor(vis_owner.syntax());
 
         if let Some(current_visibility) = vis_owner.visibility() {
             editor.replace(current_visibility.syntax(), missing_visibility.syntax());

--- a/crates/ide-assists/src/handlers/flip_binexpr.rs
+++ b/crates/ide-assists/src/handlers/flip_binexpr.rs
@@ -1,6 +1,6 @@
 use syntax::{
     SyntaxKind, T,
-    ast::{self, AstNode, BinExpr, RangeItem, syntax_factory::SyntaxFactory},
+    ast::{self, AstNode, BinExpr, RangeItem},
     syntax_editor::Position,
 };
 
@@ -49,13 +49,11 @@ pub(crate) fn flip_binexpr(acc: &mut Assists, ctx: &AssistContext<'_>) -> Option
         op_token.text_range(),
         |builder| {
             let mut editor = builder.make_editor(&expr.syntax().parent().unwrap());
-            let make = SyntaxFactory::with_mappings();
             if let FlipAction::FlipAndReplaceOp(binary_op) = action {
-                editor.replace(op_token, make.token(binary_op))
+                editor.replace(op_token, editor.make().token(binary_op))
             };
             editor.replace(lhs.syntax(), rhs.syntax());
             editor.replace(rhs.syntax(), lhs.syntax());
-            editor.add_mappings(make.finish_with_mappings());
             builder.add_file_edits(ctx.vfs_file_id(), editor);
         },
     )

--- a/crates/ide-assists/src/handlers/flip_binexpr.rs
+++ b/crates/ide-assists/src/handlers/flip_binexpr.rs
@@ -48,9 +48,10 @@ pub(crate) fn flip_binexpr(acc: &mut Assists, ctx: &AssistContext<'_>) -> Option
         "Flip binary expression",
         op_token.text_range(),
         |builder| {
-            let mut editor = builder.make_editor(&expr.syntax().parent().unwrap());
+            let editor = builder.make_editor(&expr.syntax().parent().unwrap());
+            let make = editor.make();
             if let FlipAction::FlipAndReplaceOp(binary_op) = action {
-                editor.replace(op_token, editor.make().token(binary_op))
+                editor.replace(op_token, make.token(binary_op))
             };
             editor.replace(lhs.syntax(), rhs.syntax());
             editor.replace(rhs.syntax(), lhs.syntax());
@@ -131,25 +132,25 @@ pub(crate) fn flip_range_expr(acc: &mut Assists, ctx: &AssistContext<'_>) -> Opt
         "Flip range expression",
         op.text_range(),
         |builder| {
-            let mut edit = builder.make_editor(range_expr.syntax());
+            let editor = builder.make_editor(range_expr.syntax());
 
             match (start, end) {
                 (Some(start), Some(end)) => {
-                    edit.replace(start.syntax(), end.syntax());
-                    edit.replace(end.syntax(), start.syntax());
+                    editor.replace(start.syntax(), end.syntax());
+                    editor.replace(end.syntax(), start.syntax());
                 }
                 (Some(start), None) => {
-                    edit.delete(start.syntax());
-                    edit.insert(Position::after(&op), start.syntax());
+                    editor.delete(start.syntax());
+                    editor.insert(Position::after(&op), start.syntax());
                 }
                 (None, Some(end)) => {
-                    edit.delete(end.syntax());
-                    edit.insert(Position::before(&op), end.syntax());
+                    editor.delete(end.syntax());
+                    editor.insert(Position::before(&op), end.syntax());
                 }
                 (None, None) => (),
             }
 
-            builder.add_file_edits(ctx.vfs_file_id(), edit);
+            builder.add_file_edits(ctx.vfs_file_id(), editor);
         },
     )
 }

--- a/crates/ide-assists/src/handlers/flip_comma.rs
+++ b/crates/ide-assists/src/handlers/flip_comma.rs
@@ -41,7 +41,7 @@ pub(crate) fn flip_comma(acc: &mut Assists, ctx: &AssistContext<'_>) -> Option<(
     let target = comma.text_range();
     acc.add(AssistId::refactor_rewrite("flip_comma"), "Flip comma", target, |builder| {
         let parent = comma.parent().unwrap();
-        let mut editor = builder.make_editor(&parent);
+        let editor = builder.make_editor(&parent);
 
         if let Some(parent) = ast::TokenTree::cast(parent) {
             // An attribute. It often contains a path followed by a

--- a/crates/ide-assists/src/handlers/flip_comma.rs
+++ b/crates/ide-assists/src/handlers/flip_comma.rs
@@ -2,7 +2,6 @@ use syntax::{
     AstNode, Direction, NodeOrToken, SyntaxKind, SyntaxToken, T,
     algo::non_trivia_sibling,
     ast::{self, syntax_factory::SyntaxFactory},
-    syntax_editor::SyntaxMapping,
 };
 
 use crate::{AssistContext, AssistId, Assists};
@@ -47,9 +46,8 @@ pub(crate) fn flip_comma(acc: &mut Assists, ctx: &AssistContext<'_>) -> Option<(
         if let Some(parent) = ast::TokenTree::cast(parent) {
             // An attribute. It often contains a path followed by a
             // token tree (e.g. `align(2)`), so we have to be smarter.
-            let (new_tree, mapping) = flip_tree(parent.clone(), comma);
+            let new_tree = flip_tree(parent.clone(), comma, editor.make());
             editor.replace(parent.syntax(), new_tree.syntax());
-            editor.add_mappings(mapping);
         } else {
             editor.replace(prev.clone(), next.clone());
             editor.replace(next.clone(), prev.clone());
@@ -59,7 +57,7 @@ pub(crate) fn flip_comma(acc: &mut Assists, ctx: &AssistContext<'_>) -> Option<(
     })
 }
 
-fn flip_tree(tree: ast::TokenTree, comma: SyntaxToken) -> (ast::TokenTree, SyntaxMapping) {
+fn flip_tree(tree: ast::TokenTree, comma: SyntaxToken, make: &SyntaxFactory) -> ast::TokenTree {
     let mut tree_iter = tree.token_trees_and_tokens();
     let before: Vec<_> =
         tree_iter.by_ref().take_while(|it| it.as_token() != Some(&comma)).collect();
@@ -100,10 +98,7 @@ fn flip_tree(tree: ast::TokenTree, comma: SyntaxToken) -> (ast::TokenTree, Synta
         &after[next_end..after.len() - 1],
     ]
     .concat();
-
-    let make = SyntaxFactory::with_mappings();
-    let new_token_tree = make.token_tree(tree.left_delimiter_token().unwrap().kind(), result);
-    (new_token_tree, make.finish_with_mappings())
+    make.token_tree(tree.left_delimiter_token().unwrap().kind(), result)
 }
 
 #[cfg(test)]

--- a/crates/ide-assists/src/handlers/flip_or_pattern.rs
+++ b/crates/ide-assists/src/handlers/flip_or_pattern.rs
@@ -32,7 +32,7 @@ pub(crate) fn flip_or_pattern(acc: &mut Assists, ctx: &AssistContext<'_>) -> Opt
 
     let target = pipe.text_range();
     acc.add(AssistId::refactor_rewrite("flip_or_pattern"), "Flip patterns", target, |builder| {
-        let mut editor = builder.make_editor(parent.syntax());
+        let editor = builder.make_editor(parent.syntax());
         editor.replace(before.clone(), after.clone());
         editor.replace(after, before);
         builder.add_file_edits(ctx.vfs_file_id(), editor);

--- a/crates/ide-assists/src/handlers/flip_trait_bound.rs
+++ b/crates/ide-assists/src/handlers/flip_trait_bound.rs
@@ -33,7 +33,7 @@ pub(crate) fn flip_trait_bound(acc: &mut Assists, ctx: &AssistContext<'_>) -> Op
         "Flip trait bounds",
         target,
         |builder| {
-            let mut editor = builder.make_editor(parent.syntax());
+            let editor = builder.make_editor(parent.syntax());
             editor.replace(before.clone(), after.clone());
             editor.replace(after, before);
             builder.add_file_edits(ctx.vfs_file_id(), editor);

--- a/crates/ide-assists/src/handlers/generate_blanket_trait_impl.rs
+++ b/crates/ide-assists/src/handlers/generate_blanket_trait_impl.rs
@@ -74,24 +74,26 @@ pub(crate) fn generate_blanket_trait_impl(
         name.syntax().text_range(),
         |builder| {
             let mut editor = builder.make_editor(traitd.syntax());
-            let make = SyntaxFactory::with_mappings();
-            let namety = make.ty_path(make.path_from_text(&name.text()));
+            let namety = editor.make().ty_path(editor.make().path_from_text(&name.text()));
             let trait_where_clause = traitd.where_clause().map(|it| it.reset_indent());
-            let bounds = traitd.type_bound_list().and_then(|list| exclude_sized(&make, list));
+            let bounds =
+                traitd.type_bound_list().and_then(|list| exclude_sized(editor.make(), list));
             let is_unsafe = traitd.unsafe_token().is_some();
-            let thisname = this_name(&make, &traitd);
-            let thisty = make.ty_path(make.path_from_text(&thisname.text()));
+            let thisname = this_name(editor.make(), &traitd);
+            let thisty = editor.make().ty_path(editor.make().path_from_text(&thisname.text()));
             let indent = traitd.indent_level();
 
-            let gendecl = make.generic_param_list([GenericParam::TypeParam(make.type_param(
-                thisname.clone(),
-                apply_sized(&make, has_sized(&traitd, &ctx.sema), bounds),
-            ))]);
+            let gendecl = editor.make().generic_param_list([GenericParam::TypeParam(
+                editor.make().type_param(
+                    thisname.clone(),
+                    apply_sized(editor.make(), has_sized(&traitd, &ctx.sema), bounds),
+                ),
+            )]);
 
             let trait_gen_args =
                 traitd.generic_param_list().map(|param_list| param_list.to_generic_args());
 
-            let impl_ = make.impl_trait(
+            let impl_ = editor.make().impl_trait(
                 cfg_attrs(&traitd),
                 is_unsafe,
                 traitd.generic_param_list(),
@@ -107,12 +109,11 @@ pub(crate) fn generate_blanket_trait_impl(
             );
 
             if let Some(trait_assoc_list) = traitd.assoc_item_list() {
-                let assoc_item_list =
-                    impl_.get_or_create_assoc_item_list_with_editor(&mut editor, &make);
+                let assoc_item_list = impl_.get_or_create_assoc_item_list_with_editor(&mut editor);
                 for item in trait_assoc_list.assoc_items() {
                     let item = match item {
                         ast::AssocItem::Fn(method) if method.body().is_none() => {
-                            todo_fn(&make, &method, ctx.config).into()
+                            todo_fn(editor.make(), &method, ctx.config).into()
                         }
                         ast::AssocItem::Const(_) | ast::AssocItem::TypeAlias(_) => item,
                         _ => continue,
@@ -126,7 +127,7 @@ pub(crate) fn generate_blanket_trait_impl(
             editor.insert_all(
                 Position::after(traitd.syntax()),
                 vec![
-                    make.whitespace(&format!("\n\n{indent}")).into(),
+                    editor.make().whitespace(&format!("\n\n{indent}")).into(),
                     impl_.syntax().clone().into(),
                 ],
             );
@@ -136,8 +137,6 @@ pub(crate) fn generate_blanket_trait_impl(
             {
                 builder.add_tabstop_before(cap, self_ty);
             }
-
-            editor.add_mappings(make.finish_with_mappings());
             builder.add_file_edits(ctx.vfs_file_id(), editor);
         },
     );

--- a/crates/ide-assists/src/handlers/generate_blanket_trait_impl.rs
+++ b/crates/ide-assists/src/handlers/generate_blanket_trait_impl.rs
@@ -73,27 +73,25 @@ pub(crate) fn generate_blanket_trait_impl(
         "Generate blanket trait implementation",
         name.syntax().text_range(),
         |builder| {
-            let mut editor = builder.make_editor(traitd.syntax());
-            let namety = editor.make().ty_path(editor.make().path_from_text(&name.text()));
+            let editor = builder.make_editor(traitd.syntax());
+            let make = editor.make();
+            let namety = make.ty_path(make.path_from_text(&name.text()));
             let trait_where_clause = traitd.where_clause().map(|it| it.reset_indent());
-            let bounds =
-                traitd.type_bound_list().and_then(|list| exclude_sized(editor.make(), list));
+            let bounds = traitd.type_bound_list().and_then(|list| exclude_sized(make, list));
             let is_unsafe = traitd.unsafe_token().is_some();
-            let thisname = this_name(editor.make(), &traitd);
-            let thisty = editor.make().ty_path(editor.make().path_from_text(&thisname.text()));
+            let thisname = this_name(make, &traitd);
+            let thisty = make.ty_path(make.path_from_text(&thisname.text()));
             let indent = traitd.indent_level();
 
-            let gendecl = editor.make().generic_param_list([GenericParam::TypeParam(
-                editor.make().type_param(
-                    thisname.clone(),
-                    apply_sized(editor.make(), has_sized(&traitd, &ctx.sema), bounds),
-                ),
-            )]);
+            let gendecl = make.generic_param_list([GenericParam::TypeParam(make.type_param(
+                thisname.clone(),
+                apply_sized(make, has_sized(&traitd, &ctx.sema), bounds),
+            ))]);
 
             let trait_gen_args =
                 traitd.generic_param_list().map(|param_list| param_list.to_generic_args());
 
-            let impl_ = editor.make().impl_trait(
+            let impl_ = make.impl_trait(
                 cfg_attrs(&traitd),
                 is_unsafe,
                 traitd.generic_param_list(),
@@ -109,11 +107,11 @@ pub(crate) fn generate_blanket_trait_impl(
             );
 
             if let Some(trait_assoc_list) = traitd.assoc_item_list() {
-                let assoc_item_list = impl_.get_or_create_assoc_item_list_with_editor(&mut editor);
+                let assoc_item_list = impl_.get_or_create_assoc_item_list_with_editor(&editor);
                 for item in trait_assoc_list.assoc_items() {
                     let item = match item {
                         ast::AssocItem::Fn(method) if method.body().is_none() => {
-                            todo_fn(editor.make(), &method, ctx.config).into()
+                            todo_fn(make, &method, ctx.config).into()
                         }
                         ast::AssocItem::Const(_) | ast::AssocItem::TypeAlias(_) => item,
                         _ => continue,
@@ -127,7 +125,7 @@ pub(crate) fn generate_blanket_trait_impl(
             editor.insert_all(
                 Position::after(traitd.syntax()),
                 vec![
-                    editor.make().whitespace(&format!("\n\n{indent}")).into(),
+                    make.whitespace(&format!("\n\n{indent}")).into(),
                     impl_.syntax().clone().into(),
                 ],
             );

--- a/crates/ide-assists/src/handlers/generate_default_from_new.rs
+++ b/crates/ide-assists/src/handlers/generate_default_from_new.rs
@@ -73,16 +73,15 @@ pub(crate) fn generate_default_from_new(acc: &mut Assists, ctx: &AssistContext<'
         "Generate a Default impl from a new fn",
         target,
         move |builder| {
-            let make = SyntaxFactory::without_mappings();
-            let default_impl = generate_default_impl(&make, &impl_, self_ty);
+            let mut editor = builder.make_editor(impl_.syntax());
+            let default_impl = generate_default_impl(editor.make(), &impl_, self_ty);
             let indent = IndentLevel::from_node(impl_.syntax());
             let default_impl = default_impl.indent(indent);
 
-            let mut editor = builder.make_editor(impl_.syntax());
             editor.insert_all(
                 Position::after(impl_.syntax()),
                 vec![
-                    make.whitespace(&format!("\n\n{indent}")).into(),
+                    editor.make().whitespace(&format!("\n\n{indent}")).into(),
                     default_impl.syntax().clone().into(),
                 ],
             );

--- a/crates/ide-assists/src/handlers/generate_default_from_new.rs
+++ b/crates/ide-assists/src/handlers/generate_default_from_new.rs
@@ -73,15 +73,16 @@ pub(crate) fn generate_default_from_new(acc: &mut Assists, ctx: &AssistContext<'
         "Generate a Default impl from a new fn",
         target,
         move |builder| {
-            let mut editor = builder.make_editor(impl_.syntax());
-            let default_impl = generate_default_impl(editor.make(), &impl_, self_ty);
+            let editor = builder.make_editor(impl_.syntax());
+            let make = editor.make();
+            let default_impl = generate_default_impl(make, &impl_, self_ty);
             let indent = IndentLevel::from_node(impl_.syntax());
             let default_impl = default_impl.indent(indent);
 
             editor.insert_all(
                 Position::after(impl_.syntax()),
                 vec![
-                    editor.make().whitespace(&format!("\n\n{indent}")).into(),
+                    make.whitespace(&format!("\n\n{indent}")).into(),
                     default_impl.syntax().clone().into(),
                 ],
             );

--- a/crates/ide-assists/src/handlers/generate_delegate_methods.rs
+++ b/crates/ide-assists/src/handlers/generate_delegate_methods.rs
@@ -4,7 +4,6 @@ use syntax::{
     ast::{
         self, AstNode, HasGenericParams, HasName, HasVisibility as _,
         edit::{AstNodeEdit, IndentLevel},
-        syntax_factory::SyntaxFactory,
     },
     syntax_editor::Position,
 };
@@ -107,8 +106,9 @@ pub(crate) fn generate_delegate_methods(acc: &mut Assists, ctx: &AssistContext<'
             format!("Generate delegate for `{field_name}.{name}()`",),
             target,
             |edit| {
-                let make = SyntaxFactory::without_mappings();
-                let field = make
+                let mut editor = edit.make_editor(strukt.syntax());
+                let field = editor
+                    .make()
                     .field_from_idents(["self", &field_name])
                     .expect("always be a valid expression");
                 // Create the function
@@ -135,27 +135,32 @@ pub(crate) fn generate_delegate_methods(acc: &mut Assists, ctx: &AssistContext<'
                 let is_unsafe = method_source.unsafe_token().is_some();
                 let is_gen = method_source.gen_token().is_some();
 
-                let fn_name = make.name(&name);
+                let fn_name = editor.make().name(&name);
 
                 let type_params = method_source.generic_param_list();
                 let where_clause = method_source.where_clause();
-                let params =
-                    method_source.param_list().unwrap_or_else(|| make.param_list(None, []));
+                let params = method_source
+                    .param_list()
+                    .unwrap_or_else(|| editor.make().param_list(None, []));
 
                 // compute the `body`
                 let arg_list = method_source
                     .param_list()
-                    .map(|v| convert_param_list_to_arg_list(v, &make))
-                    .unwrap_or_else(|| make.arg_list([]));
+                    .map(|v| convert_param_list_to_arg_list(v, editor.make()))
+                    .unwrap_or_else(|| editor.make().arg_list([]));
 
-                let tail_expr = make.expr_method_call(field, make.name_ref(&name), arg_list).into();
+                let tail_expr = editor
+                    .make()
+                    .expr_method_call(field, editor.make().name_ref(&name), arg_list)
+                    .into();
                 let tail_expr_finished =
-                    if is_async { make.expr_await(tail_expr).into() } else { tail_expr };
-                let body = make.block_expr([], Some(tail_expr_finished));
+                    if is_async { editor.make().expr_await(tail_expr).into() } else { tail_expr };
+                let body = editor.make().block_expr([], Some(tail_expr_finished));
 
                 let ret_type = method_source.ret_type();
 
-                let f = make
+                let f = editor
+                    .make()
                     .fn_(
                         None,
                         vis,
@@ -173,7 +178,6 @@ pub(crate) fn generate_delegate_methods(acc: &mut Assists, ctx: &AssistContext<'
                     .indent(IndentLevel(1));
                 let item = ast::AssocItem::Fn(f.clone());
 
-                let mut editor = edit.make_editor(strukt.syntax());
                 let fn_: Option<ast::AssocItem> = match impl_def {
                     Some(impl_def) => match impl_def.assoc_item_list() {
                         Some(assoc_item_list) => {
@@ -182,7 +186,7 @@ pub(crate) fn generate_delegate_methods(acc: &mut Assists, ctx: &AssistContext<'
                             Some(item)
                         }
                         None => {
-                            let assoc_item_list = make.assoc_item_list(vec![item]);
+                            let assoc_item_list = editor.make().assoc_item_list(vec![item]);
                             editor.insert(
                                 Position::last_child_of(impl_def.syntax()),
                                 assoc_item_list.syntax(),
@@ -195,13 +199,15 @@ pub(crate) fn generate_delegate_methods(acc: &mut Assists, ctx: &AssistContext<'
                         let ty_params = strukt.generic_param_list();
                         let ty_args = ty_params.as_ref().map(|it| it.to_generic_args());
                         let where_clause = strukt.where_clause();
-                        let assoc_item_list = make.assoc_item_list(vec![item]);
+                        let assoc_item_list = editor.make().assoc_item_list(vec![item]);
 
-                        let impl_def = make.impl_(
+                        let impl_def = editor.make().impl_(
                             None,
                             ty_params,
                             ty_args,
-                            syntax::ast::Type::PathType(make.ty_path(make.ident_path(name))),
+                            syntax::ast::Type::PathType(
+                                editor.make().ty_path(editor.make().ident_path(name)),
+                            ),
                             where_clause,
                             Some(assoc_item_list),
                         );
@@ -215,7 +221,7 @@ pub(crate) fn generate_delegate_methods(acc: &mut Assists, ctx: &AssistContext<'
                         editor.insert_all(
                             Position::after(strukt.syntax()),
                             vec![
-                                make.whitespace(&format!("\n\n{indent}")).into(),
+                                editor.make().whitespace(&format!("\n\n{indent}")).into(),
                                 impl_def.syntax().clone().into(),
                             ],
                         );
@@ -229,7 +235,6 @@ pub(crate) fn generate_delegate_methods(acc: &mut Assists, ctx: &AssistContext<'
                     let tabstop = edit.make_tabstop_before(cap);
                     editor.add_annotation(fn_.syntax(), tabstop);
                 }
-                editor.add_mappings(make.finish_with_mappings());
                 edit.add_file_edits(ctx.vfs_file_id(), editor);
             },
         )?;

--- a/crates/ide-assists/src/handlers/generate_delegate_methods.rs
+++ b/crates/ide-assists/src/handlers/generate_delegate_methods.rs
@@ -106,7 +106,8 @@ pub(crate) fn generate_delegate_methods(acc: &mut Assists, ctx: &AssistContext<'
             format!("Generate delegate for `{field_name}.{name}()`",),
             target,
             |edit| {
-                let mut editor = edit.make_editor(strukt.syntax());
+                let editor = edit.make_editor(strukt.syntax());
+                let make = editor.make();
                 let field = editor
                     .make()
                     .field_from_idents(["self", &field_name])
@@ -135,27 +136,24 @@ pub(crate) fn generate_delegate_methods(acc: &mut Assists, ctx: &AssistContext<'
                 let is_unsafe = method_source.unsafe_token().is_some();
                 let is_gen = method_source.gen_token().is_some();
 
-                let fn_name = editor.make().name(&name);
+                let fn_name = make.name(&name);
 
                 let type_params = method_source.generic_param_list();
                 let where_clause = method_source.where_clause();
-                let params = method_source
-                    .param_list()
-                    .unwrap_or_else(|| editor.make().param_list(None, []));
+                let params =
+                    method_source.param_list().unwrap_or_else(|| make.param_list(None, []));
 
                 // compute the `body`
                 let arg_list = method_source
                     .param_list()
-                    .map(|v| convert_param_list_to_arg_list(v, editor.make()))
-                    .unwrap_or_else(|| editor.make().arg_list([]));
+                    .map(|v| convert_param_list_to_arg_list(v, make))
+                    .unwrap_or_else(|| make.arg_list([]));
 
-                let tail_expr = editor
-                    .make()
-                    .expr_method_call(field, editor.make().name_ref(&name), arg_list)
-                    .into();
+                let tail_expr =
+                    editor.make().expr_method_call(field, make.name_ref(&name), arg_list).into();
                 let tail_expr_finished =
-                    if is_async { editor.make().expr_await(tail_expr).into() } else { tail_expr };
-                let body = editor.make().block_expr([], Some(tail_expr_finished));
+                    if is_async { make.expr_await(tail_expr).into() } else { tail_expr };
+                let body = make.block_expr([], Some(tail_expr_finished));
 
                 let ret_type = method_source.ret_type();
 
@@ -182,11 +180,11 @@ pub(crate) fn generate_delegate_methods(acc: &mut Assists, ctx: &AssistContext<'
                     Some(impl_def) => match impl_def.assoc_item_list() {
                         Some(assoc_item_list) => {
                             let item = item.indent(IndentLevel::from_node(impl_def.syntax()));
-                            assoc_item_list.add_items(&mut editor, vec![item.clone()]);
+                            assoc_item_list.add_items(&editor, vec![item.clone()]);
                             Some(item)
                         }
                         None => {
-                            let assoc_item_list = editor.make().assoc_item_list(vec![item]);
+                            let assoc_item_list = make.assoc_item_list(vec![item]);
                             editor.insert(
                                 Position::last_child_of(impl_def.syntax()),
                                 assoc_item_list.syntax(),
@@ -199,15 +197,13 @@ pub(crate) fn generate_delegate_methods(acc: &mut Assists, ctx: &AssistContext<'
                         let ty_params = strukt.generic_param_list();
                         let ty_args = ty_params.as_ref().map(|it| it.to_generic_args());
                         let where_clause = strukt.where_clause();
-                        let assoc_item_list = editor.make().assoc_item_list(vec![item]);
+                        let assoc_item_list = make.assoc_item_list(vec![item]);
 
-                        let impl_def = editor.make().impl_(
+                        let impl_def = make.impl_(
                             None,
                             ty_params,
                             ty_args,
-                            syntax::ast::Type::PathType(
-                                editor.make().ty_path(editor.make().ident_path(name)),
-                            ),
+                            syntax::ast::Type::PathType(make.ty_path(make.ident_path(name))),
                             where_clause,
                             Some(assoc_item_list),
                         );
@@ -221,7 +217,7 @@ pub(crate) fn generate_delegate_methods(acc: &mut Assists, ctx: &AssistContext<'
                         editor.insert_all(
                             Position::after(strukt.syntax()),
                             vec![
-                                editor.make().whitespace(&format!("\n\n{indent}")).into(),
+                                make.whitespace(&format!("\n\n{indent}")).into(),
                                 impl_def.syntax().clone().into(),
                             ],
                         );

--- a/crates/ide-assists/src/handlers/generate_delegate_trait.rs
+++ b/crates/ide-assists/src/handlers/generate_delegate_trait.rs
@@ -494,7 +494,7 @@ fn remove_instantiated_params(
     }
 }
 
-fn remove_useless_where_clauses(editor: &mut SyntaxEditor, delegate: &ast::Impl) {
+fn remove_useless_where_clauses(editor: &SyntaxEditor, delegate: &ast::Impl) {
     let Some(wc) = delegate.where_clause() else {
         return;
     };
@@ -563,7 +563,7 @@ fn finalize_delegate(
         return Some(delegate.clone());
     }
 
-    let (mut editor, delegate) = SyntaxEditor::with_ast_node(delegate);
+    let (editor, delegate) = SyntaxEditor::with_ast_node(delegate);
 
     // 1. Replace assoc_item_list if we have new items
     if let Some(items) = assoc_items
@@ -577,7 +577,7 @@ fn finalize_delegate(
 
     // 2. Remove useless where clauses
     if remove_where_clauses {
-        remove_useless_where_clauses(&mut editor, &delegate);
+        remove_useless_where_clauses(&editor, &delegate);
     }
 
     ast::Impl::cast(editor.finish().new_root().clone())

--- a/crates/ide-assists/src/handlers/generate_deref.rs
+++ b/crates/ide-assists/src/handlers/generate_deref.rs
@@ -138,35 +138,30 @@ fn generate_edit(
     trait_path: ModPath,
     edition: Edition,
 ) {
-    let mut editor = edit.make_editor(strukt.syntax());
+    let editor = edit.make_editor(strukt.syntax());
+    let make = editor.make();
     let strukt_adt = ast::Adt::Struct(strukt.clone());
-    let trait_ty = editor.make().ty(&trait_path.display(db, edition).to_string());
+    let trait_ty = make.ty(&trait_path.display(db, edition).to_string());
 
     let assoc_items: Vec<ast::AssocItem> = match deref_type {
         DerefType::Deref => {
             let target_alias =
-                editor.make().ty_alias([], "Target", None, None, None, Some((field_type, None)));
-            let ret_ty = editor.make().ty_ref(
-                editor.make().ty_path(editor.make().path_from_text("Self::Target")).into(),
-                false,
-            );
-            let field_expr = editor
-                .make()
-                .expr_field(editor.make().expr_path(editor.make().ident_path("self")), field_name);
-            let body = editor
-                .make()
-                .block_expr([], Some(editor.make().expr_ref(field_expr.into(), false)));
+                make.ty_alias([], "Target", None, None, None, Some((field_type, None)));
+            let ret_ty =
+                make.ty_ref(make.ty_path(make.path_from_text("Self::Target")).into(), false);
+            let field_expr = make.expr_field(make.expr_path(make.ident_path("self")), field_name);
+            let body = make.block_expr([], Some(make.expr_ref(field_expr.into(), false)));
             let fn_ = editor
                 .make()
                 .fn_(
                     [],
                     None,
-                    editor.make().name("deref"),
+                    make.name("deref"),
                     None,
                     None,
-                    editor.make().param_list(Some(editor.make().self_param()), []),
+                    make.param_list(Some(make.self_param()), []),
                     body,
-                    Some(editor.make().ret_type(ret_ty)),
+                    Some(make.ret_type(ret_ty)),
                     false,
                     false,
                     false,
@@ -176,26 +171,21 @@ fn generate_edit(
             vec![ast::AssocItem::TypeAlias(target_alias), ast::AssocItem::Fn(fn_)]
         }
         DerefType::DerefMut => {
-            let ret_ty = editor.make().ty_ref(
-                editor.make().ty_path(editor.make().path_from_text("Self::Target")).into(),
-                true,
-            );
-            let field_expr = editor
-                .make()
-                .expr_field(editor.make().expr_path(editor.make().ident_path("self")), field_name);
-            let body =
-                editor.make().block_expr([], Some(editor.make().expr_ref(field_expr.into(), true)));
+            let ret_ty =
+                make.ty_ref(make.ty_path(make.path_from_text("Self::Target")).into(), true);
+            let field_expr = make.expr_field(make.expr_path(make.ident_path("self")), field_name);
+            let body = make.block_expr([], Some(make.expr_ref(field_expr.into(), true)));
             let fn_ = editor
                 .make()
                 .fn_(
                     [],
                     None,
-                    editor.make().name("deref_mut"),
+                    make.name("deref_mut"),
                     None,
                     None,
-                    editor.make().param_list(Some(editor.make().mut_self_param()), []),
+                    make.param_list(Some(make.mut_self_param()), []),
                     body,
-                    Some(editor.make().ret_type(ret_ty)),
+                    Some(make.ret_type(ret_ty)),
                     false,
                     false,
                     false,
@@ -206,17 +196,13 @@ fn generate_edit(
         }
     };
 
-    let body = editor.make().assoc_item_list(assoc_items);
+    let body = make.assoc_item_list(assoc_items);
     let indent = strukt.indent_level();
-    let impl_ =
-        generate_trait_impl_intransitive_with_item(editor.make(), &strukt_adt, trait_ty, body)
-            .indent(indent);
+    let impl_ = generate_trait_impl_intransitive_with_item(make, &strukt_adt, trait_ty, body)
+        .indent(indent);
     editor.insert_all(
         Position::after(strukt.syntax()),
-        vec![
-            editor.make().whitespace(&format!("\n\n{indent}")).into(),
-            impl_.syntax().clone().into(),
-        ],
+        vec![make.whitespace(&format!("\n\n{indent}")).into(), impl_.syntax().clone().into()],
     );
     edit.add_file_edits(file_id, editor);
 }

--- a/crates/ide-assists/src/handlers/generate_deref.rs
+++ b/crates/ide-assists/src/handlers/generate_deref.rs
@@ -2,7 +2,7 @@ use hir::{ModPath, ModuleDef};
 use ide_db::{FileId, RootDatabase, famous_defs::FamousDefs};
 use syntax::{
     Edition,
-    ast::{self, AstNode, HasName, edit::AstNodeEdit, syntax_factory::SyntaxFactory},
+    ast::{self, AstNode, HasName, edit::AstNodeEdit},
     syntax_editor::Position,
 };
 
@@ -138,28 +138,35 @@ fn generate_edit(
     trait_path: ModPath,
     edition: Edition,
 ) {
-    let make = SyntaxFactory::with_mappings();
+    let mut editor = edit.make_editor(strukt.syntax());
     let strukt_adt = ast::Adt::Struct(strukt.clone());
-    let trait_ty = make.ty(&trait_path.display(db, edition).to_string());
+    let trait_ty = editor.make().ty(&trait_path.display(db, edition).to_string());
 
     let assoc_items: Vec<ast::AssocItem> = match deref_type {
         DerefType::Deref => {
             let target_alias =
-                make.ty_alias([], "Target", None, None, None, Some((field_type, None)));
-            let ret_ty =
-                make.ty_ref(make.ty_path(make.path_from_text("Self::Target")).into(), false);
-            let field_expr = make.expr_field(make.expr_path(make.ident_path("self")), field_name);
-            let body = make.block_expr([], Some(make.expr_ref(field_expr.into(), false)));
-            let fn_ = make
+                editor.make().ty_alias([], "Target", None, None, None, Some((field_type, None)));
+            let ret_ty = editor.make().ty_ref(
+                editor.make().ty_path(editor.make().path_from_text("Self::Target")).into(),
+                false,
+            );
+            let field_expr = editor
+                .make()
+                .expr_field(editor.make().expr_path(editor.make().ident_path("self")), field_name);
+            let body = editor
+                .make()
+                .block_expr([], Some(editor.make().expr_ref(field_expr.into(), false)));
+            let fn_ = editor
+                .make()
                 .fn_(
                     [],
                     None,
-                    make.name("deref"),
+                    editor.make().name("deref"),
                     None,
                     None,
-                    make.param_list(Some(make.self_param()), []),
+                    editor.make().param_list(Some(editor.make().self_param()), []),
                     body,
-                    Some(make.ret_type(ret_ty)),
+                    Some(editor.make().ret_type(ret_ty)),
                     false,
                     false,
                     false,
@@ -169,20 +176,26 @@ fn generate_edit(
             vec![ast::AssocItem::TypeAlias(target_alias), ast::AssocItem::Fn(fn_)]
         }
         DerefType::DerefMut => {
-            let ret_ty =
-                make.ty_ref(make.ty_path(make.path_from_text("Self::Target")).into(), true);
-            let field_expr = make.expr_field(make.expr_path(make.ident_path("self")), field_name);
-            let body = make.block_expr([], Some(make.expr_ref(field_expr.into(), true)));
-            let fn_ = make
+            let ret_ty = editor.make().ty_ref(
+                editor.make().ty_path(editor.make().path_from_text("Self::Target")).into(),
+                true,
+            );
+            let field_expr = editor
+                .make()
+                .expr_field(editor.make().expr_path(editor.make().ident_path("self")), field_name);
+            let body =
+                editor.make().block_expr([], Some(editor.make().expr_ref(field_expr.into(), true)));
+            let fn_ = editor
+                .make()
                 .fn_(
                     [],
                     None,
-                    make.name("deref_mut"),
+                    editor.make().name("deref_mut"),
                     None,
                     None,
-                    make.param_list(Some(make.mut_self_param()), []),
+                    editor.make().param_list(Some(editor.make().mut_self_param()), []),
                     body,
-                    Some(make.ret_type(ret_ty)),
+                    Some(editor.make().ret_type(ret_ty)),
                     false,
                     false,
                     false,
@@ -193,17 +206,18 @@ fn generate_edit(
         }
     };
 
-    let body = make.assoc_item_list(assoc_items);
+    let body = editor.make().assoc_item_list(assoc_items);
     let indent = strukt.indent_level();
-    let impl_ = generate_trait_impl_intransitive_with_item(&make, &strukt_adt, trait_ty, body)
-        .indent(indent);
-
-    let mut editor = edit.make_editor(strukt.syntax());
+    let impl_ =
+        generate_trait_impl_intransitive_with_item(editor.make(), &strukt_adt, trait_ty, body)
+            .indent(indent);
     editor.insert_all(
         Position::after(strukt.syntax()),
-        vec![make.whitespace(&format!("\n\n{indent}")).into(), impl_.syntax().clone().into()],
+        vec![
+            editor.make().whitespace(&format!("\n\n{indent}")).into(),
+            impl_.syntax().clone().into(),
+        ],
     );
-    editor.add_mappings(make.finish_with_mappings());
     edit.add_file_edits(file_id, editor);
 }
 

--- a/crates/ide-assists/src/handlers/generate_derive.rs
+++ b/crates/ide-assists/src/handlers/generate_derive.rs
@@ -44,11 +44,13 @@ pub(crate) fn generate_derive(acc: &mut Assists, ctx: &AssistContext<'_>) -> Opt
     acc.add(AssistId::generate("generate_derive"), "Add `#[derive]`", target, |edit| {
         match derive_attr {
             None => {
-                let mut editor = edit.make_editor(nominal.syntax());
-                let derive = editor.make().attr_outer(editor.make().meta_token_tree(
-                    editor.make().ident_path("derive"),
-                    editor.make().token_tree(T!['('], vec![]),
-                ));
+                let editor = edit.make_editor(nominal.syntax());
+                let make = editor.make();
+                let derive =
+                    make.attr_outer(make.meta_token_tree(
+                        make.ident_path("derive"),
+                        make.token_tree(T!['('], vec![]),
+                    ));
                 let indent = IndentLevel::from_node(nominal.syntax());
                 let after_attrs_and_comments = nominal
                     .syntax()
@@ -60,7 +62,7 @@ pub(crate) fn generate_derive(acc: &mut Assists, ctx: &AssistContext<'_>) -> Opt
                     after_attrs_and_comments,
                     vec![
                         derive.syntax().syntax_element(),
-                        editor.make().whitespace(&format!("\n{indent}")).syntax_element(),
+                        make.whitespace(&format!("\n{indent}")).syntax_element(),
                     ],
                 );
 

--- a/crates/ide-assists/src/handlers/generate_derive.rs
+++ b/crates/ide-assists/src/handlers/generate_derive.rs
@@ -1,7 +1,7 @@
 use syntax::{
     SyntaxKind::{ATTR, COMMENT, WHITESPACE},
     T,
-    ast::{self, AstNode, HasAttrs, edit::IndentLevel, syntax_factory::SyntaxFactory},
+    ast::{self, AstNode, HasAttrs, edit::IndentLevel},
     syntax_editor::{Element, Position},
 };
 
@@ -42,17 +42,13 @@ pub(crate) fn generate_derive(acc: &mut Assists, ctx: &AssistContext<'_>) -> Opt
     };
 
     acc.add(AssistId::generate("generate_derive"), "Add `#[derive]`", target, |edit| {
-        let make = SyntaxFactory::without_mappings();
-
         match derive_attr {
             None => {
-                let derive =
-                    make.attr_outer(make.meta_token_tree(
-                        make.ident_path("derive"),
-                        make.token_tree(T!['('], vec![]),
-                    ));
-
                 let mut editor = edit.make_editor(nominal.syntax());
+                let derive = editor.make().attr_outer(editor.make().meta_token_tree(
+                    editor.make().ident_path("derive"),
+                    editor.make().token_tree(T!['('], vec![]),
+                ));
                 let indent = IndentLevel::from_node(nominal.syntax());
                 let after_attrs_and_comments = nominal
                     .syntax()
@@ -64,7 +60,7 @@ pub(crate) fn generate_derive(acc: &mut Assists, ctx: &AssistContext<'_>) -> Opt
                     after_attrs_and_comments,
                     vec![
                         derive.syntax().syntax_element(),
-                        make.whitespace(&format!("\n{indent}")).syntax_element(),
+                        editor.make().whitespace(&format!("\n{indent}")).syntax_element(),
                     ],
                 );
 

--- a/crates/ide-assists/src/handlers/generate_enum_variant.rs
+++ b/crates/ide-assists/src/handlers/generate_enum_variant.rs
@@ -60,9 +60,9 @@ pub(crate) fn generate_enum_variant(acc: &mut Assists, ctx: &AssistContext<'_>) 
 
     acc.add(AssistId::generate("generate_enum_variant"), "Generate variant", target, |builder| {
         let mut editor = builder.make_editor(enum_node.syntax());
-        let make = SyntaxFactory::with_mappings();
-        let field_list = parent.make_field_list(ctx, &make);
-        let variant = make.variant(None, make.name(&name_ref.text()), field_list, None);
+        let field_list = parent.make_field_list(ctx, editor.make());
+        let variant =
+            editor.make().variant(None, editor.make().name(&name_ref.text()), field_list, None);
         if let Some(it) = enum_node.variant_list() {
             it.add_variant(&mut editor, &variant);
         }

--- a/crates/ide-assists/src/handlers/generate_enum_variant.rs
+++ b/crates/ide-assists/src/handlers/generate_enum_variant.rs
@@ -59,12 +59,12 @@ pub(crate) fn generate_enum_variant(acc: &mut Assists, ctx: &AssistContext<'_>) 
     let InRealFile { file_id, value: enum_node } = e.source(db)?.original_ast_node_rooted(db)?;
 
     acc.add(AssistId::generate("generate_enum_variant"), "Generate variant", target, |builder| {
-        let mut editor = builder.make_editor(enum_node.syntax());
-        let field_list = parent.make_field_list(ctx, editor.make());
-        let variant =
-            editor.make().variant(None, editor.make().name(&name_ref.text()), field_list, None);
+        let editor = builder.make_editor(enum_node.syntax());
+        let make = editor.make();
+        let field_list = parent.make_field_list(ctx, make);
+        let variant = make.variant(None, make.name(&name_ref.text()), field_list, None);
         if let Some(it) = enum_node.variant_list() {
-            it.add_variant(&mut editor, &variant);
+            it.add_variant(&editor, &variant);
         }
         builder.add_file_edits(file_id.file_id(ctx.db()), editor);
     })

--- a/crates/ide-assists/src/handlers/generate_fn_type_alias.rs
+++ b/crates/ide-assists/src/handlers/generate_fn_type_alias.rs
@@ -2,7 +2,7 @@ use either::Either;
 use ide_db::assists::{AssistId, GroupLabel};
 use syntax::{
     AstNode,
-    ast::{self, HasGenericParams, HasName, edit::IndentLevel, syntax_factory::SyntaxFactory},
+    ast::{self, HasGenericParams, HasName, edit::IndentLevel},
     syntax_editor,
 };
 
@@ -55,8 +55,7 @@ pub(crate) fn generate_fn_type_alias(acc: &mut Assists, ctx: &AssistContext<'_>)
             style.label(),
             func_node.syntax().text_range(),
             |builder| {
-                let mut edit = builder.make_editor(func);
-                let make = SyntaxFactory::without_mappings();
+                let mut editor = builder.make_editor(func);
 
                 let alias_name = format!("{}Fn", stdx::to_camel_case(&name.to_string()));
 
@@ -69,24 +68,27 @@ pub(crate) fn generate_fn_type_alias(acc: &mut Assists, ctx: &AssistContext<'_>)
                     let is_mut = self_ty.is_mutable_reference();
 
                     if let Some(adt) = self_ty.strip_references().as_adt() {
-                        let inner_type = make.ty(adt.name(ctx.db()).as_str());
+                        let inner_type = editor.make().ty(adt.name(ctx.db()).as_str());
 
-                        let ast_self_ty =
-                            if is_ref { make.ty_ref(inner_type, is_mut) } else { inner_type };
+                        let ast_self_ty = if is_ref {
+                            editor.make().ty_ref(inner_type, is_mut)
+                        } else {
+                            inner_type
+                        };
 
-                        fn_params_vec.push(make.unnamed_param(ast_self_ty));
+                        fn_params_vec.push(editor.make().unnamed_param(ast_self_ty));
                     }
                 }
 
                 fn_params_vec.extend(param_list.params().filter_map(|p| match style {
                     ParamStyle::Named => Some(p),
-                    ParamStyle::Unnamed => p.ty().map(|ty| make.unnamed_param(ty)),
+                    ParamStyle::Unnamed => p.ty().map(|ty| editor.make().unnamed_param(ty)),
                 }));
 
                 let generic_params = func_node.generic_param_list();
 
                 let is_unsafe = func_node.unsafe_token().is_some();
-                let ty = make.ty_fn_ptr(
+                let ty = editor.make().ty_fn_ptr(
                     is_unsafe,
                     func_node.abi(),
                     fn_params_vec.into_iter(),
@@ -94,7 +96,7 @@ pub(crate) fn generate_fn_type_alias(acc: &mut Assists, ctx: &AssistContext<'_>)
                 );
 
                 // Insert new alias
-                let ty_alias = make.ty_alias(
+                let ty_alias = editor.make().ty_alias(
                     None,
                     &alias_name,
                     generic_params,
@@ -104,21 +106,21 @@ pub(crate) fn generate_fn_type_alias(acc: &mut Assists, ctx: &AssistContext<'_>)
                 );
 
                 let indent = IndentLevel::from_node(insertion_node);
-                edit.insert_all(
+                editor.insert_all(
                     syntax_editor::Position::before(insertion_node),
                     vec![
                         ty_alias.syntax().clone().into(),
-                        make.whitespace(&format!("\n\n{indent}")).into(),
+                        editor.make().whitespace(&format!("\n\n{indent}")).into(),
                     ],
                 );
 
                 if let Some(cap) = ctx.config.snippet_cap
                     && let Some(name) = ty_alias.name()
                 {
-                    edit.add_annotation(name.syntax(), builder.make_placeholder_snippet(cap));
+                    editor.add_annotation(name.syntax(), builder.make_placeholder_snippet(cap));
                 }
 
-                builder.add_file_edits(ctx.vfs_file_id(), edit);
+                builder.add_file_edits(ctx.vfs_file_id(), editor);
             },
         );
     }

--- a/crates/ide-assists/src/handlers/generate_fn_type_alias.rs
+++ b/crates/ide-assists/src/handlers/generate_fn_type_alias.rs
@@ -55,8 +55,8 @@ pub(crate) fn generate_fn_type_alias(acc: &mut Assists, ctx: &AssistContext<'_>)
             style.label(),
             func_node.syntax().text_range(),
             |builder| {
-                let mut editor = builder.make_editor(func);
-
+                let editor = builder.make_editor(func);
+                let make = editor.make();
                 let alias_name = format!("{}Fn", stdx::to_camel_case(&name.to_string()));
 
                 let mut fn_params_vec = Vec::new();
@@ -68,27 +68,24 @@ pub(crate) fn generate_fn_type_alias(acc: &mut Assists, ctx: &AssistContext<'_>)
                     let is_mut = self_ty.is_mutable_reference();
 
                     if let Some(adt) = self_ty.strip_references().as_adt() {
-                        let inner_type = editor.make().ty(adt.name(ctx.db()).as_str());
+                        let inner_type = make.ty(adt.name(ctx.db()).as_str());
 
-                        let ast_self_ty = if is_ref {
-                            editor.make().ty_ref(inner_type, is_mut)
-                        } else {
-                            inner_type
-                        };
+                        let ast_self_ty =
+                            if is_ref { make.ty_ref(inner_type, is_mut) } else { inner_type };
 
-                        fn_params_vec.push(editor.make().unnamed_param(ast_self_ty));
+                        fn_params_vec.push(make.unnamed_param(ast_self_ty));
                     }
                 }
 
                 fn_params_vec.extend(param_list.params().filter_map(|p| match style {
                     ParamStyle::Named => Some(p),
-                    ParamStyle::Unnamed => p.ty().map(|ty| editor.make().unnamed_param(ty)),
+                    ParamStyle::Unnamed => p.ty().map(|ty| make.unnamed_param(ty)),
                 }));
 
                 let generic_params = func_node.generic_param_list();
 
                 let is_unsafe = func_node.unsafe_token().is_some();
-                let ty = editor.make().ty_fn_ptr(
+                let ty = make.ty_fn_ptr(
                     is_unsafe,
                     func_node.abi(),
                     fn_params_vec.into_iter(),
@@ -96,7 +93,7 @@ pub(crate) fn generate_fn_type_alias(acc: &mut Assists, ctx: &AssistContext<'_>)
                 );
 
                 // Insert new alias
-                let ty_alias = editor.make().ty_alias(
+                let ty_alias = make.ty_alias(
                     None,
                     &alias_name,
                     generic_params,
@@ -110,7 +107,7 @@ pub(crate) fn generate_fn_type_alias(acc: &mut Assists, ctx: &AssistContext<'_>)
                     syntax_editor::Position::before(insertion_node),
                     vec![
                         ty_alias.syntax().clone().into(),
-                        editor.make().whitespace(&format!("\n\n{indent}")).into(),
+                        make.whitespace(&format!("\n\n{indent}")).into(),
                     ],
                 );
 

--- a/crates/ide-assists/src/handlers/generate_from_impl_for_enum.rs
+++ b/crates/ide-assists/src/handlers/generate_from_impl_for_enum.rs
@@ -40,13 +40,14 @@ pub(crate) fn generate_from_impl_for_enum(
         "Generate `From` impl for this enum variant(s)",
         target,
         |edit| {
-            let mut editor = edit.make_editor(adt.syntax());
+            let editor = edit.make_editor(adt.syntax());
+            let make = editor.make();
             let indent = adt.indent_level();
             let mut elements = Vec::new();
 
             for variant_info in variants {
-                let impl_ = build_from_impl(editor.make(), &adt, variant_info).indent(indent);
-                elements.push(editor.make().whitespace(&format!("\n\n{indent}")).into());
+                let impl_ = build_from_impl(make, &adt, variant_info).indent(indent);
+                elements.push(make.whitespace(&format!("\n\n{indent}")).into());
                 elements.push(impl_.syntax().clone().into());
             }
 

--- a/crates/ide-assists/src/handlers/generate_from_impl_for_enum.rs
+++ b/crates/ide-assists/src/handlers/generate_from_impl_for_enum.rs
@@ -40,19 +40,17 @@ pub(crate) fn generate_from_impl_for_enum(
         "Generate `From` impl for this enum variant(s)",
         target,
         |edit| {
-            let make = SyntaxFactory::with_mappings();
+            let mut editor = edit.make_editor(adt.syntax());
             let indent = adt.indent_level();
             let mut elements = Vec::new();
 
             for variant_info in variants {
-                let impl_ = build_from_impl(&make, &adt, variant_info).indent(indent);
-                elements.push(make.whitespace(&format!("\n\n{indent}")).into());
+                let impl_ = build_from_impl(editor.make(), &adt, variant_info).indent(indent);
+                elements.push(editor.make().whitespace(&format!("\n\n{indent}")).into());
                 elements.push(impl_.syntax().clone().into());
             }
 
-            let mut editor = edit.make_editor(adt.syntax());
             editor.insert_all(Position::after(adt.syntax()), elements);
-            editor.add_mappings(make.finish_with_mappings());
             edit.add_file_edits(file_id, editor);
         },
     )

--- a/crates/ide-assists/src/handlers/generate_getter_or_setter.rs
+++ b/crates/ide-assists/src/handlers/generate_getter_or_setter.rs
@@ -438,9 +438,9 @@ fn build_source_change(
 ) {
     if let Some(impl_def) = &assist_info.impl_def {
         // We have an existing impl to add to
-        let mut editor = builder.make_editor(impl_def.syntax());
+        let editor = builder.make_editor(impl_def.syntax());
         let items = items(ctx, info_of_record_fields, &assist_info, editor.make());
-        impl_def.assoc_item_list().unwrap().add_items(&mut editor, items.clone());
+        impl_def.assoc_item_list().unwrap().add_items(&editor, items.clone());
 
         if let Some(cap) = ctx.config.snippet_cap
             && let Some(ast::AssocItem::Fn(fn_)) = items.last()
@@ -454,24 +454,25 @@ fn build_source_change(
         return;
     }
 
-    let mut editor = builder.make_editor(assist_info.strukt.syntax());
-    let items = items(ctx, info_of_record_fields, &assist_info, editor.make());
+    let editor = builder.make_editor(assist_info.strukt.syntax());
+    let make = editor.make();
+    let items = items(ctx, info_of_record_fields, &assist_info, make);
     let ty_params = assist_info.strukt.generic_param_list();
     let ty_args = ty_params.as_ref().map(|it| it.to_generic_args());
-    let impl_def = editor.make().impl_(
+    let impl_def = make.impl_(
         None,
         ty_params,
         ty_args,
         editor
             .make()
-            .ty_path(editor.make().ident_path(&assist_info.strukt.name().unwrap().to_string()))
+            .ty_path(make.ident_path(&assist_info.strukt.name().unwrap().to_string()))
             .into(),
         None,
-        Some(editor.make().assoc_item_list(items)),
+        Some(make.assoc_item_list(items)),
     );
     editor.insert_all(
         Position::after(assist_info.strukt.syntax()),
-        vec![editor.make().whitespace("\n\n").into(), impl_def.syntax().clone().into()],
+        vec![make.whitespace("\n\n").into(), impl_def.syntax().clone().into()],
     );
 
     if let Some(cap) = ctx.config.snippet_cap

--- a/crates/ide-assists/src/handlers/generate_getter_or_setter.rs
+++ b/crates/ide-assists/src/handlers/generate_getter_or_setter.rs
@@ -410,34 +410,36 @@ fn parse_record_field(
     Some(RecordFieldInfo { field_name, field_ty, fn_name, target })
 }
 
+fn items(
+    ctx: &AssistContext<'_>,
+    info_of_record_fields: Vec<RecordFieldInfo>,
+    assist_info: &AssistInfo,
+    make: &SyntaxFactory,
+) -> Vec<ast::AssocItem> {
+    info_of_record_fields
+        .iter()
+        .map(|record_field_info| {
+            let method = match assist_info.assist_type {
+                AssistType::Set => generate_setter_from_info(assist_info, record_field_info, make),
+                _ => generate_getter_from_info(ctx, assist_info, record_field_info, make),
+            };
+            let new_fn = method;
+            let new_fn = new_fn.indent(1.into());
+            new_fn.into()
+        })
+        .collect()
+}
+
 fn build_source_change(
     builder: &mut SourceChangeBuilder,
     ctx: &AssistContext<'_>,
     info_of_record_fields: Vec<RecordFieldInfo>,
     assist_info: AssistInfo,
 ) {
-    let syntax_factory = SyntaxFactory::without_mappings();
-
-    let items: Vec<ast::AssocItem> = info_of_record_fields
-        .iter()
-        .map(|record_field_info| {
-            let method = match assist_info.assist_type {
-                AssistType::Set => {
-                    generate_setter_from_info(&assist_info, record_field_info, &syntax_factory)
-                }
-                _ => {
-                    generate_getter_from_info(ctx, &assist_info, record_field_info, &syntax_factory)
-                }
-            };
-            let new_fn = method;
-            let new_fn = new_fn.indent(1.into());
-            new_fn.into()
-        })
-        .collect();
-
     if let Some(impl_def) = &assist_info.impl_def {
         // We have an existing impl to add to
         let mut editor = builder.make_editor(impl_def.syntax());
+        let items = items(ctx, info_of_record_fields, &assist_info, editor.make());
         impl_def.assoc_item_list().unwrap().add_items(&mut editor, items.clone());
 
         if let Some(cap) = ctx.config.snippet_cap
@@ -451,22 +453,25 @@ fn build_source_change(
         builder.add_file_edits(ctx.vfs_file_id(), editor);
         return;
     }
+
+    let mut editor = builder.make_editor(assist_info.strukt.syntax());
+    let items = items(ctx, info_of_record_fields, &assist_info, editor.make());
     let ty_params = assist_info.strukt.generic_param_list();
     let ty_args = ty_params.as_ref().map(|it| it.to_generic_args());
-    let impl_def = syntax_factory.impl_(
+    let impl_def = editor.make().impl_(
         None,
         ty_params,
         ty_args,
-        syntax_factory
-            .ty_path(syntax_factory.ident_path(&assist_info.strukt.name().unwrap().to_string()))
+        editor
+            .make()
+            .ty_path(editor.make().ident_path(&assist_info.strukt.name().unwrap().to_string()))
             .into(),
         None,
-        Some(syntax_factory.assoc_item_list(items)),
+        Some(editor.make().assoc_item_list(items)),
     );
-    let mut editor = builder.make_editor(assist_info.strukt.syntax());
     editor.insert_all(
         Position::after(assist_info.strukt.syntax()),
-        vec![syntax_factory.whitespace("\n\n").into(), impl_def.syntax().clone().into()],
+        vec![editor.make().whitespace("\n\n").into(), impl_def.syntax().clone().into()],
     );
 
     if let Some(cap) = ctx.config.snippet_cap

--- a/crates/ide-assists/src/handlers/generate_impl.rs
+++ b/crates/ide-assists/src/handlers/generate_impl.rs
@@ -1,7 +1,5 @@
 use syntax::{
-    ast::{
-        self, AstNode, HasGenericParams, HasName, edit::AstNodeEdit, syntax_factory::SyntaxFactory,
-    },
+    ast::{self, AstNode, HasGenericParams, HasName, edit::AstNodeEdit},
     syntax_editor::{Position, SyntaxEditor},
 };
 
@@ -15,7 +13,6 @@ use crate::{
 
 fn insert_impl(
     editor: &mut SyntaxEditor,
-    make: &SyntaxFactory,
     impl_: &ast::Impl,
     nominal: &impl AstNodeEdit,
 ) -> ast::Impl {
@@ -26,7 +23,7 @@ fn insert_impl(
         Position::after(nominal.syntax()),
         vec![
             // Add a blank line after the ADT, and indentation for the impl to match the ADT
-            make.whitespace(&format!("\n\n{indent}")).into(),
+            editor.make().whitespace(&format!("\n\n{indent}")).into(),
             impl_.syntax().clone().into(),
         ],
     );
@@ -65,13 +62,10 @@ pub(crate) fn generate_impl(acc: &mut Assists, ctx: &AssistContext<'_>) -> Optio
         format!("Generate impl for `{name}`"),
         target,
         |edit| {
-            let make = SyntaxFactory::with_mappings();
-            // Generate the impl
-            let impl_ = generate_impl_with_factory(&make, &nominal);
-
             let mut editor = edit.make_editor(nominal.syntax());
+            let impl_ = generate_impl_with_factory(editor.make(), &nominal);
 
-            let impl_ = insert_impl(&mut editor, &make, &impl_, &nominal);
+            let impl_ = insert_impl(&mut editor, &impl_, &nominal);
             // Add a tabstop after the left curly brace
             if let Some(cap) = ctx.config.snippet_cap
                 && let Some(l_curly) = impl_.assoc_item_list().and_then(|it| it.l_curly_token())
@@ -79,8 +73,6 @@ pub(crate) fn generate_impl(acc: &mut Assists, ctx: &AssistContext<'_>) -> Optio
                 let tabstop = edit.make_tabstop_after(cap);
                 editor.add_annotation(l_curly, tabstop);
             }
-
-            editor.add_mappings(make.finish_with_mappings());
             edit.add_file_edits(ctx.vfs_file_id(), editor);
         },
     )
@@ -117,13 +109,13 @@ pub(crate) fn generate_trait_impl(acc: &mut Assists, ctx: &AssistContext<'_>) ->
         format!("Generate trait impl for `{name}`"),
         target,
         |edit| {
-            let make = SyntaxFactory::with_mappings();
-            // Generate the impl
-            let impl_ = generate_trait_impl_intransitive(&make, &nominal, make.ty_placeholder());
-
             let mut editor = edit.make_editor(nominal.syntax());
-
-            let impl_ = insert_impl(&mut editor, &make, &impl_, &nominal);
+            let impl_ = generate_trait_impl_intransitive(
+                editor.make(),
+                &nominal,
+                editor.make().ty_placeholder(),
+            );
+            let impl_ = insert_impl(&mut editor, &impl_, &nominal);
             // Make the trait type a placeholder snippet
             if let Some(cap) = ctx.config.snippet_cap {
                 if let Some(trait_) = impl_.trait_() {
@@ -136,8 +128,6 @@ pub(crate) fn generate_trait_impl(acc: &mut Assists, ctx: &AssistContext<'_>) ->
                     editor.add_annotation(l_curly, tabstop);
                 }
             }
-
-            editor.add_mappings(make.finish_with_mappings());
             edit.add_file_edits(ctx.vfs_file_id(), editor);
         },
     )
@@ -176,10 +166,10 @@ pub(crate) fn generate_impl_trait(acc: &mut Assists, ctx: &AssistContext<'_>) ->
         format!("Generate `{name}` impl for type"),
         target,
         |edit| {
-            let make = SyntaxFactory::with_mappings();
             let mut editor = edit.make_editor(trait_.syntax());
 
-            let holder_arg = ast::GenericArg::TypeArg(make.type_arg(make.ty_placeholder()));
+            let holder_arg =
+                ast::GenericArg::TypeArg(editor.make().type_arg(editor.make().ty_placeholder()));
             let missing_items = utils::filter_assoc_items(
                 &ctx.sema,
                 &hir_trait.items(ctx.db()),
@@ -188,11 +178,13 @@ pub(crate) fn generate_impl_trait(acc: &mut Assists, ctx: &AssistContext<'_>) ->
             );
 
             let trait_gen_args = trait_.generic_param_list().map(|list| {
-                make.generic_arg_list(list.generic_params().map(|_| holder_arg.clone()), false)
+                editor
+                    .make()
+                    .generic_arg_list(list.generic_params().map(|_| holder_arg.clone()), false)
             });
 
             let make_impl_ = |body| {
-                make.impl_trait(
+                editor.make().impl_trait(
                     None,
                     trait_.unsafe_token().is_some(),
                     None,
@@ -200,8 +192,8 @@ pub(crate) fn generate_impl_trait(acc: &mut Assists, ctx: &AssistContext<'_>) ->
                     None,
                     None,
                     false,
-                    make.ty(&name.text()),
-                    make.ty_placeholder(),
+                    editor.make().ty(&name.text()),
+                    editor.make().ty_placeholder(),
                     None,
                     None,
                     body,
@@ -213,7 +205,7 @@ pub(crate) fn generate_impl_trait(acc: &mut Assists, ctx: &AssistContext<'_>) ->
             } else {
                 let impl_ = make_impl_(None);
                 let assoc_items = add_trait_assoc_items_to_impl(
-                    &make,
+                    editor.make(),
                     &ctx.sema,
                     ctx.config,
                     &missing_items,
@@ -221,12 +213,11 @@ pub(crate) fn generate_impl_trait(acc: &mut Assists, ctx: &AssistContext<'_>) ->
                     &impl_,
                     &target_scope,
                 );
-                let assoc_item_list = make.assoc_item_list(assoc_items);
+                let assoc_item_list = editor.make().assoc_item_list(assoc_items);
                 make_impl_(Some(assoc_item_list))
             };
 
-            let impl_ = insert_impl(&mut editor, &make, &impl_, &trait_);
-            editor.add_mappings(make.finish_with_mappings());
+            let impl_ = insert_impl(&mut editor, &impl_, &trait_);
 
             if let Some(cap) = ctx.config.snippet_cap {
                 if let Some(generics) = impl_.trait_().and_then(|it| it.generic_arg_list()) {

--- a/crates/ide-assists/src/handlers/generate_impl.rs
+++ b/crates/ide-assists/src/handlers/generate_impl.rs
@@ -11,11 +11,8 @@ use crate::{
     },
 };
 
-fn insert_impl(
-    editor: &mut SyntaxEditor,
-    impl_: &ast::Impl,
-    nominal: &impl AstNodeEdit,
-) -> ast::Impl {
+fn insert_impl(editor: &SyntaxEditor, impl_: &ast::Impl, nominal: &impl AstNodeEdit) -> ast::Impl {
+    let make = editor.make();
     let indent = nominal.indent_level();
 
     let impl_ = impl_.indent(indent);
@@ -23,7 +20,7 @@ fn insert_impl(
         Position::after(nominal.syntax()),
         vec![
             // Add a blank line after the ADT, and indentation for the impl to match the ADT
-            editor.make().whitespace(&format!("\n\n{indent}")).into(),
+            make.whitespace(&format!("\n\n{indent}")).into(),
             impl_.syntax().clone().into(),
         ],
     );
@@ -62,10 +59,11 @@ pub(crate) fn generate_impl(acc: &mut Assists, ctx: &AssistContext<'_>) -> Optio
         format!("Generate impl for `{name}`"),
         target,
         |edit| {
-            let mut editor = edit.make_editor(nominal.syntax());
-            let impl_ = generate_impl_with_factory(editor.make(), &nominal);
+            let editor = edit.make_editor(nominal.syntax());
+            let make = editor.make();
+            let impl_ = generate_impl_with_factory(make, &nominal);
 
-            let impl_ = insert_impl(&mut editor, &impl_, &nominal);
+            let impl_ = insert_impl(&editor, &impl_, &nominal);
             // Add a tabstop after the left curly brace
             if let Some(cap) = ctx.config.snippet_cap
                 && let Some(l_curly) = impl_.assoc_item_list().and_then(|it| it.l_curly_token())
@@ -109,13 +107,10 @@ pub(crate) fn generate_trait_impl(acc: &mut Assists, ctx: &AssistContext<'_>) ->
         format!("Generate trait impl for `{name}`"),
         target,
         |edit| {
-            let mut editor = edit.make_editor(nominal.syntax());
-            let impl_ = generate_trait_impl_intransitive(
-                editor.make(),
-                &nominal,
-                editor.make().ty_placeholder(),
-            );
-            let impl_ = insert_impl(&mut editor, &impl_, &nominal);
+            let editor = edit.make_editor(nominal.syntax());
+            let make = editor.make();
+            let impl_ = generate_trait_impl_intransitive(make, &nominal, make.ty_placeholder());
+            let impl_ = insert_impl(&editor, &impl_, &nominal);
             // Make the trait type a placeholder snippet
             if let Some(cap) = ctx.config.snippet_cap {
                 if let Some(trait_) = impl_.trait_() {
@@ -166,10 +161,10 @@ pub(crate) fn generate_impl_trait(acc: &mut Assists, ctx: &AssistContext<'_>) ->
         format!("Generate `{name}` impl for type"),
         target,
         |edit| {
-            let mut editor = edit.make_editor(trait_.syntax());
+            let editor = edit.make_editor(trait_.syntax());
+            let make = editor.make();
 
-            let holder_arg =
-                ast::GenericArg::TypeArg(editor.make().type_arg(editor.make().ty_placeholder()));
+            let holder_arg = ast::GenericArg::TypeArg(make.type_arg(make.ty_placeholder()));
             let missing_items = utils::filter_assoc_items(
                 &ctx.sema,
                 &hir_trait.items(ctx.db()),
@@ -184,7 +179,7 @@ pub(crate) fn generate_impl_trait(acc: &mut Assists, ctx: &AssistContext<'_>) ->
             });
 
             let make_impl_ = |body| {
-                editor.make().impl_trait(
+                make.impl_trait(
                     None,
                     trait_.unsafe_token().is_some(),
                     None,
@@ -192,8 +187,8 @@ pub(crate) fn generate_impl_trait(acc: &mut Assists, ctx: &AssistContext<'_>) ->
                     None,
                     None,
                     false,
-                    editor.make().ty(&name.text()),
-                    editor.make().ty_placeholder(),
+                    make.ty(&name.text()),
+                    make.ty_placeholder(),
                     None,
                     None,
                     body,
@@ -205,7 +200,7 @@ pub(crate) fn generate_impl_trait(acc: &mut Assists, ctx: &AssistContext<'_>) ->
             } else {
                 let impl_ = make_impl_(None);
                 let assoc_items = add_trait_assoc_items_to_impl(
-                    editor.make(),
+                    make,
                     &ctx.sema,
                     ctx.config,
                     &missing_items,
@@ -213,11 +208,11 @@ pub(crate) fn generate_impl_trait(acc: &mut Assists, ctx: &AssistContext<'_>) ->
                     &impl_,
                     &target_scope,
                 );
-                let assoc_item_list = editor.make().assoc_item_list(assoc_items);
+                let assoc_item_list = make.assoc_item_list(assoc_items);
                 make_impl_(Some(assoc_item_list))
             };
 
-            let impl_ = insert_impl(&mut editor, &impl_, &trait_);
+            let impl_ = insert_impl(&editor, &impl_, &trait_);
 
             if let Some(cap) = ctx.config.snippet_cap {
                 if let Some(generics) = impl_.trait_().and_then(|it| it.generic_arg_list()) {

--- a/crates/ide-assists/src/handlers/generate_mut_trait_impl.rs
+++ b/crates/ide-assists/src/handlers/generate_mut_trait_impl.rs
@@ -67,9 +67,9 @@ pub(crate) fn generate_mut_trait_impl(acc: &mut Assists, ctx: &AssistContext<'_>
         format!("Generate `{trait_new}` impl from this `{trait_name}` trait"),
         target,
         |edit| {
-            let (mut editor, impl_clone) = SyntaxEditor::with_ast_node(&impl_def.reset_indent());
+            let (editor, impl_clone) = SyntaxEditor::with_ast_node(&impl_def.reset_indent());
 
-            apply_generate_mut_impl(&mut editor, &impl_clone, trait_new);
+            apply_generate_mut_impl(&editor, &impl_clone, trait_new);
 
             let new_root = editor.finish();
             let new_root = new_root.new_root();
@@ -78,12 +78,13 @@ pub(crate) fn generate_mut_trait_impl(acc: &mut Assists, ctx: &AssistContext<'_>
 
             let new_impl = new_impl.indent(indent);
 
-            let mut editor = edit.make_editor(impl_def.syntax());
+            let editor = edit.make_editor(impl_def.syntax());
+            let make = editor.make();
             editor.insert_all(
                 Position::before(impl_def.syntax()),
                 vec![
                     new_impl.syntax().syntax_element(),
-                    editor.make().whitespace(&format!("\n\n{indent}")).syntax_element(),
+                    make.whitespace(&format!("\n\n{indent}")).syntax_element(),
                 ],
             );
 
@@ -97,7 +98,7 @@ pub(crate) fn generate_mut_trait_impl(acc: &mut Assists, ctx: &AssistContext<'_>
     )
 }
 
-fn delete_with_trivia(editor: &mut SyntaxEditor, node: &SyntaxNode) {
+fn delete_with_trivia(editor: &SyntaxEditor, node: &SyntaxNode) {
     let mut end: SyntaxElement = node.clone().into();
 
     if let Some(next) = node.next_sibling_or_token()
@@ -111,22 +112,23 @@ fn delete_with_trivia(editor: &mut SyntaxEditor, node: &SyntaxNode) {
 }
 
 fn apply_generate_mut_impl(
-    editor: &mut SyntaxEditor,
+    editor: &SyntaxEditor,
     impl_def: &ast::Impl,
     trait_new: &str,
 ) -> Option<()> {
+    let make = editor.make();
     let path =
         impl_def.trait_().and_then(|t| t.syntax().descendants().find_map(ast::Path::cast))?;
     let seg = path.segment()?;
     let name_ref = seg.name_ref()?;
 
-    let new_name_ref = editor.make().name_ref(trait_new);
+    let new_name_ref = make.name_ref(trait_new);
     editor.replace(name_ref.syntax(), new_name_ref.syntax());
 
     if let Some((name, new_name)) =
         impl_def.syntax().descendants().filter_map(ast::Name::cast).find_map(process_method_name)
     {
-        let new_name_node = editor.make().name(new_name);
+        let new_name_node = make.name(new_name);
         editor.replace(name.syntax(), new_name_node.syntax());
     }
 
@@ -135,14 +137,14 @@ fn apply_generate_mut_impl(
     }
 
     if let Some(self_param) = impl_def.syntax().descendants().find_map(ast::SelfParam::cast) {
-        let mut_self = editor.make().mut_self_param();
+        let mut_self = make.mut_self_param();
         editor.replace(self_param.syntax(), mut_self.syntax());
     }
 
     if let Some(ret_type) = impl_def.syntax().descendants().find_map(ast::RetType::cast)
-        && let Some(new_ty) = process_ret_type(editor.make(), &ret_type)
+        && let Some(new_ty) = process_ret_type(make, &ret_type)
     {
-        let new_ret = editor.make().ret_type(new_ty);
+        let new_ret = make.ret_type(new_ty);
         editor.replace(ret_type.syntax(), new_ret.syntax())
     }
 
@@ -158,7 +160,8 @@ fn apply_generate_mut_impl(
     Some(())
 }
 
-fn process_ref_mut(editor: &mut SyntaxEditor, fn_: &ast::Fn) {
+fn process_ref_mut(editor: &SyntaxEditor, fn_: &ast::Fn) {
+    let make = editor.make();
     let Some(expr) = fn_.body().and_then(|b| b.tail_expr()) else { return };
 
     let ast::Expr::RefExpr(ref_expr) = expr else { return };
@@ -169,8 +172,8 @@ fn process_ref_mut(editor: &mut SyntaxEditor, fn_: &ast::Fn) {
 
     let Some(amp) = ref_expr.amp_token() else { return };
 
-    let mut_kw = editor.make().token(T![mut]);
-    let space = editor.make().whitespace(" ");
+    let mut_kw = make.token(T![mut]);
+    let space = make.whitespace(" ");
 
     editor.insert(Position::after(amp.clone()), space.syntax_element());
     editor.insert(Position::after(amp), mut_kw.syntax_element());

--- a/crates/ide-assists/src/handlers/generate_mut_trait_impl.rs
+++ b/crates/ide-assists/src/handlers/generate_mut_trait_impl.rs
@@ -68,9 +68,8 @@ pub(crate) fn generate_mut_trait_impl(acc: &mut Assists, ctx: &AssistContext<'_>
         target,
         |edit| {
             let (mut editor, impl_clone) = SyntaxEditor::with_ast_node(&impl_def.reset_indent());
-            let factory = SyntaxFactory::without_mappings();
 
-            apply_generate_mut_impl(&mut editor, &factory, &impl_clone, trait_new);
+            apply_generate_mut_impl(&mut editor, &impl_clone, trait_new);
 
             let new_root = editor.finish();
             let new_root = new_root.new_root();
@@ -84,7 +83,7 @@ pub(crate) fn generate_mut_trait_impl(acc: &mut Assists, ctx: &AssistContext<'_>
                 Position::before(impl_def.syntax()),
                 vec![
                     new_impl.syntax().syntax_element(),
-                    factory.whitespace(&format!("\n\n{indent}")).syntax_element(),
+                    editor.make().whitespace(&format!("\n\n{indent}")).syntax_element(),
                 ],
             );
 
@@ -113,7 +112,6 @@ fn delete_with_trivia(editor: &mut SyntaxEditor, node: &SyntaxNode) {
 
 fn apply_generate_mut_impl(
     editor: &mut SyntaxEditor,
-    factory: &SyntaxFactory,
     impl_def: &ast::Impl,
     trait_new: &str,
 ) -> Option<()> {
@@ -122,13 +120,13 @@ fn apply_generate_mut_impl(
     let seg = path.segment()?;
     let name_ref = seg.name_ref()?;
 
-    let new_name_ref = factory.name_ref(trait_new);
+    let new_name_ref = editor.make().name_ref(trait_new);
     editor.replace(name_ref.syntax(), new_name_ref.syntax());
 
     if let Some((name, new_name)) =
         impl_def.syntax().descendants().filter_map(ast::Name::cast).find_map(process_method_name)
     {
-        let new_name_node = factory.name(new_name);
+        let new_name_node = editor.make().name(new_name);
         editor.replace(name.syntax(), new_name_node.syntax());
     }
 
@@ -137,14 +135,14 @@ fn apply_generate_mut_impl(
     }
 
     if let Some(self_param) = impl_def.syntax().descendants().find_map(ast::SelfParam::cast) {
-        let mut_self = factory.mut_self_param();
+        let mut_self = editor.make().mut_self_param();
         editor.replace(self_param.syntax(), mut_self.syntax());
     }
 
     if let Some(ret_type) = impl_def.syntax().descendants().find_map(ast::RetType::cast)
-        && let Some(new_ty) = process_ret_type(factory, &ret_type)
+        && let Some(new_ty) = process_ret_type(editor.make(), &ret_type)
     {
-        let new_ret = factory.ret_type(new_ty);
+        let new_ret = editor.make().ret_type(new_ty);
         editor.replace(ret_type.syntax(), new_ret.syntax())
     }
 
@@ -154,13 +152,13 @@ fn apply_generate_mut_impl(
             _ => None,
         })
     }) {
-        process_ref_mut(editor, factory, &fn_);
+        process_ref_mut(editor, &fn_);
     }
 
     Some(())
 }
 
-fn process_ref_mut(editor: &mut SyntaxEditor, factory: &SyntaxFactory, fn_: &ast::Fn) {
+fn process_ref_mut(editor: &mut SyntaxEditor, fn_: &ast::Fn) {
     let Some(expr) = fn_.body().and_then(|b| b.tail_expr()) else { return };
 
     let ast::Expr::RefExpr(ref_expr) = expr else { return };
@@ -171,8 +169,8 @@ fn process_ref_mut(editor: &mut SyntaxEditor, factory: &SyntaxFactory, fn_: &ast
 
     let Some(amp) = ref_expr.amp_token() else { return };
 
-    let mut_kw = factory.token(T![mut]);
-    let space = factory.whitespace(" ");
+    let mut_kw = editor.make().token(T![mut]);
+    let space = editor.make().whitespace(" ");
 
     editor.insert(Position::after(amp.clone()), space.syntax_element());
     editor.insert(Position::after(amp), mut_kw.syntax_element());

--- a/crates/ide-assists/src/handlers/generate_new.rs
+++ b/crates/ide-assists/src/handlers/generate_new.rs
@@ -3,10 +3,7 @@ use ide_db::{
     use_trivial_constructor::use_trivial_constructor,
 };
 use syntax::{
-    ast::{
-        self, AstNode, HasName, HasVisibility, StructKind, edit::AstNodeEdit,
-        syntax_factory::SyntaxFactory,
-    },
+    ast::{self, AstNode, HasName, HasVisibility, StructKind, edit::AstNodeEdit},
     syntax_editor::Position,
 };
 
@@ -38,11 +35,9 @@ use crate::{
 // ```
 pub(crate) fn generate_new(acc: &mut Assists, ctx: &AssistContext<'_>) -> Option<()> {
     let strukt = ctx.find_node_at_offset::<ast::Struct>()?;
-
-    let make = SyntaxFactory::without_mappings();
-    let field_list = match strukt.kind() {
+    let field_list: Vec<(String, ast::Type)> = match strukt.kind() {
         StructKind::Record(named) => {
-            named.fields().filter_map(|f| Some((f.name()?, f.ty()?))).collect::<Vec<_>>()
+            named.fields().filter_map(|f| Some((f.name()?.to_string(), f.ty()?))).collect()
         }
         StructKind::Tuple(tuple) => {
             let mut name_generator = NameGenerator::default();
@@ -56,12 +51,12 @@ pub(crate) fn generate_new(acc: &mut Assists, ctx: &AssistContext<'_>) -> Option
                         ctx.db(),
                         ctx.edition(),
                     ) {
-                        Some(name) => name,
-                        None => name_generator.suggest_name(&format!("_{i}")),
+                        Some(name) => name.to_string(),
+                        None => name_generator.suggest_name(&format!("_{i}")).to_string(),
                     };
-                    Some((make.name(name.as_str()), f.ty()?))
+                    Some((name, ty))
                 })
-                .collect::<Vec<_>>()
+                .collect()
         }
         StructKind::Unit => return None,
     };
@@ -74,7 +69,8 @@ pub(crate) fn generate_new(acc: &mut Assists, ctx: &AssistContext<'_>) -> Option
 
     let target = strukt.syntax().text_range();
     acc.add(AssistId::generate("generate_new"), "Generate `new`", target, |builder| {
-        let make = SyntaxFactory::with_mappings();
+        let mut editor = builder.make_editor(strukt.syntax());
+
         let trivial_constructors = field_list
             .iter()
             .map(|(name, ty)| {
@@ -100,52 +96,64 @@ pub(crate) fn generate_new(acc: &mut Assists, ctx: &AssistContext<'_>) -> Option
                     edition,
                 )?;
 
-                Some((make.name_ref(&name.text()), Some(expr)))
+                Some((editor.make().name_ref(name), Some(expr)))
             })
             .collect::<Vec<_>>();
 
         let params = field_list.iter().enumerate().filter_map(|(i, (name, ty))| {
             if trivial_constructors[i].is_none() {
-                Some(make.param(make.ident_pat(false, false, name.clone()).into(), ty.clone()))
+                Some(editor.make().param(
+                    editor.make().ident_pat(false, false, editor.make().name(name)).into(),
+                    ty.clone(),
+                ))
             } else {
                 None
             }
         });
-        let params = make.param_list(None, params);
+        let params = editor.make().param_list(None, params);
 
         let fields = field_list.iter().enumerate().map(|(i, (name, _))| {
             if let Some(constructor) = trivial_constructors[i].clone() {
                 constructor
             } else {
-                (make.name_ref(&name.text()), None)
+                (editor.make().name_ref(name), None)
             }
         });
 
         let tail_expr: ast::Expr = match strukt.kind() {
             StructKind::Record(_) => {
-                let fields = fields.map(|(name, expr)| make.record_expr_field(name, expr));
-                let fields = make.record_expr_field_list(fields);
-                make.record_expr(make.ident_path("Self"), fields).into()
+                let fields = fields.map(|(name, expr)| editor.make().record_expr_field(name, expr));
+                let fields = editor.make().record_expr_field_list(fields);
+                editor.make().record_expr(editor.make().ident_path("Self"), fields).into()
             }
             StructKind::Tuple(_) => {
                 let args = fields.map(|(arg, expr)| {
-                    let arg = || make.expr_path(make.path_unqualified(make.path_segment(arg)));
+                    let arg = || {
+                        editor.make().expr_path(
+                            editor.make().path_unqualified(editor.make().path_segment(arg)),
+                        )
+                    };
                     expr.unwrap_or_else(arg)
                 });
-                let arg_list = make.arg_list(args);
-                make.expr_call(make.expr_path(make.ident_path("Self")), arg_list).into()
+                let arg_list = editor.make().arg_list(args);
+                editor
+                    .make()
+                    .expr_call(editor.make().expr_path(editor.make().ident_path("Self")), arg_list)
+                    .into()
             }
             StructKind::Unit => unreachable!(),
         };
-        let body = make.block_expr(None, tail_expr.into());
+        let body = editor.make().block_expr(None, tail_expr.into());
 
-        let ret_type = make.ret_type(make.ty_path(make.ident_path("Self")).into());
+        let ret_type =
+            editor.make().ret_type(editor.make().ty_path(editor.make().ident_path("Self")).into());
 
-        let fn_ = make
+        let fn_ = editor
+            .make()
             .fn_(
                 [],
                 strukt.visibility(),
-                make.name("new"),
+                editor.make().name("new"),
                 None,
                 None,
                 params,
@@ -158,8 +166,6 @@ pub(crate) fn generate_new(acc: &mut Assists, ctx: &AssistContext<'_>) -> Option
             )
             .indent(1.into());
 
-        let mut editor = builder.make_editor(strukt.syntax());
-
         // Get the node for set annotation
         let contain_fn = if let Some(impl_def) = impl_def {
             let fn_ = fn_.indent(impl_def.indent_level());
@@ -169,30 +175,36 @@ pub(crate) fn generate_new(acc: &mut Assists, ctx: &AssistContext<'_>) -> Option
                 editor.insert_all(
                     Position::after(l_curly),
                     vec![
-                        make.whitespace(&format!("\n{}", impl_def.indent_level() + 1)).into(),
+                        editor
+                            .make()
+                            .whitespace(&format!("\n{}", impl_def.indent_level() + 1))
+                            .into(),
                         fn_.syntax().clone().into(),
-                        make.whitespace("\n").into(),
+                        editor.make().whitespace("\n").into(),
                     ],
                 );
                 fn_.syntax().clone()
             } else {
-                let list = make.assoc_item_list([ast::AssocItem::Fn(fn_)]);
+                let list = editor.make().assoc_item_list([ast::AssocItem::Fn(fn_)]);
                 editor.insert(Position::after(impl_def.syntax()), list.syntax());
                 list.syntax().clone()
             }
         } else {
             // Generate a new impl to add the method to
             let indent_level = strukt.indent_level();
-            let list = make.assoc_item_list([ast::AssocItem::Fn(fn_)]);
-            let impl_def =
-                generate_impl_with_item(&make, &ast::Adt::Struct(strukt.clone()), Some(list))
-                    .indent(strukt.indent_level());
+            let list = editor.make().assoc_item_list([ast::AssocItem::Fn(fn_)]);
+            let impl_def = generate_impl_with_item(
+                editor.make(),
+                &ast::Adt::Struct(strukt.clone()),
+                Some(list),
+            )
+            .indent(strukt.indent_level());
 
             // Insert it after the adt
             editor.insert_all(
                 Position::after(strukt.syntax()),
                 vec![
-                    make.whitespace(&format!("\n\n{indent_level}")).into(),
+                    editor.make().whitespace(&format!("\n\n{indent_level}")).into(),
                     impl_def.syntax().clone().into(),
                 ],
             );
@@ -235,8 +247,6 @@ pub(crate) fn generate_new(acc: &mut Assists, ctx: &AssistContext<'_>) -> Option
                 editor.add_annotation(name.syntax(), tabstop_before);
             }
         }
-
-        editor.add_mappings(make.finish_with_mappings());
         builder.add_file_edits(ctx.vfs_file_id(), editor);
     })
 }

--- a/crates/ide-assists/src/handlers/generate_new.rs
+++ b/crates/ide-assists/src/handlers/generate_new.rs
@@ -69,7 +69,8 @@ pub(crate) fn generate_new(acc: &mut Assists, ctx: &AssistContext<'_>) -> Option
 
     let target = strukt.syntax().text_range();
     acc.add(AssistId::generate("generate_new"), "Generate `new`", target, |builder| {
-        let mut editor = builder.make_editor(strukt.syntax());
+        let editor = builder.make_editor(strukt.syntax());
+        let make = editor.make();
 
         let trivial_constructors = field_list
             .iter()
@@ -96,64 +97,53 @@ pub(crate) fn generate_new(acc: &mut Assists, ctx: &AssistContext<'_>) -> Option
                     edition,
                 )?;
 
-                Some((editor.make().name_ref(name), Some(expr)))
+                Some((make.name_ref(name), Some(expr)))
             })
             .collect::<Vec<_>>();
 
         let params = field_list.iter().enumerate().filter_map(|(i, (name, ty))| {
             if trivial_constructors[i].is_none() {
-                Some(editor.make().param(
-                    editor.make().ident_pat(false, false, editor.make().name(name)).into(),
-                    ty.clone(),
-                ))
+                Some(make.param(make.ident_pat(false, false, make.name(name)).into(), ty.clone()))
             } else {
                 None
             }
         });
-        let params = editor.make().param_list(None, params);
+        let params = make.param_list(None, params);
 
         let fields = field_list.iter().enumerate().map(|(i, (name, _))| {
             if let Some(constructor) = trivial_constructors[i].clone() {
                 constructor
             } else {
-                (editor.make().name_ref(name), None)
+                (make.name_ref(name), None)
             }
         });
 
         let tail_expr: ast::Expr = match strukt.kind() {
             StructKind::Record(_) => {
-                let fields = fields.map(|(name, expr)| editor.make().record_expr_field(name, expr));
-                let fields = editor.make().record_expr_field_list(fields);
-                editor.make().record_expr(editor.make().ident_path("Self"), fields).into()
+                let fields = fields.map(|(name, expr)| make.record_expr_field(name, expr));
+                let fields = make.record_expr_field_list(fields);
+                make.record_expr(make.ident_path("Self"), fields).into()
             }
             StructKind::Tuple(_) => {
                 let args = fields.map(|(arg, expr)| {
-                    let arg = || {
-                        editor.make().expr_path(
-                            editor.make().path_unqualified(editor.make().path_segment(arg)),
-                        )
-                    };
+                    let arg = || make.expr_path(make.path_unqualified(make.path_segment(arg)));
                     expr.unwrap_or_else(arg)
                 });
-                let arg_list = editor.make().arg_list(args);
-                editor
-                    .make()
-                    .expr_call(editor.make().expr_path(editor.make().ident_path("Self")), arg_list)
-                    .into()
+                let arg_list = make.arg_list(args);
+                make.expr_call(make.expr_path(make.ident_path("Self")), arg_list).into()
             }
             StructKind::Unit => unreachable!(),
         };
-        let body = editor.make().block_expr(None, tail_expr.into());
+        let body = make.block_expr(None, tail_expr.into());
 
-        let ret_type =
-            editor.make().ret_type(editor.make().ty_path(editor.make().ident_path("Self")).into());
+        let ret_type = make.ret_type(make.ty_path(make.ident_path("Self")).into());
 
         let fn_ = editor
             .make()
             .fn_(
                 [],
                 strukt.visibility(),
-                editor.make().name("new"),
+                make.name("new"),
                 None,
                 None,
                 params,
@@ -180,31 +170,28 @@ pub(crate) fn generate_new(acc: &mut Assists, ctx: &AssistContext<'_>) -> Option
                             .whitespace(&format!("\n{}", impl_def.indent_level() + 1))
                             .into(),
                         fn_.syntax().clone().into(),
-                        editor.make().whitespace("\n").into(),
+                        make.whitespace("\n").into(),
                     ],
                 );
                 fn_.syntax().clone()
             } else {
-                let list = editor.make().assoc_item_list([ast::AssocItem::Fn(fn_)]);
+                let list = make.assoc_item_list([ast::AssocItem::Fn(fn_)]);
                 editor.insert(Position::after(impl_def.syntax()), list.syntax());
                 list.syntax().clone()
             }
         } else {
             // Generate a new impl to add the method to
             let indent_level = strukt.indent_level();
-            let list = editor.make().assoc_item_list([ast::AssocItem::Fn(fn_)]);
-            let impl_def = generate_impl_with_item(
-                editor.make(),
-                &ast::Adt::Struct(strukt.clone()),
-                Some(list),
-            )
-            .indent(strukt.indent_level());
+            let list = make.assoc_item_list([ast::AssocItem::Fn(fn_)]);
+            let impl_def =
+                generate_impl_with_item(make, &ast::Adt::Struct(strukt.clone()), Some(list))
+                    .indent(strukt.indent_level());
 
             // Insert it after the adt
             editor.insert_all(
                 Position::after(strukt.syntax()),
                 vec![
-                    editor.make().whitespace(&format!("\n\n{indent_level}")).into(),
+                    make.whitespace(&format!("\n\n{indent_level}")).into(),
                     impl_def.syntax().clone().into(),
                 ],
             );

--- a/crates/ide-assists/src/handlers/generate_single_field_struct_from.rs
+++ b/crates/ide-assists/src/handlers/generate_single_field_struct_from.rs
@@ -80,51 +80,55 @@ pub(crate) fn generate_single_field_struct_from(
         "Generate single field `From`",
         strukt.syntax().text_range(),
         |builder| {
-            let make = SyntaxFactory::with_mappings();
             let mut editor = builder.make_editor(strukt.syntax());
 
             let indent = strukt.indent_level();
             let ty_where_clause = strukt.where_clause();
             let type_gen_params = strukt.generic_param_list();
             let type_gen_args = type_gen_params.as_ref().map(|params| params.to_generic_args());
-            let trait_gen_args = Some(make.generic_arg_list(
-                [ast::GenericArg::TypeArg(make.type_arg(main_field_ty.clone()))],
+            let trait_gen_args = Some(editor.make().generic_arg_list(
+                [ast::GenericArg::TypeArg(editor.make().type_arg(main_field_ty.clone()))],
                 false,
             ));
 
-            let ty = make.ty(&strukt_name.text());
+            let ty = editor.make().ty(&strukt_name.text());
 
-            let constructor =
-                make_adt_constructor(names.as_deref(), constructors, &main_field_name, &make);
-            let body = make.block_expr([], Some(constructor));
+            let constructor = make_adt_constructor(
+                names.as_deref(),
+                constructors,
+                &main_field_name,
+                editor.make(),
+            );
+            let body = editor.make().block_expr([], Some(constructor));
 
-            let fn_ = make
+            let fn_ = editor
+                .make()
                 .fn_(
                     [],
                     None,
-                    make.name("from"),
+                    editor.make().name("from"),
                     None,
                     None,
-                    make.param_list(
+                    editor.make().param_list(
                         None,
-                        [make.param(
-                            make.path_pat(make.path_from_text(&main_field_name)),
+                        [editor.make().param(
+                            editor.make().path_pat(editor.make().path_from_text(&main_field_name)),
                             main_field_ty,
                         )],
                     ),
                     body,
-                    Some(make.ret_type(make.ty("Self"))),
+                    Some(editor.make().ret_type(editor.make().ty("Self"))),
                     false,
                     false,
                     false,
                     false,
                 )
-                .indent_with_mapping(1.into(), &make);
+                .indent_with_mapping(1.into(), editor.make());
 
             let cfg_attrs =
                 strukt.attrs().filter(|attr| matches!(attr.meta(), Some(ast::Meta::CfgMeta(_))));
 
-            let impl_ = make.impl_trait(
+            let impl_ = editor.make().impl_trait(
                 cfg_attrs,
                 false,
                 None,
@@ -132,7 +136,7 @@ pub(crate) fn generate_single_field_struct_from(
                 type_gen_params,
                 type_gen_args,
                 false,
-                make.ty("From"),
+                editor.make().ty("From"),
                 ty.clone(),
                 None,
                 ty_where_clause.map(|wc| wc.reset_indent()),
@@ -140,22 +144,19 @@ pub(crate) fn generate_single_field_struct_from(
             );
 
             let (mut impl_editor, impl_root) = SyntaxEditor::with_ast_node(&impl_);
-            let assoc_list =
-                impl_root.get_or_create_assoc_item_list_with_editor(&mut impl_editor, &make);
+            let assoc_list = impl_root.get_or_create_assoc_item_list_with_editor(&mut impl_editor);
             assoc_list.add_items(&mut impl_editor, vec![fn_.into()]);
             let impl_ = ast::Impl::cast(impl_editor.finish().new_root().clone())
                 .unwrap()
-                .indent_with_mapping(indent, &make);
+                .indent_with_mapping(indent, editor.make());
 
             editor.insert_all(
                 Position::after(strukt.syntax()),
                 vec![
-                    make.whitespace(&format!("\n\n{indent}")).into(),
+                    editor.make().whitespace(&format!("\n\n{indent}")).into(),
                     impl_.syntax().clone().into(),
                 ],
             );
-
-            editor.add_mappings(make.finish_with_mappings());
             builder.add_file_edits(ctx.vfs_file_id(), editor);
         },
     )

--- a/crates/ide-assists/src/handlers/generate_single_field_struct_from.rs
+++ b/crates/ide-assists/src/handlers/generate_single_field_struct_from.rs
@@ -80,55 +80,52 @@ pub(crate) fn generate_single_field_struct_from(
         "Generate single field `From`",
         strukt.syntax().text_range(),
         |builder| {
-            let mut editor = builder.make_editor(strukt.syntax());
+            let editor = builder.make_editor(strukt.syntax());
+            let make = editor.make();
 
             let indent = strukt.indent_level();
             let ty_where_clause = strukt.where_clause();
             let type_gen_params = strukt.generic_param_list();
             let type_gen_args = type_gen_params.as_ref().map(|params| params.to_generic_args());
-            let trait_gen_args = Some(editor.make().generic_arg_list(
-                [ast::GenericArg::TypeArg(editor.make().type_arg(main_field_ty.clone()))],
+            let trait_gen_args = Some(make.generic_arg_list(
+                [ast::GenericArg::TypeArg(make.type_arg(main_field_ty.clone()))],
                 false,
             ));
 
-            let ty = editor.make().ty(&strukt_name.text());
+            let ty = make.ty(&strukt_name.text());
 
-            let constructor = make_adt_constructor(
-                names.as_deref(),
-                constructors,
-                &main_field_name,
-                editor.make(),
-            );
-            let body = editor.make().block_expr([], Some(constructor));
+            let constructor =
+                make_adt_constructor(names.as_deref(), constructors, &main_field_name, make);
+            let body = make.block_expr([], Some(constructor));
 
             let fn_ = editor
                 .make()
                 .fn_(
                     [],
                     None,
-                    editor.make().name("from"),
+                    make.name("from"),
                     None,
                     None,
-                    editor.make().param_list(
+                    make.param_list(
                         None,
-                        [editor.make().param(
-                            editor.make().path_pat(editor.make().path_from_text(&main_field_name)),
+                        [make.param(
+                            make.path_pat(make.path_from_text(&main_field_name)),
                             main_field_ty,
                         )],
                     ),
                     body,
-                    Some(editor.make().ret_type(editor.make().ty("Self"))),
+                    Some(make.ret_type(make.ty("Self"))),
                     false,
                     false,
                     false,
                     false,
                 )
-                .indent_with_mapping(1.into(), editor.make());
+                .indent_with_mapping(1.into(), make);
 
             let cfg_attrs =
                 strukt.attrs().filter(|attr| matches!(attr.meta(), Some(ast::Meta::CfgMeta(_))));
 
-            let impl_ = editor.make().impl_trait(
+            let impl_ = make.impl_trait(
                 cfg_attrs,
                 false,
                 None,
@@ -136,24 +133,24 @@ pub(crate) fn generate_single_field_struct_from(
                 type_gen_params,
                 type_gen_args,
                 false,
-                editor.make().ty("From"),
+                make.ty("From"),
                 ty.clone(),
                 None,
                 ty_where_clause.map(|wc| wc.reset_indent()),
                 None,
             );
 
-            let (mut impl_editor, impl_root) = SyntaxEditor::with_ast_node(&impl_);
-            let assoc_list = impl_root.get_or_create_assoc_item_list_with_editor(&mut impl_editor);
-            assoc_list.add_items(&mut impl_editor, vec![fn_.into()]);
+            let (impl_editor, impl_root) = SyntaxEditor::with_ast_node(&impl_);
+            let assoc_list = impl_root.get_or_create_assoc_item_list_with_editor(&impl_editor);
+            assoc_list.add_items(&impl_editor, vec![fn_.into()]);
             let impl_ = ast::Impl::cast(impl_editor.finish().new_root().clone())
                 .unwrap()
-                .indent_with_mapping(indent, editor.make());
+                .indent_with_mapping(indent, make);
 
             editor.insert_all(
                 Position::after(strukt.syntax()),
                 vec![
-                    editor.make().whitespace(&format!("\n\n{indent}")).into(),
+                    make.whitespace(&format!("\n\n{indent}")).into(),
                     impl_.syntax().clone().into(),
                 ],
             );

--- a/crates/ide-assists/src/handlers/generate_trait_from_impl.rs
+++ b/crates/ide-assists/src/handlers/generate_trait_from_impl.rs
@@ -98,18 +98,19 @@ pub(crate) fn generate_trait_from_impl(acc: &mut Assists, ctx: &AssistContext<'_
         impl_ast.syntax().text_range(),
         |builder| {
             let trait_items: ast::AssocItemList = {
-                let (mut trait_items_editor, trait_items) =
+                let (trait_items_editor, trait_items) =
                     SyntaxEditor::with_ast_node(&impl_assoc_items);
 
                 trait_items.assoc_items().for_each(|item| {
-                    strip_body(&mut trait_items_editor, &item);
-                    remove_items_visibility(&mut trait_items_editor, &item);
+                    strip_body(&trait_items_editor, &item);
+                    remove_items_visibility(&trait_items_editor, &item);
                 });
                 ast::AssocItemList::cast(trait_items_editor.finish().new_root().clone()).unwrap()
             };
 
-            let mut editor = builder.make_editor(impl_ast.syntax());
-            let trait_ast = editor.make().trait_(
+            let editor = builder.make_editor(impl_ast.syntax());
+            let make = editor.make();
+            let trait_ast = make.trait_(
                 false,
                 &trait_name(&impl_assoc_items).text(),
                 impl_ast.generic_param_list(),
@@ -118,7 +119,7 @@ pub(crate) fn generate_trait_from_impl(acc: &mut Assists, ctx: &AssistContext<'_
             );
 
             let trait_name = trait_ast.name().expect("new trait should have a name");
-            let trait_name_ref = editor.make().name_ref(&trait_name.to_string());
+            let trait_name_ref = make.name_ref(&trait_name.to_string());
 
             // Change `impl Foo` to `impl NewTrait for Foo`
             let mut elements = vec![
@@ -134,8 +135,8 @@ pub(crate) fn generate_trait_from_impl(acc: &mut Assists, ctx: &AssistContext<'_
             }
 
             impl_assoc_items.assoc_items().for_each(|item| {
-                remove_items_visibility(&mut editor, &item);
-                remove_doc_comments(&mut editor, &item);
+                remove_items_visibility(&editor, &item);
+                remove_doc_comments(&editor, &item);
             });
 
             editor.insert_all(Position::before(impl_name.syntax()), elements);
@@ -175,7 +176,7 @@ fn trait_name(items: &ast::AssocItemList) -> ast::Name {
 }
 
 /// `E0449` Trait items always share the visibility of their trait
-fn remove_items_visibility(editor: &mut SyntaxEditor, item: &ast::AssocItem) {
+fn remove_items_visibility(editor: &SyntaxEditor, item: &ast::AssocItem) {
     if let Some(has_vis) = ast::AnyHasVisibility::cast(item.syntax().clone()) {
         if let Some(vis) = has_vis.visibility()
             && let Some(token) = vis.syntax().next_sibling_or_token()
@@ -189,7 +190,7 @@ fn remove_items_visibility(editor: &mut SyntaxEditor, item: &ast::AssocItem) {
     }
 }
 
-fn remove_doc_comments(editor: &mut SyntaxEditor, item: &ast::AssocItem) {
+fn remove_doc_comments(editor: &SyntaxEditor, item: &ast::AssocItem) {
     for doc in item.doc_comments() {
         if let Some(next) = doc.syntax().next_token()
             && next.kind() == SyntaxKind::WHITESPACE
@@ -200,7 +201,7 @@ fn remove_doc_comments(editor: &mut SyntaxEditor, item: &ast::AssocItem) {
     }
 }
 
-fn strip_body(editor: &mut SyntaxEditor, item: &ast::AssocItem) {
+fn strip_body(editor: &SyntaxEditor, item: &ast::AssocItem) {
     if let ast::AssocItem::Fn(f) = item
         && let Some(body) = f.body()
     {

--- a/crates/ide-assists/src/handlers/generate_trait_from_impl.rs
+++ b/crates/ide-assists/src/handlers/generate_trait_from_impl.rs
@@ -4,7 +4,6 @@ use syntax::{
     AstNode, AstToken, SyntaxKind, T,
     ast::{
         self, HasDocComments, HasGenericParams, HasName, HasVisibility, edit::AstNodeEdit, make,
-        syntax_factory::SyntaxFactory,
     },
     syntax_editor::{Position, SyntaxEditor},
 };
@@ -109,8 +108,8 @@ pub(crate) fn generate_trait_from_impl(acc: &mut Assists, ctx: &AssistContext<'_
                 ast::AssocItemList::cast(trait_items_editor.finish().new_root().clone()).unwrap()
             };
 
-            let factory = SyntaxFactory::with_mappings();
-            let trait_ast = factory.trait_(
+            let mut editor = builder.make_editor(impl_ast.syntax());
+            let trait_ast = editor.make().trait_(
                 false,
                 &trait_name(&impl_assoc_items).text(),
                 impl_ast.generic_param_list(),
@@ -119,7 +118,7 @@ pub(crate) fn generate_trait_from_impl(acc: &mut Assists, ctx: &AssistContext<'_
             );
 
             let trait_name = trait_ast.name().expect("new trait should have a name");
-            let trait_name_ref = factory.name_ref(&trait_name.to_string());
+            let trait_name_ref = editor.make().name_ref(&trait_name.to_string());
 
             // Change `impl Foo` to `impl NewTrait for Foo`
             let mut elements = vec![
@@ -134,7 +133,6 @@ pub(crate) fn generate_trait_from_impl(acc: &mut Assists, ctx: &AssistContext<'_
                 elements.insert(1, gen_args.syntax().clone().into());
             }
 
-            let mut editor = builder.make_editor(impl_ast.syntax());
             impl_assoc_items.assoc_items().for_each(|item| {
                 remove_items_visibility(&mut editor, &item);
                 remove_doc_comments(&mut editor, &item);
@@ -157,8 +155,6 @@ pub(crate) fn generate_trait_from_impl(acc: &mut Assists, ctx: &AssistContext<'_
                 editor.add_annotation(trait_name.syntax(), placeholder);
                 editor.add_annotation(trait_name_ref.syntax(), placeholder);
             }
-
-            editor.add_mappings(factory.finish_with_mappings());
             builder.add_file_edits(ctx.vfs_file_id(), editor);
         },
     );

--- a/crates/ide-assists/src/handlers/inline_local_variable.rs
+++ b/crates/ide-assists/src/handlers/inline_local_variable.rs
@@ -7,7 +7,7 @@ use ide_db::{
 };
 use syntax::{
     Direction, TextRange,
-    ast::{self, AstNode, AstToken, HasName, syntax_factory::SyntaxFactory},
+    ast::{self, AstNode, AstToken, HasName},
     syntax_editor::{Element, SyntaxEditor},
 };
 
@@ -98,25 +98,21 @@ pub(crate) fn inline_local_variable(acc: &mut Assists, ctx: &AssistContext<'_>) 
                 }
             }
 
-            let make = SyntaxFactory::with_mappings();
-
             for (name, should_wrap) in wrap_in_parens {
                 let replacement = if should_wrap {
-                    make.expr_paren(initializer_expr.clone()).into()
+                    editor.make().expr_paren(initializer_expr.clone()).into()
                 } else {
                     initializer_expr.clone()
                 };
 
                 if let Some(record_field) = ast::RecordExprField::for_field_name(&name) {
                     cov_mark::hit!(inline_field_shorthand);
-                    let replacement = make.record_expr_field(name, Some(replacement));
+                    let replacement = editor.make().record_expr_field(name, Some(replacement));
                     editor.replace(record_field.syntax(), replacement.syntax());
                 } else {
                     editor.replace(name.syntax(), replacement.syntax());
                 }
             }
-
-            editor.add_mappings(make.finish_with_mappings());
             builder.add_file_edits(ctx.vfs_file_id(), editor);
         },
     )

--- a/crates/ide-assists/src/handlers/inline_local_variable.rs
+++ b/crates/ide-assists/src/handlers/inline_local_variable.rs
@@ -83,7 +83,8 @@ pub(crate) fn inline_local_variable(acc: &mut Assists, ctx: &AssistContext<'_>) 
         "Inline variable",
         target.text_range(),
         move |builder| {
-            let mut editor = builder.make_editor(&target);
+            let editor = builder.make_editor(&target);
+            let make = editor.make();
             if delete_let {
                 editor.delete(let_stmt.syntax());
 
@@ -91,23 +92,23 @@ pub(crate) fn inline_local_variable(acc: &mut Assists, ctx: &AssistContext<'_>) 
                     && let Some(op_token) = bin_expr.op_token()
                 {
                     editor.delete(&op_token);
-                    remove_whitespace(op_token, Direction::Prev, &mut editor);
-                    remove_whitespace(let_stmt.syntax(), Direction::Prev, &mut editor);
+                    remove_whitespace(op_token, Direction::Prev, &editor);
+                    remove_whitespace(let_stmt.syntax(), Direction::Prev, &editor);
                 } else {
-                    remove_whitespace(let_stmt.syntax(), Direction::Next, &mut editor);
+                    remove_whitespace(let_stmt.syntax(), Direction::Next, &editor);
                 }
             }
 
             for (name, should_wrap) in wrap_in_parens {
                 let replacement = if should_wrap {
-                    editor.make().expr_paren(initializer_expr.clone()).into()
+                    make.expr_paren(initializer_expr.clone()).into()
                 } else {
                     initializer_expr.clone()
                 };
 
                 if let Some(record_field) = ast::RecordExprField::for_field_name(&name) {
                     cov_mark::hit!(inline_field_shorthand);
-                    let replacement = editor.make().record_expr_field(name, Some(replacement));
+                    let replacement = make.record_expr_field(name, Some(replacement));
                     editor.replace(record_field.syntax(), replacement.syntax());
                 } else {
                     editor.replace(name.syntax(), replacement.syntax());
@@ -200,7 +201,7 @@ fn inline_usage(
     Some(InlineData { let_stmt, delete_let, target: ast::NameOrNameRef::NameRef(name), references })
 }
 
-fn remove_whitespace(elem: impl Element, dir: Direction, editor: &mut SyntaxEditor) {
+fn remove_whitespace(elem: impl Element, dir: Direction, editor: &SyntaxEditor) {
     let token = match elem.syntax_element() {
         syntax::NodeOrToken::Node(node) => match dir {
             Direction::Next => node.last_token(),

--- a/crates/ide-assists/src/handlers/inline_type_alias.rs
+++ b/crates/ide-assists/src/handlers/inline_type_alias.rs
@@ -368,8 +368,7 @@ fn create_replacement(
             };
             let new_string = replacement_syntax.to_string();
             let new = if new_string == "_" {
-                let make = SyntaxFactory::without_mappings();
-                make.wildcard_pat().syntax().clone()
+                editor.make().wildcard_pat().syntax().clone()
             } else {
                 replacement_syntax.clone()
             };

--- a/crates/ide-assists/src/handlers/inline_type_alias.rs
+++ b/crates/ide-assists/src/handlers/inline_type_alias.rs
@@ -70,7 +70,7 @@ pub(crate) fn inline_type_alias_uses(acc: &mut Assists, ctx: &AssistContext<'_>)
 
             let mut inline_refs_for_file = |file_id, refs: Vec<FileReference>| {
                 let source = ctx.sema.parse(file_id);
-                let mut editor = builder.make_editor(source.syntax());
+                let editor = builder.make_editor(source.syntax());
 
                 let (path_types, path_type_uses) =
                     split_refs_and_uses(builder, refs, |path_type| {
@@ -101,7 +101,7 @@ pub(crate) fn inline_type_alias_uses(acc: &mut Assists, ctx: &AssistContext<'_>)
                 inline_refs_for_file(file_id, refs);
             }
             if !definition_deleted {
-                let mut editor = builder.make_editor(ast_alias.syntax());
+                let editor = builder.make_editor(ast_alias.syntax());
                 editor.delete(ast_alias.syntax());
                 builder.add_file_edits(ctx.vfs_file_id(), editor)
             }
@@ -156,7 +156,7 @@ pub(crate) fn inline_type_alias(acc: &mut Assists, ctx: &AssistContext<'_>) -> O
         "Inline type alias",
         alias_instance.syntax().text_range(),
         |builder| {
-            let mut editor = builder.make_editor(alias_instance.syntax());
+            let editor = builder.make_editor(alias_instance.syntax());
             let replace = replacement.replace_generic(&concrete_type);
             editor.replace(alias_instance.syntax(), replace);
             builder.add_file_edits(ctx.vfs_file_id(), editor);
@@ -312,8 +312,8 @@ fn create_replacement(
     const_and_type_map: &ConstAndTypeMap,
     concrete_type: &ast::Type,
 ) -> SyntaxNode {
-    let (mut editor, updated_concrete_type) = SyntaxEditor::new(concrete_type.syntax().clone());
-
+    let (editor, updated_concrete_type) = SyntaxEditor::new(concrete_type.syntax().clone());
+    let make = editor.make();
     let mut replacements: Vec<(SyntaxNode, SyntaxNode)> = Vec::new();
     let mut removals: Vec<NodeOrToken<SyntaxNode, _>> = Vec::new();
 
@@ -368,7 +368,7 @@ fn create_replacement(
             };
             let new_string = replacement_syntax.to_string();
             let new = if new_string == "_" {
-                editor.make().wildcard_pat().syntax().clone()
+                make.wildcard_pat().syntax().clone()
             } else {
                 replacement_syntax.clone()
             };

--- a/crates/ide-assists/src/handlers/introduce_named_lifetime.rs
+++ b/crates/ide-assists/src/handlers/introduce_named_lifetime.rs
@@ -97,22 +97,23 @@ fn generate_fn_def_assist(
     };
 
     acc.add(AssistId::refactor(ASSIST_NAME), ASSIST_LABEL, lifetime_loc, |edit| {
-        let mut editor = edit.make_editor(fn_def.syntax());
+        let editor = edit.make_editor(fn_def.syntax());
+        let make = editor.make();
 
         if let Some(generic_list) = fn_def.generic_param_list() {
-            insert_lifetime_param(&mut editor, &generic_list, &new_lifetime_name);
+            insert_lifetime_param(&editor, &generic_list, &new_lifetime_name);
         } else {
-            insert_new_generic_param_list_fn(&mut editor, &fn_def, &new_lifetime_name);
+            insert_new_generic_param_list_fn(&editor, &fn_def, &new_lifetime_name);
         }
 
-        editor.replace(lifetime.syntax(), editor.make().lifetime(&new_lifetime_name).syntax());
+        editor.replace(lifetime.syntax(), make.lifetime(&new_lifetime_name).syntax());
 
         if let Some(pos) = loc_needing_lifetime.and_then(|l| l.to_position()) {
             editor.insert_all(
                 pos,
                 vec![
-                    editor.make().lifetime(&new_lifetime_name).syntax().clone().into(),
-                    editor.make().whitespace(" ").into(),
+                    make.lifetime(&new_lifetime_name).syntax().clone().into(),
+                    make.whitespace(" ").into(),
                 ],
             );
         }
@@ -122,18 +123,19 @@ fn generate_fn_def_assist(
 }
 
 fn insert_new_generic_param_list_fn(
-    editor: &mut SyntaxEditor,
+    editor: &SyntaxEditor,
     fn_def: &ast::Fn,
     lifetime_name: &str,
 ) -> Option<()> {
+    let make = editor.make();
     let name = fn_def.name()?;
 
     editor.insert_all(
         Position::after(name.syntax()),
         vec![
-            editor.make().token(T![<]).syntax_element(),
-            editor.make().lifetime(lifetime_name).syntax().syntax_element(),
-            editor.make().token(T![>]).syntax_element(),
+            make.token(T![<]).syntax_element(),
+            make.lifetime(lifetime_name).syntax().syntax_element(),
+            make.token(T![>]).syntax_element(),
         ],
     );
 
@@ -164,33 +166,35 @@ fn generate_impl_def_assist(
     let new_lifetime_name = generate_unique_lifetime_param_name(impl_def.generic_param_list())?;
 
     acc.add(AssistId::refactor(ASSIST_NAME), ASSIST_LABEL, lifetime_loc, |edit| {
-        let mut editor = edit.make_editor(impl_def.syntax());
+        let editor = edit.make_editor(impl_def.syntax());
+        let make = editor.make();
 
         if let Some(generic_list) = impl_def.generic_param_list() {
-            insert_lifetime_param(&mut editor, &generic_list, &new_lifetime_name);
+            insert_lifetime_param(&editor, &generic_list, &new_lifetime_name);
         } else {
-            insert_new_generic_param_list_imp(&mut editor, &impl_def, &new_lifetime_name);
+            insert_new_generic_param_list_imp(&editor, &impl_def, &new_lifetime_name);
         }
 
-        editor.replace(lifetime.syntax(), editor.make().lifetime(&new_lifetime_name).syntax());
+        editor.replace(lifetime.syntax(), make.lifetime(&new_lifetime_name).syntax());
 
         edit.add_file_edits(file_id, editor);
     })
 }
 
 fn insert_new_generic_param_list_imp(
-    editor: &mut SyntaxEditor,
+    editor: &SyntaxEditor,
     impl_: &ast::Impl,
     lifetime_name: &str,
 ) -> Option<()> {
+    let make = editor.make();
     let impl_kw = impl_.impl_token()?;
 
     editor.insert_all(
         Position::after(impl_kw),
         vec![
-            editor.make().token(T![<]).syntax_element(),
-            editor.make().lifetime(lifetime_name).syntax().syntax_element(),
-            editor.make().token(T![>]).syntax_element(),
+            make.token(T![<]).syntax_element(),
+            make.lifetime(lifetime_name).syntax().syntax_element(),
+            make.token(T![>]).syntax_element(),
         ],
     );
 
@@ -198,21 +202,22 @@ fn insert_new_generic_param_list_imp(
 }
 
 fn insert_lifetime_param(
-    editor: &mut SyntaxEditor,
+    editor: &SyntaxEditor,
     generic_list: &ast::GenericParamList,
     lifetime_name: &str,
 ) -> Option<()> {
+    let make = editor.make();
     let r_angle = generic_list.r_angle_token()?;
     let needs_comma = generic_list.generic_params().next().is_some();
 
     let mut elements = Vec::new();
 
     if needs_comma {
-        elements.push(editor.make().token(T![,]).syntax_element());
-        elements.push(editor.make().whitespace(" ").syntax_element());
+        elements.push(make.token(T![,]).syntax_element());
+        elements.push(make.whitespace(" ").syntax_element());
     }
 
-    let lifetime = editor.make().lifetime(lifetime_name);
+    let lifetime = make.lifetime(lifetime_name);
     elements.push(lifetime.syntax().clone().into());
 
     editor.insert_all(Position::before(r_angle), elements);

--- a/crates/ide-assists/src/handlers/introduce_named_lifetime.rs
+++ b/crates/ide-assists/src/handlers/introduce_named_lifetime.rs
@@ -1,7 +1,7 @@
 use ide_db::{FileId, FxHashSet};
 use syntax::{
     AstNode, SmolStr, T, TextRange, ToSmolStr,
-    ast::{self, HasGenericParams, HasName, syntax_factory::SyntaxFactory},
+    ast::{self, HasGenericParams, HasName},
     format_smolstr,
     syntax_editor::{Element, Position, SyntaxEditor},
 };
@@ -98,22 +98,21 @@ fn generate_fn_def_assist(
 
     acc.add(AssistId::refactor(ASSIST_NAME), ASSIST_LABEL, lifetime_loc, |edit| {
         let mut editor = edit.make_editor(fn_def.syntax());
-        let factory = SyntaxFactory::with_mappings();
 
         if let Some(generic_list) = fn_def.generic_param_list() {
-            insert_lifetime_param(&mut editor, &factory, &generic_list, &new_lifetime_name);
+            insert_lifetime_param(&mut editor, &generic_list, &new_lifetime_name);
         } else {
-            insert_new_generic_param_list_fn(&mut editor, &factory, &fn_def, &new_lifetime_name);
+            insert_new_generic_param_list_fn(&mut editor, &fn_def, &new_lifetime_name);
         }
 
-        editor.replace(lifetime.syntax(), factory.lifetime(&new_lifetime_name).syntax());
+        editor.replace(lifetime.syntax(), editor.make().lifetime(&new_lifetime_name).syntax());
 
         if let Some(pos) = loc_needing_lifetime.and_then(|l| l.to_position()) {
             editor.insert_all(
                 pos,
                 vec![
-                    factory.lifetime(&new_lifetime_name).syntax().clone().into(),
-                    factory.whitespace(" ").into(),
+                    editor.make().lifetime(&new_lifetime_name).syntax().clone().into(),
+                    editor.make().whitespace(" ").into(),
                 ],
             );
         }
@@ -124,7 +123,6 @@ fn generate_fn_def_assist(
 
 fn insert_new_generic_param_list_fn(
     editor: &mut SyntaxEditor,
-    factory: &SyntaxFactory,
     fn_def: &ast::Fn,
     lifetime_name: &str,
 ) -> Option<()> {
@@ -133,9 +131,9 @@ fn insert_new_generic_param_list_fn(
     editor.insert_all(
         Position::after(name.syntax()),
         vec![
-            factory.token(T![<]).syntax_element(),
-            factory.lifetime(lifetime_name).syntax().syntax_element(),
-            factory.token(T![>]).syntax_element(),
+            editor.make().token(T![<]).syntax_element(),
+            editor.make().lifetime(lifetime_name).syntax().syntax_element(),
+            editor.make().token(T![>]).syntax_element(),
         ],
     );
 
@@ -167,15 +165,14 @@ fn generate_impl_def_assist(
 
     acc.add(AssistId::refactor(ASSIST_NAME), ASSIST_LABEL, lifetime_loc, |edit| {
         let mut editor = edit.make_editor(impl_def.syntax());
-        let factory = SyntaxFactory::without_mappings();
 
         if let Some(generic_list) = impl_def.generic_param_list() {
-            insert_lifetime_param(&mut editor, &factory, &generic_list, &new_lifetime_name);
+            insert_lifetime_param(&mut editor, &generic_list, &new_lifetime_name);
         } else {
-            insert_new_generic_param_list_imp(&mut editor, &factory, &impl_def, &new_lifetime_name);
+            insert_new_generic_param_list_imp(&mut editor, &impl_def, &new_lifetime_name);
         }
 
-        editor.replace(lifetime.syntax(), factory.lifetime(&new_lifetime_name).syntax());
+        editor.replace(lifetime.syntax(), editor.make().lifetime(&new_lifetime_name).syntax());
 
         edit.add_file_edits(file_id, editor);
     })
@@ -183,7 +180,6 @@ fn generate_impl_def_assist(
 
 fn insert_new_generic_param_list_imp(
     editor: &mut SyntaxEditor,
-    factory: &SyntaxFactory,
     impl_: &ast::Impl,
     lifetime_name: &str,
 ) -> Option<()> {
@@ -192,9 +188,9 @@ fn insert_new_generic_param_list_imp(
     editor.insert_all(
         Position::after(impl_kw),
         vec![
-            factory.token(T![<]).syntax_element(),
-            factory.lifetime(lifetime_name).syntax().syntax_element(),
-            factory.token(T![>]).syntax_element(),
+            editor.make().token(T![<]).syntax_element(),
+            editor.make().lifetime(lifetime_name).syntax().syntax_element(),
+            editor.make().token(T![>]).syntax_element(),
         ],
     );
 
@@ -203,7 +199,6 @@ fn insert_new_generic_param_list_imp(
 
 fn insert_lifetime_param(
     editor: &mut SyntaxEditor,
-    factory: &SyntaxFactory,
     generic_list: &ast::GenericParamList,
     lifetime_name: &str,
 ) -> Option<()> {
@@ -213,11 +208,11 @@ fn insert_lifetime_param(
     let mut elements = Vec::new();
 
     if needs_comma {
-        elements.push(factory.token(T![,]).syntax_element());
-        elements.push(factory.whitespace(" ").syntax_element());
+        elements.push(editor.make().token(T![,]).syntax_element());
+        elements.push(editor.make().whitespace(" ").syntax_element());
     }
 
-    let lifetime = factory.lifetime(lifetime_name);
+    let lifetime = editor.make().lifetime(lifetime_name);
     elements.push(lifetime.syntax().clone().into());
 
     editor.insert_all(Position::before(r_angle), elements);

--- a/crates/ide-assists/src/handlers/introduce_named_type_parameter.rs
+++ b/crates/ide-assists/src/handlers/introduce_named_type_parameter.rs
@@ -30,7 +30,8 @@ pub(crate) fn introduce_named_type_parameter(
         "Replace impl trait with type parameter",
         target,
         |builder| {
-            let mut editor = builder.make_editor(fn_.syntax());
+            let editor = builder.make_editor(fn_.syntax());
+            let make = editor.make();
 
             let existing_names = match fn_.generic_param_list() {
                 Some(generic_param_list) => generic_param_list
@@ -47,10 +48,8 @@ pub(crate) fn introduce_named_type_parameter(
             )
             .for_impl_trait_as_generic(&impl_trait_type);
 
-            let type_param = editor
-                .make()
-                .type_param(editor.make().name(&type_param_name), Some(type_bound_list));
-            let new_ty = editor.make().ty(&type_param_name);
+            let type_param = make.type_param(make.name(&type_param_name), Some(type_bound_list));
+            let new_ty = make.ty(&type_param_name);
 
             editor.replace(impl_trait_type.syntax(), new_ty.syntax());
             editor.add_generic_param(&fn_, type_param.clone().into());

--- a/crates/ide-assists/src/handlers/introduce_named_type_parameter.rs
+++ b/crates/ide-assists/src/handlers/introduce_named_type_parameter.rs
@@ -1,6 +1,6 @@
 use ide_db::syntax_helpers::suggest_name;
 use itertools::Itertools;
-use syntax::ast::{self, AstNode, HasGenericParams, HasName, syntax_factory::SyntaxFactory};
+use syntax::ast::{self, AstNode, HasGenericParams, HasName};
 
 use crate::{AssistContext, AssistId, Assists};
 
@@ -24,7 +24,6 @@ pub(crate) fn introduce_named_type_parameter(
     let fn_ = param.syntax().ancestors().nth(2).and_then(ast::Fn::cast)?;
     let type_bound_list = impl_trait_type.type_bound_list()?;
 
-    let make = SyntaxFactory::with_mappings();
     let target = fn_.syntax().text_range();
     acc.add(
         AssistId::refactor_rewrite("introduce_named_type_parameter"),
@@ -48,8 +47,10 @@ pub(crate) fn introduce_named_type_parameter(
             )
             .for_impl_trait_as_generic(&impl_trait_type);
 
-            let type_param = make.type_param(make.name(&type_param_name), Some(type_bound_list));
-            let new_ty = make.ty(&type_param_name);
+            let type_param = editor
+                .make()
+                .type_param(editor.make().name(&type_param_name), Some(type_bound_list));
+            let new_ty = editor.make().ty(&type_param_name);
 
             editor.replace(impl_trait_type.syntax(), new_ty.syntax());
             editor.add_generic_param(&fn_, type_param.clone().into());
@@ -58,7 +59,6 @@ pub(crate) fn introduce_named_type_parameter(
                 editor.add_annotation(type_param.syntax(), builder.make_tabstop_before(cap));
             }
 
-            editor.add_mappings(make.finish_with_mappings());
             builder.add_file_edits(ctx.vfs_file_id(), editor);
         },
     )

--- a/crates/ide-assists/src/handlers/merge_imports.rs
+++ b/crates/ide-assists/src/handlers/merge_imports.rs
@@ -72,16 +72,16 @@ pub(crate) fn merge_imports(acc: &mut Assists, ctx: &AssistContext<'_>) -> Optio
     };
 
     acc.add(AssistId::refactor_rewrite("merge_imports"), "Merge imports", target, |builder| {
-        let mut editor = builder.make_editor(&parent_node);
+        let editor = builder.make_editor(&parent_node);
 
         for edit in edits {
             match edit {
                 Remove(it) => {
                     let node = it.as_ref();
                     if let Some(left) = node.left() {
-                        left.remove(&mut editor);
+                        left.remove(&editor);
                     } else if let Some(right) = node.right() {
-                        right.remove(&mut editor);
+                        right.remove(&editor);
                     }
                 }
                 Replace(old, new) => {

--- a/crates/ide-assists/src/handlers/merge_imports.rs
+++ b/crates/ide-assists/src/handlers/merge_imports.rs
@@ -4,11 +4,7 @@ use ide_db::imports::{
     merge_imports::{MergeBehavior, try_merge_imports, try_merge_trees},
 };
 use syntax::{
-    AstNode, SyntaxElement, SyntaxNode,
-    algo::neighbor,
-    ast::{self, syntax_factory::SyntaxFactory},
-    match_ast,
-    syntax_editor::Removable,
+    AstNode, SyntaxElement, SyntaxNode, algo::neighbor, ast, match_ast, syntax_editor::Removable,
 };
 
 use crate::{
@@ -76,7 +72,6 @@ pub(crate) fn merge_imports(acc: &mut Assists, ctx: &AssistContext<'_>) -> Optio
     };
 
     acc.add(AssistId::refactor_rewrite("merge_imports"), "Merge imports", target, |builder| {
-        let make = SyntaxFactory::with_mappings();
         let mut editor = builder.make_editor(&parent_node);
 
         for edit in edits {
@@ -94,7 +89,6 @@ pub(crate) fn merge_imports(acc: &mut Assists, ctx: &AssistContext<'_>) -> Optio
                 }
             }
         }
-        editor.add_mappings(make.finish_with_mappings());
         builder.add_file_edits(ctx.vfs_file_id(), editor);
     })
 }

--- a/crates/ide-assists/src/handlers/move_bounds.rs
+++ b/crates/ide-assists/src/handlers/move_bounds.rs
@@ -46,21 +46,20 @@ pub(crate) fn move_bounds_to_where_clause(
         target,
         |builder| {
             let mut edit = builder.make_editor(&parent);
-            let make = SyntaxFactory::without_mappings();
 
             let new_preds: Vec<ast::WherePred> = type_param_list
                 .generic_params()
-                .filter_map(|param| build_predicate(param, &make))
+                .filter_map(|param| build_predicate(param, edit.make()))
                 .collect();
 
             match_ast! {
                 match (&parent) {
-                    ast::Fn(it) => it.get_or_create_where_clause(&mut edit, &make, new_preds.into_iter()),
-                    ast::Trait(it) => it.get_or_create_where_clause(&mut edit, &make, new_preds.into_iter()),
-                    ast::Impl(it) => it.get_or_create_where_clause(&mut edit, &make, new_preds.into_iter()),
-                    ast::Enum(it) => it.get_or_create_where_clause(&mut edit, &make, new_preds.into_iter()),
-                    ast::Struct(it) => it.get_or_create_where_clause(&mut edit, &make, new_preds.into_iter()),
-                    ast::TypeAlias(it) => it.get_or_create_where_clause(&mut edit, &make, new_preds.into_iter()),
+                    ast::Fn(it) => it.get_or_create_where_clause(&mut edit, new_preds.into_iter()),
+                    ast::Trait(it) => it.get_or_create_where_clause(&mut edit, new_preds.into_iter()),
+                    ast::Impl(it) => it.get_or_create_where_clause(&mut edit, new_preds.into_iter()),
+                    ast::Enum(it) => it.get_or_create_where_clause(&mut edit, new_preds.into_iter()),
+                    ast::Struct(it) => it.get_or_create_where_clause(&mut edit, new_preds.into_iter()),
+                    ast::TypeAlias(it) => it.get_or_create_where_clause(&mut edit, new_preds.into_iter()),
                     _ => return,
                 }
             };

--- a/crates/ide-assists/src/handlers/move_bounds.rs
+++ b/crates/ide-assists/src/handlers/move_bounds.rs
@@ -45,21 +45,21 @@ pub(crate) fn move_bounds_to_where_clause(
         "Move to where clause",
         target,
         |builder| {
-            let mut edit = builder.make_editor(&parent);
+            let editor = builder.make_editor(&parent);
 
             let new_preds: Vec<ast::WherePred> = type_param_list
                 .generic_params()
-                .filter_map(|param| build_predicate(param, edit.make()))
+                .filter_map(|param| build_predicate(param, editor.make()))
                 .collect();
 
             match_ast! {
                 match (&parent) {
-                    ast::Fn(it) => it.get_or_create_where_clause(&mut edit, new_preds.into_iter()),
-                    ast::Trait(it) => it.get_or_create_where_clause(&mut edit, new_preds.into_iter()),
-                    ast::Impl(it) => it.get_or_create_where_clause(&mut edit, new_preds.into_iter()),
-                    ast::Enum(it) => it.get_or_create_where_clause(&mut edit, new_preds.into_iter()),
-                    ast::Struct(it) => it.get_or_create_where_clause(&mut edit, new_preds.into_iter()),
-                    ast::TypeAlias(it) => it.get_or_create_where_clause(&mut edit, new_preds.into_iter()),
+                    ast::Fn(it) => it.get_or_create_where_clause(&editor, new_preds.into_iter()),
+                    ast::Trait(it) => it.get_or_create_where_clause(&editor, new_preds.into_iter()),
+                    ast::Impl(it) => it.get_or_create_where_clause(&editor, new_preds.into_iter()),
+                    ast::Enum(it) => it.get_or_create_where_clause(&editor, new_preds.into_iter()),
+                    ast::Struct(it) => it.get_or_create_where_clause(&editor, new_preds.into_iter()),
+                    ast::TypeAlias(it) => it.get_or_create_where_clause(&editor, new_preds.into_iter()),
                     _ => return,
                 }
             };
@@ -71,11 +71,11 @@ pub(crate) fn move_bounds_to_where_clause(
                     ast::GenericParam::ConstParam(_) => continue,
                 };
                 if let Some(tbl) = param.type_bound_list() {
-                    tbl.remove(&mut edit);
+                    tbl.remove(&editor);
                 }
             }
 
-            builder.add_file_edits(ctx.vfs_file_id(), edit);
+            builder.add_file_edits(ctx.vfs_file_id(), editor);
         },
     )
 }

--- a/crates/ide-assists/src/handlers/move_guard.rs
+++ b/crates/ide-assists/src/handlers/move_guard.rs
@@ -156,7 +156,7 @@ pub(crate) fn move_arm_cond_to_match_guard(
         "Move condition to match guard",
         replace_node.text_range(),
         |builder| {
-            let make = SyntaxFactory::without_mappings();
+            let mut editor = builder.make_editor(match_arm.syntax());
             let mut replace_arms = vec![];
 
             // Dedent if if_expr is in a BlockExpr
@@ -175,17 +175,17 @@ pub(crate) fn move_arm_cond_to_match_guard(
                     (Some(lhs), Some(rhs)) => {
                         let op_expr = |expr: Expr| {
                             if expr.precedence().needs_parentheses_in(ExprPrecedence::LAnd) {
-                                make.expr_paren(expr).into()
+                                editor.make().expr_paren(expr).into()
                             } else {
                                 expr
                             }
                         };
                         let op = syntax::ast::BinaryOp::LogicOp(syntax::ast::LogicOp::And);
-                        let expr_bin = make.expr_bin(op_expr(lhs), op, op_expr(rhs));
+                        let expr_bin = editor.make().expr_bin(op_expr(lhs), op, op_expr(rhs));
                         expr_bin.into()
                     }
                 };
-                Some(make.match_guard(condition))
+                Some(editor.make().match_guard(condition))
             };
 
             for (cond, block) in conds_blocks {
@@ -194,7 +194,8 @@ pub(crate) fn move_arm_cond_to_match_guard(
                     Some(then_expr) if only_expr => then_expr,
                     _ => block.dedent(dedent.into()).into(),
                 };
-                let new_arm = make.match_arm(match_pat.clone(), make_guard(Some(cond)), expr);
+                let new_arm =
+                    editor.make().match_arm(match_pat.clone(), make_guard(Some(cond)), expr);
                 replace_arms.push(new_arm);
             }
             if let Some(block) = tail {
@@ -207,7 +208,7 @@ pub(crate) fn move_arm_cond_to_match_guard(
                     }
                     _ => block.dedent(dedent.into()).into(),
                 };
-                let new_arm = make.match_arm(match_pat, make_guard(None), expr);
+                let new_arm = editor.make().match_arm(match_pat, make_guard(None), expr);
                 replace_arms.push(new_arm);
             } else {
                 // There's no else branch. Add a pattern without guard, unless the following match
@@ -221,20 +222,22 @@ pub(crate) fn move_arm_cond_to_match_guard(
                         cov_mark::hit!(move_guard_ifelse_has_wildcard);
                     }
                     _ => {
-                        let block_expr = make.expr_empty_block().into();
-                        replace_arms.push(make.match_arm(match_pat, make_guard(None), block_expr));
+                        let block_expr = editor.make().expr_empty_block().into();
+                        replace_arms.push(editor.make().match_arm(
+                            match_pat,
+                            make_guard(None),
+                            block_expr,
+                        ));
                     }
                 }
             }
 
-            let mut edit = builder.make_editor(match_arm.syntax());
-
-            let newline = make.whitespace(&format!("\n{indent_level}"));
+            let newline = editor.make().whitespace(&format!("\n{indent_level}"));
             let replace_arms = replace_arms.iter().map(|it| it.syntax().syntax_element());
             let replace_arms = Itertools::intersperse(replace_arms, newline.syntax_element());
-            edit.replace_with_many(match_arm.syntax(), replace_arms.collect());
+            editor.replace_with_many(match_arm.syntax(), replace_arms.collect());
 
-            builder.add_file_edits(ctx.vfs_file_id(), edit);
+            builder.add_file_edits(ctx.vfs_file_id(), editor);
         },
     )
 }

--- a/crates/ide-assists/src/handlers/move_guard.rs
+++ b/crates/ide-assists/src/handlers/move_guard.rs
@@ -73,24 +73,24 @@ pub(crate) fn move_guard_to_arm_body(acc: &mut Assists, ctx: &AssistContext<'_>)
         "Move guard to arm body",
         target,
         |builder| {
-            let mut edit = builder.make_editor(match_arm.syntax());
+            let editor = builder.make_editor(match_arm.syntax());
             for element in space_before_delete {
                 if element.kind() == WHITESPACE {
-                    edit.delete(element);
+                    editor.delete(element);
                 }
             }
             for rest_arm in &rest_arms {
-                edit.delete(rest_arm.syntax());
+                editor.delete(rest_arm.syntax());
             }
             if let Some(element) = space_after_arrow
                 && element.kind() == WHITESPACE
             {
-                edit.replace(element, make.whitespace(" "));
+                editor.replace(element, make.whitespace(" "));
             }
 
-            edit.delete(guard.syntax());
-            edit.replace(arm_expr.syntax(), if_expr.syntax());
-            builder.add_file_edits(ctx.vfs_file_id(), edit);
+            editor.delete(guard.syntax());
+            editor.replace(arm_expr.syntax(), if_expr.syntax());
+            builder.add_file_edits(ctx.vfs_file_id(), editor);
         },
     )
 }
@@ -156,7 +156,8 @@ pub(crate) fn move_arm_cond_to_match_guard(
         "Move condition to match guard",
         replace_node.text_range(),
         |builder| {
-            let mut editor = builder.make_editor(match_arm.syntax());
+            let editor = builder.make_editor(match_arm.syntax());
+            let make = editor.make();
             let mut replace_arms = vec![];
 
             // Dedent if if_expr is in a BlockExpr
@@ -175,17 +176,17 @@ pub(crate) fn move_arm_cond_to_match_guard(
                     (Some(lhs), Some(rhs)) => {
                         let op_expr = |expr: Expr| {
                             if expr.precedence().needs_parentheses_in(ExprPrecedence::LAnd) {
-                                editor.make().expr_paren(expr).into()
+                                make.expr_paren(expr).into()
                             } else {
                                 expr
                             }
                         };
                         let op = syntax::ast::BinaryOp::LogicOp(syntax::ast::LogicOp::And);
-                        let expr_bin = editor.make().expr_bin(op_expr(lhs), op, op_expr(rhs));
+                        let expr_bin = make.expr_bin(op_expr(lhs), op, op_expr(rhs));
                         expr_bin.into()
                     }
                 };
-                Some(editor.make().match_guard(condition))
+                Some(make.match_guard(condition))
             };
 
             for (cond, block) in conds_blocks {
@@ -194,8 +195,7 @@ pub(crate) fn move_arm_cond_to_match_guard(
                     Some(then_expr) if only_expr => then_expr,
                     _ => block.dedent(dedent.into()).into(),
                 };
-                let new_arm =
-                    editor.make().match_arm(match_pat.clone(), make_guard(Some(cond)), expr);
+                let new_arm = make.match_arm(match_pat.clone(), make_guard(Some(cond)), expr);
                 replace_arms.push(new_arm);
             }
             if let Some(block) = tail {
@@ -208,7 +208,7 @@ pub(crate) fn move_arm_cond_to_match_guard(
                     }
                     _ => block.dedent(dedent.into()).into(),
                 };
-                let new_arm = editor.make().match_arm(match_pat, make_guard(None), expr);
+                let new_arm = make.match_arm(match_pat, make_guard(None), expr);
                 replace_arms.push(new_arm);
             } else {
                 // There's no else branch. Add a pattern without guard, unless the following match
@@ -222,17 +222,13 @@ pub(crate) fn move_arm_cond_to_match_guard(
                         cov_mark::hit!(move_guard_ifelse_has_wildcard);
                     }
                     _ => {
-                        let block_expr = editor.make().expr_empty_block().into();
-                        replace_arms.push(editor.make().match_arm(
-                            match_pat,
-                            make_guard(None),
-                            block_expr,
-                        ));
+                        let block_expr = make.expr_empty_block().into();
+                        replace_arms.push(make.match_arm(match_pat, make_guard(None), block_expr));
                     }
                 }
             }
 
-            let newline = editor.make().whitespace(&format!("\n{indent_level}"));
+            let newline = make.whitespace(&format!("\n{indent_level}"));
             let replace_arms = replace_arms.iter().map(|it| it.syntax().syntax_element());
             let replace_arms = Itertools::intersperse(replace_arms, newline.syntax_element());
             editor.replace_with_many(match_arm.syntax(), replace_arms.collect());

--- a/crates/ide-assists/src/handlers/promote_local_to_const.rs
+++ b/crates/ide-assists/src/handlers/promote_local_to_const.rs
@@ -3,7 +3,7 @@ use ide_db::{assists::AssistId, defs::Definition};
 use stdx::to_upper_snake_case;
 use syntax::{
     AstNode,
-    ast::{self, HasName, syntax_factory::SyntaxFactory},
+    ast::{self, HasName},
 };
 
 use crate::{
@@ -68,18 +68,17 @@ pub(crate) fn promote_local_to_const(acc: &mut Assists, ctx: &AssistContext<'_>)
         "Promote local to constant",
         let_stmt.syntax().text_range(),
         |edit| {
-            let make = SyntaxFactory::with_mappings();
             let mut editor = edit.make_editor(let_stmt.syntax());
             let name = to_upper_snake_case(&name.to_string());
             let usages = Definition::Local(local).usages(&ctx.sema).all();
             if let Some(usages) = usages.references.get(&ctx.file_id()) {
-                let name_ref = make.name_ref(&name);
+                let name_ref = editor.make().name_ref(&name);
 
                 for usage in usages {
                     let Some(usage_name) = usage.name.as_name_ref().cloned() else { continue };
                     if let Some(record_field) = ast::RecordExprField::for_name_ref(&usage_name) {
-                        let path = make.ident_path(&name);
-                        let name_expr = make.expr_path(path);
+                        let path = editor.make().ident_path(&name);
+                        let name_expr = editor.make().expr_path(path);
                         utils::replace_record_field_expr(ctx, edit, record_field, name_expr);
                     } else {
                         let usage_range = usage.range;
@@ -88,7 +87,13 @@ pub(crate) fn promote_local_to_const(acc: &mut Assists, ctx: &AssistContext<'_>)
                 }
             }
 
-            let item = make.item_const(None, None, make.name(&name), make.ty(&ty), initializer);
+            let item = editor.make().item_const(
+                None,
+                None,
+                editor.make().name(&name),
+                editor.make().ty(&ty),
+                initializer,
+            );
 
             if let Some((cap, name)) = ctx.config.snippet_cap.zip(item.name()) {
                 let tabstop = edit.make_tabstop_before(cap);
@@ -97,7 +102,6 @@ pub(crate) fn promote_local_to_const(acc: &mut Assists, ctx: &AssistContext<'_>)
 
             editor.replace(let_stmt.syntax(), item.syntax());
 
-            editor.add_mappings(make.finish_with_mappings());
             edit.add_file_edits(ctx.vfs_file_id(), editor);
         },
     )

--- a/crates/ide-assists/src/handlers/promote_local_to_const.rs
+++ b/crates/ide-assists/src/handlers/promote_local_to_const.rs
@@ -68,17 +68,18 @@ pub(crate) fn promote_local_to_const(acc: &mut Assists, ctx: &AssistContext<'_>)
         "Promote local to constant",
         let_stmt.syntax().text_range(),
         |edit| {
-            let mut editor = edit.make_editor(let_stmt.syntax());
+            let editor = edit.make_editor(let_stmt.syntax());
+            let make = editor.make();
             let name = to_upper_snake_case(&name.to_string());
             let usages = Definition::Local(local).usages(&ctx.sema).all();
             if let Some(usages) = usages.references.get(&ctx.file_id()) {
-                let name_ref = editor.make().name_ref(&name);
+                let name_ref = make.name_ref(&name);
 
                 for usage in usages {
                     let Some(usage_name) = usage.name.as_name_ref().cloned() else { continue };
                     if let Some(record_field) = ast::RecordExprField::for_name_ref(&usage_name) {
-                        let path = editor.make().ident_path(&name);
-                        let name_expr = editor.make().expr_path(path);
+                        let path = make.ident_path(&name);
+                        let name_expr = make.expr_path(path);
                         utils::replace_record_field_expr(ctx, edit, record_field, name_expr);
                     } else {
                         let usage_range = usage.range;
@@ -87,13 +88,7 @@ pub(crate) fn promote_local_to_const(acc: &mut Assists, ctx: &AssistContext<'_>)
                 }
             }
 
-            let item = editor.make().item_const(
-                None,
-                None,
-                editor.make().name(&name),
-                editor.make().ty(&ty),
-                initializer,
-            );
+            let item = make.item_const(None, None, make.name(&name), make.ty(&ty), initializer);
 
             if let Some((cap, name)) = ctx.config.snippet_cap.zip(item.name()) {
                 let tabstop = edit.make_tabstop_before(cap);

--- a/crates/ide-assists/src/handlers/pull_assignment_up.rs
+++ b/crates/ide-assists/src/handlers/pull_assignment_up.rs
@@ -1,10 +1,5 @@
 use either::Either;
-use syntax::{
-    AstNode,
-    algo::find_node_at_range,
-    ast::{self, syntax_factory::SyntaxFactory},
-    syntax_editor::SyntaxEditor,
-};
+use syntax::{AstNode, algo::find_node_at_range, ast, syntax_editor::SyntaxEditor};
 
 use crate::{
     AssistId,
@@ -110,13 +105,11 @@ pub(crate) fn pull_assignment_up(acc: &mut Assists, ctx: &AssistContext<'_>) -> 
         "Pull assignment up",
         target,
         move |edit| {
-            let make = SyntaxFactory::with_mappings();
             let mut editor = edit.make_editor(tgt.syntax());
-            let assign_expr = make.expr_assignment(collector.common_lhs, new_tgt.clone());
-            let assign_stmt = make.expr_stmt(assign_expr.into());
+            let assign_expr = editor.make().expr_assignment(collector.common_lhs, new_tgt.clone());
+            let assign_stmt = editor.make().expr_stmt(assign_expr.into());
 
             editor.replace(tgt.syntax(), assign_stmt.syntax());
-            editor.add_mappings(make.finish_with_mappings());
             edit.add_file_edits(ctx.vfs_file_id(), editor);
         },
     )

--- a/crates/ide-assists/src/handlers/pull_assignment_up.rs
+++ b/crates/ide-assists/src/handlers/pull_assignment_up.rs
@@ -70,8 +70,7 @@ pub(crate) fn pull_assignment_up(acc: &mut Assists, ctx: &AssistContext<'_>) -> 
     }
     let target = tgt.syntax().text_range();
 
-    let (mut editor, edit_tgt) = SyntaxEditor::new(tgt.syntax().clone());
-
+    let (editor, edit_tgt) = SyntaxEditor::new(tgt.syntax().clone());
     let assignments: Vec<_> = collector
         .assignments
         .into_iter()
@@ -105,9 +104,10 @@ pub(crate) fn pull_assignment_up(acc: &mut Assists, ctx: &AssistContext<'_>) -> 
         "Pull assignment up",
         target,
         move |edit| {
-            let mut editor = edit.make_editor(tgt.syntax());
-            let assign_expr = editor.make().expr_assignment(collector.common_lhs, new_tgt.clone());
-            let assign_stmt = editor.make().expr_stmt(assign_expr.into());
+            let editor = edit.make_editor(tgt.syntax());
+            let make = editor.make();
+            let assign_expr = make.expr_assignment(collector.common_lhs, new_tgt.clone());
+            let assign_stmt = make.expr_stmt(assign_expr.into());
 
             editor.replace(tgt.syntax(), assign_stmt.syntax());
             edit.add_file_edits(ctx.vfs_file_id(), editor);

--- a/crates/ide-assists/src/handlers/qualify_method_call.rs
+++ b/crates/ide-assists/src/handlers/qualify_method_call.rs
@@ -59,14 +59,8 @@ pub(crate) fn qualify_method_call(acc: &mut Assists, ctx: &AssistContext<'_>) ->
         format!("Qualify `{ident}` method call"),
         range,
         |builder| {
-            let mut editor = builder.make_editor(call.syntax());
-            qualify_candidate.qualify(
-                |_| {},
-                &mut editor,
-                &receiver_path,
-                item_in_ns,
-                current_edition,
-            );
+            let editor = builder.make_editor(call.syntax());
+            qualify_candidate.qualify(|_| {}, &editor, &receiver_path, item_in_ns, current_edition);
             builder.add_file_edits(ctx.vfs_file_id(), editor);
         },
     );

--- a/crates/ide-assists/src/handlers/qualify_method_call.rs
+++ b/crates/ide-assists/src/handlers/qualify_method_call.rs
@@ -1,6 +1,6 @@
 use hir::{AsAssocItem, AssocItem, AssocItemContainer, ItemInNs, ModuleDef, db::HirDatabase};
 use ide_db::assists::AssistId;
-use syntax::{AstNode, ast, ast::syntax_factory::SyntaxFactory};
+use syntax::{AstNode, ast};
 
 use crate::{
     assist_context::{AssistContext, Assists},
@@ -59,17 +59,14 @@ pub(crate) fn qualify_method_call(acc: &mut Assists, ctx: &AssistContext<'_>) ->
         format!("Qualify `{ident}` method call"),
         range,
         |builder| {
-            let make = SyntaxFactory::with_mappings();
             let mut editor = builder.make_editor(call.syntax());
             qualify_candidate.qualify(
                 |_| {},
                 &mut editor,
-                &make,
                 &receiver_path,
                 item_in_ns,
                 current_edition,
             );
-            editor.add_mappings(make.finish_with_mappings());
             builder.add_file_edits(ctx.vfs_file_id(), editor);
         },
     );

--- a/crates/ide-assists/src/handlers/qualify_path.rs
+++ b/crates/ide-assists/src/handlers/qualify_path.rs
@@ -98,10 +98,10 @@ pub(crate) fn qualify_path(acc: &mut Assists, ctx: &AssistContext<'_>) -> Option
             label(ctx.db(), candidate, &import, current_edition),
             range,
             |builder| {
-                let mut editor = builder.make_editor(&syntax_under_caret);
+                let editor = builder.make_editor(&syntax_under_caret);
                 qualify_candidate.qualify(
                     |replace_with: String| builder.replace(range, replace_with),
-                    &mut editor,
+                    &editor,
                     &import.import_path,
                     import.item_to_import,
                     current_edition,
@@ -124,7 +124,7 @@ impl QualifyCandidate<'_> {
     pub(crate) fn qualify(
         &self,
         mut replacer: impl FnMut(String),
-        editor: &mut SyntaxEditor,
+        editor: &SyntaxEditor,
         import: &hir::ModPath,
         item: hir::ItemInNs,
         edition: Edition,
@@ -154,10 +154,11 @@ impl QualifyCandidate<'_> {
     fn qualify_fn_call(
         db: &RootDatabase,
         mcall_expr: &ast::MethodCallExpr,
-        editor: &mut SyntaxEditor,
+        editor: &SyntaxEditor,
         import: ast::Path,
         hir_fn: &hir::Function,
     ) -> Option<()> {
+        let make = editor.make();
         let receiver = mcall_expr.receiver()?;
         let method_name = mcall_expr.name_ref()?;
         let generics =
@@ -166,17 +167,16 @@ impl QualifyCandidate<'_> {
 
         if let Some(self_access) = hir_fn.self_param(db).map(|sp| sp.access(db)) {
             let receiver = match self_access {
-                hir::Access::Shared => editor.make().expr_ref(receiver, false),
-                hir::Access::Exclusive => editor.make().expr_ref(receiver, true),
+                hir::Access::Shared => make.expr_ref(receiver, false),
+                hir::Access::Exclusive => make.expr_ref(receiver, true),
                 hir::Access::Owned => receiver,
             };
             let arg_list = match arg_list {
-                Some(args) => editor.make().arg_list(iter::once(receiver).chain(args)),
-                None => editor.make().arg_list(iter::once(receiver)),
+                Some(args) => make.arg_list(iter::once(receiver).chain(args)),
+                None => make.arg_list(iter::once(receiver)),
             };
-            let call_path =
-                editor.make().path_from_text(&format!("{import}::{method_name}{generics}"));
-            let call_expr = editor.make().expr_call(editor.make().expr_path(call_path), arg_list);
+            let call_path = make.path_from_text(&format!("{import}::{method_name}{generics}"));
+            let call_expr = make.expr_call(make.expr_path(call_path), arg_list);
             editor.replace(mcall_expr.syntax(), call_expr.syntax());
         }
         Some(())
@@ -185,7 +185,7 @@ impl QualifyCandidate<'_> {
     fn qualify_trait_method(
         db: &RootDatabase,
         mcall_expr: &ast::MethodCallExpr,
-        editor: &mut SyntaxEditor,
+        editor: &SyntaxEditor,
         import: ast::Path,
         item: hir::ItemInNs,
     ) -> Option<()> {

--- a/crates/ide-assists/src/handlers/qualify_path.rs
+++ b/crates/ide-assists/src/handlers/qualify_path.rs
@@ -9,11 +9,7 @@ use ide_db::{
 };
 use syntax::Edition;
 use syntax::ast::HasGenericArgs;
-use syntax::{
-    AstNode, ast,
-    ast::{HasArgList, syntax_factory::SyntaxFactory},
-    syntax_editor::SyntaxEditor,
-};
+use syntax::{AstNode, ast, ast::HasArgList, syntax_editor::SyntaxEditor};
 
 use crate::{
     AssistId, GroupLabel,
@@ -102,17 +98,14 @@ pub(crate) fn qualify_path(acc: &mut Assists, ctx: &AssistContext<'_>) -> Option
             label(ctx.db(), candidate, &import, current_edition),
             range,
             |builder| {
-                let make = SyntaxFactory::with_mappings();
                 let mut editor = builder.make_editor(&syntax_under_caret);
                 qualify_candidate.qualify(
                     |replace_with: String| builder.replace(range, replace_with),
                     &mut editor,
-                    &make,
                     &import.import_path,
                     import.item_to_import,
                     current_edition,
                 );
-                editor.add_mappings(make.finish_with_mappings());
                 builder.add_file_edits(ctx.vfs_file_id(), editor);
             },
         );
@@ -132,7 +125,6 @@ impl QualifyCandidate<'_> {
         &self,
         mut replacer: impl FnMut(String),
         editor: &mut SyntaxEditor,
-        make: &SyntaxFactory,
         import: &hir::ModPath,
         item: hir::ItemInNs,
         edition: Edition,
@@ -151,10 +143,10 @@ impl QualifyCandidate<'_> {
                 replacer(format!("<{qualifier} as {import}>::{segment}"));
             }
             QualifyCandidate::TraitMethod(db, mcall_expr) => {
-                Self::qualify_trait_method(db, mcall_expr, editor, make, import, item);
+                Self::qualify_trait_method(db, mcall_expr, editor, import, item);
             }
             QualifyCandidate::ImplMethod(db, mcall_expr, hir_fn) => {
-                Self::qualify_fn_call(db, mcall_expr, editor, make, import, hir_fn);
+                Self::qualify_fn_call(db, mcall_expr, editor, import, hir_fn);
             }
         }
     }
@@ -163,7 +155,6 @@ impl QualifyCandidate<'_> {
         db: &RootDatabase,
         mcall_expr: &ast::MethodCallExpr,
         editor: &mut SyntaxEditor,
-        make: &SyntaxFactory,
         import: ast::Path,
         hir_fn: &hir::Function,
     ) -> Option<()> {
@@ -175,16 +166,17 @@ impl QualifyCandidate<'_> {
 
         if let Some(self_access) = hir_fn.self_param(db).map(|sp| sp.access(db)) {
             let receiver = match self_access {
-                hir::Access::Shared => make.expr_ref(receiver, false),
-                hir::Access::Exclusive => make.expr_ref(receiver, true),
+                hir::Access::Shared => editor.make().expr_ref(receiver, false),
+                hir::Access::Exclusive => editor.make().expr_ref(receiver, true),
                 hir::Access::Owned => receiver,
             };
             let arg_list = match arg_list {
-                Some(args) => make.arg_list(iter::once(receiver).chain(args)),
-                None => make.arg_list(iter::once(receiver)),
+                Some(args) => editor.make().arg_list(iter::once(receiver).chain(args)),
+                None => editor.make().arg_list(iter::once(receiver)),
             };
-            let call_path = make.path_from_text(&format!("{import}::{method_name}{generics}"));
-            let call_expr = make.expr_call(make.expr_path(call_path), arg_list);
+            let call_path =
+                editor.make().path_from_text(&format!("{import}::{method_name}{generics}"));
+            let call_expr = editor.make().expr_call(editor.make().expr_path(call_path), arg_list);
             editor.replace(mcall_expr.syntax(), call_expr.syntax());
         }
         Some(())
@@ -194,14 +186,13 @@ impl QualifyCandidate<'_> {
         db: &RootDatabase,
         mcall_expr: &ast::MethodCallExpr,
         editor: &mut SyntaxEditor,
-        make: &SyntaxFactory,
         import: ast::Path,
         item: hir::ItemInNs,
     ) -> Option<()> {
         let trait_method_name = mcall_expr.name_ref()?;
         let trait_ = item_as_trait(db, item)?;
         let method = find_trait_method(db, trait_, &trait_method_name)?;
-        Self::qualify_fn_call(db, mcall_expr, editor, make, import, &method)
+        Self::qualify_fn_call(db, mcall_expr, editor, import, &method)
     }
 }
 

--- a/crates/ide-assists/src/handlers/raw_string.rs
+++ b/crates/ide-assists/src/handlers/raw_string.rs
@@ -164,7 +164,7 @@ fn replace_literal(
 ) {
     let token = token.syntax();
     let node = token.parent().expect("no parent token");
-    let mut edit = builder.make_editor(&node);
+    let edit = builder.make_editor(&node);
     let new_literal = literal(new);
 
     edit.replace(token, mut_token(new_literal));

--- a/crates/ide-assists/src/handlers/remove_dbg.rs
+++ b/crates/ide-assists/src/handlers/remove_dbg.rs
@@ -47,7 +47,7 @@ pub(crate) fn remove_dbg(acc: &mut Assists, ctx: &AssistContext<'_>) -> Option<(
         .map(|t| t.text_range())
         .reduce(|acc, range| acc.cover(range))?;
     acc.add(AssistId::quick_fix("remove_dbg"), "Remove dbg!()", target, |builder| {
-        let mut editor = builder.make_editor(ctx.source_file().syntax());
+        let editor = builder.make_editor(ctx.source_file().syntax());
         for (range, expr) in replacements {
             if let Some(expr) = expr {
                 editor.insert(Position::before(range[0].clone()), expr.syntax());
@@ -209,7 +209,7 @@ fn replace_nested_dbgs(expanded: ast::Expr) -> ast::Expr {
         return replaced;
     }
 
-    let (mut editor, expanded) = SyntaxEditor::with_ast_node(&expanded);
+    let (editor, expanded) = SyntaxEditor::with_ast_node(&expanded);
     // We need to collect to avoid mutation during traversal.
     let macro_exprs: Vec<_> =
         expanded.syntax().descendants().filter_map(ast::MacroExpr::cast).collect();

--- a/crates/ide-assists/src/handlers/remove_else_branches.rs
+++ b/crates/ide-assists/src/handlers/remove_else_branches.rs
@@ -55,7 +55,7 @@ pub(crate) fn remove_else_branches(acc: &mut Assists, ctx: &AssistContext<'_>) -
         "Remove `else` branches",
         target,
         |builder| {
-            let mut editor = builder.make_editor(&else_token.parent().unwrap());
+            let editor = builder.make_editor(&else_token.parent().unwrap());
             match else_token.prev_token() {
                 Some(it) if it.kind() == SyntaxKind::WHITESPACE => editor.delete(it),
                 _ => (),

--- a/crates/ide-assists/src/handlers/remove_mut.rs
+++ b/crates/ide-assists/src/handlers/remove_mut.rs
@@ -22,7 +22,7 @@ pub(crate) fn remove_mut(acc: &mut Assists, ctx: &AssistContext<'_>) -> Option<(
 
     let target = mut_token.text_range();
     acc.add(AssistId::refactor("remove_mut"), "Remove `mut` keyword", target, |builder| {
-        let mut editor = builder.make_editor(&mut_token.parent().unwrap());
+        let editor = builder.make_editor(&mut_token.parent().unwrap());
         match mut_token.next_token() {
             Some(it) if it.kind() == SyntaxKind::WHITESPACE => editor.delete(it),
             _ => (),

--- a/crates/ide-assists/src/handlers/remove_parentheses.rs
+++ b/crates/ide-assists/src/handlers/remove_parentheses.rs
@@ -40,7 +40,8 @@ pub(crate) fn remove_parentheses(acc: &mut Assists, ctx: &AssistContext<'_>) -> 
         "Remove redundant parentheses",
         target,
         |builder| {
-            let mut editor = builder.make_editor(parens.syntax());
+            let editor = builder.make_editor(parens.syntax());
+            let make = editor.make();
             let prev_token = parens.syntax().first_token().and_then(|it| it.prev_token());
             let need_to_add_ws = match prev_token {
                 Some(it) => {
@@ -50,7 +51,7 @@ pub(crate) fn remove_parentheses(acc: &mut Assists, ctx: &AssistContext<'_>) -> 
                 None => false,
             };
             if need_to_add_ws {
-                editor.insert(Position::before(parens.syntax()), editor.make().whitespace(" "));
+                editor.insert(Position::before(parens.syntax()), make.whitespace(" "));
             }
             editor.replace(parens.syntax(), expr.syntax());
             builder.add_file_edits(ctx.vfs_file_id(), editor);

--- a/crates/ide-assists/src/handlers/remove_parentheses.rs
+++ b/crates/ide-assists/src/handlers/remove_parentheses.rs
@@ -1,8 +1,4 @@
-use syntax::{
-    AstNode, SyntaxKind, T,
-    ast::{self, syntax_factory::SyntaxFactory},
-    syntax_editor::Position,
-};
+use syntax::{AstNode, SyntaxKind, T, ast, syntax_editor::Position};
 
 use crate::{AssistContext, AssistId, Assists};
 
@@ -54,9 +50,7 @@ pub(crate) fn remove_parentheses(acc: &mut Assists, ctx: &AssistContext<'_>) -> 
                 None => false,
             };
             if need_to_add_ws {
-                let make = SyntaxFactory::with_mappings();
-                editor.insert(Position::before(parens.syntax()), make.whitespace(" "));
-                editor.add_mappings(make.finish_with_mappings());
+                editor.insert(Position::before(parens.syntax()), editor.make().whitespace(" "));
             }
             editor.replace(parens.syntax(), expr.syntax());
             builder.add_file_edits(ctx.vfs_file_id(), editor);

--- a/crates/ide-assists/src/handlers/remove_unused_param.rs
+++ b/crates/ide-assists/src/handlers/remove_unused_param.rs
@@ -80,7 +80,7 @@ pub(crate) fn remove_unused_param(acc: &mut Assists, ctx: &AssistContext<'_>) ->
         "Remove unused parameter",
         param.syntax().text_range(),
         |builder| {
-            let mut editor = builder.make_editor(&parent);
+            let editor = builder.make_editor(&parent);
             let elements = elements_to_remove(param.syntax());
             for element in elements {
                 editor.delete(element);
@@ -116,7 +116,7 @@ fn process_usages(
         else {
             continue;
         };
-        let mut editor = builder.make_editor(&parent);
+        let editor = builder.make_editor(&parent);
         for element in element_range {
             editor.delete(element);
         }

--- a/crates/ide-assists/src/handlers/reorder_fields.rs
+++ b/crates/ide-assists/src/handlers/reorder_fields.rs
@@ -71,14 +71,12 @@ pub(crate) fn reorder_fields(acc: &mut Assists, ctx: &AssistContext<'_>) -> Opti
         "Reorder record fields",
         target,
         |builder| {
-            let mut editor = builder.make_editor(&parent_node);
+            let editor = builder.make_editor(&parent_node);
 
             match fields {
-                Either::Left((sorted, field_list)) => {
-                    replace(&mut editor, field_list.fields(), sorted)
-                }
+                Either::Left((sorted, field_list)) => replace(&editor, field_list.fields(), sorted),
                 Either::Right((sorted, field_list)) => {
-                    replace(&mut editor, field_list.fields(), sorted)
+                    replace(&editor, field_list.fields(), sorted)
                 }
             }
 
@@ -88,7 +86,7 @@ pub(crate) fn reorder_fields(acc: &mut Assists, ctx: &AssistContext<'_>) -> Opti
 }
 
 fn replace<T: AstNode + PartialEq>(
-    editor: &mut SyntaxEditor,
+    editor: &SyntaxEditor,
     fields: impl Iterator<Item = T>,
     sorted_fields: impl IntoIterator<Item = T>,
 ) {

--- a/crates/ide-assists/src/handlers/reorder_impl_items.rs
+++ b/crates/ide-assists/src/handlers/reorder_impl_items.rs
@@ -99,7 +99,7 @@ pub(crate) fn reorder_impl_items(acc: &mut Assists, ctx: &AssistContext<'_>) -> 
         "Sort items by trait definition",
         target,
         |builder| {
-            let mut editor = builder.make_editor(&parent_node);
+            let editor = builder.make_editor(&parent_node);
 
             assoc_items
                 .into_iter()

--- a/crates/ide-assists/src/handlers/replace_arith_op.rs
+++ b/crates/ide-assists/src/handlers/replace_arith_op.rs
@@ -83,18 +83,15 @@ fn replace_arith(acc: &mut Assists, ctx: &AssistContext<'_>, kind: ArithKind) ->
         kind.label(),
         op_expr.text_range(),
         |builder| {
-            let mut editor = builder.make_editor(rhs.syntax());
+            let editor = builder.make_editor(rhs.syntax());
+            let make = editor.make();
             let method_name = kind.method_name(op);
 
             let needs_parentheses =
                 lhs.precedence().needs_parentheses_in(ast::prec::ExprPrecedence::Postfix);
-            let receiver =
-                if needs_parentheses { editor.make().expr_paren(lhs).into() } else { lhs };
-            let arith_expr = editor.make().expr_method_call(
-                receiver,
-                editor.make().name_ref(&method_name),
-                editor.make().arg_list([rhs]),
-            );
+            let receiver = if needs_parentheses { make.expr_paren(lhs).into() } else { lhs };
+            let arith_expr =
+                make.expr_method_call(receiver, make.name_ref(&method_name), make.arg_list([rhs]));
             editor.replace(op_expr, arith_expr.syntax());
             builder.add_file_edits(ctx.vfs_file_id(), editor);
         },

--- a/crates/ide-assists/src/handlers/replace_arith_op.rs
+++ b/crates/ide-assists/src/handlers/replace_arith_op.rs
@@ -1,7 +1,7 @@
 use ide_db::assists::{AssistId, GroupLabel};
 use syntax::{
     AstNode,
-    ast::{self, ArithOp, BinaryOp, syntax_factory::SyntaxFactory},
+    ast::{self, ArithOp, BinaryOp},
 };
 
 use crate::assist_context::{AssistContext, Assists};
@@ -83,19 +83,20 @@ fn replace_arith(acc: &mut Assists, ctx: &AssistContext<'_>, kind: ArithKind) ->
         kind.label(),
         op_expr.text_range(),
         |builder| {
-            let mut edit = builder.make_editor(rhs.syntax());
-            let make = SyntaxFactory::with_mappings();
+            let mut editor = builder.make_editor(rhs.syntax());
             let method_name = kind.method_name(op);
 
             let needs_parentheses =
                 lhs.precedence().needs_parentheses_in(ast::prec::ExprPrecedence::Postfix);
-            let receiver = if needs_parentheses { make.expr_paren(lhs).into() } else { lhs };
-            let arith_expr =
-                make.expr_method_call(receiver, make.name_ref(&method_name), make.arg_list([rhs]));
-            edit.replace(op_expr, arith_expr.syntax());
-
-            edit.add_mappings(make.finish_with_mappings());
-            builder.add_file_edits(ctx.vfs_file_id(), edit);
+            let receiver =
+                if needs_parentheses { editor.make().expr_paren(lhs).into() } else { lhs };
+            let arith_expr = editor.make().expr_method_call(
+                receiver,
+                editor.make().name_ref(&method_name),
+                editor.make().arg_list([rhs]),
+            );
+            editor.replace(op_expr, arith_expr.syntax());
+            builder.add_file_edits(ctx.vfs_file_id(), editor);
         },
     )
 }

--- a/crates/ide-assists/src/handlers/replace_derive_with_manual_impl.rs
+++ b/crates/ide-assists/src/handlers/replace_derive_with_manual_impl.rs
@@ -128,7 +128,8 @@ fn add_assist(
     let label = format!("Convert to manual `impl {replace_trait_path} for {annotated_name}`");
 
     acc.add(AssistId::refactor("replace_derive_with_manual_impl"), label, target, |builder| {
-        let mut editor = builder.make_editor(attr.syntax());
+        let editor = builder.make_editor(attr.syntax());
+        let make = editor.make();
         let insert_after = Position::after(adt.syntax());
         let impl_is_unsafe = trait_.map(|s| s.is_unsafe(ctx.db())).unwrap_or(false);
         let impl_def = impl_def_from_trait(
@@ -141,9 +142,9 @@ fn add_assist(
             replace_trait_path,
             impl_is_unsafe,
         );
-        update_attribute(&mut editor, old_derives, old_tree, old_trait_path, attr);
+        update_attribute(&editor, old_derives, old_tree, old_trait_path, attr);
 
-        let trait_path = editor.make().ty_path(replace_trait_path.clone()).into();
+        let trait_path = make.ty_path(replace_trait_path.clone()).into();
 
         let (impl_def, first_assoc_item) = if let Some(impl_def) = impl_def {
             (
@@ -151,7 +152,7 @@ fn add_assist(
                 impl_def.assoc_item_list().and_then(|list| list.assoc_items().next()),
             )
         } else {
-            (generate_trait_impl(editor.make(), impl_is_unsafe, adt, trait_path), None)
+            (generate_trait_impl(make, impl_is_unsafe, adt, trait_path), None)
         };
 
         if let Some(cap) = ctx.config.snippet_cap {
@@ -175,7 +176,7 @@ fn add_assist(
 
         editor.insert_all(
             insert_after,
-            vec![editor.make().whitespace("\n\n").into(), impl_def.syntax().clone().into()],
+            vec![make.whitespace("\n\n").into(), impl_def.syntax().clone().into()],
         );
         builder.add_file_edits(ctx.vfs_file_id(), editor);
     })
@@ -191,6 +192,7 @@ fn impl_def_from_trait(
     trait_path: &ast::Path,
     impl_is_unsafe: bool,
 ) -> Option<ast::Impl> {
+    let make = editor.make();
     let trait_ = trait_?;
     let target_scope = sema.scope(annotated_name.syntax())?;
 
@@ -207,11 +209,11 @@ fn impl_def_from_trait(
     if trait_items.is_empty() {
         return None;
     }
-    let trait_ty: ast::Type = editor.make().ty_path(trait_path.clone()).into();
-    let impl_def = generate_trait_impl(editor.make(), impl_is_unsafe, adt, trait_ty.clone());
+    let trait_ty: ast::Type = make.ty_path(trait_path.clone()).into();
+    let impl_def = generate_trait_impl(make, impl_is_unsafe, adt, trait_ty.clone());
 
     let assoc_items = add_trait_assoc_items_to_impl(
-        editor.make(),
+        make,
         sema,
         config,
         &trait_items,
@@ -221,10 +223,10 @@ fn impl_def_from_trait(
     );
     let assoc_item_list = if let Some((first, other)) = assoc_items.split_first() {
         let first_item = if let ast::AssocItem::Fn(func) = first
-            && let Some(body) = gen_trait_fn_body(editor.make(), func, trait_path, adt, None)
+            && let Some(body) = gen_trait_fn_body(make, func, trait_path, adt, None)
             && let Some(func_body) = func.body()
         {
-            let (mut editor, _) = SyntaxEditor::new(first.syntax().clone());
+            let (editor, _) = SyntaxEditor::new(first.syntax().clone());
             editor.replace(func_body.syntax(), body.syntax());
             ast::AssocItem::cast(editor.finish().new_root().clone())
         } else {
@@ -232,27 +234,22 @@ fn impl_def_from_trait(
         };
         let items: Vec<ast::AssocItem> =
             first_item.into_iter().chain(other.iter().cloned()).collect();
-        editor.make().assoc_item_list(items)
+        make.assoc_item_list(items)
     } else {
-        editor.make().assoc_item_list_empty()
+        make.assoc_item_list_empty()
     };
 
-    Some(generate_trait_impl_with_item(
-        editor.make(),
-        impl_is_unsafe,
-        adt,
-        trait_ty,
-        assoc_item_list,
-    ))
+    Some(generate_trait_impl_with_item(make, impl_is_unsafe, adt, trait_ty, assoc_item_list))
 }
 
 fn update_attribute(
-    editor: &mut SyntaxEditor,
+    editor: &SyntaxEditor,
     old_derives: &[ast::Path],
     old_tree: &ast::TokenTree,
     old_trait_path: &ast::Path,
     attr: &ast::Attr,
 ) {
+    let make = editor.make();
     let new_derives = old_derives
         .iter()
         .filter(|t| t.to_string() != old_trait_path.to_string())
@@ -267,16 +264,13 @@ fn update_attribute(
                 .collect::<Vec<_>>()
         });
         // ...which are interspersed with ", "
-        let tt = Itertools::intersperse(
-            tt,
-            vec![editor.make().token(T![,]), editor.make().whitespace(" ")],
-        );
+        let tt = Itertools::intersperse(tt, vec![make.token(T![,]), make.whitespace(" ")]);
         // ...wrap them into the appropriate `NodeOrToken` variant
         let tt = tt.flatten().map(syntax::NodeOrToken::Token);
         // ...and make them into a flat list of tokens
         let tt = tt.collect::<Vec<_>>();
 
-        let new_tree = editor.make().token_tree(T!['('], tt);
+        let new_tree = make.token_tree(T!['('], tt);
         editor.replace(old_tree.syntax(), new_tree.syntax());
     } else {
         // Remove the attr and any trailing whitespace

--- a/crates/ide-assists/src/handlers/replace_derive_with_manual_impl.rs
+++ b/crates/ide-assists/src/handlers/replace_derive_with_manual_impl.rs
@@ -4,7 +4,7 @@ use itertools::Itertools;
 use syntax::{
     SyntaxKind::WHITESPACE,
     T,
-    ast::{self, AstNode, HasName, syntax_factory::SyntaxFactory},
+    ast::{self, AstNode, HasName},
     syntax_editor::{Position, SyntaxEditor},
 };
 
@@ -128,10 +128,11 @@ fn add_assist(
     let label = format!("Convert to manual `impl {replace_trait_path} for {annotated_name}`");
 
     acc.add(AssistId::refactor("replace_derive_with_manual_impl"), label, target, |builder| {
-        let make = SyntaxFactory::with_mappings();
+        let mut editor = builder.make_editor(attr.syntax());
         let insert_after = Position::after(adt.syntax());
         let impl_is_unsafe = trait_.map(|s| s.is_unsafe(ctx.db())).unwrap_or(false);
         let impl_def = impl_def_from_trait(
+            &editor,
             &ctx.sema,
             ctx.config,
             adt,
@@ -140,11 +141,9 @@ fn add_assist(
             replace_trait_path,
             impl_is_unsafe,
         );
+        update_attribute(&mut editor, old_derives, old_tree, old_trait_path, attr);
 
-        let mut editor = builder.make_editor(attr.syntax());
-        update_attribute(&make, &mut editor, old_derives, old_tree, old_trait_path, attr);
-
-        let trait_path = make.ty_path(replace_trait_path.clone()).into();
+        let trait_path = editor.make().ty_path(replace_trait_path.clone()).into();
 
         let (impl_def, first_assoc_item) = if let Some(impl_def) = impl_def {
             (
@@ -152,7 +151,7 @@ fn add_assist(
                 impl_def.assoc_item_list().and_then(|list| list.assoc_items().next()),
             )
         } else {
-            (generate_trait_impl(&make, impl_is_unsafe, adt, trait_path), None)
+            (generate_trait_impl(editor.make(), impl_is_unsafe, adt, trait_path), None)
         };
 
         if let Some(cap) = ctx.config.snippet_cap {
@@ -176,14 +175,14 @@ fn add_assist(
 
         editor.insert_all(
             insert_after,
-            vec![make.whitespace("\n\n").into(), impl_def.syntax().clone().into()],
+            vec![editor.make().whitespace("\n\n").into(), impl_def.syntax().clone().into()],
         );
-        editor.add_mappings(make.finish_with_mappings());
         builder.add_file_edits(ctx.vfs_file_id(), editor);
     })
 }
 
 fn impl_def_from_trait(
+    editor: &SyntaxEditor,
     sema: &hir::Semantics<'_, ide_db::RootDatabase>,
     config: &AssistConfig,
     adt: &ast::Adt,
@@ -208,12 +207,11 @@ fn impl_def_from_trait(
     if trait_items.is_empty() {
         return None;
     }
-    let make = SyntaxFactory::without_mappings();
-    let trait_ty: ast::Type = make.ty_path(trait_path.clone()).into();
-    let impl_def = generate_trait_impl(&make, impl_is_unsafe, adt, trait_ty.clone());
+    let trait_ty: ast::Type = editor.make().ty_path(trait_path.clone()).into();
+    let impl_def = generate_trait_impl(editor.make(), impl_is_unsafe, adt, trait_ty.clone());
 
     let assoc_items = add_trait_assoc_items_to_impl(
-        &make,
+        editor.make(),
         sema,
         config,
         &trait_items,
@@ -223,7 +221,7 @@ fn impl_def_from_trait(
     );
     let assoc_item_list = if let Some((first, other)) = assoc_items.split_first() {
         let first_item = if let ast::AssocItem::Fn(func) = first
-            && let Some(body) = gen_trait_fn_body(&make, func, trait_path, adt, None)
+            && let Some(body) = gen_trait_fn_body(editor.make(), func, trait_path, adt, None)
             && let Some(func_body) = func.body()
         {
             let (mut editor, _) = SyntaxEditor::new(first.syntax().clone());
@@ -234,16 +232,21 @@ fn impl_def_from_trait(
         };
         let items: Vec<ast::AssocItem> =
             first_item.into_iter().chain(other.iter().cloned()).collect();
-        make.assoc_item_list(items)
+        editor.make().assoc_item_list(items)
     } else {
-        make.assoc_item_list_empty()
+        editor.make().assoc_item_list_empty()
     };
 
-    Some(generate_trait_impl_with_item(&make, impl_is_unsafe, adt, trait_ty, assoc_item_list))
+    Some(generate_trait_impl_with_item(
+        editor.make(),
+        impl_is_unsafe,
+        adt,
+        trait_ty,
+        assoc_item_list,
+    ))
 }
 
 fn update_attribute(
-    make: &SyntaxFactory,
     editor: &mut SyntaxEditor,
     old_derives: &[ast::Path],
     old_tree: &ast::TokenTree,
@@ -264,13 +267,16 @@ fn update_attribute(
                 .collect::<Vec<_>>()
         });
         // ...which are interspersed with ", "
-        let tt = Itertools::intersperse(tt, vec![make.token(T![,]), make.whitespace(" ")]);
+        let tt = Itertools::intersperse(
+            tt,
+            vec![editor.make().token(T![,]), editor.make().whitespace(" ")],
+        );
         // ...wrap them into the appropriate `NodeOrToken` variant
         let tt = tt.flatten().map(syntax::NodeOrToken::Token);
         // ...and make them into a flat list of tokens
         let tt = tt.collect::<Vec<_>>();
 
-        let new_tree = make.token_tree(T!['('], tt);
+        let new_tree = editor.make().token_tree(T!['('], tt);
         editor.replace(old_tree.syntax(), new_tree.syntax());
     } else {
         // Remove the attr and any trailing whitespace

--- a/crates/ide-assists/src/handlers/replace_if_let_with_match.rs
+++ b/crates/ide-assists/src/handlers/replace_if_let_with_match.rs
@@ -111,27 +111,34 @@ pub(crate) fn replace_if_let_with_match(acc: &mut Assists, ctx: &AssistContext<'
         format!("Replace if{let_} with match"),
         available_range,
         move |builder| {
-            let make = SyntaxFactory::with_mappings();
+            let mut editor = builder.make_editor(if_expr.syntax());
             let match_expr: ast::Expr = {
-                let else_arm = make_else_arm(ctx, &make, else_block, &cond_bodies);
+                let else_arm = make_else_arm(ctx, editor.make(), else_block, &cond_bodies);
                 let make_match_arm =
                     |(pat, guard, body): (_, Option<ast::Expr>, ast::BlockExpr)| {
                         // Dedent from original position, then indent for match arm
                         let body = body.dedent(indent);
                         let body = unwrap_trivial_block(body);
-                        match (pat, guard.map(|it| make.match_guard(it))) {
-                            (Some(pat), guard) => make.match_arm(pat, guard, body),
-                            (None, _) if !pat_seen => {
-                                make.match_arm(make.literal_pat("true").into(), None, body)
-                            }
-                            (None, guard) => {
-                                make.match_arm(make.wildcard_pat().into(), guard, body)
-                            }
+                        match (pat, guard.map(|it| editor.make().match_guard(it))) {
+                            (Some(pat), guard) => editor.make().match_arm(pat, guard, body),
+                            (None, _) if !pat_seen => editor.make().match_arm(
+                                editor.make().literal_pat("true").into(),
+                                None,
+                                body,
+                            ),
+                            (None, guard) => editor.make().match_arm(
+                                editor.make().wildcard_pat().into(),
+                                guard,
+                                body,
+                            ),
                         }
                     };
                 let arms = cond_bodies.into_iter().map(make_match_arm).chain([else_arm]);
                 let expr = scrutinee_to_be_expr.reset_indent();
-                let match_expr = make.expr_match(expr, make.match_arm_list(arms)).indent(indent);
+                let match_expr = editor
+                    .make()
+                    .expr_match(expr, editor.make().match_arm_list(arms))
+                    .indent(indent);
                 match_expr.into()
             };
 
@@ -139,17 +146,15 @@ pub(crate) fn replace_if_let_with_match(acc: &mut Assists, ctx: &AssistContext<'
                 if_expr.syntax().parent().is_some_and(|it| ast::IfExpr::can_cast(it.kind()));
             let expr = if has_preceding_if_expr {
                 // make sure we replace the `else if let ...` with a block so we don't end up with `else expr`
-                let block_expr = make
+                let block_expr = editor
+                    .make()
                     .block_expr([], Some(match_expr.dedent(indent).indent(IndentLevel(1))))
                     .indent(indent);
                 block_expr.into()
             } else {
                 match_expr
             };
-
-            let mut editor = builder.make_editor(if_expr.syntax());
             editor.replace(if_expr.syntax(), expr.syntax());
-            editor.add_mappings(make.finish_with_mappings());
             builder.add_file_edits(ctx.vfs_file_id(), editor);
         },
     )
@@ -267,14 +272,14 @@ pub(crate) fn replace_match_with_if_let(acc: &mut Assists, ctx: &AssistContext<'
         format!("Replace match with if{let_}"),
         match_expr.syntax().text_range(),
         move |builder| {
-            let make = SyntaxFactory::with_mappings();
+            let mut editor = builder.make_editor(match_expr.syntax());
             let make_block_expr = |expr: ast::Expr| {
                 // Blocks with modifiers (unsafe, async, etc.) are parsed as BlockExpr, but are
                 // formatted without enclosing braces. If we encounter such block exprs,
                 // wrap them in another BlockExpr.
                 match expr {
                     ast::Expr::BlockExpr(block) if block.modifier().is_none() => block,
-                    expr => make.block_expr([], Some(expr.indent(IndentLevel(1)))),
+                    expr => editor.make().block_expr([], Some(expr.indent(IndentLevel(1)))),
                 }
             };
 
@@ -287,13 +292,16 @@ pub(crate) fn replace_match_with_if_let(acc: &mut Assists, ctx: &AssistContext<'
                 ast::Pat::LiteralPat(p)
                     if p.literal().is_some_and(|it| it.token().kind() == T![false]) =>
                 {
-                    make.expr_prefix(T![!], scrutinee).into()
+                    editor.make().expr_prefix(T![!], scrutinee).into()
                 }
-                _ => make.expr_let(if_let_pat, scrutinee).into(),
+                _ => editor.make().expr_let(if_let_pat, scrutinee).into(),
             };
             let condition = if let Some(guard) = guard {
-                let guard = wrap_paren(guard, &make, ast::prec::ExprPrecedence::LAnd);
-                make.expr_bin(condition, ast::BinaryOp::LogicOp(ast::LogicOp::And), guard).into()
+                let guard = wrap_paren(guard, editor.make(), ast::prec::ExprPrecedence::LAnd);
+                editor
+                    .make()
+                    .expr_bin(condition, ast::BinaryOp::LogicOp(ast::LogicOp::And), guard)
+                    .into()
             } else {
                 condition
             };
@@ -301,7 +309,8 @@ pub(crate) fn replace_match_with_if_let(acc: &mut Assists, ctx: &AssistContext<'
             let else_expr = else_expr.reset_indent();
             let then_block = make_block_expr(then_expr);
             let else_expr = if is_empty_expr(&else_expr) { None } else { Some(else_expr) };
-            let if_let_expr = make
+            let if_let_expr = editor
+                .make()
                 .expr_if(
                     condition,
                     then_block,
@@ -309,9 +318,7 @@ pub(crate) fn replace_match_with_if_let(acc: &mut Assists, ctx: &AssistContext<'
                 )
                 .indent(IndentLevel::from_node(match_expr.syntax()));
 
-            let mut editor = builder.make_editor(match_expr.syntax());
             editor.replace(match_expr.syntax(), if_let_expr.syntax());
-            editor.add_mappings(make.finish_with_mappings());
             builder.add_file_edits(ctx.vfs_file_id(), editor);
         },
     )

--- a/crates/ide-assists/src/handlers/replace_if_let_with_match.rs
+++ b/crates/ide-assists/src/handlers/replace_if_let_with_match.rs
@@ -111,34 +111,28 @@ pub(crate) fn replace_if_let_with_match(acc: &mut Assists, ctx: &AssistContext<'
         format!("Replace if{let_} with match"),
         available_range,
         move |builder| {
-            let mut editor = builder.make_editor(if_expr.syntax());
+            let editor = builder.make_editor(if_expr.syntax());
+            let make = editor.make();
             let match_expr: ast::Expr = {
-                let else_arm = make_else_arm(ctx, editor.make(), else_block, &cond_bodies);
+                let else_arm = make_else_arm(ctx, make, else_block, &cond_bodies);
                 let make_match_arm =
                     |(pat, guard, body): (_, Option<ast::Expr>, ast::BlockExpr)| {
                         // Dedent from original position, then indent for match arm
                         let body = body.dedent(indent);
                         let body = unwrap_trivial_block(body);
-                        match (pat, guard.map(|it| editor.make().match_guard(it))) {
-                            (Some(pat), guard) => editor.make().match_arm(pat, guard, body),
-                            (None, _) if !pat_seen => editor.make().match_arm(
-                                editor.make().literal_pat("true").into(),
-                                None,
-                                body,
-                            ),
-                            (None, guard) => editor.make().match_arm(
-                                editor.make().wildcard_pat().into(),
-                                guard,
-                                body,
-                            ),
+                        match (pat, guard.map(|it| make.match_guard(it))) {
+                            (Some(pat), guard) => make.match_arm(pat, guard, body),
+                            (None, _) if !pat_seen => {
+                                make.match_arm(make.literal_pat("true").into(), None, body)
+                            }
+                            (None, guard) => {
+                                make.match_arm(make.wildcard_pat().into(), guard, body)
+                            }
                         }
                     };
                 let arms = cond_bodies.into_iter().map(make_match_arm).chain([else_arm]);
                 let expr = scrutinee_to_be_expr.reset_indent();
-                let match_expr = editor
-                    .make()
-                    .expr_match(expr, editor.make().match_arm_list(arms))
-                    .indent(indent);
+                let match_expr = make.expr_match(expr, make.match_arm_list(arms)).indent(indent);
                 match_expr.into()
             };
 
@@ -272,14 +266,15 @@ pub(crate) fn replace_match_with_if_let(acc: &mut Assists, ctx: &AssistContext<'
         format!("Replace match with if{let_}"),
         match_expr.syntax().text_range(),
         move |builder| {
-            let mut editor = builder.make_editor(match_expr.syntax());
+            let editor = builder.make_editor(match_expr.syntax());
+            let make = editor.make();
             let make_block_expr = |expr: ast::Expr| {
                 // Blocks with modifiers (unsafe, async, etc.) are parsed as BlockExpr, but are
                 // formatted without enclosing braces. If we encounter such block exprs,
                 // wrap them in another BlockExpr.
                 match expr {
                     ast::Expr::BlockExpr(block) if block.modifier().is_none() => block,
-                    expr => editor.make().block_expr([], Some(expr.indent(IndentLevel(1)))),
+                    expr => make.block_expr([], Some(expr.indent(IndentLevel(1)))),
                 }
             };
 
@@ -292,16 +287,13 @@ pub(crate) fn replace_match_with_if_let(acc: &mut Assists, ctx: &AssistContext<'
                 ast::Pat::LiteralPat(p)
                     if p.literal().is_some_and(|it| it.token().kind() == T![false]) =>
                 {
-                    editor.make().expr_prefix(T![!], scrutinee).into()
+                    make.expr_prefix(T![!], scrutinee).into()
                 }
-                _ => editor.make().expr_let(if_let_pat, scrutinee).into(),
+                _ => make.expr_let(if_let_pat, scrutinee).into(),
             };
             let condition = if let Some(guard) = guard {
-                let guard = wrap_paren(guard, editor.make(), ast::prec::ExprPrecedence::LAnd);
-                editor
-                    .make()
-                    .expr_bin(condition, ast::BinaryOp::LogicOp(ast::LogicOp::And), guard)
-                    .into()
+                let guard = wrap_paren(guard, make, ast::prec::ExprPrecedence::LAnd);
+                make.expr_bin(condition, ast::BinaryOp::LogicOp(ast::LogicOp::And), guard).into()
             } else {
                 condition
             };
@@ -409,21 +401,20 @@ fn let_and_guard(cond: &ast::Expr) -> (Option<ast::LetExpr>, Option<ast::Expr>) 
     } else if let ast::Expr::BinExpr(bin_expr) = cond
         && let Some(ast::Expr::LetExpr(let_expr)) = and_bin_expr_left(bin_expr).lhs()
     {
-        let (mut edit, new_expr) = SyntaxEditor::with_ast_node(bin_expr);
-
+        let (editor, new_expr) = SyntaxEditor::with_ast_node(bin_expr);
         let left_bin = and_bin_expr_left(&new_expr);
         if let Some(rhs) = left_bin.rhs() {
-            edit.replace(left_bin.syntax(), rhs.syntax());
+            editor.replace(left_bin.syntax(), rhs.syntax());
         } else {
             if let Some(next) = left_bin.syntax().next_sibling_or_token()
                 && next.kind() == SyntaxKind::WHITESPACE
             {
-                edit.delete(next);
+                editor.delete(next);
             }
-            edit.delete(left_bin.syntax());
+            editor.delete(left_bin.syntax());
         }
 
-        let new_expr = edit.finish().new_root().clone();
+        let new_expr = editor.finish().new_root().clone();
         (Some(let_expr), ast::Expr::cast(new_expr))
     } else {
         (None, Some(cond.clone()))

--- a/crates/ide-assists/src/handlers/replace_is_method_with_if_let_method.rs
+++ b/crates/ide-assists/src/handlers/replace_is_method_with_if_let_method.rs
@@ -1,6 +1,9 @@
 use either::Either;
 use ide_db::syntax_helpers::suggest_name;
-use syntax::ast::{self, AstNode, HasArgList, prec::ExprPrecedence, syntax_factory::SyntaxFactory};
+use syntax::{
+    ast::{self, AstNode, HasArgList, prec::ExprPrecedence, syntax_factory::SyntaxFactory},
+    syntax_editor::SyntaxEditor,
+};
 
 use crate::{
     AssistContext, AssistId, Assists,
@@ -41,9 +44,8 @@ pub(crate) fn replace_is_method_with_if_let_method(
     let method_kind = token.text().strip_suffix("_and").unwrap_or(token.text());
     match method_kind {
         "is_some" | "is_ok" => {
+            let (mut editor, _) = SyntaxEditor::new(ctx.source_file().syntax().clone());
             let receiver = call_expr.receiver()?;
-            let make = SyntaxFactory::with_mappings();
-
             let mut name_generator = suggest_name::NameGenerator::new_from_scope_locals(
                 ctx.sema.scope(has_cond.syntax()),
             );
@@ -52,7 +54,7 @@ pub(crate) fn replace_is_method_with_if_let_method(
             } else {
                 name_generator.for_variable(&receiver, &ctx.sema)
             };
-            let (pat, predicate) = method_predicate(&call_expr, &var_name, &make);
+            let (pat, predicate) = method_predicate(&call_expr, &var_name, editor.make());
 
             let (assist_id, message, text) = if method_kind == "is_some" {
                 ("replace_is_some_with_if_let_some", "Replace `is_some` with `let Some`", "Some")
@@ -65,10 +67,11 @@ pub(crate) fn replace_is_method_with_if_let_method(
                 message,
                 call_expr.syntax().text_range(),
                 |edit| {
-                    let mut editor = edit.make_editor(call_expr.syntax());
-
-                    let pat = make.tuple_struct_pat(make.ident_path(text), [pat]).into();
-                    let let_expr = make.expr_let(pat, receiver);
+                    let pat = editor
+                        .make()
+                        .tuple_struct_pat(editor.make().ident_path(text), [pat])
+                        .into();
+                    let let_expr = editor.make().expr_let(pat, receiver);
 
                     if let Some(cap) = ctx.config.snippet_cap
                         && let Some(ast::Pat::TupleStructPat(pat)) = let_expr.pat()
@@ -81,14 +84,12 @@ pub(crate) fn replace_is_method_with_if_let_method(
 
                     let new_expr = if let Some(predicate) = predicate {
                         let op = ast::BinaryOp::LogicOp(ast::LogicOp::And);
-                        let predicate = wrap_paren(predicate, &make, ExprPrecedence::LAnd);
-                        make.expr_bin(let_expr.into(), op, predicate).into()
+                        let predicate = wrap_paren(predicate, editor.make(), ExprPrecedence::LAnd);
+                        editor.make().expr_bin(let_expr.into(), op, predicate).into()
                     } else {
                         ast::Expr::from(let_expr)
                     };
                     editor.replace(call_expr.syntax(), new_expr.syntax());
-
-                    editor.add_mappings(make.finish_with_mappings());
                     edit.add_file_edits(ctx.vfs_file_id(), editor);
                 },
             )

--- a/crates/ide-assists/src/handlers/replace_is_method_with_if_let_method.rs
+++ b/crates/ide-assists/src/handlers/replace_is_method_with_if_let_method.rs
@@ -44,7 +44,8 @@ pub(crate) fn replace_is_method_with_if_let_method(
     let method_kind = token.text().strip_suffix("_and").unwrap_or(token.text());
     match method_kind {
         "is_some" | "is_ok" => {
-            let (mut editor, _) = SyntaxEditor::new(ctx.source_file().syntax().clone());
+            let (editor, _) = SyntaxEditor::new(ctx.source_file().syntax().clone());
+            let make = editor.make();
             let receiver = call_expr.receiver()?;
             let mut name_generator = suggest_name::NameGenerator::new_from_scope_locals(
                 ctx.sema.scope(has_cond.syntax()),
@@ -54,7 +55,7 @@ pub(crate) fn replace_is_method_with_if_let_method(
             } else {
                 name_generator.for_variable(&receiver, &ctx.sema)
             };
-            let (pat, predicate) = method_predicate(&call_expr, &var_name, editor.make());
+            let (pat, predicate) = method_predicate(&call_expr, &var_name, make);
 
             let (assist_id, message, text) = if method_kind == "is_some" {
                 ("replace_is_some_with_if_let_some", "Replace `is_some` with `let Some`", "Some")
@@ -67,11 +68,9 @@ pub(crate) fn replace_is_method_with_if_let_method(
                 message,
                 call_expr.syntax().text_range(),
                 |edit| {
-                    let pat = editor
-                        .make()
-                        .tuple_struct_pat(editor.make().ident_path(text), [pat])
-                        .into();
-                    let let_expr = editor.make().expr_let(pat, receiver);
+                    let make = editor.make();
+                    let pat = make.tuple_struct_pat(make.ident_path(text), [pat]).into();
+                    let let_expr = make.expr_let(pat, receiver);
 
                     if let Some(cap) = ctx.config.snippet_cap
                         && let Some(ast::Pat::TupleStructPat(pat)) = let_expr.pat()
@@ -84,8 +83,8 @@ pub(crate) fn replace_is_method_with_if_let_method(
 
                     let new_expr = if let Some(predicate) = predicate {
                         let op = ast::BinaryOp::LogicOp(ast::LogicOp::And);
-                        let predicate = wrap_paren(predicate, editor.make(), ExprPrecedence::LAnd);
-                        editor.make().expr_bin(let_expr.into(), op, predicate).into()
+                        let predicate = wrap_paren(predicate, make, ExprPrecedence::LAnd);
+                        make.expr_bin(let_expr.into(), op, predicate).into()
                     } else {
                         ast::Expr::from(let_expr)
                     };

--- a/crates/ide-assists/src/handlers/replace_let_with_if_let.rs
+++ b/crates/ide-assists/src/handlers/replace_let_with_if_let.rs
@@ -46,7 +46,8 @@ pub(crate) fn replace_let_with_if_let(acc: &mut Assists, ctx: &AssistContext<'_>
         "Replace let with if let",
         target,
         |builder| {
-            let mut editor = builder.make_editor(let_stmt.syntax());
+            let editor = builder.make_editor(let_stmt.syntax());
+            let make = editor.make();
             let ty = ctx.sema.type_of_expr(&init);
             let pat = if let_stmt.let_else().is_some() {
                 // Do not add the wrapper type that implements `Try`,
@@ -60,26 +61,23 @@ pub(crate) fn replace_let_with_if_let(acc: &mut Assists, ctx: &AssistContext<'_>
                     None => original_pat,
                     Some(var_name) => editor
                         .make()
-                        .tuple_struct_pat(editor.make().ident_path(var_name), [original_pat])
+                        .tuple_struct_pat(make.ident_path(var_name), [original_pat])
                         .into(),
                 }
             };
-            let init_expr = if let_expr_needs_paren(&init) {
-                editor.make().expr_paren(init).into()
-            } else {
-                init
-            };
+            let init_expr =
+                if let_expr_needs_paren(&init) { make.expr_paren(init).into() } else { init };
 
-            let block = editor.make().block_expr([], None);
+            let block = make.block_expr([], None);
             let block = block.indent(IndentLevel::from_node(let_stmt.syntax()));
-            let if_expr = editor.make().expr_if(
-                editor.make().expr_let(pat, init_expr).into(),
+            let if_expr = make.expr_if(
+                make.expr_let(pat, init_expr).into(),
                 block,
                 let_stmt
                     .let_else()
                     .and_then(|let_else| let_else.block_expr().map(ast::ElseBranch::from)),
             );
-            let if_stmt = editor.make().expr_stmt(if_expr.into());
+            let if_stmt = make.expr_stmt(if_expr.into());
 
             editor.replace(let_stmt.syntax(), if_stmt.syntax());
             builder.add_file_edits(ctx.vfs_file_id(), editor);

--- a/crates/ide-assists/src/handlers/replace_let_with_if_let.rs
+++ b/crates/ide-assists/src/handlers/replace_let_with_if_let.rs
@@ -47,7 +47,6 @@ pub(crate) fn replace_let_with_if_let(acc: &mut Assists, ctx: &AssistContext<'_>
         target,
         |builder| {
             let mut editor = builder.make_editor(let_stmt.syntax());
-            let make = SyntaxFactory::with_mappings();
             let ty = ctx.sema.type_of_expr(&init);
             let pat = if let_stmt.let_else().is_some() {
                 // Do not add the wrapper type that implements `Try`,
@@ -59,27 +58,30 @@ pub(crate) fn replace_let_with_if_let(acc: &mut Assists, ctx: &AssistContext<'_>
                     .map(|it| it.happy_case());
                 match happy_variant {
                     None => original_pat,
-                    Some(var_name) => {
-                        make.tuple_struct_pat(make.ident_path(var_name), [original_pat]).into()
-                    }
+                    Some(var_name) => editor
+                        .make()
+                        .tuple_struct_pat(editor.make().ident_path(var_name), [original_pat])
+                        .into(),
                 }
             };
-            let init_expr =
-                if let_expr_needs_paren(&init) { make.expr_paren(init).into() } else { init };
+            let init_expr = if let_expr_needs_paren(&init) {
+                editor.make().expr_paren(init).into()
+            } else {
+                init
+            };
 
-            let block = make.block_expr([], None);
+            let block = editor.make().block_expr([], None);
             let block = block.indent(IndentLevel::from_node(let_stmt.syntax()));
-            let if_expr = make.expr_if(
-                make.expr_let(pat, init_expr).into(),
+            let if_expr = editor.make().expr_if(
+                editor.make().expr_let(pat, init_expr).into(),
                 block,
                 let_stmt
                     .let_else()
                     .and_then(|let_else| let_else.block_expr().map(ast::ElseBranch::from)),
             );
-            let if_stmt = make.expr_stmt(if_expr.into());
+            let if_stmt = editor.make().expr_stmt(if_expr.into());
 
             editor.replace(let_stmt.syntax(), if_stmt.syntax());
-            editor.add_mappings(make.finish_with_mappings());
             builder.add_file_edits(ctx.vfs_file_id(), editor);
         },
     )

--- a/crates/ide-assists/src/handlers/replace_named_generic_with_impl.rs
+++ b/crates/ide-assists/src/handlers/replace_named_generic_with_impl.rs
@@ -71,7 +71,8 @@ pub(crate) fn replace_named_generic_with_impl(
         "Replace named generic with impl trait",
         target,
         |edit| {
-            let mut editor = edit.make_editor(type_param.syntax());
+            let editor = edit.make_editor(type_param.syntax());
+            let make = editor.make();
 
             // remove trait from generic param list
             if let Some(generic_params) = fn_.generic_param_list() {
@@ -83,12 +84,12 @@ pub(crate) fn replace_named_generic_with_impl(
                 if params.is_empty() {
                     editor.delete(generic_params.syntax());
                 } else {
-                    let new_generic_param_list = editor.make().generic_param_list(params);
+                    let new_generic_param_list = make.generic_param_list(params);
                     editor.replace(generic_params.syntax(), new_generic_param_list.syntax());
                 }
             }
 
-            let new_bounds = editor.make().impl_trait_type(type_bound_list);
+            let new_bounds = make.impl_trait_type(type_bound_list);
             for path_type in path_types_to_replace.iter().rev() {
                 editor.replace(path_type.syntax(), new_bounds.syntax());
             }

--- a/crates/ide-assists/src/handlers/replace_named_generic_with_impl.rs
+++ b/crates/ide-assists/src/handlers/replace_named_generic_with_impl.rs
@@ -5,7 +5,6 @@ use ide_db::{
     defs::Definition,
     search::{SearchScope, UsageSearchResult},
 };
-use syntax::ast::syntax_factory::SyntaxFactory;
 use syntax::{
     AstNode,
     ast::{self, HasGenericParams, HasName, HasTypeBounds, Name, NameLike, PathType},
@@ -73,7 +72,6 @@ pub(crate) fn replace_named_generic_with_impl(
         target,
         |edit| {
             let mut editor = edit.make_editor(type_param.syntax());
-            let make = SyntaxFactory::without_mappings();
 
             // remove trait from generic param list
             if let Some(generic_params) = fn_.generic_param_list() {
@@ -85,12 +83,12 @@ pub(crate) fn replace_named_generic_with_impl(
                 if params.is_empty() {
                     editor.delete(generic_params.syntax());
                 } else {
-                    let new_generic_param_list = make.generic_param_list(params);
+                    let new_generic_param_list = editor.make().generic_param_list(params);
                     editor.replace(generic_params.syntax(), new_generic_param_list.syntax());
                 }
             }
 
-            let new_bounds = make.impl_trait_type(type_bound_list);
+            let new_bounds = editor.make().impl_trait_type(type_bound_list);
             for path_type in path_types_to_replace.iter().rev() {
                 editor.replace(path_type.syntax(), new_bounds.syntax());
             }

--- a/crates/ide-assists/src/handlers/replace_qualified_name_with_use.rs
+++ b/crates/ide-assists/src/handlers/replace_qualified_name_with_use.rs
@@ -73,8 +73,8 @@ pub(crate) fn replace_qualified_name_with_use(
             // Now that we've brought the name into scope, re-qualify all paths that could be
             // affected (that is, all paths inside the node we added the `use` to).
             let scope_node = scope.as_syntax_node();
-            let mut editor = builder.make_editor(scope_node);
-            shorten_paths(&mut editor, scope_node, &original_path);
+            let editor = builder.make_editor(scope_node);
+            shorten_paths(&editor, scope_node, &original_path);
             builder.add_file_edits(ctx.vfs_file_id(), editor);
             let path = drop_generic_args(&original_path);
             let edition = ctx
@@ -111,7 +111,7 @@ fn target_path(ctx: &AssistContext<'_>, mut original_path: ast::Path) -> Option<
 }
 
 fn drop_generic_args(path: &ast::Path) -> ast::Path {
-    let (mut editor, path) = SyntaxEditor::with_ast_node(path);
+    let (editor, path) = SyntaxEditor::with_ast_node(path);
     if let Some(segment) = path.segment()
         && let Some(generic_args) = segment.generic_arg_list()
     {
@@ -122,7 +122,7 @@ fn drop_generic_args(path: &ast::Path) -> ast::Path {
 }
 
 /// Mutates `node` to shorten `path` in all descendants of `node`.
-fn shorten_paths(editor: &mut SyntaxEditor, node: &SyntaxNode, path: &ast::Path) {
+fn shorten_paths(editor: &SyntaxEditor, node: &SyntaxNode, path: &ast::Path) {
     for child in node.children() {
         match_ast! {
             match child {
@@ -141,7 +141,7 @@ fn shorten_paths(editor: &mut SyntaxEditor, node: &SyntaxNode, path: &ast::Path)
     }
 }
 
-fn maybe_replace_path(editor: &mut SyntaxEditor, path: ast::Path, target: ast::Path) -> Option<()> {
+fn maybe_replace_path(editor: &SyntaxEditor, path: ast::Path, target: ast::Path) -> Option<()> {
     if !path_eq_no_generics(path.clone(), target) {
         return None;
     }

--- a/crates/ide-assists/src/handlers/sort_items.rs
+++ b/crates/ide-assists/src/handlers/sort_items.rs
@@ -127,7 +127,7 @@ impl AddRewrite for Assists {
         target: &SyntaxNode,
     ) -> Option<()> {
         self.add(AssistId::refactor_rewrite("sort_items"), label, target.text_range(), |builder| {
-            let mut editor = builder.make_editor(target);
+            let editor = builder.make_editor(target);
 
             old.into_iter()
                 .zip(new)

--- a/crates/ide-assists/src/handlers/toggle_macro_delimiter.rs
+++ b/crates/ide-assists/src/handlers/toggle_macro_delimiter.rs
@@ -73,31 +73,29 @@ pub(crate) fn toggle_macro_delimiter(acc: &mut Assists, ctx: &AssistContext<'_>)
         },
         token_tree.syntax().text_range(),
         |builder| {
-            let mut editor = builder.make_editor(token_tree.syntax());
+            let editor = builder.make_editor(token_tree.syntax());
+            let make = editor.make();
 
             match token {
                 MacroDelims::LPar | MacroDelims::RPar => {
-                    editor.replace(ltoken, editor.make().token(T!['{']));
-                    editor.replace(rtoken, editor.make().token(T!['}']));
+                    editor.replace(ltoken, make.token(T!['{']));
+                    editor.replace(rtoken, make.token(T!['}']));
                     if let Some(sc) = semicolon {
                         editor.delete(sc);
                     }
                 }
                 MacroDelims::LBra | MacroDelims::RBra => {
-                    editor.replace(ltoken, editor.make().token(T!['(']));
-                    editor.replace(rtoken, editor.make().token(T![')']));
+                    editor.replace(ltoken, make.token(T!['(']));
+                    editor.replace(rtoken, make.token(T![')']));
                 }
                 MacroDelims::LCur | MacroDelims::RCur => {
-                    editor.replace(ltoken, editor.make().token(T!['[']));
+                    editor.replace(ltoken, make.token(T!['[']));
                     if semicolon.is_some() || !needs_semicolon(token_tree) {
-                        editor.replace(rtoken, editor.make().token(T![']']));
+                        editor.replace(rtoken, make.token(T![']']));
                     } else {
                         editor.replace_with_many(
                             rtoken,
-                            vec![
-                                editor.make().token(T![']']).into(),
-                                editor.make().token(T![;]).into(),
-                            ],
+                            vec![make.token(T![']']).into(), make.token(T![;]).into()],
                         );
                     }
                 }

--- a/crates/ide-assists/src/handlers/toggle_macro_delimiter.rs
+++ b/crates/ide-assists/src/handlers/toggle_macro_delimiter.rs
@@ -2,7 +2,7 @@ use ide_db::assists::AssistId;
 use syntax::{
     AstNode, SyntaxKind, SyntaxToken, T,
     algo::{previous_non_trivia_token, skip_trivia_token},
-    ast::{self, syntax_factory::SyntaxFactory},
+    ast,
 };
 
 use crate::{AssistContext, Assists};
@@ -73,34 +73,35 @@ pub(crate) fn toggle_macro_delimiter(acc: &mut Assists, ctx: &AssistContext<'_>)
         },
         token_tree.syntax().text_range(),
         |builder| {
-            let make = SyntaxFactory::with_mappings();
             let mut editor = builder.make_editor(token_tree.syntax());
 
             match token {
                 MacroDelims::LPar | MacroDelims::RPar => {
-                    editor.replace(ltoken, make.token(T!['{']));
-                    editor.replace(rtoken, make.token(T!['}']));
+                    editor.replace(ltoken, editor.make().token(T!['{']));
+                    editor.replace(rtoken, editor.make().token(T!['}']));
                     if let Some(sc) = semicolon {
                         editor.delete(sc);
                     }
                 }
                 MacroDelims::LBra | MacroDelims::RBra => {
-                    editor.replace(ltoken, make.token(T!['(']));
-                    editor.replace(rtoken, make.token(T![')']));
+                    editor.replace(ltoken, editor.make().token(T!['(']));
+                    editor.replace(rtoken, editor.make().token(T![')']));
                 }
                 MacroDelims::LCur | MacroDelims::RCur => {
-                    editor.replace(ltoken, make.token(T!['[']));
+                    editor.replace(ltoken, editor.make().token(T!['[']));
                     if semicolon.is_some() || !needs_semicolon(token_tree) {
-                        editor.replace(rtoken, make.token(T![']']));
+                        editor.replace(rtoken, editor.make().token(T![']']));
                     } else {
                         editor.replace_with_many(
                             rtoken,
-                            vec![make.token(T![']']).into(), make.token(T![;]).into()],
+                            vec![
+                                editor.make().token(T![']']).into(),
+                                editor.make().token(T![;]).into(),
+                            ],
                         );
                     }
                 }
             }
-            editor.add_mappings(make.finish_with_mappings());
             builder.add_file_edits(ctx.vfs_file_id(), editor);
         },
     )

--- a/crates/ide-assists/src/handlers/unmerge_imports.rs
+++ b/crates/ide-assists/src/handlers/unmerge_imports.rs
@@ -1,6 +1,6 @@
 use syntax::{
     AstNode, SyntaxKind,
-    ast::{self, HasAttrs, HasVisibility, edit::IndentLevel, make, syntax_factory::SyntaxFactory},
+    ast::{self, HasAttrs, HasVisibility, edit::IndentLevel, make},
     syntax_editor::{Element, Position, Removable},
 };
 
@@ -41,26 +41,31 @@ pub(crate) fn unmerge_imports(acc: &mut Assists, ctx: &AssistContext<'_>) -> Opt
 
     let target = tree.syntax().text_range();
     acc.add(AssistId::refactor_rewrite("unmerge_imports"), label, target, |builder| {
-        let make = SyntaxFactory::with_mappings();
-        let new_use = make.use_(
+        let mut editor = builder.make_editor(use_.syntax());
+        let new_use = editor.make().use_(
             use_.attrs(),
             use_.visibility(),
-            make.use_tree(path, tree.use_tree_list(), tree.rename(), tree.star_token().is_some()),
+            editor.make().use_tree(
+                path,
+                tree.use_tree_list(),
+                tree.rename(),
+                tree.star_token().is_some(),
+            ),
         );
 
-        let mut editor = builder.make_editor(use_.syntax());
         // Remove the use tree from the current use item
         tree.remove(&mut editor);
         // Insert a newline and indentation, followed by the new use item
         editor.insert_all(
             Position::after(use_.syntax()),
             vec![
-                make.whitespace(&format!("\n{}", IndentLevel::from_node(use_.syntax())))
+                editor
+                    .make()
+                    .whitespace(&format!("\n{}", IndentLevel::from_node(use_.syntax())))
                     .syntax_element(),
                 new_use.syntax().syntax_element(),
             ],
         );
-        editor.add_mappings(make.finish_with_mappings());
         builder.add_file_edits(ctx.vfs_file_id(), editor);
     })
 }

--- a/crates/ide-assists/src/handlers/unmerge_imports.rs
+++ b/crates/ide-assists/src/handlers/unmerge_imports.rs
@@ -41,20 +41,16 @@ pub(crate) fn unmerge_imports(acc: &mut Assists, ctx: &AssistContext<'_>) -> Opt
 
     let target = tree.syntax().text_range();
     acc.add(AssistId::refactor_rewrite("unmerge_imports"), label, target, |builder| {
-        let mut editor = builder.make_editor(use_.syntax());
-        let new_use = editor.make().use_(
+        let editor = builder.make_editor(use_.syntax());
+        let make = editor.make();
+        let new_use = make.use_(
             use_.attrs(),
             use_.visibility(),
-            editor.make().use_tree(
-                path,
-                tree.use_tree_list(),
-                tree.rename(),
-                tree.star_token().is_some(),
-            ),
+            make.use_tree(path, tree.use_tree_list(), tree.rename(), tree.star_token().is_some()),
         );
 
         // Remove the use tree from the current use item
-        tree.remove(&mut editor);
+        tree.remove(&editor);
         // Insert a newline and indentation, followed by the new use item
         editor.insert_all(
             Position::after(use_.syntax()),

--- a/crates/ide-assists/src/handlers/unmerge_match_arm.rs
+++ b/crates/ide-assists/src/handlers/unmerge_match_arm.rs
@@ -1,6 +1,6 @@
 use syntax::{
     Direction, SyntaxKind, T,
-    ast::{self, AstNode, edit::IndentLevel, syntax_factory::SyntaxFactory},
+    ast::{self, AstNode, edit::IndentLevel},
     syntax_editor::{Element, Position},
 };
 
@@ -56,15 +56,14 @@ pub(crate) fn unmerge_match_arm(acc: &mut Assists, ctx: &AssistContext<'_>) -> O
         "Unmerge match arm",
         pipe_token.text_range(),
         |edit| {
-            let make = SyntaxFactory::with_mappings();
             let mut editor = edit.make_editor(&new_parent);
             // It is guaranteed that `pats_after` has at least one element
             let new_pat = if pats_after.len() == 1 {
                 pats_after[0].clone()
             } else {
-                make.or_pat(pats_after, or_pat.leading_pipe().is_some()).into()
+                editor.make().or_pat(pats_after, or_pat.leading_pipe().is_some()).into()
             };
-            let new_match_arm = make.match_arm(new_pat, match_arm.guard(), match_arm_body);
+            let new_match_arm = editor.make().match_arm(new_pat, match_arm.guard(), match_arm_body);
             let mut pipe_index = pipe_token.index();
             if pipe_token
                 .prev_sibling_or_token()
@@ -92,16 +91,15 @@ pub(crate) fn unmerge_match_arm(acc: &mut Assists, ctx: &AssistContext<'_>) -> O
             //    we don't want to insert a comma at all.
             let has_comma_after = match_arm.comma_token().is_some();
             if !has_comma_after && !match_arm.expr().unwrap().is_block_like() {
-                insert_after_old_arm.push(make.token(T![,]).into());
+                insert_after_old_arm.push(editor.make().token(T![,]).into());
             }
 
             let indent = IndentLevel::from_node(match_arm.syntax());
-            insert_after_old_arm.push(make.whitespace(&format!("\n{indent}")).into());
+            insert_after_old_arm.push(editor.make().whitespace(&format!("\n{indent}")).into());
 
             insert_after_old_arm.push(new_match_arm.syntax().clone().into());
 
             editor.insert_all(Position::after(match_arm.syntax()), insert_after_old_arm);
-            editor.add_mappings(make.finish_with_mappings());
             edit.add_file_edits(ctx.vfs_file_id(), editor);
         },
     )

--- a/crates/ide-assists/src/handlers/unmerge_match_arm.rs
+++ b/crates/ide-assists/src/handlers/unmerge_match_arm.rs
@@ -56,14 +56,15 @@ pub(crate) fn unmerge_match_arm(acc: &mut Assists, ctx: &AssistContext<'_>) -> O
         "Unmerge match arm",
         pipe_token.text_range(),
         |edit| {
-            let mut editor = edit.make_editor(&new_parent);
+            let editor = edit.make_editor(&new_parent);
+            let make = editor.make();
             // It is guaranteed that `pats_after` has at least one element
             let new_pat = if pats_after.len() == 1 {
                 pats_after[0].clone()
             } else {
-                editor.make().or_pat(pats_after, or_pat.leading_pipe().is_some()).into()
+                make.or_pat(pats_after, or_pat.leading_pipe().is_some()).into()
             };
-            let new_match_arm = editor.make().match_arm(new_pat, match_arm.guard(), match_arm_body);
+            let new_match_arm = make.match_arm(new_pat, match_arm.guard(), match_arm_body);
             let mut pipe_index = pipe_token.index();
             if pipe_token
                 .prev_sibling_or_token()
@@ -91,11 +92,11 @@ pub(crate) fn unmerge_match_arm(acc: &mut Assists, ctx: &AssistContext<'_>) -> O
             //    we don't want to insert a comma at all.
             let has_comma_after = match_arm.comma_token().is_some();
             if !has_comma_after && !match_arm.expr().unwrap().is_block_like() {
-                insert_after_old_arm.push(editor.make().token(T![,]).into());
+                insert_after_old_arm.push(make.token(T![,]).into());
             }
 
             let indent = IndentLevel::from_node(match_arm.syntax());
-            insert_after_old_arm.push(editor.make().whitespace(&format!("\n{indent}")).into());
+            insert_after_old_arm.push(make.whitespace(&format!("\n{indent}")).into());
 
             insert_after_old_arm.push(new_match_arm.syntax().clone().into());
 

--- a/crates/ide-assists/src/handlers/unqualify_method_call.rs
+++ b/crates/ide-assists/src/handlers/unqualify_method_call.rs
@@ -50,15 +50,16 @@ pub(crate) fn unqualify_method_call(acc: &mut Assists, ctx: &AssistContext<'_>) 
         "Unqualify method call",
         call.syntax().text_range(),
         |builder| {
-            let mut editor = builder.make_editor(call.syntax());
+            let editor = builder.make_editor(call.syntax());
+            let make = editor.make();
 
-            let new_arg_list = editor.make().arg_list(args.args().skip(1));
+            let new_arg_list = make.arg_list(args.args().skip(1));
             let receiver = if first_arg.precedence().needs_parentheses_in(ExprPrecedence::Postfix) {
-                ast::Expr::from(editor.make().expr_paren(first_arg.clone()))
+                ast::Expr::from(make.expr_paren(first_arg.clone()))
             } else {
                 first_arg.clone()
             };
-            let method_call = editor.make().expr_method_call(receiver, method_name, new_arg_list);
+            let method_call = make.expr_method_call(receiver, method_name, new_arg_list);
 
             editor.replace(call.syntax(), method_call.syntax());
 
@@ -66,7 +67,7 @@ pub(crate) fn unqualify_method_call(acc: &mut Assists, ctx: &AssistContext<'_>) 
                 && let Some(trait_) = fun.container_or_implemented_trait(ctx.db())
                 && !scope.can_use_trait_methods(trait_)
             {
-                add_import(qualifier, ctx, &mut editor);
+                add_import(qualifier, ctx, &editor);
             }
 
             builder.add_file_edits(ctx.vfs_file_id(), editor);
@@ -77,7 +78,7 @@ pub(crate) fn unqualify_method_call(acc: &mut Assists, ctx: &AssistContext<'_>) 
 fn add_import(
     qualifier: ast::Path,
     ctx: &AssistContext<'_>,
-    editor: &mut syntax::syntax_editor::SyntaxEditor,
+    editor: &syntax::syntax_editor::SyntaxEditor,
 ) {
     if let Some(path_segment) = qualifier.segment() {
         // for `<i32 as std::ops::Add>`

--- a/crates/ide-assists/src/handlers/unqualify_method_call.rs
+++ b/crates/ide-assists/src/handlers/unqualify_method_call.rs
@@ -1,5 +1,5 @@
 use hir::AsAssocItem;
-use syntax::ast::{self, AstNode, HasArgList, prec::ExprPrecedence, syntax_factory::SyntaxFactory};
+use syntax::ast::{self, AstNode, HasArgList, prec::ExprPrecedence};
 
 use crate::{AssistContext, AssistId, Assists};
 
@@ -50,16 +50,15 @@ pub(crate) fn unqualify_method_call(acc: &mut Assists, ctx: &AssistContext<'_>) 
         "Unqualify method call",
         call.syntax().text_range(),
         |builder| {
-            let make = SyntaxFactory::with_mappings();
             let mut editor = builder.make_editor(call.syntax());
 
-            let new_arg_list = make.arg_list(args.args().skip(1));
+            let new_arg_list = editor.make().arg_list(args.args().skip(1));
             let receiver = if first_arg.precedence().needs_parentheses_in(ExprPrecedence::Postfix) {
-                ast::Expr::from(make.expr_paren(first_arg.clone()))
+                ast::Expr::from(editor.make().expr_paren(first_arg.clone()))
             } else {
                 first_arg.clone()
             };
-            let method_call = make.expr_method_call(receiver, method_name, new_arg_list);
+            let method_call = editor.make().expr_method_call(receiver, method_name, new_arg_list);
 
             editor.replace(call.syntax(), method_call.syntax());
 
@@ -67,10 +66,9 @@ pub(crate) fn unqualify_method_call(acc: &mut Assists, ctx: &AssistContext<'_>) 
                 && let Some(trait_) = fun.container_or_implemented_trait(ctx.db())
                 && !scope.can_use_trait_methods(trait_)
             {
-                add_import(qualifier, ctx, &make, &mut editor);
+                add_import(qualifier, ctx, &mut editor);
             }
 
-            editor.add_mappings(make.finish_with_mappings());
             builder.add_file_edits(ctx.vfs_file_id(), editor);
         },
     )
@@ -79,7 +77,6 @@ pub(crate) fn unqualify_method_call(acc: &mut Assists, ctx: &AssistContext<'_>) 
 fn add_import(
     qualifier: ast::Path,
     ctx: &AssistContext<'_>,
-    make: &SyntaxFactory,
     editor: &mut syntax::syntax_editor::SyntaxEditor,
 ) {
     if let Some(path_segment) = qualifier.segment() {
@@ -112,7 +109,6 @@ fn add_import(
                 import,
                 &ctx.config.insert_use,
                 editor,
-                make,
             );
         }
     }

--- a/crates/ide-assists/src/handlers/unwrap_block.rs
+++ b/crates/ide-assists/src/handlers/unwrap_block.rs
@@ -72,18 +72,18 @@ pub(crate) fn unwrap_block(acc: &mut Assists, ctx: &AssistContext<'_>) -> Option
     let replacement = replacement.stmt_list()?;
 
     acc.add(AssistId::refactor_rewrite("unwrap_block"), "Unwrap block", target, |builder| {
-        let mut edit = builder.make_editor(block.syntax());
+        let editor = builder.make_editor(block.syntax());
         let replacement = replacement.dedent(from_indent).indent(into_indent);
         let container = prefer_container.unwrap_or(container);
 
-        edit.replace_with_many(&container, extract_statements(replacement));
-        delete_else_before(container, &mut edit);
+        editor.replace_with_many(&container, extract_statements(replacement));
+        delete_else_before(container, &editor);
 
-        builder.add_file_edits(ctx.vfs_file_id(), edit);
+        builder.add_file_edits(ctx.vfs_file_id(), editor);
     })
 }
 
-fn delete_else_before(container: SyntaxNode, edit: &mut SyntaxEditor) {
+fn delete_else_before(container: SyntaxNode, edit: &SyntaxEditor) {
     let Some(else_token) = container
         .siblings_with_tokens(syntax::Direction::Prev)
         .skip(1)
@@ -103,7 +103,7 @@ fn delete_else_before(container: SyntaxNode, edit: &mut SyntaxEditor) {
 fn wrap_let(assign: &ast::LetStmt, replacement: ast::BlockExpr) -> ast::BlockExpr {
     let try_wrap_assign = || {
         let initializer = assign.initializer()?.syntax().syntax_element();
-        let (mut edit, replacement) = SyntaxEditor::with_ast_node(&replacement);
+        let (editor, replacement) = SyntaxEditor::with_ast_node(&replacement);
         let tail_expr = replacement.tail_expr()?;
         let before =
             assign.syntax().children_with_tokens().take_while(|it| *it != initializer).collect();
@@ -114,9 +114,9 @@ fn wrap_let(assign: &ast::LetStmt, replacement: ast::BlockExpr) -> ast::BlockExp
             .skip(1)
             .collect();
 
-        edit.insert_all(Position::before(tail_expr.syntax()), before);
-        edit.insert_all(Position::after(tail_expr.syntax()), after);
-        ast::BlockExpr::cast(edit.finish().new_root().clone())
+        editor.insert_all(Position::before(tail_expr.syntax()), before);
+        editor.insert_all(Position::after(tail_expr.syntax()), after);
+        ast::BlockExpr::cast(editor.finish().new_root().clone())
     };
     try_wrap_assign().unwrap_or(replacement)
 }

--- a/crates/ide-assists/src/handlers/unwrap_return_type.rs
+++ b/crates/ide-assists/src/handlers/unwrap_return_type.rs
@@ -66,7 +66,8 @@ pub(crate) fn unwrap_return_type(acc: &mut Assists, ctx: &AssistContext<'_>) -> 
     let happy_type = extract_wrapped_type(type_ref)?;
 
     acc.add(kind.assist_id(), kind.label(), type_ref.syntax().text_range(), |builder| {
-        let mut editor = builder.make_editor(&parent);
+        let editor = builder.make_editor(&parent);
+        let make = editor.make();
 
         let mut exprs_to_unwrap = Vec::new();
         let tail_cb = &mut |e: &_| tail_cb_impl(&mut exprs_to_unwrap, e);
@@ -118,15 +119,14 @@ pub(crate) fn unwrap_return_type(acc: &mut Assists, ctx: &AssistContext<'_>) -> 
                             .and_then(Either::<ast::ReturnExpr, ast::StmtList>::cast)
                             .unwrap();
                         match tail_parent {
-                            Either::Left(ret_expr) => editor.replace(
-                                ret_expr.syntax(),
-                                editor.make().expr_return(None).syntax(),
-                            ),
+                            Either::Left(ret_expr) => {
+                                editor.replace(ret_expr.syntax(), make.expr_return(None).syntax())
+                            }
                             Either::Right(stmt_list) => {
                                 let new_block = if stmt_list.statements().next().is_none() {
-                                    editor.make().expr_empty_block()
+                                    make.expr_empty_block()
                                 } else {
-                                    editor.make().block_expr(stmt_list.statements(), None)
+                                    make.block_expr(stmt_list.statements(), None)
                                 };
                                 editor.replace(
                                     stmt_list.syntax(),
@@ -147,7 +147,7 @@ pub(crate) fn unwrap_return_type(acc: &mut Assists, ctx: &AssistContext<'_>) -> 
                         continue;
                     }
 
-                    let new_tail_expr = editor.make().expr_unit();
+                    let new_tail_expr = make.expr_unit();
                     editor.replace(path_expr.syntax(), new_tail_expr.syntax());
                     if let Some(cap) = ctx.config.snippet_cap {
                         editor.add_annotation(

--- a/crates/ide-assists/src/handlers/unwrap_return_type.rs
+++ b/crates/ide-assists/src/handlers/unwrap_return_type.rs
@@ -5,7 +5,7 @@ use ide_db::{
 };
 use syntax::{
     AstNode, NodeOrToken, SyntaxKind,
-    ast::{self, HasArgList, HasGenericArgs, syntax_factory::SyntaxFactory},
+    ast::{self, HasArgList, HasGenericArgs},
     match_ast,
 };
 
@@ -67,7 +67,6 @@ pub(crate) fn unwrap_return_type(acc: &mut Assists, ctx: &AssistContext<'_>) -> 
 
     acc.add(kind.assist_id(), kind.label(), type_ref.syntax().text_range(), |builder| {
         let mut editor = builder.make_editor(&parent);
-        let make = SyntaxFactory::with_mappings();
 
         let mut exprs_to_unwrap = Vec::new();
         let tail_cb = &mut |e: &_| tail_cb_impl(&mut exprs_to_unwrap, e);
@@ -119,14 +118,15 @@ pub(crate) fn unwrap_return_type(acc: &mut Assists, ctx: &AssistContext<'_>) -> 
                             .and_then(Either::<ast::ReturnExpr, ast::StmtList>::cast)
                             .unwrap();
                         match tail_parent {
-                            Either::Left(ret_expr) => {
-                                editor.replace(ret_expr.syntax(), make.expr_return(None).syntax())
-                            }
+                            Either::Left(ret_expr) => editor.replace(
+                                ret_expr.syntax(),
+                                editor.make().expr_return(None).syntax(),
+                            ),
                             Either::Right(stmt_list) => {
                                 let new_block = if stmt_list.statements().next().is_none() {
-                                    make.expr_empty_block()
+                                    editor.make().expr_empty_block()
                                 } else {
-                                    make.block_expr(stmt_list.statements(), None)
+                                    editor.make().block_expr(stmt_list.statements(), None)
                                 };
                                 editor.replace(
                                     stmt_list.syntax(),
@@ -147,7 +147,7 @@ pub(crate) fn unwrap_return_type(acc: &mut Assists, ctx: &AssistContext<'_>) -> 
                         continue;
                     }
 
-                    let new_tail_expr = make.expr_unit();
+                    let new_tail_expr = editor.make().expr_unit();
                     editor.replace(path_expr.syntax(), new_tail_expr.syntax());
                     if let Some(cap) = ctx.config.snippet_cap {
                         editor.add_annotation(
@@ -168,7 +168,6 @@ pub(crate) fn unwrap_return_type(acc: &mut Assists, ctx: &AssistContext<'_>) -> 
             editor.add_annotation(final_placeholder.syntax(), builder.make_tabstop_after(cap));
         }
 
-        editor.add_mappings(make.finish_with_mappings());
         builder.add_file_edits(ctx.vfs_file_id(), editor);
     })
 }

--- a/crates/ide-assists/src/handlers/unwrap_type_to_generic_arg.rs
+++ b/crates/ide-assists/src/handlers/unwrap_type_to_generic_arg.rs
@@ -46,7 +46,7 @@ pub(crate) fn unwrap_type_to_generic_arg(acc: &mut Assists, ctx: &AssistContext<
         format!("Unwrap type to type argument {generic_arg}"),
         path_type.syntax().text_range(),
         |builder| {
-            let mut editor = builder.make_editor(path_type.syntax());
+            let editor = builder.make_editor(path_type.syntax());
             editor.replace(path_type.syntax(), generic_arg.syntax());
 
             builder.add_file_edits(ctx.vfs_file_id(), editor);

--- a/crates/ide-assists/src/handlers/wrap_return_type.rs
+++ b/crates/ide-assists/src/handlers/wrap_return_type.rs
@@ -77,19 +77,16 @@ pub(crate) fn wrap_return_type(acc: &mut Assists, ctx: &AssistContext<'_>) -> Op
             kind.label(),
             type_ref.syntax().text_range(),
             |builder| {
-                let mut editor = builder.make_editor(&parent);
-                let alias =
-                    wrapper_alias(ctx, editor.make(), core_wrapper, type_ref, &ty, kind.symbol());
+                let editor = builder.make_editor(&parent);
+                let make = editor.make();
+                let alias = wrapper_alias(ctx, make, core_wrapper, type_ref, &ty, kind.symbol());
                 let (ast_new_return_ty, semantic_new_return_ty) = alias.unwrap_or_else(|| {
                     let (ast_ty, ty_constructor) = match kind {
-                        WrapperKind::Option => (
-                            editor.make().ty_option(type_ref.clone()),
-                            famous_defs.core_option_Option(),
-                        ),
+                        WrapperKind::Option => {
+                            (make.ty_option(type_ref.clone()), famous_defs.core_option_Option())
+                        }
                         WrapperKind::Result => (
-                            editor
-                                .make()
-                                .ty_result(type_ref.clone(), editor.make().ty_infer().into()),
+                            make.ty_result(type_ref.clone(), make.ty_infer().into()),
                             famous_defs.core_result_Result(),
                         ),
                     };
@@ -124,9 +121,9 @@ pub(crate) fn wrap_return_type(acc: &mut Assists, ctx: &AssistContext<'_>) -> Op
                         continue;
                     }
 
-                    let happy_wrapped = editor.make().expr_call(
-                        editor.make().expr_path(editor.make().ident_path(kind.happy_ident())),
-                        editor.make().arg_list(iter::once(ret_expr_arg.clone())),
+                    let happy_wrapped = make.expr_call(
+                        make.expr_path(make.ident_path(kind.happy_ident())),
+                        make.arg_list(iter::once(ret_expr_arg.clone())),
                     );
                     editor.replace(ret_expr_arg.syntax(), happy_wrapped.syntax());
                 }

--- a/crates/ide-assists/src/handlers/wrap_return_type.rs
+++ b/crates/ide-assists/src/handlers/wrap_return_type.rs
@@ -78,15 +78,18 @@ pub(crate) fn wrap_return_type(acc: &mut Assists, ctx: &AssistContext<'_>) -> Op
             type_ref.syntax().text_range(),
             |builder| {
                 let mut editor = builder.make_editor(&parent);
-                let make = SyntaxFactory::with_mappings();
-                let alias = wrapper_alias(ctx, &make, core_wrapper, type_ref, &ty, kind.symbol());
+                let alias =
+                    wrapper_alias(ctx, editor.make(), core_wrapper, type_ref, &ty, kind.symbol());
                 let (ast_new_return_ty, semantic_new_return_ty) = alias.unwrap_or_else(|| {
                     let (ast_ty, ty_constructor) = match kind {
-                        WrapperKind::Option => {
-                            (make.ty_option(type_ref.clone()), famous_defs.core_option_Option())
-                        }
+                        WrapperKind::Option => (
+                            editor.make().ty_option(type_ref.clone()),
+                            famous_defs.core_option_Option(),
+                        ),
                         WrapperKind::Result => (
-                            make.ty_result(type_ref.clone(), make.ty_infer().into()),
+                            editor
+                                .make()
+                                .ty_result(type_ref.clone(), editor.make().ty_infer().into()),
                             famous_defs.core_result_Result(),
                         ),
                     };
@@ -121,9 +124,9 @@ pub(crate) fn wrap_return_type(acc: &mut Assists, ctx: &AssistContext<'_>) -> Op
                         continue;
                     }
 
-                    let happy_wrapped = make.expr_call(
-                        make.expr_path(make.ident_path(kind.happy_ident())),
-                        make.arg_list(iter::once(ret_expr_arg.clone())),
+                    let happy_wrapped = editor.make().expr_call(
+                        editor.make().expr_path(editor.make().ident_path(kind.happy_ident())),
+                        editor.make().arg_list(iter::once(ret_expr_arg.clone())),
                     );
                     editor.replace(ret_expr_arg.syntax(), happy_wrapped.syntax());
                 }
@@ -156,8 +159,6 @@ pub(crate) fn wrap_return_type(acc: &mut Assists, ctx: &AssistContext<'_>) -> Op
                         );
                     }
                 }
-
-                editor.add_mappings(make.finish_with_mappings());
                 builder.add_file_edits(ctx.vfs_file_id(), editor);
             },
         );

--- a/crates/ide-assists/src/handlers/wrap_unwrap_cfg_attr.rs
+++ b/crates/ide-assists/src/handlers/wrap_unwrap_cfg_attr.rs
@@ -192,25 +192,25 @@ fn wrap_derive(
         }
     }
     let handle_source_change = |edit: &mut SourceChangeBuilder| {
-        let mut editor = edit.make_editor(attr.syntax());
-        let new_derive = editor.make().attr_outer(editor.make().meta_token_tree(
-            editor.make().ident_path("derive"),
-            editor.make().token_tree(T!['('], new_derive),
-        ));
-        let meta = editor.make().cfg_attr_meta(
-            editor.make().cfg_flag("cfg"),
-            [editor.make().meta_token_tree(
-                editor.make().ident_path("derive"),
-                editor.make().token_tree(T!['('], cfg_derive_tokens),
+        let editor = edit.make_editor(attr.syntax());
+        let make = editor.make();
+        let new_derive = make.attr_outer(
+            make.meta_token_tree(make.ident_path("derive"), make.token_tree(T!['('], new_derive)),
+        );
+        let meta = make.cfg_attr_meta(
+            make.cfg_flag("cfg"),
+            [make.meta_token_tree(
+                make.ident_path("derive"),
+                make.token_tree(T!['('], cfg_derive_tokens),
             )],
         );
 
-        let cfg_attr = editor.make().attr_outer(meta.clone().into());
+        let cfg_attr = make.attr_outer(meta.clone().into());
         editor.replace_with_many(
             attr.syntax(),
             vec![
                 new_derive.syntax().clone().into(),
-                editor.make().whitespace("\n").into(),
+                make.whitespace("\n").into(),
                 cfg_attr.syntax().clone().into(),
             ],
         );
@@ -237,15 +237,14 @@ fn wrap_cfg_attrs(acc: &mut Assists, ctx: &AssistContext<'_>, attrs: Vec<ast::At
     let (first_attr, last_attr) = (attrs.first()?, attrs.last()?);
     let range = first_attr.syntax().text_range().cover(last_attr.syntax().text_range());
     let handle_source_change = |edit: &mut SourceChangeBuilder| {
-        let mut editor = edit.make_editor(first_attr.syntax());
-        let meta = editor.make().cfg_attr_meta(
-            editor.make().cfg_flag("cfg"),
-            attrs.iter().filter_map(|attr| attr.meta()),
-        );
+        let editor = edit.make_editor(first_attr.syntax());
+        let make = editor.make();
+        let meta =
+            make.cfg_attr_meta(make.cfg_flag("cfg"), attrs.iter().filter_map(|attr| attr.meta()));
         let cfg_attr = if first_attr.excl_token().is_some() {
-            editor.make().attr_inner(meta.clone().into())
+            make.attr_inner(meta.clone().into())
         } else {
-            editor.make().attr_outer(meta.clone().into())
+            make.attr_outer(meta.clone().into())
         };
 
         let syntax_range = first_attr.syntax().clone().into()..=last_attr.syntax().clone().into();

--- a/crates/ide-assists/src/handlers/wrap_unwrap_cfg_attr.rs
+++ b/crates/ide-assists/src/handlers/wrap_unwrap_cfg_attr.rs
@@ -2,7 +2,7 @@ use ide_db::source_change::SourceChangeBuilder;
 use itertools::Itertools;
 use syntax::{
     NodeOrToken, SyntaxToken, T, TextRange, algo,
-    ast::{self, AstNode, edit::AstNodeEdit, make, syntax_factory::SyntaxFactory},
+    ast::{self, AstNode, edit::AstNodeEdit, make},
 };
 
 use crate::{AssistContext, AssistId, Assists};
@@ -192,25 +192,25 @@ fn wrap_derive(
         }
     }
     let handle_source_change = |edit: &mut SourceChangeBuilder| {
-        let make = SyntaxFactory::with_mappings();
         let mut editor = edit.make_editor(attr.syntax());
-        let new_derive = make.attr_outer(
-            make.meta_token_tree(make.ident_path("derive"), make.token_tree(T!['('], new_derive)),
-        );
-        let meta = make.cfg_attr_meta(
-            make.cfg_flag("cfg"),
-            [make.meta_token_tree(
-                make.ident_path("derive"),
-                make.token_tree(T!['('], cfg_derive_tokens),
+        let new_derive = editor.make().attr_outer(editor.make().meta_token_tree(
+            editor.make().ident_path("derive"),
+            editor.make().token_tree(T!['('], new_derive),
+        ));
+        let meta = editor.make().cfg_attr_meta(
+            editor.make().cfg_flag("cfg"),
+            [editor.make().meta_token_tree(
+                editor.make().ident_path("derive"),
+                editor.make().token_tree(T!['('], cfg_derive_tokens),
             )],
         );
 
-        let cfg_attr = make.attr_outer(meta.clone().into());
+        let cfg_attr = editor.make().attr_outer(meta.clone().into());
         editor.replace_with_many(
             attr.syntax(),
             vec![
                 new_derive.syntax().clone().into(),
-                make.whitespace("\n").into(),
+                editor.make().whitespace("\n").into(),
                 cfg_attr.syntax().clone().into(),
             ],
         );
@@ -221,8 +221,6 @@ fn wrap_derive(
             let tabstop = edit.make_placeholder_snippet(snippet_cap);
             editor.add_annotation(cfg_predicate.syntax(), tabstop);
         }
-
-        editor.add_mappings(make.finish_with_mappings());
         edit.add_file_edits(ctx.vfs_file_id(), editor);
     };
 
@@ -239,14 +237,15 @@ fn wrap_cfg_attrs(acc: &mut Assists, ctx: &AssistContext<'_>, attrs: Vec<ast::At
     let (first_attr, last_attr) = (attrs.first()?, attrs.last()?);
     let range = first_attr.syntax().text_range().cover(last_attr.syntax().text_range());
     let handle_source_change = |edit: &mut SourceChangeBuilder| {
-        let make = SyntaxFactory::with_mappings();
         let mut editor = edit.make_editor(first_attr.syntax());
-        let meta =
-            make.cfg_attr_meta(make.cfg_flag("cfg"), attrs.iter().filter_map(|attr| attr.meta()));
+        let meta = editor.make().cfg_attr_meta(
+            editor.make().cfg_flag("cfg"),
+            attrs.iter().filter_map(|attr| attr.meta()),
+        );
         let cfg_attr = if first_attr.excl_token().is_some() {
-            make.attr_inner(meta.clone().into())
+            editor.make().attr_inner(meta.clone().into())
         } else {
-            make.attr_outer(meta.clone().into())
+            editor.make().attr_outer(meta.clone().into())
         };
 
         let syntax_range = first_attr.syntax().clone().into()..=last_attr.syntax().clone().into();
@@ -258,8 +257,6 @@ fn wrap_cfg_attrs(acc: &mut Assists, ctx: &AssistContext<'_>, attrs: Vec<ast::At
             let tabstop = edit.make_placeholder_snippet(snippet_cap);
             editor.add_annotation(cfg_flag.syntax(), tabstop);
         }
-
-        editor.add_mappings(make.finish_with_mappings());
         edit.add_file_edits(ctx.vfs_file_id(), editor);
     };
     acc.add(

--- a/crates/ide-assists/src/utils.rs
+++ b/crates/ide-assists/src/utils.rs
@@ -348,7 +348,6 @@ pub(crate) fn insert_attributes(
     before: impl Element,
     edit: &mut SyntaxEditor,
     attrs: impl IntoIterator<Item = ast::Attr>,
-    make: &SyntaxFactory,
 ) {
     let mut attrs = attrs.into_iter().peekable();
     if attrs.peek().is_none() {
@@ -357,12 +356,10 @@ pub(crate) fn insert_attributes(
     let elem = before.syntax_element();
     let indent = IndentLevel::from_element(&elem);
     let whitespace = format!("\n{indent}");
-    edit.insert_all(
-        syntax::syntax_editor::Position::before(elem),
-        attrs
-            .flat_map(|attr| [attr.syntax().clone().into(), make.whitespace(&whitespace).into()])
-            .collect(),
-    );
+    let elements: Vec<syntax::SyntaxElement> = attrs
+        .flat_map(|attr| [attr.syntax().clone().into(), edit.make().whitespace(&whitespace).into()])
+        .collect();
+    edit.insert_all(syntax::syntax_editor::Position::before(elem), elements);
 }
 
 pub(crate) fn next_prev() -> impl Iterator<Item = Direction> {

--- a/crates/ide-assists/src/utils.rs
+++ b/crates/ide-assists/src/utils.rs
@@ -248,20 +248,20 @@ pub fn add_trait_assoc_items_to_impl(
         })
         .filter_map(|item| match item {
             ast::AssocItem::Fn(fn_) if fn_.body().is_none() => {
-                let (mut fn_editor, fn_) = SyntaxEditor::with_ast_node(&fn_);
+                let (fn_editor, fn_) = SyntaxEditor::with_ast_node(&fn_);
                 let fill_expr: ast::Expr = match config.expr_fill_default {
                     ExprFillDefaultMode::Todo | ExprFillDefaultMode::Default => make.expr_todo(),
                     ExprFillDefaultMode::Underscore => make.expr_underscore().into(),
                 };
                 let new_body = make.block_expr(None::<ast::Stmt>, Some(fill_expr));
-                fn_.replace_or_insert_body(&mut fn_editor, new_body);
+                fn_.replace_or_insert_body(&fn_editor, new_body);
                 let new_fn_ = fn_editor.finish().new_root().clone();
                 ast::AssocItem::cast(new_fn_)
             }
             ast::AssocItem::TypeAlias(type_alias) => {
-                let (mut type_alias_editor, type_alias) = SyntaxEditor::with_ast_node(&type_alias);
+                let (type_alias_editor, type_alias) = SyntaxEditor::with_ast_node(&type_alias);
                 if let Some(type_bound_list) = type_alias.type_bound_list() {
-                    type_bound_list.remove(&mut type_alias_editor);
+                    type_bound_list.remove(&type_alias_editor);
                 };
                 let type_alias = type_alias_editor.finish().new_root().clone();
                 ast::AssocItem::cast(type_alias)
@@ -346,9 +346,10 @@ fn invert_special_case(make: &SyntaxFactory, expr: &ast::Expr) -> Option<ast::Ex
 
 pub(crate) fn insert_attributes(
     before: impl Element,
-    edit: &mut SyntaxEditor,
+    editor: &SyntaxEditor,
     attrs: impl IntoIterator<Item = ast::Attr>,
 ) {
+    let make = editor.make();
     let mut attrs = attrs.into_iter().peekable();
     if attrs.peek().is_none() {
         return;
@@ -357,9 +358,9 @@ pub(crate) fn insert_attributes(
     let indent = IndentLevel::from_element(&elem);
     let whitespace = format!("\n{indent}");
     let elements: Vec<syntax::SyntaxElement> = attrs
-        .flat_map(|attr| [attr.syntax().clone().into(), edit.make().whitespace(&whitespace).into()])
+        .flat_map(|attr| [attr.syntax().clone().into(), make.whitespace(&whitespace).into()])
         .collect();
-    edit.insert_all(syntax::syntax_editor::Position::before(elem), elements);
+    editor.insert_all(syntax::syntax_editor::Position::before(elem), elements);
 }
 
 pub(crate) fn next_prev() -> impl Iterator<Item = Direction> {

--- a/crates/ide-db/src/imports/insert_use.rs
+++ b/crates/ide-db/src/imports/insert_use.rs
@@ -9,7 +9,7 @@ use syntax::{
     Direction, NodeOrToken, SyntaxKind, SyntaxNode, algo,
     ast::{
         self, AstNode, HasAttrs, HasModuleItem, HasVisibility, PathSegmentKind,
-        edit_in_place::Removable, make, syntax_factory::SyntaxFactory,
+        edit_in_place::Removable, make,
     },
     syntax_editor::{Position, SyntaxEditor},
     ted,
@@ -176,9 +176,8 @@ pub fn insert_use_with_editor(
     path: ast::Path,
     cfg: &InsertUseConfig,
     syntax_editor: &mut SyntaxEditor,
-    syntax_factory: &SyntaxFactory,
 ) {
-    insert_use_with_alias_option_with_editor(scope, path, cfg, None, syntax_editor, syntax_factory);
+    insert_use_with_alias_option_with_editor(scope, path, cfg, None, syntax_editor);
 }
 
 pub fn insert_use_as_alias(
@@ -270,7 +269,6 @@ fn insert_use_with_alias_option_with_editor(
     cfg: &InsertUseConfig,
     alias: Option<ast::Rename>,
     syntax_editor: &mut SyntaxEditor,
-    syntax_factory: &SyntaxFactory,
 ) {
     let _p = tracing::info_span!("insert_use_with_alias_option").entered();
     let mut mb = match cfg.granularity {
@@ -301,7 +299,7 @@ fn insert_use_with_alias_option_with_editor(
         };
     }
 
-    let use_tree = syntax_factory.use_tree(path, None, alias, false);
+    let use_tree = syntax_editor.make().use_tree(path, None, alias, false);
     if mb == Some(MergeBehavior::One) && use_tree.path().is_some() {
         use_tree.wrap_in_tree_list();
     }
@@ -324,7 +322,7 @@ fn insert_use_with_alias_option_with_editor(
     }
     // either we weren't allowed to merge or there is no import that fits the merge conditions
     // so look for the place we have to insert to
-    insert_use_with_editor_(scope, use_item, cfg.group, syntax_editor, syntax_factory);
+    insert_use_with_editor_(scope, use_item, cfg.group, syntax_editor);
 }
 
 pub fn ast_to_remove_for_path_in_use_stmt(path: &ast::Path) -> Option<Box<dyn Removable>> {
@@ -605,7 +603,6 @@ fn insert_use_with_editor_(
     use_item: ast::Use,
     group_imports: bool,
     syntax_editor: &mut SyntaxEditor,
-    syntax_factory: &SyntaxFactory,
 ) {
     let scope_syntax = scope.as_syntax_node();
     let insert_use_tree =
@@ -656,7 +653,7 @@ fn insert_use_with_editor_(
             cov_mark::hit!(insert_group_new_group);
             syntax_editor.insert(Position::before(&node), use_item.syntax());
             if let Some(node) = algo::non_trivia_sibling(node.into(), Direction::Prev) {
-                syntax_editor.insert(Position::after(node), syntax_factory.whitespace("\n"));
+                syntax_editor.insert(Position::after(node), syntax_editor.make().whitespace("\n"));
             }
             return;
         }
@@ -664,7 +661,7 @@ fn insert_use_with_editor_(
         if let Some(node) = last {
             cov_mark::hit!(insert_group_no_group);
             syntax_editor.insert(Position::after(&node), use_item.syntax());
-            syntax_editor.insert(Position::after(node), syntax_factory.whitespace("\n"));
+            syntax_editor.insert(Position::after(node), syntax_editor.make().whitespace("\n"));
             return;
         }
     } else {
@@ -703,23 +700,20 @@ fn insert_use_with_editor_(
     {
         cov_mark::hit!(insert_empty_inner_attr);
         syntax_editor.insert(Position::after(&last_inner_element), use_item.syntax());
-        syntax_editor.insert(Position::after(last_inner_element), syntax_factory.whitespace("\n"));
+        syntax_editor
+            .insert(Position::after(last_inner_element), syntax_editor.make().whitespace("\n"));
     } else {
         match l_curly {
             Some(b) => {
                 cov_mark::hit!(insert_empty_module);
-                syntax_editor.insert(Position::after(&b), syntax_factory.whitespace("\n"));
-                syntax_editor.insert_with_whitespace(
-                    Position::after(&b),
-                    use_item.syntax(),
-                    syntax_factory,
-                );
+                syntax_editor.insert(Position::after(&b), syntax_editor.make().whitespace("\n"));
+                syntax_editor.insert_with_whitespace(Position::after(&b), use_item.syntax());
             }
             None => {
                 cov_mark::hit!(insert_empty_file);
                 syntax_editor.insert(
                     Position::first_child_of(scope_syntax),
-                    syntax_factory.whitespace("\n\n"),
+                    syntax_editor.make().whitespace("\n\n"),
                 );
                 syntax_editor.insert(Position::first_child_of(scope_syntax), use_item.syntax());
             }

--- a/crates/ide-db/src/imports/insert_use.rs
+++ b/crates/ide-db/src/imports/insert_use.rs
@@ -175,7 +175,7 @@ pub fn insert_use_with_editor(
     scope: &ImportScope,
     path: ast::Path,
     cfg: &InsertUseConfig,
-    syntax_editor: &mut SyntaxEditor,
+    syntax_editor: &SyntaxEditor,
 ) {
     insert_use_with_alias_option_with_editor(scope, path, cfg, None, syntax_editor);
 }
@@ -268,8 +268,9 @@ fn insert_use_with_alias_option_with_editor(
     path: ast::Path,
     cfg: &InsertUseConfig,
     alias: Option<ast::Rename>,
-    syntax_editor: &mut SyntaxEditor,
+    syntax_editor: &SyntaxEditor,
 ) {
+    let make = syntax_editor.make();
     let _p = tracing::info_span!("insert_use_with_alias_option").entered();
     let mut mb = match cfg.granularity {
         ImportGranularity::Crate => Some(MergeBehavior::Crate),
@@ -299,7 +300,7 @@ fn insert_use_with_alias_option_with_editor(
         };
     }
 
-    let use_tree = syntax_editor.make().use_tree(path, None, alias, false);
+    let use_tree = make.use_tree(path, None, alias, false);
     if mb == Some(MergeBehavior::One) && use_tree.path().is_some() {
         use_tree.wrap_in_tree_list();
     }
@@ -602,8 +603,9 @@ fn insert_use_with_editor_(
     scope: &ImportScope,
     use_item: ast::Use,
     group_imports: bool,
-    syntax_editor: &mut SyntaxEditor,
+    syntax_editor: &SyntaxEditor,
 ) {
+    let make = syntax_editor.make();
     let scope_syntax = scope.as_syntax_node();
     let insert_use_tree =
         use_item.use_tree().expect("`use_item` should have a use tree for `insert_path`");
@@ -653,7 +655,7 @@ fn insert_use_with_editor_(
             cov_mark::hit!(insert_group_new_group);
             syntax_editor.insert(Position::before(&node), use_item.syntax());
             if let Some(node) = algo::non_trivia_sibling(node.into(), Direction::Prev) {
-                syntax_editor.insert(Position::after(node), syntax_editor.make().whitespace("\n"));
+                syntax_editor.insert(Position::after(node), make.whitespace("\n"));
             }
             return;
         }
@@ -661,7 +663,7 @@ fn insert_use_with_editor_(
         if let Some(node) = last {
             cov_mark::hit!(insert_group_no_group);
             syntax_editor.insert(Position::after(&node), use_item.syntax());
-            syntax_editor.insert(Position::after(node), syntax_editor.make().whitespace("\n"));
+            syntax_editor.insert(Position::after(node), make.whitespace("\n"));
             return;
         }
     } else {
@@ -700,21 +702,18 @@ fn insert_use_with_editor_(
     {
         cov_mark::hit!(insert_empty_inner_attr);
         syntax_editor.insert(Position::after(&last_inner_element), use_item.syntax());
-        syntax_editor
-            .insert(Position::after(last_inner_element), syntax_editor.make().whitespace("\n"));
+        syntax_editor.insert(Position::after(last_inner_element), make.whitespace("\n"));
     } else {
         match l_curly {
             Some(b) => {
                 cov_mark::hit!(insert_empty_module);
-                syntax_editor.insert(Position::after(&b), syntax_editor.make().whitespace("\n"));
+                syntax_editor.insert(Position::after(&b), make.whitespace("\n"));
                 syntax_editor.insert_with_whitespace(Position::after(&b), use_item.syntax());
             }
             None => {
                 cov_mark::hit!(insert_empty_file);
-                syntax_editor.insert(
-                    Position::first_child_of(scope_syntax),
-                    syntax_editor.make().whitespace("\n\n"),
-                );
+                syntax_editor
+                    .insert(Position::first_child_of(scope_syntax), make.whitespace("\n\n"));
                 syntax_editor.insert(Position::first_child_of(scope_syntax), use_item.syntax());
             }
         }

--- a/crates/ide-db/src/path_transform.rs
+++ b/crates/ide-db/src/path_transform.rs
@@ -278,7 +278,7 @@ impl Ctx<'_> {
         // `transform_path` may update a node's parent and that would break the
         // tree traversal. Thus all paths in the tree are collected into a vec
         // so that such operation is safe.
-        let (mut editor, item) = SyntaxEditor::new(self.transform_path(item));
+        let (editor, item) = SyntaxEditor::new(self.transform_path(item));
         preorder_rev(&item).filter_map(ast::Lifetime::cast).for_each(|lifetime| {
             if let Some(subst) = self.lifetime_substs.get(&lifetime.syntax().text().to_string()) {
                 editor.replace(lifetime.syntax(), subst.clone().syntax());
@@ -329,22 +329,22 @@ impl Ctx<'_> {
             result
         }
 
-        let (mut editor, root_path) = SyntaxEditor::new(path.clone());
+        let (editor, root_path) = SyntaxEditor::new(path.clone());
         let result = find_child_paths_and_ident_pats(&root_path);
         for sub_path in result {
             let new = self.transform_path(sub_path.syntax());
             editor.replace(sub_path.syntax(), new);
         }
-        let (mut editor, update_sub_item) = SyntaxEditor::new(editor.finish().new_root().clone());
+        let (editor, update_sub_item) = SyntaxEditor::new(editor.finish().new_root().clone());
         let item = find_child_paths_and_ident_pats(&update_sub_item);
         for sub_path in item {
-            self.transform_path_or_ident_pat(&mut editor, &sub_path);
+            self.transform_path_or_ident_pat(&editor, &sub_path);
         }
         editor.finish().new_root().clone()
     }
     fn transform_path_or_ident_pat(
         &self,
-        editor: &mut SyntaxEditor,
+        editor: &SyntaxEditor,
         item: &Either<ast::Path, ast::IdentPat>,
     ) -> Option<()> {
         match item {
@@ -353,7 +353,7 @@ impl Ctx<'_> {
         }
     }
 
-    fn transform_path_(&self, editor: &mut SyntaxEditor, path: &ast::Path) -> Option<()> {
+    fn transform_path_(&self, editor: &SyntaxEditor, path: &ast::Path) -> Option<()> {
         if path.qualifier().is_some() {
             return None;
         }
@@ -448,7 +448,7 @@ impl Ctx<'_> {
                 };
                 let found_path = self.target_module.find_path(self.source_scope.db, def, cfg)?;
                 let res = mod_path_to_ast(&found_path, self.target_edition);
-                let (mut res_editor, res) = SyntaxEditor::with_ast_node(&res);
+                let (res_editor, res) = SyntaxEditor::with_ast_node(&res);
                 if let Some(args) = path.segment().and_then(|it| it.generic_arg_list())
                     && let Some(segment) = res.segment()
                 {
@@ -522,11 +522,7 @@ impl Ctx<'_> {
         Some(())
     }
 
-    fn transform_ident_pat(
-        &self,
-        editor: &mut SyntaxEditor,
-        ident_pat: &ast::IdentPat,
-    ) -> Option<()> {
+    fn transform_ident_pat(&self, editor: &SyntaxEditor, ident_pat: &ast::IdentPat) -> Option<()> {
         let name = ident_pat.name()?;
 
         let temp_path = make::path_from_text(&name.text());

--- a/crates/ide-diagnostics/src/handlers/type_mismatch.rs
+++ b/crates/ide-diagnostics/src/handlers/type_mismatch.rs
@@ -10,7 +10,6 @@ use syntax::{
     ast::{
         self, BlockExpr, Expr, ExprStmt, HasArgList,
         edit::{AstNodeEdit, IndentLevel},
-        syntax_factory::SyntaxFactory,
     },
 };
 
@@ -245,24 +244,21 @@ fn remove_unnecessary_wrapper(
                 .and_then(Either::<ast::ReturnExpr, ast::StmtList>::cast)?;
 
             editor = builder.make_editor(parent.syntax());
-            let make = SyntaxFactory::with_mappings();
 
             match parent {
                 Either::Left(ret_expr) => {
-                    editor.replace(ret_expr.syntax(), make.expr_return(None).syntax());
+                    editor.replace(ret_expr.syntax(), editor.make().expr_return(None).syntax());
                 }
                 Either::Right(stmt_list) => {
                     let new_block = if stmt_list.statements().next().is_none() {
-                        make.expr_empty_block()
+                        editor.make().expr_empty_block()
                     } else {
-                        make.block_expr(stmt_list.statements(), None)
+                        editor.make().block_expr(stmt_list.statements(), None)
                     };
 
                     editor.replace(stmt_list.syntax().parent()?, new_block.syntax());
                 }
             }
-
-            editor.add_mappings(make.finish_with_mappings());
         }
         _ => {
             editor = builder.make_editor(call_expr.syntax());

--- a/crates/ide-diagnostics/src/handlers/type_mismatch.rs
+++ b/crates/ide-diagnostics/src/handlers/type_mismatch.rs
@@ -234,7 +234,7 @@ fn remove_unnecessary_wrapper(
 
     let file_id = expr_ptr.file_id.original_file(db);
     let mut builder = SourceChangeBuilder::new(file_id.file_id(ctx.sema.db));
-    let mut editor;
+    let editor;
     match inner_arg {
         // We're returning `()`
         Expr::TupleExpr(tup) if tup.fields().next().is_none() => {
@@ -244,16 +244,17 @@ fn remove_unnecessary_wrapper(
                 .and_then(Either::<ast::ReturnExpr, ast::StmtList>::cast)?;
 
             editor = builder.make_editor(parent.syntax());
+            let make = editor.make();
 
             match parent {
                 Either::Left(ret_expr) => {
-                    editor.replace(ret_expr.syntax(), editor.make().expr_return(None).syntax());
+                    editor.replace(ret_expr.syntax(), make.expr_return(None).syntax());
                 }
                 Either::Right(stmt_list) => {
                     let new_block = if stmt_list.statements().next().is_none() {
-                        editor.make().expr_empty_block()
+                        make.expr_empty_block()
                     } else {
-                        editor.make().block_expr(stmt_list.statements(), None)
+                        make.block_expr(stmt_list.statements(), None)
                     };
 
                     editor.replace(stmt_list.syntax().parent()?, new_block.syntax());

--- a/crates/syntax/src/ast/edit.rs
+++ b/crates/syntax/src/ast/edit.rs
@@ -202,7 +202,6 @@ impl ast::IdentPat {
         &self,
         pat: Option<ast::Pat>,
         syntax_editor: &mut SyntaxEditor,
-        syntax_factory: &SyntaxFactory,
     ) -> ast::IdentPat {
         match pat {
             None => {
@@ -234,9 +233,9 @@ impl ast::IdentPat {
                     // Don't have an `@`, should have a name
                     let name = self.name().unwrap();
                     let elements = vec![
-                        syntax_factory.whitespace(" ").into(),
-                        syntax_factory.token(T![@]).into(),
-                        syntax_factory.whitespace(" ").into(),
+                        syntax_editor.make().whitespace(" ").into(),
+                        syntax_editor.make().token(T![@]).into(),
+                        syntax_editor.make().whitespace(" ").into(),
                         pat.syntax().clone().into(),
                     ];
 

--- a/crates/syntax/src/ast/edit.rs
+++ b/crates/syntax/src/ast/edit.rs
@@ -108,7 +108,7 @@ impl IndentLevel {
     }
 
     pub(super) fn clone_increase_indent(self, node: &SyntaxNode) -> SyntaxNode {
-        let (mut editor, node) = SyntaxEditor::new(node.clone());
+        let (editor, node) = SyntaxEditor::new(node.clone());
         let tokens = node
             .preorder_with_tokens()
             .filter_map(|event| match event {
@@ -142,7 +142,7 @@ impl IndentLevel {
     }
 
     pub(super) fn clone_decrease_indent(self, node: &SyntaxNode) -> SyntaxNode {
-        let (mut editor, node) = SyntaxEditor::new(node.clone());
+        let (editor, node) = SyntaxEditor::new(node.clone());
         let tokens = node
             .preorder_with_tokens()
             .filter_map(|event| match event {
@@ -198,11 +198,8 @@ pub trait AstNodeEdit: AstNode + Clone + Sized {
 impl<N: AstNode + Clone> AstNodeEdit for N {}
 
 impl ast::IdentPat {
-    pub fn set_pat(
-        &self,
-        pat: Option<ast::Pat>,
-        syntax_editor: &mut SyntaxEditor,
-    ) -> ast::IdentPat {
+    pub fn set_pat(&self, pat: Option<ast::Pat>, editor: &SyntaxEditor) -> ast::IdentPat {
+        let make = editor.make();
         match pat {
             None => {
                 if let Some(at_token) = self.at_token() {
@@ -212,7 +209,7 @@ impl ast::IdentPat {
                         .pat()
                         .map(|it| it.syntax().clone().into())
                         .unwrap_or_else(|| at_token.into());
-                    syntax_editor.delete_all(start..=end);
+                    editor.delete_all(start..=end);
 
                     // Remove any trailing ws
                     if let Some(last) =
@@ -225,28 +222,28 @@ impl ast::IdentPat {
             Some(pat) => {
                 if let Some(old_pat) = self.pat() {
                     // Replace existing pattern
-                    syntax_editor.replace(old_pat.syntax(), pat.syntax())
+                    editor.replace(old_pat.syntax(), pat.syntax())
                 } else if let Some(at_token) = self.at_token() {
                     // Have an `@` token but not a pattern yet
-                    syntax_editor.insert(Position::after(at_token), pat.syntax());
+                    editor.insert(Position::after(at_token), pat.syntax());
                 } else {
                     // Don't have an `@`, should have a name
                     let name = self.name().unwrap();
                     let elements = vec![
-                        syntax_editor.make().whitespace(" ").into(),
-                        syntax_editor.make().token(T![@]).into(),
-                        syntax_editor.make().whitespace(" ").into(),
+                        make.whitespace(" ").into(),
+                        make.token(T![@]).into(),
+                        make.whitespace(" ").into(),
                         pat.syntax().clone().into(),
                     ];
 
                     if self.syntax().parent().is_none() {
-                        let (mut local, local_self) = SyntaxEditor::with_ast_node(self);
+                        let (local, local_self) = SyntaxEditor::with_ast_node(self);
                         let local_name = local_self.name().unwrap();
                         local.insert_all(Position::after(local_name.syntax()), elements);
                         let edit = local.finish();
                         return ast::IdentPat::cast(edit.new_root().clone()).unwrap();
                     } else {
-                        syntax_editor.insert_all(Position::after(name.syntax()), elements);
+                        editor.insert_all(Position::after(name.syntax()), elements);
                     }
                 }
             }

--- a/crates/syntax/src/ast/syntax_factory.rs
+++ b/crates/syntax/src/ast/syntax_factory.rs
@@ -12,6 +12,7 @@ use std::cell::{RefCell, RefMut};
 
 use crate::syntax_editor::SyntaxMapping;
 
+#[derive(Debug)]
 pub struct SyntaxFactory {
     // Stored in a refcell so that the factory methods can be &self
     mappings: Option<RefCell<SyntaxMapping>>,
@@ -19,7 +20,7 @@ pub struct SyntaxFactory {
 
 impl SyntaxFactory {
     /// Creates a new [`SyntaxFactory`], generating mappings between input nodes and generated nodes.
-    pub fn with_mappings() -> Self {
+    pub(crate) fn with_mappings() -> Self {
         Self { mappings: Some(RefCell::new(SyntaxMapping::default())) }
     }
 
@@ -28,13 +29,8 @@ impl SyntaxFactory {
         Self { mappings: None }
     }
 
-    /// Gets all of the tracked syntax mappings, if any.
-    pub fn finish_with_mappings(self) -> SyntaxMapping {
-        self.mappings.unwrap_or_default().into_inner()
-    }
-
     /// Take all of the tracked syntax mappings, leaving `SyntaxMapping::default()` in its place, if any.
-    pub fn take(&self) -> SyntaxMapping {
+    pub(crate) fn take(&self) -> SyntaxMapping {
         self.mappings.as_ref().map(|mappings| mappings.take()).unwrap_or_default()
     }
 

--- a/crates/syntax/src/ast/syntax_factory/constructors.rs
+++ b/crates/syntax/src/ast/syntax_factory/constructors.rs
@@ -96,7 +96,9 @@ impl SyntaxFactory {
 
         if let Some(mut mapping) = self.mappings() {
             let mut builder = SyntaxMappingBuilder::new(ast.syntax().clone());
-            builder.map_children(input, ast.bounds().map(|b| b.syntax().clone()));
+            for (input_node, output_bound) in input.into_iter().zip(ast.bounds()) {
+                builder.map_node(input_node, output_bound.syntax().clone());
+            }
             builder.finish(&mut mapping);
         }
 
@@ -209,7 +211,7 @@ impl SyntaxFactory {
             }
             builder.map_children(
                 params_input,
-                ast.param_list().unwrap().params().map(|p| p.syntax().clone()),
+                ast.syntax().children().filter(|c| ast::Param::can_cast(c.kind())),
             );
             if let Some(ret_type) = ret_type {
                 builder
@@ -242,13 +244,17 @@ impl SyntaxFactory {
                     builder.map_node(ty.syntax().clone(), ast.ty().unwrap().syntax().clone());
                 }
             }
+            builder.finish(&mut mapping);
+
             if let Some(type_bound_list) = ast.type_bound_list() {
-                builder.map_children(
+                let mut bounds_builder =
+                    SyntaxMappingBuilder::new(type_bound_list.syntax().clone());
+                bounds_builder.map_children(
                     bounds_input,
                     type_bound_list.bounds().map(|b| b.syntax().clone()),
                 );
+                bounds_builder.finish(&mut mapping);
             }
-            builder.finish(&mut mapping);
         }
 
         ast
@@ -484,11 +490,13 @@ impl SyntaxFactory {
         if let Some(mut mapping) = self.mappings() {
             let mut builder = SyntaxMappingBuilder::new(ast.syntax().clone());
             builder.map_node(name_ref.syntax().clone(), ast.name_ref().unwrap().syntax().clone());
-            builder.map_children(
-                input,
-                ast.generic_arg_list().unwrap().generic_args().map(|a| a.syntax().clone()),
-            );
             builder.finish(&mut mapping);
+
+            let generic_arg_list = ast.generic_arg_list().unwrap();
+            let mut arg_builder = SyntaxMappingBuilder::new(generic_arg_list.syntax().clone());
+            arg_builder
+                .map_children(input, generic_arg_list.generic_args().map(|a| a.syntax().clone()));
+            arg_builder.finish(&mut mapping);
         }
 
         ast
@@ -629,9 +637,16 @@ impl SyntaxFactory {
         let ast = make::path_from_segments(segments, is_abs).clone_for_update();
 
         if let Some(mut mapping) = self.mappings() {
-            let mut builder = SyntaxMappingBuilder::new(ast.syntax().clone());
-            builder.map_children(input, ast.segments().map(|it| it.syntax().clone()));
-            builder.finish(&mut mapping);
+            let mut current_path = Some(ast.clone());
+            for input_segment in input.iter().rev() {
+                let Some(path) = current_path else { break };
+                if let Some(segment) = path.segment() {
+                    let mut builder = SyntaxMappingBuilder::new(path.syntax().clone());
+                    builder.map_node(input_segment.clone(), segment.syntax().clone());
+                    builder.finish(&mut mapping);
+                }
+                current_path = path.qualifier();
+            }
         }
 
         ast

--- a/crates/syntax/src/syntax_editor.rs
+++ b/crates/syntax/src/syntax_editor.rs
@@ -5,6 +5,7 @@
 //! [`SyntaxEditor`]: https://github.com/dotnet/roslyn/blob/43b0b05cc4f492fd5de00f6f6717409091df8daa/src/Workspaces/Core/Portable/Editing/SyntaxEditor.cs
 
 use std::{
+    cell::RefCell,
     fmt, iter,
     num::NonZeroU32,
     ops::RangeInclusive,
@@ -29,8 +30,8 @@ pub use mapping::{SyntaxMapping, SyntaxMappingBuilder};
 #[derive(Debug)]
 pub struct SyntaxEditor {
     root: SyntaxNode,
-    changes: Vec<Change>,
-    annotations: Vec<(SyntaxElement, SyntaxAnnotation)>,
+    changes: RefCell<Vec<Change>>,
+    annotations: RefCell<Vec<(SyntaxElement, SyntaxAnnotation)>>,
     make: SyntaxFactory,
 }
 
@@ -50,8 +51,8 @@ impl SyntaxEditor {
 
         let editor = Self {
             root: root.clone(),
-            changes: Vec::new(),
-            annotations: Vec::new(),
+            changes: RefCell::new(Vec::new()),
+            annotations: RefCell::new(Vec::new()),
             make: SyntaxFactory::with_mappings(),
         };
 
@@ -72,20 +73,17 @@ impl SyntaxEditor {
         &self.make
     }
 
-    pub fn add_annotation(&mut self, element: impl Element, annotation: SyntaxAnnotation) {
-        self.annotations.push((element.syntax_element(), annotation))
+    pub fn add_annotation(&self, element: impl Element, annotation: SyntaxAnnotation) {
+        self.annotations.borrow_mut().push((element.syntax_element(), annotation))
     }
 
-    pub fn add_annotation_all(
-        &mut self,
-        elements: Vec<impl Element>,
-        annotation: SyntaxAnnotation,
-    ) {
+    pub fn add_annotation_all(&self, elements: Vec<impl Element>, annotation: SyntaxAnnotation) {
         self.annotations
+            .borrow_mut()
             .extend(elements.into_iter().map(|e| e.syntax_element()).zip(iter::repeat(annotation)));
     }
 
-    pub fn merge(&mut self, mut other: SyntaxEditor) {
+    pub fn merge(&self, other: SyntaxEditor) {
         debug_assert!(
             self.root == other.root || other.root.ancestors().any(|node| node == self.root),
             "{:?} is not in the same tree as {:?}",
@@ -93,32 +91,28 @@ impl SyntaxEditor {
             self.root
         );
 
-        self.changes.append(&mut other.changes);
+        self.changes.borrow_mut().append(&mut other.changes.into_inner());
         if let Some(mut m) = self.make.mappings() {
             m.merge(other.make.take());
         }
-        self.annotations.append(&mut other.annotations);
+        self.annotations.borrow_mut().append(&mut other.annotations.into_inner());
     }
 
-    pub fn insert(&mut self, position: Position, element: impl Element) {
+    pub fn insert(&self, position: Position, element: impl Element) {
         debug_assert!(is_ancestor_or_self(&position.parent(), &self.root));
-        self.changes.push(Change::Insert(position, element.syntax_element()))
+        self.changes.borrow_mut().push(Change::Insert(position, element.syntax_element()))
     }
 
-    pub fn insert_all(&mut self, position: Position, elements: Vec<SyntaxElement>) {
+    pub fn insert_all(&self, position: Position, elements: Vec<SyntaxElement>) {
         debug_assert!(is_ancestor_or_self(&position.parent(), &self.root));
-        self.changes.push(Change::InsertAll(position, elements))
+        self.changes.borrow_mut().push(Change::InsertAll(position, elements))
     }
 
-    pub fn insert_with_whitespace(&mut self, position: Position, element: impl Element) {
+    pub fn insert_with_whitespace(&self, position: Position, element: impl Element) {
         self.insert_all_with_whitespace(position, vec![element.syntax_element()])
     }
 
-    pub fn insert_all_with_whitespace(
-        &mut self,
-        position: Position,
-        mut elements: Vec<SyntaxElement>,
-    ) {
+    pub fn insert_all_with_whitespace(&self, position: Position, mut elements: Vec<SyntaxElement>) {
         if let Some(first) = elements.first()
             && let Some(ws) = ws_before(&position, first, &self.make)
         {
@@ -132,50 +126,52 @@ impl SyntaxEditor {
         self.insert_all(position, elements)
     }
 
-    pub fn delete(&mut self, element: impl Element) {
+    pub fn delete(&self, element: impl Element) {
         let element = element.syntax_element();
         debug_assert!(is_ancestor_or_self_of_element(&element, &self.root));
         debug_assert!(
             !matches!(&element, SyntaxElement::Node(node) if node == &self.root),
             "should not delete root node"
         );
-        self.changes.push(Change::Replace(element.syntax_element(), None));
+        self.changes.borrow_mut().push(Change::Replace(element.syntax_element(), None));
     }
 
-    pub fn delete_all(&mut self, range: RangeInclusive<SyntaxElement>) {
+    pub fn delete_all(&self, range: RangeInclusive<SyntaxElement>) {
         if range.start() == range.end() {
             self.delete(range.start());
             return;
         }
 
         debug_assert!(is_ancestor_or_self_of_element(range.start(), &self.root));
-        self.changes.push(Change::ReplaceAll(range, Vec::new()))
+        self.changes.borrow_mut().push(Change::ReplaceAll(range, Vec::new()))
     }
 
-    pub fn replace(&mut self, old: impl Element, new: impl Element) {
+    pub fn replace(&self, old: impl Element, new: impl Element) {
         let old = old.syntax_element();
         debug_assert!(is_ancestor_or_self_of_element(&old, &self.root));
-        self.changes.push(Change::Replace(old.syntax_element(), Some(new.syntax_element())));
+        self.changes
+            .borrow_mut()
+            .push(Change::Replace(old.syntax_element(), Some(new.syntax_element())));
     }
 
-    pub fn replace_with_many(&mut self, old: impl Element, new: Vec<SyntaxElement>) {
+    pub fn replace_with_many(&self, old: impl Element, new: Vec<SyntaxElement>) {
         let old = old.syntax_element();
         debug_assert!(is_ancestor_or_self_of_element(&old, &self.root));
         debug_assert!(
             !(matches!(&old, SyntaxElement::Node(node) if node == &self.root) && new.len() > 1),
             "cannot replace root node with many elements"
         );
-        self.changes.push(Change::ReplaceWithMany(old.syntax_element(), new));
+        self.changes.borrow_mut().push(Change::ReplaceWithMany(old.syntax_element(), new));
     }
 
-    pub fn replace_all(&mut self, range: RangeInclusive<SyntaxElement>, new: Vec<SyntaxElement>) {
+    pub fn replace_all(&self, range: RangeInclusive<SyntaxElement>, new: Vec<SyntaxElement>) {
         if range.start() == range.end() {
             self.replace_with_many(range.start(), new);
             return;
         }
 
         debug_assert!(is_ancestor_or_self_of_element(range.start(), &self.root));
-        self.changes.push(Change::ReplaceAll(range, new))
+        self.changes.borrow_mut().push(Change::ReplaceAll(range, new))
     }
 
     pub fn finish(self) -> SyntaxEdit {
@@ -555,7 +551,8 @@ mod tests {
             .into(),
         );
 
-        let (mut editor, root) = SyntaxEditor::with_ast_node(&root);
+        let (editor, root) = SyntaxEditor::with_ast_node(&root);
+        let make = editor.make();
 
         let to_wrap = root.syntax().descendants().find_map(ast::TupleExpr::cast).unwrap();
         let to_replace = root.syntax().descendants().find_map(ast::BinExpr::cast).unwrap();
@@ -567,11 +564,11 @@ mod tests {
         editor.add_annotation(name.syntax(), placeholder_snippet);
         editor.add_annotation(name_ref.syntax(), placeholder_snippet);
 
-        let new_block = editor.make().block_expr(
+        let new_block = make.block_expr(
             [editor
                 .make()
                 .let_stmt(
-                    editor.make().ident_pat(false, false, name.clone()).into(),
+                    make.ident_pat(false, false, name.clone()).into(),
                     None,
                     Some(to_replace.clone().into()),
                 )
@@ -612,31 +609,28 @@ mod tests {
             None,
         );
 
-        let (mut editor, root) = SyntaxEditor::with_ast_node(&root);
+        let (editor, root) = SyntaxEditor::with_ast_node(&root);
+        let make = editor.make();
         let second_let = root.syntax().descendants().find_map(ast::LetStmt::cast).unwrap();
 
         editor.insert(
             Position::first_child_of(root.stmt_list().unwrap().syntax()),
-            editor
-                .make()
-                .let_stmt(
-                    make::ext::simple_ident_pat(make::name("first")).into(),
-                    None,
-                    Some(make::expr_literal("1").into()),
-                )
-                .syntax(),
+            make.let_stmt(
+                make::ext::simple_ident_pat(make::name("first")).into(),
+                None,
+                Some(make::expr_literal("1").into()),
+            )
+            .syntax(),
         );
 
         editor.insert(
             Position::after(second_let.syntax()),
-            editor
-                .make()
-                .let_stmt(
-                    make::ext::simple_ident_pat(make::name("third")).into(),
-                    None,
-                    Some(make::expr_literal("3").into()),
-                )
-                .syntax(),
+            make.let_stmt(
+                make::ext::simple_ident_pat(make::name("third")).into(),
+                None,
+                Some(make::expr_literal("3").into()),
+            )
+            .syntax(),
         );
 
         let edit = editor.finish();
@@ -666,22 +660,22 @@ mod tests {
             ),
         );
 
-        let (mut editor, root) = SyntaxEditor::with_ast_node(&root);
+        let (editor, root) = SyntaxEditor::with_ast_node(&root);
+        let make = editor.make();
 
         let inner_block =
             root.syntax().descendants().flat_map(ast::BlockExpr::cast).nth(1).unwrap();
         let second_let = root.syntax().descendants().find_map(ast::LetStmt::cast).unwrap();
 
-        let new_block_expr =
-            editor.make().block_expr([], Some(ast::Expr::BlockExpr(inner_block.clone())));
+        let new_block_expr = make.block_expr([], Some(ast::Expr::BlockExpr(inner_block.clone())));
 
-        let first_let = editor.make().let_stmt(
+        let first_let = make.let_stmt(
             make::ext::simple_ident_pat(make::name("first")).into(),
             None,
             Some(make::expr_literal("1").into()),
         );
 
-        let third_let = editor.make().let_stmt(
+        let third_let = make.let_stmt(
             make::ext::simple_ident_pat(make::name("third")).into(),
             None,
             Some(make::expr_literal("3").into()),
@@ -719,14 +713,14 @@ mod tests {
             None,
         );
 
-        let (mut editor, root) = SyntaxEditor::with_ast_node(&root);
+        let (editor, root) = SyntaxEditor::with_ast_node(&root);
+        let make = editor.make();
 
         let inner_block = root;
 
-        let new_block_expr =
-            editor.make().block_expr([], Some(ast::Expr::BlockExpr(inner_block.clone())));
+        let new_block_expr = make.block_expr([], Some(ast::Expr::BlockExpr(inner_block.clone())));
 
-        let first_let = editor.make().let_stmt(
+        let first_let = make.let_stmt(
             make::ext::simple_ident_pat(make::name("first")).into(),
             None,
             Some(make::expr_literal("1").into()),
@@ -766,7 +760,7 @@ mod tests {
             false,
         );
 
-        let (mut editor, parent_fn) = SyntaxEditor::with_ast_node(&parent_fn);
+        let (editor, parent_fn) = SyntaxEditor::with_ast_node(&parent_fn);
 
         if let Some(ret_ty) = parent_fn.ret_type() {
             editor.delete(ret_ty.syntax().clone());
@@ -793,7 +787,7 @@ mod tests {
         let arg_list =
             make::arg_list([make::expr_literal("1").into(), make::expr_literal("2").into()]);
 
-        let (mut editor, arg_list) = SyntaxEditor::with_ast_node(&arg_list);
+        let (editor, arg_list) = SyntaxEditor::with_ast_node(&arg_list);
 
         let target_expr = make::token(parser::SyntaxKind::UNDERSCORE);
 
@@ -812,7 +806,7 @@ mod tests {
         let arg_list =
             make::arg_list([make::expr_literal("1").into(), make::expr_literal("2").into()]);
 
-        let (mut editor, arg_list) = SyntaxEditor::with_ast_node(&arg_list);
+        let (editor, arg_list) = SyntaxEditor::with_ast_node(&arg_list);
 
         let target_expr = make::expr_literal("3").clone_for_update();
 
@@ -831,7 +825,7 @@ mod tests {
         let arg_list =
             make::arg_list([make::expr_literal("1").into(), make::expr_literal("2").into()]);
 
-        let (mut editor, arg_list) = SyntaxEditor::with_ast_node(&arg_list);
+        let (editor, arg_list) = SyntaxEditor::with_ast_node(&arg_list);
 
         let target_expr = make::ext::expr_unit().clone_for_update();
 

--- a/crates/syntax/src/syntax_editor.rs
+++ b/crates/syntax/src/syntax_editor.rs
@@ -30,8 +30,8 @@ pub use mapping::{SyntaxMapping, SyntaxMappingBuilder};
 pub struct SyntaxEditor {
     root: SyntaxNode,
     changes: Vec<Change>,
-    mappings: SyntaxMapping,
     annotations: Vec<(SyntaxElement, SyntaxAnnotation)>,
+    make: SyntaxFactory,
 }
 
 impl SyntaxEditor {
@@ -51,8 +51,8 @@ impl SyntaxEditor {
         let editor = Self {
             root: root.clone(),
             changes: Vec::new(),
-            mappings: SyntaxMapping::default(),
             annotations: Vec::new(),
+            make: SyntaxFactory::with_mappings(),
         };
 
         (editor, root)
@@ -66,6 +66,10 @@ impl SyntaxEditor {
         let (editor, root) = Self::new(root.syntax().clone());
 
         (editor, T::cast(root).unwrap())
+    }
+
+    pub fn make(&self) -> &SyntaxFactory {
+        &self.make
     }
 
     pub fn add_annotation(&mut self, element: impl Element, annotation: SyntaxAnnotation) {
@@ -90,7 +94,9 @@ impl SyntaxEditor {
         );
 
         self.changes.append(&mut other.changes);
-        self.mappings.merge(other.mappings);
+        if let Some(mut m) = self.make.mappings() {
+            m.merge(other.make.take());
+        }
         self.annotations.append(&mut other.annotations);
     }
 
@@ -104,28 +110,22 @@ impl SyntaxEditor {
         self.changes.push(Change::InsertAll(position, elements))
     }
 
-    pub fn insert_with_whitespace(
-        &mut self,
-        position: Position,
-        element: impl Element,
-        factory: &SyntaxFactory,
-    ) {
-        self.insert_all_with_whitespace(position, vec![element.syntax_element()], factory)
+    pub fn insert_with_whitespace(&mut self, position: Position, element: impl Element) {
+        self.insert_all_with_whitespace(position, vec![element.syntax_element()])
     }
 
     pub fn insert_all_with_whitespace(
         &mut self,
         position: Position,
         mut elements: Vec<SyntaxElement>,
-        factory: &SyntaxFactory,
     ) {
         if let Some(first) = elements.first()
-            && let Some(ws) = ws_before(&position, first, factory)
+            && let Some(ws) = ws_before(&position, first, &self.make)
         {
             elements.insert(0, ws.into());
         }
         if let Some(last) = elements.last()
-            && let Some(ws) = ws_after(&position, last, factory)
+            && let Some(ws) = ws_after(&position, last, &self.make)
         {
             elements.push(ws.into());
         }
@@ -180,10 +180,6 @@ impl SyntaxEditor {
 
     pub fn finish(self) -> SyntaxEdit {
         edit_algo::apply_edits(self)
-    }
-
-    pub fn add_mappings(&mut self, other: SyntaxMapping) {
-        self.mappings.merge(other);
     }
 }
 
@@ -538,7 +534,7 @@ mod tests {
 
     use crate::{
         AstNode,
-        ast::{self, make, syntax_factory::SyntaxFactory},
+        ast::{self, make},
     };
 
     use super::*;
@@ -564,8 +560,6 @@ mod tests {
         let to_wrap = root.syntax().descendants().find_map(ast::TupleExpr::cast).unwrap();
         let to_replace = root.syntax().descendants().find_map(ast::BinExpr::cast).unwrap();
 
-        let make = SyntaxFactory::with_mappings();
-
         let name = make::name("var_name");
         let name_ref = make::name_ref("var_name").clone_for_update();
 
@@ -573,10 +567,11 @@ mod tests {
         editor.add_annotation(name.syntax(), placeholder_snippet);
         editor.add_annotation(name_ref.syntax(), placeholder_snippet);
 
-        let new_block = make.block_expr(
-            [make
+        let new_block = editor.make().block_expr(
+            [editor
+                .make()
                 .let_stmt(
-                    make.ident_pat(false, false, name.clone()).into(),
+                    editor.make().ident_pat(false, false, name.clone()).into(),
                     None,
                     Some(to_replace.clone().into()),
                 )
@@ -586,7 +581,6 @@ mod tests {
 
         editor.replace(to_replace.syntax(), name_ref.syntax());
         editor.replace(to_wrap.syntax(), new_block.syntax());
-        editor.add_mappings(make.finish_with_mappings());
 
         let edit = editor.finish();
 
@@ -620,26 +614,29 @@ mod tests {
 
         let (mut editor, root) = SyntaxEditor::with_ast_node(&root);
         let second_let = root.syntax().descendants().find_map(ast::LetStmt::cast).unwrap();
-        let make = SyntaxFactory::without_mappings();
 
         editor.insert(
             Position::first_child_of(root.stmt_list().unwrap().syntax()),
-            make.let_stmt(
-                make::ext::simple_ident_pat(make::name("first")).into(),
-                None,
-                Some(make::expr_literal("1").into()),
-            )
-            .syntax(),
+            editor
+                .make()
+                .let_stmt(
+                    make::ext::simple_ident_pat(make::name("first")).into(),
+                    None,
+                    Some(make::expr_literal("1").into()),
+                )
+                .syntax(),
         );
 
         editor.insert(
             Position::after(second_let.syntax()),
-            make.let_stmt(
-                make::ext::simple_ident_pat(make::name("third")).into(),
-                None,
-                Some(make::expr_literal("3").into()),
-            )
-            .syntax(),
+            editor
+                .make()
+                .let_stmt(
+                    make::ext::simple_ident_pat(make::name("third")).into(),
+                    None,
+                    Some(make::expr_literal("3").into()),
+                )
+                .syntax(),
         );
 
         let edit = editor.finish();
@@ -675,17 +672,16 @@ mod tests {
             root.syntax().descendants().flat_map(ast::BlockExpr::cast).nth(1).unwrap();
         let second_let = root.syntax().descendants().find_map(ast::LetStmt::cast).unwrap();
 
-        let make = SyntaxFactory::with_mappings();
+        let new_block_expr =
+            editor.make().block_expr([], Some(ast::Expr::BlockExpr(inner_block.clone())));
 
-        let new_block_expr = make.block_expr([], Some(ast::Expr::BlockExpr(inner_block.clone())));
-
-        let first_let = make.let_stmt(
+        let first_let = editor.make().let_stmt(
             make::ext::simple_ident_pat(make::name("first")).into(),
             None,
             Some(make::expr_literal("1").into()),
         );
 
-        let third_let = make.let_stmt(
+        let third_let = editor.make().let_stmt(
             make::ext::simple_ident_pat(make::name("third")).into(),
             None,
             Some(make::expr_literal("3").into()),
@@ -697,7 +693,6 @@ mod tests {
         );
         editor.insert(Position::after(second_let.syntax()), third_let.syntax());
         editor.replace(inner_block.syntax(), new_block_expr.syntax());
-        editor.add_mappings(make.finish_with_mappings());
 
         let edit = editor.finish();
 
@@ -727,11 +722,11 @@ mod tests {
         let (mut editor, root) = SyntaxEditor::with_ast_node(&root);
 
         let inner_block = root;
-        let make = SyntaxFactory::with_mappings();
 
-        let new_block_expr = make.block_expr([], Some(ast::Expr::BlockExpr(inner_block.clone())));
+        let new_block_expr =
+            editor.make().block_expr([], Some(ast::Expr::BlockExpr(inner_block.clone())));
 
-        let first_let = make.let_stmt(
+        let first_let = editor.make().let_stmt(
             make::ext::simple_ident_pat(make::name("first")).into(),
             None,
             Some(make::expr_literal("1").into()),
@@ -742,7 +737,6 @@ mod tests {
             first_let.syntax(),
         );
         editor.replace(inner_block.syntax(), new_block_expr.syntax());
-        editor.add_mappings(make.finish_with_mappings());
 
         let edit = editor.finish();
 

--- a/crates/syntax/src/syntax_editor/edit_algo.rs
+++ b/crates/syntax/src/syntax_editor/edit_algo.rs
@@ -35,7 +35,8 @@ pub(super) fn apply_edits(editor: SyntaxEditor) -> SyntaxEdit {
     //   - changed nodes become part of the changed node set (useful for the formatter to only change those parts)
     // - Propagate annotations
 
-    let SyntaxEditor { root, mut changes, mappings, annotations } = editor;
+    let SyntaxEditor { root, mut changes, annotations, make } = editor;
+    let mappings = make.take();
 
     let mut node_depths = FxHashMap::<SyntaxNode, usize>::default();
     let mut get_node_depth = |node: SyntaxNode| {

--- a/crates/syntax/src/syntax_editor/edit_algo.rs
+++ b/crates/syntax/src/syntax_editor/edit_algo.rs
@@ -35,7 +35,9 @@ pub(super) fn apply_edits(editor: SyntaxEditor) -> SyntaxEdit {
     //   - changed nodes become part of the changed node set (useful for the formatter to only change those parts)
     // - Propagate annotations
 
-    let SyntaxEditor { root, mut changes, annotations, make } = editor;
+    let SyntaxEditor { root, changes, annotations, make } = editor;
+    let mut changes = changes.into_inner();
+    let annotations = annotations.into_inner();
     let mappings = make.take();
 
     let mut node_depths = FxHashMap::<SyntaxNode, usize>::default();

--- a/crates/syntax/src/syntax_editor/edits.rs
+++ b/crates/syntax/src/syntax_editor/edits.rs
@@ -12,20 +12,21 @@ pub trait GetOrCreateWhereClause: ast::HasGenericParams {
 
     fn get_or_create_where_clause(
         &self,
-        editor: &mut SyntaxEditor,
+        editor: &SyntaxEditor,
         new_preds: impl Iterator<Item = ast::WherePred>,
     ) {
+        let make = editor.make();
         let existing = self.where_clause();
         let all_preds: Vec<_> =
             existing.iter().flat_map(|wc| wc.predicates()).chain(new_preds).collect();
-        let new_where = editor.make().where_clause(all_preds);
+        let new_where = make.where_clause(all_preds);
 
         if let Some(existing) = &existing {
             editor.replace(existing.syntax(), new_where.syntax());
         } else if let Some(pos) = self.where_clause_position() {
             editor.insert_all(
                 pos,
-                vec![editor.make().whitespace(" ").into(), new_where.syntax().clone().into()],
+                vec![make.whitespace(" ").into(), new_where.syntax().clone().into()],
             );
         }
     }
@@ -109,7 +110,7 @@ impl GetOrCreateWhereClause for ast::Enum {
 
 impl SyntaxEditor {
     /// Adds a new generic param to the function using `SyntaxEditor`
-    pub fn add_generic_param(&mut self, function: &Fn, new_param: GenericParam) {
+    pub fn add_generic_param(&self, function: &Fn, new_param: GenericParam) {
         match function.generic_param_list() {
             Some(generic_param_list) => match generic_param_list.generic_params().last() {
                 Some(last_param) => {
@@ -173,7 +174,8 @@ impl SyntaxEditor {
     }
 }
 
-fn get_or_insert_comma_after(editor: &mut SyntaxEditor, syntax: &SyntaxNode) -> SyntaxToken {
+fn get_or_insert_comma_after(editor: &SyntaxEditor, syntax: &SyntaxNode) -> SyntaxToken {
+    let make = editor.make();
     match syntax
         .siblings_with_tokens(Direction::Next)
         .filter_map(|it| it.into_token())
@@ -181,7 +183,7 @@ fn get_or_insert_comma_after(editor: &mut SyntaxEditor, syntax: &SyntaxNode) -> 
     {
         Some(it) => it,
         None => {
-            let comma = editor.make().token(T![,]);
+            let comma = make.token(T![,]);
             editor.insert(Position::after(syntax), &comma);
             comma
         }
@@ -193,7 +195,7 @@ impl ast::AssocItemList {
     ///
     /// Attention! This function does align the first line of `item` with respect to `self`,
     /// but it does _not_ change indentation of other lines (if any).
-    pub fn add_items(&self, editor: &mut SyntaxEditor, items: Vec<ast::AssocItem>) {
+    pub fn add_items(&self, editor: &SyntaxEditor, items: Vec<ast::AssocItem>) {
         let (indent, position, whitespace) = match self.assoc_items().last() {
             Some(last_item) => (
                 IndentLevel::from_node(last_item.syntax()),
@@ -227,15 +229,16 @@ impl ast::AssocItemList {
 impl ast::Impl {
     pub fn get_or_create_assoc_item_list_with_editor(
         &self,
-        editor: &mut SyntaxEditor,
+        editor: &SyntaxEditor,
     ) -> ast::AssocItemList {
+        let make = editor.make();
         if let Some(list) = self.assoc_item_list() {
             list
         } else {
-            let list = editor.make().assoc_item_list_empty();
+            let list = make.assoc_item_list_empty();
             editor.insert_all(
                 Position::last_child_of(self.syntax()),
-                vec![editor.make().whitespace(" ").into(), list.syntax().clone().into()],
+                vec![make.whitespace(" ").into(), list.syntax().clone().into()],
             );
             list
         }
@@ -243,7 +246,8 @@ impl ast::Impl {
 }
 
 impl ast::VariantList {
-    pub fn add_variant(&self, editor: &mut SyntaxEditor, variant: &ast::Variant) {
+    pub fn add_variant(&self, editor: &SyntaxEditor, variant: &ast::Variant) {
+        let make = editor.make();
         let (indent, position) = match self.variants().last() {
             Some(last_item) => (
                 IndentLevel::from_node(last_item.syntax()),
@@ -258,16 +262,16 @@ impl ast::VariantList {
             },
         };
         let elements: Vec<SyntaxElement> = vec![
-            editor.make().whitespace(&format!("{}{indent}", "\n")).into(),
+            make.whitespace(&format!("{}{indent}", "\n")).into(),
             variant.syntax().clone().into(),
-            editor.make().token(T![,]).into(),
+            make.token(T![,]).into(),
         ];
         editor.insert_all(position, elements);
     }
 }
 
 impl ast::Fn {
-    pub fn replace_or_insert_body(&self, editor: &mut SyntaxEditor, body: ast::BlockExpr) {
+    pub fn replace_or_insert_body(&self, editor: &SyntaxEditor, body: ast::BlockExpr) {
         if let Some(old_body) = self.body() {
             editor.replace(old_body.syntax(), body.syntax());
         } else {
@@ -283,7 +287,8 @@ impl ast::Fn {
     }
 }
 
-fn normalize_ws_between_braces(editor: &mut SyntaxEditor, node: &SyntaxNode) -> Option<()> {
+fn normalize_ws_between_braces(editor: &SyntaxEditor, node: &SyntaxNode) -> Option<()> {
+    let make = editor.make();
     let l = node
         .children_with_tokens()
         .filter_map(|it| it.into_token())
@@ -298,11 +303,11 @@ fn normalize_ws_between_braces(editor: &mut SyntaxEditor, node: &SyntaxNode) -> 
     match l.next_sibling_or_token() {
         Some(ws) if ws.kind() == SyntaxKind::WHITESPACE => {
             if ws.next_sibling_or_token()?.into_token()? == r {
-                editor.replace(ws, editor.make().whitespace(&format!("\n{indent}")));
+                editor.replace(ws, make.whitespace(&format!("\n{indent}")));
             }
         }
         Some(ws) if ws.kind() == T!['}'] => {
-            editor.insert(Position::after(l), editor.make().whitespace(&format!("\n{indent}")));
+            editor.insert(Position::after(l), make.whitespace(&format!("\n{indent}")));
         }
         _ => (),
     }
@@ -310,11 +315,11 @@ fn normalize_ws_between_braces(editor: &mut SyntaxEditor, node: &SyntaxNode) -> 
 }
 
 pub trait Removable: AstNode {
-    fn remove(&self, editor: &mut SyntaxEditor);
+    fn remove(&self, editor: &SyntaxEditor);
 }
 
 impl Removable for ast::TypeBoundList {
-    fn remove(&self, editor: &mut SyntaxEditor) {
+    fn remove(&self, editor: &SyntaxEditor) {
         match self.syntax().siblings_with_tokens(Direction::Prev).find(|it| it.kind() == T![:]) {
             Some(colon) => editor.delete_all(colon..=self.syntax().clone().into()),
             None => editor.delete(self.syntax()),
@@ -323,7 +328,8 @@ impl Removable for ast::TypeBoundList {
 }
 
 impl Removable for ast::Use {
-    fn remove(&self, editor: &mut SyntaxEditor) {
+    fn remove(&self, editor: &SyntaxEditor) {
+        let make = editor.make();
         let next_ws = self
             .syntax()
             .next_sibling_or_token()
@@ -335,7 +341,7 @@ impl Removable for ast::Use {
                 if rest.is_empty() {
                     editor.delete(next_ws.syntax());
                 } else {
-                    editor.replace(next_ws.syntax(), editor.make().whitespace(rest));
+                    editor.replace(next_ws.syntax(), make.whitespace(rest));
                 }
             }
         }
@@ -345,7 +351,7 @@ impl Removable for ast::Use {
 }
 
 impl Removable for ast::UseTree {
-    fn remove(&self, editor: &mut SyntaxEditor) {
+    fn remove(&self, editor: &SyntaxEditor) {
         for dir in [Direction::Next, Direction::Prev] {
             if let Some(next_use_tree) = neighbor(self, dir) {
                 let separators = self

--- a/crates/syntax/src/syntax_editor/edits.rs
+++ b/crates/syntax/src/syntax_editor/edits.rs
@@ -3,10 +3,7 @@
 use crate::{
     AstToken, Direction, SyntaxElement, SyntaxKind, SyntaxNode, SyntaxToken, T,
     algo::neighbor,
-    ast::{
-        self, AstNode, Fn, GenericParam, HasGenericParams, HasName, edit::IndentLevel, make,
-        syntax_factory::SyntaxFactory,
-    },
+    ast::{self, AstNode, Fn, GenericParam, HasGenericParams, HasName, edit::IndentLevel, make},
     syntax_editor::{Position, SyntaxEditor},
 };
 
@@ -16,20 +13,19 @@ pub trait GetOrCreateWhereClause: ast::HasGenericParams {
     fn get_or_create_where_clause(
         &self,
         editor: &mut SyntaxEditor,
-        make: &SyntaxFactory,
         new_preds: impl Iterator<Item = ast::WherePred>,
     ) {
         let existing = self.where_clause();
         let all_preds: Vec<_> =
             existing.iter().flat_map(|wc| wc.predicates()).chain(new_preds).collect();
-        let new_where = make.where_clause(all_preds);
+        let new_where = editor.make().where_clause(all_preds);
 
         if let Some(existing) = &existing {
             editor.replace(existing.syntax(), new_where.syntax());
         } else if let Some(pos) = self.where_clause_position() {
             editor.insert_all(
                 pos,
-                vec![make.whitespace(" ").into(), new_where.syntax().clone().into()],
+                vec![editor.make().whitespace(" ").into(), new_where.syntax().clone().into()],
             );
         }
     }
@@ -178,7 +174,6 @@ impl SyntaxEditor {
 }
 
 fn get_or_insert_comma_after(editor: &mut SyntaxEditor, syntax: &SyntaxNode) -> SyntaxToken {
-    let make = SyntaxFactory::without_mappings();
     match syntax
         .siblings_with_tokens(Direction::Next)
         .filter_map(|it| it.into_token())
@@ -186,7 +181,7 @@ fn get_or_insert_comma_after(editor: &mut SyntaxEditor, syntax: &SyntaxNode) -> 
     {
         Some(it) => it,
         None => {
-            let comma = make.token(T![,]);
+            let comma = editor.make().token(T![,]);
             editor.insert(Position::after(syntax), &comma);
             comma
         }
@@ -233,15 +228,14 @@ impl ast::Impl {
     pub fn get_or_create_assoc_item_list_with_editor(
         &self,
         editor: &mut SyntaxEditor,
-        make: &SyntaxFactory,
     ) -> ast::AssocItemList {
         if let Some(list) = self.assoc_item_list() {
             list
         } else {
-            let list = make.assoc_item_list_empty();
+            let list = editor.make().assoc_item_list_empty();
             editor.insert_all(
                 Position::last_child_of(self.syntax()),
-                vec![make.whitespace(" ").into(), list.syntax().clone().into()],
+                vec![editor.make().whitespace(" ").into(), list.syntax().clone().into()],
             );
             list
         }
@@ -250,7 +244,6 @@ impl ast::Impl {
 
 impl ast::VariantList {
     pub fn add_variant(&self, editor: &mut SyntaxEditor, variant: &ast::Variant) {
-        let make = SyntaxFactory::without_mappings();
         let (indent, position) = match self.variants().last() {
             Some(last_item) => (
                 IndentLevel::from_node(last_item.syntax()),
@@ -265,9 +258,9 @@ impl ast::VariantList {
             },
         };
         let elements: Vec<SyntaxElement> = vec![
-            make.whitespace(&format!("{}{indent}", "\n")).into(),
+            editor.make().whitespace(&format!("{}{indent}", "\n")).into(),
             variant.syntax().clone().into(),
-            make.token(T![,]).into(),
+            editor.make().token(T![,]).into(),
         ];
         editor.insert_all(position, elements);
     }
@@ -291,7 +284,6 @@ impl ast::Fn {
 }
 
 fn normalize_ws_between_braces(editor: &mut SyntaxEditor, node: &SyntaxNode) -> Option<()> {
-    let make = SyntaxFactory::without_mappings();
     let l = node
         .children_with_tokens()
         .filter_map(|it| it.into_token())
@@ -306,11 +298,11 @@ fn normalize_ws_between_braces(editor: &mut SyntaxEditor, node: &SyntaxNode) -> 
     match l.next_sibling_or_token() {
         Some(ws) if ws.kind() == SyntaxKind::WHITESPACE => {
             if ws.next_sibling_or_token()?.into_token()? == r {
-                editor.replace(ws, make.whitespace(&format!("\n{indent}")));
+                editor.replace(ws, editor.make().whitespace(&format!("\n{indent}")));
             }
         }
         Some(ws) if ws.kind() == T!['}'] => {
-            editor.insert(Position::after(l), make.whitespace(&format!("\n{indent}")));
+            editor.insert(Position::after(l), editor.make().whitespace(&format!("\n{indent}")));
         }
         _ => (),
     }
@@ -332,8 +324,6 @@ impl Removable for ast::TypeBoundList {
 
 impl Removable for ast::Use {
     fn remove(&self, editor: &mut SyntaxEditor) {
-        let make = SyntaxFactory::without_mappings();
-
         let next_ws = self
             .syntax()
             .next_sibling_or_token()
@@ -345,7 +335,7 @@ impl Removable for ast::Use {
                 if rest.is_empty() {
                     editor.delete(next_ws.syntax());
                 } else {
-                    editor.replace(next_ws.syntax(), make.whitespace(rest));
+                    editor.replace(next_ws.syntax(), editor.make().whitespace(rest));
                 }
             }
         }
@@ -379,7 +369,7 @@ mod tests {
     use stdx::trim_indent;
     use test_utils::assert_eq_text;
 
-    use crate::SourceFile;
+    use crate::{SourceFile, ast::syntax_factory::SyntaxFactory};
 
     use super::*;
 

--- a/crates/syntax/src/syntax_editor/edits.rs
+++ b/crates/syntax/src/syntax_editor/edits.rs
@@ -488,9 +488,9 @@ enum Foo {
     }
 
     fn check_add_variant(before: &str, expected: &str, variant: ast::Variant) {
-        let (mut editor, enum_) = SyntaxEditor::with_ast_node(&ast_from_text::<ast::Enum>(before));
+        let (editor, enum_) = SyntaxEditor::with_ast_node(&ast_from_text::<ast::Enum>(before));
         if let Some(it) = enum_.variant_list() {
-            it.add_variant(&mut editor, &variant)
+            it.add_variant(&editor, &variant)
         }
         let edit = editor.finish();
         let after = edit.new_root.to_string();


### PR DESCRIPTION
This PR moves `SyntaxFactory` inside `SyntaxEditor` and migrates all of its `with_mapping` usages to `SyntaxEditor`’s `make` variant. Some remnants of `SyntaxFactory::without_mapping` still remain; addressing them may require additional work, as most are tied to the broader migration to `SyntaxEditor` and can be handled later.

* The first commit introduces changes to `SyntaxEditor`, including the integration of `SyntaxFactory`.
* The second commit fixes constructor mapping issues encountered during the refactor.
* The third commit migrates assists. Although large, the changes are straightforward and intuitive.


part of https://github.com/rust-lang/rust-analyzer/issues/15710 and https://github.com/rust-lang/rust-analyzer/issues/18285