### PR TITLE
fix: RunnableKind::Test should map to project_json::RunnableKind::TestOne

### DIFF
--- a/crates/rust-analyzer/src/target_spec.rs
+++ b/crates/rust-analyzer/src/target_spec.rs
@@ -99,7 +99,7 @@ impl ProjectJsonTargetSpec {
                     arg.replace("{label}", &this.label)
                 }),
             RunnableKind::Test { test_id, .. } => {
-                self.find_replace_runnable(project_json::RunnableKind::Run, &|this, arg| {
+                self.find_replace_runnable(project_json::RunnableKind::TestOne, &|this, arg| {
                     arg.replace("{label}", &this.label).replace("{test_id}", &test_id.to_string())
                 })
             }


### PR DESCRIPTION
The old code looks like a copy-paste mistake, and prevented code lenses appearing in VS Code for projects using rust-project.json.