### PR TITLE
Always use crates from sysroot in proc-macro-srv

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -56,7 +56,7 @@ jobs:
       - name: Install Rust toolchain
         run: |
           RUSTC_VERSION=$(cat rust-version)
-          rustup-toolchain-install-master ${RUSTC_VERSION} -c cargo -c rust-src -c rustfmt
+          rustup-toolchain-install-master ${RUSTC_VERSION} -c cargo -c rust-src -c rustfmt -c rustc-dev -c llvm-tools
           rustup default ${RUSTC_VERSION}
 
       # Emulate a nightly toolchain, because the toolchain installed above does not have "nightly"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1887,7 +1887,6 @@ dependencies = [
  "object",
  "paths",
  "proc-macro-test",
- "ra-ap-rustc_lexer",
  "span",
  "temp-dir",
 ]

--- a/crates/proc-macro-api/Cargo.toml
+++ b/crates/proc-macro-api/Cargo.toml
@@ -39,7 +39,6 @@ span.workspace = true
 [features]
 sysroot-abi = ["proc-macro-srv", "proc-macro-srv/sysroot-abi"]
 default = []
-in-rust-tree = []
 
 [lints]
 workspace = true

--- a/crates/proc-macro-api/src/lib.rs
+++ b/crates/proc-macro-api/src/lib.rs
@@ -8,12 +8,11 @@
 #![cfg_attr(not(feature = "sysroot-abi"), allow(unused_crate_dependencies))]
 #![cfg_attr(
     feature = "sysroot-abi",
-    feature(proc_macro_internals, proc_macro_diagnostic, proc_macro_span)
+    feature(proc_macro_internals, proc_macro_diagnostic, proc_macro_span, rustc_private)
 )]
 #![allow(internal_features, unused_features)]
-#![cfg_attr(feature = "in-rust-tree", feature(rustc_private))]
 
-#[cfg(feature = "in-rust-tree")]
+#[cfg(feature = "sysroot-abi")]
 extern crate rustc_driver as _;
 
 pub mod bidirectional_protocol;

--- a/crates/proc-macro-srv-cli/Cargo.toml
+++ b/crates/proc-macro-srv-cli/Cargo.toml
@@ -33,7 +33,6 @@ proc-macro-test.path = "../proc-macro-srv/proc-macro-test"
 default = []
 # default = ["sysroot-abi"]
 sysroot-abi = ["proc-macro-srv/sysroot-abi", "proc-macro-api/sysroot-abi"]
-in-rust-tree = ["proc-macro-srv/in-rust-tree", "sysroot-abi"]
 
 
 [[bin]]

--- a/crates/proc-macro-srv-cli/src/lib.rs
+++ b/crates/proc-macro-srv-cli/src/lib.rs
@@ -2,10 +2,9 @@
 //!
 //! This module exposes the server main loop and protocol format for integration testing.
 
-#![cfg_attr(feature = "in-rust-tree", feature(rustc_private))]
+#![cfg(feature = "sysroot-abi")]
+#![feature(rustc_private)]
 
-#[cfg(feature = "in-rust-tree")]
 extern crate rustc_driver as _;
 
-#[cfg(feature = "sysroot-abi")]
 pub mod main_loop;

--- a/crates/proc-macro-srv-cli/src/main.rs
+++ b/crates/proc-macro-srv-cli/src/main.rs
@@ -1,10 +1,10 @@
 //! A standalone binary for `proc-macro-srv`.
 //! Driver for proc macro server
-#![cfg_attr(feature = "in-rust-tree", feature(rustc_private))]
+#![cfg_attr(feature = "sysroot-abi", feature(rustc_private))]
 #![cfg_attr(not(feature = "sysroot-abi"), allow(unused_crate_dependencies))]
 #![allow(clippy::print_stdout, clippy::print_stderr)]
 
-#[cfg(feature = "in-rust-tree")]
+#[cfg(feature = "sysroot-abi")]
 extern crate rustc_driver as _;
 
 mod version;

--- a/crates/proc-macro-srv-cli/tests/bidirectional_postcard.rs
+++ b/crates/proc-macro-srv-cli/tests/bidirectional_postcard.rs
@@ -1,7 +1,6 @@
 #![cfg(feature = "sysroot-abi")]
