### PR TITLE
fix: Crash on extract_variable when selecting unresolved macro call

### DIFF
--- a/crates/ide-assists/src/handlers/extract_variable.rs
+++ b/crates/ide-assists/src/handlers/extract_variable.rs
@@ -110,6 +110,9 @@ pub(crate) fn extract_variable(acc: &mut Assists, ctx: &AssistContext<'_, '_>) -
             .skip_while(|it| !it.text_range().contains_range(range))
             .find_map(valid_target_expr(ctx))?;
         let original_range = ctx.sema.original_range(expr.syntax());
+        if !node.text_range().contains_range(original_range.range) {
+            return None;
+        }
         (cover_edit_range(&node, original_range.range), expr)
     } else {
         let expr = node
@@ -3025,5 +3028,10 @@ fn main() {
 "#,
             "Extract into variable",
         );
+    }
+
+    #[test]
+    fn repro_bad_range_unresolved_macro_paren() {
+        check_assist_not_applicable(extract_variable, "fn f() { m!$0($0 }");
     }
 }


### PR DESCRIPTION
Be defensive against the range form the token tree not being in the token tree node being edited.

Includes a unit test that previously panicked with:

    Bad range: node range 11..12, range 9..12

AI disclosure: Repro constructed with Fable 5, implementation with GPT 5.5.