### PR TITLE
fix: Don't panic on out-of-range integer literals in const positions

### DIFF
--- a/crates/hir-ty/src/consteval.rs
+++ b/crates/hir-ty/src/consteval.rs
@@ -87,18 +87,24 @@ fn intern_const_ref<'db>(
     let valtree = match (ty.kind(), value) {
         (TyKind::Uint(uint), Literal::Uint(value, _)) => {
             let size = uint.bit_width().map(Size::from_bits).unwrap_or(data_layout.pointer_size());
-            let scalar = ScalarInt::try_from_uint(*value, size).unwrap();
+            let Some(scalar) = ScalarInt::try_from_uint(*value, size) else {
+                return Ok(Const::error(interner));
+            };
             ValTreeKind::Leaf(scalar)
         }
         (TyKind::Uint(uint), Literal::Int(value, _)) => {
             // `Literal::Int` is the default, so we also need to account for the type being uint.
             let size = uint.bit_width().map(Size::from_bits).unwrap_or(data_layout.pointer_size());
-            let scalar = ScalarInt::try_from_uint(*value as u128, size).unwrap();
+            let Some(scalar) = ScalarInt::try_from_uint(*value as u128, size) else {
+                return Ok(Const::error(interner));
+            };
             ValTreeKind::Leaf(scalar)
         }
         (TyKind::Int(int), Literal::Int(value, _)) => {
             let size = int.bit_width().map(Size::from_bits).unwrap_or(data_layout.pointer_size());
-            let scalar = ScalarInt::try_from_int(*value, size).unwrap();
+            let Some(scalar) = ScalarInt::try_from_int(*value, size) else {
+                return Ok(Const::error(interner));
+            };
             ValTreeKind::Leaf(scalar)
         }
         (TyKind::Bool, Literal::Bool(value)) => ValTreeKind::Leaf(ScalarInt::from(*value)),
@@ -219,7 +225,9 @@ pub fn usize_const<'db>(db: &'db dyn HirDatabase, value: Option<u128>, krate: Cr
         return Const::error(interner);
     };
     let usize_ty = interner.default_types().types.usize;
-    let scalar = ScalarInt::try_from_uint(value, data_layout.pointer_size()).unwrap();
+    let Some(scalar) = ScalarInt::try_from_uint(value, data_layout.pointer_size()) else {
+        return Const::error(interner);
+    };
     Const::new_valtree(interner, usize_ty, ValTreeKind::Leaf(scalar))
 }
 

--- a/crates/hir-ty/src/tests/regression/new_solver.rs
+++ b/crates/hir-ty/src/tests/regression/new_solver.rs
@@ -405,6 +405,16 @@ const A: [u8; S] = [0; 8];
 }
 
 #[test]
+fn oversized_array_len_does_not_panic() {
+    // The array length literal does not fit in `usize`; interning it must not panic.
+    check_no_mismatches(
+        r#"
+fn f(_: [u8; 18446744073709551616]) {}
+    "#,
+    );
+}
+
+#[test]
 fn another_20654_case() {
     check_no_mismatches(
         r#"


### PR DESCRIPTION
Writing an array length that doesn't fit in `usize`, like `[u8; 18446744073709551616]`, makes rust-analyzer panic and then spam the log with `Propagating panic for cycle head ...` over and over.

The problem is in `intern_const_ref`: it interns the literal with `ScalarInt::try_from_uint(..).unwrap()`, but `try_from_*` returns `None` when the value doesn't fit the target type, so the `unwrap()` blows up inside a salsa query. I changed those three integer branches (and `usize_const`) to return an error const instead of unwrapping, so an out-of-range literal is just treated as an error rather than crashing.

Also added a regression test. Running `analysis-stats` on the repro reports `panics: 1` before the change and `panics: 0` after.

Closes rust-lang/rust-analyzer#22620