### PR TITLE
fix: drop lower-ranked tokens from descended set in hover

### DIFF
--- a/crates/ide/src/hover.rs
+++ b/crates/ide/src/hover.rs
@@ -242,6 +242,13 @@ fn hover_offset(
 
     descended.sort_by_cached_key(|tok| !ranker.rank_token(tok));
 
+    // Drop lower-ranked tokens: usually proc-macro-generated content sharing
+    // the cursor's span via `set_span`.
+    if let Some(top_token) = descended.first() {
+        let top_rank = ranker.rank_token(top_token);
+        descended.retain(|tok| ranker.rank_token(tok) == top_rank);
+    }
+
     let mut res = vec![];
     for token in descended {
         let is_same_kind = token.kind() == ranker.kind;

--- a/crates/ide/src/hover/tests.rs
+++ b/crates/ide/src/hover/tests.rs
@@ -2274,6 +2274,35 @@ fn foo$0() {}
 }
 
 #[test]
+fn test_hover_skips_unrelated_proc_macro_generated_tokens_at_same_span() {
+    // `generate_suffixed_type` emits an extra `struct FooSuffix;` whose
+    // identifier carries the user's `Foo` span. Hovering on `Foo` should
+    // still show only the user's type, not the spurious generated one.
+    check(
+        r#"
+//- proc_macros: generate_suffixed_type
+#[proc_macros::generate_suffixed_type]
+struct Fo$0o;
+"#,
+        expect![[r#"
+            *Foo*
+
+            ```rust
+            ra_test_fixture
+            ```
+
+            ```rust
+            struct Foo
+            ```
+
+            ---
+
+            size = 0, align = 1, no Drop
+        "#]],
+    );
+}
+
+#[test]
 fn test_hover_through_expr_in_macro() {
     check(
         r#"


### PR DESCRIPTION
## Summary

Filter the descended-token list in `hover_offset` to keep only the highest-ranked tokens. `Ranker` already scores descended tokens, but the rendering loop iterates over the full list, producing spurious hover blocks when an attribute proc macro emits tokens via `quote_spanned!{user_token.span()=> ...}`.

## Reproduction

Using `crates/test-fixture`'s existing `generate_suffixed_type` proc macro:

```rust
//- proc_macros: generate_suffixed_type
#[proc_macros::generate_suffixed_type]
struct Foo$0;
```

Hover on Foo previously rendered both struct Foo and struct FooSuffix. Test added for this.

### In the wild

Same root cause: `#[tokio::main]` (tokio-rs/tokio#5518), `#[async_trait]` (rust-lang/rust-analyzer#14993), `#[tracing::instrument]` (rust-lang/rust-analyzer#19944). For tokio, hover on Ok in `#[tokio::main] async fn main() -> Result<(), String> { Ok(()) }` previously produced 7 hover blocks including ~17KB of unrelated tokio crate docs; now 1.