### PR TITLE
Migrate split import to syntax editor

### DIFF
--- a/crates/ide-assists/src/handlers/split_import.rs
+++ b/crates/ide-assists/src/handlers/split_import.rs
@@ -30,9 +30,9 @@ pub(crate) fn split_import(acc: &mut Assists, ctx: &AssistContext<'_, '_>) -> Op
 
     let target = colon_colon.text_range();
     acc.add(AssistId::refactor_rewrite("split_import"), "Split import", target, |edit| {
-        let use_tree = edit.make_mut(use_tree.clone());
-        let path = edit.make_mut(path);
-        use_tree.split_prefix(&path);
+        let editor = edit.make_editor(use_tree.syntax());
+        use_tree.split_prefix_with_editor(&editor, &path);
+        edit.add_file_edits(ctx.vfs_file_id(), editor);
     })
 }
 

--- a/crates/syntax/src/ast/edit_in_place.rs
+++ b/crates/syntax/src/ast/edit_in_place.rs
@@ -147,6 +147,35 @@ impl ast::UseTree {
         }
     }
 
+    /// Editor variant of `split_prefix`
+    pub fn split_prefix_with_editor(&self, editor: &SyntaxEditor, prefix: &ast::Path) {
+        debug_assert_eq!(self.path(), Some(prefix.top_path()));
+
+        let make = editor.make();
+        let path = self.path().unwrap();
+        let suffix = if path == *prefix && self.use_tree_list().is_none() {
+            if self.star_token().is_some() {
+                make.use_tree_glob()
+            } else {
+                let self_path = make.path_unqualified(make.path_segment_self());
+                make.use_tree(self_path, None, None, false)
+            }
+        } else {
+            let suffix_segments = path.segments().skip(prefix.segments().count());
+            let suffix_path = make.path_from_segments(suffix_segments, false);
+            make.use_tree(
+                suffix_path,
+                self.use_tree_list(),
+                self.rename(),
+                self.star_token().is_some(),
+            )
+        };
+        let use_tree_list = make.use_tree_list(once(suffix));
+        let new_use_tree = make.use_tree(prefix.clone(), Some(use_tree_list), None, false);
+
+        editor.replace(self.syntax(), new_use_tree.syntax());
+    }
+
     /// Wraps the use tree in use tree list with no top level path (if it isn't already).
     ///
     /// # Examples

--- a/crates/syntax/src/ast/syntax_factory/constructors.rs
+++ b/crates/syntax/src/ast/syntax_factory/constructors.rs
@@ -663,6 +663,10 @@ impl SyntaxFactory {
         ast
     }
 
+    pub fn use_tree_glob(&self) -> ast::UseTree {
+        make::use_tree_glob().clone_for_update()
+    }
+
     pub fn path_unqualified(&self, segment: ast::PathSegment) -> ast::Path {
         let ast = make::path_unqualified(segment.clone()).clone_for_update();
 


### PR DESCRIPTION
part of https://github.com/rust-lang/rust-analyzer/issues/15710 and https://github.com/rust-lang/rust-analyzer/issues/18285