### PR TITLE
Avoid index panic when flycheck list is empty

### DIFF
--- a/crates/rust-analyzer/src/handlers/notification.rs
+++ b/crates/rust-analyzer/src/handlers/notification.rs
@@ -336,7 +336,9 @@ fn run_flycheck(state: &mut GlobalState, vfs_path: VfsPath) -> bool {
                             "should have exactly one flycheck handle when invocation strategy is once"
                         );
                         let saved_file = vfs_path.as_path().map(ToOwned::to_owned);
-                        world.flycheck[0].restart_workspace(saved_file);
+                        if let Some(flycheck) = world.flycheck.first() {
+                            flycheck.restart_workspace(saved_file);
+                        }
                         Ok(())
                     })
                 }

--- a/crates/rust-analyzer/src/handlers/notification.rs
+++ b/crates/rust-analyzer/src/handlers/notification.rs
@@ -331,10 +331,6 @@ fn run_flycheck(state: &mut GlobalState, vfs_path: VfsPath) -> bool {
                         // have this problem. Remove the line below when triomphe::Arc has an UnwindSafe impl
                         // like std::sync::Arc's.
                         let world = world;
-                        stdx::always!(
-                            world.flycheck.len() == 1,
-                            "should have exactly one flycheck handle when invocation strategy is once"
-                        );
                         let saved_file = vfs_path.as_path().map(ToOwned::to_owned);
                         if let Some(flycheck) = world.flycheck.first() {
                             flycheck.restart_workspace(saved_file);


### PR DESCRIPTION
Fixes rust-lang/rust-analyzer#21638.

The `InvocationStrategy::Once` path in `notification.rs` indexed `world.flycheck[0]` directly. The `always!()` above it only logs in release builds, so when the flycheck list is empty it fell through and panicked with index out of bounds (the crash in rust-lang/rust-analyzer#21638). This guards the access with `first()` and skips the restart when there's no handle.

changelog fix Avoid a panic when restarting flycheck with an empty handle list