### PR TITLE
perf: Provide better incrementality for modules

### DIFF
--- a/crates/hir-def/src/expr_store/tests/body/block.rs
+++ b/crates/hir-def/src/expr_store/tests/body/block.rs
@@ -199,6 +199,11 @@ fn f() {
                         4401,
                     ),
                 ),
+                containing_module_inside_def_map: None,
+                name_or_empty: Name {
+                    symbol: "",
+                    ctx: (),
+                },
             }"#]],
     );
 }

--- a/crates/hir-def/src/lib.rs
+++ b/crates/hir-def/src/lib.rs
@@ -48,7 +48,7 @@ pub mod find_path;
 pub mod import_map;
 pub mod visibility;
 
-use intern::Interned;
+use intern::{Interned, sym};
 use rustc_abi::ExternAbi;
 use thin_vec::ThinVec;
 
@@ -457,6 +457,11 @@ pub struct ModuleIdLt<'db> {
     /// `BlockId` of that block expression. If `None`, this module is part of the crate-level
     /// `DefMap` of `krate`.
     pub block: Option<BlockId>,
+    /// The parent module of this module, or `None` if this is the root module inside the def
+    /// map (including for block def maps).
+    pub containing_module_inside_def_map: Option<ModuleIdLt<'db>>,
+    /// The name of this module, or [`sym::__empty`] for the root module.
+    name_or_empty: Name,
 }
 pub type ModuleId = ModuleIdLt<'static>;
 
@@ -502,21 +507,23 @@ impl ModuleId {
     }
 
     pub fn name(self, db: &dyn DefDatabase) -> Option<Name> {
-        let def_map = self.def_map(db);
-        let parent = def_map[self].parent?;
-        def_map[parent].children.iter().find_map(|(name, module_id)| {
-            if *module_id == self { Some(name.clone()) } else { None }
-        })
+        let name = self.name_or_empty(db);
+        if *name.symbol() == sym::__empty { None } else { Some(name) }
     }
 
     /// Returns the module containing `self`, either the parent `mod`, or the module (or block) containing
     /// the block, if `self` corresponds to a block expression.
     pub fn containing_module(self, db: &dyn DefDatabase) -> Option<ModuleId> {
-        self.def_map(db).containing_module(self)
+        self.containing_module_inside_def_map(db)
+            .or_else(|| self.block(db).map(|block| block.loc(db).module))
+            .map(|module| {
+                // SAFETY: Not sure.
+                unsafe { module.to_static() }
+            })
     }
 
     pub fn is_block_module(self, db: &dyn DefDatabase) -> bool {
-        self.block(db).is_some() && self.def_map(db).root_module_id() == self
+        self.block(db).is_some() && self.containing_module_inside_def_map(db).is_none()
     }
 }
 

--- a/crates/hir-def/src/nameres.rs
+++ b/crates/hir-def/src/nameres.rs
@@ -66,7 +66,7 @@ use hir_expand::{
     EditionedFileId, ErasedAstId, HirFileId, InFile, MacroCallId, mod_path::ModPath, name::Name,
     proc_macro::ProcMacroKind,
 };
-use intern::Symbol;
+use intern::{Symbol, sym};
 use itertools::Itertools;
 use rustc_hash::FxHashMap;
 use span::{Edition, FileAstId, FileId, ROOT_ERASED_FILE_AST_ID};
@@ -465,7 +465,16 @@ impl DefMap {
         block: Option<BlockInfo>,
     ) -> DefMap {
         let mut modules = ModulesMap::new();
-        let root = unsafe { ModuleIdLt::new(db, krate, block.map(|it| it.block)).to_static() };
+        let root = unsafe {
+            ModuleIdLt::new(
+                db,
+                krate,
+                block.map(|it| it.block),
+                None,
+                Name::new_symbol_root(sym::__empty),
+            )
+            .to_static()
+        };
         modules.insert(root, module_data);
 
         DefMap {

--- a/crates/hir-def/src/nameres/collector.rs
+++ b/crates/hir-def/src/nameres/collector.rs
@@ -2428,6 +2428,8 @@ impl ModCollector<'_, '_> {
                 self.def_collector.db,
                 self.def_collector.def_map.krate,
                 self.def_collector.def_map.block_id(),
+                Some(self.module_id),
+                name.clone(),
             )
             .to_static()
         };


### PR DESCRIPTION
Previously module ID reuse was based on order of creation solely. Now we store the parent module and name, and so Salsa will reuse the ID for modules that have the same name and parent.

This is important as many interned IDs contain modules, so if the module is invalidated they too are.