### PR TITLE
Remove add predicate for Where syntax

### DIFF
--- a/crates/syntax/src/ast/edit_in_place.rs
+++ b/crates/syntax/src/ast/edit_in_place.rs
@@ -77,17 +77,6 @@ impl ast::GenericParamList {
     }
 }
 
-impl ast::WhereClause {
-    pub fn add_predicate(&self, predicate: ast::WherePred) {
-        if let Some(pred) = self.predicates().last()
-            && !pred.syntax().siblings_with_tokens(Direction::Next).any(|it| it.kind() == T![,])
-        {
-            ted::append_child_raw(self.syntax(), make::token(T![,]));
-        }
-        ted::append_child(self.syntax(), predicate.syntax());
-    }
-}
-
 pub trait Removable: AstNode {
     fn remove(&self);
 }

--- a/crates/syntax/src/ast/make.rs
+++ b/crates/syntax/src/ast/make.rs
@@ -294,12 +294,7 @@ fn merge_where_clause(
         (None, None) => None,
         (None, Some(bs)) => Some(bs),
         (Some(ps), None) => Some(ps),
-        (Some(ps), Some(bs)) => {
-            let preds = where_clause(std::iter::empty()).clone_for_update();
-            ps.predicates().for_each(|p| preds.add_predicate(p));
-            bs.predicates().for_each(|p| preds.add_predicate(p));
-            Some(preds)
-        }
+        (Some(ps), Some(bs)) => Some(where_clause(ps.predicates().chain(bs.predicates()))),
     }
 }
 


### PR DESCRIPTION
This PR removes add_predicate from where syntax, it was needed to do in-place edits but now we don't do it. And make::where clause already formats predicates with ",", so this add_predicate is no longer needed.

part of https://github.com/rust-lang/rust-analyzer/issues/15710 and https://github.com/rust-lang/rust-analyzer/issues/18285