### PR TITLE
feat(lsp): add `debugOverrideCommand` option

### DIFF
--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -962,6 +962,19 @@ config_data! {
 
         /// Subcommand used for bench runnables instead of `bench`.
         runnables_bench_command: String = "bench".to_owned(),
+        /// Override the command used for debugging bench runnables.
+        /// The first element of the array should be the program to execute (for example, `cargo`).
+        ///
+        /// Use the placeholders:
+        /// - `${package}`: package name.
+        /// - `${target_arg}`: target option such as `--bin`, `--test`, `--lib`, etc.
+        /// - `${target}`: target name (empty for `--lib`).
+        /// - `${test_name}`: the test path filter, e.g. `module::bench_func`.
+        /// - `${exact}`: `--exact` for single benchmarks, empty for modules.
+        /// - `${include_ignored}`: always empty for benchmarks.
+        /// - `${executable_args}`: all of the above binary args bundled together
+        ///   (includes `rust-analyzer.runnables.extraTestBinaryArgs`).
+        runnables_bench_debugOverrideCommand: Option<Vec<String>> = None,
         /// Override the command used for bench runnables.
         /// The first element of the array should be the program to execute (for example, `cargo`).
         ///
@@ -1003,6 +1016,19 @@ config_data! {
         runnables_extraTestBinaryArgs: Vec<String> = vec!["--nocapture".to_owned()],
         /// Subcommand used for test runnables instead of `test`.
         runnables_test_command: String = "test".to_owned(),
+        /// Override the command used for debugging test runnables.
+        /// The first element of the array should be the program to execute (for example, `cargo`).
+        ///
+        /// Available placeholders:
+        /// - `${package}`: package name.
+        /// - `${target_arg}`: target option such as `--bin`, `--test`, `--lib`, etc.
+        /// - `${target}`: target name (empty for `--lib`).
+        /// - `${test_name}`: the test path filter, e.g. `module::test_func`.
+        /// - `${exact}`: `--exact` for single tests, empty for modules.
+        /// - `${include_ignored}`: `--include-ignored` for single tests, empty otherwise.
+        /// - `${executable_args}`: all of the above binary args bundled together
+        ///   (includes `rust-analyzer.runnables.extraTestBinaryArgs`).
+        runnables_test_debugOverrideCommand: Option<Vec<String>> = None,
         /// Override the command used for test runnables.
         /// The first element of the array should be the program to execute (for example, `cargo`).
         ///
@@ -1684,10 +1710,14 @@ pub struct RunnablesConfig {
     pub test_command: String,
     /// Override the command used for test runnables.
     pub test_override_command: Option<Vec<String>>,
+    /// Override the command used for debugging test runnables.
+    pub test_debug_override_command: Option<Vec<String>>,
     /// Subcommand used for doctest runnables instead of `bench`.
     pub bench_command: String,
     /// Override the command used for bench runnables.
     pub bench_override_command: Option<Vec<String>>,
+    /// Override the command used for debugging bench runnables.
+    pub bench_debug_override_command: Option<Vec<String>>,
     /// Override the command used for doctest runnables.
     pub doc_test_override_command: Option<Vec<String>>,
 }
@@ -2648,8 +2678,14 @@ impl Config {
             extra_test_binary_args: self.runnables_extraTestBinaryArgs(source_root).clone(),
             test_command: self.runnables_test_command(source_root).clone(),
             test_override_command: self.runnables_test_overrideCommand(source_root).clone(),
+            test_debug_override_command: self
+                .runnables_test_debugOverrideCommand(source_root)
+                .clone(),
             bench_command: self.runnables_bench_command(source_root).clone(),
             bench_override_command: self.runnables_bench_overrideCommand(source_root).clone(),
+            bench_debug_override_command: self
+                .runnables_bench_debugOverrideCommand(source_root)
+                .clone(),
             doc_test_override_command: self.runnables_doctest_overrideCommand(source_root).clone(),
         }
     }

--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -974,7 +974,7 @@ config_data! {
         /// - `${include_ignored}`: always empty for benchmarks.
         /// - `${executable_args}`: all of the above binary args bundled together
         ///   (includes `rust-analyzer.runnables.extraTestBinaryArgs`).
-        runnables_bench_debugOverrideCommand: Option<Vec<String>> = None,
+        runnables_bench_overrideDebugCommand: Option<Vec<String>> = None,
         /// Override the command used for bench runnables.
         /// The first element of the array should be the program to execute (for example, `cargo`).
         ///
@@ -1028,7 +1028,7 @@ config_data! {
         /// - `${include_ignored}`: `--include-ignored` for single tests, empty otherwise.
         /// - `${executable_args}`: all of the above binary args bundled together
         ///   (includes `rust-analyzer.runnables.extraTestBinaryArgs`).
-        runnables_test_debugOverrideCommand: Option<Vec<String>> = None,
+        runnables_test_overrideDebugCommand: Option<Vec<String>> = None,
         /// Override the command used for test runnables.
         /// The first element of the array should be the program to execute (for example, `cargo`).
         ///
@@ -1711,13 +1711,13 @@ pub struct RunnablesConfig {
     /// Override the command used for test runnables.
     pub test_override_command: Option<Vec<String>>,
     /// Override the command used for debugging test runnables.
-    pub test_debug_override_command: Option<Vec<String>>,
+    pub test_override_debug_command: Option<Vec<String>>,
     /// Subcommand used for doctest runnables instead of `bench`.
     pub bench_command: String,
     /// Override the command used for bench runnables.
     pub bench_override_command: Option<Vec<String>>,
     /// Override the command used for debugging bench runnables.
-    pub bench_debug_override_command: Option<Vec<String>>,
+    pub bench_override_debug_command: Option<Vec<String>>,
     /// Override the command used for doctest runnables.
     pub doc_test_override_command: Option<Vec<String>>,
 }
@@ -2678,13 +2678,13 @@ impl Config {
             extra_test_binary_args: self.runnables_extraTestBinaryArgs(source_root).clone(),
             test_command: self.runnables_test_command(source_root).clone(),
             test_override_command: self.runnables_test_overrideCommand(source_root).clone(),
-            test_debug_override_command: self
-                .runnables_test_debugOverrideCommand(source_root)
+            test_override_debug_command: self
+                .runnables_test_overrideDebugCommand(source_root)
                 .clone(),
             bench_command: self.runnables_bench_command(source_root).clone(),
             bench_override_command: self.runnables_bench_overrideCommand(source_root).clone(),
-            bench_debug_override_command: self
-                .runnables_bench_debugOverrideCommand(source_root)
+            bench_override_debug_command: self
+                .runnables_bench_overrideDebugCommand(source_root)
                 .clone(),
             doc_test_override_command: self.runnables_doctest_overrideCommand(source_root).clone(),
         }

--- a/crates/rust-analyzer/src/handlers/request.rs
+++ b/crates/rust-analyzer/src/handlers/request.rs
@@ -1062,6 +1062,7 @@ pub(crate) fn handle_runnables(
                             .into_iter()
                             .collect(),
                     }),
+                    debug: None,
                 })
             }
         }
