### PR TITLE
hir-ty: report solver overflow as NextSolverError::Overflow

### DIFF
--- a/crates/hir-ty/src/next_solver/fulfill.rs
+++ b/crates/hir-ty/src/next_solver/fulfill.rs
@@ -10,7 +10,7 @@ use rustc_next_trait_solver::{
 use rustc_type_ir::{
     Interner, TypeSuperVisitable, TypeVisitable, TypeVisitableExt, TypeVisitor,
     inherent::{IntoKind, Span as _},
-    solve::{Certainty, NoSolution},
+    solve::{Certainty, MaybeCause, NoSolution},
 };
 
 use crate::next_solver::{
@@ -211,6 +211,11 @@ impl<'db> FulfillmentCtxt<'db> {
 
                 match certainty {
                     Certainty::Yes => {}
+                    Certainty::Maybe { cause: MaybeCause::Overflow { .. }, .. }
+                        if has_changed == HasChanged::No =>
+                    {
+                        errors.push(NextSolverError::Overflow(obligation));
+                    }
                     Certainty::Maybe { .. } => self.obligations.register(obligation, stalled_on),
                 }
             }


### PR DESCRIPTION
When the next_solver returned `Maybe { cause: Overflow }` and the evaluation made no inference progress, `try_evaluate_obligations` re-registered the obligation instead of alerting the caller.  Callers like `structurally_normalize_term` could not distinguish overflow from successful ambiguous resolution and would return the inference variable they had allocated, letting it leak past the infcx (e.g. across salsa query boundaries into stored MIR bodies where it caused a panic during const evaluation).

Emit `NextSolverError::Overflow` in that case so callers can fail normalization instead of propagating a dangling variable (which in my code led thence to a panic).

[The above is mostly written by AI but reviewed by a human, but now the human is talking.]

I got rust-analyzer into a panic and unable to work with a bunch of my program via some very complex types that AI could only minimize down to a mere 111 lines that were standalone. It was caused by an array sized by const code that computed the size of a complex type that itself was composed of a chain of associated types that recursed several levels.

We found two ways to avoid the panic:  (1) increasing the recursion limit from a hardcoded limit of 50, which differs from rustc's configurable value that defaults to 128, and allowed reaching a solution; and (2) actually propagating the overflow out to a point where things can take notice and stop rather than proceeding in an incorrect state.  (1) may be desired independently, but it caused issues with two regression tests.