### PR TITLE
fix(implements_trait_unique_with_infcx): only forbid the self type from being an error type

### DIFF
--- a/crates/hir-ty/src/traits.rs
+++ b/crates/hir-ty/src/traits.rs
@@ -20,7 +20,7 @@ use hir_expand::name::Name;
 use intern::sym;
 use rustc_type_ir::{
     TypeVisitableExt, TypingMode,
-    inherent::{BoundExistentialPredicates, GenericArg as _, IntoKind, Ty as _},
+    inherent::{BoundExistentialPredicates, IntoKind, Ty as _},
 };
 
 use crate::{
@@ -153,10 +153,10 @@ pub fn implements_trait_unique_with_infcx<'db>(
     let infcx = interner.infer_ctxt().build(TypingMode::non_body_analysis());
 
     let args = create_args(&infcx);
-    if args.iter().filter_map(|it| it.as_type()).any(|ty| ty.is_ty_error()) {
+    let trait_ref = rustc_type_ir::TraitRef::new_from_args(interner, trait_.into(), args);
+    if trait_ref.self_ty().is_ty_error() {
         return false;
     }
-    let trait_ref = rustc_type_ir::TraitRef::new_from_args(interner, trait_.into(), args);
 
     let obligation = Obligation::new(interner, ObligationCause::dummy(), env.param_env, trait_ref);
     infcx.predicate_must_hold_modulo_regions(&obligation)


### PR DESCRIPTION
Follow-up to https://github.com/rust-lang/rust-analyzer/pull/22486 as per https://github.com/rust-lang/rust-analyzer/pull/22486#discussion_r3441391406

cc @ChayimFriedman2 