### PR TITLE
fix: Respect `references.exclude[Tests/Imports]` in references lens

### DIFF
--- a/crates/ide/src/annotations.rs
+++ b/crates/ide/src/annotations.rs
@@ -43,6 +43,8 @@ pub struct AnnotationConfig<'a> {
     pub annotate_references: bool,
     pub annotate_method_references: bool,
     pub annotate_enum_variant_references: bool,
+    pub references_exclude_imports: bool,
+    pub references_exclude_tests: bool,
     pub location: AnnotationLocation,
     pub filter_adjacent_derive_implementations: bool,
     pub ra_fixture: RaFixtureConfig<'a>,
@@ -219,8 +221,8 @@ pub(crate) fn resolve_annotation(
                 &FindAllRefsConfig {
                     search_scope: None,
                     ra_fixture: config.ra_fixture,
-                    exclude_imports: false,
-                    exclude_tests: false,
+                    exclude_imports: config.references_exclude_imports,
+                    exclude_tests: config.references_exclude_tests,
                 },
             )
             .map(|result| {
@@ -262,6 +264,8 @@ mod tests {
         annotate_references: true,
         annotate_method_references: true,
         annotate_enum_variant_references: true,
+        references_exclude_imports: false,
+        references_exclude_tests: false,
         location: AnnotationLocation::AboveName,
         ra_fixture: RaFixtureConfig::default(),
         filter_adjacent_derive_implementations: false,
@@ -278,7 +282,7 @@ mod tests {
             .annotations(config, file_id)
             .unwrap()
             .into_iter()
-            .map(|annotation| analysis.resolve_annotation(&DEFAULT_CONFIG, annotation).unwrap())
+            .map(|annotation| analysis.resolve_annotation(config, annotation).unwrap())
             .collect();
 
         expect.assert_debug_eq(&annotations);
@@ -1043,6 +1047,41 @@ struct Foo;
                 ]
             "#]],
             &AnnotationConfig { location: AnnotationLocation::AboveWholeItem, ..DEFAULT_CONFIG },
+        );
+    }
+
+    #[test]
+    fn refs_exclude_tests() {
+        check_with_config(
+            r#"
+fn foo() {}
+
+#[test]
+fn bar() { foo() }
+            "#,
+            expect![[r#"
+                [
+                    Annotation {
+                        range: 3..6,
+                        kind: HasReferences {
+                            pos: FilePositionWrapper {
+                                file_id: FileId(
+                                    0,
+                                ),
+                                offset: 3,
+                            },
+                            data: Some(
+                                [],
+                            ),
+                        },
+                    },
+                ]
+            "#]],
+            &AnnotationConfig {
+                references_exclude_tests: true,
+                annotate_runnables: false,
+                ..DEFAULT_CONFIG
+            },
         );
     }
 }

--- a/crates/rust-analyzer/src/cli/analysis_stats.rs
+++ b/crates/rust-analyzer/src/cli/analysis_stats.rs
@@ -1435,6 +1435,8 @@ impl flags::AnalysisStats {
             annotate_references: false,
             annotate_method_references: false,
             annotate_enum_variant_references: false,
+            references_exclude_imports: false,
+            references_exclude_tests: false,
             location: ide::AnnotationLocation::AboveName,
             filter_adjacent_derive_implementations: false,
             ra_fixture: RaFixtureConfig::default(),

--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -1548,6 +1548,9 @@ pub struct LensConfig {
     pub refs_trait: bool, // for Struct, Enum, Union and Trait
     pub enum_variant_refs: bool,
 
+    pub refs_exclude_imports: bool,
+    pub refs_exclude_tests: bool,
+
     // annotations
     pub location: AnnotationLocation,
     pub filter_adjacent_derive_implementations: bool,
@@ -1591,10 +1594,6 @@ impl LensConfig {
         self.run || self.debug || self.update_test
     }
 
-    pub fn references(&self) -> bool {
-        self.method_refs || self.refs_adt || self.refs_trait || self.enum_variant_refs
-    }
-
     pub fn into_annotation_config<'a>(
         self,
         binary_target: bool,
@@ -1607,6 +1606,8 @@ impl LensConfig {
             annotate_references: self.refs_adt,
             annotate_method_references: self.method_refs,
             annotate_enum_variant_references: self.enum_variant_refs,
+            references_exclude_imports: self.refs_exclude_imports,
+            references_exclude_tests: self.refs_exclude_tests,
             location: self.location.into(),
             ra_fixture: RaFixtureConfig { minicore, disable_ra_fixture: self.disable_ra_fixture },
             filter_adjacent_derive_implementations: self.filter_adjacent_derive_implementations,
@@ -2688,18 +2689,19 @@ impl Config {
     }
 
     pub fn lens(&self) -> LensConfig {
+        let enable = *self.lens_enable();
         LensConfig {
-            run: *self.lens_enable() && *self.lens_run_enable(),
-            debug: *self.lens_enable() && *self.lens_debug_enable(),
-            update_test: *self.lens_enable()
-                && *self.lens_updateTest_enable()
-                && *self.lens_run_enable(),
-            interpret: *self.lens_enable() && *self.lens_run_enable() && *self.interpret_tests(),
-            implementations: *self.lens_enable() && *self.lens_implementations_enable(),
-            method_refs: *self.lens_enable() && *self.lens_references_method_enable(),
-            refs_adt: *self.lens_enable() && *self.lens_references_adt_enable(),
-            refs_trait: *self.lens_enable() && *self.lens_references_trait_enable(),
-            enum_variant_refs: *self.lens_enable() && *self.lens_references_enumVariant_enable(),
+            run: enable && *self.lens_run_enable(),
+            debug: enable && *self.lens_debug_enable(),
+            update_test: enable && *self.lens_updateTest_enable() && *self.lens_run_enable(),
+            interpret: enable && *self.lens_run_enable() && *self.interpret_tests(),
+            implementations: enable && *self.lens_implementations_enable(),
+            method_refs: enable && *self.lens_references_method_enable(),
+            refs_adt: enable && *self.lens_references_adt_enable(),
+            refs_trait: enable && *self.lens_references_trait_enable(),
+            enum_variant_refs: enable && *self.lens_references_enumVariant_enable(),
+            refs_exclude_imports: *self.references_excludeImports(),
+            refs_exclude_tests: *self.references_excludeTests(),
             location: *self.lens_location(),
             filter_adjacent_derive_implementations: *self
                 .gotoImplementations_filterAdjacentDerives(),


### PR DESCRIPTION
Fixes rust-lang/rust-analyzer#22614.