### PR TITLE
SCIP: Emit references for symbols referenced in macro-expansion

### DIFF
--- a/crates/ide/src/static_index.rs
+++ b/crates/ide/src/static_index.rs
@@ -6,12 +6,12 @@ use hir::{Crate, Module, Semantics, db::HirDatabase};
 use ide_db::{
     FileId, FileRange, FxHashMap, FxHashSet, RootDatabase,
     base_db::{SourceDatabase, VfsPath},
-    defs::{Definition, IdentClass},
+    defs::{Definition, IdentClass, NameClass},
     documentation::Documentation,
     famous_defs::FamousDefs,
     ra_fixture::RaFixtureConfig,
 };
-use syntax::{AstNode, SyntaxNode, SyntaxToken, TextRange};
+use syntax::{AstNode, NodeOrToken, SyntaxNode, SyntaxToken, TextRange, ast};
 
 use crate::navigation_target::UpmappingResult;
 use crate::{
@@ -98,7 +98,11 @@ pub struct StaticIndexedFile {
     pub file_id: FileId,
     pub folds: Vec<Fold>,
     pub inlay_hints: Vec<InlayHint>,
+    /// Tokens that occur in the file.
     pub tokens: Vec<(TextRange, TokenId)>,
+    /// Tokens that only occur after macro expansion. The text range
+    /// associated is the position of the macro call.
+    pub generated_tokens: Vec<(TextRange, TokenId)>,
 }
 
 fn all_modules(db: &dyn HirDatabase) -> Vec<Module> {
@@ -138,6 +142,33 @@ fn get_definitions<'db>(
         if let Some(defs) = def
             && !defs.is_empty()
         {
+            return Some(defs);
+        }
+    }
+    None
+}
+
+fn get_referenced_definitions<'db>(
+    sema: &Semantics<'db, RootDatabase>,
+    token: SyntaxToken,
+) -> Option<ArrayVec<(Definition, Option<hir::GenericSubstitution<'db>>), 2>> {
+    for token in sema.descend_into_macros_exact(token) {
+        let Some(class) = IdentClass::classify_token(sema, &token) else {
+            continue;
+        };
+
+        let mut defs = ArrayVec::new();
+        match class {
+            IdentClass::NameClass(NameClass::Definition(_)) => continue,
+            IdentClass::NameClass(NameClass::ConstReference(def)) => defs.push((def, None)),
+            IdentClass::NameClass(NameClass::PatFieldShorthand {
+                local_def: _,
+                field_ref,
+                adt_subst,
+            }) => defs.push((Definition::Field(field_ref), Some(adt_subst))),
+            IdentClass::NameRefClass(_) | IdentClass::Operator(_) => defs = class.definitions(),
+        }
+        if !defs.is_empty() {
             return Some(defs);
         }
     }
@@ -221,10 +252,16 @@ impl StaticIndex<'_> {
             show_drop_glue: true,
             ra_fixture: RaFixtureConfig::default(),
         };
-        let mut result = StaticIndexedFile { file_id, inlay_hints, folds, tokens: vec![] };
+        let mut result = StaticIndexedFile {
+            file_id,
+            inlay_hints,
+            folds,
+            tokens: vec![],
+            generated_tokens: vec![],
+        };
 
         let mut add_token =
