### PR TITLE
fix: Crash on lowering consts with associated types

### DIFF
--- a/crates/hir-ty/src/generics.rs
+++ b/crates/hir-ty/src/generics.rs
@@ -143,7 +143,7 @@ impl<'db> Generics<'db> {
         self.chain.iter()
     }
 
-    fn owner(&self) -> &SingleGenerics<'db> {
+    pub(crate) fn owner(&self) -> &SingleGenerics<'db> {
         self.chain.last().expect("must have an owner params")
     }
 

--- a/crates/hir-ty/src/lower.rs
+++ b/crates/hir-ty/src/lower.rs
@@ -290,6 +290,11 @@ impl<'db, 'a> TyLoweringContext<'db, 'a> {
         self.lifetime_elision = lifetime_elision;
     }
 
+    pub(crate) fn set_owner(&mut self, owner: &'a SingleGenerics<'db>) {
+        self.store = owner.store();
+        self.def = ExpressionStoreOwnerId::Signature(owner.def());
+    }
+
     pub(crate) fn with_interning_mode(mut self, interning_mode: LoweringMode) -> Self {
         self.interning_mode = interning_mode;
         self
@@ -1948,7 +1953,7 @@ fn resolve_type_param_assoc_type_shorthand(
 
     let mut supertraits_resolution = None;
     for maybe_parent_generics in generics.iter_owners().rev() {
-        ctx.store = maybe_parent_generics.store();
+        ctx.set_owner(maybe_parent_generics);
         for pred in maybe_parent_generics.where_predicates() {
             let (WherePredicate::TypeBound { target, bound }
             | WherePredicate::ForLifetime { lifetimes: _, target, bound }) = pred
@@ -2366,7 +2371,7 @@ fn generic_predicates(
         // Collect only diagnostics from the child, not including parents.
         ctx.diagnostics.clear();
 
-        ctx.store = maybe_parent_generics.store();
+        ctx.set_owner(maybe_parent_generics);
         for pred in maybe_parent_generics.where_predicates() {
             tracing::debug!(?pred);
             for (pred, source) in ctx.lower_where_predicate(pred, false) {
@@ -2568,14 +2573,14 @@ pub(crate) fn generic_defaults_with_diagnostics(
     let generics = generics.get().unwrap();
     let mut defaults = ThinVec::new();
     if let Some(parent) = generics.parent() {
-        ctx.store = parent.store();
+        ctx.set_owner(parent);
         defaults.extend(
             parent.iter_with_idx().map(|(idx, _id, p)| handle_generic_param(&mut ctx, idx, p)),
         );
     }
     ctx.diagnostics.clear(); // Don't include diagnostics from the parent.
     ctx.defined_anon_consts.clear();
-    ctx.store = store_for_self;
+    ctx.set_owner(generics.owner());
     defaults.extend(
         generics.iter_self_with_idx().map(|(idx, _id, p)| handle_generic_param(&mut ctx, idx, p)),
     );

--- a/crates/hir-ty/src/tests/regression.rs
+++ b/crates/hir-ty/src/tests/regression.rs
@@ -44,6 +44,26 @@ fn no_panic_on_field_of_enum() {
 }
 
 #[test]
+fn anon_const_projection_in_impl_predicate() {
+    check_no_mismatches(
+        r#"
+trait Trait {
+    type Assoc;
+}
+
+struct S<const N: usize>;
+
+impl<const N: usize> S<N>
+where
+    S<{ N }>: Trait,
+{
+    fn new(_: <S<N> as Trait>::Assoc) {}
+}
+        "#,
+    );
+}
+
+#[test]
 fn bug_585() {
     check_infer(
         r#"


### PR DESCRIPTION
Previously we'd modify TyLoweringContext::store without modifying TyLoweringContext::def. This causes a crash later when we try to look up the expression in the wrong store:

    thread 'main' panicked at crates/hir-ty/src/infer/expr.rs:326:
    should have `ExpressionStore::expr_only`

Instead, ensure we update both consistently so we can find the expression.

Add a regression test (based on code originally seen in the bitmaps crate version 3.2.1).

AI disclosure: Bisected and coded with help from Codex and GPT-5.5.