### PR TITLE
fix: fix some assist indent

### DIFF
--- a/crates/ide-assists/src/handlers/convert_bool_then.rs
+++ b/crates/ide-assists/src/handlers/convert_bool_then.rs
@@ -188,7 +188,7 @@ pub(crate) fn convert_bool_then_to_if(
             let mapless_make = SyntaxFactory::without_mappings();
             let closure_body = match closure_body.reset_indent() {
                 ast::Expr::BlockExpr(block) => block,
-                e => mapless_make.block_expr(None, Some(e)),
+                e => mapless_make.block_expr(None, Some(e.indent(1.into()))),
             };
 
             let (editor, closure_body) = SyntaxEditor::with_ast_node(&closure_body);
@@ -223,7 +223,7 @@ pub(crate) fn convert_bool_then_to_if(
             };
             let if_expr = make
                 .expr_if(
-                    cond,
+                    cond.reset_indent(),
                     closure_body,
                     Some(ast::ElseBranch::Block(make.block_expr(None, Some(none_path)))),
                 )
@@ -603,6 +603,39 @@ fn main() {
 fn main() {
     let test = &[()];
     let value = (!test.is_empty()).then(|| ());
+}
+",
+        );
+    }
+
+    #[test]
+    fn indent() {
+        check_assist(
+            convert_bool_then_to_if,
+            r"
+//- minicore:bool_impl
+fn main() {
+    let foo = |cond| cond;
+    foo(
+        true
+    ).t$0hen(|| foo(
+        false
+    ))
+}
+",
+            r"
+fn main() {
+    let foo = |cond| cond;
+    if foo(
+        true
+    )
+    {
+        Some(foo(
+            false
+        ))
+    } else {
+        None
+    }
 }
 ",
         );

--- a/crates/ide-assists/src/handlers/convert_iter_for_each_to_for.rs
+++ b/crates/ide-assists/src/handlers/convert_iter_for_each_to_for.rs
@@ -65,10 +65,11 @@ pub(crate) fn convert_iter_for_each_to_for(
             let block = match body {
                 ast::Expr::BlockExpr(block) => block.reset_indent(),
                 _ => make.block_expr(Vec::new(), Some(body.reset_indent().indent(1.into()))),
-            }
-            .indent(indent);
+            };
 
-            let expr_for_loop = make.expr_for_loop(param, receiver, block);
+            let expr_for_loop = make
+                .expr_for_loop(param.reset_indent(), receiver.reset_indent(), block)
+                .indent(indent);
             editor.replace(target_node, expr_for_loop.syntax());
             builder.add_file_edits(ctx.vfs_file_id(), editor);
         },
@@ -570,6 +571,58 @@ fn main() {
     });
 }
 "#,
+        );
+    }
+
+    #[test]
+    fn indent() {
+        check_assist(
+            convert_iter_for_each_to_for,
+            r#"
+//- minicore: iterators
+fn main() {
+    let it = |n| core::iter::repeat(n);
+    it(
+        92
+    ).$0for_each(|(x, y)| {
+        println!("x: {}, y: {}", x, y);
+    })
+}
+"#,
+            r#"
+fn main() {
+    let it = |n| core::iter::repeat(n);
+    for (x, y) in it(
+        92
+    )
+    {
+        println!("x: {}, y: {}", x, y);
+    }
+}
+"#,
+        );
+        check_assist(
+            convert_for_loop_with_for_each,
+            r"
+fn main() {
+    for $0v in vec![
+        1,
+        2,
+        3,
+    ] {
+        v *= 2;
+    }
+}",
+            r"
+fn main() {
+    vec![
+        1,
+        2,
+        3,
+    ].into_iter().for_each(|v| {
+        v *= 2;
+    });
+}",
         );
     }
 }

--- a/crates/ide-assists/src/handlers/convert_let_else_to_match.rs
+++ b/crates/ide-assists/src/handlers/convert_let_else_to_match.rs
@@ -95,7 +95,7 @@ pub(crate) fn convert_let_else_to_match(
             );
             let else_arm = make.match_arm(make.wildcard_pat().into(), None, else_expr);
             let arms = [binding_arm, else_arm].map(|arm| arm.indent(1.into()));
