### PR TITLE
suggest code action fixes produced from diagnostics under cursor, even if they have effects elsewhere

### DIFF
--- a/crates/rust-analyzer/src/diagnostics.rs
+++ b/crates/rust-analyzer/src/diagnostics.rs
@@ -60,7 +60,7 @@ pub(crate) struct DiagnosticCollection {
 #[derive(Debug, Clone)]
 pub(crate) struct Fix {
     // Fixes may be triggerable from multiple ranges.
-    pub(crate) ranges: SmallVec<[lsp_types::Range; 1]>,
+    pub(crate) ranges: SmallVec<[lsp_types::Range; 2]>,
     pub(crate) action: lsp_ext::CodeAction,
 }
 
@@ -181,11 +181,12 @@ impl DiagnosticCollection {
             }
         }
 
-        if let Some(fix) = fix {
+        if let Some(mut fix) = fix {
             let check_fixes = Arc::make_mut(&mut self.check_fixes);
             if check_fixes.len() <= flycheck_id {
                 check_fixes.resize_with(flycheck_id + 1, Default::default);
             }
+            fix.ranges.push(diagnostic.range);
             check_fixes[flycheck_id]
                 .entry(package_id.clone())
                 .or_default()

--- a/crates/rust-analyzer/src/handlers/request.rs
+++ b/crates/rust-analyzer/src/handlers/request.rs
@@ -1575,6 +1575,7 @@ pub(crate) fn handle_code_action(
             .copied()
             .filter_map(|range| from_proto::text_range(&line_index, range).ok())
             .any(|fix_range| fix_range.intersect(frange.range).is_some());
+
         if intersect_fix_range {
             res.push(fix.action.clone());
         }


### PR DESCRIPTION
the point of this, at least for me, is mostly the 
"feature(x) is unstable" errors.
this allows you to code-action fix them from the point of feature usage.