### PR TITLE
perf: Reduce parser joint-token allocation

### DIFF
--- a/crates/parser/src/input.rs
+++ b/crates/parser/src/input.rs
@@ -27,7 +27,7 @@ impl Input {
     pub fn with_capacity(capacity: usize) -> Self {
         Self {
             kind: Vec::with_capacity(capacity),
-            joint: Vec::with_capacity(capacity / size_of::<bits>()),
+            joint: Vec::with_capacity(capacity.div_ceil(bits::BITS as usize)),
             contextual_kind: Vec::with_capacity(capacity),
             edition: Vec::with_capacity(capacity),
         }


### PR DESCRIPTION
## Summary
- Reserve parser joint-token storage by bitset word count, not byte count.
- This avoids over-allocating the `joint` side table when parser input is created.

## Measurement
- 1,000,000-token capacity: `125,000` -> `15,625` `u64` words.
- Allocation reduction: `875,000` bytes.

## Testing Done
- [x] `cargo test -p parser --quiet` (`319 passed, 0 failed`)
