### PR TITLE
Backwards compatible CompletionImport#as_underscore

### DIFF
--- a/crates/rust-analyzer/src/lsp/ext.rs
+++ b/crates/rust-analyzer/src/lsp/ext.rs
@@ -858,6 +858,7 @@ pub struct InlayHintResolveData {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct CompletionImport {
     pub full_import_path: String,
+    #[serde(default)]
     pub as_underscore: bool,
 }
 

--- a/docs/book/src/contributing/lsp-extensions.md
+++ b/docs/book/src/contributing/lsp-extensions.md
@@ -1,5 +1,5 @@
 <!---
-lsp/ext.rs hash: dc4ba5f417c74aa6
+lsp/ext.rs hash: edab2f3c124dc28e
 
 If you need to change the above hash to make the test pass, please check if you
 need to adjust this doc as well and ping this issue:


### PR DESCRIPTION
Commit [f42e02aa](https://github.com/rust-lang/rust-analyzer/commit/f42e02aaff84d7b613ab9057036e93010c23b93f#diff-1f818ad963401fe13a8a29e158447fa51390f3026ecba9de2e38a1cbdcaf9f4cR95) introduced a new, required field which breaks auto-import in emacs in the very same fashion as issue rust-lang/rust-analyzer#18767.

This PR makes the field optional; it does not, however, fix the issue per se for emacs users since `lsp-mode` still sends a `null`.