### PR TITLE
ide: show Run lens for crate-root main under cfg(test)

### DIFF
--- a/crates/ide/src/runnables.rs
+++ b/crates/ide/src/runnables.rs
@@ -320,7 +320,7 @@ pub(crate) fn runnable_fn(
 ) -> Option<Runnable> {
     let edition = def.krate(sema.db).edition(sema.db);
     let under_cfg_test = has_cfg_test(def.module(sema.db).attrs(sema.db).cfgs(sema.db));
-    let kind = if !under_cfg_test && def.is_main(sema.db) {
+    let kind = if def.is_main(sema.db) && !(under_cfg_test && def.exported_main(sema.db)) {
         RunnableKind::Bin
     } else {
         let test_id = || {
@@ -1708,6 +1708,22 @@ fn exp_main() {}
                     "(Bin, NavigationTarget { file_id: FileId(0), full_range: 36..80, focus_range: 67..75, name: \"exp_main\", kind: Function })",
                     "(TestMod, NavigationTarget { file_id: FileId(0), full_range: 83..168, focus_range: 100..115, name: \"test_mod_inline\", kind: Module, description: \"mod test_mod_inline\" }, Atom(Flag(\"test\")))",
                     "(TestMod, NavigationTarget { file_id: FileId(0), full_range: 192..218, focus_range: 209..217, name: \"test_mod\", kind: Module, description: \"mod test_mod\" }, Atom(Flag(\"test\")))",
+                ]
+            "#]],
+        )
+    }
+
+    #[test]
+    fn main_runnable_even_with_cfg_test() {
+        check(
+            r#"
+//- /lib.rs crate:foo cfg:test
+$0
+fn main() {}
+"#,
+            expect![[r#"
+                [
+                    "(Bin, NavigationTarget { file_id: FileId(0), full_range: 1..13, focus_range: 4..8, name: \"main\", kind: Function })",
                 ]
             "#]],
         )


### PR DESCRIPTION
Fix: rust-lang/rust-analyzer#21948 
fixes missing “▶ Run” code lenses for benchmark crates that define a crate-root `fn main()` but are analyzed under `cfg(test)`, which previously caused the main runnable to be suppressed. Now, crate-root `fn main()` still produces a Bin runnable even when the crate is `cfg(test)`.It also preserves existing behavior for test-only modules by continuing to suppress “run binary” lenses for functions that only look like main via `#[export_name = "main"]` inside `#[cfg(test)]` contexts, avoiding extra runnables.
Tests cover both scenarios, including a new expect-test ensuring `fn main()` remains runnable under `cfg(test)`, and the existing `exported-main-in-cfg(test)` behavior.