### PR TITLE
fix UB in smol_str borsh_non_utf8 test cases

### DIFF
--- a/lib/smol_str/tests/test.rs
+++ b/lib/smol_str/tests/test.rs
@@ -443,11 +443,10 @@ mod borsh_tests {
     }
     #[test]
     fn borsh_non_utf8_stack() {
-        let invalid_utf8: Vec<u8> = vec![0xF0, 0x9F, 0x8F]; // Incomplete UTF-8 sequence
+        let invalid_utf8: &[u8] = &[0xF0, 0x9F, 0x8F]; // Incomplete UTF-8 sequence
 
-        let wrong_utf8 = SmolStr::from(unsafe { String::from_utf8_unchecked(invalid_utf8) });
         let mut buffer = Vec::new();
-        borsh::BorshSerialize::serialize(&wrong_utf8, &mut buffer).unwrap();
+        borsh::BorshSerialize::serialize(invalid_utf8, &mut buffer).unwrap();
         let mut cursor = Cursor::new(buffer);
         let result = SmolStr::deserialize_reader(&mut cursor);
         assert!(result.is_err());
@@ -455,14 +454,13 @@ mod borsh_tests {
 
     #[test]
     fn borsh_non_utf8_heap() {
-        let invalid_utf8: Vec<u8> = vec![
+        let invalid_utf8: &[u8] = &[
             0xC1, 0x8A, 0x5F, 0xE2, 0x3A, 0x9E, 0x3B, 0xAA, 0x01, 0x08, 0x6F, 0x2F, 0xC0, 0x32,
             0xAB, 0xE1, 0x9A, 0x2F, 0x4A, 0x3F, 0x25, 0x0D, 0x8A, 0x2A, 0x19, 0x11, 0xF0, 0x7F,
             0x0E, 0x80,
         ];
-        let wrong_utf8 = SmolStr::from(unsafe { String::from_utf8_unchecked(invalid_utf8) });
         let mut buffer = Vec::new();
-        borsh::BorshSerialize::serialize(&wrong_utf8, &mut buffer).unwrap();
+        borsh::BorshSerialize::serialize(invalid_utf8, &mut buffer).unwrap();
         let mut cursor = Cursor::new(buffer);
         let result = SmolStr::deserialize_reader(&mut cursor);
         assert!(result.is_err());


### PR DESCRIPTION
This was discovered by an AI-driven unsafe code analysis.

This is test code, so it's not too important to fix, but it impacts the miri-ability of this crate. I _think_ all the same behaviors are being tested, the only thing this doesn't test is the SmolStr serialization path, which shouldn't be being tested with UB strings anyway.

I think just testing the deserialization path is the way to go here, and the test is better as a result.