### PR TITLE
fix: no complete functional update in non last

### DIFF
--- a/crates/ide-completion/src/completions/record.rs
+++ b/crates/ide-completion/src/completions/record.rs
@@ -1,7 +1,8 @@
 //! Complete fields in record literals and patterns.
 use ide_db::SymbolKind;
 use syntax::{
-    SmolStr,
+    SmolStr, T,
+    algo::next_non_trivia_token,
     ast::{self, Expr},
 };
 
@@ -97,7 +98,9 @@ pub(crate) fn add_default_update(
     let impls_default_trait = default_trait
         .zip(ty)
         .is_some_and(|(default_trait, ty)| ty.original.impls_trait(ctx.db, default_trait, &[]));
-    if impls_default_trait {
+    let ends_of_record_list =
+        next_non_trivia_token(ctx.token.clone()).is_none_or(|it| it.kind() == T!['}']);
+    if impls_default_trait && ends_of_record_list {
         // FIXME: This should make use of scope_def like completions so we get all the other goodies
         // that is we should handle this like actually completing the default function
         let completion_text = "..Default::default()";

--- a/crates/ide-completion/src/tests/record.rs
+++ b/crates/ide-completion/src/tests/record.rs
@@ -157,6 +157,8 @@ fn foo(f: Struct) {
 fn in_functional_update() {
     cov_mark::check!(functional_update);
 
+    // FIXME: This should filter out all completions that do not have the type `Foo`
+    // I think maybe ranking by type match is enough
     check(
         r#"
 //- minicore:default
@@ -210,7 +212,6 @@ fn main() {
 #[test]
 fn functional_update_no_dot() {
     cov_mark::check!(functional_update_field);
-    // FIXME: This should filter out all completions that do not have the type `Foo`
     check(
         r#"
 //- minicore:default
@@ -271,6 +272,48 @@ fn main() {
     let thing = 1;
     let foo = Foo { foo1: 0, foo2: 0 };
     let foo2 = Foo { thing, $0 ..Default::default() }
+}
+"#,
+        expect![[r#"
+            fd foo1 u32
+            fd foo2 u32
+        "#]],
+    );
+}
+
+#[test]
+fn functional_update_non_last() {
+    check(
+        r#"
+//- minicore:default
+struct Foo { foo1: u32, foo2: u32 }
+impl Default for Foo {
+    fn default() -> Self { loop {} }
+}
+
+fn main() {
+    let thing = 1;
+    let foo = Foo { foo1: 0, foo2: 0 };
+    let foo2 = Foo { $0 thing }
+}
+"#,
+        expect![[r#"
+            fd foo1 u32
+            fd foo2 u32
+        "#]],
+    );
+    check(
+        r#"
+//- minicore:default
+struct Foo { foo1: u32, foo2: u32 }
+impl Default for Foo {
+    fn default() -> Self { loop {} }
+}
+
+fn main() {
+    let thing = 1;
+    let foo = Foo { foo1: 0, foo2: 0 };
+    let foo2 = Foo { $0thing }
 }
 "#,
         expect![[r#"


### PR DESCRIPTION
Fixes rust-lang/rust-analyzer#22461

Example
---
```rust
#[derive(Default)]
struct Foo { foo1: u32, foo2: u32 }
fn main() {
    let thing = 1;
    let foo = Foo { foo1: 0, foo2: 0 };
    let foo2 = Foo { $0 thing }
}
```

**Before this PR**

```
fd ..Default::default()
fd foo1 u32
fd foo2 u32
```

**After this PR**

```
fd foo1 u32
fd foo2 u32
```
