### PR TITLE
minor: Timeout tests after 5 minutes with nextest

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,2 @@
+[profile.default]
+slow-timeout = { period = "60s", terminate-after = 5 }


### PR DESCRIPTION
Since we have hanging tests, to not waste CI cycles before we find the cause.