### PR TITLE
fix: duplicated words in stdx/assert.rs and ide/inject.rs doc-comments

### DIFF
--- a/crates/ide/src/syntax_highlighting/inject.rs
+++ b/crates/ide/src/syntax_highlighting/inject.rs
@@ -177,7 +177,7 @@ pub(super) fn doc_comment(
         match sema.first_crate(vfs_file_id) {
             Some(krate) => krate.base().data(sema.db).proc_macro_cwd.clone(),
             None => {
-                // Arbitrarily pick /, since from_single_file treats this file as as /main.rs anyway.
+                // Arbitrarily pick /, since from_single_file treats this file as /main.rs anyway.
                 Arc::new(ide_db::base_db::AbsPathBuf::try_from("/").unwrap())
             }
         }

--- a/crates/stdx/src/assert.rs
+++ b/crates/stdx/src/assert.rs
@@ -43,7 +43,7 @@
 
 /// Asserts that the condition is always true and returns its actual value.
 ///
-/// If the condition is true does nothing and and evaluates to true.
+/// If the condition is true does nothing and evaluates to true.
 ///
 /// If the condition is false:
 /// * panics if `force` feature or `debug_assertions` are enabled,
@@ -71,7 +71,7 @@ macro_rules! always {
 
 /// Asserts that the condition is never true and returns its actual value.
 ///
-/// If the condition is false does nothing and and evaluates to false.
+/// If the condition is false does nothing and evaluates to false.
 ///
 /// If the condition is true:
 /// * panics if `force` feature or `debug_assertions` are enabled,


### PR DESCRIPTION
Three one-line typo fixes for duplicated words in doc-comments:
- `crates/stdx/src/assert.rs` — "/// If the condition is true does nothing and and evaluates to true." → "...does nothing and evaluates to true."
- `crates/stdx/src/assert.rs` — "/// If the condition is false does nothing and and evaluates to false." → "...does nothing and evaluates to false."
- `crates/ide/src/syntax_highlighting/inject.rs` — "// Arbitrarily pick /, since from_single_file treats this file as as /main.rs anyway." → "...treats this file as /main.rs anyway."

No code/behavior change.