### PR TITLE
project-model: Introduce cargo.configExtraArgs.

### DIFF
--- a/crates/project-model/src/cargo_config_file.rs
+++ b/crates/project-model/src/cargo_config_file.rs
@@ -17,10 +17,12 @@ impl CargoConfigFile {
         manifest: &ManifestPath,
         extra_env: &FxHashMap<String, Option<String>>,
         sysroot: &Sysroot,
+        config_extra_args: &[String],
     ) -> Option<Self> {
         let mut cargo_config = sysroot.tool(Tool::Cargo, manifest.parent(), extra_env);
         cargo_config
             .args(["-Z", "unstable-options", "config", "get", "--format", "toml", "--show-origin"])
+            .args(config_extra_args)
             .env("RUSTC_BOOTSTRAP", "1");
         if manifest.is_rust_manifest() {
             cargo_config.arg("-Zscript");

--- a/crates/project-model/src/cargo_workspace.rs
+++ b/crates/project-model/src/cargo_workspace.rs
@@ -133,6 +133,8 @@ pub struct CargoConfig {
     pub extra_args: Vec<String>,
     /// Extra args passed only to `cargo metadata`, not other cargo commands.
     pub metadata_extra_args: Vec<String>,
+    /// Extra args passed only to `cargo config get` when reading `.cargo/config.toml`.
+    pub config_extra_args: Vec<String>,
     /// Extra env vars to set when invoking the cargo command
     pub extra_env: FxHashMap<String, Option<String>>,
     pub invocation_strategy: InvocationStrategy,

--- a/crates/project-model/src/workspace.rs
+++ b/crates/project-model/src/workspace.rs
@@ -217,6 +217,7 @@ impl ProjectWorkspace {
             rustc_source,
             extra_args,
             metadata_extra_args,
+            config_extra_args,
             extra_env,
             set_test,
             cfg_overrides,
@@ -269,7 +270,7 @@ impl ProjectWorkspace {
 
         tracing::info!(workspace = %cargo_toml, src_root = ?sysroot.rust_lib_src_root(), root = ?sysroot.root(), "Using sysroot");
         progress("querying project metadata".to_owned());
-        let config_file = CargoConfigFile::load(cargo_toml, extra_env, &sysroot);
+        let config_file = CargoConfigFile::load(cargo_toml, extra_env, &sysroot, config_extra_args);
         let config_file_ = config_file.clone();
         let toolchain_config = QueryConfig::Cargo(&sysroot, cargo_toml, &config_file_);
         let targets =
@@ -549,7 +550,12 @@ impl ProjectWorkspace {
             None => Sysroot::empty(),
         };
 
-        let config_file = CargoConfigFile::load(detached_file, &config.extra_env, &sysroot);
+        let config_file = CargoConfigFile::load(
+            detached_file,
+            &config.extra_env,
+            &sysroot,
+            &config.config_extra_args,
+        );
         let query_config = QueryConfig::Cargo(&sysroot, detached_file, &config_file);
         let toolchain = version::get(query_config, &config.extra_env).ok().flatten();
         let targets = target_tuple::get(query_config, config.target.as_deref(), &config.extra_env)

--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -833,6 +833,8 @@ config_data! {
         cargo_cfgs: Vec<String> = {
             vec!["debug_assertions".into(), "miri".into()]
         },
+        /// Extra arguments passed only to `cargo config` not to other cargo invocations.
+        cargo_configExtraArgs: Vec<String> = vec![],
         /// Extra arguments that are passed to every cargo invocation.
         cargo_extraArgs: Vec<String> = vec![],
         /// Extra environment variables that will be set when running cargo, rustc
@@ -2484,6 +2486,7 @@ impl Config {
             set_test: *self.cfg_setTest(source_root),
             no_deps: *self.cargo_noDeps(source_root),
             metadata_extra_args: self.cargo_metadataExtraArgs(source_root).clone(),
+            config_extra_args: self.cargo_configExtraArgs(source_root).clone(),
         }
     }
 

--- a/docs/book/src/configuration_generated.md
+++ b/docs/book/src/configuration_generated.md
@@ -142,6 +142,13 @@ To enable a name with a value, use `"key=value"`.
 To disable, prefix the entry with a `!`.
 
 
+## rust-analyzer.cargo.configExtraArgs {#cargo.configExtraArgs}
+
+Default: `[]`
+
+Extra arguments passed only to `cargo config` not to other cargo invocations.
+
+
 ## rust-analyzer.cargo.extraArgs {#cargo.extraArgs}
 
 Default: `[]`

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -974,6 +974,19 @@
             {
                 "title": "Cargo",
                 "properties": {
+                    "rust-analyzer.cargo.configExtraArgs": {
+                        "markdownDescription": "Extra arguments passed only to `cargo config` not to other cargo invocations.",
+                        "default": [],
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                }
+            },
+            {
+                "title": "Cargo",
+                "properties": {
                     "rust-analyzer.cargo.extraArgs": {
                         "markdownDescription": "Extra arguments that are passed to every cargo invocation.",
                         "default": [],


### PR DESCRIPTION
Much like cargo.metadataExtraArgs. This is necessary so that rust-analyzer can have a consistent view of the configuration in the project.