### PR TITLE
project-model: Pass config flags to cargo metadata / cargo config commands

### DIFF
--- a/crates/project-model/src/cargo_config_file.rs
+++ b/crates/project-model/src/cargo_config_file.rs
@@ -16,12 +16,14 @@ impl CargoConfigFile {
     pub(crate) fn load(
         manifest: &ManifestPath,
         extra_env: &FxHashMap<String, Option<String>>,
+        extra_args: &[String],
         sysroot: &Sysroot,
     ) -> Option<Self> {
         let mut cargo_config = sysroot.tool(Tool::Cargo, manifest.parent(), extra_env);
         cargo_config
             .args(["-Z", "unstable-options", "config", "get", "--format", "toml", "--show-origin"])
             .env("RUSTC_BOOTSTRAP", "1");
+        cargo_config.args(extra_args);
         if manifest.is_rust_manifest() {
             cargo_config.arg("-Zscript");
         }

--- a/crates/project-model/src/cargo_workspace.rs
+++ b/crates/project-model/src/cargo_workspace.rs
@@ -672,15 +672,15 @@ impl FetchMetadata {
 
         let mut other_options = vec![];
         // cargo metadata only supports a subset of flags of what cargo usually accepts, and usually
-        // the only relevant flags for metadata here are unstable ones, so we pass those along
-        // but nothing else
+        // the only relevant flags for metadata here are unstable ones and --config, so we pass
+        // those along but nothing else
         let mut extra_args = config.extra_args.iter();
         while let Some(arg) = extra_args.next() {
-            if arg == "-Z"
-                && let Some(arg) = extra_args.next()
+            if (arg == "-Z" || arg == "--config")
+                && let Some(next) = extra_args.next()
             {
-                other_options.push("-Z".to_owned());
                 other_options.push(arg.to_owned());
+                other_options.push(next.to_owned());
             }
         }
         other_options.extend(config.metadata_extra_args.iter().cloned());

--- a/crates/project-model/src/workspace.rs
+++ b/crates/project-model/src/workspace.rs
@@ -245,6 +245,7 @@ impl ProjectWorkspace {
         // Resolve the Cargo.toml to the workspace root as we base the `target` dir off of it.
         let mut cmd = sysroot.tool(Tool::Cargo, workspace_dir, extra_env);
         cmd.args(["locate-project", "--workspace", "--manifest-path", cargo_toml.as_str()]);
+        cmd.args(extra_args);
         let cargo_toml = &match utf8_stdout(&mut cmd) {
             Ok(output) => {
                 #[derive(serde_derive::Deserialize)]
@@ -269,7 +270,7 @@ impl ProjectWorkspace {
 
         tracing::info!(workspace = %cargo_toml, src_root = ?sysroot.rust_lib_src_root(), root = ?sysroot.root(), "Using sysroot");
         progress("querying project metadata".to_owned());
-        let config_file = CargoConfigFile::load(cargo_toml, extra_env, &sysroot);
+        let config_file = CargoConfigFile::load(cargo_toml, extra_env, extra_args, &sysroot);
         let config_file_ = config_file.clone();
         let toolchain_config = QueryConfig::Cargo(&sysroot, cargo_toml, &config_file_);
         let targets =
@@ -549,7 +550,8 @@ impl ProjectWorkspace {
             None => Sysroot::empty(),
         };
 
-        let config_file = CargoConfigFile::load(detached_file, &config.extra_env, &sysroot);
+        let config_file =
+            CargoConfigFile::load(detached_file, &config.extra_env, &config.extra_args, &sysroot);
         let query_config = QueryConfig::Cargo(&sysroot, detached_file, &config_file);
         let toolchain = version::get(query_config, &config.extra_env).ok().flatten();
         let targets = target_tuple::get(query_config, config.target.as_deref(), &config.extra_env)


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=2051235 for some of the discussion. If you want to point cargo to some extra configuration, this makes extraArgs able to do it.