@@ -1083,6 +1084,7 @@ pub(crate) fn handle_runnables(
                         executable_args: Vec::new(),
                         environment: Default::default(),
                     }),
+                    debug: None,
                 });
             };
         }

--- a/crates/rust-analyzer/src/handlers/request.rs
+++ b/crates/rust-analyzer/src/handlers/request.rs
@@ -1008,7 +1008,7 @@ pub(crate) fn handle_runnables(
                 res.push(runnable);
             }
 
-            if let lsp_ext::RunnableArgs::Cargo(r) = &mut runnable.args
+            if let lsp_ext::RunnableArgs::Cargo(r) = &mut runnable.command.args
                 && let Some(TargetSpec::Cargo(CargoTargetSpec {
                     sysroot_root: Some(sysroot_root),
                     ..
@@ -1049,19 +1049,21 @@ pub(crate) fn handle_runnables(
                         all_targets = if all_targets { " --all-targets" } else { "" }
                     ),
                     location: None,
-                    args: lsp_ext::RunnableArgs::Cargo(lsp_ext::CargoRunnableArgs {
-                        workspace_root: Some(spec.workspace_root.clone().into()),
-                        cwd: cwd.into(),
-                        override_cargo: config.override_cargo.clone(),
-                        cargo_args,
-                        executable_args: Vec::new(),
-                        environment: spec
-                            .sysroot_root
-                            .as_ref()
-                            .map(|root| ("RUSTC_TOOLCHAIN".to_owned(), root.to_string()))
-                            .into_iter()
-                            .collect(),
-                    }),
+                    command: lsp_ext::RunnableCommand {
+                        args: lsp_ext::RunnableArgs::Cargo(lsp_ext::CargoRunnableArgs {
+                            workspace_root: Some(spec.workspace_root.clone().into()),
+                            cwd: cwd.into(),
+                            override_cargo: config.override_cargo.clone(),
+                            cargo_args,
+                            executable_args: Vec::new(),
+                            environment: spec
+                                .sysroot_root
+                                .as_ref()
+                                .map(|root| ("RUSTC_TOOLCHAIN".to_owned(), root.to_string()))
+                                .into_iter()
+                                .collect(),
+                        }),
+                    },
                     debug: None,
                 })
             }
@@ -1076,14 +1078,16 @@ pub(crate) fn handle_runnables(
                 res.push(lsp_ext::Runnable {
                     label: "cargo check --workspace".to_owned(),
                     location: None,
-                    args: lsp_ext::RunnableArgs::Cargo(lsp_ext::CargoRunnableArgs {
-                        workspace_root: None,
-                        cwd: path.as_path().unwrap().to_path_buf().into(),
-                        override_cargo: config.override_cargo,
-                        cargo_args,
-                        executable_args: Vec::new(),
-                        environment: Default::default(),
-                    }),
+                    command: lsp_ext::RunnableCommand {
+                        args: lsp_ext::RunnableArgs::Cargo(lsp_ext::CargoRunnableArgs {
+                            workspace_root: None,
+                            cwd: path.as_path().unwrap().to_path_buf().into(),
+                            override_cargo: config.override_cargo,
+                            cargo_args,
+                            executable_args: Vec::new(),
+                            environment: Default::default(),
+                        }),
+                    },
                     debug: None,
                 });
             };

--- a/crates/rust-analyzer/src/lsp/ext.rs
+++ b/crates/rust-analyzer/src/lsp/ext.rs
@@ -453,6 +453,15 @@ pub struct Runnable {
     pub location: Option<lsp_types::LocationLink>,
     #[serde(flatten)]
     pub args: RunnableArgs,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub debug: Option<RunnableCommand>,
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct RunnableCommand {
+    pub kind: RunnableKind,
+    pub args: RunnableArgs,
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone)]

--- a/crates/rust-analyzer/src/lsp/ext.rs
+++ b/crates/rust-analyzer/src/lsp/ext.rs
@@ -452,7 +452,7 @@ pub struct Runnable {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub location: Option<lsp_types::LocationLink>,
     #[serde(flatten)]
-    pub args: RunnableArgs,
+    pub command: RunnableCommand,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub debug: Option<RunnableCommand>,
 }
@@ -460,7 +460,7 @@ pub struct Runnable {
 #[derive(Deserialize, Serialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct RunnableCommand {
-    pub kind: RunnableKind,
+    #[serde(flatten)]
     pub args: RunnableArgs,
 }
 
