### PR TITLE
minor: Fix garbage collection running too frequently

### DIFF
--- a/crates/rust-analyzer/src/main_loop.rs
+++ b/crates/rust-analyzer/src/main_loop.rs
@@ -478,6 +478,7 @@ impl GlobalState {
             (false, false)
         };
 
+        let mut gc_elapsed = None;
         if self.is_quiescent() {
             let became_quiescent = !was_quiescent;
             if became_quiescent {
@@ -541,8 +542,10 @@ impl GlobalState {
                 && self.fmt_pool.handle.is_empty()
                 && current_revision != self.last_gc_revision
             {
+                let gc_start = Instant::now();
                 self.analysis_host.trigger_garbage_collection();
-                self.last_gc_revision = current_revision;
+                self.last_gc_revision = self.analysis_host.raw_database().nonce_and_revision().1;
+                gc_elapsed = Some(gc_start.elapsed());
             }
         }
 
@@ -588,10 +591,14 @@ impl GlobalState {
         let loop_duration = loop_start.elapsed();
         if loop_duration > Duration::from_millis(100) && was_quiescent {
             tracing::warn!(
-                "overly long loop turn took {loop_duration:?} (event handling took {event_handling_duration:?}): {event_dbg_msg}"
+                "overly long loop turn took {loop_duration:?}:\n\
+                (event handling took {event_handling_duration:?}): {event_dbg_msg}\n\
+                (garbage collection took {gc_elapsed:?})"
             );
             self.poke_rust_analyzer_developer(format!(
-                "overly long loop turn took {loop_duration:?} (event handling took {event_handling_duration:?}): {event_dbg_msg}"
+                "overly long loop turn took {loop_duration:?}:\n\
+                (event handling took {event_handling_duration:?}): {event_dbg_msg}\n\
+                (garbage collection took {gc_elapsed:?})"
             ));
         }
     }


### PR DESCRIPTION
`trigger_garbage_collection` bumps the revision, which cause the `current_revision != self.last_gc_revision` to always evaluate to true