### PR TITLE
fix(test-utils): drain inactive_regions by inactive_line_region

### DIFF
--- a/crates/test-utils/src/fixture.rs
+++ b/crates/test-utils/src/fixture.rs
@@ -507,7 +507,7 @@ impl MiniCore {
                 active_regions.drain(active_regions.len() - active_line_region..);
             }
             if inactive_line_region > 0 {
-                inactive_regions.drain(inactive_regions.len() - active_line_region..);
+                inactive_regions.drain(inactive_regions.len() - inactive_line_region..);
             }
         }
 


### PR DESCRIPTION
In `MiniCore::source_code`, the inactive line-region drain reused `active_line_region` (the active branch's counter) when computing how many entries to remove from `inactive_regions`. The fix restores symmetry between the active and inactive branches.

🤖 Spotted via AI-assisted code review.