### PR TITLE
internal: move `ExpandDatabase::syntax_context` out of the query group

### DIFF
--- a/crates/hir-def/src/nameres/collector.rs
+++ b/crates/hir-def/src/nameres/collector.rs
@@ -81,7 +81,7 @@ pub(super) fn collect_defs(
     let proc_macros = if krate.is_proc_macro {
         db.proc_macros_for_crate(def_map.krate)
             .and_then(|proc_macros| {
-                proc_macros.list(db.syntax_context(tree_id.file_id(), krate.edition))
+                proc_macros.list(tree_id.file_id().syntax_context(db, krate.edition))
             })
             .unwrap_or_default()
     } else {

--- a/crates/hir-expand/src/db.rs
+++ b/crates/hir-expand/src/db.rs
@@ -2,7 +2,7 @@
 
 use base_db::{Crate, SourceDatabase};
 use mbe::MatchedArmIndex;
-use span::{AstIdMap, Edition, Span, SyntaxContext};
+use span::{AstIdMap, Span};
 use std::borrow::Cow;
 use syntax::{AstNode, Parse, SyntaxError, SyntaxNode, SyntaxToken, T, ast};
 use syntax_bridge::{DocCommentDesugarMode, syntax_node_to_token_tree};
@@ -136,19 +136,6 @@ pub trait ExpandDatabase: SourceDatabase {
         &self,
         macro_call: MacroCallId,
     ) -> Option<ExpandResult<Arc<[SyntaxError]>>>;
-
-    #[salsa::transparent]
-    fn syntax_context(&self, file: HirFileId, edition: Edition) -> SyntaxContext;
-}
-
-fn syntax_context(db: &dyn ExpandDatabase, file: HirFileId, edition: Edition) -> SyntaxContext {
-    match file {
-        HirFileId::FileId(_) => SyntaxContext::root(edition),
-        HirFileId::MacroFile(m) => {
-            let kind = &m.loc(db).kind;
-            db.macro_arg_considering_derives(m, kind).2.ctx
-        }
-    }
 }
 
 fn resolve_span(db: &dyn ExpandDatabase, Span { range, anchor, ctx: _ }: Span) -> FileRange {

--- a/crates/hir-expand/src/lib.rs
+++ b/crates/hir-expand/src/lib.rs
@@ -1128,6 +1128,16 @@ impl HirFileId {
             HirFileId::MacroFile(_) => None,
         }
     }
+
+    pub fn syntax_context(self, db: &dyn ExpandDatabase, edition: Edition) -> SyntaxContext {
+        match self {
+            HirFileId::FileId(_) => SyntaxContext::root(edition),
+            HirFileId::MacroFile(m) => {
+                let kind = &m.loc(db).kind;
+                db.macro_arg_considering_derives(m, kind).2.ctx
+            }
+        }
+    }
 }
 
 impl PartialEq<EditionedFileId> for HirFileId {


### PR DESCRIPTION
Part of https://github.com/rust-lang/rust-analyzer/issues/22657

I thought that, rather than removing the whole query group in one big PR (which could complicate reviewing), I'd chip away at a small number of related queries at a time.

This PR changes `ExpandDatabase::syntax_context` to be a method on `HirFileId`, as it's a mapping from `HirFileId` to `SyntaxContext`, which uses `Edition` as an additional input.

cc @Veykril 