### PR TITLE
migrate convert closure to fn to  SyntaxEditor

### DIFF
--- a/crates/ide-assists/src/handlers/convert_closure_to_fn.rs
+++ b/crates/ide-assists/src/handlers/convert_closure_to_fn.rs
@@ -1,20 +1,19 @@
 use either::Either;
-use hir::{CaptureKind, ClosureCapture, FileRangeWrapper, HirDisplay};
+use hir::{CaptureKind, ClosureCapture, HirDisplay};
 use ide_db::{
-    FxHashSet, assists::AssistId, base_db::SourceDatabase, defs::Definition,
-    search::FileReferenceNode, source_change::SourceChangeBuilder,
+    FxHashSet, assists::AssistId, defs::Definition, search::FileReferenceNode,
+    source_change::SourceChangeBuilder,
 };
-use stdx::format_to;
 use syntax::{
-    AstNode, Direction, SyntaxKind, SyntaxNode, T, TextSize, ToSmolStr,
-    algo::{skip_trivia_token, skip_whitespace_token},
+    AstNode, AstPtr, Direction, SyntaxKind, SyntaxNode, T, ToSmolStr,
+    algo::skip_trivia_token,
     ast::{
         self, HasArgList, HasGenericParams, HasName,
         edit::{AstNodeEdit, IndentLevel},
-        make,
+        syntax_factory::SyntaxFactory,
     },
     hacks::parse_expr_from_str,
-    ted,
+    syntax_editor::{Position, SyntaxEditor},
 };
 
 use crate::assist_context::{AssistContext, Assists};
@@ -52,11 +51,14 @@ use crate::assist_context::{AssistContext, Assists};
 // }
 // ```
 pub(crate) fn convert_closure_to_fn(acc: &mut Assists, ctx: &AssistContext<'_>) -> Option<()> {
+    let (editor, root) = SyntaxEditor::new(ctx.source_file().syntax().clone());
+    let make = editor.make();
     let closure = ctx.find_node_at_offset::<ast::ClosureExpr>()?;
     if ctx.find_node_at_offset::<ast::Expr>() != Some(ast::Expr::ClosureExpr(closure.clone())) {
         // Not inside the parameter list.
         return None;
     }
+    let closure_ptr = AstPtr::new(&closure);
     let closure_name = closure.syntax().parent().and_then(|parent| {
         let closure_decl = ast::LetStmt::cast(parent)?;
         match closure_decl.pat()? {
@@ -64,6 +66,8 @@ pub(crate) fn convert_closure_to_fn(acc: &mut Assists, ctx: &AssistContext<'_>) 
             _ => None,
         }
     });
+    let closure_decl_ptr =
+        closure_name.as_ref().map(|(closure_decl, _, _)| AstPtr::new(closure_decl));
     let module = ctx.sema.scope(closure.syntax())?.module();
     let closure_ty = ctx.sema.type_of_expr(&closure.clone().into())?;
     let callable = closure_ty.original.as_callable(ctx.db())?;
@@ -85,14 +89,14 @@ pub(crate) fn convert_closure_to_fn(acc: &mut Assists, ctx: &AssistContext<'_>) 
                     let ty = param_ty
                         .display_source_code(ctx.db(), module.into(), true)
                         .unwrap_or_else(|_| "_".to_owned());
-                    Some(make::param(node.pat()?, make::ty(&ty)))
+                    Some(make.param(node.pat()?, make.ty(&ty)))
                 }
             }
         })
         .collect::<Option<Vec<_>>>()?;
     let capture_params_start = params.len();
 
