### PR TITLE
Fix trait auto import appearing again when trait already been imported as _

### DIFF
--- a/crates/ide-completion/src/render.rs
+++ b/crates/ide-completion/src/render.rs
@@ -878,6 +878,33 @@ mod tests {
     }
 
     #[test]
+    fn trait_imported_as_underscore_should_not_appear_auto_import_again() {
+        // make sure there has no `requires_import`
+        // see https://github.com/rust-lang/rust-analyzer/issues/19767
+        check_relevance(
+            r#"
+//- /dep.rs crate:dep
+pub trait MyTrait {
+    fn my_method(&self);
+}
+
+//- /main.rs crate:main deps:dep
+use dep::MyTrait as _;
+struct MyStruct;
+impl dep::MyTrait for MyStruct {
+    fn my_method(&self) {}
+}
+fn main() {
+    MyStruct::my_method$0
+}
+"#,
+            expect![[r#"
+                me my_method(…) fn(&self) []
+            "#]],
+        );
+    }
+
+    #[test]
     fn set_struct_type_completion_info() {
         check_relevance(
             r#"

--- a/crates/ide-db/src/imports/import_assets.rs
+++ b/crates/ide-db/src/imports/import_assets.rs
@@ -454,6 +454,7 @@ impl<'db> ImportAssets<'db> {
                 |trait_to_import| {
                     !scope_definitions
                         .contains(&ScopeDef::ModuleDef(ModuleDef::Trait(trait_to_import)))
+                        && !scope.can_use_trait_methods(trait_to_import)
                 },
             ),
         }


### PR DESCRIPTION
Fixed https://github.com/rust-lang/rust-analyzer/issues/19767

Fix trait method appearing in auto-import when trait is already imported as `_`.

### Before
```
me my_method(…) fn(&self) []
me my_method(…) fn(&self) [requires_import]
```

### After
```
me my_method(…) fn(&self) []
```