### PR TITLE
fix: no use sad pattern on happy arm with guard

### DIFF
--- a/crates/ide-assists/src/handlers/replace_if_let_with_match.rs
+++ b/crates/ide-assists/src/handlers/replace_if_let_with_match.rs
@@ -171,7 +171,7 @@ fn make_else_arm(
     let (pattern, expr) = if let Some(else_expr) = else_expr {
         let pattern = match conditionals {
             [(None, Some(_), _)] => make.literal_pat("false").into(),
-            [(Some(pat), _, _)] => match ctx
+            [(Some(pat), None, _)] => match ctx
                 .sema
                 .type_of_pat(pat)
                 .and_then(|ty| TryEnum::from_ty(&ctx.sema, &ty.adjusted()))
@@ -956,6 +956,31 @@ fn foo(x: Option<i32>) {
     }
 
     #[test]
+    fn special_case_option_with_guard() {
+        check_assist(
+            replace_if_let_with_match,
+            r#"
+//- minicore: option
+fn foo(x: Option<i32>) {
+    $0if let Some(x) = x && x != 4 {
+        println!("{}", x)
+    } else {
+        println!("none")
+    }
+}
+"#,
+            r#"
+fn foo(x: Option<i32>) {
+    match x {
+        Some(x) if x != 4 => println!("{}", x),
+        _ => println!("none"),
+    }
+}
+"#,
+        );
+    }
+
+    #[test]
     fn special_case_option_ref() {
         check_assist(
             replace_if_let_with_match,
@@ -999,6 +1024,31 @@ fn foo(x: Option<i32>) {
     match x {
         None => println!("none"),
         Some(_) => println!("some"),
+    }
+}
+"#,
+        );
+    }
+
+    #[test]
+    fn special_case_inverted_option_with_guard() {
+        check_assist(
+            replace_if_let_with_match,
+            r#"
+//- minicore: option
+fn foo(x: Option<i32>) {
+    $0if let None = x && other_cond {
+        println!("none")
+    } else {
+        println!("some")
+    }
+}
+"#,
+            r#"
+fn foo(x: Option<i32>) {
+    match x {
+        None if other_cond => println!("none"),
+        _ => println!("some"),
     }
 }
 "#,


### PR DESCRIPTION
For replace_if_let_with_match assist

Example
---
```rust
fn foo(x: Option<i32>) {
    $0if let Some(x) = x && x != 4 {
        println!("{}", x)
    } else {
        println!("none")
    }
}
```

**Before this PR**

```rust
fn foo(x: Option<i32>) {
    match x {
        Some(x) if x != 4 => println!("{}", x),
        None => println!("none"),
    }
}
```

**After this PR**

```rust
fn foo(x: Option<i32>) {
    match x {
        Some(x) if x != 4 => println!("{}", x),
        _ => println!("none"),
    }
}
```
