### PR TITLE
fix: mark enum variants as deprecated when their parent enum is deprecated

### DIFF
--- a/crates/ide-completion/src/render.rs
+++ b/crates/ide-completion/src/render.rs
@@ -120,6 +120,15 @@ impl<'a> RenderContext<'a> {
                 })
     }
 
+    /// Whether an enum variant should be rendered as deprecated.
+    ///
+    /// A variant inherits deprecation from its parent enum, matching rustc's
+    /// behavior where `#[deprecated]` on an enum applies to its variants.
+    fn is_variant_deprecated(&self, variant: hir::EnumVariant) -> bool {
+        let db = self.db();
+        variant.attrs(db).is_deprecated() || variant.parent_enum(db).attrs(db).is_deprecated()
+    }
+
     // FIXME: remove this
     fn docs(&self, def: impl HasDocs) -> Option<Documentation<'a>> {
         def.docs(self.db())
@@ -583,6 +592,7 @@ fn scope_def_docs(db: &RootDatabase, resolution: ScopeDef) -> Option<Documentati
 fn scope_def_is_deprecated(ctx: &RenderContext<'_>, resolution: ScopeDef) -> bool {
     let db = ctx.db();
     match resolution {
+        ScopeDef::ModuleDef(hir::ModuleDef::EnumVariant(it)) => ctx.is_variant_deprecated(it),
         ScopeDef::ModuleDef(it) => ctx.is_deprecated(it, it.as_assoc_item(db)),
         ScopeDef::GenericParam(it) => {
             ctx.is_deprecated(it, None /* generic params can't be assoc items */)

--- a/crates/ide-completion/src/render/literal.rs
+++ b/crates/ide-completion/src/render/literal.rs
@@ -192,9 +192,7 @@ impl Variant {
             Variant::Struct(it) => {
                 ctx.is_deprecated(it, None /* structs can't be assoc items */)
             }
-            Variant::EnumVariant(it) => {
-                ctx.is_deprecated(it, None /* enum variants can't be assoc items */)
-            }
+            Variant::EnumVariant(it) => ctx.is_variant_deprecated(it),
         }
     }
 

--- a/crates/ide-completion/src/tests/expression.rs
+++ b/crates/ide-completion/src/tests/expression.rs
@@ -3162,6 +3162,41 @@ fn foo() {
 }
 
 #[test]
+fn deprecated_enum_marks_variants_deprecated() {
+    // regression: rust-lang/rust-analyzer#22090 — a variant inherits the
+    // `#[deprecated]` attribute of its parent enum.
+    check(
+        r#"
+#[deprecated]
+enum Foo { Bar }
+fn main() { let _ = Foo::$0; }
+"#,
+        expect![[r#"
+            ev Bar Bar DEPRECATED
+        "#]],
+    );
+}
+
+#[test]
+fn deprecated_variant_of_undeprecated_enum_still_deprecated() {
+    // regression guard for rust-lang/rust-analyzer#22090 — the existing
+    // per-variant `#[deprecated]` behavior must keep working.
+    check(
+        r#"
+enum Foo {
+    #[deprecated] Bar,
+    Baz,
+}
+fn main() { let _ = Foo::$0; }
+"#,
+        expect![[r#"
+            ev Bar Bar DEPRECATED
+            ev Baz Baz
+        "#]],
+    );
+}
+
+#[test]
 fn non_std_test_attr_macro() {
     check(
         r#"

--- a/crates/ide-completion/src/tests/expression.rs
+++ b/crates/ide-completion/src/tests/expression.rs
@@ -3163,8 +3163,6 @@ fn foo() {
 
 #[test]
 fn deprecated_enum_marks_variants_deprecated() {
-    // regression: rust-lang/rust-analyzer#22090 — a variant inherits the
-    // `#[deprecated]` attribute of its parent enum.
     check(
         r#"
 #[deprecated]

--- a/crates/ide-completion/src/tests/expression.rs
+++ b/crates/ide-completion/src/tests/expression.rs
@@ -3179,8 +3179,6 @@ fn main() { let _ = Foo::$0; }
 
 #[test]
 fn deprecated_variant_of_undeprecated_enum_still_deprecated() {
-    // regression guard for rust-lang/rust-analyzer#22090 — the existing
-    // per-variant `#[deprecated]` behavior must keep working.
     check(
         r#"
 enum Foo {


### PR DESCRIPTION
Closes rust-lang/rust-analyzer#22090.

- Completion items for variants of a `#[deprecated]` enum were not rendered as deprecated because `RenderContext::is_deprecated` only consulted the def's own attributes. PR rust-lang/rust-analyzer#22083 handled the trait→assoc-item propagation at the render layer. 

- This extends the same pattern to enum→variant via a small `is_variant_deprecated` helper, wired into both the path-completion and literal-completion render paths. Closes rust-lang/rust-analyzer#22090.