### PR TITLE
internal: inline `ExpandDatabase::expand_proc_macro` into its only caller

### DIFF
--- a/crates/hir-expand/src/db.rs
+++ b/crates/hir-expand/src/db.rs
@@ -275,7 +275,7 @@ pub fn expand_speculative(
         }
         MacroDefKind::Declarative(it, _) => db
             .decl_macro_expander(loc.krate, it)
-            .expand_unhygienic(db, tt, loc.kind.call_style(), span),
+            .expand_unhygienic(db, &tt, loc.kind.call_style(), span),
         MacroDefKind::BuiltIn(_, it) => {
             it.expand(db, actual_macro_call, &tt, span).map_err(Into::into)
         }
@@ -547,9 +547,9 @@ fn macro_expand<'db>(
 
             let arg = macro_arg;
             let res = match loc.def.kind {
-                MacroDefKind::Declarative(id, _) => db
-                    .decl_macro_expander(loc.def.krate, id)
-                    .expand(db, arg.clone(), macro_call_id, span),
+                MacroDefKind::Declarative(id, _) => {
+                    db.decl_macro_expander(loc.def.krate, id).expand(db, arg, macro_call_id, span)
+                }
                 MacroDefKind::BuiltIn(_, it) => {
                     it.expand(db, macro_call_id, arg, span).map_err(Into::into).zip_val(None)
                 }
@@ -589,7 +589,7 @@ fn macro_expand<'db>(
                 }
                 MacroDefKind::ProcMacro(_, _, _) => unreachable!(),
             };
-            (ExpandResult { value: res.value, err: res.err }, span)
+            (res, span)
         }
     };
 

--- a/crates/hir-expand/src/db.rs
+++ b/crates/hir-expand/src/db.rs
@@ -107,13 +107,6 @@ pub trait ExpandDatabase: SourceDatabase {
         id: AstId<ast::Macro>,
     ) -> &DeclarativeMacroExpander;
 
-    /// Special case of the previous query for procedural macros. We can't LRU
-    /// proc macros, since they are not deterministic in general, and
-    /// non-determinism breaks salsa in a very, very, very bad way.
-    /// @edwin0cheng heroically debugged this once! See #4315 for details
-    #[salsa::invoke(expand_proc_macro)]
-    #[salsa::transparent]
-    fn expand_proc_macro(&self, call: MacroCallId) -> &ExpandResult<tt::TopSubtree>;
     /// Retrieves the span to be used for a proc-macro expansions spans.
     /// This is a firewall query as it requires parsing the file, which we don't want proc-macros to
     /// directly depend on as that would cause to frequent invalidations, mainly because of the
@@ -535,8 +528,7 @@ fn macro_expand<'db>(
 
     let (ExpandResult { value: (tt, matched_arm), err }, span) = match loc.def.kind {
         MacroDefKind::ProcMacro(..) => {
-            return db
-                .expand_proc_macro(macro_call_id)
+            return expand_proc_macro(db, macro_call_id)
                 .as_ref()
                 .map(|it| (Cow::Borrowed(it), None));
         }
@@ -617,6 +609,10 @@ fn proc_macro_span(db: &dyn ExpandDatabase, ast: AstId<ast::Fn>) -> Span {
     span_map.span_for_range(range)
 }
 
+/// Special case of [`macro_expand`] for procedural macros. We can't LRU
+/// proc macros, since they are not deterministic in general, and
+/// non-determinism breaks salsa in a very, very, very bad way.
+/// @edwin0cheng heroically debugged this once! See #4315 for details
 #[salsa_macros::tracked(returns(ref))]
 fn expand_proc_macro(db: &dyn ExpandDatabase, id: MacroCallId) -> ExpandResult<tt::TopSubtree> {
     let loc = id.loc(db);

--- a/crates/hir-expand/src/declarative.rs
+++ b/crates/hir-expand/src/declarative.rs
@@ -32,7 +32,7 @@ impl DeclarativeMacroExpander {
     pub fn expand(
         &self,
         db: &dyn ExpandDatabase,
-        tt: tt::TopSubtree,
+        tt: &tt::TopSubtree,
         call_id: MacroCallId,
         span: Span,
     ) -> ExpandResult<(tt::TopSubtree, Option<u32>)> {
@@ -46,7 +46,7 @@ impl DeclarativeMacroExpander {
                 .mac
                 .expand(
                     db,
-                    &tt,
+                    tt,
                     |s| {
                         s.ctx =
                             apply_mark(db, s.ctx, call_id.into(), self.transparency, self.edition)
@@ -61,7 +61,7 @@ impl DeclarativeMacroExpander {
     pub fn expand_unhygienic(
         &self,
         db: &dyn ExpandDatabase,
-        tt: tt::TopSubtree,
+        tt: &tt::TopSubtree,
         call_style: MacroCallStyle,
         call_site: Span,
     ) -> ExpandResult<tt::TopSubtree> {
@@ -72,7 +72,7 @@ impl DeclarativeMacroExpander {
             ),
             None => self
                 .mac
-                .expand(db, &tt, |_| (), call_style, call_site)
+                .expand(db, tt, |_| (), call_style, call_site)
                 .map(TupleExt::head)
                 .map_err(Into::into),
         }

--- a/crates/load-cargo/src/lib.rs
+++ b/crates/load-cargo/src/lib.rs
@@ -171,7 +171,7 @@ pub fn load_workspace_into_db(
             .map(|(crate_id, path)| {
                 (
                     crate_id,
-                    path.map_or_else(Err, |(_, path)| {
+                    path.and_then(|(_, path)| {
                         proc_macro_server.as_ref().map_err(Clone::clone).and_then(
                             |proc_macro_server| load_proc_macro(proc_macro_server, &path, &[]),
                         )


### PR DESCRIPTION
Part of https://github.com/rust-lang/rust-analyzer/issues/22657

The query was only called by one function (`macro_expand`), and the function backing the query (`expand_proc_macro`) is located in the same module as `macro_expand`, so I think it's fine to call `expand_proc_macro` directly, instead of going through a query.

cc @Veykril 