@@ -893,21 +893,24 @@ mod tests {
         let runnable = Runnable {
             label: "cargo test -p my-crate".to_owned(),
             location: None,
-            args: RunnableArgs::Cargo(CargoRunnableArgs {
-                environment: [("RUSTC_TOOLCHAIN".to_owned(), "/toolchain".to_owned())]
-                    .into_iter()
-                    .collect(),
-                cwd: "/project".into(),
-                override_cargo: None,
-                workspace_root: Some("/project".into()),
-                cargo_args: vec![
-                    "test".into(),
-                    "--package".into(),
-                    "my-crate".into(),
-                    "--lib".into(),
-                ],
-                executable_args: vec!["my_test".into(), "--exact".into()],
-            }),
+            command: RunnableCommand {
+                args: RunnableArgs::Cargo(CargoRunnableArgs {
+                    environment: [("RUSTC_TOOLCHAIN".to_owned(), "/toolchain".to_owned())]
+                        .into_iter()
+                        .collect(),
+                    cwd: "/project".into(),
+                    override_cargo: None,
+                    workspace_root: Some("/project".into()),
+                    cargo_args: vec![
+                        "test".into(),
+                        "--package".into(),
+                        "my-crate".into(),
+                        "--lib".into(),
+                    ],
+                    executable_args: vec!["my_test".into(), "--exact".into()],
+                }),
+            },
+            debug: None,
         };
         let expected = json!({
             "label": "cargo test -p my-crate",
@@ -927,8 +930,8 @@ mod tests {
 
         let deserialized: Runnable =
             serde_json::from_value(expected).expect("cargo runnable should deserialize");
-        let RunnableArgs::Cargo(cargo) = &deserialized.args else {
-            panic!("expected Cargo variant, got {:?}", deserialized.args);
+        let RunnableArgs::Cargo(cargo) = &deserialized.command.args else {
+            panic!("expected Cargo variant, got {:?}", deserialized.command.args);
         };
         assert_eq!(cargo.cargo_args, vec!["test", "--package", "my-crate", "--lib"]);
         assert_eq!(cargo.executable_args, vec!["my_test", "--exact"]);
@@ -939,14 +942,22 @@ mod tests {
         let runnable = Runnable {
             label: "nextest test_one".to_owned(),
             location: None,
-            args: RunnableArgs::Shell(ShellRunnableArgs {
-                environment: [("RUSTC_TOOLCHAIN".to_owned(), "/toolchain".to_owned())]
-                    .into_iter()
-                    .collect(),
-                cwd: "/project".into(),
-                program: "cargo".into(),
-                args: vec!["nextest".into(), "run".into(), "--package".into(), "my-crate".into()],
-            }),
+            command: RunnableCommand {
+                args: RunnableArgs::Shell(ShellRunnableArgs {
+                    environment: [("RUSTC_TOOLCHAIN".to_owned(), "/toolchain".to_owned())]
+                        .into_iter()
+                        .collect(),
+                    cwd: "/project".into(),
+                    program: "cargo".into(),
+                    args: vec![
+                        "nextest".into(),
+                        "run".into(),
+                        "--package".into(),
+                        "my-crate".into(),
+                    ],
+                }),
+            },
+            debug: None,
         };
         let expected = json!({
             "label": "nextest test_one",
@@ -966,8 +977,8 @@ mod tests {
         // used. This test ensures that the `kind` tag is used.
         let deserialized: Runnable =
             serde_json::from_value(expected).expect("shell runnable should deserialize");
-        let RunnableArgs::Shell(shell) = &deserialized.args else {
-            panic!("expected Shell variant, got {:?}", deserialized.args);
+        let RunnableArgs::Shell(shell) = &deserialized.command.args else {
+            panic!("expected Shell variant, got {:?}", deserialized.command.args);
         };
         assert_eq!(shell.program, "cargo");
         assert_eq!(shell.args, vec!["nextest", "run", "--package", "my-crate"]);

--- a/crates/rust-analyzer/src/lsp/to_proto.rs
+++ b/crates/rust-analyzer/src/lsp/to_proto.rs
@@ -1597,11 +1597,21 @@ pub(crate) fn runnable(
             let label = runnable.label(Some(&target));
             let location = location_link(snap, None, runnable.nav)?;
 
-            let environment = spec
+            let environment: rustc_hash::FxHashMap<_, _> = spec
                 .sysroot_root
+                .as_ref()
                 .map(|root| ("RUSTC_TOOLCHAIN".to_owned(), root.to_string()))
                 .into_iter()
                 .collect();
+            let debug =
+                CargoTargetSpec::debug_override_command(snap, Some(spec.clone()), &runnable.kind)
+                    .and_then(|override_command| {
+                        shell_runnable_command(
+                            override_command,
+                            environment.clone(),
+                            cwd.clone().into(),
+                        )
+                    });
 
             Ok(match override_command {
                 Some(override_command) => match override_command.split_first() {
@@ -1614,6 +1624,7 @@ pub(crate) fn runnable(
                             program: program.to_string(),
                             args: args.to_vec(),
                         }),
+                        debug,
                     }),
                     _ => None,
                 },
@@ -1628,6 +1639,7 @@ pub(crate) fn runnable(
                         executable_args,
                         environment,
                     }),
+                    debug,
                 }),
             })
         }
@@ -1647,6 +1659,7 @@ pub(crate) fn runnable(
                         label,
                         location: Some(location),
                         args: lsp_ext::RunnableArgs::Shell(runnable_args),
+                        debug: None,
                     }))
                 }
                 None => Ok(None),
@@ -1673,9 +1686,27 @@ pub(crate) fn runnable(
                     executable_args,
                     environment: Default::default(),
                 }),
+                debug: None,
             }))
         }
     }