-    let mut body = closure.body()?.clone_for_update();
+    let body = closure.body()?;
     let mut is_gen = false;
     let mut is_async = closure.async_token().is_some();
     if is_async {
@@ -100,47 +104,143 @@ pub(crate) fn convert_closure_to_fn(acc: &mut Assists, ctx: &AssistContext<'_>) 
     }
     // We defer the wrapping of the body in the block, because `make::block()` will generate a new node,
     // but we need to locate `AstPtr`s inside the body.
-    let mut wrap_body_in_block = true;
-    if let ast::Expr::BlockExpr(block) = &body {
-        if let Some(async_token) = block.async_token()
-            && !is_async
-        {
-            is_async = true;
-            ret_ty = ret_ty.future_output(ctx.db())?;
-            let token_idx = async_token.index();
-            let whitespace_tokens_after_count = async_token
-                .siblings_with_tokens(Direction::Next)
-                .skip(1)
-                .take_while(|token| token.kind() == SyntaxKind::WHITESPACE)
-                .count();
-            body.syntax().splice_children(
-                token_idx..token_idx + whitespace_tokens_after_count + 1,
-                Vec::new(),
-            );
-        }
-        if let Some(gen_token) = block.gen_token() {
-            is_gen = true;
-            ret_ty = ret_ty.iterator_item(ctx.db())?;
-            let token_idx = gen_token.index();
-            let whitespace_tokens_after_count = gen_token
-                .siblings_with_tokens(Direction::Next)
-                .skip(1)
-                .take_while(|token| token.kind() == SyntaxKind::WHITESPACE)
-                .count();
-            body.syntax().splice_children(
-                token_idx..token_idx + whitespace_tokens_after_count + 1,
-                Vec::new(),
-            );
+    let (strip_async_from_body, strip_gen_from_body, wrap_body_in_block) =
+        if let ast::Expr::BlockExpr(block) = &body {
+            let strip_async = block.async_token().is_some() && !is_async;
+            let strip_gen = block.gen_token().is_some();
+            if strip_async {
+                is_async = true;
+                ret_ty = ret_ty.future_output(ctx.db())?;
+            }
+            if strip_gen {
+                is_gen = true;
+                ret_ty = ret_ty.iterator_item(ctx.db())?;
+            }
+
+            let has_other_modifiers = block.try_block_modifier().is_some()
+                || block.unsafe_token().is_some()
+                || block.label().is_some()
+                || block.const_token().is_some();
+            let keeps_unstripped_async_or_gen = (block.async_token().is_some() && !strip_async)
+                || (block.gen_token().is_some() && !strip_gen);
+            (strip_async, strip_gen, has_other_modifiers || keeps_unstripped_async_or_gen)
+        } else {
+            (false, false, true)
+        };
+
+    let (insert_before_stmt, insert_in_closure_body, insert_before_tail_expr) =
+        if closure_name.is_none() {
+            let top_stmt = closure.syntax().ancestors().skip(1).find_map(|ancestor| {
+                ast::Stmt::cast(ancestor.clone()).map(Either::Left).or_else(|| {
+                    ast::ClosureExpr::cast(ancestor.clone())
+                        .map(Either::Left)
+                        .or_else(|| ast::BlockExpr::cast(ancestor).map(Either::Right))
+                        .map(Either::Right)
+                })
+            })?;
+            match top_stmt {
+                Either::Left(stmt) => (Some(AstPtr::new(&stmt)), None, None),
+                Either::Right(Either::Left(closure_inside_closure)) => {
+                    (None, Some(AstPtr::new(&closure_inside_closure.body()?)), None)
+                }
+                Either::Right(Either::Right(block_expr)) => {
+                    (None, None, Some(AstPtr::new(&block_expr.tail_expr()?)))
+                }
+            }
+        } else {
+            (None, None, None)
+        };
+
+    let captures = closure_ty.captured_items(ctx.db());
+    let capture_tys =
+        captures.iter().map(|capture| capture.captured_ty(ctx.db())).collect::<Vec<_>>();
+
+    let mut captures_as_args = Vec::with_capacity(captures.len());
+    let body_root = body.syntax().ancestors().last().unwrap();
+    // We need to defer this work because otherwise the text range of elements is being messed up, and
+    // replacements for the next captures won't work.
+    let mut capture_usages_replacement_map = Vec::with_capacity(captures.len());
+    for (capture, capture_ty) in std::iter::zip(&captures, &capture_tys) {
+        // FIXME: Allow configuring the replacement of `self`.
+        let is_self = capture.local().is_self(ctx.db()) && !capture.has_field_projections();
+        let capture_name = if is_self {
+            make.name("this")
+        } else {
+            make.name(&capture.place_to_name(ctx.db(), ctx.edition()))
+        };
+
+        closure_mentioned_generic_params.extend(capture_ty.generic_params(ctx.db()));
+        let capture_ty = capture_ty
+            .display_source_code(ctx.db(), module.into(), true)
+            .unwrap_or_else(|_| "_".to_owned());
+        let param = make.param(
+            ast::Pat::IdentPat(make.ident_pat(false, false, capture_name.clone_subtree())),
+            make.ty(&capture_ty),
+        );
+        if is_self {
+            // Always put `this` first.
+            params.insert(capture_params_start, param);
+        } else {
+            params.push(param);
         }
 
-        if block.try_block_modifier().is_none()
-            && block.unsafe_token().is_none()
-            && block.label().is_none()
-            && block.const_token().is_none()
-            && block.async_token().is_none()
-        {
-            wrap_body_in_block = false;
+        for capture_usage in capture.usages().sources(ctx.db()) {
+            if capture_usage.file_id() != ctx.file_id() {
+                // This is from a macro, don't change it.
+                continue;
+            }
+
+            let capture_usage_source = capture_usage.source();
+            let capture_usage_source = capture_usage_source.to_node(&body_root);
+            let mut expr = match capture_usage_source {
+                Either::Left(expr) => expr,
+                Either::Right(pat) => {
+                    let Some(expr) = expr_of_pat(pat) else { continue };
+                    expr
+                }
+            };
+
+            if !capture_usage.is_ref() {
+                expr = peel_ref(expr);
+            }
+
+            let replacement = wrap_capture_in_deref_if_needed(
+                make,
+                &expr,
+                &capture_name,
+                capture.kind(),
+                matches!(expr, ast::Expr::RefExpr(_)) || capture_usage.is_ref(),
+            );
+            capture_usages_replacement_map.push((AstPtr::new(&expr), replacement));
         }
+
+        let capture_as_arg = capture_as_arg(make, ctx, capture);
+        if is_self {
+            captures_as_args.insert(0, capture_as_arg);
+        } else {
+            captures_as_args.push(capture_as_arg);
+        }
+    }
+
+    let (closure_type_params, closure_where_clause) =
+        compute_closure_type_params(make, ctx, closure_mentioned_generic_params, &closure);
+    let body = rewrite_closure_body(
+        &closure,
+        &body,
+        &capture_usages_replacement_map,
+        strip_async_from_body,
+        strip_gen_from_body,
+    )?;
+
+    let closure_name_or_default =
+        closure_name.as_ref().map(|(_, _, it)| it.clone()).unwrap_or_else(|| make.name("fun_name"));
+    let closure_expr = closure_ptr.to_node(&root);
+
+    let body = if wrap_body_in_block {
+        let body = body.clone().dedent(IndentLevel(1));
+        make.block_expr([], Some(body))
+    } else {
+        ast::BlockExpr::cast(body.syntax().clone())?
     };
 
     acc.add(
@@ -148,109 +248,17 @@ pub(crate) fn convert_closure_to_fn(acc: &mut Assists, ctx: &AssistContext<'_>) 
         "Convert closure to fn",
         closure.param_list()?.syntax().text_range(),
         |builder| {
-            let closure_name_or_default = closure_name
-                .as_ref()
-                .map(|(_, _, it)| it.clone())
-                .unwrap_or_else(|| make::name("fun_name"));
-            let captures = closure_ty.captured_items(ctx.db());
-            let capture_tys =
-                captures.iter().map(|capture| capture.captured_ty(ctx.db())).collect::<Vec<_>>();
-
-            let mut captures_as_args = Vec::with_capacity(captures.len());
-
-            let body_root = body.syntax().ancestors().last().unwrap();
-            // We need to defer this work because otherwise the text range of elements is being messed up, and
-            // replacements for the next captures won't work.
-            let mut capture_usages_replacement_map = Vec::with_capacity(captures.len());
-
-            for (capture, capture_ty) in std::iter::zip(&captures, &capture_tys) {
-                // FIXME: Allow configuring the replacement of `self`.
-                let is_self = capture.local().is_self(ctx.db()) && !capture.has_field_projections();
-                let capture_name = if is_self {
-                    make::name("this")
-                } else {
-                    make::name(&capture.place_to_name(ctx.db(), ctx.edition()))
-                };
-
-                closure_mentioned_generic_params.extend(capture_ty.generic_params(ctx.db()));
-
-                let capture_ty = capture_ty
-                    .display_source_code(ctx.db(), module.into(), true)
-                    .unwrap_or_else(|_| "_".to_owned());
-                let param = make::param(
-                    ast::Pat::IdentPat(make::ident_pat(false, false, capture_name.clone_subtree())),
-                    make::ty(&capture_ty),
-                );
-                if is_self {
-                    // Always put `this` first.
-                    params.insert(capture_params_start, param);
-                } else {
-                    params.push(param);
-                }
-
-                for capture_usage in capture.usages().sources(ctx.db()) {
-                    if capture_usage.file_id() != ctx.file_id() {
-                        // This is from a macro, don't change it.
-                        continue;
-                    }
-
-                    let capture_usage_source = capture_usage.source();
-                    let capture_usage_source = capture_usage_source.to_node(&body_root);
-                    let mut expr = match capture_usage_source {
-                        Either::Left(expr) => expr,
-                        Either::Right(pat) => {
-                            let Some(expr) = expr_of_pat(pat) else { continue };
-                            expr
-                        }
-                    };
-                    if !capture_usage.is_ref() {
-                        expr = peel_ref(expr);
-                    }
-                    let replacement = wrap_capture_in_deref_if_needed(
-                        &expr,
-                        &capture_name,
-                        capture.kind(),
-                        matches!(expr, ast::Expr::RefExpr(_)) || capture_usage.is_ref(),
-                    )
-                    .clone_for_update();
-                    capture_usages_replacement_map.push((expr, replacement));
-                }
-
-                let capture_as_arg = capture_as_arg(ctx, capture);
-                if is_self {
-                    captures_as_args.insert(0, capture_as_arg);
-                } else {
-                    captures_as_args.push(capture_as_arg);
-                }
-            }
-
-            let (closure_type_params, closure_where_clause) =
-                compute_closure_type_params(ctx, closure_mentioned_generic_params, &closure);
-
-            for (old, new) in capture_usages_replacement_map {
-                if old == body {
-                    body = new;
-                } else {
-                    ted::replace(old.syntax(), new.syntax());
-                }
-            }
-
-            let body = if wrap_body_in_block {
-                make::block_expr([], Some(body.reset_indent().indent(1.into())))
-            } else {
-                ast::BlockExpr::cast(body.syntax().clone()).unwrap()
-            };
-
-            let params = make::param_list(None, params);
+            let make = editor.make();
+            let params = make.param_list(None, params);
             let ret_ty = if ret_ty.is_unit() {
                 None
             } else {
                 let ret_ty = ret_ty
                     .display_source_code(ctx.db(), module.into(), true)
                     .unwrap_or_else(|_| "_".to_owned());
-                Some(make::ret_type(make::ty(&ret_ty)))
+                Some(make.ret_type(make.ty(&ret_ty)))
             };
-            let mut fn_ = make::fn_(
+            let mut fn_ = make.fn_(
                 None,
                 None,
                 closure_name_or_default.clone(),
@@ -264,72 +272,57 @@ pub(crate) fn convert_closure_to_fn(acc: &mut Assists, ctx: &AssistContext<'_>) 
                 false,
                 is_gen,
             );
-            fn_ = fn_.dedent(IndentLevel::from_token(&fn_.syntax().last_token().unwrap()));
+            if let Some(last_token) = fn_.syntax().last_token() {
+                fn_ = fn_.dedent(IndentLevel::from_token(&last_token));
+            }
 
-            builder.edit_file(ctx.vfs_file_id());
             match &closure_name {
                 Some((closure_decl, _, _)) => {
                     fn_ = fn_.indent(closure_decl.indent_level());
-                    builder.replace(closure_decl.syntax().text_range(), fn_.to_string());
+                    if let Some(closure_decl_ptr) = &closure_decl_ptr {
+                        let closure_decl = closure_decl_ptr.to_node(&root);
+                        editor.replace(closure_decl.syntax(), fn_.syntax());
+                    }
                 }
                 None => {
-                    let Some(top_stmt) =
-                        closure.syntax().ancestors().skip(1).find_map(|ancestor| {
-                            ast::Stmt::cast(ancestor.clone()).map(Either::Left).or_else(|| {
-                                ast::ClosureExpr::cast(ancestor.clone())
-                                    .map(Either::Left)
-                                    .or_else(|| ast::BlockExpr::cast(ancestor).map(Either::Right))
-                                    .map(Either::Right)
-                            })
-                        })
-                    else {
-                        return;
-                    };
-                    builder.replace(
-                        closure.syntax().text_range(),
-                        closure_name_or_default.to_string(),
-                    );
-                    match top_stmt {
-                        Either::Left(stmt) => {
-                            let indent = stmt.indent_level();
-                            fn_ = fn_.indent(indent);
-                            let range = stmt
-                                .syntax()
-                                .first_token()
-                                .and_then(|token| {
-                                    skip_whitespace_token(token.prev_token()?, Direction::Prev)
-                                })
-                                .map(|it| it.text_range().end())
-                                .unwrap_or_else(|| stmt.syntax().text_range().start());
-                            builder.insert(range, format!("\n{indent}{fn_}"));
-                        }
-                        Either::Right(Either::Left(closure_inside_closure)) => {
-                            let Some(closure_body) = closure_inside_closure.body() else { return };
-                            // FIXME: Maybe we can indent this properly, adding newlines and all, but this is hard.
-                            builder.insert(
-                                closure_body.syntax().text_range().start(),
-                                format!("{{ {fn_} "),
-                            );
-                            builder
-                                .insert(closure_body.syntax().text_range().end(), " }".to_owned());
-                        }
-                        Either::Right(Either::Right(block_expr)) => {
-                            let Some(tail_expr) = block_expr.tail_expr() else { return };
-                            let Some(insert_in) =
-                                tail_expr.syntax().first_token().and_then(|token| {
-                                    skip_whitespace_token(token.prev_token()?, Direction::Prev)
-                                })
-                            else {
-                                return;
-                            };
-                            let indent = tail_expr.indent_level();
-                            fn_ = fn_.indent(indent);
-                            builder
-                                .insert(insert_in.text_range().end(), format!("\n{indent}{fn_}"));
-                        }
+                    if let Some(stmt_ptr) = &insert_before_stmt {
+                        let replacement =
+                            make.expr_path(make.path_from_text(&closure_name_or_default.text()));
+                        editor.replace(closure_expr.syntax(), replacement.syntax());
+                        let stmt = stmt_ptr.to_node(&root);
+                        let fn_ = fn_.indent(stmt.indent_level());
+                        editor.insert_all(
+                            Position::before(stmt.syntax()),
+                            vec![
+                                fn_.syntax().clone().into(),
+                                make.whitespace(&format!("\n{}", stmt.indent_level())).into(),
+                            ],
+                        );
+                    } else if let Some(closure_body_ptr) = &insert_in_closure_body {
+                        let closure_body = closure_body_ptr.to_node(&root);
+                        let body_with_fn = parse_expr_from_str(
+                            &format!("{{ {fn_} {closure_name_or_default} }}"),
+                            ctx.edition(),
+                        )
+                        .expect("generated closure body should parse");
+                        editor.replace(closure_body.syntax(), body_with_fn.syntax());
+                    } else if let Some(tail_expr_ptr) = &insert_before_tail_expr {
+                        let replacement =
+                            make.expr_path(make.path_from_text(&closure_name_or_default.text()));
+                        editor.replace(closure_expr.syntax(), replacement.syntax());
+                        let tail_expr = tail_expr_ptr.to_node(&root);
+                        let fn_ = fn_.indent(tail_expr.indent_level());
+                        editor.insert_all(
+                            Position::before(tail_expr.syntax()),
+                            vec![
+                                fn_.syntax().clone().into(),
+                                make.whitespace(&format!("\n{}", tail_expr.indent_level())).into(),
+                            ],
+                        );
                     }
                 }
             }
+            builder.add_file_edits(ctx.vfs_file_id(), editor);
 
             handle_calls(
                 builder,
@@ -346,6 +339,7 @@ pub(crate) fn convert_closure_to_fn(acc: &mut Assists, ctx: &AssistContext<'_>) 
 }
 
 fn compute_closure_type_params(
+    make: &SyntaxFactory,
     ctx: &AssistContext<'_>,
     mentioned_generic_params: FxHashSet<hir::GenericParam>,
     closure: &ast::ClosureExpr,
@@ -472,11 +466,11 @@ fn compute_closure_type_params(
         }))
         .collect::<Vec<_>>();
     let where_clause =
-        (!include_where_bounds.is_empty()).then(|| make::where_clause(include_where_bounds));
+        (!include_where_bounds.is_empty()).then(|| make.where_clause(include_where_bounds));
 
     // FIXME: Consider generic parameters that do not appear in params/return type/captures but
     // written explicitly inside the closure.
-    (Some(make::generic_param_list(include_params)), where_clause)
+    (Some(make.generic_param_list(include_params)), where_clause)
 }
 
 fn peel_parens(mut expr: ast::Expr) -> ast::Expr {
@@ -497,12 +491,13 @@ fn peel_ref(mut expr: ast::Expr) -> ast::Expr {
 }
 
 fn wrap_capture_in_deref_if_needed(
+    make: &SyntaxFactory,
     expr: &ast::Expr,
     capture_name: &ast::Name,
     capture_kind: CaptureKind,
     is_ref: bool,
 ) -> ast::Expr {
-    let capture_name = make::expr_path(make::path_from_text(&capture_name.text()));
+    let capture_name = make.expr_path(make.path_from_text(&capture_name.text()));
     if capture_kind == CaptureKind::Move || is_ref {
         return capture_name;
     }
@@ -524,10 +519,14 @@ fn wrap_capture_in_deref_if_needed(
     if does_autoderef {
         return capture_name;
     }
-    make::expr_prefix(T![*], capture_name).into()
+    make.expr_prefix(T![*], capture_name).into()
 }
 
-fn capture_as_arg(ctx: &AssistContext<'_>, capture: &ClosureCapture<'_>) -> ast::Expr {
+fn capture_as_arg(
+    make: &SyntaxFactory,
+    ctx: &AssistContext<'_>,
+    capture: &ClosureCapture<'_>,
+) -> ast::Expr {
     let place = parse_expr_from_str(
         &capture.display_place_source_code(ctx.db(), ctx.edition()),
         ctx.edition(),
@@ -543,7 +542,7 @@ fn capture_as_arg(ctx: &AssistContext<'_>, capture: &ClosureCapture<'_>) -> ast:
     {
         return expr.expr().expect("`display_place_source_code()` produced an invalid expr");
     }
-    make::expr_ref(place, needs_mut)
+    make.expr_ref(place, needs_mut)
 }
 
 fn handle_calls(
@@ -603,61 +602,102 @@ fn handle_call(
     });
     let has_existing_args = args.args().next().is_some();
 
-    let FileRangeWrapper { file_id, range } = ctx.sema.original_range_opt(args.syntax())?;
+    let file_id = ctx.sema.original_range_opt(args.syntax())?.file_id.file_id(ctx.db());
     let first_arg_indent = args.args().next().map(|it| it.indent_level());
     let arg_list_indent = args.indent_level();
     let insert_newlines =
         first_arg_indent.is_some_and(|first_arg_indent| first_arg_indent != arg_list_indent);
-    let indent =
-        if insert_newlines { first_arg_indent.unwrap().to_string() } else { String::new() };
-    // FIXME: This text manipulation seems risky.
-    let text = ctx.db().file_text(file_id.file_id(ctx.db())).text(ctx.db());
-    let mut text = text[..u32::from(range.end()).try_into().unwrap()].trim_end();
-    if !text.ends_with(')') {
-        return None;
-    }
-    text = text[..text.len() - 1].trim_end();
-    let offset = TextSize::new(text.len().try_into().unwrap());
+    let indent = first_arg_indent.unwrap_or(arg_list_indent).to_string();
 
-    let mut to_insert = String::new();
+    let editor = builder.make_editor(args.syntax());
+    let make = editor.make();
+    let r_paren = args.syntax().last_token()?;
+    let insert_pos = match r_paren.prev_token() {
+        Some(prev) if prev.kind() == SyntaxKind::WHITESPACE => Position::before(prev),
+        _ => Position::before(r_paren),
+    };
+    let mut elements = Vec::new();
     if has_existing_args && !has_trailing_comma {
-        to_insert.push(',');
+        elements.push(make.token(T![,]).into());
     }
     if insert_newlines {
-        to_insert.push('\n');
+        elements.push(make.whitespace("\n").into());
+    } else if has_existing_args {
+        elements.push(make.whitespace(" ").into());
     }
-    let (last_arg, rest_args) =
-        captures_as_args.split_last().expect("already checked has captures");
-    if !insert_newlines && has_existing_args {
-        to_insert.push(' ');
-    }
-    if let Some((first_arg, rest_args)) = rest_args.split_first() {
-        format_to!(to_insert, "{indent}{first_arg},",);
+    for (index, arg) in captures_as_args.iter().enumerate() {
         if insert_newlines {
-            to_insert.push('\n');
+            elements.push(make.whitespace(&indent).into());
         }
-        for new_arg in rest_args {
-            if !insert_newlines {
-                to_insert.push(' ');
-            }
-            format_to!(to_insert, "{indent}{new_arg},",);
+        elements.push(arg.syntax().clone().into());
+        let is_last = index + 1 == captures_as_args.len();
+        if !is_last || has_trailing_comma {
+            elements.push(make.token(T![,]).into());
+        }
+        if !is_last {
             if insert_newlines {
-                to_insert.push('\n');
+                elements.push(make.whitespace("\n").into());
+            } else {
+                elements.push(make.whitespace(" ").into());
             }
         }
-        if !insert_newlines {
-            to_insert.push(' ');
-        }
     }
-    format_to!(to_insert, "{indent}{last_arg}");
-    if has_trailing_comma {
-        to_insert.push(',');
-    }
-
-    builder.edit_file(file_id.file_id(ctx.db()));
-    builder.insert(offset, to_insert);
+    editor.insert_all(insert_pos, elements);
+    builder.add_file_edits(file_id, editor);
 
     Some(())
+}
+
+fn rewrite_closure_body(
+    closure: &ast::ClosureExpr,
+    original_body: &ast::Expr,
+    capture_usages_replacement_map: &[(AstPtr<ast::Expr>, ast::Expr)],
+    strip_async_from_body: bool,
+    strip_gen_from_body: bool,
+) -> Option<ast::Expr> {
+    if capture_usages_replacement_map.is_empty() && !strip_async_from_body && !strip_gen_from_body {
+        return Some(original_body.clone());
+    }
+
+    let closure_start = closure.syntax().text_range().start();
+    let (editor, node) = SyntaxEditor::new(closure.syntax().ancestors().last()?.clone());
+    let closure_expr = AstPtr::new(closure).to_node(&node);
+    for (old_expr_ptr, new_expr) in capture_usages_replacement_map {
+        let old_expr = old_expr_ptr.to_node(&node);
+        editor.replace(old_expr.syntax(), new_expr.syntax());
+    }
+
+    if strip_async_from_body || strip_gen_from_body {
+        let body = closure_expr.body().unwrap_or_else(|| original_body.clone());
+        if let ast::Expr::BlockExpr(block) = body {
+            let delete_with_following_whitespace = |token: syntax::SyntaxToken| {
+                let trailing_ws: Vec<_> = token
+                    .siblings_with_tokens(Direction::Next)
+                    .skip(1)
+                    .take_while(|t| {
+                        t.as_token().is_some_and(|t| t.kind() == SyntaxKind::WHITESPACE)
+                    })
+                    .filter_map(|t| t.into_token())
+                    .collect();
+                editor.delete(token);
+                for ws in trailing_ws {
+                    editor.delete(ws);
+                }
+            };
+
+            if strip_async_from_body && let Some(async_tok) = block.async_token() {
+                delete_with_following_whitespace(async_tok);
+            }
+            if strip_gen_from_body && let Some(gen_tok) = block.gen_token() {
+                delete_with_following_whitespace(gen_tok);
+            }
+        }
+    }
+
+    editor.finish().new_root().descendants().find_map(|node| {
+        let closure = ast::ClosureExpr::cast(node)?;
+        (closure.syntax().text_range().start() == closure_start).then(|| closure.body()).flatten()
+    })
 }
 
 fn peel_blocks_and_refs_and_parens(mut expr: ast::Expr) -> ast::Expr {


### PR DESCRIPTION
This PR migrates the `convert_closure_to_fn` assist to `SyntaxEditor`. 

part of https://github.com/rust-lang/rust-analyzer/issues/15710 and https://github.com/rust-lang/rust-analyzer/issues/18285