### PR TITLE
internal: remove `ExpandDatabase::proc_macro_span` in favor of the underlying fn

### DIFF
--- a/crates/hir-def/src/nameres/collector.rs
+++ b/crates/hir-def/src/nameres/collector.rs
@@ -2531,12 +2531,8 @@ impl ModCollector<'_, '_> {
         // Case 1: builtin macros
         let expander = if attrs.by_key(sym::rustc_builtin_macro).exists() {
             // `#[rustc_builtin_macro = "builtin_name"]` overrides the `macro_rules!` name.
-            let name;
             let name = match attrs.by_key(sym::rustc_builtin_macro).string_value_with_span() {
-                Some((it, span)) => {
-                    name = Name::new_symbol(Symbol::intern(it), span.ctx);
-                    &name
-                }
+                Some((it, span)) => &Name::new_symbol(Symbol::intern(it), span.ctx),
                 None => {
                     let explicit_name =
                         attrs.by_key(sym::rustc_builtin_macro).tt_values().next().and_then(|tt| {
@@ -2546,10 +2542,7 @@ impl ModCollector<'_, '_> {
                             }
                         });
                     match explicit_name {
-                        Some(ident) => {
-                            name = ident.as_name();
-                            &name
-                        }
+                        Some(ident) => &ident.as_name(),
                         None => &mac.name,
                     }
                 }

--- a/crates/hir-def/src/nameres/tests/incremental.rs
+++ b/crates/hir-def/src/nameres/tests/incremental.rs
@@ -305,8 +305,7 @@ fn f() { foo }
                 "parse_macro_expansion",
                 "expand_proc_macro",
                 "macro_arg",
-                "create_data_ExpandDatabase",
-                "proc_macro_span_shim",
+                "proc_macro_span",
             ]
         "#]],
         expect![[r#"
@@ -442,8 +441,7 @@ pub struct S {}
                 "parse_macro_expansion",
                 "expand_proc_macro",
                 "macro_arg",
-                "create_data_ExpandDatabase",
-                "proc_macro_span_shim",
+                "proc_macro_span",
             ]
         "#]],
         expect![[r#"

--- a/crates/hir-expand/src/db.rs
+++ b/crates/hir-expand/src/db.rs
@@ -600,8 +600,8 @@ fn macro_expand<'db>(
 
 fn proc_macro_span(db: &dyn ExpandDatabase, ast: AstId<ast::Fn>) -> Span {
     let root = db.parse_or_expand(ast.file_id);
-    let ast_id_map = &db.ast_id_map(ast.file_id);
-    let span_map = &db.span_map(ast.file_id);
+    let ast_id_map = db.ast_id_map(ast.file_id);
+    let span_map = db.span_map(ast.file_id);
 
     let node = ast_id_map.get(ast.value).to_node(&root);
     let range = ast::HasName::name(&node)

--- a/crates/hir-expand/src/db.rs
+++ b/crates/hir-expand/src/db.rs
@@ -107,14 +107,6 @@ pub trait ExpandDatabase: SourceDatabase {
         id: AstId<ast::Macro>,
     ) -> &DeclarativeMacroExpander;
 
-    /// Retrieves the span to be used for a proc-macro expansions spans.
-    /// This is a firewall query as it requires parsing the file, which we don't want proc-macros to
-    /// directly depend on as that would cause to frequent invalidations, mainly because of the
-    /// parse queries being LRU cached. If they weren't the invalidations would only happen if the
-    /// user wrote in the file that defines the proc-macro.
-    #[salsa::invoke_interned(proc_macro_span)]
-    fn proc_macro_span(&self, fun: AstId<ast::Fn>) -> Span;
-
     #[salsa::invoke(parse_macro_expansion_error)]
     #[salsa::transparent]
     fn parse_macro_expansion_error(
@@ -249,7 +241,7 @@ pub fn expand_speculative(
     // Otherwise the expand query will fetch the non speculative attribute args and pass those instead.
     let mut speculative_expansion = match loc.def.kind {
         MacroDefKind::ProcMacro(ast, expander, _) => {
-            let span = db.proc_macro_span(ast);
+            let span = proc_macro_span(db, ast);
             tt.set_top_subtree_delimiter_kind(tt::DelimiterKind::Invisible);
             tt.set_top_subtree_delimiter_span(tt::DelimSpan::from_single(span));
             expander.expand(
@@ -598,15 +590,24 @@ fn macro_expand<'db>(
     ExpandResult { value: (Cow::Owned(tt), matched_arm), err }
 }
 
+/// Retrieves the span to be used for a proc-macro expansions spans.
+/// This is a firewall query as it requires parsing the file, which we don't want proc-macros to
+/// directly depend on as that would cause to frequent invalidations, mainly because of the
+/// parse queries being LRU cached. If they weren't the invalidations would only happen if the
+/// user wrote in the file that defines the proc-macro.
 fn proc_macro_span(db: &dyn ExpandDatabase, ast: AstId<ast::Fn>) -> Span {
-    let root = db.parse_or_expand(ast.file_id);
-    let ast_id_map = db.ast_id_map(ast.file_id);
-    let span_map = db.span_map(ast.file_id);
+    #[salsa::tracked]
+    fn proc_macro_span(db: &dyn ExpandDatabase, ast: AstId<ast::Fn>, _: ()) -> Span {
+        let root = db.parse_or_expand(ast.file_id);
+        let ast_id_map = db.ast_id_map(ast.file_id);
+        let span_map = db.span_map(ast.file_id);
 
-    let node = ast_id_map.get(ast.value).to_node(&root);
-    let range = ast::HasName::name(&node)
-        .map_or_else(|| node.syntax().text_range(), |name| name.syntax().text_range());
-    span_map.span_for_range(range)
+        let node = ast_id_map.get(ast.value).to_node(&root);
+        let range = ast::HasName::name(&node)
+            .map_or_else(|| node.syntax().text_range(), |name| name.syntax().text_range());
+        span_map.span_for_range(range)
+    }
+    proc_macro_span(db, ast, ())
 }
 
 /// Special case of [`macro_expand`] for procedural macros. We can't LRU
@@ -629,7 +630,7 @@ fn expand_proc_macro(db: &dyn ExpandDatabase, id: MacroCallId) -> ExpandResult<t
     };
 
     let ExpandResult { value: mut tt, err } = {
-        let span = db.proc_macro_span(ast);
+        let span = proc_macro_span(db, ast);
         expander.expand(
             db,
             loc.def.krate,


### PR DESCRIPTION
Part of https://github.com/rust-lang/rust-analyzer/issues/22657

The query was only called by two functions, and they are located in the same module as the function backing the query (`proc_macro_span`), so I think it's fine to call the latter directly, instead of going through a query.

The transformation is made somewhat ugly by the query having been defined as `#[salsa::invoke_interned]`, ~~but this seems to be the way to do things: https://github.com/rust-lang/rust-analyzer/pull/22063/files#diff-5828430af308cfce455219d40dac23f272baf89378ada6febee5d6a186ffe0fbL255-R268~~ (EDIT: I was made aware of a nicer solution: https://github.com/rust-lang/rust-analyzer/pull/22699#discussion_r3509149402).

cc @Veykril 