### PR TITLE
fix: pass -Zjson-target-spec for .json target specs

### DIFF
--- a/crates/project-model/src/build_dependencies.rs
+++ b/crates/project-model/src/build_dependencies.rs
@@ -461,6 +461,11 @@ impl WorkspaceBuildScripts {
 
                 if let Some(target) = &config.target {
                     cmd.args(["--target", target]);
+                    // .json target specs require `-Zjson-target-spec` since rust-lang/cargo#16557.
+                    if target.ends_with(".json") {
+                        requires_unstable_options = true;
+                        cmd.arg("-Zjson-target-spec");
+                    }
                 }
                 let mut lockfile_copy = None;
                 if let Some(toolchain) = toolchain {

--- a/crates/project-model/src/cargo_workspace.rs
+++ b/crates/project-model/src/cargo_workspace.rs
@@ -699,6 +699,10 @@ impl FetchMetadata {
             other_options.extend(
                 config.targets.iter().flat_map(|it| ["--filter-platform".to_owned(), it.clone()]),
             );
+            // .json target specs require `-Zjson-target-spec` since rust-lang/cargo#16557.
+            if config.targets.iter().any(|it| it.ends_with(".json")) {
+                other_options.push("-Zjson-target-spec".to_owned());
+            }
         }
 
         command.other_options(other_options.clone());


### PR DESCRIPTION
Since rust-lang/cargo#16557, cargo metadata and cargo check reject `--filter-platform path/to/foo.json` and `--target path/to/foo.json` unless `-Zjson-target-spec` is also passed (which itself requires `-Zunstable-options`).  rust-analyzer hits this whenever a user configures a JSON target spec via `rust-analyzer.cargo.target` or via `.cargo/config.toml`'s `[build] target = "...json"`, surfacing as a metadata failure on workspace load.

Detect when the configured target ends in `.json` and push the flag in both code paths (cargo_workspace.rs for cargo metadata, build_dependencies.rs for cargo check).  The existing `-Z` detection in each function then handles `-Zunstable-options` and the `__CARGO_TEST_CHANNEL_OVERRIDE_DO_NOT_USE_THIS` env var.

Matches the existing `target.ends_with(".json")` idiom already used in workspace.rs and toolchain_info/target_tuple.rs.

Closes rust-lang/rust-analyzer#21821.