### PR TITLE
Create directory for `cargo xtask metrics rustc_tests`

### DIFF
--- a/crates/rust-analyzer/src/cli/rustc_tests.rs
+++ b/crates/rust-analyzer/src/cli/rustc_tests.rs
@@ -64,6 +64,7 @@ impl Tester {
     fn new() -> Result<Self> {
         let mut path = AbsPathBuf::assert_utf8(std::env::temp_dir());
         path.push("ra-rustc-test");
+        std::fs::create_dir_all(&path)?;
         let tmp_file = path.join("ra-rustc-test.rs");
         std::fs::write(&tmp_file, "")?;
         let cargo_config = CargoConfig {


### PR DESCRIPTION
In c0f428d55b425c8ba18039a3687cdcdc47e111d1 (https://github.com/rust-lang/rust-analyzer/pull/20018) this code was adjusted to handle a change in `load_workspace`.

The change assumed that the `ra-rustc-test` folder existed in the `std::env::temp_dir`, but this assumption is not always correct.

## Testing

You can test with `cargo xtask metrics rustc_tests`.

Note: If you run the command multiple times you may need to `rm -r target/metrics/rust` to clean the directory.