### PR TITLE
fix: Keep the same nonce when cloning a `RootDatabase`

### DIFF
--- a/crates/ide-db/src/lib.rs
+++ b/crates/ide-db/src/lib.rs
@@ -112,7 +112,7 @@ impl Clone for RootDatabase {
             storage: self.storage.clone(),
             files: self.files.clone(),
             crates_map: self.crates_map.clone(),
-            nonce: Nonce::new(),
+            nonce: self.nonce,
         }
     }
 }


### PR DESCRIPTION
It has the same data.