### PR TITLE
fix: Pass proc_macro_cwd to Analysis::from_single_file()

### DIFF
--- a/crates/base-db/src/lib.rs
+++ b/crates/base-db/src/lib.rs
@@ -37,7 +37,7 @@ use rustc_hash::{FxHashSet, FxHasher};
 use salsa::{Durability, Setter};
 pub use semver::{BuildMetadata, Prerelease, Version, VersionReq};
 use triomphe::Arc;
-pub use vfs::{AnchoredPath, AnchoredPathBuf, FileId, VfsPath, file_set::FileSet};
+pub use vfs::{AbsPathBuf, AnchoredPath, AnchoredPathBuf, FileId, VfsPath, file_set::FileSet};
 
 pub type FxIndexSet<T> = indexmap::IndexSet<T, rustc_hash::FxBuildHasher>;
 pub type FxIndexMap<K, V> =

--- a/crates/ide/src/lib.rs
+++ b/crates/ide/src/lib.rs
@@ -70,7 +70,7 @@ use ide_db::ra_fixture::RaFixtureAnalysis;
 use ide_db::{
     FxHashMap, FxIndexSet,
     base_db::{
-        CrateOrigin, CrateWorkspaceData, Env, FileSet, SourceDatabase, VfsPath,
+        AbsPathBuf, CrateOrigin, CrateWorkspaceData, Env, FileSet, SourceDatabase, VfsPath,
         salsa::{Cancelled, Database},
     },
     prime_caches, symbol_index,
@@ -253,7 +253,7 @@ impl Analysis {
     // Creates an analysis instance for a single file, without any external
     // dependencies, stdlib support or ability to apply changes. See
     // `AnalysisHost` for creating a fully-featured analysis.
-    pub fn from_single_file(text: String) -> (Analysis, FileId) {
+    pub fn from_single_file(text: String, proc_macro_cwd: Arc<AbsPathBuf>) -> (Analysis, FileId) {
         let mut host = AnalysisHost::default();
         let file_id = FileId::from_raw(0);
         let mut file_set = FileSet::default();
@@ -267,11 +267,6 @@ impl Analysis {
         // Default to enable test for single file.
         let mut cfg_options = CfgOptions::default();
 
-        // FIXME: This is less than ideal
-        let proc_macro_cwd = Arc::new(
-            TryFrom::try_from(&*std::env::current_dir().unwrap().as_path().to_string_lossy())
-                .unwrap(),
-        );
         let crate_attrs = Vec::new();
         cfg_options.insert_atom(sym::test);
         crate_graph.add_crate_root(

--- a/crates/ide/src/syntax_highlighting/inject.rs
+++ b/crates/ide/src/syntax_highlighting/inject.rs
@@ -9,6 +9,7 @@ use syntax::{
     SyntaxNode, TextRange, TextSize,
     ast::{self, IsString},
 };
+use triomphe::Arc;
 
 use crate::{
     Analysis, HlMod, HlRange, HlTag, RootDatabase,
@@ -92,6 +93,7 @@ pub(super) fn doc_comment(
         Some(it) => it,
         None => return,
     };
+    let vfs_file_id = src_file_id.file_id(sema.db);
     let src_file_id: HirFileId = src_file_id.into();
     let Some(docs) = attributes.hir_docs(sema.db) else { return };
 
@@ -171,7 +173,16 @@ pub(super) fn doc_comment(
 
     inj.add_unmapped("\n}");
 
-    let (analysis, tmp_file_id) = Analysis::from_single_file(inj.take_text());
+    let proc_macro_cwd = {
+        match sema.first_crate(vfs_file_id) {
+            Some(krate) => krate.base().data(sema.db).proc_macro_cwd.clone(),
+            None => {
+                // Arbitrarily pick /, since from_single_file treats this file as as /main.rs anyway.
+                Arc::new(ide_db::base_db::AbsPathBuf::try_from("/").unwrap())
+            }
+        }
+    };
+    let (analysis, tmp_file_id) = Analysis::from_single_file(inj.take_text(), proc_macro_cwd);
 
     if let Ok(ranges) = analysis.with_db(|db| {
         super::highlight(

--- a/crates/rust-analyzer/src/cli/highlight.rs
+++ b/crates/rust-analyzer/src/cli/highlight.rs
@@ -1,12 +1,15 @@
 //! Read Rust code on stdin, print HTML highlighted version to stdout.
 
 use ide::Analysis;
+use ide_db::base_db::AbsPathBuf;
+use triomphe::Arc;
 
 use crate::cli::{flags, read_stdin};
 
 impl flags::Highlight {
     pub fn run(self) -> anyhow::Result<()> {
-        let (analysis, file_id) = Analysis::from_single_file(read_stdin()?);
+        let cwd = AbsPathBuf::assert_utf8(std::env::current_dir()?);
+        let (analysis, file_id) = Analysis::from_single_file(read_stdin()?, Arc::new(cwd));
         let html = analysis.highlight_as_html(file_id, self.rainbow).unwrap();
         println!("{html}");
         Ok(())

--- a/crates/rust-analyzer/src/cli/symbols.rs
+++ b/crates/rust-analyzer/src/cli/symbols.rs
@@ -1,12 +1,15 @@
 //! Read Rust code on stdin, print syntax tree on stdout.
 use ide::{Analysis, FileStructureConfig};
+use ide_db::base_db::AbsPathBuf;
+use triomphe::Arc;
 
 use crate::cli::{flags, read_stdin};
 
 impl flags::Symbols {
     pub fn run(self) -> anyhow::Result<()> {
         let text = read_stdin()?;
-        let (analysis, file_id) = Analysis::from_single_file(text);
+        let cwd = AbsPathBuf::assert_utf8(std::env::current_dir()?);
+        let (analysis, file_id) = Analysis::from_single_file(text, Arc::new(cwd));
         let structure = analysis
             // The default setting in config.rs (document_symbol_search_excludeLocals) is to exclude
             // locals because it is unlikely that users want document search to return the names of

--- a/crates/rust-analyzer/src/lsp/to_proto.rs
+++ b/crates/rust-analyzer/src/lsp/to_proto.rs
@@ -2028,6 +2028,7 @@ pub(crate) fn rename_error(err: RenameError) -> LspError {
 mod tests {
     use expect_test::{Expect, expect};
     use ide::{Analysis, FilePosition};
+    use ide_db::base_db::AbsPathBuf;
     use ide_db::source_change::Snippet;
     use test_utils::extract_offset;
     use triomphe::Arc;
@@ -2048,7 +2049,10 @@ fn main() {
     }
 }"#;
 
-        let (analysis, file_id) = Analysis::from_single_file(text.to_owned());
+        let (analysis, file_id) = Analysis::from_single_file(
+            text.to_owned(),
+            Arc::new(AbsPathBuf::assert_utf8(std::env::current_dir().unwrap())),
+        );
         let folds = analysis.folding_ranges(file_id, true).unwrap();
         assert_eq!(folds.len(), 5);
 
@@ -2084,7 +2088,10 @@ fn bar(_: usize) {}
 "#;
 
         let (offset, text) = extract_offset(text);
-        let (analysis, file_id) = Analysis::from_single_file(text);
+        let (analysis, file_id) = Analysis::from_single_file(
+            text,
+            Arc::new(AbsPathBuf::assert_utf8(std::env::current_dir().unwrap())),
+        );
         let help = signature_help(
             analysis.signature_help(FilePosition { file_id, offset }).unwrap().unwrap(),
             CallInfoConfig { params_only: false, docs: true },


### PR DESCRIPTION
If the directory that rust-analyzer was started in no longer exists, all semantic highlighting requests crash and the user sees a lot of errors in their editor.

    [Error - 2:31:20 PM] Request textDocument/semanticTokens/full failed.
      Message: request handler panicked: called `Result::unwrap()` on an `Err` value: Os { code: 2, kind: NotFound, message: "No such file or directory" }
      Code: -32603

This is because Analysis::from_single_file() used std::env::current_dir().unwrap() for proc_maco_cwd, and current_dir() returns Err if the working directory no longer exists.

I've encountered this when the user's project is a filesystem that is unmounted and remounted. I believe it can also happen when the user has multiple workspaces open in their editor and they delete the directory that rust-analyzer happened to be started in.

Instead, pass proc_macro_cwd explicitly to from_single_file. This is more correct, and removes a FIXME.

I've also checked the other usages of std::env::current_dir().unwrap() but all the other cases look like unit tests.

AI: Code was partially written with Claude.