### PR TITLE
fix: Suppress infer vars in monomorphization

### DIFF
--- a/crates/hir-ty/src/mir/monomorphization.rs
+++ b/crates/hir-ty/src/mir/monomorphization.rs
@@ -65,6 +65,9 @@ impl<'db> FallibleTypeFolder<DbInterner<'db>> for Filler<'db> {
                         ty,
                     )
                     .map_err(|_| MirLowerError::NotSupported("can't normalize alias".to_owned()))?;
+                // Normalization could introduce infer vars (for example, if the alias cannot be normalized),
+                // and we must not have infer vars in the body.
+                let ty = ty.replace_infer_with_error(self.infcx.interner);
                 ty.try_super_fold_with(self)
             }
             TyKind::Param(param) => Ok(self


### PR DESCRIPTION
Having infer vars can cause panics down the road, when we try to resolve them on a different `InferCtxt`. Generally infer vars must not cross the pass they initiated in.

Fixes rust-lang/rust-analyzer#22102.