### PR TITLE
fix: show Run lens for fn main in bench targets

### DIFF
--- a/crates/rust-analyzer/src/handlers/request.rs
+++ b/crates/rust-analyzer/src/handlers/request.rs
@@ -1662,7 +1662,10 @@ pub(crate) fn handle_code_lens(
                 .map(|spec| {
                     matches!(
                         spec.target_kind(),
-                        TargetKind::Bin | TargetKind::Example | TargetKind::Test
+                        TargetKind::Bin
+                            | TargetKind::Example
+                            | TargetKind::Test
+                            | TargetKind::Bench
                     )
                 })
                 .unwrap_or(false),
@@ -2345,7 +2348,7 @@ fn should_skip_target(runnable: &Runnable, cargo_spec: Option<&TargetSpec>) -> b
             match &cargo_spec {
                 Some(spec) => !matches!(
                     spec.target_kind(),
-                    TargetKind::Bin | TargetKind::Example | TargetKind::Test
+                    TargetKind::Bin | TargetKind::Example | TargetKind::Test | TargetKind::Bench
                 ),
                 None => true,
             }


### PR DESCRIPTION
`crates/rust-analyzer/src/handlers/request.rs` enumerates `TargetKind::Bin | TargetKind::Example | TargetKind::Test` in two places (code-lens annotation config at line 1660 and `should_skip_target` at line 2341) but omits `TargetKind::Bench`.  The existing analogous list in `target_spec.rs:255` does include `Bench`, so this looks like a copy-paste oversight.  Result: a `fn main()` in `benches/*.rs` with `harness = false` produces a `RunnableKind::Bin` runnable, but the annotation layer's `should_skip_runnable` skips it because the LSP config passes `binary_target = false` for bench targets.

Closes rust-lang/rust-analyzer#21948.