### PR TITLE
feat: add handler for E0627

### DIFF
--- a/crates/hir-ty/src/infer.rs
+++ b/crates/hir-ty/src/infer.rs
@@ -508,6 +508,10 @@ pub enum InferenceDiagnostic {
         #[type_visitable(ignore)]
         pat: PatId,
     },
+    YieldOutsideCoroutine {
+        #[type_visitable(ignore)]
+        expr: ExprId,
+    },
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]

--- a/crates/hir-ty/src/infer/expr.rs
+++ b/crates/hir-ty/src/infer/expr.rs
@@ -597,7 +597,9 @@ impl<'db> InferenceContext<'_, 'db> {
                     }
                     resume_ty
                 } else {
-                    // FIXME: report error (yield expr in non-coroutine)
+                    self.push_diagnostic(InferenceDiagnostic::YieldOutsideCoroutine {
+                        expr: tgt_expr,
+                    });
                     self.types.types.error
                 }
             }

--- a/crates/hir/src/diagnostics.rs
+++ b/crates/hir/src/diagnostics.rs
@@ -178,6 +178,7 @@ diagnostics![AnyDiagnostic<'db> ->
     TypeMustBeKnown<'db>,
     UnionExprMustHaveExactlyOneField,
     UnimplementedTrait<'db>,
+    YieldOutsideCoroutine,
 ];
 
 #[derive(Debug)]
@@ -671,6 +672,11 @@ pub struct MutableRefBinding {
     pub pat: InFile<ExprOrPatPtr>,
 }
 
+#[derive(Debug)]
+pub struct YieldOutsideCoroutine {
+    pub expr: InFile<ExprOrPatPtr>,
+}
+
 impl<'db> AnyDiagnostic<'db> {
     pub(crate) fn body_validation_diagnostic(
         db: &'db dyn HirDatabase,
@@ -1101,6 +1107,9 @@ impl<'db> AnyDiagnostic<'db> {
             InferenceDiagnostic::MutableRefBinding { pat } => {
                 let pat = pat_syntax(*pat)?.map(Into::into);
                 MutableRefBinding { pat }.into()
+            }
+            &InferenceDiagnostic::YieldOutsideCoroutine { expr } => {
+                YieldOutsideCoroutine { expr: expr_syntax(expr)? }.into()
             }
         })
     }

--- a/crates/ide-diagnostics/src/handlers/yield_outside_coroutine.rs
+++ b/crates/ide-diagnostics/src/handlers/yield_outside_coroutine.rs
@@ -1,0 +1,34 @@
+use crate::{Diagnostic, DiagnosticCode, DiagnosticsContext};
+
+// Diagnostic: yield-outside-of-coroutine
+//
+// This diagnostic is triggered if the `yield` keyword is used outside of a coroutine.
+pub(crate) fn yield_outside_coroutine(
+    ctx: &DiagnosticsContext<'_, '_>,
+    d: &hir::YieldOutsideCoroutine,
+) -> Diagnostic {
+    Diagnostic::new_with_syntax_node_ptr(
+        ctx,
+        DiagnosticCode::RustcHardError("E0627"),
+        "yield expression outside of coroutine",
+        d.expr.map(|it| it.into()),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::tests::check_diagnostics;
+
+    #[test]
+    fn yield_in_regular_function() {
+        check_diagnostics(
+            r#"
+//- minicore: coroutine
+fn foo() {
+    yield 1;
+  //^^^^^^^ error: yield expression outside of coroutine
+}
+"#,
+        );
+    }
+}

--- a/crates/ide-diagnostics/src/lib.rs
+++ b/crates/ide-diagnostics/src/lib.rs
@@ -101,6 +101,7 @@ mod handlers {
     pub(crate) mod unresolved_module;
     pub(crate) mod unused_must_use;
     pub(crate) mod unused_variables;
+    pub(crate) mod yield_outside_coroutine;
 
     // The handlers below are unusual, the implement the diagnostics as well.
     pub(crate) mod field_shorthand;
@@ -553,6 +554,7 @@ pub fn semantic_diagnostics(
             AnyDiagnostic::UnimplementedTrait(d) => handlers::unimplemented_trait::unimplemented_trait(&ctx, &d),
             AnyDiagnostic::FruInDestructuringAssignment(d) => handlers::fru_in_destructuring_assignment::fru_in_destructuring_assignment(&ctx, &d),
             AnyDiagnostic::ExplicitDropMethodUse(d) => handlers::explicit_drop_method_use::explicit_drop_method_use(&ctx, &d),
+            AnyDiagnostic::YieldOutsideCoroutine(d) => handlers::yield_outside_coroutine::yield_outside_coroutine(&ctx, &d),
         };
         res.push(d)
     }


### PR DESCRIPTION
rust-lang/rust-analyzer#22140

This pull request addresses the FIXME in rust-analyzer/crates/hir-ty/src/infer/expr.rs 

Previously, using a yield expression outside of a coroutine context silently returned an error type during inference.
This PR:

- adds YieldOutsideCoroutine to InferenceDiagnostic
- emits the diagnostic from the inference engine
- exposes the diagnostic through HIR
- adds an IDE handler and tests

*Note: I used an AI assistant as a pair-programming tool to help navigate the codebase and structure this contribution.*