### PR TITLE
fix: editor postfix dedent uses current cursor

### DIFF
--- a/crates/ide-completion/src/completions/postfix.rs
+++ b/crates/ide-completion/src/completions/postfix.rs
@@ -1658,7 +1658,9 @@ fn foo(x: Option<i32>, y: Option<i32>) {
     let _f = || {
         x
             .and(y)
-            .map(|it| it+2)
+            .map(|it| {
+                it+2
+            })
             .$0
     };
 }
@@ -1668,7 +1670,9 @@ fn foo(x: Option<i32>, y: Option<i32>) {
     let _f = || {
         let $0 = x
 .and(y)
-.map(|it| it+2);
+.map(|it| {
+    it+2
+});
     };
 }
 "#,

--- a/crates/ide-completion/src/completions/postfix.rs
+++ b/crates/ide-completion/src/completions/postfix.rs
@@ -398,7 +398,7 @@ fn get_receiver_text(
     }
     let file_text = sema.db.file_text(range.file_id.file_id(sema.db));
     let text = file_text.text(sema.db);
-    let indent_spaces = indent_of_tail_line(&text[TextRange::up_to(range.range.start())]);
+    let indent_spaces = indent_of_tail_line(&text[TextRange::up_to(range.range.end())]);
     let mut text = stdx::dedent_by(indent_spaces, &text[range.range]);
 
     // The receiver texts should be interpreted as-is, as they are expected to be
@@ -1667,8 +1667,8 @@ fn foo(x: Option<i32>, y: Option<i32>) {
 fn foo(x: Option<i32>, y: Option<i32>) {
     let _f = || {
         let $0 = x
-    .and(y)
-    .map(|it| it+2);
+.and(y)
+.map(|it| it+2);
     };
 }
 "#,


### PR DESCRIPTION
Fixup rust-lang/rust-analyzer#21324

I realized that the editor indentation is based on the current cursor position, not the position after completion

Example
---
```rust
fn foo(x: Option<i32>, y: Option<i32>) {
    let _f = || {
        x
            .and(y)
            .map(|it| it+2)
            .let;
    };
}
```

**Before this PR**

```rust
fn foo(x: Option<i32>, y: Option<i32>) {
    let _f = || {
        let $0 = x
                .and(y)
                .map(|it| it+2);
    };
}
```

**After this PR**

```rust
fn foo(x: Option<i32>, y: Option<i32>) {
    let _f = || {
        let $0 = x
            .and(y)
            .map(|it| it+2);
    };
}
```
