### PR TITLE
Show `const` in the signature help if applicable

### DIFF
--- a/crates/ide/src/signature_help.rs
+++ b/crates/ide/src/signature_help.rs
@@ -174,6 +174,9 @@ fn signature_help_for_call(
     match callable.kind() {
         hir::CallableKind::Function(func) => {
             res.doc = func.docs(db).map(Documentation::into_owned);
+            if func.is_const(db) {
+                format_to!(res.signature, "const ");
+            }
             if func.is_async(db) {
                 format_to!(res.signature, "async ");
             }
@@ -2661,6 +2664,24 @@ fn main() {
             expect![[r#"
                 async fn conn_mut<F: FnOnce() -> T, T>(f: F) -> Result<T, i32>
                                                        ^^^^
+            "#]],
+        );
+    }
+
+    #[test]
+    fn test_const_function() {
+        check(
+            r#"
+//- minicore: sized, fn
+pub const fn foo(x: u32, y: u32) -> u32 { x + y }
+
+fn main() {
+    foo($0)
+}
+            "#,
+            expect![[r#"
+                const fn foo(x: u32, y: u32) -> u32
+                             ^^^^^^  ------
             "#]],
         );
     }


### PR DESCRIPTION
Closes https://github.com/rust-lang/rust-analyzer/issues/16701

Before:

<img width="481" height="247" alt="before" src="https://github.com/user-attachments/assets/d7e61beb-53ed-495c-84a9-0212ee475609" />


After:

<img width="516" height="243" alt="after" src="https://github.com/user-attachments/assets/9a5c5ed0-cba0-4ba6-a76f-fa3e4c0d7c7c" />
