### PR TITLE
perf: Hoist attribute qualifier segment collection

### DIFF
--- a/crates/ide-completion/src/completions/attribute.rs
+++ b/crates/ide-completion/src/completions/attribute.rs
@@ -127,6 +127,7 @@ pub(crate) fn complete_attribute_path(
     }
     let qualifier_path =
         if let Qualified::With { path, .. } = qualified { Some(path) } else { None };
+    let qualifier_segments = qualifier_path.iter().flat_map(|q| q.segments()).collect::<Vec<_>>();
 
     let attributes = annotated_item_kind.and_then(|kind| {
         if ast::Expr::can_cast(kind) {
@@ -141,9 +142,8 @@ pub(crate) fn complete_attribute_path(
         // add the missing parts to the label and snippet
         let mut label = attr_completion.label.to_owned();
         let mut snippet = attr_completion.snippet.map(|s| s.to_owned());
-        let segments = qualifier_path.iter().flat_map(|q| q.segments()).collect::<Vec<_>>();
         let qualifiers = attr_completion.qualifiers;
-        let matching_qualifiers = segments
+        let matching_qualifiers = qualifier_segments
             .iter()
             .zip(qualifiers)
             .take_while(|(s, q)| s.name_ref().is_some_and(|t| t.text() == **q))


### PR DESCRIPTION
## Summary
- Collect qualified attribute path segments once per completion request.
- Reuse the collected segments while evaluating attribute candidates.

## Measurement
- Isolated request-shaped qualifier loop median: `860.05ns` -> `64.68ns`.

## Testing Done
- [x] `cargo test -p ide-completion attribute --quiet` (`65 passed, 0 failed`)
