### PR TITLE
internal: decide not to use `'db` in `NavigationTarget.docs`

### DIFF
--- a/crates/ide/src/navigation_target.rs
+++ b/crates/ide/src/navigation_target.rs
@@ -50,7 +50,6 @@ pub struct NavigationTarget {
     pub kind: Option<SymbolKind>,
     pub container_name: Option<Symbol>,
     pub description: Option<String>,
-    // FIXME: Use the database lifetime here.
     pub docs: Option<Documentation<'static>>,
     /// In addition to a `name` field, a `NavigationTarget` may also be aliased
     /// In such cases we want a `NavigationTarget` to be accessible by its alias


### PR DESCRIPTION
Supersedes https://github.com/rust-lang/rust-analyzer/pull/22470, as per https://github.com/rust-lang/rust-analyzer/pull/22470#issuecomment-4580150555

cc @ChayimFriedman2 since you were the one who added the FIXME
cc @Veykril since you reviewed the original PR