### PR TITLE
Bump salsa

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2453,9 +2453,9 @@ checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "salsa"
-version = "0.25.2"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e2aa2fca57727371eeafc975acc8e6f4c52f8166a78035543f6ee1c74c2dcc"
+checksum = "f77debccd43ba198e9cee23efd7f10330ff445e46a98a2b107fed9094a1ee676"
 dependencies = [
  "boxcar",
  "crossbeam-queue",
@@ -2478,15 +2478,15 @@ dependencies = [
 
 [[package]]
 name = "salsa-macro-rules"
-version = "0.25.2"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfc2a1e7bf06964105515451d728f2422dedc3a112383324a00b191a5c397a3"
+checksum = "ea07adbf42d91cc076b7daf3b38bc8168c19eb362c665964118a89bc55ef19a5"
 
 [[package]]
 name = "salsa-macros"
-version = "0.25.2"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d844c1aa34946da46af683b5c27ec1088a3d9d84a2b837a108223fd830220e1"
+checksum = "d16d4d8b66451b9c75ddf740b7fc8399bc7b8ba33e854a5d7526d18708f67b05"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,13 +135,13 @@ rayon = "1.10.0"
 rowan = "=0.15.18"
 # Ideally we'd not enable the macros feature but unfortunately the `tracked` attribute does not work
 # on impls without it
-salsa = { version = "0.25.2", default-features = false, features = [
+salsa = { version = "0.26", default-features = false, features = [
     "rayon",
     "salsa_unstable",
     "macros",
     "inventory",
 ] }
-salsa-macros = "0.25.2"
+salsa-macros = "0.26"
 semver = "1.0.26"
 serde = { version = "1.0.219" }
 serde_derive = { version = "1.0.219" }

--- a/crates/hir-ty/src/tests/regression.rs
+++ b/crates/hir-ty/src/tests/regression.rs
@@ -2363,6 +2363,7 @@ fn test() {
 }
 "#,
         expect![[r#"
+            46..49 'Foo': Foo<N>
             93..97 'self': Foo<N>
             108..125 '{     ...     }': usize
             118..119 'N': usize

--- a/crates/ide/src/lib.rs
+++ b/crates/ide/src/lib.rs
@@ -64,6 +64,7 @@ use cfg::CfgOptions;
 use fetch_crates::CrateInfo;
 use hir::{ChangeWithProcMacros, EditionedFileId, crate_def_map, sym};
 use ide_db::base_db::relevant_crates;
+use ide_db::base_db::salsa::Durability;
 use ide_db::line_index;
 use ide_db::ra_fixture::RaFixtureAnalysis;
 use ide_db::{
@@ -203,10 +204,18 @@ impl AnalysisHost {
         self.db.per_query_memory_usage()
     }
     pub fn trigger_cancellation(&mut self) {
-        self.db.trigger_cancellation();
+        // We need to do a synthetic write right now due to how fixpoint cycles handle cancellation
+        // the revision bump there is a reset marker for clearing fixpoint poisoning.
+        // That is `trigger_cancellation` is currently bugged wrt to cancellation.
+        // self.db.trigger_cancellation();
+        self.db.synthetic_write(Durability::LOW);
     }
     pub fn trigger_garbage_collection(&mut self) {
-        self.db.trigger_lru_eviction();
+        // We need to do a synthetic write right now due to how fixpoint cycles handle cancellation
+        // the revision bump there is a reset marker for clearing fixpoint poisoning.
+        // That is `trigger_lru_eviction` is currently bugged wrt to cancellation.
+        // self.db.trigger_lru_eviction();
+        self.db.synthetic_write(Durability::LOW);
         // SAFETY: `trigger_lru_eviction` triggers cancellation, so all running queries were canceled.
         unsafe { hir::collect_ty_garbage() };
     }

--- a/crates/span/src/hygiene.rs
+++ b/crates/span/src/hygiene.rs
@@ -81,25 +81,24 @@ const _: () = {
     #[derive(Hash)]
     struct StructKey<'db, T0, T1, T2, T3>(T0, T1, T2, T3, std::marker::PhantomData<&'db ()>);
 
-    impl<'db, T0, T1, T2, T3> zalsa_::interned::HashEqLike<StructKey<'db, T0, T1, T2, T3>>
-        for SyntaxContextData
+    impl<'db, T0, T1, T2, T3> zalsa_::HashEqLike<StructKey<'db, T0, T1, T2, T3>> for SyntaxContextData
     where
-        Option<MacroCallId>: zalsa_::interned::HashEqLike<T0>,
-        Transparency: zalsa_::interned::HashEqLike<T1>,
-        Edition: zalsa_::interned::HashEqLike<T2>,
-        SyntaxContext: zalsa_::interned::HashEqLike<T3>,
+        Option<MacroCallId>: zalsa_::HashEqLike<T0>,
+        Transparency: zalsa_::HashEqLike<T1>,
+        Edition: zalsa_::HashEqLike<T2>,
+        SyntaxContext: zalsa_::HashEqLike<T3>,
     {
         fn hash<H: std::hash::Hasher>(&self, h: &mut H) {
-            zalsa_::interned::HashEqLike::<T0>::hash(&self.outer_expn, &mut *h);
-            zalsa_::interned::HashEqLike::<T1>::hash(&self.outer_transparency, &mut *h);
-            zalsa_::interned::HashEqLike::<T2>::hash(&self.edition, &mut *h);
-            zalsa_::interned::HashEqLike::<T3>::hash(&self.parent, &mut *h);
+            zalsa_::HashEqLike::<T0>::hash(&self.outer_expn, &mut *h);
+            zalsa_::HashEqLike::<T1>::hash(&self.outer_transparency, &mut *h);
+            zalsa_::HashEqLike::<T2>::hash(&self.edition, &mut *h);
+            zalsa_::HashEqLike::<T3>::hash(&self.parent, &mut *h);
         }
         fn eq(&self, data: &StructKey<'db, T0, T1, T2, T3>) -> bool {
-            zalsa_::interned::HashEqLike::<T0>::eq(&self.outer_expn, &data.0)
-                && zalsa_::interned::HashEqLike::<T1>::eq(&self.outer_transparency, &data.1)
-                && zalsa_::interned::HashEqLike::<T2>::eq(&self.edition, &data.2)
-                && zalsa_::interned::HashEqLike::<T3>::eq(&self.parent, &data.3)
+            zalsa_::HashEqLike::<T0>::eq(&self.outer_expn, &data.0)
+                && zalsa_::HashEqLike::<T1>::eq(&self.outer_transparency, &data.1)
+                && zalsa_::HashEqLike::<T2>::eq(&self.edition, &data.2)
+                && zalsa_::HashEqLike::<T3>::eq(&self.parent, &data.3)
         }
     }
     impl zalsa_struct_::Configuration for SyntaxContext {
@@ -203,10 +202,10 @@ const _: () = {
     impl<'db> SyntaxContext {
         pub fn new<
             Db,
-            T0: zalsa_::interned::Lookup<Option<MacroCallId>> + std::hash::Hash,
-            T1: zalsa_::interned::Lookup<Transparency> + std::hash::Hash,
-            T2: zalsa_::interned::Lookup<Edition> + std::hash::Hash,
-            T3: zalsa_::interned::Lookup<SyntaxContext> + std::hash::Hash,
+            T0: zalsa_::Lookup<Option<MacroCallId>> + std::hash::Hash,
+            T1: zalsa_::Lookup<Transparency> + std::hash::Hash,
+            T2: zalsa_::Lookup<Edition> + std::hash::Hash,
+            T3: zalsa_::Lookup<SyntaxContext> + std::hash::Hash,
         >(
             db: &'db Db,
             outer_expn: T0,
@@ -218,10 +217,10 @@ const _: () = {
         ) -> Self
         where
             Db: ?Sized + salsa::Database,
-            Option<MacroCallId>: zalsa_::interned::HashEqLike<T0>,
-            Transparency: zalsa_::interned::HashEqLike<T1>,
-            Edition: zalsa_::interned::HashEqLike<T2>,
-            SyntaxContext: zalsa_::interned::HashEqLike<T3>,
+            Option<MacroCallId>: zalsa_::HashEqLike<T0>,
+            Transparency: zalsa_::HashEqLike<T1>,
+            Edition: zalsa_::HashEqLike<T2>,
+            SyntaxContext: zalsa_::HashEqLike<T3>,
         {
             let (zalsa, zalsa_local) = db.zalsas();
 
@@ -236,10 +235,10 @@ const _: () = {
                     std::marker::PhantomData,
                 ),
                 |id, data| SyntaxContextData {
-                    outer_expn: zalsa_::interned::Lookup::into_owned(data.0),
-                    outer_transparency: zalsa_::interned::Lookup::into_owned(data.1),
-                    edition: zalsa_::interned::Lookup::into_owned(data.2),
-                    parent: zalsa_::interned::Lookup::into_owned(data.3),
+                    outer_expn: zalsa_::Lookup::into_owned(data.0),
+                    outer_transparency: zalsa_::Lookup::into_owned(data.1),
+                    edition: zalsa_::Lookup::into_owned(data.2),
+                    parent: zalsa_::Lookup::into_owned(data.3),
                     opaque: opaque(zalsa_::FromId::from_id(id)),
                     opaque_and_semiopaque: opaque_and_semiopaque(zalsa_::FromId::from_id(id)),
                 },


### PR DESCRIPTION
The bump from https://github.com/rust-lang/rust-analyzer/pull/21380

The cause of the panics is our use of the alternative global cancellation mechanisms, they are actually currently bugged in salsa due to how fixpoint poisoning works. This PR does not include the local cancellation changes from that PR for now just to confirm the changes here for now, we can add that stuff back in a follow up

Fixes https://github.com/rust-lang/rust-analyzer/issues/22045