### PR TITLE
fix: add macro semicolon in item position

### DIFF
--- a/crates/ide-completion/src/config.rs
+++ b/crates/ide-completion/src/config.rs
@@ -27,6 +27,7 @@ pub struct CompletionConfig<'a> {
     pub callable: Option<CallableSnippets>,
     pub add_colons_to_module: bool,
     pub add_semicolon_to_unit: bool,
+    pub add_semicolon_to_macro: MacroSemicolonStyle,
     pub snippet_cap: Option<SnippetCap>,
     pub insert_use: InsertUseConfig,
     pub prefer_no_std: bool,
@@ -46,6 +47,15 @@ pub enum AutoImportExclusionType {
     Methods,
     SubItems,
     Variants,
+}
+
+// FIXME: Implement 'Auto' mode
+// https://github.com/rust-lang/rust-analyzer/pull/22536#issuecomment-4834287685
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub enum MacroSemicolonStyle {
+    None,
+    Item,
+    Always,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/crates/ide-completion/src/context.rs
+++ b/crates/ide-completion/src/context.rs
@@ -886,22 +886,22 @@ impl<'a, 'db> CompletionContext<'a, 'db> {
         );
 
         // FIXME: This should be part of `CompletionAnalysis` / `expand_and_analyze`
-        let complete_semicolon = if !config.add_semicolon_to_unit {
-            CompleteSemicolon::DoNotComplete
-        } else if let Some(term_node) =
-            sema.token_ancestors_with_macros(token.clone()).find(|node| {
-                matches!(
-                    node.kind(),
-                    BLOCK_EXPR
-                        | MATCH_ARM
-                        | CLOSURE_EXPR
-                        | ARG_LIST
-                        | PAREN_EXPR
-                        | ARRAY_EXPR
-                        | MATCH_EXPR
-                )
-            })
-        {
+        let term_node = sema.token_ancestors_with_macros(token.clone()).find(|node| {
+            if Either::<ast::Type, ast::Pat>::can_cast(node.kind()) {
+                return true;
+            }
+            matches!(
+                node.kind(),
+                BLOCK_EXPR
+                    | MATCH_ARM
+                    | CLOSURE_EXPR
+                    | ARG_LIST
+                    | PAREN_EXPR
+                    | ARRAY_EXPR
+                    | MATCH_EXPR
+            )
+        });
+        let complete_semicolon = if let Some(term_node) = term_node {
             let next_token = iter::successors(token.next_token(), |it| it.next_token())
                 .map(|it| it.kind())
                 .find(|kind| !kind.is_trivia());

--- a/crates/ide-completion/src/lib.rs
+++ b/crates/ide-completion/src/lib.rs
@@ -34,7 +34,7 @@ use crate::{
 };
 
 pub use crate::{
-    config::{AutoImportExclusionType, CallableSnippets, CompletionConfig},
+    config::{AutoImportExclusionType, CallableSnippets, CompletionConfig, MacroSemicolonStyle},
     item::{
         CompletionItem, CompletionItemImport, CompletionItemKind, CompletionItemRefMode,
         CompletionRelevance, CompletionRelevancePostfixMatch, CompletionRelevanceReturnType,

--- a/crates/ide-completion/src/render/function.rs
+++ b/crates/ide-completion/src/render/function.rs
@@ -266,7 +266,7 @@ pub(super) fn add_call_parens<'b>(
 
         (snippet, "(…)")
     };
-    if ret_type.is_unit() {
+    if ret_type.is_unit() && ctx.config.add_semicolon_to_unit {
         match ctx.complete_semicolon {
             CompleteSemicolon::DoNotComplete => {}
             CompleteSemicolon::CompleteSemi | CompleteSemicolon::CompleteComma => {

--- a/crates/ide-completion/src/render/macro_.rs
+++ b/crates/ide-completion/src/render/macro_.rs
@@ -81,7 +81,7 @@ fn render(
     match ctx.snippet_cap() {
         Some(cap) if needs_bang && !has_call_parens => {
             let semi = match ket {
-                ")" | "]" if is_item => ";",
+                ")" | "]" if is_item && completion.config.add_semicolon_to_unit => ";",
                 _ => "",
             };
             let snippet = format!("{escaped_name}!{bra}$0{ket}{semi}");

--- a/crates/ide-completion/src/render/macro_.rs
+++ b/crates/ide-completion/src/render/macro_.rs
@@ -18,7 +18,15 @@ pub(crate) fn render_macro(
     macro_: hir::Macro,
 ) -> Builder {
     let _p = tracing::info_span!("render_macro").entered();
-    render(ctx, *kind == PathKind::Use, *has_macro_bang, *has_call_parens, name, macro_)
+    render(
+        ctx,
+        *kind == PathKind::Use,
+        matches!(kind, PathKind::Item { .. }),
+        *has_macro_bang,
+        *has_call_parens,
+        name,
+        macro_,
+    )
 }
 
 pub(crate) fn render_macro_pat(
@@ -28,12 +36,13 @@ pub(crate) fn render_macro_pat(
     macro_: hir::Macro,
 ) -> Builder {
     let _p = tracing::info_span!("render_macro_pat").entered();
-    render(ctx, false, false, false, name, macro_)
+    render(ctx, false, false, false, false, name, macro_)
 }
 
 fn render(
     ctx @ RenderContext { completion, .. }: RenderContext<'_, '_>,
     is_use_path: bool,
+    is_item: bool,
     has_macro_bang: bool,
     has_call_parens: bool,
     name: hir::Name,
@@ -71,7 +80,11 @@ fn render(
 
     match ctx.snippet_cap() {
         Some(cap) if needs_bang && !has_call_parens => {
-            let snippet = format!("{escaped_name}!{bra}$0{ket}");
+            let semi = match ket {
+                ")" | "]" if is_item => ";",
+                _ => "",
+            };
+            let snippet = format!("{escaped_name}!{bra}$0{ket}{semi}");
             let lookup = banged_name(name);
             item.insert_snippet(cap, snippet).lookup_by(lookup);
         }
@@ -256,6 +269,81 @@ fn main() { $0 }
 macro_rules! foo { () => {} }
 pub use crate::foo as bar;
 fn main() { bar![$0] }
+"#,
+        );
+    }
+
+    #[test]
+    fn macro_semicolons() {
+        check_edit(
+            "foo!",
+            r#"
+macro_rules! foo { () => {} }
+f$0
+"#,
+            r#"
+macro_rules! foo { () => {} }
+foo!($0);
+"#,
+        );
+
+        check_edit(
+            "foo!",
+            r#"
+#[rust_analyzer::macro_style(brackets)]
+macro_rules! foo { () => {} }
+f$0
+"#,
+            r#"
+#[rust_analyzer::macro_style(brackets)]
+macro_rules! foo { () => {} }
+foo![$0];
+"#,
+        );
+
+        check_edit(
+            "foo!",
+            r#"
+#[rust_analyzer::macro_style(braces)]
+macro_rules! foo { () => {} }
+f$0
+"#,
+            r#"
+#[rust_analyzer::macro_style(braces)]
+macro_rules! foo { () => {} }
+foo! {$0}
+"#,
+        );
+
+        check_edit(
+            "foo!",
+            r#"
+macro_rules! foo { () => {} }
+impl () {
+    f$0
+}
+"#,
+            r#"
+macro_rules! foo { () => {} }
+impl () {
+    foo!($0);
+}
+"#,
+        );
+
+        check_edit(
+            "foo!",
+            r#"
+macro_rules! foo { () => {} }
+mod bar {
+    f$0
+}
+"#,
+            r#"
+macro_rules! foo { () => {} }
+mod bar {
+    foo!($0);
+}
 "#,
         );
     }

--- a/crates/ide-completion/src/render/macro_.rs
+++ b/crates/ide-completion/src/render/macro_.rs
@@ -5,7 +5,8 @@ use ide_db::{SymbolKind, documentation::Documentation};
 use syntax::{SmolStr, ToSmolStr, format_smolstr};
 
 use crate::{
-    context::{PathCompletionCtx, PathKind, PatternContext},
+    MacroSemicolonStyle,
+    context::{CompleteSemicolon, PathCompletionCtx, PathKind, PatternContext},
     item::{Builder, CompletionItem},
     render::RenderContext,
 };
@@ -80,8 +81,16 @@ fn render(
 
     match ctx.snippet_cap() {
         Some(cap) if needs_bang && !has_call_parens => {
+            let needs_semi = match completion.config.add_semicolon_to_macro {
+                MacroSemicolonStyle::None => false,
+                MacroSemicolonStyle::Item => is_item,
+                MacroSemicolonStyle::Always => {
+                    is_item
+                        || matches!(completion.complete_semicolon, CompleteSemicolon::CompleteSemi)
+                }
+            };
             let semi = match ket {
-                ")" | "]" if is_item && completion.config.add_semicolon_to_unit => ";",
+                ")" | "]" if needs_semi => ";",
                 _ => "",
             };
             let snippet = format!("{escaped_name}!{bra}$0{ket}{semi}");
@@ -171,7 +180,7 @@ fn guess_macro_braces(
 
 #[cfg(test)]
 mod tests {
-    use crate::tests::check_edit;
+    use crate::tests::{TEST_CONFIG, check_edit, check_edit_with_config};
 
     #[test]
     fn dont_insert_macro_call_parens_unnecessary() {
@@ -275,6 +284,22 @@ fn main() { bar![$0] }
 
     #[test]
     fn macro_semicolons() {
+        check_edit_with_config(
+            crate::CompletionConfig {
+                add_semicolon_to_macro: crate::MacroSemicolonStyle::None,
+                ..TEST_CONFIG
+            },
+            "foo!",
+            r#"
+macro_rules! foo { () => {} }
+f$0
+"#,
+            r#"
+macro_rules! foo { () => {} }
+foo!($0)
+"#,
+        );
+
         check_edit(
             "foo!",
             r#"
@@ -344,6 +369,92 @@ macro_rules! foo { () => {} }
 mod bar {
     foo!($0);
 }
+"#,
+        );
+    }
+
+    #[test]
+    fn macro_semicolons_always() {
+        let config = || crate::CompletionConfig {
+            add_semicolon_to_macro: crate::MacroSemicolonStyle::Always,
+            ..TEST_CONFIG
+        };
+        check_edit_with_config(
+            config(),
+            "foo!",
+            r#"
+macro_rules! foo { () => {} }
+f$0
+"#,
+            r#"
+macro_rules! foo { () => {} }
+foo!($0);
+"#,
+        );
+
+        check_edit_with_config(
+            config(),
+            "foo!",
+            r#"
+macro_rules! foo { () => {} }
+fn main() { f$0 }
+"#,
+            r#"
+macro_rules! foo { () => {} }
+fn main() { foo!($0); }
+"#,
+        );
+
+        check_edit_with_config(
+            config(),
+            "foo!",
+            r#"
+macro_rules! foo { () => {} }
+fn main() { g(f$0) }
+"#,
+            r#"
+macro_rules! foo { () => {} }
+fn main() { g(foo!($0)) }
+"#,
+        );
+
+        check_edit_with_config(
+            config(),
+            "foo!",
+            r#"
+macro_rules! foo { () => {} }
+fn main() { let f$0 = (); }
+"#,
+            r#"
+macro_rules! foo { () => {} }
+fn main() { let foo!($0) = (); }
+"#,
+        );
+
+        // XXX: Maybe add comma to better?
+        check_edit_with_config(
+            config(),
+            "foo!",
+            r#"
+macro_rules! foo { () => {} }
+fn main() { match () { () => f$0 } }
+"#,
+            r#"
+macro_rules! foo { () => {} }
+fn main() { match () { () => foo!($0) } }
+"#,
+        );
+
+        check_edit_with_config(
+            config(),
+            "foo!",
+            r#"
+macro_rules! foo { () => {} }
+fn main() -> f$0 {}
+"#,
+            r#"
+macro_rules! foo { () => {} }
+fn main() -> foo!($0) {}
 "#,
         );
     }

--- a/crates/ide-completion/src/tests.rs
+++ b/crates/ide-completion/src/tests.rs
@@ -74,6 +74,7 @@ pub(crate) const TEST_CONFIG: CompletionConfig<'_> = CompletionConfig {
     callable: Some(CallableSnippets::FillArguments),
     add_colons_to_module: true,
     add_semicolon_to_unit: true,
+    add_semicolon_to_macro: crate::MacroSemicolonStyle::Item,
     snippet_cap: SnippetCap::new(true),
     insert_use: InsertUseConfig {
         granularity: ImportGranularity::Crate,

--- a/crates/ide/src/lib.rs
+++ b/crates/ide/src/lib.rs
@@ -130,8 +130,8 @@ pub use ide_assists::{
 };
 pub use ide_completion::{
     CallableSnippets, CompletionConfig, CompletionFieldsToResolve, CompletionItem,
-    CompletionItemImport, CompletionItemKind, CompletionItemRefMode, CompletionRelevance, Snippet,
-    SnippetScope,
+    CompletionItemImport, CompletionItemKind, CompletionItemRefMode, CompletionRelevance,
+    MacroSemicolonStyle, Snippet, SnippetScope,
 };
 pub use ide_db::{
     FileId, FilePosition, FileRange, RootDatabase, Severity, SymbolKind,

--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -635,6 +635,9 @@ config_data! {
         /// Will not be completed in `use`.
         completion_addColonsToModule: bool = true,
 
+        /// Automatically add a semicolon for macros.
+        completion_addSemicolonToMacro: MacroSemicolonStyle = MacroSemicolonStyle::Item,
+
         /// Automatically add a semicolon when completing unit-returning functions.
         ///
         /// In `match` arms it completes a comma instead.
@@ -1924,6 +1927,11 @@ impl Config {
             },
             add_colons_to_module: *self.completion_addColonsToModule(source_root),
             add_semicolon_to_unit: *self.completion_addSemicolonToUnit(source_root),
+            add_semicolon_to_macro: match self.completion_addSemicolonToMacro(source_root) {
+                MacroSemicolonStyle::None => ide::MacroSemicolonStyle::None,
+                MacroSemicolonStyle::Item => ide::MacroSemicolonStyle::Item,
+                MacroSemicolonStyle::Always => ide::MacroSemicolonStyle::Always,
+            },
             snippet_cap: SnippetCap::new(self.completion_snippet()),
             insert_use: self.insert_use_config(source_root),
             prefer_no_std: self.imports_preferNoStd(source_root).to_owned(),
@@ -3076,6 +3084,14 @@ pub enum AutoImportExclusionType {
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "snake_case")]
+pub enum MacroSemicolonStyle {
+    None,
+    Item,
+    Always,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "snake_case")]
 enum ImportGranularityDef {
     Preserve,
     Item,
@@ -4214,7 +4230,18 @@ fn field_props(field: &str, ty: &str, doc: &[&str], default: &str) -> serde_json
                         }
                     }
                 ]
-             }
+            }
+        },
+        "MacroSemicolonStyle" => set! {
+            "type": {
+                "type": "string",
+                "enum": ["none", "item", "always"],
+                "enumDescriptions": [
+                    "Never complete semicolon",
+                    "Complete semicolon when path in item position",
+                    "Always complete semicolon"
+                ],
+            },
         },
         _ => panic!("missing entry for {ty}: {default} (field {field})"),
     }

--- a/crates/rust-analyzer/src/integrated_benchmarks.rs
+++ b/crates/rust-analyzer/src/integrated_benchmarks.rs
@@ -13,7 +13,7 @@
 use hir::ChangeWithProcMacros;
 use ide::{
     AnalysisHost, CallableSnippets, CompletionConfig, CompletionFieldsToResolve, DiagnosticsConfig,
-    FilePosition, RaFixtureConfig, TextSize,
+    FilePosition, MacroSemicolonStyle, RaFixtureConfig, TextSize,
 };
 use ide_db::{
     SnippetCap,
@@ -339,6 +339,7 @@ fn completion_config() -> CompletionConfig<'static> {
         limit: None,
         add_colons_to_module: true,
         add_semicolon_to_unit: true,
+        add_semicolon_to_macro: MacroSemicolonStyle::Item,
         fields_to_resolve: CompletionFieldsToResolve::empty(),
         exclude_flyimport: vec![],
         exclude_traits: &[],

--- a/docs/book/src/configuration_generated.md
+++ b/docs/book/src/configuration_generated.md
@@ -393,6 +393,13 @@ Automatically add `::` when completing the module.
 Will not be completed in `use`.
 
 
+## rust-analyzer.completion.addSemicolonToMacro {#completion.addSemicolonToMacro}
+
+Default: `"item"`
+
+Automatically add a semicolon for macros.
+
+
 ## rust-analyzer.completion.addSemicolonToUnit {#completion.addSemicolonToUnit}
 
 Default: `true`

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -1327,6 +1327,28 @@
             {
                 "title": "Completion",
                 "properties": {
+                    "rust-analyzer.completion.addSemicolonToMacro": {
+                        "markdownDescription": "Automatically add a semicolon for macros.",
+                        "default": "item",
+                        "type": {
+                            "type": "string",
+                            "enum": [
+                                "none",
+                                "item",
+                                "always"
+                            ],
+                            "enumDescriptions": [
+                                "Never complete semicolon",
+                                "Complete semicolon when path in item position",
+                                "Always complete semicolon"
+                            ]
+                        }
+                    }
+                }
+            },
+            {
+                "title": "Completion",
+                "properties": {
                     "rust-analyzer.completion.addSemicolonToUnit": {
                         "markdownDescription": "Automatically add a semicolon when completing unit-returning functions.\n\nIn `match` arms it completes a comma instead.",
                         "default": true,


### PR DESCRIPTION
Example
---
```rust
macro_rules! foo { () => {} }
f$0
```

**Before this PR**

```rust
macro_rules! foo { () => {} }
foo!($0)
```

**After this PR**

```rust
macro_rules! foo { () => {} }
foo!($0);
```
