### PR TITLE
fix lsp-extensions section header

### DIFF
--- a/docs/book/src/contributing/lsp-extensions.md
+++ b/docs/book/src/contributing/lsp-extensions.md
@@ -653,7 +653,7 @@ Note that this functionality is intended primarily to inform the end user about 
 In particular, it's valid for the client to completely ignore this extension.
 Clients are discouraged from but are allowed to use the `health` status to decide if it's worth sending a request to the server.
 
-### Controlling Flycheck
+## Controlling Flycheck
 
 The flycheck/checkOnSave feature can be controlled via notifications sent by the client to the server.
 


### PR DESCRIPTION
this header is indented one too far. it isn't part of "server status".