### PR TITLE
ide-diagnostics: emit error for explicit destructor calls

### DIFF
--- a/crates/hir-ty/src/infer.rs
+++ b/crates/hir-ty/src/infer.rs
@@ -437,6 +437,10 @@ pub enum InferenceDiagnostic {
         #[type_visitable(ignore)]
         has_self_arg: bool,
     },
+    ExplicitDestructorCall {
+        #[type_visitable(ignore)]
+        expr: ExprId,
+    },
     InvalidLhsOfAssignment {
         #[type_visitable(ignore)]
         lhs: ExprId,

--- a/crates/hir-ty/src/method_resolution/confirm.rs
+++ b/crates/hir-ty/src/method_resolution/confirm.rs
@@ -582,7 +582,9 @@ impl<'a, 'b, 'db> ConfirmContext<'a, 'b, 'db> {
     fn check_for_illegal_method_calls(&self) {
         // Disallow calls to the method `drop` defined in the `Drop` trait.
         if self.ctx.lang_items.Drop_drop.is_some_and(|drop_fn| drop_fn == self.candidate) {
-            // FIXME: Report an error.
+            self.ctx.push_diagnostic(InferenceDiagnostic::ExplicitDestructorCall {
+                expr: self.call_expr,
+            });
         }
     }
 

--- a/crates/hir/src/diagnostics.rs
+++ b/crates/hir/src/diagnostics.rs
@@ -105,6 +105,7 @@ diagnostics![AnyDiagnostic<'db> ->
     CastToUnsized<'db>,
     ExpectedArrayOrSlicePat<'db>,
     ExpectedFunction<'db>,
+    ExplicitDestructorCall,
     FunctionalRecordUpdateOnNonStruct,
     GenericDefaultRefersToSelf,
     InactiveCode,
@@ -307,6 +308,11 @@ pub struct ExpectedArrayOrSlicePat<'db> {
 pub struct ExpectedFunction<'db> {
     pub call: InFile<ExprOrPatPtr>,
     pub found: Type<'db>,
+}
+
+#[derive(Debug)]
+pub struct ExplicitDestructorCall {
+    pub expr: InFile<ExprOrPatPtr>,
 }
 
 #[derive(Debug)]
@@ -874,6 +880,9 @@ impl<'db> AnyDiagnostic<'db> {
             }
             &InferenceDiagnostic::FunctionalRecordUpdateOnNonStruct { base_expr } => {
                 FunctionalRecordUpdateOnNonStruct { base_expr: expr_syntax(base_expr)? }.into()
+            }
+            &InferenceDiagnostic::ExplicitDestructorCall { expr } => {
+                ExplicitDestructorCall { expr: expr_syntax(expr)? }.into()
             }
             InferenceDiagnostic::TypedHole { expr, expected } => {
                 let expr = expr_syntax(*expr)?;

--- a/crates/ide-diagnostics/src/handlers/explicit_destructor_call.rs
+++ b/crates/ide-diagnostics/src/handlers/explicit_destructor_call.rs
@@ -1,0 +1,72 @@
+use crate::{Diagnostic, DiagnosticCode, DiagnosticsContext};
+
+// Diagnostic: explicit-destructor-call
+//
+// This diagnostic is triggered when the method `Drop::drop` is called
+// explicitly.  Use `drop` (the free function in `std::mem`) instead.
+pub(crate) fn explicit_destructor_call(
+    ctx: &DiagnosticsContext<'_, '_>,
+    d: &hir::ExplicitDestructorCall,
+) -> Diagnostic {
+    Diagnostic::new_with_syntax_node_ptr(
+        ctx,
+        DiagnosticCode::RustcHardError("E0040"),
+        "explicit use of destructor method",
+        d.expr.map(|it| it.into()),
+    )
+    .stable()
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::tests::check_diagnostics;
+
+    #[test]
+    fn explicit_drop_call_on_droppable_value() {
+        check_diagnostics(
+            r#"
+//- minicore: drop, sized
+struct S;
+impl core::ops::Drop for S {
+    fn drop(&mut self) {}
+}
+fn f(mut s: S) {
+    s.drop();
+  //^^^^^^^^ error: explicit use of destructor method
+}
+"#,
+        );
+    }
+
+    #[test]
+    fn free_function_drop_is_allowed() {
+        check_diagnostics(
+            r#"
+//- minicore: drop, sized
+struct S;
+impl core::ops::Drop for S {
+    fn drop(&mut self) {}
+}
+fn f(s: S) {
+    drop(s);
+}
+"#,
+        );
+    }
+
+    #[test]
+    fn inherent_method_named_drop_is_allowed() {
+        check_diagnostics(
+            r#"
+//- minicore: drop, sized
+struct S;
+impl S {
+    fn drop(&self) {}
+}
+fn f(s: S) {
+    s.drop();
+}
+"#,
+        );
+    }
+}

--- a/crates/ide-diagnostics/src/lib.rs
+++ b/crates/ide-diagnostics/src/lib.rs
@@ -36,6 +36,7 @@ mod handlers {
     pub(crate) mod elided_lifetimes_in_path;
     pub(crate) mod expected_array_or_slice_pat;
     pub(crate) mod expected_function;
+    pub(crate) mod explicit_destructor_call;
     pub(crate) mod functional_record_update_on_non_struct;
     pub(crate) mod generic_args_prohibited;
     pub(crate) mod generic_default_refers_to_self;
@@ -428,6 +429,7 @@ pub fn semantic_diagnostics(
             AnyDiagnostic::CastToUnsized(d) => handlers::invalid_cast::cast_to_unsized(&ctx, &d),
             AnyDiagnostic::ExpectedArrayOrSlicePat(d) => handlers::expected_array_or_slice_pat::expected_array_or_slice_pat(&ctx, &d),
             AnyDiagnostic::ExpectedFunction(d) => handlers::expected_function::expected_function(&ctx, &d),
+            AnyDiagnostic::ExplicitDestructorCall(d) => handlers::explicit_destructor_call::explicit_destructor_call(&ctx, &d),
             AnyDiagnostic::FunctionalRecordUpdateOnNonStruct(d) => handlers::functional_record_update_on_non_struct::functional_record_update_on_non_struct(&ctx, &d),
             AnyDiagnostic::InactiveCode(d) => match handlers::inactive_code::inactive_code(&ctx, &d) {
                 Some(it) => it,


### PR DESCRIPTION
Resolves a FIXME in check_for_illegal_method_calls at hir-ty/src/method_resolution/confirm.rs that previously allowed expressions like `s.drop()` to type-check without error.  Adds an InferenceDiagnostic::ExplicitDestructorCall variant, plumbs the cooked diagnostic through hir, and renders it as RustcHardError E0040 ("explicit use of destructor method").

This catches the method-call form only; the UFCS form `Drop::drop(&mut s)` goes through a different resolution path and is out of scope for this FIXME.

Tests: explicit drop call on a Drop-implementing type errors; the free `drop(s)` function does not; an inherent method named `drop` on a non-Drop type does not.

Part of rust-lang/rust-analyzer#22140.