-            let match_ = make.expr_match(init, make.match_arm_list(arms));
+            let match_ = make.expr_match(init.reset_indent(), make.match_arm_list(arms));
             let match_ = match_.indent(let_stmt.indent_level());
 
             if bindings.is_empty() {
@@ -617,12 +617,17 @@ fn main() {
             r#"
 fn main() {
     let v = vec![1, 2, 3];
-    let &[mut x, y, ..] = &v.iter().collect::<Vec<_>>()[..] else$0 { return };
+    let &[mut x, y, ..] = &v
+        .iter()
+        .collect::<Vec<_>>()[..] else$0 { return };
 }"#,
             r#"
 fn main() {
     let v = vec![1, 2, 3];
-    let (mut x, y) = match &v.iter().collect::<Vec<_>>()[..] {
+    let (mut x, y) = match &v
+        .iter()
+        .collect::<Vec<_>>()[..]
+    {
         &[x, y, ..] => (x, y),
         _ => return,
     };

--- a/crates/ide-assists/src/handlers/convert_while_to_loop.rs
+++ b/crates/ide-assists/src/handlers/convert_while_to_loop.rs
@@ -55,12 +55,10 @@ pub(crate) fn convert_while_to_loop(acc: &mut Assists, ctx: &AssistContext<'_, '
             let make = editor.make();
             let while_indent_level = IndentLevel::from_node(while_expr.syntax());
 
-            let break_block = make
-                .block_expr(
-                    iter::once(make.expr_stmt(make.expr_break(None, None).into()).into()),
-                    None,
-                )
-                .indent(IndentLevel(1));
+            let break_block = make.block_expr(
+                iter::once(make.expr_stmt(make.expr_break(None, None).into()).into()),
+                None,
+            );
 
             editor.replace_all(
                 while_kw.syntax_element()..=while_cond.syntax().syntax_element(),
@@ -68,14 +66,17 @@ pub(crate) fn convert_while_to_loop(acc: &mut Assists, ctx: &AssistContext<'_, '
             );
 
             if is_pattern_cond(while_cond.clone()) {
-                let then_branch = while_body.reset_indent().indent(IndentLevel(1));
-                let if_expr = make.expr_if(while_cond, then_branch, Some(break_block.into()));
+                let then_branch = while_body.reset_indent();
+                let if_expr = make
+                    .expr_if(while_cond.reset_indent(), then_branch, Some(break_block.into()))
+                    .indent(IndentLevel(1));
                 let stmts = iter::once(make.expr_stmt(if_expr.into()).into());
                 let block_expr = make.block_expr(stmts, None);
                 editor.replace(while_body.syntax(), block_expr.indent(while_indent_level).syntax());
             } else {
-                let if_cond = invert_boolean_expression(make, while_cond);
-                let if_expr = make.expr_if(if_cond, break_block, None).indent(while_indent_level);
+                let if_cond = invert_boolean_expression(make, while_cond.reset_indent());
+                let if_expr =
+                    make.expr_if(if_cond, break_block, None).indent(while_indent_level + 1);
                 if !while_body.syntax().text().contains_char('\n') {
                     editor.insert(
                         Position::after(&l_curly),
@@ -305,9 +306,12 @@ fn main() {
             convert_while_to_loop,
             r#"
 fn main() {
+    let cond = |cond| cond;
     {
         {
-            while$0 cond {
+            while$0 cond(
+                true
+            ) {
                 foo(
                     "xxx",
                 );
@@ -318,10 +322,14 @@ fn main() {
 "#,
             r#"
 fn main() {
+    let cond = |cond| cond;
     {
         {
             loop {
-                if !cond {
+                if !cond(
+                    true
+                )
+                {
                     break;
                 }
                 foo(
@@ -340,7 +348,9 @@ fn main() {
 fn main() {
     {
         {
-            while$0 let Some(_) = foo() {
+            while$0 let Some(_) = foo(
+                "xxx"
+            ) {
                 bar(
                     "xxx",
                 );
@@ -354,7 +364,10 @@ fn main() {
     {
         {
             loop {
-                if let Some(_) = foo() {
+                if let Some(_) = foo(
+                    "xxx"
+                )
+                {
                     bar(
                         "xxx",
                     );

--- a/crates/ide-assists/src/handlers/desugar_try_expr.rs
+++ b/crates/ide-assists/src/handlers/desugar_try_expr.rs
@@ -90,7 +90,7 @@ pub(crate) fn desugar_try_expr(acc: &mut Assists, ctx: &AssistContext<'_, '_>) -
             let match_arm_list = make.match_arm_list([happy_arm, sad_arm]);
 
             let expr_match = make
-                .expr_match(expr.clone(), match_arm_list)
+                .expr_match(expr.reset_indent(), match_arm_list)
                 .indent(IndentLevel::from_node(try_expr.syntax()));
 
             editor.replace(try_expr.syntax(), expr_match.syntax());
@@ -284,6 +284,53 @@ fn test() {
 fn test() {
     let Ok(pat): Result<bool, _> = Ok(true) else {
         return Err(todo!());
+    };
+}
+            "#,
+            "Replace try expression with let else",
+        );
+    }
+
+    #[test]
+    fn test_desugar_try_expr_indent() {
+        check_assist(
+            desugar_try_expr,
+            r#"
+//- minicore: try, option
+fn test() {
+    let pat = Some(
+        true
+    )$0?;
+}
+            "#,
+            r#"
+fn test() {
+    let pat = match Some(
+        true
+    )
+    {
+        Some(it) => it,
+        None => return None,
+    };
+}
+            "#,
+        );
+        check_assist_by_label(
+            desugar_try_expr,
+            r#"
+//- minicore: try, option
+fn test() {
+    let pat = Some(
+        true
+    )$0?;
+}
+            "#,
+            r#"
+fn test() {
+    let Some(pat) = Some(
+        true
+    ) else {
+        return None;
     };
 }
             "#,

--- a/crates/ide-assists/src/handlers/replace_let_with_if_let.rs
+++ b/crates/ide-assists/src/handlers/replace_let_with_if_let.rs
@@ -67,19 +67,19 @@ pub(crate) fn replace_let_with_if_let(
                     }
                 }
             };
+            let init = init.reset_indent();
+            let let_else = let_stmt.let_else().map(|it| it.reset_indent());
             let init_expr =
                 if let_expr_needs_paren(&init) { make.expr_paren(init).into() } else { init };
 
             let block = make.block_expr([], None);
-            let block = block.indent(IndentLevel::from_node(let_stmt.syntax()));
             let if_expr = make.expr_if(
                 make.expr_let(pat, init_expr).into(),
                 block,
-                let_stmt
-                    .let_else()
-                    .and_then(|let_else| let_else.block_expr().map(ast::ElseBranch::from)),
+                let_else.and_then(|let_else| let_else.block_expr().map(ast::ElseBranch::from)),
             );
-            let if_stmt = make.expr_stmt(if_expr.into());
+            let if_stmt =
+                make.expr_stmt(if_expr.into()).indent(IndentLevel::from_node(let_stmt.syntax()));
 
             editor.replace(let_stmt.syntax(), if_stmt.syntax());
             builder.add_file_edits(ctx.vfs_file_id(), editor);
@@ -223,6 +223,34 @@ fn main() {
     let a = Some(1);
     if let Some(_) = a {
     } else { unreachable!() }
+}
+            ",
+        )
+    }
+
+    #[test]
+    fn indent() {
+        check_assist(
+            replace_let_with_if_let,
+            r"
+//- minicore: option
+fn main() {
+    $0let Some(_) = Some(
+        1
+    ) else {
+        unreachable!()
+    };
+}
+            ",
+            r"
+fn main() {
+    if let Some(_) = Some(
+        1
+    )
+    {
+    } else {
+        unreachable!()
+    }
 }
             ",
         )


### PR DESCRIPTION
For exprs like `non_newline.call(newline)` `non_newline(newline)` etc, is it worth adding some `if` in rust-lang/rust-analyzer#21719 to exclude newline?

# Example
**Before this PR**:
```
fn main() {
    {
        {
            loop {
                if let Some(_) = foo(
                            "xxx"
                        )
            {
                    bar(
                        "xxx",
                    );
                } else {
                    break;
                }
            }
        }
    }
}
```
**After this PR**:
```
fn main() {
    {
        {
            loop {
                if let Some(_) = foo(
                    "xxx"
                )
                {
                    bar(
                        "xxx",
                    );
                } else {
                    break;
                }
            }
        }
    }
}
```
