### PR TITLE
fix: Crash when computing diagnostics with MIR and error types

### DIFF
--- a/crates/hir-ty/src/mir/lower.rs
+++ b/crates/hir-ty/src/mir/lower.rs
@@ -1404,11 +1404,14 @@ impl<'a, 'db> MirLowerCtx<'a, 'db> {
         expr_id: ExprId,
     ) -> Result<'db, ()> {
         if let Expr::Field { expr, name } = &self.store[expr_id] {
-            if let TyKind::Tuple(..) = self.expr_ty_after_adjustments(*expr).kind() {
+            if let TyKind::Tuple(tys) = self.expr_ty_after_adjustments(*expr).kind() {
                 let index =
                     name.as_tuple_index().ok_or(MirLowerError::TypeError("named field on tuple"))?
                         as u32;
-                *place = place.project(ProjectionElem::Field(FieldIndex(index)))
+                if tys.get(index as usize).is_none() {
+                    return Err(MirLowerError::TypeError("tuple field index out of range"));
+                }
+                *place = place.project(ProjectionElem::Field(FieldIndex(index)));
             } else {
                 let field = self
                     .infer

--- a/crates/hir-ty/src/mir/lower/pattern_matching.rs
+++ b/crates/hir-ty/src/mir/lower/pattern_matching.rs
@@ -137,7 +137,8 @@ impl<'db> MirLowerCtx<'_, 'db> {
             }
             Pat::Wild => (current, current_else),
             Pat::Tuple { args, ellipsis } => {
-                let subst = match self.infer.pat_ty(pattern).kind() {
+                let place_ty = cond_place.ty(&self.result, &self.infcx, self.env).ty;
+                let subst = match place_ty.kind() {
                     TyKind::Tuple(s) => s,
                     _ => {
                         return Err(MirLowerError::TypeError(

--- a/crates/hir-ty/src/mir/lower/tests.rs
+++ b/crates/hir-ty/src/mir/lower/tests.rs
@@ -121,3 +121,16 @@ fn tuple_field() {
     "#,
     );
 }
+
+#[test]
+fn borrowck_alias_projection_recovery_does_not_panic() {
+    check_borrowck(
+        r#"
+//- minicore: sized
+trait Tr { type A; }
+fn alias<T: Tr>(x: T::A) {
+    let (a, b) = x;
+}
+    "#,
+    );
+}

--- a/crates/hir-ty/src/mir/lower/tests.rs
+++ b/crates/hir-ty/src/mir/lower/tests.rs
@@ -108,3 +108,16 @@ pub struct AssocTy {
     "#,
     );
 }
+
+#[test]
+fn borrowck_tuple_field_projection_recovery_does_not_panic() {
+    check_borrowck(
+        r#"
+//- minicore: sized
+fn tuple_field() {
+    let t = (1,);
+    let x = t.1;
+}
+    "#,
+    );
+}


### PR DESCRIPTION
Previously MIR would panic if we tried to access out-of-bounds tuple elements or fields in a value with an error type. This would produce an error of the form:

     field FieldIndex(1) out of range: (i32,)
     can't project out of {type error}
     field FieldIndex(99) out of range: (&'{region error} str, u32)

Instead, handle error types gracefully, and add unit tests.

AI disclosure: Some Fable 5 and GPT 5.5 usage, any errors are of course mine :)