### PR TITLE
ide-diagnostics: emit error for duplicate field in record pattern

### DIFF
--- a/crates/hir-ty/src/infer/pat.rs
+++ b/crates/hir-ty/src/infer/pat.rs
@@ -1185,7 +1185,10 @@ https://doc.rust-lang.org/reference/types.html#trait-objects";
         for (field_idx, field) in fields.iter().enumerate() {
             match used_fields.entry(field.name.clone()) {
                 Occupied(_occupied) => {
-                    // FIXME: Emit an error, field specified twice.
+                    self.push_diagnostic(InferenceDiagnostic::DuplicateField {
+                        field: field.pat.into(),
+                        variant,
+                    });
                 }
                 Vacant(vacant) => {
                     vacant.insert(field_idx);

--- a/crates/ide-diagnostics/src/handlers/duplicate_field.rs
+++ b/crates/ide-diagnostics/src/handlers/duplicate_field.rs
@@ -81,4 +81,43 @@ fn main() {
 "#,
         );
     }
+
+    #[test]
+    fn duplicate_field_in_struct_pattern() {
+        check_diagnostics(
+            r#"
+struct S { foo: i32, bar: i32 }
+fn f(s: S) {
+    let S {
+        foo,
+        bar,
+        foo,
+      //^^^ error: field specified more than once
+        ..
+    } = s;
+    let _ = (foo, bar);
+}
+"#,
+        );
+    }
+
+    #[test]
+    fn duplicate_field_in_enum_variant_pattern() {
+        check_diagnostics(
+            r#"
+enum E { V { foo: i32, bar: i32 } }
+fn f(e: E) {
+    match e {
+        E::V {
+            foo,
+            bar,
+            foo,
+          //^^^ error: field specified more than once
+            ..
+        } => { let _ = (foo, bar); }
+    }
+}
+"#,
+        );
+    }
 }


### PR DESCRIPTION
Resolves the second of the FIXMEs called out in rust-lang/rust-analyzer#22140, parallel to rust-lang/rust-analyzer#22235 which handled the record-expression case.  The diagnostic infrastructure was added in rust-lang/rust-analyzer#22235; this PR only needs the push at the new site plus the two pattern tests.