+}
+
+fn shell_runnable_command(
+    override_command: Vec<String>,
+    environment: rustc_hash::FxHashMap<String, String>,
+    cwd: paths::Utf8PathBuf,
+) -> Option<lsp_ext::RunnableCommand> {
+    let (program, args) = override_command.split_first()?;
+    Some(lsp_ext::RunnableCommand {
+        kind: lsp_ext::RunnableKind::Shell,
+        args: lsp_ext::RunnableArgs::Shell(lsp_ext::ShellRunnableArgs {
+            environment,
+            cwd,
+            program: program.to_string(),
+            args: args.to_vec(),
+        }),
+    })
 }
 
 pub(crate) fn code_lens(
@@ -1980,6 +2011,7 @@ pub(crate) fn make_update_runnable(
 
     let mut runnable = runnable.clone();
     runnable.label = format!("{} + {}", runnable.label, label);
+    runnable.debug = None;
 
     let lsp_ext::RunnableArgs::Cargo(r) = &mut runnable.args else {
         return None;

--- a/crates/rust-analyzer/src/lsp/to_proto.rs
+++ b/crates/rust-analyzer/src/lsp/to_proto.rs
@@ -1604,7 +1604,7 @@ pub(crate) fn runnable(
                 .into_iter()
                 .collect();
             let debug =
-                CargoTargetSpec::debug_override_command(snap, Some(spec.clone()), &runnable.kind)
+                CargoTargetSpec::override_debug_command(snap, Some(spec.clone()), &runnable.kind)
                     .and_then(|override_command| {
                         shell_runnable_command(
                             override_command,
@@ -1618,12 +1618,14 @@ pub(crate) fn runnable(
                     Some((program, args)) => Some(lsp_ext::Runnable {
                         label,
                         location: Some(location),
-                        args: lsp_ext::RunnableArgs::Shell(lsp_ext::ShellRunnableArgs {
-                            environment,
-                            cwd: cwd.into(),
-                            program: program.to_string(),
-                            args: args.to_vec(),
-                        }),
+                        command: lsp_ext::RunnableCommand {
+                            args: lsp_ext::RunnableArgs::Shell(lsp_ext::ShellRunnableArgs {
+                                environment,
+                                cwd: cwd.into(),
+                                program: program.to_string(),
+                                args: args.to_vec(),
+                            }),
+                        },
                         debug,
                     }),
                     _ => None,
@@ -1631,14 +1633,16 @@ pub(crate) fn runnable(
                 None => Some(lsp_ext::Runnable {
                     label,
                     location: Some(location),
-                    args: lsp_ext::RunnableArgs::Cargo(lsp_ext::CargoRunnableArgs {
-                        workspace_root: Some(workspace_root.into()),
-                        override_cargo: config.override_cargo,
-                        cargo_args,
-                        cwd: cwd.into(),
-                        executable_args,
-                        environment,
-                    }),
+                    command: lsp_ext::RunnableCommand {
+                        args: lsp_ext::RunnableArgs::Cargo(lsp_ext::CargoRunnableArgs {
+                            workspace_root: Some(workspace_root.into()),
+                            override_cargo: config.override_cargo,
+                            cargo_args,
+                            cwd: cwd.into(),
+                            executable_args,
+                            environment,
+                        }),
+                    },
                     debug,
                 }),
             })
@@ -1649,17 +1653,19 @@ pub(crate) fn runnable(
 
             match spec.runnable_args(&runnable.kind) {
                 Some(json_shell_runnable_args) => {
-                    let runnable_args = ShellRunnableArgs {
-                        program: json_shell_runnable_args.program,
-                        args: json_shell_runnable_args.args,
-                        cwd: json_shell_runnable_args.cwd,
-                        environment: Default::default(),
+                    let command = lsp_ext::RunnableCommand {
+                        args: lsp_ext::RunnableArgs::Shell(ShellRunnableArgs {
+                            program: json_shell_runnable_args.program,
+                            args: json_shell_runnable_args.args,
+                            cwd: json_shell_runnable_args.cwd,
+                            environment: Default::default(),
+                        }),
                     };
                     Ok(Some(lsp_ext::Runnable {
                         label,
                         location: Some(location),
-                        args: lsp_ext::RunnableArgs::Shell(runnable_args),
-                        debug: None,
+                        command: command.clone(),
+                        debug: Some(command),
                     }))
                 }
                 None => Ok(None),
@@ -1675,9 +1681,7 @@ pub(crate) fn runnable(
             let label = runnable.label(None);
             let location = location_link(snap, None, runnable.nav)?;
 
-            Ok(Some(lsp_ext::Runnable {
-                label,
-                location: Some(location),
+            let command = lsp_ext::RunnableCommand {
                 args: lsp_ext::RunnableArgs::Cargo(lsp_ext::CargoRunnableArgs {
                     workspace_root: None,
                     override_cargo: config.override_cargo,
@@ -1686,7 +1690,13 @@ pub(crate) fn runnable(
                     executable_args,
                     environment: Default::default(),
                 }),
-                debug: None,
+            };
+
+            Ok(Some(lsp_ext::Runnable {
+                label,
+                location: Some(location),
+                command: command.clone(),
+                debug: Some(command),
             }))
         }
     }
@@ -1699,7 +1709,6 @@ fn shell_runnable_command(
 ) -> Option<lsp_ext::RunnableCommand> {
     let (program, args) = override_command.split_first()?;
     Some(lsp_ext::RunnableCommand {
-        kind: lsp_ext::RunnableKind::Shell,
         args: lsp_ext::RunnableArgs::Shell(lsp_ext::ShellRunnableArgs {
             environment,
             cwd,
@@ -1732,7 +1741,7 @@ pub(crate) fn code_lens(
             let r = runnable(snap, run)?;
 
             if let Some(r) = r {
-                let has_root = match &r.args {
+                let has_root = match &r.command.args {
                     lsp_ext::RunnableArgs::Cargo(c) => c.workspace_root.is_some(),
                     lsp_ext::RunnableArgs::Shell(_) => true,
                 };
@@ -2013,7 +2022,7 @@ pub(crate) fn make_update_runnable(
     runnable.label = format!("{} + {}", runnable.label, label);
     runnable.debug = None;
 
-    let lsp_ext::RunnableArgs::Cargo(r) = &mut runnable.args else {
+    let lsp_ext::RunnableArgs::Cargo(r) = &mut runnable.command.args else {
         return None;
     };
 

--- a/crates/rust-analyzer/src/target_spec.rs
+++ b/crates/rust-analyzer/src/target_spec.rs
@@ -221,13 +221,64 @@ impl CargoTargetSpec {
             RunnableKind::DocTest { test_id } => {
                 (config.doc_test_override_command, Some(test_id.to_string()))
             }
-            RunnableKind::Bin => match spec {
+            RunnableKind::Bin => match &spec {
                 Some(CargoTargetSpec { target_kind: TargetKind::Test, .. }) => {
                     (config.test_override_command, None)
                 }
                 _ => (None, None),
             },
         };
+
+        Self::expand_override_command(
+            spec.as_ref(),
+            kind,
+            args,
+            test_name,
+            config.extra_test_binary_args,
+        )
+    }
+
+    pub(crate) fn debug_override_command(
+        snap: &GlobalStateSnapshot,
+        spec: Option<CargoTargetSpec>,
+        kind: &RunnableKind,
+    ) -> Option<Vec<String>> {
+        let config = snap.config.runnables(None);
+        let (args, test_name) = match kind {
+            RunnableKind::Test { test_id, .. } => {
+                (config.test_debug_override_command, Some(test_id.to_string()))
+            }
+            RunnableKind::TestMod { path } => {
+                (config.test_debug_override_command, Some(path.clone()))
+            }
+            RunnableKind::Bench { test_id } => {
+                (config.bench_debug_override_command, Some(test_id.to_string()))
+            }
+            RunnableKind::Bin => match &spec {
+                Some(CargoTargetSpec { target_kind: TargetKind::Test, .. }) => {
+                    (config.test_debug_override_command, None)
+                }
+                _ => (None, None),
+            },
+            _ => (None, None),
+        };
+
+        Self::expand_override_command(
+            spec.as_ref(),
+            kind,
+            args,
+            test_name,
+            config.extra_test_binary_args,
+        )
+    }
+
+    fn expand_override_command(
+        spec: Option<&CargoTargetSpec>,
+        kind: &RunnableKind,
+        args: Option<Vec<String>>,
+        test_name: Option<String>,
+        extra_test_binary_args: Vec<String>,
+    ) -> Option<Vec<String>> {
         let test_name = test_name.unwrap_or_default();
 
         let exact = match kind {
@@ -256,7 +307,7 @@ impl CargoTargetSpec {
             _ => "",
         };
 
-        let replace_placeholders = |arg: String| match &spec {
+        let replace_placeholders = |arg: String| match spec {
             Some(spec) => arg
                 .replace("${package}", &spec.package)
                 .replace("${target_arg}", target_arg(spec.target_kind))
@@ -267,7 +318,6 @@ impl CargoTargetSpec {
             _ => arg,
         };
 
-        let extra_test_binary_args = config.extra_test_binary_args;
         let executable_args = Self::executable_args_for(kind, extra_test_binary_args);
 
         args.map(|mut args| {

--- a/crates/rust-analyzer/src/target_spec.rs
+++ b/crates/rust-analyzer/src/target_spec.rs
@@ -238,7 +238,7 @@ impl CargoTargetSpec {
         )
     }
 
-    pub(crate) fn debug_override_command(
+    pub(crate) fn override_debug_command(
         snap: &GlobalStateSnapshot,
         spec: Option<CargoTargetSpec>,
         kind: &RunnableKind,
@@ -246,17 +246,17 @@ impl CargoTargetSpec {
         let config = snap.config.runnables(None);
         let (args, test_name) = match kind {
             RunnableKind::Test { test_id, .. } => {
-                (config.test_debug_override_command, Some(test_id.to_string()))
+                (config.test_override_debug_command, Some(test_id.to_string()))
             }
             RunnableKind::TestMod { path } => {
-                (config.test_debug_override_command, Some(path.clone()))
+                (config.test_override_debug_command, Some(path.clone()))
             }
             RunnableKind::Bench { test_id } => {
-                (config.bench_debug_override_command, Some(test_id.to_string()))
+                (config.bench_override_debug_command, Some(test_id.to_string()))
             }
             RunnableKind::Bin => match &spec {
                 Some(CargoTargetSpec { target_kind: TargetKind::Test, .. }) => {
-                    (config.test_debug_override_command, None)
+                    (config.test_override_debug_command, None)
                 }
                 _ => (None, None),
             },

--- a/crates/rust-analyzer/tests/slow-tests/main.rs
+++ b/crates/rust-analyzer/tests/slow-tests/main.rs
@@ -350,6 +350,82 @@ fn main() {}
     );
 }
 
+#[test]
+fn test_runnables_debug_override_command() {
+    if skip_slow_tests() {
+        return;
+    }
+
+    let server = Project::with_fixture(
+        r#"
+//- /foo/Cargo.toml
+[package]
+name = "foo"
+version = "0.0.0"
+
+//- /foo/tests/spam.rs
+#[test]
+fn test_eggs() {}
+"#,
+    )
+    .with_config(json!({
+        "runnables": {
+            "test": {
+                "overrideCommand": [
+                    "cargo", "nextest", "run",
+                    "--package", "${package}", "${target_arg}", "${target}",
+                    "--", "${executable_args}",
+                ],
+                "debugOverrideCommand": [
+                    "cargo", "nextest", "run",
+                    "--debugger", "codelldb-launch --",
+                    "--package", "${package}", "${target_arg}", "${target}",
+                    "--", "${executable_args}",
+                ],
+            },
+        },
+    }))
+    .root("foo")
+    .server()
+    .wait_until_workspace_is_loaded();
+
+    server.request::<Runnables>(
+        RunnablesParams { text_document: server.doc_id("foo/tests/spam.rs"), position: None },
+        json!([
+            {
+                "args": {
+                    "args": [
+                        "nextest", "run",
+                        "--package", "foo", "--test", "spam",
+                        "--", "test_eggs", "--exact", "--nocapture", "--include-ignored",
+                    ],
+                    "cwd": server.path().join("foo"),
+                    "program": "cargo",
+                },
+                "debug": {
+                    "args": {
+                        "args": [
+                            "nextest", "run",
+                            "--debugger", "codelldb-launch --",
+                            "--package", "foo", "--test", "spam",
+                            "--", "test_eggs", "--exact", "--nocapture", "--include-ignored",
+                        ],
+                        "cwd": server.path().join("foo"),
+                        "program": "cargo",
+                    },
+                    "kind": "shell",
+                },
+                "kind": "shell",
+                "label": "test test_eggs",
+                "location": "{...}",
+            },
+            "{...}",
+            "{...}",
+            "{...}",
+        ]),
+    );
+}
+
 // Each package in these workspaces should be run from its own root
 #[test]
 fn test_path_dependency_runnables() {

--- a/crates/rust-analyzer/tests/slow-tests/main.rs
+++ b/crates/rust-analyzer/tests/slow-tests/main.rs
@@ -351,7 +351,7 @@ fn main() {}
 }
 
 #[test]
-fn test_runnables_debug_override_command() {
+fn test_runnables_override_debug_command() {
     if skip_slow_tests() {
         return;
     }
@@ -376,7 +376,7 @@ fn test_eggs() {}
                     "--package", "${package}", "${target_arg}", "${target}",
                     "--", "${executable_args}",
                 ],
-                "debugOverrideCommand": [
+                "overrideDebugCommand": [
                     "cargo", "nextest", "run",
                     "--debugger", "codelldb-launch --",
                     "--package", "${package}", "${target_arg}", "${target}",

--- a/docs/book/src/configuration_generated.md
+++ b/docs/book/src/configuration_generated.md
@@ -1406,11 +1406,11 @@ Default: `"bench"`
 Subcommand used for bench runnables instead of `bench`.
 
 
-## rust-analyzer.runnables.bench.debugOverrideCommand {#runnables.bench.debugOverrideCommand}
+## rust-analyzer.runnables.bench.overrideCommand {#runnables.bench.overrideCommand}
 
 Default: `null`
 
-Override the command used for debugging bench runnables.
+Override the command used for bench runnables.
 The first element of the array should be the program to execute (for example, `cargo`).
 
 Use the placeholders:
@@ -1424,11 +1424,11 @@ Use the placeholders:
   (includes `rust-analyzer.runnables.extraTestBinaryArgs`).
 
 
-## rust-analyzer.runnables.bench.overrideCommand {#runnables.bench.overrideCommand}
+## rust-analyzer.runnables.bench.overrideDebugCommand {#runnables.bench.overrideDebugCommand}
 
 Default: `null`
 
-Override the command used for bench runnables.
+Override the command used for debugging bench runnables.
 The first element of the array should be the program to execute (for example, `cargo`).
 
 Use the placeholders:
@@ -1500,11 +1500,11 @@ Default: `"test"`
 Subcommand used for test runnables instead of `test`.
 
 
-## rust-analyzer.runnables.test.debugOverrideCommand {#runnables.test.debugOverrideCommand}
+## rust-analyzer.runnables.test.overrideCommand {#runnables.test.overrideCommand}
 
 Default: `null`
 
-Override the command used for debugging test runnables.
+Override the command used for test runnables.
 The first element of the array should be the program to execute (for example, `cargo`).
 
 Available placeholders:
@@ -1518,11 +1518,11 @@ Available placeholders:
   (includes `rust-analyzer.runnables.extraTestBinaryArgs`).
 
 
-## rust-analyzer.runnables.test.overrideCommand {#runnables.test.overrideCommand}
+## rust-analyzer.runnables.test.overrideDebugCommand {#runnables.test.overrideDebugCommand}
 
 Default: `null`
 
-Override the command used for test runnables.
+Override the command used for debugging test runnables.
 The first element of the array should be the program to execute (for example, `cargo`).
 
 Available placeholders:

--- a/docs/book/src/configuration_generated.md
+++ b/docs/book/src/configuration_generated.md
@@ -1406,6 +1406,24 @@ Default: `"bench"`
 Subcommand used for bench runnables instead of `bench`.
 
 
+## rust-analyzer.runnables.bench.debugOverrideCommand {#runnables.bench.debugOverrideCommand}
+
+Default: `null`
+
+Override the command used for debugging bench runnables.
+The first element of the array should be the program to execute (for example, `cargo`).
+
+Use the placeholders:
+- `${package}`: package name.
+- `${target_arg}`: target option such as `--bin`, `--test`, `--lib`, etc.
+- `${target}`: target name (empty for `--lib`).
+- `${test_name}`: the test path filter, e.g. `module::bench_func`.
+- `${exact}`: `--exact` for single benchmarks, empty for modules.
+- `${include_ignored}`: always empty for benchmarks.
+- `${executable_args}`: all of the above binary args bundled together
+  (includes `rust-analyzer.runnables.extraTestBinaryArgs`).
+
+
 ## rust-analyzer.runnables.bench.overrideCommand {#runnables.bench.overrideCommand}
 
 Default: `null`
@@ -1480,6 +1498,24 @@ they will end up being interpreted as options to
 Default: `"test"`
 
 Subcommand used for test runnables instead of `test`.
+
+
+## rust-analyzer.runnables.test.debugOverrideCommand {#runnables.test.debugOverrideCommand}
+
+Default: `null`
+
+Override the command used for debugging test runnables.
+The first element of the array should be the program to execute (for example, `cargo`).
+
+Available placeholders:
+- `${package}`: package name.
+- `${target_arg}`: target option such as `--bin`, `--test`, `--lib`, etc.
+- `${target}`: target name (empty for `--lib`).
+- `${test_name}`: the test path filter, e.g. `module::test_func`.
+- `${exact}`: `--exact` for single tests, empty for modules.
+- `${include_ignored}`: `--include-ignored` for single tests, empty otherwise.
+- `${executable_args}`: all of the above binary args bundled together
+  (includes `rust-analyzer.runnables.extraTestBinaryArgs`).
 
 
 ## rust-analyzer.runnables.test.overrideCommand {#runnables.test.overrideCommand}

--- a/docs/book/src/contributing/lsp-extensions.md
+++ b/docs/book/src/contributing/lsp-extensions.md
@@ -1,5 +1,5 @@
 <!---
-lsp/ext.rs hash: 57ae57d2a5c65b14 
+lsp/ext.rs hash: 28a6bc69c6bcf74e
 
 If you need to change the above hash to make the test pass, please check if you
 need to adjust this doc as well and ping this issue:

--- a/docs/book/src/contributing/lsp-extensions.md
+++ b/docs/book/src/contributing/lsp-extensions.md
@@ -369,6 +369,13 @@ interface Runnable {
     // the type of `args` is specific to `kind`. The actual running is handled by the client.
     kind: string;
     args: any;
+    /// Optional command to use when debugging this runnable.
+    debug?: RunnableCommand;
+}
+
+interface RunnableCommand {
+    kind: string;
+    args: any;
 }
 ```
 

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -2918,6 +2918,22 @@
             {
                 "title": "Runnables",
                 "properties": {
+                    "rust-analyzer.runnables.bench.debugOverrideCommand": {
+                        "markdownDescription": "Override the command used for debugging bench runnables.\nThe first element of the array should be the program to execute (for example, `cargo`).\n\nUse the placeholders:\n- `${package}`: package name.\n- `${target_arg}`: target option such as `--bin`, `--test`, `--lib`, etc.\n- `${target}`: target name (empty for `--lib`).\n- `${test_name}`: the test path filter, e.g. `module::bench_func`.\n- `${exact}`: `--exact` for single benchmarks, empty for modules.\n- `${include_ignored}`: always empty for benchmarks.\n- `${executable_args}`: all of the above binary args bundled together\n    (includes `rust-analyzer.runnables.extraTestBinaryArgs`).",
+                        "default": null,
+                        "type": [
+                            "null",
+                            "array"
+                        ],
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                }
+            },
+            {
+                "title": "Runnables",
+                "properties": {
                     "rust-analyzer.runnables.bench.overrideCommand": {
                         "markdownDescription": "Override the command used for bench runnables.\nThe first element of the array should be the program to execute (for example, `cargo`).\n\nUse the placeholders:\n- `${package}`: package name.\n- `${target_arg}`: target option such as `--bin`, `--test`, `--lib`, etc.\n- `${target}`: target name (empty for `--lib`).\n- `${test_name}`: the test path filter, e.g. `module::bench_func`.\n- `${exact}`: `--exact` for single benchmarks, empty for modules.\n- `${include_ignored}`: always empty for benchmarks.\n- `${executable_args}`: all of the above binary args bundled together\n    (includes `rust-analyzer.runnables.extraTestBinaryArgs`).",
                         "default": null,
@@ -2995,6 +3011,22 @@
                         "markdownDescription": "Subcommand used for test runnables instead of `test`.",
                         "default": "test",
                         "type": "string"
+                    }
+                }
+            },
+            {
+                "title": "Runnables",
+                "properties": {
+                    "rust-analyzer.runnables.test.debugOverrideCommand": {
+                        "markdownDescription": "Override the command used for debugging test runnables.\nThe first element of the array should be the program to execute (for example, `cargo`).\n\nAvailable placeholders:\n- `${package}`: package name.\n- `${target_arg}`: target option such as `--bin`, `--test`, `--lib`, etc.\n- `${target}`: target name (empty for `--lib`).\n- `${test_name}`: the test path filter, e.g. `module::test_func`.\n- `${exact}`: `--exact` for single tests, empty for modules.\n- `${include_ignored}`: `--include-ignored` for single tests, empty otherwise.\n- `${executable_args}`: all of the above binary args bundled together\n    (includes `rust-analyzer.runnables.extraTestBinaryArgs`).",
+                        "default": null,
+                        "type": [
+                            "null",
+                            "array"
+                        ],
+                        "items": {
+                            "type": "string"
+                        }
                     }
                 }
             },

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -2918,8 +2918,8 @@
             {
                 "title": "Runnables",
                 "properties": {
-                    "rust-analyzer.runnables.bench.debugOverrideCommand": {
-                        "markdownDescription": "Override the command used for debugging bench runnables.\nThe first element of the array should be the program to execute (for example, `cargo`).\n\nUse the placeholders:\n- `${package}`: package name.\n- `${target_arg}`: target option such as `--bin`, `--test`, `--lib`, etc.\n- `${target}`: target name (empty for `--lib`).\n- `${test_name}`: the test path filter, e.g. `module::bench_func`.\n- `${exact}`: `--exact` for single benchmarks, empty for modules.\n- `${include_ignored}`: always empty for benchmarks.\n- `${executable_args}`: all of the above binary args bundled together\n    (includes `rust-analyzer.runnables.extraTestBinaryArgs`).",
+                    "rust-analyzer.runnables.bench.overrideCommand": {
+                        "markdownDescription": "Override the command used for bench runnables.\nThe first element of the array should be the program to execute (for example, `cargo`).\n\nUse the placeholders:\n- `${package}`: package name.\n- `${target_arg}`: target option such as `--bin`, `--test`, `--lib`, etc.\n- `${target}`: target name (empty for `--lib`).\n- `${test_name}`: the test path filter, e.g. `module::bench_func`.\n- `${exact}`: `--exact` for single benchmarks, empty for modules.\n- `${include_ignored}`: always empty for benchmarks.\n- `${executable_args}`: all of the above binary args bundled together\n    (includes `rust-analyzer.runnables.extraTestBinaryArgs`).",
                         "default": null,
                         "type": [
                             "null",
@@ -2934,8 +2934,8 @@
             {
                 "title": "Runnables",
                 "properties": {
-                    "rust-analyzer.runnables.bench.overrideCommand": {
-                        "markdownDescription": "Override the command used for bench runnables.\nThe first element of the array should be the program to execute (for example, `cargo`).\n\nUse the placeholders:\n- `${package}`: package name.\n- `${target_arg}`: target option such as `--bin`, `--test`, `--lib`, etc.\n- `${target}`: target name (empty for `--lib`).\n- `${test_name}`: the test path filter, e.g. `module::bench_func`.\n- `${exact}`: `--exact` for single benchmarks, empty for modules.\n- `${include_ignored}`: always empty for benchmarks.\n- `${executable_args}`: all of the above binary args bundled together\n    (includes `rust-analyzer.runnables.extraTestBinaryArgs`).",
+                    "rust-analyzer.runnables.bench.overrideDebugCommand": {
+                        "markdownDescription": "Override the command used for debugging bench runnables.\nThe first element of the array should be the program to execute (for example, `cargo`).\n\nUse the placeholders:\n- `${package}`: package name.\n- `${target_arg}`: target option such as `--bin`, `--test`, `--lib`, etc.\n- `${target}`: target name (empty for `--lib`).\n- `${test_name}`: the test path filter, e.g. `module::bench_func`.\n- `${exact}`: `--exact` for single benchmarks, empty for modules.\n- `${include_ignored}`: always empty for benchmarks.\n- `${executable_args}`: all of the above binary args bundled together\n    (includes `rust-analyzer.runnables.extraTestBinaryArgs`).",
                         "default": null,
                         "type": [
                             "null",
@@ -3017,8 +3017,8 @@
             {
                 "title": "Runnables",
                 "properties": {
-                    "rust-analyzer.runnables.test.debugOverrideCommand": {
-                        "markdownDescription": "Override the command used for debugging test runnables.\nThe first element of the array should be the program to execute (for example, `cargo`).\n\nAvailable placeholders:\n- `${package}`: package name.\n- `${target_arg}`: target option such as `--bin`, `--test`, `--lib`, etc.\n- `${target}`: target name (empty for `--lib`).\n- `${test_name}`: the test path filter, e.g. `module::test_func`.\n- `${exact}`: `--exact` for single tests, empty for modules.\n- `${include_ignored}`: `--include-ignored` for single tests, empty otherwise.\n- `${executable_args}`: all of the above binary args bundled together\n    (includes `rust-analyzer.runnables.extraTestBinaryArgs`).",
+                    "rust-analyzer.runnables.test.overrideCommand": {
+                        "markdownDescription": "Override the command used for test runnables.\nThe first element of the array should be the program to execute (for example, `cargo`).\n\nAvailable placeholders:\n- `${package}`: package name.\n- `${target_arg}`: target option such as `--bin`, `--test`, `--lib`, etc.\n- `${target}`: target name (empty for `--lib`).\n- `${test_name}`: the test path filter, e.g. `module::test_func`.\n- `${exact}`: `--exact` for single tests, empty for modules.\n- `${include_ignored}`: `--include-ignored` for single tests, empty otherwise.\n- `${executable_args}`: all of the above binary args bundled together\n    (includes `rust-analyzer.runnables.extraTestBinaryArgs`).",
                         "default": null,
                         "type": [
                             "null",
@@ -3033,8 +3033,8 @@
             {
                 "title": "Runnables",
                 "properties": {
-                    "rust-analyzer.runnables.test.overrideCommand": {
-                        "markdownDescription": "Override the command used for test runnables.\nThe first element of the array should be the program to execute (for example, `cargo`).\n\nAvailable placeholders:\n- `${package}`: package name.\n- `${target_arg}`: target option such as `--bin`, `--test`, `--lib`, etc.\n- `${target}`: target name (empty for `--lib`).\n- `${test_name}`: the test path filter, e.g. `module::test_func`.\n- `${exact}`: `--exact` for single tests, empty for modules.\n- `${include_ignored}`: `--include-ignored` for single tests, empty otherwise.\n- `${executable_args}`: all of the above binary args bundled together\n    (includes `rust-analyzer.runnables.extraTestBinaryArgs`).",
+                    "rust-analyzer.runnables.test.overrideDebugCommand": {
+                        "markdownDescription": "Override the command used for debugging test runnables.\nThe first element of the array should be the program to execute (for example, `cargo`).\n\nAvailable placeholders:\n- `${package}`: package name.\n- `${target_arg}`: target option such as `--bin`, `--test`, `--lib`, etc.\n- `${target}`: target name (empty for `--lib`).\n- `${test_name}`: the test path filter, e.g. `module::test_func`.\n- `${exact}`: `--exact` for single tests, empty for modules.\n- `${include_ignored}`: `--include-ignored` for single tests, empty otherwise.\n- `${executable_args}`: all of the above binary args bundled together\n    (includes `rust-analyzer.runnables.extraTestBinaryArgs`).",
                         "default": null,
                         "type": [
                             "null",

--- a/editors/code/src/debug.ts
+++ b/editors/code/src/debug.ts
@@ -50,6 +50,7 @@ export async function makeDebugConfig(ctx: Ctx, runnable: ra.Runnable): Promise<
 export async function startDebugSession(ctx: Ctx, runnable: ra.Runnable): Promise<boolean> {
     let debugConfig: vscode.DebugConfiguration | undefined;
     let message = "";
+    const { runnable: debugRunnable, hasDebugOverride } = runnableForDebug(runnable);
 
     const wsLaunchSection = vscode.workspace.getConfiguration("launch");
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -61,8 +62,12 @@ export async function startDebugSession(ctx: Ctx, runnable: ra.Runnable): Promis
     if (-1 !== index) {
         debugConfig = configurations[index];
         message = " (from launch.json)";
+    } else if (hasDebugOverride && debugRunnable.kind === "shell") {
+        const task = await createTaskFromRunnable(debugRunnable, ctx.config, true);
+        await vscode.tasks.executeTask(task);
+        return true;
     } else {
-        debugConfig = await getDebugConfiguration(ctx.config, runnable);
+        debugConfig = await getDebugConfiguration(ctx.config, debugRunnable);
     }
 
     if (!debugConfig) return false;
@@ -70,6 +75,23 @@ export async function startDebugSession(ctx: Ctx, runnable: ra.Runnable): Promis
     log.debug(`Launching debug configuration${message}:`);
     log.debug(JSON.stringify(debugConfig, null, 2));
     return vscode.debug.startDebugging(undefined, debugConfig);
+}
+
+function runnableForDebug(runnable: ra.Runnable): {
+    runnable: ra.Runnable;
+    hasDebugOverride: boolean;
+} {
+    const debug = runnable.debug;
+    if (!debug) {
+        return { runnable, hasDebugOverride: false };
+    }
+
+    const debugRunnable: ra.Runnable =
+        debug.kind === "cargo"
+            ? { ...runnable, kind: "cargo", args: debug.args }
+            : { ...runnable, kind: "shell", args: debug.args };
+
+    return { runnable: debugRunnable, hasDebugOverride: true };
 }
 
 function createCommandLink(extensionId: string): string {

--- a/editors/code/src/dependencies_provider.ts
+++ b/editors/code/src/dependencies_provider.ts
@@ -6,9 +6,9 @@ import * as ra from "./lsp_ext";
 import type { FetchDependencyListResult } from "./lsp_ext";
 import { unwrapUndefinable } from "./util";
 
-export class RustDependenciesProvider implements vscode.TreeDataProvider<
-    Dependency | DependencyFile
-> {
+export class RustDependenciesProvider
+    implements vscode.TreeDataProvider<Dependency | DependencyFile>
+{
     dependenciesMap: { [id: string]: Dependency | DependencyFile };
     ctx: CtxInit;
 

--- a/editors/code/src/lsp_ext.ts
+++ b/editors/code/src/lsp_ext.ts
@@ -232,7 +232,10 @@ export type OpenCargoTomlParams = {
 export type Runnable = {
     label: string;
     location?: lc.LocationLink;
-} & (RunnableCargo | RunnableShell);
+    debug?: RunnableCommand;
+} & RunnableCommand;
+
+export type RunnableCommand = RunnableCargo | RunnableShell;
 
 type RunnableCargo = {
     kind: "cargo";

--- a/editors/code/src/run.ts
+++ b/editors/code/src/run.ts
@@ -146,6 +146,7 @@ export function prepareEnv(inheritEnv: boolean, runnableEnv?: Env, runnableEnvCf
 export async function createTaskFromRunnable(
     runnable: ra.Runnable,
     config: Config,
+    includeShellExtraEnv = false,
 ): Promise<vscode.Task> {
     const target = vscode.workspace.workspaceFolders?.[0];
 
@@ -186,7 +187,13 @@ export async function createTaskFromRunnable(
         };
         options = {
             cwd: runnableArgs.cwd,
-            env: prepareBaseEnv(true),
+            env: includeShellExtraEnv
+                ? prepareEnv(
+                      true,
+                      runnableArgs.environment,
+                      config.runnablesExtraEnv(runnable.label),
+                  )
+                : prepareBaseEnv(true),
         };
     }
 


### PR DESCRIPTION
Closes rust-lang/rust-analyzer#22128

Adds `debugOverrideCommand` for test and bench runnables so debug can use a different command from Run. This is needed for runners like nextest, where running a test and debugging a test require different command shapes.

The setting is opt-in. Existing `overrideCommand`, Cargo debug config generation, and matching `launch.json` entries keep their current behavior.

For reference, here's my setup with this PR active.

```json
{
    "rust-analyzer.server.path": "$HOME/Workspaces/rust-analyzer/target/debug/rust-analyzer",
    "rust-analyzer.runnables.test.overrideCommand": [
        "nix",
        "shell",
        "nixpkgs#cargo-nextest",
        "-c",
        "cargo",
        "nextest",
        "run",
        "--config",
        "profile.dev.debug=2",
        "--package",
        "${package}",
        "${target_arg}",
        "${target}",
        "--",
        "${test_name}",
        "${exact}",
        "${include_ignored}"
    ],
    "rust-analyzer.runnables.test.debugOverrideCommand": [
        "nix",
        "shell",
        "nixpkgs#cargo-nextest",
        "-c",
        "cargo",
        "nextest",
        "run",
        "--config",
        "profile.dev.debug=2",
        "--package",
        "${package}",
        "${target_arg}",
        "${target}",
        "--debugger",
        "$HOME/.vscode/extensions/vadimcn.vscode-lldb-1.12.1/bin/codelldb-launch --connect 127.0.0.1:12345 --",
        "--",
        "${test_name}",
        "${exact}",
        "${include_ignored}"
    ],
    "rust-analyzer.runnables.extraEnv": {
        "CODELLDB_LAUNCH_CONFIG": "{ token: 'secret' }"
    },
    "lldb.rpcServer": {
        "host": "127.0.0.1",
        "port": 12345,
        "token": "secret"
    }
}
```