### PR TITLE
minor: remove whitespaces in remove use-tree braces

### DIFF
--- a/crates/ide-assists/src/handlers/remove_unused_imports.rs
+++ b/crates/ide-assists/src/handlers/remove_unused_imports.rs
@@ -693,9 +693,7 @@ mod m {
     }
 }
 
-use m::
-    x::B
-;
+use m::x::B;
 
 fn main() {
     B;

--- a/crates/syntax/src/ast/node_ext.rs
+++ b/crates/syntax/src/ast/node_ext.rs
@@ -473,13 +473,19 @@ impl ast::UseTreeList {
                 false
             }
         };
+        let remove_whitespace = |element: Option<SyntaxElement>| match element {
+            Some(element) if element.kind() == SyntaxKind::WHITESPACE => editor.delete(element),
+            _ => (),
+        };
 
         let remove_brace_in_use_tree_list = |u: &ast::UseTreeList| {
             if has_single_subtree_that_is_not_self(u) {
                 if let Some(a) = u.l_curly_token() {
+                    remove_whitespace(a.next_sibling_or_token());
                     editor.delete(a)
                 }
                 if let Some(a) = u.r_curly_token() {
+                    remove_whitespace(a.prev_sibling_or_token());
                     editor.delete(a)
                 }
                 u.comma().for_each(|u| editor.delete(u));


### PR DESCRIPTION
Example
---
```rust
struct X; struct Y;
mod z {
    $0use super::{
        X, Y,
    };$0
    fn w() { let x = X; }
}
```

**Before this PR**

```rust
struct X; struct Y;
mod z {
    use super::
        X
    ;
    fn w() { let x = X; }
}
```

**After this PR**

```rust
struct X; struct Y;
mod z {
    use super::X;
    fn w() { let x = X(); }
}
```
