### PR TITLE
fix: allow wildcard params in foreign fn declarations

### DIFF
--- a/crates/hir-def/src/expr_store/lower.rs
+++ b/crates/hir-def/src/expr_store/lower.rs
@@ -2570,9 +2570,9 @@ impl<'db> ExprCollector<'db> {
     }
 
     fn collect_extern_fn_param(&mut self, pat: Option<ast::Pat>) -> PatId {
-        // `extern` functions cannot have pattern-matched parameters, and furthermore, the identifiers
-        // in their parameters are always interpreted as bindings, even if in a normal function they
-        // won't be, because they would refer to a path pattern.
+        // parameters of functions in `extern` blocks can only be simple identifiers and wildcards.
+        // Furthermore, the identifiers in their parameters are always interpreted as bindings, even
+        // if in a normal function they won't be, because they would refer to a path pattern.
         let Some(pat) = pat else { return self.missing_pat() };
 
         match &pat {
@@ -2588,6 +2588,7 @@ impl<'db> ExprCollector<'db> {
                 self.add_definition_to_binding(binding, pat);
                 pat
             }
+            ast::Pat::WildcardPat(_) => self.collect_pat_top(Some(pat)),
             _ => {
                 self.store.diagnostics.push(ExpressionStoreDiagnostics::PatternArgInExternFn {
                     node: self.expander.in_file(AstPtr::new(&pat)),

--- a/crates/hir-def/src/expr_store/lower.rs
+++ b/crates/hir-def/src/expr_store/lower.rs
@@ -2588,7 +2588,7 @@ impl<'db> ExprCollector<'db> {
                 self.add_definition_to_binding(binding, pat);
                 pat
             }
-            ast::Pat::WildcardPat(_) => self.collect_pat_top(Some(pat)),
+            ast::Pat::WildcardPat(_) => self.alloc_pat(Pat::Wild, AstPtr::new(&pat)),
             _ => {
                 self.store.diagnostics.push(ExpressionStoreDiagnostics::PatternArgInExternFn {
                     node: self.expander.in_file(AstPtr::new(&pat)),

--- a/crates/ide-diagnostics/src/handlers/pattern_arg_in_extern_fn.rs
+++ b/crates/ide-diagnostics/src/handlers/pattern_arg_in_extern_fn.rs
@@ -21,6 +21,24 @@ mod tests {
     use crate::tests::check_diagnostics;
 
     #[test]
+    fn ident_pattern_allowed() {
+        check_diagnostics(
+            r#"
+unsafe extern { fn foo(a: i32); }
+            "#,
+        );
+    }
+
+    #[test]
+    fn wildcard_pattern_allowed() {
+        check_diagnostics(
+            r#"
+unsafe extern { fn foo(_: i32); }
+            "#,
+        );
+    }
+
+    #[test]
     fn tuple_pattern() {
         check_diagnostics(
             r#"


### PR DESCRIPTION
A wildcard `_` param in an extern block produces a [E0130](https://doc.rust-lang.org/stable/error_codes/E0130.html) diagnostic, but compiles just fine.

- accept wildcards in addition to identifiers for parameters in `extern` blocks
- add tests to verify diagnostics are not generated for the simple ident and wildcard case

See https://doc.rust-lang.org/reference/items/external-blocks.html#r-items.extern.fn.param-patterns