### PR TITLE
fix: use add deref in assign instead add `&mut` for value

### DIFF
--- a/crates/ide-diagnostics/src/handlers/type_mismatch.rs
+++ b/crates/ide-diagnostics/src/handlers/type_mismatch.rs
@@ -120,6 +120,19 @@ fn add_or_fix_reference(
         return None;
     }
 
+    let expr = expr_ptr.to_node(ctx.db());
+    let assign = expr.syntax().parent().and_then(ast::BinExpr::cast).filter(|it| {
+        it.op_kind() == Some(ast::BinaryOp::Assignment { op: None }) && it.rhs() == Some(expr)
+    });
+    if let Some(assign) = assign
+        && expected_mutability.is_mut()
+        && let Some(range) = ctx.sema.original_range_opt(assign.syntax())
+    {
+        let edit = TextEdit::insert(range.range.start(), "*".to_owned());
+        let source_change = SourceChange::from_text_edit(range.file_id.file_id(ctx.db()), edit);
+        acc.push(fix("add_deref_here", "Add deref here", source_change, range.range));
+    }
+
     let ampersands = format!("&{}", expected_mutability.as_keyword_for_ref());
 
     let edit = TextEdit::insert(range.range.start(), ampersands);
@@ -503,6 +516,22 @@ fn main() {
     test((&mut 123));
 }
 fn test(_arg: &mut i32) {}
+            "#,
+        );
+    }
+
+    #[test]
+    fn add_deref_in_assign() {
+        check_fix(
+            r#"
+fn test(arg: &mut i32) {
+    arg = $02;
+}
+            "#,
+            r#"
+fn test(arg: &mut i32) {
+    *arg = 2;
+}
             "#,
         );
     }

--- a/crates/ide-diagnostics/src/handlers/type_mismatch.rs
+++ b/crates/ide-diagnostics/src/handlers/type_mismatch.rs
@@ -131,6 +131,7 @@ fn add_or_fix_reference(
         let edit = TextEdit::insert(range.range.start(), "*".to_owned());
         let source_change = SourceChange::from_text_edit(range.file_id.file_id(ctx.db()), edit);
         acc.push(fix("add_deref_here", "Add deref here", source_change, range.range));
+        return Some(());
     }
 
     let ampersands = format!("&{}", expected_mutability.as_keyword_for_ref());

--- a/crates/ide-diagnostics/src/handlers/type_mismatch.rs
+++ b/crates/ide-diagnostics/src/handlers/type_mismatch.rs
@@ -121,9 +121,11 @@ fn add_or_fix_reference(
     }
 
     let expr = expr_ptr.to_node(ctx.db());
-    let assign = expr.syntax().parent().and_then(ast::BinExpr::cast).filter(|it| {
-        it.op_kind() == Some(ast::BinaryOp::Assignment { op: None }) && it.rhs() == Some(expr)
-    });
+    let assign = expr
+        .syntax()
+        .parent()
+        .and_then(ast::BinExpr::cast)
+        .filter(|it| it.op_kind() == Some(ast::BinaryOp::Assignment { op: None }));
     if let Some(assign) = assign
         && expected_mutability.is_mut()
         && let Some(range) = ctx.sema.original_range_opt(assign.syntax())


### PR DESCRIPTION
Close rust-lang/rust-analyzer#22456

Example
---
```rust
fn test(arg: &mut i32) {
    arg = $02;
}
```

**Before this PR**

```rust
fn test(arg: &mut i32) {
    arg = &mut 2;
}
```

**After this PR**

```rust
fn test(arg: &mut i32) {
    *arg = 2;
}
```
