### PR TITLE
fix: resolve each definition when a use statement imports multiple items

### DIFF
--- a/crates/hir/src/source_analyzer.rs
+++ b/crates/hir/src/source_analyzer.rs
@@ -1484,7 +1484,7 @@ impl<'db> SourceAnalyzer<'db> {
         let hir_path =
             collector.lower_path(path.clone(), &mut ExprCollector::impl_trait_error_allocator)?;
         let (store, _) = collector.store.finish();
-        Some(resolve_hir_path_(
+        let PathResolutionPerNs { type_ns, value_ns, macro_ns } = resolve_hir_path_(
             db,
             &self.resolver,
             self.infer_body,
@@ -1493,7 +1493,11 @@ impl<'db> SourceAnalyzer<'db> {
             name_hygiene(db, InFile::new(self.file_id, path.syntax())),
             Some(&store),
             true,
-        ))
+        );
+        if type_ns.is_none() && value_ns.is_none() && macro_ns.is_none() {
+            return None;
+        }
+        Some(PathResolutionPerNs { type_ns, value_ns, macro_ns })
     }
 
     pub(crate) fn record_literal_missing_fields(
@@ -1956,11 +1960,13 @@ fn resolve_hir_path_(
     };
 
     if resolve_per_ns {
-        PathResolutionPerNs {
-            type_ns: types().or_else(items),
-            value_ns: values(),
-            macro_ns: macros(),
+        let type_ns = types().or_else(items);
+        if let Some(PathResolution::Def(ModuleDef::Module(module))) = type_ns
+            && module.is_crate_root(db)
+        {
+            return PathResolutionPerNs { type_ns, value_ns: None, macro_ns: None };
         }
+        PathResolutionPerNs { type_ns, value_ns: values(), macro_ns: macros() }
     } else {
         let res = if prefer_value_ns {
             values()

--- a/crates/ide-assists/src/handlers/add_turbo_fish.rs
+++ b/crates/ide-assists/src/handlers/add_turbo_fish.rs
@@ -70,7 +70,9 @@ pub(crate) fn add_turbo_fish(acc: &mut Assists, ctx: &AssistContext<'_, '_>) -> 
 
     let def = match NameRefClass::classify(&ctx.sema, &name_ref)? {
         NameRefClass::Definition(def, _) => def,
-        NameRefClass::FieldShorthand { .. } | NameRefClass::ExternCrateShorthand { .. } => {
+        NameRefClass::DefinitionPerNs { .. }
+        | NameRefClass::FieldShorthand { .. }
+        | NameRefClass::ExternCrateShorthand { .. } => {
             return None;
         }
     };

--- a/crates/ide-assists/src/handlers/expand_glob_import.rs
+++ b/crates/ide-assists/src/handlers/expand_glob_import.rs
@@ -383,20 +383,26 @@ fn find_imported_defs(ctx: &AssistContext<'_, '_>, use_item: Use) -> Vec<Definit
             use_item.syntax().siblings(dir.to_owned()).filter(|n| ast::Use::can_cast(n.kind()))
         })
         .flat_map(|n| n.descendants().filter_map(ast::NameRef::cast))
-        .filter_map(|r| match NameRefClass::classify(&ctx.sema, &r)? {
-            NameRefClass::Definition(
-                def @ (Definition::Macro(_)
-                | Definition::Module(_)
-                | Definition::Function(_)
-                | Definition::Adt(_)
-                | Definition::EnumVariant(_)
-                | Definition::Const(_)
-                | Definition::Static(_)
-                | Definition::Trait(_)
-                | Definition::TypeAlias(_)),
-                _,
-            ) => Some(def),
-            _ => None,
+        .flat_map(|r| match NameRefClass::classify(&ctx.sema, &r) {
+            Some(NameRefClass::Definition(def, _)) => vec![def],
+            Some(NameRefClass::DefinitionPerNs { type_ns, value_ns, macro_ns }) => {
+                [type_ns, value_ns, macro_ns].into_iter().flatten().collect()
+            }
+            _ => vec![],
+        })
+        .filter(|def| {
+            matches!(
+                def,
+                Definition::Macro(_)
+                    | Definition::Module(_)
+                    | Definition::Function(_)
+                    | Definition::Adt(_)
+                    | Definition::EnumVariant(_)
+                    | Definition::Const(_)
+                    | Definition::Static(_)
+                    | Definition::Trait(_)
+                    | Definition::TypeAlias(_)
+            )
         })
         .collect()
 }

--- a/crates/ide-db/src/defs.rs
+++ b/crates/ide-db/src/defs.rs
@@ -18,8 +18,8 @@ use hir::{
     ExpressionStoreOwner, ExternAssocItem, ExternCrateDecl, Field, Function, GenericDef,
     GenericParam, GenericSubstitution, HasContainer, HasVisibility, HirDisplay, Impl,
     InlineAsmOperand, ItemContainer, Label, Local, Macro, Module, ModuleDef, Name, PathResolution,
-    Semantics, Static, StaticLifetime, Struct, ToolModule, Trait, TupleField, TypeAlias, Variant,
-    Visibility,
+    PathResolutionPerNs, Semantics, Static, StaticLifetime, Struct, ToolModule, Trait, TupleField,
+    TypeAlias, Variant, Visibility,
 };
 use span::Edition;
 use stdx::{format_to, impl_from};
@@ -447,6 +447,17 @@ impl<'db> IdentClass<'db> {
                 res.push((Definition::Field(field_ref), Some(adt_subst)));
             }
             IdentClass::NameRefClass(NameRefClass::Definition(it, subst)) => res.push((it, subst)),
+            IdentClass::NameRefClass(NameRefClass::DefinitionPerNs {
+                type_ns,
+                value_ns,
+                macro_ns,
+            }) => {
+                res.extend(
+                    [type_ns, value_ns, macro_ns]
+                        .into_iter()
+                        .filter_map(|def| def.map(|def| (def, None))),
+                );
+            }
             IdentClass::NameRefClass(NameRefClass::FieldShorthand {
                 local_ref,
                 field_ref,
@@ -488,6 +499,13 @@ impl<'db> IdentClass<'db> {
                 res.push(Definition::Field(field_ref));
             }
             IdentClass::NameRefClass(NameRefClass::Definition(it, _)) => res.push(it),
+            IdentClass::NameRefClass(NameRefClass::DefinitionPerNs {
+                type_ns,
+                value_ns,
+                macro_ns,
+            }) => {
+                res.extend([type_ns, value_ns, macro_ns].into_iter().flatten());
+            }
             IdentClass::NameRefClass(NameRefClass::FieldShorthand {
                 local_ref,
                 field_ref,
@@ -723,6 +741,11 @@ impl OperatorClass {
 #[derive(Debug)]
 pub enum NameRefClass<'db> {
     Definition(Definition, Option<GenericSubstitution<'db>>),
+    DefinitionPerNs {
+        type_ns: Option<Definition>,
+        value_ns: Option<Definition>,
+        macro_ns: Option<Definition>,
+    },
     FieldShorthand {
         local_ref: Local,
         field_ref: Field,
@@ -773,6 +796,19 @@ impl<'db> NameRefClass<'db> {
                     return Some(NameRefClass::Definition(Definition::Macro(macro_def), None));
                 }
             }
+
+            if name_ref.ident_token().is_some()
+                && path.syntax().parent().and_then(ast::UseTree::cast).is_some()
+                && let Some(PathResolutionPerNs { type_ns, value_ns, macro_ns }) =
+                    sema.resolve_path_per_ns(&path)
+            {
+                return Some(NameRefClass::DefinitionPerNs {
+                    type_ns: type_ns.map(Definition::from),
+                    value_ns: value_ns.map(Definition::from),
+                    macro_ns: macro_ns.map(Definition::from),
+                });
+            }
+
             return sema
                 .resolve_path_with_subst(&path)
                 .map(|(res, subst)| NameRefClass::Definition(res.into(), subst));

--- a/crates/ide-db/src/search.rs
+++ b/crates/ide-db/src/search.rs
@@ -1256,6 +1256,21 @@ impl<'a, 'db> FindUsages<'a, 'db> {
         }
 
         match NameRefClass::classify(self.sema, name_ref) {
+            Some(NameRefClass::DefinitionPerNs { type_ns, value_ns, macro_ns })
+                if [type_ns, value_ns, macro_ns].contains(&Some(self.def))
+                    && !matches!(
+                        self.def,
+                        Definition::Local(_) | Definition::GenericParam(_) | Definition::Label(_)
+                    ) =>
+            {
+                let FileRange { file_id, range } = self.sema.original_range(name_ref.syntax());
+                let reference = FileReference {
+                    range,
+                    name: FileReferenceNode::NameRef(name_ref.clone()),
+                    category: ReferenceCategory::IMPORT,
+                };
+                sink(file_id, reference)
+            }
             Some(NameRefClass::Definition(def, _))
                 if self.def == def
                     // is our def a trait assoc item? then we want to find all assoc items from trait impls of our trait

--- a/crates/ide/src/doc_links.rs
+++ b/crates/ide/src/doc_links.rs
@@ -164,6 +164,9 @@ pub(crate) fn external_docs(
         match node {
             ast::NameRef(name_ref) => match NameRefClass::classify(sema, &name_ref)? {
                 NameRefClass::Definition(def, _) => def,
+                NameRefClass::DefinitionPerNs { type_ns, value_ns, macro_ns } => {
+                    type_ns.or(value_ns).or(macro_ns)?
+                }
                 NameRefClass::FieldShorthand { local_ref: _, field_ref, adt_subst: _ } => {
                     Definition::Field(field_ref)
                 }

--- a/crates/ide/src/goto_declaration.rs
+++ b/crates/ide/src/goto_declaration.rs
@@ -38,6 +38,7 @@ pub(crate) fn goto_declaration(
                 match parent {
                     ast::NameRef(name_ref) => match NameRefClass::classify(&sema, &name_ref)? {
                         NameRefClass::Definition(it, _) => Some(it),
+                        NameRefClass::DefinitionPerNs { .. } => None,
                         NameRefClass::FieldShorthand { field_ref, .. } =>
                             return field_ref.try_to_nav(&sema),
                         NameRefClass::ExternCrateShorthand { decl, .. } =>

--- a/crates/ide/src/goto_definition.rs
+++ b/crates/ide/src/goto_definition.rs
@@ -4197,4 +4197,26 @@ struct Struct {
         "#,
         );
     }
+
+    #[test]
+    fn goto_def_mod_and_fn_in_use() {
+        check(
+            r#"
+mod bar {
+    use super::$0foo;
+
+    pub fn test() {
+        foo();
+    }
+}
+
+pub mod foo {
+     // ^^^
+    pub fn buz() {}
+}
+fn foo() {}
+// ^^^
+            "#,
+        )
+    }
 }

--- a/crates/ide/src/goto_implementation.rs
+++ b/crates/ide/src/goto_implementation.rs
@@ -52,7 +52,8 @@ pub(crate) fn goto_implementation(
                     ast::NameLike::NameRef(name_ref) => NameRefClass::classify(&sema, name_ref)
                         .and_then(|class| match class {
                             NameRefClass::Definition(def, _) => Some(def),
-                            NameRefClass::FieldShorthand { .. }
+                            NameRefClass::DefinitionPerNs { .. }
+                            | NameRefClass::FieldShorthand { .. }
                             | NameRefClass::ExternCrateShorthand { .. } => None,
                         }),
                     ast::NameLike::Lifetime(_) => None,

--- a/crates/ide/src/highlight_related.rs
+++ b/crates/ide/src/highlight_related.rs
@@ -2549,4 +2549,30 @@ fn main() {
         "#,
         );
     }
+
+    #[test]
+    fn mod_and_fn_in_use() {
+        check(
+            r#"
+mod bar {
+    use super::foo$0;
+            // ^^^ import
+
+    pub fn test() {
+        foo();
+     // ^^^
+        foo::buz();
+     // ^^^
+    }
+}
+
+pub mod foo {
+     // ^^^
+    pub fn buz() {}
+}
+fn foo() {}
+// ^^^
+            "#,
+        )
+    }
 }

--- a/crates/ide/src/hover.rs
+++ b/crates/ide/src/hover.rs
@@ -289,6 +289,13 @@ fn hover_offset(
                             vec![((Definition::ExternCrateDecl(decl), None), None, false, node)]
                         }
 
+                        IdentClass::NameRefClass(NameRefClass::DefinitionPerNs { type_ns, value_ns, macro_ns }) => {
+                            [type_ns, value_ns, macro_ns]
+                                .into_iter()
+                                .filter_map(|def| def.map(|def| ((def, None), None, false, node.clone())))
+                                .collect::<Vec<_>>()
+                        }
+
                         class => {
                             let render_extras = matches!(class, IdentClass::NameClass(_))
                                 // Render extra information for `Self` keyword as well

--- a/crates/ide/src/hover/tests.rs
+++ b/crates/ide/src/hover/tests.rs
@@ -11793,3 +11793,71 @@ pub struct Bar;
         "#]],
     );
 }
+
+#[test]
+fn hover_mod_and_fn_in_use() {
+    check(
+        r#"
+mod bar {
+    pub fn foo() {}
+    pub mod foo {
+        pub fn bar() {}
+    }
+}
+
+fn main() {
+    use bar::$0foo;
+}
+"#,
+        expect![[r#"
+            *foo*
+
+            ```rust
+            ra_test_fixture::bar
+            ```
+
+            ```rust
+            pub mod foo
+            ```
+
+            ---
+
+            ```rust
+            ra_test_fixture::bar
+            ```
+
+            ```rust
+            pub fn foo()
+            ```
+        "#]],
+    );
+}
+
+#[test]
+fn hover_mod_and_fn_in_use_as_qualifier() {
+    check(
+        r#"
+mod bar {
+    pub fn foo() {}
+    pub mod foo {
+        pub fn bar() {}
+    }
+}
+
+fn main() {
+    use bar::$0foo::bar;
+}
+"#,
+        expect![[r#"
+            *foo*
+
+            ```rust
+            ra_test_fixture::bar
+            ```
+
+            ```rust
+            pub mod foo
+            ```
+        "#]],
+    );
+}

--- a/crates/ide/src/references.rs
+++ b/crates/ide/src/references.rs
@@ -267,6 +267,9 @@ pub(crate) fn find_defs(
                     ast::NameLike::NameRef(name_ref) => {
                         match NameRefClass::classify(sema, &name_ref)? {
                             NameRefClass::Definition(def, _) => def,
+                            NameRefClass::DefinitionPerNs { type_ns, value_ns, macro_ns } => {
+                                type_ns.or(value_ns).or(macro_ns)?
+                            }
                             NameRefClass::FieldShorthand {
                                 local_ref,
                                 field_ref: _,

--- a/crates/ide/src/rename.rs
+++ b/crates/ide/src/rename.rs
@@ -333,6 +333,9 @@ fn find_definitions(
                     NameRefClass::classify(sema, name_ref)
                         .map(|class| match class {
                             NameRefClass::Definition(def, _) => def,
+                            NameRefClass::DefinitionPerNs { type_ns, value_ns, macro_ns } => {
+                                type_ns.or(value_ns).or(macro_ns).unwrap()
+                            }
                             NameRefClass::FieldShorthand { local_ref, field_ref: _, adt_subst: _ } => {
                                 Definition::Local(local_ref)
                             }

--- a/crates/ide/src/syntax_highlighting/highlight.rs
+++ b/crates/ide/src/syntax_highlighting/highlight.rs
@@ -295,6 +295,9 @@ fn highlight_name_ref(
         None => return HlTag::UnresolvedReference.into(),
     };
     let mut h = match name_class {
+        NameRefClass::DefinitionPerNs { type_ns, value_ns, macro_ns } => {
+            highlight_def(sema, krate, type_ns.or(value_ns).or(macro_ns).unwrap(), edition, true)
+        }
         NameRefClass::Definition(def, _) => {
             if let Definition::Local(local) = &def {
                 *binding_hash = Some(local.as_id() as u64);


### PR DESCRIPTION
When it finds definitions on a NameRef of a use statement, it returns multiple definitions as NameRefClass::DefinitionPerNs. Each definition is registered in the vector of definiotns.

In goto_definition, hover and highlights, It show multiple items in use statement.

Fixes rust-lang/rust-analyzer#22632

AI-disclosure: Antigravity

<img width="573" height="451" alt="スクリーンショット 2026-06-28 13 31 19" src="https://github.com/user-attachments/assets/a6620774-0714-4819-880d-2f2681a4f18e" />
<img width="400" height="188" alt="スクリーンショット 2026-06-28 13 31 50" src="https://github.com/user-attachments/assets/e54a4e37-8c63-4414-bb11-13d47ff5b39c" />
