### PR TITLE
project-model: Don't pass metadata extra args to sysroot.

### DIFF
--- a/crates/project-model/src/workspace.rs
+++ b/crates/project-model/src/workspace.rs
@@ -1953,7 +1953,7 @@ fn sysroot_metadata_config(
         features: Default::default(),
         targets,
         extra_args: Default::default(),
-        metadata_extra_args: config.metadata_extra_args.clone(),
+        metadata_extra_args: Default::default(),
         extra_env: config.extra_env.clone(),
         toolchain_version,
         kind: "sysroot",


### PR DESCRIPTION
The same way we don't pass extraArgs. The sysroot config is not likely to work with the workspace config options.