### PR TITLE
fix: add parentheses on record expr for replace_let_with_if_let

### DIFF
--- a/crates/ide-assists/src/handlers/replace_let_with_if_let.rs
+++ b/crates/ide-assists/src/handlers/replace_let_with_if_let.rs
@@ -88,6 +88,11 @@ pub(crate) fn replace_let_with_if_let(acc: &mut Assists, ctx: &AssistContext<'_>
 fn let_expr_needs_paren(expr: &ast::Expr) -> bool {
     let make = SyntaxFactory::without_mappings();
     let fake_expr_let = make.expr_let(make.tuple_pat(None).into(), make.expr_unit());
+    let fake_if = make.expr_if(fake_expr_let.into(), make.expr_empty_block(), None);
+    let Some(ast::Expr::LetExpr(fake_expr_let)) = fake_if.condition() else {
+        stdx::never!();
+        return false;
+    };
     let Some(fake_expr) = fake_expr_let.expr() else {
         stdx::never!();
         return false;
@@ -176,6 +181,24 @@ fn main() {
             r"
 fn main() {
     if let x = (true || false) {
+    }
+}
+            ",
+        )
+    }
+
+    #[test]
+    fn replace_let_record_expr() {
+        check_assist(
+            replace_let_with_if_let,
+            r"
+fn main() {
+    $0let x = Foo { x };
+}
+            ",
+            r"
+fn main() {
+    if let x = (Foo { x }) {
     }
 }
             ",


### PR DESCRIPTION
Example
---
```rust
fn main() {
    $0let x = Foo { x };
}
```

**Before this PR**

```rust
fn main() {
    if let x = Foo {
    }
}
```

**After this PR**

```rust
fn main() {
    if let x = (Foo { x }) {
    }
}
```
