### PR TITLE
fix: use package id as argument to `--package` if package is not unique

### DIFF
--- a/crates/rust-analyzer/src/target_spec.rs
+++ b/crates/rust-analyzer/src/target_spec.rs
@@ -319,7 +319,11 @@ impl CargoTargetSpec {
 
     pub(crate) fn push_to(self, buf: &mut Vec<String>, kind: &RunnableKind) {
         buf.push("--package".to_owned());
-        buf.push(self.package);
+        if self.package.contains(":") {
+            buf.push(self.package_id.to_string());
+        } else {
+            buf.push(self.package);
+        }
 
         // Can't mix --doc with other target flags
         if let RunnableKind::DocTest { .. } = kind {


### PR DESCRIPTION
A simple fix that does not need much changes, not sure how to add a test for this tbrh.

We could a do another fix as well checking if package is "unique" by comparing the versions (I have it in works as well, if this not good, I'll push that one)