### PR TITLE
feat: complete `::` on module def

### DIFF
--- a/crates/ide-completion/src/completions/dot.rs
+++ b/crates/ide-completion/src/completions/dot.rs
@@ -1093,7 +1093,7 @@ impl Foo { fn foo(&mut self) { let _: fn(&mut Self) = |this| { $0 } } }"#,
                 me this.foo() fn(&mut self)
                 lc self            &mut Foo
                 lc this            &mut Foo
-                md core
+                md core::
                 sp Self                 Foo
                 st Foo                  Foo
                 tt Fn
@@ -1117,7 +1117,7 @@ impl Foo { fn foo(&self) { let _: fn(&Self) = |foo| { $0 } } }"#,
                 me self.foo() fn(&self)
                 lc foo             &Foo
                 lc self            &Foo
-                md core
+                md core::
                 sp Self             Foo
                 st Foo              Foo
                 tt Fn
@@ -1137,7 +1137,7 @@ impl Foo { fn foo(&self) { let _: fn(&Self) = || { $0 } } }"#,
                 fd self.field       i32
                 me self.foo() fn(&self)
                 lc self            &Foo
-                md core
+                md core::
                 sp Self             Foo
                 st Foo              Foo
                 tt Fn
@@ -1159,7 +1159,7 @@ impl Foo { fn foo(&self) { let _: fn(&Self, &Self) = |foo, other| { $0 } } }"#,
                 lc foo             &Foo
                 lc other           &Foo
                 lc self            &Foo
-                md core
+                md core::
                 sp Self             Foo
                 st Foo              Foo
                 tt Fn

--- a/crates/ide-completion/src/completions/item_list/trait_impl.rs
+++ b/crates/ide-completion/src/completions/item_list/trait_impl.rs
@@ -1744,7 +1744,7 @@ impl Trait for () {
                 me fn bar(..)
                 me fn baz(..)
                 me fn foo(..)
-                md proc_macros
+                md proc_macros::
                 kw crate::
                 kw self::
             "#]],

--- a/crates/ide-completion/src/config.rs
+++ b/crates/ide-completion/src/config.rs
@@ -25,6 +25,7 @@ pub struct CompletionConfig<'a> {
     pub term_search_fuel: u64,
     pub full_function_signatures: bool,
     pub callable: Option<CallableSnippets>,
+    pub add_colons_to_module: bool,
     pub add_semicolon_to_unit: bool,
     pub snippet_cap: Option<SnippetCap>,
     pub insert_use: InsertUseConfig,

--- a/crates/ide-completion/src/render.rs
+++ b/crates/ide-completion/src/render.rs
@@ -471,6 +471,11 @@ fn render_resolution_path(
                 .insert_snippet(cap, ""); // set is snippet
         }
     }
+    let allow_module_path = matches!(path_ctx.kind, PathKind::Use);
+    if !allow_module_path && matches!(resolution, ScopeDef::ModuleDef(Module(_))) {
+        insert_text = format_smolstr!("{insert_text}::");
+        item.lookup_by(name.clone()).label(insert_text.clone());
+    }
     adds_ret_type_arrow(completion, path_ctx, &mut item, insert_text.into());
 
     let mut set_item_relevance = |ty: Type<'_>| {
