### PR TITLE
fix: Crash on term search with missing type parameters

### DIFF
--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -2582,6 +2582,15 @@ impl Function {
         ret_type.derived(EarlyBinder::bind(ret_type.ty).instantiate(interner, args))
     }
 
+    pub(crate) fn can_instantiate_with_args(
+        self,
+        db: &dyn HirDatabase,
+        provided_args: usize,
+    ) -> bool {
+        let (_, sig) = self.fn_sig(db);
+        !sig_has_unsubstituted_params(sig, provided_args)
+    }
+
     fn adapt_generic_args<'db>(
         self,
         interner: DbInterner<'db>,
@@ -7335,6 +7344,38 @@ fn generic_args_from_tys<'db>(
             next_solver::GenericArg::error_from_id(interner, id)
         }
     })
+}
+
+fn sig_has_unsubstituted_params<'db>(sig: PolyFnSig<'db>, provided_args: usize) -> bool {
+    struct Visitor {
+        provided_args: usize,
+    }
+
+    impl<'db> TypeVisitor<DbInterner<'db>> for Visitor {
+        type Result = ControlFlow<()>;
+
+        fn visit_ty(&mut self, ty: Ty<'db>) -> Self::Result {
+            if let TyKind::Param(param) = ty.kind()
+                && param.index as usize >= self.provided_args
+            {
+                return ControlFlow::Break(());
+            }
+
+            ty.super_visit_with(self)
+        }
+
+        fn visit_const(&mut self, konst: hir_ty::next_solver::Const<'db>) -> Self::Result {
+            if let ConstKind::Param(param) = konst.kind()
+                && param.index as usize >= self.provided_args
+            {
+                return ControlFlow::Break(());
+            }
+
+            konst.super_visit_with(self)
+        }
+    }
+
+    sig.visit_with(&mut Visitor { provided_args }).is_break()
 }
 
 fn has_non_default_type_params(db: &dyn HirDatabase, generic_def: GenericDefId) -> bool {

--- a/crates/hir/src/term_search/tactics.rs
+++ b/crates/hir/src/term_search/tactics.rs
@@ -363,6 +363,10 @@ pub(super) fn free_function<'a, 'lt, 'db, DB: HirDatabase>(
                             })
                             .collect::<Option<_>>()?;
 
+                        if !it.can_instantiate_with_args(db, generics.len()) {
+                            return None;
+                        }
+
                         let ret_ty = it.ret_type_with_args(db, generics.iter().cloned());
                         // Filter out private and unsafe functions
                         if !it.is_visible_from(db, module)
@@ -489,6 +493,10 @@ pub(super) fn impl_method<'a, 'lt, 'db, DB: HirDatabase>(
             // Ignore functions with generics for now as they kill the performance
             // Also checking bounds for generics is problematic
             if !fn_generics.type_or_const_params(db).is_empty() {
+                return None;
+            }
+
+            if !it.can_instantiate_with_args(db, ty.type_arguments().count()) {
                 return None;
             }
 
@@ -687,6 +695,10 @@ pub(super) fn impl_static_method<'a, 'lt, 'db, DB: HirDatabase>(
             // Ignore functions with generics for now as they kill the performance
             // Also checking bounds for generics is problematic
             if !fn_generics.type_or_const_params(db).is_empty() {
+                return None;
+            }
+
+            if !it.can_instantiate_with_args(db, ty.type_arguments().count()) {
                 return None;
             }
 

--- a/crates/rust-analyzer/tests/slow-tests/main.rs
+++ b/crates/rust-analyzer/tests/slow-tests/main.rs
@@ -25,14 +25,14 @@ use std::{collections::HashMap, path::PathBuf, time::Instant};
 use ide_db::FxHashMap;
 use lsp_types::{
     CodeActionContext, CodeActionParams, CompletionParams, DidOpenTextDocumentParams,
-    DocumentFormattingParams, DocumentRangeFormattingParams, FileRename, FormattingOptions,
-    GotoDefinitionParams, HoverParams, InlayHint, InlayHintLabel, InlayHintParams,
-    PartialResultParams, Position, Range, RenameFilesParams, TextDocumentItem,
+    DocumentDiagnosticParams, DocumentFormattingParams, DocumentRangeFormattingParams, FileRename,
+    FormattingOptions, GotoDefinitionParams, HoverParams, InlayHint, InlayHintLabel,
+    InlayHintParams, PartialResultParams, Position, Range, RenameFilesParams, TextDocumentItem,
     TextDocumentPositionParams, WorkDoneProgressParams,
     notification::DidOpenTextDocument,
     request::{
-        CodeActionRequest, Completion, Formatting, GotoTypeDefinition, HoverRequest,
-        InlayHintRequest, InlayHintResolveRequest, RangeFormatting, WillRenameFiles,
+        CodeActionRequest, Completion, DocumentDiagnosticRequest, Formatting, GotoTypeDefinition,
+        HoverRequest, InlayHintRequest, InlayHintResolveRequest, RangeFormatting, WillRenameFiles,
         WorkspaceSymbolRequest,
     },
 };
@@ -78,6 +78,50 @@ use std::collections::Spam;
         work_done_progress_params: WorkDoneProgressParams::default(),
     });
     assert!(res.to_string().contains("HashMap"));
+}
+
+#[test]
+fn typed_hole_diagnostic_on_incomplete_code() {
+    if skip_slow_tests() {
+        return;
+    }
+
+    let server = Project::with_fixture(
+        r#"
+//- /Cargo.toml
+[package]
+name = "foo"
+version = "0.0.0"
+
+//- /src/lib.rs
+use std::time::Duration;
+
+fn some_fn() {
+    let
+
+    for _ in 0..2 {}
+}
+"#,
+    )
+    .with_config(serde_json::json!({
+        "cargo": { "sysroot": "discover" },
+    }))
+    .server()
+    .wait_until_workspace_is_loaded();
+
+    let res = server.send_request::<DocumentDiagnosticRequest>(DocumentDiagnosticParams {
+        text_document: server.doc_id("src/lib.rs"),
+        identifier: Some("rust-analyzer".to_owned()),
+        previous_result_id: None,
+        work_done_progress_params: WorkDoneProgressParams::default(),
+        partial_result_params: PartialResultParams::default(),
+    });
+
+    assert_eq!(res["kind"], "full", "{res}");
+    assert!(
+        res["items"].as_array().is_some_and(|items| !items.is_empty()),
+        "Expected some diagnostics"
+    );
 }
 
 #[test]


### PR DESCRIPTION
As of rust-lang/rust#142317, `ra_ap_rustc_type_ir::binder::EarlyBinder::instantiate()` panics when passing zero type parameters to a type that requires some type parameters.

Term search can trigger this assert on incomplete code. Add a check that the signature has the correct number of missing type parameters before calling instantiate(), and add a regression test.

Fixes rust-lang/rust-analyzer#21568
Fixes rust-lang/rust-analyzer#21849

AI disclosure: Initial test and implementation written by Codex.