### PR TITLE
internal: migrate `ExpandDatabase::*span_map` queries

### DIFF
--- a/crates/hir-def/src/attrs/docs.rs
+++ b/crates/hir-def/src/attrs/docs.rs
@@ -402,7 +402,7 @@ fn expand_doc_macro_call<'db>(
         resolver: source_ctx.resolver.clone(),
         file_id: expansion_file_id,
         ast_id_map: expansion_file_id.ast_id_map(expander.db),
-        span_map: expander.db.span_map(expansion_file_id),
+        span_map: expansion_file_id.span_map(expander.db),
     };
     Some((expr, new_source_ctx))
 }
@@ -457,7 +457,7 @@ fn extend_with_attrs<'a, 'db>(
                                             resolver,
                                             file_id,
                                             ast_id_map: file_id.ast_id_map(db),
-                                            span_map: db.span_map(file_id),
+                                            span_map: file_id.span_map(db),
                                         },
                                     )
                                 });

--- a/crates/hir-def/src/expr_store/expander.rs
+++ b/crates/hir-def/src/expr_store/expander.rs
@@ -46,7 +46,7 @@ impl<'db> Expander<'db> {
             current_file_id,
             recursion_depth: 0,
             recursion_limit,
-            span_map: db.span_map(current_file_id),
+            span_map: current_file_id.span_map(db),
             ast_id_map: current_file_id.ast_id_map(db),
         }
     }

