### PR TITLE
Fix: renaming mut vars removed `mut` in patterns generated by macro

### DIFF
--- a/crates/ide-db/src/rename.rs
+++ b/crates/ide-db/src/rename.rs
@@ -701,28 +701,36 @@ fn source_edit_from_def(
         for source in local.sources(sema.db) {
             let source = match source.source.clone().original_ast_node_rooted(sema.db) {
                 Some(source) => source,
-                None => match source
-                    .source
-                    .syntax()
-                    .original_file_range_opt(sema.db)
-                    .map(TupleExt::head)
-                {
-                    Some(FileRange { file_id: file_id2, range }) => {
-                        file_id = Some(file_id2);
-                        edit.replace(
-                            range,
-                            new_name.display(sema.db, file_id2.edition(sema.db)).to_string(),
-                        );
-                        continue;
+                None => {
+                    match source
+                        .as_ident_pat()
+                        .and_then(|x| x.name())
+                        .and_then(|x| sema.original_range_opt(x.syntax()))
+                        .or_else(|| {
+                            source
+                                .source
+                                .syntax()
+                                .original_file_range_opt(sema.db)
+                                .map(TupleExt::head)
+                        }) {
+                        Some(FileRange { file_id: file_id2, range }) => {
+                            file_id = Some(file_id2);
+                            edit.replace(
+                                range,
+                                new_name.display(sema.db, file_id2.edition(sema.db)).to_string(),
+                            );
+                            continue;
+                        }
+                        None => {
+                            bail!("Can't rename local that is defined in a macro declaration")
+                        }
                     }
-                    None => {
-                        bail!("Can't rename local that is defined in a macro declaration")
-                    }
-                },
+                }
             };
             file_id = Some(source.file_id);
             if let Either::Left(pat) = source.value {
                 let name_range = pat.name().unwrap().syntax().text_range();
+
                 // special cases required for renaming fields/locals in Record patterns
                 if let Some(pat_field) = pat.syntax().parent().and_then(ast::RecordPatField::cast) {
                     if let Some(name_ref) = pat_field.name_ref() {

--- a/crates/ide/src/rename.rs
+++ b/crates/ide/src/rename.rs
@@ -4085,19 +4085,16 @@ impl<'a, T> Foo<'a, T> {}
         check(
             "new",
             r#"
+//- minicore: option
 macro_rules! pat_macro {
     ($pat:pat) => {
         $pat
     };
 }
-enum CustomOption<T> {
-    None,
-    Some(T),
-}
 
 pub fn main() {
-    match CustomOption::None {
-        pat_macro!(CustomOption::Some(mut old$0)) => {
+    match None {
+        pat_macro!(Some(mut old$0)) => {
             old += 1,
         }
         None => {}
@@ -4110,14 +4107,10 @@ macro_rules! pat_macro {
         $pat
     };
 }
-enum CustomOption<T> {
-    None,
-    Some(T),
-}
 
 pub fn main() {
-    match CustomOption::None {
-        pat_macro!(CustomOption::Some(mut new)) => {
+    match None {
+        pat_macro!(Some(mut new)) => {
             new += 1,
         }
         None => {}
@@ -4131,19 +4124,16 @@ pub fn main() {
         check(
             "new",
             r#"
+//- minicore: option
 macro_rules! pat_macro {
     ($pat:pat) => {
         $pat
     };
 }
-enum CustomOption<T> {
-    None,
-    Some(T),
-}
 
 pub fn main() {
-    match CustomOption::None {
-        pat_macro!(CustomOption::Some(ref old$0)) => {
+    match None {
+        pat_macro!(Some(ref old$0)) => {
             old += 1,
         }
         None => {}
@@ -4156,14 +4146,10 @@ macro_rules! pat_macro {
         $pat
     };
 }
-enum CustomOption<T> {
-    None,
-    Some(T),
-}
 
 pub fn main() {
-    match CustomOption::None {
-        pat_macro!(CustomOption::Some(ref new)) => {
+    match None {
+        pat_macro!(Some(ref new)) => {
             new += 1,
         }
         None => {}

--- a/crates/ide/src/rename.rs
+++ b/crates/ide/src/rename.rs
@@ -4079,4 +4079,51 @@ impl<'a, T> Foo<'a, T> {}
 "#,
         );
     }
+
+    #[test]
+    fn test_rename_mut_pattern_with_macro() {
+        check(
+            "new",
+            r#"
+macro_rules! pat_macro {
+    ($pat:pat) => {
+        $pat
+    };
+}
+enum CustomOption<T> {
+    None,
+    Some(T),
+}
+
+pub fn main() {
+    match CustomOption::None {
+        pat_macro!(CustomOption::Some(mut old$0)) => {
+            old += 1,
+        }
+        None => {}
+    }
+}
+"#,
+            r#"
+macro_rules! pat_macro {
+    ($pat:pat) => {
+        $pat
+    };
+}
+enum CustomOption<T> {
+    None,
+    Some(T),
+}
+
+pub fn main() {
+    match CustomOption::None {
+        pat_macro!(CustomOption::Some(mut new)) => {
+            new += 1,
+        }
+        None => {}
+    }
+}
+"#,
+        );
+    }
 }

--- a/crates/ide/src/rename.rs
+++ b/crates/ide/src/rename.rs
@@ -4126,4 +4126,50 @@ pub fn main() {
 "#,
         );
     }
+    #[test]
+    fn test_rename_ref_pattern_with_macro() {
+        check(
+            "new",
+            r#"
+macro_rules! pat_macro {
+    ($pat:pat) => {
+        $pat
+    };
+}
+enum CustomOption<T> {
+    None,
+    Some(T),
+}
+
+pub fn main() {
+    match CustomOption::None {
+        pat_macro!(CustomOption::Some(ref old$0)) => {
+            old += 1,
+        }
+        None => {}
+    }
+}
+"#,
+            r#"
+macro_rules! pat_macro {
+    ($pat:pat) => {
+        $pat
+    };
+}
+enum CustomOption<T> {
+    None,
+    Some(T),
+}
+
+pub fn main() {
+    match CustomOption::None {
+        pat_macro!(CustomOption::Some(ref new)) => {
+            new += 1,
+        }
+        None => {}
+    }
+}
+"#,
+        );
+    }
 }


### PR DESCRIPTION
Renaming a pattern which is generated by a macro removed the `mut` keyword.
This also fixes it for `ref` (see tests).

Fixes rust-lang/rust-analyzer#22301



