### PR TITLE
Repartition source roots after running build scripts

### DIFF
--- a/crates/rust-analyzer/src/reload.rs
+++ b/crates/rust-analyzer/src/reload.rs
@@ -732,6 +732,10 @@ impl GlobalState {
         self.source_root_config = project_folders.source_root_config;
         self.local_roots_parent_map = Arc::new(self.source_root_config.source_root_parent_map());
 
+        let mut change = ChangeWithProcMacros::default();
+        change.set_roots(self.source_root_config.partition(&self.vfs.read().0));
+        self.analysis_host.apply_change(change);
+
         info!(?cause, "recreating the crate graph");
         self.recreate_crate_graph(cause, switching_from_empty_workspace);
 


### PR DESCRIPTION
I ran into an issue where rust-analyzer fails to pick up build script outputs when an application crate is located in a subdirectory of a library crate it depends on.

The root problem is: After running build scripts, we add their output directories to the source root configuration. The discovery of new files in the output directories implicitly causes the workspace to be repartitioned into source roots.

However, this fails in this folder structure, which causes build script output files to be found early when searching a parent directory of the application. In this case, the build script outputs are not seen as new files, and so they don't trigger this implicit repartitioning of the workspace and are not associated with the correct source root.

This PR fixes the issue by explicitly repartitioning the workspace after changing the source root configuration, ensuring configuration changes apply correctly even if they don't cause the discovery of a *new* file.

<details><summary>More details about the issue</summary>
I have a library crate which contains an (example) application crate in a subdirectory. The application depends on the library, and the library contains a `build.rs` which generates some code that is `include!`'d by the library.

<details><summary>Minimal reproduction</summary>

**`library/Cargo.toml`**:
```toml
[package]
name = "library"
version = "0.1.0"
edition = "2024"

[dependencies]
```

**`library/build.rs`**:
```rs
fn main() {
    std::fs::write(
        std::env::var("OUT_DIR").unwrap() + "/include.rs",
        r#"pub const FOO: &str = "hello, world";"#,
    )
    .unwrap();
}
```

**`library/src/lib.rs`**:
```rs
include!(concat!(env!("OUT_DIR"), "/include.rs"));
```

**`library/application/Cargo.toml`**:
```toml
[package]
name = "application"
version = "0.1.0"
edition = "2024"

[dependencies]
library = { path = ".." }
```

**`library/application/src/main.rs`**:
```rs
fn main() {
    println!("{}", library::FOO);
}
```

</details>

When running `rust-analyzer` within the application, the `include!` fails with the error "failed to load file `/path/to/library/application/target/.../library-<hash>/out/include.rs`", despite the path being present on the disk; and definitions within the generated code are unavailable to RA.

I debugged the error and found it was because `include.rs` was missing from `library`'s source root. 

When loading a workspace, RA:

1. Discovers files in each crate, excluding the `target/` directory, and partitions them into the appropriate source roots
2. Runs each crate's build script, adding its output directory to the crate's source root configuration
3. Discovers files in the build script output directories

The discovery of the new files then [causes the VFS to be repartitioned](https://github.com/rust-lang/rust-analyzer/blob/33f097b09ba82406dec061c78fe542c009fc1e7b/crates/rust-analyzer/src/global_state.rs#L436), ensuring the build script outputs are placed into the appropriate source roots.

But this fails when crates are placed in this nested folder structure. Step 1 finds the build script outputs early (I think they're found when scanning the `library/` crate, since `library/application/target` is not `library`'s target directory and so is not skipped). By the time we get to step 3, all the files have already been discovered, and so we don't notice a change in the project structure and source root repartitioning does not get a chance to run with the configuration from step 2.
</details>