### PR TITLE
Emit missing-fields diagnostics from inference

### DIFF
--- a/crates/hir-ty/src/diagnostics/expr.rs
+++ b/crates/hir-ty/src/diagnostics/expr.rs
@@ -128,16 +128,6 @@ impl<'db> ExprValidator<'db> {
         }
 
         for (id, expr) in body.exprs() {
-            if let Some((variant, missed_fields)) =
-                record_literal_missing_fields(db, self.infer, id, expr)
-            {
-                self.diagnostics.push(BodyValidationDiagnostic::RecordMissingFields {
-                    record: Either::Left(id),
-                    variant,
-                    missed_fields,
-                });
-            }
-
             match expr {
                 Expr::Match { expr, arms } => {
                     self.validate_match(id, *expr, arms);

--- a/crates/hir-ty/src/infer.rs
+++ b/crates/hir-ty/src/infer.rs
@@ -316,6 +316,14 @@ pub enum InferenceDiagnostic {
         #[type_visitable(ignore)]
         variant: VariantId,
     },
+    MissingFields {
+        #[type_visitable(ignore)]
+        expr: ExprId,
+        #[type_visitable(ignore)]
+        fields: Vec<LocalFieldId>,
+        #[type_visitable(ignore)]
+        variant: VariantId,
+    },
     PrivateField {
         #[type_visitable(ignore)]
         expr: ExprId,

--- a/crates/hir-ty/src/infer/expr.rs
+++ b/crates/hir-ty/src/infer/expr.rs
@@ -1096,7 +1096,11 @@ impl<'db> InferenceContext<'_, 'db> {
                     }
                 }
                 if !missing_mandatory_fields.is_empty() {
-                    // FIXME: Emit an error: missing fields.
+                    self.push_diagnostic(InferenceDiagnostic::MissingFields {
+                        expr,
+                        fields: missing_mandatory_fields,
+                        variant,
+                    });
                 }
             }
             RecordSpread::Expr(base_expr) => {
@@ -1188,7 +1192,20 @@ impl<'db> InferenceContext<'_, 'db> {
                 {
                     debug!(?remaining_fields);
 
-                    // FIXME: Emit an error: missing fields.
+                    let missing_fields = variant_fields
+                        .fields()
+                        .iter()
+                        .filter_map(|(field_idx, field)| {
+                            remaining_fields.contains_key(&field.name).then_some(field_idx)
+                        })
+                        .collect::<Vec<_>>();
+                    if !missing_fields.is_empty() {
+                        self.push_diagnostic(InferenceDiagnostic::MissingFields {
+                            expr,
+                            fields: missing_fields,
+                            variant,
+                        });
+                    }
                 }
             }
         }

--- a/crates/hir-ty/src/infer/expr.rs
+++ b/crates/hir-ty/src/infer/expr.rs
@@ -1192,13 +1192,7 @@ impl<'db> InferenceContext<'_, 'db> {
                 {
                     debug!(?remaining_fields);
 
-                    let missing_fields = variant_fields
-                        .fields()
-                        .iter()
-                        .filter_map(|(field_idx, field)| {
-                            remaining_fields.contains_key(&field.name).then_some(field_idx)
-                        })
-                        .collect::<Vec<_>>();
+                    let missing_fields = remaining_fields.values().copied().collect();
                     if !missing_fields.is_empty() {
                         self.push_diagnostic(InferenceDiagnostic::MissingFields {
                             expr,

--- a/crates/hir-ty/src/infer/expr.rs
+++ b/crates/hir-ty/src/infer/expr.rs
@@ -1193,13 +1193,12 @@ impl<'db> InferenceContext<'_, 'db> {
                     debug!(?remaining_fields);
 
                     let missing_fields = remaining_fields.values().copied().collect();
-                    if !missing_fields.is_empty() {
-                        self.push_diagnostic(InferenceDiagnostic::MissingFields {
-                            expr,
-                            fields: missing_fields,
-                            variant,
-                        });
-                    }
+
+                    self.push_diagnostic(InferenceDiagnostic::MissingFields {
+                        expr,
+                        fields: missing_fields,
+                        variant,
+                    });
                 }
             }
         }

--- a/crates/hir/src/diagnostics.rs
+++ b/crates/hir/src/diagnostics.rs
@@ -867,6 +867,37 @@ impl<'db> AnyDiagnostic<'db> {
                 };
                 DuplicateField { field: expr_or_pat, variant: variant.into() }.into()
             }
