### PR TITLE
fix: prefer bench command when target is bench to avoid cargo run

### DIFF
--- a/crates/rust-analyzer/src/target_spec.rs
+++ b/crates/rust-analyzer/src/target_spec.rs
@@ -153,6 +153,9 @@ impl CargoTargetSpec {
                     Some(CargoTargetSpec { target_kind: TargetKind::Test, .. }) => {
                         config.test_command
                     }
+                    Some(CargoTargetSpec { target_kind: TargetKind::Bench, .. }) => {
+                        config.bench_command
+                    }
                     _ => "run".to_owned(),
                 };
                 cargo_args.push(subcommand);
@@ -224,6 +227,9 @@ impl CargoTargetSpec {
             RunnableKind::Bin => match spec {
                 Some(CargoTargetSpec { target_kind: TargetKind::Test, .. }) => {
                     (config.test_override_command, None)
+                }
+                Some(CargoTargetSpec { target_kind: TargetKind::Bench, .. }) => {
+                    (config.bench_override_command, None)
                 }
                 _ => (None, None),
             },


### PR DESCRIPTION
fixes rust-lang/rust-analyzer#22515

Seems like if there is a harness used, both in integration test and benchmarks, the `main` function in that crate does have `RunnableKind::Bin` but we instead use `CargoTargetSpec::target_kind` to determine the command to run.

The fix was made with Github Copilot. I was trying to test its capabilities :sweat_smile:. Not sure if I would use it again.