### PR TITLE
fix: flip coerce_never type_mismatch tys

### DIFF
--- a/crates/hir-ty/src/infer/expr.rs
+++ b/crates/hir-ty/src/infer/expr.rs
@@ -306,7 +306,7 @@ impl<'db> InferenceContext<'_, 'db> {
             }
         } else {
             if let Some(expected_ty) = expected.only_has_type(&mut self.table) {
-                _ = self.demand_eqtype(expr.into(), ty, expected_ty);
+                _ = self.demand_eqtype(expr.into(), expected_ty, ty);
             }
             ty
         }

--- a/crates/ide-diagnostics/src/handlers/type_mismatch.rs
+++ b/crates/ide-diagnostics/src/handlers/type_mismatch.rs
@@ -1207,6 +1207,20 @@ fn f() {
     }
 
     #[test]
+    fn type_mismatch_in_condition() {
+        check_diagnostics(
+            r#"
+fn f() {
+    if 1 {}
+     //^ error: expected bool, found i32
+    match () { _ if 1 => (), _ => () }
+                  //^ error: expected bool, found i32
+}
+"#,
+        );
+    }
+
+    #[test]
     fn regression_14768() {
         check_diagnostics(
             r#"


### PR DESCRIPTION
Example
---
**Before this PR**

```rust
fn f() {
    if 1 {}
     //^ error: expected i32, found bool
    match () { _ if 1 => (), _ => () }
                  //^ error: expected i32, found bool
}
```

**After this PR**

```rust
fn f() {
    if 1 {}
     //^ error: expected bool, found i32
    match () { _ if 1 => (), _ => () }
                  //^ error: expected bool, found i32
}
```
