### PR TITLE
internal: move `ExpandDatabase::proc_macros` out of the query group

### DIFF
--- a/crates/hir-def/src/db.rs
+++ b/crates/hir-def/src/db.rs
@@ -4,6 +4,7 @@ use hir_expand::{
     EditionedFileId, HirFileId, InFile, Lookup, MacroCallId, MacroDefId, MacroDefKind,
     db::ExpandDatabase,
 };
+use salsa::{Durability, Setter};
 use triomphe::Arc;
 
 use crate::{
@@ -16,10 +17,6 @@ use crate::{
 
 #[query_group::query_group]
 pub trait DefDatabase: ExpandDatabase + SourceDatabase {
-    /// Whether to expand procedural macros during name resolution.
-    #[salsa::input]
-    fn expand_proc_attr_macros(&self) -> bool;
-
     /// Computes an [`ItemTree`] for the given file or macro expansion.
     #[salsa::invoke(file_item_tree)]
     #[salsa::transparent]
@@ -45,6 +42,23 @@ pub trait DefDatabase: ExpandDatabase + SourceDatabase {
 
     #[salsa::invoke(include_macro_invoc)]
     fn include_macro_invoc(&self, crate_id: Crate) -> Arc<[(MacroCallId, EditionedFileId)]>;
+}
+
+/// Whether to expand procedural macros during name resolution.
+#[salsa::input(singleton, debug)]
+pub(crate) struct ExpandProcAttrMacros {
+    #[returns(copy)]
+    pub(crate) enabled: bool,
+}
+
+pub fn set_expand_proc_attr_macros(db: &mut dyn DefDatabase, enabled: bool) {
+    if let Some(expand_proc_attr_macros) = ExpandProcAttrMacros::try_get(db) {
+        if expand_proc_attr_macros.enabled(db) != enabled {
+            expand_proc_attr_macros.set_enabled(db).with_durability(Durability::HIGH).to(enabled);
+        }
+    } else {
+        _ = ExpandProcAttrMacros::builder(enabled).durability(Durability::HIGH).new(db);
+    }
 }
 
 // return: macro call id and include file id

--- a/crates/hir-def/src/expr_store/tests/body/block.rs
+++ b/crates/hir-def/src/expr_store/tests/body/block.rs
@@ -190,13 +190,13 @@ fn f() {
     "#,
         expect![[r#"
             ModuleIdLt {
-                [salsa id]: Id(3403),
+                [salsa id]: Id(3003),
                 krate: Crate(
-                    Id(2000),
+                    Id(1c00),
                 ),
                 block: Some(
                     BlockId(
-                        4401,
+                        4001,
                     ),
                 ),
                 containing_module_inside_def_map: None,

--- a/crates/hir-def/src/expr_store/tests/body/block.rs
+++ b/crates/hir-def/src/expr_store/tests/body/block.rs
@@ -190,13 +190,13 @@ fn f() {
     "#,
         expect![[r#"
             ModuleIdLt {
-                [salsa id]: Id(3003),
+                [salsa id]: Id(2c03),
                 krate: Crate(
                     Id(1c00),
                 ),
                 block: Some(
                     BlockId(
-                        4001,
+                        3c01,
                     ),
                 ),
                 containing_module_inside_def_map: None,

--- a/crates/hir-def/src/macro_expansion_tests/mbe.rs
+++ b/crates/hir-def/src/macro_expansion_tests/mbe.rs
@@ -35,9 +35,9 @@ macro_rules! f {
     };
 }
 
-struct#0:MacroRules[BE8F, 0]@58..64#16384# MyTraitMap2#0:MacroCall[BE8F, 0]@31..42#ROOT2024# {#0:MacroRules[BE8F, 0]@72..73#16384#
-    map#0:MacroRules[BE8F, 0]@86..89#16384#:#0:MacroRules[BE8F, 0]@89..90#16384# #0:MacroRules[BE8F, 0]@89..90#16384#::#0:MacroRules[BE8F, 0]@91..93#16384#std#0:MacroRules[BE8F, 0]@93..96#16384#::#0:MacroRules[BE8F, 0]@96..98#16384#collections#0:MacroRules[BE8F, 0]@98..109#16384#::#0:MacroRules[BE8F, 0]@109..111#16384#HashSet#0:MacroRules[BE8F, 0]@111..118#16384#<#0:MacroRules[BE8F, 0]@118..119#16384#(#0:MacroRules[BE8F, 0]@119..120#16384#)#0:MacroRules[BE8F, 0]@120..121#16384#>#0:MacroRules[BE8F, 0]@121..122#16384#,#0:MacroRules[BE8F, 0]@122..123#16384#
-}#0:MacroRules[BE8F, 0]@132..133#16384#
+struct#0:MacroRules[BE8F, 0]@58..64#15360# MyTraitMap2#0:MacroCall[BE8F, 0]@31..42#ROOT2024# {#0:MacroRules[BE8F, 0]@72..73#15360#
+    map#0:MacroRules[BE8F, 0]@86..89#15360#:#0:MacroRules[BE8F, 0]@89..90#15360# #0:MacroRules[BE8F, 0]@89..90#15360#::#0:MacroRules[BE8F, 0]@91..93#15360#std#0:MacroRules[BE8F, 0]@93..96#15360#::#0:MacroRules[BE8F, 0]@96..98#15360#collections#0:MacroRules[BE8F, 0]@98..109#15360#::#0:MacroRules[BE8F, 0]@109..111#15360#HashSet#0:MacroRules[BE8F, 0]@111..118#15360#<#0:MacroRules[BE8F, 0]@118..119#15360#(#0:MacroRules[BE8F, 0]@119..120#15360#)#0:MacroRules[BE8F, 0]@120..121#15360#>#0:MacroRules[BE8F, 0]@121..122#15360#,#0:MacroRules[BE8F, 0]@122..123#15360#
+}#0:MacroRules[BE8F, 0]@132..133#15360#
 "#]],
     );
 }
@@ -197,7 +197,7 @@ macro_rules! mk_struct {
 #[macro_use]
 mod foo;
 
-struct#1:MacroRules[DB0C, 0]@59..65#16384# Foo#0:MacroCall[DB0C, 0]@32..35#ROOT2024#(#1:MacroRules[DB0C, 0]@70..71#16384#u32#0:MacroCall[DB0C, 0]@41..44#ROOT2024#)#1:MacroRules[DB0C, 0]@74..75#16384#;#1:MacroRules[DB0C, 0]@75..76#16384#
+struct#1:MacroRules[DB0C, 0]@59..65#15360# Foo#0:MacroCall[DB0C, 0]@32..35#ROOT2024#(#1:MacroRules[DB0C, 0]@70..71#15360#u32#0:MacroCall[DB0C, 0]@41..44#ROOT2024#)#1:MacroRules[DB0C, 0]@74..75#15360#;#1:MacroRules[DB0C, 0]@75..76#15360#
 "#]],
     );
 }
@@ -423,10 +423,10 @@ m! { foo, bar }
 macro_rules! m {
     ($($i:ident),*) => ( impl Bar { $(fn $i() {})* } );
 }
-impl#\16384# Bar#\16384# {#\16384#
-    fn#\16384# foo#\ROOT2024#(#\16384#)#\16384# {#\16384#}#\16384#
-    fn#\16384# bar#\ROOT2024#(#\16384#)#\16384# {#\16384#}#\16384#
-}#\16384#
+impl#\15360# Bar#\15360# {#\15360#
+    fn#\15360# foo#\ROOT2024#(#\15360#)#\15360# {#\15360#}#\15360#
+    fn#\15360# bar#\ROOT2024#(#\15360#)#\15360# {#\15360#}#\15360#
+}#\15360#
 "#]],
     );
 }

--- a/crates/hir-def/src/macro_expansion_tests/mbe.rs
+++ b/crates/hir-def/src/macro_expansion_tests/mbe.rs
@@ -35,9 +35,9 @@ macro_rules! f {
     };
 }
 
-struct#0:MacroRules[BE8F, 0]@58..64#17408# MyTraitMap2#0:MacroCall[BE8F, 0]@31..42#ROOT2024# {#0:MacroRules[BE8F, 0]@72..73#17408#
-    map#0:MacroRules[BE8F, 0]@86..89#17408#:#0:MacroRules[BE8F, 0]@89..90#17408# #0:MacroRules[BE8F, 0]@89..90#17408#::#0:MacroRules[BE8F, 0]@91..93#17408#std#0:MacroRules[BE8F, 0]@93..96#17408#::#0:MacroRules[BE8F, 0]@96..98#17408#collections#0:MacroRules[BE8F, 0]@98..109#17408#::#0:MacroRules[BE8F, 0]@109..111#17408#HashSet#0:MacroRules[BE8F, 0]@111..118#17408#<#0:MacroRules[BE8F, 0]@118..119#17408#(#0:MacroRules[BE8F, 0]@119..120#17408#)#0:MacroRules[BE8F, 0]@120..121#17408#>#0:MacroRules[BE8F, 0]@121..122#17408#,#0:MacroRules[BE8F, 0]@122..123#17408#
-}#0:MacroRules[BE8F, 0]@132..133#17408#
+struct#0:MacroRules[BE8F, 0]@58..64#16384# MyTraitMap2#0:MacroCall[BE8F, 0]@31..42#ROOT2024# {#0:MacroRules[BE8F, 0]@72..73#16384#
+    map#0:MacroRules[BE8F, 0]@86..89#16384#:#0:MacroRules[BE8F, 0]@89..90#16384# #0:MacroRules[BE8F, 0]@89..90#16384#::#0:MacroRules[BE8F, 0]@91..93#16384#std#0:MacroRules[BE8F, 0]@93..96#16384#::#0:MacroRules[BE8F, 0]@96..98#16384#collections#0:MacroRules[BE8F, 0]@98..109#16384#::#0:MacroRules[BE8F, 0]@109..111#16384#HashSet#0:MacroRules[BE8F, 0]@111..118#16384#<#0:MacroRules[BE8F, 0]@118..119#16384#(#0:MacroRules[BE8F, 0]@119..120#16384#)#0:MacroRules[BE8F, 0]@120..121#16384#>#0:MacroRules[BE8F, 0]@121..122#16384#,#0:MacroRules[BE8F, 0]@122..123#16384#
+}#0:MacroRules[BE8F, 0]@132..133#16384#
 "#]],
     );
 }
@@ -197,7 +197,7 @@ macro_rules! mk_struct {
 #[macro_use]
 mod foo;
 
-struct#1:MacroRules[DB0C, 0]@59..65#17408# Foo#0:MacroCall[DB0C, 0]@32..35#ROOT2024#(#1:MacroRules[DB0C, 0]@70..71#17408#u32#0:MacroCall[DB0C, 0]@41..44#ROOT2024#)#1:MacroRules[DB0C, 0]@74..75#17408#;#1:MacroRules[DB0C, 0]@75..76#17408#
+struct#1:MacroRules[DB0C, 0]@59..65#16384# Foo#0:MacroCall[DB0C, 0]@32..35#ROOT2024#(#1:MacroRules[DB0C, 0]@70..71#16384#u32#0:MacroCall[DB0C, 0]@41..44#ROOT2024#)#1:MacroRules[DB0C, 0]@74..75#16384#;#1:MacroRules[DB0C, 0]@75..76#16384#
 "#]],
     );
 }
@@ -423,10 +423,10 @@ m! { foo, bar }
 macro_rules! m {
     ($($i:ident),*) => ( impl Bar { $(fn $i() {})* } );
 }
