### PR TITLE
fix: deduplicate `warnings` lint in completion

### DIFF
--- a/crates/ide-db/src/generated/lints.rs
+++ b/crates/ide-db/src/generated/lints.rs
@@ -1790,13 +1790,6 @@ pub const DEFAULT_LINTS: &[Lint] = &[
         warn_since: None,
         deny_since: None,
     },
-    Lint {
-        label: "warnings",
-        description: r##"lint group for: all lints that are set to issue warnings"##,
-        default_severity: Severity::Allow,
-        warn_since: None,
-        deny_since: None,
-    },
 ];
 
 pub const DEFAULT_LINT_GROUPS: &[LintGroup] = &[

--- a/xtask/src/codegen/lints.rs
+++ b/xtask/src/codegen/lints.rs
@@ -352,6 +352,9 @@ fn generate_lint_descriptor(sh: &Shell, buf: &mut String) {
         push_lint_completion(buf, name, lint);
     }
     for (name, (group, _)) in &lint_groups {
+        if name == "warnings" {
+            continue;
+        }
         push_lint_completion(buf, name, group);
     }
     buf.push_str("];\n\n");


### PR DESCRIPTION
The `warnings` lint appeared twice in completions because it exists as both an individual lint and a lint group. The codegen already skips `warnings` when building `DEFAULT_LINT_GROUPS`, but was missing the same skip when adding lint groups to `DEFAULT_LINTS`.

This adds the same `if name == "warnings" { continue; }` guard to the lint-groups-to-`DEFAULT_LINTS` loop, matching the existing pattern for `DEFAULT_LINT_GROUPS`.

Closes rust-lang/rust-analyzer#21943.

Drafted with AI assistance, reviewed and tested by me.