### PR TITLE
ide-diagnostics: emit error for mismatched array pattern length

### DIFF
--- a/crates/hir-ty/src/infer.rs
+++ b/crates/hir-ty/src/infer.rs
@@ -319,6 +319,16 @@ pub enum InferenceDiagnostic {
         #[type_visitable(ignore)]
         variant: VariantId,
     },
+    MismatchedArrayPatLen {
+        #[type_visitable(ignore)]
+        pat: PatId,
+        #[type_visitable(ignore)]
+        expected: u128,
+        #[type_visitable(ignore)]
+        found: u128,
+        #[type_visitable(ignore)]
+        has_rest: bool,
+    },
     PrivateField {
         #[type_visitable(ignore)]
         expr: ExprId,

--- a/crates/hir-ty/src/infer/pat.rs
+++ b/crates/hir-ty/src/infer/pat.rs
@@ -1649,7 +1649,12 @@ https://doc.rust-lang.org/reference/types.html#trait-objects";
                     return (None, arr_ty);
                 }
 
-                // FIXME: Emit an error: incorrect length.
+                self.push_diagnostic(InferenceDiagnostic::MismatchedArrayPatLen {
+                    pat,
+                    expected: len,
+                    found: min_len,
+                    has_rest: false,
+                });
             } else if let Some(pat_len) = len.checked_sub(min_len) {
                 // The variable-length pattern was there,
                 // so it has an array type with the remaining elements left as its size...
@@ -1657,7 +1662,12 @@ https://doc.rust-lang.org/reference/types.html#trait-objects";
             } else {
                 // ...however, in this case, there were no remaining elements.
                 // That is, the slice pattern requires more than the array type offers.
-                // FIXME: Emit an error.
+                self.push_diagnostic(InferenceDiagnostic::MismatchedArrayPatLen {
+                    pat,
+                    expected: len,
+                    found: min_len,
+                    has_rest: true,
+                });
             }
         } else if slice.is_none() {
             // We have a pattern with a fixed length,

--- a/crates/hir/src/diagnostics.rs
+++ b/crates/hir/src/diagnostics.rs
@@ -81,6 +81,7 @@ diagnostics![AnyDiagnostic<'db> ->
     NonExhaustiveLet,
     NonExhaustiveRecordExpr,
     NoSuchField,
+    MismatchedArrayPatLen,
     PatternArgInExternFn,
     PrivateAssocItem,
     PrivateField,
@@ -229,6 +230,14 @@ pub struct MismatchedTupleStructPatArgCount {
     pub expr_or_pat: InFile<ExprOrPatPtr>,
     pub expected: usize,
     pub found: usize,
+}
+
+#[derive(Debug)]
+pub struct MismatchedArrayPatLen {
+    pub pat: InFile<ExprOrPatPtr>,
+    pub expected: u128,
+    pub found: u128,
+    pub has_rest: bool,
 }
 
 #[derive(Debug)]
@@ -671,6 +680,10 @@ impl<'db> AnyDiagnostic<'db> {
                 };
                 let private = private.map(|id| Field { id, parent: variant.into() });
                 NoSuchField { field: expr_or_pat, private, variant }.into()
+            }
+            &InferenceDiagnostic::MismatchedArrayPatLen { pat, expected, found, has_rest } => {
+                let pat = pat_syntax(pat)?.map(Into::into);
+                MismatchedArrayPatLen { pat, expected, found, has_rest }.into()
             }
             &InferenceDiagnostic::MismatchedArgCount { call_expr, expected, found } => {
                 MismatchedArgCount { call_expr: expr_syntax(call_expr)?, expected, found }.into()

--- a/crates/ide-diagnostics/src/handlers/mismatched_array_pat_len.rs
+++ b/crates/ide-diagnostics/src/handlers/mismatched_array_pat_len.rs
@@ -1,0 +1,114 @@
+use crate::{Diagnostic, DiagnosticCode, DiagnosticsContext};
+
+// Diagnostic: mismatched-array-pat-len
+//
+// This diagnostic is triggered when an array pattern's element count does not
+// match the array's declared length.
+pub(crate) fn mismatched_array_pat_len(
+    ctx: &DiagnosticsContext<'_, '_>,
+    d: &hir::MismatchedArrayPatLen,
+) -> Diagnostic {
+    let (code, message) = if d.has_rest {
+        (
+            "E0528",
+            format!(
+                "pattern requires at least {} element{} but array has {}",
+                d.found,
+                if d.found == 1 { "" } else { "s" },
+                d.expected,
+            ),
+        )
+    } else {
+        (
+            "E0527",
+            format!(
+                "pattern requires {} element{} but array has {}",
+                d.found,
+                if d.found == 1 { "" } else { "s" },
+                d.expected,
+            ),
+        )
+    };
+    Diagnostic::new_with_syntax_node_ptr(
+        ctx,
+        DiagnosticCode::RustcHardError(code),
+        message,
+        d.pat.map(Into::into),
+    )
+    .stable()
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::tests::check_diagnostics;
+
+    #[test]
+    fn array_pattern_too_few_elements() {
+        check_diagnostics(
+            r#"
+fn f(arr: [i32; 3]) {
+    let [_a, _b] = arr;
+      //^^^^^^^^ error: pattern requires 2 elements but array has 3
+}
+"#,
+        );
+    }
+
+    #[test]
+    fn array_pattern_too_many_elements() {
+        check_diagnostics(
+            r#"
+fn f(arr: [i32; 2]) {
+    let [_a, _b, _c] = arr;
+      //^^^^^^^^^^^^ error: pattern requires 3 elements but array has 2
+}
+"#,
+        );
+    }
+
+    #[test]
+    fn array_pattern_with_rest_too_short() {
+        check_diagnostics(
+            r#"
+fn f(arr: [i32; 2]) {
+    let [_a, _b, _c, ..] = arr;
+      //^^^^^^^^^^^^^^^^ error: pattern requires at least 3 elements but array has 2
+}
+"#,
+        );
+    }
+
+    #[test]
+    fn array_pattern_with_rest_ok() {
+        check_diagnostics(
+            r#"
+fn f(arr: [i32; 5]) {
+    let [_a, _b, ..] = arr;
+}
+"#,
+        );
+    }
+
+    #[test]
+    fn array_pattern_exact_length_ok() {
+        check_diagnostics(
+            r#"
+fn f(arr: [i32; 3]) {
+    let [_a, _b, _c] = arr;
+}
+"#,
+        );
+    }
+
+    #[test]
+    fn array_pattern_singular_element_uses_singular() {
+        check_diagnostics(
+            r#"
+fn f(arr: [i32; 3]) {
+    let [_a] = arr;
+      //^^^^ error: pattern requires 1 element but array has 3
+}
+"#,
+        );
+    }
+}

--- a/crates/ide-diagnostics/src/lib.rs
+++ b/crates/ide-diagnostics/src/lib.rs
@@ -47,6 +47,7 @@ mod handlers {
     pub(crate) mod macro_error;
     pub(crate) mod malformed_derive;
     pub(crate) mod mismatched_arg_count;
+    pub(crate) mod mismatched_array_pat_len;
     pub(crate) mod missing_fields;
     pub(crate) mod missing_lifetime;
     pub(crate) mod missing_match_arms;
@@ -425,6 +426,7 @@ pub fn semantic_diagnostics(
             },
             AnyDiagnostic::MalformedDerive(d) => handlers::malformed_derive::malformed_derive(&ctx, &d),
             AnyDiagnostic::MismatchedArgCount(d) => handlers::mismatched_arg_count::mismatched_arg_count(&ctx, &d),
+            AnyDiagnostic::MismatchedArrayPatLen(d) => handlers::mismatched_array_pat_len::mismatched_array_pat_len(&ctx, &d),
             AnyDiagnostic::MissingFields(d) => handlers::missing_fields::missing_fields(&ctx, &d),
             AnyDiagnostic::MissingMatchArms(d) => handlers::missing_match_arms::missing_match_arms(&ctx, &d),
             AnyDiagnostic::MissingUnsafe(d) => handlers::missing_unsafe::missing_unsafe(&ctx, &d),


### PR DESCRIPTION
Resolves two FIXMEs in hir-ty/src/infer/pat.rs's check_array_pat_len.  Adds an InferenceDiagnostic::MismatchedArrayPatLen variant that distinguishes exact-length mismatches (rustc E0527) from rest-pat under-length cases (E0528). Renders to "pattern requires N elements but array has M" or "pattern requires at least N elements but array has M" respectively.

Tests cover too-few, too-many, rest-too-short, rest-ok, exact-ok, and singular-element pluralization.

Part of rust-lang/rust-analyzer#22140.