### PR TITLE
feat: support flyimport exclude variants

### DIFF
--- a/crates/ide-completion/src/config.rs
+++ b/crates/ide-completion/src/config.rs
@@ -45,6 +45,7 @@ pub enum AutoImportExclusionType {
     Always,
     Methods,
     SubItems,
+    Variants,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/crates/ide-completion/src/context.rs
+++ b/crates/ide-completion/src/context.rs
@@ -868,10 +868,22 @@ impl<'a, 'db> CompletionContext<'a, 'db> {
                 _ => None,
             })
             .collect::<Vec<_>>();
+        let exclude_variants = exclude_flyimport
+            .iter()
+            .flat_map(|it| match it {
+                (ModuleDef::Adt(hir::Adt::Enum(enum_)), AutoImportExclusionType::Variants) => {
+                    enum_.variants(db)
+                }
+                _ => vec![],
+            })
+            .collect::<Vec<_>>();
         exclude_flyimport
             .extend(exclude_traits.iter().map(|&t| (t.into(), AutoImportExclusionType::Always)));
         exclude_flyimport
             .extend(exclude_subitems.into_iter().map(|it| (it, AutoImportExclusionType::Always)));
+        exclude_flyimport.extend(
+            exclude_variants.into_iter().map(|it| (it.into(), AutoImportExclusionType::Always)),
+        );
 
         // FIXME: This should be part of `CompletionAnalysis` / `expand_and_analyze`
         let complete_semicolon = if !config.add_semicolon_to_unit {

--- a/crates/ide-completion/src/tests/expression.rs
+++ b/crates/ide-completion/src/tests/expression.rs
@@ -3042,6 +3042,76 @@ fn foo() {
 }
 
 #[test]
+fn flyimport_excluded_enum_variants_from_flyimport() {
+    check_with_config(
+        CompletionConfig {
+            exclude_flyimport: vec![(
+                "ra_test_fixture::Foo".to_owned(),
+                AutoImportExclusionType::Variants,
+            )],
+            ..TEST_CONFIG
+        },
+        r#"
+enum Foo {
+    Variant1,
+    Variant2,
+}
+fn foo() {
+    V$0
+}
+        "#,
+        expect![[r#"
+            ct CONST                   Unit
+            en Enum                    Enum
+            en Foo                      Foo
+            fn foo()                   fn()
+            fn function()              fn()
+            ma makro!(…) macro_rules! makro
+            md module::
+            sc STATIC                  Unit
+            st Record                Record
+            st Tuple                  Tuple
+            st Unit                    Unit
+            un Union                  Union
+            ev TupleV(…)        TupleV(u32)
+            bt u32                      u32
+            kw async
+            kw const
+            kw crate::
+            kw enum
+            kw extern
+            kw false
+            kw fn
+            kw for
+            kw if
+            kw if let
+            kw impl
+            kw impl for
+            kw let
+            kw letm
+            kw loop
+            kw match
+            kw mod
+            kw return
+            kw self::
+            kw static
+            kw struct
+            kw trait
+            kw true
+            kw type
+            kw union
+            kw unsafe
+            kw use
+            kw while
+            kw while let
+            sn macro_rules
+            sn pd
+            sn ppd
+        "#]],
+    );
+}
+
+#[test]
 fn excluded_trait_method_is_excluded_from_path_completion() {
     check_with_config(
         CompletionConfig {

--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -665,6 +665,9 @@ config_data! {
         /// For modules the type "sub_items" can be used to only exclude the all items in it but not the module
         /// itself. This does not include items defined in nested modules.
         ///
+        /// For enums the type "variants" can be used to only exclude the all variants in it but not the enum
+        /// itself.
+        ///
         /// This setting also inherits `#rust-analyzer.completion.excludeTraits#`.
         completion_autoimport_exclude: Vec<AutoImportExclusion> = vec![
             AutoImportExclusion::Verbose { path: "core::borrow::Borrow".to_owned(), r#type: AutoImportExclusionType::Methods },
@@ -1944,6 +1947,9 @@ impl Config {
                             AutoImportExclusionType::SubItems => {
                                 ide_completion::AutoImportExclusionType::SubItems
                             }
+                            AutoImportExclusionType::Variants => {
+                                ide_completion::AutoImportExclusionType::Variants
+                            }
                         },
                     ),
                 })
@@ -3004,6 +3010,7 @@ pub enum AutoImportExclusionType {
     Always,
     Methods,
     SubItems,
+    Variants,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -4135,7 +4142,7 @@ fn field_props(field: &str, ty: &str, doc: &[&str], default: &str) -> serde_json
                             },
                             "type": {
                                 "type": "string",
-                                "enum": ["always", "methods", "sub_items"],
+                                "enum": ["always", "methods", "sub_items", "variants"],
                                 "enumDescriptions": [
                                     "Do not show this item or its methods (if it is a trait) in auto-import completions.",
                                     "Do not show this trait's methods in auto-import completions.",

--- a/docs/book/src/configuration_generated.md
+++ b/docs/book/src/configuration_generated.md
@@ -449,6 +449,9 @@ itself.
 For modules the type "sub_items" can be used to only exclude the all items in it but not the module
 itself. This does not include items defined in nested modules.
 
+For enums the type "variants" can be used to only exclude the all variants in it but not the enum
+itself.
+
 This setting also inherits `#rust-analyzer.completion.excludeTraits#`.
 
 

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -1333,7 +1333,7 @@
                 "title": "Completion",
                 "properties": {
                     "rust-analyzer.completion.autoimport.exclude": {
-                        "markdownDescription": "A list of full paths to items to exclude from auto-importing completions.\n\nTraits in this list won't have their methods suggested in completions unless the trait\nis in scope.\n\nYou can either specify a string path which defaults to type \"always\" or use the more\nverbose form `{ \"path\": \"path::to::item\", type: \"always\" }`.\n\nFor traits the type \"methods\" can be used to only exclude the methods but not the trait\nitself.\n\nFor modules the type \"sub_items\" can be used to only exclude the all items in it but not the module\nitself. This does not include items defined in nested modules.\n\nThis setting also inherits `#rust-analyzer.completion.excludeTraits#`.",
+                        "markdownDescription": "A list of full paths to items to exclude from auto-importing completions.\n\nTraits in this list won't have their methods suggested in completions unless the trait\nis in scope.\n\nYou can either specify a string path which defaults to type \"always\" or use the more\nverbose form `{ \"path\": \"path::to::item\", type: \"always\" }`.\n\nFor traits the type \"methods\" can be used to only exclude the methods but not the trait\nitself.\n\nFor modules the type \"sub_items\" can be used to only exclude the all items in it but not the module\nitself. This does not include items defined in nested modules.\n\nFor enums the type \"variants\" can be used to only exclude the all variants in it but not the enum\nitself.\n\nThis setting also inherits `#rust-analyzer.completion.excludeTraits#`.",
                         "default": [
                             {
                                 "path": "core::borrow::Borrow",
@@ -1361,7 +1361,8 @@
                                             "enum": [
                                                 "always",
                                                 "methods",
-                                                "sub_items"
+                                                "sub_items",
+                                                "variants"
                                             ],
                                             "enumDescriptions": [
                                                 "Do not show this item or its methods (if it is a trait) in auto-import completions.",


### PR DESCRIPTION
Due to rust-lang/rust-analyzer#22385, some large enum may need to be exclude variants, e.g `std::ascii::Char`

Example
---
```json
{
    "rust-analyzer.completion.autoimport.exclude": [
        {"path": "xxx_crate::Foo", "type": "variants"},
    ]
}
```

```rust
enum Foo {
    Variant1,
    Variant2,
}
fn main() {
    V$0
}
```

**Before this PR**

```
ev TupleV(…)                 TupleV(u32)
ev Variant1 (use Foo::Variant1) Variant1
ev Variant2 (use Foo::Variant2) Variant2
bt u32                               u32
```

**After this PR**

```
ev TupleV(…)                 TupleV(u32)
bt u32                               u32
```
