### PR TITLE
fix: Fix proc macros `TokenStream::from_str()` for doc comments

### DIFF
--- a/crates/proc-macro-srv/src/tests/mod.rs
+++ b/crates/proc-macro-srv/src/tests/mod.rs
@@ -84,7 +84,7 @@ pub struct Foo {
               GROUP [] 1 1 1
                 IDENT 1 doc
                 PUNCT 1 = [alone]
-                LITER 1 Str / The domain where this federated instance is running
+                LITER 1 Str  The domain where this federated instance is running
               PUNCT 1 # [joint]
               GROUP [] 1 1 1
                 IDENT 1 helper
@@ -120,7 +120,7 @@ pub struct Foo {
               GROUP [] 1 1 1
                 IDENT 1 doc
                 PUNCT 1 = [alone]
-                LITER 1 Str / The domain where this federated instance is running
+                LITER 1 Str  The domain where this federated instance is running
               PUNCT 1 # [joint]
               GROUP [] 1 1 1
                 IDENT 1 helper
@@ -156,7 +156,7 @@ pub struct Foo {
               GROUP [] 42:Root[0000, 0]@0..0#0 42:Root[0000, 0]@0..0#0 42:Root[0000, 0]@0..0#0
                 IDENT 42:Root[0000, 0]@0..0#0 doc
                 PUNCT 42:Root[0000, 0]@0..0#0 = [alone]
-                LITER 42:Root[0000, 0]@75..130#0 Str / The domain where this federated instance is running
+                LITER 42:Root[0000, 0]@75..130#0 Str  The domain where this federated instance is running
               PUNCT 42:Root[0000, 0]@135..136#0 # [joint]
               GROUP [] 42:Root[0000, 0]@136..137#0 42:Root[0000, 0]@157..158#0 42:Root[0000, 0]@136..158#0
                 IDENT 42:Root[0000, 0]@137..143#0 helper
@@ -192,7 +192,7 @@ pub struct Foo {
               GROUP [] 42:Root[0000, 0]@0..0#0 42:Root[0000, 0]@0..0#0 42:Root[0000, 0]@0..0#0
                 IDENT 42:Root[0000, 0]@0..0#0 doc
                 PUNCT 42:Root[0000, 0]@0..0#0 = [alone]
-                LITER 42:Root[0000, 0]@75..130#0 Str / The domain where this federated instance is running
+                LITER 42:Root[0000, 0]@75..130#0 Str  The domain where this federated instance is running
               PUNCT 42:Root[0000, 0]@135..136#0 # [joint]
               GROUP [] 42:Root[0000, 0]@136..137#0 42:Root[0000, 0]@157..158#0 42:Root[0000, 0]@136..158#0
                 IDENT 42:Root[0000, 0]@137..143#0 helper

--- a/crates/proc-macro-srv/src/token_stream.rs
+++ b/crates/proc-macro-srv/src/token_stream.rs
@@ -190,7 +190,7 @@ impl<S> TokenStream<S> {
                     continue;
                 }
                 rustc_lexer::TokenKind::LineComment { doc_style: Some(doc_style) } => {
-                    let text = &s[range.start + 2..range.end];
+                    let text = &s[range.start + 3..range.end];
                     tokenstream.push(TokenTree::Punct(Punct { ch: b'#', joint: false, span }));
                     if doc_style == DocStyle::Inner {
                         tokenstream.push(TokenTree::Punct(Punct { ch: b'!', joint: false, span }));
@@ -216,7 +216,7 @@ impl<S> TokenStream<S> {
                 }
                 rustc_lexer::TokenKind::BlockComment { doc_style: Some(doc_style), terminated } => {
                     let text =
-                        &s[range.start + 2..if terminated { range.end - 2 } else { range.end }];
+                        &s[range.start + 3..if terminated { range.end - 2 } else { range.end }];
                     tokenstream.push(TokenTree::Punct(Punct { ch: b'#', joint: false, span }));
                     if doc_style == DocStyle::Inner {
                         tokenstream.push(TokenTree::Punct(Punct { ch: b'!', joint: false, span }));
@@ -757,5 +757,11 @@ mod tests {
             TokenStream::from_str("{} () [] <> ;/., \"gfhdgfuiofghd\" 0f32 r#\"dff\"# 'r#lt", ())
                 .unwrap();
         assert_eq!(token_stream.to_string(), "{}()[]<> ;/., \"gfhdgfuiofghd\"0f32 r#\"dff\"#'r#lt");
+    }
+
+    #[test]
+    fn doc_comment_from_str() {
+        let token_stream = TokenStream::from_str("/// foo", ()).unwrap();
+        assert_eq!(token_stream.to_string(), r#"# [doc = " foo"]"#);
     }
 }


### PR DESCRIPTION
We should strip `///` (or `//!` or `/**` or `/*!`), which is 3 characters, not 2.

Fixes https://github.com/rust-lang/rust-analyzer/issues/22731.