### PR TITLE
internal: Ignore workspace/diagnostic/refresh in slow tests

### DIFF
--- a/crates/rust-analyzer/tests/slow-tests/flycheck.rs
+++ b/crates/rust-analyzer/tests/slow-tests/flycheck.rs
@@ -76,7 +76,6 @@ fn main() {
 }
 
 #[test]
-#[ignore = "this test tends to stuck, FIXME: investigate that"]
 fn test_flycheck_diagnostic_with_override_command() {
     if skip_slow_tests() {
         return;
@@ -113,7 +112,6 @@ fn main() {}
 }
 
 #[test]
-#[ignore = "this test tends to stuck, FIXME: investigate that"]
 fn test_flycheck_diagnostics_with_override_command_cleared_after_fix() {
     if skip_slow_tests() {
         return;

--- a/crates/rust-analyzer/tests/slow-tests/support.rs
+++ b/crates/rust-analyzer/tests/slow-tests/support.rs
@@ -372,9 +372,13 @@ impl Server {
                 Message::Request(req) => {
                     if req.method == "client/registerCapability" {
                         let params = req.params.to_string();
-                        if ["workspace/didChangeWatchedFiles", "textDocument/didSave"]
-                            .into_iter()
-                            .any(|it| params.contains(it))
+                        if [
+                            "workspace/diagnostic/refresh",
+                            "workspace/didChangeWatchedFiles",
+                            "textDocument/didSave",
+                        ]
+                        .into_iter()
+                        .any(|it| params.contains(it))
                         {
                             continue;
                         }


### PR DESCRIPTION
Not sure about this, but might fix https://github.com/rust-lang/rust-analyzer/pull/22389#issuecomment-4470210564.