### PR TITLE
fix: walkthrough_create_project file not packaged

### DIFF
--- a/editors/code/.vscodeignore
+++ b/editors/code/.vscodeignore
@@ -12,4 +12,4 @@
 !ra_syntax_tree.tmGrammar.json
 !server
 !README.md
-!walkthrough-setup-tips.md
+!walkthrough-*


### PR DESCRIPTION
Fixes rust-lang/rust-analyzer#22687 