### PR TITLE
fix: alias subItems to sub_items

### DIFF
--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -3003,6 +3003,7 @@ pub enum AutoImportExclusion {
 pub enum AutoImportExclusionType {
     Always,
     Methods,
+    #[serde(alias = "subItems")]
     SubItems,
 }
 


### PR DESCRIPTION
Alternative to rust-lang/rust-analyzer#22444

Example
---
```rust
{
    "rust-analyzer.completion.autoimport.exclude": [
        {"path": "std::intrinsics", "type": "subItems"},
    }
}
```

**Before this PR**

```
invalid config value: /completion/autoimport/exclude: data
did not match any variant of untagged enum
AutoImportExclusion;
```

**After this PR**

no errors
