### PR TITLE
Use windows-sys 0.61

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1924,7 +1924,7 @@ dependencies = [
  "libc",
  "perf-event",
  "tikv-jemalloc-ctl",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -2355,7 +2355,7 @@ dependencies = [
  "vfs",
  "vfs-notify",
  "walkdir",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.0",
  "xflags",
  "xshell",
 ]
@@ -2694,7 +2694,7 @@ dependencies = [
  "libc",
  "miow",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]

--- a/crates/profile/Cargo.toml
+++ b/crates/profile/Cargo.toml
@@ -23,7 +23,7 @@ perf-event = "=0.4.8"
 libc.workspace = true
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.60", features = [
+windows-sys = { version = "0.61", features = [
     "Win32_System_Threading",
     "Win32_System_ProcessStatus",
 ] }

--- a/crates/rust-analyzer/Cargo.toml
+++ b/crates/rust-analyzer/Cargo.toml
@@ -78,7 +78,7 @@ paths.workspace = true
 ra-ap-rustc_type_ir.workspace = true
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.60", features = [
+windows-sys = { version = "0.61", features = [
   "Win32_System_Diagnostics_Debug",
   "Win32_System_Threading",
 ] }

--- a/crates/stdx/Cargo.toml
+++ b/crates/stdx/Cargo.toml
@@ -26,7 +26,7 @@ libc.workspace = true
 
 [target.'cfg(windows)'.dependencies]
 miow = "0.6.0"
-windows-sys = { version = "0.60", features = ["Win32_Foundation"] }
+windows-sys = { version = "0.61", features = ["Win32_Foundation"] }
 
 [features]
 # Uncomment to enable for the whole crate graph


### PR DESCRIPTION
This version no longer requires using big import libraries and instead uses raw-dylib. windows-sys 0.60 is still pulled in by the notify crate. The upcoming 9.0 version of notify will use windows-sys 0.61.