### PR TITLE
fix: correct resolution to value when it shares the same name with type

### DIFF
--- a/crates/hir/src/source_analyzer.rs
+++ b/crates/hir/src/source_analyzer.rs
@@ -1155,7 +1155,7 @@ impl<'db> SourceAnalyzer<'db> {
         let parent = path.syntax().parent();
         let parent = || parent.clone();
 
-        let mut prefer_value_ns = false;
+        let mut prefer_value_ns = parent().and_then(ast::PathExpr::cast).is_some();
         let resolved = (|| {
             let infer = self.infer()?;
             if let Some(path_expr) = parent().and_then(ast::PathExpr::cast) {

--- a/crates/ide/src/goto_definition.rs
+++ b/crates/ide/src/goto_definition.rs
@@ -999,6 +999,21 @@ impl Trait for T {
 }"#,
         );
     }
+
+    #[test]
+    fn goto_def_array_length_prefers_value_namespace() {
+        check(
+            r#"
+struct N;
+
+trait Trait {}
+
+impl<const N: usize> Trait for [N; N$0] {}
+         //^
+"#,
+        );
+    }
+
     #[test]
     fn goto_def_in_mac_call_in_attr_invoc() {
         check(


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust-analyzer/issues/21693.

tried to do the least amount of changes.
`prefer_value_ns` is evaluated before resolve closure, as ChayimFriedman2 said it should be implemented.