### PR TITLE
fix: Parse `return #[attr] expr`

### DIFF
--- a/crates/parser/src/grammar/expressions.rs
+++ b/crates/parser/src/grammar/expressions.rs
@@ -1,7 +1,5 @@
 mod atom;
 
-use crate::grammar::attributes::ATTRIBUTE_FIRST;
-
 use super::*;
 
 pub(super) use atom::{EXPR_RECOVERY_SET, LITERAL_FIRST, literal, parse_asm_expr};
@@ -324,7 +322,7 @@ fn expr_bp(
 }
 
 const LHS_FIRST: TokenSet =
-    atom::ATOM_EXPR_FIRST.union(TokenSet::new(&[T![&], T![*], T![!], T![.], T![-], T![_]]));
+    atom::ATOM_EXPR_FIRST.union(TokenSet::new(&[T![&], T![*], T![!], T![.], T![-], T![_], T![#]]));
 
 fn lhs(p: &mut Parser<'_>, r: Restrictions) -> Option<(CompletedMarker, BlockLike)> {
     let m;
@@ -653,7 +651,7 @@ fn arg_list(p: &mut Parser<'_>) {
         T![')'],
         T![,],
         || "expected expression".into(),
-        EXPR_FIRST.union(ATTRIBUTE_FIRST),
+        EXPR_FIRST,
         |p| expr(p).is_some(),
     );
     m.complete(p, ARG_LIST);

--- a/crates/parser/src/grammar/expressions/atom.rs
+++ b/crates/parser/src/grammar/expressions/atom.rs
@@ -888,6 +888,10 @@ fn return_expr(p: &mut Parser<'_>) -> CompletedMarker {
     let m = p.start();
     p.bump(T![return]);
     if p.at_ts(EXPR_FIRST) {
+        // test return_attr
+        // fn foo() {
+        //     return #[attr] 1;
+        // }
         expr(p);
     }
     m.complete(p, RETURN_EXPR)

--- a/crates/parser/test_data/generated/runner.rs
+++ b/crates/parser/test_data/generated/runner.rs
@@ -584,6 +584,8 @@ mod ok {
         run_and_expect_no_errors("test_data/parser/inline/ok/reference_type.rs");
     }
     #[test]
+    fn return_attr() { run_and_expect_no_errors("test_data/parser/inline/ok/return_attr.rs"); }
+    #[test]
     fn return_expr() { run_and_expect_no_errors("test_data/parser/inline/ok/return_expr.rs"); }
     #[test]
     fn return_type_syntax_in_path() {

--- a/crates/parser/test_data/parser/inline/ok/return_attr.rast
+++ b/crates/parser/test_data/parser/inline/ok/return_attr.rast
@@ -1,0 +1,34 @@
+SOURCE_FILE
+  FN
+    FN_KW "fn"
+    WHITESPACE " "
+    NAME
+      IDENT "foo"
+    PARAM_LIST
+      L_PAREN "("
+      R_PAREN ")"
+    WHITESPACE " "
+    BLOCK_EXPR
+      STMT_LIST
+        L_CURLY "{"
+        WHITESPACE "\n    "
+        EXPR_STMT
+          RETURN_EXPR
+            RETURN_KW "return"
+            WHITESPACE " "
+            LITERAL
+              ATTR
+                POUND "#"
+                L_BRACK "["
+                PATH_META
+                  PATH
+                    PATH_SEGMENT
+                      NAME_REF
+                        IDENT "attr"
+                R_BRACK "]"
+              WHITESPACE " "
+              INT_NUMBER "1"
+          SEMICOLON ";"
+        WHITESPACE "\n"
+        R_CURLY "}"
+  WHITESPACE "\n"

--- a/crates/parser/test_data/parser/inline/ok/return_attr.rs
+++ b/crates/parser/test_data/parser/inline/ok/return_attr.rs
@@ -1,0 +1,3 @@
+fn foo() {
+    return #[attr] 1;
+}


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust-analyzer/issues/22149.