### PR TITLE
internal: remove `#[salsa::invoke_interned]` support from `#[query_group]`

### DIFF
--- a/crates/query-group-macro/src/lib.rs
+++ b/crates/query-group-macro/src/lib.rs
@@ -4,7 +4,7 @@ use std::vec;
 
 use proc_macro::TokenStream;
 use proc_macro2::Span;
-use queries::{GeneratedInputStruct, Queries, TrackedQuery, Transparent};
+use queries::{Queries, TrackedQuery, Transparent};
 use quote::{ToTokens, format_ident, quote};
 use syn::parse::{Parse, ParseStream};
 use syn::punctuated::Punctuated;
@@ -83,7 +83,6 @@ fn filter_attrs(attrs: Vec<Attribute>) -> (Vec<Attribute>, Vec<SalsaAttr>) {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum QueryKind {
-    Tracked,
     TrackedWithSalsaStruct,
     Transparent,
 }
@@ -193,11 +192,6 @@ pub(crate) fn query_group_impl(
                         let c = syn::parse::<Parenthesized<Cycle>>(tts)?;
                         cycle = Some(c.0);
                     }
-                    "invoke_interned" => {
-                        let path = syn::parse::<Parenthesized<Path>>(tts)?;
-                        invoke = Some(path.0.clone());
-                        query_kind = QueryKind::Tracked;
-                    }
                     "invoke" => {
                         let path = syn::parse::<Parenthesized<Path>>(tts)?;
                         invoke = Some(path.0.clone());
@@ -224,27 +218,9 @@ pub(crate) fn query_group_impl(
             }
 
             match (query_kind, invoke) {
-                // tracked function. it might have an invoke, or might not.
-                (QueryKind::Tracked, invoke) => {
-                    let method = TrackedQuery {
-                        trait_name: trait_name_ident.clone(),
-                        generated_struct: Some(GeneratedInputStruct {
-                            input_struct_name: input_struct_name.clone(),
-                            create_data_ident: create_data_ident.clone(),
-                        }),
-                        signature: signature.clone(),
-                        pat_and_tys: pat_and_tys.clone(),
-                        invoke,
-                        cycle,
-                        default: method.default.take(),
-                    };
-
-                    trait_methods.push(Queries::TrackedQuery(method));
-                }
                 (QueryKind::TrackedWithSalsaStruct, invoke) => {
                     let method = TrackedQuery {
                         trait_name: trait_name_ident.clone(),
-                        generated_struct: None,
                         signature: signature.clone(),
                         pat_and_tys: pat_and_tys.clone(),
                         invoke,

--- a/crates/query-group-macro/src/queries.rs
+++ b/crates/query-group-macro/src/queries.rs
@@ -12,12 +12,6 @@ pub(crate) struct TrackedQuery {
     pub(crate) invoke: Option<Path>,
     pub(crate) default: Option<syn::Block>,
     pub(crate) cycle: Option<Cycle>,
-    pub(crate) generated_struct: Option<GeneratedInputStruct>,
-}
-
-pub(crate) struct GeneratedInputStruct {
-    pub(crate) input_struct_name: Ident,
-    pub(crate) create_data_ident: Ident,
 }
 
 impl ToTokens for TrackedQuery {
@@ -64,37 +58,16 @@ impl ToTokens for TrackedQuery {
             }
         };
 
-        let method = match &self.generated_struct {
-            Some(generated_struct) => {
-                let input_struct_name = &generated_struct.input_struct_name;
-                let create_data_ident = &generated_struct.create_data_ident;
+        let method = quote! {
+            #sig {
+                #annotation
+                fn #shim<'db>(
+                    db: &'db dyn #trait_name,
+                    #(#pat_and_tys),*
+                ) #ret
+                    #invoke_block
 
-                quote! {
-                    #sig {
-                        #annotation
-                        fn #shim<'db>(
-                            db: &'db dyn #trait_name,
-                            _input: #input_struct_name,
-                            #(#pat_and_tys),*
-                        ) #ret
-                            #invoke_block
-                        #shim(self, #create_data_ident(self), #(#params),*)
-                    }
-                }
-            }
-            None => {
-                quote! {
-                    #sig {
-                        #annotation
-                        fn #shim<'db>(
-                            db: &'db dyn #trait_name,
-                            #(#pat_and_tys),*
-                        ) #ret
-                            #invoke_block
-
-                        #shim(self, #(#params),*)
-                    }
-                }
+                #shim(self, #(#params),*)
             }
         };
 

--- a/crates/query-group-macro/tests/arity.rs
+++ b/crates/query-group-macro/tests/arity.rs
@@ -2,16 +2,16 @@ use query_group_macro::query_group;
 
 #[query_group]
 pub trait ArityDb: salsa::Database {
-    #[salsa::invoke_interned(one)]
+    #[salsa::transparent]
     fn one(&self, a: ()) -> String;
 
-    #[salsa::invoke_interned(two)]
+    #[salsa::transparent]
     fn two(&self, a: (), b: ()) -> String;
 
-    #[salsa::invoke_interned(three)]
+    #[salsa::transparent]
     fn three(&self, a: (), b: (), c: ()) -> String;
 
-    #[salsa::invoke_interned(none)]
+    #[salsa::transparent]
     fn none(&self) -> String;
 }
 

--- a/crates/query-group-macro/tests/hello_world.rs
+++ b/crates/query-group-macro/tests/hello_world.rs
@@ -12,42 +12,18 @@ struct InputString {
 #[query_group]
 pub trait HelloWorldDatabase: salsa::Database {
     // unadorned query
-    #[salsa::invoke_interned(length_query)]
-    fn length_query(&self, key: ()) -> usize;
-
-    // unadorned query
     fn length_query_with_no_params(&self) -> usize;
-
-    // renamed/invoke query
-    #[salsa::invoke_interned(invoke_length_query_actual)]
-    fn invoke_length_query(&self, key: ()) -> usize;
 
     // not a query. should not invoked
     #[salsa::transparent]
     fn transparent_length(&self, key: ()) -> usize;
-
-    #[salsa::transparent]
-    #[salsa::invoke_interned(transparent_and_invoke_length_actual)]
-    fn transparent_and_invoke_length(&self, key: ()) -> usize;
-}
-
-fn length_query(db: &dyn HelloWorldDatabase, _key: ()) -> usize {
-    InputString::get(db).inner(db).len()
 }
 
 fn length_query_with_no_params(db: &dyn HelloWorldDatabase) -> usize {
     InputString::get(db).inner(db).len()
 }
 
-fn invoke_length_query_actual(db: &dyn HelloWorldDatabase, _key: ()) -> usize {
-    InputString::get(db).inner(db).len()
-}
-
 fn transparent_length(db: &dyn HelloWorldDatabase, _key: ()) -> usize {
-    InputString::get(db).inner(db).len()
-}
-
-fn transparent_and_invoke_length_actual(db: &dyn HelloWorldDatabase, _key: ()) -> usize {
     InputString::get(db).inner(db).len()
 }
 
@@ -56,32 +32,13 @@ fn unadorned_query() {
     let db = LoggerDb::default();
 
     InputString::new(&db, String::from("Hello, world!"));
-    let len = db.length_query(());
+    let len = db.length_query_with_no_params();
 
     assert_eq!(len, 13);
     db.assert_logs(expect![[r#"
         [
             "salsa_event(WillCheckCancellation)",
-            "salsa_event(WillExecute { database_key: create_data_HelloWorldDatabase(Id(400)) })",
-            "salsa_event(WillCheckCancellation)",
-            "salsa_event(WillExecute { database_key: length_query_shim(Id(c00)) })",
-        ]"#]]);
-}
-
-#[test]
-fn invoke_query() {
-    let db = LoggerDb::default();
-
-    InputString::new(&db, String::from("Hello, world!"));
-    let len = db.invoke_length_query(());
-
-    assert_eq!(len, 13);
-    db.assert_logs(expect![[r#"
-        [
-            "salsa_event(WillCheckCancellation)",
-            "salsa_event(WillExecute { database_key: create_data_HelloWorldDatabase(Id(400)) })",
-            "salsa_event(WillCheckCancellation)",
-            "salsa_event(WillExecute { database_key: invoke_length_query_shim(Id(c00)) })",
+            "salsa_event(WillExecute { database_key: length_query_with_no_params_shim(Id(400)) })",
         ]"#]]);
 }
 
@@ -94,21 +51,4 @@ fn transparent() {
 
     assert_eq!(len, 13);
     db.assert_logs(expect!["[]"]);
-}
-
-#[test]
-fn transparent_invoke() {
-    let db = LoggerDb::default();
-
-    InputString::new(&db, String::from("Hello, world!"));
-    let len = db.transparent_and_invoke_length(());
-
-    assert_eq!(len, 13);
-    db.assert_logs(expect![[r#"
-        [
-            "salsa_event(WillCheckCancellation)",
-            "salsa_event(WillExecute { database_key: create_data_HelloWorldDatabase(Id(400)) })",
-            "salsa_event(WillCheckCancellation)",
-            "salsa_event(WillExecute { database_key: transparent_and_invoke_length_shim(Id(c00)) })",
-        ]"#]]);
 }

--- a/crates/query-group-macro/tests/multiple_dbs.rs
+++ b/crates/query-group-macro/tests/multiple_dbs.rs
@@ -8,13 +8,13 @@ struct InputString {
 #[query_group]
 pub trait DatabaseOne: salsa::Database {
     // unadorned query
-    #[salsa::invoke_interned(length)]
+    #[salsa::transparent]
     fn length(&self, key: ()) -> usize;
 }
 
 #[query_group]
 pub trait DatabaseTwo: DatabaseOne {
-    #[salsa::invoke_interned(second_length)]
+    #[salsa::transparent]
     fn second_length(&self, key: ()) -> usize;
 }
 

--- a/crates/query-group-macro/tests/result.rs
+++ b/crates/query-group-macro/tests/result.rs
@@ -14,10 +14,10 @@ struct InputString {
 
 #[query_group]
 pub trait ResultDatabase: salsa::Database {
-    #[salsa::invoke_interned(length)]
+    #[salsa::transparent]
     fn length(&self, key: ()) -> Result<usize, Error>;
 
-    #[salsa::invoke_interned(length2)]
+    #[salsa::transparent]
     fn length2(&self, key: ()) -> Result<usize, Error>;
 }
 
@@ -37,14 +37,5 @@ fn test_queries_with_results() {
     assert_eq!(db.length(()), Ok(input.len()));
     assert_eq!(db.length2(()), Ok(input.len()));
 
-    db.assert_logs(expect![[r#"
-        [
-            "salsa_event(WillCheckCancellation)",
-            "salsa_event(WillExecute { database_key: create_data_ResultDatabase(Id(400)) })",
-            "salsa_event(WillCheckCancellation)",
-            "salsa_event(WillExecute { database_key: length_shim(Id(c00)) })",
-            "salsa_event(WillCheckCancellation)",
-            "salsa_event(WillCheckCancellation)",
-            "salsa_event(WillExecute { database_key: length2_shim(Id(1000)) })",
-        ]"#]]);
+    db.assert_logs(expect!["[]"]);
 }

--- a/crates/query-group-macro/tests/supertrait.rs
+++ b/crates/query-group-macro/tests/supertrait.rs
@@ -8,7 +8,7 @@ pub trait SourceDb: salsa::Database {
 
 #[query_group]
 pub trait RootDb: SourceDb {
-    #[salsa::invoke_interned(parse)]
+    #[salsa::transparent]
     fn parse(&self, id: usize) -> String;
 }
 

--- a/crates/query-group-macro/tests/tuples.rs
+++ b/crates/query-group-macro/tests/tuples.rs
@@ -11,7 +11,7 @@ struct InputString {
 
 #[query_group]
 pub trait HelloWorldDatabase: salsa::Database {
-    #[salsa::invoke_interned(length_query)]
+    #[salsa::transparent]
     fn length_query(&self, key: ()) -> (usize, usize);
 }
 
@@ -28,11 +28,5 @@ fn query() {
     let len = db.length_query(());
 
     assert_eq!(len, (13, 13));
-    db.assert_logs(expect![[r#"
-        [
-            "salsa_event(WillCheckCancellation)",
-            "salsa_event(WillExecute { database_key: create_data_HelloWorldDatabase(Id(400)) })",
-            "salsa_event(WillCheckCancellation)",
-            "salsa_event(WillExecute { database_key: length_query_shim(Id(c00)) })",
-        ]"#]]);
+    db.assert_logs(expect!["[]"]);
 }


### PR DESCRIPTION
Part of https://github.com/rust-lang/rust-analyzer/issues/22657

Turns out the query removed in https://github.com/rust-lang/rust-analyzer/pull/22699 was the last one of this kind.

RE: tests: I replaced some of the occurrences of `#[salsa::invoke_interned]` with `#[salsa::transparent]`. I think this technically means those functions are no longer queries, and so I would need to also rewrite their underlying functions to be compatible with `#[salsa::tracked]`, as was done in https://github.com/rust-lang/rust-analyzer/pull/22699, but I could not be bothered...

cc @Veykril