### PR TITLE
Filter package-scoped features

### DIFF
--- a/crates/rust-analyzer/src/flycheck.rs
+++ b/crates/rust-analyzer/src/flycheck.rs
@@ -63,7 +63,12 @@ pub(crate) enum Target {
 }
 
 impl CargoOptions {
-    pub(crate) fn apply_on_command(&self, cmd: &mut Command, ws_target_dir: Option<&Utf8Path>) {
+    pub(crate) fn apply_on_command(
+        &self,
+        cmd: &mut Command,
+        ws_target_dir: Option<&Utf8Path>,
+        package_repr: Option<&str>,
+    ) {
         for target in &self.target_tuples {
             cmd.args(["--target", target.as_str()]);
         }
@@ -83,8 +88,24 @@ impl CargoOptions {
                 cmd.arg("--no-default-features");
             }
             if !self.features.is_empty() {
+                // If we are scoped to a particular package, filter any features of the form
+                // `crate/feature` which target other packages.
+                let features = if let Some(name) = package_repr {
+                    let filtered = self
+                        .features
+                        .iter()
+                        .filter(|f| match f.split_once('/') {
+                            Some((c, _)) => c == name,
+                            None => true,
+                        })
+                        .map(|s| s.as_str())
+                        .collect::<Vec<_>>();
+                    filtered.join(" ")
+                } else {
+                    self.features.join(" ")
+                };
                 cmd.arg("--features");
-                cmd.arg(self.features.join(" "));
+                cmd.arg(features);
             }
         }
         if let Some(target_dir) = self.target_dir_config.target_dir(ws_target_dir) {
@@ -890,12 +911,18 @@ impl FlycheckActor {
                 cmd.env("CARGO_LOG", "cargo::core::compiler::fingerprint=info");
                 cmd.arg(&cargo_options.subcommand);
 
-                match scope {
-                    FlycheckScope::Workspace => cmd.arg("--workspace"),
+                let package_repr = match scope {
+                    FlycheckScope::Workspace => {
+                        cmd.arg("--workspace");
+                        None
+                    }
                     FlycheckScope::Package {
                         package: PackageSpecifier::Cargo { package_id },
                         ..
-                    } => cmd.arg("-p").arg(&package_id.repr),
+                    } => {
+                        cmd.arg("-p").arg(&package_id.repr);
+                        Some(package_id.repr.as_str())
+                    }
                     FlycheckScope::Package {
                         package: PackageSpecifier::BuildInfo { .. }, ..
                     } => {
@@ -935,6 +962,7 @@ impl FlycheckActor {
                 cargo_options.apply_on_command(
                     &mut cmd,
                     self.ws_target_dir.as_ref().map(Utf8PathBuf::as_path),
+                    package_repr,
                 );
                 cmd.args(&cargo_options.extra_args);
                 Some((cmd, FlycheckCommandOrigin::Cargo))

--- a/crates/rust-analyzer/src/test_runner.rs
+++ b/crates/rust-analyzer/src/test_runner.rs
@@ -124,7 +124,7 @@ impl CargoTestHandle {
         cmd.arg("--no-fail-fast");
         cmd.arg("--manifest-path");
         cmd.arg(root.join("Cargo.toml"));
-        options.apply_on_command(&mut cmd, ws_target_dir);
+        options.apply_on_command(&mut cmd, ws_target_dir, Some(&test_target.package));
         cmd.arg("--");
         if let Some(path) = path {
             cmd.arg(path);


### PR DESCRIPTION
When `rust-analyzer` runs a flycheck on a binary package after a file write, it uses `check -p` regardless of `rust-analyzer.check.workspace`.  This interacts poorly with package-specific features (in `package/feature` form) enabled in `rust-analyzer.cargo.features`.

Consider a workspace with two binary crates, `foo` and `bar`, each with a non-default feature:
```toml
[package]
name = "foo"
version = "0.1.0"
edition = "2024"

[features]
omg = []
```
```toml
[package]
name = "bar"
version = "0.1.0"
edition = "2024"

[features]
lol = []
```

I would like to enable both features, so I have configured `rust-analyzer` as such:
```
rust-analyzer.cargo.features = ["foo/omg", "bar/lol"]
```

The initial indexing and check work fine, because they happen in the workspace scope, and all of those features exist.

However, if I edit and save a file within one of the crates, the subsequent check happens with a **package scope**.  This fails because **all of the features** are still passed to `cargo check`, but it's only targeting a single package:
```
2026-05-22T20:17:40.648309-04:00 ERROR Flycheck failed to run the following command:
CommandHandle {
  program: "/Users/mjk/.cargo/bin/cargo",
  arguments: [
    "check", "-p", "bar", "--bin", "bar", "--message-format=json",
    "--manifest-path", "/Users/mjk/code/r-a-test/Cargo.toml",
    "--keep-going", "--features", "foo/omg bar/lol"
  ],
  current_dir: Some("/Users/mjk/code/r-a-test")
},
error=Cargo watcher failed, the command produced no valid metadata (exit code: ExitStatus(unix_wait_status(25856))):
error: the package 'bar' does not contain this feature: foo/omg
```

(Repro repo is at [`mkeeter/ra-crate-features`](https://github.com/mkeeter/ra-crate-features/))

--------------------------------------------------------------------------------

This PR adjusts `CargoOptions::apply_on_command` to take an optional package name.  When the package name is present, package-specific features (`package/feat`) that _do not match_ aren't passed to the cargo subcommand.  Unscoped features (`feat`) are unmodified.

I believe this is a strict improvement to the previous behavior: passing package-specific features for packages not being built would always fail, and this PR eliminates those failure modes.  It doesn't fix everything: unscoped features in `rust-analyzer.cargo.features` may still lead to failures, but that's a preexisting condition.

(This took a few false starts; apologies for the noise in https://github.com/rust-lang/rust-analyzer/discussions/22421 and https://github.com/rust-lang/rust-analyzer/pull/22422)