### PR TITLE
minor: Remove redundant database query in mutability diagnostics

### DIFF
--- a/crates/ide-diagnostics/src/handlers/mutability_errors.rs
+++ b/crates/ide-diagnostics/src/handlers/mutability_errors.rs
@@ -87,7 +87,6 @@ pub(crate) fn unused_mut(ctx: &DiagnosticsContext<'_>, d: &hir::UnusedMut) -> Op
             use_range,
         )])
     })();
-    let ast = d.local.primary_source(ctx.sema.db).syntax_ptr();
     Some(
         Diagnostic::new_with_syntax_node_ptr(
             ctx,


### PR DESCRIPTION
The `unused_mut` diagnostic previously called
`d.local.primary_source(ctx.sema.db).syntax_ptr()` twice, resulting in a redundant database query. This removes the second invocation, reusing the `ast` variable that was already declared.