### PR TITLE
Avoiding temporary lowercase allocations

### DIFF
--- a/crates/project-model/src/build_dependencies.rs
+++ b/crates/project-model/src/build_dependencies.rs
@@ -558,10 +558,12 @@ impl WorkspaceBuildScripts {
     }
 }
 
+const DLL_EXTENSIONS: &[&str] = &["dll", "dylib", "so"];
+
 // FIXME: Find a better way to know if it is a dylib.
 fn is_dylib(path: &Utf8Path) -> bool {
-    match path.extension().map(|e| e.to_owned().to_lowercase()) {
+    match path.extension() {
         None => false,
-        Some(ext) => matches!(ext.as_str(), "dll" | "dylib" | "so"),
+        Some(ext) => DLL_EXTENSIONS.iter().any(|e| e.eq_ignore_ascii_case(ext)),
     }
 }

--- a/crates/rust-analyzer/src/cli/flags.rs
+++ b/crates/rust-analyzer/src/cli/flags.rs
@@ -402,10 +402,10 @@ impl FromStr for Severity {
     type Err = String;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match &*s.to_ascii_lowercase() {
-            "weak" => Ok(Self::Weak),
-            "warning" => Ok(Self::Warning),
-            "error" => Ok(Self::Error),
+        match s {
+            weak if weak.eq_ignore_ascii_case("weak") => Ok(Self::Weak),
+            warning if warning.eq_ignore_ascii_case("warning") => Ok(Self::Warning),
+            error if error.eq_ignore_ascii_case("error") => Ok(Self::Error),
             _ => Err(format!("unknown severity `{s}`")),
         }
     }


### PR DESCRIPTION
## Objective

- Remove unnecessary temporary lowercase allocations from several ASCII-only case-insensitive comparisons.
