### PR TITLE
fix: normalize expected tuple struct pat field

### DIFF
--- a/crates/ide-completion/src/context/analysis.rs
+++ b/crates/ide-completion/src/context/analysis.rs
@@ -791,13 +791,9 @@ fn expected_type_and_name<'db>(
                     (ty, None)
                 },
                 ast::TupleStructPat(it) => {
-                    let fields = it.path().and_then(|path| match sema.resolve_path(&path)? {
-                        hir::PathResolution::Def(hir::ModuleDef::Adt(adt)) => Some(adt.as_struct()?.fields(sema.db)),
-                        hir::PathResolution::Def(hir::ModuleDef::EnumVariant(variant)) => Some(variant.fields(sema.db)),
-                        _ => None,
-                    });
+                    let fields = sema.type_of_pat(&it.clone().into()).map(|ty| ty.original.fields(sema.db));
                     let nr = it.fields().take_while(|it| it.syntax().text_range().end() <= token.text_range().start()).count();
-                    let ty = fields.and_then(|fields| Some(fields.get(nr)?.ty(sema.db).to_type(sema.db)));
+                    let ty = fields.and_then(|fields| Some(fields.get(nr)?.1.clone()));
                     (ty, None)
                 },
                 ast::Fn(it) => {

--- a/crates/ide-completion/src/context/tests.rs
+++ b/crates/ide-completion/src/context/tests.rs
@@ -329,6 +329,17 @@ fn foo(x: Foo) -> Foo {
 "#,
         expect![[r#"ty: u32, name: ?"#]],
     );
+
+    check_expected_type_and_name(
+        r#"
+//- minicore: option
+struct Foo<T>(T);
+fn foo(x: Foo<Option<i32>>) -> Foo {
+   match x { Foo($0) => () }
+}
+"#,
+        expect![[r#"ty: Option<i32>, name: ?"#]],
+    );
 }
 
 #[test]


### PR DESCRIPTION
Fixes rust-lang/rust-analyzer#22200

Example
---
```rust
struct Foo<T>(T);
fn foo(x: Foo<Option<i32>>) -> Foo {
   match x { Foo($0) => () }
}
```

**Before this PR**

```rust
ty: T, name: ?
```

**After this PR**

```rust
ty: Option<i32>, name: ?
```
