### PR TITLE
fix: parse field expr keyword field to field-expr node

### DIFF
--- a/crates/ide-completion/src/context/tests.rs
+++ b/crates/ide-completion/src/context/tests.rs
@@ -810,3 +810,39 @@ fn foo() {
         expect![[r#"ty: bool, name: ?"#]],
     );
 }
+
+#[test]
+fn expected_type_some_incomplete_ast() {
+    check_expected_type_and_name(
+        r#"
+fn foo(x: u32) {
+    foo(y.$0)
+}
+"#,
+        expect!["ty: u32, name: x"],
+    );
+    check_expected_type_and_name(
+        r#"
+fn foo(x: u32) {
+    foo(y.in$0)
+}
+"#,
+        expect!["ty: u32, name: x"],
+    );
+    check_expected_type_and_name(
+        r#"
+fn foo(x: u32) {
+    foo(y::$0)
+}
+"#,
+        expect!["ty: u32, name: x"],
+    );
+    check_expected_type_and_name(
+        r#"
+fn foo(x: u32) {
+    foo(crate::$0)
+}
+"#,
+        expect!["ty: u32, name: x"],
+    );
+}

--- a/crates/parser/src/grammar/expressions.rs
+++ b/crates/parser/src/grammar/expressions.rs
@@ -597,6 +597,14 @@ fn field_expr<const FLOAT_RECOVERY: bool>(
             }
             (false, m) => Ok(m.complete(p, FIELD_EXPR)),
         };
+    } else if !p.at(EOF) && p.current().is_keyword(p.current_edition()) {
+        // test_err field_expr_keyword_field
+        // fn foo() {
+        //     x.ref;
+        //     f(x.ref);
+        //     f(2.ref);
+        // }
+        p.err_and_bump("expected field name or number");
     } else {
         p.error("expected field name or number");
     }

--- a/crates/parser/test_data/generated/runner.rs
+++ b/crates/parser/test_data/generated/runner.rs
@@ -827,6 +827,10 @@ mod err {
     #[test]
     fn empty_segment() { run_and_expect_errors("test_data/parser/inline/err/empty_segment.rs"); }
     #[test]
+    fn field_expr_keyword_field() {
+        run_and_expect_errors("test_data/parser/inline/err/field_expr_keyword_field.rs");
+    }
+    #[test]
     fn fn_pointer_type_missing_fn() {
         run_and_expect_errors("test_data/parser/inline/err/fn_pointer_type_missing_fn.rs");
     }

--- a/crates/parser/test_data/parser/inline/err/field_expr_keyword_field.rast
+++ b/crates/parser/test_data/parser/inline/err/field_expr_keyword_field.rast
@@ -1,0 +1,70 @@
+SOURCE_FILE
+  FN
+    FN_KW "fn"
+    WHITESPACE " "
+    NAME
+      IDENT "foo"
+    PARAM_LIST
+      L_PAREN "("
+      R_PAREN ")"
+    WHITESPACE " "
+    BLOCK_EXPR
+      STMT_LIST
+        L_CURLY "{"
+        WHITESPACE "\n    "
+        EXPR_STMT
+          FIELD_EXPR
+            PATH_EXPR
+              PATH
+                PATH_SEGMENT
+                  NAME_REF
+                    IDENT "x"
+            DOT "."
+            ERROR
+              REF_KW "ref"
+          SEMICOLON ";"
+        WHITESPACE "\n    "
+        EXPR_STMT
+          CALL_EXPR
+            PATH_EXPR
+              PATH
+                PATH_SEGMENT
+                  NAME_REF
+                    IDENT "f"
+            ARG_LIST
+              L_PAREN "("
+              FIELD_EXPR
+                PATH_EXPR
+                  PATH
+                    PATH_SEGMENT
+                      NAME_REF
+                        IDENT "x"
+                DOT "."
+                ERROR
+                  REF_KW "ref"
+              R_PAREN ")"
+          SEMICOLON ";"
+        WHITESPACE "\n    "
+        EXPR_STMT
+          CALL_EXPR
+            PATH_EXPR
+              PATH
+                PATH_SEGMENT
+                  NAME_REF
+                    IDENT "f"
+            ARG_LIST
+              L_PAREN "("
+              FIELD_EXPR
+                LITERAL
+                  INT_NUMBER "2"
+                DOT "."
+                ERROR
+                  REF_KW "ref"
+              R_PAREN ")"
+          SEMICOLON ";"
+        WHITESPACE "\n"
+        R_CURLY "}"
+  WHITESPACE "\n"
+error 17: expected field name or number
+error 30: expected field name or number
+error 44: expected field name or number

--- a/crates/parser/test_data/parser/inline/err/field_expr_keyword_field.rs
+++ b/crates/parser/test_data/parser/inline/err/field_expr_keyword_field.rs
@@ -1,0 +1,5 @@
+fn foo() {
+    x.ref;
+    f(x.ref);
+    f(2.ref);
+}


### PR DESCRIPTION
This makes the completion more coherent and helpful for climbing trees

Example
---
```rust
const _=x.ref
```

**Before this PR**

```
CONST
  CONST_KW "const"
  WHITESPACE " "
  UNDERSCORE "_"
  EQ "="
  FIELD_EXPR
    PATH_EXPR
      PATH
        PATH_SEGMENT
          NAME_REF
            IDENT "x"
    DOT "."
ERROR
  REF_KW "ref"
ERROR
  SEMICOLON ";"
```

**After this PR**

```rust
CONST
  CONST_KW "const"
  WHITESPACE " "
  UNDERSCORE "_"
  EQ "="
  FIELD_EXPR
    PATH_EXPR
      PATH
        PATH_SEGMENT
          NAME_REF
            IDENT "x"
    DOT "."
    ERROR
      REF_KW "ref"
  SEMICOLON ";"
```

---
```rust
struct S { indent: u8 }
fn foo(_: &mut u8) {}
fn main() {
    let mut s = S { indent: 2 };
    foo(s.in$0)
}
```

**Before this PR**

`ty: (), name: ?`

```
indent
```

**After this PR**

`ty: &mut u8, name: ?`

```
&mut indent
indent
```
