### PR TITLE
fix: do not complete semicolon in match-expr place

### DIFF
--- a/crates/ide-completion/src/context.rs
+++ b/crates/ide-completion/src/context.rs
@@ -858,7 +858,13 @@ impl<'a, 'db> CompletionContext<'a, 'db> {
             sema.token_ancestors_with_macros(token.clone()).find(|node| {
                 matches!(
                     node.kind(),
-                    BLOCK_EXPR | MATCH_ARM | CLOSURE_EXPR | ARG_LIST | PAREN_EXPR | ARRAY_EXPR
+                    BLOCK_EXPR
+                        | MATCH_ARM
+                        | CLOSURE_EXPR
+                        | ARG_LIST
+                        | PAREN_EXPR
+                        | ARRAY_EXPR
+                        | MATCH_EXPR
                 )
             })
         {

--- a/crates/ide-completion/src/render/function.rs
+++ b/crates/ide-completion/src/render/function.rs
@@ -952,4 +952,23 @@ fn bar() {
 "#,
         );
     }
+
+    #[test]
+    fn no_semicolon_in_match() {
+        check_edit(
+            r#"foo"#,
+            r#"
+fn foo() {}
+fn bar() {
+    match fo$0 {}
+}
+"#,
+            r#"
+fn foo() {}
+fn bar() {
+    match foo()$0 {}
+}
+"#,
+        );
+    }
 }


### PR DESCRIPTION
Example
---
```rust
fn foo() {}
fn bar() {
    match fo$0 {}
}
```

**Before this PR**

```rust
fn foo() {}
fn bar() {
    match foo();$0 {}
}
```

**After this PR**

```rust
fn foo() {}
fn bar() {
    match foo()$0 {}
}
```
