### PR TITLE
fix: Remove usage of `references_error()` in upvar inference

### DIFF
--- a/crates/hir-ty/src/infer/closure/analysis.rs
+++ b/crates/hir-ty/src/infer/closure/analysis.rs
@@ -44,7 +44,7 @@ use macros::{TypeFoldable, TypeVisitable};
 use rustc_ast_ir::Mutability;
 use rustc_hash::{FxBuildHasher, FxHashMap};
 use rustc_type_ir::{
-    BoundVar, ClosureKind, TypeVisitableExt as _,
+    BoundVar, ClosureKind,
     inherent::{AdtDef as _, GenericArgs as _, IntoKind as _, Ty as _},
 };
 use smallvec::{SmallVec, smallvec};
@@ -403,9 +403,7 @@ impl<'a, 'db> InferenceContext<'a, 'db> {
         // For coroutine-closures, we additionally must compute the
         // `coroutine_captures_by_ref_ty` type, which is used to generate the by-ref
         // version of the coroutine-closure's output coroutine.
-        if let UpvarArgs::CoroutineClosure(args) = args
-            && !args.references_error()
-        {
+        if let UpvarArgs::CoroutineClosure(args) = args {
             let closure_env_region: Region<'_> = Region::new_bound(
                 self.interner(),
                 rustc_type_ir::INNERMOST,

--- a/crates/ide-diagnostics/src/handlers/type_must_be_known.rs
+++ b/crates/ide-diagnostics/src/handlers/type_must_be_known.rs
@@ -116,4 +116,25 @@ fn foo() {
         "#,
         );
     }
+
+    #[test]
+    fn async_closure_does_not_trigger() {
+        check_diagnostics(
+            r#"
+//- minicore: async_fn
+struct Task<R>(R);
+fn spawn_in<AsyncFn, R>(_f: AsyncFn) -> Task<R>
+where
+    R: 'static,
+    AsyncFn: AsyncFnOnce(&()) -> R + 'static,
+{
+    loop {}
+}
+
+fn foo() {
+    spawn_in(async move |cx| {});
+}
+        "#,
+        );
+    }
 }


### PR DESCRIPTION
Generally right now r-a cannot use this method, as lifetime errors are too common. We could replace it by `references_no_lt_error()`, but I decided to just remove it since not inferring the things in that `if` will cause writeback to error (with a cryptic error) on the coroutine closure as having unresolved infer vars. We could change that, but removing the condition seems to be unable to cause harm as nothing in this `if` relies on error types to not be present.