### PR TITLE
Fix loop label rename

### DIFF
--- a/crates/ide-db/src/search.rs
+++ b/crates/ide-db/src/search.rs
@@ -339,6 +339,37 @@ impl Definition {
             };
         }
 
+        if let Definition::Label(label) = self {
+            let def = match label.parent(db) {
+                ExpressionStoreOwner::Body(def) => match def {
+                    DefWithBody::Function(f) => f.source(db).map(|src| src.syntax().cloned()),
+                    DefWithBody::Const(c) => c.source(db).map(|src| src.syntax().cloned()),
+                    DefWithBody::Static(s) => s.source(db).map(|src| src.syntax().cloned()),
+                    DefWithBody::EnumVariant(v) => v.source(db).map(|src| src.syntax().cloned()),
+                },
+                ExpressionStoreOwner::Signature(def) => match def {
+                    hir::GenericDef::Function(it) => it.source(db).map(|src| src.syntax().cloned()),
+                    hir::GenericDef::Adt(it) => it.source(db).map(|src| src.syntax().cloned()),
+                    hir::GenericDef::Trait(it) => it.source(db).map(|src| src.syntax().cloned()),
+                    hir::GenericDef::TypeAlias(it) => {
+                        it.source(db).map(|src| src.syntax().cloned())
+                    }
+                    hir::GenericDef::Impl(it) => it.source(db).map(|src| src.syntax().cloned()),
+                    hir::GenericDef::Const(it) => it.source(db).map(|src| src.syntax().cloned()),
+                    hir::GenericDef::Static(it) => it.source(db).map(|src| src.syntax().cloned()),
+                },
+                ExpressionStoreOwner::VariantFields(it) => {
+                    it.source(db).map(|src| src.syntax().cloned())
+                }
+            };
+            return match def {
+                Some(def) => SearchScope::file_range(
+                    def.as_ref().original_file_range_with_macro_call_input(db),
+                ),
+                None => SearchScope::single_file(file_id),
+            };
+        }
+
         if let Definition::InlineAsmOperand(op) = self {
             let def = match op.parent(db) {
                 ExpressionStoreOwner::Body(def) => match def {

--- a/crates/ide/src/rename.rs
+++ b/crates/ide/src/rename.rs
@@ -2893,6 +2893,66 @@ fn main() {
     }
 
     #[test]
+    fn test_rename_label_from_definition() {
+        check(
+            "new_label",
+            r#"
+//- minicore: iterators
+fn main() {
+    let xes = [1, 2, 3];
+    'testlabel$0: for x in xes.iter() {
+        if x == 5 {
+            continue 'testlabel;
+        }
+        println!("{x");
+    }
+}
+            "#,
+            r#"
+fn main() {
+    let xes = [1, 2, 3];
+    'new_label: for x in xes.iter() {
+        if x == 5 {
+            continue 'new_label;
+        }
+        println!("{x");
+    }
+}
+            "#,
+        );
+    }
+
+    #[test]
+    fn test_rename_label_from_reference() {
+        check(
+            "new_label",
+            r#"
+//- minicore: iterators
+fn main() {
+    let xes = [1, 2, 3];
+    'testlabel: for x in xes.iter() {
+        if x == 5 {
+            continue 'testlabel$0;
+        }
+        println!("{x");
+    }
+}
+            "#,
+            r#"
+fn main() {
+    let xes = [1, 2, 3];
+    'new_label: for x in xes.iter() {
+        if x == 5 {
+            continue 'new_label;
+        }
+        println!("{x");
+    }
+}
+            "#,
+        );
+    }
+
+    #[test]
     fn test_self_to_self() {
         cov_mark::check!(rename_self_to_self);
         check(

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -3344,7 +3344,8 @@
                 }
             },
             "explorer.fileNesting.patterns": {
-                "Cargo.toml": "Cargo.lock"
+                "Cargo.toml": "Cargo.lock",
+                "mod.rs": "*.rs"
             }
         },
         "problemPatterns": [

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -3344,8 +3344,7 @@
                 }
             },
             "explorer.fileNesting.patterns": {
-                "Cargo.toml": "Cargo.lock",
-                "mod.rs": "*.rs"
+                "Cargo.toml": "Cargo.lock"
             }
         },
         "problemPatterns": [


### PR DESCRIPTION
This PR restricts the search scope of Definition::Label to its containing body and adds regression tests for renaming labels from both definition and reference sites.