### PR TITLE
Show `unsafe` in the signature help if applicable

### DIFF
--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -2760,6 +2760,13 @@ impl Function {
         }
     }
 
+    pub fn is_unsafe(self, db: &dyn HirDatabase) -> bool {
+        match self.id {
+            AnyFunctionId::FunctionId(id) => FunctionSignature::of(db, id).is_unsafe(),
+            AnyFunctionId::BuiltinDeriveImplMethod { .. } => false,
+        }
+    }
+
     pub fn is_varargs(self, db: &dyn HirDatabase) -> bool {
         match self.id {
             AnyFunctionId::FunctionId(id) => FunctionSignature::of(db, id).is_varargs(),

--- a/crates/ide/src/signature_help.rs
+++ b/crates/ide/src/signature_help.rs
@@ -180,6 +180,9 @@ fn signature_help_for_call(
             if func.is_async(db) {
                 format_to!(res.signature, "async ");
             }
+            if func.is_unsafe(db) {
+                format_to!(res.signature, "unsafe ");
+            }
             format_to!(res.signature, "fn {}", func.name(db).display(db, edition));
 
             let generic_params = GenericDef::Function(func)
@@ -2682,6 +2685,60 @@ fn main() {
             expect![[r#"
                 const fn foo(x: u32, y: u32) -> u32
                              ^^^^^^  ------
+            "#]],
+        );
+    }
+
+    #[test]
+    fn test_unsafe_function() {
+        check(
+            r#"
+//- minicore: sized, fn
+pub unsafe fn foo(x: u32, y: u32) -> u32 { x + y }
+
+fn main() {
+    unsafe { foo($0) }
+}
+            "#,
+            expect![[r#"
+                unsafe fn foo(x: u32, y: u32) -> u32
+                              ^^^^^^  ------
+            "#]],
+        );
+    }
+
+    #[test]
+    fn test_const_unsafe_function() {
+        check(
+            r#"
+//- minicore: sized, fn
+pub const unsafe fn foo(x: u32, y: u32) -> u32 { x + y }
+
+fn main() {
+    unsafe { foo($0) }
+}
+            "#,
+            expect![[r#"
+                const unsafe fn foo(x: u32, y: u32) -> u32
+                                    ^^^^^^  ------
+            "#]],
+        );
+    }
+
+    #[test]
+    fn test_async_unsafe_function() {
+        check(
+            r#"
+//- minicore: sized, fn, future
+pub async unsafe fn foo(x: u32, y: u32) -> u32 { x + y }
+
+fn main() {
+    unsafe { foo($0) }
+}
+            "#,
+            expect![[r#"
+                async unsafe fn foo(x: u32, y: u32) -> u32
+                                    ^^^^^^  ------
             "#]],
         );
     }


### PR DESCRIPTION
Based on https://github.com/rust-lang/rust-analyzer/pull/22358#issuecomment-4467692850

Before: 

<img width="691" height="283" alt="before" src="https://github.com/user-attachments/assets/5c21ec53-eda3-445e-a6d1-6cf7ad3e0363" />

After:

<img width="702" height="277" alt="after" src="https://github.com/user-attachments/assets/5f21d73f-4743-4e52-a8df-7aaf776cf58e" />
