### PR TITLE
Enable salsa feature for syntax-bridge

### DIFF
--- a/crates/syntax-bridge/Cargo.toml
+++ b/crates/syntax-bridge/Cargo.toml
@@ -20,8 +20,7 @@ syntax.workspace = true
 parser.workspace = true
 tt.workspace = true
 stdx.workspace = true
-# span = {workspace = true, default-features = false} does not work
-span = { path = "../span", version = "0.0.0", default-features = false}
+span.workspace = true
 intern.workspace = true
 
 [dev-dependencies]


### PR DESCRIPTION
https://github.com/rust-lang/rust-analyzer/pull/22501#issuecomment-4590126074, the proc-macro stuff doesn't depend on the crate anymore so we can enable it again.