### PR TITLE
fix: Crash on static constants in array length positions

### DIFF
--- a/crates/hir-ty/src/next_solver/interner.rs
+++ b/crates/hir-ty/src/next_solver/interner.rs
@@ -1128,6 +1128,9 @@ impl<'db> Interner for DbInterner<'db> {
             SolverDefId::ConstId(def_id) => {
                 AliasTermKind::UnevaluatedConst { def_id: GeneralConstIdWrapper(def_id.into()) }
             }
+            SolverDefId::StaticId(def_id) => {
+                AliasTermKind::UnevaluatedConst { def_id: GeneralConstIdWrapper(def_id.into()) }
+            }
             SolverDefId::AnonConstId(def_id) => {
                 AliasTermKind::UnevaluatedConst { def_id: GeneralConstIdWrapper(def_id.into()) }
             }

--- a/crates/hir-ty/src/tests/regression/new_solver.rs
+++ b/crates/hir-ty/src/tests/regression/new_solver.rs
@@ -395,6 +395,16 @@ fn main() {
 }
 
 #[test]
+fn static_as_array_len_does_not_panic() {
+    check_no_mismatches(
+        r#"
+static S: usize = 8;
+const A: [u8; S] = [0; 8];
+    "#,
+    );
+}
+
+#[test]
 fn another_20654_case() {
     check_no_mismatches(
         r#"


### PR DESCRIPTION
We were missing a match case in the solver interner: `SolverDefId::StaticId` wasn't covered, so we hit the `unimplemented!()` base case.

This occurred when coercing array lengths with statics, see the new test case.

Fixes rust-lang/rust-analyzer#22600

AI disclosure: Written with help by Codex and GPT 5.5.