### PR TITLE
fix: don't panic on `impl ?Sized` for introduce_named_type_parameter

### DIFF
--- a/crates/ide-assists/src/handlers/introduce_named_type_parameter.rs
+++ b/crates/ide-assists/src/handlers/introduce_named_type_parameter.rs
@@ -183,6 +183,15 @@ fn foo<
     }
 
     #[test]
+    fn replace_impl_question_bounds() {
+        check_assist(
+            introduce_named_type_parameter,
+            r#"fn foo(bar: &$0impl ?Sized) {}"#,
+            r#"fn foo<$0S: ?Sized>(bar: &S) {}"#,
+        );
+    }
+
+    #[test]
     fn replace_impl_with_mut() {
         check_assist(
             introduce_named_type_parameter,

--- a/crates/ide-db/src/syntax_helpers/suggest_name.rs
+++ b/crates/ide-db/src/syntax_helpers/suggest_name.rs
@@ -193,7 +193,10 @@ impl NameGenerator {
     pub fn for_impl_trait_as_generic(&mut self, ty: &ast::ImplTraitType) -> SmolStr {
         let c = ty
             .type_bound_list()
-            .and_then(|bounds| bounds.syntax().text().char_at(0.into()))
+            .and_then(|bounds| {
+                let ty = bounds.bounds().next()?.ty()?;
+                ty.syntax().text().char_at(0.into()).filter(|ch| ch.is_alphabetic())
+            })
             .unwrap_or('T');
 
         self.suggest_name(&c.to_string())


### PR DESCRIPTION
Example
---
```rust
fn foo(bar: &$0impl ?Sized) {}
```

**Before this PR**

```
panic: Failed to make ast node `syntax::ast::generated::nodes::Name` from text mod ?;
```

**After this PR**

```rust
fn foo<$0S: ?Sized>(bar: &S) {}
```
