### PR TITLE
perf: Provide access to `RootDatabase`'s `LineIndex` for the proc macro protocol

### DIFF
--- a/crates/base-db/src/lib.rs
+++ b/crates/base-db/src/lib.rs
@@ -7,6 +7,7 @@ extern crate rustc_driver as _;
 
 pub use salsa;
 pub use salsa_macros;
+use span::TextSize;
 
 // FIXME: Rename this crate, base db is non descriptive
 mod change;
@@ -280,6 +281,8 @@ pub trait SourceDatabase: salsa::Database {
     fn crates_map(&self) -> Arc<CratesMap>;
 
     fn nonce_and_revision(&self) -> (Nonce, salsa::Revision);
+
+    fn line_column(&self, file: FileId, offset: TextSize) -> Result<(u32, u32), ()>;
 }
 
 static NEXT_NONCE: AtomicUsize = AtomicUsize::new(0);

--- a/crates/hir-def/src/test_db.rs
+++ b/crates/hir-def/src/test_db.rs
@@ -142,6 +142,10 @@ impl SourceDatabase for TestDB {
     fn nonce_and_revision(&self) -> (Nonce, salsa::Revision) {
         (self.nonce, salsa::plumbing::ZalsaDatabase::zalsa(self).current_revision())
     }
+
+    fn line_column(&self, _file: FileId, _offset: syntax::TextSize) -> Result<(u32, u32), ()> {
+        Err(())
+    }
 }
 
 impl TestDB {

--- a/crates/hir-ty/src/test_db.rs
+++ b/crates/hir-ty/src/test_db.rs
@@ -132,6 +132,10 @@ impl SourceDatabase for TestDB {
     fn nonce_and_revision(&self) -> (Nonce, salsa::Revision) {
         (self.nonce, salsa::plumbing::ZalsaDatabase::zalsa(self).current_revision())
     }
+
+    fn line_column(&self, _file: FileId, _offset: syntax::TextSize) -> Result<(u32, u32), ()> {
+        Err(())
+    }
 }
 
 #[salsa_macros::db]

--- a/crates/ide-db/src/lib.rs
+++ b/crates/ide-db/src/lib.rs
@@ -180,6 +180,10 @@ impl SourceDatabase for RootDatabase {
     fn nonce_and_revision(&self) -> (Nonce, salsa::Revision) {
         (self.nonce, salsa::plumbing::ZalsaDatabase::zalsa(self).current_revision())
     }
+
+    fn line_column(&self, file: FileId, offset: syntax::TextSize) -> Result<(u32, u32), ()> {
+        line_index(self, file).try_line_col(offset).map(|lc| (lc.line, lc.col)).ok_or(())
+    }
 }
 
 impl Default for RootDatabase {

--- a/crates/load-cargo/src/lib.rs
+++ b/crates/load-cargo/src/lib.rs
@@ -609,11 +609,9 @@ impl ProcMacroExpander for Expander {
             SubRequest::LineColumn { file_id, ast_id, offset } => {
                 let range =
                     resolve_sub_span(db, file_id, ast_id, TextRange::empty(TextSize::from(offset)));
-                let source = db.file_text(range.file_id.file_id(db)).text(db);
-                let line_index = ide_db::line_index::LineIndex::new(source);
-                let (line, column) = line_index
-                    .try_line_col(range.range.start())
-                    .map(|lc| (lc.line + 1, lc.col + 1))
+                let (line, column) = db
+                    .line_column(range.file_id.file_id(db), range.range.start())
+                    .map(|(line, col)| (line + 1, col + 1))
                     .unwrap_or((1, 1));
                 // proc_macro::Span line/column are 1-based
                 Ok(SubResponse::LineColumnResult { line, column })


### PR DESCRIPTION
Instead of recreating it.