### PR TITLE
fix: `extract_module` missing import for macro calls

### DIFF
--- a/crates/ide-assists/src/handlers/extract_module.rs
+++ b/crates/ide-assists/src/handlers/extract_module.rs
@@ -733,6 +733,7 @@ fn check_def_in_mod_and_out_sel(
         Definition::Static(x) => check_item!(x),
         Definition::Trait(x) => check_item!(x),
         Definition::TypeAlias(x) => check_item!(x),
+        Definition::Macro(x) => check_item!(x),
         _ => {}
     }
 
@@ -1811,6 +1812,35 @@ mod foo {
     }
 }
 "#,
+        )
+    }
+
+    #[test]
+    fn test_extract_module_macro_call_import() {
+        check_assist(
+            extract_module,
+            r"
+macro_rules! my_macro {
+    () => {};
+}
+
+$0fn bar() {
+    my_macro!();
+}$0
+            ",
+            r"
+macro_rules! my_macro {
+    () => {};
+}
+
+mod modname {
+    use super::my_macro;
+
+    pub(crate) fn bar() {
+        my_macro!();
+    }
+}
+            ",
         )
     }
 }


### PR DESCRIPTION
`check_def_in_mod_and_out_sel` had arms for every item kind (`Function`, `Adt`, `Const`, etc.) but no arm for `Definition::Macro`. it fell through to `_ => {}` and returned `(false, false)`, making `def_out_sel` always false for macros. in downstream the condition `(def_out_sel || !is_item) && use_stmt_not_in_sel` was never satisfied so no import was added to the extracted module.

add `Definition::Macro(x) => check_item!(x),` to the match so the macros source location is checked the same way as other items.

closes https://github.com/rust-lang/rust-analyzer/issues/20209