### PR TITLE
Remove docs about removed `analysis-bench` command

### DIFF
--- a/docs/book/src/contributing/README.md
+++ b/docs/book/src/contributing/README.md
@@ -206,13 +206,6 @@ To measure time for from-scratch analysis, use something like this:
 cargo run --release -p rust-analyzer -- analysis-stats ../chalk/
 ```
 
-For measuring time of incremental analysis, use either of these:
-
-```bash
-cargo run --release -p rust-analyzer -- analysis-bench ../chalk/ --highlight ../chalk/chalk-engine/src/logic.rs
-cargo run --release -p rust-analyzer -- analysis-bench ../chalk/ --complete ../chalk/chalk-engine/src/logic.rs:94:0
-```
-
 Look for `fn benchmark_xxx` tests for a quick way to reproduce performance problems.
 
 ## Release Process


### PR DESCRIPTION
This command as removed in 797185e1b66fb0d6ec1dedf206616890b5e3fef3 (https://github.com/rust-lang/rust-analyzer/pull/8254).