### PR TITLE
fix: Make `InferenceResult::binding_mode()` fallible

### DIFF
--- a/crates/hir-ty/src/infer.rs
+++ b/crates/hir-ty/src/infer.rs
@@ -1110,8 +1110,8 @@ impl InferenceResult {
         self.expr_adjustments.get(&id).map(|it| &**it)
     }
 
-    pub fn binding_mode(&self, id: PatId) -> BindingMode {
-        self.binding_modes[id]
+    pub fn binding_mode(&self, id: PatId) -> Option<BindingMode> {
+        self.binding_modes.get(id).copied()
     }
 
     // This method is consumed by external tools to run rust-analyzer as a library. Don't remove, please.

--- a/crates/hir-ty/src/infer/closure/analysis/expr_use_visitor.rs
+++ b/crates/hir-ty/src/infer/closure/analysis/expr_use_visitor.rs
@@ -949,7 +949,7 @@ impl<'a, 'b, 'db, D: Delegate<'db>> ExprUseVisitor<'a, 'b, 'db, D> {
                     // In a cases of pattern like `let pat = upvar`, don't use the span
                     // of the pattern, as this just looks confusing, instead use the span
                     // of the discriminant.
-                    match this.cx.result.binding_mode(pat).0 {
+                    match this.cx.result.binding_mode(pat).ok_or(ErrorGuaranteed)?.0 {
                         ByRef::Yes(m) => {
                             let bk = BorrowKind::from_mutbl(m);
                             this.delegate.borrow(place, bk, this.cx);
@@ -1220,7 +1220,7 @@ impl<'db, D: Delegate<'db>> ExprUseVisitor<'_, '_, 'db, D> {
         // and if so, figures out what the type *being borrowed* is.
         match self.cx.store[pat] {
             Pat::Bind { .. } => {
-                let bm = self.cx.result.binding_mode(pat);
+                let bm = self.cx.result.binding_mode(pat).ok_or(ErrorGuaranteed)?;
 
                 if let ByRef::Yes(_) = bm.0 {
                     // a bind-by-ref means that the base_ty will be the type of the ident itself,

--- a/crates/hir/src/source_analyzer.rs
+++ b/crates/hir/src/source_analyzer.rs
@@ -449,7 +449,7 @@ impl<'db> SourceAnalyzer<'db> {
     ) -> Option<BindingMode> {
         let id = self.pat_id(&pat.clone().into())?;
         let infer = self.infer()?;
-        Some(match infer.binding_mode(id.as_pat()?) {
+        Some(match infer.binding_mode(id.as_pat()?)? {
             hir_ty::BindingMode(hir_ty::ByRef::No, _) => BindingMode::Move,
             hir_ty::BindingMode(hir_ty::ByRef::Yes(hir_ty::next_solver::Mutability::Mut), _) => {
                 BindingMode::Ref(Mutability::Mut)


### PR DESCRIPTION
The pattern can be missing a binding mode when there was a cycle, and the `InferenceResult` is empty.

This should fix the nightly releases.