### PR TITLE
Distribute windows builts with mimalloc 

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,36 +29,44 @@ jobs:
           - os: windows-latest
             target: x86_64-pc-windows-msvc
             code-target: win32-x64
+            allocator: mimalloc
             pgo: clap-rs/clap@v4.5.36
           - os: windows-latest
             target: i686-pc-windows-msvc
+            allocator: mimalloc
             pgo: clap-rs/clap@v4.5.36
           - os: windows-latest
             target: aarch64-pc-windows-msvc
             code-target: win32-arm64
+            allocator: mimalloc
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             # Use a container with glibc 2.28
             # Zig is not used because it doesn't work with PGO
             container: quay.io/pypa/manylinux_2_28_x86_64
             code-target: linux-x64
+            allocator: system
             pgo: clap-rs/clap@v4.5.36
           - os: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
             container: quay.io/pypa/manylinux_2_28_aarch64
             code-target: linux-arm64
+            allocator: system
             pgo: clap-rs/clap@v4.5.36
           - os: ubuntu-latest
             target: arm-unknown-linux-gnueabihf
             zig_target: arm-unknown-linux-gnueabihf.2.28
             code-target: linux-armhf
+            allocator: system
           - os: macos-14
             target: x86_64-apple-darwin
             code-target: darwin-x64
+            allocator: system
             pgo: clap-rs/clap@v4.5.36
           - os: macos-14
             target: aarch64-apple-darwin
             code-target: darwin-arm64
+            allocator: system
             pgo: clap-rs/clap@v4.5.36
 
     name: dist (${{ matrix.target }})
@@ -67,6 +75,7 @@ jobs:
 
     env:
       RA_TARGET: ${{ matrix.target }}
+      ALLOCATOR_FLAG: ${{ matrix.allocator != 'system' && format('--{0}', matrix.allocator) || '' }}
 
     steps:
       - name: Checkout repository
@@ -102,11 +111,11 @@ jobs:
 
       - name: Dist (plain)
         if: ${{ !matrix.zig_target }}
-        run: cargo xtask dist --client-patch-version ${{ github.run_number }} ${{ matrix.pgo && format('--pgo {0}', matrix.pgo) || ''}}
+        run: cargo xtask dist --client-patch-version ${{ github.run_number }} ${{ env.ALLOCATOR_FLAG }} ${{ matrix.pgo && format('--pgo {0}', matrix.pgo) || ''}}
 
       - name: Dist (using zigbuild)
         if: ${{ matrix.zig_target }}
-        run: RA_TARGET=${{ matrix.zig_target}} cargo xtask dist --client-patch-version ${{ github.run_number }} --zig ${{ matrix.pgo && format('--pgo {0}', matrix.pgo) || ''}}
+        run: RA_TARGET=${{ matrix.zig_target}} cargo xtask dist --client-patch-version ${{ github.run_number }} --zig ${{ env.ALLOCATOR_FLAG }} ${{ matrix.pgo && format('--pgo {0}', matrix.pgo) || ''}}
 
       - run: npm ci
         working-directory: editors/code


### PR DESCRIPTION
It is vastly faster than the system allocator for our workload on windows. We tend to allocate a lot of small objects on differing threads which causes the system allocator lock to contend and block a lot.