### PR TITLE
Encode the name instead of index in `EnumVariantId`

### DIFF
--- a/crates/base-db/src/lib.rs
+++ b/crates/base-db/src/lib.rs
@@ -49,6 +49,7 @@ macro_rules! impl_intern_key {
         #[salsa_macros::interned(no_lifetime, revisions = usize::MAX)]
         #[derive(PartialOrd, Ord)]
         pub struct $id {
+            #[returns(ref)]
             pub loc: $loc,
         }
 

--- a/crates/hir-def/src/db.rs
+++ b/crates/hir-def/src/db.rs
@@ -7,8 +7,7 @@ use hir_expand::{
 use triomphe::Arc;
 
 use crate::{
-    AssocItemId, AttrDefId, Macro2Loc, MacroExpander, MacroId, MacroRulesLoc, MacroRulesLocFlags,
-    TraitId,
+    AssocItemId, AttrDefId, MacroExpander, MacroId, MacroRulesLocFlags, TraitId,
     attrs::AttrFlags,
     item_tree::{ItemTree, file_item_tree},
     nameres::crate_def_map,
@@ -81,7 +80,7 @@ fn macro_def(db: &dyn DefDatabase, id: MacroId) -> MacroDefId {
 
     match id {
         MacroId::Macro2Id(it) => {
-            let loc: Macro2Loc = it.lookup(db);
+            let loc = it.lookup(db);
 
             MacroDefId {
                 krate: loc.container.krate(db),
@@ -92,7 +91,7 @@ fn macro_def(db: &dyn DefDatabase, id: MacroId) -> MacroDefId {
             }
         }
         MacroId::MacroRulesId(it) => {
-            let loc: MacroRulesLoc = it.lookup(db);
+            let loc = it.lookup(db);
 
             MacroDefId {
                 krate: loc.container.krate(db),

--- a/crates/hir-def/src/find_path.rs
+++ b/crates/hir-def/src/find_path.rs
@@ -142,9 +142,7 @@ fn find_path_inner(ctx: &FindPathCtx<'_>, item: ItemInNs, max_len: usize) -> Opt
         // - if the item is an enum variant, refer to it via the enum
         let loc = variant.lookup(ctx.db);
         if let Some(mut path) = find_path_inner(ctx, ItemInNs::Types(loc.parent.into()), max_len) {
-            path.push_segment(
-                loc.parent.enum_variants(ctx.db).variants[loc.index as usize].1.clone(),
-            );
+            path.push_segment(loc.name.clone());
             return Some(path);
         }
         // If this doesn't work, it seems we have no way of referring to the

--- a/crates/hir-def/src/lang_item.rs
+++ b/crates/hir-def/src/lang_item.rs
@@ -74,7 +74,7 @@ pub fn crate_lang_items(db: &dyn DefDatabase, krate: Crate) -> Option<Box<LangIt
                 }
                 ModuleDefId::AdtId(AdtId::EnumId(e)) => {
                     lang_items.collect_lang_item(db, e);
-                    e.enum_variants(db).variants.iter().for_each(|&(id, _, _)| {
+                    e.enum_variants(db).variants.values().for_each(|&(id, _)| {
                         lang_items.collect_lang_item(db, id);
                     });
                 }

--- a/crates/hir-def/src/lib.rs
+++ b/crates/hir-def/src/lib.rs
@@ -298,7 +298,7 @@ impl EnumId {
     pub fn enum_variants_with_diagnostics(
         self,
         db: &dyn DefDatabase,
-    ) -> &(EnumVariants, Option<ThinVec<InactiveEnumVariantCode>>) {
+    ) -> &(EnumVariants, ThinVec<InactiveEnumVariantCode>) {
         EnumVariants::of(db, self)
     }
 }

--- a/crates/hir-def/src/lib.rs
+++ b/crates/hir-def/src/lib.rs
@@ -367,18 +367,33 @@ impl ExternBlockId {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct EnumVariantLoc {
     pub id: AstId<ast::Variant>,
     pub parent: EnumId,
-    pub index: u32,
+    pub name: Name,
 }
 impl_intern!(EnumVariantId, EnumVariantLoc);
 impl_loc!(EnumVariantLoc, id: Variant, parent: EnumId);
 
+impl EnumVariantLoc {
+    pub fn index(&self, db: &dyn DefDatabase) -> usize {
+        self.parent
+            .enum_variants(db)
+            .variants
+            .get_full(&self.name)
+            .expect("parent enum should include this variant")
+            .0
+    }
+}
+
 impl EnumVariantId {
     pub fn fields(self, db: &dyn DefDatabase) -> &VariantFields {
         VariantFields::of(db, self.into())
+    }
+
+    pub fn index(self, db: &dyn DefDatabase) -> usize {
+        self.loc(db).index(db)
     }
 
     pub fn fields_with_source_map(

--- a/crates/hir-def/src/nameres.rs
+++ b/crates/hir-def/src/nameres.rs
@@ -427,7 +427,7 @@ pub(crate) fn crate_local_def_map(db: &dyn DefDatabase, crate_id: Crate) -> DefM
 
 #[salsa_macros::tracked(returns(ref))]
 pub fn block_def_map(db: &dyn DefDatabase, block_id: BlockId) -> DefMap {
-    let BlockLoc { ast_id, module } = block_id.lookup(db);
+    let BlockLoc { ast_id, module } = *block_id.lookup(db);
 
     let visibility = Visibility::Module(module, VisibilityExplicitness::Implicit);
     let module_data =

--- a/crates/hir-def/src/nameres/assoc.rs
+++ b/crates/hir-def/src/nameres/assoc.rs
@@ -50,7 +50,7 @@ impl TraitItems {
         db: &dyn DefDatabase,
         tr: TraitId,
     ) -> (TraitItems, DefDiagnostics) {
-        let ItemLoc { container: module_id, id: ast_id } = tr.lookup(db);
+        let ItemLoc { container: module_id, id: ast_id } = *tr.lookup(db);
         let ast_id_map = db.ast_id_map(ast_id.file_id);
         let source = ast_id.with_value(ast_id_map.get(ast_id.value)).to_node(db);
         if source.eq_token().is_some() {
@@ -115,7 +115,7 @@ impl ImplItems {
     #[salsa::tracked(returns(ref))]
     pub fn of(db: &dyn DefDatabase, id: ImplId) -> (ImplItems, DefDiagnostics) {
         let _p = tracing::info_span!("impl_items_with_diagnostics_query").entered();
-        let ItemLoc { container: module_id, id: ast_id } = id.lookup(db);
+        let ItemLoc { container: module_id, id: ast_id } = *id.lookup(db);
 
         let collector =
             AssocItemCollector::new(db, module_id, ItemContainerId::ImplId(id), ast_id.file_id);

--- a/crates/hir-def/src/nameres/collector.rs
+++ b/crates/hir-def/src/nameres/collector.rs
@@ -1027,7 +1027,7 @@ impl<'db> DefCollector<'db> {
                             .enum_variants(self.db)
                             .variants
                             .iter()
-                            .map(|&(variant, ref name, _)| {
+                            .map(|(name, &(variant, _))| {
                                 let res = PerNs::both(variant.into(), variant.into(), vis, None);
                                 (Some(name.clone()), res)
                             })

--- a/crates/hir-def/src/nameres/path_resolution.rs
+++ b/crates/hir-def/src/nameres/path_resolution.rs
@@ -519,12 +519,8 @@ impl DefMap {
                     // enum variant
                     cov_mark::hit!(can_import_enum_variant);
 
-                    let res = e
-                        .enum_variants(db)
-                        .variants
-                        .iter()
-                        .find(|(_, name, _)| name == segment)
-                        .map(|&(variant, _, shape)| match shape {
+                    let res = e.enum_variants(db).variants.get(segment).map(|&(variant, shape)| {
+                        match shape {
                             FieldsShape::Record => {
                                 PerNs::types(variant.into(), Visibility::Public, None)
                             }
@@ -534,7 +530,8 @@ impl DefMap {
                                 Visibility::Public,
                                 None,
                             ),
-                        });
+                        }
+                    });
                     // FIXME: Need to filter visibility here and below? Not sure.
                     return match res {
                         Some(res) => {

--- a/crates/hir-def/src/signatures.rs
+++ b/crates/hir-def/src/signatures.rs
@@ -1,6 +1,6 @@
 //! Item signature IR definitions
 
-use std::{cell::LazyCell, ops::Not as _};
+use std::cell::LazyCell;
 
 use bitflags::bitflags;
 use cfg::{CfgExpr, CfgOptions};
@@ -1065,7 +1065,7 @@ impl EnumVariants {
     pub(crate) fn of(
         db: &dyn DefDatabase,
         e: EnumId,
-    ) -> (EnumVariants, Option<ThinVec<InactiveEnumVariantCode>>) {
+    ) -> (EnumVariants, ThinVec<InactiveEnumVariantCode>) {
         let loc = e.lookup(db);
         let source = loc.source(db);
         let ast_id_map = db.ast_id_map(source.file_id);
@@ -1073,7 +1073,7 @@ impl EnumVariants {
         let mut diagnostics = ThinVec::new();
         let cfg_options = loc.container.krate(db).cfg_options(db);
         let Some(variants) = source.value.variant_list() else {
-            return (EnumVariants { variants: FxIndexMap::default() }, None);
+            return (EnumVariants { variants: FxIndexMap::default() }, ThinVec::new());
         };
         let mut variants = variants
             .variants()
@@ -1103,8 +1103,9 @@ impl EnumVariants {
             })
             .collect::<FxIndexMap<_, _>>();
         variants.shrink_to_fit();
+        diagnostics.shrink_to_fit();
 
-        (EnumVariants { variants }, diagnostics.is_empty().not().then_some(diagnostics))
+        (EnumVariants { variants }, diagnostics)
     }
 }
 

--- a/crates/hir-def/src/signatures.rs
+++ b/crates/hir-def/src/signatures.rs
@@ -19,8 +19,9 @@ use thin_vec::ThinVec;
 use triomphe::Arc;
 
 use crate::{
-    ConstId, EnumId, EnumVariantId, EnumVariantLoc, ExternBlockId, FunctionId, HasModule, ImplId,
-    ItemContainerId, ModuleId, StaticId, StructId, TraitId, TypeAliasId, UnionId, VariantId,
+    ConstId, EnumId, EnumVariantId, EnumVariantLoc, ExternBlockId, FunctionId, FxIndexMap,
+    HasModule, ImplId, ItemContainerId, ModuleId, StaticId, StructId, TraitId, TypeAliasId,
+    UnionId, VariantId,
     attrs::AttrFlags,
     db::DefDatabase,
     expr_store::{
@@ -1055,7 +1056,7 @@ pub struct InactiveEnumVariantCode {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct EnumVariants {
-    pub variants: Box<[(EnumVariantId, Name, FieldsShape)]>,
+    pub variants: FxIndexMap<Name, (EnumVariantId, FieldsShape)>,
 }
 
 #[salsa::tracked]
@@ -1071,23 +1072,24 @@ impl EnumVariants {
 
         let mut diagnostics = ThinVec::new();
         let cfg_options = loc.container.krate(db).cfg_options(db);
-        let mut index = 0;
         let Some(variants) = source.value.variant_list() else {
-            return (EnumVariants { variants: Box::default() }, None);
+            return (EnumVariants { variants: FxIndexMap::default() }, None);
         };
-        let variants = variants
+        let mut variants = variants
             .variants()
             .filter_map(|variant| {
                 let ast_id = ast_id_map.ast_id(&variant);
                 match AttrFlags::is_cfg_enabled_for(&variant, cfg_options) {
                     Ok(()) => {
-                        let enum_variant =
-                            EnumVariantLoc { id: source.with_value(ast_id), parent: e, index }
-                                .intern(db);
-                        index += 1;
                         let name = as_name_opt(variant.name());
+                        let enum_variant = EnumVariantLoc {
+                            id: source.with_value(ast_id),
+                            parent: e,
+                            name: name.clone(),
+                        }
+                        .intern(db);
                         let shape = adt_shape(variant.kind());
-                        Some((enum_variant, name, shape))
+                        Some((name, (enum_variant, shape)))
                     }
                     Err(cfg) => {
                         diagnostics.push(InactiveEnumVariantCode {
@@ -1099,7 +1101,8 @@ impl EnumVariants {
                     }
                 }
             })
-            .collect();
+            .collect::<FxIndexMap<_, _>>();
+        variants.shrink_to_fit();
 
         (EnumVariants { variants }, diagnostics.is_empty().not().then_some(diagnostics))
     }
@@ -1107,26 +1110,28 @@ impl EnumVariants {
 
 impl EnumVariants {
     pub fn variant(&self, name: &Name) -> Option<EnumVariantId> {
-        self.variants.iter().find_map(|(v, n, _)| if n == name { Some(*v) } else { None })
+        self.variants.get(name).map(|&(id, _)| id)
     }
 
     pub fn variant_name_by_id(&self, variant_id: EnumVariantId) -> Option<Name> {
         self.variants
             .iter()
-            .find_map(|(id, name, _)| if *id == variant_id { Some(name.clone()) } else { None })
+            .find_map(|(name, (id, _))| if *id == variant_id { Some(name.clone()) } else { None })
     }
 
     // [Adopted from rustc](https://github.com/rust-lang/rust/blob/bd53aa3bf7a24a70d763182303bd75e5fc51a9af/compiler/rustc_middle/src/ty/adt.rs#L446-L448)
     pub fn is_payload_free(&self, db: &dyn DefDatabase) -> bool {
-        self.variants.iter().all(|&(v, _, _)| {
+        self.variants.values().all(|&(v, shape)| {
             // The condition check order is slightly modified from rustc
             // to improve performance by early returning with relatively fast checks
-            let variant = v.fields(db);
-            if !variant.fields().is_empty() {
-                return false;
-            }
+
             // The outer if condition is whether this variant has const ctor or not
-            if !matches!(variant.shape, FieldsShape::Unit) {
+            if !matches!(shape, FieldsShape::Unit) {
+                let variant = v.fields(db);
+                if !variant.fields().is_empty() {
+                    return false;
+                }
+
                 let body = Body::of(db, v.into());
                 // A variant with explicit discriminant
                 if !matches!(body[body.root_expr()], crate::hir::Expr::Missing) {

--- a/crates/hir-expand/src/db.rs
+++ b/crates/hir-expand/src/db.rs
@@ -149,8 +149,8 @@ fn syntax_context(db: &dyn ExpandDatabase, file: HirFileId, edition: Edition) ->
     match file {
         HirFileId::FileId(_) => SyntaxContext::root(edition),
         HirFileId::MacroFile(m) => {
-            let kind = m.loc(db).kind;
-            db.macro_arg_considering_derives(m, &kind).2.ctx
+            let kind = &m.loc(db).kind;
+            db.macro_arg_considering_derives(m, kind).2.ctx
         }
     }
 }
@@ -542,11 +542,11 @@ impl<'db> TokenExpander<'db> {
     }
 }
 
-fn macro_expand(
-    db: &dyn ExpandDatabase,
+fn macro_expand<'db>(
+    db: &'db dyn ExpandDatabase,
     macro_call_id: MacroCallId,
-    loc: MacroCallLoc,
-) -> ExpandResult<(Cow<'_, tt::TopSubtree>, MatchedArmIndex)> {
+    loc: &MacroCallLoc,
+) -> ExpandResult<(Cow<'db, tt::TopSubtree>, MatchedArmIndex)> {
     let _p = tracing::info_span!("macro_expand").entered();
 
     let (ExpandResult { value: (tt, matched_arm), err }, span) = match loc.def.kind {

--- a/crates/hir-expand/src/lib.rs
+++ b/crates/hir-expand/src/lib.rs
@@ -81,7 +81,7 @@ macro_rules! impl_intern_lookup {
         impl $crate::Lookup for $id {
             type Database = dyn $db;
             type Data = $loc;
-            fn lookup(&self, db: &Self::Database) -> Self::Data {
+            fn lookup<'db>(&self, db: &'db Self::Database) -> &'db Self::Data {
                 self.loc(db)
             }
         }
@@ -98,7 +98,7 @@ pub trait Intern {
 pub trait Lookup {
     type Database: ?Sized;
     type Data;
-    fn lookup(&self, db: &Self::Database) -> Self::Data;
+    fn lookup<'db>(&self, db: &'db Self::Database) -> &'db Self::Data;
 }
 
 impl_intern_lookup!(ExpandDatabase, MacroCallId, MacroCallLoc);
@@ -714,24 +714,27 @@ impl MacroCallKind {
     /// - fn_like! {}, it spans the path and token tree
     /// - #\[derive], it spans the `#[derive(...)]` attribute and the annotated item
     /// - #\[attr], it spans the `#[attr(...)]` attribute and the annotated item
-    pub fn original_call_range_with_input(self, db: &dyn ExpandDatabase) -> FileRange {
-        let mut kind = self;
+    pub fn original_call_range_with_input(&self, db: &dyn ExpandDatabase) -> FileRange {
+        let get_range = |kind: &_| match kind {
+            MacroCallKind::FnLike { ast_id, .. } => ast_id.erase(),
+            MacroCallKind::Derive { ast_id, .. } => ast_id.erase(),
+            MacroCallKind::Attr { ast_id, .. } => ast_id.erase(),
+        };
+
+        let mut ast_id = get_range(self);
+        let mut file_id = self.file_id();
         let file_id = loop {
-            match kind.file_id() {
+            match file_id {
                 HirFileId::MacroFile(file) => {
-                    kind = file.loc(db).kind;
+                    let kind = &file.loc(db).kind;
+                    ast_id = get_range(kind);
+                    file_id = kind.file_id();
                 }
                 HirFileId::FileId(file_id) => break file_id,
             }
         };
 
-        let range = match kind {
-            MacroCallKind::FnLike { ast_id, .. } => ast_id.to_ptr(db).text_range(),
-            MacroCallKind::Derive { ast_id, .. } => ast_id.to_ptr(db).text_range(),
-            MacroCallKind::Attr { ast_id, .. } => ast_id.to_ptr(db).text_range(),
-        };
-
-        FileRange { range, file_id }
+        FileRange { range: ast_id.to_ptr(db).text_range(), file_id }
     }
 
     /// Returns the original file range that best describes the location of this macro call.
@@ -739,18 +742,8 @@ impl MacroCallKind {
     /// Here we try to roughly match what rustc does to improve diagnostics: fn-like macros
     /// get the macro path (rustc shows the whole `ast::MacroCall`), attribute macros get the
     /// attribute's range, and derives get only the specific derive that is being referred to.
-    pub fn original_call_range(self, db: &dyn ExpandDatabase, krate: Crate) -> FileRange {
-        let mut kind = self;
-        let file_id = loop {
-            match kind.file_id() {
-                HirFileId::MacroFile(file) => {
-                    kind = file.loc(db).kind;
-                }
-                HirFileId::FileId(file_id) => break file_id,
-            }
-        };
-
-        let range = match kind {
+    pub fn original_call_range(&self, db: &dyn ExpandDatabase, krate: Crate) -> FileRange {
+        let get_range = |kind: &_| match kind {
             MacroCallKind::FnLike { ast_id, .. } => {
                 let node = ast_id.to_node(db);
                 node.path()
@@ -761,11 +754,24 @@ impl MacroCallKind {
             }
             MacroCallKind::Derive { ast_id, derive_attr_index, .. } => {
                 // FIXME: should be the range of the macro name, not the whole derive
-                derive_attr_index.find_attr_range(db, krate, ast_id).1.syntax().text_range()
+                derive_attr_index.find_attr_range(db, krate, *ast_id).1.syntax().text_range()
             }
             // FIXME: handle `cfg_attr`
             MacroCallKind::Attr { ast_id, censored_attr_ids: attr_ids, .. } => {
-                attr_ids.invoc_attr().find_attr_range(db, krate, ast_id).1.syntax().text_range()
+                attr_ids.invoc_attr().find_attr_range(db, krate, *ast_id).1.syntax().text_range()
+            }
+        };
+
+        let mut range = get_range(self);
+        let mut file_id = self.file_id();
+        let file_id = loop {
+            match file_id {
+                HirFileId::MacroFile(file) => {
+                    let kind = &file.loc(db).kind;
+                    range = get_range(kind);
+                    file_id = kind.file_id();
+                }
+                HirFileId::FileId(file_id) => break file_id,
             }
         };
 
@@ -797,7 +803,7 @@ pub struct ExpansionInfo<'db> {
     arg: InFile<Option<SyntaxNode>>,
     exp_map: &'db ExpansionSpanMap,
     arg_map: SpanMap<'db>,
-    loc: MacroCallLoc,
+    loc: &'db MacroCallLoc,
 }
 
 impl<'db> ExpansionInfo<'db> {
@@ -1056,6 +1062,7 @@ intern::impl_internable!(ModPath);
 #[salsa_macros::interned(no_lifetime, debug, revisions = usize::MAX)]
 #[doc(alias = "MacroFileId")]
 pub struct MacroCallId {
+    #[returns(ref)]
     pub loc: MacroCallLoc,
 }
 

--- a/crates/hir-ty/src/builtin_derive.rs
+++ b/crates/hir-ty/src/builtin_derive.rs
@@ -305,7 +305,7 @@ fn simple_trait_predicates<'db>(
             loc.trait_,
         ),
         AdtId::EnumId(id) => {
-            for &(variant_id, _, _) in &id.enum_variants(interner.db).variants {
+            for &(variant_id, _) in id.enum_variants(interner.db).variants.values() {
                 extend_assoc_type_bounds(
                     interner,
                     &mut assoc_type_bounds,

--- a/crates/hir-ty/src/consteval.rs
+++ b/crates/hir-ty/src/consteval.rs
@@ -400,12 +400,10 @@ pub(crate) fn const_eval_discriminant_variant(
     let body = Body::of(db, def);
     let loc = variant_id.lookup(db);
     if matches!(body[body.root_expr()], Expr::Missing) {
-        let prev_idx = loc.index.checked_sub(1);
+        let prev_idx = loc.index(db).checked_sub(1);
         let value = match prev_idx {
             Some(prev_idx) => {
-                1 + db.const_eval_discriminant(
-                    loc.parent.enum_variants(db).variants[prev_idx as usize].0,
-                )?
+                1 + db.const_eval_discriminant(loc.parent.enum_variants(db).variants[prev_idx].0)?
             }
             _ => 0,
         };

--- a/crates/hir-ty/src/diagnostics/decl_check.rs
+++ b/crates/hir-ty/src/diagnostics/decl_check.rs
@@ -504,15 +504,15 @@ impl<'a> DeclValidator<'a> {
     fn validate_enum_variants(&mut self, enum_id: EnumId) {
         let data = enum_id.enum_variants(self.db);
 
-        for (variant_id, _, _) in data.variants.iter() {
+        for (variant_id, _) in data.variants.values() {
             self.validate_enum_variant_fields(*variant_id);
         }
 
         let edition = self.edition(enum_id);
         let mut enum_variants_replacements = data
             .variants
-            .iter()
-            .filter_map(|(_, name, _)| {
+            .keys()
+            .filter_map(|name| {
                 to_camel_case(&name.display_no_db(edition).to_smolstr()).map(|new_name| {
                     Replacement {
                         current_name: name.clone(),

--- a/crates/hir-ty/src/diagnostics/match_check.rs
+++ b/crates/hir-ty/src/diagnostics/match_check.rs
@@ -330,13 +330,7 @@ impl<'db> HirDisplay<'db> for Pat<'db> {
                     match variant {
                         VariantId::EnumVariantId(v) => {
                             let loc = v.lookup(f.db);
-                            write!(
-                                f,
-                                "{}",
-                                loc.parent.enum_variants(f.db).variants[loc.index as usize]
-                                    .1
-                                    .display(f.db, f.edition())
-                            )?;
+                            write!(f, "{}", loc.name.display(f.db, f.edition()))?;
                         }
                         VariantId::StructId(s) => write!(
                             f,

--- a/crates/hir-ty/src/diagnostics/match_check/pat_analysis.rs
+++ b/crates/hir-ty/src/diagnostics/match_check/pat_analysis.rs
@@ -49,8 +49,7 @@ pub(crate) struct EnumVariantContiguousIndex(usize);
 impl EnumVariantContiguousIndex {
     fn from_enum_variant_id(db: &dyn HirDatabase, target_evid: EnumVariantId) -> Self {
         // Find the index of this variant in the list of variants.
-        use hir_def::Lookup;
-        let i = target_evid.lookup(db).index as usize;
+        let i = target_evid.index(db);
         EnumVariantContiguousIndex(i)
     }
 
@@ -438,7 +437,7 @@ impl<'a, 'db> PatCx for MatchCheckCtx<'a, 'db> {
                             ConstructorSet::NoConstructors
                         } else {
                             let mut variants = IndexVec::with_capacity(enum_data.variants.len());
-                            for &(variant, _, _) in enum_data.variants.iter() {
+                            for &(variant, _) in enum_data.variants.values() {
                                 let is_uninhabited = is_enum_variant_uninhabited_from(
                                     cx.infcx, variant, subst, cx.module, self.env,
                                 );

--- a/crates/hir-ty/src/display.rs
+++ b/crates/hir-ty/src/display.rs
@@ -990,13 +990,7 @@ fn render_const_scalar_inner<'db>(
                         return f.write_str("<failed-to-detect-variant>");
                     };
                     let loc = var_id.lookup(f.db);
-                    write!(
-                        f,
-                        "{}",
-                        loc.parent.enum_variants(f.db).variants[loc.index as usize]
-                            .1
-                            .display(f.db, f.edition())
-                    )?;
+                    write!(f, "{}", loc.name.display(f.db, f.edition()))?;
                     let field_types = f.db.field_types(var_id.into());
                     render_variant_after_name(
                         var_id.fields(f.db),
@@ -1362,13 +1356,7 @@ impl<'db> HirDisplay<'db> for Ty<'db> {
                     }
                     CallableDefId::EnumVariantId(e) => {
                         let loc = e.lookup(db);
-                        write!(
-                            f,
-                            "{}",
-                            loc.parent.enum_variants(db).variants[loc.index as usize]
-                                .1
-                                .display(db, f.edition())
-                        )?
+                        write!(f, "{}", loc.name.display(db, f.edition()))?
                     }
                 };
                 f.end_location_link();

--- a/crates/hir-ty/src/drop.rs
+++ b/crates/hir-ty/src/drop.rs
@@ -100,8 +100,8 @@ fn has_drop_glue_impl<'db>(
                 AdtId::EnumId(id) => id
                     .enum_variants(db)
                     .variants
-                    .iter()
-                    .map(|&(variant, _, _)| {
+                    .values()
+                    .map(|&(variant, _)| {
                         db.field_types(variant.into())
                             .iter()
                             .map(|(_, field_ty)| {

--- a/crates/hir-ty/src/infer/closure/analysis/expr_use_visitor.rs
+++ b/crates/hir-ty/src/infer/closure/analysis/expr_use_visitor.rs
@@ -1473,7 +1473,7 @@ impl<'db, D: Delegate<'db>> ExprUseVisitor<'_, '_, 'db, D> {
     fn variant_index_for_adt(&self, pat_id: PatId) -> Result<(u32, VariantId)> {
         let variant = self.cx.result.variant_resolution_for_pat(pat_id).ok_or(ErrorGuaranteed)?;
         let variant_idx = match variant {
-            VariantId::EnumVariantId(variant) => variant.loc(self.cx.db).index,
+            VariantId::EnumVariantId(variant) => variant.index(self.cx.db) as u32,
             VariantId::StructId(_) | VariantId::UnionId(_) => 0,
         };
         Ok((variant_idx, variant))

--- a/crates/hir-ty/src/inhabitedness.rs
+++ b/crates/hir-ty/src/inhabitedness.rs
@@ -125,7 +125,7 @@ impl<'a, 'db> UninhabitedFrom<'a, 'db> {
             AdtId::EnumId(e) => {
                 let enum_data = e.enum_variants(self.db());
 
-                for &(variant, _, _) in enum_data.variants.iter() {
+                for &(variant, _) in enum_data.variants.values() {
                     let variant_inhabitedness = self.visit_variant(variant.into(), subst);
                     match variant_inhabitedness {
                         Break(VisiblyUninhabited) => (),

--- a/crates/hir-ty/src/layout/adt.rs
+++ b/crates/hir-ty/src/layout/adt.rs
@@ -60,8 +60,8 @@ pub fn layout_of_adt_query(
             let variants = e.enum_variants(db);
             let r = variants
                 .variants
-                .iter()
-                .map(|&(v, _, _)| handle_variant(v.into(), v.fields(db)))
+                .values()
+                .map(|&(v, _)| handle_variant(v.into(), v.fields(db)))
                 .collect::<Result<SmallVec<_>, _>>()?;
             (r, AttrFlags::repr(db, e.into()).unwrap_or_default(), false)
         }

--- a/crates/hir-ty/src/mir/eval.rs
+++ b/crates/hir-ty/src/mir/eval.rs
@@ -844,7 +844,7 @@ impl<'a, 'db: 'a> Evaluator<'a, 'db> {
                         Variants::Multiple { variants, .. } => {
                             &variants[match f.parent {
                                 hir_def::VariantId::EnumVariantId(it) => {
-                                    RustcEnumVariantIdx(it.lookup(self.db).index as usize)
+                                    RustcEnumVariantIdx(it.index(self.db))
                                 }
                                 _ => {
                                     return Err(MirEvalError::InternalError(
@@ -1837,8 +1837,7 @@ impl<'a, 'db: 'a> Evaluator<'a, 'db> {
                     _ => not_supported!("multi variant layout for non-enums"),
                 };
                 let mut discriminant = self.const_eval_discriminant(enum_variant_id)?;
-                let lookup = enum_variant_id.lookup(self.db);
-                let rustc_enum_variant_idx = RustcEnumVariantIdx(lookup.index as usize);
+                let rustc_enum_variant_idx = RustcEnumVariantIdx(enum_variant_id.index(self.db));
                 let variant_layout = variants[rustc_enum_variant_idx].clone();
                 let have_tag = match tag_encoding {
                     TagEncoding::Direct => true,

--- a/crates/hir-ty/src/mir/lower.rs
+++ b/crates/hir-ty/src/mir/lower.rs
@@ -2309,10 +2309,7 @@ pub fn mir_body_query<'db>(db: &'db dyn HirDatabase, def: InferBodyId) -> Result
             .to_string(),
         InferBodyId::DefWithBodyId(DefWithBodyId::VariantId(it)) => {
             let loc = it.lookup(db);
-            loc.parent.enum_variants(db).variants[loc.index as usize]
-                .1
-                .display(db, edition)
-                .to_string()
+            loc.name.display(db, edition).to_string()
         }
         InferBodyId::AnonConstId(_) => "{const}".to_owned(),
     };

--- a/crates/hir-ty/src/mir/pretty.rs
+++ b/crates/hir-ty/src/mir/pretty.rs
@@ -341,9 +341,7 @@ impl<'a, 'db> MirPrettyCtx<'a, 'db> {
                             w!(
                                 this,
                                 " as {}).{}",
-                                loc.parent.enum_variants(this.db).variants[loc.index as usize]
-                                    .1
-                                    .display(this.db, this.display_target.edition),
+                                loc.name.display(this.db, this.display_target.edition),
                                 name.display(this.db, this.display_target.edition)
                             );
                         }

--- a/crates/hir-ty/src/next_solver/interner.rs
+++ b/crates/hir-ty/src/next_solver/interner.rs
@@ -608,8 +608,8 @@ impl<'db> inherent::AdtDef<DbInterner<'db>> for AdtDef {
             hir_def::AdtId::EnumId(id) => id
                 .enum_variants(db)
                 .variants
-                .iter()
-                .flat_map(|&(variant_id, _, _)| field_tys(variant_id.into()))
+                .values()
+                .flat_map(|&(variant_id, _)| field_tys(variant_id.into()))
                 .collect(),
         };
 

--- a/crates/hir-ty/src/opaques.rs
+++ b/crates/hir-ty/src/opaques.rs
@@ -132,7 +132,7 @@ pub(crate) fn tait_hidden_types(
     let param_env =
         db.trait_environment(ExpressionStoreOwnerId::from(GenericDefId::from(type_alias)));
 
-    let defining_bodies = tait_defining_bodies(db, &loc);
+    let defining_bodies = tait_defining_bodies(db, loc);
 
     let mut result = ArenaMap::with_capacity(taits_count);
     for defining_body in defining_bodies {

--- a/crates/hir-ty/src/representability.rs
+++ b/crates/hir-ty/src/representability.rs
@@ -29,7 +29,7 @@ pub(crate) fn representability(db: &dyn HirDatabase, id: AdtId) -> Representabil
         AdtId::StructId(id) => variant_representability(db, id.into()),
         AdtId::UnionId(id) => variant_representability(db, id.into()),
         AdtId::EnumId(id) => {
-            for &(variant, ..) in &id.enum_variants(db).variants {
+            for &(variant, ..) in id.enum_variants(db).variants.values() {
                 rtry!(variant_representability(db, variant.into()));
             }
             Representability::Representable
@@ -105,7 +105,7 @@ fn params_in_repr(db: &dyn HirDatabase, def_id: AdtId) -> Box<[bool]> {
         AdtId::StructId(def_id) => handle_variant(def_id.into()),
         AdtId::UnionId(def_id) => handle_variant(def_id.into()),
         AdtId::EnumId(def_id) => {
-            for &(variant, ..) in &def_id.enum_variants(db).variants {
+            for &(variant, ..) in def_id.enum_variants(db).variants.values() {
                 handle_variant(variant.into());
             }
         }

--- a/crates/hir-ty/src/tests.rs
+++ b/crates/hir-ty/src/tests.rs
@@ -460,7 +460,7 @@ fn infer_with_mismatches(content: &str, include_mismatches: bool) -> String {
                         AdtId::EnumId(id) => variants.extend(
                             id.enum_variants(&db)
                                 .variants
-                                .iter()
+                                .values()
                                 .map(|&(variant, ..)| (variant.into(), krate)),
                         ),
                     }
@@ -600,7 +600,7 @@ pub(crate) fn visit_module(
                     visit_body(db, body, cb);
                 }
                 ModuleDefId::AdtId(AdtId::EnumId(it)) => {
-                    it.enum_variants(db).variants.iter().for_each(|&(it, _, _)| {
+                    it.enum_variants(db).variants.values().for_each(|&(it, _)| {
                         let body = Body::of(db, it.into());
                         cb(it.into());
                         visit_body(db, body, cb);

--- a/crates/hir-ty/src/variance.rs
+++ b/crates/hir-ty/src/variance.rs
@@ -135,7 +135,7 @@ impl<'db> Context<'db> {
                     AdtId::StructId(s) => add_constraints_from_variant(VariantId::StructId(s)),
                     AdtId::UnionId(u) => add_constraints_from_variant(VariantId::UnionId(u)),
                     AdtId::EnumId(e) => {
-                        e.enum_variants(db).variants.iter().for_each(|&(variant, _, _)| {
+                        e.enum_variants(db).variants.values().for_each(|&(variant, _)| {
                             add_constraints_from_variant(VariantId::EnumVariantId(variant))
                         });
                     }

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -796,7 +796,7 @@ impl Module {
                                     );
                                 }
                             }
-                            for &(v, _, _) in &variants.variants {
+                            for &(v, _) in variants.variants.values() {
                                 let source_map = &v.fields_with_source_map(db).1;
                                 push_ty_diagnostics(
                                     db,
@@ -1644,7 +1644,7 @@ impl Enum {
     }
 
     pub fn variants(self, db: &dyn HirDatabase) -> Vec<EnumVariant> {
-        self.id.enum_variants(db).variants.iter().map(|&(id, _, _)| EnumVariant { id }).collect()
+        self.id.enum_variants(db).variants.values().map(|&(id, _)| EnumVariant { id }).collect()
     }
 
     pub fn num_variants(self, db: &dyn HirDatabase) -> usize {
@@ -1763,9 +1763,7 @@ impl EnumVariant {
     }
 
     pub fn name(self, db: &dyn HirDatabase) -> Name {
-        let lookup = self.id.lookup(db);
-        let enum_ = lookup.parent;
-        enum_.enum_variants(db).variants[lookup.index as usize].1.clone()
+        self.id.lookup(db).name.clone()
     }
 
     pub fn fields(self, db: &dyn HirDatabase) -> Vec<Field> {
@@ -1800,7 +1798,7 @@ impl EnumVariant {
             layout::Variants::Multiple { variants, .. } => Layout(
                 {
                     let lookup = self.id.lookup(db);
-                    let rustc_enum_variant_idx = RustcEnumVariantIdx(lookup.index as usize);
+                    let rustc_enum_variant_idx = RustcEnumVariantIdx(lookup.index(db));
                     Arc::new(variants[rustc_enum_variant_idx].clone())
                 },
                 db.target_data_layout(parent_enum.krate(db).into()).unwrap(),
@@ -5694,8 +5692,8 @@ impl<'db> Type<'db> {
                             AdtId::EnumId(id) => id
                                 .enum_variants(self.interner.db())
                                 .variants
-                                .iter()
-                                .map(|&(variant_id, _, _)| variant_id_to_fields(variant_id.into()))
+                                .values()
+                                .map(|&(variant_id, _)| variant_id_to_fields(variant_id.into()))
                                 .collect(),
                             AdtId::UnionId(id) => {
                                 vec![variant_id_to_fields(id.into())]

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -7467,11 +7467,11 @@ fn body_param_env_from_has_crate<'db>(
 
 // FIXME: We probably don't want to expose this.
 pub trait MacroCallIdExt {
-    fn loc(self, db: &dyn HirDatabase) -> hir_expand::MacroCallLoc;
+    fn loc(self, db: &dyn HirDatabase) -> &hir_expand::MacroCallLoc;
 }
 impl MacroCallIdExt for span::MacroCallId {
     #[inline]
-    fn loc(self, db: &dyn HirDatabase) -> hir_expand::MacroCallLoc {
+    fn loc(self, db: &dyn HirDatabase) -> &hir_expand::MacroCallLoc {
         hir_expand::MacroCallId::from(self).loc(db)
     }
 }

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -781,20 +781,18 @@ impl Module {
                             let (variants, diagnostics) = e.id.enum_variants_with_diagnostics(db);
                             let file = e.id.lookup(db).id.file_id;
                             let ast_id_map = db.ast_id_map(file);
-                            if let Some(diagnostics) = &diagnostics {
-                                for diag in diagnostics.iter() {
-                                    acc.push(
-                                        InactiveCode {
-                                            node: InFile::new(
-                                                file,
-                                                ast_id_map.get(diag.ast_id).syntax_node_ptr(),
-                                            ),
-                                            cfg: diag.cfg.clone(),
-                                            opts: diag.opts.clone(),
-                                        }
-                                        .into(),
-                                    );
-                                }
+                            for diag in diagnostics {
+                                acc.push(
+                                    InactiveCode {
+                                        node: InFile::new(
+                                            file,
+                                            ast_id_map.get(diag.ast_id).syntax_node_ptr(),
+                                        ),
+                                        cfg: diag.cfg.clone(),
+                                        opts: diag.opts.clone(),
+                                    }
+                                    .into(),
+                                );
                             }
                             for &(v, _) in variants.variants.values() {
                                 let source_map = &v.fields_with_source_map(db).1;

--- a/crates/hir/src/semantics.rs
+++ b/crates/hir/src/semantics.rs
@@ -1323,7 +1323,7 @@ impl<'db> SemanticsImpl<'db> {
                             .map(|(call_id, item)| {
                                 let item_range = item.syntax().text_range();
                                 let loc = call_id.loc(db);
-                                let text_range = match loc.kind {
+                                let text_range = match &loc.kind {
                                     hir_expand::MacroCallKind::Attr {
                                         censored_attr_ids: attr_ids,
                                         ..
@@ -2436,7 +2436,7 @@ impl<'db> SemanticsImpl<'db> {
             AnyImplId::ImplId(id) => id,
             AnyImplId::BuiltinDeriveImplId(id) => return Some(id.loc(self.db).adt.into()),
         };
-        let source = hir_def::src::HasSource::ast_ptr(&id.loc(self.db), self.db);
+        let source = hir_def::src::HasSource::ast_ptr(id.loc(self.db), self.db);
         let mut file_id = source.file_id;
         let adt_ast_id = loop {
             let macro_call = file_id.macro_file()?;

--- a/crates/hir/src/semantics/child_by_source.rs
+++ b/crates/hir/src/semantics/child_by_source.rs
@@ -202,7 +202,7 @@ impl ChildBySource for EnumId {
 
         let ast_id_map = db.ast_id_map(loc.id.file_id);
 
-        self.enum_variants(db).variants.iter().for_each(|&(variant, _, _)| {
+        self.enum_variants(db).variants.values().for_each(|&(variant, _)| {
             res[keys::ENUM_VARIANT].insert(ast_id_map.get(variant.lookup(db).id.value), variant);
         });
         let (_, source_map) = EnumSignature::with_source_map(db, *self);

--- a/crates/hir/src/symbols.rs
+++ b/crates/hir/src/symbols.rs
@@ -190,7 +190,7 @@ impl<'a> SymbolCollector<'a> {
                     let enum_name = Symbol::intern(EnumSignature::of(this.db, id).name.as_str());
                     this.with_container_name(Some(enum_name), |this| {
                         let variants = id.enum_variants(this.db);
-                        for (variant_id, variant_name, _) in &variants.variants {
+                        for (variant_name, (variant_id, _)) in &variants.variants {
                             this.push_decl(*variant_id, variant_name, true, None);
                         }
                     });

--- a/crates/ide/src/navigation_target.rs
+++ b/crates/ide/src/navigation_target.rs
@@ -964,7 +964,7 @@ pub(crate) fn orig_range_with_focus_r(
                             // *should* contain the name
                             _ => {
                                 let call = call();
-                                let kind = call.kind;
+                                let kind = &call.kind;
                                 let range = kind.clone().original_call_range_with_input(db);
                                 //If the focus range is in the attribute/derive body, we
                                 // need to point the call site to the entire body, if not, fall back


### PR DESCRIPTION
The most important reason is incrementality. While not a lot of things depend on the stability of `EnumVariantId`, it's still useful to have them stable.

However it turns out that many things actually do want the name, more than those that want the index.

Best reviewed commit by commit. Blocked on https://github.com/rust-lang/rust-analyzer/pull/22328.