-#![cfg_attr(feature = "in-rust-tree", feature(rustc_private))]
+#![feature(rustc_private)]
 
-#[cfg(feature = "in-rust-tree")]
 extern crate rustc_driver as _;
 
 mod common {

--- a/crates/proc-macro-srv-cli/tests/legacy_json.rs
+++ b/crates/proc-macro-srv-cli/tests/legacy_json.rs
@@ -4,9 +4,8 @@
 //! channels without needing to spawn the actual server and client processes.
 
 #![cfg(feature = "sysroot-abi")]
-#![cfg_attr(feature = "in-rust-tree", feature(rustc_private))]
+#![feature(rustc_private)]
 
-#[cfg(feature = "in-rust-tree")]
 extern crate rustc_driver as _;
 
 mod common {

--- a/crates/proc-macro-srv/Cargo.toml
+++ b/crates/proc-macro-srv/Cargo.toml
@@ -23,8 +23,6 @@ paths.workspace = true
 span = { path = "../span", version = "0.0.0", default-features = false}
 intern.workspace = true
 
-ra-ap-rustc_lexer.workspace = true
-
 
 [target.'cfg(unix)'.dependencies]
 libc.workspace = true
@@ -39,7 +37,6 @@ proc-macro-test.path = "./proc-macro-test"
 [features]
 default = []
 sysroot-abi = []
-in-rust-tree = ["sysroot-abi"]
 
 [lints]
 workspace = true

--- a/crates/proc-macro-srv/src/lib.rs
+++ b/crates/proc-macro-srv/src/lib.rs
@@ -11,23 +11,14 @@
 //!   rustc rather than `unstable`. (Although in general ABI compatibility is still an issue)…
 
 #![cfg(feature = "sysroot-abi")]
-#![cfg_attr(feature = "in-rust-tree", feature(rustc_private))]
-#![feature(proc_macro_internals, proc_macro_diagnostic, proc_macro_span)]
+#![feature(proc_macro_internals, proc_macro_diagnostic, proc_macro_span, rustc_private)]
 #![expect(unreachable_pub, internal_features, clippy::disallowed_types, clippy::print_stderr)]
 #![allow(unused_features, unused_crate_dependencies)]
 #![deny(deprecated_safe, clippy::undocumented_unsafe_blocks)]
 
-#[cfg(not(feature = "in-rust-tree"))]
-extern crate proc_macro as rustc_proc_macro;
-#[cfg(feature = "in-rust-tree")]
 extern crate rustc_driver as _;
-#[cfg(feature = "in-rust-tree")]
-extern crate rustc_proc_macro;
-
-#[cfg(not(feature = "in-rust-tree"))]
-extern crate ra_ap_rustc_lexer as rustc_lexer;
-#[cfg(feature = "in-rust-tree")]
 extern crate rustc_lexer;
+extern crate rustc_proc_macro;
 
 mod bridge;
 mod dylib;

--- a/crates/proc-macro-srv/src/lib.rs
+++ b/crates/proc-macro-srv/src/lib.rs
@@ -7,8 +7,6 @@
 //!
 //! * We use `tt` for proc-macro `TokenStream` server, it is easier to manipulate and interact with
 //!   RA than `proc-macro2` token stream.
-//! * By **copying** the whole rustc `lib_proc_macro` code, we are able to build this with `stable`
-//!   rustc rather than `unstable`. (Although in general ABI compatibility is still an issue)…
 
 #![cfg(feature = "sysroot-abi")]
 #![feature(proc_macro_internals, proc_macro_diagnostic, proc_macro_span, rustc_private)]

--- a/crates/rust-analyzer/Cargo.toml
+++ b/crates/rust-analyzer/Cargo.toml
@@ -108,7 +108,6 @@ in-rust-tree = [
   "ide/in-rust-tree",
   "load-cargo/in-rust-tree",
   "parser/in-rust-tree",
-  "proc-macro-api/in-rust-tree",
   "syntax/in-rust-tree",
 ]
 dhat = ["dep:dhat"]


### PR DESCRIPTION
Unlike the rest of rust-analyzer it only compiles on nightly anyway. And this makes it easier to add dependencies on other rustc crates like rustc_metadata for parsing crate metadata in the future.