### PR TITLE
Run StaticIndex::compute over multiple threads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1043,6 +1043,7 @@ dependencies = [
  "arrayvec",
  "cfg",
  "cov-mark",
+ "dashmap",
  "dot",
  "either",
  "expect-test",

--- a/crates/ide/Cargo.toml
+++ b/crates/ide/Cargo.toml
@@ -15,6 +15,7 @@ doctest = false
 [dependencies]
 cov-mark = "2.0.0"
 arrayvec.workspace = true
+dashmap.workspace = true
 either.workspace = true
 itertools.workspace = true
 tracing.workspace = true

--- a/crates/ide/src/lib.rs
+++ b/crates/ide/src/lib.rs
@@ -240,7 +240,7 @@ impl Default for AnalysisHost {
 /// entry point for asking semantic information about the world. When the world
 /// state is advanced using `AnalysisHost::apply_change` method, all existing
 /// `Analysis` are canceled (most method return `Err(Canceled)`).
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Analysis {
     db: RootDatabase,
 }

--- a/crates/ide/src/static_index.rs
+++ b/crates/ide/src/static_index.rs
@@ -196,11 +196,9 @@ fn index_file<'a>(
     let mut result = StaticIndexedFile { file_id, folds, tokens: vec![] };
 
     let mut add_token = |def: Definition<'a>, range: TextRange, scope_node: &SyntaxNode| {
-        let id = if let Some(it) = def_map.get(&def) {
-            *it
-        } else {
+        let id = *def_map.entry(def).or_insert_with(|| {
             let nav = def.try_to_nav(&sema).map(UpmappingResult::call_site);
-            let it = token_store.insert(TokenStaticData {
+            token_store.insert(TokenStaticData {
                 documentation: documentation_for_definition(&sema, def, scope_node),
                 hover: Some(hover_for_definition(
                     &sema,
@@ -226,10 +224,8 @@ fn index_file<'a>(
                 display_name: def.name(db).map(|name| name.display(db, edition).to_string()),
                 signature: Some(def.label(db, display_target)),
                 kind: def_to_kind(db, def),
-            });
-            def_map.insert(def, it);
-            it
-        };
+            })
+        });
         let token = token_store.get_mut(id).unwrap();
         token.references.push(ReferenceData {
             range: FileRange { range, file_id },

--- a/crates/ide/src/static_index.rs
+++ b/crates/ide/src/static_index.rs
@@ -5,7 +5,7 @@ use arrayvec::ArrayVec;
 use either::Either;
 use hir::{Crate, Module, Semantics, db::HirDatabase};
 use ide_db::{
-    FileId, FileRange, FxHashMap, FxHashSet, RootDatabase,
+    FileId, FileRange, FxHashMap, RootDatabase,
     base_db::{SourceDatabase, VfsPath},
     defs::{Definition, IdentClass},
     documentation::Documentation,
@@ -270,21 +270,37 @@ impl<'a> StaticIndex<'a> {
         vendored_libs_config: VendoredLibrariesConfig<'_>,
     ) -> StaticIndex<'a> {
         let db = &analysis.db;
-        hir::attach_db(db, || {
-            let work = all_modules(db).into_iter().filter(|module| {
-                let file_id = module.definition_source_file_id(db).original_file(db);
-                let source_root =
-                    db.file_source_root(file_id.file_id(&analysis.db)).source_root_id(db);
-                let source_root = db.source_root(source_root).source_root(db);
-                let is_vendored = match vendored_libs_config {
-                    VendoredLibrariesConfig::Included { workspace_root } => source_root
-                        .path_for_file(&file_id.file_id(&analysis.db))
-                        .is_some_and(|module_path| module_path.starts_with(workspace_root)),
-                    VendoredLibrariesConfig::Excluded => false,
-                };
 
-                !source_root.is_library || is_vendored
+        let files_to_index = {
+            let mut files_to_index: Vec<_> = hir::attach_db(db, || {
+                let modules = all_modules(db).into_iter();
+
+                let modules_to_index = modules.filter(|module| {
+                    let file_id = module.definition_source_file_id(db).original_file(db);
+                    let source_root = db.file_source_root(file_id.file_id(db)).source_root_id(db);
+                    let source_root = db.source_root(source_root).source_root(db);
+                    let is_vendored = match vendored_libs_config {
+                        VendoredLibrariesConfig::Included { workspace_root } => source_root
+                            .path_for_file(&file_id.file_id(db))
+                            .is_some_and(|module_path| module_path.starts_with(workspace_root)),
+                        VendoredLibrariesConfig::Excluded => false,
+                    };
+
+                    !source_root.is_library || is_vendored
+                });
+
+                let files_to_index = modules_to_index.map(|module| {
+                    module.definition_source_file_id(db).original_file(db).file_id(db)
+                });
+
+                files_to_index.collect()
             });
+            files_to_index.sort();
+            files_to_index.dedup();
+            files_to_index
+        };
+
+        hir::attach_db(db, || {
             let mut this = StaticIndex {
                 files: vec![],
                 tokens: Default::default(),
@@ -292,15 +308,8 @@ impl<'a> StaticIndex<'a> {
                 db,
                 def_map: Default::default(),
             };
-            let mut visited_files = FxHashSet::default();
-            for module in work {
-                let file_id =
-                    module.definition_source_file_id(db).original_file(db).file_id(&analysis.db);
-                if visited_files.contains(&file_id) {
-                    continue;
-                }
+            for file_id in files_to_index {
                 this.add_file(file_id);
-                visited_files.insert(file_id);
             }
             this
         })

--- a/crates/ide/src/static_index.rs
+++ b/crates/ide/src/static_index.rs
@@ -1,11 +1,17 @@
 //! This module provides `StaticIndex` which is used for powering
 //! read-only code browsers and emitting LSIF
 
+use std::sync::atomic::{AtomicUsize, Ordering};
+
 use arrayvec::ArrayVec;
+use dashmap::{
+    DashMap,
+    mapref::one::{Ref, RefMut},
+};
 use either::Either;
 use hir::{Crate, Module, Semantics, db::HirDatabase};
 use ide_db::{
-    FileId, FileRange, FxHashMap, RootDatabase,
+    FileId, FileRange, RootDatabase,
     base_db::{SourceDatabase, VfsPath},
     defs::{Definition, IdentClass},
     documentation::Documentation,
@@ -84,25 +90,28 @@ impl TokenId {
 }
 
 #[derive(Default, Debug)]
-pub struct TokenStore(Vec<TokenStaticData>);
+pub struct TokenStore {
+    data: DashMap<TokenId, TokenStaticData>,
+    last_index: AtomicUsize,
+}
 
 impl TokenStore {
-    pub fn insert(&mut self, data: TokenStaticData) -> TokenId {
-        let id = TokenId(self.0.len());
-        self.0.push(data);
+    pub fn insert(&self, data: TokenStaticData) -> TokenId {
+        let id = TokenId(self.last_index.fetch_add(1, Ordering::Relaxed));
+        self.data.insert(id, data);
         id
     }
 
-    pub fn get_mut(&mut self, id: TokenId) -> Option<&mut TokenStaticData> {
-        self.0.get_mut(id.0)
+    pub fn get_mut(&self, id: TokenId) -> Option<RefMut<'_, TokenId, TokenStaticData>> {
+        self.data.get_mut(&id)
     }
 
-    pub fn get(&self, id: TokenId) -> Option<&TokenStaticData> {
-        self.0.get(id.0)
+    pub fn get(&self, id: TokenId) -> Option<Ref<'_, TokenId, TokenStaticData>> {
+        self.data.get(&id)
     }
 
     pub fn iter(self) -> impl Iterator<Item = (TokenId, TokenStaticData)> {
-        self.0.into_iter().enumerate().map(|(id, data)| (TokenId(id), data))
+        self.data.into_iter()
     }
 }
 
@@ -163,8 +172,8 @@ pub enum VendoredLibrariesConfig<'a> {
 
 fn index_file<'a>(
     analysis: &'a Analysis,
-    token_store: &mut TokenStore,
-    def_map: &mut FxHashMap<Definition<'a>, TokenId>,
+    token_store: &TokenStore,
+    def_map: &DashMap<Definition<'a>, TokenId>,
     file_id: FileId,
 ) -> Option<StaticIndexedFile> {
     let db = &analysis.db;
@@ -226,7 +235,7 @@ fn index_file<'a>(
                 kind: def_to_kind(db, def),
             })
         });
-        let token = token_store.get_mut(id).unwrap();
+        let mut token = token_store.get_mut(id).unwrap();
         token.references.push(ReferenceData {
             range: FileRange { range, file_id },
             is_definition: match def.try_to_nav(&sema).map(UpmappingResult::call_site) {
@@ -260,7 +269,11 @@ fn index_file<'a>(
 }
 
 impl StaticIndex {
-    pub fn compute(analysis: &Analysis, vendored_libs_config: VendoredLibrariesConfig<'_>) -> Self {
+    pub fn compute(
+        analysis: &Analysis,
+        vendored_libs_config: VendoredLibrariesConfig<'_>,
+        num_threads: usize,
+    ) -> Self {
         let db = &analysis.db;
 
         let files_to_index = {
@@ -292,15 +305,42 @@ impl StaticIndex {
             files_to_index
         };
 
-        let mut tokens = Default::default();
-        let mut def_map = Default::default();
-        hir::attach_db(db, || {
-            let files = files_to_index
-                .into_iter()
-                .flat_map(|file_id| index_file(analysis, &mut tokens, &mut def_map, file_id))
+        // Because Analysis is not Sync, each thread needs to get exclusive access to its own Analysis clone.
+        // The Definitions which are used as keys in def_map inherit the lifetime of these Analysis clones, so analyses should live longer than def_map.
+        // NOTE this assumes that Definitions yielded from multiple untouched Analysis clones still compare equal.
+        let mut analyses: Vec<_> = (0..num_threads).map(|_| analysis.clone()).collect();
+
+        let def_map = Default::default();
+        let tokens = Default::default();
+        let files = std::thread::scope(|s| {
+            let threads: Vec<_> = analyses
+                .iter_mut()
+                .enumerate()
+                .map(|(thread_index, analysis)| {
+                    let files_to_index = files_to_index
+                        .iter()
+                        .copied()
+                        .enumerate()
+                        .filter(move |(index, _)| index % num_threads == thread_index)
+                        .map(|(_, file_id)| file_id);
+
+                    s.spawn(|| {
+                        let analysis = analysis;
+                        hir::attach_db(&analysis.db, || {
+                            files_to_index
+                                .into_iter()
+                                .flat_map(|file_id| {
+                                    index_file(analysis, &tokens, &def_map, file_id)
+                                })
+                                .collect::<Vec<_>>()
+                        })
+                    })
+                })
                 .collect();
-            StaticIndex { files, tokens }
-        })
+            threads.into_iter().flat_map(|join_handle| join_handle.join().unwrap()).collect()
+        });
+
+        StaticIndex { files, tokens }
     }
 }
 
@@ -370,7 +410,7 @@ mod tests {
         vendored_libs_config: VendoredLibrariesConfig<'_>,
     ) {
         let (analysis, ranges) = fixture::annotations_without_marker(ra_fixture);
-        let s = StaticIndex::compute(&analysis, vendored_libs_config);
+        let s = StaticIndex::compute(&analysis, vendored_libs_config, 1);
         let mut range_set: FxHashSet<_> = ranges.iter().map(|it| it.0).collect();
         for f in s.files {
             for (range, _) in f.tokens {
@@ -396,7 +436,7 @@ mod tests {
         vendored_libs_config: VendoredLibrariesConfig<'_>,
     ) {
         let (analysis, ranges) = fixture::annotations_without_marker(ra_fixture);
-        let s = StaticIndex::compute(&analysis, vendored_libs_config);
+        let s = StaticIndex::compute(&analysis, vendored_libs_config, 1);
         let mut range_set: FxHashSet<_> = ranges.iter().map(|it| it.0).collect();
         for (_, t) in s.tokens.iter() {
             if let Some(t) = t.definition {
@@ -421,7 +461,7 @@ mod tests {
         vendored_libs_config: VendoredLibrariesConfig<'_>,
     ) {
         let (analysis, ranges) = fixture::annotations_without_marker(ra_fixture);
-        let s = StaticIndex::compute(&analysis, vendored_libs_config);
+        let s = StaticIndex::compute(&analysis, vendored_libs_config, 1);
         let mut range_set: FxHashMap<_, i32> = ranges.iter().map(|it| (it.0, 0)).collect();
 
         // Make sure that all references have at least one range. We use a HashMap instead of a

--- a/crates/ide/src/static_index.rs
+++ b/crates/ide/src/static_index.rs
@@ -26,12 +26,9 @@ use crate::{
 ///
 /// The intended use-case is powering read-only code browsers and emitting LSIF/SCIP.
 #[derive(Debug)]
-pub struct StaticIndex<'a> {
+pub struct StaticIndex {
     pub files: Vec<StaticIndexedFile>,
     pub tokens: TokenStore,
-    analysis: &'a Analysis,
-    db: &'a RootDatabase,
-    def_map: FxHashMap<Definition<'a>, TokenId>,
 }
 
 #[derive(Debug)]
@@ -164,111 +161,110 @@ pub enum VendoredLibrariesConfig<'a> {
     Excluded,
 }
 
-impl<'a> StaticIndex<'a> {
-    fn add_file(&mut self, file_id: FileId) {
-        let current_crate = crates_for(self.db, file_id).pop().map(Into::into);
-        let folds = self.analysis.folding_ranges(file_id, true).unwrap();
-        // hovers
-        let sema = hir::Semantics::new(self.db);
-        let root = sema.parse_guess_edition(file_id).syntax().clone();
-        let edition = sema.attach_first_edition(file_id).edition(sema.db);
-        let display_target = match sema.first_crate(file_id) {
-            Some(krate) => krate.to_display_target(sema.db),
-            None => return,
-        };
-        let tokens = root.descendants_with_tokens().filter_map(|it| match it {
-            syntax::NodeOrToken::Node(_) => None,
-            syntax::NodeOrToken::Token(it) => Some(it),
-        });
-        let hover_config = HoverConfig {
-            links_in_hover: true,
-            memory_layout: None,
-            documentation: true,
-            keywords: true,
-            format: crate::HoverDocFormat::Markdown,
-            max_trait_assoc_items_count: None,
-            max_fields_count: Some(5),
-            max_enum_variants_count: Some(5),
-            max_subst_ty_len: SubstTyLen::Unlimited,
-            show_drop_glue: true,
-            ra_fixture: RaFixtureConfig::default(),
-        };
-        let mut result = StaticIndexedFile { file_id, folds, tokens: vec![] };
+fn index_file<'a>(
+    analysis: &'a Analysis,
+    token_store: &mut TokenStore,
+    def_map: &mut FxHashMap<Definition<'a>, TokenId>,
+    file_id: FileId,
+) -> Option<StaticIndexedFile> {
+    let db = &analysis.db;
 
-        let mut add_token = |def: Definition<'a>, range: TextRange, scope_node: &SyntaxNode| {
-            let id = if let Some(it) = self.def_map.get(&def) {
-                *it
-            } else {
-                let nav = def.try_to_nav(&sema).map(UpmappingResult::call_site);
-                let it = self.tokens.insert(TokenStaticData {
-                    documentation: documentation_for_definition(&sema, def, scope_node),
-                    hover: Some(hover_for_definition(
-                        &sema,
-                        file_id,
-                        def,
-                        None,
-                        scope_node,
-                        None,
-                        false,
-                        &hover_config,
-                        edition,
-                        display_target,
-                    )),
-                    definition: nav.as_ref().map(|it| FileRange {
-                        file_id: it.file_id,
-                        range: it.focus_or_full_range(),
-                    }),
-                    definition_body: nav.as_ref().map(|it| FileRange {
-                        file_id: it.file_id,
-                        range: definition_range_excluding_trivia(&sema, it.file_id, it.full_range),
-                    }),
-                    references: vec![],
-                    moniker: current_crate.and_then(|cc| def_to_moniker(self.db, def, cc)),
-                    display_name: def
-                        .name(self.db)
-                        .map(|name| name.display(self.db, edition).to_string()),
-                    signature: Some(def.label(self.db, display_target)),
-                    kind: def_to_kind(self.db, def),
-                });
-                self.def_map.insert(def, it);
-                it
-            };
-            let token = self.tokens.get_mut(id).unwrap();
-            token.references.push(ReferenceData {
-                range: FileRange { range, file_id },
-                is_definition: match def.try_to_nav(&sema).map(UpmappingResult::call_site) {
-                    Some(it) => it.file_id == file_id && it.focus_or_full_range() == range,
-                    None => false,
-                },
+    let current_crate = crates_for(db, file_id).pop().map(Into::into);
+    let folds = analysis.folding_ranges(file_id, true).unwrap();
+    // hovers
+    let sema = hir::Semantics::new(db);
+    let root = sema.parse_guess_edition(file_id).syntax().clone();
+    let edition = sema.attach_first_edition(file_id).edition(sema.db);
+    let display_target = sema.first_crate(file_id)?.to_display_target(sema.db);
+    let tokens = root.descendants_with_tokens().filter_map(|it| match it {
+        syntax::NodeOrToken::Node(_) => None,
+        syntax::NodeOrToken::Token(it) => Some(it),
+    });
+    let hover_config = HoverConfig {
+        links_in_hover: true,
+        memory_layout: None,
+        documentation: true,
+        keywords: true,
+        format: crate::HoverDocFormat::Markdown,
+        max_trait_assoc_items_count: None,
+        max_fields_count: Some(5),
+        max_enum_variants_count: Some(5),
+        max_subst_ty_len: SubstTyLen::Unlimited,
+        show_drop_glue: true,
+        ra_fixture: RaFixtureConfig::default(),
+    };
+    let mut result = StaticIndexedFile { file_id, folds, tokens: vec![] };
+
+    let mut add_token = |def: Definition<'a>, range: TextRange, scope_node: &SyntaxNode| {
+        let id = if let Some(it) = def_map.get(&def) {
+            *it
+        } else {
+            let nav = def.try_to_nav(&sema).map(UpmappingResult::call_site);
+            let it = token_store.insert(TokenStaticData {
+                documentation: documentation_for_definition(&sema, def, scope_node),
+                hover: Some(hover_for_definition(
+                    &sema,
+                    file_id,
+                    def,
+                    None,
+                    scope_node,
+                    None,
+                    false,
+                    &hover_config,
+                    edition,
+                    display_target,
+                )),
+                definition: nav
+                    .as_ref()
+                    .map(|it| FileRange { file_id: it.file_id, range: it.focus_or_full_range() }),
+                definition_body: nav.as_ref().map(|it| FileRange {
+                    file_id: it.file_id,
+                    range: definition_range_excluding_trivia(&sema, it.file_id, it.full_range),
+                }),
+                references: vec![],
+                moniker: current_crate.and_then(|cc| def_to_moniker(db, def, cc)),
+                display_name: def.name(db).map(|name| name.display(db, edition).to_string()),
+                signature: Some(def.label(db, display_target)),
+                kind: def_to_kind(db, def),
             });
-            result.tokens.push((range, id));
+            def_map.insert(def, it);
+            it
         };
+        let token = token_store.get_mut(id).unwrap();
+        token.references.push(ReferenceData {
+            range: FileRange { range, file_id },
+            is_definition: match def.try_to_nav(&sema).map(UpmappingResult::call_site) {
+                Some(it) => it.file_id == file_id && it.focus_or_full_range() == range,
+                None => false,
+            },
+        });
+        result.tokens.push((range, id));
+    };
 
-        if let Some(module) = sema.file_to_module_def(file_id) {
-            let def = Definition::Module(module);
-            let range = root.text_range();
-            add_token(def, range, &root);
-        }
-
-        for token in tokens {
-            let range = token.text_range();
-            let node = token.parent().unwrap();
-            match hir::attach_db(self.db, || get_definitions(&sema, token.clone())) {
-                Some(defs) => {
-                    for (def, _) in defs {
-                        add_token(def, range, &node);
-                    }
-                }
-                None => continue,
-            };
-        }
-        self.files.push(result);
+    if let Some(module) = sema.file_to_module_def(file_id) {
+        let def = Definition::Module(module);
+        let range = root.text_range();
+        add_token(def, range, &root);
     }
 
-    pub fn compute(
-        analysis: &'a Analysis,
-        vendored_libs_config: VendoredLibrariesConfig<'_>,
-    ) -> StaticIndex<'a> {
+    for token in tokens {
+        let range = token.text_range();
+        let node = token.parent().unwrap();
+        match hir::attach_db(db, || get_definitions(&sema, token.clone())) {
+            Some(defs) => {
+                for (def, _) in defs {
+                    add_token(def, range, &node);
+                }
+            }
+            None => continue,
+        };
+    }
+
+    Some(result)
+}
+
+impl StaticIndex {
+    pub fn compute(analysis: &Analysis, vendored_libs_config: VendoredLibrariesConfig<'_>) -> Self {
         let db = &analysis.db;
 
         let files_to_index = {
@@ -300,18 +296,14 @@ impl<'a> StaticIndex<'a> {
             files_to_index
         };
 
+        let mut tokens = Default::default();
+        let mut def_map = Default::default();
         hir::attach_db(db, || {
-            let mut this = StaticIndex {
-                files: vec![],
-                tokens: Default::default(),
-                analysis,
-                db,
-                def_map: Default::default(),
-            };
-            for file_id in files_to_index {
-                this.add_file(file_id);
-            }
-            this
+            let files = files_to_index
+                .into_iter()
+                .flat_map(|file_id| index_file(analysis, &mut tokens, &mut def_map, file_id))
+                .collect();
+            StaticIndex { files, tokens }
         })
     }
 }

--- a/crates/rust-analyzer/src/cli/lsif.rs
+++ b/crates/rust-analyzer/src/cli/lsif.rs
@@ -317,7 +317,7 @@ impl flags::Lsif {
             VendoredLibrariesConfig::Included { workspace_root: &path.clone().into() }
         };
 
-        let si = StaticIndex::compute(&analysis, vendored_libs_config);
+        let si = StaticIndex::compute(&analysis, vendored_libs_config, 1);
 
         let mut lsif = LsifManager::new(&analysis, db, &vfs, out);
         lsif.add_vertex(lsif::Vertex::MetaData(lsif::MetaData {
@@ -333,7 +333,22 @@ impl flags::Lsif {
         for file in si.files {
             lsif.add_file(file);
         }
-        for (id, token) in si.tokens.iter() {
+
+        // The output order depends on the iteration order, make that order somewhat stable to avoid making lsif_contains_generated_constant flaky
+        let tokens = {
+            let mut tokens: Vec<_> = si.tokens.iter().collect();
+            tokens.sort_by_key(|(_, token)| {
+                (
+                    token.references[0].range.file_id,
+                    token.references[0].range.range.start(),
+                    token.references[0].range.range.end(),
+                    token.kind,
+                )
+            });
+            tokens
+        };
+
+        for (id, token) in tokens {
             lsif.add_token(id, token);
         }
         eprintln!("Generating LSIF finished in {:?}", now.elapsed());

--- a/crates/rust-analyzer/src/cli/scip.rs
+++ b/crates/rust-analyzer/src/cli/scip.rs
@@ -22,7 +22,8 @@ use crate::{
 
 impl flags::Scip {
     pub fn run(self) -> anyhow::Result<()> {
-        eprintln!("Generating SCIP start...");
+        let num_threads = self.num_threads.unwrap_or_else(num_cpus::get_physical);
+        eprintln!("Generating SCIP start with {num_threads} threads...");
         let now = Instant::now();
 
         let no_progress = &|s| eprintln!("rust-analyzer: Loading {s}");
@@ -52,7 +53,7 @@ impl flags::Scip {
             load_out_dirs_from_check: true,
             with_proc_macro_server: ProcMacroServerChoice::Sysroot,
             prefill_caches: true,
-            num_worker_threads: self.num_threads.unwrap_or_else(num_cpus::get_physical),
+            num_worker_threads: num_threads,
             proc_macro_processes: config.proc_macro_num_processes(),
         };
         let cargo_config = config.cargo(None);
@@ -72,7 +73,7 @@ impl flags::Scip {
             VendoredLibrariesConfig::Included { workspace_root: &root.clone().into() }
         };
 
-        let si = StaticIndex::compute(&analysis, vendored_libs_config);
+        let si = StaticIndex::compute(&analysis, vendored_libs_config, num_threads);
 
         let metadata = scip_types::Metadata {
             version: scip_types::ProtocolVersion::UnspecifiedProtocolVersion.into(),
@@ -145,7 +146,7 @@ impl flags::Scip {
                 let token = si.tokens.get(id).unwrap();
 
                 let Some(TokenSymbols { symbol, enclosing_symbol, is_inherent_impl }) =
-                    symbol_generator.token_symbols(id, token)
+                    symbol_generator.token_symbols(id, token.value())
                 else {
                     // token did not have a moniker, so there is no reasonable occurrence to emit
                     // see ide::moniker::def_to_moniker
@@ -171,7 +172,7 @@ impl flags::Scip {
                             symbols.push(compute_symbol_info(
                                 symbol.clone(),
                                 enclosing_symbol,
-                                token,
+                                token.value(),
                             ));
                         }
                     }
@@ -253,7 +254,7 @@ impl flags::Scip {
             }
 
             let TokenSymbols { symbol, enclosing_symbol, .. } = symbol_generator
-                .token_symbols(id, token)
+                .token_symbols(id, token.value())
                 .expect("To have been referenced, the symbol must be in the cache.");
 
             record_error_if_symbol_already_used(
@@ -263,7 +264,11 @@ impl flags::Scip {
                 &line_index,
                 text_range,
             );
-            external_symbols.push(compute_symbol_info(symbol.clone(), enclosing_symbol, token));
+            external_symbols.push(compute_symbol_info(
+                symbol.clone(),
+                enclosing_symbol,
+                token.value(),
+            ));
         }
 
         let index = scip_types::Index {
@@ -544,6 +549,7 @@ mod test {
             VendoredLibrariesConfig::Included {
                 workspace_root: &VfsPath::new_virtual_path("/workspace".to_owned()),
             },
+            1,
         );
 
         let FilePosition { file_id, offset } = position;
@@ -912,6 +918,7 @@ pub mod example_mod {
             VendoredLibrariesConfig::Included {
                 workspace_root: &VfsPath::new_virtual_path("/workspace".to_owned()),
             },
+            1,
         );
 
         let file = si.files.first().unwrap();
@@ -935,6 +942,7 @@ pub mod example_mod {
             VendoredLibrariesConfig::Included {
                 workspace_root: &VfsPath::new_virtual_path("/workspace".to_owned()),
             },
+            1,
         );
 
         let file = si.files.first().unwrap();
@@ -963,6 +971,7 @@ pub mod example_mod {
             VendoredLibrariesConfig::Included {
                 workspace_root: &VfsPath::new_virtual_path("/workspace".to_owned()),
             },
+            1,
         );
 
         let file = si.files.first().unwrap();
@@ -995,6 +1004,7 @@ pub mod example_mod {
             VendoredLibrariesConfig::Included {
                 workspace_root: &VfsPath::new_virtual_path("/workspace".to_owned()),
             },
+            1,
         );
 
         let file = si.files.first().unwrap();


### PR DESCRIPTION
Each thread takes care of the files whose index in the precomputed list is congruent to the thread index modulo the thread count and generates a partial StaticIndex. All those StaticIndex instances are then simply concatenated together.

On my laptop with 16 threads this brings the time required to generate an SCIP index of Firefox from 110 seconds with 130% CPU usage down to 45 seconds, with 430% CPU usage.

Fixes rust-lang/rust-analyzer#18140 