### PR TITLE
minor: Clarify that `SmolStr` doesn't allocate when cloning

### DIFF
--- a/lib/smol_str/README.md
+++ b/lib/smol_str/README.md
@@ -8,7 +8,7 @@
 A `SmolStr` is a string type that has the following properties:
 
 * `size_of::<SmolStr>() == 24` (therefore `== size_of::<String>()` on 64 bit platforms)
-* `Clone` is `O(1)`
+* `Clone` is `O(1)` (no allocation)
 * Strings are stack-allocated if they are:
     * Up to 23 bytes long
     * Longer than 23 bytes, but substrings of `WS` (see `src/lib.rs`). Such strings consist

--- a/lib/smol_str/src/lib.rs
+++ b/lib/smol_str/src/lib.rs
@@ -15,8 +15,8 @@ use core::{
 
 /// A `SmolStr` is a string type that has the following properties:
 ///
-/// * `size_of::<SmolStr>() == 24` (therefor `== size_of::<String>()` on 64 bit platforms)
-/// * `Clone` is `O(1)`
+/// * `size_of::<SmolStr>() == 24` (therefore `== size_of::<String>()` on 64 bit platforms)
+/// * `Clone` is `O(1)` (no allocation)
 /// * Strings are stack-allocated if they are:
 ///     * Up to 23 bytes long
 ///     * Longer than 23 bytes, but substrings of `WS` (see below). Such strings consist


### PR DESCRIPTION
Technically, `O(1)` doesn't imply this, but it may also not be clear to everyone that it makes this very probable.