### PR TITLE
fix: Assertion failure on closure with unbound function

### DIFF
--- a/crates/hir-ty/src/infer/callee.rs
+++ b/crates/hir-ty/src/infer/callee.rs
@@ -585,13 +585,7 @@ impl<'a, 'db> DeferredCallResolution<'db> {
                     method_callee.args,
                 );
             }
-            None => {
-                assert!(
-                    ctx.lang_items.FnOnce.is_none(),
-                    "Expected to find a suitable `Fn`/`FnMut`/`FnOnce` implementation for `{:?}`",
-                    self.closure_ty
-                )
-            }
+            None => {}
         }
     }
 }

--- a/crates/hir-ty/src/tests/regression.rs
+++ b/crates/hir-ty/src/tests/regression.rs
@@ -2935,3 +2935,15 @@ impl Foo for Bar {
 "#,
     );
 }
+
+#[test]
+fn regression_unresolved_deferred_closure_call_resolution() {
+    check_no_mismatches(
+        r#"
+//- minicore: fn
+fn caller() {
+    let _: &[u8] = &(|| encode_fn())();
+}
+"#,
+    );
+}


### PR DESCRIPTION
Previously that we asserted that callee inference always succeeded when FnOnce is defined. This isn't true when we have a closure that references an unbound function.

I originally noticed this when investigating a configuration where rust-analyzer couldn't see generated files from a library (e.g. a build.rs or buck equivalent), but rust-analyzer should be tolerant of unbound functions in general.

Remove the failing assertion. I've also added a unit test.

AI disclosure: Bisected by Opus 4.8, initial implementation by GPT 5.5.