### PR TITLE
fix: Support Cargo 1.97.0 lockfile path setting

### DIFF
--- a/crates/project-model/src/build_dependencies.rs
+++ b/crates/project-model/src/build_dependencies.rs
@@ -474,8 +474,14 @@ impl WorkspaceBuildScripts {
                                 cmd.arg("--lockfile-path");
                                 cmd.arg(lockfile_copy.path.as_str());
                             }
-                            LockfileUsage::WithEnvVar => {
+                            LockfileUsage::WithEnvVarUnstable => {
                                 cmd.arg("-Zlockfile-path");
+                                cmd.env(
+                                    "CARGO_RESOLVER_LOCKFILE_PATH",
+                                    lockfile_copy.path.as_os_str(),
+                                );
+                            }
+                            LockfileUsage::WithEnvVar => {
                                 cmd.env(
                                     "CARGO_RESOLVER_LOCKFILE_PATH",
                                     lockfile_copy.path.as_os_str(),

--- a/crates/project-model/src/cargo_config_file.rs
+++ b/crates/project-model/src/cargo_config_file.rs
@@ -141,7 +141,9 @@ pub(crate) struct LockfileCopy {
 pub(crate) enum LockfileUsage {
     /// Rust [1.82.0, 1.95.0). `cargo <subcmd> --lockfile-path <lockfile path>`
     WithFlag,
-    /// Rust >= 1.95.0. `CARGO_RESOLVER_LOCKFILE_PATH=<lockfile path> cargo <subcmd>`
+    /// Rust [1.95.0, 1.97.0). `CARGO_RESOLVER_LOCKFILE_PATH=<lockfile path> cargo -Zlockfile-path <subcmd>`
+    WithEnvVarUnstable,
+    /// Rust >= 1.97.0. `CARGO_RESOLVER_LOCKFILE_PATH=<lockfile path> cargo <subcmd>`
     WithEnvVar,
 }
 
@@ -158,7 +160,7 @@ pub(crate) fn make_lockfile_copy(
             build: semver::BuildMetadata::EMPTY,
         };
 
-    const MINIMUM_TOOLCHAIN_VERSION_SUPPORTING_LOCKFILE_PATH_ENV: semver::Version =
+    const MINIMUM_TOOLCHAIN_VERSION_SUPPORTING_LOCKFILE_PATH_ENV_UNSTABLE: semver::Version =
         semver::Version {
             major: 1,
             minor: 95,
@@ -167,8 +169,20 @@ pub(crate) fn make_lockfile_copy(
             build: semver::BuildMetadata::EMPTY,
         };
 
+    const MINIMUM_TOOLCHAIN_VERSION_SUPPORTING_LOCKFILE_PATH_ENV: semver::Version =
+        semver::Version {
+            major: 1,
+            minor: 97,
+            patch: 0,
+            pre: semver::Prerelease::EMPTY,
+            build: semver::BuildMetadata::EMPTY,
+        };
+
     let usage = if *toolchain_version >= MINIMUM_TOOLCHAIN_VERSION_SUPPORTING_LOCKFILE_PATH_ENV {
         LockfileUsage::WithEnvVar
+    } else if *toolchain_version >= MINIMUM_TOOLCHAIN_VERSION_SUPPORTING_LOCKFILE_PATH_ENV_UNSTABLE
+    {
+        LockfileUsage::WithEnvVarUnstable
     } else if *toolchain_version >= MINIMUM_TOOLCHAIN_VERSION_SUPPORTING_LOCKFILE_PATH_FLAG {
         LockfileUsage::WithFlag
     } else {

--- a/crates/project-model/src/cargo_workspace.rs
+++ b/crates/project-model/src/cargo_workspace.rs
@@ -763,8 +763,11 @@ impl FetchMetadata {
                     other_options.push("--lockfile-path".to_owned());
                     other_options.push(lockfile_copy.path.to_string());
                 }
-                LockfileUsage::WithEnvVar => {
+                LockfileUsage::WithEnvVarUnstable => {
                     other_options.push("-Zlockfile-path".to_owned());
+                    command.env("CARGO_RESOLVER_LOCKFILE_PATH", lockfile_copy.path.as_os_str());
+                }
+                LockfileUsage::WithEnvVar => {
                     command.env("CARGO_RESOLVER_LOCKFILE_PATH", lockfile_copy.path.as_os_str());
                 }
             }


### PR DESCRIPTION
The `resolver.lockfile_path` setting was stabilized, so we can omit the `-Zlockfile-path` argument.

Due to the recent stuff I checked that.