### PR TITLE
fix: pretty assoc const when trait in macro

### DIFF
--- a/crates/ide-completion/src/completions/item_list/trait_impl.rs
+++ b/crates/ide-completion/src/completions/item_list/trait_impl.rs
@@ -511,7 +511,7 @@ fn make_const_compl_syntax(
     let len = end - start;
     let range = TextRange::new(0.into(), len);
 
-    let syntax = const_.text().slice(range).to_string();
+    let syntax = const_.text().slice(range).to_smolstr();
 
     format_smolstr!("{} =", syntax.trim_end())
 }
@@ -537,9 +537,10 @@ fn function_declaration(
         .map_or(end, |f| f.text_range().start());
 
     let len = end - start;
-    let syntax = node.text().slice(..len).to_string();
+    let mut syntax = node.text().slice(..len).to_string();
+    syntax.truncate(syntax.trim_end().len());
 
-    syntax.trim_end().to_owned()
+    syntax
 }
 
 #[cfg(test)]

--- a/crates/ide-completion/src/completions/item_list/trait_impl.rs
+++ b/crates/ide-completion/src/completions/item_list/trait_impl.rs
@@ -265,6 +265,7 @@ fn get_transformed_assoc_item(
     ctx: &CompletionContext<'_, '_>,
     assoc_item: ast::AssocItem,
     impl_def: hir::Impl,
+    macro_file: Option<MacroCallId>,
 ) -> Option<ast::AssocItem> {
     let trait_ = impl_def.trait_(ctx.db)?;
     let source_scope = &ctx.sema.scope(assoc_item.syntax())?;
@@ -278,7 +279,16 @@ fn get_transformed_assoc_item(
     let assoc_item = ast::AssocItem::cast(transform.apply(assoc_item.syntax()))?;
     let (editor, assoc_item) = SyntaxEditor::with_ast_node(&assoc_item);
     assoc_item.remove_attrs_and_docs(&editor);
-    ast::AssocItem::cast(editor.finish().new_root().clone())
+    let transformed = editor.finish().new_root().clone();
+
+    let prettied = if let Some(macro_file) = macro_file {
+        let span_map = macro_file.expansion_span_map(ctx.db);
+        prettify_macro_expansion(ctx.db, transformed, span_map, ctx.krate.into())
+    } else {
+        transformed
+    };
+
+    ast::AssocItem::cast(prettied)
 }
 
 /// Transform a relevant associated item to inline generics from the impl, remove attrs and docs, etc.
@@ -383,7 +393,9 @@ fn add_type_alias_impl(
 
     if let Some(source) = ctx.sema.source(type_alias) {
         let assoc_item = ast::AssocItem::TypeAlias(source.value);
-        if let Some(transformed_item) = get_transformed_assoc_item(ctx, assoc_item, impl_def) {
+        if let Some(transformed_item) =
+            get_transformed_assoc_item(ctx, assoc_item, impl_def, source.file_id.macro_file())
+        {
             let transformed_ty = match transformed_item {
                 ast::AssocItem::TypeAlias(ty) => ty,
                 _ => unreachable!(),
@@ -458,14 +470,15 @@ fn add_const_impl(
         && let Some(source) = ctx.sema.source(const_)
     {
         let assoc_item = ast::AssocItem::Const(source.value);
-        if let Some(transformed_item) = get_transformed_assoc_item(ctx, assoc_item, impl_def) {
+        if let Some(transformed_item) =
+            get_transformed_assoc_item(ctx, assoc_item, impl_def, source.file_id.macro_file())
+        {
             let transformed_const = match transformed_item {
                 ast::AssocItem::Const(const_) => const_,
                 _ => unreachable!(),
             };
 
-            let label =
-                make_const_compl_syntax(ctx, &transformed_const, source.file_id.macro_file());
+            let label = make_const_compl_syntax(&transformed_const);
             let replacement = format!("{label} ");
 
             let mut item =
@@ -488,17 +501,8 @@ fn add_const_impl(
     }
 }
 
-fn make_const_compl_syntax(
-    ctx: &CompletionContext<'_, '_>,
-    const_: &ast::Const,
-    macro_file: Option<MacroCallId>,
-) -> SmolStr {
-    let const_ = if let Some(macro_file) = macro_file {
-        let span_map = macro_file.expansion_span_map(ctx.db);
-        prettify_macro_expansion(ctx.db, const_.syntax().clone(), span_map, ctx.krate.into())
-    } else {
-        const_.syntax().clone()
-    };
+fn make_const_compl_syntax(const_: &ast::Const) -> SmolStr {
+    let const_ = const_.syntax();
 
     let start = const_.text_range().start();
     let const_end = const_.text_range().end();
@@ -1364,6 +1368,44 @@ impl Foo for Test {
     fn foo(&mut self,bar: i64,baz: &mut u32) -> Result<(),u32> {
     $0
 }
+}
+"#,
+        );
+
+        check_edit(
+            "type T",
+            r#"
+macro_rules! noop {
+    ($($item: item)*) => {
+        $($item)*
+    }
+}
+
+noop! {
+    trait Foo {
+        type T where Self: Sized;
+    }
+}
+
+impl Foo for () {
+    $0
+}
+"#,
+            r#"
+macro_rules! noop {
+    ($($item: item)*) => {
+        $($item)*
+    }
+}
+
+noop! {
+    trait Foo {
+        type T where Self: Sized;
+    }
+}
+
+impl Foo for () {
+    type T = $0 where Self: Sized;
 }
 "#,
         );


### PR DESCRIPTION
Fixes rust-lang/rust-analyzer#17769

Example
---
```diff
-typeT = $0 whereSelf:Sized;
+type T = $0 where Self: Sized;
```
