### PR TITLE
fix: no hint ra@gennew param

### DIFF
--- a/crates/hir-expand/src/name.rs
+++ b/crates/hir-expand/src/name.rs
@@ -201,8 +201,13 @@ impl Name {
 
     #[inline]
     pub fn is_generated(&self) -> bool {
-        self.as_str().starts_with("<ra@gennew>")
+        is_generated(self.as_str())
     }
+}
+
+#[inline]
+pub fn is_generated(name: &str) -> bool {
+    name.starts_with("<ra@gennew>")
 }
 
 struct Display<'a> {

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -164,7 +164,7 @@ pub use {
         },
         inert_attr_macro::AttributeTemplate,
         mod_path::{ModPath, PathKind, tool_path},
-        name::Name,
+        name::{self, Name},
         prettify_macro_expansion,
         proc_macro::{ProcMacros, ProcMacrosBuilder},
         tt,

--- a/crates/ide/src/inlay_hints/implicit_drop.rs
+++ b/crates/ide/src/inlay_hints/implicit_drop.rs
@@ -9,6 +9,7 @@ use hir::{
     DefWithBody,
     db::HirDatabase as _,
     mir::{MirSpan, TerminatorKind},
+    name,
 };
 use ide_db::{FileRange, famous_defs::FamousDefs};
 
@@ -95,7 +96,7 @@ pub(super) fn hints(
             };
             let binding = &hir[binding_idx];
             let name = binding.name.display_no_db(display_target.edition).to_smolstr();
-            if name.starts_with("<ra@") {
+            if name::is_generated(&name) {
                 continue; // Ignore desugared variables
             }
             let mut label = InlayHintLabel::simple(

--- a/crates/ide/src/inlay_hints/param_name.rs
+++ b/crates/ide/src/inlay_hints/param_name.rs
@@ -7,7 +7,7 @@
 use std::iter::zip;
 
 use either::Either;
-use hir::{EditionedFileId, Semantics};
+use hir::{EditionedFileId, Semantics, name};
 use ide_db::{RootDatabase, famous_defs::FamousDefs};
 
 use stdx::to_lower_snake_case;
@@ -195,15 +195,16 @@ fn should_hide_param_name_hint(
     // - the argument is a qualified constructing or call expression where the qualifier is an ADT
     // - exact argument<->parameter match(ignoring leading and trailing underscore) or
     //   parameter is a prefix/suffix of argument with _ splitting it off
-    // - param starts with `ra_fixture` or `<ra@`
+    // - param starts with `ra_fixture`
     // - param is a well known name in a unary function
+    // - param is generated name
 
     let param_name = param_name.trim_matches('_');
     if param_name.is_empty() {
         return true;
     }
 
-    if param_name.starts_with("ra_fixture") || param_name.starts_with("<ra@") {
+    if param_name.starts_with("ra_fixture") || name::is_generated(param_name) {
         return true;
     }
 

--- a/crates/ide/src/inlay_hints/param_name.rs
+++ b/crates/ide/src/inlay_hints/param_name.rs
@@ -195,7 +195,7 @@ fn should_hide_param_name_hint(
     // - the argument is a qualified constructing or call expression where the qualifier is an ADT
     // - exact argument<->parameter match(ignoring leading and trailing underscore) or
     //   parameter is a prefix/suffix of argument with _ splitting it off
-    // - param starts with `ra_fixture`
+    // - param starts with `ra_fixture` or `<ra@`
     // - param is a well known name in a unary function
 
     let param_name = param_name.trim_matches('_');
@@ -203,7 +203,7 @@ fn should_hide_param_name_hint(
         return true;
     }
 
-    if param_name.starts_with("ra_fixture") {
+    if param_name.starts_with("ra_fixture") || param_name.starts_with("<ra@") {
         return true;
     }
 
@@ -608,6 +608,7 @@ impl Test {
 fn test_func(mut foo: i32, bar: i32, msg: &str, _: i32, last: i32) -> i32 {
     foo + bar
 }
+async fn test_async(foo: i32, _: i32) {}
 
 fn main() {
     let not_literal = 1;
@@ -631,6 +632,8 @@ fn main() {
         None,
       //^^^^ docs
     );
+    test_async(1, 2)
+             //^ foo
 }"#,
         );
     }


### PR DESCRIPTION
Example
---
**Before this PR**

```rust
async fn test_async(foo: i32, _: i32) {}
fn main() {
    test_async(1, 2)
             //^ foo
                //^ <ra@gennew>0
```

**After this PR**

```rust
async fn test_async(foo: i32, _: i32) {}
fn main() {
    test_async(1, 2)
             //^ foo
```
