### PR TITLE
fix: Parse impl restrictions after the visibility

### DIFF
--- a/crates/parser/src/grammar/items.rs
+++ b/crates/parser/src/grammar/items.rs
@@ -119,6 +119,25 @@ pub(super) fn opt_item(p: &mut Parser<'_>, m: Marker, is_in_extern: bool) -> Res
     let mut has_mods = false;
     let mut has_extern = false;
 
+    if p.at(T![impl])
+        && p.nth(1) == T!['(']
+        && ((matches!(p.nth(2), T![crate] | T![super] | T![self]) && p.nth(3) == T![')'])
+            || p.nth(2) == T![in])
+    {
+        // test impl_restrictions
+        // pub impl(crate) unsafe trait Foo {}
+        // impl(in super::bar) trait Bar {}
+        // impl () {}
+        // impl (i32) {}
+        let m = p.start();
+        p.bump(T![impl]);
+        if !opt_visibility_inner(p, false) {
+            p.error("expected an impl restriction");
+        }
+        m.complete(p, IMPL_RESTRICTION);
+        has_mods = true;
+    }
+
     // modifiers
     if p.at(T![const]) && p.nth(1) != T!['{'] {
         p.eat(T![const]);
@@ -164,25 +183,6 @@ pub(super) fn opt_item(p: &mut Parser<'_>, m: Marker, is_in_extern: bool) -> Res
     }
     if p.at_contextual_kw(T![auto]) && p.nth(1) == T![trait] {
         p.bump_remap(T![auto]);
-        has_mods = true;
-    }
-
-    if p.at(T![impl])
-        && p.nth(1) == T!['(']
-        && ((matches!(p.nth(2), T![crate] | T![super] | T![self]) && p.nth(3) == T![')'])
-            || p.nth(2) == T![in])
-    {
-        // test impl_restrictions
-        // pub unsafe impl(crate) trait Foo {}
-        // impl(in super::bar) trait Bar {}
-        // impl () {}
-        // impl (i32) {}
-        let m = p.start();
-        p.bump(T![impl]);
-        if !opt_visibility_inner(p, false) {
-            p.error("expected an impl restriction");
-        }
-        m.complete(p, IMPL_RESTRICTION);
         has_mods = true;
     }
 

--- a/crates/parser/test_data/parser/inline/ok/impl_restrictions.rast
+++ b/crates/parser/test_data/parser/inline/ok/impl_restrictions.rast
@@ -3,8 +3,6 @@ SOURCE_FILE
     VISIBILITY
       PUB_KW "pub"
     WHITESPACE " "
-    UNSAFE_KW "unsafe"
-    WHITESPACE " "
     IMPL_RESTRICTION
       IMPL_KW "impl"
       VISIBILITY_INNER
@@ -14,6 +12,8 @@ SOURCE_FILE
             NAME_REF
               CRATE_KW "crate"
         R_PAREN ")"
+    WHITESPACE " "
+    UNSAFE_KW "unsafe"
     WHITESPACE " "
     TRAIT_KW "trait"
     WHITESPACE " "

--- a/crates/parser/test_data/parser/inline/ok/impl_restrictions.rs
+++ b/crates/parser/test_data/parser/inline/ok/impl_restrictions.rs
@@ -1,4 +1,4 @@
-pub unsafe impl(crate) trait Foo {}
+pub impl(crate) unsafe trait Foo {}
 impl(in super::bar) trait Bar {}
 impl () {}
 impl (i32) {}


### PR DESCRIPTION
To match rustc, see https://github.com/rust-lang/rust-analyzer/issues/22021.