### PR TITLE
fix(cfg): correct separator index in CfgDiff disable loop

### DIFF
--- a/crates/cfg/src/lib.rs
+++ b/crates/cfg/src/lib.rs
@@ -222,7 +222,7 @@ impl fmt::Display for CfgDiff {
             for (i, atom) in self.disable.iter().enumerate() {
                 let sep = match i {
                     0 => "",
-                    _ if i == self.enable.len() - 1 => " and ",
+                    _ if i == self.disable.len() - 1 => " and ",
                     _ => ", ",
                 };
                 f.write_str(sep)?;

--- a/crates/cfg/src/tests.rs
+++ b/crates/cfg/src/tests.rs
@@ -194,6 +194,10 @@ fn hints() {
 
     check_enable_hints("#![cfg(test)]", &opts, &[]);
     check_enable_hints("#![cfg(not(test))]", &opts, &["disable test"]);
+
+    opts.insert_atom(Symbol::intern("a"));
+    opts.insert_atom(Symbol::intern("b"));
+    check_enable_hints("#![cfg(all(not(a), not(b)))]", &opts, &["disable a and b"]);
 }
 
 /// Tests that we don't suggest hints for cfgs that express an inconsistent formula.


### PR DESCRIPTION
The disable loop reused `self.enable.len() - 1` when detecting the last atom, causing wrong "and" placement (and a debug-mode panic when enable was empty). Add a regression test for `disable a and b`.

🤖 Spotted via AI-assisted code review.