@@ -942,7 +947,7 @@ fn main() {
                 st dep::test_mod_b::Struct {…} dep::test_mod_b::Struct {  } [type_could_unify]
                 ex dep::test_mod_b::Struct {  }  [type_could_unify]
                 st Struct Struct [type_could_unify+requires_import]
-                md dep  []
+                md dep::  []
                 fn main() fn() []
                 fn test(…) fn(Struct) []
                 st Struct Struct [requires_import]
@@ -980,7 +985,7 @@ fn main() {
 "#,
             expect![[r#"
                 un Union Union [type_could_unify+requires_import]
-                md dep  []
+                md dep::  []
                 fn main() fn() []
                 fn test(…) fn(Union) []
                 en Union Union [requires_import]
@@ -1018,7 +1023,7 @@ fn main() {
                 ev dep::test_mod_b::Enum::variant dep::test_mod_b::Enum::variant [type_could_unify]
                 ex dep::test_mod_b::Enum::variant  [type_could_unify]
                 en Enum Enum [type_could_unify+requires_import]
-                md dep  []
+                md dep::  []
                 fn main() fn() []
                 fn test(…) fn(Enum) []
                 en Enum Enum [requires_import]
@@ -1055,7 +1060,7 @@ fn main() {
             expect![[r#"
                 ev dep::test_mod_b::Enum::Variant dep::test_mod_b::Enum::Variant [type_could_unify]
                 ex dep::test_mod_b::Enum::Variant  [type_could_unify]
-                md dep  []
+                md dep::  []
                 fn main() fn() []
                 fn test(…) fn(Enum) []
             "#]],
@@ -1085,7 +1090,7 @@ fn main() {
 }
 "#,
             expect![[r#"
-                md dep  []
+                md dep::  []
                 fn main() fn() []
                 fn test(…) fn(fn(usize) -> i32) []
                 fn function fn(usize) -> i32 [requires_import]
@@ -1118,7 +1123,7 @@ fn main() {
 "#,
             expect![[r#"
                 ct CONST i32 [type_could_unify+requires_import]
-                md dep  []
+                md dep::  []
                 fn main() fn() []
                 fn test(…) fn(i32) []
                 ct CONST i64 [requires_import]
@@ -1150,7 +1155,7 @@ fn main() {
 "#,
             expect![[r#"
                 sc STATIC i32 [type_could_unify+requires_import]
-                md dep  []
+                md dep::  []
                 fn main() fn() []
                 fn test(…) fn(i32) []
                 sc STATIC i64 [requires_import]
@@ -1528,15 +1533,16 @@ fn main() { let _: m::Spam = S$0 }
                         detail: "fn()",
                     },
                     CompletionItem {
-                        label: "m",
+                        label: "m::",
                         detail_left: None,
                         detail_right: None,
                         source_range: 75..76,
                         delete: 75..76,
-                        insert: "m",
+                        insert: "m::",
                         kind: SymbolKind(
                             Module,
                         ),
+                        lookup: "m",
                     },
                     CompletionItem {
                         label: "m::Spam::Bar(…)",
@@ -1632,15 +1638,16 @@ fn main() { som$0 }
             expect![[r#"
                 [
                     CompletionItem {
-                        label: "something_deprecated",
+                        label: "something_deprecated::",
                         detail_left: None,
                         detail_right: None,
                         source_range: 55..58,
                         delete: 55..58,
-                        insert: "something_deprecated",
+                        insert: "something_deprecated::",
                         kind: SymbolKind(
                             Module,
                         ),
+                        lookup: "something_deprecated",
                         deprecated: true,
                         relevance: CompletionRelevance {
                             exact_name_match: false,
@@ -2811,8 +2818,8 @@ mod b {
             expect![[r#"
                 st Fooa Fooa []
                 tt Foob  []
-                md a  []
-                md b  []
+                md a::  []
+                md b::  []
             "#]],
         );
     }
@@ -2970,7 +2977,7 @@ fn main() {
                 tt Clone  []
                 tt Copy  []
                 fn bar(…) fn(Foo) []
-                md core  []
+                md core::  []
                 fn main() fn() []
             "#]],
         );
@@ -3012,7 +3019,7 @@ fn main() {
                 st &S [type]
                 st T T []
                 st &T [type]
-                md core  []
+                md core::  []
                 fn foo(…) fn(&S) []
                 fn main() fn() []
             "#]],
@@ -3061,7 +3068,7 @@ fn main() {
                 st &mut S [type]
                 st T T []
                 st &mut T [type]
-                md core  []
+                md core::  []
                 fn foo(…) fn(&mut S) []
                 fn main() fn() []
             "#]],
@@ -3164,7 +3171,7 @@ fn main() {
                 st &T [type]
                 fn bar() fn() -> T []
                 fn &bar() [type]
-                md core  []
+                md core::  []
                 fn foo(…) fn(&S) []
                 fn main() fn() []
             "#]],
@@ -3842,7 +3849,7 @@ fn f() {
             expect![[r#"
                 st Buffer Buffer []
                 fn f() fn() []
-                md std  []
+                md std::  []
                 tt BufRead  [requires_import]
                 st BufReader BufReader [requires_import]
                 st BufWriter BufWriter [requires_import]

--- a/crates/ide-completion/src/render.rs
+++ b/crates/ide-completion/src/render.rs
@@ -471,7 +471,7 @@ fn render_resolution_path(
                 .insert_snippet(cap, ""); // set is snippet
         }
     }
-    let allow_module_path = matches!(path_ctx.kind, PathKind::Use);
+    let allow_module_path = matches!(path_ctx.kind, PathKind::Use) || !config.add_colons_to_module;
     if !allow_module_path && matches!(resolution, ScopeDef::ModuleDef(Module(_))) {
         insert_text = format_smolstr!("{insert_text}::");
         item.lookup_by(name.clone()).label(insert_text.clone());

--- a/crates/ide-completion/src/tests.rs
+++ b/crates/ide-completion/src/tests.rs
@@ -72,6 +72,7 @@ pub(crate) const TEST_CONFIG: CompletionConfig<'_> = CompletionConfig {
     term_search_fuel: 200,
     full_function_signatures: false,
     callable: Some(CallableSnippets::FillArguments),
+    add_colons_to_module: true,
     add_semicolon_to_unit: true,
     snippet_cap: SnippetCap::new(true),
     insert_use: InsertUseConfig {

--- a/crates/ide-completion/src/tests/attribute.rs
+++ b/crates/ide-completion/src/tests/attribute.rs
@@ -64,7 +64,7 @@ pub struct Foo(#[m$0] i32);
             at unsafe(…)
             at used
             at warn(…)
-            md mac
+            md mac::
             kw crate::
             kw self::
         "#]],
@@ -128,7 +128,7 @@ pub struct Foo(#[$0] i32);
             at unsafe(…)
             at used
             at warn(…)
-            md mac
+            md mac::
             kw crate::
             kw self::
         "#]],
@@ -162,7 +162,7 @@ struct Foo;
             at repr(…)
             at unsafe(…)
             at warn(…)
-            md proc_macros
+            md proc_macros::
             kw crate::
             kw self::
         "#]],
@@ -463,7 +463,7 @@ struct Foo;
             at repr(…)
             at unsafe(…)
             at warn(…)
-            md core
+            md core::
             kw crate::
             kw self::
         "#]],
@@ -1137,7 +1137,7 @@ mod derive {
                 de PartialEq, Eq
                 de PartialEq, Eq, PartialOrd, Ord
                 de PartialEq, PartialOrd
-                md core
+                md core::
                 kw crate::
                 kw self::
             "#]],
@@ -1159,7 +1159,7 @@ mod derive {
                 de Eq
                 de Eq, PartialOrd, Ord
                 de PartialOrd
-                md core
+                md core::
                 kw crate::
                 kw self::
             "#]],
@@ -1181,7 +1181,7 @@ mod derive {
                 de Eq
                 de Eq, PartialOrd, Ord
                 de PartialOrd
-                md core
+                md core::
                 kw crate::
                 kw self::
             "#]],
@@ -1202,7 +1202,7 @@ mod derive {
                 de Default macro Default
                 de PartialOrd
                 de PartialOrd, Ord
-                md core
+                md core::
                 kw crate::
                 kw self::
             "#]],
@@ -1219,8 +1219,8 @@ mod derive {
 "#,
             expect![[r#"
                 de DeriveIdentity (use proc_macros::DeriveIdentity) proc_macro DeriveIdentity
-                md core
-                md proc_macros
+                md core::
+                md proc_macros::
                 kw crate::
                 kw self::
             "#]],
@@ -1234,8 +1234,8 @@ use proc_macros::DeriveIdentity;
 "#,
             expect![[r#"
                 de DeriveIdentity proc_macro DeriveIdentity
-                md core
-                md proc_macros
+                md core::
+                md proc_macros::
                 kw crate::
                 kw self::
             "#]],

--- a/crates/ide-completion/src/tests/expression.rs
+++ b/crates/ide-completion/src/tests/expression.rs
@@ -48,8 +48,8 @@ fn baz() {
             fn create_foo(…)   fn(&FooDesc)
             fn function()              fn()
             ma makro!(…) macro_rules! makro
-            md _69latrick
-            md module
+            md _69latrick::
+            md module::
             sc STATIC                  Unit
             st FooDesc              FooDesc
             st Record                Record
@@ -149,8 +149,8 @@ impl Unit {
             me self.foo()          fn(self)
             lc self                    Unit
             ma makro!(…) macro_rules! makro
-            md module
-            md qualified
+            md module::
+            md qualified::
             sp Self                    Unit
             sc STATIC                  Unit
             st Record                Record
@@ -212,8 +212,8 @@ impl Unit {
             en Enum                    Enum
             fn function()              fn()
             ma makro!(…) macro_rules! makro
-            md module
-            md qualified
+            md module::
+            md qualified::
             sc STATIC                  Unit
             st Record                Record
             st Tuple                  Tuple
@@ -2224,7 +2224,7 @@ pub struct UnstableThisShouldNotBeListed;
 "#,
         expect![[r#"
             fn main() fn()
-            md std
+            md std::
             bt u32     u32
             kw async
             kw const
@@ -2278,7 +2278,7 @@ pub struct UnstableButWeAreOnNightlyAnyway;
 "#,
         expect![[r#"
             fn main()                                                     fn()
-            md std
+            md std::
             st UnstableButWeAreOnNightlyAnyway UnstableButWeAreOnNightlyAnyway
             bt u32                                                         u32
             kw async
@@ -2333,7 +2333,7 @@ pub mod intrinsics {}
     "#,
         expect![[r#"
             fn main() fn()
-            md std
+            md std::
             bt u32     u32
             kw async
             kw const
@@ -2383,10 +2383,10 @@ fn main() {
 pub mod intrinsics {}
     "#,
         expect![[r#"
-            fn main() fn()
-            md intrinsics
-            md std
-            bt u32     u32
+            fn main()  fn()
+            md intrinsics::
+            md std::
+            bt u32      u32
             kw async
             kw const
             kw crate::
@@ -2622,7 +2622,7 @@ fn main() {
             ma helper!(…) macro_rules! helper
             ma m!(…)           macro_rules! m
             ma makro!(…)   macro_rules! makro
-            md module
+            md module::
             sc STATIC                    Unit
             st Record                  Record
             st Tuple                    Tuple
@@ -3085,12 +3085,12 @@ fn bar() {
             ma format_args_nl!(…)       macro_rules! format_args_nl
             ma panic!(…)                         macro_rules! panic
             ma print!(…)                         macro_rules! print
-            md core
-            md result (use core::result)
-            md rust_2015 (use core::prelude::rust_2015)
-            md rust_2018 (use core::prelude::rust_2018)
-            md rust_2021 (use core::prelude::rust_2021)
-            md rust_2024 (use core::prelude::rust_2024)
+            md core::
+            md result:: (use core::result)
+            md rust_2015:: (use core::prelude::rust_2015)
+            md rust_2018:: (use core::prelude::rust_2018)
+            md rust_2021:: (use core::prelude::rust_2021)
+            md rust_2024:: (use core::prelude::rust_2024)
             tt Clone
             tt Copy
             tt FromIterator
@@ -3205,9 +3205,9 @@ fn foo() {
 }
     "#,
         expect![[r#"
-            fn foo()  fn()
-            md proc_macros
-            bt u32     u32
+            fn foo()    fn()
+            md proc_macros::
+            bt u32       u32
             kw async
             kw const
             kw crate::
@@ -3255,9 +3255,9 @@ fn foo() {
 }
     "#,
         expect![[r#"
-            fn foo()  fn()
-            md proc_macros
-            bt u32     u32
+            fn foo()    fn()
+            md proc_macros::
+            bt u32       u32
             kw async
             kw const
             kw crate::

--- a/crates/ide-completion/src/tests/expression.rs
+++ b/crates/ide-completion/src/tests/expression.rs
@@ -5,8 +5,8 @@ use crate::{
     CompletionConfig,
     config::AutoImportExclusionType,
     tests::{
-        BASE_ITEMS_FIXTURE, TEST_CONFIG, check, check_edit, check_with_base_items,
-        completion_list_with_config,
+        BASE_ITEMS_FIXTURE, TEST_CONFIG, check, check_edit, check_edit_with_config,
+        check_with_base_items, completion_list_with_config,
     },
 };
 
@@ -1146,6 +1146,22 @@ fn break_value_no_block() {
         "break",
         r#"fn f() -> i32 { loop { match () { () => $0 } } }"#,
         r#"fn f() -> i32 { loop { match () { () => break $0 } } }"#,
+    );
+}
+
+#[test]
+fn complete_module_colons() {
+    check_edit(
+        "module",
+        r#"mod module {} fn foo() { $0 }"#,
+        r#"mod module {} fn foo() { module:: }"#,
+    );
+
+    check_edit_with_config(
+        CompletionConfig { add_colons_to_module: false, ..TEST_CONFIG },
+        "module",
+        r#"mod module {} fn foo() { $0 }"#,
+        r#"mod module {} fn foo() { module }"#,
     );
 }
 

--- a/crates/ide-completion/src/tests/flyimport.rs
+++ b/crates/ide-completion/src/tests/flyimport.rs
@@ -1772,7 +1772,7 @@ fn function() {
 "#,
         expect![[r#"
             st FooStruct (use outer::FooStruct) BarStruct
-            md foo (use outer::foo)
+            md foo:: (use outer::foo)
             fn foo_fun() (use outer::foo_fun)        fn()
         "#]],
     );

--- a/crates/ide-completion/src/tests/item.rs
+++ b/crates/ide-completion/src/tests/item.rs
@@ -15,7 +15,7 @@ impl Tra$0
         expect![[r#"
             en Enum                    Enum
             ma makro!(…) macro_rules! makro
-            md module
+            md module::
             st Record                Record
             st Tuple                  Tuple
             st Unit                    Unit
@@ -41,7 +41,7 @@ impl Trait for Str$0
         expect![[r#"
             en Enum                    Enum
             ma makro!(…) macro_rules! makro
-            md module
+            md module::
             st Record                Record
             st Tuple                  Tuple
             st Unit                    Unit
@@ -118,7 +118,7 @@ fn completes_where() {
         expect![[r#"
             en Enum (adds ->)          Enum
             ma makro!(…) macro_rules! makro
-            md module (adds ->)
+            md module:: (adds ->)
             st Record (adds ->)      Record
             st Tuple (adds ->)        Tuple
             st Unit (adds ->)          Unit
@@ -363,7 +363,7 @@ fn bar() {
             ma expand_to_test!(…) macro_rules! expand_to_test
             ma makro!(…)                   macro_rules! makro
             ma test!(…)                            macro test
-            md module
+            md module::
             sc STATIC                                    Unit
             st Record                                  Record
             st Tuple                                    Tuple

--- a/crates/ide-completion/src/tests/item_list.rs
+++ b/crates/ide-completion/src/tests/item_list.rs
@@ -43,7 +43,7 @@ fn in_source_file_item_list() {
         r#"$0"#,
         expect![[r#"
             ma makro!(…) macro_rules! makro
-            md module
+            md module::
             kw async
             kw const
             kw crate::
@@ -77,7 +77,7 @@ fn in_item_list_after_attr() {
         r#"#[attr] $0"#,
         expect![[r#"
             ma makro!(…) macro_rules! makro
-            md module
+            md module::
             kw async
             kw const
             kw crate::
@@ -111,7 +111,7 @@ fn in_item_list_after_inner_attr() {
         r#"#![attr] $0"#,
         expect![[r#"
             ma makro!(…) macro_rules! makro
-            md module
+            md module::
             kw async
             kw const
             kw crate::
@@ -145,7 +145,7 @@ fn in_qualified_path() {
         r#"crate::$0"#,
         expect![[r#"
             ma makro!(…) macro_rules! makro
-            md module
+            md module::
         "#]],
     )
 }
@@ -315,7 +315,7 @@ fn in_impl_assoc_item_list() {
         r#"impl Struct { $0 }"#,
         expect![[r#"
             ma makro!(…) macro_rules! makro
-            md module
+            md module::
             kw async
             kw const
             kw crate::
@@ -335,7 +335,7 @@ fn in_impl_assoc_item_list_after_attr() {
         r#"impl Struct { #[attr] $0 }"#,
         expect![[r#"
             ma makro!(…) macro_rules! makro
-            md module
+            md module::
             kw async
             kw const
             kw crate::
@@ -355,7 +355,7 @@ fn in_trait_assoc_item_list() {
         r"trait Foo { $0 }",
         expect![[r#"
             ma makro!(…) macro_rules! makro
-            md module
+            md module::
             kw async
             kw const
             kw crate::
@@ -373,7 +373,7 @@ fn in_trait_assoc_fn_missing_body() {
         r#"trait Foo { fn function(); $0 }"#,
         expect![[r#"
             ma makro!(…) macro_rules! makro
-            md module
+            md module::
             kw async
             kw const
             kw crate::
@@ -391,7 +391,7 @@ fn in_trait_assoc_const_missing_body() {
         r#"trait Foo { const CONST: (); $0 }"#,
         expect![[r#"
             ma makro!(…) macro_rules! makro
-            md module
+            md module::
             kw async
             kw const
             kw crate::
@@ -409,7 +409,7 @@ fn in_trait_assoc_type_aliases_missing_ty() {
         r#"trait Foo { type Type; $0 }"#,
         expect![[r#"
             ma makro!(…) macro_rules! makro
-            md module
+            md module::
             kw async
             kw const
             kw crate::
@@ -448,7 +448,7 @@ impl Test for () {
             fn fn function1()
             fn fn function2()
             ma makro!(…) macro_rules! makro
-            md module
+            md module::
             ta type Type1 =
             kw crate::
             kw self::
@@ -514,7 +514,7 @@ fn after_unit_struct() {
         r#"struct S; f$0"#,
         expect![[r#"
             ma makro!(…) macro_rules! makro
-            md module
+            md module::
             kw async
             kw const
             kw crate::
@@ -664,7 +664,7 @@ fn inside_extern_blocks() {
         r#"extern { $0 }"#,
         expect![[r#"
             ma makro!(…) macro_rules! makro
-            md module
+            md module::
             kw crate::
             kw fn
             kw pub
@@ -681,7 +681,7 @@ fn inside_extern_blocks() {
         r#"unsafe extern { $0 }"#,
         expect![[r#"
             ma makro!(…) macro_rules! makro
-            md module
+            md module::
             kw crate::
             kw fn
             kw pub

--- a/crates/ide-completion/src/tests/predicate.rs
+++ b/crates/ide-completion/src/tests/predicate.rs
@@ -13,7 +13,7 @@ struct Foo<'lt, T, const C: usize> where $0 {}
         expect![[r#"
             en Enum                    Enum
             ma makro!(…) macro_rules! makro
-            md module
+            md module::
             st Foo<…> Foo<'_, {unknown}, _>
             st Record                Record
             st Tuple                  Tuple
@@ -39,7 +39,7 @@ struct Foo<'lt, T, const C: usize> where T: $0 {}
 "#,
         expect![[r#"
             ma makro!(…) macro_rules! makro
-            md module
+            md module::
             tt Trait
             kw crate::
             kw self::
@@ -57,7 +57,7 @@ struct Foo<'lt, T, const C: usize> where 'lt: $0 {}
 "#,
         expect![[r#"
             ma makro!(…) macro_rules! makro
-            md module
+            md module::
             tt Trait
             kw crate::
             kw self::
@@ -73,7 +73,7 @@ struct Foo<'lt, T, const C: usize> where for<'a> T: $0 {}
 "#,
         expect![[r#"
             ma makro!(…) macro_rules! makro
-            md module
+            md module::
             tt Trait
             kw crate::
             kw self::
@@ -90,7 +90,7 @@ struct Foo<'lt, T, const C: usize> where for<'a> $0 {}
         expect![[r#"
             en Enum                    Enum
             ma makro!(…) macro_rules! makro
-            md module
+            md module::
             st Foo<…> Foo<'_, {unknown}, _>
             st Record                Record
             st Tuple                  Tuple
@@ -119,7 +119,7 @@ impl Record {
         expect![[r#"
             en Enum                    Enum
             ma makro!(…) macro_rules! makro
-            md module
+            md module::
             sp Self                  Record
             st Record                Record
             st Tuple                  Tuple
@@ -149,7 +149,7 @@ struct Foo<T> where T: $0 {}
 pub trait Trait {}
 "#,
         expect![[r#"
-            md std
+            md std::
             kw crate::
             kw self::
         "#]],
@@ -169,7 +169,7 @@ struct Foo<T> where T: $0 {}
 pub trait Trait {}
 "#,
         expect![[r#"
-            md std
+            md std::
             tt Trait
             kw crate::
             kw self::

--- a/crates/ide-completion/src/tests/record.rs
+++ b/crates/ide-completion/src/tests/record.rs
@@ -176,7 +176,7 @@ fn main() {
             fn main()                          fn()
             lc foo                              Foo
             lc thing                            i32
-            md core
+            md core::
             st Foo                              Foo
             st Foo {…} Foo { foo1: u32, foo2: u32 }
             tt Default

--- a/crates/ide-completion/src/tests/special.rs
+++ b/crates/ide-completion/src/tests/special.rs
@@ -65,7 +65,7 @@ pub mod prelude {
 }
 "#,
         expect![[r#"
-            md std
+            md std::
             st Option Option
             bt u32       u32
         "#]],
@@ -95,7 +95,7 @@ mod macros {
         expect![[r#"
             fn f()                       fn()
             ma concat!(…) macro_rules! concat
-            md std
+            md std::
             bt u32                        u32
         "#]],
     );
@@ -123,8 +123,8 @@ pub mod prelude {
 }
 "#,
         expect![[r#"
-            md core
-            md std
+            md core::
+            md std::
             st String String
             bt u32       u32
         "#]],
@@ -153,7 +153,7 @@ pub mod prelude {
             "#,
         expect![[r#"
             fn f() fn()
-            md std
+            md std::
             bt u32  u32
         "#]],
     );
@@ -181,8 +181,8 @@ pub mod prelude {
 }
             "#,
         expect![[r#"
-                md std
-            "#]],
+            md std::
+        "#]],
     );
 }
 
@@ -714,7 +714,7 @@ mod m {
 "#,
         expect![[r#"
             fn z() fn()
-            md z
+            md z::
         "#]],
     );
 }
@@ -1126,7 +1126,7 @@ fn foo { ::$0 }
 "#,
         Some(':'),
         expect![[r#"
-            md core
+            md core::
         "#]],
     );
     check_with_trigger_character(
@@ -1136,7 +1136,7 @@ fn foo { /* test */::$0 }
 "#,
         Some(':'),
         expect![[r#"
-            md core
+            md core::
         "#]],
     );
 
@@ -1488,7 +1488,7 @@ fn here_we_go() {
 "#,
         expect![[r#"
             fn here_we_go()                  fn()
-            md foo
+            md foo::
             st Bar (alias Qux) (use foo::Bar) Bar
             bt u32                            u32
             kw const

--- a/crates/ide-completion/src/tests/type_pos.rs
+++ b/crates/ide-completion/src/tests/type_pos.rs
@@ -14,7 +14,7 @@ struct Foo<'lt, T, const C: usize> {
         expect![[r#"
             en Enum                    Enum
             ma makro!(…) macro_rules! makro
-            md module
+            md module::
             sp Self   Foo<'_, {unknown}, _>
             st Foo<…> Foo<'_, {unknown}, _>
             st Record                Record
@@ -43,7 +43,7 @@ struct Foo<'lt, T, const C: usize>(f$0);
         expect![[r#"
             en Enum                    Enum
             ma makro!(…) macro_rules! makro
-            md module
+            md module::
             sp Self   Foo<'_, {unknown}, _>
             st Foo<…> Foo<'_, {unknown}, _>
             st Record                Record
@@ -75,7 +75,7 @@ fn x<'lt, T, const C: usize>() -> $0
         expect![[r#"
             en Enum                    Enum
             ma makro!(…) macro_rules! makro
-            md module
+            md module::
             st Record                Record
             st Tuple                  Tuple
             st Unit                    Unit
@@ -102,7 +102,7 @@ fn x() u$0
         expect![[r#"
             en Enum (adds ->)          Enum
             ma makro!(…) macro_rules! makro
-            md module (adds ->)
+            md module:: (adds ->)
             st Record (adds ->)      Record
             st Tuple (adds ->)        Tuple
             st Unit (adds ->)          Unit
@@ -126,7 +126,7 @@ fn x() $0
         expect![[r#"
             en Enum (adds ->)          Enum
             ma makro!(…) macro_rules! makro
-            md module (adds ->)
+            md module:: (adds ->)
             st Record (adds ->)      Record
             st Tuple (adds ->)        Tuple
             st Unit (adds ->)          Unit
@@ -216,7 +216,7 @@ fn foo() $0
 "#,
         r#"
 mod foo { pub type Num = u32; }
-fn foo() -> foo
+fn foo() -> foo::
 "#,
     );
 
@@ -253,7 +253,7 @@ fn foo()$0
 "#,
         r#"
 mod foo { pub type Num = u32; }
-fn foo() ->foo
+fn foo() ->foo::
 "#,
     );
 }
@@ -306,7 +306,7 @@ fn x() u$0 {&2u32}
         expect![[r#"
             en Enum (adds ->)          Enum
             ma makro!(…) macro_rules! makro
-            md module (adds ->)
+            md module:: (adds ->)
             st Record (adds ->)      Record
             st Tuple (adds ->)        Tuple
             st Unit (adds ->)          Unit
@@ -346,7 +346,7 @@ fn x<'lt, T, const C: usize>(_: &()) -> &$0
         expect![[r#"
             en Enum                    Enum
             ma makro!(…) macro_rules! makro
-            md module
+            md module::
             st Record                Record
             st Tuple                  Tuple
             st Unit                    Unit
@@ -380,7 +380,7 @@ fn foo() -> B$0 {
         expect![[r#"
             en Enum                    Enum
             ma makro!(…) macro_rules! makro
-            md module
+            md module::
             st Record                Record
             st Tuple                  Tuple
             st Unit                    Unit
@@ -408,7 +408,7 @@ const FOO: $0 = Foo(2);
         expect![[r#"
             en Enum                    Enum
             ma makro!(…) macro_rules! makro
-            md module
+            md module::
             st Foo<…>        Foo<{unknown}>
             st Record                Record
             st Tuple                  Tuple
@@ -437,7 +437,7 @@ static FOO: $0 = Foo(2);
         expect![[r#"
             en Enum                    Enum
             ma makro!(…) macro_rules! makro
-            md module
+            md module::
             st Foo<…>        Foo<{unknown}>
             st Record                Record
             st Tuple                  Tuple
@@ -468,7 +468,7 @@ fn f2() {
         expect![[r#"
             en Enum                    Enum
             ma makro!(…) macro_rules! makro
-            md module
+            md module::
             st Record                Record
             st Tuple                  Tuple
             st Unit                    Unit
@@ -500,7 +500,7 @@ fn f2() {
         expect![[r#"
             en Enum                    Enum
             ma makro!(…) macro_rules! makro
-            md module
+            md module::
             st Record                Record
             st Tuple                  Tuple
             st Unit                    Unit
@@ -529,7 +529,7 @@ fn f2(x: u64) -> $0 {
         expect![[r#"
             en Enum                    Enum
             ma makro!(…) macro_rules! makro
-            md module
+            md module::
             st Record                Record
             st Tuple                  Tuple
             st Unit                    Unit
@@ -559,7 +559,7 @@ fn f2(x: $0) {
         expect![[r#"
             en Enum                    Enum
             ma makro!(…) macro_rules! makro
-            md module
+            md module::
             st Record                Record
             st Tuple                  Tuple
             st Unit                    Unit
@@ -595,8 +595,8 @@ fn foo<'lt, T, const C: usize>() {
         expect![[r#"
             en Enum                    Enum
             ma makro!(…) macro_rules! makro
-            md a
-            md module
+            md a::
+            md module::
             st Record                Record
             st Tuple                  Tuple
             st Unit                    Unit
@@ -628,7 +628,7 @@ fn foo<'lt, T, const C: usize>() {
         expect![[r#"
             en Enum                    Enum
             ma makro!(…) macro_rules! makro
-            md module
+            md module::
             st Foo<…>        Foo<{unknown}>
             st Record                Record
             st Tuple                  Tuple
@@ -660,7 +660,7 @@ fn foo<'lt, T, const C: usize>() {
         expect![[r#"
             en Enum                    Enum
             ma makro!(…) macro_rules! makro
-            md module
+            md module::
             st Record                Record
             st Tuple                  Tuple
             st Unit                    Unit
@@ -686,7 +686,7 @@ fn foo<'lt, T, const C: usize>() {
         expect![[r#"
             en Enum                    Enum
             ma makro!(…) macro_rules! makro
-            md module
+            md module::
             st Record                Record
             st Tuple                  Tuple
             st Unit                    Unit
@@ -729,7 +729,7 @@ fn foo<'lt, T: Trait2<$0>, const CONST_PARAM: usize>(_: T) {}
         expect![[r#"
             en Enum                    Enum
             ma makro!(…) macro_rules! makro
-            md module
+            md module::
             st Record                Record
             st Tuple                  Tuple
             st Unit                    Unit
@@ -758,7 +758,7 @@ fn foo<'lt, T: Trait2<self::$0>, const CONST_PARAM: usize>(_: T) {}
         expect![[r#"
             en Enum                    Enum
             ma makro!(…) macro_rules! makro
-            md module
+            md module::
             st Record                Record
             st Tuple                  Tuple
             st Unit                    Unit
@@ -783,7 +783,7 @@ impl Tr<$0
         expect![[r#"
             en Enum                        Enum
             ma makro!(…)     macro_rules! makro
-            md module
+            md module::
             sp Self dyn Tr<{unknown}> + 'static
             st Record                    Record
             st S                              S
@@ -834,7 +834,7 @@ fn f(t: impl MyTrait<u$0
         expect![[r#"
             en Enum                    Enum
             ma makro!(…) macro_rules! makro
-            md module
+            md module::
             st Record                Record
             st Tuple                  Tuple
             st Unit                    Unit
@@ -863,7 +863,7 @@ fn f(t: impl MyTrait<u8, u$0
         expect![[r#"
             en Enum                    Enum
             ma makro!(…) macro_rules! makro
-            md module
+            md module::
             st Record                Record
             st Tuple                  Tuple
             st Unit                    Unit
@@ -910,7 +910,7 @@ fn f(t: impl MyTrait<u$0
         expect![[r#"
             en Enum                    Enum
             ma makro!(…) macro_rules! makro
-            md module
+            md module::
             st Record                Record
             st Tuple                  Tuple
             st Unit                    Unit
@@ -939,7 +939,7 @@ fn f(t: impl MyTrait<u8, u$0
         expect![[r#"
             en Enum                        Enum
             ma makro!(…)     macro_rules! makro
-            md module
+            md module::
             st Record                    Record
             st Tuple                      Tuple
             st Unit                        Unit
@@ -988,7 +988,7 @@ fn f(t: impl MyTrait<Item1 = $0
         expect![[r#"
             en Enum                    Enum
             ma makro!(…) macro_rules! makro
-            md module
+            md module::
             st Record                Record
             st Tuple                  Tuple
             st Unit                    Unit
@@ -1017,7 +1017,7 @@ fn f(t: impl MyTrait<Item1 = u8, Item2 = $0
         expect![[r#"
             en Enum                    Enum
             ma makro!(…) macro_rules! makro
-            md module
+            md module::
             st Record                Record
             st Tuple                  Tuple
             st Unit                    Unit
@@ -1069,7 +1069,7 @@ struct Foo {
 pub struct S;
 "#,
         expect![[r#"
-            md std
+            md std::
             sp Self Foo
             st Foo  Foo
             bt u32  u32
@@ -1098,7 +1098,7 @@ struct Foo {
 pub struct S;
 "#,
         expect![[r#"
-            md std
+            md std::
             sp Self Foo
             st Foo  Foo
             st S      S
@@ -1128,7 +1128,7 @@ fn completes_const_and_type_generics_separately() {
         expect![[r#"
             en Enum                    Enum
             ma makro!(…) macro_rules! makro
-            md module
+            md module::
             st Foo                      Foo
             st Record                Record
             st Tuple                  Tuple
@@ -1182,7 +1182,7 @@ fn completes_const_and_type_generics_separately() {
         expect![[r#"
             en Enum                    Enum
             ma makro!(…) macro_rules! makro
-            md module
+            md module::
             st Foo                      Foo
             st Record                Record
             st Tuple                  Tuple
@@ -1233,7 +1233,7 @@ fn completes_const_and_type_generics_separately() {
         expect![[r#"
             en Enum                    Enum
             ma makro!(…) macro_rules! makro
-            md module
+            md module::
             st Foo                      Foo
             st Record                Record
             st Tuple                  Tuple
@@ -1444,7 +1444,7 @@ struct Bar;
 impl $0 for Bar { }
 "#,
         expect![[r#"
-            md module
+            md module::
             tt Foo
             tt Trait
             kw crate::
@@ -1467,7 +1467,7 @@ mod outer {
 impl outer::$0 for Bar { }
 "#,
         expect![[r#"
-            md inner
+            md inner::
             tt Foo
         "#]],
     );

--- a/crates/ide-completion/src/tests/visibility.rs
+++ b/crates/ide-completion/src/tests/visibility.rs
@@ -44,7 +44,7 @@ mod foo {
 mod bar {}
 "#,
         expect![[r#"
-            md foo
+            md foo::
         "#]],
     );
     check(
@@ -59,7 +59,7 @@ mod qux {
 mod bar {}
 "#,
         expect![[r#"
-            md qux
+            md qux::
         "#]],
     );
     check(
@@ -74,7 +74,7 @@ mod qux {
 mod bar {}
 "#,
         expect![[r#"
-            md foo
+            md foo::
         "#]],
     );
 }

--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -627,6 +627,11 @@ config_data! {
         /// Term search fuel in "units of work" for assists (Defaults to 1800).
         assist_termSearch_fuel: usize = 1800,
 
+        /// Automatically add `::` when completing the module.
+        ///
+        /// Will not be completed in `use`.
+        completion_addColonsToModule: bool = true,
+
         /// Automatically add a semicolon when completing unit-returning functions.
         ///
         /// In `match` arms it completes a comma instead.
@@ -1901,6 +1906,7 @@ impl Config {
                 CallableCompletionDef::AddParentheses => Some(CallableSnippets::AddParentheses),
                 CallableCompletionDef::None => None,
             },
+            add_colons_to_module: *self.completion_addColonsToModule(source_root),
             add_semicolon_to_unit: *self.completion_addSemicolonToUnit(source_root),
             snippet_cap: SnippetCap::new(self.completion_snippet()),
             insert_use: self.insert_use_config(source_root),

--- a/crates/rust-analyzer/src/integrated_benchmarks.rs
+++ b/crates/rust-analyzer/src/integrated_benchmarks.rs
@@ -162,36 +162,7 @@ fn integrated_completion_benchmark() {
     {
         let _span = profile::cpu_span();
         let analysis = host.analysis();
-        let config = CompletionConfig {
-            enable_postfix_completions: true,
-            enable_imports_on_the_fly: true,
-            enable_self_on_the_fly: true,
-            enable_private_editable: true,
-            enable_term_search: true,
-            term_search_fuel: 200,
-            full_function_signatures: false,
-            callable: Some(CallableSnippets::FillArguments),
-            snippet_cap: SnippetCap::new(true),
-            insert_use: InsertUseConfig {
-                granularity: ImportGranularity::Crate,
-                prefix_kind: hir::PrefixKind::ByCrate,
-                enforce_granularity: true,
-                group: true,
-                skip_glob_imports: true,
-            },
-            prefer_no_std: false,
-            prefer_prelude: true,
-            prefer_absolute: false,
-            snippets: Vec::new(),
-            limit: None,
-            add_semicolon_to_unit: true,
-            fields_to_resolve: CompletionFieldsToResolve::empty(),
-            exclude_flyimport: vec![],
-            exclude_traits: &[],
-            enable_auto_await: true,
-            enable_auto_iter: true,
-            ra_fixture: RaFixtureConfig::default(),
-        };
+        let config = completion_config();
         let position =
             FilePosition { file_id, offset: TextSize::try_from(completion_offset).unwrap() };
         analysis.completions(&config, position, None).unwrap();
@@ -217,36 +188,7 @@ fn integrated_completion_benchmark() {
         let _p = tracing::info_span!("unqualified path completion").entered();
         let _span = profile::cpu_span();
         let analysis = host.analysis();
-        let config = CompletionConfig {
-            enable_postfix_completions: true,
-            enable_imports_on_the_fly: true,
-            enable_self_on_the_fly: true,
-            enable_private_editable: true,
-            enable_term_search: true,
-            term_search_fuel: 200,
-            full_function_signatures: false,
-            callable: Some(CallableSnippets::FillArguments),
-            snippet_cap: SnippetCap::new(true),
-            insert_use: InsertUseConfig {
-                granularity: ImportGranularity::Crate,
-                prefix_kind: hir::PrefixKind::ByCrate,
-                enforce_granularity: true,
-                group: true,
-                skip_glob_imports: true,
-            },
-            prefer_no_std: false,
-            prefer_prelude: true,
-            prefer_absolute: false,
-            snippets: Vec::new(),
-            limit: None,
-            add_semicolon_to_unit: true,
-            fields_to_resolve: CompletionFieldsToResolve::empty(),
-            exclude_flyimport: vec![],
-            exclude_traits: &[],
-            enable_auto_await: true,
-            enable_auto_iter: true,
-            ra_fixture: RaFixtureConfig::default(),
-        };
+        let config = completion_config();
         let position =
             FilePosition { file_id, offset: TextSize::try_from(completion_offset).unwrap() };
         analysis.completions(&config, position, None).unwrap();
@@ -270,36 +212,7 @@ fn integrated_completion_benchmark() {
         let _p = tracing::info_span!("dot completion").entered();
         let _span = profile::cpu_span();
         let analysis = host.analysis();
-        let config = CompletionConfig {
-            enable_postfix_completions: true,
-            enable_imports_on_the_fly: true,
-            enable_self_on_the_fly: true,
-            enable_private_editable: true,
-            enable_term_search: true,
-            term_search_fuel: 200,
-            full_function_signatures: false,
-            callable: Some(CallableSnippets::FillArguments),
-            snippet_cap: SnippetCap::new(true),
-            insert_use: InsertUseConfig {
-                granularity: ImportGranularity::Crate,
-                prefix_kind: hir::PrefixKind::ByCrate,
-                enforce_granularity: true,
-                group: true,
-                skip_glob_imports: true,
-            },
-            prefer_no_std: false,
-            prefer_prelude: true,
-            prefer_absolute: false,
-            snippets: Vec::new(),
-            limit: None,
-            add_semicolon_to_unit: true,
-            fields_to_resolve: CompletionFieldsToResolve::empty(),
-            exclude_flyimport: vec![],
-            exclude_traits: &[],
-            enable_auto_await: true,
-            enable_auto_iter: true,
-            ra_fixture: RaFixtureConfig::default(),
-        };
+        let config = completion_config();
         let position =
             FilePosition { file_id, offset: TextSize::try_from(completion_offset).unwrap() };
         analysis.completions(&config, position, None).unwrap();
@@ -399,4 +312,37 @@ fn patch(what: &mut String, from: &str, to: &str) -> usize {
     let idx = what.find(from).unwrap();
     *what = what.replacen(from, to, 1);
     idx
+}
+
+fn completion_config() -> CompletionConfig<'static> {
+    CompletionConfig {
+        enable_postfix_completions: true,
+        enable_imports_on_the_fly: true,
+        enable_self_on_the_fly: true,
+        enable_private_editable: true,
+        enable_term_search: true,
+        term_search_fuel: 200,
+        full_function_signatures: false,
+        callable: Some(CallableSnippets::FillArguments),
+        snippet_cap: SnippetCap::new(true),
+        insert_use: InsertUseConfig {
+            granularity: ImportGranularity::Crate,
+            prefix_kind: hir::PrefixKind::ByCrate,
+            enforce_granularity: true,
+            group: true,
+            skip_glob_imports: true,
+        },
+        prefer_no_std: false,
+        prefer_prelude: true,
+        prefer_absolute: false,
+        snippets: Vec::new(),
+        limit: None,
+        add_semicolon_to_unit: true,
+        fields_to_resolve: CompletionFieldsToResolve::empty(),
+        exclude_flyimport: vec![],
+        exclude_traits: &[],
+        enable_auto_await: true,
+        enable_auto_iter: true,
+        ra_fixture: RaFixtureConfig::default(),
+    }
 }

--- a/crates/rust-analyzer/src/integrated_benchmarks.rs
+++ b/crates/rust-analyzer/src/integrated_benchmarks.rs
@@ -337,6 +337,7 @@ fn completion_config() -> CompletionConfig<'static> {
         prefer_absolute: false,
         snippets: Vec::new(),
         limit: None,
+        add_colons_to_module: true,
         add_semicolon_to_unit: true,
         fields_to_resolve: CompletionFieldsToResolve::empty(),
         exclude_flyimport: vec![],

--- a/docs/book/src/configuration_generated.md
+++ b/docs/book/src/configuration_generated.md
@@ -375,6 +375,15 @@ If false, `-p <package>` will be passed instead if applicable. In case it is not
 check will be performed.
 
 
+## rust-analyzer.completion.addColonsToModule {#completion.addColonsToModule}
+
+Default: `true`
+
+Automatically add `::` when completing the module.
+
+Will not be completed in `use`.
+
+
 ## rust-analyzer.completion.addSemicolonToUnit {#completion.addSemicolonToUnit}
 
 Default: `true`

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -1277,6 +1277,16 @@
             {
                 "title": "Completion",
                 "properties": {
+                    "rust-analyzer.completion.addColonsToModule": {
+                        "markdownDescription": "Automatically add `::` when completing the module.\n\nWill not be completed in `use`.",
+                        "default": true,
+                        "type": "boolean"
+                    }
+                }
+            },
+            {
+                "title": "Completion",
+                "properties": {
                     "rust-analyzer.completion.addSemicolonToUnit": {
                         "markdownDescription": "Automatically add a semicolon when completing unit-returning functions.\n\nIn `match` arms it completes a comma instead.",
                         "default": true,


### PR DESCRIPTION
Example
---
```rust
fn main() {
    c$0
}
```

**Before this PR**

```text
md core
...
```

**After this PR**

```text
md core::
...
```
