### PR TITLE
internal: Document some little-known features

### DIFF
--- a/crates/ide/src/goto_definition.rs
+++ b/crates/ide/src/goto_definition.rs
@@ -40,6 +40,21 @@ pub struct GotoDefinitionConfig<'a> {
 // | VS Code | <kbd>F12</kbd> |
 //
 // ![Go to Definition](https://user-images.githubusercontent.com/48062697/113065563-025fbe00-91b1-11eb-83e4-a5a703610b23.gif)
+//
+// #### Special Go to Definitions
+//
+// You can go to definition on operators and keywords as well. The behavior goes as follows:
+//
+//  - On overloadable operators, this will take you to the `impl` of the operator's trait for this type, or to the trait if
+//    the impl cannot be determined.
+//  - For `?` on `Result` that goes through a non-trivial `From` (i.e. not the blanket `impl<T> From<T> for T`), it'll take
+//    you to the `From` impl.
+//  - On control flow keywords (loops, conditions, etc.) and `fn`, it'll take you to all exit points for this construct
+//    or its entrance, the opposite of the keyword you're at (e.g. on `fn` it'll take you to all exit points, and on `return`
+//    it'll take you to the `fn`).
+//  - It'll skip known blanket impls from the standard library where possible. For example, on a `try_into()` that comes
+//    from the blanket `impl<T: TryFrom<U>, U> TryInto<T> for U`, it'll take you to the `TryFrom` impl, and if it also
+//    comes from the blanket `impl<T: From<U>, U> TryFrom<U> for T`, it'll take you to the `From` impl.
 pub(crate) fn goto_definition(
     db: &RootDatabase,
     FilePosition { file_id, offset }: FilePosition,

--- a/crates/ide/src/rename.rs
+++ b/crates/ide/src/rename.rs
@@ -121,6 +121,17 @@ pub(crate) fn prepare_rename(
 // | VS Code | <kbd>F2</kbd> |
 //
 // ![Rename](https://user-images.githubusercontent.com/48062697/113065582-055aae80-91b1-11eb-8ade-2b58e6d81883.gif)
+//
+// #### Magic Renames
+//
+// rust-analyzer supports some special renames that do additional magic:
+//
+//  - **Anonymous lifetime renames**. You can rename `'_` to any lifetime name (the new name must start with `'`),
+//    and rust-analyzer will automatically add the new lifetime to the list of generic parameters.
+//  - **`self` renames**. You can rename parameters to/from `self`. Renaming `self` into another name will update
+//    all callers using method syntax to call the function like an associated function. Renaming to `self` is only
+//    supported for the first parameter inside an `impl` and when the `Self` type matches the type of the parameter,
+//    and will update callers to use method call syntax.
 pub(crate) fn rename(
     db: &RootDatabase,
     position: FilePosition,


### PR DESCRIPTION
We have a big discoverability problem with our features, but if we don't document them, how can we even expect people to find them?!