### PR TITLE
implement custom `Debug` for `MiniCore`

### DIFF
--- a/crates/ide-db/src/lib.rs
+++ b/crates/ide-db/src/lib.rs
@@ -385,7 +385,7 @@ pub enum Severity {
     Allow,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Clone, Copy)]
 pub struct MiniCore<'a>(&'a str);
 
 impl<'a> MiniCore<'a> {
@@ -397,6 +397,15 @@ impl<'a> MiniCore<'a> {
     #[inline]
     pub const fn default() -> Self {
         Self(test_utils::MiniCore::RAW_SOURCE)
+    }
+}
+
+impl std::fmt::Debug for MiniCore<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("MiniCore")
+            // don't print the whole contents if they correspond to the default
+            .field(if self.0 == test_utils::MiniCore::RAW_SOURCE { &"<default>" } else { &self.0 })
+            .finish()
     }
 }
 


### PR DESCRIPTION
When the contents correspond to the default, just output `MiniCore("<default>")` instead of the whole thing.

Helps reduce the length of the debug output in the common case.
