### PR TITLE
internal: Upgrade rustc crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2067,9 +2067,9 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "ra-ap-rustc_abi"
-version = "0.160.0"
+version = "0.165.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b917ab47d7036977be4c984321af3e0de089229404d68ea9a286f50aa464697"
+checksum = "2f25a779e21ca3bba6795193b16508c8ab159f96ee4b07349893fd272065b525"
 dependencies = [
  "bitflags 2.9.4",
  "ra-ap-rustc_hashes",
@@ -2079,33 +2079,33 @@ dependencies = [
 
 [[package]]
 name = "ra-ap-rustc_ast_ir"
-version = "0.160.0"
+version = "0.165.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "021d80bea67458b8c90cc25bfdca6f911ea818a41905e370c1f310cced1dd07e"
+checksum = "0218ca6c7b096466e85a497e6150c39be5b7bc36637fe62c1cd20370a9d9aac7"
 
 [[package]]
 name = "ra-ap-rustc_hashes"
-version = "0.160.0"
+version = "0.165.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bb89395306ecfc980d252f77a4038d8b8bb578a25c856b545cbeeb3fde8358e"
+checksum = "d6b410bacf1a7c8038f376fa6283003784d568ac012e35fc0aeefa9a5ab11a2e"
 dependencies = [
  "rustc-stable-hash",
 ]
 
 [[package]]
 name = "ra-ap-rustc_index"
-version = "0.160.0"
+version = "0.165.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84219d028a1954c4340ddde11adffe93eb83e476e942718fe926f4d99637cbbe"
+checksum = "2271b55e4a5d0cc0cbe9bdf8056c07ac69e32919a48ce66722ed0526d62588c3"
 dependencies = [
  "ra-ap-rustc_index_macros",
 ]
 
 [[package]]
 name = "ra-ap-rustc_index_macros"
-version = "0.160.0"
+version = "0.165.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3908fdfa258c663d8ee407e6b4a205b0880e323b533c0df7edceafbd54a02fb6"
+checksum = "b6a89e743fb881a1e13544e3395a5ad9ad9280d56384256a121066119abd7af2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2114,9 +2114,9 @@ dependencies = [
 
 [[package]]
 name = "ra-ap-rustc_lexer"
-version = "0.160.0"
+version = "0.165.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34b50f19d5856b8e2b36150e89b53a6102ab096e8044e1f55fd6fef977b10d85"
+checksum = "a6d7c9cc05e0e6b72a214a455a106d9b22b0494164d50a657b17bd319534c218"
 dependencies = [
  "memchr",
  "unicode-ident",
@@ -2125,9 +2125,9 @@ dependencies = [
 
 [[package]]
 name = "ra-ap-rustc_next_trait_solver"
-version = "0.160.0"
+version = "0.165.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76f83dcc451bcee8a99e284a583d5b3d82db5a200107a256a40ef132c4988f1b"
+checksum = "cb3017c2f0ace80b8e6068b9c613aa56ed50e0374bf44a891447511f1264e40d"
 dependencies = [
  "derive-where",
  "ra-ap-rustc_index",
@@ -2138,9 +2138,9 @@ dependencies = [
 
 [[package]]
 name = "ra-ap-rustc_parse_format"
-version = "0.160.0"
+version = "0.165.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31236bdc6cbcae8af42d0b2db2fa8d812a8715b90a2ba5afb1132b37a4d0bbc"
+checksum = "4a737f844bdef8ac5ab54dadf2f34704b4d06beef9236d71080bb34db697220b"
 dependencies = [
  "ra-ap-rustc_lexer",
  "rustc-literal-escaper 0.0.7",
@@ -2148,9 +2148,9 @@ dependencies = [
 
 [[package]]
 name = "ra-ap-rustc_pattern_analysis"
-version = "0.160.0"
+version = "0.165.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fc4edac740e896fba4b3b4d9c423083e3eac49947732561ddfb2377e1f57829"
+checksum = "6de3d4c7d6078cce3c40c55717b8b15002a80b9fa8849faea496a365324861b4"
 dependencies = [
  "ra-ap-rustc_index",
  "rustc-hash 2.1.1",
@@ -2161,9 +2161,9 @@ dependencies = [
 
 [[package]]
 name = "ra-ap-rustc_type_ir"
-version = "0.160.0"
+version = "0.165.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8efa119afc1bcadd821b27aa94332abf79c48ac0a972cb78932f63004ba4cdd9"
+checksum = "8c5d9a4d3e7bee7313599bc6d794037247ac0165f03857379cf4fc3097199e05"
 dependencies = [
  "arrayvec",
  "bitflags 2.9.4",
@@ -2182,9 +2182,9 @@ dependencies = [
 
 [[package]]
 name = "ra-ap-rustc_type_ir_macros"
-version = "0.160.0"
+version = "0.165.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6b1dc03abfabc7179393c282892c73a3f0e4bbd5f0b6c87ff42c2b142e68f57"
+checksum = "024598d1f54272acd83d28c121f8a2e82e216dd7be1e40158b66b2d12fa214c0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,14 +86,14 @@ vfs-notify = { path = "./crates/vfs-notify", version = "0.0.0" }
 vfs = { path = "./crates/vfs", version = "0.0.0" }
 edition = { path = "./crates/edition", version = "0.0.0" }
 
-ra-ap-rustc_lexer = { version = "0.160", default-features = false }
-ra-ap-rustc_parse_format = { version = "0.160", default-features = false }
-ra-ap-rustc_index = { version = "0.160", default-features = false }
-ra-ap-rustc_abi = { version = "0.160", default-features = false }
-ra-ap-rustc_pattern_analysis = { version = "0.160", default-features = false }
-ra-ap-rustc_ast_ir = { version = "0.160", default-features = false }
-ra-ap-rustc_type_ir = { version = "0.160", default-features = false }
-ra-ap-rustc_next_trait_solver = { version = "0.160", default-features = false }
+ra-ap-rustc_lexer = { version = "0.165", default-features = false }
+ra-ap-rustc_parse_format = { version = "0.165", default-features = false }
+ra-ap-rustc_index = { version = "0.165", default-features = false }
+ra-ap-rustc_abi = { version = "0.165", default-features = false }
+ra-ap-rustc_pattern_analysis = { version = "0.165", default-features = false }
+ra-ap-rustc_ast_ir = { version = "0.165", default-features = false }
+ra-ap-rustc_type_ir = { version = "0.165", default-features = false }
+ra-ap-rustc_next_trait_solver = { version = "0.165", default-features = false }
 
 # local crates that aren't published to crates.io. These should not have versions.
 

--- a/crates/hir-def/src/expr_store/lower.rs
+++ b/crates/hir-def/src/expr_store/lower.rs
@@ -18,6 +18,7 @@ use hir_expand::{
     span_map::SpanMap,
 };
 use intern::{Symbol, sym};
+use rustc_abi::ExternAbi;
 use rustc_hash::FxHashMap;
 use smallvec::SmallVec;
 use stdx::never;
@@ -683,15 +684,13 @@ impl<'db> ExprCollector<'db> {
                 } else {
                     Vec::with_capacity(1)
                 };
-                fn lower_abi(abi: ast::Abi) -> Symbol {
-                    match abi.abi_string() {
-                        Some(tok) => Symbol::intern(tok.text_without_quotes()),
-                        // `extern` default to be `extern "C"`.
-                        _ => sym::C,
-                    }
+                fn lower_abi(abi: ast::Abi) -> ExternAbi {
+                    abi.abi_string()
+                        .and_then(|abi| abi.text_without_quotes().parse().ok())
+                        .unwrap_or(ExternAbi::FALLBACK)
                 }
 
-                let abi = inner.abi().map(lower_abi);
+                let abi = inner.abi().map(lower_abi).unwrap_or(ExternAbi::Rust);
                 params.push((None, ret_ty));
                 TypeRef::Fn(Box::new(FnType {
                     is_varargs,

--- a/crates/hir-def/src/expr_store/pretty.rs
+++ b/crates/hir-def/src/expr_store/pretty.rs
@@ -8,6 +8,7 @@ use std::{
 
 use hir_expand::{Lookup, mod_path::PathKind};
 use itertools::Itertools;
+use rustc_abi::ExternAbi;
 use span::Edition;
 use stdx::never;
 use syntax::ast::{HasName, RangeOp};
@@ -292,7 +293,7 @@ pub fn print_function(
     if flags.contains(FnFlags::EXPLICIT_SAFE) {
         w!(p, "safe ");
     }
-    if let Some(abi) = abi {
+    if *abi != ExternAbi::Rust {
         w!(p, "extern \"{}\" ", abi.as_str());
     }
     w!(p, "fn ");
@@ -1315,9 +1316,9 @@ impl Printer<'_> {
                 if fn_.is_unsafe {
                     w!(self, "unsafe ");
                 }
-                if let Some(abi) = &fn_.abi {
+                if fn_.abi != ExternAbi::Rust {
                     w!(self, "extern ");
-                    w!(self, "{}", abi.as_str());
+                    w!(self, "{}", fn_.abi.as_str());
                     w!(self, " ");
                 }
                 w!(self, "fn(");

--- a/crates/hir-def/src/hir/type_ref.rs
+++ b/crates/hir-def/src/hir/type_ref.rs
@@ -2,8 +2,8 @@
 //! be directly created from an ast::TypeRef, without further queries.
 
 use hir_expand::name::Name;
-use intern::Symbol;
 use la_arena::Idx;
+use rustc_abi::ExternAbi;
 use thin_vec::ThinVec;
 
 use crate::{
@@ -100,7 +100,7 @@ pub struct FnType {
     pub params: Box<[(Option<Name>, TypeRefId)]>,
     pub is_varargs: bool,
     pub is_unsafe: bool,
-    pub abi: Option<Symbol>,
+    pub abi: ExternAbi,
 }
 
 impl FnType {

--- a/crates/hir-def/src/lib.rs
+++ b/crates/hir-def/src/lib.rs
@@ -47,8 +47,9 @@ pub mod find_path;
 pub mod import_map;
 pub mod visibility;
 
-use intern::{Interned, Symbol};
+use intern::Interned;
 pub use rustc_abi as layout;
+use rustc_abi::ExternAbi;
 use thin_vec::ThinVec;
 
 pub use crate::signatures::LocalFieldId;
@@ -360,10 +361,8 @@ impl_intern!(ExternCrateId, ExternCrateLoc, intern_extern_crate, lookup_intern_e
 type ExternBlockLoc = ItemLoc<ast::ExternBlock>;
 impl_intern!(ExternBlockId, ExternBlockLoc, intern_extern_block, lookup_intern_extern_block);
 
-#[salsa::tracked]
 impl ExternBlockId {
-    #[salsa::tracked]
-    pub fn abi(self, db: &dyn DefDatabase) -> Option<Symbol> {
+    pub fn abi(self, db: &dyn DefDatabase) -> ExternAbi {
         signatures::extern_block_abi(db, self)
     }
 }

--- a/crates/hir-def/src/signatures.rs
+++ b/crates/hir-def/src/signatures.rs
@@ -8,9 +8,9 @@ use hir_expand::{
     InFile, Intern, Lookup,
     name::{AsName, Name},
 };
-use intern::{Symbol, sym};
+use intern::sym;
 use la_arena::{Arena, Idx};
-use rustc_abi::{IntegerType, ReprOptions};
+use rustc_abi::{ExternAbi, IntegerType, ReprOptions};
 use syntax::{
     AstNode, NodeOrToken, SyntaxNodePtr, T,
     ast::{self, HasGenericParams, HasName, HasVisibility, IsString},
@@ -607,7 +607,7 @@ pub struct FunctionSignature {
     pub store: ExpressionStore,
     pub params: Box<[TypeRefId]>,
     pub ret_type: Option<TypeRefId>,
-    pub abi: Option<Symbol>,
+    pub abi: ExternAbi,
     pub flags: FnFlags,
 }
 
@@ -677,14 +677,18 @@ impl FunctionSignature {
             .abi()
             .map(|abi| {
                 abi.abi_string()
-                    .map_or_else(|| sym::C, |it| Symbol::intern(it.text_without_quotes()))
+                    .and_then(|abi| abi.text_without_quotes().parse().ok())
+                    .unwrap_or(ExternAbi::FALLBACK)
             })
             .or_else(|| match loc.container {
-                ItemContainerId::ExternBlockId(extern_block) => extern_block_abi(db, extern_block),
+                ItemContainerId::ExternBlockId(extern_block) => {
+                    Some(extern_block_abi(db, extern_block))
+                }
                 ItemContainerId::ModuleId(_)
                 | ItemContainerId::ImplId(_)
                 | ItemContainerId::TraitId(_) => None,
-            });
+            })
+            .unwrap_or(ExternAbi::Rust);
         let (store, source_map, generic_params, params, ret_type, self_param, variadic) =
             lower_function(db, module, source, id);
         if self_param {
@@ -771,8 +775,6 @@ impl FunctionSignature {
     pub fn is_intrinsic(db: &dyn DefDatabase, id: FunctionId) -> bool {
         let data = FunctionSignature::of(db, id);
         data.flags.contains(FnFlags::RUSTC_INTRINSIC)
-            // Keep this around for a bit until extern "rustc-intrinsic" abis are no longer used
-            || data.abi.as_ref().is_some_and(|abi| *abi == sym::rust_dash_intrinsic)
     }
 }
 
@@ -1136,16 +1138,12 @@ impl EnumVariants {
     }
 }
 
-pub(crate) fn extern_block_abi(
-    db: &dyn DefDatabase,
-    extern_block: ExternBlockId,
-) -> Option<Symbol> {
+#[salsa::tracked]
+pub(crate) fn extern_block_abi(db: &dyn DefDatabase, extern_block: ExternBlockId) -> ExternAbi {
     let source = extern_block.lookup(db).source(db);
-    source.value.abi().map(|abi| {
-        match abi.abi_string() {
-            Some(tok) => Symbol::intern(tok.text_without_quotes()),
-            // `extern` default to be `extern "C"`.
-            _ => sym::C,
-        }
-    })
+    source
+        .value
+        .abi()
+        .and_then(|abi| abi.abi_string()?.text_without_quotes().parse().ok())
+        .unwrap_or(ExternAbi::FALLBACK)
 }

--- a/crates/hir-ty/src/builtin_derive.rs
+++ b/crates/hir-ty/src/builtin_derive.rs
@@ -21,7 +21,8 @@ use crate::{
     db::HirDatabase,
     next_solver::{
         AliasTy, Clause, Clauses, DbInterner, EarlyBinder, GenericArgs, ParamEnv,
-        StoredEarlyBinder, StoredTy, TraitRef, Ty, TyKind, fold::fold_tys, generics::Generics,
+        StoredEarlyBinder, StoredTy, TraitRef, Ty, TyKind, Unnormalized, fold::fold_tys,
+        generics::Generics,
     },
 };
 
@@ -197,6 +198,7 @@ pub fn predicates(db: &dyn HirDatabase, impl_: BuiltinDeriveImplId) -> GenericPr
             };
             let duplicated_bounds =
                 adt_predicates.explicit_predicates().iter_identity().filter_map(|pred| {
+                    let pred = pred.skip_norm_wip();
                     let mentions_pointee =
                         pred.visit_with(&mut MentionsPointee { pointee_param_idx }).is_break();
                     if !mentions_pointee {
@@ -218,6 +220,7 @@ pub fn predicates(db: &dyn HirDatabase, impl_: BuiltinDeriveImplId) -> GenericPr
                     adt_predicates
                         .explicit_predicates()
                         .iter_identity()
+                        .map(Unnormalized::skip_norm_wip)
                         .chain(duplicated_bounds)
                         .chain(unsize_bound),
                 )
@@ -319,6 +322,7 @@ fn simple_trait_predicates<'db>(
             adt_predicates
                 .explicit_predicates()
                 .iter_identity()
+                .map(Unnormalized::skip_norm_wip)
                 .chain(extra_predicates)
                 .chain(assoc_type_bounds),
         )
@@ -361,7 +365,7 @@ fn extend_assoc_type_bounds<'db>(
 
     let mut visitor = ProjectionFinder { interner, assoc_type_bounds, trait_id, trait_ };
     for (_, field) in fields.iter() {
-        field.get().instantiate_identity().visit_with(&mut visitor);
+        field.get().instantiate_identity().skip_norm_wip().visit_with(&mut visitor);
     }
 }
 

--- a/crates/hir-ty/src/consteval/tests.rs
+++ b/crates/hir-ty/src/consteval/tests.rs
@@ -2565,9 +2565,8 @@ fn const_transfer_memory() {
 fn anonymous_const_block() {
     check_number(
         r#"
-    extern "rust-intrinsic" {
-        pub fn size_of<T>() -> usize;
-    }
+    #[rustc_intrinsic]
+    pub fn size_of<T>() -> usize;
 
     const fn f<T>() -> usize {
         let r = const { size_of::<T>() };

--- a/crates/hir-ty/src/consteval/tests/intrinsics.rs
+++ b/crates/hir-ty/src/consteval/tests/intrinsics.rs
@@ -204,12 +204,11 @@ fn const_eval_select() {
     check_number(
         r#"
         //- minicore: fn
-        extern "rust-intrinsic" {
-            pub fn const_eval_select<ARG, F, G, RET>(arg: ARG, called_in_const: F, called_at_rt: G) -> RET
-            where
-                G: FnOnce<ARG, Output = RET>,
-                F: FnOnce<ARG, Output = RET>;
-        }
+        #[rustc_intrinsic]
+        pub fn const_eval_select<ARG, F, G, RET>(arg: ARG, called_in_const: F, called_at_rt: G) -> RET
+        where
+            G: FnOnce<ARG, Output = RET>,
+            F: FnOnce<ARG, Output = RET>;
 
         const fn in_const(x: i32, y: i32) -> i32 {
             x + y
@@ -229,9 +228,8 @@ fn const_eval_select() {
 fn wrapping_add() {
     check_number(
         r#"
-        extern "rust-intrinsic" {
-            pub fn wrapping_add<T>(a: T, b: T) -> T;
-        }
+        #[rustc_intrinsic]
+        pub fn wrapping_add<T>(a: T, b: T) -> T;
 
         const GOAL: u8 = wrapping_add(10, 250);
         "#,
@@ -244,10 +242,10 @@ fn ptr_offset_from() {
     check_number(
         r#"
         //- minicore: index, slice, coerce_unsized
-        extern "rust-intrinsic" {
-            pub fn ptr_offset_from<T>(ptr: *const T, base: *const T) -> isize;
-            pub fn ptr_offset_from_unsigned<T>(ptr: *const T, base: *const T) -> usize;
-        }
+        #[rustc_intrinsic]
+        pub fn ptr_offset_from<T>(ptr: *const T, base: *const T) -> isize;
+        #[rustc_intrinsic]
+        pub fn ptr_offset_from_unsigned<T>(ptr: *const T, base: *const T) -> usize;
 
         const GOAL: isize = {
             let x = [1, 2, 3, 4, 5i32];
@@ -265,9 +263,8 @@ fn ptr_offset_from() {
 fn saturating() {
     check_number(
         r#"
-        extern "rust-intrinsic" {
-            pub fn saturating_add<T>(a: T, b: T) -> T;
-        }
+        #[rustc_intrinsic]
+        pub fn saturating_add<T>(a: T, b: T) -> T;
 
         const GOAL: u8 = saturating_add(10, 250);
         "#,
@@ -275,9 +272,8 @@ fn saturating() {
     );
     check_number(
         r#"
-        extern "rust-intrinsic" {
-            pub fn saturating_sub<T>(a: T, b: T) -> T;
-        }
+        #[rustc_intrinsic]
+        pub fn saturating_sub<T>(a: T, b: T) -> T;
 
         const GOAL: bool = saturating_sub(5u8, 7) == 0 && saturating_sub(8u8, 4) == 4;
         "#,
@@ -285,9 +281,8 @@ fn saturating() {
     );
     check_number(
         r#"
-        extern "rust-intrinsic" {
-            pub fn saturating_add<T>(a: T, b: T) -> T;
-        }
+        #[rustc_intrinsic]
+        pub fn saturating_add<T>(a: T, b: T) -> T;
 
         const GOAL: i8 = saturating_add(5, 8);
         "#,
@@ -330,9 +325,8 @@ fn allocator() {
 fn overflowing_add() {
     check_number(
         r#"
-        extern "rust-intrinsic" {
-            pub fn add_with_overflow<T>(x: T, y: T) -> (T, bool);
-        }
+        #[rustc_intrinsic]
+        pub fn add_with_overflow<T>(x: T, y: T) -> (T, bool);
 
         const GOAL: u8 = add_with_overflow(1, 2).0;
         "#,
@@ -340,9 +334,8 @@ fn overflowing_add() {
     );
     check_number(
         r#"
-        extern "rust-intrinsic" {
-            pub fn add_with_overflow<T>(x: T, y: T) -> (T, bool);
-        }
+        #[rustc_intrinsic]
+        pub fn add_with_overflow<T>(x: T, y: T) -> (T, bool);
 
         const GOAL: u8 = add_with_overflow(1, 2).1 as u8;
         "#,
@@ -357,9 +350,8 @@ fn needs_drop() {
         //- minicore: drop, manually_drop, copy, sized, phantom_data
         use core::mem::ManuallyDrop;
         use core::marker::PhantomData;
-        extern "rust-intrinsic" {
-            pub fn needs_drop<T: ?Sized>() -> bool;
-        }
+        #[rustc_intrinsic]
+        pub fn needs_drop<T: ?Sized>() -> bool;
         struct X;
         struct NeedsDrop;
         impl Drop for NeedsDrop {
@@ -405,9 +397,8 @@ fn discriminant_value() {
         r#"
         //- minicore: discriminant, option
         use core::marker::DiscriminantKind;
-        extern "rust-intrinsic" {
-            pub fn discriminant_value<T>(v: &T) -> <T as DiscriminantKind>::Discriminant;
-        }
+        #[rustc_intrinsic]
+        pub fn discriminant_value<T>(v: &T) -> <T as DiscriminantKind>::Discriminant;
         const GOAL: bool = {
             discriminant_value(&Some(2i32)) == discriminant_value(&Some(5i32))
                 && discriminant_value(&Some(2i32)) != discriminant_value(&None::<i32>)
@@ -442,11 +433,12 @@ fn floating_point() {
     // FIXME(#17451): Add `f16` and `f128` tests once intrinsics are added.
     check_number(
         r#"
-        extern "rust-intrinsic" {
-            pub fn sqrtf32(x: f32) -> f32;
-            pub fn powf32(a: f32, x: f32) -> f32;
-            pub fn fmaf32(a: f32, b: f32, c: f32) -> f32;
-        }
+        #[rustc_intrinsic]
+        pub fn sqrtf32(x: f32) -> f32;
+        #[rustc_intrinsic]
+        pub fn powf32(a: f32, x: f32) -> f32;
+        #[rustc_intrinsic]
+        pub fn fmaf32(a: f32, b: f32, c: f32) -> f32;
 
         const GOAL: f32 = sqrtf32(1.2) + powf32(3.4, 5.6) + fmaf32(-7.8, 1.3, 2.4);
         "#,
@@ -458,11 +450,12 @@ fn floating_point() {
     #[allow(unknown_lints, clippy::unnecessary_min_or_max)]
     check_number(
         r#"
-        extern "rust-intrinsic" {
-            pub fn powif64(a: f64, x: i32) -> f64;
-            pub fn sinf64(x: f64) -> f64;
-            pub fn minnumf64(x: f64, y: f64) -> f64;
-        }
+        #[rustc_intrinsic]
+        pub fn powif64(a: f64, x: i32) -> f64;
+        #[rustc_intrinsic]
+        pub fn sinf64(x: f64) -> f64;
+        #[rustc_intrinsic]
+        pub fn minnumf64(x: f64, y: f64) -> f64;
 
         const GOAL: f64 = powif64(1.2, 5) + sinf64(3.4) + minnumf64(-7.8, 1.3);
         "#,
@@ -478,21 +471,32 @@ fn atomic() {
     check_number(
         r#"
         //- minicore: copy
-        extern "rust-intrinsic" {
-            pub fn atomic_load_seqcst<T: Copy>(src: *const T) -> T;
-            pub fn atomic_xchg_acquire<T: Copy>(dst: *mut T, src: T) -> T;
-            pub fn atomic_cxchg_release_seqcst<T: Copy>(dst: *mut T, old: T, src: T) -> (T, bool);
-            pub fn atomic_cxchgweak_acquire_acquire<T: Copy>(dst: *mut T, old: T, src: T) -> (T, bool);
-            pub fn atomic_store_release<T: Copy>(dst: *mut T, val: T);
-            pub fn atomic_xadd_acqrel<T: Copy>(dst: *mut T, src: T) -> T;
-            pub fn atomic_xsub_seqcst<T: Copy>(dst: *mut T, src: T) -> T;
-            pub fn atomic_and_acquire<T: Copy>(dst: *mut T, src: T) -> T;
-            pub fn atomic_nand_seqcst<T: Copy>(dst: *mut T, src: T) -> T;
-            pub fn atomic_or_release<T: Copy>(dst: *mut T, src: T) -> T;
-            pub fn atomic_xor_seqcst<T: Copy>(dst: *mut T, src: T) -> T;
-            pub fn atomic_fence_seqcst();
-            pub fn atomic_singlethreadfence_acqrel();
-        }
+        #[rustc_intrinsic]
+        pub fn atomic_load_seqcst<T: Copy>(src: *const T) -> T;
+        #[rustc_intrinsic]
+        pub fn atomic_xchg_acquire<T: Copy>(dst: *mut T, src: T) -> T;
+        #[rustc_intrinsic]
+        pub fn atomic_cxchg_release_seqcst<T: Copy>(dst: *mut T, old: T, src: T) -> (T, bool);
+        #[rustc_intrinsic]
+        pub fn atomic_cxchgweak_acquire_acquire<T: Copy>(dst: *mut T, old: T, src: T) -> (T, bool);
+        #[rustc_intrinsic]
+        pub fn atomic_store_release<T: Copy>(dst: *mut T, val: T);
+        #[rustc_intrinsic]
+        pub fn atomic_xadd_acqrel<T: Copy>(dst: *mut T, src: T) -> T;
+        #[rustc_intrinsic]
+        pub fn atomic_xsub_seqcst<T: Copy>(dst: *mut T, src: T) -> T;
+        #[rustc_intrinsic]
+        pub fn atomic_and_acquire<T: Copy>(dst: *mut T, src: T) -> T;
+        #[rustc_intrinsic]
+        pub fn atomic_nand_seqcst<T: Copy>(dst: *mut T, src: T) -> T;
+        #[rustc_intrinsic]
+        pub fn atomic_or_release<T: Copy>(dst: *mut T, src: T) -> T;
+        #[rustc_intrinsic]
+        pub fn atomic_xor_seqcst<T: Copy>(dst: *mut T, src: T) -> T;
+        #[rustc_intrinsic]
+        pub fn atomic_fence_seqcst();
+        #[rustc_intrinsic]
+        pub fn atomic_singlethreadfence_acqrel();
 
         fn should_not_reach() {
             _ // fails the test if executed
@@ -528,10 +532,10 @@ fn offset() {
     check_number(
         r#"
         //- minicore: coerce_unsized, index, slice
-        extern "rust-intrinsic" {
-            pub fn offset<Ptr, Delta>(dst: Ptr, offset: Delta) -> Ptr;
-            pub fn arith_offset<T>(dst: *const T, offset: isize) -> *const T;
-        }
+        #[rustc_intrinsic]
+        pub fn offset<Ptr, Delta>(dst: Ptr, offset: Delta) -> Ptr;
+        #[rustc_intrinsic]
+        pub fn arith_offset<T>(dst: *const T, offset: isize) -> *const T;
 
         const GOAL: i32 = unsafe {
             let ar: &[(i32, i32, i32)] = &[
@@ -557,9 +561,8 @@ fn arith_offset() {
     check_number(
         r#"
         //- minicore: coerce_unsized, index, slice
-        extern "rust-intrinsic" {
-            pub fn arith_offset<T>(dst: *const T, offset: isize) -> *const T;
-        }
+        #[rustc_intrinsic]
+        pub fn arith_offset<T>(dst: *const T, offset: isize) -> *const T;
 
         const GOAL: u8 = unsafe {
             let ar: &[(u8, u8, u8)] = &[
@@ -583,9 +586,8 @@ fn arith_offset() {
 fn copy_nonoverlapping() {
     check_number(
         r#"
-        extern "rust-intrinsic" {
-            pub fn copy_nonoverlapping<T>(src: *const T, dst: *mut T, count: usize);
-        }
+        #[rustc_intrinsic]
+        pub fn copy_nonoverlapping<T>(src: *const T, dst: *mut T, count: usize);
 
         const GOAL: u8 = unsafe {
             let mut x = 2;
@@ -602,9 +604,8 @@ fn copy_nonoverlapping() {
 fn write_bytes() {
     check_number(
         r#"
-        extern "rust-intrinsic" {
-            fn write_bytes<T>(dst: *mut T, val: u8, count: usize);
-        }
+        #[rustc_intrinsic]
+        fn write_bytes<T>(dst: *mut T, val: u8, count: usize);
 
         const GOAL: i32 = unsafe {
             let mut x = 2;
@@ -620,9 +621,8 @@ fn write_bytes() {
 fn write_via_move() {
     check_number(
         r#"
-        extern "rust-intrinsic" {
-            fn write_via_move<T>(ptr: *mut T, value: T);
-        }
+        #[rustc_intrinsic]
+        fn write_via_move<T>(ptr: *mut T, value: T);
 
         const GOAL: i32 = unsafe {
             let mut x = 2;
@@ -639,9 +639,8 @@ fn copy() {
     check_number(
         r#"
         //- minicore: coerce_unsized, index, slice
-        extern "rust-intrinsic" {
-            pub fn copy<T>(src: *const T, dst: *mut T, count: usize);
-        }
+        #[rustc_intrinsic]
+        pub fn copy<T>(src: *const T, dst: *mut T, count: usize);
 
         const GOAL: i32 = unsafe {
             let mut x = [1i32, 2, 3, 4, 5];
@@ -659,9 +658,8 @@ fn copy() {
 fn ctpop() {
     check_number(
         r#"
-        extern "rust-intrinsic" {
-            pub fn ctpop<T: Copy>(x: T) -> T;
-        }
+        #[rustc_intrinsic]
+        pub fn ctpop<T: Copy>(x: T) -> T;
 
         const GOAL: i64 = ctpop(-29);
         "#,
@@ -673,9 +671,8 @@ fn ctpop() {
 fn ctlz() {
     check_number(
         r#"
-        extern "rust-intrinsic" {
-            pub fn ctlz<T: Copy>(x: T) -> T;
-        }
+        #[rustc_intrinsic]
+        pub fn ctlz<T: Copy>(x: T) -> T;
 
         const GOAL: u8 = ctlz(0b0001_1100_u8);
         "#,
@@ -687,9 +684,8 @@ fn ctlz() {
 fn cttz() {
     check_number(
         r#"
-        extern "rust-intrinsic" {
-            pub fn cttz<T: Copy>(x: T) -> T;
-        }
+        #[rustc_intrinsic]
+        pub fn cttz<T: Copy>(x: T) -> T;
 
         const GOAL: i64 = cttz(-24);
         "#,
@@ -701,9 +697,8 @@ fn cttz() {
 fn rotate() {
     check_number(
         r#"
-        extern "rust-intrinsic" {
-            pub fn rotate_left<T: Copy>(x: T, y: T) -> T;
-        }
+        #[rustc_intrinsic]
+        pub fn rotate_left<T: Copy>(x: T, y: T) -> T;
 
         const GOAL: i64 = rotate_left(0xaa00000000006e1i64, 12);
         "#,
@@ -711,9 +706,8 @@ fn rotate() {
     );
     check_number(
         r#"
-        extern "rust-intrinsic" {
-            pub fn rotate_right<T: Copy>(x: T, y: T) -> T;
-        }
+        #[rustc_intrinsic]
+        pub fn rotate_right<T: Copy>(x: T, y: T) -> T;
 
         const GOAL: i64 = rotate_right(0x6e10aa, 12);
         "#,
@@ -721,9 +715,8 @@ fn rotate() {
     );
     check_number(
         r#"
-        extern "rust-intrinsic" {
-            pub fn rotate_left<T: Copy>(x: T, y: T) -> T;
-        }
+        #[rustc_intrinsic]
+        pub fn rotate_left<T: Copy>(x: T, y: T) -> T;
 
         const GOAL: i8 = rotate_left(129, 2);
         "#,

--- a/crates/hir-ty/src/diagnostics/decl_check.rs
+++ b/crates/hir-ty/src/diagnostics/decl_check.rs
@@ -33,7 +33,7 @@ use hir_expand::{
     HirFileId,
     name::{AsName, Name},
 };
-use intern::sym;
+use rustc_abi::ExternAbi;
 use stdx::{always, never};
 use syntax::{
     AstNode, AstPtr, ToSmolStr,
@@ -211,7 +211,7 @@ impl<'a> DeclValidator<'a> {
             // Don't run the lint on extern "[not Rust]" fn items with the
             // #[no_mangle] attribute.
             let no_mangle = AttrFlags::query(self.db, func.into()).contains(AttrFlags::NO_MANGLE);
-            if no_mangle && data.abi.as_ref().is_some_and(|abi| *abi != sym::Rust) {
+            if no_mangle && data.abi != ExternAbi::Rust {
                 cov_mark::hit!(extern_func_no_mangle_ignored);
             } else {
                 self.create_incorrect_case_diagnostic_for_item_name(

--- a/crates/hir-ty/src/diagnostics/match_check/pat_analysis.rs
+++ b/crates/hir-ty/src/diagnostics/match_check/pat_analysis.rs
@@ -149,7 +149,7 @@ impl<'a, 'db> MatchCheckCtx<'a, 'db> {
         let fields_len = variant.fields(self.db).fields().len() as u32;
 
         (0..fields_len).map(|idx| LocalFieldId::from_raw(idx.into())).map(move |fid| {
-            let ty = field_tys[fid].get().instantiate(self.infcx.interner, substs);
+            let ty = field_tys[fid].get().instantiate(self.infcx.interner, substs).skip_norm_wip();
             let ty = self
                 .infcx
                 .at(&ObligationCause::dummy(), self.env)

--- a/crates/hir-ty/src/diagnostics/unsafe_check.rs
+++ b/crates/hir-ty/src/diagnostics/unsafe_check.rs
@@ -298,7 +298,7 @@ impl<'db> UnsafeVisitor<'db> {
                     self.check_call(current, func);
                 }
                 if let TyKind::FnPtr(_, hdr) = callee.kind()
-                    && hdr.safety == Safety::Unsafe
+                    && hdr.safety() == Safety::Unsafe
                 {
                     self.on_unsafe_op(current.into(), UnsafetyReason::UnsafeFnCall);
                 }

--- a/crates/hir-ty/src/display.rs
+++ b/crates/hir-ty/src/display.rs
@@ -11,7 +11,7 @@ use base_db::{Crate, FxIndexMap};
 use either::Either;
 use hir_def::{
     ExpressionStoreOwnerId, FindPathConfig, GenericDefId, GenericParamId, HasModule,
-    ItemContainerId, LocalFieldId, Lookup, ModuleDefId, ModuleId, TraitId,
+    ItemContainerId, LocalFieldId, Lookup, ModuleDefId, ModuleId, TraitId, TypeAliasId,
     expr_store::{ExpressionStore, path::Path},
     find_path::{self, PrefixKind},
     hir::{
@@ -35,6 +35,7 @@ use hir_expand::{mod_path::PathKind, name::Name};
 use intern::{Internable, Interned, sym};
 use itertools::Itertools;
 use la_arena::ArenaMap;
+use rustc_abi::ExternAbi;
 use rustc_apfloat::{
     Float,
     ieee::{Half as f16, Quad as f128},
@@ -50,7 +51,7 @@ use span::Edition;
 use stdx::never;
 
 use crate::{
-    CallableDefId, FnAbi, ImplTraitId, MemoryMap, ParamEnvAndCrate, consteval,
+    CallableDefId, ImplTraitId, MemoryMap, ParamEnvAndCrate, consteval,
     db::{GeneralConstId, HirDatabase},
     generics::{ProvenanceSplit, generics},
     layout::Layout,
@@ -59,8 +60,8 @@ use crate::{
     next_solver::{
         AliasTy, Allocation, Clause, ClauseKind, Const, ConstKind, DbInterner,
         ExistentialPredicate, FnSig, GenericArg, GenericArgKind, GenericArgs, ParamEnv, PolyFnSig,
-        Region, SolverDefId, StoredEarlyBinder, StoredTy, Term, TermKind, TraitPredicate, TraitRef,
-        Ty, TyKind, TypingMode, ValTree,
+        Region, StoredEarlyBinder, StoredTy, Term, TermId, TermKind, TraitPredicate, TraitRef, Ty,
+        TyKind, TypingMode, Unnormalized, ValTree,
         abi::Safety,
         infer::{DbInternerInferExt, traits::ObligationCause},
     },
@@ -190,7 +191,7 @@ impl<'db> HirFormatter<'_, 'db> {
             } else {
                 match target.kind {
                     AliasTyKind::Projection { def_id } => {
-                        let def_id = def_id.expect_type_alias();
+                        let def_id = def_id.0;
                         let ItemContainerId::TraitId(trait_) = def_id.loc(self.db).container else {
                             panic!("expected an assoc type");
                         };
@@ -653,6 +654,7 @@ fn write_projection<'db>(
     f: &mut HirFormatter<'_, 'db>,
     alias: &AliasTy<'db>,
     needs_parens_if_multi: bool,
+    def_id: TypeAliasId,
 ) -> Result {
     f.format_bounds_with(*alias, |f| {
         if f.should_truncate() {
@@ -671,6 +673,7 @@ fn write_projection<'db>(
             // `GenericDefId` from the formatted type (store it inside the `HirFormatter`).
             let bounds = GenericPredicates::query_all(f.db, param.id.parent())
                 .iter_identity()
+                .map(Unnormalized::skip_norm_wip)
                 .filter(|wc| {
                     let ty = match wc.kind().skip_binder() {
                         ClauseKind::Trait(tr) => tr.self_ty(),
@@ -699,13 +702,7 @@ fn write_projection<'db>(
         self_ty.hir_fmt(f)?;
         write!(f, " as ")?;
         trait_ref.hir_fmt(f)?;
-        write!(
-            f,
-            ">::{}",
-            TypeAliasSignature::of(f.db, alias.kind.def_id().expect_type_alias())
-                .name
-                .display(f.db, f.edition())
-        )?;
+        write!(f, ">::{}", TypeAliasSignature::of(f.db, def_id).name.display(f.db, f.edition()))?;
         let proj_params = &alias.args.as_slice()[trait_ref.args.len()..];
         hir_fmt_generics(f, proj_params, None, None)
     })
@@ -1223,7 +1220,7 @@ fn render_variant_after_name<'db>(
         FieldsShape::Record | FieldsShape::Tuple => {
             let render_field = |f: &mut HirFormatter<'_, 'db>, id: LocalFieldId| {
                 let offset = layout.fields.offset(u32::from(id.into_raw()) as usize).bytes_usize();
-                let ty = field_types[id].get().instantiate(f.interner, args);
+                let ty = field_types[id].get().instantiate(f.interner, args).skip_norm_wip();
                 let Ok(layout) = f.db.layout_of_ty(ty.store(), param_env.store()) else {
                     return f.write_str("<layout-error>");
                 };
@@ -1334,7 +1331,8 @@ impl<'db> HirDisplay<'db> for Ty<'db> {
             }
             TyKind::FnDef(def, args) => {
                 let def = def.0;
-                let sig = db.callable_item_signature(def).instantiate(interner, args);
+                let sig =
+                    db.callable_item_signature(def).instantiate(interner, args).skip_norm_wip();
 
                 if f.display_kind.is_source_code() {
                     // `FnDef` is anonymous and there's no surface syntax for it. Show it as a
@@ -1344,7 +1342,7 @@ impl<'db> HirDisplay<'db> for Ty<'db> {
                 if let Safety::Unsafe = sig.safety() {
                     write!(f, "unsafe ")?;
                 }
-                if !matches!(sig.abi(), FnAbi::Rust | FnAbi::RustCall) {
+                if !sig.abi().is_rustic_abi() {
                     f.write_str("extern \"")?;
                     f.write_str(sig.abi().as_str())?;
                     f.write_str("\" ")?;
@@ -1480,8 +1478,8 @@ impl<'db> HirDisplay<'db> for Ty<'db> {
 
                 hir_fmt_generics(f, parameters.as_slice(), Some(def.def_id().into()), None)?;
             }
-            TyKind::Alias(alias_ty @ AliasTy { kind: AliasTyKind::Projection { .. }, .. }) => {
-                write_projection(f, &alias_ty, trait_bounds_need_parens)?
+            TyKind::Alias(alias_ty @ AliasTy { kind: AliasTyKind::Projection { def_id }, .. }) => {
+                write_projection(f, &alias_ty, trait_bounds_need_parens, def_id.0)?
             }
             TyKind::Foreign(alias) => {
                 let type_alias = TypeAliasSignature::of(db, alias.0);
@@ -1490,10 +1488,7 @@ impl<'db> HirDisplay<'db> for Ty<'db> {
                 f.end_location_link();
             }
             TyKind::Alias(alias_ty @ AliasTy { kind: AliasTyKind::Opaque { def_id }, .. }) => {
-                let opaque_ty_id = match def_id {
-                    SolverDefId::InternedOpaqueTyId(id) => id,
-                    _ => unreachable!(),
-                };
+                let opaque_ty_id = def_id.0;
                 if !f.display_kind.allows_opaque() {
                     return Err(HirDisplayError::DisplaySourceCodeError(
                         DisplaySourceCodeError::OpaqueType,
@@ -1503,6 +1498,7 @@ impl<'db> HirDisplay<'db> for Ty<'db> {
                 let data = impl_trait_id.predicates(db);
                 let bounds = data
                     .iter_instantiated_copied(interner, alias_ty.args.as_slice())
+                    .map(Unnormalized::skip_norm_wip)
                     .collect::<Vec<_>>();
                 let krate = match impl_trait_id {
                     ImplTraitId::ReturnTypeImplTrait(func, _) => {
@@ -1670,6 +1666,7 @@ impl<'db> HirDisplay<'db> for Ty<'db> {
                         TypeParamProvenance::ArgumentImplTrait => {
                             let bounds = GenericPredicates::query_all(f.db, param.id.parent())
                                 .iter_identity()
+                                .map(Unnormalized::skip_norm_wip)
                                 .filter(|wc| match wc.kind().skip_binder() {
                                     ClauseKind::Trait(tr) => tr.self_ty() == *self,
                                     ClauseKind::Projection(proj) => proj.self_ty() == *self,
@@ -1878,7 +1875,9 @@ fn generic_args_sans_defaults<'ga, 'db>(
                 let should_show = |arg: GenericArg<'db>, i: usize| match default_parameters.get(i) {
                     None => true,
                     Some(default_parameter) => {
-                        arg != default_parameter.instantiate(f.interner, &parameters[..i])
+                        arg != default_parameter
+                            .instantiate(f.interner, &parameters[..i])
+                            .skip_norm_wip()
                     }
                 };
                 let mut default_from = 0;
@@ -1961,8 +1960,8 @@ fn hir_fmt_tys<'db>(
 
 impl<'db> HirDisplay<'db> for PolyFnSig<'db> {
     fn hir_fmt(&self, f: &mut HirFormatter<'_, 'db>) -> Result {
-        let FnSig { inputs_and_output, c_variadic, safety, abi: _ } = self.skip_binder();
-        if let Safety::Unsafe = safety {
+        let FnSig { inputs_and_output, fn_sig_kind } = self.skip_binder();
+        if let Safety::Unsafe = fn_sig_kind.safety() {
             write!(f, "unsafe ")?;
         }
         // FIXME: Enable this when the FIXME on FnAbi regarding PartialEq is fixed.
@@ -1973,7 +1972,7 @@ impl<'db> HirDisplay<'db> for PolyFnSig<'db> {
         // }
         write!(f, "fn(")?;
         f.write_joined(inputs_and_output.inputs(), ", ")?;
-        if c_variadic {
+        if fn_sig_kind.c_variadic() {
             if inputs_and_output.inputs().is_empty() {
                 write!(f, "...")?;
             } else {
@@ -2176,6 +2175,9 @@ fn write_bounds_like_dyn_trait<'db>(
                 }
             }
             ClauseKind::Projection(projection) => {
+                let TermId::TypeAliasId(assoc_ty_id) = projection.def_id().0 else {
+                    continue;
+                };
                 // in types in actual Rust, these will always come
                 // after the corresponding Implemented predicate
                 if angle_open {
@@ -2184,7 +2186,6 @@ fn write_bounds_like_dyn_trait<'db>(
                     write!(f, "<")?;
                     angle_open = true;
                 }
-                let assoc_ty_id = projection.def_id().expect_type_alias();
                 let type_alias = TypeAliasSignature::of(f.db, assoc_ty_id);
                 f.start_location_link(assoc_ty_id.into());
                 write!(f, "{}", type_alias.name.display(f.db, f.edition()))?;
@@ -2490,9 +2491,9 @@ impl<'db> HirDisplayWithExpressionStore<'db> for TypeRefId {
                 if fn_.is_unsafe {
                     write!(f, "unsafe ")?;
                 }
-                if let Some(abi) = &fn_.abi {
+                if fn_.abi != ExternAbi::Rust {
                     f.write_str("extern \"")?;
-                    f.write_str(abi.as_str())?;
+                    f.write_str(fn_.abi.as_str())?;
                     f.write_str("\" ")?;
                 }
                 write!(f, "fn(")?;

--- a/crates/hir-ty/src/drop.rs
+++ b/crates/hir-ty/src/drop.rs
@@ -87,7 +87,7 @@ fn has_drop_glue_impl<'db>(
                         .map(|(_, field_ty)| {
                             has_drop_glue_impl(
                                 infcx,
-                                field_ty.get().instantiate(infcx.interner, subst),
+                                field_ty.get().instantiate(infcx.interner, subst).skip_norm_wip(),
                                 env,
                                 visited,
                             )
@@ -107,7 +107,10 @@ fn has_drop_glue_impl<'db>(
                             .map(|(_, field_ty)| {
                                 has_drop_glue_impl(
                                     infcx,
-                                    field_ty.get().instantiate(infcx.interner, subst),
+                                    field_ty
+                                        .get()
+                                        .instantiate(infcx.interner, subst)
+                                        .skip_norm_wip(),
                                     env,
                                     visited,
                                 )

--- a/crates/hir-ty/src/dyn_compatibility.rs
+++ b/crates/hir-ty/src/dyn_compatibility.rs
@@ -22,7 +22,7 @@ use crate::{
     lower::{GenericPredicates, associated_ty_item_bounds},
     next_solver::{
         AliasTy, Binder, Clause, Clauses, DbInterner, EarlyBinder, GenericArgs, ParamEnv, ParamTy,
-        SolverDefId, TraitPredicate, TraitRef, Ty, TypingMode,
+        SolverDefId, TraitPredicate, TraitRef, Ty, TypingMode, Unnormalized,
         infer::{
             DbInternerInferExt,
             traits::{Obligation, ObligationCause},
@@ -146,8 +146,8 @@ pub fn generics_require_sized_self(db: &dyn HirDatabase, def: GenericDefId) -> b
     // FIXME: We should use `explicit_predicates_of` here, which hasn't been implemented to
     // rust-analyzer yet
     // https://github.com/rust-lang/rust/blob/ddaf12390d3ffb7d5ba74491a48f3cd528e5d777/compiler/rustc_hir_analysis/src/collect/predicates_of.rs#L490
-    elaborate::elaborate(interner, predicates.iter_identity()).any(|pred| {
-        match pred.kind().skip_binder() {
+    elaborate::elaborate(interner, predicates.iter_identity().map(Unnormalized::skip_norm_wip)).any(
+        |pred| match pred.kind().skip_binder() {
             ClauseKind::Trait(trait_pred) => {
                 if sized == trait_pred.def_id().0
                     && let rustc_type_ir::TyKind::Param(param_ty) =
@@ -160,17 +160,17 @@ pub fn generics_require_sized_self(db: &dyn HirDatabase, def: GenericDefId) -> b
                 }
             }
             _ => false,
-        }
-    })
+        },
+    )
 }
 
 // rustc gathers all the spans that references `Self` for error rendering,
 // but we don't have good way to render such locations.
 // So, just return single boolean value for existence of such `Self` reference
 fn predicates_reference_self(db: &dyn HirDatabase, trait_: TraitId) -> bool {
-    GenericPredicates::query_explicit(db, trait_.into())
-        .iter_identity()
-        .any(|pred| predicate_references_self(db, trait_, pred, AllowSelfProjection::No))
+    GenericPredicates::query_explicit(db, trait_.into()).iter_identity().any(|pred| {
+        predicate_references_self(db, trait_, pred.skip_norm_wip(), AllowSelfProjection::No)
+    })
 }
 
 // Same as the above, `predicates_reference_self`
@@ -248,11 +248,7 @@ fn contains_illegal_self_type_reference<'db, T: rustc_type_ir::TypeVisitable<DbI
                     proj @ AliasTy { kind: AliasTyKind::Projection { .. }, .. },
                 ) => match self.allow_self_projection {
                     AllowSelfProjection::Yes => {
-                        let trait_ = proj.trait_def_id(interner);
-                        let trait_ = match trait_ {
-                            SolverDefId::TraitId(id) => id,
-                            _ => unreachable!(),
-                        };
+                        let trait_ = proj.trait_def_id(interner).0;
                         if self.super_traits.is_none() {
                             self.super_traits = Some(
                                 elaborate::supertrait_def_ids(interner, self.trait_.into())
@@ -404,7 +400,7 @@ fn receiver_is_dispatchable<'db>(
     func: FunctionId,
     sig: &EarlyBinder<'db, Binder<'db, rustc_type_ir::FnSig<DbInterner<'db>>>>,
 ) -> bool {
-    let sig = sig.instantiate_identity();
+    let sig = sig.instantiate_identity().skip_norm_wip();
 
     let module = trait_.module(db);
     let interner = DbInterner::new_with(db, module.krate(db));
@@ -468,6 +464,7 @@ fn receiver_is_dispatchable<'db>(
                 interner,
                 generic_predicates
                     .iter_identity()
+                    .map(Unnormalized::skip_norm_wip)
                     .chain([unsize_predicate.upcast(interner), trait_predicate.upcast(interner)])
                     .chain(meta_sized_predicate),
             ),
@@ -494,7 +491,7 @@ fn receiver_for_self_ty<'db>(
         if index == 0 { self_ty.into() } else { mk_param(interner, index, kind) }
     });
 
-    EarlyBinder::bind(receiver_ty).instantiate(interner, args)
+    EarlyBinder::bind(receiver_ty).instantiate(interner, args).skip_norm_wip()
 }
 
 fn contains_illegal_impl_trait_in_trait<'db>(
@@ -515,11 +512,7 @@ fn contains_illegal_impl_trait_in_trait<'db>(
                 ..
             }) = ty.kind()
             {
-                let id = match def_id {
-                    SolverDefId::InternedOpaqueTyId(id) => id,
-                    _ => unreachable!(),
-                };
-                self.0.insert(id);
+                self.0.insert(def_id.0);
             }
             ty.super_visit_with(self)
         }

--- a/crates/hir-ty/src/infer.rs
+++ b/crates/hir-ty/src/infer.rs
@@ -204,7 +204,7 @@ fn infer_anon_const_query(db: &dyn HirDatabase, def: AnonConstId) -> InferenceRe
 
     ctx.infer_expr(
         loc.expr,
-        &Expectation::has_type(loc.ty.get().instantiate_identity()),
+        &Expectation::has_type(loc.ty.get().instantiate_identity().skip_norm_wip()),
         ExprIsRead::Yes,
     );
 
@@ -2006,7 +2006,7 @@ impl<'body, 'db> InferenceContext<'body, 'db> {
                             .map(|it| it.get())
                         {
                             Some(field) => {
-                                ty = field.instantiate(self.interner(), substs);
+                                ty = field.instantiate(self.interner(), substs).skip_norm_wip();
                             }
                             None => break,
                         }
@@ -2197,7 +2197,7 @@ impl<'body, 'db> InferenceContext<'body, 'db> {
 
             if let Some(TypeNs::SelfType(impl_)) = type_ns
                 && let Some(trait_ref) = self.db.impl_trait(impl_)
-                && let trait_ref = trait_ref.instantiate_identity()
+                && let trait_ref = trait_ref.instantiate_identity().skip_norm_wip()
                 && let Some(assoc_type) = trait_ref
                     .def_id
                     .0
@@ -2262,14 +2262,16 @@ impl<'body, 'db> InferenceContext<'body, 'db> {
                         let ty = self
                             .db
                             .ty(var.lookup(self.db).parent.into())
-                            .instantiate(interner, args);
+                            .instantiate(interner, args)
+                            .skip_norm_wip();
                         let ty = self.insert_type_vars(ty, Span::Dummy);
                         return (ty, Some(var.into()));
                     }
                     ValueNs::StructId(strukt) => {
                         let args = path_ctx.substs_from_path(strukt.into(), true, false);
                         drop(ctx);
-                        let ty = self.db.ty(strukt.into()).instantiate(interner, args);
+                        let ty =
+                            self.db.ty(strukt.into()).instantiate(interner, args).skip_norm_wip();
                         let ty = self.insert_type_vars(ty, Span::Dummy);
                         return (ty, Some(strukt.into()));
                     }
@@ -2291,26 +2293,30 @@ impl<'body, 'db> InferenceContext<'body, 'db> {
             TypeNs::AdtId(AdtId::StructId(strukt)) => {
                 let args = path_ctx.substs_from_path(strukt.into(), true, false);
                 drop(ctx);
-                let ty = self.db.ty(strukt.into()).instantiate(interner, args);
+                let ty = self.db.ty(strukt.into()).instantiate(interner, args).skip_norm_wip();
                 let ty = self.insert_type_vars(ty, Span::Dummy);
                 forbid_unresolved_segments(self, (ty, Some(strukt.into())), unresolved)
             }
             TypeNs::AdtId(AdtId::UnionId(u)) => {
                 let args = path_ctx.substs_from_path(u.into(), true, false);
                 drop(ctx);
-                let ty = self.db.ty(u.into()).instantiate(interner, args);
+                let ty = self.db.ty(u.into()).instantiate(interner, args).skip_norm_wip();
                 let ty = self.insert_type_vars(ty, Span::Dummy);
                 forbid_unresolved_segments(self, (ty, Some(u.into())), unresolved)
             }
             TypeNs::EnumVariantId(var) => {
                 let args = path_ctx.substs_from_path(var.into(), true, false);
                 drop(ctx);
-                let ty = self.db.ty(var.lookup(self.db).parent.into()).instantiate(interner, args);
+                let ty = self
+                    .db
+                    .ty(var.lookup(self.db).parent.into())
+                    .instantiate(interner, args)
+                    .skip_norm_wip();
                 let ty = self.insert_type_vars(ty, Span::Dummy);
                 forbid_unresolved_segments(self, (ty, Some(var.into())), unresolved)
             }
             TypeNs::SelfType(impl_id) => {
-                let mut ty = self.db.impl_self_ty(impl_id).instantiate_identity();
+                let mut ty = self.db.impl_self_ty(impl_id).instantiate_identity().skip_norm_wip();
 
                 let Some(remaining_idx) = unresolved else {
                     drop(ctx);
@@ -2428,7 +2434,7 @@ impl<'body, 'db> InferenceContext<'body, 'db> {
                 let args = path_ctx.substs_from_path_segment(it.into(), true, None, false);
                 drop(ctx);
                 let interner = DbInterner::conjure();
-                let ty = self.db.ty(it.into()).instantiate(interner, args);
+                let ty = self.db.ty(it.into()).instantiate(interner, args).skip_norm_wip();
                 let ty = self.insert_type_vars(ty, Span::Dummy);
 
                 self.resolve_variant_on_alias(node, ty, unresolved, mod_path)

--- a/crates/hir-ty/src/infer/callee.rs
+++ b/crates/hir-ty/src/infer/callee.rs
@@ -2,6 +2,7 @@
 
 use std::iter;
 
+use rustc_abi::ExternAbi;
 use tracing::debug;
 
 use hir_def::{CallableDefId, ConstParamId, hir::ExprId, signatures::FunctionSignature};
@@ -11,7 +12,7 @@ use rustc_type_ir::{
 };
 
 use crate::{
-    Adjust, Adjustment, AutoBorrow, FnAbi,
+    Adjust, Adjustment, AutoBorrow,
     autoderef::{GeneralAutoderef, InferenceContextAutoderef},
     infer::{
         AllowTwoPhase, AutoBorrowMutability, Expectation, InferenceContext, InferenceDiagnostic,
@@ -181,9 +182,9 @@ impl<'db> InferenceContext<'_, 'db> {
                         interner.coroutine_for_closure(def_id),
                         tupled_upvars_ty,
                     ),
-                    coroutine_closure_sig.c_variadic,
-                    coroutine_closure_sig.safety,
-                    coroutine_closure_sig.abi,
+                    coroutine_closure_sig.fn_sig_kind.c_variadic(),
+                    coroutine_closure_sig.fn_sig_kind.safety(),
+                    coroutine_closure_sig.fn_sig_kind.abi(),
                 );
                 let adjust_steps = autoderef.adjust_steps_as_infer_ok();
                 let adjustments = autoderef.ctx().table.register_infer_ok(adjust_steps);
@@ -430,8 +431,11 @@ impl<'db> InferenceContext<'_, 'db> {
     ) -> Ty<'db> {
         let (fn_sig, def_id) = match callee_ty.kind() {
             TyKind::FnDef(def_id, args) => {
-                let fn_sig =
-                    self.db.callable_item_signature(def_id.0).instantiate(self.interner(), args);
+                let fn_sig = self
+                    .db
+                    .callable_item_signature(def_id.0)
+                    .instantiate(self.interner(), args)
+                    .skip_norm_wip();
                 (fn_sig, Some(def_id.0))
             }
 
@@ -460,11 +464,11 @@ impl<'db> InferenceContext<'_, 'db> {
             expected,
             arg_exprs,
             &indices_to_skip,
-            fn_sig.c_variadic,
+            fn_sig.c_variadic(),
             TupleArgumentsFlag::DontTupleArguments,
         );
 
-        if fn_sig.abi == FnAbi::RustCall
+        if fn_sig.abi() == ExternAbi::RustCall
             && let Some(ty) = fn_sig.inputs().last().copied()
             && let Some(tuple_trait) = self.lang_items.Tuple
         {
@@ -494,7 +498,7 @@ impl<'db> InferenceContext<'_, 'db> {
             expected,
             arg_exprs,
             &[],
-            fn_sig.c_variadic,
+            fn_sig.c_variadic(),
             TupleArgumentsFlag::TupleArguments,
         );
 
@@ -515,7 +519,7 @@ impl<'db> InferenceContext<'_, 'db> {
             expected,
             arg_exprs,
             &[],
-            method.sig.c_variadic,
+            method.sig.c_variadic(),
             TupleArgumentsFlag::TupleArguments,
         );
 

--- a/crates/hir-ty/src/infer/cast.rs
+++ b/crates/hir-ty/src/infer/cast.rs
@@ -542,7 +542,8 @@ fn pointer_kind<'db>(
             if let Some((last_field, _)) = struct_data.fields().iter().last() {
                 let last_field_ty = ctx.db.field_types(id.into())[last_field]
                     .get()
-                    .instantiate(ctx.interner(), subst);
+                    .instantiate(ctx.interner(), subst)
+                    .skip_norm_wip();
                 pointer_kind(expr, last_field_ty, ctx)
             } else {
                 Ok(Some(PointerKind::Thin))

--- a/crates/hir-ty/src/infer/closure.rs
+++ b/crates/hir-ty/src/infer/closure.rs
@@ -9,6 +9,7 @@ use hir_def::{
     hir::{ClosureKind, CoroutineKind, CoroutineSource, ExprId, PatId},
     type_ref::TypeRefId,
 };
+use rustc_abi::ExternAbi;
 use rustc_type_ir::{
     AliasTyKind, ClosureArgs, ClosureArgsParts, CoroutineArgs, CoroutineArgsParts,
     CoroutineClosureArgs, CoroutineClosureArgsParts, InferTy, Interner, TypeSuperVisitable,
@@ -18,12 +19,13 @@ use rustc_type_ir::{
 use tracing::{debug, instrument};
 
 use crate::{
-    FnAbi, Span,
+    Span,
     db::{InternedClosure, InternedClosureId, InternedCoroutineClosureId, InternedCoroutineId},
     infer::{BreakableKind, Diverges, coerce::CoerceMany, pat::PatOrigin},
     next_solver::{
         AliasTy, Binder, ClauseKind, DbInterner, ErrorGuaranteed, FnSig, GenericArg, GenericArgs,
-        PolyFnSig, PolyProjectionPredicate, Predicate, PredicateKind, SolverDefId, Ty, TyKind,
+        PolyFnSig, PolyProjectionPredicate, Predicate, PredicateKind, SolverDefId, TermId, Ty,
+        TyKind, Unnormalized,
         abi::Safety,
         infer::{
             BoundRegionConversionTime, InferOk, InferResult,
@@ -115,9 +117,9 @@ impl<'db> InferenceContext<'_, 'db> {
                     interner.mk_fn_sig(
                         [Ty::new_tup(interner, sig.inputs())],
                         sig.output(),
-                        sig.c_variadic,
-                        sig.safety,
-                        sig.abi,
+                        sig.c_variadic(),
+                        sig.safety(),
+                        sig.abi(),
                     )
                 });
 
@@ -241,9 +243,9 @@ impl<'db> InferenceContext<'_, 'db> {
                                         ),
                                     ],
                                     Ty::new_tup(interner, &[bound_yield_ty, bound_return_ty]),
-                                    sig.c_variadic,
-                                    sig.safety,
-                                    sig.abi,
+                                    sig.c_variadic(),
+                                    sig.safety(),
+                                    sig.abi(),
                                 )
                             }),
                         ),
@@ -285,9 +287,9 @@ impl<'db> InferenceContext<'_, 'db> {
                 liberated_sig = interner.mk_fn_sig(
                     liberated_sig.inputs().iter().copied(),
                     coroutine_output_ty,
-                    liberated_sig.c_variadic,
-                    liberated_sig.safety,
-                    liberated_sig.abi,
+                    liberated_sig.c_variadic(),
+                    liberated_sig.safety(),
+                    liberated_sig.abi(),
                 );
 
                 (
@@ -367,9 +369,10 @@ impl<'db> InferenceContext<'_, 'db> {
                     expected_ty,
                     closure_kind,
                     def_id
-                        .expect_opaque_ty()
+                        .0
                         .predicates(self.db)
                         .iter_instantiated_copied(self.interner(), args.as_slice())
+                        .map(Unnormalized::skip_norm_wip)
                         .map(|clause| clause.as_predicate()),
                 ),
             TyKind::Dynamic(object_type, ..) => {
@@ -655,7 +658,7 @@ impl<'db> InferenceContext<'_, 'db> {
                 bound.predicate.kind().skip_binder()
                 && let ret_projection = bound.predicate.kind().rebind(ret_projection)
                 && let Some(ret_projection) = ret_projection.no_bound_vars()
-                && let SolverDefId::TypeAliasId(assoc_type) = ret_projection.def_id()
+                && let TermId::TypeAliasId(assoc_type) = ret_projection.def_id().0
                 && Some(assoc_type) == self.lang_items.FutureOutput
             {
                 return_ty = Some(ret_projection.term.expect_type());
@@ -808,9 +811,9 @@ impl<'db> InferenceContext<'_, 'db> {
             self.interner().mk_fn_sig(
                 sig.inputs().iter().copied(),
                 sig.output(),
-                sig.c_variadic,
+                sig.c_variadic(),
                 Safety::Safe,
-                FnAbi::RustCall,
+                ExternAbi::RustCall,
             )
         });
 
@@ -931,9 +934,9 @@ impl<'db> InferenceContext<'_, 'db> {
             expected_sigs.liberated_sig = table.interner().mk_fn_sig(
                 inputs,
                 supplied_output_ty,
-                expected_sigs.liberated_sig.c_variadic,
+                expected_sigs.liberated_sig.c_variadic(),
                 Safety::Safe,
-                FnAbi::RustCall,
+                ExternAbi::RustCall,
             );
 
             Ok(InferOk { value: expected_sigs, obligations: all_obligations })
@@ -1001,7 +1004,7 @@ impl<'db> InferenceContext<'_, 'db> {
             supplied_return,
             false,
             Safety::Safe,
-            FnAbi::RustCall,
+            ExternAbi::RustCall,
         ))
     }
 
@@ -1048,9 +1051,10 @@ impl<'db> InferenceContext<'_, 'db> {
                 return Some(self.types.types.error);
             }
             TyKind::Alias(AliasTy { kind: AliasTyKind::Opaque { def_id }, args, .. }) => def_id
-                .expect_opaque_ty()
+                .0
                 .predicates(self.db)
                 .iter_instantiated_copied(self.interner(), &args)
+                .map(Unnormalized::skip_norm_wip)
                 .find_map(|p| get_future_output(p.as_predicate()))?,
             TyKind::Error(_) => return Some(ret_ty),
             _ => {
@@ -1091,7 +1095,7 @@ impl<'db> InferenceContext<'_, 'db> {
         // The `Future` trait has only one associated item, `Output`,
         // so check that this is what we see.
         let output_assoc_item = self.lang_items.FutureOutput;
-        if output_assoc_item != Some(predicate.projection_term.def_id.expect_type_alias()) {
+        if output_assoc_item.map(Into::into) != Some(predicate.def_id().0) {
             panic!(
                 "projecting associated item `{:?}` from future, which is not Output `{:?}`",
                 predicate.projection_term.kind(self.interner()),
@@ -1135,7 +1139,7 @@ impl<'db> InferenceContext<'_, 'db> {
             err_ty,
             false,
             Safety::Safe,
-            FnAbi::RustCall,
+            ExternAbi::RustCall,
         ));
 
         debug!("supplied_sig_of_closure: result={:?}", result);

--- a/crates/hir-ty/src/infer/closure/analysis.rs
+++ b/crates/hir-ty/src/infer/closure/analysis.rs
@@ -41,6 +41,7 @@ use hir_def::{
     resolver::ValueNs,
 };
 use macros::{TypeFoldable, TypeVisitable};
+use rustc_abi::ExternAbi;
 use rustc_ast_ir::Mutability;
 use rustc_hash::{FxBuildHasher, FxHashMap};
 use rustc_type_ir::{
@@ -52,7 +53,7 @@ use span::Edition;
 use tracing::{debug, instrument};
 
 use crate::{
-    FnAbi, Span,
+    Span,
     infer::{
         CaptureInfo, CaptureSourceStack, CapturedPlace, InferenceContext, UpvarCapture,
         closure::analysis::expr_use_visitor::{
@@ -459,7 +460,7 @@ impl<'a, 'db> InferenceContext<'a, 'db> {
                         tupled_upvars_ty_for_borrow,
                         false,
                         Safety::Safe,
-                        FnAbi::Rust,
+                        ExternAbi::Rust,
                     ),
                     self.types.coroutine_captures_by_ref_bound_var_kinds,
                 ),

--- a/crates/hir-ty/src/infer/closure/analysis/expr_use_visitor.rs
+++ b/crates/hir-ty/src/infer/closure/analysis/expr_use_visitor.rs
@@ -772,7 +772,10 @@ impl<'a, 'b, 'db, D: Delegate<'db>> ExprUseVisitor<'a, 'b, 'db, D> {
                         let field_place = self.cat_projection(
                             with_expr.into(),
                             with_place.clone(),
-                            adt_field_types[f_index].get().instantiate(self.cx.interner(), args),
+                            adt_field_types[f_index]
+                                .get()
+                                .instantiate(self.cx.interner(), args)
+                                .skip_norm_wip(),
                             ProjectionKind::Field {
                                 field_idx: f_index.into_raw().into_u32(),
                                 variant_idx: 0,

--- a/crates/hir-ty/src/infer/coerce.rs
+++ b/crates/hir-ty/src/infer/coerce.rs
@@ -710,7 +710,7 @@ where
         self.commit_if_ok(|this| {
             if let TyKind::FnPtr(_, hdr_b) = b.kind()
                 && fn_ty_a.safety().is_safe()
-                && !hdr_b.safety.is_safe()
+                && !hdr_b.safety().is_safe()
             {
                 let unsafe_a = Ty::safe_to_unsafe_fn_ty(this.interner(), fn_ty_a);
                 this.unify_and(
@@ -759,7 +759,8 @@ where
                             return Err(TypeError::ForceInlineCast);
                         }
 
-                        if b_hdr.safety.is_safe() && attrs.contains(AttrFlags::HAS_TARGET_FEATURE) {
+                        if b_hdr.safety().is_safe() && attrs.contains(AttrFlags::HAS_TARGET_FEATURE)
+                        {
                             let fn_target_features =
                                 TargetFeatures::from_fn_no_implications(self.db(), def_id);
                             // Allow the coercion if the current function has all the features that would be
@@ -807,7 +808,7 @@ where
                 //     `fn(arg0,arg1,...) -> _`
                 // or
                 //     `unsafe fn(arg0,arg1,...) -> _`
-                let safety = hdr.safety;
+                let safety = hdr.safety();
                 let closure_sig =
                     self.interner().signature_unclosure(args_a.as_closure().sig(), safety);
                 let pointer_ty = Ty::new_fn_ptr(self.interner(), closure_sig);

--- a/crates/hir-ty/src/infer/expr.rs
+++ b/crates/hir-ty/src/infer/expr.rs
@@ -823,7 +823,8 @@ impl<'db> InferenceContext<'_, 'db> {
                                     this.interner(),
                                     this.interner()
                                         .fn_sig(def)
-                                        .instantiate(this.interner(), parameters),
+                                        .instantiate(this.interner(), parameters)
+                                        .skip_norm_wip(),
                                 );
                                 _ = this.coerce(
                                     expr,
@@ -1042,14 +1043,14 @@ impl<'db> InferenceContext<'_, 'db> {
                     });
                 }
 
-                variant_field_tys[i].get().instantiate(interner, args)
+                variant_field_tys[i].get().instantiate(interner, args).skip_norm_wip()
             } else {
                 if let Some(field_idx) = seen_fields.get(&name) {
                     self.push_diagnostic(InferenceDiagnostic::DuplicateField {
                         field: field.expr.into(),
                         variant,
                     });
-                    variant_field_tys[*field_idx].get().instantiate(interner, args)
+                    variant_field_tys[*field_idx].get().instantiate(interner, args).skip_norm_wip()
                 } else {
                     self.push_diagnostic(InferenceDiagnostic::NoSuchField {
                         field: field.expr.into(),
@@ -1106,10 +1107,13 @@ impl<'db> InferenceContext<'_, 'db> {
                         for (field_idx, field) in variant_fields.fields().iter() {
                             let fru_ty = variant_field_tys[field_idx]
                                 .get()
-                                .instantiate(interner, fresh_args);
+                                .instantiate(interner, fresh_args)
+                                .skip_norm_wip();
                             if remaining_fields.remove(&field.name).is_some() {
-                                let target_ty =
-                                    variant_field_tys[field_idx].get().instantiate(interner, args);
+                                let target_ty = variant_field_tys[field_idx]
+                                    .get()
+                                    .instantiate(interner, args)
+                                    .skip_norm_wip();
                                 let cause = ObligationCause::new(expr);
                                 match self.table.at(&cause).sup(target_ty, fru_ty) {
                                     Ok(InferOk { obligations, value: () }) => {
@@ -1647,7 +1651,8 @@ impl<'db> InferenceContext<'_, 'db> {
             }
             let ty = self.db.field_types(field_id.parent)[field_id.local_id]
                 .get()
-                .instantiate(interner, parameters);
+                .instantiate(interner, parameters)
+                .skip_norm_wip();
             Some((Either::Left(field_id), ty))
         });
 
@@ -1665,7 +1670,8 @@ impl<'db> InferenceContext<'_, 'db> {
                     self.table.register_infer_ok(autoderef.adjust_steps_as_infer_ok());
                 let ty = self.db.field_types(field_id.parent)[field_id.local_id]
                     .get()
-                    .instantiate(self.interner(), subst);
+                    .instantiate(self.interner(), subst)
+                    .skip_norm_wip();
                 let ty = self.process_remote_user_written_ty(ty);
 
                 (ty, Either::Left(field_id), adjustments, false)
@@ -1733,7 +1739,11 @@ impl<'db> InferenceContext<'_, 'db> {
         // FIXME: Using fresh infer vars for the method args isn't optimal,
         // we can do better by going thorough the full probe/confirm machinery.
         let args = self.table.fresh_args_for_item(Span::Dummy, def_id.into());
-        let sig = self.db.callable_item_signature(def_id.into()).instantiate(self.interner(), args);
+        let sig = self
+            .db
+            .callable_item_signature(def_id.into())
+            .instantiate(self.interner(), args)
+            .skip_norm_wip();
         let sig = self.infcx().instantiate_binder_with_fresh_vars(
             Span::Dummy,
             BoundRegionConversionTime::FnCall,
@@ -1909,7 +1919,7 @@ impl<'db> InferenceContext<'_, 'db> {
             expected,
             args,
             &[],
-            sig.c_variadic,
+            sig.c_variadic(),
             TupleArgumentsFlag::DontTupleArguments,
         );
         ret_ty

--- a/crates/hir-ty/src/infer/opaques.rs
+++ b/crates/hir-ty/src/infer/opaques.rs
@@ -75,7 +75,7 @@ impl<'db> InferenceContext<'_, 'db> {
 
         let interner = self.interner();
         let TypingMode::Analysis { defining_opaque_types_and_generators } =
-            self.table.infer_ctxt.typing_mode()
+            self.table.infer_ctxt.typing_mode_raw()
         else {
             unreachable!();
         };
@@ -108,8 +108,9 @@ impl<'db> InferenceContext<'_, 'db> {
                         continue;
                     }
 
-                    let expected =
-                        EarlyBinder::bind(ty.ty).instantiate(interner, opaque_type_key.args);
+                    let expected = EarlyBinder::bind(ty.ty)
+                        .instantiate(interner, opaque_type_key.args)
+                        .skip_norm_wip();
                     _ = self.demand_eqtype_fixme_no_diag(expected, hidden_type.ty);
                 }
 

--- a/crates/hir-ty/src/infer/pat.rs
+++ b/crates/hir-ty/src/infer/pat.rs
@@ -1070,7 +1070,8 @@ https://doc.rust-lang.org/reference/types.html#trait-objects";
         {
             for (i, &subpat) in subpats.iter().enumerate_and_adjust(variant_fields.len(), ddpos) {
                 let field_id = LocalFieldId::from_raw(la_arena::RawIdx::from_u32(i as u32));
-                let field_ty = variant_field_tys[field_id].get().instantiate(interner, args);
+                let field_ty =
+                    variant_field_tys[field_id].get().instantiate(interner, args).skip_norm_wip();
                 self.infer_pat(subpat, field_ty, pat_info);
             }
             if let Err(()) = had_err {
@@ -1089,7 +1090,7 @@ https://doc.rust-lang.org/reference/types.html#trait-objects";
             for (i, &pat) in subpats.iter().enumerate() {
                 let field_id = LocalFieldId::from_raw(la_arena::RawIdx::from_u32(i as u32));
                 let expected = match variant_field_tys.get(field_id) {
-                    Some(field_ty) => field_ty.get().instantiate(interner, args),
+                    Some(field_ty) => field_ty.get().instantiate(interner, args).skip_norm_wip(),
                     None => self.types.types.error,
                 };
                 self.infer_pat(pat, expected, pat_info);
@@ -1201,7 +1202,7 @@ https://doc.rust-lang.org/reference/types.html#trait-objects";
                         });
                     }
 
-                    variant_field_tys[field_idx].get().instantiate(interner, args)
+                    variant_field_tys[field_idx].get().instantiate(interner, args).skip_norm_wip()
                 }
                 None => {
                     inexistent_fields.push(field);

--- a/crates/hir-ty/src/infer/path.rs
+++ b/crates/hir-ty/src/infer/path.rs
@@ -16,7 +16,7 @@ use crate::{
     lower::{GenericPredicates, LifetimeElisionKind},
     method_resolution::{self, CandidateId, MethodError},
     next_solver::{
-        GenericArg, GenericArgs, TraitRef, Ty, infer::traits::ObligationCause,
+        GenericArg, GenericArgs, TraitRef, Ty, Unnormalized, infer::traits::ObligationCause,
         util::clauses_as_obligations,
     },
 };
@@ -42,7 +42,7 @@ impl<'db> InferenceContext<'_, 'db> {
 
         self.add_required_obligations_for_value_path(id, generic_def, args);
 
-        let ty = self.db.value_ty(value_def)?.instantiate(self.interner(), args);
+        let ty = self.db.value_ty(value_def)?.instantiate(self.interner(), args).skip_norm_wip();
         let ty = self.process_remote_user_written_ty(ty);
         Some((value, ty))
     }
@@ -78,7 +78,7 @@ impl<'db> InferenceContext<'_, 'db> {
                 };
             }
             ValueNs::ImplSelf(impl_id) => {
-                let ty = self.db.impl_self_ty(impl_id).instantiate_identity();
+                let ty = self.db.impl_self_ty(impl_id).instantiate_identity().skip_norm_wip();
                 return if let Some((AdtId::StructId(struct_id), substs)) = ty.as_adt() {
                     Some(ValuePathResolution::GenericDef(
                         struct_id.into(),
@@ -237,7 +237,9 @@ impl<'db> InferenceContext<'_, 'db> {
         let predicates = GenericPredicates::query_all(self.db, def);
         let param_env = self.table.param_env;
         self.table.register_predicates(clauses_as_obligations(
-            predicates.iter_instantiated(interner, subst.as_slice()),
+            predicates
+                .iter_instantiated(interner, subst.as_slice())
+                .map(Unnormalized::skip_norm_wip),
             ObligationCause::new(node),
             param_env,
         ));
@@ -315,8 +317,11 @@ impl<'db> InferenceContext<'_, 'db> {
         let substs = match container {
             ItemContainerId::ImplId(impl_id) => {
                 let impl_substs = self.table.fresh_args_for_item(id.into(), impl_id.into());
-                let impl_self_ty =
-                    self.db.impl_self_ty(impl_id).instantiate(self.interner(), impl_substs);
+                let impl_self_ty = self
+                    .db
+                    .impl_self_ty(impl_id)
+                    .instantiate(self.interner(), impl_substs)
+                    .skip_norm_wip();
                 _ = self.demand_eqtype(id, impl_self_ty, ty);
                 impl_substs
             }

--- a/crates/hir-ty/src/inhabitedness.rs
+++ b/crates/hir-ty/src/inhabitedness.rs
@@ -169,7 +169,7 @@ impl<'a, 'db> UninhabitedFrom<'a, 'db> {
         subst: GenericArgs<'db>,
     ) -> ControlFlow<VisiblyUninhabited> {
         if vis.is_none_or(|it| it.is_visible_from(self.db(), self.target_mod)) {
-            let ty = ty.instantiate(self.interner(), subst);
+            let ty = ty.instantiate(self.interner(), subst).skip_norm_wip();
             ty.visit_with(self)
         } else {
             CONTINUE_OPAQUELY_INHABITED

--- a/crates/hir-ty/src/layout.rs
+++ b/crates/hir-ty/src/layout.rs
@@ -142,10 +142,10 @@ fn layout_of_simd_ty<'db>(
     // where T is a primitive scalar (integer/float/pointer).
     let fields = db.field_types(id.into());
     let mut fields = fields.iter();
-    let Some(TyKind::Array(e_ty, e_len)) = fields
-        .next()
-        .filter(|_| fields.next().is_none())
-        .map(|f| (*f.1).get().instantiate(DbInterner::new_no_crate(db), args).kind())
+    let Some(TyKind::Array(e_ty, e_len)) =
+        fields.next().filter(|_| fields.next().is_none()).map(|f| {
+            (*f.1).get().instantiate(DbInterner::new_no_crate(db), args).skip_norm_wip().kind()
+        })
     else {
         return Err(LayoutError::InvalidSimdType);
     };
@@ -405,7 +405,7 @@ fn field_ty<'a>(
     fd: LocalFieldId,
     args: GenericArgs<'a>,
 ) -> Ty<'a> {
-    db.field_types(def)[fd].get().instantiate(DbInterner::new_no_crate(db), args)
+    db.field_types(def)[fd].get().instantiate(DbInterner::new_no_crate(db), args).skip_norm_wip()
 }
 
 fn scalar_unit(dl: &TargetDataLayout, value: Primitive) -> Scalar {

--- a/crates/hir-ty/src/layout/adt.rs
+++ b/crates/hir-ty/src/layout/adt.rs
@@ -1,6 +1,6 @@
 //! Compute the binary representation of structs, unions and enums
 
-use std::{cmp, ops::Bound};
+use std::cmp;
 
 use hir_def::{
     AdtId, VariantId,
@@ -79,7 +79,6 @@ pub fn layout_of_adt_query(
             &variants,
             matches!(def, AdtId::EnumId(..)),
             is_special_no_niche,
-            layout_scalar_valid_range(db, def),
             |min, max| repr_discr(dl, &repr, min, max).unwrap_or((Integer::I8, false)),
             variants.iter_enumerated().filter_map(|(id, _)| {
                 let AdtId::EnumId(e) = def else { return None };
@@ -105,15 +104,6 @@ pub(crate) fn layout_of_adt_cycle_result(
     _trait_env: StoredParamEnvAndCrate,
 ) -> Result<Arc<Layout>, LayoutError> {
     Err(LayoutError::RecursiveTypeWithoutIndirection)
-}
-
-fn layout_scalar_valid_range(db: &dyn HirDatabase, def: AdtId) -> (Bound<u128>, Bound<u128>) {
-    let range = AttrFlags::rustc_layout_scalar_valid_range(db, def);
-    let get = |value| match value {
-        Some(it) => Bound::Included(it),
-        None => Bound::Unbounded,
-    };
-    (get(range.start), get(range.end))
 }
 
 /// Finds the appropriate Integer type and signedness for the given

--- a/crates/hir-ty/src/layout/tests.rs
+++ b/crates/hir-ty/src/layout/tests.rs
@@ -90,7 +90,7 @@ fn eval_goal(
                 adt_id,
                 GenericArgs::identity_for_item(interner, adt_id.into()),
             ),
-            Either::Right(ty_id) => db.ty(ty_id.into()).instantiate_identity(),
+            Either::Right(ty_id) => db.ty(ty_id.into()).instantiate_identity().skip_norm_wip(),
         };
         let param_env = db.trait_environment(
             match adt_or_type_alias_id {
@@ -529,6 +529,7 @@ fn tuple_ptr_with_dst_tail() {
 }
 
 #[test]
+#[ignore = "FIXME: We need to have proper pattern types"]
 fn non_zero_and_non_null() {
     size_and_align! {
         minicore: non_zero, non_null, option;

--- a/crates/hir-ty/src/lib.rs
+++ b/crates/hir-ty/src/lib.rs
@@ -73,9 +73,9 @@ use hir_def::{
 };
 use hir_expand::name::Name;
 use indexmap::{IndexMap, map::Entry};
-use intern::{Symbol, sym};
 use macros::GenericTypeVisitable;
 use mir::{MirEvalError, VTableMap};
+use rustc_abi::ExternAbi;
 use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet};
 use rustc_type_ir::{
     BoundVarIndexKind, TypeSuperVisitable, TypeVisitableExt,
@@ -220,137 +220,6 @@ pub fn type_or_const_param_idx(db: &dyn HirDatabase, id: TypeOrConstParamId) -> 
 
 pub fn lifetime_param_idx(db: &dyn HirDatabase, id: LifetimeParamId) -> u32 {
     generics::generics(db, id.parent).lifetime_param_idx(id)
-}
-
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum FnAbi {
-    Aapcs,
-    AapcsUnwind,
-    AvrInterrupt,
-    AvrNonBlockingInterrupt,
-    C,
-    CCmseNonsecureCall,
-    CCmseNonsecureEntry,
-    CDecl,
-    CDeclUnwind,
-    CUnwind,
-    Efiapi,
-    Fastcall,
-    FastcallUnwind,
-    Msp430Interrupt,
-    PtxKernel,
-    RiscvInterruptM,
-    RiscvInterruptS,
-    Rust,
-    RustCall,
-    RustCold,
-    RustIntrinsic,
-    Stdcall,
-    StdcallUnwind,
-    System,
-    SystemUnwind,
-    Sysv64,
-    Sysv64Unwind,
-    Thiscall,
-    ThiscallUnwind,
-    Unadjusted,
-    Vectorcall,
-    VectorcallUnwind,
-    Wasm,
-    Win64,
-    Win64Unwind,
-    X86Interrupt,
-    RustPreserveNone,
-    Unknown,
-}
-
-impl FnAbi {
-    #[rustfmt::skip]
-    pub fn from_symbol(s: &Symbol) -> FnAbi {
-        match s {
-            s if *s == sym::aapcs_dash_unwind => FnAbi::AapcsUnwind,
-            s if *s == sym::aapcs => FnAbi::Aapcs,
-            s if *s == sym::avr_dash_interrupt => FnAbi::AvrInterrupt,
-            s if *s == sym::avr_dash_non_dash_blocking_dash_interrupt => FnAbi::AvrNonBlockingInterrupt,
-            s if *s == sym::C_dash_cmse_dash_nonsecure_dash_call => FnAbi::CCmseNonsecureCall,
-            s if *s == sym::C_dash_cmse_dash_nonsecure_dash_entry => FnAbi::CCmseNonsecureEntry,
-            s if *s == sym::C_dash_unwind => FnAbi::CUnwind,
-            s if *s == sym::C => FnAbi::C,
-            s if *s == sym::cdecl_dash_unwind => FnAbi::CDeclUnwind,
-            s if *s == sym::cdecl => FnAbi::CDecl,
-            s if *s == sym::efiapi => FnAbi::Efiapi,
-            s if *s == sym::fastcall_dash_unwind => FnAbi::FastcallUnwind,
-            s if *s == sym::fastcall => FnAbi::Fastcall,
-            s if *s == sym::msp430_dash_interrupt => FnAbi::Msp430Interrupt,
-            s if *s == sym::ptx_dash_kernel => FnAbi::PtxKernel,
-            s if *s == sym::riscv_dash_interrupt_dash_m => FnAbi::RiscvInterruptM,
-            s if *s == sym::riscv_dash_interrupt_dash_s => FnAbi::RiscvInterruptS,
-            s if *s == sym::rust_dash_call => FnAbi::RustCall,
-            s if *s == sym::rust_dash_cold => FnAbi::RustCold,
-            s if *s == sym::rust_dash_preserve_dash_none => FnAbi::RustPreserveNone,
-            s if *s == sym::rust_dash_intrinsic => FnAbi::RustIntrinsic,
-            s if *s == sym::Rust => FnAbi::Rust,
-            s if *s == sym::stdcall_dash_unwind => FnAbi::StdcallUnwind,
-            s if *s == sym::stdcall => FnAbi::Stdcall,
-            s if *s == sym::system_dash_unwind => FnAbi::SystemUnwind,
-            s if *s == sym::system => FnAbi::System,
-            s if *s == sym::sysv64_dash_unwind => FnAbi::Sysv64Unwind,
-            s if *s == sym::sysv64 => FnAbi::Sysv64,
-            s if *s == sym::thiscall_dash_unwind => FnAbi::ThiscallUnwind,
-            s if *s == sym::thiscall => FnAbi::Thiscall,
-            s if *s == sym::unadjusted => FnAbi::Unadjusted,
-            s if *s == sym::vectorcall_dash_unwind => FnAbi::VectorcallUnwind,
-            s if *s == sym::vectorcall => FnAbi::Vectorcall,
-            s if *s == sym::wasm => FnAbi::Wasm,
-            s if *s == sym::win64_dash_unwind => FnAbi::Win64Unwind,
-            s if *s == sym::win64 => FnAbi::Win64,
-            s if *s == sym::x86_dash_interrupt => FnAbi::X86Interrupt,
-            _ => FnAbi::Unknown,
-        }
-    }
-
-    pub fn as_str(self) -> &'static str {
-        match self {
-            FnAbi::Aapcs => "aapcs",
-            FnAbi::AapcsUnwind => "aapcs-unwind",
-            FnAbi::AvrInterrupt => "avr-interrupt",
-            FnAbi::AvrNonBlockingInterrupt => "avr-non-blocking-interrupt",
-            FnAbi::C => "C",
-            FnAbi::CCmseNonsecureCall => "C-cmse-nonsecure-call",
-            FnAbi::CCmseNonsecureEntry => "C-cmse-nonsecure-entry",
-            FnAbi::CDecl => "C-decl",
-            FnAbi::CDeclUnwind => "cdecl-unwind",
-            FnAbi::CUnwind => "C-unwind",
-            FnAbi::Efiapi => "efiapi",
-            FnAbi::Fastcall => "fastcall",
-            FnAbi::FastcallUnwind => "fastcall-unwind",
-            FnAbi::Msp430Interrupt => "msp430-interrupt",
-            FnAbi::PtxKernel => "ptx-kernel",
-            FnAbi::RiscvInterruptM => "riscv-interrupt-m",
-            FnAbi::RiscvInterruptS => "riscv-interrupt-s",
-            FnAbi::Rust => "Rust",
-            FnAbi::RustCall => "rust-call",
-            FnAbi::RustCold => "rust-cold",
-            FnAbi::RustPreserveNone => "rust-preserve-none",
-            FnAbi::RustIntrinsic => "rust-intrinsic",
-            FnAbi::Stdcall => "stdcall",
-            FnAbi::StdcallUnwind => "stdcall-unwind",
-            FnAbi::System => "system",
-            FnAbi::SystemUnwind => "system-unwind",
-            FnAbi::Sysv64 => "sysv64",
-            FnAbi::Sysv64Unwind => "sysv64-unwind",
-            FnAbi::Thiscall => "thiscall",
-            FnAbi::ThiscallUnwind => "thiscall-unwind",
-            FnAbi::Unadjusted => "unadjusted",
-            FnAbi::Vectorcall => "vectorcall",
-            FnAbi::VectorcallUnwind => "vectorcall-unwind",
-            FnAbi::Wasm => "wasm",
-            FnAbi::Win64 => "win64",
-            FnAbi::Win64Unwind => "win64-unwind",
-            FnAbi::X86Interrupt => "x86-interrupt",
-            FnAbi::Unknown => "unknown-abi",
-        }
-    }
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Hash)]
@@ -594,7 +463,7 @@ pub fn callable_sig_from_fn_trait<'db>(
         ret,
         false,
         Safety::Safe,
-        FnAbi::Rust,
+        ExternAbi::Rust,
     ));
     Some((trait_, sig))
 }

--- a/crates/hir-ty/src/lower.rs
+++ b/crates/hir-ty/src/lower.rs
@@ -37,6 +37,7 @@ use hir_def::{
 use hir_expand::name::Name;
 use la_arena::{Arena, ArenaMap, Idx};
 use path::{PathDiagnosticCallback, PathLoweringContext};
+use rustc_abi::ExternAbi;
 use rustc_ast_ir::Mutability;
 use rustc_hash::FxHashSet;
 use rustc_type_ir::{
@@ -51,16 +52,16 @@ use thin_vec::ThinVec;
 use tracing::debug;
 
 use crate::{
-    FnAbi, ImplTraitId, TyLoweringDiagnostic, TyLoweringDiagnosticKind,
+    ImplTraitId, TyLoweringDiagnostic, TyLoweringDiagnosticKind,
     consteval::{create_anon_const, path_to_const},
     db::{AnonConstId, GeneralConstId, HirDatabase, InternedOpaqueTyId},
     generics::{Generics, SingleGenerics, generics},
     next_solver::{
         AliasTy, Binder, BoundExistentialPredicates, Clause, ClauseKind, Clauses, Const, ConstKind,
-        DbInterner, EarlyBinder, EarlyParamRegion, ErrorGuaranteed, FxIndexMap, GenericArg,
-        GenericArgs, ParamConst, ParamEnv, PolyFnSig, Predicate, Region, SolverDefId,
-        StoredClauses, StoredEarlyBinder, StoredGenericArg, StoredGenericArgs, StoredPolyFnSig,
-        StoredTraitRef, StoredTy, TraitPredicate, TraitRef, Ty, Tys, abi::Safety,
+        DbInterner, EarlyBinder, EarlyParamRegion, ErrorGuaranteed, FnSigKind, FxIndexMap,
+        GenericArg, GenericArgs, ParamConst, ParamEnv, PolyFnSig, Predicate, Region, StoredClauses,
+        StoredEarlyBinder, StoredGenericArg, StoredGenericArgs, StoredPolyFnSig, StoredTraitRef,
+        StoredTy, TraitPredicate, TraitRef, Ty, Tys, Unnormalized, abi::Safety,
         util::BottomUpFolder,
     },
 };
@@ -430,8 +431,7 @@ impl<'db, 'a> TyLoweringContext<'db, 'a> {
                             |f| ImplTraitId::ReturnTypeImplTrait(f, idx),
                             |a| ImplTraitId::TypeAliasImplTrait(a, idx),
                         );
-                        let opaque_ty_id: SolverDefId =
-                            self.db.intern_impl_trait_id(impl_trait_id).into();
+                        let opaque_ty_id = self.db.intern_impl_trait_id(impl_trait_id);
 
                         // We don't want to lower the bounds inside the binders
                         // we're currently in, because they don't end up inside
@@ -448,12 +448,13 @@ impl<'db, 'a> TyLoweringContext<'db, 'a> {
                             });
                         self.impl_trait_mode.opaque_type_data[idx] = actual_opaque_type_data;
 
-                        let args = GenericArgs::identity_for_item(self.interner, opaque_ty_id);
+                        let args =
+                            GenericArgs::identity_for_item(self.interner, opaque_ty_id.into());
                         Ty::new_alias(
                             self.interner,
                             AliasTy::new_from_args(
                                 self.interner,
-                                AliasTyKind::Opaque { def_id: opaque_ty_id },
+                                AliasTyKind::Opaque { def_id: opaque_ty_id.into() },
                                 args,
                             ),
                         )
@@ -485,9 +486,11 @@ impl<'db, 'a> TyLoweringContext<'db, 'a> {
         Ty::new_fn_ptr(
             interner,
             Binder::dummy(FnSig {
-                abi: fn_.abi.as_ref().map_or(FnAbi::Rust, FnAbi::from_symbol),
-                safety: if fn_.is_unsafe { Safety::Unsafe } else { Safety::Safe },
-                c_variadic: fn_.is_varargs,
+                fn_sig_kind: FnSigKind::new(
+                    fn_.abi,
+                    if fn_.is_unsafe { Safety::Unsafe } else { Safety::Safe },
+                    fn_.is_varargs,
+                ),
                 inputs_and_output: Tys::new_from_slice(&args),
             }),
         )
@@ -760,7 +763,7 @@ impl<'db, 'a> TyLoweringContext<'db, 'a> {
             let mut projection_bounds = FxIndexMap::default();
             for proj in projections {
                 let key = (
-                    proj.skip_binder().def_id().expect_type_alias(),
+                    proj.skip_binder().def_id().0,
                     interner.anonymize_bound_vars(
                         proj.map_bound(|proj| proj.projection_term.trait_ref(interner)),
                     ),
@@ -808,7 +811,7 @@ impl<'db, 'a> TyLoweringContext<'db, 'a> {
                                     .0
                                     .trait_items(self.db)
                                     .associated_types()
-                                    .map(|item| (item, trait_ref)),
+                                    .map(|item| (item.into(), trait_ref)),
                             );
                         }
                         ClauseKind::Projection(pred) => {
@@ -842,7 +845,7 @@ impl<'db, 'a> TyLoweringContext<'db, 'a> {
                             // the discussion in #56288 for alternatives.
                             if !references_self {
                                 let key = (
-                                    pred.skip_binder().projection_term.def_id.expect_type_alias(),
+                                    pred.skip_binder().def_id().0,
                                     interner.anonymize_bound_vars(pred.map_bound(|proj| {
                                         proj.projection_term.trait_ref(interner)
                                     })),
@@ -868,7 +871,7 @@ impl<'db, 'a> TyLoweringContext<'db, 'a> {
                 .filter_map(|key| projection_bounds.get(&key).copied())
                 .collect();
 
-            projection_bounds.sort_unstable_by_key(|proj| proj.skip_binder().def_id());
+            projection_bounds.sort_unstable_by_key(|proj| proj.skip_binder().def_id().0);
 
             let principal = principal.map(|principal| {
                 principal.map_bound(|principal| {
@@ -950,13 +953,13 @@ impl<'db, 'a> TyLoweringContext<'db, 'a> {
         }
     }
 
-    fn lower_impl_trait(&mut self, def_id: SolverDefId, bounds: &[TypeBound]) -> ImplTrait {
+    fn lower_impl_trait(&mut self, def_id: InternedOpaqueTyId, bounds: &[TypeBound]) -> ImplTrait {
         let interner = self.interner;
         cov_mark::hit!(lower_rpit);
-        let args = GenericArgs::identity_for_item(interner, def_id);
+        let args = GenericArgs::identity_for_item(interner, def_id.into());
         let self_ty = Ty::new_alias(
             self.interner,
-            AliasTy::new_from_args(interner, rustc_type_ir::Opaque { def_id }, args),
+            AliasTy::new_from_args(interner, rustc_type_ir::Opaque { def_id: def_id.into() }, args),
         );
         let (predicates, assoc_ty_bounds_start) =
             self.with_shifted_in(DebruijnIndex::from_u32(1), |ctx| {
@@ -1799,7 +1802,9 @@ fn resolve_type_param_assoc_type_shorthand(
             let (assoc_type, args) = assoc_type_and_args
                 .get_with(|(assoc_type, args)| (*assoc_type, args.as_ref()))
                 .skip_binder();
-            let args = EarlyBinder::bind(args).instantiate(interner, bounded_trait_ref.args);
+            let args = EarlyBinder::bind(args)
+                .instantiate(interner, bounded_trait_ref.args)
+                .skip_norm_wip();
             let current_result = StoredEarlyBinder::bind((assoc_type, args.store()));
             if let Some(this_trait_resolution) = &this_trait_resolution {
                 if *this_trait_resolution == current_result {
@@ -1896,10 +1901,9 @@ pub(crate) fn type_alias_bounds_with_diagnostics(
         LifetimeElisionKind::AnonymousReportError,
     );
     let interner = ctx.interner;
-    let def_id = type_alias.into();
 
-    let item_args = GenericArgs::identity_for_item(interner, def_id);
-    let interner_ty = Ty::new_projection_from_args(interner, def_id, item_args);
+    let item_args = GenericArgs::identity_for_item(interner, type_alias.into());
+    let interner_ty = Ty::new_projection_from_args(interner, type_alias.into(), item_args);
 
     let mut bounds = Vec::new();
     let mut assoc_ty_bounds = Vec::new();
@@ -2088,8 +2092,10 @@ pub(crate) fn param_env_from_predicates<'db>(
     interner: DbInterner<'db>,
     predicates: &'db GenericPredicates,
 ) -> ParamEnv<'db> {
-    let clauses =
-        rustc_type_ir::elaborate::elaborate(interner, predicates.all_predicates().iter_identity());
+    let clauses = rustc_type_ir::elaborate::elaborate(
+        interner,
+        predicates.all_predicates().iter_identity().map(Unnormalized::skip_norm_wip),
+    );
     let clauses = Clauses::new_from_iter(interner, clauses);
 
     // FIXME: We should normalize projections here, like rustc does.
@@ -2459,10 +2465,12 @@ fn fn_sig_for_fn(
 
     // If/when we track late bound vars, we need to switch this to not be `dummy`
     let result = StoredEarlyBinder::bind(StoredPolyFnSig::new(Binder::dummy(FnSig {
-        abi: data.abi.as_ref().map_or(FnAbi::Rust, FnAbi::from_symbol),
-        c_variadic: data.is_varargs(),
-        safety: if data.is_unsafe() { Safety::Unsafe } else { Safety::Safe },
         inputs_and_output,
+        fn_sig_kind: FnSigKind::new(
+            data.abi,
+            if data.is_unsafe() { Safety::Unsafe } else { Safety::Safe },
+            data.is_varargs(),
+        ),
     })));
     TyLoweringResult::from_ctx(result, ctx_params)
 }
@@ -2485,9 +2493,7 @@ fn fn_sig_for_struct_constructor(
     let inputs_and_output =
         Tys::new_from_iter(DbInterner::new_no_crate(db), params.chain(Some(ret)));
     StoredEarlyBinder::bind(StoredPolyFnSig::new(Binder::dummy(FnSig {
-        abi: FnAbi::Rust,
-        c_variadic: false,
-        safety: Safety::Safe,
+        fn_sig_kind: FnSigKind::new(ExternAbi::Rust, Safety::Safe, false),
         inputs_and_output,
     })))
 }
@@ -2504,9 +2510,7 @@ fn fn_sig_for_enum_variant_constructor(
     let inputs_and_output =
         Tys::new_from_iter(DbInterner::new_no_crate(db), params.chain(Some(ret)));
     StoredEarlyBinder::bind(StoredPolyFnSig::new(Binder::dummy(FnSig {
-        abi: FnAbi::Rust,
-        c_variadic: false,
-        safety: Safety::Safe,
+        fn_sig_kind: FnSigKind::new(ExternAbi::Rust, Safety::Safe, false),
         inputs_and_output,
     })))
 }
@@ -2607,5 +2611,8 @@ pub(crate) fn associated_type_by_name_including_super_traits_allow_ambiguity<'db
         .get_with(|(assoc_type, trait_args)| (*assoc_type, trait_args.as_ref()))
         .skip_binder();
     let interner = DbInterner::new_no_crate(db);
-    Some((assoc_type, EarlyBinder::bind(trait_args).instantiate(interner, trait_ref.args)))
+    Some((
+        assoc_type,
+        EarlyBinder::bind(trait_args).instantiate(interner, trait_ref.args).skip_norm_wip(),
+    ))
 }

--- a/crates/hir-ty/src/lower/path.rs
+++ b/crates/hir-ty/src/lower/path.rs
@@ -34,8 +34,8 @@ use crate::{
         LifetimeElisionKind, PathDiagnosticCallbackData, const_param_ty,
     },
     next_solver::{
-        Binder, Clause, Const, DbInterner, EarlyBinder, ErrorGuaranteed, GenericArg, GenericArgs,
-        Predicate, ProjectionPredicate, Region, TraitRef, Ty,
+        AliasTermKind, Binder, Clause, Const, DbInterner, EarlyBinder, ErrorGuaranteed, GenericArg,
+        GenericArgs, Predicate, ProjectionPredicate, Region, TraitRef, Ty,
     },
 };
 
@@ -498,7 +498,7 @@ impl<'a, 'b, 'db> PathLoweringContext<'a, 'b, 'db> {
                 let Some(impl_trait) = db.impl_trait(impl_) else {
                     return error_ty();
                 };
-                let impl_trait = impl_trait.instantiate_identity();
+                let impl_trait = impl_trait.instantiate_identity().skip_norm_wip();
                 // Searching for `Self::Assoc` in `impl Trait for Type` is like searching for `Self::Assoc` in `Trait`.
                 let AssocTypeShorthandResolution::Resolved(assoc_type) =
                     super::resolve_type_param_assoc_type_shorthand(
@@ -514,7 +514,12 @@ impl<'a, 'b, 'db> PathLoweringContext<'a, 'b, 'db> {
                 let (assoc_type, trait_args) = assoc_type
                     .get_with(|(assoc_type, trait_args)| (*assoc_type, trait_args.as_ref()))
                     .skip_binder();
-                (assoc_type, EarlyBinder::bind(trait_args).instantiate(interner, impl_trait.args))
+                (
+                    assoc_type,
+                    EarlyBinder::bind(trait_args)
+                        .instantiate(interner, impl_trait.args)
+                        .skip_norm_wip(),
+                )
             }
             _ => return error_ty(),
         };
@@ -543,7 +548,7 @@ impl<'a, 'b, 'db> PathLoweringContext<'a, 'b, 'db> {
         };
         let args = self.substs_from_path_segment(generic_def, infer_args, None, false);
         let ty = ty_query(self.ctx.db, typeable);
-        ty.instantiate(self.ctx.interner, args)
+        ty.instantiate(self.ctx.interner, args).skip_norm_wip()
     }
 
     /// Collect generic arguments from a path into a `Substs`. See also
@@ -749,12 +754,11 @@ impl<'a, 'b, 'db> PathLoweringContext<'a, 'b, 'db> {
                 infer_args: bool,
                 preceding_args: &[GenericArg<'db>],
             ) -> GenericArg<'db> {
-                let default =
-                    || {
-                        self.ctx.ctx.db.generic_defaults(def).get(preceding_args.len()).map(
-                            |default| default.instantiate(self.ctx.ctx.interner, preceding_args),
-                        )
-                    };
+                let default = || {
+                    self.ctx.ctx.db.generic_defaults(def).get(preceding_args.len()).map(|default| {
+                        default.instantiate(self.ctx.ctx.interner, preceding_args).skip_norm_wip()
+                    })
+                };
                 match param {
                     GenericParamDataRef::LifetimeParamData(_) => {
                         Region::new(self.ctx.ctx.interner, rustc_type_ir::ReError(ErrorGuaranteed))
@@ -902,8 +906,11 @@ impl<'a, 'b, 'db> PathLoweringContext<'a, 'b, 'db> {
                     interner,
                     super_trait_args.iter().chain(args.iter().skip(super_trait_args.len())),
                 );
-                let projection_term =
-                    AliasTerm::new_from_args(interner, associated_ty.into(), args);
+                let projection_term = AliasTerm::new_from_args(
+                    interner,
+                    AliasTermKind::ProjectionTy { def_id: associated_ty.into() },
+                    args,
+                );
                 let mut predicates: SmallVec<[_; 1]> = SmallVec::with_capacity(
                     binding.type_ref.as_ref().map_or(0, |_| 1) + binding.bounds.len(),
                 );

--- a/crates/hir-ty/src/method_resolution.rs
+++ b/crates/hir-ty/src/method_resolution.rs
@@ -41,7 +41,7 @@ use crate::{
     lower::GenericPredicates,
     next_solver::{
         AnyImplId, Binder, ClauseKind, DbInterner, FnSig, GenericArgs, ParamEnv, PredicateKind,
-        SimplifiedType, SolverDefId, TraitRef, Ty, TyKind, TypingMode,
+        SimplifiedType, SolverDefId, TraitRef, Ty, TyKind, TypingMode, Unnormalized,
         infer::{
             BoundRegionConversionTime, DbInternerInferExt, InferCtxt, InferOk,
             select::ImplSource,
@@ -289,8 +289,11 @@ impl<'db> InferenceTable<'db> {
         // N.B., instantiate late-bound regions before normalizing the
         // function signature so that normalization does not need to deal
         // with bound regions.
-        let fn_sig =
-            self.db.callable_item_signature(method_item.into()).instantiate(interner, args);
+        let fn_sig = self
+            .db
+            .callable_item_signature(method_item.into())
+            .instantiate(interner, args)
+            .skip_norm_wip();
         let fn_sig = self.infer_ctxt.instantiate_binder_with_fresh_vars(
             cause.span(),
             BoundRegionConversionTime::FnCall,
@@ -307,7 +310,7 @@ impl<'db> InferenceTable<'db> {
         // any late-bound regions appearing in its bounds.
         let bounds = GenericPredicates::query_all(self.db, method_item.into());
         let bounds = clauses_as_obligations(
-            bounds.iter_instantiated(interner, args.as_slice()),
+            bounds.iter_instantiated(interner, args.as_slice()).map(Unnormalized::skip_norm_wip),
             cause,
             self.param_env,
         );
@@ -596,7 +599,7 @@ impl InherentImpls {
                 for impl_id in module_data.scope.inherent_impls() {
                     let interner = DbInterner::new_no_crate(db);
                     let self_ty = db.impl_self_ty(impl_id);
-                    let self_ty = self_ty.instantiate_identity();
+                    let self_ty = self_ty.instantiate_identity().skip_norm_wip();
                     if let Some(self_ty) =
                         simplify_type(interner, self_ty, TreatParams::InstantiateWithInfer)
                     {
@@ -711,7 +714,7 @@ impl TraitImpls {
             for (_module_id, module_data) in def_map.modules() {
                 for impl_id in module_data.scope.trait_impls() {
                     let trait_ref = match db.impl_trait(impl_id) {
-                        Some(tr) => tr.instantiate_identity(),
+                        Some(tr) => tr.instantiate_identity().skip_norm_wip(),
                         None => continue,
                     };
                     // Reservation impls should be ignored during trait resolution, so we never need

--- a/crates/hir-ty/src/method_resolution/confirm.rs
+++ b/crates/hir-ty/src/method_resolution/confirm.rs
@@ -27,7 +27,7 @@ use crate::{
     next_solver::{
         Binder, Clause, ClauseKind, Const, DbInterner, EarlyParamRegion, ErrorGuaranteed, FnSig,
         GenericArg, GenericArgs, ParamConst, PolyExistentialTraitRef, PolyTraitRef, Region,
-        TraitRef, Ty, TyKind,
+        TraitRef, Ty, TyKind, Unnormalized,
         infer::{
             BoundRegionConversionTime, InferCtxt,
             traits::{ObligationCause, PredicateObligation},
@@ -137,7 +137,8 @@ impl<'a, 'b, 'db> ConfirmContext<'a, 'b, 'db> {
         );
         let illegal_sized_bound = self.predicates_require_illegal_sized_bound(
             GenericPredicates::query_all(self.db(), self.candidate.into())
-                .iter_instantiated(self.interner(), filler_args.as_slice()),
+                .iter_instantiated(self.interner(), filler_args.as_slice())
+                .map(Unnormalized::skip_norm_wip),
         );
 
         // Unify the (adjusted) self type with what the method expects.
@@ -512,13 +513,17 @@ impl<'a, 'b, 'db> ConfirmContext<'a, 'b, 'db> {
         let def_id = self.candidate;
         let method_predicates = clauses_as_obligations(
             GenericPredicates::query_all(self.db(), def_id.into())
-                .iter_instantiated(self.interner(), all_args),
+                .iter_instantiated(self.interner(), all_args)
+                .map(Unnormalized::skip_norm_wip),
             ObligationCause::new(self.call_expr),
             self.ctx.table.param_env,
         );
 
-        let sig =
-            self.db().callable_item_signature(def_id.into()).instantiate(self.interner(), all_args);
+        let sig = self
+            .db()
+            .callable_item_signature(def_id.into())
+            .instantiate(self.interner(), all_args)
+            .skip_norm_wip();
         debug!("type scheme instantiated, sig={:?}", sig);
 
         let sig = self.instantiate_binder_with_fresh_vars(sig);

--- a/crates/hir-ty/src/method_resolution/probe.rs
+++ b/crates/hir-ty/src/method_resolution/probe.rs
@@ -32,7 +32,7 @@ use crate::{
     },
     next_solver::{
         Binder, Canonical, ClauseKind, DbInterner, FnSig, GenericArg, GenericArgs, Goal, ParamEnv,
-        PolyTraitRef, Predicate, Region, SimplifiedType, TraitRef, Ty, TyKind,
+        PolyTraitRef, Predicate, Region, SimplifiedType, TraitRef, Ty, TyKind, Unnormalized,
         infer::{
             BoundRegionConversionTime, InferCtxt, InferOk,
             canonical::{QueryResponse, canonicalizer::OriginalQueryValues},
@@ -1585,8 +1585,11 @@ impl<'a, 'db, Choice: ProbeChoice<'db>> ProbeContext<'a, 'db, Choice> {
                 InherentImplCandidate { impl_def_id, .. } => {
                     let impl_args =
                         self.infcx().fresh_args_for_item(self.ctx.call_span, impl_def_id.into());
-                    let impl_ty =
-                        self.db().impl_self_ty(impl_def_id).instantiate(self.interner(), impl_args);
+                    let impl_ty = self
+                        .db()
+                        .impl_self_ty(impl_def_id)
+                        .instantiate(self.interner(), impl_args)
+                        .skip_norm_wip();
                     (xform_self_ty, xform_ret_ty) =
                         self.xform_self_ty(probe.item, impl_ty, impl_args.as_slice());
                     match ocx.relate(
@@ -1605,7 +1608,9 @@ impl<'a, 'db, Choice: ProbeChoice<'db>> ProbeContext<'a, 'db, Choice> {
                     // Check whether the impl imposes obligations we have to worry about.
                     let impl_bounds = GenericPredicates::query_all(self.db(), impl_def_id.into());
                     let impl_bounds = clauses_as_obligations(
-                        impl_bounds.iter_instantiated(self.interner(), impl_args.as_slice()),
+                        impl_bounds
+                            .iter_instantiated(self.interner(), impl_args.as_slice())
+                            .map(Unnormalized::skip_norm_wip),
                         ObligationCause::new(self.ctx.call_span),
                         self.param_env(),
                     );
@@ -2054,7 +2059,7 @@ impl<'a, 'db, Choice: ProbeChoice<'db>> ProbeContext<'a, 'db, Choice> {
             fn_sig.instantiate(self.interner(), args)
         };
 
-        self.interner().instantiate_bound_regions_with_erased(xform_fn_sig)
+        self.interner().instantiate_bound_regions_with_erased(xform_fn_sig.skip_norm_wip())
     }
 
     fn with_impl_item(&mut self, def_id: ImplId, callback: impl FnMut(&mut Self, CandidateId)) {

--- a/crates/hir-ty/src/mir.rs
+++ b/crates/hir-ty/src/mir.rs
@@ -197,9 +197,10 @@ impl<V: PartialEq> ProjectionElem<V> {
                 }
             },
             ProjectionElem::Field(Either::Left(f)) => match base.kind() {
-                TyKind::Adt(_, subst) => {
-                    db.field_types(f.parent)[f.local_id].get().instantiate(interner, subst)
-                }
+                TyKind::Adt(_, subst) => db.field_types(f.parent)[f.local_id]
+                    .get()
+                    .instantiate(interner, subst)
+                    .skip_norm_wip(),
                 ty => {
                     never!("Only adt has field, found {:?}", ty);
                     Ty::new_error(interner, ErrorGuaranteed)

--- a/crates/hir-ty/src/mir/eval.rs
+++ b/crates/hir-ty/src/mir/eval.rs
@@ -467,6 +467,7 @@ impl MirEvalError {
                     ItemContainerId::ImplId(impl_id) => Some({
                         db.impl_self_ty(impl_id)
                             .instantiate_identity()
+                            .skip_norm_wip()
                             .display(db, display_target)
                             .to_string()
                     }),
@@ -1715,7 +1716,7 @@ impl<'a, 'db: 'a> Evaluator<'a, 'db> {
             if let Some(ty) =
                 field_types.iter().last().map(|it| it.1.get().instantiate(self.interner(), subst))
             {
-                return self.coerce_unsized_look_through_fields(ty, goal);
+                return self.coerce_unsized_look_through_fields(ty.skip_norm_wip(), goal);
             }
         }
         Err(MirEvalError::CoerceUnsizedError(ty.store()))
@@ -1792,10 +1793,12 @@ impl<'a, 'db: 'a> Evaluator<'a, 'db> {
                     };
                     let target_last_field = self.db.field_types(id.into())[last_field]
                         .get()
-                        .instantiate(self.interner(), target_subst);
+                        .instantiate(self.interner(), target_subst)
+                        .skip_norm_wip();
                     let current_last_field = self.db.field_types(id.into())[last_field]
                         .get()
-                        .instantiate(self.interner(), current_subst);
+                        .instantiate(self.interner(), current_subst)
+                        .skip_norm_wip();
                     return self.unsizing_ptr_from_addr(
                         target_last_field,
                         current_last_field,
@@ -2435,7 +2438,10 @@ impl<'a, 'db: 'a> Evaluator<'a, 'db> {
                                 .fields
                                 .offset(u32::from(f.into_raw()) as usize)
                                 .bytes_usize();
-                            let ty = field_types[f].get().instantiate(this.interner(), subst);
+                            let ty = field_types[f]
+                                .get()
+                                .instantiate(this.interner(), subst)
+                                .skip_norm_wip();
                             let size = this.layout(ty)?.size.bytes_usize();
                             rec(
                                 this,
@@ -2461,7 +2467,10 @@ impl<'a, 'db: 'a> Evaluator<'a, 'db> {
                             for (f, _) in data.fields().iter() {
                                 let offset =
                                     l.fields.offset(u32::from(f.into_raw()) as usize).bytes_usize();
-                                let ty = field_types[f].get().instantiate(this.interner(), subst);
+                                let ty = field_types[f]
+                                    .get()
+                                    .instantiate(this.interner(), subst)
+                                    .skip_norm_wip();
                                 let size = this.layout(ty)?.size.bytes_usize();
                                 rec(
                                     this,
@@ -2547,7 +2556,7 @@ impl<'a, 'db: 'a> Evaluator<'a, 'db> {
                 AdtId::StructId(s) => {
                     for (i, (_, ty)) in self.db.field_types(s.into()).iter().enumerate() {
                         let offset = layout.fields.offset(i).bytes_usize();
-                        let ty = ty.get().instantiate(self.interner(), args);
+                        let ty = ty.get().instantiate(self.interner(), args).skip_norm_wip();
                         self.patch_addresses(
                             patch_map,
                             ty_of_bytes,
@@ -2568,7 +2577,7 @@ impl<'a, 'db: 'a> Evaluator<'a, 'db> {
                     ) {
                         for (i, (_, ty)) in self.db.field_types(ev.into()).iter().enumerate() {
                             let offset = layout.fields.offset(i).bytes_usize();
-                            let ty = ty.get().instantiate(self.interner(), args);
+                            let ty = ty.get().instantiate(self.interner(), args).skip_norm_wip();
                             self.patch_addresses(
                                 patch_map,
                                 ty_of_bytes,
@@ -3084,7 +3093,8 @@ impl<'a, 'db: 'a> Evaluator<'a, 'db> {
                                     let addr = addr.offset(offset);
                                     let ty = field_types[field]
                                         .get()
-                                        .instantiate(self.interner(), subst);
+                                        .instantiate(self.interner(), subst)
+                                        .skip_norm_wip();
                                     self.run_drop_glue_deep(ty, locals, addr, &[], span)?;
                                 }
                             }

--- a/crates/hir-ty/src/mir/eval/shim.rs
+++ b/crates/hir-ty/src/mir/eval/shim.rs
@@ -4,7 +4,7 @@
 use std::cmp::{self, Ordering};
 
 use hir_def::{attrs::AttrFlags, signatures::FunctionSignature};
-use intern::sym;
+use rustc_abi::ExternAbi;
 use rustc_type_ir::inherent::{GenericArgs as _, IntoKind, SliceLike, Ty as _};
 use stdx::never;
 
@@ -59,7 +59,9 @@ impl<'a, 'db: 'a> Evaluator<'a, 'db> {
             );
         }
         let is_extern_c = match def.lookup(self.db).container {
-            hir_def::ItemContainerId::ExternBlockId(block) => block.abi(self.db) == Some(sym::C),
+            hir_def::ItemContainerId::ExternBlockId(block) => {
+                matches!(block.abi(self.db), ExternAbi::C { .. })
+            }
             _ => false,
         };
         if is_extern_c {
@@ -1368,7 +1370,8 @@ impl<'a, 'db: 'a> Evaluator<'a, 'db> {
                     .unwrap()
                     .1
                     .get()
-                    .instantiate(self.interner(), subst);
+                    .instantiate(self.interner(), subst)
+                    .skip_norm_wip();
                 let sized_part_size =
                     layout.fields.offset(field_types.iter().count() - 1).bytes_usize();
                 let sized_part_align = layout.align.bytes() as usize;

--- a/crates/hir-ty/src/mir/eval/shim/simd.rs
+++ b/crates/hir-ty/src/mir/eval/shim/simd.rs
@@ -21,7 +21,8 @@ impl<'a, 'db: 'a> Evaluator<'a, 'db> {
                             };
                             let field_ty = self.db.field_types(id.into())[first_field]
                                 .get()
-                                .instantiate(self.interner(), subst);
+                                .instantiate(self.interner(), subst)
+                                .skip_norm_wip();
                             return Ok((fields.len(), field_ty));
                         }
                         return Err(MirEvalError::InternalError(

--- a/crates/hir-ty/src/mir/lower.rs
+++ b/crates/hir-ty/src/mir/lower.rs
@@ -1546,7 +1546,7 @@ impl<'a, 'db> MirLowerCtx<'a, 'db> {
             GeneralConstId::StaticId(id) => self.db.value_ty(id.into()).unwrap(),
             GeneralConstId::AnonConstId(id) => id.loc(self.db).ty.get(),
         };
-        let ty = ty.instantiate(self.interner(), subst);
+        let ty = ty.instantiate(self.interner(), subst).skip_norm_wip();
         Ok(Operand {
             kind: OperandKind::Constant { konst: konst.store(), ty: ty.store() },
             span: None,

--- a/crates/hir-ty/src/next_solver.rs
+++ b/crates/hir-ty/src/next_solver.rs
@@ -39,6 +39,7 @@ pub use interner::*;
 pub use opaques::*;
 pub use predicate::*;
 pub use region::*;
+use rustc_type_ir::MayBeErased;
 pub use solver::*;
 pub use ty::*;
 
@@ -48,6 +49,7 @@ pub use rustc_ast_ir::Mutability;
 
 pub type Binder<'db, T> = rustc_type_ir::Binder<DbInterner<'db>, T>;
 pub type EarlyBinder<'db, T> = rustc_type_ir::EarlyBinder<DbInterner<'db>, T>;
+pub type Unnormalized<'db, T> = rustc_type_ir::Unnormalized<DbInterner<'db>, T>;
 pub type Canonical<'db, T> = rustc_type_ir::Canonical<DbInterner<'db>, T>;
 pub type CanonicalVarValues<'db> = rustc_type_ir::CanonicalVarValues<DbInterner<'db>>;
 pub type CanonicalVarKind<'db> = rustc_type_ir::CanonicalVarKind<DbInterner<'db>>;
@@ -55,7 +57,7 @@ pub type CanonicalQueryInput<'db, V> = rustc_type_ir::CanonicalQueryInput<DbInte
 pub type AliasTy<'db> = rustc_type_ir::AliasTy<DbInterner<'db>>;
 pub type FnSig<'db> = rustc_type_ir::FnSig<DbInterner<'db>>;
 pub type PolyFnSig<'db> = Binder<'db, rustc_type_ir::FnSig<DbInterner<'db>>>;
-pub type TypingMode<'db> = rustc_type_ir::TypingMode<DbInterner<'db>>;
+pub type TypingMode<'db, S = MayBeErased> = rustc_type_ir::TypingMode<DbInterner<'db>, S>;
 pub type TypeError<'db> = rustc_type_ir::error::TypeError<DbInterner<'db>>;
 pub type QueryResult<'db> = rustc_type_ir::solve::QueryResult<DbInterner<'db>>;
 pub type FxIndexMap<K, V> = rustc_type_ir::data_structures::IndexMap<K, V>;

--- a/crates/hir-ty/src/next_solver/abi.rs
+++ b/crates/hir-ty/src/next_solver/abi.rs
@@ -1,7 +1,10 @@
 //! ABI-related things in the next-trait-solver.
-use rustc_type_ir::{error::TypeError, relate::Relate};
-
-use crate::FnAbi;
+use rustc_abi::ExternAbi;
+use rustc_ast_ir::visit::VisitorResult;
+use rustc_type_ir::{
+    FallibleTypeFolder, TypeFoldable, TypeFolder, TypeVisitable, TypeVisitor, error::TypeError,
+    relate::Relate,
+};
 
 use super::interner::DbInterner;
 
@@ -40,9 +43,32 @@ impl<'db> rustc_type_ir::inherent::Safety<DbInterner<'db>> for Safety {
             Self::Safe => "",
         }
     }
+
+    fn unsafe_mode() -> Self {
+        Safety::Unsafe
+    }
 }
 
-impl<'db> Relate<DbInterner<'db>> for FnAbi {
+impl<'db> TypeVisitable<DbInterner<'db>> for ExternAbi {
+    fn visit_with<V: TypeVisitor<DbInterner<'db>>>(&self, _visitor: &mut V) -> V::Result {
+        V::Result::output()
+    }
+}
+
+impl<'db> TypeFoldable<DbInterner<'db>> for ExternAbi {
+    fn try_fold_with<F: FallibleTypeFolder<DbInterner<'db>>>(
+        self,
+        _folder: &mut F,
+    ) -> Result<Self, F::Error> {
+        Ok(self)
+    }
+
+    fn fold_with<F: TypeFolder<DbInterner<'db>>>(self, _folder: &mut F) -> Self {
+        self
+    }
+}
+
+impl<'db> Relate<DbInterner<'db>> for ExternAbi {
     fn relate<R: rustc_type_ir::relate::TypeRelation<DbInterner<'db>>>(
         _relation: &mut R,
         a: Self,
@@ -53,15 +79,5 @@ impl<'db> Relate<DbInterner<'db>> for FnAbi {
         } else {
             Err(TypeError::AbiMismatch(rustc_type_ir::error::ExpectedFound::new(a, b)))
         }
-    }
-}
-
-impl<'db> rustc_type_ir::inherent::Abi<DbInterner<'db>> for FnAbi {
-    fn rust() -> Self {
-        FnAbi::Rust
-    }
-
-    fn is_rust(self) -> bool {
-        matches!(self, FnAbi::Rust)
     }
 }

--- a/crates/hir-ty/src/next_solver/binder.rs
+++ b/crates/hir-ty/src/next_solver/binder.rs
@@ -1,13 +1,10 @@
 use hir_def::TraitId;
 use macros::{TypeFoldable, TypeVisitable};
 
-use crate::{
-    FnAbi,
-    next_solver::{
-        Binder, Clauses, DbInterner, EarlyBinder, FnSig, GenericArg, PolyFnSig,
-        StoredBoundVarKinds, StoredClauses, StoredGenericArg, StoredGenericArgs, StoredTy,
-        StoredTys, TraitRef, Ty, abi::Safety,
-    },
+use crate::next_solver::{
+    Binder, Clauses, DbInterner, EarlyBinder, FnSig, FnSigKind, GenericArg, PolyFnSig,
+    StoredBoundVarKinds, StoredClauses, StoredGenericArg, StoredGenericArgs, StoredTy, StoredTys,
+    TraitRef, Ty,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -74,9 +71,7 @@ impl StoredEarlyBinder<StoredTraitRef> {
 pub struct StoredPolyFnSig {
     bound_vars: StoredBoundVarKinds,
     inputs_and_output: StoredTys,
-    c_variadic: bool,
-    safety: Safety,
-    abi: FnAbi,
+    fn_sig_kind: FnSigKind<'static>,
 }
 
 impl StoredPolyFnSig {
@@ -87,9 +82,11 @@ impl StoredPolyFnSig {
         Self {
             bound_vars,
             inputs_and_output: sig.inputs_and_output.store(),
-            c_variadic: sig.c_variadic,
-            safety: sig.safety,
-            abi: sig.abi,
+            fn_sig_kind: FnSigKind::new(
+                sig.fn_sig_kind.abi(),
+                sig.fn_sig_kind.safety(),
+                sig.fn_sig_kind.c_variadic(),
+            ),
         }
     }
 
@@ -98,9 +95,7 @@ impl StoredPolyFnSig {
         Binder::bind_with_vars(
             FnSig {
                 inputs_and_output: self.inputs_and_output.as_ref(),
-                c_variadic: self.c_variadic,
-                safety: self.safety,
-                abi: self.abi,
+                fn_sig_kind: self.fn_sig_kind,
             },
             self.bound_vars.as_ref(),
         )

--- a/crates/hir-ty/src/next_solver/def_id.rs
+++ b/crates/hir-ty/src/next_solver/def_id.rs
@@ -310,26 +310,6 @@ impl TryFrom<SolverDefId> for GenericDefId {
     }
 }
 
-impl SolverDefId {
-    #[inline]
-    #[track_caller]
-    pub fn expect_opaque_ty(self) -> InternedOpaqueTyId {
-        match self {
-            SolverDefId::InternedOpaqueTyId(it) => it,
-            _ => panic!("expected opaque type, found {self:?}"),
-        }
-    }
-
-    #[inline]
-    #[track_caller]
-    pub fn expect_type_alias(self) -> TypeAliasId {
-        match self {
-            SolverDefId::TypeAliasId(it) => it,
-            _ => panic!("expected type alias, found {self:?}"),
-        }
-    }
-}
-
 impl<'db> inherent::DefId<DbInterner<'db>> for SolverDefId {
     fn as_local(self) -> Option<SolverDefId> {
         Some(self)
@@ -341,6 +321,26 @@ impl<'db> inherent::DefId<DbInterner<'db>> for SolverDefId {
 
 macro_rules! declare_id_wrapper {
     ($name:ident, $wraps:ident) => {
+        declare_id_wrapper!($name, $wraps, SolverDefId);
+    };
+
+    ($name:ident, $wraps:ident, $local:ident) => {
+        declare_id_wrapper!($name, $wraps, $local, no_try_from);
+
+        impl TryFrom<SolverDefId> for $name {
+            type Error = ();
+
+            #[inline]
+            fn try_from(value: SolverDefId) -> Result<Self, Self::Error> {
+                match value {
+                    SolverDefId::$wraps(it) => Ok(Self(it)),
+                    _ => Err(()),
+                }
+            }
+        }
+    };
+
+    ($name:ident, $wraps:ident, $local:ident, no_try_from) => {
         #[derive(Clone, Copy, PartialEq, Eq, Hash)]
         pub struct $name(pub $wraps);
 
@@ -371,20 +371,8 @@ macro_rules! declare_id_wrapper {
             }
         }
 
-        impl TryFrom<SolverDefId> for $name {
-            type Error = ();
-
-            #[inline]
-            fn try_from(value: SolverDefId) -> Result<Self, Self::Error> {
-                match value {
-                    SolverDefId::$wraps(it) => Ok(Self(it)),
-                    _ => Err(()),
-                }
-            }
-        }
-
-        impl<'db> inherent::DefId<DbInterner<'db>> for $name {
-            fn as_local(self) -> Option<SolverDefId> {
+        impl<'db> inherent::DefId<DbInterner<'db>, $local> for $name {
+            fn as_local(self) -> Option<$local> {
                 Some(self.into())
             }
             fn is_local(self) -> bool {
@@ -400,6 +388,89 @@ declare_id_wrapper!(ClosureIdWrapper, InternedClosureId);
 declare_id_wrapper!(CoroutineIdWrapper, InternedCoroutineId);
 declare_id_wrapper!(CoroutineClosureIdWrapper, InternedCoroutineClosureId);
 declare_id_wrapper!(AdtIdWrapper, AdtId);
+declare_id_wrapper!(OpaqueTyIdWrapper, InternedOpaqueTyId, OpaqueTyIdWrapper);
+
+macro_rules! declare_ty_const_pair {
+    ( $ty_id_name:ident, $const_id_name:ident, $term_id_name:ident ) => {
+        declare_id_wrapper!($ty_id_name, TypeAliasId);
+        declare_id_wrapper!($const_id_name, ConstId);
+        declare_id_wrapper!($term_id_name, TermId, SolverDefId, no_try_from);
+
+        impl TryFrom<SolverDefId> for $term_id_name {
+            type Error = ();
+
+            #[inline]
+            fn try_from(value: SolverDefId) -> Result<Self, Self::Error> {
+                match value {
+                    SolverDefId::TypeAliasId(it) => Ok(Self(TermId::TypeAliasId(it))),
+                    SolverDefId::ConstId(it) => Ok(Self(TermId::ConstId(it))),
+                    _ => Err(()),
+                }
+            }
+        }
+
+        impl From<$ty_id_name> for $term_id_name {
+            fn from(value: $ty_id_name) -> Self {
+                $term_id_name(TermId::TypeAliasId(value.0))
+            }
+        }
+
+        impl From<$const_id_name> for $term_id_name {
+            fn from(value: $const_id_name) -> Self {
+                $term_id_name(TermId::ConstId(value.0))
+            }
+        }
+
+        impl TryFrom<$term_id_name> for $ty_id_name {
+            type Error = ();
+
+            fn try_from(value: $term_id_name) -> Result<Self, Self::Error> {
+                match value.0 {
+                    TermId::TypeAliasId(id) => Ok($ty_id_name(id)),
+                    TermId::ConstId(_) => Err(()),
+                }
+            }
+        }
+
+        impl TryFrom<$term_id_name> for $const_id_name {
+            type Error = ();
+
+            fn try_from(value: $term_id_name) -> Result<Self, Self::Error> {
+                match value.0 {
+                    TermId::ConstId(id) => Ok($const_id_name(id)),
+                    TermId::TypeAliasId(_) => Err(()),
+                }
+            }
+        }
+
+        impl From<$const_id_name> for GeneralConstIdWrapper {
+            fn from(value: $const_id_name) -> Self {
+                GeneralConstIdWrapper(GeneralConstId::ConstId(value.0))
+            }
+        }
+    };
+}
+
+declare_ty_const_pair!(TraitAssocTyId, TraitAssocConstId, TraitAssocTermId);
+declare_ty_const_pair!(ImplOrTraitAssocTyId, ImplOrTraitAssocConstId, ImplOrTraitAssocTermId);
+declare_ty_const_pair!(FreeTyAliasId, FreeConstAliasId, FreeTermAliasId);
+declare_ty_const_pair!(InherentAssocTyId, InherentAssocConstId, InherentAssocTermId);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum TermId {
+    TypeAliasId(TypeAliasId),
+    ConstId(ConstId),
+}
+impl_from!(TypeAliasId, ConstId for TermId);
+
+impl From<TermId> for SolverDefId {
+    fn from(value: TermId) -> Self {
+        match value {
+            TermId::TypeAliasId(id) => id.into(),
+            TermId::ConstId(id) => id.into(),
+        }
+    }
+}
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
 pub struct GeneralConstIdWrapper(pub GeneralConstId);

--- a/crates/hir-ty/src/next_solver/fulfill.rs
+++ b/crates/hir-ty/src/next_solver/fulfill.rs
@@ -243,7 +243,7 @@ impl<'db> FulfillmentCtxt<'db> {
         &mut self,
         infcx: &InferCtxt<'db>,
     ) -> PredicateObligations<'db> {
-        let stalled_coroutines = match infcx.typing_mode() {
+        let stalled_coroutines = match infcx.typing_mode_raw().assert_not_erased() {
             TypingMode::Analysis { defining_opaque_types_and_generators } => {
                 defining_opaque_types_and_generators
             }

--- a/crates/hir-ty/src/next_solver/generic_arg.rs
+++ b/crates/hir-ty/src/next_solver/generic_arg.rs
@@ -579,7 +579,7 @@ impl<'db> GenericArgs<'db> {
     {
         let defaults = interner.db.generic_defaults(def_id);
         Self::for_item(interner, def_id.into(), |idx, id, prev| match defaults.get(idx as usize) {
-            Some(default) => default.instantiate(interner, prev),
+            Some(default) => default.instantiate(interner, prev).skip_norm_wip(),
             None => fallback(idx, id, prev),
         })
     }
@@ -614,7 +614,7 @@ impl<'db> GenericArgs<'db> {
         Self::fill_rest(interner, def_id.into(), first, |idx, id, prev| {
             defaults
                 .get(idx as usize)
-                .map(|default| default.instantiate(interner, prev))
+                .map(|default| default.instantiate(interner, prev).skip_norm_wip())
                 .unwrap_or_else(|| fallback(idx, id, prev))
         })
     }

--- a/crates/hir-ty/src/next_solver/infer/canonical/instantiate.rs
+++ b/crates/hir-ty/src/next_solver/infer/canonical/instantiate.rs
@@ -437,7 +437,7 @@ impl<'db> InferCtxt<'db> {
             // the generic args of the opaque with the generic params of its hidden type version.
             obligations.extend(
                 self.at(cause, param_env)
-                    .eq(Ty::new_opaque(self.interner, a.def_id, a.args), b)?
+                    .eq(Ty::new_opaque(self.interner, a.def_id.0, a.args), b)?
                     .obligations,
             );
         }

--- a/crates/hir-ty/src/next_solver/infer/context.rs
+++ b/crates/hir-ty/src/next_solver/infer/context.rs
@@ -5,6 +5,7 @@ use rustc_type_ir::{
     RegionVid, TyVid, TypeFoldable, TypingMode, UniverseIndex,
     inherent::{Const as _, IntoKind, Ty as _},
     relate::combine::PredicateEmittingRelation,
+    solve::VisibleForLeakCheck,
 };
 
 use crate::{
@@ -29,8 +30,12 @@ impl<'db> rustc_type_ir::InferCtxtLike for InferCtxt<'db> {
         true
     }
 
-    fn typing_mode(&self) -> TypingMode<DbInterner<'db>> {
-        self.typing_mode()
+    fn disable_trait_solver_fast_paths(&self) -> bool {
+        false
+    }
+
+    fn typing_mode_raw(&self) -> TypingMode<DbInterner<'db>> {
+        self.typing_mode_raw()
     }
 
     fn universe(&self) -> UniverseIndex {
@@ -257,11 +262,23 @@ impl<'db> rustc_type_ir::InferCtxtLike for InferCtxt<'db> {
         self.probe(|_| probe())
     }
 
-    fn sub_regions(&self, sub: Region<'db>, sup: Region<'db>, _span: Span) {
+    fn sub_regions(
+        &self,
+        sub: Region<'db>,
+        sup: Region<'db>,
+        _vis: VisibleForLeakCheck,
+        _span: Span,
+    ) {
         self.inner.borrow_mut().unwrap_region_constraints().make_subregion(sub, sup);
     }
 
-    fn equate_regions(&self, a: Region<'db>, b: Region<'db>, _span: Span) {
+    fn equate_regions(
+        &self,
+        a: Region<'db>,
+        b: Region<'db>,
+        _vis: VisibleForLeakCheck,
+        _span: Span,
+    ) {
         self.inner.borrow_mut().unwrap_region_constraints().make_eqregion(a, b);
     }
 

--- a/crates/hir-ty/src/next_solver/infer/errors.rs
+++ b/crates/hir-ty/src/next_solver/infer/errors.rs
@@ -6,7 +6,7 @@ use rustc_type_ir::{
     AliasRelationDirection, AliasTermKind, PredicatePolarity,
     error::ExpectedFound,
     inherent::IntoKind as _,
-    solve::{CandidateSource, Certainty, GoalSource, MaybeCause, NoSolution},
+    solve::{CandidateSource, Certainty, GoalSource, MaybeCause, MaybeInfo, NoSolution},
 };
 use tracing::{instrument, trace};
 
@@ -147,7 +147,7 @@ fn fulfillment_error_for_no_solution<'db>(
                         GeneralConstId::StaticId(statik) => db.value_ty(statik.into()).unwrap(),
                         GeneralConstId::AnonConstId(konst) => konst.loc(db).ty.get(),
                     };
-                    ct_ty.instantiate(interner, uv.args)
+                    ct_ty.instantiate(interner, uv.args).skip_norm_wip()
                 }
                 ConstKind::Param(param_ct) => param_ct.find_const_ty_from_env(obligation.param_env),
                 ConstKind::Value(cv) => cv.ty,
@@ -203,16 +203,16 @@ fn fulfillment_error_for_stalled<'db>(
             None,
         ) {
             Ok(GoalEvaluation {
-                certainty: Certainty::Maybe { cause: MaybeCause::Ambiguity, .. },
+                certainty: Certainty::Maybe(MaybeInfo { cause: MaybeCause::Ambiguity, .. }),
                 ..
             }) => (FulfillmentErrorCode::Ambiguity { overflow: None }, true),
             Ok(GoalEvaluation {
                 certainty:
-                    Certainty::Maybe {
+                    Certainty::Maybe(MaybeInfo {
                         cause:
                             MaybeCause::Overflow { suggest_increasing_limit, keep_constraints: _ },
                         ..
-                    },
+                    }),
                 ..
             }) => (
                 FulfillmentErrorCode::Ambiguity { overflow: Some(suggest_increasing_limit) },
@@ -495,8 +495,8 @@ impl<'db> BestObligation<'db> {
                 self.detect_error_in_self_ty_normalization(goal, pred.self_ty())?;
             }
             Some(PredicateKind::NormalizesTo(pred))
-                if let AliasTermKind::ProjectionTy | AliasTermKind::ProjectionConst =
-                    pred.alias.kind(interner) =>
+                if let AliasTermKind::ProjectionTy { .. }
+                | AliasTermKind::ProjectionConst { .. } = pred.alias.kind(interner) =>
             {
                 self.detect_error_in_self_ty_normalization(goal, pred.alias.self_ty())?;
                 self.detect_non_well_formed_assoc_item(goal, pred.alias)?;
@@ -520,8 +520,8 @@ impl<'db> ProofTreeVisitor<'db> for BestObligation<'db> {
         let interner = goal.infcx().interner;
         // Skip goals that aren't the *reason* for our goal's failure.
         match (self.consider_ambiguities, goal.result()) {
-            (true, Ok(Certainty::Maybe { cause: MaybeCause::Ambiguity, .. })) | (false, Err(_)) => {
-            }
+            (true, Ok(Certainty::Maybe(MaybeInfo { cause: MaybeCause::Ambiguity, .. })))
+            | (false, Err(_)) => {}
             _ => return ControlFlow::Continue(()),
         }
 
@@ -559,7 +559,7 @@ impl<'db> ProofTreeVisitor<'db> for BestObligation<'db> {
             PredicateKind::NormalizesTo(normalizes_to)
                 if matches!(
                     normalizes_to.alias.kind(interner),
-                    AliasTermKind::ProjectionTy | AliasTermKind::ProjectionConst
+                    AliasTermKind::ProjectionTy { .. } | AliasTermKind::ProjectionConst { .. }
                 ) =>
             {
                 ChildMode::Trait(pred.kind().rebind(TraitPredicate {

--- a/crates/hir-ty/src/next_solver/infer/mod.rs
+++ b/crates/hir-ty/src/next_solver/infer/mod.rs
@@ -11,7 +11,6 @@ use hir_def::{GenericParamId, TraitId};
 use opaque_types::{OpaqueHiddenType, OpaqueTypeStorage};
 use region_constraints::{RegionConstraintCollector, RegionConstraintStorage};
 use rustc_next_trait_solver::solve::{GoalEvaluation, SolverDelegateEvalExt};
-use rustc_pattern_analysis::Captures;
 use rustc_type_ir::{
     ClosureKind, ConstVid, FloatVarValue, FloatVid, GenericArgKind, InferConst, InferTy,
     IntVarValue, IntVid, OutlivesPredicate, RegionVid, TermKind, TyVid, TypeFoldable, TypeFolder,
@@ -403,7 +402,7 @@ impl<'db> InferOk<'db, ()> {
 
 impl<'db> InferCtxt<'db> {
     #[inline(always)]
-    pub fn typing_mode(&self) -> TypingMode<'db> {
+    pub fn typing_mode_raw(&self) -> TypingMode<'db> {
         self.typing_mode
     }
 
@@ -931,7 +930,7 @@ impl<'db> InferCtxt<'db> {
 
     #[inline(always)]
     pub fn can_define_opaque_ty(&self, id: impl Into<SolverDefId>) -> bool {
-        match self.typing_mode_unchecked() {
+        match self.typing_mode_raw().assert_not_erased() {
             TypingMode::Analysis { defining_opaque_types_and_generators } => {
                 defining_opaque_types_and_generators.contains(&id.into())
             }
@@ -1201,7 +1200,7 @@ impl<'db> InferCtxt<'db> {
     #[inline]
     pub fn is_ty_infer_var_definitely_unchanged<'a>(
         &'a self,
-    ) -> impl Fn(TyOrConstInferVar) -> bool + Captures<'db> + 'a {
+    ) -> impl Fn(TyOrConstInferVar) -> bool + use<'a, 'db> {
         // This hoists the borrow/release out of the loop body.
         let inner = self.inner.try_borrow();
 

--- a/crates/hir-ty/src/next_solver/inspect.rs
+++ b/crates/hir-ty/src/next_solver/inspect.rs
@@ -7,7 +7,7 @@ use rustc_next_trait_solver::{
 use rustc_type_ir::{
     VisitorResult,
     inherent::IntoKind,
-    solve::{Certainty, GoalSource, MaybeCause, NoSolution},
+    solve::{Certainty, GoalSource, MaybeCause, MaybeInfo, NoSolution},
 };
 
 use crate::{
@@ -344,7 +344,10 @@ impl<'a, 'db> InspectGoal<'a, 'db> {
                 inspect::ProbeStep::MakeCanonicalResponse { shallow_certainty: c } => {
                     assert!(matches!(
                         shallow_certainty.replace(c),
-                        None | Some(Certainty::Maybe { cause: MaybeCause::Ambiguity, .. })
+                        None | Some(Certainty::Maybe(MaybeInfo {
+                            cause: MaybeCause::Ambiguity,
+                            ..
+                        }))
                     ));
                 }
                 inspect::ProbeStep::NestedProbe(ref probe) => {

--- a/crates/hir-ty/src/next_solver/interner.rs
+++ b/crates/hir-ty/src/next_solver/interner.rs
@@ -11,7 +11,8 @@ pub use tls_db::{attach_db, attach_db_allow_change, with_attached_db};
 
 use base_db::Crate;
 use hir_def::{
-    AdtId, CallableDefId, EnumId, HasModule, ItemContainerId, StructId, UnionId, VariantId,
+    AdtId, CallableDefId, EnumId, HasModule, ItemContainerId, StructId, TraitId, TypeAliasId,
+    UnionId, VariantId,
     attrs::AttrFlags,
     expr_store::ExpressionStore,
     hir::{ClosureKind as HirClosureKind, CoroutineKind as HirCoroutineKind, ExprId},
@@ -21,31 +22,35 @@ use hir_def::{
         StructFlags, StructSignature, TraitFlags, TraitSignature, UnionSignature,
     },
 };
+use rustc_abi::ExternAbi;
 use rustc_hash::FxHashSet;
 use rustc_index::bit_set::DenseBitSet;
 use rustc_type_ir::{
-    AliasTermKind, AliasTy, AliasTyKind, BoundVar, CoroutineWitnessTypes, DebruijnIndex,
-    EarlyBinder, FlagComputation, Flags, GenericArgKind, GenericTypeVisitable, ImplPolarity,
-    InferTy, Interner, TraitRef, TypeFlags, TypeVisitableExt, Upcast, Variance,
+    AliasTy, BoundVar, CoroutineWitnessTypes, DebruijnIndex, EarlyBinder, FlagComputation, Flags,
+    FnSigKind, GenericArgKind, GenericTypeVisitable, ImplPolarity, InferTy, Interner, TraitRef,
+    TypeFlags, TypeVisitableExt, Upcast, Variance,
     elaborate::elaborate,
     error::TypeError,
     fast_reject,
     inherent::{self, Const as _, GenericsOf, IntoKind, SliceLike as _, Span as _, Ty as _},
-    lang_items::{SolverAdtLangItem, SolverLangItem, SolverTraitLangItem},
+    lang_items::{SolverAdtLangItem, SolverProjectionLangItem, SolverTraitLangItem},
     solve::{AdtDestructorKind, SizedTraitKind},
 };
 
 use crate::{
-    FnAbi, InferBodyId, Span,
+    InferBodyId, Span,
     db::{HirDatabase, InternedClosure, InternedCoroutineId},
     lower::GenericPredicates,
     method_resolution::TraitImpls,
     next_solver::{
-        AdtIdWrapper, AnyImplId, BoundConst, CallableIdWrapper, CanonicalVarKind, ClosureIdWrapper,
-        Consts, CoroutineClosureIdWrapper, CoroutineIdWrapper, Ctor, FnSig, FxIndexMap,
-        GeneralConstIdWrapper, LateParamRegion, OpaqueTypeKey, RegionAssumptions, ScalarInt,
-        SimplifiedType, SolverContext, SolverDefIds, TraitIdWrapper, TypeAliasIdWrapper,
-        UnevaluatedConst,
+        AdtIdWrapper, AliasTermKind, AliasTyKind, AnyImplId, BoundConst, CallableIdWrapper,
+        CanonicalVarKind, ClosureIdWrapper, Consts, CoroutineClosureIdWrapper, CoroutineIdWrapper,
+        Ctor, FnSig, FreeConstAliasId, FreeTermAliasId, FreeTyAliasId, FxIndexMap,
+        GeneralConstIdWrapper, ImplOrTraitAssocConstId, ImplOrTraitAssocTermId,
+        ImplOrTraitAssocTyId, InherentAssocConstId, InherentAssocTermId, InherentAssocTyId,
+        LateParamRegion, OpaqueTyIdWrapper, OpaqueTypeKey, RegionAssumptions, ScalarInt,
+        SimplifiedType, SolverContext, SolverDefIds, TermId, TraitAssocConstId, TraitAssocTermId,
+        TraitAssocTyId, TraitIdWrapper, TypeAliasIdWrapper, UnevaluatedConst, Unnormalized,
         util::{explicit_item_bounds, explicit_item_self_bounds},
     },
 };
@@ -666,6 +671,10 @@ impl<'db> inherent::Features<DbInterner<'db>> for Features {
         false
     }
 
+    fn generic_const_args(self) -> bool {
+        false
+    }
+
     fn feature_bound_holds_in_crate(self, _symbol: Symbol) -> bool {
         false
     }
@@ -837,11 +846,7 @@ impl_foldable_for_interned_slice!(PatList);
 
 macro_rules! as_lang_item {
     (
-        $solver_enum:ident, $self:ident, $def_id:expr;
-
-        ignore = {
-            $( $ignore:ident ),* $(,)?
-        }
+        $solver_enum:ident, $self:ident, $def_id:expr, $id_ty:ty;
 
         $( $variant:ident ),* $(,)?
     ) => {{
@@ -850,11 +855,10 @@ macro_rules! as_lang_item {
         if let Some(it) = None::<$solver_enum> {
             match it {
                 $( $solver_enum::$variant => {} )*
-                $( $solver_enum::$ignore => {} )*
             }
         }
         match $def_id {
-            $( def_id if lang_items.$variant.is_some_and(|it| it == def_id) => Some($solver_enum::$variant), )*
+            $( def_id if let Some(it) = lang_items.$variant && <$id_ty>::from(it) == def_id => Some($solver_enum::$variant), )*
             _ => None
         }
     }};
@@ -864,17 +868,12 @@ macro_rules! is_lang_item {
     (
         $solver_enum:ident, $self:ident, $def_id:expr, $expected_variant:ident;
 
-        ignore = {
-            $( $ignore:ident ),* $(,)?
-        }
-
         $( $variant:ident ),* $(,)?
     ) => {{
         let lang_items = $self.lang_items();
         let def_id = $def_id;
         match $expected_variant {
             $( $solver_enum::$variant => lang_items.$variant.is_some_and(|it| it == def_id), )*
-            $( $solver_enum::$ignore => false, )*
         }
     }};
 }
@@ -892,6 +891,20 @@ impl<'db> Interner for DbInterner<'db> {
     type AdtId = AdtIdWrapper;
     type ImplId = AnyImplId;
     type UnevaluatedConstId = GeneralConstIdWrapper;
+    type TraitAssocTyId = TraitAssocTyId;
+    type TraitAssocConstId = TraitAssocConstId;
+    type TraitAssocTermId = TraitAssocTermId;
+    type OpaqueTyId = OpaqueTyIdWrapper;
+    type LocalOpaqueTyId = OpaqueTyIdWrapper;
+    type FreeTyAliasId = FreeTyAliasId;
+    type FreeConstAliasId = FreeConstAliasId;
+    type FreeTermAliasId = FreeTermAliasId;
+    type ImplOrTraitAssocTyId = ImplOrTraitAssocTyId;
+    type ImplOrTraitAssocConstId = ImplOrTraitAssocConstId;
+    type ImplOrTraitAssocTermId = ImplOrTraitAssocTermId;
+    type InherentAssocTyId = InherentAssocTyId;
+    type InherentAssocConstId = InherentAssocConstId;
+    type InherentAssocTermId = InherentAssocTermId;
     type Span = Span;
 
     type GenericArgs = GenericArgs<'db>;
@@ -945,7 +958,6 @@ impl<'db> Interner for DbInterner<'db> {
     type Pat = Pattern<'db>;
     type PatList = PatList<'db>;
     type Safety = Safety;
-    type Abi = FnAbi;
 
     type Const = Const<'db>;
     type ParamConst = ParamConst;
@@ -1075,7 +1087,9 @@ impl<'db> Interner for DbInterner<'db> {
             //
             // We currently always use the type from HIR typeck which ignores regions. This
             // should be fine.
-            SolverDefId::InternedOpaqueTyId(_) => self.type_of_opaque_hir_typeck(def_id),
+            SolverDefId::InternedOpaqueTyId(def_id) => {
+                self.type_of_opaque_hir_typeck(def_id.into())
+            }
             SolverDefId::FunctionId(id) => self.db.value_ty(id.into()).unwrap(),
             SolverDefId::Ctor(id) => {
                 let id = match id {
@@ -1092,40 +1106,40 @@ impl<'db> Interner for DbInterner<'db> {
         AdtDef::new(def_id.0, self)
     }
 
-    fn alias_term_kind(
-        self,
-        alias: rustc_type_ir::AliasTerm<Self>,
-    ) -> rustc_type_ir::AliasTermKind {
-        match alias.def_id {
-            SolverDefId::InternedOpaqueTyId(_) => AliasTermKind::OpaqueTy,
+    fn alias_term_kind_from_def_id(self, def_id: SolverDefId) -> AliasTermKind<'db> {
+        match def_id {
+            SolverDefId::InternedOpaqueTyId(def_id) => {
+                AliasTermKind::OpaqueTy { def_id: def_id.into() }
+            }
             SolverDefId::TypeAliasId(type_alias) => match type_alias.loc(self.db).container {
                 ItemContainerId::ImplId(impl_)
                     if ImplSignature::of(self.db, impl_).target_trait.is_none() =>
                 {
-                    AliasTermKind::InherentTy
+                    AliasTermKind::InherentTy { def_id: type_alias.into() }
                 }
                 ItemContainerId::TraitId(_) | ItemContainerId::ImplId(_) => {
-                    AliasTermKind::ProjectionTy
+                    AliasTermKind::ProjectionTy { def_id: type_alias.into() }
                 }
-                _ => AliasTermKind::FreeTy,
+                _ => AliasTermKind::FreeTy { def_id: type_alias.into() },
             },
             // rustc creates an `AnonConst` for consts, and evaluates them with CTFE (normalizing projections
             // via selection, similar to ours `find_matching_impl()`, and not with the trait solver), so mimic it.
-            SolverDefId::ConstId(_) | SolverDefId::AnonConstId(_) => {
-                AliasTermKind::UnevaluatedConst
+            SolverDefId::ConstId(def_id) => {
+                AliasTermKind::UnevaluatedConst { def_id: GeneralConstIdWrapper(def_id.into()) }
             }
-            _ => unimplemented!("Unexpected alias: {:?}", alias.def_id),
+            SolverDefId::AnonConstId(def_id) => {
+                AliasTermKind::UnevaluatedConst { def_id: GeneralConstIdWrapper(def_id.into()) }
+            }
+            _ => unimplemented!("Unexpected alias: {:?}", def_id),
         }
     }
 
     fn trait_ref_and_own_args_for_alias(
         self,
-        def_id: Self::DefId,
+        def_id: Self::TraitAssocTermId,
         args: Self::GenericArgs,
     ) -> (rustc_type_ir::TraitRef<Self>, Self::GenericArgsSlice) {
-        let SolverDefId::TraitId(trait_def_id) = self.parent(def_id) else {
-            panic!("expected a trait");
-        };
+        let trait_def_id = self.projection_parent(def_id).0;
         let trait_generics = crate::generics::generics(self.db, trait_def_id.into());
         let trait_generics_len = trait_generics.len();
         let trait_args = GenericArgs::new_from_slice(&args.as_slice()[..trait_generics_len]);
@@ -1155,42 +1169,52 @@ impl<'db> Interner for DbInterner<'db> {
         Tys::new_from_iter(self, args)
     }
 
-    fn parent(self, def_id: Self::DefId) -> Self::DefId {
-        use hir_def::Lookup;
-
-        let container = match def_id {
-            SolverDefId::FunctionId(it) => it.lookup(self.db()).container,
-            SolverDefId::TypeAliasId(it) => it.lookup(self.db()).container,
-            SolverDefId::ConstId(it) => it.lookup(self.db()).container,
-            SolverDefId::InternedClosureId(it) => {
-                return it.loc(self.db).owner.into();
-            }
-            SolverDefId::InternedCoroutineId(it) => {
-                return it.loc(self.db).owner.into();
-            }
-            SolverDefId::InternedCoroutineClosureId(it) => {
-                return it.loc(self.db).owner.into();
-            }
-            SolverDefId::AnonConstId(it) => return it.loc(self.db).owner.into(),
-            SolverDefId::StaticId(_)
-            | SolverDefId::AdtId(_)
-            | SolverDefId::TraitId(_)
-            | SolverDefId::ImplId(_)
-            | SolverDefId::BuiltinDeriveImplId(_)
-            | SolverDefId::EnumVariantId(..)
-            | SolverDefId::Ctor(..)
-            | SolverDefId::InternedOpaqueTyId(..) => panic!(),
+    fn projection_parent(self, def_id: Self::TraitAssocTermId) -> Self::TraitId {
+        let container = match def_id.0 {
+            TermId::TypeAliasId(def_id) => def_id.loc(self.db).container,
+            TermId::ConstId(def_id) => def_id.loc(self.db).container,
         };
+        let ItemContainerId::TraitId(trait_) = container else {
+            panic!("a TraitAssocTermId can only come from a trait")
+        };
+        trait_.into()
+    }
 
+    fn impl_or_trait_assoc_term_parent(self, def_id: Self::ImplOrTraitAssocTermId) -> Self::DefId {
+        let container = match def_id.0 {
+            TermId::TypeAliasId(def_id) => def_id.loc(self.db).container,
+            TermId::ConstId(def_id) => def_id.loc(self.db).container,
+        };
         match container {
-            ItemContainerId::ImplId(it) => it.into(),
-            ItemContainerId::TraitId(it) => it.into(),
-            ItemContainerId::ModuleId(_) | ItemContainerId::ExternBlockId(_) => panic!(),
+            ItemContainerId::ImplId(impl_) => impl_.into(),
+            ItemContainerId::TraitId(trait_) => trait_.into(),
+            ItemContainerId::ExternBlockId(_) | ItemContainerId::ModuleId(_) => {
+                panic!("only impl or trait can be the parent of ImplOrTraitAssocTermId")
+            }
+        }
+    }
+
+    fn inherent_alias_term_parent(self, def_id: Self::InherentAssocTermId) -> Self::ImplId {
+        let container = match def_id.0 {
+            TermId::TypeAliasId(def_id) => def_id.loc(self.db).container,
+            TermId::ConstId(def_id) => def_id.loc(self.db).container,
+        };
+        match container {
+            ItemContainerId::ImplId(impl_) => impl_.into(),
+            ItemContainerId::ExternBlockId(_)
+            | ItemContainerId::ModuleId(_)
+            | ItemContainerId::TraitId(_) => {
+                panic!("only impl can be the parent of InherentAliasTermId")
+            }
         }
     }
 
     fn recursion_limit(self) -> usize {
         50
+    }
+
+    fn is_type_const(self, _def_id: Self::DefId) -> bool {
+        false
     }
 
     fn features(self) -> Features {
@@ -1245,22 +1269,24 @@ impl<'db> Interner for DbInterner<'db> {
 
         // Search for a predicate like `Self : Sized` amongst the trait bounds.
         let predicates = self.predicates_of(def_id);
-        elaborate(self, predicates.iter_identity()).any(|pred| match pred.kind().skip_binder() {
-            ClauseKind::Trait(ref trait_pred) => {
-                trait_pred.def_id() == sized_def_id
-                    && matches!(
-                        trait_pred.self_ty().kind(),
-                        TyKind::Param(ParamTy { index: 0, .. })
-                    )
+        elaborate(self, predicates.iter_identity().map(Unnormalized::skip_norm_wip)).any(|pred| {
+            match pred.kind().skip_binder() {
+                ClauseKind::Trait(ref trait_pred) => {
+                    trait_pred.def_id() == sized_def_id
+                        && matches!(
+                            trait_pred.self_ty().kind(),
+                            TyKind::Param(ParamTy { index: 0, .. })
+                        )
+                }
+                ClauseKind::RegionOutlives(_)
+                | ClauseKind::TypeOutlives(_)
+                | ClauseKind::Projection(_)
+                | ClauseKind::ConstArgHasType(_, _)
+                | ClauseKind::WellFormed(_)
+                | ClauseKind::ConstEvaluatable(_)
+                | ClauseKind::HostEffect(..)
+                | ClauseKind::UnstableFeature(_) => false,
             }
-            ClauseKind::RegionOutlives(_)
-            | ClauseKind::TypeOutlives(_)
-            | ClauseKind::Projection(_)
-            | ClauseKind::ConstArgHasType(_, _)
-            | ClauseKind::WellFormed(_)
-            | ClauseKind::ConstEvaluatable(_)
-            | ClauseKind::HostEffect(..)
-            | ClauseKind::UnstableFeature(_) => false,
         })
     }
 
@@ -1382,22 +1408,22 @@ impl<'db> Interner for DbInterner<'db> {
         false
     }
 
-    fn require_lang_item(self, lang_item: SolverLangItem) -> Self::DefId {
+    fn require_projection_lang_item(
+        self,
+        lang_item: SolverProjectionLangItem,
+    ) -> Self::TraitAssocTyId {
         let lang_items = self.lang_items();
         let lang_item = match lang_item {
-            SolverLangItem::AsyncFnKindUpvars => lang_items.AsyncFnKindUpvars,
-            SolverLangItem::AsyncFnOnceOutput => lang_items.AsyncFnOnceOutput,
-            SolverLangItem::CallOnceFuture => lang_items.CallOnceFuture,
-            SolverLangItem::CallRefFuture => lang_items.CallRefFuture,
-            SolverLangItem::CoroutineReturn => lang_items.CoroutineReturn,
-            SolverLangItem::CoroutineYield => lang_items.CoroutineYield,
-            SolverLangItem::FutureOutput => lang_items.FutureOutput,
-            SolverLangItem::Metadata => lang_items.Metadata,
-            SolverLangItem::DynMetadata => {
-                return lang_items.DynMetadata.expect("Lang item required but not found.").into();
-            }
-            SolverLangItem::FieldBase => lang_items.FieldBase,
-            SolverLangItem::FieldType => lang_items.FieldType,
+            SolverProjectionLangItem::AsyncFnKindUpvars => lang_items.AsyncFnKindUpvars,
+            SolverProjectionLangItem::AsyncFnOnceOutput => lang_items.AsyncFnOnceOutput,
+            SolverProjectionLangItem::CallOnceFuture => lang_items.CallOnceFuture,
+            SolverProjectionLangItem::CallRefFuture => lang_items.CallRefFuture,
+            SolverProjectionLangItem::CoroutineReturn => lang_items.CoroutineReturn,
+            SolverProjectionLangItem::CoroutineYield => lang_items.CoroutineYield,
+            SolverProjectionLangItem::FutureOutput => lang_items.FutureOutput,
+            SolverProjectionLangItem::Metadata => lang_items.Metadata,
+            SolverProjectionLangItem::FieldBase => lang_items.FieldBase,
+            SolverProjectionLangItem::FieldType => lang_items.FieldType,
         };
         lang_item.expect("Lang item required but not found.").into()
     }
@@ -1409,9 +1435,6 @@ impl<'db> Interner for DbInterner<'db> {
             SolverTraitLangItem::AsyncFnKindHelper => lang_items.AsyncFnKindHelper,
             SolverTraitLangItem::AsyncFnMut => lang_items.AsyncFnMut,
             SolverTraitLangItem::AsyncFnOnce => lang_items.AsyncFnOnce,
-            SolverTraitLangItem::AsyncFnOnceOutput => unimplemented!(
-                "This is incorrectly marked as `SolverTraitLangItem`, and is not used by the solver."
-            ),
             SolverTraitLangItem::AsyncIterator => lang_items.AsyncIterator,
             SolverTraitLangItem::Clone => lang_items.Clone,
             SolverTraitLangItem::Copy => lang_items.Copy,
@@ -1444,24 +1467,25 @@ impl<'db> Interner for DbInterner<'db> {
     fn require_adt_lang_item(self, lang_item: SolverAdtLangItem) -> AdtIdWrapper {
         let lang_items = self.lang_items();
         let lang_item = match lang_item {
-            SolverAdtLangItem::Option => lang_items.Option,
-            SolverAdtLangItem::Poll => lang_items.Poll,
+            SolverAdtLangItem::Option => lang_items.Option.map(Into::into),
+            SolverAdtLangItem::Poll => lang_items.Poll.map(Into::into),
+            SolverAdtLangItem::DynMetadata => lang_items.DynMetadata.map(Into::into),
         };
-        AdtIdWrapper(lang_item.expect("Lang item required but not found.").into())
+        AdtIdWrapper(lang_item.expect("Lang item required but not found."))
     }
 
-    fn is_lang_item(self, def_id: Self::DefId, lang_item: SolverLangItem) -> bool {
-        self.as_lang_item(def_id)
+    fn is_projection_lang_item(
+        self,
+        def_id: Self::TraitAssocTyId,
+        lang_item: SolverProjectionLangItem,
+    ) -> bool {
+        self.as_projection_lang_item(def_id)
             .map_or(false, |l| std::mem::discriminant(&l) == std::mem::discriminant(&lang_item))
     }
 
     fn is_trait_lang_item(self, def_id: Self::TraitId, lang_item: SolverTraitLangItem) -> bool {
         is_lang_item!(
             SolverTraitLangItem, self, def_id.0, lang_item;
-
-            ignore = {
-                AsyncFnOnceOutput, // This is incorrectly marked as `SolverTraitLangItem`, and is not used by the solver.
-            }
 
             Sized,
             MetaSized,
@@ -1483,12 +1507,12 @@ impl<'db> Interner for DbInterner<'db> {
             Unpin,
             Tuple,
             Iterator,
-            AsyncIterator,
             AsyncFn,
             AsyncFnMut,
             AsyncFnOnce,
             TrivialClone,
             AsyncFnKindHelper,
+            AsyncIterator,
             BikeshedGuaranteedNoDrop,
             FusedIterator,
             Field,
@@ -1501,59 +1525,29 @@ impl<'db> Interner for DbInterner<'db> {
             .map_or(false, |l| std::mem::discriminant(&l) == std::mem::discriminant(&lang_item))
     }
 
-    fn as_lang_item(self, def_id: Self::DefId) -> Option<SolverLangItem> {
-        match def_id {
-            SolverDefId::TypeAliasId(id) => {
-                as_lang_item!(
-                    SolverLangItem, self, id;
+    fn as_projection_lang_item(
+        self,
+        def_id: Self::TraitAssocTyId,
+    ) -> Option<SolverProjectionLangItem> {
+        as_lang_item!(
+            SolverProjectionLangItem, self, def_id.0, TypeAliasId;
 
-                    ignore = {
-                        DynMetadata,
-                    }
-
-                    Metadata,
-                    CoroutineReturn,
-                    CoroutineYield,
-                    FutureOutput,
-                    CallRefFuture,
-                    CallOnceFuture,
-                    AsyncFnOnceOutput,
-                    AsyncFnKindUpvars,
-                    FieldBase,
-                    FieldType,
-                )
-            }
-            SolverDefId::AdtId(AdtId::StructId(id)) => {
-                as_lang_item!(
-                    SolverLangItem, self, id;
-
-                    ignore = {
-                        AsyncFnKindUpvars,
-                        Metadata,
-                        CoroutineReturn,
-                        CoroutineYield,
-                        FutureOutput,
-                        CallRefFuture,
-                        CallOnceFuture,
-                        AsyncFnOnceOutput,
-                        FieldBase,
-                        FieldType,
-                    }
-
-                    DynMetadata,
-                )
-            }
-            _ => panic!("Unexpected SolverDefId in as_lang_item"),
-        }
+            Metadata,
+            CoroutineReturn,
+            CoroutineYield,
+            FutureOutput,
+            CallRefFuture,
+            CallOnceFuture,
+            AsyncFnOnceOutput,
+            AsyncFnKindUpvars,
+            FieldBase,
+            FieldType,
+        )
     }
 
     fn as_trait_lang_item(self, def_id: Self::TraitId) -> Option<SolverTraitLangItem> {
         as_lang_item!(
-            SolverTraitLangItem, self, def_id.0;
-
-            ignore = {
-                AsyncFnOnceOutput, // This is incorrectly marked as `SolverTraitLangItem`, and is not used by the solver.
-            }
+            SolverTraitLangItem, self, def_id.0, TraitId;
 
             Sized,
             MetaSized,
@@ -1575,12 +1569,12 @@ impl<'db> Interner for DbInterner<'db> {
             Unpin,
             Tuple,
             Iterator,
-            AsyncIterator,
             AsyncFn,
             AsyncFnMut,
             AsyncFnOnce,
             TrivialClone,
             AsyncFnKindHelper,
+            AsyncIterator,
             BikeshedGuaranteedNoDrop,
             FusedIterator,
             Field,
@@ -1588,16 +1582,12 @@ impl<'db> Interner for DbInterner<'db> {
     }
 
     fn as_adt_lang_item(self, def_id: Self::AdtId) -> Option<SolverAdtLangItem> {
-        let AdtId::EnumId(def_id) = def_id.0 else {
-            panic!("Unexpected SolverDefId in as_adt_lang_item");
-        };
         as_lang_item!(
-            SolverAdtLangItem, self, def_id;
-
-            ignore = {}
+            SolverAdtLangItem, self, def_id.0, AdtId;
 
             Option,
             Poll,
+            DynMetadata,
         )
     }
 
@@ -1766,7 +1756,7 @@ impl<'db> Interner for DbInterner<'db> {
         });
     }
 
-    fn has_item_definition(self, _def_id: Self::DefId) -> bool {
+    fn has_item_definition(self, _def_id: Self::ImplOrTraitAssocTermId) -> bool {
         // FIXME(next-solver): should check if the associated item has a value.
         true
     }
@@ -1892,7 +1882,7 @@ impl<'db> Interner for DbInterner<'db> {
         let field_types = self.db().field_types(variant);
         let mut unsizing_params = DenseBitSet::new_empty(num_params);
         let ty = field_types[tail_field.0].get();
-        for arg in ty.instantiate_identity().walk() {
+        for arg in ty.instantiate_identity().skip_norm_wip().walk() {
             if let Some(i) = maybe_unsizing_param_idx(arg) {
                 unsizing_params.insert(i);
             }
@@ -1901,7 +1891,7 @@ impl<'db> Interner for DbInterner<'db> {
         // Ensure none of the other fields mention the parameters used
         // in unsizing.
         for field in prefix_fields {
-            for arg in field_types[field.0].get().instantiate_identity().walk() {
+            for arg in field_types[field.0].get().instantiate_identity().skip_norm_wip().walk() {
                 if let Some(i) = maybe_unsizing_param_idx(arg) {
                     unsizing_params.remove(i);
                 }
@@ -2044,26 +2034,23 @@ impl<'db> Interner for DbInterner<'db> {
 
     fn opt_alias_variances(
         self,
-        _kind: impl Into<rustc_type_ir::AliasTermKind>,
-        _def_id: Self::DefId,
+        _kind: impl Into<AliasTermKind<'db>>,
     ) -> Option<Self::VariancesOf> {
         None
     }
 
-    fn type_of_opaque_hir_typeck(self, def_id: Self::LocalDefId) -> EarlyBinder<Self, Self::Ty> {
-        match def_id {
-            SolverDefId::InternedOpaqueTyId(opaque) => {
-                let impl_trait_id = self.db().lookup_intern_impl_trait_id(opaque);
-                match impl_trait_id {
-                    crate::ImplTraitId::ReturnTypeImplTrait(func, idx) => {
-                        crate::opaques::rpit_hidden_types(self.db, func)[idx].get()
-                    }
-                    crate::ImplTraitId::TypeAliasImplTrait(type_alias, idx) => {
-                        crate::opaques::tait_hidden_types(self.db, type_alias)[idx].get()
-                    }
-                }
+    fn type_of_opaque_hir_typeck(
+        self,
+        opaque: Self::LocalOpaqueTyId,
+    ) -> EarlyBinder<Self, Self::Ty> {
+        let impl_trait_id = self.db().lookup_intern_impl_trait_id(opaque.0);
+        match impl_trait_id {
+            crate::ImplTraitId::ReturnTypeImplTrait(func, idx) => {
+                crate::opaques::rpit_hidden_types(self.db, func)[idx].get()
             }
-            _ => panic!("Unexpected SolverDefId in type_of_opaque_hir_typeck"),
+            crate::ImplTraitId::TypeAliasImplTrait(type_alias, idx) => {
+                crate::opaques::tait_hidden_types(self.db, type_alias)[idx].get()
+            }
         }
     }
 
@@ -2150,16 +2137,20 @@ impl<'db> Interner for DbInterner<'db> {
         rustc_type_ir::AnonConstKind::GCE
     }
 
-    fn alias_ty_kind_from_def_id(self, def_id: Self::DefId) -> AliasTyKind<DbInterner<'db>> {
+    fn alias_ty_kind_from_def_id(self, def_id: Self::DefId) -> AliasTyKind<'db> {
         match def_id {
             SolverDefId::TypeAliasId(type_alias) => match type_alias.loc(self.db).container {
                 ItemContainerId::ExternBlockId(_) | ItemContainerId::ModuleId(_) => {
-                    AliasTyKind::Free { def_id }
+                    AliasTyKind::Free { def_id: type_alias.into() }
                 }
-                ItemContainerId::ImplId(_) => AliasTyKind::Inherent { def_id },
-                ItemContainerId::TraitId(_) => AliasTyKind::Projection { def_id },
+                ItemContainerId::ImplId(_) => AliasTyKind::Inherent { def_id: type_alias.into() },
+                ItemContainerId::TraitId(_) => {
+                    AliasTyKind::Projection { def_id: type_alias.into() }
+                }
             },
-            SolverDefId::InternedOpaqueTyId(_) => AliasTyKind::Opaque { def_id },
+            SolverDefId::InternedOpaqueTyId(def_id) => {
+                AliasTyKind::Opaque { def_id: def_id.into() }
+            }
             _ => unreachable!(),
         }
     }
@@ -2249,7 +2240,7 @@ impl<'db> DbInterner<'db> {
         output: Ty<'db>,
         c_variadic: bool,
         safety: Safety,
-        abi: FnAbi,
+        abi: ExternAbi,
     ) -> FnSig<'db>
     where
         I: IntoIterator<Item = Ty<'db>>,
@@ -2259,9 +2250,7 @@ impl<'db> DbInterner<'db> {
                 self,
                 inputs.into_iter().chain(std::iter::once(output)),
             ),
-            c_variadic,
-            safety,
-            abi,
+            fn_sig_kind: FnSigKind::new(abi, safety, c_variadic),
         }
     }
 
@@ -2270,15 +2259,7 @@ impl<'db> DbInterner<'db> {
     where
         I: IntoIterator<Item = Ty<'db>>,
     {
-        FnSig {
-            inputs_and_output: Tys::new_from_iter(
-                self,
-                inputs.into_iter().chain(std::iter::once(output)),
-            ),
-            c_variadic: false,
-            safety: Safety::Safe,
-            abi: FnAbi::Rust,
-        }
+        self.mk_fn_sig(inputs, output, false, Safety::Safe, ExternAbi::Rust)
     }
 }
 
@@ -2345,10 +2326,22 @@ TrivialTypeTraversalImpls! {
     CoroutineIdWrapper,
     CoroutineClosureIdWrapper,
     AdtIdWrapper,
+    TraitAssocTyId,
+    TraitAssocConstId,
+    TraitAssocTermId,
+    ImplOrTraitAssocTyId,
+    ImplOrTraitAssocConstId,
+    ImplOrTraitAssocTermId,
+    FreeTyAliasId,
+    FreeConstAliasId,
+    FreeTermAliasId,
+    InherentAssocTyId,
+    InherentAssocConstId,
+    InherentAssocTermId,
+    OpaqueTyIdWrapper,
     AnyImplId,
     GeneralConstIdWrapper,
     Safety,
-    FnAbi,
     Span,
     ParamConst,
     ParamTy,

--- a/crates/hir-ty/src/next_solver/ir_print.rs
+++ b/crates/hir-ty/src/next_solver/ir_print.rs
@@ -3,6 +3,8 @@
 use hir_def::signatures::{TraitSignature, TypeAliasSignature};
 use rustc_type_ir::{self as ty, ir_print::IrPrint};
 
+use crate::next_solver::TermId;
+
 use super::SolverDefId;
 use super::interner::DbInterner;
 
@@ -32,7 +34,7 @@ impl<'db> IrPrint<ty::AliasTerm<Self>> for DbInterner<'db> {
     }
 
     fn print_debug(t: &ty::AliasTerm<Self>, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        crate::with_attached_db(|db| match t.def_id {
+        crate::with_attached_db(|db| match t.def_id() {
             SolverDefId::TypeAliasId(id) => fmt.write_str(&format!(
                 "AliasTerm({:?}[{:?}])",
                 TypeAliasSignature::of(db, id).name.as_str(),
@@ -141,8 +143,8 @@ impl<'db> IrPrint<ty::ExistentialProjection<Self>> for DbInterner<'db> {
         fmt: &mut std::fmt::Formatter<'_>,
     ) -> std::fmt::Result {
         crate::with_attached_db(|db| {
-            let id = match t.def_id {
-                SolverDefId::TypeAliasId(id) => id,
+            let id = match t.def_id.0 {
+                TermId::TypeAliasId(id) => id,
                 _ => panic!("Expected trait."),
             };
             fmt.write_str(&format!(
@@ -167,7 +169,7 @@ impl<'db> IrPrint<ty::ProjectionPredicate<Self>> for DbInterner<'db> {
         fmt: &mut std::fmt::Formatter<'_>,
     ) -> std::fmt::Result {
         crate::with_attached_db(|db| {
-            let id = match t.projection_term.def_id {
+            let id = match t.projection_term.def_id() {
                 SolverDefId::TypeAliasId(id) => id,
                 _ => panic!("Expected trait."),
             };

--- a/crates/hir-ty/src/next_solver/predicate.rs
+++ b/crates/hir-ty/src/next_solver/predicate.rs
@@ -885,7 +885,9 @@ impl<'db> rustc_type_ir::inherent::Clause<DbInterner<'db>> for Clause<'db> {
         let shifted_pred =
             cx.shift_bound_var_indices(trait_bound_vars.len(), bound_pred.skip_binder());
         // 2) Self: Bar1<'a, '^0.1> -> T: Bar1<'^0.0, '^0.1>
-        let new = EarlyBinder::bind(shifted_pred).instantiate(cx, trait_ref.skip_binder().args);
+        let new = EarlyBinder::bind(shifted_pred)
+            .instantiate(cx, trait_ref.skip_binder().args)
+            .skip_norm_wip();
         // 3) ['x] + ['b] -> ['x, 'b]
         let bound_vars =
             BoundVarKinds::new_from_iter(cx, trait_bound_vars.iter().chain(pred_bound_vars.iter()));

--- a/crates/hir-ty/src/next_solver/region.rs
+++ b/crates/hir-ty/src/next_solver/region.rs
@@ -18,6 +18,7 @@ use crate::next_solver::{
 use super::{SolverDefId, interner::DbInterner};
 
 pub type RegionKind<'db> = rustc_type_ir::RegionKind<DbInterner<'db>>;
+pub type RegionConstraint<'db> = rustc_type_ir::RegionConstraint<DbInterner<'db>>;
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Region<'db> {

--- a/crates/hir-ty/src/next_solver/solver.rs
+++ b/crates/hir-ty/src/next_solver/solver.rs
@@ -10,7 +10,7 @@ use rustc_type_ir::{
     TypeVisitableExt,
     inherent::{IntoKind, Term as _, Ty as _},
     lang_items::SolverTraitLangItem,
-    solve::{Certainty, NoSolution},
+    solve::{Certainty, FetchEligibleAssocItemResponse, NoSolution, VisibleForLeakCheck},
 };
 use tracing::debug;
 
@@ -18,14 +18,15 @@ use crate::{
     ParamEnvAndCrate, Span,
     db::GeneralConstId,
     next_solver::{
-        AliasTy, AnyImplId, CanonicalVarKind, Clause, ClauseKind, CoercePredicate, GenericArgs,
-        ParamEnv, Predicate, PredicateKind, SubtypePredicate, Ty, TyKind, UnevaluatedConst,
-        fold::fold_tys, util::sizedness_fast_path,
+        AliasTy, AnyImplId, CanonicalVarKind, Clause, ClauseKind, CoercePredicate, ErrorGuaranteed,
+        GenericArgs, ImplOrTraitAssocTermId, OpaqueTyIdWrapper, ParamEnv, Predicate, PredicateKind,
+        RegionConstraint, SubtypePredicate, TermId, TraitAssocTermId, Ty, TyKind, TypingMode,
+        UnevaluatedConst, fold::fold_tys, util::sizedness_fast_path,
     },
 };
 
 use super::{
-    Const, DbInterner, ErrorGuaranteed, GenericArg, SolverDefId,
+    Const, DbInterner, GenericArg,
     infer::{DbInternerInferExt, InferCtxt, canonical::instantiate::CanonicalExt},
 };
 
@@ -99,14 +100,9 @@ impl<'db> SolverDelegate for SolverContext<'db> {
         None
     }
 
-    fn make_deduplicated_outlives_constraints(
+    fn make_deduplicated_region_constraints(
         &self,
-    ) -> Vec<
-        rustc_type_ir::OutlivesPredicate<
-            Self::Interner,
-            <Self::Interner as rustc_type_ir::Interner>::GenericArg,
-        >,
-    > {
+    ) -> Vec<(RegionConstraint<'db>, VisibleForLeakCheck)> {
         // FIXME: add if we care about regions
         vec![]
     }
@@ -134,14 +130,13 @@ impl<'db> SolverDelegate for SolverContext<'db> {
 
     fn add_item_bounds_for_hidden_type(
         &self,
-        def_id: SolverDefId,
+        opaque_id: OpaqueTyIdWrapper,
         args: GenericArgs<'db>,
         param_env: ParamEnv<'db>,
         hidden_ty: Ty<'db>,
         goals: &mut Vec<Goal<'db, Predicate<'db>>>,
     ) {
         let interner = self.interner;
-        let opaque_id = def_id.expect_opaque_ty();
         // Require that the hidden type is well-formed. We have to
         // make sure we wf-check the hidden type to fix #114728.
         //
@@ -163,14 +158,14 @@ impl<'db> SolverDelegate for SolverContext<'db> {
                     kind: AliasTyKind::Opaque { def_id: def_id2 },
                     args: args2,
                     ..
-                }) if def_id == def_id2 && args == args2 => hidden_ty,
+                }) if opaque_id == def_id2 && args == args2 => hidden_ty,
                 _ => ty,
             })
         };
 
-        let item_bounds = opaque_id.predicates(interner.db);
+        let item_bounds = opaque_id.0.predicates(interner.db);
         for predicate in item_bounds.iter_instantiated_copied(interner, args.as_slice()) {
-            let predicate = replace_opaques_in(predicate);
+            let predicate = replace_opaques_in(predicate.skip_norm_wip());
 
             // Require that the predicate holds for the concrete type.
             debug!(?predicate);
@@ -181,16 +176,16 @@ impl<'db> SolverDelegate for SolverContext<'db> {
     fn fetch_eligible_assoc_item(
         &self,
         _goal_trait_ref: rustc_type_ir::TraitRef<Self::Interner>,
-        trait_assoc_def_id: SolverDefId,
+        trait_assoc_def_id: TraitAssocTermId,
         impl_id: AnyImplId,
-    ) -> Result<Option<SolverDefId>, ErrorGuaranteed> {
+    ) -> FetchEligibleAssocItemResponse<Self::Interner> {
         let AnyImplId::ImplId(impl_id) = impl_id else {
             // Builtin derive traits don't have type/consts assoc items.
-            return Ok(None);
+            return FetchEligibleAssocItemResponse::Err(ErrorGuaranteed);
         };
         let impl_items = impl_id.impl_items(self.0.interner.db());
-        let id = match trait_assoc_def_id {
-            SolverDefId::TypeAliasId(trait_assoc_id) => {
+        let id = match trait_assoc_def_id.0 {
+            TermId::TypeAliasId(trait_assoc_id) => {
                 let trait_assoc_data = TypeAliasSignature::of(self.0.interner.db, trait_assoc_id);
                 impl_items
                     .items
@@ -207,9 +202,9 @@ impl<'db> SolverDelegate for SolverContext<'db> {
                     .or_else(|| {
                         if trait_assoc_data.ty.is_some() { Some(trait_assoc_id) } else { None }
                     })
-                    .map(SolverDefId::TypeAliasId)
+                    .map(|def| ImplOrTraitAssocTermId(TermId::TypeAliasId(def)))
             }
-            SolverDefId::ConstId(trait_assoc_id) => {
+            TermId::ConstId(trait_assoc_id) => {
                 let trait_assoc_data = ConstSignature::of(self.0.interner.db, trait_assoc_id);
                 let trait_assoc_name = trait_assoc_data
                     .name
@@ -232,11 +227,20 @@ impl<'db> SolverDelegate for SolverContext<'db> {
                             if trait_assoc_data.has_body() { Some(trait_assoc_id) } else { None }
                         },
                     )
-                    .map(SolverDefId::ConstId)
+                    .map(|def| ImplOrTraitAssocTermId(TermId::ConstId(def)))
             }
-            _ => panic!("Unexpected SolverDefId"),
         };
-        Ok(id)
+        match id {
+            Some(id) => FetchEligibleAssocItemResponse::Found(id),
+            None => match self.typing_mode_raw() {
+                TypingMode::ErasedNotCoherence(_) => {
+                    FetchEligibleAssocItemResponse::NotFoundBecauseErased
+                }
+                typing_mode => {
+                    FetchEligibleAssocItemResponse::NotFound(typing_mode.assert_not_erased())
+                }
+            },
+        }
     }
 
     fn is_transmutable(

--- a/crates/hir-ty/src/next_solver/structural_normalize.rs
+++ b/crates/hir-ty/src/next_solver/structural_normalize.rs
@@ -30,7 +30,7 @@ impl<'db> At<'_, 'db> {
     ) -> Result<Term<'db>, Vec<NextSolverError<'db>>> {
         assert!(!term.is_infer(), "should have resolved vars before calling");
 
-        if term.to_alias_term().is_none() {
+        if term.to_alias_term(self.infcx.interner).is_none() {
             return Ok(term);
         }
 

--- a/crates/hir-ty/src/next_solver/ty.rs
+++ b/crates/hir-ty/src/next_solver/ty.rs
@@ -9,11 +9,11 @@ use hir_def::{
 use hir_def::{TraitId, type_ref::Rawness};
 use intern::{Interned, InternedRef, impl_internable};
 use macros::GenericTypeVisitable;
-use rustc_abi::{Float, Integer, Size};
+use rustc_abi::{ExternAbi, Float, Integer, Size};
 use rustc_ast_ir::{Mutability, try_visit, visit::VisitorResult};
 use rustc_type_ir::{
-    AliasTyKind, BoundVar, BoundVarIndexKind, ClosureKind, DebruijnIndex, FlagComputation, Flags,
-    FloatTy, FloatVid, GenericTypeVisitable, InferTy, IntTy, IntVid, Interner, TyVid, TypeFoldable,
+    BoundVar, BoundVarIndexKind, ClosureKind, DebruijnIndex, FlagComputation, Flags, FloatTy,
+    FloatVid, GenericTypeVisitable, InferTy, IntTy, IntVid, Interner, TyVid, TypeFoldable,
     TypeSuperFoldable, TypeSuperVisitable, TypeVisitable, TypeVisitableExt, TypeVisitor, UintTy,
     Upcast, WithCachedTypeInfo,
     inherent::{
@@ -26,13 +26,12 @@ use rustc_type_ir::{
 };
 
 use crate::{
-    FnAbi,
-    db::HirDatabase,
+    db::{HirDatabase, InternedOpaqueTyId},
     lower::GenericPredicates,
     next_solver::{
         AdtDef, AliasTy, Binder, CallableIdWrapper, Clause, ClauseKind, ClosureIdWrapper, Const,
         CoroutineClosureIdWrapper, CoroutineIdWrapper, FnSig, GenericArgKind, PolyFnSig, Predicate,
-        Region, TraitRef, TypeAliasIdWrapper,
+        Region, TraitRef, TypeAliasIdWrapper, Unnormalized,
         abi::Safety,
         impl_foldable_for_interned_slice, impl_stored_interned, interned_slice,
         util::{CoroutineArgsExt, IntegerTypeExt},
@@ -47,6 +46,9 @@ use super::{
 pub type SimplifiedType = rustc_type_ir::fast_reject::SimplifiedType<SolverDefId>;
 pub type TyKind<'db> = rustc_type_ir::TyKind<DbInterner<'db>>;
 pub type FnHeader<'db> = rustc_type_ir::FnHeader<DbInterner<'db>>;
+pub type AliasTyKind<'db> = rustc_type_ir::AliasTyKind<DbInterner<'db>>;
+pub type AliasTermKind<'db> = rustc_type_ir::AliasTermKind<DbInterner<'db>>;
+pub type FnSigKind<'db> = rustc_type_ir::FnSigKind<DbInterner<'db>>;
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Ty<'db> {
@@ -174,12 +176,12 @@ impl<'db> Ty<'db> {
 
     pub fn new_opaque(
         interner: DbInterner<'db>,
-        def_id: SolverDefId,
+        def_id: InternedOpaqueTyId,
         args: GenericArgs<'db>,
     ) -> Self {
         Ty::new_alias(
             interner,
-            AliasTy::new_from_args(interner, AliasTyKind::Opaque { def_id }, args),
+            AliasTy::new_from_args(interner, AliasTyKind::Opaque { def_id: def_id.into() }, args),
         )
     }
 
@@ -281,9 +283,9 @@ impl<'db> Ty<'db> {
                 tys.last().is_none_or(|ty| ty.has_trivial_sizedness(tcx, sizedness))
             }
 
-            TyKind::Adt(def, args) => def
-                .sizedness_constraint(tcx, sizedness)
-                .is_none_or(|ty| ty.instantiate(tcx, args).has_trivial_sizedness(tcx, sizedness)),
+            TyKind::Adt(def, args) => def.sizedness_constraint(tcx, sizedness).is_none_or(|ty| {
+                ty.instantiate(tcx, args).skip_norm_wip().has_trivial_sizedness(tcx, sizedness)
+            }),
 
             TyKind::Alias(..) | TyKind::Param(_) | TyKind::Placeholder(..) | TyKind::Bound(..) => {
                 false
@@ -534,7 +536,7 @@ impl<'db> Ty<'db> {
     /// unsafe.
     pub fn safe_to_unsafe_fn_ty(interner: DbInterner<'db>, sig: PolyFnSig<'db>) -> Ty<'db> {
         assert!(sig.safety().is_safe());
-        Ty::new_fn_ptr(interner, sig.map_bound(|sig| FnSig { safety: Safety::Unsafe, ..sig }))
+        Ty::new_fn_ptr(interner, sig.map_bound(|sig| sig.set_safety(Safety::Unsafe)))
     }
 
     /// Returns the type of `*ty`.
@@ -571,7 +573,7 @@ impl<'db> Ty<'db> {
     pub fn callable_sig(self, interner: DbInterner<'db>) -> Option<Binder<'db, FnSig<'db>>> {
         match self.kind() {
             TyKind::FnDef(callable, args) => {
-                Some(interner.fn_sig(callable).instantiate(interner, args))
+                Some(interner.fn_sig(callable).instantiate(interner, args).skip_norm_wip())
             }
             TyKind::FnPtr(sig, hdr) => Some(sig.with(hdr)),
             TyKind::Closure(_, closure_args) => {
@@ -595,9 +597,7 @@ impl<'db> Ty<'db> {
                                 .iter()
                                 .chain(std::iter::once(return_ty)),
                         ),
-                        c_variadic: sig.c_variadic,
-                        safety: sig.safety,
-                        abi: sig.abi,
+                        fn_sig_kind: sig.fn_sig_kind,
                     }
                 }))
             }
@@ -731,9 +731,10 @@ impl<'db> Ty<'db> {
         match self.kind() {
             TyKind::Alias(AliasTy { kind: AliasTyKind::Opaque { def_id }, args, .. }) => Some(
                 def_id
-                    .expect_opaque_ty()
+                    .0
                     .predicates(db)
                     .iter_instantiated_copied(interner, args.as_slice())
+                    .map(Unnormalized::skip_norm_wip)
                     .collect(),
             ),
             TyKind::Param(param) => {
@@ -745,6 +746,7 @@ impl<'db> Ty<'db> {
                         TypeParamProvenance::ArgumentImplTrait => {
                             let predicates = GenericPredicates::query_all(db, param.id.parent())
                                 .iter_identity()
+                                .map(Unnormalized::skip_norm_wip)
                                 .filter(|wc| match wc.kind().skip_binder() {
                                     ClauseKind::Trait(tr) => tr.self_ty() == self,
                                     ClauseKind::Projection(pred) => pred.self_ty() == self,
@@ -1502,7 +1504,7 @@ impl<'db> DbInterner<'db> {
                 TyKind::Tuple(params) => params,
                 _ => panic!(),
             };
-            self.mk_fn_sig(params, s.output(), s.c_variadic, safety, FnAbi::Rust)
+            self.mk_fn_sig(params, s.output(), s.c_variadic(), safety, ExternAbi::Rust)
         })
     }
 }

--- a/crates/hir-ty/src/next_solver/util.rs
+++ b/crates/hir-ty/src/next_solver/util.rs
@@ -430,7 +430,7 @@ pub fn sizedness_constraint_for_ty<'db>(
             }
 
             adt.struct_tail_ty(interner).and_then(|tail_ty| {
-                let tail_ty = tail_ty.instantiate(interner, args);
+                let tail_ty = tail_ty.instantiate(interner, args).skip_norm_wip();
                 sizedness_constraint_for_ty(interner, sizedness, tail_ty)
             })
         }

--- a/crates/hir-ty/src/opaques.rs
+++ b/crates/hir-ty/src/opaques.rs
@@ -155,7 +155,7 @@ pub(crate) fn tait_hidden_types(
                     _ = ocx.eq(
                         &cause,
                         param_env,
-                        entry.get().get().instantiate_identity(),
+                        entry.get().get().instantiate_identity().skip_norm_wip(),
                         hidden_type,
                     );
                 }

--- a/crates/hir-ty/src/representability.rs
+++ b/crates/hir-ty/src/representability.rs
@@ -47,7 +47,7 @@ pub(crate) fn representability_cycle(
 
 fn variant_representability(db: &dyn HirDatabase, id: VariantId) -> Representability {
     for ty in db.field_types(id).values() {
-        rtry!(representability_ty(db, ty.get().instantiate_identity()));
+        rtry!(representability_ty(db, ty.get().instantiate_identity().skip_norm_wip()));
     }
     Representability::Representable
 }
@@ -94,7 +94,11 @@ fn params_in_repr(db: &dyn HirDatabase, def_id: AdtId) -> Box<[bool]> {
         .collect::<Box<[bool]>>();
     let mut handle_variant = |variant| {
         for field in db.field_types(variant).values() {
-            params_in_repr_ty(db, field.get().instantiate_identity(), &mut params_in_repr);
+            params_in_repr_ty(
+                db,
+                field.get().instantiate_identity().skip_norm_wip(),
+                &mut params_in_repr,
+            );
         }
     };
     match def_id {

--- a/crates/hir-ty/src/specialization.rs
+++ b/crates/hir-ty/src/specialization.rs
@@ -11,7 +11,7 @@ use crate::{
     db::HirDatabase,
     lower::GenericPredicates,
     next_solver::{
-        DbInterner, TypingMode,
+        DbInterner, TypingMode, Unnormalized,
         infer::{DbInternerInferExt, traits::ObligationCause},
         obligation_ctxt::ObligationCtxt,
         util::clauses_as_obligations,
@@ -81,7 +81,7 @@ fn specializes_query(
     let infcx = interner.infer_ctxt().build(TypingMode::non_body_analysis());
 
     let specializing_impl_trait_ref =
-        db.impl_trait(specializing_impl_def_id).unwrap().instantiate_identity();
+        db.impl_trait(specializing_impl_def_id).unwrap().instantiate_identity().skip_norm_wip();
     let cause = &ObligationCause::dummy();
     debug!(
         "fulfill_implication({:?}, trait_ref={:?} |- {:?} applies)",
@@ -96,7 +96,8 @@ fn specializes_query(
     let parent_impl_trait_ref = db
         .impl_trait(parent_impl_def_id)
         .expect("expected source impl to be a trait impl")
-        .instantiate(interner, parent_args);
+        .instantiate(interner, parent_args)
+        .skip_norm_wip();
 
     // do the impls unify? If not, no specialization.
     let Ok(()) = ocx.eq(cause, param_env, specializing_impl_trait_ref, parent_impl_trait_ref)
@@ -109,7 +110,8 @@ fn specializes_query(
     // only be referenced via projection predicates.
     ocx.register_obligations(clauses_as_obligations(
         GenericPredicates::query_all(db, parent_impl_def_id.into())
-            .iter_instantiated(interner, parent_args.as_slice()),
+            .iter_instantiated(interner, parent_args.as_slice())
+            .map(Unnormalized::skip_norm_wip),
         *cause,
         param_env,
     ));

--- a/crates/hir-ty/src/traits.rs
+++ b/crates/hir-ty/src/traits.rs
@@ -154,7 +154,7 @@ fn implements_trait_unique_impl<'db>(
 }
 
 pub fn is_inherent_impl_coherent(db: &dyn HirDatabase, def_map: &DefMap, impl_id: ImplId) -> bool {
-    let self_ty = db.impl_self_ty(impl_id).instantiate_identity();
+    let self_ty = db.impl_self_ty(impl_id).instantiate_identity().skip_norm_wip();
     let self_ty = self_ty.kind();
     let impl_allowed = match self_ty {
         TyKind::Tuple(_)
@@ -246,7 +246,7 @@ pub fn check_orphan_rules<'db>(db: &'db dyn HirDatabase, impl_: ImplId) -> bool 
     let local_crate = impl_.lookup(db).container.krate(db);
     let is_local = |tgt_crate| tgt_crate == local_crate;
 
-    let trait_ref = impl_trait.instantiate_identity();
+    let trait_ref = impl_trait.instantiate_identity().skip_norm_wip();
     let trait_id = trait_ref.def_id.0;
     if is_local(trait_id.module(db).krate(db)) {
         // trait to be implemented is local

--- a/crates/hir-ty/src/utils.rs
+++ b/crates/hir-ty/src/utils.rs
@@ -5,10 +5,9 @@ use std::iter::Enumerate;
 
 use base_db::target::{self, TargetData};
 use hir_def::{
-    EnumId, EnumVariantId, FunctionId, Lookup, TraitId, attrs::AttrFlags, lang_item::LangItems,
+    EnumId, EnumVariantId, FunctionId, Lookup, TraitId, lang_item::LangItems,
     signatures::FunctionSignature,
 };
-use intern::sym;
 use rustc_abi::TargetDataLayout;
 use span::Edition;
 
@@ -105,21 +104,10 @@ pub fn is_fn_unsafe_to_call(
 
     let loc = func.lookup(db);
     match loc.container {
-        hir_def::ItemContainerId::ExternBlockId(block) => {
-            let is_intrinsic_block = block.abi(db) == Some(sym::rust_dash_intrinsic);
-            if is_intrinsic_block {
-                // legacy intrinsics
-                // extern "rust-intrinsic" intrinsics are unsafe unless they have the rustc_safe_intrinsic attribute
-                if AttrFlags::query(db, func.into()).contains(AttrFlags::RUSTC_SAFE_INTRINSIC) {
-                    Unsafety::Safe
-                } else {
-                    Unsafety::Unsafe
-                }
-            } else {
-                // Function in an `extern` block are always unsafe to call, except when
-                // it is marked as `safe`.
-                if data.is_safe() { Unsafety::Safe } else { Unsafety::Unsafe }
-            }
+        hir_def::ItemContainerId::ExternBlockId(_) => {
+            // Function in an `extern` block are always unsafe to call, except when
+            // it is marked as `safe`.
+            if data.is_safe() { Unsafety::Safe } else { Unsafety::Unsafe }
         }
         _ => Unsafety::Safe,
     }

--- a/crates/hir-ty/src/variance.rs
+++ b/crates/hir-ty/src/variance.rs
@@ -126,7 +126,7 @@ impl<'db> Context<'db> {
                 let mut add_constraints_from_variant = |variant| {
                     for (_, field) in db.field_types(variant).iter() {
                         self.add_constraints_from_ty(
-                            field.get().instantiate_identity(),
+                            field.get().instantiate_identity().skip_norm_wip(),
                             Variance::Covariant,
                         );
                     }

--- a/crates/hir/src/display.rs
+++ b/crates/hir/src/display.rs
@@ -7,6 +7,7 @@ use hir_def::{
     expr_store::{Body, ExpressionStore},
     hir::generics::{GenericParams, TypeOrConstParamData, TypeParamProvenance, WherePredicate},
     item_tree::FieldsShape,
+    layout::ExternAbi,
     signatures::{
         ConstSignature, FunctionSignature, ImplSignature, StaticFlags, StaticSignature, TraitFlags,
         TraitSignature, TypeAliasSignature,
@@ -22,10 +23,10 @@ use hir_ty::{
         hir_display_with_store, write_bounds_like_dyn_trait_with_prefix, write_params_bounds,
         write_visibility,
     },
-    next_solver::ClauseKind,
+    next_solver::{ClauseKind, Unnormalized},
 };
 use itertools::Itertools;
-use rustc_type_ir::inherent::IntoKind;
+use rustc_type_ir::inherent::IntoKind as _;
 
 use crate::{
     Adt, AnyFunctionId, AsAssocItem, AssocItem, AssocItemContainer, Const, ConstParam, Crate, Enum,
@@ -171,8 +172,8 @@ fn write_function<'db>(f: &mut HirFormatter<'_, 'db>, func_id: FunctionId) -> Re
     if func.is_unsafe_to_call(db, None, f.edition()) {
         f.write_str("unsafe ")?;
     }
-    if let Some(abi) = &data.abi {
-        write!(f, "extern \"{}\" ", abi.as_str())?;
+    if data.abi != ExternAbi::Rust {
+        write!(f, "extern \"{}\" ", data.abi.as_str())?;
     }
     write!(f, "fn {}", data.name.display(f.db, f.edition()))?;
 
@@ -582,6 +583,7 @@ impl<'db> HirDisplay<'db> for TypeParam {
         let predicates = GenericPredicates::query_all(f.db, self.id.parent());
         let predicates = predicates
             .iter_identity()
+            .map(Unnormalized::skip_norm_wip)
             .filter(|wc| match wc.kind().skip_binder() {
                 ClauseKind::Trait(tr) => tr.self_ty() == ty,
                 ClauseKind::Projection(proj) => proj.self_ty() == ty,

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -173,7 +173,7 @@ pub use {
     // FIXME: Properly encapsulate mir
     hir_ty::mir,
     hir_ty::{
-        CastError, FnAbi, PointerCast, attach_db, attach_db_allow_change,
+        CastError, PointerCast, attach_db, attach_db_allow_change,
         consteval::ConstEvalError,
         diagnostics::UnsafetyReason,
         display::{ClosureStyle, DisplayTarget, HirDisplay, HirDisplayError, HirWrite},
@@ -946,7 +946,7 @@ impl Module {
                     .collect();
 
                 if !missing.is_empty() {
-                    let self_ty = db.impl_self_ty(impl_id).instantiate_identity();
+                    let self_ty = db.impl_self_ty(impl_id).instantiate_identity().skip_norm_wip();
                     let self_ty = structurally_normalize_ty(
                         &infcx,
                         self_ty,
@@ -1345,7 +1345,7 @@ impl<'db> InstantiatedField<'db> {
 
         let var_id = self.inner.parent.into();
         let field = db.field_types(var_id)[self.inner.id].get();
-        let ty = field.instantiate(interner, self.args);
+        let ty = field.instantiate(interner, self.args).skip_norm_wip();
         TypeNs::new(db, var_id, ty)
     }
 }
@@ -1440,7 +1440,7 @@ impl Field {
         };
         let interner = DbInterner::new_no_crate(db);
         let args = generic_args_from_tys(interner, def_id.into(), generics.map(|ty| ty.ty));
-        let ty = db.field_types(var_id)[self.id].get().instantiate(interner, args);
+        let ty = db.field_types(var_id)[self.id].get().instantiate(interner, args).skip_norm_wip();
         Type::new(db, var_id, ty)
     }
 
@@ -1570,7 +1570,7 @@ impl<'db> InstantiatedStruct<'db> {
         let interner = DbInterner::new_no_crate(db);
 
         let ty = db.ty(self.inner.id.into());
-        TypeNs::new(db, self.inner.id, ty.instantiate(interner, self.args))
+        TypeNs::new(db, self.inner.id, ty.instantiate(interner, self.args).skip_norm_wip())
     }
 }
 
@@ -1732,7 +1732,7 @@ impl<'db> InstantiatedEnum<'db> {
         let interner = DbInterner::new_no_crate(db);
 
         let ty = db.ty(self.inner.id.into());
-        TypeNs::new(db, self.inner.id, ty.instantiate(interner, self.args))
+        TypeNs::new(db, self.inner.id, ty.instantiate(interner, self.args).skip_norm_wip())
     }
 }
 
@@ -2017,12 +2017,12 @@ impl AnonConst {
     pub fn ty<'db>(self, db: &'db dyn HirDatabase) -> Type<'db> {
         let loc = self.id.loc(db);
         let env = body_param_env_from_has_crate(db, loc.owner);
-        Type { env, ty: loc.ty.get().instantiate_identity() }
+        Type { env, ty: loc.ty.get().instantiate_identity().skip_norm_wip() }
     }
 
     pub fn eval(self, db: &dyn HirDatabase) -> Result<EvaluatedConst<'_>, ConstEvalError> {
         let interner = DbInterner::new_no_crate(db);
-        let ty = self.id.loc(db).ty.get().instantiate_identity();
+        let ty = self.id.loc(db).ty.get().instantiate_identity().skip_norm_wip();
         db.anon_const_eval(self.id, GenericArgs::empty(interner), None).map(|it| EvaluatedConst {
             allocation: it,
             def: self.id.into(),
@@ -2486,7 +2486,8 @@ impl Function {
                 let resolver = id.resolver(db);
                 let interner = DbInterner::new_no_crate(db);
                 // FIXME: This shouldn't be `instantiate_identity()`, we shouldn't leak `TyKind::Param`s.
-                let callable_sig = db.callable_item_signature(id.into()).instantiate_identity();
+                let callable_sig =
+                    db.callable_item_signature(id.into()).instantiate_identity().skip_norm_wip();
                 let ty = Ty::new_fn_ptr(interner, callable_sig);
                 Type::new_with_resolver_inner(db, &resolver, ty)
             }
@@ -2563,10 +2564,13 @@ impl Function {
                 // `impl_generics_len - impl_trait_ref.args.len()`.
                 let trait_method_fn_ptr = Ty::new_fn_ptr(
                     interner,
-                    db.callable_item_signature(trait_method.into()).instantiate_identity(),
+                    db.callable_item_signature(trait_method.into())
+                        .instantiate_identity()
+                        .skip_norm_wip(),
                 );
-                let impl_trait_ref =
-                    hir_ty::builtin_derive::impl_trait(interner, impl_).instantiate_identity();
+                let impl_trait_ref = hir_ty::builtin_derive::impl_trait(interner, impl_)
+                    .instantiate_identity()
+                    .skip_norm_wip();
                 let trait_method_args =
                     GenericArgs::identity_for_item(interner, trait_method.into());
                 let trait_method_own_args = GenericArgs::new_from_iter(
@@ -2581,8 +2585,9 @@ impl Function {
                     interner,
                     impl_trait_ref.args.iter().chain(shifted_trait_method_own_args),
                 );
-                let impl_method_fn_ptr =
-                    EarlyBinder::bind(trait_method_fn_ptr).instantiate(interner, impl_method_args);
+                let impl_method_fn_ptr = EarlyBinder::bind(trait_method_fn_ptr)
+                    .instantiate(interner, impl_method_args)
+                    .skip_norm_wip();
                 Type { env, ty: impl_method_fn_ptr }
             }
         }
@@ -2613,7 +2618,7 @@ impl Function {
         let ret_type = self.ret_type(db);
         let interner = DbInterner::new_no_crate(db);
         let args = self.adapt_generic_args(interner, generics);
-        ret_type.derived(EarlyBinder::bind(ret_type.ty).instantiate(interner, args))
+        ret_type.derived(EarlyBinder::bind(ret_type.ty).instantiate(interner, args).skip_norm_wip())
     }
 
     fn adapt_generic_args<'db>(
@@ -2728,7 +2733,7 @@ impl Function {
                 idx: param.idx,
                 ty: Type {
                     env: param.ty.env,
-                    ty: EarlyBinder::bind(param.ty.ty).instantiate(interner, args),
+                    ty: EarlyBinder::bind(param.ty.ty).instantiate(interner, args).skip_norm_wip(),
                 },
             })
             .collect()
@@ -3093,7 +3098,7 @@ impl SelfParam {
         let interner = DbInterner::new_no_crate(db);
         let args = self.func.adapt_generic_args(interner, generics);
         let Type { env, ty } = self.ty(db);
-        Type { env, ty: EarlyBinder::bind(ty).instantiate(interner, args) }
+        Type { env, ty: EarlyBinder::bind(ty).instantiate(interner, args).skip_norm_wip() }
     }
 }
 
@@ -3191,7 +3196,7 @@ impl Const {
     /// Evaluate the constant.
     pub fn eval(self, db: &dyn HirDatabase) -> Result<EvaluatedConst<'_>, ConstEvalError> {
         let interner = DbInterner::new_no_crate(db);
-        let ty = db.value_ty(self.id.into()).unwrap().instantiate_identity();
+        let ty = db.value_ty(self.id.into()).unwrap().instantiate_identity().skip_norm_wip();
         db.const_eval(self.id, GenericArgs::empty(interner), None).map(|it| EvaluatedConst {
             allocation: it,
             def: self.id.into(),
@@ -3271,7 +3276,7 @@ impl Static {
 
     /// Evaluate the static initializer.
     pub fn eval(self, db: &dyn HirDatabase) -> Result<EvaluatedConst<'_>, ConstEvalError> {
-        let ty = db.value_ty(self.id.into()).unwrap().instantiate_identity();
+        let ty = db.value_ty(self.id.into()).unwrap().instantiate_identity().skip_norm_wip();
         db.const_eval_static(self.id).map(|it| EvaluatedConst {
             allocation: it,
             def: self.id.into(),
@@ -4861,7 +4866,7 @@ fn generic_arg_from_param(db: &dyn HirDatabase, id: TypeOrConstParamId) -> Optio
     let defaults = db.generic_defaults(id.parent);
     let ty = defaults.get(local_idx as usize)?;
     // FIXME: This shouldn't be `instantiate_identity()`, we shouldn't leak `TyKind::Param`s.
-    Some(ty.instantiate_identity())
+    Some(ty.instantiate_identity().skip_norm_wip())
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
@@ -5036,7 +5041,7 @@ impl Impl {
     pub fn trait_ref(self, db: &dyn HirDatabase) -> Option<TraitRef<'_>> {
         match self.id {
             AnyImplId::ImplId(id) => {
-                let trait_ref = db.impl_trait(id)?.instantiate_identity();
+                let trait_ref = db.impl_trait(id)?.instantiate_identity().skip_norm_wip();
                 let resolver = id.resolver(db);
                 Some(TraitRef::new_with_resolver(db, &resolver, trait_ref))
             }
@@ -5048,8 +5053,9 @@ impl Impl {
                     param_env: hir_ty::builtin_derive::param_env(interner, id),
                     krate,
                 };
-                let trait_ref =
-                    hir_ty::builtin_derive::impl_trait(interner, id).instantiate_identity();
+                let trait_ref = hir_ty::builtin_derive::impl_trait(interner, id)
+                    .instantiate_identity()
+                    .skip_norm_wip();
                 Some(TraitRef { env, trait_ref })
             }
         }
@@ -5060,7 +5066,7 @@ impl Impl {
             AnyImplId::ImplId(id) => {
                 let resolver = id.resolver(db);
                 // FIXME: This shouldn't be `instantiate_identity()`, we shouldn't leak `TyKind::Param`s.
-                let ty = db.impl_self_ty(id).instantiate_identity();
+                let ty = db.impl_self_ty(id).instantiate_identity().skip_norm_wip();
                 Type::new_with_resolver_inner(db, &resolver, ty)
             }
             AnyImplId::BuiltinDeriveImplId(id) => {
@@ -5073,6 +5079,7 @@ impl Impl {
                 };
                 let ty = hir_ty::builtin_derive::impl_trait(interner, id)
                     .instantiate_identity()
+                    .skip_norm_wip()
                     .self_ty();
                 Type { env, ty }
             }
@@ -5548,13 +5555,13 @@ impl<'db> Type<'db> {
             }
         };
         let args = GenericArgs::error_for_item(interner, def.into());
-        Type::new(db, def, ty.instantiate(interner, args))
+        Type::new(db, def, ty.instantiate(interner, args).skip_norm_wip())
     }
 
     // FIXME: We shouldn't leak `TyKind::Param`s.
     fn from_def_params(db: &'db dyn HirDatabase, def: impl Into<TyDefId> + HasResolver) -> Self {
         let ty = db.ty(def.into());
-        Type::new(db, def, ty.instantiate_identity())
+        Type::new(db, def, ty.instantiate_identity().skip_norm_wip())
     }
 
     fn from_value_def(
@@ -5578,7 +5585,7 @@ impl<'db> Type<'db> {
             }
         };
         let args = GenericArgs::error_for_item(interner, def.into());
-        Type::new(db, def, ty.instantiate(interner, args))
+        Type::new(db, def, ty.instantiate(interner, args).skip_norm_wip())
     }
 
     pub fn new_slice(ty: Self) -> Self {
@@ -5656,7 +5663,10 @@ impl<'db> Type<'db> {
                                     .fields()
                                     .iter()
                                     .map(|(idx, _)| {
-                                        field_types[idx].get().instantiate(self.interner, args)
+                                        field_types[idx]
+                                            .get()
+                                            .instantiate(self.interner, args)
+                                            .skip_norm_wip()
                                     })
                                     .filter(|it| !it.references_non_lt_error())
                                     .collect()
@@ -5980,7 +5990,7 @@ impl<'db> Type<'db> {
             .iter()
             .map(|(local_id, ty)| {
                 let def = Field { parent: variant_id.into(), id: local_id };
-                let ty = ty.get().instantiate(interner, substs);
+                let ty = ty.get().instantiate(interner, substs).skip_norm_wip();
                 (def, self.derived(ty))
             })
             .collect()
@@ -6483,7 +6493,7 @@ impl<'db> Type<'db> {
         else {
             return None;
         };
-        match def_id.expect_type_alias().loc(db).container {
+        match def_id.0.loc(db).container {
             ItemContainerId::TraitId(id) => Some(Trait { id }),
             _ => None,
         }

--- a/crates/hir/src/source_analyzer.rs
+++ b/crates/hir/src/source_analyzer.rs
@@ -519,7 +519,7 @@ impl<'db> SourceAnalyzer<'db> {
         let expr_id = self.expr_id(call.clone().into())?.as_expr()?;
         let (func, args) = self.infer()?.method_resolution(expr_id)?;
         let interner = DbInterner::new_no_crate(db);
-        let ty = db.value_ty(func.into())?.instantiate(interner, args);
+        let ty = db.value_ty(func.into())?.instantiate(interner, args).skip_norm_wip();
         let ty = Type::new_with_resolver(db, &self.resolver, ty);
         let mut res = ty.as_callable(db)?;
         res.is_bound_method = true;
@@ -868,8 +868,10 @@ impl<'db> SourceAnalyzer<'db> {
         let variant = self.infer()?.variant_resolution_for_expr_or_pat(expr_id)?;
         let variant_data = variant.fields(db);
         let field = FieldId { parent: variant, local_id: variant_data.field(&local_name)? };
-        let field_ty =
-            (*db.field_types(variant).get(field.local_id)?).get().instantiate(interner, subst);
+        let field_ty = (*db.field_types(variant).get(field.local_id)?)
+            .get()
+            .instantiate(interner, subst)
+            .skip_norm_wip();
         Some((
             field.into(),
             local,
@@ -891,8 +893,10 @@ impl<'db> SourceAnalyzer<'db> {
         let variant_data = variant.fields(db);
         let field = FieldId { parent: variant, local_id: variant_data.field(&field_name)? };
         let (adt, subst) = self.infer()?.pat_ty(pat_id.as_pat()?).as_adt()?;
-        let field_ty =
-            (*db.field_types(variant).get(field.local_id)?).get().instantiate(interner, subst);
+        let field_ty = (*db.field_types(variant).get(field.local_id)?)
+            .get()
+            .instantiate(interner, subst)
+            .skip_norm_wip();
         Some((
             field.into(),
             Type::new_with_resolver(db, &self.resolver, field_ty),
@@ -961,24 +965,25 @@ impl<'db> SourceAnalyzer<'db> {
             if let Either::Right(container) = &mut container {
                 *container = structurally_normalize_ty(&infcx, *container, trait_env.param_env);
             }
-            let handle_variants = |variant: VariantId,
-                                   subst: GenericArgs<'db>,
-                                   container: &mut _| {
-                let fields = variant.fields(db);
-                let field = fields.field(&field_name.as_name())?;
-                let field_types = db.field_types(variant);
-                *container = Either::Right(field_types[field].get().instantiate(interner, subst));
-                let generic_def = match variant {
-                    VariantId::EnumVariantId(it) => it.loc(db).parent.into(),
-                    VariantId::StructId(it) => it.into(),
-                    VariantId::UnionId(it) => it.into(),
+            let handle_variants =
+                |variant: VariantId, subst: GenericArgs<'db>, container: &mut _| {
+                    let fields = variant.fields(db);
+                    let field = fields.field(&field_name.as_name())?;
+                    let field_types = db.field_types(variant);
+                    *container = Either::Right(
+                        field_types[field].get().instantiate(interner, subst).skip_norm_wip(),
+                    );
+                    let generic_def = match variant {
+                        VariantId::EnumVariantId(it) => it.loc(db).parent.into(),
+                        VariantId::StructId(it) => it.into(),
+                        VariantId::UnionId(it) => it.into(),
+                    };
+                    Some((
+                        Either::Right(Field { parent: variant.into(), id: field }),
+                        generic_def,
+                        subst,
+                    ))
                 };
-                Some((
-                    Either::Right(Field { parent: variant.into(), id: field }),
-                    generic_def,
-                    subst,
-                ))
-            };
             let temp_ty = Ty::new_error(interner, ErrorGuaranteed);
             let (field_def, generic_def, subst) =
                 match std::mem::replace(&mut container, Either::Right(temp_ty)) {
@@ -1322,7 +1327,7 @@ impl<'db> SourceAnalyzer<'db> {
                         args,
                         ..
                     }) => {
-                        let assoc_id = def_id.expect_type_alias();
+                        let assoc_id = def_id.0;
                         (
                             GenericSubstitution::new(assoc_id.into(), args, env),
                             PathResolution::Def(ModuleDef::TypeAlias(assoc_id.into())),
@@ -1453,7 +1458,7 @@ impl<'db> SourceAnalyzer<'db> {
             .into_iter()
             .map(|local_id| {
                 let field = FieldId { parent: variant, local_id };
-                let ty = field_types[local_id].get().instantiate(interner, substs);
+                let ty = field_types[local_id].get().instantiate(interner, substs).skip_norm_wip();
                 (field.into(), Type::new_with_resolver_inner(db, &self.resolver, ty))
             })
             .collect()

--- a/crates/ide-completion/src/tests/flyimport.rs
+++ b/crates/ide-completion/src/tests/flyimport.rs
@@ -1809,9 +1809,8 @@ fn intrinsics() {
         r#"
     //- /core.rs crate:core
     pub mod intrinsics {
-        extern "rust-intrinsic" {
-            pub fn transmute<Src, Dst>(src: Src) -> Dst;
-        }
+        #[rustc_intrinsic]
+        pub unsafe fn transmute<Src, Dst>(src: Src) -> Dst;
     }
     pub mod mem {
         pub use crate::intrinsics::transmute;
@@ -1829,9 +1828,8 @@ fn intrinsics() {
         r#"
 //- /core.rs crate:core
 pub mod intrinsics {
-    extern "rust-intrinsic" {
-        pub fn transmute<Src, Dst>(src: Src) -> Dst;
-    }
+    #[rustc_intrinsic]
+    pub unsafe fn transmute<Src, Dst>(src: Src) -> Dst;
 }
 pub mod mem {
     pub use crate::intrinsics::transmute;

--- a/crates/ide-diagnostics/src/handlers/missing_unsafe.rs
+++ b/crates/ide-diagnostics/src/handlers/missing_unsafe.rs
@@ -274,25 +274,6 @@ fn main() {
     }
 
     #[test]
-    fn no_missing_unsafe_diagnostic_with_legacy_safe_intrinsic() {
-        check_diagnostics(
-            r#"
-extern "rust-intrinsic" {
-    #[rustc_safe_intrinsic]
-    pub fn bitreverse(x: u32) -> u32; // Safe intrinsic
-    pub fn floorf32(x: f32) -> f32; // Unsafe intrinsic
-}
-
-fn main() {
-    let _ = bitreverse(12);
-    let _ = floorf32(12.0);
-          //^^^^^^^^^^^^^^💡 error: call to unsafe function is unsafe and requires an unsafe function or block
-}
-"#,
-        );
-    }
-
-    #[test]
     fn no_missing_unsafe_diagnostic_with_deprecated_safe_2024() {
         check_diagnostics(
             r#"
@@ -411,30 +392,6 @@ static mut STATIC_MUT: Ty = Ty { a: 0 };
 
 fn main() {
     let _x = unsafe { STATIC_MUT.a };
-}
-"#,
-        )
-    }
-
-    #[test]
-    fn add_unsafe_block_when_calling_unsafe_intrinsic() {
-        check_fix(
-            r#"
-extern "rust-intrinsic" {
-    pub fn floorf32(x: f32) -> f32;
-}
-
-fn main() {
-    let _ = floorf32$0(12.0);
-}
-"#,
-            r#"
-extern "rust-intrinsic" {
-    pub fn floorf32(x: f32) -> f32;
-}
-
-fn main() {
-    let _ = unsafe { floorf32(12.0) };
 }
 "#,
         )

--- a/crates/ide/src/hover/tests.rs
+++ b/crates/ide/src/hover/tests.rs
@@ -5972,9 +5972,8 @@ const FOO$0: f64 = 1.0f64;
 fn hover_const_eval_floating_point() {
     check(
         r#"
-extern "rust-intrinsic" {
-    pub fn expf64(x: f64) -> f64;
-}
+#[rustc_intrinsic]
+pub fn expf64(x: f64) -> f64;
 
 const FOO$0: f64 = expf64(1.2);
 "#,


### PR DESCRIPTION
Notable changes:

 - Aliases' def_id was changed to be in `AliasTyKind` and `AliasTermKind`, and be typed.
 - rustc now eagerly normalizes with the new solver; to aid with that, it has the `Unnormalized` helper. We currently just call `skip_norm_wip()` everywhere.  We'll need to change that eventually.
 - Niche attributes are no longer supported by `rustc_abi`, we need to migrate to pattern types.
 - `FnAbi` was removed in favor of `rustc_abi::ExternAbi`. This also removes support for legacy intrinsics (`extern "rust-intrinsic"`), but they're quite old by now so it's presumably okay.