### PR TITLE
fix: `inline_call` produces invalid `Generic<T>` syntax when inlining `Self` across impl blocks

### DIFF
--- a/crates/ide-assists/src/handlers/inline_call.rs
+++ b/crates/ide-assists/src/handlers/inline_call.rs
@@ -21,9 +21,10 @@ use syntax::{
     ast::{
         self, HasArgList, HasGenericArgs, Pat, PathExpr,
         edit::{AstNodeEdit, IndentLevel},
+        make,
         syntax_factory::SyntaxFactory,
     },
-    syntax_editor::SyntaxEditor,
+    syntax_editor::{Position, SyntaxEditor},
 };
 
 use crate::{
@@ -438,18 +439,32 @@ fn inline(
             .collect();
         for self_tok in self_tokens {
             let replace_with = if !is_in_type_path(&self_tok)
-                && let Some(generic_arg_list) = t.generic_arg_list()
+                && let Some(args) = t.generic_arg_list()
             {
-                // Strip the outer generic arg list and reparse, since turbofish-less
-                // generics aren't valid in expression position. The outermost
-                // `GenericArgList` text is unique within `t`'s text (any inner generics
-                // are nested inside it), so `replacen(.., 1)` is safe.
                 let stripped = t.syntax().text().to_string().replacen(
-                    &generic_arg_list.syntax().text().to_string(),
+                    &args.syntax().text().to_string(),
                     "",
                     1,
                 );
-                editor.make().ty(&stripped).syntax().clone()
+                // Lifetimes are inferred; only type/const params need turbofish in
+                // expression position (e.g. `Generic<T>(x)` is not valid there).
+                let type_args: Vec<_> = args
+                    .generic_args()
+                    .filter(|a| !matches!(a, ast::GenericArg::LifetimeArg(_)))
+                    .collect();
+                if type_args.is_empty() {
+                    editor.make().ty(&stripped).syntax().clone()
+                } else {
+                    let base = editor.make().path_from_text(&stripped);
+                    let (path_ed, path_node) = SyntaxEditor::with_ast_node(&base);
+                    if let Some(seg) = path_node.segment() {
+                        path_ed.insert(
+                            Position::last_child_of(seg.syntax()),
+                            make::turbofish_generic_arg_list(type_args).syntax(),
+                        );
+                    }
+                    path_ed.finish().new_root().clone()
+                }
             } else {
                 t.syntax().clone()
             };
@@ -1721,6 +1736,45 @@ fn a() -> bool {
     {
         let this = &Enum::A;
         this == &Enum::A || this == &Enum::B
+    }
+}
+"#,
+        )
+    }
+
+    #[test]
+    fn inline_call_across_generic_impl_blocks() {
+        // rust-lang/rust-analyzer#19827: inlining across two separate `impl<T>` blocks for the
+        // same generic type must not produce `Generic<T>(...)` (invalid) — use turbofish instead.
+        check_assist(
+            inline_call,
+            r#"
+struct Generic<T>(T);
+
+impl<T> Generic<T> {
+    fn new() -> Self {
+        Generic::new2$0()
+    }
+}
+
+impl<T> Generic<T> {
+    fn new2() -> Self {
+        Self(todo!())
+    }
+}
+"#,
+            r#"
+struct Generic<T>(T);
+
+impl<T> Generic<T> {
+    fn new() -> Self {
+        Generic::<T>(todo!())
+    }
+}
+
+impl<T> Generic<T> {
+    fn new2() -> Self {
+        Self(todo!())
     }
 }
 "#,

--- a/crates/ide-db/src/path_transform.rs
+++ b/crates/ide-db/src/path_transform.rs
@@ -507,16 +507,31 @@ impl Ctx<'_> {
                         cfg,
                     )?;
 
-                    if let Some(qual) =
-                        mod_path_to_ast_with_factory(make, &found_path, self.target_edition)
-                            .qualifier()
+                    let base_path =
+                        mod_path_to_ast_with_factory(make, &found_path, self.target_edition);
+                    let (path_editor, base_path) = SyntaxEditor::with_ast_node(&base_path);
+
+                    if let Some(args) =
+                        path_ty.path().and_then(|p| p.segment()).and_then(|s| s.generic_arg_list())
+                        && let Some(segment) = base_path.segment()
                     {
-                        editor.replace(
-                            path.syntax(),
-                            make::path_concat(qual, path_ty.path()?).syntax(),
-                        );
-                        return Some(());
+                        let new_args = if is_path_in_expr_ctx(path) {
+                            make::turbofish_generic_arg_list(args.generic_args())
+                        } else {
+                            make::generic_arg_list(args.generic_args())
+                        };
+                        if let Some(old_args) = segment.generic_arg_list() {
+                            path_editor.replace(old_args.syntax(), new_args.syntax());
+                        } else {
+                            path_editor.insert(
+                                syntax_editor::Position::last_child_of(segment.syntax()),
+                                new_args.syntax(),
+                            );
+                        }
                     }
+
+                    editor.replace(path.syntax().clone(), path_editor.finish().new_root().clone());
+                    return Some(());
                 }
 
                 editor.replace(path.syntax(), ast_ty.syntax());
@@ -596,6 +611,12 @@ impl Ctx<'_> {
             _ => None,
         }
     }
+}
+
+/// `Generic<T>` is invalid in expression position; `Generic::<T>` must be used instead.
+fn is_path_in_expr_ctx(path: &ast::Path) -> bool {
+    let top = path.top_path();
+    top.syntax().parent().and_then(ast::PathExpr::cast).is_some()
 }
 
 // FIXME: It would probably be nicer if we could get this via HIR (i.e. get the


### PR DESCRIPTION
when a function using `Self` as a constructor (e.g. `Self(x)`) is inlined from a different `impl<T>` block the `Self` token was expanded to the bare type name without generics, producing `Generic(x)`. the original code stripped all generic args to avoid the invalid `Generic<T>(x)` syntax in expression position.

fix by emitting turbofish `Generic::<T>` for type/const params instead of stripping them. lifetime params are still omitted since they are always inferred in expression position.

also fix `PathTransform`'s `SelfType` arm to use `mod_path_to_ast_with_factory` (returning an `ast::Path` not a `PathType`) and attach generic args as turbofish when in expression context. this covers the case where `PathTransform` is applied with an explicit generic arg list at the call site.

fixes rust-lang/rust-analyzer#19827