### PR TITLE
Don't count C-variadic `...` as a parameter for fn pointers

### DIFF
--- a/crates/hir-def/src/expr_store/lower.rs
+++ b/crates/hir-def/src/expr_store/lower.rs
@@ -671,6 +671,7 @@ impl<'db> ExprCollector<'db> {
                     }
 
                     pl.params()
+                        .filter(|it| it.dotdotdot_token().is_none())
                         .map(|it| {
                             let type_ref = self.lower_type_ref_opt(it.ty(), impl_trait_lower_fn);
                             let name = match it.pat() {

--- a/crates/ide-diagnostics/src/handlers/mismatched_arg_count.rs
+++ b/crates/ide-diagnostics/src/handlers/mismatched_arg_count.rs
@@ -355,6 +355,30 @@ fn f() {
     }
 
     #[test]
+    fn varargs_fn_pointer() {
+        check_diagnostics(
+            r#"
+struct Funcs {
+    f: unsafe extern "C" fn(u8, u8, ...) -> i32,
+    g: unsafe extern "C" fn(...) -> i32,
+}
+
+fn f(funcs: Funcs) {
+    unsafe {
+        (funcs.f)(0, 1);
+        (funcs.f)(0, 1, 2);
+        (funcs.f)(0);
+                 //^ error: expected 2 arguments, found 1
+        (funcs.g)();
+        (funcs.g)(0);
+        (funcs.g)(0, 1);
+    }
+}
+        "#,
+        )
+    }
+
+    #[test]
     fn arg_count_lambda() {
         check_diagnostics(
             r#"


### PR DESCRIPTION
rust-analyzer reported E0107 when calling a C-variadic `extern "C"`
function *pointer* with only its named arguments, e.g.:

```rust
struct Funcs {
    set_option: unsafe extern "C" fn(*mut Env, Opt, ...) -> i32,
}
unsafe { (funcs().set_option)(env, Opt::A) }; // false E0107
```

rustc and `cargo check` accept this.

Root cause: the fn-pointer type lowering in `expr_store/lower.rs`
included the `...` slot in the lowered parameter list, so the arity
check in `check_call_arguments` treated it as a required argument.
The function-*declaration* path already excludes it (the rust-lang/rust-analyzer#3088 fix);
this mirrors that filtering for fn pointers.

Added a regression test in `mismatched_arg_count.rs`.

Fixes rust-lang/rust-analyzer#22573