### PR TITLE
minor: Use `std::env::home_dir` instead of home crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1003,15 +1003,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "home"
-version = "0.5.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
-dependencies = [
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "icu_collections"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3148,7 +3139,6 @@ name = "toolchain"
 version = "0.0.0"
 dependencies = [
  "camino",
- "home",
 ]
 
 [[package]]

--- a/crates/toolchain/Cargo.toml
+++ b/crates/toolchain/Cargo.toml
@@ -13,7 +13,6 @@ rust-version.workspace = true
 doctest = false
 
 [dependencies]
-home = "0.5.11"
 camino.workspace = true
 
 [lints]

--- a/crates/toolchain/src/lib.rs
+++ b/crates/toolchain/src/lib.rs
@@ -119,7 +119,7 @@ fn get_cargo_home() -> Option<Utf8PathBuf> {
         return Utf8PathBuf::try_from(PathBuf::from(path)).ok();
     }
 
-    if let Some(mut path) = home::home_dir() {
+    if let Some(mut path) = env::home_dir() {
         path.push(".cargo");
         return Utf8PathBuf::try_from(path).ok();
     }


### PR DESCRIPTION
Closes rust-lang/rust-analyzer#22570