### PR TITLE
fix: avoid panic in merge imports on trailing path separator

### DIFF
--- a/crates/ide-assists/src/handlers/merge_imports.rs
+++ b/crates/ide-assists/src/handlers/merge_imports.rs
@@ -827,4 +827,15 @@ use top::{a::A, b::{B as D, B as C}};
 ",
         );
     }
+
+    #[test]
+    fn test_merge_with_trailing_path_separator() {
+        check_assist_not_applicable(
+            merge_imports,
+            r"
+use foo::bar;
+use foo::$0;
+",
+        );
+    }
 }

--- a/crates/ide-db/src/imports/merge_imports.rs
+++ b/crates/ide-db/src/imports/merge_imports.rs
@@ -827,7 +827,10 @@ fn split_prefix(
             make.use_tree(self_path, None, use_tree.rename(), false)
         }
     } else {
-        let suffix_segments = path.segments().skip(prefix.segments().count());
+        let suffix_segments: Vec<_> = path.segments().skip(prefix.segments().count()).collect();
+        if suffix_segments.is_empty() {
+            return None;
+        }
         let suffix_path = make.path_from_segments(suffix_segments, false);
         make.use_tree(
             suffix_path,


### PR DESCRIPTION
fix rust-lang/rust-analyzer#22724
from the log, i make the minimal panic reproducer:
```rust
use foo::bar;
use foo::;
```
this is because `merge_imports::split_prefix` thinks the remaining suffix still contain at least one segment.
it ignore some bad cases like `foo::;` .