### PR TITLE
Remove unnecessary feature flags from tests

### DIFF
--- a/crates/ide-assists/src/handlers/destructure_tuple_binding.rs
+++ b/crates/ide-assists/src/handlers/destructure_tuple_binding.rs
@@ -1236,15 +1236,11 @@ fn main {
         fn destructure_in_sub_pattern() {
             check_sub_pattern_assist(
                 r#"
-#![feature(bindings_after_at)]
-
 fn main() {
     let $0t = (1,2);
 }
                 "#,
                 r#"
-#![feature(bindings_after_at)]
-
 fn main() {
     let t @ ($0_0, _1) = (1,2);
 }

--- a/crates/ide-assists/src/handlers/replace_if_let_with_match.rs
+++ b/crates/ide-assists/src/handlers/replace_if_let_with_match.rs
@@ -712,13 +712,11 @@ impl VariantData {
         check_assist(
             replace_if_let_with_match,
             r#"
-#![feature(if_let_guard)]
 fn main() {
     if $0let true = true && let Some(1) = None {} else { other() }
 }
 "#,
             r#"
-#![feature(if_let_guard)]
 fn main() {
     match true {
         true if let Some(1) = None => {}
@@ -731,7 +729,6 @@ fn main() {
         check_assist(
             replace_if_let_with_match,
             r#"
-#![feature(if_let_guard)]
 fn main() {
     if true {
         $0if let ParenExpr(expr) = cond
@@ -758,7 +755,6 @@ fn main() {
 }
 "#,
             r#"
-#![feature(if_let_guard)]
 fn main() {
     if true {
         match cond {
@@ -816,13 +812,11 @@ fn main() {
         check_assist(
             replace_if_let_with_match,
             r#"
-#![feature(if_let_guard)]
 fn main() {
     if $0let true = true && let Some(1) = None {}
 }
 "#,
             r#"
-#![feature(if_let_guard)]
 fn main() {
     match true {
         true if let Some(1) = None => {}

--- a/crates/ide-diagnostics/src/handlers/invalid_cast.rs
+++ b/crates/ide-diagnostics/src/handlers/invalid_cast.rs
@@ -1025,7 +1025,6 @@ fn _slice(bar: &[i32]) -> bool {
         check_diagnostics(
             r#"
 //- minicore: coerce_unsized, dispatch_from_dyn
-#![feature(trait_upcasting)]
 trait Foo {}
 trait Bar: Foo {}
 


### PR DESCRIPTION
The `bindings_after_at`, `if_let_guard`, and `trait_upcasting` features are stable, so the tests for these features no longer require enabling them.