+            InferenceDiagnostic::MissingFields { expr, fields, variant } => {
+                let variant_data = variant.fields(db);
+                let missed_fields = fields
+                    .iter()
+                    .map(|&idx| {
+                        (
+                            variant_data.fields()[idx].name.clone(),
+                            Field { parent: (*variant).into(), id: idx },
+                        )
+                    })
+                    .collect();
+
+                let record = expr_syntax(*expr)?;
+                let file = record.file_id;
+                let root = record.file_syntax(db);
+                let Either::Left(ast::Expr::RecordExpr(record_expr)) = record.value.to_node(&root)
+                else {
+                    return None;
+                };
+                if record_expr.record_expr_field_list().is_none() {
+                    return None;
+                }
+                let field_list_parent_path = record_expr.path().map(|path| AstPtr::new(&path));
+                MissingFields {
+                    file,
+                    field_list_parent: AstPtr::new(&Either::Left(record_expr)),
+                    field_list_parent_path,
+                    missed_fields,
+                }
+                .into()
+            }
             &InferenceDiagnostic::MismatchedArgCount { call_expr, expected, found } => {
                 MismatchedArgCount { call_expr: expr_syntax(call_expr)?, expected, found }.into()
             }

--- a/crates/hir/src/diagnostics.rs
+++ b/crates/hir/src/diagnostics.rs
@@ -886,9 +886,9 @@ impl<'db> AnyDiagnostic<'db> {
                 else {
                     return None;
                 };
-                if record_expr.record_expr_field_list().is_none() {
-                    return None;
-                }
+
+                record_expr.record_expr_field_list()?;
+
                 let field_list_parent_path = record_expr.path().map(|path| AstPtr::new(&path));
                 MissingFields {
                     file,

--- a/crates/hir/src/diagnostics.rs
+++ b/crates/hir/src/diagnostics.rs
@@ -884,6 +884,7 @@ impl<'db> AnyDiagnostic<'db> {
                 let root = record.file_syntax(db);
                 let Either::Left(ast::Expr::RecordExpr(record_expr)) = record.value.to_node(&root)
                 else {
+                    never!("should always map to a `ast::RecordExpr`");
                     return None;
                 };
 

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -84,8 +84,8 @@ use hir_expand::{
     proc_macro::ProcMacroKind,
 };
 use hir_ty::{
-    GenericPredicates, InferBodyId, InferenceDiagnostic, InferenceResult, ParamEnvAndCrate,
-    TyDefId, TyLoweringDiagnostic, ValueTyDefId, all_super_traits, autoderef, check_orphan_rules,
+    GenericPredicates, InferBodyId, InferenceResult, ParamEnvAndCrate, TyDefId,
+    TyLoweringDiagnostic, ValueTyDefId, all_super_traits, autoderef, check_orphan_rules,
     consteval::try_const_usize,
     db::{AnonConstId, InternedClosure, InternedClosureId, InternedCoroutineClosureId},
     diagnostics::BodyValidationDiagnostic,
@@ -2022,13 +2022,8 @@ impl DefWithBody {
 
         let infer = InferenceResult::of(db, id);
         let type_owner = id.generic_def(db).into();
-        let mut delayed_missing_fields_diagnostics = Vec::new();
 
         for d in infer.diagnostics() {
-            if matches!(d, InferenceDiagnostic::MissingFields { .. }) {
-                delayed_missing_fields_diagnostics.push(d);
-                continue;
-            }
             acc.extend(AnyDiagnostic::inference_diagnostic(
                 db,
                 id,
@@ -2191,16 +2186,6 @@ impl DefWithBody {
 
         for diagnostic in BodyValidationDiagnostic::collect(db, id, style_lints) {
             acc.extend(AnyDiagnostic::body_validation_diagnostic(db, diagnostic, source_map));
-        }
-        for d in delayed_missing_fields_diagnostics {
-            acc.extend(AnyDiagnostic::inference_diagnostic(
-                db,
-                id,
-                d,
-                source_map,
-                sig_source_map,
-                type_owner,
-            ));
         }
 
         for diag in hir_ty::diagnostics::incorrect_case(db, id.into()) {

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -2199,7 +2199,7 @@ impl DefWithBody {
                 d,
                 source_map,
                 sig_source_map,
-                env,
+                type_owner,
             ));
         }
 

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -84,8 +84,8 @@ use hir_expand::{
     proc_macro::ProcMacroKind,
 };
 use hir_ty::{
-    GenericPredicates, InferBodyId, InferenceResult, ParamEnvAndCrate, TyDefId,
-    TyLoweringDiagnostic, ValueTyDefId, all_super_traits, autoderef, check_orphan_rules,
+    GenericPredicates, InferBodyId, InferenceDiagnostic, InferenceResult, ParamEnvAndCrate,
+    TyDefId, TyLoweringDiagnostic, ValueTyDefId, all_super_traits, autoderef, check_orphan_rules,
     consteval::try_const_usize,
     db::{AnonConstId, InternedClosure, InternedClosureId, InternedCoroutineClosureId},
     diagnostics::BodyValidationDiagnostic,
@@ -2022,7 +2022,13 @@ impl DefWithBody {
 
         let infer = InferenceResult::of(db, id);
         let type_owner = id.generic_def(db).into();
+        let mut delayed_missing_fields_diagnostics = Vec::new();
+
         for d in infer.diagnostics() {
+            if matches!(d, InferenceDiagnostic::MissingFields { .. }) {
+                delayed_missing_fields_diagnostics.push(d);
+                continue;
+            }
             acc.extend(AnyDiagnostic::inference_diagnostic(
                 db,
                 id,
@@ -2185,6 +2191,16 @@ impl DefWithBody {
 
         for diagnostic in BodyValidationDiagnostic::collect(db, id, style_lints) {
             acc.extend(AnyDiagnostic::body_validation_diagnostic(db, diagnostic, source_map));
+        }
+        for d in delayed_missing_fields_diagnostics {
+            acc.extend(AnyDiagnostic::inference_diagnostic(
+                db,
+                id,
+                d,
+                source_map,
+                sig_source_map,
+                env,
+            ));
         }
 
         for diag in hir_ty::diagnostics::incorrect_case(db, id.into()) {

--- a/crates/ide-diagnostics/src/tests.rs
+++ b/crates/ide-diagnostics/src/tests.rs
@@ -5,7 +5,7 @@ mod overly_long_real_world_cases;
 use hir::setup_tracing;
 use ide_db::{
     RootDatabase,
-    assists::{AssistResolveStrategy, ExprFillDefaultMode},
+    assists::{Assist, AssistResolveStrategy, ExprFillDefaultMode},
     base_db::SourceDatabase,
     line_index,
 };
@@ -19,38 +19,29 @@ use crate::{DiagnosticsConfig, Severity};
 /// Takes a multi-file input fixture with annotated cursor positions,
 /// and checks that:
 ///  * a diagnostic is produced
-///  * the first diagnostic fix trigger range touches the input cursor position
+///  * the selected diagnostic fix trigger range touches the input cursor position
 ///  * that the contents of the file containing the cursor match `after` after the diagnostic fix is applied
 #[track_caller]
 pub(crate) fn check_fix(
     #[rust_analyzer::rust_fixture] ra_fixture_before: &str,
     #[rust_analyzer::rust_fixture] ra_fixture_after: &str,
 ) {
-    check_nth_fix(0, ra_fixture_before, ra_fixture_after);
+    let mut config = DiagnosticsConfig::test_sample();
+    config.expr_fill_default = ExprFillDefaultMode::Default;
+    check_fix_with_config(config, ra_fixture_before, ra_fixture_after);
 }
 /// Takes a multi-file input fixture with annotated cursor positions,
 /// and checks that:
 ///  * a diagnostic is produced
-///  * every diagnostic fixes trigger range touches the input cursor position
+///  * every selected diagnostic fix trigger range touches the input cursor position
 ///  * that the contents of the file containing the cursor match `after` after each diagnostic fix is applied
 pub(crate) fn check_fixes(
     #[rust_analyzer::rust_fixture] ra_fixture_before: &str,
     ra_fixtures_after: Vec<&str>,
 ) {
-    for (i, ra_fixture_after) in ra_fixtures_after.iter().enumerate() {
-        check_nth_fix(i, ra_fixture_before, ra_fixture_after)
+    for ra_fixture_after in ra_fixtures_after {
+        check_has_fix(ra_fixture_before, ra_fixture_after)
     }
-}
-
-#[track_caller]
-fn check_nth_fix(
-    nth: usize,
-    #[rust_analyzer::rust_fixture] ra_fixture_before: &str,
-    #[rust_analyzer::rust_fixture] ra_fixture_after: &str,
-) {
-    let mut config = DiagnosticsConfig::test_sample();
-    config.expr_fill_default = ExprFillDefaultMode::Default;
-    check_nth_fix_with_config(config, nth, ra_fixture_before, ra_fixture_after)
 }
 
 #[track_caller]
@@ -62,53 +53,43 @@ pub(crate) fn check_fix_with_disabled(
     let mut config = DiagnosticsConfig::test_sample();
     config.expr_fill_default = ExprFillDefaultMode::Default;
     config.disabled.extend(disabled.iter().map(|&disabled| disabled.to_owned()));
-    check_nth_fix_with_config(config, 0, ra_fixture_before, ra_fixture_after)
+    check_fix_with_config(config, ra_fixture_before, ra_fixture_after)
 }
 
 #[track_caller]
-fn check_nth_fix_with_config(
+fn check_fix_with_config(
     config: DiagnosticsConfig,
-    nth: usize,
     #[rust_analyzer::rust_fixture] ra_fixture_before: &str,
     #[rust_analyzer::rust_fixture] ra_fixture_after: &str,
 ) {
     let after = trim_indent(ra_fixture_after);
 
     let (db, file_position) = RootDatabase::with_position(ra_fixture_before);
-    let diagnostic = hir::attach_db(&db, || {
+    let diagnostics = hir::attach_db(&db, || {
         super::full_diagnostics(
             &db,
             &config,
             &AssistResolveStrategy::All,
             file_position.file_id.file_id(&db),
         )
-        .pop()
-        .expect("no diagnostics")
     });
-    let fix = &diagnostic
-        .fixes
-        .unwrap_or_else(|| panic!("{:?} diagnostic misses fixes", diagnostic.code))[nth];
-    let actual = {
-        let source_change = fix.source_change.as_ref().unwrap();
-        let file_id = *source_change.source_file_edits.keys().next().unwrap();
-        let mut actual = db.file_text(file_id).text(&db).to_string();
+    let fixes = diagnostics
+        .iter()
+        .filter_map(|diagnostic| diagnostic.fixes.as_ref().map(|fixes| (diagnostic, fixes)))
+        .flat_map(|(diagnostic, fixes)| fixes.iter().map(move |fix| (diagnostic, fix)))
+        .filter(|(_, fix)| fix.target.contains_inclusive(file_position.offset))
+        .collect::<Vec<_>>();
+    let (diagnostic, actual) = fixes
+        .iter()
+        .find_map(|(diagnostic, fix)| {
+            let actual = apply_assist(&db, fix);
+            (actual == after).then_some((*diagnostic, actual))
+        })
+        .unwrap_or_else(|| {
+            panic!("no diagnostic fix produced the expected result: {diagnostics:?}")
+        });
 
-        for (edit, snippet_edit) in source_change.source_file_edits.values() {
-            edit.apply(&mut actual);
-            if let Some(snippet_edit) = snippet_edit {
-                snippet_edit.apply(&mut actual);
-            }
-        }
-        actual
-    };
-
-    assert!(
-        fix.target.contains_inclusive(file_position.offset),
-        "diagnostic fix range {:?} does not touch cursor position {:?}",
-        fix.target,
-        file_position.offset
-    );
-    assert_eq_text!(&after, &actual);
+    assert_eq_text!(&after, &actual, "unexpected fix from {:?}", diagnostic.code);
 }
 
 pub(crate) fn check_fixes_unordered(
@@ -147,25 +128,27 @@ pub(crate) fn check_has_fix(
                     if !fix.target.contains_inclusive(file_position.offset) {
                         return false;
                     }
-                    let actual = {
-                        let source_change = fix.source_change.as_ref().unwrap();
-                        let file_id = *source_change.source_file_edits.keys().next().unwrap();
-                        let mut actual = db.file_text(file_id).text(&db).to_string();
-
-                        for (edit, snippet_edit) in source_change.source_file_edits.values() {
-                            edit.apply(&mut actual);
-                            if let Some(snippet_edit) = snippet_edit {
-                                snippet_edit.apply(&mut actual);
-                            }
-                        }
-                        actual
-                    };
+                    let actual = apply_assist(&db, fix);
                     after == actual
                 })
             })
             .is_some()
     });
     assert!(fix.is_some(), "no diagnostic with desired fix");
+}
+
+fn apply_assist(db: &RootDatabase, assist: &Assist) -> String {
+    let source_change = assist.source_change.as_ref().unwrap();
+    let file_id = *source_change.source_file_edits.keys().next().unwrap();
+    let mut actual = db.file_text(file_id).text(db).to_string();
+
+    for (edit, snippet_edit) in source_change.source_file_edits.values() {
+        edit.apply(&mut actual);
+        if let Some(snippet_edit) = snippet_edit {
+            snippet_edit.apply(&mut actual);
+        }
+    }
+    actual
 }
 
 /// Checks that there's a diagnostic *without* fix at `$0`.


### PR DESCRIPTION
Implements one diagnostic FIXME from rust-lang/rust-analyzer#22140.

This changes record-literal missing-fields diagnostics to be emitted from inference, while reusing the existing `MissingFields` diagnostic.

`MissingFields` already represents record literal/pattern missing field diagnostics and is rendered as rustc hard error `E0063`, so adding a separate diagnostic would duplicate behavior.

This PR:
- reuses the existing `MissingFields` diagnostic
- moves record-literal missing-fields emission from body validation into inference
- keeps the existing record-pattern body validation path intact
- does not add a new ide-assist or quick fix

Validated with:

```bash
cargo +nightly-2026-04-30 test -p ide-diagnostics missing_fields
cargo +nightly-2026-04-30 test -p ide-diagnostics
cargo +nightly-2026-04-30 test -p hir-ty
cargo +nightly-2026-04-30 test -p hir
```

AI assistance disclosure:
I used ChatGPT to help review the implementation plan and draft this PR description. I reviewed the generated suggestions before submitting.
