### PR TITLE
fix: handle empty `/**/` in block_to_line assist

### DIFF
--- a/crates/ide-assists/src/handlers/convert_comment_block.rs
+++ b/crates/ide-assists/src/handlers/convert_comment_block.rs
@@ -382,6 +382,21 @@ fn main() {
     }
 
     #[test]
+    fn empty_block_to_line() {
+        check_assist(
+            convert_comment_block,
+            r#"
+/**/$0
+fn main() {}
+"#,
+            r#"
+
+fn main() {}
+"#,
+        );
+    }
+
+    #[test]
     fn end_of_line_block_to_line() {
         check_assist_not_applicable(
             convert_comment_block,

--- a/crates/syntax/src/ast/token_ext.rs
+++ b/crates/syntax/src/ast/token_ext.rs
@@ -32,11 +32,7 @@ impl ast::Comment {
     }
 
     pub fn prefix(&self) -> &'static str {
-        let &(prefix, _kind) = CommentKind::BY_PREFIX
-            .iter()
-            .find(|&(prefix, kind)| self.kind() == *kind && self.text().starts_with(prefix))
-            .unwrap();
-        prefix
+        self.kind().prefix()
     }
 
     /// Returns the textual content of a doc comment node as a single string with prefix and suffix


### PR DESCRIPTION
block_to_line sliced &text[prefix.len()..text.len()-2], which panicked on `/**/` since its prefix matches the entire comment (len 4) and text.len() - 2 = 2, producing the invalid range [4..2].

use strip_prefix/strip_suffix and emit a plain `//` when the body is empty after trimming.

fixes https://github.com/rust-lang/rust-analyzer/issues/22071