### PR TITLE
feat: completions imports exclude supports sub items

### DIFF
--- a/crates/ide-completion/src/completions/flyimport.rs
+++ b/crates/ide-completion/src/completions/flyimport.rs
@@ -389,7 +389,7 @@ fn filter_excluded_flyimport(ctx: &CompletionContext<'_, '_>, import: &LocatedIm
     }
     let method_imported = import.item_to_import != import.original_item;
     if method_imported
-        && (is_exclude_flyimport.is_some()
+        && (is_exclude_flyimport == Some(AutoImportExclusionType::Methods)
             || ctx.exclude_flyimport.contains_key(&import.original_item.into_module_def()))
     {
         // If this is a method, exclude it either if it was excluded itself (which may not be caught above,

--- a/crates/ide-completion/src/completions/flyimport.rs
+++ b/crates/ide-completion/src/completions/flyimport.rs
@@ -389,7 +389,7 @@ fn filter_excluded_flyimport(ctx: &CompletionContext<'_, '_>, import: &LocatedIm
     }
     let method_imported = import.item_to_import != import.original_item;
     if method_imported
-        && (is_exclude_flyimport == Some(AutoImportExclusionType::Methods)
+        && (is_exclude_flyimport.is_some()
             || ctx.exclude_flyimport.contains_key(&import.original_item.into_module_def()))
     {
         // If this is a method, exclude it either if it was excluded itself (which may not be caught above,

--- a/crates/ide-completion/src/config.rs
+++ b/crates/ide-completion/src/config.rs
@@ -44,6 +44,7 @@ pub struct CompletionConfig<'a> {
 pub enum AutoImportExclusionType {
     Always,
     Methods,
+    SubItems,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/crates/ide-completion/src/context.rs
+++ b/crates/ide-completion/src/context.rs
@@ -848,8 +848,23 @@ impl<'a, 'db> CompletionContext<'a, 'db> {
                     .map(|it| (it.into_module_def(), *kind))
             })
             .collect();
+        let exclude_subitems = exclude_flyimport
+            .iter()
+            .flat_map(|it| match it {
+                (ModuleDef::Module(module), AutoImportExclusionType::SubItems) => {
+                    module.scope(db, None)
+                }
+                _ => vec![],
+            })
+            .filter_map(|(_, def)| match def {
+                ScopeDef::ModuleDef(module_def) => Some(module_def),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
         exclude_flyimport
             .extend(exclude_traits.iter().map(|&t| (t.into(), AutoImportExclusionType::Always)));
+        exclude_flyimport
+            .extend(exclude_subitems.into_iter().map(|it| (it, AutoImportExclusionType::Always)));
 
         // FIXME: This should be part of `CompletionAnalysis` / `expand_and_analyze`
         let complete_semicolon = if !config.add_semicolon_to_unit {

--- a/crates/ide-completion/src/tests/expression.rs
+++ b/crates/ide-completion/src/tests/expression.rs
@@ -2967,18 +2967,18 @@ fn flyimport_excluded_mod_items_from_flyimport() {
     check_with_config(
         CompletionConfig {
             exclude_flyimport: vec![(
-                "ra_test_fixture::pack::module2".to_owned(),
+                "ra_test_fixture::xpack::xmodule2".to_owned(),
                 AutoImportExclusionType::SubItems,
             )],
             ..TEST_CONFIG
         },
         r#"
-mod pack {
-    mod module1 {
+mod xpack {
+    mod xmodule1 {
         pub struct XOther;
     }
-    pub mod module2 {
-        pub use super::module1::*;
+    pub mod xmodule2 {
+        pub use super::xmodule1::*;
         pub struct XStruct;
         pub fn xfn() {}
     }
@@ -2989,20 +2989,21 @@ fn foo() {
 }
         "#,
         expect![[r#"
-            ct CONST                   Unit
-            en Enum                    Enum
-            fn foo()                   fn()
-            fn function()              fn()
-            ma makro!(…) macro_rules! makro
+            ct CONST                       Unit
+            en Enum                        Enum
+            fn foo()                       fn()
+            fn function()                  fn()
+            ma makro!(…)     macro_rules! makro
             md module::
-            md pack::
-            sc STATIC                  Unit
-            st Record                Record
-            st Tuple                  Tuple
-            st Unit                    Unit
-            un Union                  Union
-            ev TupleV(…)        TupleV(u32)
-            bt u32                      u32
+            md xmodule2:: (use xpack::xmodule2)
+            md xpack::
+            sc STATIC                      Unit
+            st Record                    Record
+            st Tuple                      Tuple
+            st Unit                        Unit
+            un Union                      Union
+            ev TupleV(…)            TupleV(u32)
+            bt u32                          u32
             kw async
             kw const
             kw crate::

--- a/crates/ide-completion/src/tests/expression.rs
+++ b/crates/ide-completion/src/tests/expression.rs
@@ -2963,6 +2963,83 @@ fn foo() {
 }
 
 #[test]
+fn flyimport_excluded_mod_items_from_flyimport() {
+    check_with_config(
+        CompletionConfig {
+            exclude_flyimport: vec![(
+                "ra_test_fixture::pack::module2".to_owned(),
+                AutoImportExclusionType::SubItems,
+            )],
+            ..TEST_CONFIG
+        },
+        r#"
+mod pack {
+    mod module1 {
+        pub struct XOther;
+    }
+    pub mod module2 {
+        pub use super::module1::*;
+        pub struct XStruct;
+        pub fn xfn() {}
+    }
+}
+
+fn foo() {
+    x$0
+}
+        "#,
+        expect![[r#"
+            ct CONST                   Unit
+            en Enum                    Enum
+            fn foo()                   fn()
+            fn function()              fn()
+            ma makro!(…) macro_rules! makro
+            md module::
+            md pack::
+            sc STATIC                  Unit
+            st Record                Record
+            st Tuple                  Tuple
+            st Unit                    Unit
+            un Union                  Union
+            ev TupleV(…)        TupleV(u32)
+            bt u32                      u32
+            kw async
+            kw const
+            kw crate::
+            kw enum
+            kw extern
+            kw false
+            kw fn
+            kw for
+            kw if
+            kw if let
+            kw impl
+            kw impl for
+            kw let
+            kw letm
+            kw loop
+            kw match
+            kw mod
+            kw return
+            kw self::
+            kw static
+            kw struct
+            kw trait
+            kw true
+            kw type
+            kw union
+            kw unsafe
+            kw use
+            kw while
+            kw while let
+            sn macro_rules
+            sn pd
+            sn ppd
+        "#]],
+    );
+}
+
+#[test]
 fn excluded_trait_method_is_excluded_from_path_completion() {
     check_with_config(
         CompletionConfig {

--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -662,6 +662,9 @@ config_data! {
         /// For traits the type "methods" can be used to only exclude the methods but not the trait
         /// itself.
         ///
+        /// For modules the type "subItems" can be used to only exclude the sub items but not the module
+        /// itself.
+        ///
         /// This setting also inherits `#rust-analyzer.completion.excludeTraits#`.
         completion_autoimport_exclude: Vec<AutoImportExclusion> = vec![
             AutoImportExclusion::Verbose { path: "core::borrow::Borrow".to_owned(), r#type: AutoImportExclusionType::Methods },
@@ -1938,6 +1941,9 @@ impl Config {
                             AutoImportExclusionType::Methods => {
                                 ide_completion::AutoImportExclusionType::Methods
                             }
+                            AutoImportExclusionType::SubItems => {
+                                ide_completion::AutoImportExclusionType::SubItems
+                            }
                         },
                     ),
                 })
@@ -2997,6 +3003,7 @@ pub enum AutoImportExclusion {
 pub enum AutoImportExclusionType {
     Always,
     Methods,
+    SubItems,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -4128,10 +4135,11 @@ fn field_props(field: &str, ty: &str, doc: &[&str], default: &str) -> serde_json
                             },
                             "type": {
                                 "type": "string",
-                                "enum": ["always", "methods"],
+                                "enum": ["always", "methods", "subItems"],
                                 "enumDescriptions": [
                                     "Do not show this item or its methods (if it is a trait) in auto-import completions.",
-                                    "Do not show this traits methods in auto-import completions."
+                                    "Do not show this traits methods in auto-import completions.",
+                                    "Do not show this modules sub items in auto-import completions."
                                 ],
                             },
                         }

--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -662,8 +662,8 @@ config_data! {
         /// For traits the type "methods" can be used to only exclude the methods but not the trait
         /// itself.
         ///
-        /// For modules the type "subItems" can be used to only exclude the sub items but not the module
-        /// itself.
+        /// For modules the type "subItems" can be used to only exclude the all items in it but not the module
+        /// itself. This does not include items defined in nested modules.
         ///
         /// This setting also inherits `#rust-analyzer.completion.excludeTraits#`.
         completion_autoimport_exclude: Vec<AutoImportExclusion> = vec![
@@ -4138,8 +4138,8 @@ fn field_props(field: &str, ty: &str, doc: &[&str], default: &str) -> serde_json
                                 "enum": ["always", "methods", "subItems"],
                                 "enumDescriptions": [
                                     "Do not show this item or its methods (if it is a trait) in auto-import completions.",
-                                    "Do not show this traits methods in auto-import completions.",
-                                    "Do not show this modules sub items in auto-import completions."
+                                    "Do not show this trait's methods in auto-import completions.",
+                                    "Do not show this module's all items in it in auto-import completions."
                                 ],
                             },
                         }

--- a/docs/book/src/configuration_generated.md
+++ b/docs/book/src/configuration_generated.md
@@ -446,6 +446,9 @@ verbose form `{ "path": "path::to::item", type: "always" }`.
 For traits the type "methods" can be used to only exclude the methods but not the trait
 itself.
 
+For modules the type "subItems" can be used to only exclude the sub items but not the module
+itself.
+
 This setting also inherits `#rust-analyzer.completion.excludeTraits#`.
 
 

--- a/docs/book/src/configuration_generated.md
+++ b/docs/book/src/configuration_generated.md
@@ -446,8 +446,8 @@ verbose form `{ "path": "path::to::item", type: "always" }`.
 For traits the type "methods" can be used to only exclude the methods but not the trait
 itself.
 
-For modules the type "subItems" can be used to only exclude the sub items but not the module
-itself.
+For modules the type "subItems" can be used to only exclude the all items in it but not the module
+itself. This does not include items defined in nested modules.
 
 This setting also inherits `#rust-analyzer.completion.excludeTraits#`.
 

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -1328,7 +1328,7 @@
                 "title": "Completion",
                 "properties": {
                     "rust-analyzer.completion.autoimport.exclude": {
-                        "markdownDescription": "A list of full paths to items to exclude from auto-importing completions.\n\nTraits in this list won't have their methods suggested in completions unless the trait\nis in scope.\n\nYou can either specify a string path which defaults to type \"always\" or use the more\nverbose form `{ \"path\": \"path::to::item\", type: \"always\" }`.\n\nFor traits the type \"methods\" can be used to only exclude the methods but not the trait\nitself.\n\nThis setting also inherits `#rust-analyzer.completion.excludeTraits#`.",
+                        "markdownDescription": "A list of full paths to items to exclude from auto-importing completions.\n\nTraits in this list won't have their methods suggested in completions unless the trait\nis in scope.\n\nYou can either specify a string path which defaults to type \"always\" or use the more\nverbose form `{ \"path\": \"path::to::item\", type: \"always\" }`.\n\nFor traits the type \"methods\" can be used to only exclude the methods but not the trait\nitself.\n\nFor modules the type \"subItems\" can be used to only exclude the sub items but not the module\nitself.\n\nThis setting also inherits `#rust-analyzer.completion.excludeTraits#`.",
                         "default": [
                             {
                                 "path": "core::borrow::Borrow",
@@ -1355,11 +1355,13 @@
                                             "type": "string",
                                             "enum": [
                                                 "always",
-                                                "methods"
+                                                "methods",
+                                                "subItems"
                                             ],
                                             "enumDescriptions": [
                                                 "Do not show this item or its methods (if it is a trait) in auto-import completions.",
-                                                "Do not show this traits methods in auto-import completions."
+                                                "Do not show this traits methods in auto-import completions.",
+                                                "Do not show this modules sub items in auto-import completions."
                                             ]
                                         }
                                     }

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -1328,7 +1328,7 @@
                 "title": "Completion",
                 "properties": {
                     "rust-analyzer.completion.autoimport.exclude": {
-                        "markdownDescription": "A list of full paths to items to exclude from auto-importing completions.\n\nTraits in this list won't have their methods suggested in completions unless the trait\nis in scope.\n\nYou can either specify a string path which defaults to type \"always\" or use the more\nverbose form `{ \"path\": \"path::to::item\", type: \"always\" }`.\n\nFor traits the type \"methods\" can be used to only exclude the methods but not the trait\nitself.\n\nFor modules the type \"subItems\" can be used to only exclude the sub items but not the module\nitself.\n\nThis setting also inherits `#rust-analyzer.completion.excludeTraits#`.",
+                        "markdownDescription": "A list of full paths to items to exclude from auto-importing completions.\n\nTraits in this list won't have their methods suggested in completions unless the trait\nis in scope.\n\nYou can either specify a string path which defaults to type \"always\" or use the more\nverbose form `{ \"path\": \"path::to::item\", type: \"always\" }`.\n\nFor traits the type \"methods\" can be used to only exclude the methods but not the trait\nitself.\n\nFor modules the type \"subItems\" can be used to only exclude the all items in it but not the module\nitself. This does not include items defined in nested modules.\n\nThis setting also inherits `#rust-analyzer.completion.excludeTraits#`.",
                         "default": [
                             {
                                 "path": "core::borrow::Borrow",
@@ -1360,8 +1360,8 @@
                                             ],
                                             "enumDescriptions": [
                                                 "Do not show this item or its methods (if it is a trait) in auto-import completions.",
-                                                "Do not show this traits methods in auto-import completions.",
-                                                "Do not show this modules sub items in auto-import completions."
+                                                "Do not show this trait's methods in auto-import completions.",
+                                                "Do not show this module's all items in it in auto-import completions."
                                             ]
                                         }
                                     }


### PR DESCRIPTION
Close rust-lang/rust-analyzer#20468

Similar to implementing https://github.com/rust-lang/rust-analyzer/issues/20468#issuecomment-3343893620 , but non-based string

Example
---
**Before this PR**

```json
{
    "rust-analyzer.completion.autoimport.exclude": [
        {"path":"std::intrinsics::AtomicOrdering","type":"always"},
        {"path":"std::intrinsics::ConstParamTy","type":"always"},
        // ... 223 items
    ]
}
```

**After this PR**

```json
{
    "rust-analyzer.completion.autoimport.exclude": [
        {"path":"std::intrinsics","type":"sub_items"},
    ]
}
```
