### PR TITLE
Add tree top method to Syntax node

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2359,9 +2359,9 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rowan"
-version = "0.15.18"
+version = "0.15.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f509095fc8cc0c8c8564016771d458079c11a8d857e65861f045145c0d3208"
+checksum = "a2441aaccb50f4267d4f0f58b21e0138e96a449f361ed57a2673a83c9bca0772"
 dependencies = [
  "countme",
  "hashbrown 0.14.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,7 +123,7 @@ process-wrap = { version = "9.1.0", features = ["std"] }
 pulldown-cmark-to-cmark = "10.0.4"
 pulldown-cmark = { version = "0.9.6", default-features = false }
 rayon = "1.10.0"
-rowan = "=0.15.18"
+rowan = "=0.15.19"
 # Ideally we'd not enable the macros feature but unfortunately the `tracked` attribute does not work
 # on impls without it
 salsa = { version = "0.27.0", default-features = false, features = [

--- a/crates/hir/src/semantics.rs
+++ b/crates/hir/src/semantics.rs
@@ -522,7 +522,7 @@ impl<'db> SemanticsImpl<'db> {
                         let file_id = declaration_tree_id.file_id();
                         let in_file = InFile::new(file_id, declaration);
                         let node = in_file.to_node(self.db);
-                        let root = find_root(node.syntax());
+                        let root = node.syntax().tree_top();
                         self.cache(root, file_id);
                         Some(in_file.with_value(node.syntax().clone()))
                     }
@@ -531,7 +531,7 @@ impl<'db> SemanticsImpl<'db> {
             }
             HirFileId::MacroFile(macro_file) => {
                 let node = macro_file.loc(self.db).to_node(self.db);
-                let root = find_root(&node.value);
+                let root = node.value.tree_top();
                 self.cache(root, node.file_id);
                 Some(node)
             }
@@ -544,7 +544,7 @@ impl<'db> SemanticsImpl<'db> {
         let def_map = module.id.def_map(self.db);
         let definition = def_map[module.id].origin.definition_source(self.db);
         let definition = definition.map(|it| it.node());
-        let root_node = find_root(&definition.value);
+        let root_node = definition.value.tree_top();
         self.cache(root_node, definition.file_id);
         definition
     }
@@ -1067,7 +1067,8 @@ impl<'db> SemanticsImpl<'db> {
                         && let Some(p) = first.parent()
                     {
                         let range = first.text_range().cover(last.text_range());
-                        let node = find_root(&p)
+                        let node = p
+                            .tree_top()
                             .covering_element(range)
                             .ancestors()
                             .take_while(|it| it.text_range() == range)
@@ -1577,7 +1578,7 @@ impl<'db> SemanticsImpl<'db> {
     pub fn original_ast_node<N: AstNode>(&self, node: N) -> Option<N> {
         self.wrap_node_infile(node).original_ast_node_rooted(self.db).map(
             |InRealFile { file_id, value }| {
-                self.cache(find_root(value.syntax()), file_id.into());
+                self.cache(value.syntax().tree_top(), file_id.into());
                 value
             },
         )
@@ -1589,7 +1590,7 @@ impl<'db> SemanticsImpl<'db> {
         let InFile { file_id, .. } = self.find_file(node);
         InFile::new(file_id, node).original_syntax_node_rooted(self.db).map(
             |InRealFile { file_id, value }| {
-                self.cache(find_root(&value), file_id.into());
+                self.cache(value.tree_top(), file_id.into());
                 value
             },
         )
@@ -2171,7 +2172,7 @@ impl<'db> SemanticsImpl<'db> {
     pub fn source<Def: HasSource>(&self, def: Def) -> Option<InFile<Def::Ast>> {
         // FIXME: source call should go through the parse cache
         let res = def.source(self.db)?;
-        self.cache(find_root(res.value.syntax()), res.file_id);
+        self.cache(res.value.syntax().tree_top(), res.file_id);
         Some(res)
     }
 
@@ -2375,7 +2376,7 @@ impl<'db> SemanticsImpl<'db> {
 
     /// Wraps the node in a [`InFile`] with the file id it belongs to.
     fn find_file<'node>(&self, node: &'node SyntaxNode) -> InFile<&'node SyntaxNode> {
-        let root_node = find_root(node);
+        let root_node = node.tree_top();
         let file_id = self.lookup(&root_node).unwrap_or_else(|| {
             panic!(
                 "\n\nFailed to lookup {:?} in this Semantics.\n\
@@ -2461,7 +2462,7 @@ impl<'db> SemanticsImpl<'db> {
             }
         };
         let adt_source = adt_ast_id.to_in_file_node(self.db);
-        self.cache(adt_source.value.syntax().ancestors().last().unwrap(), adt_source.file_id);
+        self.cache(adt_source.value.syntax().tree_top(), adt_source.file_id);
         ToDef::to_def(self, adt_source.as_ref())
     }
 
@@ -2700,10 +2701,6 @@ impl ToDef for ast::IdentPat {
     fn to_def(sema: &SemanticsImpl<'_>, src: InFile<&Self>) -> Option<Self::Def> {
         sema.with_ctx(|ctx| ctx.bind_pat_to_def(src, sema))
     }
-}
-
-fn find_root(node: &SyntaxNode) -> SyntaxNode {
-    node.ancestors().last().unwrap()
 }
 
 /// `SemanticsScope` encapsulates the notion of a scope (the set of visible

--- a/crates/ide-assists/src/handlers/extract_variable.rs
+++ b/crates/ide-assists/src/handlers/extract_variable.rs
@@ -101,7 +101,7 @@ pub(crate) fn extract_variable(acc: &mut Assists, ctx: &AssistContext<'_, '_>) -
         let last_descend = ctx.sema.descend_into_macros_single_exact(last.clone());
         let range = first_descend.text_range().cover(last_descend.text_range());
 
-        if first_descend.parent_ancestors().last() != last_descend.parent_ancestors().last() {
+        if first_descend.tree_top() != last_descend.tree_top() {
             return None;
         }
 
@@ -198,13 +198,12 @@ pub(crate) fn extract_variable(acc: &mut Assists, ctx: &AssistContext<'_, '_>) -
             |edit| {
                 let (var_name, expr_replace) = kind.get_name_and_expr(ctx, &analysis);
 
-                let to_replace =
-                    if expr_replace.ancestors().last() == to_replace.start().ancestors().last() {
-                        let element = expr_replace.clone().syntax_element();
-                        element.clone()..=element
-                    } else {
-                        to_replace.clone()
-                    };
+                let to_replace = if expr_replace.tree_top() == to_replace.start().tree_top() {
+                    let element = expr_replace.clone().syntax_element();
+                    element.clone()..=element
+                } else {
+                    to_replace.clone()
+                };
 
                 let editor = edit.make_editor(&place);
                 let make = editor.make();

--- a/crates/ide-assists/src/handlers/inline_call.rs
+++ b/crates/ide-assists/src/handlers/inline_call.rs
@@ -79,7 +79,7 @@ pub(crate) fn inline_into_callers(acc: &mut Assists, ctx: &AssistContext<'_, '_>
 
     let function = ctx.sema.to_def(&ast_func)?;
 
-    let def_file_editor = SyntaxEditor::new(ast_func.syntax().ancestors().last().unwrap()).0;
+    let def_file_editor = SyntaxEditor::new(ast_func.syntax().tree_top()).0;
     let params = get_fn_params(ctx.sema.db, function, &param_list, def_file_editor.make())?;
 
     let mut file_editors = FxHashMap::default();
@@ -255,7 +255,7 @@ pub(crate) fn inline_call(acc: &mut Assists, ctx: &AssistContext<'_, '_>) -> Opt
         return None;
     }
     let syntax = call_info.node.syntax().clone();
-    let editor = SyntaxEditor::new(syntax.ancestors().last().unwrap()).0;
+    let editor = SyntaxEditor::new(syntax.tree_top()).0;
     let params = get_fn_params(ctx.sema.db, function, &param_list, editor.make())?;
 
     if call_info.arguments.len() != params.len() {

--- a/crates/ide-assists/src/handlers/merge_imports.rs
+++ b/crates/ide-assists/src/handlers/merge_imports.rs
@@ -36,7 +36,7 @@ pub(crate) fn merge_imports(acc: &mut Assists, ctx: &AssistContext<'_, '_>) -> O
 
         let use_item = tree.syntax().parent().and_then(ast::Use::cast)?;
         let neighbor = next_prev().find_map(|dir| neighbor(&use_item, dir))?;
-        let (editor, _) = SyntaxEditor::new(use_item.syntax().parent()?.ancestors().last()?);
+        let (editor, _) = SyntaxEditor::new(use_item.syntax().parent()?.tree_top());
         merge_uses(use_item, vec![neighbor], &ctx.config.insert_use, &editor)?;
         (target, editor)
     } else {
@@ -51,7 +51,7 @@ pub(crate) fn merge_imports(acc: &mut Assists, ctx: &AssistContext<'_, '_>) -> O
         });
 
         let first_selected = selected_nodes.next()?;
-        let (editor, _) = SyntaxEditor::new(parent_node.ancestors().last().unwrap());
+        let (editor, _) = SyntaxEditor::new(parent_node.tree_top());
         match_ast! {
             match first_selected {
                 ast::Use(use_item) => {

--- a/crates/ide-assists/src/handlers/normalize_import.rs
+++ b/crates/ide-assists/src/handlers/normalize_import.rs
@@ -25,7 +25,7 @@ pub(crate) fn normalize_import(acc: &mut Assists, ctx: &AssistContext<'_, '_>) -
     };
 
     let target = use_item.syntax().text_range();
-    let (editor, _) = SyntaxEditor::new(use_item.syntax().ancestors().last().unwrap());
+    let (editor, _) = SyntaxEditor::new(use_item.syntax().tree_top());
     let normalized_use_item =
         try_normalize_import(editor.make(), &use_item, ctx.config.insert_use.granularity.into())?;
     editor.replace(use_item.syntax(), normalized_use_item.syntax());

--- a/crates/ide-db/src/source_change.rs
+++ b/crates/ide-db/src/source_change.rs
@@ -264,7 +264,7 @@ impl SourceChangeBuilder {
     }
 
     pub fn make_editor(&self, node: &SyntaxNode) -> SyntaxEditor {
-        SyntaxEditor::new(node.ancestors().last().unwrap_or_else(|| node.clone())).0
+        SyntaxEditor::new(node.tree_top()).0
     }
 
     pub fn add_file_edits(&mut self, file_id: impl Into<FileId>, editor: SyntaxEditor) {

--- a/crates/ide-diagnostics/src/handlers/missing_fields.rs
+++ b/crates/ide-diagnostics/src/handlers/missing_fields.rs
@@ -117,7 +117,7 @@ fn fixes(ctx: &DiagnosticsContext<'_, '_>, d: &hir::MissingFields) -> Option<Vec
             });
 
             let old_field_list = field_list_parent.record_expr_field_list()?;
-            let root = old_field_list.syntax().ancestors().last()?;
+            let root = old_field_list.syntax().tree_top();
             let (editor, _) = SyntaxEditor::new(root);
             let make = editor.make();
 
@@ -178,7 +178,7 @@ fn fixes(ctx: &DiagnosticsContext<'_, '_>, d: &hir::MissingFields) -> Option<Vec
             let missing_fields = ctx.sema.record_pattern_missing_fields(field_list_parent);
 
             let old_field_list = field_list_parent.record_pat_field_list()?;
-            let root = old_field_list.syntax().ancestors().last()?;
+            let root = old_field_list.syntax().tree_top();
             let (editor, _) = SyntaxEditor::new(root);
             let make = editor.make();
 

--- a/crates/ide/src/rename.rs
+++ b/crates/ide/src/rename.rs
@@ -813,7 +813,7 @@ fn rename_elided_lifetime(
     new_name: &str,
 ) -> RenameResult<SourceChange> {
     let parent = lifetime_token.parent().unwrap();
-    let root = parent.ancestors().last().unwrap();
+    let root = parent.tree_top();
 
     let mut builder = SourceChangeBuilder::new(position.file_id);
 


### PR DESCRIPTION
This PR adds tree top method to syntax node, to fetch the root, instead of letting the user do that everytime.