### PR TITLE
fix: Don't fetch diagnostics until proc-macros are loaded

### DIFF
--- a/crates/project-model/src/build_dependencies.rs
+++ b/crates/project-model/src/build_dependencies.rs
@@ -382,7 +382,6 @@ impl WorkspaceBuildScripts {
                     }
                     Message::CompilerArtifact(message) => {
                         with_output_for(&message.package_id, &mut |name, data| {
-                            progress(format!("proc-macro {name} built"));
                             if data.proc_macro_dylib_path == ProcMacroDylibPath::NotBuilt {
                                 data.proc_macro_dylib_path = ProcMacroDylibPath::NotProcMacro;
                             }
@@ -392,6 +391,7 @@ impl WorkspaceBuildScripts {
                                     .kind
                                     .contains(&cargo_metadata::TargetKind::ProcMacro)
                             {
+                                progress(format!("proc-macro {name} built"));
                                 data.proc_macro_dylib_path =
                                     match message.filenames.iter().find(|file| is_dylib(file)) {
                                         Some(filename) => {

--- a/crates/rust-analyzer/src/main_loop.rs
+++ b/crates/rust-analyzer/src/main_loop.rs
@@ -660,8 +660,20 @@ impl GlobalState {
                 let subscriptions = subscriptions.clone();
                 // Do not fetch semantic diagnostics (and populate query results) if we haven't even
                 // loaded the initial workspace yet.
-                let fetch_semantic =
-                    self.vfs_done && self.fetch_workspaces_queue.last_op_result().is_some();
+                //
+                // Only fetch semantic diagnostics when
+                // - we have fully populated the VFS
+                // - have a workspace
+                // - have finished fetching the build data once
+                // - and have finished loading the proc-macros once
+                let fetch_semantic = self.vfs_done
+                    && self.fetch_workspaces_queue.last_op_result().is_some()
+                    && (!self.config.run_build_scripts(None)
+                        || (self.fetch_build_data_queue.last_op_result().is_none()
+                            && !self.fetch_build_data_queue.op_in_progress()))
+                    && (!self.config.expand_proc_macros()
+                        || (self.fetch_proc_macros_queue.last_op_result().is_none()
+                            && !self.fetch_proc_macros_queue.op_in_progress()));
                 move |sender| {
                     // We aren't observing the semantics token cache here
                     let snapshot = AssertUnwindSafe(&snapshot);


### PR DESCRIPTION
Otherwise we should a bunch of false diagnostics on startup