--- a/crates/hir-def/src/find_path.rs
+++ b/crates/hir-def/src/find_path.rs
@@ -644,7 +644,6 @@ mod tests {
     use std::cell::LazyCell;
 
     use expect_test::{Expect, expect};
-    use hir_expand::db::ExpandDatabase;
     use itertools::Itertools;
     use span::Edition;
     use stdx::format_to;
@@ -674,7 +673,7 @@ mod tests {
             syntax::SourceFile::parse(&format!("use {path};"), span::Edition::CURRENT);
         let ast_path =
             parsed_path_file.syntax_node().descendants().find_map(syntax::ast::Path::cast).unwrap();
-        let span_map = LazyCell::new(|| db.span_map(pos.file_id.into()));
+        let span_map = LazyCell::new(|| hir_expand::HirFileId::from(pos.file_id).span_map(&db));
         let mod_path =
             ModPath::from_src(&db, ast_path, &mut |range| span_map.span_for_range(range).ctx)
                 .unwrap();

--- a/crates/hir-def/src/find_path.rs
+++ b/crates/hir-def/src/find_path.rs
@@ -641,6 +641,8 @@ fn find_local_import_locations(
 
 #[cfg(test)]
 mod tests {
+    use std::cell::LazyCell;
+
     use expect_test::{Expect, expect};
     use hir_expand::db::ExpandDatabase;
     use itertools::Itertools;
@@ -672,10 +674,10 @@ mod tests {
             syntax::SourceFile::parse(&format!("use {path};"), span::Edition::CURRENT);
         let ast_path =
             parsed_path_file.syntax_node().descendants().find_map(syntax::ast::Path::cast).unwrap();
-        let mod_path = ModPath::from_src(&db, ast_path, &mut |range| {
-            db.span_map(pos.file_id.into()).span_for_range(range).ctx
-        })
-        .unwrap();
+        let span_map = LazyCell::new(|| db.span_map(pos.file_id.into()));
+        let mod_path =
+            ModPath::from_src(&db, ast_path, &mut |range| span_map.span_for_range(range).ctx)
+                .unwrap();
 
         let (def_map, local_def_map) = module.local_def_map(&db);
         let resolved = def_map

--- a/crates/hir-def/src/item_tree/lower.rs
+++ b/crates/hir-def/src/item_tree/lower.rs
@@ -56,7 +56,7 @@ impl<'db> Ctx<'db> {
     }
 
     pub(super) fn span_map(&self) -> SpanMap<'_> {
-        *self.span_map.get_or_init(|| self.db.span_map(self.file))
+        *self.span_map.get_or_init(|| self.file.span_map(self.db))
     }
 
     pub(super) fn lower_module_items(mut self, item_owner: &dyn HasModuleItem) -> ItemTree {

--- a/crates/hir-def/src/macro_expansion_tests/mod.rs
+++ b/crates/hir-def/src/macro_expansion_tests/mod.rs
@@ -465,11 +465,12 @@ m!(g);
         ModuleSource::SourceFile(it) => it,
         ModuleSource::Module(_) | ModuleSource::BlockExpr(_) => panic!(),
     };
+    let span_map = db.real_span_map(file_id);
     let no_downmap_spans: Vec<_> = source_file
         .syntax()
         .descendants()
         .map(|node| {
-            let mut span = db.real_span_map(file_id).span_for_range(node.text_range());
+            let mut span = span_map.span_for_range(node.text_range());
             span.anchor.ast_id = NO_DOWNMAP_ERASED_FILE_AST_ID_MARKER;
             span
         })

--- a/crates/hir-def/src/macro_expansion_tests/mod.rs
+++ b/crates/hir-def/src/macro_expansion_tests/mod.rs
@@ -18,7 +18,7 @@ use std::{any::TypeId, iter, ops::Range, sync};
 
 use expect_test::Expect;
 use hir_expand::{
-    AstId, ExpansionInfo, InFile, MacroCallId, MacroCallKind, MacroKind,
+    AstId, ExpansionInfo, HirFileId, InFile, MacroCallId, MacroCallKind, MacroKind,
     builtin::quote::quote,
     db::ExpandDatabase,
     proc_macro::{ProcMacro, ProcMacroExpander, ProcMacroExpansionError, ProcMacroKind},
@@ -215,7 +215,7 @@ pub fn identity_when_valid(_attr: TokenStream, item: TokenStream) -> TokenStream
             }
             let pp = pretty_print_macro_expansion(
                 src.value,
-                db.span_map(src.file_id),
+                src.file_id.span_map(&db),
                 show_spans,
                 show_ctxt,
             );
@@ -230,7 +230,7 @@ pub fn identity_when_valid(_attr: TokenStream, item: TokenStream) -> TokenStream
         if let Some(macro_file) = src.file_id.macro_file() {
             let pp = pretty_print_macro_expansion(
                 src.value.syntax().clone(),
-                db.span_map(macro_file.into()),
+                HirFileId::from(macro_file).span_map(&db),
                 false,
                 false,
             );
@@ -245,7 +245,7 @@ pub fn identity_when_valid(_attr: TokenStream, item: TokenStream) -> TokenStream
         {
             let pp = pretty_print_macro_expansion(
                 src.value.syntax().clone(),
-                db.span_map(macro_file.into()),
+                HirFileId::from(macro_file).span_map(&db),
                 false,
                 false,
             );
@@ -465,7 +465,7 @@ m!(g);
         ModuleSource::SourceFile(it) => it,
         ModuleSource::Module(_) | ModuleSource::BlockExpr(_) => panic!(),
     };
-    let span_map = db.real_span_map(file_id);
+    let span_map = HirFileId::from(file_id).span_map(&db);
     let no_downmap_spans: Vec<_> = source_file
         .syntax()
         .descendants()

--- a/crates/hir-def/src/nameres/assoc.rs
+++ b/crates/hir-def/src/nameres/assoc.rs
@@ -163,7 +163,7 @@ impl<'db> AssocItemCollector<'db> {
             def_map,
             local_def_map,
             ast_id_map: file_id.ast_id_map(db),
-            span_map: db.span_map(file_id),
+            span_map: file_id.span_map(db),
             cfg_options: module_id.krate(db).cfg_options(db),
             file_id,
             container,

--- a/crates/hir-def/src/signatures.rs
+++ b/crates/hir-def/src/signatures.rs
@@ -990,7 +990,7 @@ fn lower_fields<Field: ast::HasAttrs + ast::HasVisibility>(
     let mut col = ExprCollector::new(db, module, fields.file_id);
     let override_visibility = override_visibility.map(|vis| {
         LazyCell::new(|| {
-            let span_map = db.span_map(fields.file_id);
+            let span_map = fields.file_id.span_map(db);
             visibility_from_ast(db, vis, &mut |range| span_map.span_for_range(range).ctx)
         })
     });

--- a/crates/hir-def/src/src.rs
+++ b/crates/hir-def/src/src.rs
@@ -53,7 +53,7 @@ fn use_tree_source_map(db: &dyn DefDatabase, use_ast_id: AstId<ast::Use>) -> Are
     let ast_use_tree = ast.use_tree().expect("missing `use_tree`");
     let mut span_map = None;
     crate::item_tree::lower_use_tree(db, ast_use_tree, &mut |range| {
-        span_map.get_or_insert_with(|| db.span_map(use_ast_id.file_id)).span_for_range(range).ctx
+        span_map.get_or_insert_with(|| use_ast_id.file_id.span_map(db)).span_for_range(range).ctx
     })
     .expect("failed to lower use tree")
     .1

--- a/crates/hir-def/src/visibility.rs
+++ b/crates/hir-def/src/visibility.rs
@@ -306,7 +306,7 @@ pub fn visibility_from_ast(
 ) -> Visibility {
     let mut span_map = None;
     let raw_vis = crate::item_tree::visibility_from_ast(db, ast_vis.value, &mut |range| {
-        span_map.get_or_insert_with(|| db.span_map(ast_vis.file_id)).span_for_range(range).ctx
+        span_map.get_or_insert_with(|| ast_vis.file_id.span_map(db)).span_for_range(range).ctx
     });
     match raw_vis {
         RawVisibility::PubSelf(explicitness) => {

--- a/crates/hir-expand/src/builtin/fn_macro.rs
+++ b/crates/hir-expand/src/builtin/fn_macro.rs
@@ -828,7 +828,7 @@ fn include_expand(
     // FIXME: Parse errors
     ExpandResult::ok(syntax_node_to_token_tree(
         &editioned_file_id.parse(db).syntax_node(),
-        db.span_map(editioned_file_id.into()),
+        crate::HirFileId::from(editioned_file_id).span_map(db),
         span,
         syntax_bridge::DocCommentDesugarMode::ProcMacro,
     ))

--- a/crates/hir-expand/src/builtin/fn_macro.rs
+++ b/crates/hir-expand/src/builtin/fn_macro.rs
@@ -22,7 +22,6 @@ use crate::{
     db::ExpandDatabase,
     hygiene::{span_with_call_site_ctxt, span_with_def_site_ctxt},
     name,
-    span_map::SpanMap,
     tt::{self, DelimSpan, TtElement, TtIter},
 };
 
@@ -826,11 +825,10 @@ fn include_expand(
             );
         }
     };
-    let span_map = db.real_span_map(editioned_file_id);
     // FIXME: Parse errors
     ExpandResult::ok(syntax_node_to_token_tree(
         &editioned_file_id.parse(db).syntax_node(),
-        SpanMap::RealSpanMap(span_map),
+        db.span_map(editioned_file_id.into()),
         span,
         syntax_bridge::DocCommentDesugarMode::ProcMacro,
     ))

--- a/crates/hir-expand/src/db.rs
+++ b/crates/hir-expand/src/db.rs
@@ -14,7 +14,7 @@ use crate::{
     fixup::{self, SyntaxFixupUndoInfo},
     hygiene::{span_with_call_site_ctxt, span_with_def_site_ctxt, span_with_mixed_site_ctxt},
     proc_macro::CustomProcMacroExpander,
-    span_map::{ExpansionSpanMap, RealSpanMap, SpanMap},
+    span_map::{RealSpanMap, SpanMap},
     tt,
 };
 
@@ -39,18 +39,6 @@ pub enum TokenExpander<'db> {
 pub trait ExpandDatabase: SourceDatabase {
     #[salsa::transparent]
     fn resolve_span(&self, span: Span) -> FileRange;
-
-    #[salsa::transparent]
-    #[salsa::invoke(SpanMap::new)]
-    fn span_map(&self, file_id: HirFileId) -> SpanMap<'_>;
-
-    #[salsa::transparent]
-    #[salsa::invoke(crate::span_map::expansion_span_map)]
-    fn expansion_span_map(&self, file_id: MacroCallId) -> &ExpansionSpanMap;
-
-    #[salsa::invoke(crate::span_map::real_span_map)]
-    #[salsa::transparent]
-    fn real_span_map(&self, file_id: EditionedFileId) -> &RealSpanMap;
 
     /// Fetches the expander for this macro.
     #[salsa::transparent]

--- a/crates/hir-expand/src/files.rs
+++ b/crates/hir-expand/src/files.rs
@@ -342,7 +342,7 @@ impl<SN: Borrow<SyntaxNode>> InFile<SN> {
 
         let FileRange { file_id: editioned_file_id, range } = map_node_range_up_rooted(
             db,
-            db.expansion_span_map(file_id),
+            file_id.expansion_span_map(db),
             self.value.borrow().text_range(),
         )?;
 
@@ -385,7 +385,7 @@ impl InFile<SyntaxToken> {
             HirFileId::MacroFile(mac_file) => {
                 let (range, ctxt) = span_for_offset(
                     db,
-                    db.expansion_span_map(mac_file),
+                    mac_file.expansion_span_map(db),
                     self.value.text_range().start(),
                 );
 
@@ -411,7 +411,7 @@ impl InFile<SyntaxToken> {
             HirFileId::MacroFile(mac_file) => {
                 let (range, ctxt) = span_for_offset(
                     db,
-                    db.expansion_span_map(mac_file),
+                    mac_file.expansion_span_map(db),
                     self.value.text_range().start(),
                 );
 
@@ -425,7 +425,7 @@ impl InFile<SyntaxToken> {
 
 impl InMacroFile<TextSize> {
     pub fn original_file_range(self, db: &dyn db::ExpandDatabase) -> (FileRange, SyntaxContext) {
-        span_for_offset(db, db.expansion_span_map(self.file_id), self.value)
+        span_for_offset(db, self.file_id.expansion_span_map(db), self.value)
     }
 }
 
@@ -439,7 +439,7 @@ impl InFile<TextRange> {
                 (FileRange { file_id, range: self.value }, SyntaxContext::root(file_id.edition(db)))
             }
             HirFileId::MacroFile(mac_file) => {
-                match map_node_range_up(db, db.expansion_span_map(mac_file), self.value) {
+                match map_node_range_up(db, mac_file.expansion_span_map(db), self.value) {
                     Some(it) => it,
                     None => {
                         let loc = mac_file.loc(db);
@@ -457,7 +457,7 @@ impl InFile<TextRange> {
         match self.file_id {
             HirFileId::FileId(file_id) => FileRange { file_id, range: self.value },
             HirFileId::MacroFile(mac_file) => {
-                match map_node_range_up_rooted(db, db.expansion_span_map(mac_file), self.value) {
+                match map_node_range_up_rooted(db, mac_file.expansion_span_map(db), self.value) {
                     Some(it) => it,
                     _ => {
                         let loc = mac_file.loc(db);
@@ -475,7 +475,7 @@ impl InFile<TextRange> {
         match self.file_id {
             HirFileId::FileId(file_id) => FileRange { file_id, range: self.value },
             HirFileId::MacroFile(mac_file) => {
-                match map_node_range_up_rooted(db, db.expansion_span_map(mac_file), self.value) {
+                match map_node_range_up_rooted(db, mac_file.expansion_span_map(db), self.value) {
                     Some(it) => it,
                     _ => {
                         let loc = mac_file.loc(db);
@@ -496,7 +496,7 @@ impl InFile<TextRange> {
                 SyntaxContext::root(file_id.edition(db)),
             )),
             HirFileId::MacroFile(mac_file) => {
-                map_node_range_up(db, db.expansion_span_map(mac_file), self.value)
+                map_node_range_up(db, mac_file.expansion_span_map(db), self.value)
             }
         }
     }
@@ -508,7 +508,7 @@ impl InFile<TextRange> {
         match self.file_id {
             HirFileId::FileId(file_id) => Some(FileRange { file_id, range: self.value }),
             HirFileId::MacroFile(mac_file) => {
-                map_node_range_up_rooted(db, db.expansion_span_map(mac_file), self.value)
+                map_node_range_up_rooted(db, mac_file.expansion_span_map(db), self.value)
             }
         }
     }
@@ -530,7 +530,7 @@ impl<N: AstNode> InFile<N> {
 
         let FileRange { file_id: editioned_file_id, range } = map_node_range_up_rooted(
             db,
-            db.expansion_span_map(file_id),
+            file_id.expansion_span_map(db),
             self.value.syntax().text_range(),
         )?;
 

--- a/crates/hir-expand/src/lib.rs
+++ b/crates/hir-expand/src/lib.rs
@@ -28,7 +28,6 @@ mod fixup;
 mod prettify_macro_expansion_;
 
 use salsa::plumbing::{AsId, FromId};
-use stdx::TupleExt;
 use thin_vec::ThinVec;
 use triomphe::Arc;
 
@@ -1216,8 +1215,8 @@ impl<'db> ExpansionInfo<'db> {
                     self.arg.file_id,
                     arg_map
                         .ranges_with_span_exact(span)
-                        .filter(|(range, _)| range.intersect(arg_range).is_some())
-                        .map(TupleExt::head)
+                        .map(|(range, _)| range)
+                        .filter(|range| range.intersect(arg_range).is_some())
                         .collect(),
                 )
             }

--- a/crates/hir-expand/src/lib.rs
+++ b/crates/hir-expand/src/lib.rs
@@ -792,7 +792,7 @@ fn proc_macro_span(db: &dyn ExpandDatabase, ast: AstId<ast::Fn>) -> Span {
     fn proc_macro_span(db: &dyn ExpandDatabase, ast: AstId<ast::Fn>, _: ()) -> Span {
         let root = ast.file_id.parse_or_expand(db);
         let ast_id_map = ast.file_id.ast_id_map(db);
-        let span_map = db.span_map(ast.file_id);
+        let span_map = ast.file_id.span_map(db);
 
         let node = ast_id_map.get(ast.value).to_node(&root);
         let range = ast::HasName::name(&node)
@@ -1228,7 +1228,7 @@ impl<'db> ExpansionInfo<'db> {
         let loc = macro_file.loc(db);
 
         let arg_tt = loc.kind.arg(db);
-        let arg_map = db.span_map(arg_tt.file_id);
+        let arg_map = arg_tt.file_id.span_map(db);
 
         let (parse, exp_map) = &macro_file.parse_macro_expansion(db).value;
         let expanded = InMacroFile { file_id: macro_file, value: parse.syntax_node() };
@@ -1530,9 +1530,10 @@ impl HirFileId {
         db: &dyn ExpandDatabase,
     ) -> (Parse<SyntaxNode>, SpanMap<'_>) {
         match self {
-            HirFileId::FileId(file_id) => {
-                (file_id.parse(db).to_syntax(), SpanMap::RealSpanMap(db.real_span_map(file_id)))
-            }
+            HirFileId::FileId(file_id) => (
+                file_id.parse(db).to_syntax(),
+                SpanMap::RealSpanMap(crate::span_map::real_span_map(db, file_id)),
+            ),
             HirFileId::MacroFile(macro_file) => {
                 let (parse, map) = &macro_file.parse_macro_expansion(db).value;
                 (parse.clone(), SpanMap::ExpansionSpanMap(map))

--- a/crates/hir-expand/src/span_map.rs
+++ b/crates/hir-expand/src/span_map.rs
@@ -30,7 +30,7 @@ impl<'db> SpanMap<'db> {
             // FIXME: Is it correct for us to only take the span at the start? This feels somewhat
             // wrong. The context will be right, but the range could be considered wrong. See
             // https://github.com/rust-lang/rust/issues/23480, we probably want to fetch the span at
-            // the start and end, then merge them like rustc does in `Span::to
+            // the start and end, then merge them like rustc does in `Span::to`
             Self::ExpansionSpanMap(span_map) => span_map.span_at(range.start()),
             Self::RealSpanMap(span_map) => span_map.span_for_range(range),
         }
@@ -40,9 +40,7 @@ impl<'db> SpanMap<'db> {
     pub(crate) fn new(db: &'db dyn ExpandDatabase, file_id: HirFileId) -> SpanMap<'db> {
         match file_id {
             HirFileId::FileId(file_id) => SpanMap::RealSpanMap(db.real_span_map(file_id)),
-            HirFileId::MacroFile(m) => {
-                SpanMap::ExpansionSpanMap(&m.parse_macro_expansion(db).value.1)
-            }
+            HirFileId::MacroFile(m) => SpanMap::ExpansionSpanMap(db.expansion_span_map(m)),
         }
     }
 }

--- a/crates/hir-expand/src/span_map.rs
+++ b/crates/hir-expand/src/span_map.rs
@@ -35,16 +35,20 @@ impl<'db> SpanMap<'db> {
             Self::RealSpanMap(span_map) => span_map.span_for_range(range),
         }
     }
+}
 
+impl HirFileId {
     #[inline]
-    pub(crate) fn new(db: &'db dyn ExpandDatabase, file_id: HirFileId) -> SpanMap<'db> {
-        match file_id {
-            HirFileId::FileId(file_id) => SpanMap::RealSpanMap(db.real_span_map(file_id)),
-            HirFileId::MacroFile(m) => SpanMap::ExpansionSpanMap(db.expansion_span_map(m)),
+    pub fn span_map<'db>(self, db: &'db dyn ExpandDatabase) -> SpanMap<'db> {
+        match self {
+            HirFileId::FileId(file_id) => SpanMap::RealSpanMap(real_span_map(db, file_id)),
+            HirFileId::MacroFile(m) => SpanMap::ExpansionSpanMap(m.expansion_span_map(db)),
         }
     }
 }
 
+/// This is an implementation detail of [`HirFileId::span_map`]. Outside this crate, use
+/// `HirFileId::from(file_id).span_map(db)` instead of `real_span_map(db, file_id)`.
 #[salsa_macros::tracked(returns(ref))]
 pub(crate) fn real_span_map(
     db: &dyn ExpandDatabase,
@@ -109,9 +113,8 @@ pub(crate) fn real_span_map(
     )
 }
 
-pub(crate) fn expansion_span_map(
-    db: &dyn ExpandDatabase,
-    file_id: MacroCallId,
-) -> &ExpansionSpanMap {
-    &file_id.parse_macro_expansion(db).value.1
+impl MacroCallId {
+    pub fn expansion_span_map(self, db: &dyn ExpandDatabase) -> &ExpansionSpanMap {
+        &self.parse_macro_expansion(db).value.1
+    }
 }

--- a/crates/hir/src/semantics.rs
+++ b/crates/hir/src/semantics.rs
@@ -1002,7 +1002,8 @@ impl<'db> SemanticsImpl<'db> {
         else {
             return tok.into();
         };
-        let span = self.db.real_span_map(tok.file_id).span_for_range(tok.value.text_range());
+        let span =
+            HirFileId::from(tok.file_id).span_map(self.db).span_for_range(tok.value.text_range());
         let Some(InMacroFile { file_id, value: mut mapped_tokens }) = self.with_ctx(|ctx| {
             Some(
                 ctx.cache
@@ -1254,7 +1255,7 @@ impl<'db> SemanticsImpl<'db> {
         let _p = tracing::info_span!("descend_into_macros_impl").entered();
 
         let db = self.db;
-        let span = db.span_map(file_id).span_for_range(token.text_range());
+        let span = file_id.span_map(db).span_for_range(token.text_range());
 
         // Process the expansion of a call, pushing all tokens with our span in the expansion back onto our stack
         let process_expansion_for_token =

--- a/crates/hir/src/source_analyzer.rs
+++ b/crates/hir/src/source_analyzer.rs
@@ -2108,7 +2108,7 @@ pub(crate) fn name_hygiene(db: &dyn HirDatabase, name: InFile<&SyntaxNode>) -> H
     let Some(macro_file) = name.file_id.macro_file() else {
         return HygieneId::ROOT;
     };
-    let span_map = db.expansion_span_map(macro_file);
+    let span_map = macro_file.expansion_span_map(db);
     let ctx = span_map.span_at(name.value.text_range().start()).ctx;
     HygieneId::new(ctx.opaque_and_semiopaque(db))
 }

--- a/crates/ide-assists/src/handlers/inline_call.rs
+++ b/crates/ide-assists/src/handlers/inline_call.rs
@@ -1,11 +1,7 @@
 use std::collections::BTreeSet;
 
 use either::Either;
-use hir::{
-    FileRange, PathResolution, Semantics, TypeInfo,
-    db::{ExpandDatabase, HirDatabase},
-    sym,
-};
+use hir::{FileRange, PathResolution, Semantics, TypeInfo, db::HirDatabase, sym};
 use ide_db::{
     EditionedFileId, FxHashMap, RootDatabase,
     base_db::Crate,
@@ -352,7 +348,7 @@ fn inline(
     let file_id = sema.hir_file_for(fn_body.syntax());
     let body_to_clone = if let Some(macro_file) = file_id.macro_file() {
         cov_mark::hit!(inline_call_defined_in_macro);
-        let span_map = sema.db.expansion_span_map(macro_file);
+        let span_map = macro_file.expansion_span_map(sema.db);
         let body_prettified =
             prettify_macro_expansion(sema.db, fn_body.syntax().clone(), span_map, *krate);
         if let Some(body) = ast::BlockExpr::cast(body_prettified) { body } else { fn_body.clone() }
@@ -496,7 +492,7 @@ fn inline(
             let param_ty = param_ty.clone().map(|param_ty| {
                 let file_id = sema.hir_file_for(param_ty.syntax());
                 if let Some(macro_file) = file_id.macro_file() {
-                    let span_map = sema.db.expansion_span_map(macro_file);
+                    let span_map = macro_file.expansion_span_map(sema.db);
                     let param_ty_prettified = prettify_macro_expansion(
                         sema.db,
                         param_ty.syntax().clone(),

--- a/crates/ide-assists/src/handlers/inline_macro.rs
+++ b/crates/ide-assists/src/handlers/inline_macro.rs
@@ -1,4 +1,3 @@
-use hir::db::ExpandDatabase;
 use ide_db::syntax_helpers::prettify_macro_expansion;
 use syntax::ast::{self, AstNode, edit::IndentLevel};
 
@@ -58,7 +57,7 @@ pub(crate) fn inline_macro(acc: &mut Assists, ctx: &AssistContext<'_, '_>) -> Op
         text_range,
         |builder| {
             let expanded = ctx.sema.parse_or_expand(macro_call.into());
-            let span_map = ctx.sema.db.expansion_span_map(macro_call);
+            let span_map = macro_call.expansion_span_map(ctx.sema.db);
             // Don't call `prettify_macro_expansion()` outside the actual assist action; it does some heavy rowan tree manipulation,
             // which can be very costly for big macros when it is done *even without the assist being invoked*.
             let expanded = prettify_macro_expansion(ctx.db(), expanded, span_map, target_crate_id);

--- a/crates/ide-assists/src/handlers/replace_if_let_with_match.rs
+++ b/crates/ide-assists/src/handlers/replace_if_let_with_match.rs
@@ -1,4 +1,3 @@
-use hir::db::ExpandDatabase;
 use itertools::Itertools;
 use std::iter::successors;
 
@@ -512,7 +511,7 @@ fn pretty_pat_inside_macro(
         let pretty_node = hir::prettify_macro_expansion(
             db,
             pat,
-            db.expansion_span_map(file_id),
+            file_id.expansion_span_map(db),
             scope.module().krate(db).into(),
         );
         ast::Pat::cast(pretty_node)

--- a/crates/ide-assists/src/utils.rs
+++ b/crates/ide-assists/src/utils.rs
@@ -5,7 +5,7 @@ use std::slice;
 pub(crate) use gen_trait_fn_body::gen_trait_fn_body;
 use hir::{
     HasAttrs as HirHasAttrs, HirDisplay, InFile, ModuleDef, PathResolution, Semantics,
-    db::{ExpandDatabase, HirDatabase},
+    db::HirDatabase,
 };
 use ide_db::{
     RootDatabase,
@@ -241,7 +241,7 @@ pub fn add_trait_assoc_items_to_impl(
         .map(|InFile { file_id, value: original_item }| {
             let mut cloned_item = {
                 if let Some(macro_file) = file_id.macro_file() {
-                    let span_map = sema.db.expansion_span_map(macro_file);
+                    let span_map = macro_file.expansion_span_map(sema.db);
                     let item_prettified = prettify_macro_expansion(
                         sema.db,
                         original_item.syntax().clone(),

--- a/crates/ide-completion/src/completions/item_list/trait_impl.rs
+++ b/crates/ide-completion/src/completions/item_list/trait_impl.rs
@@ -31,7 +31,7 @@
 //! }
 //! ```
 
-use hir::{MacroCallId, Name, db::ExpandDatabase};
+use hir::{MacroCallId, Name};
 use ide_db::text_edit::TextEdit;
 use ide_db::{
     SymbolKind, documentation::HasDocs, path_transform::PathTransform,
@@ -494,7 +494,7 @@ fn make_const_compl_syntax(
     macro_file: Option<MacroCallId>,
 ) -> SmolStr {
     let const_ = if let Some(macro_file) = macro_file {
-        let span_map = ctx.db.expansion_span_map(macro_file);
+        let span_map = macro_file.expansion_span_map(ctx.db);
         prettify_macro_expansion(ctx.db, const_.syntax().clone(), span_map, ctx.krate.into())
     } else {
         const_.syntax().clone()
@@ -522,7 +522,7 @@ fn function_declaration(
     macro_file: Option<MacroCallId>,
 ) -> String {
     let node = if let Some(macro_file) = macro_file {
-        let span_map = ctx.db.expansion_span_map(macro_file);
+        let span_map = macro_file.expansion_span_map(ctx.db);
         prettify_macro_expansion(ctx.db, node.syntax().clone(), span_map, ctx.krate.into())
     } else {
         node.syntax().clone()

--- a/crates/ide-db/src/path_transform.rs
+++ b/crates/ide-db/src/path_transform.rs
@@ -151,7 +151,7 @@ impl<'a> PathTransform<'a> {
                 prettify_macro_expansion(
                     db,
                     node,
-                    db.expansion_span_map(file_id),
+                    file_id.expansion_span_map(db),
                     self.target_scope.module().krate(db).into(),
                 )
             }

--- a/crates/ide-diagnostics/src/lib.rs
+++ b/crates/ide-diagnostics/src/lib.rs
@@ -117,10 +117,7 @@ mod tests;
 
 use std::sync::LazyLock;
 
-use hir::{
-    Crate, DisplayTarget, InFile, MacroCallIdExt, Semantics, db::ExpandDatabase,
-    diagnostics::AnyDiagnostic,
-};
+use hir::{Crate, DisplayTarget, InFile, MacroCallIdExt, Semantics, diagnostics::AnyDiagnostic};
 use ide_db::{
     FileId, FileRange, FxHashMap, FxHashSet, RootDatabase, Severity, SnippetCap,
     assists::{Assist, AssistId, AssistResolveStrategy, ExprFillDefaultMode},
@@ -618,7 +615,7 @@ fn handle_diag_from_macros(
     node: &InFile<SyntaxNode>,
 ) -> bool {
     let Some(macro_file) = node.file_id.macro_file() else { return true };
-    let span_map = sema.db.expansion_span_map(macro_file);
+    let span_map = macro_file.expansion_span_map(sema.db);
     let mut spans = span_map.spans_for_range(node.text_range());
     if spans.any(|span| {
         span.ctx.outer_expn(sema.db).is_some_and(|expansion| {

--- a/crates/ide/src/expand_macro.rs
+++ b/crates/ide/src/expand_macro.rs
@@ -1,4 +1,3 @@
-use hir::db::ExpandDatabase;
 use hir::{ExpandResult, InFile, Semantics};
 use ide_db::{
     FileId, RootDatabase, base_db::Crate, helpers::pick_best_token,
@@ -67,7 +66,7 @@ pub(crate) fn expand_macro(db: &RootDatabase, position: FilePosition) -> Option<
             .count();
         let ExpandResult { err, value: expansion } = expansions.get(idx)?.clone()?;
         let expansion_file_id = sema.hir_file_for(&expansion).macro_file()?;
-        let expansion_span_map = db.expansion_span_map(expansion_file_id);
+        let expansion_span_map = expansion_file_id.expansion_span_map(db);
         let mut expansion = format(
             db,
             SyntaxKind::MACRO_ITEMS,
@@ -159,7 +158,7 @@ fn expand_macro_recur(
     }
     let file_id =
         sema.hir_file_for(&expanded).macro_file().expect("expansion must produce a macro file");
-    let expansion_span_map = sema.db.expansion_span_map(file_id);
+    let expansion_span_map = file_id.expansion_span_map(sema.db);
     result_span_map.merge(
         TextRange::at(offset_in_original_node, macro_call.syntax().text_range().len()),
         expanded.text_range().len(),

--- a/crates/ide/src/hover/render.rs
+++ b/crates/ide/src/hover/render.rs
@@ -6,7 +6,6 @@ use hir::{
     Adt, AsAssocItem, AsExternAssocItem, CaptureKind, DisplayTarget, DropGlue,
     DynCompatibilityViolation, HasCrate, HasSource, HirDisplay, Layout, LayoutError,
     MethodViolationCode, Name, Semantics, Symbol, Trait, Type, TypeInfo, Variant,
-    db::ExpandDatabase,
 };
 use ide_db::{
     RootDatabase,
@@ -543,7 +542,7 @@ pub(super) fn definition(
                     let source = it.source(db)?;
                     let mut body = source.value.body()?.syntax().clone();
                     if let Some(macro_file) = source.file_id.macro_file() {
-                        let span_map = db.expansion_span_map(macro_file);
+                        let span_map = macro_file.expansion_span_map(db);
                         body = prettify_macro_expansion(db, body, span_map, it.krate(db).into());
                     }
                     if env::var_os("RA_DEV").is_some() {
@@ -575,7 +574,7 @@ pub(super) fn definition(
                     let source = it.source(db)?;
                     let mut body = source.value.body()?.syntax().clone();
                     if let Some(macro_file) = source.file_id.macro_file() {
-                        let span_map = db.expansion_span_map(macro_file);
+                        let span_map = macro_file.expansion_span_map(db);
                         body = prettify_macro_expansion(db, body, span_map, it.krate(db).into());
                     }
                     if env::var_os("RA_DEV").is_some() {


### PR DESCRIPTION
Part of https://github.com/rust-lang/rust-analyzer/issues/22657

See [#t-compiler/rust-analyzer > Migrating &#96;ExpandDatabase&#96; @ 💬](https://rust-lang.zulipchat.com/#narrow/channel/185405-t-compiler.2Frust-analyzer/topic/Migrating.20.60ExpandDatabase.60/near/608175071) for the discussion.