### PR TITLE
Re-enable CI cache

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,9 @@ name: CI
 on:
   pull_request:
   merge_group:
+  push:
+    branches:
+      - master
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -105,12 +108,13 @@ jobs:
         if: matrix.os == 'macos-latest'
         run: echo "::add-matcher::.github/rust.json"
 
-      # - name: Cache Dependencies
-      #   uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6
-      #   with:
-      #     workspaces: |
-      #       . -> target
-      #       ./crates/proc-macro-srv/proc-macro-test/imp -> target
+      - name: Cache Dependencies
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          cache-workspace-crates: true
+          workspaces: |
+            . -> target
+            ./crates/proc-macro-srv/proc-macro-test/imp -> target
 
       - name: Install nextest
         uses: taiki-e/install-action@nextest
@@ -144,8 +148,11 @@ jobs:
           rustup default stable
           rustup component add rustfmt
 
-      # - name: Cache Dependencies
-      #   uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6
+      - name: Cache Dependencies
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          cache-workspace-crates: "true"
+          key: wip2
 
       - name: Bump opt-level
         run: sed -i '/\[profile.dev]/a opt-level=1' Cargo.toml
@@ -213,9 +220,6 @@ jobs:
           rustup default nightly-2026-02-10
           rustup component add miri
 
-      # - name: Cache Dependencies
-      #   uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6
-
       - run: cargo miri test -p intern
 
   # Weird targets to catch non-portable code
@@ -242,8 +246,6 @@ jobs:
           rustup update --no-self-update stable
           rustup target add ${{ matrix.target }}
 
-      # - name: Cache Dependencies
-      #   uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6
 
       - run: cargo check --target=${{ matrix.target }} --all-targets -p ide
         if: ${{ matrix.ide-only }}

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -30,6 +30,11 @@ jobs:
       - name: Install nextest
         uses: taiki-e/install-action@nextest
 
+      - name: Cache Dependencies
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          cache-workspace-crates: true
+
       - name: Generate code coverage
         run: cargo llvm-cov --workspace --lcov --output-path lcov.info
 


### PR DESCRIPTION
Proposed in https://rust-lang.zulipchat.com/#narrow/channel/185405-t-compiler.2Frust-analyzer/topic/Moving.20off.20merge.20queue.20to.20new.20bors.3F/with/598734807.

It should now actually work, because CI was switched to run also on the `master` branch. The `coverage` workflow seemed to be quite slow (~5 minutes), so I also enabled the `rust-cache` action for it; the workflow was already running on pushes to `master`.

I removed two commented (previous) usages of `rust-cache`, because the corresponding jobs seem to be quite fast these days (<1m).

I pinned the version to https://github.com/Swatinem/rust-cache/commit/c19371144df3bb44fab255c43d04cbc2ab54d1c4, which is the latest released version of [rust-cache](https://github.com/Swatinem/rust-cache/releases/tag/v2.9.1) as of today, `2.9.1`.
