### PR TITLE
Emit correct monikers for definitions nested in a function

### DIFF
--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -629,6 +629,11 @@ impl Module {
         Some(Module { id: parent_id })
     }
 
+    pub fn block(self, db: &dyn HirDatabase) -> Option<ast::BlockExpr> {
+        let block_id = self.id.block(db)?;
+        Some(block_id.loc(db).ast_id.to_node(db))
+    }
+
     /// Finds nearest non-block ancestor `Module` (`self` included).
     pub fn nearest_non_block_module(self, db: &dyn HirDatabase) -> Module {
         let mut id = self.id;

--- a/crates/hir/src/semantics.rs
+++ b/crates/hir/src/semantics.rs
@@ -56,10 +56,10 @@ use syntax::{
 
 use crate::{
     Adjust, Adjustment, Adt, AnyFunctionId, AutoBorrow, BindingMode, BuiltinAttr, Callable, Const,
-    ConstParam, Crate, DeriveHelper, Enum, EnumVariant, ExpressionStoreOwner, Field, Function,
-    GenericSubstitution, HasSource, Impl, InFile, InlineAsmOperand, ItemInNs, Label, LifetimeParam,
-    Local, Macro, Module, ModuleDef, Name, OverloadedDeref, ScopeDef, Static, Struct, ToolModule,
-    Trait, TupleField, Type, TypeAlias, TypeParam, Union, Variant,
+    ConstParam, Crate, DefWithBody, DeriveHelper, Enum, EnumVariant, ExpressionStoreOwner, Field,
+    Function, GenericSubstitution, HasSource, Impl, InFile, InlineAsmOperand, ItemInNs, Label,
+    LifetimeParam, Local, Macro, Module, ModuleDef, Name, OverloadedDeref, ScopeDef, Static,
+    Struct, ToolModule, Trait, TupleField, Type, TypeAlias, TypeParam, Union, Variant,
     db::HirDatabase,
     semantics::source_to_def::{ChildContainer, SourceToDefCache, SourceToDefCtx},
     source_analyzer::{SourceAnalyzer, resolve_hir_path},
@@ -2276,6 +2276,19 @@ impl<'db> SemanticsImpl<'db> {
             )
         });
         InFile::new(file_id, node)
+    }
+
+    pub fn enclosing_body(&self, expr: &ast::Expr) -> Option<DefWithBody> {
+        let enclosing_item =
+            expr.syntax().ancestors().find_map(Either::<ast::Item, ast::Variant>::cast)?;
+
+        match &enclosing_item {
+            Either::Left(ast::Item::Fn(it)) => self.to_def(it).map(DefWithBody::Function),
+            Either::Left(ast::Item::Const(it)) => self.to_def(it).map(DefWithBody::Const),
+            Either::Left(ast::Item::Static(it)) => self.to_def(it).map(DefWithBody::Static),
+            Either::Left(_) => None,
+            Either::Right(it) => self.to_def(it).map(DefWithBody::EnumVariant),
+        }
     }
 
     /// Returns `true` if the `node` is inside an `unsafe` context.

--- a/crates/ide/src/moniker.rs
+++ b/crates/ide/src/moniker.rs
@@ -3,7 +3,7 @@
 
 use core::fmt;
 
