### PR TITLE
fix: Avoid type unification errors in term search

### DIFF
--- a/crates/hir/src/term_search.rs
+++ b/crates/hir/src/term_search.rs
@@ -175,6 +175,7 @@ impl<'db> LookupTable<'db> {
     /// transitive. For example `Vec<i32>` and `FxHashSet<i32>` both unify with `Iterator<Item = i32>`,
     /// but they clearly do not unify themselves.
     fn insert(&mut self, ty: Type<'db>, exprs: impl Iterator<Item = Expr<'db>>) {
+        let ty = ty.instantiate_with_errors();
         match self.data.get_mut(&ty) {
             Some(it) => {
                 it.extend_with_threshold(self.many_threshold, exprs);


### PR DESCRIPTION
Fixes rust-lang/rust-analyzer#22659.