### PR TITLE
Fix extract_type_alias and provide inlay hints for const `_` placeholders

### DIFF
--- a/crates/hir-def/src/hir.rs
+++ b/crates/hir-def/src/hir.rs
@@ -33,7 +33,7 @@ use crate::{
         HygieneId,
         path::{GenericArgs, Path},
     },
-    type_ref::{Mutability, Rawness},
+    type_ref::{ConstRef, Mutability, Rawness},
 };
 
 pub use syntax::ast::{ArithOp, BinaryOp, CmpOp, LogicOp, Ordering, RangeOp, UnaryOp};
@@ -150,6 +150,38 @@ impl From<PatId> for ExprOrPatIdPacked {
         Self(value | Self::PAT_BIT)
     }
 }
+
+// FIXME: Like ExprOrPatId above, eventually encode this as a single u32?
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq, salsa::Update)]
+pub enum TypeRefIdOrConstRef {
+    TypeRefId(TypeRefId),
+    ConstRef(ConstRef),
+}
+
+impl TypeRefIdOrConstRef {
+    pub fn as_type_ref(self) -> Option<TypeRefId> {
+        match self {
+            Self::TypeRefId(v) => Some(v),
+            _ => None,
+        }
+    }
+
+    pub fn is_type_ref(&self) -> bool {
+        matches!(self, Self::TypeRefId(_))
+    }
+
+    pub fn as_const_ref(self) -> Option<ConstRef> {
+        match self {
+            Self::ConstRef(v) => Some(v),
+            _ => None,
+        }
+    }
+
+    pub fn is_expr(&self) -> bool {
+        matches!(self, Self::ConstRef(_))
+    }
+}
+stdx::impl_from!(TypeRefId, ConstRef for TypeRefIdOrConstRef);
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Label {

--- a/crates/hir-ty/src/infer.rs
+++ b/crates/hir-ty/src/infer.rs
@@ -47,7 +47,7 @@ use hir_def::{
     TupleFieldId, TupleId, VariantId,
     attrs::AttrFlags,
     expr_store::{Body, ExpressionStore, HygieneId, body::Param, path::Path},
-    hir::{BindingId, ExprId, ExprOrPatId, ExprOrPatIdPacked, LabelId, PatId},
+    hir::{BindingId, ExprId, ExprOrPatId, ExprOrPatIdPacked, LabelId, PatId, TypeRefIdOrConstRef},
     lang_item::LangItems,
     layout::Integer,
     resolver::{HasResolver, ResolveValueResult, Resolver, TypeNs, ValueNs},
@@ -99,8 +99,9 @@ use crate::{
     },
     method_resolution::CandidateId,
     next_solver::{
-        AliasTy, Const, ConstKind, DbInterner, ErrorGuaranteed, GenericArgs, Region, StoredFnSig,
-        StoredGenericArg, StoredGenericArgs, StoredTy, StoredTys, Term, Ty, TyKind, Tys,
+        AliasTy, Const, ConstKind, DbInterner, ErrorGuaranteed, GenericArgs, Region, StoredConst,
+        StoredFnSig, StoredGenericArg, StoredGenericArgs, StoredTy, StoredTys, Term, Ty, TyKind,
+        Tys,
         abi::Safety,
         infer::{InferCtxt, ObligationInspector, traits::ObligationCause},
     },
@@ -775,6 +776,7 @@ pub struct InferenceResult<'db> {
     pub(crate) type_of_pat: ArenaMap<PatId, StoredTy>,
     pub(crate) type_of_binding: ArenaMap<BindingId, StoredTy>,
     pub(crate) type_of_type_placeholder: FxHashMap<TypeRefId, StoredTy>,
+    pub(crate) const_of_const_placeholder: FxHashMap<TypeRefIdOrConstRef, StoredConst>,
     pub(crate) type_of_opaque: FxHashMap<InternedOpaqueTyId<'db>, StoredTy>,
 
     /// Whether there are any type-mismatching errors in the result.
@@ -1122,6 +1124,7 @@ impl<'db> InferenceResult<'db> {
             type_of_pat: Default::default(),
             type_of_binding: Default::default(),
             type_of_type_placeholder: Default::default(),
+            const_of_const_placeholder: Default::default(),
             type_of_opaque: Default::default(),
             skipped_ref_pats: Default::default(),
             has_errors: Default::default(),
@@ -1196,6 +1199,14 @@ impl<'db> InferenceResult<'db> {
     }
     pub fn type_of_type_placeholder<'a>(&self, type_ref: TypeRefId) -> Option<Ty<'a>> {
         self.type_of_type_placeholder.get(&type_ref).map(|ty| ty.as_ref())
+    }
+    pub fn placeholder_consts<'a>(&self) -> impl Iterator<Item = (TypeRefIdOrConstRef, Const<'a>)> {
+        self.const_of_const_placeholder
+            .iter()
+            .map(|(&type_ref_or_const, const_)| (type_ref_or_const, const_.as_ref()))
+    }
+    pub fn const_of_const_placeholder<'a>(&self, expr: TypeRefIdOrConstRef) -> Option<Const<'a>> {
+        self.const_of_const_placeholder.get(&expr).map(|ty| ty.as_ref())
     }
     pub fn type_of_expr_or_pat<'a>(&self, id: ExprOrPatId) -> Option<Ty<'a>> {
         match id {
@@ -1483,6 +1494,7 @@ impl<'db> InferenceContext<'db> {
             type_of_pat,
             type_of_binding,
             type_of_type_placeholder,
+            const_of_const_placeholder,
             type_of_opaque,
             has_errors: _,
             diagnostics: _,
@@ -1514,6 +1526,7 @@ impl<'db> InferenceContext<'db> {
         merge_arena_maps(type_of_pat, &other.type_of_pat);
         merge_arena_maps(type_of_binding, &other.type_of_binding);
         merge_hash_maps(type_of_type_placeholder, &other.type_of_type_placeholder);
+        merge_hash_maps(const_of_const_placeholder, &other.const_of_const_placeholder);
         merge_hash_maps(type_of_opaque, &other.type_of_opaque);
         merge_hash_maps(expr_adjustments, &other.expr_adjustments);
         merge_hash_maps(pat_adjustments, &other.pat_adjustments);
@@ -1649,6 +1662,7 @@ impl<'db> InferenceContext<'db> {
             type_of_pat,
             type_of_binding,
             type_of_type_placeholder,
+            const_of_const_placeholder,
             type_of_opaque,
             skipped_ref_pats,
             closures_data,
@@ -1687,6 +1701,10 @@ impl<'db> InferenceContext<'db> {
             resolver.resolve_completely(ty);
         }
         type_of_type_placeholder.shrink_to_fit();
+        for const_ in const_of_const_placeholder.values_mut() {
+            resolver.resolve_completely(const_);
+        }
+        const_of_const_placeholder.shrink_to_fit();
         type_of_opaque.shrink_to_fit();
 
         if let Some(nodes_with_type_mismatches) = nodes_with_type_mismatches {
@@ -1993,6 +2011,7 @@ impl<'db> InferenceContext<'db> {
             InferenceTyDiagnosticSource::Body => Some(&mut InferenceTyLoweringVarsCtx {
                 table: &mut self.table,
                 type_of_type_placeholder: &mut self.result.type_of_type_placeholder,
+                const_of_const_placeholder: &mut self.result.const_of_const_placeholder,
             } as _),
             InferenceTyDiagnosticSource::Signature => None,
         };
@@ -2335,6 +2354,7 @@ impl<'db> InferenceContext<'db> {
         let mut vars_ctx = InferenceTyLoweringVarsCtx {
             table: &mut self.table,
             type_of_type_placeholder: &mut self.result.type_of_type_placeholder,
+            const_of_const_placeholder: &mut self.result.const_of_const_placeholder,
         };
         let mut ctx = TyLoweringContext::new(
             self.db,

--- a/crates/hir-ty/src/infer/diagnostics.rs
+++ b/crates/hir-ty/src/infer/diagnostics.rs
@@ -7,6 +7,8 @@ use std::ops::{Deref, DerefMut};
 
 use either::Either;
 use hir_def::expr_store::path::Path;
+use hir_def::hir::TypeRefIdOrConstRef;
+use hir_def::type_ref::ConstRef;
 use hir_def::{ExpressionStoreOwnerId, GenericDefId};
 use hir_def::{expr_store::ExpressionStore, type_ref::TypeRefId};
 use hir_def::{
@@ -27,7 +29,7 @@ use crate::{
         ForbidParamsAfterReason, LifetimeElisionKind, TyLoweringContext, TyLoweringInferVarsCtx,
         path::{PathDiagnosticCallback, PathLoweringContext},
     },
-    next_solver::{Const, Region, StoredTy, Ty},
+    next_solver::{Const, Region, StoredConst, StoredTy, Ty},
 };
 
 // Unfortunately, this struct needs to use interior mutability (but we encapsulate it)
@@ -65,6 +67,7 @@ pub(crate) struct PathDiagnosticCallbackData<'a> {
 pub(super) struct InferenceTyLoweringVarsCtx<'a, 'db> {
     pub(super) table: &'a mut InferenceTable<'db>,
     pub(super) type_of_type_placeholder: &'a mut FxHashMap<TypeRefId, StoredTy>,
+    pub(super) const_of_const_placeholder: &'a mut FxHashMap<TypeRefIdOrConstRef, StoredConst>,
 }
 
 impl<'db> TyLoweringInferVarsCtx<'db> for InferenceTyLoweringVarsCtx<'_, 'db> {
@@ -78,7 +81,18 @@ impl<'db> TyLoweringInferVarsCtx<'db> for InferenceTyLoweringVarsCtx<'_, 'db> {
         ty
     }
     fn next_const_var(&mut self, span: Span) -> Const<'db> {
-        self.table.infer_ctxt.next_const_var(span)
+        let const_ = self.table.infer_ctxt.next_const_var(span);
+
+        let type_ref_id_or_const_ref = match span {
+            Span::ExprId(expr) => Some(TypeRefIdOrConstRef::ConstRef(ConstRef { expr })),
+            Span::TypeRefId(type_ref) => Some(type_ref.into()),
+            _ => None,
+        };
+        if let Some(key) = type_ref_id_or_const_ref {
+            self.const_of_const_placeholder.insert(key, const_.store());
+        }
+
+        const_
     }
     fn next_region_var(&mut self, span: Span) -> Region<'db> {
         self.table.infer_ctxt.next_region_var(span)

--- a/crates/hir-ty/src/infer/path.rs
+++ b/crates/hir-ty/src/infer/path.rs
@@ -153,6 +153,7 @@ impl<'db> InferenceContext<'db> {
         let mut vars_ctx = InferenceTyLoweringVarsCtx {
             table: &mut self.table,
             type_of_type_placeholder: &mut self.result.type_of_type_placeholder,
+            const_of_const_placeholder: &mut self.result.const_of_const_placeholder,
         };
         let mut ctx = TyLoweringContext::new(
             self.db,

--- a/crates/hir-ty/src/lib.rs
+++ b/crates/hir-ty/src/lib.rs
@@ -67,7 +67,7 @@ use hir_def::{
     GenericDefId, HasModule, LifetimeParamId, ModuleId, StaticId, TypeAliasId, TypeOrConstParamId,
     TypeParamId,
     expr_store::{Body, ExpressionStore},
-    hir::{BindingId, ExprId, ExprOrPatId, ExprOrPatIdPacked, PatId},
+    hir::{BindingId, ExprId, ExprOrPatId, ExprOrPatIdPacked, PatId, TypeRefIdOrConstRef},
     resolver::{HasResolver, Resolver, TypeNs},
     type_ref::{Rawness, TypeRefId},
 };
@@ -537,6 +537,15 @@ impl From<ExprOrPatIdPacked> for Span {
         match value.unpack() {
             ExprOrPatId::ExprId(idx) => idx.into(),
             ExprOrPatId::PatId(idx) => idx.into(),
+        }
+    }
+}
+
+impl From<TypeRefIdOrConstRef> for Span {
+    fn from(value: TypeRefIdOrConstRef) -> Self {
+        match value {
+            TypeRefIdOrConstRef::TypeRefId(idx) => idx.into(),
+            TypeRefIdOrConstRef::ConstRef(idx) => idx.expr.into(),
         }
     }
 }

--- a/crates/hir-ty/src/next_solver/consts.rs
+++ b/crates/hir-ty/src/next_solver/consts.rs
@@ -217,6 +217,15 @@ impl<'db> TypeVisitable<DbInterner<'db>> for Const<'db> {
     }
 }
 
+impl<'db> TypeVisitable<DbInterner<'db>> for StoredConst {
+    fn visit_with<V: rustc_type_ir::TypeVisitor<DbInterner<'db>>>(
+        &self,
+        visitor: &mut V,
+    ) -> V::Result {
+        self.as_ref().visit_with(visitor)
+    }
+}
+
 impl<'db> TypeSuperVisitable<DbInterner<'db>> for Const<'db> {
     fn super_visit_with<V: rustc_type_ir::TypeVisitor<DbInterner<'db>>>(
         &self,
@@ -245,6 +254,18 @@ impl<'db> TypeFoldable<DbInterner<'db>> for Const<'db> {
     }
     fn fold_with<F: rustc_type_ir::TypeFolder<DbInterner<'db>>>(self, folder: &mut F) -> Self {
         folder.fold_const(self)
+    }
+}
+
+impl<'db> TypeFoldable<DbInterner<'db>> for StoredConst {
+    fn try_fold_with<F: rustc_type_ir::FallibleTypeFolder<DbInterner<'db>>>(
+        self,
+        folder: &mut F,
+    ) -> Result<Self, F::Error> {
+        Ok(self.as_ref().try_fold_with(folder)?.store())
+    }
+    fn fold_with<F: rustc_type_ir::TypeFolder<DbInterner<'db>>>(self, folder: &mut F) -> Self {
+        self.as_ref().fold_with(folder).store()
     }
 }
 

--- a/crates/hir-ty/src/tests.rs
+++ b/crates/hir-ty/src/tests.rs
@@ -19,7 +19,7 @@ use hir_def::{
     AdtId, AssocItemId, DefWithBodyId, GenericDefId, HasModule, Lookup, ModuleDefId, ModuleId,
     SyntheticSyntax, VariantId,
     expr_store::{Body, BodySourceMap, ExpressionStore, ExpressionStoreSourceMap},
-    hir::{ExprId, Pat, PatId},
+    hir::{ExprId, Pat, PatId, TypeRefIdOrConstRef},
     item_scope::ItemScope,
     nameres::DefMap,
     src::HasSource,
@@ -83,6 +83,7 @@ fn check_impl(
         let mut had_annotations = false;
         let mut mismatches = FxHashMap::default();
         let mut types = FxHashMap::default();
+        let mut consts = FxHashMap::default();
         let mut adjustments = FxHashMap::default();
         for (file_id, annotations) in db.extract_annotations() {
             for (range, expected) in annotations {
@@ -91,6 +92,8 @@ fn check_impl(
                     types.insert(file_range, expected);
                 } else if let Some(ty) = expected.strip_prefix("type: ") {
                     types.insert(file_range, ty.to_owned());
+                } else if let Some(const_) = expected.strip_prefix("const: ") {
+                    consts.insert(file_range, const_.to_owned());
                 } else if expected.starts_with("expected") {
                     mismatches.insert(file_range, expected);
                 } else if let Some(adjs) = expected.strip_prefix("adjustments:") {
@@ -243,6 +246,29 @@ fn check_impl(
                     assert_eq!(actual, expected, "type annotation differs at {:#?}", range.range);
                 }
             }
+
+            for (type_ref_id_or_const_ref, const_) in inference_result.placeholder_consts() {
+                let node = match type_ref_id_or_const_ref {
+                    TypeRefIdOrConstRef::TypeRefId(type_ref) => {
+                        type_node(body_source_map, type_ref, &db)
+                    }
+                    TypeRefIdOrConstRef::ConstRef(const_ref) => {
+                        expr_node(body_source_map, const_ref.expr, &db)
+                    }
+                };
+                let Some(node) = node else { continue };
+                let range = node.as_ref().original_file_range_rooted(&db);
+                if let Some(expected) = consts.remove(&range) {
+                    let actual = salsa::attach(&db, || {
+                        if display_source {
+                            const_.display_source_code(&db, def.module(&db), true).unwrap()
+                        } else {
+                            const_.display_test(&db, display_target).to_string()
+                        }
+                    });
+                    assert_eq!(actual, expected, "const annotation differs at {:#?}", range.range);
+                }
+            }
         }
 
         let mut buf = String::new();
@@ -259,6 +285,12 @@ fn check_impl(
             format_to!(buf, "Unchecked type annotations:\n");
             for t in types {
                 format_to!(buf, "{:?}: type {}\n", t.0.range, t.1);
+            }
+        }
+        if !consts.is_empty() {
+            format_to!(buf, "Unchecked const annotations:\n");
+            for c in consts {
+                format_to!(buf, "{:?}: const {}\n", c.0.range, c.1);
             }
         }
         if !adjustments.is_empty() {

--- a/crates/hir-ty/src/tests/display_source_code.rs
+++ b/crates/hir-ty/src/tests/display_source_code.rs
@@ -1,4 +1,4 @@
-use super::check_types_source_code;
+use super::{check, check_types_source_code};
 
 #[test]
 fn qualify_path_to_submodule() {
@@ -248,19 +248,21 @@ fn test() {
 }
 
 #[test]
-fn type_placeholder_type() {
-    check_types_source_code(
+fn type_and_const_placeholders() {
+    check(
         r#"
-struct S<T>(T);
+struct S<T, const N: usize>([T; N]);
 fn test() {
-    let f: S<_> = S(3);
-           //^ i32
+    let f: S<_, _> = S([1, 2]);
+           //^ type: i32
+              //^ const: 2
     let f: [_; _] = [4_u32, 5, 6];
-          //^ u32
+          //^ type: u32
+             //^ const: 3
     let f: (_, _, _) = (1_u32, 1_i32, false);
-          //^ u32
-             //^ i32
-                //^ bool
+          //^ type: u32
+             //^ type: i32
+                //^ type: bool
 }
 "#,
     );

--- a/crates/hir/src/semantics.rs
+++ b/crates/hir/src/semantics.rs
@@ -36,7 +36,7 @@ use hir_ty::{
     diagnostics::unsafe_operations,
     infer_query_with_inspect,
     next_solver::{
-        AnyImplId, DbInterner,
+        AnyImplId, Const as ResolvedConst, DbInterner,
         format_proof_tree::{ProofTreeData, dump_proof_tree_structured},
     },
 };
@@ -1708,6 +1708,18 @@ impl<'db> SemanticsImpl<'db> {
         analyze.type_of_type(self.db, ty)
     }
 
+    pub fn resolve_infer(
+        &self,
+        ty: &ast::InferType,
+    ) -> Option<Either<Type<'db>, ResolvedConst<'db>>> {
+        let analyze = self.analyze(ty.syntax())?;
+        if let Some(const_) = analyze.resolve_infer_type_as_const(ty) {
+            return Some(Either::Right(const_));
+        }
+        let ty = analyze.type_of_type(self.db, &ast::Type::InferType(ty.clone()))?;
+        Some(Either::Left(ty))
+    }
+
     pub fn resolve_trait(&self, path: &ast::Path) -> Option<Trait> {
         let parent_ty = path.syntax().parent().and_then(ast::Type::cast)?;
         let analyze = self.analyze(path.syntax())?;
@@ -1870,6 +1882,13 @@ impl<'db> SemanticsImpl<'db> {
 
     fn resolve_try_expr(&self, try_expr: &ast::TryExpr) -> Option<Function> {
         self.analyze(try_expr.syntax())?.resolve_try_expr(self.db, try_expr)
+    }
+
+    pub fn resolve_underscore_expr(
+        &self,
+        underscore_expr: &ast::UnderscoreExpr,
+    ) -> Option<ResolvedConst<'db>> {
+        self.analyze(underscore_expr.syntax())?.resolve_underscore_expr(underscore_expr)
     }
 
     /// The type that the associated `try` block, closure or function expects.

--- a/crates/hir/src/source_analyzer.rs
+++ b/crates/hir/src/source_analyzer.rs
@@ -43,8 +43,8 @@ use hir_ty::{
     lang_items::lang_items_for_bin_op,
     method_resolution::{self, CandidateId},
     next_solver::{
-        AliasTy, DbInterner, DefaultAny, EarlyBinder, ErrorGuaranteed, GenericArgs, ParamEnv,
-        Region, Ty, TyKind, TypingMode, infer::DbInternerInferExt,
+        AliasTy, Const as ResolvedConst, DbInterner, DefaultAny, EarlyBinder, ErrorGuaranteed,
+        GenericArgs, ParamEnv, Region, Ty, TyKind, TypingMode, infer::DbInternerInferExt,
     },
     traits::{WherePredicateEvaluation, structurally_normalize_ty, where_predicate_must_hold},
 };
@@ -962,6 +962,22 @@ impl<'db> SourceAnalyzer<'db> {
         let substs = GenericArgs::new_from_slice(&[ty.into()]);
 
         Some(self.resolve_impl_method_or_trait_def(db, op_fn, substs))
+    }
+
+    pub(crate) fn resolve_underscore_expr(
+        &self,
+        underscore_expr: &ast::UnderscoreExpr,
+    ) -> Option<ResolvedConst<'db>> {
+        let expr = self.expr_id(ast::Expr::UnderscoreExpr(underscore_expr.clone()))?.as_expr()?;
+        self.infer()?.const_of_const_placeholder(ConstRef { expr }.into())
+    }
+
+    pub(crate) fn resolve_infer_type_as_const(
+        &self,
+        infer_type: &ast::InferType,
+    ) -> Option<ResolvedConst<'db>> {
+        let type_ref = self.type_id(&ast::Type::InferType(infer_type.clone()))?;
+        self.infer()?.const_of_const_placeholder(type_ref.into())
     }
 
     pub(crate) fn resolve_record_field(

--- a/crates/hir/src/source_analyzer.rs
+++ b/crates/hir/src/source_analyzer.rs
@@ -25,7 +25,7 @@ use hir_def::{
     lang_item::LangItems,
     nameres::MacroSubNs,
     resolver::{ResolveValueResult, Resolver, TypeNs, ValueNs, resolver_for_scope},
-    type_ref::{Mutability, TypeRefId},
+    type_ref::{ConstRef, Mutability, TypeRefId},
     visibility::Visibility,
 };
 use hir_expand::{
@@ -492,7 +492,25 @@ impl<'db> SourceAnalyzer<'db> {
                     self.types.types.error
                 }
             }
-            fn next_const_var(&mut self, _span: hir_ty::Span) -> hir_ty::next_solver::Const<'db> {
+            fn next_const_var(&mut self, span: hir_ty::Span) -> hir_ty::next_solver::Const<'db> {
+                if let Some(infer) = self.infer {
+                    match span {
+                        hir_ty::Span::TypeRefId(type_ref) => {
+                            if let Some(const_) = infer.const_of_const_placeholder(type_ref.into())
+                            {
+                                return const_;
+                            }
+                        }
+                        hir_ty::Span::ExprId(expr) => {
+                            if let Some(const_) =
+                                infer.const_of_const_placeholder(ConstRef { expr }.into())
+                            {
+                                return const_;
+                            }
+                        }
+                        _ => {}
+                    }
+                }
                 self.types.consts.error
             }
             fn next_region_var(&mut self, _span: hir_ty::Span) -> Region<'db> {

--- a/crates/ide-assists/src/handlers/extract_type_alias.rs
+++ b/crates/ide-assists/src/handlers/extract_type_alias.rs
@@ -428,6 +428,48 @@ fn main() {
     }
 
     #[test]
+    fn inferred_array_length() {
+        check_assist(
+            extract_type_alias,
+            r#"
+fn main() {
+    let a: $0[i32; _]$0 = [1, 2, 3];
+}
+            "#,
+            r#"
+type $0Type = [i32; 3];
+
+fn main() {
+    let a: Type = [1, 2, 3];
+}
+            "#,
+        )
+    }
+
+    #[test]
+    fn inferred_generic_const_parameter() {
+        check_assist(
+            extract_type_alias,
+            r#"
+struct Wrap<const N: usize>([i32; N]);
+
+fn main() {
+    let wrap: $0Wrap<_>$0 = Wrap([1, 2, 3]);
+}
+            "#,
+            r#"
+struct Wrap<const N: usize>([i32; N]);
+
+type $0Type = Wrap<3>;
+
+fn main() {
+    let wrap: Type = Wrap([1, 2, 3]);
+}
+            "#,
+        )
+    }
+
+    #[test]
     fn inferred_type() {
         check_assist(
             extract_type_alias,

--- a/crates/ide/src/inlay_hints.rs
+++ b/crates/ide/src/inlay_hints.rs
@@ -253,6 +253,7 @@ fn hints(
                     ),
                     ast::Expr::RangeExpr(it) => range_exclusive::hints(hints, famous_defs, config, it),
                     ast::Expr::Literal(it) => ra_fixture::hints(hints, famous_defs.0, file_id, config, it),
+                    ast::Expr::UnderscoreExpr(it) => placeholders::const_hints(hints, famous_defs, config, display_target, it),
                     _ => Some(()),
                 }
             },

--- a/crates/ide/src/inlay_hints/placeholders.rs
+++ b/crates/ide/src/inlay_hints/placeholders.rs
@@ -4,11 +4,12 @@
 //!           //^ = i32
 //! ```
 
-use hir::DisplayTarget;
+use either::Either;
+use hir::{DisplayTarget, HirDisplay};
 use ide_db::famous_defs::FamousDefs;
 use syntax::{
     AstNode,
-    ast::{InferType, Type},
+    ast::{InferType, UnderscoreExpr},
 };
 
 use crate::{InlayHint, InlayHintPosition, InlayHintsConfig, InlayKind, inlay_hints::label_of_ty};
@@ -27,10 +28,47 @@ pub(super) fn type_hints(
     let syntax = placeholder.syntax();
     let range = syntax.text_range();
 
-    let ty = sema.resolve_type(&Type::InferType(placeholder))?;
+    let type_or_const = sema.resolve_infer(&placeholder)?;
 
-    let mut label = label_of_ty(famous_defs, config, &ty, display_target)?;
+    let mut label = match type_or_const {
+        Either::Left(ty) => label_of_ty(famous_defs, config, &ty, display_target)?,
+        Either::Right(const_) => {
+            const_.display_truncated(sema.db, config.max_length, display_target).to_string().into()
+        }
+    };
     label.prepend_str("= ");
+
+    acc.push(InlayHint {
+        range,
+        kind: InlayKind::Type,
+        label,
+        text_edit: None,
+        position: InlayHintPosition::After,
+        pad_left: true,
+        pad_right: false,
+        resolve_parent: None,
+    });
+    Some(())
+}
+
+pub(super) fn const_hints(
+    acc: &mut Vec<InlayHint>,
+    FamousDefs(sema, _): &FamousDefs<'_, '_>,
+    config: &InlayHintsConfig<'_>,
+    display_target: DisplayTarget,
+    placeholder: UnderscoreExpr,
+) -> Option<()> {
+    if !config.type_hints || config.hide_inferred_type_hints {
+        return None;
+    }
+
+    let syntax = placeholder.syntax();
+    let range = syntax.text_range();
+
+    let const_ = sema.resolve_underscore_expr(&placeholder)?;
+
+    let display = const_.display_truncated(sema.db, config.max_length, display_target);
+    let label = format!("= {display}").into();
 
     acc.push(InlayHint {
         range,
@@ -58,17 +96,20 @@ mod tests {
     }
 
     #[test]
-    fn inferred_types() {
+    fn inferred_types_and_consts() {
         check_type_infer(
             r#"
-struct S<T>(T);
+struct S<T, const N: usize>([T; N]);
 
 fn foo() {
-    let t: (_, _, [_; _]) = (1_u32, S(2), [false] as _);
+    let t: (_, S<_, _>, [_; _]) = (1_u32, S([2, 3]) as _, [false] as _);
           //^ = u32
-             //^ = S<i32>
-                 //^ = bool
-                                                   //^ = [bool; 1]
+               //^ = i32
+                  //^ = 2
+                       //^ = bool
+                          //^ = 1
+                                                     //^ = S<i32, 2>
+                                                                   //^ = [bool; 1]
 }
 "#,
         );


### PR DESCRIPTION
This is basically the extension of https://github.com/rust-lang/rust-analyzer/pull/20125 to const generics.

Before:
<img width="721" height="156" alt="image" src="https://github.com/user-attachments/assets/de637ba5-8145-482d-ad2d-d8901a5b60d2" />

After:
<img width="721" height="156" alt="image" src="https://github.com/user-attachments/assets/d0c2805a-8292-400f-a83a-c4b0ccba7ec2" />

Blocked on rust-lang/rust-analyzer#22237.