-impl#\17408# Bar#\17408# {#\17408#
-    fn#\17408# foo#\ROOT2024#(#\17408#)#\17408# {#\17408#}#\17408#
-    fn#\17408# bar#\ROOT2024#(#\17408#)#\17408# {#\17408#}#\17408#
-}#\17408#
+impl#\16384# Bar#\16384# {#\16384#
+    fn#\16384# foo#\ROOT2024#(#\16384#)#\16384# {#\16384#}#\16384#
+    fn#\16384# bar#\ROOT2024#(#\16384#)#\16384# {#\16384#}#\16384#
+}#\16384#
 "#]],
     );
 }

--- a/crates/hir-def/src/nameres/collector.rs
+++ b/crates/hir-def/src/nameres/collector.rs
@@ -616,7 +616,7 @@ impl<'db> DefCollector<'db> {
         let (expander, kind) = match self.proc_macros.iter().find(|(n, _, _)| n == &def.name) {
             Some(_)
                 if kind == hir_expand::proc_macro::ProcMacroKind::Attr
-                    && !self.db.expand_proc_attr_macros() =>
+                    && !crate::db::ExpandProcAttrMacros::get(self.db).enabled(self.db) =>
             {
                 (CustomProcMacroExpander::disabled_proc_attr(), kind)
             }

--- a/crates/hir-def/src/nameres/tests/incremental.rs
+++ b/crates/hir-def/src/nameres/tests/incremental.rs
@@ -305,6 +305,7 @@ fn f() { foo }
                 "parse_macro_expansion",
                 "expand_proc_macro",
                 "macro_arg",
+                "create_data_ExpandDatabase",
                 "proc_macro_span_shim",
             ]
         "#]],
@@ -441,6 +442,7 @@ pub struct S {}
                 "parse_macro_expansion",
                 "expand_proc_macro",
                 "macro_arg",
+                "create_data_ExpandDatabase",
                 "proc_macro_span_shim",
             ]
         "#]],

