### PR TITLE
feat: add inlayHints.typeHints.renderColons option

### DIFF
--- a/crates/ide/src/inlay_hints.rs
+++ b/crates/ide/src/inlay_hints.rs
@@ -302,6 +302,7 @@ fn hints(
 #[derive(Clone, Debug)]
 pub struct InlayHintsConfig<'a> {
     pub render_colons: bool,
+    pub type_hints_render_colons: bool,
     pub type_hints: bool,
     pub type_hints_placement: TypeHintsPlacement,
     pub sized_bound: bool,
@@ -922,6 +923,7 @@ mod tests {
     pub(super) const DISABLED_CONFIG: InlayHintsConfig<'_> = InlayHintsConfig {
         discriminant_hints: DiscriminantHints::Never,
         render_colons: false,
+        type_hints_render_colons: true,
         type_hints: false,
         type_hints_placement: TypeHintsPlacement::Inline,
         parameter_hints: false,

--- a/crates/ide/src/inlay_hints/bind_pat.rs
+++ b/crates/ide/src/inlay_hints/bind_pat.rs
@@ -96,7 +96,9 @@ pub(super) fn hints(
         None
     };
 
-    let render_colons = config.render_colons && !matches!(type_ascriptable, Some(Some(_)));
+    let render_colons = config.render_colons
+        && config.type_hints_render_colons
+        && !matches!(type_ascriptable, Some(Some(_)));
     if render_colons {
         label.prepend_str(": ");
     }
@@ -234,6 +236,88 @@ fn main() {
                 [
                     (
                         20..33,
+                        [
+                            "i32",
+                        ],
+                    ),
+                ]
+            "#]],
+        );
+    }
+
+    #[test]
+    fn type_hints_render_colons_renders_colon_by_default() {
+        let mut config =
+            InlayHintsConfig { type_hints: true, render_colons: true, ..DISABLED_CONFIG };
+        config.type_hints_placement = TypeHintsPlacement::EndOfLine;
+        check_expect(
+            config,
+            r#"
+fn main() {
+    let foo = 92_i32;
+}
+            "#,
+            expect![[r#"
+                [
+                    (
+                        20..33,
+                        [
+                            ": i32",
+                        ],
+                    ),
+                ]
+            "#]],
+        );
+    }
+
+    #[test]
+    fn type_hints_render_colons_suppresses_eol_colon_when_disabled() {
+        let mut config = InlayHintsConfig {
+            type_hints: true,
+            render_colons: true,
+            type_hints_render_colons: false,
+            ..DISABLED_CONFIG
+        };
+        config.type_hints_placement = TypeHintsPlacement::EndOfLine;
+        check_expect(
+            config,
+            r#"
+fn main() {
+    let foo = 92_i32;
+}
+            "#,
+            expect![[r#"
+                [
+                    (
+                        20..33,
+                        [
+                            "i32",
+                        ],
+                    ),
+                ]
+            "#]],
+        );
+    }
+
+    #[test]
+    fn type_hints_render_colons_suppresses_inline_colon_when_disabled() {
+        let config = InlayHintsConfig {
+            type_hints: true,
+            render_colons: true,
+            type_hints_render_colons: false,
+            ..DISABLED_CONFIG
+        };
+        check_expect(
+            config,
+            r#"
+fn main() {
+    let foo = 92_i32;
+}
+            "#,
+            expect![[r#"
+                [
+                    (
+                        20..23,
                         [
                             "i32",
                         ],

--- a/crates/ide/src/static_index.rs
+++ b/crates/ide/src/static_index.rs
@@ -158,6 +158,7 @@ impl StaticIndex<'_> {
             .inlay_hints(
                 &InlayHintsConfig {
                     render_colons: true,
+                    type_hints_render_colons: true,
                     discriminant_hints: crate::DiscriminantHints::Fieldless,
                     type_hints: true,
                     type_hints_placement: TypeHintsPlacement::Inline,

--- a/crates/rust-analyzer/src/cli/analysis_stats.rs
+++ b/crates/rust-analyzer/src/cli/analysis_stats.rs
@@ -1384,6 +1384,7 @@ impl flags::AnalysisStats {
             _ = analysis.inlay_hints(
                 &InlayHintsConfig {
                     render_colons: false,
+                    type_hints_render_colons: true,
                     type_hints: true,
                     type_hints_placement: ide::TypeHintsPlacement::Inline,
                     sized_bound: false,

--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -317,6 +317,11 @@ config_data! {
         /// Where to render type hints relative to their binding pattern.
         inlayHints_typeHints_location: TypeHintsLocation = TypeHintsLocation::Inline,
 
+        /// Whether to render the leading colon for type hints.  When `false`, suppresses
+        /// type-hint colons regardless of placement; parameter-hint colons are still
+        /// controlled by `#rust-analyzer.inlayHints.renderColons#`.
+        inlayHints_typeHints_renderColons: bool = true,
+
         /// Enable the experimental support for interpreting tests.
         interpret_tests: bool = false,
 
@@ -2065,6 +2070,7 @@ impl Config {
 
         InlayHintsConfig {
             render_colons: self.inlayHints_renderColons().to_owned(),
+            type_hints_render_colons: self.inlayHints_typeHints_renderColons().to_owned(),
             type_hints: self.inlayHints_typeHints_enable().to_owned(),
             type_hints_placement: match self.inlayHints_typeHints_location() {
                 TypeHintsLocation::Inline => ide::TypeHintsPlacement::Inline,

--- a/docs/book/src/configuration_generated.md
+++ b/docs/book/src/configuration_generated.md
@@ -1180,6 +1180,15 @@ Default: `"inline"`
 Where to render type hints relative to their binding pattern.
 
 
+## rust-analyzer.inlayHints.typeHints.renderColons {#inlayHints.typeHints.renderColons}
+
+Default: `true`
+
+Whether to render the leading colon for type hints.  When `false`, suppresses
+type-hint colons regardless of placement; parameter-hint colons are still
+controlled by `#rust-analyzer.inlayHints.renderColons#`.
+
+
 ## rust-analyzer.interpret.tests {#interpret.tests}
 
 Default: `false`

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -2556,6 +2556,16 @@
                 }
             },
             {
+                "title": "Inlay Hints",
+                "properties": {
+                    "rust-analyzer.inlayHints.typeHints.renderColons": {
+                        "markdownDescription": "Whether to render the leading colon for type hints.    When `false`, suppresses\ntype-hint colons regardless of placement; parameter-hint colons are still\ncontrolled by `#rust-analyzer.inlayHints.renderColons#`.",
+                        "default": true,
+                        "type": "boolean"
+                    }
+                }
+            },
+            {
                 "title": "Interpret",
                 "properties": {
                     "rust-analyzer.interpret.tests": {


### PR DESCRIPTION
Adds a granular config option requested in rust-lang/rust-analyzer#22305: suppress the leading colon for type hints when `inlayHints.typeHints.location` is `end_of_line`, without disabling colons globally via `inlayHints.renderColons`.

Default is `true`, so current behaviour is preserved unchanged.  Inline-placed type hints are unaffected.