### PR TITLE
internal: Don't rely on FxHashSet order

### DIFF
--- a/crates/rust-analyzer/src/cli/scip.rs
+++ b/crates/rust-analyzer/src/cli/scip.rs
@@ -237,7 +237,7 @@ impl flags::Scip {
             let token = si.tokens.get(id).unwrap();
 
             let Some(definition) = token.definition else {
-                break;
+                continue;
             };
 
             let file_id = definition.file_id;


### PR DESCRIPTION
Previously, SCIP generation would iterate over all the external symbols by calling `.difference()` on an FxHashSet and iterating over them. If any tokens had a moniker but no definition, the loop would terminate early.

AFAICS this code is unreachable today (all the monikers also have definitions), but the code is clearly wrong. Ensure we process all tokens regardless of the order.