### PR TITLE
fix: Parse OR pattern types

### DIFF
--- a/crates/hir-ty/src/layout.rs
+++ b/crates/hir-ty/src/layout.rs
@@ -418,17 +418,15 @@ pub fn layout_of_ty_query(
                                 .iter()
                                 .map(|pat| match pat.kind() {
                                     PatternKind::Range { start, end } => Ok::<_, LayoutError>((
-                                        extract_const_value(start)
-                                            .unwrap()
+                                        extract_const_value(start)?
                                             .try_to_bits(db, trait_env.as_ref())
                                             .ok_or(LayoutError::Unknown)?,
-                                        extract_const_value(end)
-                                            .unwrap()
+                                        extract_const_value(end)?
                                             .try_to_bits(db, trait_env.as_ref())
                                             .ok_or(LayoutError::Unknown)?,
                                     )),
                                     PatternKind::NotNull | PatternKind::Or(_) => {
-                                        unreachable!("mixed or patterns are not allowed")
+                                        Err(LayoutError::Unknown)
                                     }
                                 })
                                 .collect();

--- a/crates/hir-ty/src/layout/tests.rs
+++ b/crates/hir-ty/src/layout/tests.rs
@@ -535,12 +535,20 @@ fn non_zero_and_non_null() {
     }
     check_size_and_align(
         r#"
-const END: usize = 10;
-struct Goal(core::pattern_type!(usize is 0..=END));
-    "#,
+    const END: usize = 10;
+    struct Goal(core::pattern_type!(usize is 0..=END));
+        "#,
         "//- minicore: pat\n",
         8,
         8,
+    );
+    check_size_and_align(
+        r#"
+pub struct Goal(core::pattern_type!(i32 is ..0 | 1..));
+    "#,
+        "//- minicore: pat\n",
+        4,
+        4,
     );
 }
 

--- a/crates/parser/src/grammar/types.rs
+++ b/crates/parser/src/grammar/types.rs
@@ -1,4 +1,4 @@
-use crate::grammar::entry::prefix::pat;
+use crate::grammar::entry::prefix::pat_top;
 
 use super::*;
 
@@ -430,7 +430,7 @@ fn pattern_type(p: &mut Parser<'_>) {
         if !p.eat_contextual_kw(T![is]) {
             p.error("expected `is`")
         }
-        pat(p);
+        pat_top(p);
         p.expect(T![')']);
         m.complete(p, PATTERN_TYPE);
     } else {

--- a/crates/test-utils/src/minicore.rs
+++ b/crates/test-utils/src/minicore.rs
@@ -2349,6 +2349,18 @@ pub mod pat {
         }
     }
 
+    impl const RangePattern for i32 {
+        const MIN: i32 = 0x80_00_00_00;
+        const MAX: i32 = 0x7F_FF_FF_FF;
+        fn sub_one(self) -> Self {
+            if self == Self::MIN {
+                panic!("exclusive range end at minimum value of type")
+            } else {
+                self - 1
+            }
+        }
+    }
+
     // region:coerce_unsized
     impl<T: crate::marker::PointeeSized, U: crate::marker::PointeeSized>
         crate::ops::CoerceUnsized<pattern_type!(*const U is !null)> for pattern_type!(*const T is !null)


### PR DESCRIPTION
`pat()` does not parse or patterns.

This is required to support `NonZero`.