### PR TITLE
internal: Ignore another hangy test

### DIFF
--- a/crates/rust-analyzer/tests/slow-tests/flycheck.rs
+++ b/crates/rust-analyzer/tests/slow-tests/flycheck.rs
@@ -76,6 +76,7 @@ fn main() {
 }
 
 #[test]
+#[ignore = "this test tends to stuck, FIXME: investigate that"]
 fn test_flycheck_diagnostic_with_override_command() {
     if skip_slow_tests() {
         return;


### PR DESCRIPTION
CI commonly gets stuck lately. I'm not entirely sure this test is the cause since nextest does not show the hanging test but I think I saw it hanging in the past and also its friend, `test_flycheck_diagnostics_with_override_command_cleared_after_fix()`, was used to hang.

CC @Wilfred.