### PR TITLE
fix: analysis expected ty in enum variant

### DIFF
--- a/crates/hir/src/semantics.rs
+++ b/crates/hir/src/semantics.rs
@@ -1947,6 +1947,14 @@ impl<'db> SemanticsImpl<'db> {
         self.analyze(field.syntax())?.resolve_record_pat_field(self.db, field)
     }
 
+    pub fn resolve_tuple_struct_pat_fields(
+        &self,
+        tuple_struct_pat: &ast::TupleStructPat,
+    ) -> Option<Vec<(Field, Type<'db>)>> {
+        self.analyze(tuple_struct_pat.syntax())?
+            .resolve_tuple_struct_pat_fields(self.db, tuple_struct_pat)
+    }
+
     // FIXME: Replace this with `resolve_macro_call2`
     pub fn resolve_macro_call(&self, macro_call: &ast::MacroCall) -> Option<Macro> {
         let macro_call = self.find_file(macro_call.syntax()).with_value(macro_call);

--- a/crates/hir/src/semantics.rs
+++ b/crates/hir/src/semantics.rs
@@ -1947,6 +1947,7 @@ impl<'db> SemanticsImpl<'db> {
         self.analyze(field.syntax())?.resolve_record_pat_field(self.db, field)
     }
 
+    // FIXME: Remove this from https://github.com/rust-lang/rust-analyzer/pull/22449#discussion_r3299763452
     pub fn resolve_tuple_struct_pat_fields(
         &self,
         tuple_struct_pat: &ast::TupleStructPat,

--- a/crates/hir/src/source_analyzer.rs
+++ b/crates/hir/src/source_analyzer.rs
@@ -933,6 +933,28 @@ impl<'db> SourceAnalyzer<'db> {
         ))
     }
 
+    pub(crate) fn resolve_tuple_struct_pat_fields(
+        &self,
+        db: &'db dyn HirDatabase,
+        tuple_struct_pat: &ast::TupleStructPat,
+    ) -> Option<Vec<(Field, Type<'db>)>> {
+        let interner = DbInterner::new_no_crate(db);
+        let pat_id = self.pat_id(&tuple_struct_pat.clone().into())?;
+        let variant_id = self.infer()?.variant_resolution_for_pat(pat_id.as_pat()?)?;
+        let (_adt, substs) = self.infer()?.pat_ty(pat_id.as_pat()?).as_adt()?;
+
+        Some(
+            db.field_types(variant_id)
+                .iter()
+                .map(|(local_id, ty)| {
+                    let def = Field { parent: variant_id.into(), id: local_id };
+                    let ty = ty.get().instantiate(interner, substs).skip_norm_wip();
+                    (def, self.ty(ty))
+                })
+                .collect(),
+        )
+    }
+
     pub(crate) fn resolve_bind_pat_to_const(
         &self,
         db: &'db dyn HirDatabase,

--- a/crates/ide-completion/src/context/analysis.rs
+++ b/crates/ide-completion/src/context/analysis.rs
@@ -801,7 +801,7 @@ fn expected_type_and_name<'db>(
                     (ty, None)
                 },
                 ast::TupleStructPat(it) => {
-                    let fields = sema.type_of_pat(&it.clone().into()).map(|ty| ty.original.fields(sema.db));
+                    let fields = sema.resolve_tuple_struct_pat_fields(&it);
                     let nr = it.fields().take_while(|it| it.syntax().text_range().end() <= token.text_range().start()).count();
                     let ty = fields.and_then(|fields| Some(rebase_ty(fields.get(nr)?.1.clone())));
                     (ty, None)

--- a/crates/ide-completion/src/context/tests.rs
+++ b/crates/ide-completion/src/context/tests.rs
@@ -340,6 +340,16 @@ fn foo(x: Foo<Option<i32>>) -> Foo {
 "#,
         expect![[r#"ty: Option<i32>, name: ?"#]],
     );
+    check_expected_type_and_name(
+        r#"
+//- minicore: option
+enum Foo<T> { Var(T) };
+fn foo(x: Foo<Option<i32>>) -> Foo {
+   match x { Foo::Var($0) => () }
+}
+"#,
+        expect![[r#"ty: Option<i32>, name: ?"#]],
+    );
 }
 
 #[test]


### PR DESCRIPTION
Fixup rust-lang/rust-analyzer#22425

Example
---
```rust
enum Foo<T> { Var(T) };
fn foo(x: Foo<Option<i32>>) -> Foo {
   match x { Foo::Var($0) => () }
}
```

**Before this PR**

```rust
ty: ?, name: ?
```

**After this PR**

```rust
ty: Option<i32>, name: ?
```
