### PR TITLE
fix: surface generic substitution when hovering inside a call's arguments

### DIFF
--- a/crates/ide/src/hover.rs
+++ b/crates/ide/src/hover.rs
@@ -361,6 +361,64 @@ fn hover_offset(
             };
             render::type_info_of(sema, config, &Either::Left(call_expr), edition, display_target)
         };
+        // When the cursor is inside a call's argument list, also surface the
+        // hover for the called function itself if the call has a generic
+        // substitution. Without this, hovering on an argument like `42` only
+        // shows `i32`, hiding the resolved generic types of the enclosing
+        // call.
+        let enclosing_call_subst = || {
+            let arg_list = token
+                .parent_ancestors()
+                .take_while(|n| !ast::Item::can_cast(n.kind()))
+                .find_map(ast::ArgList::cast)?;
+            let name_ref = match arg_list.syntax().parent().and_then(|p| {
+                syntax::match_ast! {
+                    match p {
+                        ast::CallExpr(call) => {
+                            call.expr().and_then(|e| match e {
+                                ast::Expr::PathExpr(p) => p
+                                    .path()
+                                    .and_then(|p| p.segment())
+                                    .and_then(|s| s.name_ref()),
+                                _ => None,
+                            })
+                        },
+                        ast::MethodCallExpr(call) => call.name_ref(),
+                        _ => None,
+                    }
+                }
+            }) {
+                Some(it) => it,
+                None => return None,
+            };
+            IdentClass::classify_node(sema, name_ref.syntax())?
+                .definitions()
+                .into_iter()
+                .filter(|(_, subst)| {
+                    subst
+                        .as_ref()
+                        .is_some_and(|s| s.types(sema.db).iter().any(|(_, ty)| !ty.is_unknown()))
+                })
+                .map(|(def, subst)| {
+                    hover_for_definition(
+                        sema,
+                        file_id,
+                        def,
+                        subst,
+                        name_ref.syntax(),
+                        None,
+                        false,
+                        config,
+                        edition,
+                        display_target,
+                    )
+                })
+                .reduce(|mut acc: HoverResult, HoverResult { markup, actions }| {
+                    acc.actions.extend(actions);
+                    acc.markup = Markup::from(format!("{}\n\n---\n{markup}", acc.markup));
+                    acc
+                })
+        };
         let closure = || {
             if !is_same_kind || token.kind() != T![|] {
                 return None;
@@ -380,6 +438,9 @@ fn hover_offset(
             .or_else(literal)
         {
             res.push(result)
+        }
+        if let Some(result) = enclosing_call_subst() {
+            res.push(result);
         }
     }
 

--- a/crates/ide/src/hover/tests.rs
+++ b/crates/ide/src/hover/tests.rs
@@ -10236,6 +10236,182 @@ fn bar() {
 }
 
 #[test]
+fn subst_inside_call_arg_list() {
+    // Regression test for https://github.com/rust-lang/rust-analyzer/issues/22164.
+    // Hovering inside the argument list of a generic function call should
+    // surface the call's generic substitution, regardless of whether the
+    // cursor lands on `(`, `)` or one of the arguments.
+
+    // Cursor right after `(` of a no-argument call.
+    check(
+        r#"
+fn foo<T>() -> T { loop {} }
+
+fn bar() {
+    let _: i32 = foo($0);
+}
+        "#,
+        expect![[r#"
+            *)*
+            ```rust
+            i32
+            ```
+
+            ---
+
+            ```rust
+            ra_test_fixture
+            ```
+
+            ```rust
+            fn foo<T>() -> T
+            ```
+
+            ---
+
+            `T` = `i32`
+        "#]],
+    );
+    // Cursor on an argument literal of a call with arguments.
+    check(
+        r#"
+fn foo<T>(v: i32) -> T { loop {} }
+
+fn bar() {
+    let _: i32 = foo($042);
+}
+        "#,
+        expect![[r#"
+            *42*
+            ```rust
+            i32
+            ```
+            ---
+
+            value of literal: ` 42 (0x2A|0b101010) `
+
+            ---
+
+            ```rust
+            ra_test_fixture
+            ```
+
+            ```rust
+            fn foo<T>(v: i32) -> T
+            ```
+
+            ---
+
+            `T` = `i32`
+        "#]],
+    );
+    // Cursor after the last argument of a call with arguments.
+    check(
+        r#"
+fn foo<T>(v: i32) -> T { loop {} }
+
+fn bar() {
+    let _: i32 = foo(42$0);
+}
+        "#,
+        expect![[r#"
+            *42*
+            ```rust
+            i32
+            ```
+            ---
+
+            value of literal: ` 42 (0x2A|0b101010) `
+
+            ---
+
+            ```rust
+            ra_test_fixture
+            ```
+
+            ```rust
+            fn foo<T>(v: i32) -> T
+            ```
+
+            ---
+
+            `T` = `i32`
+        "#]],
+    );
+    // Nested calls: cursor inside the inner call's arg list should expose the
+    // inner call's substitution, not the outer's.
+    check(
+        r#"
+fn inner<T>(v: T) -> T { v }
+fn outer<U>(v: U) -> U { v }
+
+fn bar() {
+    let _: i32 = outer(inner(42$0));
+}
+        "#,
+        expect![[r#"
+            *42*
+            ```rust
+            i32
+            ```
+            ---
+
+            value of literal: ` 42 (0x2A|0b101010) `
+
+            ---
+
+            ```rust
+            ra_test_fixture
+            ```
+
+            ```rust
+            fn inner<T>(v: T) -> T
+            ```
+
+            ---
+
+            `T` = `i32`
+        "#]],
+    );
+    // Method calls should behave the same way.
+    check(
+        r#"
+struct S;
+impl S {
+    fn foo<T>(&self, v: i32) -> T { loop {} }
+}
+
+fn bar() {
+    let _: i32 = S.foo($042);
+}
+        "#,
+        expect![[r#"
+            *42*
+            ```rust
+            i32
+            ```
+            ---
+
+            value of literal: ` 42 (0x2A|0b101010) `
+
+            ---
+
+            ```rust
+            ra_test_fixture::S
+            ```
+
+            ```rust
+            fn foo<T>(&self, v: i32) -> T
+            ```
+
+            ---
+
+            `T` = `i32`
+        "#]],
+    );
+}
+
+#[test]
 fn subst_record_constructor() {
     check(
         r#"


### PR DESCRIPTION
Fixes rust-lang/rust-analyzer#22164.

Hovering inside the parentheses of a generic function call only surfaced the generic substitution (e.g. `T = i32`) when the call had no arguments — the cursor would land on `(` or `)` and `pick_best_token` would pick the paren. Once the call had arguments, the cursor landed on the argument literal/expression instead, and the substitution information became unreachable from inside the parens (the user's reported workaround was assigning the call to a `let` binding and hovering on the binding).

This adds a small post-step in `hover_offset`: when the cursor token is descended from an `ArgList` of a `CallExpr` or `MethodCallExpr`, also produce the hover for the called function itself (the same hover as if the cursor were on the function's name). It's gated on the call having a non-trivial generic substitution (at least one substituted type that isn't `unknown`), so the existing `hover_call_parens` style behaviour for non-generic calls is preserved. The per-argument hover (`i32` for `42`, etc.) is preserved and merged with the new block via the standard `\n\n---\n` joiner.

Tested with new cases in `crates/ide/src/hover/tests.rs::subst_inside_call_arg_list` covering:
- cursor inside `()` of a no-argument generic call (existing behaviour preserved)
- cursor on an argument literal of a generic call with arguments (the bug)
- cursor right before `)` after the last argument
- nested calls (inner call's substitution wins)
- generic method calls