### PR TITLE
fix: no complete where kw after qualified path

### DIFF
--- a/crates/ide-completion/src/completions.rs
+++ b/crates/ide-completion/src/completions.rs
@@ -34,7 +34,8 @@ use crate::{
     CompletionContext, CompletionItem, CompletionItemKind,
     context::{
         DotAccess, ItemListKind, NameContext, NameKind, NameRefContext, NameRefKind,
-        PathCompletionCtx, PathKind, PatternContext, TypeAscriptionTarget, TypeLocation, Visible,
+        PathCompletionCtx, PathKind, PatternContext, Qualified, TypeAscriptionTarget, TypeLocation,
+        Visible,
     },
     item::Builder,
     render::{
@@ -752,6 +753,7 @@ pub(super) fn complete_name_ref(
                             if let TypeAscriptionTarget::RetType { item: Some(item), .. } =
                                 ascription
                                 && path_ctx.required_thin_arrow().is_some()
+                                && matches!(path_ctx.qualified, Qualified::No)
                             {
                                 keyword::complete_for_and_where(acc, ctx, &item.clone().into());
                             }

--- a/crates/ide-completion/src/tests/item.rs
+++ b/crates/ide-completion/src/tests/item.rs
@@ -2,7 +2,7 @@
 //!
 //! Except for use items which are tested in [super::use_tree] and mod declarations with are tested
 //! in [crate::completions::mod_].
-use expect_test::expect;
+use expect_test::{Expect, expect};
 
 use crate::tests::{check, check_edit, check_with_base_items};
 
@@ -135,6 +135,12 @@ fn completes_where() {
         "#]],
     );
     check_with_base_items(
+        r"fn func() -> foo::Bar $0",
+        expect![[r#"
+            kw where
+        "#]],
+    );
+    check_with_base_items(
         r"enum Enum $0",
         expect![[r#"
         kw where
@@ -147,6 +153,62 @@ fn completes_where() {
     "#]],
     );
     check_with_base_items(
+        r"trait Trait $0 {}",
+        expect![[r#"
+        kw where
+    "#]],
+    );
+}
+
+#[test]
+fn completes_where_in_stmt_list() {
+    fn check_in_stmt_list(#[rust_analyzer::rust_fixture] ra_fixture: &str, expect: Expect) {
+        check(&format!("const _: () = {{{ra_fixture}}};"), expect);
+    }
+    check_in_stmt_list(
+        r"struct Struct $0",
+        expect![[r#"
+        kw where
+    "#]],
+    );
+    check_in_stmt_list(
+        r"struct Struct $0 {}",
+        expect![[r#"
+        kw where
+    "#]],
+    );
+    check_in_stmt_list(
+        r"fn func() $0",
+        expect![[r#"
+            bt u32 (adds ->) u32
+            kw crate:: (adds ->)
+            kw dyn (adds ->)
+            kw fn (adds ->)
+            kw for (adds ->)
+            kw impl (adds ->)
+            kw self:: (adds ->)
+            kw where
+        "#]],
+    );
+    check_in_stmt_list(
+        r"fn func() -> foo::Bar $0",
+        expect![[r#"
+            kw where
+        "#]],
+    );
+    check_in_stmt_list(
+        r"enum Enum $0",
+        expect![[r#"
+        kw where
+    "#]],
+    );
+    check_in_stmt_list(
+        r"enum Enum $0 {}",
+        expect![[r#"
+        kw where
+    "#]],
+    );
+    check_in_stmt_list(
         r"trait Trait $0 {}",
         expect![[r#"
         kw where

--- a/crates/ide-completion/src/tests/type_pos.rs
+++ b/crates/ide-completion/src/tests/type_pos.rs
@@ -142,6 +142,26 @@ fn x() $0
             kw where
         "#]],
     );
+
+    check_with_base_items(
+        r#"
+mod foo { pub struct Bar; }
+fn x() foo::$0
+"#,
+        expect![[r#"
+            st Bar (adds ->) Bar
+        "#]],
+    );
+
+    check_with_base_items(
+        r#"
+mod foo { pub struct Bar; }
+fn x() foo::b$0
+"#,
+        expect![[r#"
+            st Bar (adds ->) Bar
+        "#]],
+    );
 }
 
 #[test]


### PR DESCRIPTION
Partial of rust-lang/rust-analyzer#21012

Example
---
```rust
mod foo { pub struct Bar; }
fn x() foo::b$0
```

**Before this PR**

```text
st Bar (adds ->) Bar
kw where
```

**After this PR**

```text
st Bar (adds ->) Bar
```
