### PR TITLE
Fix unresolved-references DB attachment

### DIFF
--- a/crates/rust-analyzer/src/cli/unresolved_references.rs
+++ b/crates/rust-analyzer/src/cli/unresolved_references.rs
@@ -53,42 +53,44 @@ impl flags::UnresolvedReferences {
         let db = host.raw_database();
         let sema = Semantics::new(db);
 
-        let mut visited_files = FxHashSet::default();
+        hir::attach_db(db, || {
+            let mut visited_files = FxHashSet::default();
 
-        let work = all_modules(db).into_iter().filter(|module| {
-            let file_id = module.definition_source_file_id(db).original_file(db);
-            let source_root = db.file_source_root(file_id.file_id(db)).source_root_id(db);
-            let source_root = db.source_root(source_root).source_root(db);
-            !source_root.is_library
-        });
+            let work = all_modules(db).into_iter().filter(|module| {
+                let file_id = module.definition_source_file_id(db).original_file(db);
+                let source_root = db.file_source_root(file_id.file_id(db)).source_root_id(db);
+                let source_root = db.source_root(source_root).source_root(db);
+                !source_root.is_library
+            });
 
-        for module in work {
-            let file_id = module.definition_source_file_id(db).original_file(db);
-            let file_id = file_id.file_id(db);
-            if !visited_files.contains(&file_id) {
-                let crate_name = module
-                    .krate(db)
-                    .display_name(db)
-                    .as_deref()
-                    .unwrap_or(&sym::unknown)
-                    .to_owned();
-                let file_path = vfs.file_path(file_id);
-                eprintln!("processing crate: {crate_name}, module: {file_path}",);
+            for module in work {
+                let file_id = module.definition_source_file_id(db).original_file(db);
+                let file_id = file_id.file_id(db);
+                if !visited_files.contains(&file_id) {
+                    let crate_name = module
+                        .krate(db)
+                        .display_name(db)
+                        .as_deref()
+                        .unwrap_or(&sym::unknown)
+                        .to_owned();
+                    let file_path = vfs.file_path(file_id);
+                    eprintln!("processing crate: {crate_name}, module: {file_path}",);
 
-                let line_index = line_index(db, file_id);
-                let file_text = db.file_text(file_id);
+                    let line_index = line_index(db, file_id);
+                    let file_text = db.file_text(file_id);
 
-                for range in find_unresolved_references(db, &sema, file_id, &module) {
-                    let line_col = line_index.line_col(range.start());
-                    let line = line_col.line + 1;
-                    let col = line_col.col + 1;
-                    let text = &file_text.text(db)[range];
-                    println!("{file_path}:{line}:{col}: {text}");
+                    for range in find_unresolved_references(db, &sema, file_id, &module) {
+                        let line_col = line_index.line_col(range.start());
+                        let line = line_col.line + 1;
+                        let col = line_col.col + 1;
+                        let text = &file_text.text(db)[range];
+                        println!("{file_path}:{line}:{col}: {text}");
+                    }
+
+                    visited_files.insert(file_id);
                 }
-
-                visited_files.insert(file_id);
             }
-        }
+        });
 
         eprintln!();
         eprintln!("scan complete");

--- a/crates/rust-analyzer/tests/slow-tests/cli.rs
+++ b/crates/rust-analyzer/tests/slow-tests/cli.rs
@@ -3,6 +3,26 @@ use test_utils::skip_slow_tests;
 
 use crate::support::Project;
 
+#[test]
+fn unresolved_references_empty_crate_does_not_panic() {
+    if skip_slow_tests() {
+        return;
+    }
+
+    Project::with_fixture(
+        r#"
+//- /Cargo.toml
+[package]
+name = "foo"
+version = "0.0.0"
+edition = "2024"
+
+//- /src/lib.rs
+"#,
+    )
+    .run_unresolved_references();
+}
+
 // If you choose to change the test fixture here, please inform the ferrocene/needy maintainers by
 // opening an issue at https://github.com/ferrocene/needy as the tool relies on specific token
 // mapping behavior.

--- a/crates/rust-analyzer/tests/slow-tests/support.rs
+++ b/crates/rust-analyzer/tests/slow-tests/support.rs
@@ -127,6 +127,46 @@ impl Project<'_> {
         String::from_utf8(buf).unwrap()
     }
 
+    pub(crate) fn run_unresolved_references(self) {
+        let tmp_dir = self.tmp_dir.unwrap_or_else(|| {
+            if self.root_dir_contains_symlink { TestDir::new_symlink() } else { TestDir::new() }
+        });
+
+        let FixtureWithProjectMeta {
+            fixture,
+            mini_core,
+            proc_macro_names,
+            toolchain,
+            target_data_layout: _,
+            target_arch: _,
+        } = FixtureWithProjectMeta::parse(self.fixture);
+        assert!(proc_macro_names.is_empty());
+        assert!(mini_core.is_none());
+        assert!(toolchain.is_none());
+
+        for entry in fixture {
+            let path = tmp_dir.path().join(&entry.path['/'.len_utf8()..]);
+            fs::create_dir_all(path.parent().unwrap()).unwrap();
+            fs::write(path.as_path(), entry.text.as_bytes()).unwrap();
+        }
+
+        let tmp_dir_path = AbsPathBuf::assert(tmp_dir.path().to_path_buf());
+        let root = self
+            .roots
+            .into_iter()
+            .map(|root| tmp_dir_path.join(root))
+            .next()
+            .unwrap_or(tmp_dir_path);
+        flags::UnresolvedReferences {
+            path: root.into(),
+            disable_build_scripts: true,
+            disable_proc_macros: true,
+            proc_macro_srv: None,
+        }
+        .run()
+        .unwrap();
+    }
+
     pub(crate) fn server(self) -> Server {
         Project::server_with_lock(self, false)
     }


### PR DESCRIPTION
## Summary

Fixes a panic in the `rust-analyzer unresolved-references` CLI command by attaching the HIR database while the command walks modules, classifies name references, and filters inactive-code diagnostics.

The command currently panics before reporting results, even for an empty Cargo library crate:

```text
thread 'BIG_STACK_THREAD' panicked at crates/hir-ty/src/next_solver/interner.rs:2440:42:
Try to use attached db, but not db is attached
```

`analysis-stats` already wraps solver-heavy work in `hir::attach_db(db, || ...)`; this applies the same pattern to `unresolved-references`.

## Test

```text
RUN_SLOW_TESTS=1 cargo test -p rust-analyzer --test slow-tests unresolved_references_empty_crate_does_not_panic -- --nocapture
cargo fmt --check
```