-use hir::{Adt, AsAssocItem, Crate, HirDisplay, MacroKind, Semantics};
+use hir::{Adt, AsAssocItem, Crate, HirDisplay, MacroKind, Module, Semantics};
 use ide_db::{
     FilePosition, RootDatabase,
     base_db::{CrateOrigin, LangCrateOrigin},
@@ -102,7 +102,7 @@ impl fmt::Display for MonikerIdentifier {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum MonikerKind {
     Import,
     Export,
@@ -113,14 +113,14 @@ pub enum MonikerResult {
     /// Uniquely identifies a definition.
     Moniker(Moniker),
     /// Specifies that the definition is a local, and so does not have a unique identifier. Provides
-    /// a unique identifier for the container.
-    Local { enclosing_moniker: Option<Moniker> },
+    /// unique identifiers for containers, from the closest to the farthest.
+    Local { enclosing_monikers: Vec<Moniker> },
 }
 
-impl MonikerResult {
-    pub fn from_def(db: &RootDatabase, def: Definition, from_crate: Crate) -> Option<Self> {
-        def_to_moniker(db, def, from_crate)
-    }
+// moniker is relative to root, root is either crate root or block module
+struct PartialMonikerResult {
+    moniker: Moniker,
+    root: Module,
 }
 
 /// Information which uniquely identifies a definition which might be referenceable outside of the
@@ -160,7 +160,7 @@ pub(crate) fn moniker(
     })?;
     if let Some(doc_comment) = token_as_doc_comment(&original_token) {
         return doc_comment.get_definition_with_descend_at(sema, offset, |def, _, _| {
-            let m = def_to_moniker(db, def, current_crate)?;
+            let m = def_to_moniker(sema, def, current_crate)?;
             Some(RangeInfo::new(original_token.text_range(), vec![m]))
         });
     }
@@ -168,9 +168,9 @@ pub(crate) fn moniker(
         .descend_into_macros_exact(original_token.clone())
         .into_iter()
         .filter_map(|token| {
-            IdentClass::classify_token(sema, &token).map(IdentClass::definitions_no_ops).map(|it| {
-                it.into_iter().flat_map(|def| def_to_moniker(sema.db, def, current_crate))
-            })
+            IdentClass::classify_token(sema, &token)
+                .map(IdentClass::definitions_no_ops)
+                .map(|it| it.into_iter().flat_map(|def| def_to_moniker(sema, def, current_crate)))
         })
         .flatten()
         .unique()
@@ -242,47 +242,57 @@ pub(crate) fn def_to_kind(db: &RootDatabase, def: Definition) -> SymbolInformati
 ///
 /// * `Some(MonikerResult::Moniker(_))` provides a unique `Moniker` which refers to a definition.
 ///
-/// * `Some(MonikerResult::Local { .. })` provides a `Moniker` for the definition enclosing a local.
+/// * `Some(MonikerResult::Local { .. })` provides a `Moniker` for the definitions enclosing a local.
 ///
 /// * `None` is returned for definitions which are not in a module: `BuiltinAttr`, `BuiltinType`,
 ///   `BuiltinLifetime`, `TupleField`, `ToolModule`, and `InlineAsmRegOrRegClass`. TODO: it might be
 ///   sensible to provide monikers that refer to some non-existent crate of compiler builtin
 ///   definitions.
 pub(crate) fn def_to_moniker(
-    db: &RootDatabase,
+    sema: &Semantics<'_, RootDatabase>,
     definition: Definition,
     from_crate: Crate,
 ) -> Option<MonikerResult> {
-    match definition {
+    let db = sema.db;
+    let mut local = false;
+    let mut def = definition;
+    match def {
         Definition::Local(_) | Definition::Label(_) | Definition::GenericParam(_) => {
-            return Some(MonikerResult::Local {
-                enclosing_moniker: enclosing_def_to_moniker(db, definition, from_crate),
-            });
+            local = true;
+            def = def.enclosing_definition(db)?;
         }
         _ => {}
     }
-    Some(MonikerResult::Moniker(def_to_non_local_moniker(db, definition, from_crate)?))
-}
-
-fn enclosing_def_to_moniker(
-    db: &RootDatabase,
-    mut def: Definition,
-    from_crate: Crate,
-) -> Option<Moniker> {
+    let mut enclosing_monikers = vec![];
     loop {
-        let enclosing_def = def.enclosing_definition(db)?;
-        if let Some(enclosing_moniker) = def_to_non_local_moniker(db, enclosing_def, from_crate) {
-            return Some(enclosing_moniker);
+        let result = def_to_moniker_step(sema, def, from_crate)?;
+        let PartialMonikerResult { moniker, root } = result;
+        enclosing_monikers.push(moniker);
+        if root.is_crate_root(db) {
+            break;
+        } else if let Some(block_expr) = root.block(db) {
+            let expr = block_expr.into();
+            def = sema.enclosing_body(&expr)?.try_into().ok()?;
+        } else {
+            break;
         }
-        def = enclosing_def;
+    }
+    if enclosing_monikers.len() == 1 && !local {
+        Some(MonikerResult::Moniker(enclosing_monikers[0].clone()))
+    } else {
+        if !local {
+            enclosing_monikers.remove(0);
+        }
+        Some(MonikerResult::Local { enclosing_monikers })
     }
 }
 
-fn def_to_non_local_moniker(
-    db: &RootDatabase,
+fn def_to_moniker_step(
+    sema: &Semantics<'_, RootDatabase>,
     definition: Definition,
     from_crate: Crate,
-) -> Option<Moniker> {
+) -> Option<PartialMonikerResult> {
+    let db = sema.db;
     let module = match definition {
         Definition::Module(module) if module.is_crate_root(db) => module,
         _ => definition.module(db)?,
@@ -290,6 +300,7 @@ fn def_to_non_local_moniker(
     let krate = module.krate(db);
     let edition = krate.edition(db);
 
+    let mut root = None;
     // Add descriptors for this definition and every enclosing definition.
     let mut reverse_description = vec![];
     let mut def = definition;
@@ -330,6 +341,12 @@ fn def_to_non_local_moniker(
                                     desc: MonikerDescriptorKind::Namespace,
                                 });
                             }
+                            root = Some(module);
+                            break;
+                        }
+                        Definition::Module(module) if module.block(db).is_some() => {
+                            root = Some(module);
+                            break;
                         }
                         _ => {
                             tracing::error!(?def, "Encountered enclosing definition with no name");
@@ -349,7 +366,8 @@ fn def_to_non_local_moniker(
     reverse_description.reverse();
     let description = reverse_description;
 
-    Some(Moniker {
+    let root = root?;
+    let moniker = Moniker {
         identifier: MonikerIdentifier {
             crate_name: krate.display_name(db)?.crate_name().to_string(),
             description,
@@ -381,7 +399,9 @@ fn def_to_non_local_moniker(
             };
             PackageInformation { name: name.as_str().to_owned(), repo, version }
         },
-    })
+    };
+
+    Some(PartialMonikerResult { moniker, root })
 }
 
 fn display<'db, T: HirDisplay<'db>>(db: &'db RootDatabase, module: hir::Module, it: T) -> String {
@@ -414,24 +434,27 @@ mod tests {
         }
     }
 
+    struct MonikerExpectation<'a> {
+        identifier: &'a str,
+        package: &'a str,
+        kind: MonikerKind,
+    }
+
     #[track_caller]
     fn check_local_moniker(
         #[rust_analyzer::rust_fixture] ra_fixture: &str,
-        identifier: &str,
-        package: &str,
-        kind: MonikerKind,
+        expected_list: &[MonikerExpectation<'_>],
     ) {
         let (analysis, position) = fixture::position(ra_fixture);
         let x = analysis.moniker(position).unwrap().expect("no moniker found").info;
         assert_eq!(x.len(), 1);
         match x.into_iter().next().unwrap() {
-            MonikerResult::Local { enclosing_moniker: Some(x) } => {
-                assert_eq!(identifier, x.identifier.to_string());
-                assert_eq!(package, format!("{:?}", x.package_information));
-                assert_eq!(kind, x.kind);
-            }
-            MonikerResult::Local { enclosing_moniker: None } => {
-                panic!("Unexpected local with no enclosing moniker");
+            MonikerResult::Local { enclosing_monikers } => {
+                for (actual, expected) in enclosing_monikers.iter().zip(expected_list) {
+                    assert_eq!(actual.identifier.to_string(), expected.identifier);
+                    assert_eq!(format!("{:?}", actual.package_information), expected.package);
+                    assert_eq!(actual.kind, expected.kind);
+                }
             }
             MonikerResult::Moniker(_) => {
                 panic!("Unexpected non-local moniker");
@@ -450,8 +473,8 @@ mod tests {
         let x = analysis.moniker(position).unwrap().expect("no moniker found").info;
         assert_eq!(x.len(), 1);
         match x.into_iter().next().unwrap() {
-            MonikerResult::Local { enclosing_moniker } => {
-                panic!("Unexpected local enclosed in {enclosing_moniker:?}");
+            MonikerResult::Local { enclosing_monikers } => {
+                panic!("Unexpected local enclosed in {enclosing_monikers:?}");
             }
             MonikerResult::Moniker(x) => {
                 assert_eq!(identifier, x.identifier.to_string());
@@ -605,9 +628,28 @@ pub mod module {
     }
 }
 "#,
-            "foo::module::func",
-            r#"PackageInformation { name: "foo", repo: Some("https://a.b/foo.git"), version: Some("0.1.0") }"#,
-            MonikerKind::Export,
+            &[MonikerExpectation {
+                identifier: "foo::module::func",
+                package: r#"PackageInformation { name: "foo", repo: Some("https://a.b/foo.git"), version: Some("0.1.0") }"#,
+                kind: MonikerKind::Export,
+            }],
+        );
+    }
+
+    #[test]
+    fn nested() {
+        check_local_moniker(
+            r#"
+//- /foo/lib.rs crate:foo@0.1.0,https://a.b/foo.git library
+fn func() {
+    fn nested$0() {}
+}
+"#,
+            &[MonikerExpectation {
+                identifier: "foo::func",
+                package: r#"PackageInformation { name: "foo", repo: Some("https://a.b/foo.git"), version: Some("0.1.0") }"#,
+                kind: MonikerKind::Export,
+            }],
         );
     }
 }

--- a/crates/ide/src/static_index.rs
+++ b/crates/ide/src/static_index.rs
@@ -249,7 +249,7 @@ impl StaticIndex<'_> {
                         .map(UpmappingResult::call_site)
                         .map(|it| FileRange { file_id: it.file_id, range: it.full_range }),
                     references: vec![],
-                    moniker: current_crate.and_then(|cc| def_to_moniker(self.db, def, cc)),
+                    moniker: current_crate.and_then(|cc| def_to_moniker(&sema, def, cc)),
                     display_name: def
                         .name(self.db)
                         .map(|name| name.display(self.db, edition).to_string()),

--- a/crates/rust-analyzer/src/cli/scip.rs
+++ b/crates/rust-analyzer/src/cli/scip.rs
@@ -302,9 +302,6 @@ Known rust-analyzer bugs that can cause this:
   * Definitions in crate example binaries which have the same symbol as definitions in the library
     or some other example.
 
-  * Struct/enum/const/static/impl definitions nested in a function do not mention the function name.
-    See #18771.
-
 Duplicate symbols encountered:
 ";
 
@@ -456,13 +453,13 @@ impl SymbolGenerator {
                             _ => false,
                         },
                     },
-                    MonikerResult::Local { enclosing_moniker } => {
+                    MonikerResult::Local { enclosing_monikers } => {
                         let local_symbol = scip::types::Symbol::new_local(local_count);
                         local_count += 1;
                         TokenSymbols {
                             symbol: scip::symbol::format_symbol(local_symbol),
-                            enclosing_symbol: enclosing_moniker
-                                .as_ref()
+                            enclosing_symbol: enclosing_monikers
+                                .last()
                                 .map(moniker_to_symbol)
                                 .map(scip::symbol::format_symbol),
                             is_inherent_impl: false,
@@ -563,14 +560,12 @@ mod test {
                         Some(MonikerResult::Moniker(moniker)) => {
                             Some(scip::symbol::format_symbol(moniker_to_symbol(moniker)))
                         }
-                        Some(MonikerResult::Local { enclosing_moniker: Some(moniker) }) => {
+                        Some(MonikerResult::Local { enclosing_monikers }) => {
+                            let moniker = enclosing_monikers.last().unwrap();
                             Some(format!(
                                 "local enclosed by {}",
                                 scip::symbol::format_symbol(moniker_to_symbol(moniker))
                             ))
-                        }
-                        Some(MonikerResult::Local { enclosing_moniker: None }) => {
-                            Some("unenclosed local".to_owned())
                         }
                     };
                     break;
@@ -834,7 +829,6 @@ pub mod example_mod {
         );
     }
 
-    // FIXME: This test represents current misbehavior.
     #[test]
     fn symbol_for_nested_function() {
         check_symbol(
@@ -844,13 +838,10 @@ pub mod example_mod {
        pub fn inner_func$0() {}
     }
     "#,
-            "rust-analyzer cargo main . inner_func().",
-            // FIXME: This should be a local:
-            // "local enclosed by rust-analyzer cargo main . func().",
+            "local enclosed by rust-analyzer cargo main . func().",
         );
     }
 
-    // FIXME: This test represents current misbehavior.
     #[test]
     fn symbol_for_struct_in_function() {
         check_symbol(
@@ -860,13 +851,10 @@ pub mod example_mod {
        struct SomeStruct$0 {}
     }
     "#,
-            "rust-analyzer cargo main . SomeStruct#",
-            // FIXME: This should be a local:
-            // "local enclosed by rust-analyzer cargo main . func().",
+            "local enclosed by rust-analyzer cargo main . func().",
         );
     }
 
-    // FIXME: This test represents current misbehavior.
     #[test]
     fn symbol_for_const_in_function() {
         check_symbol(
@@ -876,13 +864,10 @@ pub mod example_mod {
        const SOME_CONST$0: u32 = 1;
     }
     "#,
-            "rust-analyzer cargo main . SOME_CONST.",
-            // FIXME: This should be a local:
-            // "local enclosed by rust-analyzer cargo main . func().",
+            "local enclosed by rust-analyzer cargo main . func().",
         );
     }
 
-    // FIXME: This test represents current misbehavior.
     #[test]
     fn symbol_for_static_in_function() {
         check_symbol(
@@ -892,9 +877,7 @@ pub mod example_mod {
        static SOME_STATIC$0: u32 = 1;
     }
     "#,
-            "rust-analyzer cargo main . SOME_STATIC.",
-            // FIXME: This should be a local:
-            // "local enclosed by rust-analyzer cargo main . func().",
+            "local enclosed by rust-analyzer cargo main . func().",
         );
     }
 

--- a/crates/rust-analyzer/tests/slow-tests/cli.rs
+++ b/crates/rust-analyzer/tests/slow-tests/cli.rs
@@ -100,36 +100,30 @@ mod tests {
         {"id":58,"type":"edge","label":"item","document":1,"property":"references","inVs":[13,23],"outV":55}
         {"id":59,"type":"vertex","label":"hoverResult","result":{"contents":{"kind":"markdown","value":"\n```rust\nfoo\n```\n\n```rust\nconst REQ_001: &str = \"encoded_data\"\n```"}}}
         {"id":60,"type":"edge","label":"textDocument/hover","inV":59,"outV":16}
-        {"id":61,"type":"vertex","label":"moniker","scheme":"rust-analyzer","identifier":"foo::REQ_001","unique":"scheme","kind":"export"}
-        {"id":62,"type":"edge","label":"packageInformation","inV":31,"outV":61}
-        {"id":63,"type":"edge","label":"moniker","inV":61,"outV":16}
-        {"id":64,"type":"vertex","label":"definitionResult"}
-        {"id":65,"type":"edge","label":"item","document":1,"inVs":[15],"outV":64}
-        {"id":66,"type":"edge","label":"textDocument/definition","inV":64,"outV":16}
-        {"id":67,"type":"vertex","label":"referenceResult"}
-        {"id":68,"type":"edge","label":"textDocument/references","inV":67,"outV":16}
-        {"id":69,"type":"edge","label":"item","document":1,"property":"definitions","inVs":[15],"outV":67}
-        {"id":70,"type":"vertex","label":"hoverResult","result":{"contents":{"kind":"markdown","value":"\n```rust\nfoo\n```\n\n```rust\nmod tests\n```"}}}
-        {"id":71,"type":"edge","label":"textDocument/hover","inV":70,"outV":19}
-        {"id":72,"type":"vertex","label":"moniker","scheme":"rust-analyzer","identifier":"foo::tests","unique":"scheme","kind":"export"}
-        {"id":73,"type":"edge","label":"packageInformation","inV":31,"outV":72}
-        {"id":74,"type":"edge","label":"moniker","inV":72,"outV":19}
-        {"id":75,"type":"vertex","label":"definitionResult"}
-        {"id":76,"type":"edge","label":"item","document":1,"inVs":[18],"outV":75}
-        {"id":77,"type":"edge","label":"textDocument/definition","inV":75,"outV":19}
-        {"id":78,"type":"vertex","label":"referenceResult"}
-        {"id":79,"type":"edge","label":"textDocument/references","inV":78,"outV":19}
-        {"id":80,"type":"edge","label":"item","document":1,"property":"definitions","inVs":[18],"outV":78}
-        {"id":81,"type":"vertex","label":"hoverResult","result":{"contents":{"kind":"markdown","value":"\n```rust\nfoo::tests\n```\n\n```rust\nconst REQ_002: &str = \"encoded_data\"\n```"}}}
-        {"id":82,"type":"edge","label":"textDocument/hover","inV":81,"outV":26}
-        {"id":83,"type":"vertex","label":"moniker","scheme":"rust-analyzer","identifier":"foo::tests::REQ_002","unique":"scheme","kind":"export"}
-        {"id":84,"type":"edge","label":"packageInformation","inV":31,"outV":83}
-        {"id":85,"type":"edge","label":"moniker","inV":83,"outV":26}
-        {"id":86,"type":"vertex","label":"definitionResult"}
-        {"id":87,"type":"edge","label":"item","document":1,"inVs":[25],"outV":86}
-        {"id":88,"type":"edge","label":"textDocument/definition","inV":86,"outV":26}
-        {"id":89,"type":"vertex","label":"referenceResult"}
-        {"id":90,"type":"edge","label":"textDocument/references","inV":89,"outV":26}
-        {"id":91,"type":"edge","label":"item","document":1,"property":"definitions","inVs":[25],"outV":89}
+        {"id":61,"type":"vertex","label":"definitionResult"}
+        {"id":62,"type":"edge","label":"item","document":1,"inVs":[15],"outV":61}
+        {"id":63,"type":"edge","label":"textDocument/definition","inV":61,"outV":16}
+        {"id":64,"type":"vertex","label":"referenceResult"}
+        {"id":65,"type":"edge","label":"textDocument/references","inV":64,"outV":16}
+        {"id":66,"type":"edge","label":"item","document":1,"property":"definitions","inVs":[15],"outV":64}
+        {"id":67,"type":"vertex","label":"hoverResult","result":{"contents":{"kind":"markdown","value":"\n```rust\nfoo\n```\n\n```rust\nmod tests\n```"}}}
+        {"id":68,"type":"edge","label":"textDocument/hover","inV":67,"outV":19}
+        {"id":69,"type":"vertex","label":"moniker","scheme":"rust-analyzer","identifier":"foo::tests","unique":"scheme","kind":"export"}
+        {"id":70,"type":"edge","label":"packageInformation","inV":31,"outV":69}
+        {"id":71,"type":"edge","label":"moniker","inV":69,"outV":19}
+        {"id":72,"type":"vertex","label":"definitionResult"}
+        {"id":73,"type":"edge","label":"item","document":1,"inVs":[18],"outV":72}
+        {"id":74,"type":"edge","label":"textDocument/definition","inV":72,"outV":19}
+        {"id":75,"type":"vertex","label":"referenceResult"}
+        {"id":76,"type":"edge","label":"textDocument/references","inV":75,"outV":19}
+        {"id":77,"type":"edge","label":"item","document":1,"property":"definitions","inVs":[18],"outV":75}
+        {"id":78,"type":"vertex","label":"hoverResult","result":{"contents":{"kind":"markdown","value":"\n```rust\nfoo::tests\n```\n\n```rust\nconst REQ_002: &str = \"encoded_data\"\n```"}}}
+        {"id":79,"type":"edge","label":"textDocument/hover","inV":78,"outV":26}
+        {"id":80,"type":"vertex","label":"definitionResult"}
+        {"id":81,"type":"edge","label":"item","document":1,"inVs":[25],"outV":80}
+        {"id":82,"type":"edge","label":"textDocument/definition","inV":80,"outV":26}
+        {"id":83,"type":"vertex","label":"referenceResult"}
+        {"id":84,"type":"edge","label":"textDocument/references","inV":83,"outV":26}
+        {"id":85,"type":"edge","label":"item","document":1,"property":"definitions","inVs":[25],"outV":83}
     "#]].assert_eq(stdout);
 }


### PR DESCRIPTION
Handle definitions in "block modules". I followed hints in rust-lang/rust-analyzer#18771.

Fix rust-lang/rust-analyzer#18771
Fix rust-lang/rust-analyzer#22089