### PR TITLE
internal: remove redundant editor.make() calls

### DIFF
--- a/crates/ide-assists/src/handlers/add_turbo_fish.rs
+++ b/crates/ide-assists/src/handlers/add_turbo_fish.rs
@@ -103,7 +103,6 @@ pub(crate) fn add_turbo_fish(acc: &mut Assists, ctx: &AssistContext<'_>) -> Opti
                         );
                     }
 
-                    let make = editor.make();
                     let placeholder_ty = make.ty_placeholder();
 
                     if let Some(pat) = let_stmt.pat() {

--- a/crates/ide-assists/src/handlers/convert_bool_then.rs
+++ b/crates/ide-assists/src/handlers/convert_bool_then.rs
@@ -215,8 +215,7 @@ pub(crate) fn convert_bool_then_to_if(acc: &mut Assists, ctx: &AssistContext<'_>
                 ast::Expr::ParenExpr(expr) => expr.expr().unwrap_or(receiver),
                 _ => receiver,
             };
-            let if_expr = editor
-                .make()
+            let if_expr = make
                 .expr_if(
                     cond,
                     closure_body,

--- a/crates/ide-assists/src/handlers/convert_let_else_to_match.rs
+++ b/crates/ide-assists/src/handlers/convert_let_else_to_match.rs
@@ -181,15 +181,11 @@ fn remove_mut_and_collect_idents(
                     })
                 })
                 .collect::<Option<Vec<_>>>()?;