-            |def: Definition, range: TextRange, scope_node: &SyntaxNode, _is_generated: bool| {
+            |def: Definition, range: TextRange, scope_node: &SyntaxNode, is_generated: bool| {
                 let id = if let Some(it) = self.def_map.get(&def) {
                     *it
                 } else {
@@ -263,18 +300,22 @@ impl StaticIndex<'_> {
                 let token = self.tokens.get_mut(id).unwrap();
                 token.references.push(ReferenceData {
                     range: FileRange { range, file_id },
-                    is_definition: match def.try_to_nav(&sema).map(UpmappingResult::call_site) {
-                        Some(it) => it.file_id == file_id && it.focus_or_full_range() == range,
+                    is_definition: match token.definition {
+                        Some(it) => it.file_id == file_id && it.range == range,
                         None => false,
                     },
                 });
-                result.tokens.push((range, id));
+                if is_generated {
+                    result.generated_tokens.push((range, id));
+                } else {
+                    result.tokens.push((range, id));
+                }
             };
 
         if let Some(module) = sema.file_to_module_def(file_id) {
             let def = Definition::Module(module);
             let range = root.text_range();
-            add_token(def, range, &root);
+            add_token(def, range, &root, false);
         }
 
         for token in tokens {
@@ -283,12 +324,63 @@ impl StaticIndex<'_> {
             match hir::attach_db(self.db, || get_definitions(&sema, token.clone())) {
                 Some(defs) => {
                     for (def, _) in defs {
-                        add_token(def, range, &node);
+                        add_token(def, range, &node, false);
                     }
                 }
                 None => continue,
             };
         }
+
+        // Walk expanded tokens and record references that occur due
+        // macro expansion or proc-macro expansion.
+        let mut seen_generated: FxHashSet<(Definition, TextRange)> = FxHashSet::default();
+        for node in root.descendants() {
+            let expansions: Vec<(SyntaxNode, TextRange)> = hir::attach_db(self.db, || {
+                if let Some(macro_call) = ast::MacroCall::cast(node.clone()) {
+                    // For macros, just expand one level for simplicity and performance.
+                    let call_site = macro_call.syntax().text_range();
+                    sema.expand_macro_call(&macro_call)
+                        .map(|exp| vec![(exp.value, call_site)])
+                        .unwrap_or_default()
+                } else if let Some(meta) = ast::Meta::cast(node.clone()) {
+                    // Derive macros: each derive on the attribute expands
+                    // separately. Non-derive attrs yield None here.
+                    let call_site = meta.parent_attr().map_or_else(
+                        || meta.syntax().text_range(),
+                        |attr| attr.syntax().text_range(),
+                    );
+                    sema.expand_derive_macro(&meta)
+                        .map(|exps| {
+                            exps.into_iter().flatten().map(|er| (er.value, call_site)).collect()
+                        })
+                        .unwrap_or_default()
+                } else if let Some(item) = ast::Item::cast(node.clone()) {
+                    // Attribute proc-macros attached to an item.
+                    let call_site = item.syntax().text_range();
+                    sema.expand_attr_macro(&item)
+                        .map(|er| vec![(er.value.value, call_site)])
+                        .unwrap_or_default()
+                } else {
+                    Vec::new()
+                }
+            });
+
+            for (expansion, call_site) in expansions {
+                for token in expansion.descendants_with_tokens().filter_map(NodeOrToken::into_token)
+                {
+                    let defs = hir::attach_db(self.db, || {
+                        get_referenced_definitions(&sema, token.clone())
+                    });
+                    let Some(defs) = defs else { continue };
+                    for (def, _) in defs {
+                        if seen_generated.insert((def, call_site)) {
+                            add_token(def, call_site, &node, true);
+                        }
+                    }
+                }
+            }
+        }
+
         self.files.push(result);
     }
 

--- a/crates/ide/src/static_index.rs
+++ b/crates/ide/src/static_index.rs
@@ -223,52 +223,53 @@ impl StaticIndex<'_> {
         };
         let mut result = StaticIndexedFile { file_id, inlay_hints, folds, tokens: vec![] };
 
-        let mut add_token = |def: Definition, range: TextRange, scope_node: &SyntaxNode| {
-            let id = if let Some(it) = self.def_map.get(&def) {
-                *it
-            } else {
-                let it = self.tokens.insert(TokenStaticData {
-                    documentation: documentation_for_definition(&sema, def, scope_node),
-                    hover: Some(hover_for_definition(
-                        &sema,
-                        file_id,
-                        def,
-                        None,
-                        scope_node,
-                        None,
-                        false,
-                        &hover_config,
-                        edition,
-                        display_target,
-                    )),
-                    definition: def.try_to_nav(&sema).map(UpmappingResult::call_site).map(|it| {
-                        FileRange { file_id: it.file_id, range: it.focus_or_full_range() }
-                    }),
-                    definition_body: def
-                        .try_to_nav(&sema)
-                        .map(UpmappingResult::call_site)
-                        .map(|it| FileRange { file_id: it.file_id, range: it.full_range }),
-                    references: vec![],
-                    moniker: current_crate.and_then(|cc| def_to_moniker(self.db, def, cc)),
-                    display_name: def
-                        .name(self.db)
-                        .map(|name| name.display(self.db, edition).to_string()),
-                    signature: Some(def.label(self.db, display_target)),
-                    kind: def_to_kind(self.db, def),
+        let mut add_token =
+            |def: Definition, range: TextRange, scope_node: &SyntaxNode, _is_generated: bool| {
+                let id = if let Some(it) = self.def_map.get(&def) {
+                    *it
+                } else {
+                    let it = self.tokens.insert(TokenStaticData {
+                        documentation: documentation_for_definition(&sema, def, scope_node),
+                        hover: Some(hover_for_definition(
+                            &sema,
+                            file_id,
+                            def,
+                            None,
+                            scope_node,
+                            None,
+                            false,
+                            &hover_config,
+                            edition,
+                            display_target,
+                        )),
+                        definition: def.try_to_nav(&sema).map(UpmappingResult::call_site).map(
+                            |it| FileRange { file_id: it.file_id, range: it.focus_or_full_range() },
+                        ),
+                        definition_body: def
+                            .try_to_nav(&sema)
+                            .map(UpmappingResult::call_site)
+                            .map(|it| FileRange { file_id: it.file_id, range: it.full_range }),
+                        references: vec![],
+                        moniker: current_crate.and_then(|cc| def_to_moniker(self.db, def, cc)),
+                        display_name: def
+                            .name(self.db)
+                            .map(|name| name.display(self.db, edition).to_string()),
+                        signature: Some(def.label(self.db, display_target)),
+                        kind: def_to_kind(self.db, def),
+                    });
+                    self.def_map.insert(def, it);
+                    it
+                };
+                let token = self.tokens.get_mut(id).unwrap();
+                token.references.push(ReferenceData {
+                    range: FileRange { range, file_id },
+                    is_definition: match def.try_to_nav(&sema).map(UpmappingResult::call_site) {
+                        Some(it) => it.file_id == file_id && it.focus_or_full_range() == range,
+                        None => false,
+                    },
                 });
-                self.def_map.insert(def, it);
-                it
+                result.tokens.push((range, id));
             };
-            let token = self.tokens.get_mut(id).unwrap();
-            token.references.push(ReferenceData {
-                range: FileRange { range, file_id },
-                is_definition: match def.try_to_nav(&sema).map(UpmappingResult::call_site) {
-                    Some(it) => it.file_id == file_id && it.focus_or_full_range() == range,
-                    None => false,
-                },
-            });
-            result.tokens.push((range, id));
-        };
 
         if let Some(module) = sema.file_to_module_def(file_id) {
             let def = Definition::Module(module);

--- a/crates/rust-analyzer/src/cli/lsif.rs
+++ b/crates/rust-analyzer/src/cli/lsif.rs
@@ -152,7 +152,12 @@ impl LsifManager<'_, '_> {
     }
 
     fn add_token(&mut self, id: TokenId, token: TokenStaticData) {
-        let result_set_id = self.get_token_id(id);
+        // Ignore tokens that didn't occur in the original file
+        // (i.e. those from macro expansion).
+        let Some(&result_set_id) = self.token_map.get(&id) else {
+            return;
+        };
+
         if let Some(hover) = token.hover {
             let hover_id = self.add_vertex(lsif::Vertex::HoverResult {
                 result: lsp_types::Hover {

--- a/crates/rust-analyzer/src/cli/scip.rs
+++ b/crates/rust-analyzer/src/cli/scip.rs
@@ -132,7 +132,7 @@ impl flags::Scip {
         // Generates symbols from token monikers.
         let mut symbol_generator = SymbolGenerator::default();
 
-        for StaticIndexedFile { file_id, tokens, .. } in si.files {
+        for StaticIndexedFile { file_id, tokens, generated_tokens, .. } in si.files {
             symbol_generator.clear_document_local_state();
 
             let Some(relative_path) = get_relative_filepath(&vfs, &root, file_id) else { continue };
@@ -207,6 +207,36 @@ impl flags::Scip {
                     diagnostics: Vec::new(),
                     special_fields: Default::default(),
                     enclosing_range,
+                });
+            }
+
+            // Emit macro-expansion-generated references with the SCIP
+            // `Generated` role. These resolve to real definitions but their
+            // only occurrence is synthesized inside an expansion; recording
+            // them at the macro call-site lets reachability tooling see the
+            // edge, while keeping them out of `tokens` means find-references is
+            // unaffected. Always references (never definitions).
+            for (text_range, id) in generated_tokens.into_iter() {
+                let token = si.tokens.get(id).unwrap();
+
+                let Some(TokenSymbols { symbol, .. }) = symbol_generator.token_symbols(id, token)
+                else {
+                    continue;
+                };
+
+                // Record the reference so the external-symbols pass below emits
+                // SymbolInformation when the definition lives in another file.
+                token_ids_referenced.insert(id);
+
+                occurrences.push(scip_types::Occurrence {
+                    range: text_range_to_scip_range(&line_index, text_range),
+                    symbol,
+                    symbol_roles: scip_types::SymbolRole::Generated as i32,
+                    override_documentation: Vec::new(),
+                    syntax_kind: Default::default(),
+                    diagnostics: Vec::new(),
+                    special_fields: Default::default(),
+                    enclosing_range: Vec::new(),
                 });
             }
 
@@ -587,6 +617,25 @@ mod test {
         assert_eq!(found_symbol.unwrap(), expected);
     }
 
+    fn generated_token_names(#[rust_analyzer::rust_fixture] ra_fixture: &str) -> Vec<String> {
+        let (host, _position) = position(ra_fixture);
+        let analysis = host.analysis();
+        let si = StaticIndex::compute(
+            &analysis,
+            VendoredLibrariesConfig::Included {
+                workspace_root: &VfsPath::new_virtual_path("/workspace".to_owned()),
+            },
+        );
+        si.files
+            .iter()
+            .flat_map(|file| {
+                file.generated_tokens
+                    .iter()
+                    .filter_map(|&(_range, id)| si.tokens.get(id).unwrap().display_name.clone())
+            })
+            .collect()
+    }
+
     #[test]
     fn basic() {
         check_symbol(
@@ -602,6 +651,41 @@ pub mod example_mod {
 }
 "#,
             "rust-analyzer cargo foo 0.1.0 example_mod/func().",
+        );
+    }
+
+    #[test]
+    fn macro_generated_reference_is_indexed() {
+        // `foo` is only ever called from inside the expansion of `gen_call!`,
+        // so it has no occurrence among the original source tokens. It must
+        // still get a generated occurrence at the macro call-site; this
+        // underpins the SCIP `Generated` role support that keeps macro-only
+        // references from looking dead.
+        let fixture = r#"
+//- /workspace/lib.rs crate:main
+macro_rules! gen_call {
+    () => { fn __generated() { foo(); } };
+}
+fn foo() {}
+gen_call!();
+fn main() {}$0
+"#;
+
+        // The macro-only call to `foo` is recorded as a generated occurrence,
+        // and we do not spuriously record generated definitions or the macro
+        // invocation itself as uses.
+        let names = generated_token_names(fixture);
+        assert!(
+            names.iter().any(|n| n == "foo"),
+            "expected a macro-generated reference to `foo` from the gen_call! expansion, got {names:?}"
+        );
+        assert!(
+            !names.iter().any(|n| n == "__generated"),
+            "must not record generated definitions as uses, got {names:?}"
+        );
+        assert!(
+            !names.iter().any(|n| n == "gen_call"),
+            "must not record the macro invocation itself as a use, got {names:?}"
         );
     }
 


### PR DESCRIPTION
Previously, we only emitted references from source tokens. This causes issues with find-references tools built on top of SCIP. For example, the following code would produce a SCIP index with no references to `greeting`.

    use askama::Template;

    #[derive(Template)]
    #[template(source = "{{ crate::greeting() }}", ext = "txt")]
    struct Page;

    fn greeting() -> &'static str {
        "hello from askama"
    }

Instead, walk macro-expanded tokens and emit SCIP references with the Generated role.

Whilst this is strictly more work, SCIP generation time increased by less than 10% when testing on the crates inside rust-analyzer.

(I've split out a commit that reindents the closure a bunch, to hopefully make the actual logic changes easier to read.)

AI disclosure: Partially written by Codex and GPT-5.5.