### PR TITLE
fix(21943): remove duplicate lints

### DIFF
--- a/crates/ide-db/src/generated/lints.rs
+++ b/crates/ide-db/src/generated/lints.rs
@@ -1790,13 +1790,6 @@ pub const DEFAULT_LINTS: &[Lint] = &[
         warn_since: None,
         deny_since: None,
     },
-    Lint {
-        label: "warnings",
-        description: r##"lint group for: all lints that are set to issue warnings"##,
-        default_severity: Severity::Allow,
-        warn_since: None,
-        deny_since: None,
-    },
 ];
 
 pub const DEFAULT_LINT_GROUPS: &[LintGroup] = &[

--- a/xtask/src/codegen/lints.rs
+++ b/xtask/src/codegen/lints.rs
@@ -3,7 +3,7 @@
 #![allow(clippy::disallowed_types)]
 
 use std::{
-    collections::{HashMap, hash_map},
+    collections::{HashMap, HashSet, hash_map},
     fs,
     path::Path,
     str::FromStr,
@@ -348,10 +348,12 @@ fn generate_lint_descriptor(sh: &Shell, buf: &mut String) {
     buf.push_str(r#"pub const DEFAULT_LINTS: &[Lint] = &["#);
     buf.push('\n');
 
+    let mut known_lints: HashSet<&String> = HashSet::with_capacity(lints.len() + lint_groups.len());
     for (name, lint) in &lints {
         push_lint_completion(buf, name, lint);
+        known_lints.insert(name);
     }
-    for (name, (group, _)) in &lint_groups {
+    for (name, (group, _)) in lint_groups.iter().filter(|(name, _)| !known_lints.contains(name)) {
         push_lint_completion(buf, name, group);
     }
     buf.push_str("];\n\n");
@@ -372,10 +374,15 @@ fn generate_lint_descriptor(sh: &Shell, buf: &mut String) {
     buf.push_str(r#"pub const RUSTDOC_LINTS: &[Lint] = &["#);
     buf.push('\n');
 
+    let mut known_rustdoc_lints: HashSet<&String> =
+        HashSet::with_capacity(lints_rustdoc.len() + lint_groups_rustdoc.len());
     for (name, lint) in &lints_rustdoc {
         push_lint_completion(buf, name, lint);
+        known_rustdoc_lints.insert(name);
     }
-    for (name, (group, _)) in &lint_groups_rustdoc {
+    for (name, (group, _)) in
+        lint_groups_rustdoc.iter().filter(|(name, _)| !known_rustdoc_lints.contains(name))
+    {
         push_lint_completion(buf, name, group);
     }
     buf.push_str("];\n\n");


### PR DESCRIPTION
In this PR, I filter the lints that have already been added by name.
There are 2 main groups, the default lints and the rustdoc lints.
This should avoid having duplicates.

Fixes rust-lang/rust-analyzer#21943

PS: I've tried regenerating the lints, it introduced many changes which are not really related, so I manually removed them instead.