-            editor
-                .make()
-                .record_pat_with_fields(
-                    p.path()?,
-                    editor
-                        .make()
-                        .record_pat_field_list(fields, p.record_pat_field_list()?.rest_pat()),
-                )
-                .into()
+            make.record_pat_with_fields(
+                p.path()?,
+                make.record_pat_field_list(fields, p.record_pat_field_list()?.rest_pat()),
+            )
+            .into()
         }
         ast::Pat::RefPat(p) => {
             let inner = p.pat()?;

--- a/crates/ide-assists/src/handlers/convert_match_to_let_else.rs
+++ b/crates/ide-assists/src/handlers/convert_match_to_let_else.rs
@@ -137,9 +137,7 @@ fn rename_variable(pat: &ast::Pat, extracted: &[Name], binding: ast::Pat) -> Syn
             if let Some(name_ref) = record_pat_field.field_name() {
                 editor.replace(
                     record_pat_field.syntax(),
-                    editor
-                        .make()
-                        .record_pat_field(make.name_ref(&name_ref.text()), binding.clone())
+                    make.record_pat_field(make.name_ref(&name_ref.text()), binding.clone())
                         .syntax(),
                 );
             }

--- a/crates/ide-assists/src/handlers/convert_tuple_return_type_to_struct.rs
+++ b/crates/ide-assists/src/handlers/convert_tuple_return_type_to_struct.rs
@@ -149,9 +149,7 @@ fn replace_usages(
                 for tuple_pat in tuple_pats {
                     editor.replace(
                         tuple_pat.syntax(),
-                        editor
-                            .make()
-                            .tuple_struct_pat(make.path_from_text(struct_name), tuple_pat.fields())
+                        make.tuple_struct_pat(make.path_from_text(struct_name), tuple_pat.fields())
                             .syntax(),
                     );
                 }

--- a/crates/ide-assists/src/handlers/convert_while_to_loop.rs
+++ b/crates/ide-assists/src/handlers/convert_while_to_loop.rs
@@ -55,8 +55,7 @@ pub(crate) fn convert_while_to_loop(acc: &mut Assists, ctx: &AssistContext<'_>) 
             let make = editor.make();
             let while_indent_level = IndentLevel::from_node(while_expr.syntax());
 
-            let break_block = editor
-                .make()
+            let break_block = make
                 .block_expr(
                     iter::once(make.expr_stmt(make.expr_break(None, None).into()).into()),
                     None,

--- a/crates/ide-assists/src/handlers/destructure_struct_binding.rs
+++ b/crates/ide-assists/src/handlers/destructure_struct_binding.rs
@@ -152,9 +152,8 @@ impl StructEditData {
                 // If the binding is nested inside a record, we need to wrap the new
                 // destructured pattern in a non-shorthand record field
                 if self.need_record_field_name {
-                    let new_pat = editor
-                        .make()
-                        .record_pat_field(make.name_ref(&self.name.to_string()), new_pat);
+                    let new_pat =
+                        make.record_pat_field(make.name_ref(&self.name.to_string()), new_pat);
                     editor.replace(pat.syntax(), new_pat.syntax())
                 } else {
                     editor.replace(pat.syntax(), new_pat.syntax())
@@ -294,7 +293,7 @@ fn destructure_pat(
                 // Use shorthand syntax if possible
                 if old_name == new_name {
                     make.record_pat_field_shorthand(
-                        editor.make().ident_pat(is_ref, is_mut, make.name(old_name)).into(),
+                        make.ident_pat(is_ref, is_mut, make.name(old_name)).into(),
                     )
                 } else {
                     make.record_pat_field(

--- a/crates/ide-assists/src/handlers/desugar_try_expr.rs
+++ b/crates/ide-assists/src/handlers/desugar_try_expr.rs
@@ -69,8 +69,7 @@ pub(crate) fn desugar_try_expr(acc: &mut Assists, ctx: &AssistContext<'_>) -> Op
             let make = editor.make();
             let sad_pat = match try_enum {
                 TryEnum::Option => make.path_pat(make.ident_path("None")),
-                TryEnum::Result => editor
-                    .make()
+                TryEnum::Result => make
                     .tuple_struct_pat(
                         make.ident_path("Err"),
                         iter::once(make.path_pat(make.ident_path("err"))),
@@ -90,8 +89,7 @@ pub(crate) fn desugar_try_expr(acc: &mut Assists, ctx: &AssistContext<'_>) -> Op
 
             let match_arm_list = make.match_arm_list([happy_arm, sad_arm]);
 
-            let expr_match = editor
-                .make()
+            let expr_match = make
                 .expr_match(expr.clone(), match_arm_list)
                 .indent(IndentLevel::from_node(try_expr.syntax()));
 
@@ -121,23 +119,16 @@ pub(crate) fn desugar_try_expr(acc: &mut Assists, ctx: &AssistContext<'_>) -> Op
                         TryEnum::Result => make.ty_result(ty, make.ty_infer().into()).into(),
                     }),
                     expr,
-                    editor
-                        .make()
-                        .block_expr(
-                            iter::once(
-                                editor
-                                    .make()
-                                    .expr_stmt(
-                                        editor
-                                            .make()
-                                            .expr_return(Some(sad_expr(try_enum, make, fill_expr)))
-                                            .into(),
-                                    )
-                                    .into(),
-                            ),
-                            None,
-                        )
-                        .indent(indent_level),
+                    make.block_expr(
+                        iter::once(
+                            make.expr_stmt(
+                                make.expr_return(Some(sad_expr(try_enum, make, fill_expr))).into(),
+                            )
+                            .into(),
+                        ),
+                        None,
+                    )
+                    .indent(indent_level),
                 );
                 editor.replace(let_stmt.syntax(), new_let_stmt.syntax());
                 builder.add_file_edits(ctx.vfs_file_id(), editor);

--- a/crates/ide-assists/src/handlers/expand_rest_pattern.rs
+++ b/crates/ide-assists/src/handlers/expand_rest_pattern.rs
@@ -55,16 +55,12 @@ fn expand_record_rest_pattern(
             let make = editor.make();
             let new_fields = old_field_list.fields().chain(matched_fields.iter().map(|(f, _)| {
                 make.record_pat_field_shorthand(
-                    editor
-                        .make()
-                        .ident_pat(
-                            false,
-                            false,
-                            editor
-                                .make()
-                                .name(&f.name(ctx.sema.db).display_no_db(edition).to_smolstr()),
-                        )
-                        .into(),
+                    make.ident_pat(
+                        false,
+                        false,
+                        make.name(&f.name(ctx.sema.db).display_no_db(edition).to_smolstr()),
+                    )
+                    .into(),
                 )
             }));
             let new_field_list = make.record_pat_field_list(new_fields, None);

--- a/crates/ide-assists/src/handlers/generate_delegate_methods.rs
+++ b/crates/ide-assists/src/handlers/generate_delegate_methods.rs
@@ -108,8 +108,7 @@ pub(crate) fn generate_delegate_methods(acc: &mut Assists, ctx: &AssistContext<'
             |edit| {
                 let editor = edit.make_editor(strukt.syntax());
                 let make = editor.make();
-                let field = editor
-                    .make()
+                let field = make
                     .field_from_idents(["self", &field_name])
                     .expect("always be a valid expression");
                 // Create the function
@@ -149,16 +148,14 @@ pub(crate) fn generate_delegate_methods(acc: &mut Assists, ctx: &AssistContext<'
                     .map(|v| convert_param_list_to_arg_list(v, make))
                     .unwrap_or_else(|| make.arg_list([]));
 
-                let tail_expr =
-                    editor.make().expr_method_call(field, make.name_ref(&name), arg_list).into();
+                let tail_expr = make.expr_method_call(field, make.name_ref(&name), arg_list).into();
                 let tail_expr_finished =
                     if is_async { make.expr_await(tail_expr).into() } else { tail_expr };
                 let body = make.block_expr([], Some(tail_expr_finished));
 
                 let ret_type = method_source.ret_type();
 
-                let f = editor
-                    .make()
+                let f = make
                     .fn_(
                         None,
                         vis,

--- a/crates/ide-assists/src/handlers/generate_deref.rs
+++ b/crates/ide-assists/src/handlers/generate_deref.rs
@@ -151,8 +151,7 @@ fn generate_edit(
                 make.ty_ref(make.ty_path(make.path_from_text("Self::Target")).into(), false);
             let field_expr = make.expr_field(make.expr_path(make.ident_path("self")), field_name);
             let body = make.block_expr([], Some(make.expr_ref(field_expr.into(), false)));
-            let fn_ = editor
-                .make()
+            let fn_ = make
                 .fn_(
                     [],
                     None,
@@ -175,8 +174,7 @@ fn generate_edit(
                 make.ty_ref(make.ty_path(make.path_from_text("Self::Target")).into(), true);
             let field_expr = make.expr_field(make.expr_path(make.ident_path("self")), field_name);
             let body = make.block_expr([], Some(make.expr_ref(field_expr.into(), true)));
-            let fn_ = editor
-                .make()
+            let fn_ = make
                 .fn_(
                     [],
                     None,

--- a/crates/ide-assists/src/handlers/generate_getter_or_setter.rs
+++ b/crates/ide-assists/src/handlers/generate_getter_or_setter.rs
@@ -463,10 +463,7 @@ fn build_source_change(
         None,
         ty_params,
         ty_args,
-        editor
-            .make()
-            .ty_path(make.ident_path(&assist_info.strukt.name().unwrap().to_string()))
-            .into(),
+        make.ty_path(make.ident_path(&assist_info.strukt.name().unwrap().to_string())).into(),
         None,
         Some(make.assoc_item_list(items)),
     );

--- a/crates/ide-assists/src/handlers/generate_impl.rs
+++ b/crates/ide-assists/src/handlers/generate_impl.rs
@@ -173,9 +173,7 @@ pub(crate) fn generate_impl_trait(acc: &mut Assists, ctx: &AssistContext<'_>) ->
             );
 
             let trait_gen_args = trait_.generic_param_list().map(|list| {
-                editor
-                    .make()
-                    .generic_arg_list(list.generic_params().map(|_| holder_arg.clone()), false)
+                make.generic_arg_list(list.generic_params().map(|_| holder_arg.clone()), false)
             });
 
             let make_impl_ = |body| {

--- a/crates/ide-assists/src/handlers/generate_new.rs
+++ b/crates/ide-assists/src/handlers/generate_new.rs
@@ -138,8 +138,7 @@ pub(crate) fn generate_new(acc: &mut Assists, ctx: &AssistContext<'_>) -> Option
 
         let ret_type = make.ret_type(make.ty_path(make.ident_path("Self")).into());
 
-        let fn_ = editor
-            .make()
+        let fn_ = make
             .fn_(
                 [],
                 strukt.visibility(),
@@ -165,10 +164,7 @@ pub(crate) fn generate_new(acc: &mut Assists, ctx: &AssistContext<'_>) -> Option
                 editor.insert_all(
                     Position::after(l_curly),
                     vec![
-                        editor
-                            .make()
-                            .whitespace(&format!("\n{}", impl_def.indent_level() + 1))
-                            .into(),
+                        make.whitespace(&format!("\n{}", impl_def.indent_level() + 1)).into(),
                         fn_.syntax().clone().into(),
                         make.whitespace("\n").into(),
                     ],

--- a/crates/ide-assists/src/handlers/generate_single_field_struct_from.rs
+++ b/crates/ide-assists/src/handlers/generate_single_field_struct_from.rs
@@ -98,8 +98,7 @@ pub(crate) fn generate_single_field_struct_from(
                 make_adt_constructor(names.as_deref(), constructors, &main_field_name, make);
             let body = make.block_expr([], Some(constructor));
 
-            let fn_ = editor
-                .make()
+            let fn_ = make
                 .fn_(
                     [],
                     None,

--- a/crates/ide-assists/src/handlers/replace_if_let_with_match.rs
+++ b/crates/ide-assists/src/handlers/replace_if_let_with_match.rs
@@ -140,8 +140,7 @@ pub(crate) fn replace_if_let_with_match(acc: &mut Assists, ctx: &AssistContext<'
                 if_expr.syntax().parent().is_some_and(|it| ast::IfExpr::can_cast(it.kind()));
             let expr = if has_preceding_if_expr {
                 // make sure we replace the `else if let ...` with a block so we don't end up with `else expr`
-                let block_expr = editor
-                    .make()
+                let block_expr = make
                     .block_expr([], Some(match_expr.dedent(indent).indent(IndentLevel(1))))
                     .indent(indent);
                 block_expr.into()
@@ -301,8 +300,7 @@ pub(crate) fn replace_match_with_if_let(acc: &mut Assists, ctx: &AssistContext<'
             let else_expr = else_expr.reset_indent();
             let then_block = make_block_expr(then_expr);
             let else_expr = if is_empty_expr(&else_expr) { None } else { Some(else_expr) };
-            let if_let_expr = editor
-                .make()
+            let if_let_expr = make
                 .expr_if(
                     condition,
                     then_block,

--- a/crates/ide-assists/src/handlers/replace_let_with_if_let.rs
+++ b/crates/ide-assists/src/handlers/replace_let_with_if_let.rs
@@ -59,10 +59,9 @@ pub(crate) fn replace_let_with_if_let(acc: &mut Assists, ctx: &AssistContext<'_>
                     .map(|it| it.happy_case());
                 match happy_variant {
                     None => original_pat,
-                    Some(var_name) => editor
-                        .make()
-                        .tuple_struct_pat(make.ident_path(var_name), [original_pat])
-                        .into(),
+                    Some(var_name) => {
+                        make.tuple_struct_pat(make.ident_path(var_name), [original_pat]).into()
+                    }
                 }
             };
             let init_expr =

--- a/crates/ide-assists/src/handlers/unmerge_imports.rs
+++ b/crates/ide-assists/src/handlers/unmerge_imports.rs
@@ -55,9 +55,7 @@ pub(crate) fn unmerge_imports(acc: &mut Assists, ctx: &AssistContext<'_>) -> Opt
         editor.insert_all(
             Position::after(use_.syntax()),
             vec![
-                editor
-                    .make()
-                    .whitespace(&format!("\n{}", IndentLevel::from_node(use_.syntax())))
+                make.whitespace(&format!("\n{}", IndentLevel::from_node(use_.syntax())))
                     .syntax_element(),
                 new_use.syntax().syntax_element(),
             ],


### PR DESCRIPTION
fixup rust-lang/rust-analyzer#22049