--- a/crates/hir-def/src/test_db.rs
+++ b/crates/hir-def/src/test_db.rs
@@ -15,7 +15,6 @@ use triomphe::Arc;
 
 use crate::{
     Lookup, ModuleDefId, ModuleId,
-    db::DefDatabase,
     expr_store::{Body, scope::ExprScopes},
     nameres::{DefMap, ModuleSource, block_def_map, crate_def_map},
     src::HasSource,
@@ -48,7 +47,7 @@ impl Default for TestDB {
             crates_map: Default::default(),
             nonce: Nonce::new(),
         };
-        this.set_expand_proc_attr_macros_with_durability(true, Durability::HIGH);
+        crate::db::set_expand_proc_attr_macros(&mut this, true);
         // This needs to be here otherwise `CrateGraphBuilder` panics.
         set_all_crates_with_durability(&mut this, std::iter::empty(), Durability::HIGH);
         _ = base_db::LibraryRoots::builder(Default::default())

--- a/crates/hir-expand/src/change.rs
+++ b/crates/hir-expand/src/change.rs
@@ -2,7 +2,6 @@
 //! state. Changes are transactional.
 use base_db::{CrateGraphBuilder, FileChange, SourceRoot, salsa::Durability};
 use span::FileId;
-use triomphe::Arc;
 
 use crate::{db::ExpandDatabase, proc_macro::ProcMacrosBuilder};
 
@@ -16,12 +15,13 @@ impl ChangeWithProcMacros {
     pub fn apply(self, db: &mut impl ExpandDatabase) {
         let crates_id_map = self.source_change.apply(db);
         if let Some(proc_macros) = self.proc_macros {
-            let proc_macros = proc_macros.build(
+            proc_macros.build_in(
+                db,
+                Durability::HIGH,
                 crates_id_map
                     .as_ref()
                     .expect("cannot set proc macros without setting the crate graph too"),
             );
-            db.set_proc_macros_with_durability(Arc::new(proc_macros), Durability::HIGH);
         }
     }
 

--- a/crates/hir-expand/src/db.rs
+++ b/crates/hir-expand/src/db.rs
@@ -17,7 +17,7 @@ use crate::{
     declarative::DeclarativeMacroExpander,
     fixup::{self, SyntaxFixupUndoInfo},
     hygiene::{span_with_call_site_ctxt, span_with_def_site_ctxt, span_with_mixed_site_ctxt},
-    proc_macro::{CrateProcMacros, CustomProcMacroExpander, ProcMacros},
+    proc_macro::{CrateProcMacros, CustomProcMacroExpander},
     span_map::{ExpansionSpanMap, RealSpanMap, SpanMap},
     tt,
 };
@@ -50,10 +50,6 @@ pub enum TokenExpander<'db> {
 
 #[query_group::query_group]
 pub trait ExpandDatabase: SourceDatabase {
-    /// The proc macros. Do not use this! Use `proc_macros_for_crate()` instead.
-    #[salsa::input]
-    fn proc_macros(&self) -> Arc<ProcMacros>;
-
     /// Incrementality query to prevent queries from directly depending on `ExpandDatabase::proc_macros`.
     #[salsa::invoke(crate::proc_macro::proc_macros_for_crate)]
     fn proc_macros_for_crate(&self, krate: Crate) -> Option<Arc<CrateProcMacros>>;

--- a/crates/hir-expand/src/proc_macro.rs
+++ b/crates/hir-expand/src/proc_macro.rs
@@ -7,6 +7,7 @@ use std::{panic::RefUnwindSafe, sync};
 use base_db::{Crate, CrateBuilderId, CratesIdMap, Env, ProcMacroLoadingError};
 use intern::Symbol;
 use rustc_hash::FxHashMap;
+use salsa::{Durability, Setter};
 use span::Span;
 use triomphe::Arc;
 
@@ -83,14 +84,24 @@ impl ProcMacrosBuilder {
         );
     }
 
-    pub(crate) fn build(self, crates_id_map: &CratesIdMap) -> ProcMacros {
+    /// Builds [`ProcMacros`] and adds id to `db` with the provided `durability`.
+    pub(crate) fn build_in(
+        self,
+        db: &mut dyn ExpandDatabase,
+        durability: Durability,
+        crates_id_map: &CratesIdMap,
+    ) {
         let mut map = self
             .0
             .into_iter()
             .map(|(krate, proc_macro)| (crates_id_map[&krate], proc_macro))
             .collect::<FxHashMap<_, _>>();
         map.shrink_to_fit();
-        ProcMacros(map)
+        ProcMacros::try_get(db)
+            .unwrap_or_else(|| ProcMacros::new(db, Default::default()))
+            .set_by_crate(db)
+            .with_durability(durability)
+            .to(map);
     }
 }
 
@@ -107,11 +118,19 @@ impl FromIterator<(CrateBuilderId, ProcMacroLoadResult)> for ProcMacrosBuilder {
 #[derive(Debug, PartialEq, Eq)]
 pub struct CrateProcMacros(StoredProcMacroLoadResult);
 
-#[derive(Default, Debug)]
-pub struct ProcMacros(FxHashMap<Crate, Arc<CrateProcMacros>>);
+#[salsa::input(singleton, debug)]
+pub struct ProcMacros {
+    #[returns(ref)]
+    pub by_crate: FxHashMap<Crate, Arc<CrateProcMacros>>,
+}
+
 impl ProcMacros {
-    fn get(&self, krate: Crate) -> Option<Arc<CrateProcMacros>> {
-        self.0.get(&krate).cloned()
+    pub fn init_default(db: &dyn ExpandDatabase, durability: Durability) {
+        _ = Self::builder(Default::default()).durability(durability).new(db);
+    }
+
+    fn get_for_crate(&self, db: &dyn ExpandDatabase, krate: Crate) -> Option<Arc<CrateProcMacros>> {
+        self.by_crate(db).get(&krate).cloned()
     }
 }
 
@@ -352,5 +371,5 @@ pub(crate) fn proc_macros_for_crate(
     db: &dyn ExpandDatabase,
     krate: Crate,
 ) -> Option<Arc<CrateProcMacros>> {
-    db.proc_macros().get(krate)
+    ProcMacros::get(db).get_for_crate(db, krate)
 }

--- a/crates/hir-ty/src/test_db.rs
+++ b/crates/hir-ty/src/test_db.rs
@@ -7,7 +7,7 @@ use base_db::{
     SourceRootId, SourceRootInput, all_crates, relevant_crates, set_all_crates_with_durability,
 };
 
-use hir_def::{ModuleId, db::DefDatabase, nameres::crate_def_map};
+use hir_def::{ModuleId, nameres::crate_def_map};
 use hir_expand::EditionedFileId;
 use rustc_hash::FxHashMap;
 use salsa::Durability;
@@ -43,7 +43,7 @@ impl Default for TestDB {
             crates_map: Default::default(),
             nonce: Nonce::new(),
         };
-        this.set_expand_proc_attr_macros_with_durability(true, Durability::HIGH);
+        hir_def::db::set_expand_proc_attr_macros(&mut this, true);
         // This needs to be here otherwise `CrateGraphBuilder` panics.
         set_all_crates_with_durability(&mut this, std::iter::empty(), Durability::HIGH);
         _ = base_db::LibraryRoots::builder(Default::default())

--- a/crates/hir/src/db.rs
+++ b/crates/hir/src/db.rs
@@ -3,6 +3,6 @@
 //! we didn't do that.
 //!
 //! But we need this for at least LRU caching at the query level.
-pub use hir_def::db::DefDatabase;
+pub use hir_def::db::{DefDatabase, set_expand_proc_attr_macros};
 pub use hir_expand::db::ExpandDatabase;
 pub use hir_ty::db::HirDatabase;

--- a/crates/ide-db/src/lib.rs
+++ b/crates/ide-db/src/lib.rs
@@ -65,7 +65,7 @@ use base_db::{
 };
 use hir::{
     FilePositionWrapper, FileRangeWrapper,
-    db::{DefDatabase, ExpandDatabase, HirDatabase},
+    db::{ExpandDatabase, HirDatabase},
 };
 use triomphe::Arc;
 
@@ -210,13 +210,13 @@ impl RootDatabase {
         _ = base_db::LocalRoots::builder(Default::default())
             .durability(Durability::MEDIUM)
             .new(&db);
-        db.set_expand_proc_attr_macros_with_durability(false, Durability::HIGH);
+        hir::db::set_expand_proc_attr_macros(&mut db, false);
         db.update_base_query_lru_capacities(lru_capacity);
         db
     }
 
     pub fn enable_proc_attr_macros(&mut self) {
-        self.set_expand_proc_attr_macros_with_durability(true, Durability::HIGH);
+        hir::db::set_expand_proc_attr_macros(self, true);
     }
 
     pub fn update_base_query_lru_capacities(&mut self, _lru_capacity: Option<u16>) {

--- a/crates/ide-db/src/lib.rs
+++ b/crates/ide-db/src/lib.rs
@@ -63,10 +63,7 @@ use base_db::{
     CrateGraphBuilder, CratesMap, FileSourceRootInput, FileText, Files, Nonce, SourceDatabase,
     SourceRoot, SourceRootId, SourceRootInput, set_all_crates_with_durability,
 };
-use hir::{
-    FilePositionWrapper, FileRangeWrapper,
-    db::{ExpandDatabase, HirDatabase},
-};
+use hir::{FilePositionWrapper, FileRangeWrapper, db::HirDatabase};
 use triomphe::Arc;
 
 use crate::line_index::LineIndex;
@@ -203,7 +200,7 @@ impl RootDatabase {
         // This needs to be here otherwise `CrateGraphBuilder` will panic.
         set_all_crates_with_durability(&mut db, std::iter::empty(), Durability::HIGH);
         CrateGraphBuilder::default().set_in_db(&mut db);
-        db.set_proc_macros_with_durability(Default::default(), Durability::MEDIUM);
+        hir::ProcMacros::init_default(&db, Durability::MEDIUM);
         _ = base_db::LibraryRoots::builder(Default::default())
             .durability(Durability::MEDIUM)
             .new(&db);

--- a/crates/ide-db/src/test_data/test_doc_alias.txt
+++ b/crates/ide-db/src/test_data/test_doc_alias.txt
@@ -2,7 +2,7 @@
     (
         Module {
             id: ModuleIdLt {
-                [salsa id]: Id(2c00),
+                [salsa id]: Id(2800),
             },
         },
         [
@@ -12,7 +12,7 @@
                     Struct(
                         Struct {
                             id: StructId(
-                                3401,
+                                3001,
                             ),
                         },
                     ),
@@ -20,7 +20,7 @@
                 loc: DeclarationLocation {
                     hir_file_id: FileId(
                         EditionedFileId(
-                            Id(2800),
+                            Id(2400),
                         ),
                     ),
                     ptr: SyntaxNodePtr {
@@ -49,7 +49,7 @@
                     Struct(
                         Struct {
                             id: StructId(
-                                3400,
+                                3000,
                             ),
                         },
                     ),
@@ -57,7 +57,7 @@
                 loc: DeclarationLocation {
                     hir_file_id: FileId(
                         EditionedFileId(
-                            Id(2800),
+                            Id(2400),
                         ),
                     ),
                     ptr: SyntaxNodePtr {
@@ -86,7 +86,7 @@
                     Struct(
                         Struct {
                             id: StructId(
-                                3400,
+                                3000,
                             ),
                         },
                     ),
@@ -94,7 +94,7 @@
                 loc: DeclarationLocation {
                     hir_file_id: FileId(
                         EditionedFileId(
-                            Id(2800),
+                            Id(2400),
                         ),
                     ),
                     ptr: SyntaxNodePtr {
@@ -123,7 +123,7 @@
                     Struct(
                         Struct {
                             id: StructId(
-                                3400,
+                                3000,
                             ),
                         },
                     ),
@@ -131,7 +131,7 @@
                 loc: DeclarationLocation {
                     hir_file_id: FileId(
                         EditionedFileId(
-                            Id(2800),
+                            Id(2400),
                         ),
                     ),
                     ptr: SyntaxNodePtr {
@@ -160,7 +160,7 @@
                     Struct(
                         Struct {
                             id: StructId(
-                                3400,
+                                3000,
                             ),
                         },
                     ),
@@ -168,7 +168,7 @@
                 loc: DeclarationLocation {
                     hir_file_id: FileId(
                         EditionedFileId(
-                            Id(2800),
+                            Id(2400),
                         ),
                     ),
                     ptr: SyntaxNodePtr {
@@ -197,7 +197,7 @@
                     Struct(
                         Struct {
                             id: StructId(
-                                3401,
+                                3001,
                             ),
                         },
                     ),
@@ -205,7 +205,7 @@
                 loc: DeclarationLocation {
                     hir_file_id: FileId(
                         EditionedFileId(
-                            Id(2800),
+                            Id(2400),
                         ),
                     ),
                     ptr: SyntaxNodePtr {
@@ -234,7 +234,7 @@
                     Struct(
                         Struct {
                             id: StructId(
-                                3400,
+                                3000,
                             ),
                         },
                     ),
@@ -242,7 +242,7 @@
                 loc: DeclarationLocation {
                     hir_file_id: FileId(
                         EditionedFileId(
-                            Id(2800),
+                            Id(2400),
                         ),
                     ),
                     ptr: SyntaxNodePtr {

--- a/crates/ide-db/src/test_data/test_doc_alias.txt
+++ b/crates/ide-db/src/test_data/test_doc_alias.txt
@@ -2,7 +2,7 @@
     (
         Module {
             id: ModuleIdLt {
-                [salsa id]: Id(3000),
+                [salsa id]: Id(2c00),
             },
         },
         [
@@ -12,7 +12,7 @@
                     Struct(
                         Struct {
                             id: StructId(
-                                3801,
+                                3401,
                             ),
                         },
                     ),
@@ -20,7 +20,7 @@
                 loc: DeclarationLocation {
                     hir_file_id: FileId(
                         EditionedFileId(
-                            Id(2c00),
+                            Id(2800),
                         ),
                     ),
                     ptr: SyntaxNodePtr {
@@ -49,7 +49,7 @@
                     Struct(
                         Struct {
                             id: StructId(
-                                3800,
+                                3400,
                             ),
                         },
                     ),
@@ -57,7 +57,7 @@
                 loc: DeclarationLocation {
                     hir_file_id: FileId(
                         EditionedFileId(
-                            Id(2c00),
+                            Id(2800),
                         ),
                     ),
                     ptr: SyntaxNodePtr {
@@ -86,7 +86,7 @@
                     Struct(
                         Struct {
                             id: StructId(
-                                3800,
+                                3400,
                             ),
                         },
                     ),
@@ -94,7 +94,7 @@
                 loc: DeclarationLocation {
                     hir_file_id: FileId(
                         EditionedFileId(
-                            Id(2c00),
+                            Id(2800),
                         ),
                     ),
                     ptr: SyntaxNodePtr {
@@ -123,7 +123,7 @@
                     Struct(
                         Struct {
                             id: StructId(
-                                3800,
+                                3400,
                             ),
                         },
                     ),
@@ -131,7 +131,7 @@
                 loc: DeclarationLocation {
                     hir_file_id: FileId(
                         EditionedFileId(
-                            Id(2c00),
+                            Id(2800),
                         ),
                     ),
                     ptr: SyntaxNodePtr {
@@ -160,7 +160,7 @@
                     Struct(
                         Struct {
                             id: StructId(
-                                3800,
+                                3400,
                             ),
                         },
                     ),
@@ -168,7 +168,7 @@
                 loc: DeclarationLocation {
                     hir_file_id: FileId(
                         EditionedFileId(
-                            Id(2c00),
+                            Id(2800),
                         ),
                     ),
                     ptr: SyntaxNodePtr {
@@ -197,7 +197,7 @@
                     Struct(
                         Struct {
                             id: StructId(
-                                3801,
+                                3401,
                             ),
                         },
                     ),
@@ -205,7 +205,7 @@
                 loc: DeclarationLocation {
                     hir_file_id: FileId(
                         EditionedFileId(
-                            Id(2c00),
+                            Id(2800),
                         ),
                     ),
                     ptr: SyntaxNodePtr {
@@ -234,7 +234,7 @@
                     Struct(
                         Struct {
                             id: StructId(
-                                3800,
+                                3400,
                             ),
                         },
                     ),
@@ -242,7 +242,7 @@
                 loc: DeclarationLocation {
                     hir_file_id: FileId(
                         EditionedFileId(
-                            Id(2c00),
+                            Id(2800),
                         ),
                     ),
                     ptr: SyntaxNodePtr {

--- a/crates/ide-db/src/test_data/test_symbol_index_collection.txt
+++ b/crates/ide-db/src/test_data/test_symbol_index_collection.txt
@@ -2,7 +2,7 @@
     (
         Module {
             id: ModuleIdLt {
-                [salsa id]: Id(2c00),
+                [salsa id]: Id(2800),
             },
         },
         [
@@ -11,14 +11,14 @@
                 def: EnumVariant(
                     EnumVariant {
                         id: EnumVariantId(
-                            7400,
+                            7000,
                         ),
                     },
                 ),
                 loc: DeclarationLocation {
                     hir_file_id: FileId(
                         EditionedFileId(
-                            Id(2800),
+                            Id(2400),
                         ),
                     ),
                     ptr: SyntaxNodePtr {
@@ -48,14 +48,14 @@
                 def: TypeAlias(
                     TypeAlias {
                         id: TypeAliasId(
-                            6800,
+                            6400,
                         ),
                     },
                 ),
                 loc: DeclarationLocation {
                     hir_file_id: FileId(
                         EditionedFileId(
-                            Id(2800),
+                            Id(2400),
                         ),
                     ),
                     ptr: SyntaxNodePtr {
@@ -83,14 +83,14 @@
                 def: EnumVariant(
                     EnumVariant {
                         id: EnumVariantId(
-                            7401,
+                            7001,
                         ),
                     },
                 ),
                 loc: DeclarationLocation {
                     hir_file_id: FileId(
                         EditionedFileId(
-                            Id(2800),
+                            Id(2400),
                         ),
                     ),
                     ptr: SyntaxNodePtr {
@@ -120,14 +120,14 @@
                 def: Const(
                     Const {
                         id: ConstId(
-                            6000,
+                            5c00,
                         ),
                     },
                 ),
                 loc: DeclarationLocation {
                     hir_file_id: FileId(
                         EditionedFileId(
-                            Id(2800),
+                            Id(2400),
                         ),
                     ),
                     ptr: SyntaxNodePtr {
@@ -155,14 +155,14 @@
                 def: Const(
                     Const {
                         id: ConstId(
-                            6002,
+                            5c02,
                         ),
                     },
                 ),
                 loc: DeclarationLocation {
                     hir_file_id: FileId(
                         EditionedFileId(
-                            Id(2800),
+                            Id(2400),
                         ),
                     ),
                     ptr: SyntaxNodePtr {
@@ -191,7 +191,7 @@
                     Enum(
                         Enum {
                             id: EnumId(
-                                4c00,
+                                4800,
                             ),
                         },
                     ),
@@ -199,7 +199,7 @@
                 loc: DeclarationLocation {
                     hir_file_id: FileId(
                         EditionedFileId(
-                            Id(2800),
+                            Id(2400),
                         ),
                     ),
                     ptr: SyntaxNodePtr {
@@ -228,7 +228,7 @@
                     Macro {
                         id: Macro2Id(
                             Macro2Id(
-                                4800,
+                                4400,
                             ),
                         ),
                     },
@@ -236,7 +236,7 @@
                 loc: DeclarationLocation {
                     hir_file_id: FileId(
                         EditionedFileId(
-                            Id(2800),
+                            Id(2400),
                         ),
                     ),
                     ptr: SyntaxNodePtr {
@@ -265,7 +265,7 @@
                     Macro {
                         id: Macro2Id(
                             Macro2Id(
-                                4800,
+                                4400,
                             ),
                         ),
                     },
@@ -273,7 +273,7 @@
                 loc: DeclarationLocation {
                     hir_file_id: FileId(
                         EditionedFileId(
-                            Id(2800),
+                            Id(2400),
                         ),
                     ),
                     ptr: SyntaxNodePtr {
@@ -301,14 +301,14 @@
                 def: Static(
                     Static {
                         id: StaticId(
-                            6400,
+                            6000,
                         ),
                     },
                 ),
                 loc: DeclarationLocation {
                     hir_file_id: FileId(
                         EditionedFileId(
-                            Id(2800),
+                            Id(2400),
                         ),
                     ),
                     ptr: SyntaxNodePtr {
@@ -337,7 +337,7 @@
                     Struct(
                         Struct {
                             id: StructId(
-                                4401,
+                                4001,
                             ),
                         },
                     ),
@@ -345,7 +345,7 @@
                 loc: DeclarationLocation {
                     hir_file_id: FileId(
                         EditionedFileId(
-                            Id(2800),
+                            Id(2400),
                         ),
                     ),
                     ptr: SyntaxNodePtr {
@@ -374,7 +374,7 @@
                     Struct(
                         Struct {
                             id: StructId(
-                                4400,
+                                4000,
                             ),
                         },
                     ),
@@ -382,7 +382,7 @@
                 loc: DeclarationLocation {
                     hir_file_id: MacroFile(
                         MacroCallId(
-                            Id(3c00),
+                            Id(3800),
                         ),
                     ),
                     ptr: SyntaxNodePtr {
@@ -411,7 +411,7 @@
                     Struct(
                         Struct {
                             id: StructId(
-                                4405,
+                                4005,
                             ),
                         },
                     ),
@@ -419,7 +419,7 @@
                 loc: DeclarationLocation {
                     hir_file_id: FileId(
                         EditionedFileId(
-                            Id(2800),
+                            Id(2400),
                         ),
                     ),
                     ptr: SyntaxNodePtr {
@@ -450,7 +450,7 @@
                     Struct(
                         Struct {
                             id: StructId(
-                                4406,
+                                4006,
                             ),
                         },
                     ),
@@ -458,7 +458,7 @@
                 loc: DeclarationLocation {
                     hir_file_id: FileId(
                         EditionedFileId(
-                            Id(2800),
+                            Id(2400),
                         ),
                     ),
                     ptr: SyntaxNodePtr {
@@ -489,7 +489,7 @@
                     Struct(
                         Struct {
                             id: StructId(
-                                4407,
+                                4007,
                             ),
                         },
                     ),
@@ -497,7 +497,7 @@
                 loc: DeclarationLocation {
                     hir_file_id: FileId(
                         EditionedFileId(
-                            Id(2800),
+                            Id(2400),
                         ),
                     ),
                     ptr: SyntaxNodePtr {
@@ -526,7 +526,7 @@
                     Struct(
                         Struct {
                             id: StructId(
-                                4402,
+                                4002,
                             ),
                         },
                     ),
@@ -534,7 +534,7 @@
                 loc: DeclarationLocation {
                     hir_file_id: FileId(
                         EditionedFileId(
-                            Id(2800),
+                            Id(2400),
                         ),
                     ),
                     ptr: SyntaxNodePtr {
@@ -562,14 +562,14 @@
                 def: Trait(
                     Trait {
                         id: TraitId(
-                            5800,
+                            5400,
                         ),
                     },
                 ),
                 loc: DeclarationLocation {
                     hir_file_id: FileId(
                         EditionedFileId(
-                            Id(2800),
+                            Id(2400),
                         ),
                     ),
                     ptr: SyntaxNodePtr {
@@ -598,7 +598,7 @@
                     Macro {
                         id: Macro2Id(
                             Macro2Id(
-                                4800,
+                                4400,
                             ),
                         ),
                     },
@@ -606,7 +606,7 @@
                 loc: DeclarationLocation {
                     hir_file_id: FileId(
                         EditionedFileId(
-                            Id(2800),
+                            Id(2400),
                         ),
                     ),
                     ptr: SyntaxNodePtr {
@@ -635,7 +635,7 @@
                     Union(
                         Union {
                             id: UnionId(
-                                5000,
+                                4c00,
                             ),
                         },
                     ),
@@ -643,7 +643,7 @@
                 loc: DeclarationLocation {
                     hir_file_id: FileId(
                         EditionedFileId(
-                            Id(2800),
+                            Id(2400),
                         ),
                     ),
                     ptr: SyntaxNodePtr {
@@ -671,14 +671,14 @@
                 def: Module(
                     Module {
                         id: ModuleIdLt {
-                            [salsa id]: Id(2c01),
+                            [salsa id]: Id(2801),
                         },
                     },
                 ),
                 loc: DeclarationLocation {
                     hir_file_id: FileId(
                         EditionedFileId(
-                            Id(2800),
+                            Id(2400),
                         ),
                     ),
                     ptr: SyntaxNodePtr {
@@ -706,14 +706,14 @@
                 def: Module(
                     Module {
                         id: ModuleIdLt {
-                            [salsa id]: Id(2c02),
+                            [salsa id]: Id(2802),
                         },
                     },
                 ),
                 loc: DeclarationLocation {
                     hir_file_id: FileId(
                         EditionedFileId(
-                            Id(2800),
+                            Id(2400),
                         ),
                     ),
                     ptr: SyntaxNodePtr {
@@ -742,7 +742,7 @@
                     Macro {
                         id: MacroRulesId(
                             MacroRulesId(
-                                3801,
+                                3401,
                             ),
                         ),
                     },
@@ -750,7 +750,7 @@
                 loc: DeclarationLocation {
                     hir_file_id: FileId(
                         EditionedFileId(
-                            Id(2800),
+                            Id(2400),
                         ),
                     ),
                     ptr: SyntaxNodePtr {
@@ -778,14 +778,14 @@
                 def: Function(
                     FunctionId(
                         FunctionId(
-                            5c02,
+                            5802,
                         ),
                     ),
                 ),
                 loc: DeclarationLocation {
                     hir_file_id: FileId(
                         EditionedFileId(
-                            Id(2800),
+                            Id(2400),
                         ),
                     ),
                     ptr: SyntaxNodePtr {
@@ -815,14 +815,14 @@
                 def: Function(
                     FunctionId(
                         FunctionId(
-                            5c01,
+                            5801,
                         ),
                     ),
                 ),
                 loc: DeclarationLocation {
                     hir_file_id: FileId(
                         EditionedFileId(
-                            Id(2800),
+                            Id(2400),
                         ),
                     ),
                     ptr: SyntaxNodePtr {
@@ -853,7 +853,7 @@
                     Macro {
                         id: MacroRulesId(
                             MacroRulesId(
-                                3800,
+                                3400,
                             ),
                         ),
                     },
@@ -861,7 +861,7 @@
                 loc: DeclarationLocation {
                     hir_file_id: FileId(
                         EditionedFileId(
-                            Id(2800),
+                            Id(2400),
                         ),
                     ),
                     ptr: SyntaxNodePtr {
@@ -889,14 +889,14 @@
                 def: Function(
                     FunctionId(
                         FunctionId(
-                            5c00,
+                            5800,
                         ),
                     ),
                 ),
                 loc: DeclarationLocation {
                     hir_file_id: FileId(
                         EditionedFileId(
-                            Id(2800),
+                            Id(2400),
                         ),
                     ),
                     ptr: SyntaxNodePtr {
@@ -925,7 +925,7 @@
                     Macro {
                         id: MacroRulesId(
                             MacroRulesId(
-                                3801,
+                                3401,
                             ),
                         ),
                     },
@@ -933,7 +933,7 @@
                 loc: DeclarationLocation {
                     hir_file_id: FileId(
                         EditionedFileId(
-                            Id(2800),
+                            Id(2400),
                         ),
                     ),
                     ptr: SyntaxNodePtr {
@@ -961,14 +961,14 @@
                 def: Function(
                     FunctionId(
                         FunctionId(
-                            5c03,
+                            5803,
                         ),
                     ),
                 ),
                 loc: DeclarationLocation {
                     hir_file_id: FileId(
                         EditionedFileId(
-                            Id(2800),
+                            Id(2400),
                         ),
                     ),
                     ptr: SyntaxNodePtr {
@@ -998,7 +998,7 @@
     (
         Module {
             id: ModuleIdLt {
-                [salsa id]: Id(2c01),
+                [salsa id]: Id(2801),
             },
         },
         [
@@ -1008,7 +1008,7 @@
                     Struct(
                         Struct {
                             id: StructId(
-                                4403,
+                                4003,
                             ),
                         },
                     ),
@@ -1016,7 +1016,7 @@
                 loc: DeclarationLocation {
                     hir_file_id: FileId(
                         EditionedFileId(
-                            Id(2800),
+                            Id(2400),
                         ),
                     ),
                     ptr: SyntaxNodePtr {
@@ -1044,7 +1044,7 @@
     (
         Module {
             id: ModuleIdLt {
-                [salsa id]: Id(2c02),
+                [salsa id]: Id(2802),
             },
         },
         [
@@ -1053,14 +1053,14 @@
                 def: Trait(
                     Trait {
                         id: TraitId(
-                            5800,
+                            5400,
                         ),
                     },
                 ),
                 loc: DeclarationLocation {
                     hir_file_id: FileId(
                         EditionedFileId(
-                            Id(2801),
+                            Id(2401),
                         ),
                     ),
                     ptr: SyntaxNodePtr {
@@ -1089,7 +1089,7 @@
                     Macro {
                         id: Macro2Id(
                             Macro2Id(
-                                4800,
+                                4400,
                             ),
                         ),
                     },
@@ -1097,7 +1097,7 @@
                 loc: DeclarationLocation {
                     hir_file_id: FileId(
                         EditionedFileId(
-                            Id(2801),
+                            Id(2401),
                         ),
                     ),
                     ptr: SyntaxNodePtr {
@@ -1126,7 +1126,7 @@
                     Struct(
                         Struct {
                             id: StructId(
-                                4404,
+                                4004,
                             ),
                         },
                     ),
@@ -1134,7 +1134,7 @@
                 loc: DeclarationLocation {
                     hir_file_id: FileId(
                         EditionedFileId(
-                            Id(2801),
+                            Id(2401),
                         ),
                     ),
                     ptr: SyntaxNodePtr {
@@ -1163,7 +1163,7 @@
                     Macro {
                         id: Macro2Id(
                             Macro2Id(
-                                4800,
+                                4400,
                             ),
                         ),
                     },
@@ -1171,7 +1171,7 @@
                 loc: DeclarationLocation {
                     hir_file_id: FileId(
                         EditionedFileId(
-                            Id(2801),
+                            Id(2401),
                         ),
                     ),
                     ptr: SyntaxNodePtr {
@@ -1200,7 +1200,7 @@
                     Struct(
                         Struct {
                             id: StructId(
-                                4404,
+                                4004,
                             ),
                         },
                     ),
@@ -1208,7 +1208,7 @@
                 loc: DeclarationLocation {
                     hir_file_id: FileId(
                         EditionedFileId(
-                            Id(2801),
+                            Id(2401),
                         ),
                     ),
                     ptr: SyntaxNodePtr {

--- a/crates/ide-db/src/test_data/test_symbol_index_collection.txt
+++ b/crates/ide-db/src/test_data/test_symbol_index_collection.txt
@@ -2,7 +2,7 @@
     (
         Module {
             id: ModuleIdLt {
-                [salsa id]: Id(3000),
+                [salsa id]: Id(2c00),
             },
         },
         [
@@ -11,14 +11,14 @@
                 def: EnumVariant(
                     EnumVariant {
                         id: EnumVariantId(
-                            7800,
+                            7400,
                         ),
                     },
                 ),
                 loc: DeclarationLocation {
                     hir_file_id: FileId(
                         EditionedFileId(
-                            Id(2c00),
+                            Id(2800),
                         ),
                     ),
                     ptr: SyntaxNodePtr {
@@ -48,14 +48,14 @@
                 def: TypeAlias(
                     TypeAlias {
                         id: TypeAliasId(
-                            6c00,
+                            6800,
                         ),
                     },
                 ),
                 loc: DeclarationLocation {
                     hir_file_id: FileId(
                         EditionedFileId(
-                            Id(2c00),
+                            Id(2800),
                         ),
                     ),
                     ptr: SyntaxNodePtr {
@@ -83,14 +83,14 @@
                 def: EnumVariant(
                     EnumVariant {
                         id: EnumVariantId(
-                            7801,
+                            7401,
                         ),
                     },
                 ),
                 loc: DeclarationLocation {
                     hir_file_id: FileId(
                         EditionedFileId(
-                            Id(2c00),
+                            Id(2800),
                         ),
                     ),
                     ptr: SyntaxNodePtr {
@@ -120,14 +120,14 @@
                 def: Const(
                     Const {
                         id: ConstId(
-                            6400,
+                            6000,
                         ),
                     },
                 ),
                 loc: DeclarationLocation {
                     hir_file_id: FileId(
                         EditionedFileId(
-                            Id(2c00),
+                            Id(2800),
                         ),
                     ),
                     ptr: SyntaxNodePtr {
@@ -155,14 +155,14 @@
                 def: Const(
                     Const {
                         id: ConstId(
-                            6402,
+                            6002,
                         ),
                     },
                 ),
                 loc: DeclarationLocation {
                     hir_file_id: FileId(
                         EditionedFileId(
-                            Id(2c00),
+                            Id(2800),
                         ),
                     ),
                     ptr: SyntaxNodePtr {
@@ -191,7 +191,7 @@
                     Enum(
                         Enum {
                             id: EnumId(
-                                5000,
+                                4c00,
                             ),
                         },
                     ),
@@ -199,7 +199,7 @@
                 loc: DeclarationLocation {
                     hir_file_id: FileId(
                         EditionedFileId(
-                            Id(2c00),
+                            Id(2800),
                         ),
                     ),
                     ptr: SyntaxNodePtr {
@@ -228,7 +228,7 @@
                     Macro {
                         id: Macro2Id(
                             Macro2Id(
-                                4c00,
+                                4800,
                             ),
                         ),
                     },
@@ -236,7 +236,7 @@
                 loc: DeclarationLocation {
                     hir_file_id: FileId(
                         EditionedFileId(
-                            Id(2c00),
+                            Id(2800),
                         ),
                     ),
                     ptr: SyntaxNodePtr {
@@ -265,7 +265,7 @@
                     Macro {
                         id: Macro2Id(
                             Macro2Id(
-                                4c00,
+                                4800,
                             ),
                         ),
                     },
@@ -273,7 +273,7 @@
                 loc: DeclarationLocation {
                     hir_file_id: FileId(
                         EditionedFileId(
-                            Id(2c00),
+                            Id(2800),
                         ),
                     ),
                     ptr: SyntaxNodePtr {
@@ -301,14 +301,14 @@
                 def: Static(
                     Static {
                         id: StaticId(
-                            6800,
+                            6400,
                         ),
                     },
                 ),
                 loc: DeclarationLocation {
                     hir_file_id: FileId(
                         EditionedFileId(
-                            Id(2c00),
+                            Id(2800),
                         ),
                     ),
                     ptr: SyntaxNodePtr {
@@ -337,7 +337,7 @@
                     Struct(
                         Struct {
                             id: StructId(
-                                4801,
+                                4401,
                             ),
                         },
                     ),
@@ -345,7 +345,7 @@
                 loc: DeclarationLocation {
                     hir_file_id: FileId(
                         EditionedFileId(
-                            Id(2c00),
+                            Id(2800),
                         ),
                     ),
                     ptr: SyntaxNodePtr {
@@ -374,7 +374,7 @@
                     Struct(
                         Struct {
                             id: StructId(
-                                4800,
+                                4400,
                             ),
                         },
                     ),
@@ -382,7 +382,7 @@
                 loc: DeclarationLocation {
                     hir_file_id: MacroFile(
                         MacroCallId(
-                            Id(4000),
+                            Id(3c00),
                         ),
                     ),
                     ptr: SyntaxNodePtr {
@@ -411,7 +411,7 @@
                     Struct(
                         Struct {
                             id: StructId(
-                                4805,
+                                4405,
                             ),
                         },
                     ),
@@ -419,7 +419,7 @@
                 loc: DeclarationLocation {
                     hir_file_id: FileId(
                         EditionedFileId(
-                            Id(2c00),
+                            Id(2800),
                         ),
                     ),
                     ptr: SyntaxNodePtr {
@@ -450,7 +450,7 @@
                     Struct(
                         Struct {
                             id: StructId(
-                                4806,
+                                4406,
                             ),
                         },
                     ),
@@ -458,7 +458,7 @@
                 loc: DeclarationLocation {
                     hir_file_id: FileId(
                         EditionedFileId(
-                            Id(2c00),
+                            Id(2800),
                         ),
                     ),
                     ptr: SyntaxNodePtr {
@@ -489,7 +489,7 @@
                     Struct(
                         Struct {
                             id: StructId(
-                                4807,
+                                4407,
                             ),
                         },
                     ),
@@ -497,7 +497,7 @@
                 loc: DeclarationLocation {
                     hir_file_id: FileId(
                         EditionedFileId(
-                            Id(2c00),
+                            Id(2800),
                         ),
                     ),
                     ptr: SyntaxNodePtr {
@@ -526,7 +526,7 @@
                     Struct(
                         Struct {
                             id: StructId(
-                                4802,
+                                4402,
                             ),
                         },
                     ),
@@ -534,7 +534,7 @@
                 loc: DeclarationLocation {
                     hir_file_id: FileId(
                         EditionedFileId(
-                            Id(2c00),
+                            Id(2800),
                         ),
                     ),
                     ptr: SyntaxNodePtr {
@@ -562,14 +562,14 @@
                 def: Trait(
                     Trait {
                         id: TraitId(
-                            5c00,
+                            5800,
                         ),
                     },
                 ),
                 loc: DeclarationLocation {
                     hir_file_id: FileId(
                         EditionedFileId(
-                            Id(2c00),
+                            Id(2800),
                         ),
                     ),
                     ptr: SyntaxNodePtr {
@@ -598,7 +598,7 @@
                     Macro {
                         id: Macro2Id(
                             Macro2Id(
-                                4c00,
+                                4800,
                             ),
                         ),
                     },
@@ -606,7 +606,7 @@
                 loc: DeclarationLocation {
                     hir_file_id: FileId(
                         EditionedFileId(
-                            Id(2c00),
+                            Id(2800),
                         ),
                     ),
                     ptr: SyntaxNodePtr {
@@ -635,7 +635,7 @@
                     Union(
                         Union {
                             id: UnionId(
-                                5400,
+                                5000,
                             ),
                         },
                     ),
@@ -643,7 +643,7 @@
                 loc: DeclarationLocation {
                     hir_file_id: FileId(
                         EditionedFileId(
-                            Id(2c00),
+                            Id(2800),
                         ),
                     ),
                     ptr: SyntaxNodePtr {
@@ -671,14 +671,14 @@
                 def: Module(
                     Module {
                         id: ModuleIdLt {
-                            [salsa id]: Id(3001),
+                            [salsa id]: Id(2c01),
                         },
                     },
                 ),
                 loc: DeclarationLocation {
                     hir_file_id: FileId(
                         EditionedFileId(
-                            Id(2c00),
+                            Id(2800),
                         ),
                     ),
                     ptr: SyntaxNodePtr {
@@ -706,14 +706,14 @@
                 def: Module(
                     Module {
                         id: ModuleIdLt {
-                            [salsa id]: Id(3002),
+                            [salsa id]: Id(2c02),
                         },
                     },
                 ),
                 loc: DeclarationLocation {
                     hir_file_id: FileId(
                         EditionedFileId(
-                            Id(2c00),
+                            Id(2800),
                         ),
                     ),
                     ptr: SyntaxNodePtr {
@@ -742,7 +742,7 @@
                     Macro {
                         id: MacroRulesId(
                             MacroRulesId(
-                                3c01,
+                                3801,
                             ),
                         ),
                     },
@@ -750,7 +750,7 @@
                 loc: DeclarationLocation {
                     hir_file_id: FileId(
                         EditionedFileId(
-                            Id(2c00),
+                            Id(2800),
                         ),
                     ),
                     ptr: SyntaxNodePtr {
@@ -778,14 +778,14 @@
                 def: Function(
                     FunctionId(
                         FunctionId(
-                            6002,
+                            5c02,
                         ),
                     ),
                 ),
                 loc: DeclarationLocation {
                     hir_file_id: FileId(
                         EditionedFileId(
-                            Id(2c00),
+                            Id(2800),
                         ),
                     ),
                     ptr: SyntaxNodePtr {
@@ -815,14 +815,14 @@
                 def: Function(
                     FunctionId(
                         FunctionId(
-                            6001,
+                            5c01,
                         ),
                     ),
                 ),
                 loc: DeclarationLocation {
                     hir_file_id: FileId(
                         EditionedFileId(
-                            Id(2c00),
+                            Id(2800),
                         ),
                     ),
                     ptr: SyntaxNodePtr {
@@ -853,7 +853,7 @@
                     Macro {
                         id: MacroRulesId(
                             MacroRulesId(
-                                3c00,
+                                3800,
                             ),
                         ),
                     },
@@ -861,7 +861,7 @@
                 loc: DeclarationLocation {
                     hir_file_id: FileId(
                         EditionedFileId(
-                            Id(2c00),
+                            Id(2800),
                         ),
                     ),
                     ptr: SyntaxNodePtr {
@@ -889,14 +889,14 @@
                 def: Function(
                     FunctionId(
                         FunctionId(
-                            6000,
+                            5c00,
                         ),
                     ),
                 ),
                 loc: DeclarationLocation {
                     hir_file_id: FileId(
                         EditionedFileId(
-                            Id(2c00),
+                            Id(2800),
                         ),
                     ),
                     ptr: SyntaxNodePtr {
@@ -925,7 +925,7 @@
                     Macro {
                         id: MacroRulesId(
                             MacroRulesId(
-                                3c01,
+                                3801,
                             ),
                         ),
                     },
@@ -933,7 +933,7 @@
                 loc: DeclarationLocation {
                     hir_file_id: FileId(
                         EditionedFileId(
-                            Id(2c00),
+                            Id(2800),
                         ),
                     ),
                     ptr: SyntaxNodePtr {
@@ -961,14 +961,14 @@
                 def: Function(
                     FunctionId(
                         FunctionId(
-                            6003,
+                            5c03,
                         ),
                     ),
                 ),
                 loc: DeclarationLocation {
                     hir_file_id: FileId(
                         EditionedFileId(
-                            Id(2c00),
+                            Id(2800),
                         ),
                     ),
                     ptr: SyntaxNodePtr {
@@ -998,7 +998,7 @@
     (
         Module {
             id: ModuleIdLt {
-                [salsa id]: Id(3001),
+                [salsa id]: Id(2c01),
             },
         },
         [
@@ -1008,7 +1008,7 @@
                     Struct(
                         Struct {
                             id: StructId(
-                                4803,
+                                4403,
                             ),
                         },
                     ),
@@ -1016,7 +1016,7 @@
                 loc: DeclarationLocation {
                     hir_file_id: FileId(
                         EditionedFileId(
-                            Id(2c00),
+                            Id(2800),
                         ),
                     ),
                     ptr: SyntaxNodePtr {
@@ -1044,7 +1044,7 @@
     (
         Module {
             id: ModuleIdLt {
-                [salsa id]: Id(3002),
+                [salsa id]: Id(2c02),
             },
         },
         [
@@ -1053,14 +1053,14 @@
                 def: Trait(
                     Trait {
                         id: TraitId(
-                            5c00,
+                            5800,
                         ),
                     },
                 ),
                 loc: DeclarationLocation {
                     hir_file_id: FileId(
                         EditionedFileId(
-                            Id(2c01),
+                            Id(2801),
                         ),
                     ),
                     ptr: SyntaxNodePtr {
@@ -1089,7 +1089,7 @@
                     Macro {
                         id: Macro2Id(
                             Macro2Id(
-                                4c00,
+                                4800,
                             ),
                         ),
                     },
@@ -1097,7 +1097,7 @@
                 loc: DeclarationLocation {
                     hir_file_id: FileId(
                         EditionedFileId(
-                            Id(2c01),
+                            Id(2801),
                         ),
                     ),
                     ptr: SyntaxNodePtr {
@@ -1126,7 +1126,7 @@
                     Struct(
                         Struct {
                             id: StructId(
-                                4804,
+                                4404,
                             ),
                         },
                     ),
@@ -1134,7 +1134,7 @@
                 loc: DeclarationLocation {
                     hir_file_id: FileId(
                         EditionedFileId(
-                            Id(2c01),
+                            Id(2801),
                         ),
                     ),
                     ptr: SyntaxNodePtr {
@@ -1163,7 +1163,7 @@
                     Macro {
                         id: Macro2Id(
                             Macro2Id(
-                                4c00,
+                                4800,
                             ),
                         ),
                     },
@@ -1171,7 +1171,7 @@
                 loc: DeclarationLocation {
                     hir_file_id: FileId(
                         EditionedFileId(
-                            Id(2c01),
+                            Id(2801),
                         ),
                     ),
                     ptr: SyntaxNodePtr {
@@ -1200,7 +1200,7 @@
                     Struct(
                         Struct {
                             id: StructId(
-                                4804,
+                                4404,
                             ),
                         },
                     ),
@@ -1208,7 +1208,7 @@
                 loc: DeclarationLocation {
                     hir_file_id: FileId(
                         EditionedFileId(
-                            Id(2c01),
+                            Id(2801),
                         ),
                     ),
                     ptr: SyntaxNodePtr {

--- a/crates/ide-db/src/test_data/test_symbols_exclude_imports.txt
+++ b/crates/ide-db/src/test_data/test_symbols_exclude_imports.txt
@@ -5,7 +5,7 @@
             Struct(
                 Struct {
                     id: StructId(
-                        3c00,
+                        3800,
                     ),
                 },
             ),
@@ -13,7 +13,7 @@
         loc: DeclarationLocation {
             hir_file_id: FileId(
                 EditionedFileId(
-                    Id(2c01),
+                    Id(2801),
                 ),
             ),
             ptr: SyntaxNodePtr {

--- a/crates/ide-db/src/test_data/test_symbols_exclude_imports.txt
+++ b/crates/ide-db/src/test_data/test_symbols_exclude_imports.txt
@@ -5,7 +5,7 @@
             Struct(
                 Struct {
                     id: StructId(
-                        3800,
+                        3400,
                     ),
                 },
             ),
@@ -13,7 +13,7 @@
         loc: DeclarationLocation {
             hir_file_id: FileId(
                 EditionedFileId(
-                    Id(2801),
+                    Id(2401),
                 ),
             ),
             ptr: SyntaxNodePtr {

--- a/crates/ide-db/src/test_data/test_symbols_with_imports.txt
+++ b/crates/ide-db/src/test_data/test_symbols_with_imports.txt
@@ -5,7 +5,7 @@
             Struct(
                 Struct {
                     id: StructId(
-                        3800,
+                        3400,
                     ),
                 },
             ),
@@ -13,7 +13,7 @@
         loc: DeclarationLocation {
             hir_file_id: FileId(
                 EditionedFileId(
-                    Id(2801),
+                    Id(2401),
                 ),
             ),
             ptr: SyntaxNodePtr {
@@ -42,7 +42,7 @@
             Struct(
                 Struct {
                     id: StructId(
-                        3800,
+                        3400,
                     ),
                 },
             ),
@@ -50,7 +50,7 @@
         loc: DeclarationLocation {
             hir_file_id: FileId(
                 EditionedFileId(
-                    Id(2800),
+                    Id(2400),
                 ),
             ),
             ptr: SyntaxNodePtr {

--- a/crates/ide-db/src/test_data/test_symbols_with_imports.txt
+++ b/crates/ide-db/src/test_data/test_symbols_with_imports.txt
@@ -5,7 +5,7 @@
             Struct(
                 Struct {
                     id: StructId(
-                        3c00,
+                        3800,
                     ),
                 },
             ),
@@ -13,7 +13,7 @@
         loc: DeclarationLocation {
             hir_file_id: FileId(
                 EditionedFileId(
-                    Id(2c01),
+                    Id(2801),
                 ),
             ),
             ptr: SyntaxNodePtr {
@@ -42,7 +42,7 @@
             Struct(
                 Struct {
                     id: StructId(
-                        3c00,
+                        3800,
                     ),
                 },
             ),
@@ -50,7 +50,7 @@
         loc: DeclarationLocation {
             hir_file_id: FileId(
                 EditionedFileId(
-                    Id(2c00),
+                    Id(2800),
                 ),
             ),
             ptr: SyntaxNodePtr {

--- a/crates/query-group-macro/src/lib.rs
+++ b/crates/query-group-macro/src/lib.rs
@@ -1,14 +1,10 @@
 //! A macro that mimics the old Salsa-style `#[query_group]` macro.
 
-use core::fmt;
 use std::vec;
 
 use proc_macro::TokenStream;
 use proc_macro2::Span;
-use queries::{
-    GeneratedInputStruct, InputQuery, InputSetter, InputSetterWithDurability, Queries, SetterKind,
-    TrackedQuery, Transparent,
-};
+use queries::{GeneratedInputStruct, Queries, TrackedQuery, Transparent};
 use quote::{ToTokens, format_ident, quote};
 use syn::parse::{Parse, ParseStream};
 use syn::punctuated::Punctuated;
@@ -23,18 +19,6 @@ pub fn query_group(args: TokenStream, input: TokenStream) -> TokenStream {
     match query_group_impl(args, input.clone()) {
         Ok(tokens) => tokens,
         Err(e) => token_stream_with_error(input, e),
-    }
-}
-
-#[derive(Debug)]
-struct InputStructField {
-    name: proc_macro2::TokenStream,
-    ty: proc_macro2::TokenStream,
-}
-
-impl fmt::Display for InputStructField {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.name)
     }
 }
 
@@ -99,7 +83,6 @@ fn filter_attrs(attrs: Vec<Attribute>) -> (Vec<Attribute>, Vec<SalsaAttr>) {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum QueryKind {
-    Input,
     Tracked,
     TrackedWithSalsaStruct,
     Transparent,
@@ -182,14 +165,10 @@ pub(crate) fn query_group_impl(
     let input_struct_name = format_ident!("{}Data", trait_name_ident);
     let create_data_ident = format_ident!("create_data_{}", trait_name_ident);
 
-    let mut input_struct_fields: Vec<InputStructField> = vec![];
     let mut trait_methods = vec![];
-    let mut setter_trait_methods = vec![];
-    let mut lookup_signatures = vec![];
 
     for item in &mut item_trait.items {
         if let syn::TraitItem::Fn(method) = item {
-            let method_name = &method.sig.ident;
             let signature = &method.sig;
 
             let (_attrs, salsa_attrs) = filter_attrs(method.attrs.clone());
@@ -214,15 +193,6 @@ pub(crate) fn query_group_impl(
                     "cycle" => {
                         let c = syn::parse::<Parenthesized<Cycle>>(tts)?;
                         cycle = Some(c.0);
-                    }
-                    "input" => {
-                        if !pat_and_tys.is_empty() {
-                            return Err(syn::Error::new(
-                                span,
-                                "input methods cannot have a parameter",
-                            ));
-                        }
-                        query_kind = QueryKind::Input;
                     }
                     "invoke_interned" => {
                         let path = syn::parse::<Parenthesized<Path>>(tts)?;
@@ -252,49 +222,15 @@ pub(crate) fn query_group_impl(
                 }
             }
 
-            let syn::ReturnType::Type(_, return_ty) = signature.output.clone() else {
+            let syn::ReturnType::Type(_, _) = signature.output.clone() else {
                 return Err(syn::Error::new(signature.span(), "Queries must have a return type"));
             };
-
-            if let syn::Type::Path(ref ty_path) = *return_ty
-                && matches!(query_kind, QueryKind::Input)
-            {
-                let field = InputStructField {
-                    name: method_name.to_token_stream(),
-                    ty: ty_path.path.to_token_stream(),
-                };
-
-                input_struct_fields.push(field);
-            }
 
             if let Some(block) = &mut method.default {
                 SelfToDbRewriter.visit_block_mut(block);
             }
 
             match (query_kind, invoke) {
-                // input
-                (QueryKind::Input, None) => {
-                    let query = InputQuery {
-                        signature: method.sig.clone(),
-                        create_data_ident: create_data_ident.clone(),
-                    };
-                    let value = Queries::InputQuery(query);
-                    trait_methods.push(value);
-
-                    let setter = InputSetter {
-                        signature: method.sig.clone(),
-                        return_type: *return_ty.clone(),
-                        create_data_ident: create_data_ident.clone(),
-                    };
-                    setter_trait_methods.push(SetterKind::Plain(setter));
-
-                    let setter = InputSetterWithDurability {
-                        signature: method.sig.clone(),
-                        return_type: *return_ty.clone(),
-                        create_data_ident: create_data_ident.clone(),
-                    };
-                    setter_trait_methods.push(SetterKind::WithDurability(setter));
-                }
                 // tracked function. it might have an invoke, or might not.
                 (QueryKind::Tracked, invoke) => {
                     let method = TrackedQuery {
@@ -336,60 +272,22 @@ pub(crate) fn query_group_impl(
                     };
                     trait_methods.push(Queries::Transparent(method));
                 }
-                (QueryKind::Input, Some(path)) => {
-                    return Err(syn::Error::new(
-                        path.span(),
-                        "Inputs cannot be used with an `#[invoke]`".to_string(),
-                    ));
-                }
             }
         }
     }
 
-    let fields = input_struct_fields
-        .into_iter()
-        .map(|input| {
-            let name = input.name;
-            let ret = input.ty;
-            quote! { #name: Option<#ret> }
-        })
-        .collect::<Vec<proc_macro2::TokenStream>>();
-
     let input_struct = quote! {
         #[salsa_macros::input]
-        pub(crate) struct #input_struct_name {
-            #(#fields),*
-        }
+        pub(crate) struct #input_struct_name {}
     };
-
-    let field_params = std::iter::repeat_n(quote! { None }, fields.len())
-        .collect::<Vec<proc_macro2::TokenStream>>();
 
     let create_data_method = quote! {
         #[allow(non_snake_case)]
         #[salsa_macros::tracked]
         fn #create_data_ident(db: &dyn #trait_name_ident) -> #input_struct_name {
-            #input_struct_name::new(db, #(#field_params),*)
+            #input_struct_name::new(db)
         }
     };
-
-    let mut setter_signatures = vec![];
-    let mut setter_methods = vec![];
-    for trait_item in setter_trait_methods
-        .iter()
-        .map(|method| method.to_token_stream())
-        .map(|tokens| syn::parse2::<syn::TraitItemFn>(tokens).unwrap())
-    {
-        let mut methods_sans_body = trait_item.clone();
-        methods_sans_body.default = None;
-        methods_sans_body.semi_token = Some(syn::Token![;](trait_item.span()));
-
-        setter_signatures.push(TraitItem::Fn(methods_sans_body));
-        setter_methods.push(TraitItem::Fn(trait_item));
-    }
-
-    item_trait.items.append(&mut setter_signatures);
-    item_trait.items.append(&mut lookup_signatures);
 
     let trait_impl = quote! {
         #[salsa_macros::db]
@@ -398,8 +296,6 @@ pub(crate) fn query_group_impl(
             DB: #supertraits,
         {
             #(#trait_methods)*
-
-            #(#setter_methods)*
         }
     };
     RemoveAttrsFromTraitMethods.visit_item_trait_mut(&mut item_trait);

--- a/crates/query-group-macro/src/queries.rs
+++ b/crates/query-group-macro/src/queries.rs
@@ -1,7 +1,7 @@
 //! The IR of the `#[query_group]` macro.
 
 use quote::{ToTokens, format_ident, quote, quote_spanned};
-use syn::{FnArg, Ident, PatType, Path, Receiver, ReturnType, parse_quote, spanned::Spanned};
+use syn::{Ident, PatType, Path, spanned::Spanned};
 
 use crate::Cycle;
 
@@ -104,132 +104,6 @@ impl ToTokens for TrackedQuery {
     }
 }
 
-pub(crate) struct InputQuery {
-    pub(crate) signature: syn::Signature,
-    pub(crate) create_data_ident: Ident,
-}
-
-impl ToTokens for InputQuery {
-    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
-        let sig = &self.signature;
-        let fn_ident = &sig.ident;
-        let create_data_ident = &self.create_data_ident;
-
-        let method = quote! {
-            #sig {
-                let data = #create_data_ident(self);
-                data.#fn_ident(self).unwrap()
-            }
-        };
-        method.to_tokens(tokens);
-    }
-}
-
-pub(crate) struct InputSetter {
-    pub(crate) signature: syn::Signature,
-    pub(crate) return_type: syn::Type,
-    pub(crate) create_data_ident: Ident,
-}
-
-impl ToTokens for InputSetter {
-    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
-        let sig = &mut self.signature.clone();
-
-        let ty = &self.return_type;
-        let fn_ident = &sig.ident;
-        let create_data_ident = &self.create_data_ident;
-
-        let setter_ident = format_ident!("set_{}", fn_ident);
-        sig.ident = setter_ident.clone();
-
-        let value_argument: PatType = parse_quote!(__value: #ty);
-        sig.inputs.push(FnArg::Typed(value_argument.clone()));
-
-        // make `&self` `&mut self` instead.
-        let mut_receiver: Receiver = parse_quote!(&mut self);
-        if let Some(og) = sig.inputs.first_mut() {
-            *og = FnArg::Receiver(mut_receiver)
-        }
-
-        // remove the return value.
-        sig.output = ReturnType::Default;
-
-        let value = &value_argument.pat;
-        let method = quote! {
-            #sig {
-                use salsa::Setter;
-                let data = #create_data_ident(self);
-                data.#setter_ident(self).to(Some(#value));
-            }
-        };
-        method.to_tokens(tokens);
-    }
-}
-
-pub(crate) struct InputSetterWithDurability {
-    pub(crate) signature: syn::Signature,
-    pub(crate) return_type: syn::Type,
-    pub(crate) create_data_ident: Ident,
-}
-
-impl ToTokens for InputSetterWithDurability {
-    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
-        let sig = &mut self.signature.clone();
-
-        let ty = &self.return_type;
-        let fn_ident = &sig.ident;
-        let setter_ident = format_ident!("set_{}", fn_ident);
-
-        let create_data_ident = &self.create_data_ident;
-
-        sig.ident = format_ident!("set_{}_with_durability", fn_ident);
-
-        let value_argument: PatType = parse_quote!(__value: #ty);
-        sig.inputs.push(FnArg::Typed(value_argument.clone()));
-
-        let durability_argument: PatType = parse_quote!(durability: salsa::Durability);
-        sig.inputs.push(FnArg::Typed(durability_argument.clone()));
-
-        // make `&self` `&mut self` instead.
-        let mut_receiver: Receiver = parse_quote!(&mut self);
-        if let Some(og) = sig.inputs.first_mut() {
-            *og = FnArg::Receiver(mut_receiver)
-        }
-
-        // remove the return value.
-        sig.output = ReturnType::Default;
-
-        let value = &value_argument.pat;
-        let durability = &durability_argument.pat;
-        let method = quote! {
-            #sig {
-                use salsa::Setter;
-                let data = #create_data_ident(self);
-                data.#setter_ident(self)
-                    .with_durability(#durability)
-                    .to(Some(#value));
-            }
-        };
-        method.to_tokens(tokens);
-    }
-}
-
-pub(crate) enum SetterKind {
-    Plain(InputSetter),
-    WithDurability(InputSetterWithDurability),
-}
-
-impl ToTokens for SetterKind {
-    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
-        match self {
-            SetterKind::Plain(input_setter) => input_setter.to_tokens(tokens),
-            SetterKind::WithDurability(input_setter_with_durability) => {
-                input_setter_with_durability.to_tokens(tokens)
-            }
-        }
-    }
-}
-
 pub(crate) struct Transparent {
     pub(crate) signature: syn::Signature,
     pub(crate) pat_and_tys: Vec<PatType>,
@@ -270,7 +144,6 @@ impl ToTokens for Transparent {
 #[allow(clippy::large_enum_variant)]
 pub(crate) enum Queries {
     TrackedQuery(TrackedQuery),
-    InputQuery(InputQuery),
     Transparent(Transparent),
 }
 
@@ -278,7 +151,6 @@ impl ToTokens for Queries {
     fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
         match self {
             Queries::TrackedQuery(tracked_query) => tracked_query.to_tokens(tokens),
-            Queries::InputQuery(input_query) => input_query.to_tokens(tokens),
             Queries::Transparent(transparent) => transparent.to_tokens(tokens),
         }
     }

--- a/crates/query-group-macro/tests/hello_world.rs
+++ b/crates/query-group-macro/tests/hello_world.rs
@@ -4,13 +4,13 @@ use query_group_macro::query_group;
 mod logger_db;
 use logger_db::LoggerDb;
 
+#[salsa::input(singleton)]
+struct InputString {
+    inner: String,
+}
+
 #[query_group]
 pub trait HelloWorldDatabase: salsa::Database {
-    // input
-    // // input with no params
-    #[salsa::input]
-    fn input_string(&self) -> String;
-
     // unadorned query
     #[salsa::invoke_interned(length_query)]
     fn length_query(&self, key: ()) -> usize;
@@ -32,98 +32,83 @@ pub trait HelloWorldDatabase: salsa::Database {
 }
 
 fn length_query(db: &dyn HelloWorldDatabase, _key: ()) -> usize {
-    db.input_string().len()
+    InputString::get(db).inner(db).len()
 }
 
 fn length_query_with_no_params(db: &dyn HelloWorldDatabase) -> usize {
-    db.input_string().len()
+    InputString::get(db).inner(db).len()
 }
 
 fn invoke_length_query_actual(db: &dyn HelloWorldDatabase, _key: ()) -> usize {
-    db.input_string().len()
+    InputString::get(db).inner(db).len()
 }
 
 fn transparent_length(db: &dyn HelloWorldDatabase, _key: ()) -> usize {
-    db.input_string().len()
+    InputString::get(db).inner(db).len()
 }
 
 fn transparent_and_invoke_length_actual(db: &dyn HelloWorldDatabase, _key: ()) -> usize {
-    db.input_string().len()
+    InputString::get(db).inner(db).len()
 }
 
 #[test]
 fn unadorned_query() {
-    let mut db = LoggerDb::default();
+    let db = LoggerDb::default();
 
-    db.set_input_string(String::from("Hello, world!"));
+    InputString::new(&db, String::from("Hello, world!"));
     let len = db.length_query(());
 
     assert_eq!(len, 13);
     db.assert_logs(expect![[r#"
         [
             "salsa_event(WillCheckCancellation)",
-            "salsa_event(WillExecute { database_key: create_data_HelloWorldDatabase(Id(0)) })",
+            "salsa_event(WillExecute { database_key: create_data_HelloWorldDatabase(Id(400)) })",
             "salsa_event(WillCheckCancellation)",
-            "salsa_event(DidValidateMemoizedValue { database_key: create_data_HelloWorldDatabase(Id(0)) })",
-            "salsa_event(WillCheckCancellation)",
-            "salsa_event(WillExecute { database_key: length_query_shim(Id(800)) })",
-            "salsa_event(WillCheckCancellation)",
+            "salsa_event(WillExecute { database_key: length_query_shim(Id(c00)) })",
         ]"#]]);
 }
 
 #[test]
 fn invoke_query() {
-    let mut db = LoggerDb::default();
+    let db = LoggerDb::default();
 
-    db.set_input_string(String::from("Hello, world!"));
+    InputString::new(&db, String::from("Hello, world!"));
     let len = db.invoke_length_query(());
 
     assert_eq!(len, 13);
     db.assert_logs(expect![[r#"
         [
             "salsa_event(WillCheckCancellation)",
-            "salsa_event(WillExecute { database_key: create_data_HelloWorldDatabase(Id(0)) })",
+            "salsa_event(WillExecute { database_key: create_data_HelloWorldDatabase(Id(400)) })",
             "salsa_event(WillCheckCancellation)",
-            "salsa_event(DidValidateMemoizedValue { database_key: create_data_HelloWorldDatabase(Id(0)) })",
-            "salsa_event(WillCheckCancellation)",
-            "salsa_event(WillExecute { database_key: invoke_length_query_shim(Id(800)) })",
-            "salsa_event(WillCheckCancellation)",
+            "salsa_event(WillExecute { database_key: invoke_length_query_shim(Id(c00)) })",
         ]"#]]);
 }
 
 #[test]
 fn transparent() {
-    let mut db = LoggerDb::default();
+    let db = LoggerDb::default();
 
-    db.set_input_string(String::from("Hello, world!"));
+    InputString::new(&db, String::from("Hello, world!"));
     let len = db.transparent_length(());
 
     assert_eq!(len, 13);
-    db.assert_logs(expect![[r#"
-        [
-            "salsa_event(WillCheckCancellation)",
-            "salsa_event(WillExecute { database_key: create_data_HelloWorldDatabase(Id(0)) })",
-            "salsa_event(WillCheckCancellation)",
-            "salsa_event(DidValidateMemoizedValue { database_key: create_data_HelloWorldDatabase(Id(0)) })",
-        ]"#]]);
+    db.assert_logs(expect!["[]"]);
 }
 
 #[test]
 fn transparent_invoke() {
-    let mut db = LoggerDb::default();
+    let db = LoggerDb::default();
 
-    db.set_input_string(String::from("Hello, world!"));
+    InputString::new(&db, String::from("Hello, world!"));
     let len = db.transparent_and_invoke_length(());
 
     assert_eq!(len, 13);
     db.assert_logs(expect![[r#"
         [
             "salsa_event(WillCheckCancellation)",
-            "salsa_event(WillExecute { database_key: create_data_HelloWorldDatabase(Id(0)) })",
+            "salsa_event(WillExecute { database_key: create_data_HelloWorldDatabase(Id(400)) })",
             "salsa_event(WillCheckCancellation)",
-            "salsa_event(DidValidateMemoizedValue { database_key: create_data_HelloWorldDatabase(Id(0)) })",
-            "salsa_event(WillCheckCancellation)",
-            "salsa_event(WillExecute { database_key: transparent_and_invoke_length_shim(Id(800)) })",
-            "salsa_event(WillCheckCancellation)",
+            "salsa_event(WillExecute { database_key: transparent_and_invoke_length_shim(Id(c00)) })",
         ]"#]]);
 }

--- a/crates/query-group-macro/tests/lru.rs
+++ b/crates/query-group-macro/tests/lru.rs
@@ -4,12 +4,13 @@ mod logger_db;
 use logger_db::LoggerDb;
 use query_group_macro::query_group;
 
+#[salsa::input(singleton)]
+struct InputString {
+    inner: String,
+}
+
 #[query_group]
 pub trait LruDB: salsa::Database {
-    // // input with no params
-    #[salsa::input]
-    fn input_string(&self) -> String;
-
     #[salsa::lru(16)]
     #[salsa::invoke_interned(length_query)]
     fn length_query(&self, key: ()) -> usize;
@@ -20,49 +21,43 @@ pub trait LruDB: salsa::Database {
 }
 
 fn length_query(db: &dyn LruDB, _key: ()) -> usize {
-    db.input_string().len()
+    InputString::get(db).inner(db).len()
 }
 
 fn invoked_query(db: &dyn LruDB, _key: ()) -> usize {
-    db.input_string().len()
+    InputString::get(db).inner(db).len()
 }
 
 #[test]
 fn plain_lru() {
-    let mut db = LoggerDb::default();
+    let db = LoggerDb::default();
 
-    db.set_input_string(String::from("Hello, world!"));
+    InputString::new(&db, String::from("Hello, world!"));
     let len = db.length_query(());
 
     assert_eq!(len, 13);
     db.assert_logs(expect![[r#"
         [
             "salsa_event(WillCheckCancellation)",
-            "salsa_event(WillExecute { database_key: create_data_LruDB(Id(0)) })",
+            "salsa_event(WillExecute { database_key: create_data_LruDB(Id(400)) })",
             "salsa_event(WillCheckCancellation)",
-            "salsa_event(DidValidateMemoizedValue { database_key: create_data_LruDB(Id(0)) })",
-            "salsa_event(WillCheckCancellation)",
-            "salsa_event(WillExecute { database_key: length_query_shim(Id(800)) })",
-            "salsa_event(WillCheckCancellation)",
+            "salsa_event(WillExecute { database_key: length_query_shim(Id(c00)) })",
         ]"#]]);
 }
 
 #[test]
 fn invoke_lru() {
-    let mut db = LoggerDb::default();
+    let db = LoggerDb::default();
 
-    db.set_input_string(String::from("Hello, world!"));
+    InputString::new(&db, String::from("Hello, world!"));
     let len = db.length_query_invoke(());
 
     assert_eq!(len, 13);
     db.assert_logs(expect![[r#"
         [
             "salsa_event(WillCheckCancellation)",
-            "salsa_event(WillExecute { database_key: create_data_LruDB(Id(0)) })",
+            "salsa_event(WillExecute { database_key: create_data_LruDB(Id(400)) })",
             "salsa_event(WillCheckCancellation)",
-            "salsa_event(DidValidateMemoizedValue { database_key: create_data_LruDB(Id(0)) })",
-            "salsa_event(WillCheckCancellation)",
-            "salsa_event(WillExecute { database_key: length_query_invoke_shim(Id(800)) })",
-            "salsa_event(WillCheckCancellation)",
+            "salsa_event(WillExecute { database_key: length_query_invoke_shim(Id(c00)) })",
         ]"#]]);
 }

--- a/crates/query-group-macro/tests/multiple_dbs.rs
+++ b/crates/query-group-macro/tests/multiple_dbs.rs
@@ -1,10 +1,12 @@
 use query_group_macro::query_group;
 
+#[salsa::input(singleton)]
+struct InputString {
+    inner: String,
+}
+
 #[query_group]
 pub trait DatabaseOne: salsa::Database {
-    #[salsa::input]
-    fn input_string(&self) -> String;
-
     // unadorned query
     #[salsa::invoke_interned(length)]
     fn length(&self, key: ()) -> usize;
@@ -17,9 +19,9 @@ pub trait DatabaseTwo: DatabaseOne {
 }
 
 fn length(db: &dyn DatabaseOne, _key: ()) -> usize {
-    db.input_string().len()
+    InputString::get(db).inner(db).len()
 }
 
 fn second_length(db: &dyn DatabaseTwo, _key: ()) -> usize {
-    db.input_string().len()
+    InputString::get(db).inner(db).len()
 }

--- a/crates/query-group-macro/tests/result.rs
+++ b/crates/query-group-macro/tests/result.rs
@@ -7,11 +7,13 @@ use query_group_macro::query_group;
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Error;
 
+#[salsa::input(singleton)]
+struct InputString {
+    inner: String,
+}
+
 #[query_group]
 pub trait ResultDatabase: salsa::Database {
-    #[salsa::input]
-    fn input_string(&self) -> String;
-
     #[salsa::invoke_interned(length)]
     fn length(&self, key: ()) -> Result<usize, Error>;
 
@@ -20,33 +22,29 @@ pub trait ResultDatabase: salsa::Database {
 }
 
 fn length(db: &dyn ResultDatabase, _key: ()) -> Result<usize, Error> {
-    Ok(db.input_string().len())
+    Ok(InputString::get(db).inner(db).len())
 }
 
 fn length2(db: &dyn ResultDatabase, _key: ()) -> Result<usize, Error> {
-    Ok(db.input_string().len())
+    Ok(InputString::get(db).inner(db).len())
 }
 
 #[test]
 fn test_queries_with_results() {
-    let mut db = LoggerDb::default();
+    let db = LoggerDb::default();
     let input = "hello";
-    db.set_input_string(input.to_owned());
+    _ = InputString::new(&db, input.to_owned());
     assert_eq!(db.length(()), Ok(input.len()));
     assert_eq!(db.length2(()), Ok(input.len()));
 
     db.assert_logs(expect![[r#"
         [
             "salsa_event(WillCheckCancellation)",
-            "salsa_event(WillExecute { database_key: create_data_ResultDatabase(Id(0)) })",
+            "salsa_event(WillExecute { database_key: create_data_ResultDatabase(Id(400)) })",
             "salsa_event(WillCheckCancellation)",
-            "salsa_event(DidValidateMemoizedValue { database_key: create_data_ResultDatabase(Id(0)) })",
-            "salsa_event(WillCheckCancellation)",
-            "salsa_event(WillExecute { database_key: length_shim(Id(800)) })",
+            "salsa_event(WillExecute { database_key: length_shim(Id(c00)) })",
             "salsa_event(WillCheckCancellation)",
             "salsa_event(WillCheckCancellation)",
-            "salsa_event(WillCheckCancellation)",
-            "salsa_event(WillExecute { database_key: length2_shim(Id(c00)) })",
-            "salsa_event(WillCheckCancellation)",
+            "salsa_event(WillExecute { database_key: length2_shim(Id(1000)) })",
         ]"#]]);
 }

--- a/crates/query-group-macro/tests/tuples.rs
+++ b/crates/query-group-macro/tests/tuples.rs
@@ -4,36 +4,35 @@ mod logger_db;
 use expect_test::expect;
 use logger_db::LoggerDb;
 
+#[salsa::input(singleton)]
+struct InputString {
+    inner: String,
+}
+
 #[query_group]
 pub trait HelloWorldDatabase: salsa::Database {
-    #[salsa::input]
-    fn input_string(&self) -> String;
-
     #[salsa::invoke_interned(length_query)]
     fn length_query(&self, key: ()) -> (usize, usize);
 }
 
 fn length_query(db: &dyn HelloWorldDatabase, _key: ()) -> (usize, usize) {
-    let len = db.input_string().len();
+    let len = InputString::get(db).inner(db).len();
     (len, len)
 }
 
 #[test]
 fn query() {
-    let mut db = LoggerDb::default();
+    let db = LoggerDb::default();
 
-    db.set_input_string(String::from("Hello, world!"));
+    _ = InputString::new(&db, String::from("Hello, world!"));
     let len = db.length_query(());
 
     assert_eq!(len, (13, 13));
     db.assert_logs(expect![[r#"
         [
             "salsa_event(WillCheckCancellation)",
-            "salsa_event(WillExecute { database_key: create_data_HelloWorldDatabase(Id(0)) })",
+            "salsa_event(WillExecute { database_key: create_data_HelloWorldDatabase(Id(400)) })",
             "salsa_event(WillCheckCancellation)",
-            "salsa_event(DidValidateMemoizedValue { database_key: create_data_HelloWorldDatabase(Id(0)) })",
-            "salsa_event(WillCheckCancellation)",
-            "salsa_event(WillExecute { database_key: length_query_shim(Id(800)) })",
-            "salsa_event(WillCheckCancellation)",
+            "salsa_event(WillExecute { database_key: length_query_shim(Id(c00)) })",
         ]"#]]);
 }

--- a/crates/rust-analyzer/src/reload.rs
+++ b/crates/rust-analyzer/src/reload.rs
@@ -15,10 +15,10 @@
 // FIXME: This is a mess that needs some untangling work
 use std::{iter, mem, sync::atomic::AtomicUsize, time::Duration};
 
-use hir::{ChangeWithProcMacros, ProcMacrosBuilder, db::DefDatabase};
+use hir::{ChangeWithProcMacros, ProcMacrosBuilder};
 use ide_db::{
     FxHashMap,
-    base_db::{CrateGraphBuilder, ProcMacroLoadingError, ProcMacroPaths, salsa::Durability},
+    base_db::{CrateGraphBuilder, ProcMacroLoadingError, ProcMacroPaths},
 };
 use itertools::Itertools;
 use load_cargo::{ProjectFolders, load_proc_macro};
@@ -109,14 +109,10 @@ impl GlobalState {
             self.reload_flycheck();
         }
 
-        if self.analysis_host.raw_database().expand_proc_attr_macros()
-            != self.config.expand_proc_attr_macros()
-        {
-            self.analysis_host.raw_database_mut().set_expand_proc_attr_macros_with_durability(
-                self.config.expand_proc_attr_macros(),
-                Durability::HIGH,
-            );
-        }
+        hir::db::set_expand_proc_attr_macros(
+            self.analysis_host.raw_database_mut(),
+            self.config.expand_proc_attr_macros(),
+        );
 
         if self.config.cargo(None) != old_config.cargo(None) {
             let req = FetchWorkspaceRequest { path: None, force_crate_graph_reload: false };


### PR DESCRIPTION
This required several non-trivial changes:
- Rename the existing `ProcMacros::get` to `ProcMacros::get_for_crate` (feel free to suggest a better name), to avoid clashing with the new getter created by salsa.
- Change `ProcMacroBuilder::build` to take `db` and `durability`, as it will need to build `ProcMacros` inside the db. Also rename it to `build_in`, to reflect the change in functionality.
- `ProcMacros` is now stored in the database directly, instead of being wrapped in an `Arc`. This should be fine though, since its `by_crate` field is marked with `#[returns(ref)]`.

@rustbot blocked on https://github.com/rust-lang/rust-analyzer/pull/22639, but mostly for easier rebasing later

cc @Veykril 