### PR TITLE
internal: Improve panic message when FileSourceRootInput is missing

### DIFF
--- a/crates/base-db/src/lib.rs
+++ b/crates/base-db/src/lib.rs
@@ -170,14 +170,30 @@ impl Files {
         };
     }
 
-    pub fn file_source_root(&self, id: vfs::FileId) -> FileSourceRootInput {
+    pub fn file_source_root(
+        &self,
+        db: &dyn SourceDatabase,
+        id: vfs::FileId,
+    ) -> FileSourceRootInput {
         let file_source_root = match self.file_source_roots.get(&id) {
             Some(file_source_root) => file_source_root,
             None => panic!(
-                "Unable to get `FileSourceRootInput` with `vfs::FileId` ({id:?}); this is a bug",
+                "Unable to get `FileSourceRootInput` with `vfs::FileId` ({id:?}, path: {}); this is a bug",
+                self.path_for_file(db, id)
+                    .map_or_else(|| "<unknown>".to_owned(), |path| path.to_string()),
             ),
         };
         *file_source_root
+    }
+
+    fn path_for_file(&self, db: &dyn SourceDatabase, id: vfs::FileId) -> Option<vfs::VfsPath> {
+        for source_root in &*self.source_roots {
+            let source_root = *source_root.value();
+            if let Some(path) = source_root.source_root(db).path_for_file(&id) {
+                return Some(path.clone());
+            }
+        }
+        None
     }
 
     pub fn set_file_source_root_with_durability(

--- a/crates/hir-def/src/test_db.rs
+++ b/crates/hir-def/src/test_db.rs
@@ -122,7 +122,7 @@ impl SourceDatabase for TestDB {
     }
 
     fn file_source_root(&self, id: base_db::FileId) -> FileSourceRootInput {
-        self.files.file_source_root(id)
+        self.files.file_source_root(self, id)
     }
 
     fn set_file_source_root_with_durability(

--- a/crates/hir-ty/src/test_db.rs
+++ b/crates/hir-ty/src/test_db.rs
@@ -112,7 +112,7 @@ impl SourceDatabase for TestDB {
     }
 
     fn file_source_root(&self, id: base_db::FileId) -> FileSourceRootInput {
-        self.files.file_source_root(id)
+        self.files.file_source_root(self, id)
     }
 
     fn set_file_source_root_with_durability(

--- a/crates/ide-db/src/lib.rs
+++ b/crates/ide-db/src/lib.rs
@@ -160,7 +160,7 @@ impl SourceDatabase for RootDatabase {
     }
 
     fn file_source_root(&self, id: vfs::FileId) -> FileSourceRootInput {
-        self.files.file_source_root(id)
+        self.files.file_source_root(self, id)
     }
 
     fn set_file_source_root_with_durability(


### PR DESCRIPTION
I'm seeing several occurrences of errors of the form:

```
Unable to get `FileSourceRootInput` with `vfs::FileId` (FileId(22452)); this is a bug
```

I suspect it occurs when the user has many projects open, but I can't reliably reproduce yet. In the meantime, include the actual file name to aid debugging.

AI disclosure: Partially written with Codex and GPT 5.5.