### PR TITLE
Handle TyKind::{Pat,UnsafeBinder} in has_drop_glue

### DIFF
--- a/crates/hir-ty/src/drop.rs
+++ b/crates/hir-ty/src/drop.rs
@@ -6,7 +6,6 @@ use hir_def::{
 };
 use rustc_hash::FxHashSet;
 use rustc_type_ir::inherent::{AdtDef, GenericArgs as _, IntoKind};
-use stdx::never;
 
 use crate::{
     consteval,
@@ -177,9 +176,7 @@ fn has_drop_glue_impl<'db>(
             }
         }
         TyKind::Infer(..) => unreachable!("inference vars shouldn't exist out of inference"),
-        TyKind::Pat(..) | TyKind::UnsafeBinder(..) => {
-            never!("we do not handle pattern and unsafe binder types");
-            DropGlue::None
-        }
+        TyKind::Pat(ty, _) => has_drop_glue_impl(infcx, ty, env, visited),
+        TyKind::UnsafeBinder(ty) => has_drop_glue_impl(infcx, ty.skip_binder(), env, visited),
     }
 }

--- a/crates/ide/src/hover/tests.rs
+++ b/crates/ide/src/hover/tests.rs
@@ -3153,6 +3153,35 @@ fn test_hover_layout_of_enum() {
 }
 
 #[test]
+fn test_hover_layout_nonzero_type_alias() {
+    check(
+        r#"//- minicore: non_zero
+use core::num;
+trait Trait { type Inner; }
+impl Trait for u8 { type Inner = num::NonZeroU8; }
+#[repr(transparent)]
+struct NonZero<T: Trait>(T::Inner);
+type NonZeroU8$0 = NonZero<u8>;
+"#,
+        expect![[r#"
+            *NonZeroU8*
+
+            ```rust
+            ra_test_fixture
+            ```
+
+            ```rust
+            type NonZeroU8 = NonZero<u8>
+            ```
+
+            ---
+
+            size = 1, align = 1, niches = 1, no Drop
+        "#]],
+    );
+}
+
+#[test]
 fn test_hover_layout_padding_info() {
     check(
         r#"struct $0Foo {


### PR DESCRIPTION
`TyKind::Pat` is hit on stable through `core::num::NonZero*` types which use it internally. `TyKind::UnsafeBinder` isn't hit yet, but added for completeness, since `has_drop_glue` ends up being called on hover.

Sort of a follow-up to https://github.com/rust-lang/rust-analyzer/pull/22368.