### PR TITLE
fix: Support named consts in range pattern types

### DIFF
--- a/crates/hir-def/src/expr_store/lower.rs
+++ b/crates/hir-def/src/expr_store/lower.rs
@@ -2968,12 +2968,33 @@ impl<'db> ExprCollector<'db> {
     }
 
     fn lower_ty_pat_range_side(&mut self, pat: ast::Pat) -> ExprId {
+        let ptr = AstPtr::new(&pat);
         match &pat {
             ast::Pat::LiteralPat(it) => {
                 let Some((literal, _)) = pat_literal_to_hir(it) else { return self.missing_expr() };
-                self.alloc_expr_from_pat(Expr::Literal(literal), AstPtr::new(&pat))
+                self.alloc_expr_from_pat(Expr::Literal(literal), ptr)
             }
-            _ => self.missing_expr(),
+            ast::Pat::ConstBlockPat(it) => {
+                if let Some(block) = it.block_expr() {
+                    let expr_id = self.with_label_rib(RibKind::Constant, |this| {
+                        this.with_binding_owner(|this| this.collect_block(block))
+                    });
+                    self.alloc_expr_from_pat(Expr::Const(expr_id), ptr)
+                } else {
+                    self.missing_expr()
+                }
+            }
+            ast::Pat::PathPat(it) => {
+                let path = it
+                    .path()
+                    .and_then(|path| self.lower_path(path, &mut Self::impl_trait_error_allocator));
+                self.alloc_expr_from_pat(path.map(Expr::Path).unwrap_or(Expr::Missing), ptr)
+            }
+            ast::Pat::IdentPat(it) if it.is_simple_ident() => {
+                let name = it.name().map(|nr| nr.as_name()).unwrap_or_else(Name::missing);
+                self.alloc_expr_from_pat(Expr::Path(name.into()), ptr)
+            }
+            _ => self.missing_expr(), // FIXME: Emit an error.
         }
     }
 

--- a/crates/hir-ty/src/layout/tests.rs
+++ b/crates/hir-ty/src/layout/tests.rs
@@ -182,6 +182,7 @@ fn check_fail(#[rust_analyzer::rust_fixture] ra_fixture: &str, e: LayoutError) {
     assert_eq!(r, Err(e));
 }
 
+#[rust_analyzer::macro_style(braces)]
 macro_rules! size_and_align {
     (minicore: $($x:tt),*;$($t:tt)*) => {
         {
@@ -535,6 +536,15 @@ fn non_zero_and_non_null() {
         use core::{num::NonZeroU8, ptr::NonNull};
         struct Goal(Option<NonZeroU8>, Option<NonNull<i32>>);
     }
+    check_size_and_align(
+        r#"
+const END: usize = 10;
+struct Goal(core::pattern_type!(usize is 0..=END));
+    "#,
+        "//- minicore: pat\n",
+        8,
+        8,
+    );
 }
 
 #[test]


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust-analyzer/issues/22395. https://github.com/rust-lang/rust-analyzer/pull/22368 is not on prerelease yet, but even with it this issue is not fixed, because `Vec`'s capacity field uses a range pattern type with constant.