### PR TITLE
fix: no complete module colons before exists colons

### DIFF
--- a/crates/ide-completion/src/render.rs
+++ b/crates/ide-completion/src/render.rs
@@ -471,7 +471,9 @@ fn render_resolution_path(
                 .insert_snippet(cap, ""); // set is snippet
         }
     }
-    let allow_module_path = matches!(path_ctx.kind, PathKind::Use) || !config.add_colons_to_module;
+    let allow_module_path = matches!(path_ctx.kind, PathKind::Use)
+        || completion.token.next_token().is_some_and(|it| it.kind() == syntax::T![::])
+        || !config.add_colons_to_module;
     if !allow_module_path && matches!(resolution, ScopeDef::ModuleDef(Module(_))) {
         insert_text = format_smolstr!("{insert_text}::");
         item.lookup_by(name.clone()).label(insert_text.clone());

--- a/crates/ide-completion/src/tests/expression.rs
+++ b/crates/ide-completion/src/tests/expression.rs
@@ -1157,11 +1157,38 @@ fn complete_module_colons() {
         r#"mod module {} fn foo() { module:: }"#,
     );
 
+    check_edit(
+        "module",
+        r#"mod module {} fn foo() { $0foo::bar }"#,
+        r#"mod module {} fn foo() { module::foo::bar }"#,
+    );
+
     check_edit_with_config(
         CompletionConfig { add_colons_to_module: false, ..TEST_CONFIG },
         "module",
         r#"mod module {} fn foo() { $0 }"#,
         r#"mod module {} fn foo() { module }"#,
+    );
+}
+
+#[test]
+fn complete_module_exists_colons() {
+    check_edit(
+        "module",
+        r#"mod module {} fn foo() { $0::bar }"#,
+        r#"mod module {} fn foo() { module::bar }"#,
+    );
+
+    check_edit(
+        "module",
+        r#"
+macro_rules! i { ($i:ident) => { $i::bar } }
+mod module {}
+fn foo() { i!($0) }"#,
+        r#"
+macro_rules! i { ($i:ident) => { $i::bar } }
+mod module {}
+fn foo() { i!(module) }"#,
     );
 }
 


### PR DESCRIPTION
Partial of rust-lang/rust-analyzer#22259
Related https://github.com/rust-lang/rust-analyzer/pull/22259#issuecomment-4467777062

Example
---
```rust
mod module {}
fn foo() { $0::bar }
```

**Before this PR**

```rust
mod module {}
fn foo() { module::::bar }
```

**After this PR**

```rust
mod module {}
fn foo() { module::bar }
```
