### PR TITLE
feat: cross-parent module move in willRenameFiles

### DIFF
--- a/crates/ide-db/src/rename.rs
+++ b/crates/ide-db/src/rename.rs
@@ -28,21 +28,26 @@ use crate::{
 };
 use base_db::AnchoredPathBuf;
 use either::Either;
-use hir::{FieldSource, FileRange, HasCrate, InFile, ModuleSource, Name, Semantics, sym};
+use hir::{
+    FieldSource, FileRange, HasCrate, InFile, ModPath, ModuleSource, Name, PathKind, Semantics,
+    sym,
+};
 use itertools::Itertools;
 use rustc_hash::FxHashSet;
 use span::{Edition, FileId, SyntaxContext};
 use stdx::{TupleExt, never};
 use syntax::{
-    AstNode, SyntaxKind, T, TextRange,
-    ast::{self, HasName},
+    AstNode, SyntaxElement, SyntaxKind, SyntaxNode, T, TextRange, TextSize,
+    ast::{self, HasAttrs, HasName, HasVisibility},
+    syntax_editor::{Position, Removable, SyntaxEditor},
 };
 
 use crate::{
     RootDatabase,
     defs::Definition,
+    helpers::mod_path_to_ast_with_factory,
     search::{FileReference, FileReferenceNode},
-    source_change::{FileSystemEdit, SourceChange},
+    source_change::{FileSystemEdit, SourceChange, SourceChangeBuilder},
     syntax_helpers::node_ext::expr_as_name_ref,
     traits::convert_to_def_in_trait,
 };
@@ -343,6 +348,341 @@ fn rename_mod(
     source_change.extend(ref_edits);
 
     Ok(source_change)
+}
+
+/// Emits text edits only; the caller moves the file.
+///
+/// Unlike [`rename_mod`], which flips a single name token, a move changes the
+/// module's whole path, so references are spliced against freshly computed
+/// segments — HIR still describes the pre-move tree.
+pub fn move_mod(
+    sema: &Semantics<'_, RootDatabase>,
+    module: hir::Module,
+    new_parent: hir::Module,
+    new_leaf: &str,
+) -> Result<SourceChange> {
+    let db = sema.db;
+
+    if module.is_crate_root(db) {
+        bail!("Cannot move the crate root");
+    }
+
+    let InFile { file_id: def_file, .. } = module.definition_source(db);
+    let edition = def_file.edition(db);
+    let (new_leaf_name, kind) = IdentifierKind::classify(edition, new_leaf)?;
+    if kind != IdentifierKind::Ident {
+        bail!("Invalid name `{new_leaf}`: cannot name a module this way");
+    }
+
+    let old_segs: Vec<Name> = module.path_segments(db).collect();
+    let mut new_segs: Vec<Name> = new_parent.path_segments(db).collect();
+    new_segs.push(new_leaf_name.clone());
+
+    let decl = module
+        .declaration_source(db)
+        .ok_or_else(|| format_err!("module has no `mod …;` declaration"))?;
+    let decl_file = decl.file_id.original_file(db).file_id(db);
+    let new_parent_def = new_parent.definition_source(db);
+    let new_parent_file = new_parent_def.file_id.original_file(db).file_id(db);
+    if matches!(new_parent_def.value, ModuleSource::BlockExpr(_)) {
+        bail!("Cannot move a module into a block");
+    }
+
+    let mut builder = SourceChangeBuilder::new(decl_file);
+
+    let relocated = relocated_declaration(&decl.value, &new_leaf_name, db, edition);
+
+    let decl_editor = builder.make_editor(decl.value.syntax());
+    decl.value.remove(&decl_editor);
+    builder.add_file_edits(decl_file, decl_editor);
+
+    let parent_node = match &new_parent_def.value {
+        ModuleSource::SourceFile(sf) => sf.syntax().clone(),
+        ModuleSource::Module(m) => m
+            .item_list()
+            .ok_or_else(|| format_err!("new parent module has no item list"))?
+            .syntax()
+            .clone(),
+        ModuleSource::BlockExpr(_) => unreachable!("rejected above"),
+    };
+    let parent_editor = builder.make_editor(&parent_node);
+    parent_editor.insert_all(
+        Position::last_child_of(&parent_node),
+        vec![relocated.syntax().clone().into(), parent_editor.make().whitespace("\n").into()],
+    );
+    builder.add_file_edits(new_parent_file, parent_editor);
+
+    let def = Definition::Module(module);
+    let moved_crate = module.krate(db);
+    let usages = def.usages(sema).all();
+    for (file_id, references) in usages.iter() {
+        let edition = file_id.edition(db);
+        let prefix = crate_root_prefix_for(sema, file_id.file_id(db), moved_crate, db);
+        let source_file = sema.parse(file_id);
+        let editor = builder.make_editor(source_file.syntax());
+        rewrite_references_for_move(references, &new_segs, prefix.as_ref(), &editor, db, edition);
+        builder.add_file_edits(file_id.file_id(db), editor);
+    }
+
+    // Disjoint from the rewrites above, which target references *to* the moved
+    // module — something a `super::` written inside it can never be.
+    let def_src = module.definition_source(db);
+    let moved_file_id = def_src.file_id.original_file(db).file_id(db);
+    let moved_node = def_src.value.node();
+    let super_editor = builder.make_editor(&moved_node);
+    reanchor_super_in_moved_file(&moved_node, &old_segs, &super_editor, edition);
+    builder.add_file_edits(moved_file_id, super_editor);
+
+    Ok(builder.finish())
+}
+
+/// Cloning the node, rather than re-printing `mod <leaf>;`, keeps visibility,
+/// attributes and doc comments.
+fn relocated_declaration(
+    decl: &ast::Module,
+    new_leaf: &Name,
+    db: &RootDatabase,
+    edition: Edition,
+) -> ast::Module {
+    let (editor, decl) = SyntaxEditor::with_ast_node(decl);
+    if let Some(name) = decl.name() {
+        let renamed = editor.make().name(&new_leaf.display(db, edition).to_string());
+        editor.replace(name.syntax(), renamed.syntax());
+    }
+    ast::Module::cast(editor.finish().new_root().clone()).unwrap()
+}
+
+/// `None` for a same-crate reference, else the extern crate name `ref_file`'s
+/// crate depends on it under (which honours `package = "…"` renames).
+fn crate_root_prefix_for(
+    sema: &Semantics<'_, RootDatabase>,
+    ref_file: FileId,
+    moved_crate: hir::Crate,
+    db: &RootDatabase,
+) -> Option<Name> {
+    let ref_crate = sema.file_to_module_def(ref_file)?.krate(db);
+    if ref_crate == moved_crate {
+        return None;
+    }
+    ref_crate.dependencies(db).into_iter().find(|dep| dep.krate == moved_crate).map(|dep| dep.name)
+}
+
+/// As spelled from a referencing file: `crate::…` inside the same crate, else
+/// `<extern crate>::…`.
+fn abs_mod_path(new_segs: &[Name], extern_prefix: Option<&Name>) -> ModPath {
+    match extern_prefix {
+        None => ModPath::from_segments(PathKind::Crate, new_segs.iter().cloned()),
+        Some(krate) => ModPath::from_segments(
+            PathKind::Plain,
+            std::iter::once(krate.clone()).chain(new_segs.iter().cloned()),
+        ),
+    }
+}
+
+/// By path prefix rather than name token: a qualified reference has its leading
+/// path replaced wholesale, a bare one only its leaf, and only if it changed.
+fn rewrite_references_for_move(
+    references: &[FileReference],
+    new_segs: &[Name],
+    extern_prefix: Option<&Name>,
+    editor: &SyntaxEditor,
+    db: &RootDatabase,
+    edition: Edition,
+) {
+    let make = editor.make();
+    // A `ModPath`, not a node: a node cannot be inserted into the tree twice, so
+    // every splice site renders its own.
+    let new_abs = abs_mod_path(new_segs, extern_prefix);
+    // `new_segs` is a path to the moved module, so it always ends in that module's own
+    // name. Defaulting to "" here would silently splice in a malformed path instead.
+    let new_leaf = new_segs
+        .last()
+        .expect("path to the moved module cannot be empty")
+        .display(db, edition)
+        .to_string();
+
+    let mut edited_ranges: Vec<TextSize> = Vec::new();
+    // Bucketed by enclosing `use`: rewriting `use a::{m::X, m::Y}` member-by-member
+    // would split out the first and leave the second pointing at a vanished `a::m`.
+    let mut use_groups: Vec<(ast::Use, Vec<(ast::UseTree, ast::Path)>)> = Vec::new();
+    for FileReference { range, name, .. } in references {
+        if edited_ranges.contains(&range.start()) {
+            continue;
+        }
+        let Some(name_ref) = name.as_name_ref() else { continue };
+        // A macro-expanded reference has a differing node/range — can't splice safely.
+        if name_ref.syntax().text_range() != *range {
+            continue;
+        }
+        let Some(segment) = name_ref.syntax().parent().and_then(ast::PathSegment::cast) else {
+            continue;
+        };
+        // Keyword-anchored references are relative and only reachable from inside
+        // the moved subtree, which travels along — rewriting them would corrupt.
+        if matches!(
+            segment.kind(),
+            Some(
+                ast::PathSegmentKind::SuperKw
+                    | ast::PathSegmentKind::SelfKw
+                    | ast::PathSegmentKind::CrateKw
+                    | ast::PathSegmentKind::SelfTypeKw
+            )
+        ) {
+            continue;
+        }
+        let Some(path) = segment.syntax().parent().and_then(ast::Path::cast) else { continue };
+        // In `use a::{m, n}` the member's real prefix lives on an outer `UseTree`,
+        // so it can't be rewritten in place — defer to the whole-group pass below.
+        let in_use_group =
+            name_ref.syntax().ancestors().any(|it| ast::UseTreeList::can_cast(it.kind()));
+        if in_use_group {
+            if let Some(member) = name_ref.syntax().ancestors().find_map(ast::UseTree::cast)
+                && let Some(use_item) = member.syntax().ancestors().find_map(ast::Use::cast)
+            {
+                let ur = use_item.syntax().text_range();
+                match use_groups.iter_mut().find(|(u, _)| u.syntax().text_range() == ur) {
+                    Some((_, members)) => members.push((member, path)),
+                    None => use_groups.push((use_item, vec![(member, path)])),
+                }
+                edited_ranges.push(range.start());
+            }
+            continue;
+        }
+        if path.qualifier().is_some() {
+            let new_path = mod_path_to_ast_with_factory(make, &new_abs, edition);
+            editor.replace(path.syntax(), new_path.syntax());
+            edited_ranges.push(range.start());
+        } else if name_ref.text().as_str() != new_leaf {
+            editor.replace(name_ref.syntax(), make.name_ref(&new_leaf).syntax());
+            edited_ranges.push(range.start());
+        }
+    }
+    for (use_item, members) in &use_groups {
+        rewrite_use_group_for_move(use_item, members, &new_abs, editor, edition);
+    }
+}
+
+/// Each member importing through the moved module becomes its own
+/// `use <new_abs><tail>;`, with the tail copied verbatim.
+fn rewrite_use_group_for_move(
+    use_item: &ast::Use,
+    members: &[(ast::UseTree, ast::Path)],
+    new_abs: &ModPath,
+    editor: &SyntaxEditor,
+    edition: Edition,
+) {
+    let make = editor.make();
+
+    let mut extracted: Vec<(TextSize, ast::Use)> = members
+        .iter()
+        .map(|(member, path_to_module)| {
+            let mut path = mod_path_to_ast_with_factory(make, new_abs, edition);
+            for segment in segments_after(member.path().as_ref(), path_to_module) {
+                path = make.path_qualified(path, segment);
+            }
+            let tree = make.use_tree(
+                path,
+                member.use_tree_list(),
+                member.rename(),
+                member.star_token().is_some(),
+            );
+            let new_use = make.use_(use_item.attrs(), use_item.visibility(), tree);
+            (member.syntax().text_range().start(), new_use)
+        })
+        .collect();
+    extracted.sort_by_key(|(pos, _)| *pos);
+
+    let mut elements: Vec<SyntaxElement> = Vec::new();
+    for (i, (_, new_use)) in extracted.iter().enumerate() {
+        if i > 0 {
+            elements.push(make.whitespace("\n").into());
+        }
+        elements.push(new_use.syntax().clone().into());
+    }
+
+    // An all-moved list would be left as an empty `{}`, so swap the whole `use` out.
+    let emptied = use_item.use_tree().and_then(|it| it.use_tree_list()).is_some_and(|top| {
+        let moved_from_top = members
+            .iter()
+            .filter(|(member, _)| {
+                member.syntax().parent().and_then(ast::UseTreeList::cast).as_ref() == Some(&top)
+            })
+            .count();
+        moved_from_top == top.use_trees().count()
+    });
+    if emptied {
+        editor.replace_with_many(use_item.syntax(), elements);
+        return;
+    }
+
+    for (member, _) in members {
+        member.remove(editor);
+    }
+    editor.insert_all_with_whitespace(Position::before(use_item.syntax()), elements);
+}
+
+/// Segments of `path` that follow `prefix`, in source order.
+fn segments_after(path: Option<&ast::Path>, prefix: &ast::Path) -> Vec<ast::PathSegment> {
+    let mut segments = Vec::new();
+    let mut current = path.cloned();
+    while let Some(path) = current {
+        if path.syntax().text_range() == prefix.syntax().text_range() {
+            break;
+        }
+        if let Some(segment) = path.segment() {
+            segments.push(segment);
+        }
+        current = path.qualifier();
+    }
+    segments.reverse();
+    segments
+}
+
+/// A run of `k` supers denotes `old_segs` minus its last `k` segments. Only the
+/// leading run is rewritten, so the splice stops before the `{` of a grouped
+/// `use super::{a, b}` and cannot corrupt it.
+fn reanchor_super_in_moved_file(
+    moved_node: &SyntaxNode,
+    old_segs: &[Name],
+    editor: &SyntaxEditor,
+    edition: Edition,
+) {
+    for path in moved_node.descendants().filter_map(ast::Path::cast) {
+        if path.segment().and_then(|s| s.kind()) != Some(ast::PathSegmentKind::SuperKw) {
+            continue;
+        }
+        // Handle each run once, at its top: a `super` parent means a longer run.
+        if let Some(parent) = path.syntax().parent().and_then(ast::Path::cast)
+            && parent.segment().and_then(|s| s.kind()) == Some(ast::PathSegmentKind::SuperKw)
+        {
+            continue;
+        }
+        // Inside an inline module `super` is relative to it, not to the file.
+        if path.syntax().ancestors().any(|n| ast::Module::can_cast(n.kind())) {
+            continue;
+        }
+        // `pub(super)` has no `in`, so it cannot take a `crate::…` path.
+        if path.syntax().ancestors().any(|n| ast::Visibility::can_cast(n.kind())) {
+            continue;
+        }
+        let mut k = 0usize;
+        let mut cur = Some(path.clone());
+        while let Some(p) = cur {
+            if p.segment().and_then(|s| s.kind()) == Some(ast::PathSegmentKind::SuperKw) {
+                k += 1;
+                cur = p.qualifier();
+            } else {
+                cur = None;
+            }
+        }
+        if k == 0 || k > old_segs.len() {
+            continue;
+        }
+        let modprefix = &old_segs[..old_segs.len() - k];
+        let replacement =
+            mod_path_to_ast_with_factory(editor.make(), &abs_mod_path(modprefix, None), edition);
+        editor.replace(path.syntax(), replacement.syntax());
+    }
 }
 
 fn rename_reference<'db>(

--- a/crates/ide-db/src/rename.rs
+++ b/crates/ide-db/src/rename.rs
@@ -28,21 +28,26 @@ use crate::{
 };
 use base_db::AnchoredPathBuf;
 use either::Either;
-use hir::{FieldSource, FileRange, HasCrate, InFile, ModuleSource, Name, Semantics, sym};
+use hir::{
+    FieldSource, FileRange, HasCrate, InFile, ModPath, ModuleSource, Name, PathKind, Semantics,
+    sym,
+};
 use itertools::Itertools;
 use rustc_hash::FxHashSet;
 use span::{Edition, FileId, SyntaxContext};
 use stdx::{TupleExt, never};
 use syntax::{
-    AstNode, SyntaxKind, T, TextRange,
-    ast::{self, HasName},
+    AstNode, SyntaxElement, SyntaxKind, SyntaxNode, T, TextRange, TextSize,
+    ast::{self, HasAttrs, HasName, HasVisibility},
+    syntax_editor::{Position, Removable, SyntaxEditor},
 };
 
 use crate::{
     RootDatabase,
     defs::Definition,
+    helpers::mod_path_to_ast_with_factory,
     search::{FileReference, FileReferenceNode},
-    source_change::{FileSystemEdit, SourceChange},
+    source_change::{FileSystemEdit, SourceChange, SourceChangeBuilder},
     syntax_helpers::node_ext::expr_as_name_ref,
     traits::convert_to_def_in_trait,
 };
@@ -343,6 +348,340 @@ fn rename_mod(
     source_change.extend(ref_edits);
 
     Ok(source_change)
+}
+
+/// Moves a file-based module under a new parent. Emits text edits only; the
+/// caller moves the file.
+///
+/// Unlike [`rename_mod`], a move changes the module's whole path, so references
+/// are spliced against freshly computed segments — HIR still describes the
+/// pre-move tree.
+pub fn move_mod(
+    sema: &Semantics<'_, RootDatabase>,
+    module: hir::Module,
+    new_parent: hir::Module,
+    new_leaf: &str,
+) -> Result<SourceChange> {
+    let db = sema.db;
+
+    if module.is_crate_root(db) {
+        bail!("Cannot move the crate root");
+    }
+
+    let InFile { file_id: def_file, .. } = module.definition_source(db);
+    let edition = def_file.edition(db);
+    let (new_leaf_name, kind) = IdentifierKind::classify(edition, new_leaf)?;
+    if kind != IdentifierKind::Ident {
+        bail!("Invalid name `{new_leaf}`: cannot name a module this way");
+    }
+
+    let old_segs: Vec<Name> = module.path_segments(db).collect();
+    let mut new_segs: Vec<Name> = new_parent.path_segments(db).collect();
+    new_segs.push(new_leaf_name.clone());
+
+    let decl = module
+        .declaration_source(db)
+        .ok_or_else(|| format_err!("module has no `mod …;` declaration"))?;
+    let decl_file = decl.file_id.original_file(db).file_id(db);
+    let new_parent_def = new_parent.definition_source(db);
+    let new_parent_file = new_parent_def.file_id.original_file(db).file_id(db);
+    if matches!(new_parent_def.value, ModuleSource::BlockExpr(_)) {
+        bail!("Cannot move a module into a block");
+    }
+
+    let mut builder = SourceChangeBuilder::new(decl_file);
+
+    let relocated = relocated_declaration(&decl.value, &new_leaf_name, db, edition);
+
+    let decl_editor = builder.make_editor(decl.value.syntax());
+    decl.value.remove(&decl_editor);
+    builder.add_file_edits(decl_file, decl_editor);
+
+    let parent_node = match &new_parent_def.value {
+        ModuleSource::SourceFile(sf) => sf.syntax().clone(),
+        ModuleSource::Module(m) => m
+            .item_list()
+            .ok_or_else(|| format_err!("new parent module has no item list"))?
+            .syntax()
+            .clone(),
+        ModuleSource::BlockExpr(_) => unreachable!("rejected above"),
+    };
+    let parent_editor = builder.make_editor(&parent_node);
+    parent_editor.insert_all(
+        Position::last_child_of(&parent_node),
+        vec![relocated.syntax().clone().into(), parent_editor.make().whitespace("\n").into()],
+    );
+    builder.add_file_edits(new_parent_file, parent_editor);
+
+    let def = Definition::Module(module);
+    let moved_crate = module.krate(db);
+    let usages = def.usages(sema).all();
+    for (file_id, references) in usages.iter() {
+        let edition = file_id.edition(db);
+        let prefix = crate_root_prefix_for(sema, file_id.file_id(db), moved_crate, db);
+        let source_file = sema.parse(file_id);
+        let editor = builder.make_editor(source_file.syntax());
+        rewrite_references_for_move(references, &new_segs, prefix.as_ref(), &editor, db, edition);
+        builder.add_file_edits(file_id.file_id(db), editor);
+    }
+
+    // Disjoint from the rewrites above, which target references *to* the moved
+    // module — something a `super::` written inside it can never be.
+    let def_src = module.definition_source(db);
+    let moved_file_id = def_src.file_id.original_file(db).file_id(db);
+    let moved_node = def_src.value.node();
+    let super_editor = builder.make_editor(&moved_node);
+    reanchor_super_in_moved_file(&moved_node, &old_segs, &super_editor, edition);
+    builder.add_file_edits(moved_file_id, super_editor);
+
+    Ok(builder.finish())
+}
+
+/// Cloning the node, rather than re-printing `mod <leaf>;`, keeps visibility,
+/// attributes and doc comments.
+fn relocated_declaration(
+    decl: &ast::Module,
+    new_leaf: &Name,
+    db: &RootDatabase,
+    edition: Edition,
+) -> ast::Module {
+    let (editor, decl) = SyntaxEditor::with_ast_node(decl);
+    if let Some(name) = decl.name() {
+        let renamed = editor.make().name(&new_leaf.display(db, edition).to_string());
+        editor.replace(name.syntax(), renamed.syntax());
+    }
+    ast::Module::cast(editor.finish().new_root().clone()).unwrap()
+}
+
+/// `None` for a same-crate reference, else the name `ref_file`'s crate depends
+/// on it under (which honours `package = "…"` renames).
+fn crate_root_prefix_for(
+    sema: &Semantics<'_, RootDatabase>,
+    ref_file: FileId,
+    moved_crate: hir::Crate,
+    db: &RootDatabase,
+) -> Option<Name> {
+    let ref_crate = sema.file_to_module_def(ref_file)?.krate(db);
+    if ref_crate == moved_crate {
+        return None;
+    }
+    ref_crate.dependencies(db).into_iter().find(|dep| dep.krate == moved_crate).map(|dep| dep.name)
+}
+
+/// `crate::…` inside the same crate, else `<extern crate>::…`.
+fn abs_mod_path(new_segs: &[Name], extern_prefix: Option<&Name>) -> ModPath {
+    match extern_prefix {
+        None => ModPath::from_segments(PathKind::Crate, new_segs.iter().cloned()),
+        Some(krate) => ModPath::from_segments(
+            PathKind::Plain,
+            std::iter::once(krate.clone()).chain(new_segs.iter().cloned()),
+        ),
+    }
+}
+
+/// By path prefix rather than name token: a qualified reference has its leading
+/// path replaced wholesale, a bare one only its leaf, and only if it changed.
+fn rewrite_references_for_move(
+    references: &[FileReference],
+    new_segs: &[Name],
+    extern_prefix: Option<&Name>,
+    editor: &SyntaxEditor,
+    db: &RootDatabase,
+    edition: Edition,
+) {
+    let make = editor.make();
+    // A `ModPath`, not a node: a node cannot be inserted into the tree twice, so
+    // every splice site renders its own.
+    let new_abs = abs_mod_path(new_segs, extern_prefix);
+    // `new_segs` is a path to the moved module, so it always ends in that module's own
+    // name. Defaulting to "" here would silently splice in a malformed path instead.
+    let new_leaf = new_segs
+        .last()
+        .expect("path to the moved module cannot be empty")
+        .display(db, edition)
+        .to_string();
+
+    let mut edited_ranges: Vec<TextSize> = Vec::new();
+    // Bucketed by enclosing `use`: rewriting `use a::{m::X, m::Y}` member-by-member
+    // would split out the first and leave the second pointing at a vanished `a::m`.
+    let mut use_groups: Vec<(ast::Use, Vec<(ast::UseTree, ast::Path)>)> = Vec::new();
+    for FileReference { range, name, .. } in references {
+        if edited_ranges.contains(&range.start()) {
+            continue;
+        }
+        let Some(name_ref) = name.as_name_ref() else { continue };
+        // A macro-expanded reference has a differing node/range — can't splice safely.
+        if name_ref.syntax().text_range() != *range {
+            continue;
+        }
+        let Some(segment) = name_ref.syntax().parent().and_then(ast::PathSegment::cast) else {
+            continue;
+        };
+        // Keyword-anchored references are relative and only reachable from inside
+        // the moved subtree, which travels along — rewriting them would corrupt.
+        if matches!(
+            segment.kind(),
+            Some(
+                ast::PathSegmentKind::SuperKw
+                    | ast::PathSegmentKind::SelfKw
+                    | ast::PathSegmentKind::CrateKw
+                    | ast::PathSegmentKind::SelfTypeKw
+            )
+        ) {
+            continue;
+        }
+        let Some(path) = segment.syntax().parent().and_then(ast::Path::cast) else { continue };
+        // In `use a::{m, n}` the member's real prefix lives on an outer `UseTree`,
+        // so it can't be rewritten in place — defer to the whole-group pass below.
+        let in_use_group =
+            name_ref.syntax().ancestors().any(|it| ast::UseTreeList::can_cast(it.kind()));
+        if in_use_group {
+            if let Some(member) = name_ref.syntax().ancestors().find_map(ast::UseTree::cast)
+                && let Some(use_item) = member.syntax().ancestors().find_map(ast::Use::cast)
+            {
+                let ur = use_item.syntax().text_range();
+                match use_groups.iter_mut().find(|(u, _)| u.syntax().text_range() == ur) {
+                    Some((_, members)) => members.push((member, path)),
+                    None => use_groups.push((use_item, vec![(member, path)])),
+                }
+                edited_ranges.push(range.start());
+            }
+            continue;
+        }
+        if path.qualifier().is_some() {
+            let new_path = mod_path_to_ast_with_factory(make, &new_abs, edition);
+            editor.replace(path.syntax(), new_path.syntax());
+            edited_ranges.push(range.start());
+        } else if name_ref.text() != new_leaf {
+            editor.replace(name_ref.syntax(), make.name_ref(&new_leaf).syntax());
+            edited_ranges.push(range.start());
+        }
+    }
+    for (use_item, members) in &use_groups {
+        rewrite_use_group_for_move(use_item, members, &new_abs, editor, edition);
+    }
+}
+
+/// Each member importing through the moved module becomes its own `use`.
+fn rewrite_use_group_for_move(
+    use_item: &ast::Use,
+    members: &[(ast::UseTree, ast::Path)],
+    new_abs: &ModPath,
+    editor: &SyntaxEditor,
+    edition: Edition,
+) {
+    let make = editor.make();
+
+    let mut extracted: Vec<(TextSize, ast::Use)> = members
+        .iter()
+        .map(|(member, path_to_module)| {
+            let mut path = mod_path_to_ast_with_factory(make, new_abs, edition);
+            for segment in segments_after(member.path().as_ref(), path_to_module) {
+                path = make.path_qualified(path, segment);
+            }
+            let tree = make.use_tree(
+                path,
+                member.use_tree_list(),
+                member.rename(),
+                member.star_token().is_some(),
+            );
+            let new_use = make.use_(use_item.attrs(), use_item.visibility(), tree);
+            (member.syntax().text_range().start(), new_use)
+        })
+        .collect();
+    extracted.sort_by_key(|(pos, _)| *pos);
+
+    let mut elements: Vec<SyntaxElement> = Vec::new();
+    for (i, (_, new_use)) in extracted.iter().enumerate() {
+        if i > 0 {
+            elements.push(make.whitespace("\n").into());
+        }
+        elements.push(new_use.syntax().clone().into());
+    }
+
+    // An all-moved list would be left as an empty `{}`, so swap the whole `use` out.
+    let emptied = use_item.use_tree().and_then(|it| it.use_tree_list()).is_some_and(|top| {
+        let moved_from_top = members
+            .iter()
+            .filter(|(member, _)| {
+                member.syntax().parent().and_then(ast::UseTreeList::cast).as_ref() == Some(&top)
+            })
+            .count();
+        moved_from_top == top.use_trees().count()
+    });
+    if emptied {
+        editor.replace_with_many(use_item.syntax(), elements);
+        return;
+    }
+
+    for (member, _) in members {
+        member.remove(editor);
+    }
+    editor.insert_all_with_whitespace(Position::before(use_item.syntax()), elements);
+}
+
+/// Segments of `path` that follow `prefix`, in source order.
+fn segments_after(path: Option<&ast::Path>, prefix: &ast::Path) -> Vec<ast::PathSegment> {
+    let mut segments = Vec::new();
+    let mut current = path.cloned();
+    while let Some(path) = current {
+        if path.syntax().text_range() == prefix.syntax().text_range() {
+            break;
+        }
+        if let Some(segment) = path.segment() {
+            segments.push(segment);
+        }
+        current = path.qualifier();
+    }
+    segments.reverse();
+    segments
+}
+
+/// A run of `k` supers denotes `old_segs` minus its last `k` segments. Only the
+/// leading run is rewritten, so the splice stops before the `{` of a grouped
+/// `use super::{a, b}`.
+fn reanchor_super_in_moved_file(
+    moved_node: &SyntaxNode,
+    old_segs: &[Name],
+    editor: &SyntaxEditor,
+    edition: Edition,
+) {
+    for path in moved_node.descendants().filter_map(ast::Path::cast) {
+        if path.segment().and_then(|s| s.kind()) != Some(ast::PathSegmentKind::SuperKw) {
+            continue;
+        }
+        // Handle each run once, at its top: a `super` parent means a longer run.
+        if let Some(parent) = path.syntax().parent().and_then(ast::Path::cast)
+            && parent.segment().and_then(|s| s.kind()) == Some(ast::PathSegmentKind::SuperKw)
+        {
+            continue;
+        }
+        // Inside an inline module `super` is relative to it, not to the file.
+        if path.syntax().ancestors().any(|n| ast::Module::can_cast(n.kind())) {
+            continue;
+        }
+        // `pub(super)` has no `in`, so it cannot take a `crate::…` path.
+        if path.syntax().ancestors().any(|n| ast::Visibility::can_cast(n.kind())) {
+            continue;
+        }
+        let mut k = 0usize;
+        let mut cur = Some(path.clone());
+        while let Some(p) = cur {
+            if p.segment().and_then(|s| s.kind()) == Some(ast::PathSegmentKind::SuperKw) {
+                k += 1;
+                cur = p.qualifier();
+            } else {
+                cur = None;
+            }
+        }
+        if k == 0 || k > old_segs.len() {
+            continue;
+        }
+        let modprefix = &old_segs[..old_segs.len() - k];
+        let replacement =
+            mod_path_to_ast_with_factory(editor.make(), &abs_mod_path(modprefix, None), edition);
+        editor.replace(path.syntax(), replacement.syntax());
+    }
 }
 
 fn rename_reference<'db>(

--- a/crates/ide-db/src/rename.rs
+++ b/crates/ide-db/src/rename.rs
@@ -29,8 +29,8 @@ use crate::{
 use base_db::AnchoredPathBuf;
 use either::Either;
 use hir::{
-    FieldSource, FileRange, HasCrate, InFile, ModPath, ModuleSource, Name, PathKind, Semantics,
-    sym,
+    EditionedFileId, FieldSource, FileRange, FindPathConfig, HasCrate, HasSource, HirFileId,
+    InFile, ModPath, ModuleSource, Name, PathKind, Semantics, sym,
 };
 use itertools::Itertools;
 use rustc_hash::FxHashSet;
@@ -38,6 +38,7 @@ use span::{Edition, FileId, SyntaxContext};
 use stdx::{TupleExt, never};
 use syntax::{
     AstNode, SyntaxElement, SyntaxKind, SyntaxNode, T, TextRange, TextSize,
+    algo::find_node_at_range,
     ast::{self, HasAttrs, HasName, HasVisibility},
     syntax_editor::{Position, Removable, SyntaxEditor},
 };
@@ -46,6 +47,8 @@ use crate::{
     RootDatabase,
     defs::Definition,
     helpers::mod_path_to_ast_with_factory,
+    imports::insert_use::{ImportScope, InsertUseConfig, insert_use_with_editor},
+    path_transform::PathTransform,
     search::{FileReference, FileReferenceNode},
     source_change::{FileSystemEdit, SourceChange, SourceChangeBuilder},
     syntax_helpers::node_ext::expr_as_name_ref,
@@ -437,8 +440,454 @@ pub fn move_mod(
     Ok(builder.finish())
 }
 
-/// Cloning the node, rather than re-printing `mod <leaf>;`, keeps visibility,
-/// attributes and doc comments.
+/// Must stay in sync with [`crate::path_transform`]: [`stale_self_path`]
+/// recognises the stale path by re-deriving what that pass produced, so a
+/// different config here would silently match nothing.
+const MOVE_FIND_PATH: FindPathConfig = FindPathConfig {
+    prefer_no_std: false,
+    prefer_prelude: true,
+    prefer_absolute: false,
+    allow_unstable: true,
+};
+
+/// Move a single item into another module. Emits text edits only.
+///
+/// Where [`move_mod`] relocates a whole file-module, which travels with its own
+/// `use` list, an item is torn away from its neighbours: paths *inside* it are
+/// re-resolved from the destination, qualified references *to* it are spliced
+/// against its new path, and files holding a bare reference — which resolved
+/// only by proximity — get an import. A private item still referred to from
+/// outside the destination is widened to `pub(crate)`.
+pub fn move_item(
+    sema: &Semantics<'_, RootDatabase>,
+    def: hir::ModuleDef,
+    dst: hir::Module,
+    insert_use_cfg: &InsertUseConfig,
+) -> Result<SourceChange> {
+    let db = sema.db;
+
+    let name = def.name(db).ok_or_else(|| format_err!("item has no name"))?;
+    let src_module = def.module(db).ok_or_else(|| format_err!("item has no parent module"))?;
+    if src_module == dst {
+        bail!("Item already lives in the destination module");
+    }
+
+    let (src_file, item) = item_syntax(sema, def)?;
+    let src_file_id = src_file.file_id(db);
+
+    // `pub(super)` and `pub(in …)` name a module relative to where the item sits.
+    // Carried verbatim they would keep parsing and quietly mean someone else.
+    if let Some(vis) =
+        ast::AnyHasVisibility::cast(item.syntax().clone()).and_then(|it| it.visibility())
+        && matches!(vis.kind(), ast::VisibilityKind::PubSuper | ast::VisibilityKind::In(_))
+    {
+        bail!("Cannot move an item with `pub(super)`/`pub(in …)` visibility");
+    }
+
+    let (dst_file_id, dst_node) = destination_item_list(sema, dst)?;
+    if dst_file_id == src_file_id
+        && dst_node.text_range().contains_range(item.syntax().text_range())
+    {
+        bail!("Cannot move an item into a module that contains it");
+    }
+
+    let mut new_segs: Vec<Name> = dst.path_segments(db).collect();
+    new_segs.push(name);
+
+    let mov = ItemMove { def, item: &item, src_file, dst, new_segs, krate: src_module.krate(db) };
+    let mut builder = SourceChangeBuilder::new(src_file_id);
+
+    let widen = mov.rewrite_outside_references(sema, insert_use_cfg, &mut builder);
+    let respelled = mov.respell_unreachable_paths(sema, &mut builder)?;
+    let relocated = mov.relocated(sema, &dst_node, &respelled, widen)?;
+
+    let src_editor = builder.make_editor(item.syntax());
+    remove_item_taking_line(item.syntax(), &src_editor);
+    builder.add_file_edits(src_file_id, src_editor);
+
+    let dst_editor = builder.make_editor(&dst_node);
+    // A file that has items gets a blank line between them; an empty one would
+    // otherwise open with a blank line of its own.
+    let mut elements: Vec<SyntaxElement> = Vec::new();
+    if dst_node.children().next().is_some() {
+        elements.push(dst_editor.make().whitespace("\n\n").into());
+    }
+    elements.push(relocated.into());
+    elements.push(dst_editor.make().whitespace("\n").into());
+    dst_editor.insert_all(Position::last_child_of(&dst_node), elements);
+    builder.add_file_edits(dst_file_id, dst_editor);
+
+    Ok(builder.finish())
+}
+
+/// One [`move_item`] in progress: what is being torn out, and where it lands.
+struct ItemMove<'a> {
+    def: hir::ModuleDef,
+    item: &'a ast::Item,
+    src_file: EditionedFileId,
+    dst: hir::Module,
+    /// Path to the item once moved, ending in its own name.
+    new_segs: Vec<Name>,
+    krate: hir::Crate,
+}
+
+impl ItemMove<'_> {
+    /// Rewrites every reference that stays behind, importing the item into the
+    /// files that reached it by proximity. Returns whether any reference sits
+    /// outside the destination subtree, i.e. whether the item has to be widened.
+    fn rewrite_outside_references(
+        &self,
+        sema: &Semantics<'_, RootDatabase>,
+        insert_use_cfg: &InsertUseConfig,
+        builder: &mut SourceChangeBuilder,
+    ) -> bool {
+        let db = sema.db;
+        let src_file_id = self.src_file.file_id(db);
+        let item_range = self.item.syntax().text_range();
+
+        // Files whose bare references stop resolving once the item is no longer a
+        // neighbour, paired with the path they have to import it by.
+        let mut needs_import: Vec<(EditionedFileId, ModPath)> = Vec::new();
+        let mut referred_from_outside_dst = false;
+
+        for (ref_file, references) in Definition::from(self.def).usages(sema).all().iter() {
+            let ref_file_id = ref_file.file_id(db);
+            // References inside the item travel with it, and rewriting them here
+            // would edit a range this pass is about to delete.
+            let references: Vec<FileReference> = references
+                .iter()
+                .filter(|it| !(ref_file_id == src_file_id && item_range.contains_range(it.range)))
+                .cloned()
+                .collect();
+            if references.is_empty() {
+                continue;
+            }
+
+            let prefix = crate_root_prefix_for(sema, ref_file_id, self.krate, db);
+            let inside_dst = sema.file_to_module_def(ref_file_id).is_some_and(|it| {
+                it == self.dst || it.path_to_root(db).into_iter().any(|m| m == self.dst)
+            });
+            if !inside_dst {
+                referred_from_outside_dst = true;
+                // A bare reference alongside a `use` of the item keeps working: that
+                // `use` is a reference too, and is rewritten below. One *without* is
+                // either a neighbour's call or a glob import, and needs a `use` of
+                // its own — spelled against the destination, which is where the item
+                // will be but HIR does not yet say it is.
+                let imported_here = references.iter().any(is_use_reference);
+                if !imported_here && references.iter().any(is_bare_reference) {
+                    needs_import.push((ref_file, abs_mod_path(&self.new_segs, prefix.as_ref())));
+                }
+            }
+
+            let source_file = sema.parse(ref_file);
+            let editor = builder.make_editor(source_file.syntax());
+            rewrite_references_for_move(
+                &references,
+                &self.new_segs,
+                prefix.as_ref(),
+                &editor,
+                db,
+                ref_file.edition(db),
+            );
+            builder.add_file_edits(ref_file_id, editor);
+        }
+
+        for (ref_file, path) in needs_import {
+            let source_file = sema.parse(ref_file);
+            let Some(scope) = ImportScope::find_insert_use_container(source_file.syntax(), sema)
+            else {
+                continue;
+            };
+            let editor = builder.make_editor(source_file.syntax());
+            let path = mod_path_to_ast_with_factory(editor.make(), &path, ref_file.edition(db));
+            insert_use_with_editor(&scope, path, insert_use_cfg, &editor);
+            builder.add_file_edits(ref_file.file_id(db), editor);
+        }
+
+        referred_from_outside_dst
+    }
+
+    /// Widens the private neighbours the body calls, and returns how each of
+    /// their paths has to be respelled.
+    ///
+    /// [`PathTransform`] asks the database, which still describes the old code,
+    /// so it would leave a path that only resolved from inside the source module
+    /// exactly as written — and it would stop resolving.
+    fn respell_unreachable_paths(
+        &self,
+        sema: &Semantics<'_, RootDatabase>,
+        builder: &mut SourceChangeBuilder,
+    ) -> Result<Vec<(Vec<String>, ModPath)>> {
+        let db = sema.db;
+        let item_range = self.item.syntax().text_range();
+        let mut respelled: Vec<(Vec<String>, ModPath)> = Vec::new();
+
+        for path in self.item.syntax().descendants().filter_map(ast::Path::cast) {
+            // Qualifiers are rewritten as part of the whole path they belong to.
+            if path.syntax().parent().and_then(ast::Path::cast).is_some() {
+                continue;
+            }
+            let Some(hir::PathResolution::Def(target)) = sema.resolve_path(&path) else { continue };
+            if self.dst.find_path(db, target, MOVE_FIND_PATH).is_some() {
+                continue;
+            }
+            let Ok((target_file, target_item)) = item_syntax(sema, target) else { continue };
+            // An item nested inside the one being moved travels with it, so its
+            // bare name keeps meaning what it meant.
+            if target_file == self.src_file
+                && item_range.contains_range(target_item.syntax().text_range())
+            {
+                continue;
+            }
+            let Some(target_module) = target.module(db) else { continue };
+            if target_module.krate(db) != self.krate {
+                bail!(
+                    "`{}` is not reachable from the destination and lives in another crate",
+                    path.syntax().text()
+                );
+            }
+            let Some(target_name) = target.name(db) else { continue };
+            let Some(segments) = path_segment_texts(&path) else { continue };
+
+            let mut target_segs: Vec<Name> = target_module.path_segments(db).collect();
+            target_segs.push(target_name);
+            respelled.push((segments, abs_mod_path(&target_segs, None)));
+
+            let vis_editor = builder.make_editor(target_item.syntax());
+            widen_to_pub_crate(target_item.syntax(), &vis_editor);
+            builder.add_file_edits(target_file.file_id(db), vis_editor);
+        }
+        Ok(respelled)
+    }
+
+    /// The item as it must read at the destination: paths re-resolved from there,
+    /// its own name un-stale-d, visibility widened if it lost its neighbours.
+    fn relocated(
+        &self,
+        sema: &Semantics<'_, RootDatabase>,
+        dst_node: &SyntaxNode,
+        respelled: &[(Vec<String>, ModPath)],
+        widen: bool,
+    ) -> Result<SyntaxNode> {
+        let db = sema.db;
+        let edition = self.src_file.edition(db);
+        let source_scope =
+            sema.scope(self.item.syntax()).ok_or_else(|| format_err!("item has no scope"))?;
+        let target_scope =
+            sema.scope(dst_node).ok_or_else(|| format_err!("destination has no scope"))?;
+        let transformed = PathTransform::generic_transformation(&target_scope, &source_scope)
+            .apply(self.item.syntax());
+
+        // `new` may hand back a detached copy, so every node below has to come
+        // from the root it returns — the original would belong to another tree.
+        let (editor, root) = SyntaxEditor::new(transformed);
+        // A reference to the item from within itself — recursion, or a helper
+        // calling itself — was resolved against the pre-move tree, so the pass
+        // above spelled out a path to where the item used to be.
+        let stale = stale_self_path(db, self.def, self.dst, edition);
+        let leaf = self
+            .new_segs
+            .last()
+            .expect("path to the moved item ends in its name")
+            .display(db, edition)
+            .to_string();
+        for path in root.descendants().filter_map(ast::Path::cast) {
+            let Some(segments) = path_segment_texts(&path) else { continue };
+            if stale.as_deref() == Some(segments.as_slice()) {
+                let make = editor.make();
+                let bare = make.path_unqualified(make.path_segment(make.name_ref(&leaf)));
+                editor.replace(path.syntax(), bare.syntax());
+            } else if let Some((_, abs)) = respelled.iter().find(|(it, _)| *it == segments) {
+                let spelled = mod_path_to_ast_with_factory(editor.make(), abs, edition);
+                editor.replace(path.syntax(), spelled.syntax());
+            }
+        }
+        if widen {
+            widen_to_pub_crate(&root, &editor);
+        }
+        Ok(editor.finish().new_root().clone())
+    }
+}
+
+/// The node an item is appended to: the file itself for a file-module, the item
+/// list for an inline one.
+fn destination_item_list(
+    sema: &Semantics<'_, RootDatabase>,
+    dst: hir::Module,
+) -> Result<(FileId, SyntaxNode)> {
+    let db = sema.db;
+    let source = dst.definition_source(db);
+    let file = source.file_id.original_file(db);
+    let root = sema.parse(file).syntax().clone();
+    let node = match &source.value {
+        ModuleSource::SourceFile(_) => root,
+        ModuleSource::Module(it) => {
+            let list =
+                it.item_list().ok_or_else(|| format_err!("destination module has no item list"))?;
+            find_node_at_range::<ast::ItemList>(&root, list.syntax().text_range())
+                .ok_or_else(|| format_err!("destination module not found in its file"))?
+                .syntax()
+                .clone()
+        }
+        ModuleSource::BlockExpr(_) => bail!("Cannot move an item into a block"),
+    };
+    Ok((file.file_id(db), node))
+}
+
+/// The item's syntax in the tree `sema` owns: `HasSource` hands out a parse of
+/// its own, which scope lookups and path resolution reject.
+fn item_syntax(
+    sema: &Semantics<'_, RootDatabase>,
+    def: hir::ModuleDef,
+) -> Result<(EditionedFileId, ast::Item)> {
+    let db = sema.db;
+    let item = item_to_move(db, def)?;
+    let file = match item.file_id {
+        HirFileId::FileId(it) => it,
+        HirFileId::MacroFile(_) => bail!("Cannot move a macro-generated item"),
+    };
+    let node = find_node_at_range::<ast::Item>(
+        sema.parse(file).syntax(),
+        item.value.syntax().text_range(),
+    )
+    .ok_or_else(|| format_err!("item not found in its own file"))?;
+    Ok((file, node))
+}
+
+/// Gives `node` at least crate-wide visibility.
+fn widen_to_pub_crate(node: &SyntaxNode, editor: &SyntaxEditor) {
+    let existing = ast::AnyHasVisibility::cast(node.clone()).and_then(|it| it.visibility());
+    // `pub(self)` is private spelled out, and reaches exactly as far.
+    if existing.as_ref().is_some_and(|vis| !matches!(vis.kind(), ast::VisibilityKind::PubSelf)) {
+        return;
+    }
+    let vis = editor.make().visibility_pub_crate();
+    match existing {
+        Some(old) => editor.replace(old.syntax(), vis.syntax()),
+        None => {
+            // Attributes and doc comments come first and stay first.
+            if let Some(anchor) = node.children_with_tokens().find(|it| {
+                !matches!(
+                    it.kind(),
+                    SyntaxKind::WHITESPACE | SyntaxKind::COMMENT | SyntaxKind::ATTR
+                )
+            }) {
+                editor.insert_all(
+                    Position::before(anchor),
+                    vec![vis.syntax().clone().into(), editor.make().whitespace(" ").into()],
+                );
+            }
+        }
+    }
+}
+
+/// Rejects the kinds whose meaning is not carried by their text alone.
+fn item_to_move(db: &RootDatabase, def: hir::ModuleDef) -> Result<InFile<ast::Item>> {
+    fn node_of<N: AstNode>(src: Option<InFile<N>>) -> Option<InFile<SyntaxNode>> {
+        src.map(|it| InFile::new(it.file_id, it.value.syntax().clone()))
+    }
+
+    let src = match def {
+        hir::ModuleDef::Function(it) => node_of(it.source(db)),
+        hir::ModuleDef::Adt(hir::Adt::Struct(it)) => node_of(it.source(db)),
+        hir::ModuleDef::Adt(hir::Adt::Enum(it)) => node_of(it.source(db)),
+        hir::ModuleDef::Adt(hir::Adt::Union(it)) => node_of(it.source(db)),
+        hir::ModuleDef::Const(it) => node_of(it.source(db)),
+        hir::ModuleDef::Static(it) => node_of(it.source(db)),
+        hir::ModuleDef::Trait(it) => node_of(it.source(db)),
+        hir::ModuleDef::TypeAlias(it) => node_of(it.source(db)),
+        // A module is a file plus a mod-tree, not an item: see [`move_mod`].
+        hir::ModuleDef::Module(_) => bail!("Cannot move a module as an item"),
+        hir::ModuleDef::EnumVariant(_) => bail!("Cannot move an enum variant out of its enum"),
+        hir::ModuleDef::BuiltinType(_) => bail!("Cannot move a builtin type"),
+        // `macro_rules!` is visible by textual order, so where it sits in the
+        // file is part of what it means.
+        hir::ModuleDef::Macro(_) => bail!("Cannot move a macro"),
+    };
+    let src = src.ok_or_else(|| format_err!("item has no source"))?;
+    let item =
+        ast::Item::cast(src.value).ok_or_else(|| format_err!("item is not a top-level item"))?;
+    Ok(InFile::new(src.file_id, item))
+}
+
+/// A reference inside a `use`, i.e. what makes that file's bare ones resolve.
+fn is_use_reference(reference: &FileReference) -> bool {
+    reference
+        .name
+        .as_name_ref()
+        .is_some_and(|it| it.syntax().ancestors().any(|it| ast::Use::can_cast(it.kind())))
+}
+
+/// Resolved by proximity rather than by path: `foo()`, not `a::foo()`.
+fn is_bare_reference(reference: &FileReference) -> bool {
+    let Some(name_ref) = reference.name.as_name_ref() else { return false };
+    if name_ref.syntax().ancestors().any(|it| ast::Use::can_cast(it.kind())) {
+        return false;
+    }
+    name_ref
+        .syntax()
+        .parent()
+        .and_then(ast::PathSegment::cast)
+        .and_then(|it| it.syntax().parent())
+        .and_then(ast::Path::cast)
+        .is_some_and(|it| it.qualifier().is_none())
+}
+
+/// How the destination-scope rewrite spells the item *before* it has moved.
+/// `None` when there is nothing to match: an unreachable item is left alone by
+/// that pass, and a relative spelling is not comparable by text.
+fn stale_self_path(
+    db: &RootDatabase,
+    def: hir::ModuleDef,
+    dst: hir::Module,
+    edition: Edition,
+) -> Option<Vec<String>> {
+    let path = dst.find_path(db, def, MOVE_FIND_PATH)?;
+    let mut segments = match path.kind {
+        PathKind::Crate => vec!["crate".to_owned()],
+        PathKind::Plain => Vec::new(),
+        _ => return None,
+    };
+    segments.extend(path.segments().iter().map(|it| it.display(db, edition).to_string()));
+    Some(segments)
+}
+
+/// Deletes the item along with the newline it sat on, so the source file is not
+/// left with a hole. The first item in a file has no whitespace in front of it
+/// to take, so it takes what follows instead.
+fn remove_item_taking_line(node: &SyntaxNode, editor: &SyntaxEditor) {
+    let whitespace = |element: Option<SyntaxElement>| {
+        element.and_then(|it| it.into_token()).filter(|it| it.kind() == SyntaxKind::WHITESPACE)
+    };
+    if let Some(ws) = whitespace(node.prev_sibling_or_token()) {
+        editor.delete(ws);
+    } else if let Some(ws) = whitespace(node.next_sibling_or_token()) {
+        editor.delete(ws);
+    }
+    editor.delete(node);
+}
+
+/// Plain segment names of `path`, or `None` if any segment is a keyword like
+/// `super` — those denote a place, not a name, and cannot be compared by text.
+fn path_segment_texts(path: &ast::Path) -> Option<Vec<String>> {
+    let mut segments = Vec::new();
+    let mut current = Some(path.clone());
+    while let Some(path) = current {
+        let segment = path.segment()?;
+        match segment.kind()? {
+            ast::PathSegmentKind::Name(name) => segments.push(name.text().to_owned()),
+            ast::PathSegmentKind::CrateKw => segments.push("crate".to_owned()),
+            _ => return None,
+        }
+        current = path.qualifier();
+    }
+    segments.reverse();
+    Some(segments)
+}
+
+/// Clones the declaration rather than re-printing `mod <leaf>;`, which would
+/// drop its visibility, attributes and doc comments.
 fn relocated_declaration(
     decl: &ast::Module,
     new_leaf: &Name,

--- a/crates/ide/src/lib.rs
+++ b/crates/ide/src/lib.rs
@@ -881,6 +881,18 @@ impl Analysis {
         self.with_db(|db| rename::will_rename_file(db, file_id, new_name_stem, config))
     }
 
+    /// Move a module under a new parent, given by its crate-relative segments
+    /// (`[]` = crate root). Unlike [`Self::will_rename_file`], this handles moves
+    /// across module parents.
+    pub fn will_move_module(
+        &self,
+        file_id: FileId,
+        new_parent_segments: &[String],
+        new_leaf: &str,
+    ) -> Cancellable<Option<SourceChange>> {
+        self.with_db(|db| rename::will_move_module(db, file_id, new_parent_segments, new_leaf))
+    }
+
     pub fn structural_search_replace(
         &self,
         query: &str,

--- a/crates/ide/src/lib.rs
+++ b/crates/ide/src/lib.rs
@@ -137,6 +137,7 @@ pub use ide_db::{
     assists::ExprFillDefaultMode,
     base_db::{Crate, CrateGraphBuilder, FileChange, SourceRoot, SourceRootId},
     documentation::Documentation,
+    imports::insert_use::InsertUseConfig,
     label::Label,
     line_index::{LineCol, LineIndex},
     prime_caches::ParallelPrimeCachesProgress,
@@ -900,6 +901,19 @@ impl Analysis {
         new_leaf: &str,
     ) -> Cancellable<Option<SourceChange>> {
         self.with_db(|db| rename::will_move_module(db, file_id, new_parent_segments, new_leaf))
+    }
+
+    /// Move an item into another module, both named by absolute path
+    /// (`my_crate::a::foo` into `my_crate::b`). Addressed by name rather than by
+    /// a gesture, as [`Self::will_move_module`] is: there is none for dragging
+    /// an item.
+    pub fn move_item_to_module(
+        &self,
+        item_path: &str,
+        destination: &str,
+        insert_use_cfg: &InsertUseConfig,
+    ) -> Cancellable<Result<SourceChange, RenameError>> {
+        self.with_db(|db| rename::move_item(db, item_path, destination, insert_use_cfg))
     }
 
     pub fn structural_search_replace(

--- a/crates/ide/src/lib.rs
+++ b/crates/ide/src/lib.rs
@@ -890,6 +890,18 @@ impl Analysis {
         self.with_db(|db| rename::will_rename_file(db, file_id, new_name_stem, config))
     }
 
+    /// Move a module under a new parent, given by its crate-relative segments
+    /// (`[]` = crate root). Unlike [`Self::will_rename_file`], this handles moves
+    /// across module parents.
+    pub fn will_move_module(
+        &self,
+        file_id: FileId,
+        new_parent_segments: &[String],
+        new_leaf: &str,
+    ) -> Cancellable<Option<SourceChange>> {
+        self.with_db(|db| rename::will_move_module(db, file_id, new_parent_segments, new_leaf))
+    }
+
     pub fn structural_search_replace(
         &self,
         query: &str,

--- a/crates/ide/src/rename.rs
+++ b/crates/ide/src/rename.rs
@@ -242,6 +242,34 @@ pub(crate) fn will_rename_file(
     Some(change)
 }
 
+/// Move a file-based module under a new parent module and fix the mod-tree plus
+/// all references. The new parent is given as its absolute crate-relative
+/// segments (e.g. `["state"]`, or `[]` for the crate root); `new_leaf` is the
+/// module's name at the destination. See [`ide_db::rename::move_mod`].
+pub(crate) fn will_move_module(
+    db: &RootDatabase,
+    file_id: FileId,
+    new_parent_segments: &[String],
+    new_leaf: &str,
+) -> Option<SourceChange> {
+    let sema = Semantics::new(db);
+    let module = sema.file_to_module_def(file_id)?;
+    let root = module.krate(db).root_module(db);
+    let new_parent = if new_parent_segments.is_empty() {
+        root
+    } else {
+        let segs = new_parent_segments.iter().map(|s| Name::new_root(s));
+        root.resolve_mod_path(db, segs)?.find_map(|item| match item {
+            hir::ItemInNs::Types(hir::ModuleDef::Module(m)) => Some(m),
+            _ => None,
+        })?
+    };
+    let mut change = ide_db::rename::move_mod(&sema, module, new_parent, new_leaf).ok()?;
+    // The editor performs the physical file move; we only supply text edits.
+    change.file_system_edits.clear();
+    Some(change)
+}
+
 // FIXME: Should support `extern crate`.
 fn alias_fallback(
     syntax: &SyntaxNode,
@@ -955,6 +983,1016 @@ mod tests {
             .unwrap()
             .expect("Expect returned a RenameError");
         expect.assert_eq(&filter_expect(source_change))
+    }
+
+    fn check_expect_will_move(
+        new_parent_segments: &[&str],
+        new_leaf: &str,
+        #[rust_analyzer::rust_fixture] ra_fixture: &str,
+        expect: Expect,
+    ) {
+        let (analysis, position) = fixture::position(ra_fixture);
+        let segs: Vec<String> = new_parent_segments.iter().map(|s| s.to_string()).collect();
+        let source_change = analysis
+            .will_move_module(position.file_id, &segs, new_leaf)
+            .unwrap()
+            .expect("Expect returned a RenameError");
+        expect.assert_eq(&filter_expect(source_change))
+    }
+
+    #[test]
+    fn will_move_module_cross_parent() {
+        // Move `m` from parent `a` to parent `b`: drop `pub mod m;` in a.rs, add
+        // it in b.rs, and rewrite the `crate::a::m` reference to `crate::b::m`.
+        check_expect_will_move(
+            &["b"],
+            "m",
+            r#"
+//- /lib.rs
+mod a;
+mod b;
+fn f() { crate::a::m::g(); }
+//- /a.rs
+pub mod m;
+//- /a/m.rs
+$0pub fn g() {}
+//- /b.rs
+"#,
+            expect![[r#"
+                source_file_edits: [
+                    (
+                        FileId(
+                            0,
+                        ),
+                        [
+                            Indel {
+                                insert: "b",
+                                delete: 30..31,
+                            },
+                        ],
+                    ),
+                    (
+                        FileId(
+                            1,
+                        ),
+                        [
+                            Indel {
+                                insert: "",
+                                delete: 0..11,
+                            },
+                        ],
+                    ),
+                    (
+                        FileId(
+                            3,
+                        ),
+                        [
+                            Indel {
+                                insert: "pub mod m;\n",
+                                delete: 0..0,
+                            },
+                        ],
+                    ),
+                ]
+                file_system_edits: []
+            "#]],
+        );
+    }
+
+    #[test]
+    fn will_move_module_removes_indented_declaration() {
+        // The declaration is indented, so removing it must take the whole line.
+        check_expect_will_move(
+            &["b"],
+            "m",
+            r#"
+//- /lib.rs
+mod a;
+mod b;
+fn f() { crate::a::inner::m::g(); }
+//- /a.rs
+pub mod inner {
+    pub mod m;
+}
+//- /a/inner/m.rs
+$0pub fn g() {}
+//- /b.rs
+"#,
+            expect![[r#"
+                source_file_edits: [
+                    (
+                        FileId(
+                            0,
+                        ),
+                        [
+                            Indel {
+                                insert: "crate",
+                                delete: 23..31,
+                            },
+                            Indel {
+                                insert: "b",
+                                delete: 33..38,
+                            },
+                        ],
+                    ),
+                    (
+                        FileId(
+                            1,
+                        ),
+                        [
+                            Indel {
+                                insert: "\n}",
+                                delete: 15..32,
+                            },
+                        ],
+                    ),
+                    (
+                        FileId(
+                            3,
+                        ),
+                        [
+                            Indel {
+                                insert: "pub mod m;\n",
+                                delete: 0..0,
+                            },
+                        ],
+                    ),
+                ]
+                file_system_edits: []
+            "#]],
+        );
+    }
+
+    #[test]
+    fn will_move_module_cross_crate_reference() {
+        // `m` lives in crate `foo` at `foo::a::m` and is referenced from crate
+        // `main` as `foo::a::m::g()`. Moving `m` from `a` to `b` inside `foo` must
+        // rewrite the cross-crate reference to `foo::b::m` — keeping the EXTERN
+        // crate name `foo`, NOT `crate::b::m` (which would name `main`'s root).
+        check_expect_will_move(
+            &["b"],
+            "m",
+            r#"
+//- /main.rs crate:main deps:foo
+fn f() { foo::a::m::g(); }
+//- /lib.rs crate:foo
+pub mod a;
+pub mod b;
+//- /a.rs
+pub mod m;
+//- /a/m.rs
+$0pub fn g() {}
+//- /b.rs
+"#,
+            expect![[r#"
+                source_file_edits: [
+                    (
+                        FileId(
+                            0,
+                        ),
+                        [
+                            Indel {
+                                insert: "b",
+                                delete: 14..15,
+                            },
+                        ],
+                    ),
+                    (
+                        FileId(
+                            4,
+                        ),
+                        [
+                            Indel {
+                                insert: "pub mod m;\n",
+                                delete: 0..0,
+                            },
+                        ],
+                    ),
+                    (
+                        FileId(
+                            2,
+                        ),
+                        [
+                            Indel {
+                                insert: "",
+                                delete: 0..11,
+                            },
+                        ],
+                    ),
+                ]
+                file_system_edits: []
+            "#]],
+        );
+    }
+
+    #[test]
+    fn will_move_module_use_group_keeps_visibility() {
+        // The extracted import is built from the original `use` item, so the
+        // re-export stays a re-export instead of silently becoming private.
+        check_expect_will_move(
+            &["b"],
+            "m",
+            r#"
+//- /lib.rs
+mod a;
+mod b;
+pub use crate::a::{m, n};
+//- /a.rs
+pub mod m;
+pub mod n {}
+//- /a/m.rs
+$0pub fn g() {}
+//- /b.rs
+"#,
+            expect![[r#"
+                source_file_edits: [
+                    (
+                        FileId(
+                            0,
+                        ),
+                        [
+                            Indel {
+                                insert: "crate::b",
+                                delete: 22..27,
+                            },
+                            Indel {
+                                insert: "m",
+                                delete: 29..38,
+                            },
+                            Indel {
+                                insert: "pub use crate::a::{n};\n",
+                                delete: 40..40,
+                            },
+                        ],
+                    ),
+                    (
+                        FileId(
+                            1,
+                        ),
+                        [
+                            Indel {
+                                insert: "n {}",
+                                delete: 8..10,
+                            },
+                            Indel {
+                                insert: "",
+                                delete: 11..24,
+                            },
+                        ],
+                    ),
+                    (
+                        FileId(
+                            3,
+                        ),
+                        [
+                            Indel {
+                                insert: "pub mod m;\n",
+                                delete: 0..0,
+                            },
+                        ],
+                    ),
+                ]
+                file_system_edits: []
+            "#]],
+        );
+    }
+
+    #[test]
+    fn will_move_module_splits_use_group() {
+        // `use crate::a::{m, n};` imports the moved module `m` inside a group.
+        // Moving `m` to `b` must split it out into its own `use crate::b::m;`
+        // statement, leaving `use crate::a::{n};` for the sibling.
+        check_expect_will_move(
+            &["b"],
+            "m",
+            r#"
+//- /lib.rs
+mod a;
+mod b;
+use crate::a::{m, n};
+//- /a.rs
+pub mod m;
+pub mod n {}
+//- /a/m.rs
+$0pub fn g() {}
+//- /b.rs
+"#,
+            expect![[r#"
+                source_file_edits: [
+                    (
+                        FileId(
+                            0,
+                        ),
+                        [
+                            Indel {
+                                insert: "crate::b",
+                                delete: 18..23,
+                            },
+                            Indel {
+                                insert: "m",
+                                delete: 25..34,
+                            },
+                            Indel {
+                                insert: "use crate::a::{n};\n",
+                                delete: 36..36,
+                            },
+                        ],
+                    ),
+                    (
+                        FileId(
+                            1,
+                        ),
+                        [
+                            Indel {
+                                insert: "n {}",
+                                delete: 8..10,
+                            },
+                            Indel {
+                                insert: "",
+                                delete: 11..24,
+                            },
+                        ],
+                    ),
+                    (
+                        FileId(
+                            3,
+                        ),
+                        [
+                            Indel {
+                                insert: "pub mod m;\n",
+                                delete: 0..0,
+                            },
+                        ],
+                    ),
+                ]
+                file_system_edits: []
+            "#]],
+        );
+    }
+
+    #[test]
+    fn will_move_module_use_group_sole_member() {
+        // `use crate::a::{m};` — `m` is the only member, so the whole `use` item is
+        // replaced with `use crate::b::m;` (no empty `{}` left behind).
+        check_expect_will_move(
+            &["b"],
+            "m",
+            r#"
+//- /lib.rs
+mod a;
+mod b;
+use crate::a::{m};
+//- /a.rs
+pub mod m;
+//- /a/m.rs
+$0pub fn g() {}
+//- /b.rs
+"#,
+            expect![[r#"
+                source_file_edits: [
+                    (
+                        FileId(
+                            0,
+                        ),
+                        [
+                            Indel {
+                                insert: "crate::b",
+                                delete: 18..23,
+                            },
+                            Indel {
+                                insert: "m",
+                                delete: 25..31,
+                            },
+                        ],
+                    ),
+                    (
+                        FileId(
+                            1,
+                        ),
+                        [
+                            Indel {
+                                insert: "",
+                                delete: 0..11,
+                            },
+                        ],
+                    ),
+                    (
+                        FileId(
+                            3,
+                        ),
+                        [
+                            Indel {
+                                insert: "pub mod m;\n",
+                                delete: 0..0,
+                            },
+                        ],
+                    ),
+                ]
+                file_system_edits: []
+            "#]],
+        );
+    }
+
+    #[test]
+    fn will_move_module_use_group_through_m() {
+        // `use crate::a::{m::X, n};` imports item `X` THROUGH the moved module.
+        // Splitting must carry the tail: `use crate::b::m::X;` + `use crate::a::{n};`.
+        check_expect_will_move(
+            &["b"],
+            "m",
+            r#"
+//- /lib.rs
+mod a;
+mod b;
+use crate::a::{m::X, n};
+//- /a.rs
+pub mod m;
+pub mod n {}
+//- /a/m.rs
+$0pub struct X;
+//- /b.rs
+"#,
+            expect![[r#"
+                source_file_edits: [
+                    (
+                        FileId(
+                            0,
+                        ),
+                        [
+                            Indel {
+                                insert: "crate::b::m",
+                                delete: 18..23,
+                            },
+                            Indel {
+                                insert: "X",
+                                delete: 25..37,
+                            },
+                            Indel {
+                                insert: "use crate::a::{n};\n",
+                                delete: 39..39,
+                            },
+                        ],
+                    ),
+                    (
+                        FileId(
+                            1,
+                        ),
+                        [
+                            Indel {
+                                insert: "n {}",
+                                delete: 8..10,
+                            },
+                            Indel {
+                                insert: "",
+                                delete: 11..24,
+                            },
+                        ],
+                    ),
+                    (
+                        FileId(
+                            3,
+                        ),
+                        [
+                            Indel {
+                                insert: "pub mod m;\n",
+                                delete: 0..0,
+                            },
+                        ],
+                    ),
+                ]
+                file_system_edits: []
+            "#]],
+        );
+    }
+
+    #[test]
+    fn will_move_module_use_group_into_m_nested_and_glob() {
+        // Nested list `{m::{X, Y}}` and glob `{m::*}` both carry their tail wholesale.
+        check_expect_will_move(
+            &["b"],
+            "m",
+            r#"
+//- /lib.rs
+mod a;
+mod b;
+use crate::a::{m::{X, Y}, n};
+use crate::a::{m::*, k};
+//- /a.rs
+pub mod m;
+pub mod n {}
+pub mod k {}
+//- /a/m.rs
+$0pub struct X;
+pub struct Y;
+//- /b.rs
+"#,
+            expect![[r#"
+                source_file_edits: [
+                    (
+                        FileId(
+                            0,
+                        ),
+                        [
+                            Indel {
+                                insert: "crate::b",
+                                delete: 18..23,
+                            },
+                            Indel {
+                                insert: "m",
+                                delete: 25..26,
+                            },
+                            Indel {
+                                insert: "X",
+                                delete: 29..38,
+                            },
+                            Indel {
+                                insert: "Y",
+                                delete: 40..41,
+                            },
+                            Indel {
+                                insert: "n}",
+                                delete: 59..67,
+                            },
+                            Indel {
+                                insert: "use crate::b::m::*;\nuse crate::a::{k};\n",
+                                delete: 69..69,
+                            },
+                        ],
+                    ),
+                    (
+                        FileId(
+                            1,
+                        ),
+                        [
+                            Indel {
+                                insert: "n {}",
+                                delete: 8..10,
+                            },
+                            Indel {
+                                insert: "k",
+                                delete: 19..20,
+                            },
+                            Indel {
+                                insert: "",
+                                delete: 24..37,
+                            },
+                        ],
+                    ),
+                    (
+                        FileId(
+                            3,
+                        ),
+                        [
+                            Indel {
+                                insert: "pub mod m;\n",
+                                delete: 0..0,
+                            },
+                        ],
+                    ),
+                ]
+                file_system_edits: []
+            "#]],
+        );
+    }
+
+    #[test]
+    fn will_move_module_use_group_two_members_through_m() {
+        // `use crate::a::{m::X, m::Y};` — both members reach through `m`, so the whole
+        // group empties: the `use` is replaced wholesale with one standalone import
+        // per member (`use crate::b::m::X;\nuse crate::b::m::Y;`). Group-wise handling
+        // rewrites BOTH members, not just the first.
+        check_expect_will_move(
+            &["b"],
+            "m",
+            r#"
+//- /lib.rs
+mod a;
+mod b;
+use crate::a::{m::X, m::Y};
+//- /a.rs
+pub mod m;
+//- /a/m.rs
+$0pub struct X;
+pub struct Y;
+//- /b.rs
+"#,
+            expect![[r#"
+                source_file_edits: [
+                    (
+                        FileId(
+                            0,
+                        ),
+                        [
+                            Indel {
+                                insert: "crate::b::m",
+                                delete: 18..23,
+                            },
+                            Indel {
+                                insert: "X",
+                                delete: 25..40,
+                            },
+                            Indel {
+                                insert: "use crate::b::m::Y;\n",
+                                delete: 42..42,
+                            },
+                        ],
+                    ),
+                    (
+                        FileId(
+                            1,
+                        ),
+                        [
+                            Indel {
+                                insert: "",
+                                delete: 0..11,
+                            },
+                        ],
+                    ),
+                    (
+                        FileId(
+                            3,
+                        ),
+                        [
+                            Indel {
+                                insert: "pub mod m;\n",
+                                delete: 0..0,
+                            },
+                        ],
+                    ),
+                ]
+                file_system_edits: []
+            "#]],
+        );
+    }
+
+    #[test]
+    fn will_move_module_use_group_two_members_with_survivor() {
+        // `use crate::a::{m::X, m::Y, n};` — two members reach `m`, one sibling (`n`)
+        // stays. Group-wise handling splits BOTH moved members out into their own
+        // imports and deletes them as one overlap-free run, leaving `use crate::a::{n};`.
+        check_expect_will_move(
+            &["b"],
+            "m",
+            r#"
+//- /lib.rs
+mod a;
+mod b;
+use crate::a::{m::X, m::Y, n};
+//- /a.rs
+pub mod m;
+pub mod n {}
+//- /a/m.rs
+$0pub struct X;
+pub struct Y;
+//- /b.rs
+"#,
+            expect![[r#"
+                source_file_edits: [
+                    (
+                        FileId(
+                            0,
+                        ),
+                        [
+                            Indel {
+                                insert: "crate::b::m",
+                                delete: 18..23,
+                            },
+                            Indel {
+                                insert: "X",
+                                delete: 25..43,
+                            },
+                            Indel {
+                                insert: "use crate::b::m::Y;\nuse crate::a::{n};\n",
+                                delete: 45..45,
+                            },
+                        ],
+                    ),
+                    (
+                        FileId(
+                            1,
+                        ),
+                        [
+                            Indel {
+                                insert: "n {}",
+                                delete: 8..10,
+                            },
+                            Indel {
+                                insert: "",
+                                delete: 11..24,
+                            },
+                        ],
+                    ),
+                    (
+                        FileId(
+                            3,
+                        ),
+                        [
+                            Indel {
+                                insert: "pub mod m;\n",
+                                delete: 0..0,
+                            },
+                        ],
+                    ),
+                ]
+                file_system_edits: []
+            "#]],
+        );
+    }
+
+    #[test]
+    fn will_move_module_mod_rs_directory_module() {
+        // Move the `mod.rs`-style directory module `a` (with a child `child`) from the
+        // crate root under `b`. The editor physically moves the whole `a/` directory;
+        // we only fix the mod-tree (drop `mod a;` in lib.rs, add it in b.rs) and rewrite
+        // references. A reference *through* the moved module — `crate::a::child::g` — is
+        // rewritten by the same path-prefix pass (the `a` segment carries `::child::g`).
+        check_expect_will_move(
+            &["b"],
+            "a",
+            r#"
+//- /lib.rs
+mod a;
+mod b;
+fn f() { crate::a::child::g(); }
+//- /a/mod.rs
+$0pub mod child;
+//- /a/child.rs
+pub fn g() {}
+//- /b.rs
+"#,
+            expect![[r#"
+                source_file_edits: [
+                    (
+                        FileId(
+                            0,
+                        ),
+                        [
+                            Indel {
+                                insert: "b",
+                                delete: 4..5,
+                            },
+                            Indel {
+                                insert: "fn",
+                                delete: 7..10,
+                            },
+                            Indel {
+                                insert: "f() { crate::b::a::child::g(); }",
+                                delete: 11..13,
+                            },
+                            Indel {
+                                insert: "",
+                                delete: 14..47,
+                            },
+                        ],
+                    ),
+                    (
+                        FileId(
+                            3,
+                        ),
+                        [
+                            Indel {
+                                insert: "mod a;\n",
+                                delete: 0..0,
+                            },
+                        ],
+                    ),
+                ]
+                file_system_edits: []
+            "#]],
+        );
+    }
+
+    #[test]
+    fn will_move_module_reanchors_super_in_moved_file() {
+        // Move `m` from `a` to `b`. Inside m.rs, `super::sib` (super == crate::a)
+        // must be re-anchored to `crate::a::sib` — both in a `use` and in an expr
+        // path — because after the move `super` would point at `b`.
+        check_expect_will_move(
+            &["b"],
+            "m",
+            r#"
+//- /lib.rs
+mod a;
+mod b;
+//- /a.rs
+pub mod m;
+pub mod sib;
+//- /a/sib.rs
+pub fn h() {}
+//- /a/m.rs
+$0use super::sib;
+pub fn g() { super::sib::h(); }
+//- /b.rs
+"#,
+            expect![[r#"
+                source_file_edits: [
+                    (
+                        FileId(
+                            4,
+                        ),
+                        [
+                            Indel {
+                                insert: "pub mod m;\n",
+                                delete: 0..0,
+                            },
+                        ],
+                    ),
+                    (
+                        FileId(
+                            1,
+                        ),
+                        [
+                            Indel {
+                                insert: "sib",
+                                delete: 8..9,
+                            },
+                            Indel {
+                                insert: "",
+                                delete: 11..24,
+                            },
+                        ],
+                    ),
+                    (
+                        FileId(
+                            3,
+                        ),
+                        [
+                            Indel {
+                                insert: "crate::a",
+                                delete: 4..9,
+                            },
+                            Indel {
+                                insert: "crate::a",
+                                delete: 29..34,
+                            },
+                        ],
+                    ),
+                ]
+                file_system_edits: []
+            "#]],
+        );
+    }
+
+    #[test]
+    fn will_move_module_reanchors_multi_super_runs() {
+        // `m` lives at crate::a::b::m. Move it to crate::x::m. A `super::super`
+        // run (== crate::a, drop 2 of 3 segments) and a `super` run (== crate::a::b)
+        // must each re-anchor to a different absolute prefix.
+        check_expect_will_move(
+            &["x"],
+            "m",
+            r#"
+//- /lib.rs
+mod a;
+mod x;
+//- /a.rs
+pub mod b;
+pub mod sib_a;
+//- /a/sib_a.rs
+pub fn p() {}
+//- /a/b.rs
+pub mod m;
+pub mod sib_b;
+//- /a/b/sib_b.rs
+pub fn q() {}
+//- /a/b/m.rs
+$0use super::super::sib_a;
+pub fn g() { super::sib_b::q(); }
+//- /x.rs
+"#,
+            expect![[r#"
+                source_file_edits: [
+                    (
+                        FileId(
+                            5,
+                        ),
+                        [
+                            Indel {
+                                insert: "crate",
+                                delete: 4..9,
+                            },
+                            Indel {
+                                insert: "a",
+                                delete: 11..16,
+                            },
+                            Indel {
+                                insert: "crate::a::b",
+                                delete: 38..43,
+                            },
+                        ],
+                    ),
+                    (
+                        FileId(
+                            6,
+                        ),
+                        [
+                            Indel {
+                                insert: "pub mod m;\n",
+                                delete: 0..0,
+                            },
+                        ],
+                    ),
+                    (
+                        FileId(
+                            3,
+                        ),
+                        [
+                            Indel {
+                                insert: "sib_b",
+                                delete: 8..9,
+                            },
+                            Indel {
+                                insert: "",
+                                delete: 11..26,
+                            },
+                        ],
+                    ),
+                ]
+                file_system_edits: []
+            "#]],
+        );
+    }
+
+    #[test]
+    fn will_move_module_super_boundaries() {
+        // Grouped `use super::{…}` re-anchors ONLY the leading `super` (never
+        // crossing the `{`); `self::` is left intact; and a `super` inside a
+        // nested inline `mod` is a documented boundary — skipped, not miswritten.
+        check_expect_will_move(
+            &["b"],
+            "m",
+            r#"
+//- /lib.rs
+mod a;
+mod b;
+//- /a.rs
+pub mod m;
+pub mod sib;
+pub mod sib2;
+//- /a/sib.rs
+pub fn h() {}
+//- /a/sib2.rs
+pub fn h2() {}
+//- /a/m.rs
+$0use super::{sib, sib2};
+pub mod child { pub fn c() { super::super::sib::h(); } }
+pub fn g() {
+    self::child::c();
+    super::sib::h();
+}
+//- /b.rs
+"#,
+            expect![[r#"
+                source_file_edits: [
+                    (
+                        FileId(
+                            4,
+                        ),
+                        [
+                            Indel {
+                                insert: "crate::a",
+                                delete: 4..9,
+                            },
+                            Indel {
+                                insert: "crate::a",
+                                delete: 120..125,
+                            },
+                        ],
+                    ),
+                    (
+                        FileId(
+                            5,
+                        ),
+                        [
+                            Indel {
+                                insert: "pub mod m;\n",
+                                delete: 0..0,
+                            },
+                        ],
+                    ),
+                    (
+                        FileId(
+                            1,
+                        ),
+                        [
+                            Indel {
+                                insert: "sib",
+                                delete: 8..9,
+                            },
+                            Indel {
+                                insert: "sib2",
+                                delete: 19..22,
+                            },
+                            Indel {
+                                insert: "",
+                                delete: 24..38,
+                            },
+                        ],
+                    ),
+                ]
+                file_system_edits: []
+            "#]],
+        );
     }
 
     fn check_prepare(#[rust_analyzer::rust_fixture] ra_fixture: &str, expect: Expect) {

--- a/crates/ide/src/rename.rs
+++ b/crates/ide/src/rename.rs
@@ -242,6 +242,33 @@ pub(crate) fn will_rename_file(
     Some(change)
 }
 
+/// Move a file-based module under a new parent, given as its crate-relative
+/// segments (`["state"]`, or `[]` for the crate root). See
+/// [`ide_db::rename::move_mod`].
+pub(crate) fn will_move_module(
+    db: &RootDatabase,
+    file_id: FileId,
+    new_parent_segments: &[String],
+    new_leaf: &str,
+) -> Option<SourceChange> {
+    let sema = Semantics::new(db);
+    let module = sema.file_to_module_def(file_id)?;
+    let root = module.krate(db).root_module(db);
+    let new_parent = if new_parent_segments.is_empty() {
+        root
+    } else {
+        let segs = new_parent_segments.iter().map(|s| Name::new_root(s));
+        root.resolve_mod_path(db, segs)?.find_map(|item| match item {
+            hir::ItemInNs::Types(hir::ModuleDef::Module(m)) => Some(m),
+            _ => None,
+        })?
+    };
+    let mut change = ide_db::rename::move_mod(&sema, module, new_parent, new_leaf).ok()?;
+    // The editor performs the physical file move; we only supply text edits.
+    change.file_system_edits.clear();
+    Some(change)
+}
+
 // FIXME: Should support `extern crate`.
 fn alias_fallback(
     syntax: &SyntaxNode,
@@ -955,6 +982,1016 @@ mod tests {
             .unwrap()
             .expect("Expect returned a RenameError");
         expect.assert_eq(&filter_expect(source_change))
+    }
+
+    fn check_expect_will_move(
+        new_parent_segments: &[&str],
+        new_leaf: &str,
+        #[rust_analyzer::rust_fixture] ra_fixture: &str,
+        expect: Expect,
+    ) {
+        let (analysis, position) = fixture::position(ra_fixture);
+        let segs: Vec<String> = new_parent_segments.iter().map(|s| s.to_string()).collect();
+        let source_change = analysis
+            .will_move_module(position.file_id, &segs, new_leaf)
+            .unwrap()
+            .expect("Expect returned a RenameError");
+        expect.assert_eq(&filter_expect(source_change))
+    }
+
+    #[test]
+    fn will_move_module_cross_parent() {
+        // Move `m` from parent `a` to parent `b`: drop `pub mod m;` in a.rs, add
+        // it in b.rs, and rewrite the `crate::a::m` reference to `crate::b::m`.
+        check_expect_will_move(
+            &["b"],
+            "m",
+            r#"
+//- /lib.rs
+mod a;
+mod b;
+fn f() { crate::a::m::g(); }
+//- /a.rs
+pub mod m;
+//- /a/m.rs
+$0pub fn g() {}
+//- /b.rs
+"#,
+            expect![[r#"
+                source_file_edits: [
+                    (
+                        FileId(
+                            0,
+                        ),
+                        [
+                            Indel {
+                                insert: "b",
+                                delete: 30..31,
+                            },
+                        ],
+                    ),
+                    (
+                        FileId(
+                            1,
+                        ),
+                        [
+                            Indel {
+                                insert: "",
+                                delete: 0..11,
+                            },
+                        ],
+                    ),
+                    (
+                        FileId(
+                            3,
+                        ),
+                        [
+                            Indel {
+                                insert: "pub mod m;\n",
+                                delete: 0..0,
+                            },
+                        ],
+                    ),
+                ]
+                file_system_edits: []
+            "#]],
+        );
+    }
+
+    #[test]
+    fn will_move_module_removes_indented_declaration() {
+        // The declaration is indented, so removing it must take the whole line.
+        check_expect_will_move(
+            &["b"],
+            "m",
+            r#"
+//- /lib.rs
+mod a;
+mod b;
+fn f() { crate::a::inner::m::g(); }
+//- /a.rs
+pub mod inner {
+    pub mod m;
+}
+//- /a/inner/m.rs
+$0pub fn g() {}
+//- /b.rs
+"#,
+            expect![[r#"
+                source_file_edits: [
+                    (
+                        FileId(
+                            0,
+                        ),
+                        [
+                            Indel {
+                                insert: "crate",
+                                delete: 23..31,
+                            },
+                            Indel {
+                                insert: "b",
+                                delete: 33..38,
+                            },
+                        ],
+                    ),
+                    (
+                        FileId(
+                            1,
+                        ),
+                        [
+                            Indel {
+                                insert: "\n}",
+                                delete: 15..32,
+                            },
+                        ],
+                    ),
+                    (
+                        FileId(
+                            3,
+                        ),
+                        [
+                            Indel {
+                                insert: "pub mod m;\n",
+                                delete: 0..0,
+                            },
+                        ],
+                    ),
+                ]
+                file_system_edits: []
+            "#]],
+        );
+    }
+
+    #[test]
+    fn will_move_module_cross_crate_reference() {
+        // `m` lives in crate `foo` at `foo::a::m` and is referenced from crate
+        // `main` as `foo::a::m::g()`. Moving `m` from `a` to `b` inside `foo` must
+        // rewrite the cross-crate reference to `foo::b::m` — keeping the EXTERN
+        // crate name `foo`, NOT `crate::b::m` (which would name `main`'s root).
+        check_expect_will_move(
+            &["b"],
+            "m",
+            r#"
+//- /main.rs crate:main deps:foo
+fn f() { foo::a::m::g(); }
+//- /lib.rs crate:foo
+pub mod a;
+pub mod b;
+//- /a.rs
+pub mod m;
+//- /a/m.rs
+$0pub fn g() {}
+//- /b.rs
+"#,
+            expect![[r#"
+                source_file_edits: [
+                    (
+                        FileId(
+                            0,
+                        ),
+                        [
+                            Indel {
+                                insert: "b",
+                                delete: 14..15,
+                            },
+                        ],
+                    ),
+                    (
+                        FileId(
+                            4,
+                        ),
+                        [
+                            Indel {
+                                insert: "pub mod m;\n",
+                                delete: 0..0,
+                            },
+                        ],
+                    ),
+                    (
+                        FileId(
+                            2,
+                        ),
+                        [
+                            Indel {
+                                insert: "",
+                                delete: 0..11,
+                            },
+                        ],
+                    ),
+                ]
+                file_system_edits: []
+            "#]],
+        );
+    }
+
+    #[test]
+    fn will_move_module_use_group_keeps_visibility() {
+        // The extracted import is built from the original `use` item, so the
+        // re-export stays a re-export instead of silently becoming private.
+        check_expect_will_move(
+            &["b"],
+            "m",
+            r#"
+//- /lib.rs
+mod a;
+mod b;
+pub use crate::a::{m, n};
+//- /a.rs
+pub mod m;
+pub mod n {}
+//- /a/m.rs
+$0pub fn g() {}
+//- /b.rs
+"#,
+            expect![[r#"
+                source_file_edits: [
+                    (
+                        FileId(
+                            0,
+                        ),
+                        [
+                            Indel {
+                                insert: "crate::b",
+                                delete: 22..27,
+                            },
+                            Indel {
+                                insert: "m",
+                                delete: 29..38,
+                            },
+                            Indel {
+                                insert: "pub use crate::a::{n};\n",
+                                delete: 40..40,
+                            },
+                        ],
+                    ),
+                    (
+                        FileId(
+                            1,
+                        ),
+                        [
+                            Indel {
+                                insert: "n {}",
+                                delete: 8..10,
+                            },
+                            Indel {
+                                insert: "",
+                                delete: 11..24,
+                            },
+                        ],
+                    ),
+                    (
+                        FileId(
+                            3,
+                        ),
+                        [
+                            Indel {
+                                insert: "pub mod m;\n",
+                                delete: 0..0,
+                            },
+                        ],
+                    ),
+                ]
+                file_system_edits: []
+            "#]],
+        );
+    }
+
+    #[test]
+    fn will_move_module_splits_use_group() {
+        // `use crate::a::{m, n};` imports the moved module `m` inside a group.
+        // Moving `m` to `b` must split it out into its own `use crate::b::m;`
+        // statement, leaving `use crate::a::{n};` for the sibling.
+        check_expect_will_move(
+            &["b"],
+            "m",
+            r#"
+//- /lib.rs
+mod a;
+mod b;
+use crate::a::{m, n};
+//- /a.rs
+pub mod m;
+pub mod n {}
+//- /a/m.rs
+$0pub fn g() {}
+//- /b.rs
+"#,
+            expect![[r#"
+                source_file_edits: [
+                    (
+                        FileId(
+                            0,
+                        ),
+                        [
+                            Indel {
+                                insert: "crate::b",
+                                delete: 18..23,
+                            },
+                            Indel {
+                                insert: "m",
+                                delete: 25..34,
+                            },
+                            Indel {
+                                insert: "use crate::a::{n};\n",
+                                delete: 36..36,
+                            },
+                        ],
+                    ),
+                    (
+                        FileId(
+                            1,
+                        ),
+                        [
+                            Indel {
+                                insert: "n {}",
+                                delete: 8..10,
+                            },
+                            Indel {
+                                insert: "",
+                                delete: 11..24,
+                            },
+                        ],
+                    ),
+                    (
+                        FileId(
+                            3,
+                        ),
+                        [
+                            Indel {
+                                insert: "pub mod m;\n",
+                                delete: 0..0,
+                            },
+                        ],
+                    ),
+                ]
+                file_system_edits: []
+            "#]],
+        );
+    }
+
+    #[test]
+    fn will_move_module_use_group_sole_member() {
+        // `use crate::a::{m};` — `m` is the only member, so the whole `use` item is
+        // replaced with `use crate::b::m;` (no empty `{}` left behind).
+        check_expect_will_move(
+            &["b"],
+            "m",
+            r#"
+//- /lib.rs
+mod a;
+mod b;
+use crate::a::{m};
+//- /a.rs
+pub mod m;
+//- /a/m.rs
+$0pub fn g() {}
+//- /b.rs
+"#,
+            expect![[r#"
+                source_file_edits: [
+                    (
+                        FileId(
+                            0,
+                        ),
+                        [
+                            Indel {
+                                insert: "crate::b",
+                                delete: 18..23,
+                            },
+                            Indel {
+                                insert: "m",
+                                delete: 25..31,
+                            },
+                        ],
+                    ),
+                    (
+                        FileId(
+                            1,
+                        ),
+                        [
+                            Indel {
+                                insert: "",
+                                delete: 0..11,
+                            },
+                        ],
+                    ),
+                    (
+                        FileId(
+                            3,
+                        ),
+                        [
+                            Indel {
+                                insert: "pub mod m;\n",
+                                delete: 0..0,
+                            },
+                        ],
+                    ),
+                ]
+                file_system_edits: []
+            "#]],
+        );
+    }
+
+    #[test]
+    fn will_move_module_use_group_through_m() {
+        // `use crate::a::{m::X, n};` imports item `X` THROUGH the moved module.
+        // Splitting must carry the tail: `use crate::b::m::X;` + `use crate::a::{n};`.
+        check_expect_will_move(
+            &["b"],
+            "m",
+            r#"
+//- /lib.rs
+mod a;
+mod b;
+use crate::a::{m::X, n};
+//- /a.rs
+pub mod m;
+pub mod n {}
+//- /a/m.rs
+$0pub struct X;
+//- /b.rs
+"#,
+            expect![[r#"
+                source_file_edits: [
+                    (
+                        FileId(
+                            0,
+                        ),
+                        [
+                            Indel {
+                                insert: "crate::b::m",
+                                delete: 18..23,
+                            },
+                            Indel {
+                                insert: "X",
+                                delete: 25..37,
+                            },
+                            Indel {
+                                insert: "use crate::a::{n};\n",
+                                delete: 39..39,
+                            },
+                        ],
+                    ),
+                    (
+                        FileId(
+                            1,
+                        ),
+                        [
+                            Indel {
+                                insert: "n {}",
+                                delete: 8..10,
+                            },
+                            Indel {
+                                insert: "",
+                                delete: 11..24,
+                            },
+                        ],
+                    ),
+                    (
+                        FileId(
+                            3,
+                        ),
+                        [
+                            Indel {
+                                insert: "pub mod m;\n",
+                                delete: 0..0,
+                            },
+                        ],
+                    ),
+                ]
+                file_system_edits: []
+            "#]],
+        );
+    }
+
+    #[test]
+    fn will_move_module_use_group_into_m_nested_and_glob() {
+        // Nested list `{m::{X, Y}}` and glob `{m::*}` both carry their tail wholesale.
+        check_expect_will_move(
+            &["b"],
+            "m",
+            r#"
+//- /lib.rs
+mod a;
+mod b;
+use crate::a::{m::{X, Y}, n};
+use crate::a::{m::*, k};
+//- /a.rs
+pub mod m;
+pub mod n {}
+pub mod k {}
+//- /a/m.rs
+$0pub struct X;
+pub struct Y;
+//- /b.rs
+"#,
+            expect![[r#"
+                source_file_edits: [
+                    (
+                        FileId(
+                            0,
+                        ),
+                        [
+                            Indel {
+                                insert: "crate::b",
+                                delete: 18..23,
+                            },
+                            Indel {
+                                insert: "m",
+                                delete: 25..26,
+                            },
+                            Indel {
+                                insert: "X",
+                                delete: 29..38,
+                            },
+                            Indel {
+                                insert: "Y",
+                                delete: 40..41,
+                            },
+                            Indel {
+                                insert: "n}",
+                                delete: 59..67,
+                            },
+                            Indel {
+                                insert: "use crate::b::m::*;\nuse crate::a::{k};\n",
+                                delete: 69..69,
+                            },
+                        ],
+                    ),
+                    (
+                        FileId(
+                            1,
+                        ),
+                        [
+                            Indel {
+                                insert: "n {}",
+                                delete: 8..10,
+                            },
+                            Indel {
+                                insert: "k",
+                                delete: 19..20,
+                            },
+                            Indel {
+                                insert: "",
+                                delete: 24..37,
+                            },
+                        ],
+                    ),
+                    (
+                        FileId(
+                            3,
+                        ),
+                        [
+                            Indel {
+                                insert: "pub mod m;\n",
+                                delete: 0..0,
+                            },
+                        ],
+                    ),
+                ]
+                file_system_edits: []
+            "#]],
+        );
+    }
+
+    #[test]
+    fn will_move_module_use_group_two_members_through_m() {
+        // `use crate::a::{m::X, m::Y};` — both members reach through `m`, so the whole
+        // group empties: the `use` is replaced wholesale with one standalone import
+        // per member (`use crate::b::m::X;\nuse crate::b::m::Y;`). Group-wise handling
+        // rewrites BOTH members, not just the first.
+        check_expect_will_move(
+            &["b"],
+            "m",
+            r#"
+//- /lib.rs
+mod a;
+mod b;
+use crate::a::{m::X, m::Y};
+//- /a.rs
+pub mod m;
+//- /a/m.rs
+$0pub struct X;
+pub struct Y;
+//- /b.rs
+"#,
+            expect![[r#"
+                source_file_edits: [
+                    (
+                        FileId(
+                            0,
+                        ),
+                        [
+                            Indel {
+                                insert: "crate::b::m",
+                                delete: 18..23,
+                            },
+                            Indel {
+                                insert: "X",
+                                delete: 25..40,
+                            },
+                            Indel {
+                                insert: "use crate::b::m::Y;\n",
+                                delete: 42..42,
+                            },
+                        ],
+                    ),
+                    (
+                        FileId(
+                            1,
+                        ),
+                        [
+                            Indel {
+                                insert: "",
+                                delete: 0..11,
+                            },
+                        ],
+                    ),
+                    (
+                        FileId(
+                            3,
+                        ),
+                        [
+                            Indel {
+                                insert: "pub mod m;\n",
+                                delete: 0..0,
+                            },
+                        ],
+                    ),
+                ]
+                file_system_edits: []
+            "#]],
+        );
+    }
+
+    #[test]
+    fn will_move_module_use_group_two_members_with_survivor() {
+        // `use crate::a::{m::X, m::Y, n};` — two members reach `m`, one sibling (`n`)
+        // stays. Group-wise handling splits BOTH moved members out into their own
+        // imports and deletes them as one overlap-free run, leaving `use crate::a::{n};`.
+        check_expect_will_move(
+            &["b"],
+            "m",
+            r#"
+//- /lib.rs
+mod a;
+mod b;
+use crate::a::{m::X, m::Y, n};
+//- /a.rs
+pub mod m;
+pub mod n {}
+//- /a/m.rs
+$0pub struct X;
+pub struct Y;
+//- /b.rs
+"#,
+            expect![[r#"
+                source_file_edits: [
+                    (
+                        FileId(
+                            0,
+                        ),
+                        [
+                            Indel {
+                                insert: "crate::b::m",
+                                delete: 18..23,
+                            },
+                            Indel {
+                                insert: "X",
+                                delete: 25..43,
+                            },
+                            Indel {
+                                insert: "use crate::b::m::Y;\nuse crate::a::{n};\n",
+                                delete: 45..45,
+                            },
+                        ],
+                    ),
+                    (
+                        FileId(
+                            1,
+                        ),
+                        [
+                            Indel {
+                                insert: "n {}",
+                                delete: 8..10,
+                            },
+                            Indel {
+                                insert: "",
+                                delete: 11..24,
+                            },
+                        ],
+                    ),
+                    (
+                        FileId(
+                            3,
+                        ),
+                        [
+                            Indel {
+                                insert: "pub mod m;\n",
+                                delete: 0..0,
+                            },
+                        ],
+                    ),
+                ]
+                file_system_edits: []
+            "#]],
+        );
+    }
+
+    #[test]
+    fn will_move_module_mod_rs_directory_module() {
+        // Move the `mod.rs`-style directory module `a` (with a child `child`) from the
+        // crate root under `b`. The editor physically moves the whole `a/` directory;
+        // we only fix the mod-tree (drop `mod a;` in lib.rs, add it in b.rs) and rewrite
+        // references. A reference *through* the moved module — `crate::a::child::g` — is
+        // rewritten by the same path-prefix pass (the `a` segment carries `::child::g`).
+        check_expect_will_move(
+            &["b"],
+            "a",
+            r#"
+//- /lib.rs
+mod a;
+mod b;
+fn f() { crate::a::child::g(); }
+//- /a/mod.rs
+$0pub mod child;
+//- /a/child.rs
+pub fn g() {}
+//- /b.rs
+"#,
+            expect![[r#"
+                source_file_edits: [
+                    (
+                        FileId(
+                            0,
+                        ),
+                        [
+                            Indel {
+                                insert: "b",
+                                delete: 4..5,
+                            },
+                            Indel {
+                                insert: "fn",
+                                delete: 7..10,
+                            },
+                            Indel {
+                                insert: "f() { crate::b::a::child::g(); }",
+                                delete: 11..13,
+                            },
+                            Indel {
+                                insert: "",
+                                delete: 14..47,
+                            },
+                        ],
+                    ),
+                    (
+                        FileId(
+                            3,
+                        ),
+                        [
+                            Indel {
+                                insert: "mod a;\n",
+                                delete: 0..0,
+                            },
+                        ],
+                    ),
+                ]
+                file_system_edits: []
+            "#]],
+        );
+    }
+
+    #[test]
+    fn will_move_module_reanchors_super_in_moved_file() {
+        // Move `m` from `a` to `b`. Inside m.rs, `super::sib` (super == crate::a)
+        // must be re-anchored to `crate::a::sib` — both in a `use` and in an expr
+        // path — because after the move `super` would point at `b`.
+        check_expect_will_move(
+            &["b"],
+            "m",
+            r#"
+//- /lib.rs
+mod a;
+mod b;
+//- /a.rs
+pub mod m;
+pub mod sib;
+//- /a/sib.rs
+pub fn h() {}
+//- /a/m.rs
+$0use super::sib;
+pub fn g() { super::sib::h(); }
+//- /b.rs
+"#,
+            expect![[r#"
+                source_file_edits: [
+                    (
+                        FileId(
+                            4,
+                        ),
+                        [
+                            Indel {
+                                insert: "pub mod m;\n",
+                                delete: 0..0,
+                            },
+                        ],
+                    ),
+                    (
+                        FileId(
+                            1,
+                        ),
+                        [
+                            Indel {
+                                insert: "sib",
+                                delete: 8..9,
+                            },
+                            Indel {
+                                insert: "",
+                                delete: 11..24,
+                            },
+                        ],
+                    ),
+                    (
+                        FileId(
+                            3,
+                        ),
+                        [
+                            Indel {
+                                insert: "crate::a",
+                                delete: 4..9,
+                            },
+                            Indel {
+                                insert: "crate::a",
+                                delete: 29..34,
+                            },
+                        ],
+                    ),
+                ]
+                file_system_edits: []
+            "#]],
+        );
+    }
+
+    #[test]
+    fn will_move_module_reanchors_multi_super_runs() {
+        // `m` lives at crate::a::b::m. Move it to crate::x::m. A `super::super`
+        // run (== crate::a, drop 2 of 3 segments) and a `super` run (== crate::a::b)
+        // must each re-anchor to a different absolute prefix.
+        check_expect_will_move(
+            &["x"],
+            "m",
+            r#"
+//- /lib.rs
+mod a;
+mod x;
+//- /a.rs
+pub mod b;
+pub mod sib_a;
+//- /a/sib_a.rs
+pub fn p() {}
+//- /a/b.rs
+pub mod m;
+pub mod sib_b;
+//- /a/b/sib_b.rs
+pub fn q() {}
+//- /a/b/m.rs
+$0use super::super::sib_a;
+pub fn g() { super::sib_b::q(); }
+//- /x.rs
+"#,
+            expect![[r#"
+                source_file_edits: [
+                    (
+                        FileId(
+                            5,
+                        ),
+                        [
+                            Indel {
+                                insert: "crate",
+                                delete: 4..9,
+                            },
+                            Indel {
+                                insert: "a",
+                                delete: 11..16,
+                            },
+                            Indel {
+                                insert: "crate::a::b",
+                                delete: 38..43,
+                            },
+                        ],
+                    ),
+                    (
+                        FileId(
+                            6,
+                        ),
+                        [
+                            Indel {
+                                insert: "pub mod m;\n",
+                                delete: 0..0,
+                            },
+                        ],
+                    ),
+                    (
+                        FileId(
+                            3,
+                        ),
+                        [
+                            Indel {
+                                insert: "sib_b",
+                                delete: 8..9,
+                            },
+                            Indel {
+                                insert: "",
+                                delete: 11..26,
+                            },
+                        ],
+                    ),
+                ]
+                file_system_edits: []
+            "#]],
+        );
+    }
+
+    #[test]
+    fn will_move_module_super_boundaries() {
+        // Grouped `use super::{…}` re-anchors ONLY the leading `super` (never
+        // crossing the `{`); `self::` is left intact; and a `super` inside a
+        // nested inline `mod` is a documented boundary — skipped, not miswritten.
+        check_expect_will_move(
+            &["b"],
+            "m",
+            r#"
+//- /lib.rs
+mod a;
+mod b;
+//- /a.rs
+pub mod m;
+pub mod sib;
+pub mod sib2;
+//- /a/sib.rs
+pub fn h() {}
+//- /a/sib2.rs
+pub fn h2() {}
+//- /a/m.rs
+$0use super::{sib, sib2};
+pub mod child { pub fn c() { super::super::sib::h(); } }
+pub fn g() {
+    self::child::c();
+    super::sib::h();
+}
+//- /b.rs
+"#,
+            expect![[r#"
+                source_file_edits: [
+                    (
+                        FileId(
+                            4,
+                        ),
+                        [
+                            Indel {
+                                insert: "crate::a",
+                                delete: 4..9,
+                            },
+                            Indel {
+                                insert: "crate::a",
+                                delete: 120..125,
+                            },
+                        ],
+                    ),
+                    (
+                        FileId(
+                            5,
+                        ),
+                        [
+                            Indel {
+                                insert: "pub mod m;\n",
+                                delete: 0..0,
+                            },
+                        ],
+                    ),
+                    (
+                        FileId(
+                            1,
+                        ),
+                        [
+                            Indel {
+                                insert: "sib",
+                                delete: 8..9,
+                            },
+                            Indel {
+                                insert: "sib2",
+                                delete: 19..22,
+                            },
+                            Indel {
+                                insert: "",
+                                delete: 24..38,
+                            },
+                        ],
+                    ),
+                ]
+                file_system_edits: []
+            "#]],
+        );
     }
 
     fn check_prepare(#[rust_analyzer::rust_fixture] ra_fixture: &str, expect: Expect) {

--- a/crates/ide/src/rename.rs
+++ b/crates/ide/src/rename.rs
@@ -8,6 +8,7 @@ use hir::{AsAssocItem, FindPathConfig, HasContainer, HirDisplay, InFile, Name, S
 use ide_db::{
     FileId, FileRange, RootDatabase,
     defs::{Definition, NameClass, NameRefClass},
+    imports::insert_use::InsertUseConfig,
     rename::{IdentifierKind, RenameDefinition, bail, format_err, source_edit_from_references},
     source_change::SourceChangeBuilder,
 };
@@ -267,6 +268,113 @@ pub(crate) fn will_move_module(
     // The editor performs the physical file move; we only supply text edits.
     change.file_system_edits.clear();
     Some(change)
+}
+
+/// Move an item into another module, both named by absolute path as they would
+/// be written in source: `my_crate::a::foo` into `my_crate::b`.
+///
+/// Paths rather than a [`FilePosition`], because the caller here is as likely to
+/// be a script running a batch of moves as a cursor. See
+/// [`ide_db::rename::move_item`].
+pub(crate) fn move_item(
+    db: &RootDatabase,
+    item_path: &str,
+    destination: &str,
+    insert_use_cfg: &InsertUseConfig,
+) -> RenameResult<SourceChange> {
+    let sema = Semantics::new(db);
+    let item = resolve_item_path(db, item_path)?;
+    let dst = resolve_module_path(db, destination)?;
+    ide_db::rename::move_item(&sema, item, dst, insert_use_cfg)
+}
+
+/// Crate-relative segments of `path`, paired with every crate its head names —
+/// plural, because a lib and a bin target can share one.
+fn split_crate_path(
+    db: &RootDatabase,
+    path: &str,
+) -> RenameResult<(Vec<hir::Crate>, Vec<Name>, String)> {
+    let mut segments = path.split("::").map(str::trim).filter(|it| !it.is_empty());
+    let crate_name =
+        segments.next().ok_or_else(|| format_err!("`{path}` names no crate"))?.to_owned();
+    let segments: Vec<Name> = segments.map(Name::new_root).collect();
+    let crates: Vec<hir::Crate> = hir::Crate::all(db)
+        .into_iter()
+        .filter(|krate| {
+            krate.display_name(db).is_some_and(|it| it.crate_name().to_string() == crate_name)
+        })
+        .collect();
+    if crates.is_empty() {
+        bail!("No crate named `{crate_name}` in this workspace");
+    }
+    Ok((crates, segments, crate_name))
+}
+
+/// Walks the module tree by name rather than resolving the path: a refactoring
+/// tool addresses code by where it *is*, and a private item — the usual thing
+/// to move out of an overgrown file — resolves from nowhere else.
+fn descend_modules(db: &RootDatabase, from: hir::Module, segments: &[Name]) -> Option<hir::Module> {
+    segments.iter().try_fold(from, |module, segment| {
+        module.children(db).find(|it| it.name(db).as_ref() == Some(segment))
+    })
+}
+
+fn resolve_module_path(db: &RootDatabase, path: &str) -> RenameResult<hir::Module> {
+    let (crates, segments, _) = split_crate_path(db, path)?;
+    let mut found: Vec<hir::Module> = crates
+        .into_iter()
+        .filter_map(|krate| descend_modules(db, krate.root_module(db), &segments))
+        .collect();
+    found.dedup();
+    match found.len() {
+        1 => Ok(found.remove(0)),
+        0 => bail!("`{path}` does not name a module"),
+        _ => bail!("`{path}` names a module in more than one crate of that name"),
+    }
+}
+
+fn resolve_item_path(db: &RootDatabase, path: &str) -> RenameResult<hir::ModuleDef> {
+    let (crates, segments, crate_name) = split_crate_path(db, path)?;
+    let Some((item_name, module_segments)) = segments.split_last() else {
+        bail!("`{path}` names a crate, not an item");
+    };
+    let mut found: Vec<hir::ModuleDef> = crates
+        .into_iter()
+        .filter_map(|krate| {
+            let module = descend_modules(db, krate.root_module(db), module_segments)?;
+            module.declarations(db).into_iter().find(|it| it.name(db).as_ref() == Some(item_name))
+        })
+        .collect();
+    found.dedup();
+    match found.len() {
+        1 => Ok(found.remove(0)),
+        // Naming what the module does hold tells a typo apart from a wrong idea
+        // of where the item lives.
+        0 => bail!(
+            "`{path}` does not name an item{}",
+            neighbours_hint(db, &crate_name, module_segments)
+        ),
+        _ => bail!("`{path}` names an item in more than one crate of that name"),
+    }
+}
+
+/// ` (module `x` declares: a, b, c)`, or nothing when even the module is wrong.
+fn neighbours_hint(db: &RootDatabase, crate_name: &str, module_segments: &[Name]) -> String {
+    let Ok(module) = resolve_module_path(
+        db,
+        &std::iter::once(crate_name.to_owned())
+            .chain(module_segments.iter().map(|it| it.as_str().to_owned()))
+            .join("::"),
+    ) else {
+        return String::new();
+    };
+    let names = module
+        .declarations(db)
+        .into_iter()
+        .filter_map(|it| it.name(db))
+        .map(|it| it.as_str().to_owned())
+        .join(", ");
+    if names.is_empty() { String::new() } else { format!(" (that module declares: {names})") }
 }
 
 // FIXME: Should support `extern crate`.
@@ -874,10 +982,11 @@ fn rename_elided_lifetime(
 #[cfg(test)]
 mod tests {
     use expect_test::{Expect, expect};
+    use ide_db::imports::insert_use::{ImportGranularity, InsertUseConfig};
     use ide_db::source_change::SourceChange;
     use ide_db::text_edit::TextEdit;
     use itertools::Itertools;
-    use stdx::trim_indent;
+    use stdx::{format_to, trim_indent};
     use test_utils::assert_eq_text;
 
     use crate::fixture;
@@ -982,6 +1091,316 @@ mod tests {
             .unwrap()
             .expect("Expect returned a RenameError");
         expect.assert_eq(&filter_expect(source_change))
+    }
+
+    const TEST_INSERT_USE: InsertUseConfig = InsertUseConfig {
+        granularity: ImportGranularity::Crate,
+        prefix_kind: hir::PrefixKind::Plain,
+        enforce_granularity: true,
+        group: true,
+        skip_glob_imports: true,
+    };
+
+    /// Renders every touched file with the change applied, rather than the raw
+    /// indels: a path spelled from the wrong module, or an import landing in the
+    /// wrong file, is invisible in offsets.
+    #[track_caller]
+    fn check_move_item(
+        item: &str,
+        destination: &str,
+        #[rust_analyzer::rust_fixture] ra_fixture: &str,
+        expect: Expect,
+    ) {
+        let (analysis, _) = fixture::file(ra_fixture);
+        let rendered =
+            match analysis.move_item_to_module(item, destination, &TEST_INSERT_USE).unwrap() {
+                Ok(source_change) => {
+                    let mut rendered = String::new();
+                    for (&file_id, (edit, _)) in
+                        source_change.source_file_edits.iter().sorted_by_key(|&(&id, _)| id)
+                    {
+                        let mut text = analysis.file_text(file_id).unwrap().to_string();
+                        edit.apply(&mut text);
+                        format_to!(rendered, "//- {file_id:?}\n{text}\n");
+                    }
+                    rendered
+                }
+                Err(err) => format!("error: {err}"),
+            };
+        expect.assert_eq(&rendered)
+    }
+
+    #[test]
+    fn move_item_rewrites_qualified_reference() {
+        check_move_item(
+            "ra_test_fixture::a::foo",
+            "ra_test_fixture::b",
+            r#"
+//- /lib.rs
+mod a;
+mod b;
+fn f() { crate::a::foo(); }
+//- /a.rs
+pub fn foo() {}
+//- /b.rs
+"#,
+            expect![[r#"
+                //- FileId(0)
+                mod a;
+                mod b;
+                fn f() { crate::b::foo(); }
+
+                //- FileId(1)
+
+                //- FileId(2)
+                pub fn foo() {}
+
+            "#]],
+        );
+    }
+
+    #[test]
+    fn move_item_imports_bare_reference_left_behind() {
+        // `foo` resolved for `g` by being its neighbour. It stops being one, so
+        // the source file has to import it — and a private item would no longer
+        // be reachable from there at all, hence `pub(crate)`.
+        check_move_item(
+            "ra_test_fixture::a::foo",
+            "ra_test_fixture::b",
+            r#"
+//- /lib.rs
+mod a;
+mod b;
+//- /a.rs
+fn foo() {}
+pub fn g() { foo(); }
+//- /b.rs
+"#,
+            expect![[r#"
+                //- FileId(1)
+                use crate::b::foo;
+
+                pub fn g() { foo(); }
+
+                //- FileId(2)
+                pub(crate) fn foo() {}
+
+            "#]],
+        );
+    }
+
+    #[test]
+    fn move_item_respells_body_paths_from_destination() {
+        // The body's own paths were resolved against `a`: `helper` was a bare
+        // neighbour call and `S` came in through a `use` that stays behind.
+        check_move_item(
+            "ra_test_fixture::a::foo",
+            "ra_test_fixture::b",
+            r#"
+//- /lib.rs
+mod a;
+mod b;
+pub struct S;
+//- /a.rs
+use crate::S;
+pub(crate) fn helper() -> S { S }
+pub fn foo() -> S { helper() }
+//- /b.rs
+"#,
+            expect![[r#"
+                //- FileId(1)
+                use crate::S;
+                pub(crate) fn helper() -> S { S }
+
+                //- FileId(2)
+                pub fn foo() -> crate::S { crate::a::helper() }
+
+            "#]],
+        );
+    }
+
+    #[test]
+    fn move_item_widens_a_private_neighbour_it_calls() {
+        // `helper` was reachable only from inside `a`, so the destination cannot
+        // even spell it. Leaving the call as written would emit code that does
+        // not compile, so the neighbour is widened and the call spelled out.
+        check_move_item(
+            "ra_test_fixture::a::foo",
+            "ra_test_fixture::b",
+            r#"
+//- /lib.rs
+mod a;
+mod b;
+//- /a.rs
+fn helper() {}
+pub fn foo() { helper(); }
+//- /b.rs
+"#,
+            expect![[r#"
+                //- FileId(1)
+                pub(crate) fn helper() {}
+
+                //- FileId(2)
+                pub fn foo() { crate::a::helper(); }
+
+            "#]],
+        );
+    }
+
+    #[test]
+    fn move_item_keeps_recursive_call_bare() {
+        // The self-call resolves to the item being moved, so spelling it out
+        // from the destination would name a place it is leaving.
+        check_move_item(
+            "ra_test_fixture::a::foo",
+            "ra_test_fixture::b",
+            r#"
+//- /lib.rs
+mod a;
+mod b;
+//- /a.rs
+pub fn foo(n: u32) -> u32 { if n == 0 { 0 } else { foo(n - 1) } }
+//- /b.rs
+"#,
+            expect![[r#"
+                //- FileId(1)
+
+                //- FileId(2)
+                pub fn foo(n: u32) -> u32 { if n == 0 { 0 } else { foo(n - 1) } }
+
+            "#]],
+        );
+    }
+
+    #[test]
+    fn move_item_splits_use_group() {
+        check_move_item(
+            "ra_test_fixture::a::foo",
+            "ra_test_fixture::b",
+            r#"
+//- /lib.rs
+mod a;
+mod b;
+mod c;
+//- /a.rs
+pub fn foo() {}
+pub fn bar() {}
+//- /b.rs
+//- /c.rs
+use crate::a::{bar, foo};
+fn f() { foo(); bar(); }
+"#,
+            expect![[r#"
+                //- FileId(1)
+                pub fn bar() {}
+
+                //- FileId(2)
+                pub fn foo() {}
+
+                //- FileId(3)
+                use crate::b::foo;
+                use crate::a::{bar};
+                fn f() { foo(); bar(); }
+
+            "#]],
+        );
+    }
+
+    #[test]
+    fn move_item_moves_a_type_and_leaves_its_impl() {
+        // An impl block is not part of the type's item, and an inherent impl is
+        // valid from any module of the crate — so it stays, with its self-type
+        // reference re-spelled.
+        check_move_item(
+            "ra_test_fixture::a::S",
+            "ra_test_fixture::b",
+            r#"
+//- /lib.rs
+mod a;
+mod b;
+//- /a.rs
+pub struct S;
+impl S { pub fn new() -> S { S } }
+//- /b.rs
+"#,
+            expect![[r#"
+                //- FileId(1)
+                use crate::b::S;
+
+                impl S { pub fn new() -> S { S } }
+
+                //- FileId(2)
+                pub struct S;
+
+            "#]],
+        );
+    }
+
+    #[test]
+    fn move_item_carries_its_comments_and_attributes() {
+        // What is written *about* an item is part of it: a doc comment, a plain
+        // comment sitting on top of it, and its attributes all travel along.
+        check_move_item(
+            "ra_test_fixture::a::foo",
+            "ra_test_fixture::b",
+            r#"
+//- /lib.rs
+mod a;
+mod b;
+//- /a.rs
+// why this exists
+/// What it does.
+#[inline]
+pub fn foo() {}
+
+pub fn after() {}
+//- /b.rs
+"#,
+            expect![[r#"
+                //- FileId(1)
+                pub fn after() {}
+
+                //- FileId(2)
+                // why this exists
+                /// What it does.
+                #[inline]
+                pub fn foo() {}
+
+            "#]],
+        );
+    }
+
+    #[test]
+    fn move_item_rejects_what_text_alone_does_not_carry() {
+        check_move_item(
+            "ra_test_fixture::a::m",
+            "ra_test_fixture::b",
+            r#"
+//- /lib.rs
+mod a;
+mod b;
+//- /a.rs
+pub mod m {}
+//- /b.rs
+"#,
+            expect!["error: Cannot move a module as an item"],
+        );
+    }
+
+    #[test]
+    fn move_item_reports_an_unknown_path() {
+        check_move_item(
+            "ra_test_fixture::a::nope",
+            "ra_test_fixture::b",
+            r#"
+//- /lib.rs
+mod a;
+mod b;
+//- /a.rs
+//- /b.rs
+"#,
+            expect!["error: `ra_test_fixture::a::nope` does not name an item"],
+        );
     }
 
     fn check_expect_will_move(

--- a/crates/rust-analyzer/src/handlers/request.rs
+++ b/crates/rust-analyzer/src/handlers/request.rs
@@ -771,6 +771,31 @@ pub(crate) fn handle_workspace_symbol(
     }
 }
 
+/// Crate-relative module segments of a moved file's new parent, e.g.
+/// `…/src/state/foo.rs` → `["state"]`. Since the module tree mirrors the directory
+/// tree below the crate root file's directory, those are just the destination's
+/// directory components. `None` if the destination escapes that root.
+fn new_parent_module_segments(
+    snap: &GlobalStateSnapshot,
+    file_id: FileId,
+    to_path: &std::path::Path,
+) -> Option<Vec<String>> {
+    let krate = snap.analysis.crates_for(file_id).ok()?.into_iter().next()?;
+    let root_file = snap.analysis.crate_root(krate).ok()?;
+    let root_vfs_path = snap.file_id_to_file_path(root_file);
+    let root_dir: &AbsPath = root_vfs_path.as_path()?.parent()?;
+    let new_parent_dir = to_path.parent()?;
+    // A non-plain component (`..`, `.`, non-UTF-8) means this is not a normal
+    // in-tree module directory, so bail rather than emit a bogus module path.
+    let rel = new_parent_dir.strip_prefix(root_dir).ok()?;
+    rel.components()
+        .map(|c| match c {
+            std::path::Component::Normal(s) => s.to_str().map(str::to_owned),
+            _ => None,
+        })
+        .collect()
+}
+
 pub(crate) fn handle_will_rename_files(
     snap: GlobalStateSnapshot,
     params: lsp_types::RenameFilesParams,
@@ -787,10 +812,10 @@ pub(crate) fn handle_will_rename_files(
             let from_path = from.to_file_path().ok()?;
             let to_path = to.to_file_path().ok()?;
 
-            // Limit to single-level moves for now.
-            match (from_path.parent(), to_path.parent()) {
+            Some(match (from_path.parent(), to_path.parent()) {
+                // Same-directory rename: only the module's leaf name changes.
                 (Some(p1), Some(p2)) if p1 == p2 => {
-                    if from_path.is_dir() {
+                    let (file_id, new_name): (Option<FileId>, String) = if from_path.is_dir() {
                         // add '/' to end of url -- from `file://path/to/folder` to `file://path/to/folder/`
                         let mut old_folder_name = from_path.file_stem()?.to_str()?.to_owned();
                         old_folder_name.push('/');
@@ -798,33 +823,51 @@ pub(crate) fn handle_will_rename_files(
 
                         let imitate_from_url = from_with_trailing_slash.join("mod.rs").ok()?;
                         let new_file_name = to_path.file_name()?.to_str()?;
-                        Some((
-                            snap.url_to_file_id(&imitate_from_url).ok()?,
-                            new_file_name.to_owned(),
-                        ))
+                        (snap.url_to_file_id(&imitate_from_url).ok()?, new_file_name.to_owned())
                     } else {
                         let old_name = from_path.file_stem()?.to_str()?;
                         let new_name = to_path.file_stem()?.to_str()?;
                         match (old_name, new_name) {
-                            ("mod", _) => None,
-                            (_, "mod") => None,
-                            _ => Some((snap.url_to_file_id(&from).ok()?, new_name.to_owned())),
+                            ("mod", _) | (_, "mod") => return None,
+                            _ => (snap.url_to_file_id(&from).ok()?, new_name.to_owned()),
                         }
-                    }
+                    };
+                    let file_id = file_id?;
+                    let source_root = snap.analysis.source_root_id(file_id).ok();
+                    snap.analysis
+                        .will_rename_file(file_id, &new_name, &snap.config.rename(source_root))
+                        .ok()??
                 }
-                _ => None,
-            }
-        })
-        .filter_map(|(file_id, new_name)| {
-            let file_id = file_id?;
-            let source_root = snap.analysis.source_root_id(file_id).ok();
-            snap.analysis
-                .will_rename_file(file_id, &new_name, &snap.config.rename(source_root))
-                .ok()?
+                // Cross-parent move: fix the mod tree and rewrite all references.
+                (Some(_), Some(_)) => {
+                    let (file_id, new_leaf): (Option<FileId>, String) = if from_path.is_dir() {
+                        // A dragged folder is a `mod.rs`-style module; imitate the
+                        // URL of its `mod.rs` as the branch above does.
+                        let mut old_folder_name = from_path.file_stem()?.to_str()?.to_owned();
+                        old_folder_name.push('/');
+                        let from_with_trailing_slash = from.join(&old_folder_name).ok()?;
+                        let imitate_from_url = from_with_trailing_slash.join("mod.rs").ok()?;
+                        let new_leaf = to_path.file_stem()?.to_str()?.to_owned();
+                        (snap.url_to_file_id(&imitate_from_url).ok()?, new_leaf)
+                    } else {
+                        let old_leaf = from_path.file_stem()?.to_str()?;
+                        let new_leaf = to_path.file_stem()?.to_str()?;
+                        if old_leaf == "mod" || new_leaf == "mod" {
+                            return None;
+                        }
+                        (snap.url_to_file_id(&from).ok()?, new_leaf.to_owned())
+                    };
+                    let file_id = file_id?;
+                    let segments = new_parent_module_segments(&snap, file_id, &to_path)?;
+                    snap.analysis.will_move_module(file_id, &segments, &new_leaf).ok()??
+                }
+                _ => return None,
+            })
         })
         .collect();
 
-    // Drop file system edits since we're just renaming things on the same level
+    // Drop file system edits: the editor performs the move itself, we only
+    // contribute text edits.
     let mut source_changes = source_changes.into_iter();
     let mut source_change = source_changes.next().unwrap_or_default();
     source_change.file_system_edits.clear();

--- a/crates/rust-analyzer/src/handlers/request.rs
+++ b/crates/rust-analyzer/src/handlers/request.rs
@@ -772,6 +772,30 @@ pub(crate) fn handle_workspace_symbol(
     }
 }
 
+/// Crate-relative module segments of a moved file's new parent, e.g.
+/// `…/src/state/foo.rs` → `["state"]`: below the crate root's directory the
+/// module tree mirrors the directory tree. `None` if the destination escapes it.
+fn new_parent_module_segments(
+    snap: &GlobalStateSnapshot,
+    file_id: FileId,
+    to_path: &std::path::Path,
+) -> Option<Vec<String>> {
+    let krate = snap.analysis.crates_for(file_id).ok()?.into_iter().next()?;
+    let root_file = snap.analysis.crate_root(krate).ok()?;
+    let root_vfs_path = snap.file_id_to_file_path(root_file);
+    let root_dir: &AbsPath = root_vfs_path.as_path()?.parent()?;
+    let new_parent_dir = to_path.parent()?;
+    // A non-plain component (`..`, `.`, non-UTF-8) means this is not a normal
+    // in-tree module directory, so bail rather than emit a bogus module path.
+    let rel = new_parent_dir.strip_prefix(root_dir).ok()?;
+    rel.components()
+        .map(|c| match c {
+            std::path::Component::Normal(s) => s.to_str().map(str::to_owned),
+            _ => None,
+        })
+        .collect()
+}
+
 pub(crate) fn handle_will_rename_files(
     snap: GlobalStateSnapshot,
     params: lsp_types::RenameFilesParams,
@@ -785,10 +809,10 @@ pub(crate) fn handle_will_rename_files(
             let from_path = from.to_file_path().ok()?;
             let to_path = to.to_file_path().ok()?;
 
-            // Limit to single-level moves for now.
-            match (from_path.parent(), to_path.parent()) {
+            Some(match (from_path.parent(), to_path.parent()) {
+                // Same-directory rename: only the module's leaf name changes.
                 (Some(p1), Some(p2)) if p1 == p2 => {
-                    if from_path.is_dir() {
+                    let (file_id, new_name): (Option<FileId>, String) = if from_path.is_dir() {
                         // add '/' to end of url -- from `file://path/to/folder` to `file://path/to/folder/`
                         let mut old_folder_name = from_path.file_stem()?.to_str()?.to_owned();
                         old_folder_name.push('/');
@@ -796,33 +820,51 @@ pub(crate) fn handle_will_rename_files(
 
                         let imitate_from_url = from_with_trailing_slash.join("mod.rs").ok()?;
                         let new_file_name = to_path.file_name()?.to_str()?;
-                        Some((
-                            snap.url_to_file_id(&imitate_from_url).ok()?,
-                            new_file_name.to_owned(),
-                        ))
+                        (snap.url_to_file_id(&imitate_from_url).ok()?, new_file_name.to_owned())
                     } else {
                         let old_name = from_path.file_stem()?.to_str()?;
                         let new_name = to_path.file_stem()?.to_str()?;
                         match (old_name, new_name) {
-                            ("mod", _) => None,
-                            (_, "mod") => None,
-                            _ => Some((snap.url_to_file_id(&from).ok()?, new_name.to_owned())),
+                            ("mod", _) | (_, "mod") => return None,
+                            _ => (snap.url_to_file_id(&from).ok()?, new_name.to_owned()),
                         }
-                    }
+                    };
+                    let file_id = file_id?;
+                    let source_root = snap.analysis.source_root_id(file_id).ok();
+                    snap.analysis
+                        .will_rename_file(file_id, &new_name, &snap.config.rename(source_root))
+                        .ok()??
                 }
-                _ => None,
-            }
-        })
-        .filter_map(|(file_id, new_name)| {
-            let file_id = file_id?;
-            let source_root = snap.analysis.source_root_id(file_id).ok();
-            snap.analysis
-                .will_rename_file(file_id, &new_name, &snap.config.rename(source_root))
-                .ok()?
+                // Cross-parent move: fix the mod tree and rewrite all references.
+                (Some(_), Some(_)) => {
+                    let (file_id, new_leaf): (Option<FileId>, String) = if from_path.is_dir() {
+                        // A dragged folder is a `mod.rs`-style module; imitate the
+                        // URL of its `mod.rs` as the branch above does.
+                        let mut old_folder_name = from_path.file_stem()?.to_str()?.to_owned();
+                        old_folder_name.push('/');
+                        let from_with_trailing_slash = from.join(&old_folder_name).ok()?;
+                        let imitate_from_url = from_with_trailing_slash.join("mod.rs").ok()?;
+                        let new_leaf = to_path.file_stem()?.to_str()?.to_owned();
+                        (snap.url_to_file_id(&imitate_from_url).ok()?, new_leaf)
+                    } else {
+                        let old_leaf = from_path.file_stem()?.to_str()?;
+                        let new_leaf = to_path.file_stem()?.to_str()?;
+                        if old_leaf == "mod" || new_leaf == "mod" {
+                            return None;
+                        }
+                        (snap.url_to_file_id(&from).ok()?, new_leaf.to_owned())
+                    };
+                    let file_id = file_id?;
+                    let segments = new_parent_module_segments(&snap, file_id, &to_path)?;
+                    snap.analysis.will_move_module(file_id, &segments, &new_leaf).ok()??
+                }
+                _ => return None,
+            })
         })
         .collect();
 
-    // Drop file system edits since we're just renaming things on the same level
+    // Drop file system edits: the editor performs the move itself, we only
+    // contribute text edits.
     let mut source_changes = source_changes.into_iter();
     let mut source_change = source_changes.next().unwrap_or_default();
     source_change.file_system_edits.clear();

--- a/crates/rust-analyzer/src/handlers/request.rs
+++ b/crates/rust-analyzer/src/handlers/request.rs
@@ -2220,6 +2220,23 @@ pub(crate) fn handle_move_item(
     }
 }
 
+pub(crate) fn handle_move_item_to_module(
+    snap: GlobalStateSnapshot,
+    params: lsp_ext::MoveItemToModuleParams,
+) -> anyhow::Result<Option<lsp_types::WorkspaceEdit>> {
+    let _p = tracing::info_span!("handle_move_item_to_module").entered();
+
+    // Both ends are named, not pointed at, so there is no file to take the
+    // per-source-root config from.
+    let insert_use = snap.config.assist(None).insert_use;
+    let source_change = snap
+        .analysis
+        .move_item_to_module(&params.item, &params.destination, &insert_use)?
+        .map_err(to_proto::rename_error)?;
+
+    Ok(Some(to_proto::workspace_edit(&snap, source_change)?))
+}
+
 pub(crate) fn handle_view_recursive_memory_layout(
     snap: GlobalStateSnapshot,
     params: lsp_types::TextDocumentPositionParams,

--- a/crates/rust-analyzer/src/lsp/ext.rs
+++ b/crates/rust-analyzer/src/lsp/ext.rs
@@ -821,6 +821,28 @@ pub enum MoveItemDirection {
     Down,
 }
 
+/// Relocate an item to another module. Both ends are named by absolute path, as
+/// they would be written in source: no editor gesture points at an item and a
+/// module the way dragging a file does at a module and its new parent.
+pub enum MoveItemToModuleRequest {}
+
+impl Request for MoveItemToModuleRequest {
+    type Params = MoveItemToModuleParams;
+    type Result = Option<lsp_types::WorkspaceEdit>;
+    const METHOD: LspRequestMethod<'_> = LspRequestMethod::new("experimental/moveItemToModule");
+    const MESSAGE_DIRECTION: MessageDirection = MessageDirection::ClientToServer;
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct MoveItemToModuleParams {
+    /// The item to move, e.g. `my_crate::a::foo`.
+    pub item: String,
+    /// The module to move it into, e.g. `my_crate::b`; the crate name alone
+    /// names the crate root.
+    pub destination: String,
+}
+
 #[derive(Debug)]
 pub enum WorkspaceSymbolRequest {}
 

--- a/crates/rust-analyzer/src/main_loop.rs
+++ b/crates/rust-analyzer/src/main_loop.rs
@@ -1432,6 +1432,7 @@ impl GlobalState {
             .on::<NO_RETRY, lsp_ext::ExternalDocsRequest>(handlers::handle_open_docs)
             .on::<NO_RETRY, lsp_ext::OpenCargoTomlRequest>(handlers::handle_open_cargo_toml)
             .on::<NO_RETRY, lsp_ext::MoveItemRequest>(handlers::handle_move_item)
+            .on::<RETRY, lsp_ext::MoveItemToModuleRequest>(handlers::handle_move_item_to_module)
             //
             .on::<NO_RETRY, lsp_ext::InternalTestingFetchConfigRequest>(handlers::internal_testing_fetch_config)
             .on::<RETRY, lsp_ext::EvaluatePredicateRequest>(handlers::handle_evaluate_predicate)

--- a/crates/rust-analyzer/tests/slow-tests/main.rs
+++ b/crates/rust-analyzer/tests/slow-tests/main.rs
@@ -1415,6 +1415,180 @@ use crate::old_folder::nested::foo as bar;
 }
 
 #[test]
+fn test_will_rename_files_cross_parent() {
+    if skip_slow_tests() {
+        return;
+    }
+
+    let tmp_dir = TestDir::new();
+    let tmp_dir_str = tmp_dir.path().as_str().to_owned();
+    let base_path = PathBuf::from(format!("file://{tmp_dir_str}"));
+
+    let code = r#"
+//- /Cargo.toml
+[package]
+name = "foo"
+version = "0.0.0"
+
+//- /src/lib.rs
+mod a;
+mod b;
+use crate::a::m::S;
+
+//- /src/a.rs
+pub mod m;
+
+//- /src/a/m.rs
+pub struct S;
+
+//- /src/b.rs
+
+"#;
+    let server =
+        Project::with_fixture(code).tmp_dir(tmp_dir).server().wait_until_workspace_is_loaded();
+
+    // Move `src/a/m.rs` -> `src/b/m.rs`: module `m` is dragged under a new parent `b`.
+    // This exercises the cross-parent arm of `handle_will_rename_files`, which routes
+    // to `will_move_module`. Expect the mod-tree to be fixed (drop `pub mod m;` from
+    // `a.rs`, add it under `b.rs`) and the reference `crate::a::m::S` rewritten to
+    // `crate::b::m::S`. (The per-file edit content is asserted exhaustively by the
+    // `will_move_module_*` unit tests in `ide`; here we pin the LSP wiring.)
+    server.request::<WillRenameFilesRequest>(
+        RenameFilesParams {
+            files: vec![FileRename {
+                old_uri: base_path.join("src/a/m.rs").to_str().unwrap().to_owned(),
+                new_uri: base_path.join("src/b/m.rs").to_str().unwrap().to_owned(),
+            }],
+        },
+        json!({
+          "documentChanges": [
+            {
+              "textDocument": { "uri": "file://[..]/src/lib.rs", "version": null },
+              "edits": [
+                {
+                  "range": {
+                    "start": { "line": 2, "character": 4 },
+                    "end": { "line": 2, "character": 15 }
+                  },
+                  "newText": "crate::b::m"
+                }
+              ]
+            },
+            {
+              "textDocument": { "uri": "file://[..]/src/b.rs", "version": null },
+              "edits": [
+                {
+                  "range": {
+                    "start": { "line": 1, "character": 0 },
+                    "end": { "line": 1, "character": 0 }
+                  },
+                  "newText": "pub mod m;\n"
+                }
+              ]
+            },
+            {
+              "textDocument": { "uri": "file://[..]/src/a.rs", "version": null },
+              "edits": [
+                {
+                  "range": {
+                    "start": { "line": 0, "character": 0 },
+                    "end": { "line": 1, "character": 0 }
+                  },
+                  "newText": ""
+                }
+              ]
+            }
+          ]
+        }),
+    );
+}
+
+#[test]
+fn test_will_rename_files_cross_parent_folder() {
+    if skip_slow_tests() {
+        return;
+    }
+
+    let tmp_dir = TestDir::new();
+    let tmp_dir_str = tmp_dir.path().as_str().to_owned();
+    let base_path = PathBuf::from(format!("file://{tmp_dir_str}"));
+
+    let code = r#"
+//- /Cargo.toml
+[package]
+name = "foo"
+version = "0.0.0"
+
+//- /src/lib.rs
+mod a;
+mod b;
+use crate::a::child::S;
+
+//- /src/a/mod.rs
+pub mod child;
+
+//- /src/a/child.rs
+pub struct S;
+
+//- /src/b.rs
+
+"#;
+    let server =
+        Project::with_fixture(code).tmp_dir(tmp_dir).server().wait_until_workspace_is_loaded();
+
+    // Drag the whole `src/a` folder under `b`: `src/a` -> `src/b/a`. This is a
+    // `mod.rs`-style directory module dragged to a new parent. The cross-parent arm
+    // resolves the folder's `mod.rs` and routes to `will_move_module`. Expect the
+    // mod-tree fixed (drop `mod a;` from `lib.rs`, add it under `b.rs`) and the
+    // reference *through* the module, `crate::a::child::S`, rewritten to
+    // `crate::b::a::child::S`. The editor moves the directory physically; RA emits
+    // only text edits.
+    server.request::<WillRenameFilesRequest>(
+        RenameFilesParams {
+            files: vec![FileRename {
+                old_uri: base_path.join("src/a").to_str().unwrap().to_owned(),
+                new_uri: base_path.join("src/b/a").to_str().unwrap().to_owned(),
+            }],
+        },
+        json!({
+          "documentChanges": [
+            {
+              "textDocument": { "uri": "file://[..]/src/lib.rs", "version": null },
+              "edits": [
+                {
+                  "range": {
+                    "start": { "line": 0, "character": 0 },
+                    "end": { "line": 1, "character": 0 }
+                  },
+                  "newText": ""
+                },
+                {
+                  "range": {
+                    "start": { "line": 2, "character": 4 },
+                    "end": { "line": 2, "character": 12 }
+                  },
+                  "newText": "crate::b::a"
+                }
+              ]
+            },
+            {
+              "textDocument": { "uri": "file://[..]/src/b.rs", "version": null },
+              "edits": [
+                {
+                  "range": {
+                    "start": { "line": 1, "character": 0 },
+                    "end": { "line": 1, "character": 0 }
+                  },
+                  "newText": "mod a;\n"
+                }
+              ]
+            }
+          ]
+        }),
+    );
+}
+
+#[test]
 fn test_exclude_config_works() {
     if skip_slow_tests() {
         return;

--- a/crates/rust-analyzer/tests/slow-tests/main.rs
+++ b/crates/rust-analyzer/tests/slow-tests/main.rs
@@ -1418,6 +1418,180 @@ use crate::old_folder::nested::foo as bar;
 }
 
 #[test]
+fn test_will_rename_files_cross_parent() {
+    if skip_slow_tests() {
+        return;
+    }
+
+    let tmp_dir = TestDir::new();
+    let tmp_dir_str = tmp_dir.path().as_str().to_owned();
+    let base_path = PathBuf::from(format!("file://{tmp_dir_str}"));
+
+    let code = r#"
+//- /Cargo.toml
+[package]
+name = "foo"
+version = "0.0.0"
+
+//- /src/lib.rs
+mod a;
+mod b;
+use crate::a::m::S;
+
+//- /src/a.rs
+pub mod m;
+
+//- /src/a/m.rs
+pub struct S;
+
+//- /src/b.rs
+
+"#;
+    let server =
+        Project::with_fixture(code).tmp_dir(tmp_dir).server().wait_until_workspace_is_loaded();
+
+    // Move `src/a/m.rs` -> `src/b/m.rs`: module `m` is dragged under a new parent `b`.
+    // This exercises the cross-parent arm of `handle_will_rename_files`, which routes
+    // to `will_move_module`. Expect the mod-tree to be fixed (drop `pub mod m;` from
+    // `a.rs`, add it under `b.rs`) and the reference `crate::a::m::S` rewritten to
+    // `crate::b::m::S`. (The per-file edit content is asserted exhaustively by the
+    // `will_move_module_*` unit tests in `ide`; here we pin the LSP wiring.)
+    server.request::<WillRenameFilesRequest>(
+        RenameFilesParams {
+            files: vec![FileRename {
+                old_uri: Uri::parse(base_path.join("src/a/m.rs").to_str().unwrap()).unwrap(),
+                new_uri: Uri::parse(base_path.join("src/b/m.rs").to_str().unwrap()).unwrap(),
+            }],
+        },
+        json!({
+          "documentChanges": [
+            {
+              "textDocument": { "uri": "file://[..]/src/lib.rs", "version": null },
+              "edits": [
+                {
+                  "range": {
+                    "start": { "line": 2, "character": 4 },
+                    "end": { "line": 2, "character": 15 }
+                  },
+                  "newText": "crate::b::m"
+                }
+              ]
+            },
+            {
+              "textDocument": { "uri": "file://[..]/src/b.rs", "version": null },
+              "edits": [
+                {
+                  "range": {
+                    "start": { "line": 1, "character": 0 },
+                    "end": { "line": 1, "character": 0 }
+                  },
+                  "newText": "pub mod m;\n"
+                }
+              ]
+            },
+            {
+              "textDocument": { "uri": "file://[..]/src/a.rs", "version": null },
+              "edits": [
+                {
+                  "range": {
+                    "start": { "line": 0, "character": 0 },
+                    "end": { "line": 1, "character": 0 }
+                  },
+                  "newText": ""
+                }
+              ]
+            }
+          ]
+        }),
+    );
+}
+
+#[test]
+fn test_will_rename_files_cross_parent_folder() {
+    if skip_slow_tests() {
+        return;
+    }
+
+    let tmp_dir = TestDir::new();
+    let tmp_dir_str = tmp_dir.path().as_str().to_owned();
+    let base_path = PathBuf::from(format!("file://{tmp_dir_str}"));
+
+    let code = r#"
+//- /Cargo.toml
+[package]
+name = "foo"
+version = "0.0.0"
+
+//- /src/lib.rs
+mod a;
+mod b;
+use crate::a::child::S;
+
+//- /src/a/mod.rs
+pub mod child;
+
+//- /src/a/child.rs
+pub struct S;
+
+//- /src/b.rs
+
+"#;
+    let server =
+        Project::with_fixture(code).tmp_dir(tmp_dir).server().wait_until_workspace_is_loaded();
+
+    // Drag the whole `src/a` folder under `b`: `src/a` -> `src/b/a`. This is a
+    // `mod.rs`-style directory module dragged to a new parent. The cross-parent arm
+    // resolves the folder's `mod.rs` and routes to `will_move_module`. Expect the
+    // mod-tree fixed (drop `mod a;` from `lib.rs`, add it under `b.rs`) and the
+    // reference *through* the module, `crate::a::child::S`, rewritten to
+    // `crate::b::a::child::S`. The editor moves the directory physically; RA emits
+    // only text edits.
+    server.request::<WillRenameFilesRequest>(
+        RenameFilesParams {
+            files: vec![FileRename {
+                old_uri: Uri::parse(base_path.join("src/a").to_str().unwrap()).unwrap(),
+                new_uri: Uri::parse(base_path.join("src/b/a").to_str().unwrap()).unwrap(),
+            }],
+        },
+        json!({
+          "documentChanges": [
+            {
+              "textDocument": { "uri": "file://[..]/src/lib.rs", "version": null },
+              "edits": [
+                {
+                  "range": {
+                    "start": { "line": 0, "character": 0 },
+                    "end": { "line": 1, "character": 0 }
+                  },
+                  "newText": ""
+                },
+                {
+                  "range": {
+                    "start": { "line": 2, "character": 4 },
+                    "end": { "line": 2, "character": 12 }
+                  },
+                  "newText": "crate::b::a"
+                }
+              ]
+            },
+            {
+              "textDocument": { "uri": "file://[..]/src/b.rs", "version": null },
+              "edits": [
+                {
+                  "range": {
+                    "start": { "line": 1, "character": 0 },
+                    "end": { "line": 1, "character": 0 }
+                  },
+                  "newText": "mod a;\n"
+                }
+              ]
+            }
+          ]
+        }),
+    );
+}
+
+#[test]
 fn test_exclude_config_works() {
     if skip_slow_tests() {
         return;

--- a/crates/rust-analyzer/tests/slow-tests/main.rs
+++ b/crates/rust-analyzer/tests/slow-tests/main.rs
@@ -1418,6 +1418,84 @@ use crate::old_folder::nested::foo as bar;
 }
 
 #[test]
+fn test_move_item_to_module() {
+    if skip_slow_tests() {
+        return;
+    }
+
+    let tmp_dir = TestDir::new();
+
+    let code = r#"
+//- /Cargo.toml
+[package]
+name = "foo"
+version = "0.0.0"
+
+//- /src/lib.rs
+mod a;
+mod b;
+
+//- /src/a.rs
+fn helper() {}
+pub fn moved() { helper(); }
+
+//- /src/b.rs
+
+"#;
+    let server =
+        Project::with_fixture(code).tmp_dir(tmp_dir).server().wait_until_workspace_is_loaded();
+
+    // Move `foo::a::moved` into module `foo::b`, addressed by path — there is no
+    // editor gesture for this, so the request carries names rather than a
+    // position. The item's text leaves `a.rs` and lands in `b.rs`; the private
+    // neighbour it calls is widened to `pub(crate)` and the call spelled out,
+    // since the destination could not otherwise name it. (The edits are asserted
+    // exhaustively by the `move_item_*` unit tests in `ide`; here we pin the LSP
+    // wiring.)
+    server.request::<rust_analyzer::lsp::ext::MoveItemToModuleRequest>(
+        rust_analyzer::lsp::ext::MoveItemToModuleParams {
+            item: "foo::a::moved".to_owned(),
+            destination: "foo::b".to_owned(),
+        },
+        json!({
+          "documentChanges": [
+            {
+              "textDocument": { "uri": "file://[..]/src/b.rs", "version": null },
+              "edits": [
+                {
+                  "range": {
+                    "start": { "line": 1, "character": 0 },
+                    "end": { "line": 1, "character": 0 }
+                  },
+                  "newText": "pub fn moved() { crate::a::helper(); }\n"
+                }
+              ]
+            },
+            {
+              "textDocument": { "uri": "file://[..]/src/a.rs", "version": null },
+              "edits": [
+                {
+                  "range": {
+                    "start": { "line": 0, "character": 0 },
+                    "end": { "line": 0, "character": 0 }
+                  },
+                  "newText": "pub(crate) "
+                },
+                {
+                  "range": {
+                    "start": { "line": 0, "character": 14 },
+                    "end": { "line": 3, "character": 0 }
+                  },
+                  "newText": "\n\n"
+                }
+              ]
+            }
+          ]
+        }),
+    );
+}
+
+#[test]
 fn test_will_rename_files_cross_parent() {
     if skip_slow_tests() {
         return;
@@ -1463,6 +1541,9 @@ pub struct S;
                 new_uri: Uri::parse(base_path.join("src/b/m.rs").to_str().unwrap()).unwrap(),
             }],
         },
+        // The reference edit is the one character that actually differs: the
+        // rewritten path is spliced as a tree, and the edit is the diff of the
+        // trees, not the whole path re-spelled.
         json!({
           "documentChanges": [
             {
@@ -1470,10 +1551,10 @@ pub struct S;
               "edits": [
                 {
                   "range": {
-                    "start": { "line": 2, "character": 4 },
-                    "end": { "line": 2, "character": 15 }
+                    "start": { "line": 2, "character": 11 },
+                    "end": { "line": 2, "character": 12 }
                   },
-                  "newText": "crate::b::m"
+                  "newText": "b"
                 }
               ]
             },
@@ -1495,9 +1576,9 @@ pub struct S;
                 {
                   "range": {
                     "start": { "line": 0, "character": 0 },
-                    "end": { "line": 1, "character": 0 }
+                    "end": { "line": 2, "character": 0 }
                   },
-                  "newText": ""
+                  "newText": "\n"
                 }
               ]
             }
@@ -1553,6 +1634,9 @@ pub struct S;
                 new_uri: Uri::parse(base_path.join("src/b/a").to_str().unwrap()).unwrap(),
             }],
         },
+        // Text-wise this leaves `mod b;` and `use crate::b::a::child::S;`. The
+        // edits express that as a diff of the trees — dropping `mod a;` shifts
+        // what the following lines are, rather than deleting a line outright.
         json!({
           "documentChanges": [
             {
@@ -1560,17 +1644,31 @@ pub struct S;
               "edits": [
                 {
                   "range": {
-                    "start": { "line": 0, "character": 0 },
-                    "end": { "line": 1, "character": 0 }
+                    "start": { "line": 0, "character": 4 },
+                    "end": { "line": 0, "character": 5 }
                   },
-                  "newText": ""
+                  "newText": "b"
                 },
                 {
                   "range": {
-                    "start": { "line": 2, "character": 4 },
-                    "end": { "line": 2, "character": 12 }
+                    "start": { "line": 1, "character": 0 },
+                    "end": { "line": 1, "character": 3 }
                   },
-                  "newText": "crate::b::a"
+                  "newText": "use"
+                },
+                {
+                  "range": {
+                    "start": { "line": 1, "character": 4 },
+                    "end": { "line": 1, "character": 5 }
+                  },
+                  "newText": "crate::b::a::child::S"
+                },
+                {
+                  "range": {
+                    "start": { "line": 1, "character": 6 },
+                    "end": { "line": 4, "character": 0 }
+                  },
+                  "newText": "\n\n"
                 }
               ]
             },

--- a/crates/syntax/src/syntax_editor/edits.rs
+++ b/crates/syntax/src/syntax_editor/edits.rs
@@ -448,48 +448,73 @@ impl Removable for ast::TypeBoundList {
     }
 }
 
+/// The whitespace token adjoining `node` in `dir`, if the neighbour is whitespace at all.
+fn adjoining_ws(node: &SyntaxNode, dir: Direction) -> Option<ast::Whitespace> {
+    let element = match dir {
+        Direction::Next => node.next_sibling_or_token(),
+        Direction::Prev => node.prev_sibling_or_token(),
+    };
+    element.and_then(|it| it.into_token()).and_then(ast::Whitespace::cast)
+}
+
+/// Deletes `node` and the line it sits on, indentation included — otherwise a
+/// declaration nested in an inline module strands its indent on a blank line.
+///
+/// `collapse_next` gets a say on the whitespace *after* `node`: returning true deletes
+/// it outright instead of trimming it back to the next line's indent. Callers removing
+/// a run of adjacent items use this to keep blank lines from opening up between them.
+fn remove_taking_line(
+    node: &SyntaxNode,
+    editor: &SyntaxEditor,
+    collapse_next: impl FnOnce(&ast::Whitespace) -> bool,
+) {
+    let make = editor.make();
+    if let Some(next_ws) = adjoining_ws(node, Direction::Next) {
+        let ws_text = next_ws.syntax().text();
+        // Only the newline belongs to our line; what follows is the *next* line's indent.
+        if let Some(rest) = ws_text.strip_prefix('\n') {
+            if rest.is_empty() || collapse_next(&next_ws) {
+                editor.delete(next_ws.syntax());
+            } else {
+                editor.replace(next_ws.syntax(), make.whitespace(rest));
+            }
+        }
+    }
+    if let Some(prev_ws) = adjoining_ws(node, Direction::Prev) {
+        let ws_text = prev_ws.syntax().text();
+        // Keep everything through the last newline and drop the rest: that is exactly
+        // our own indentation, and the preceding line stays untouched.
+        let prev_newline = ws_text.rfind('\n').map(|x| x + 1).unwrap_or(0);
+        let rest = &ws_text[0..prev_newline];
+        if rest.is_empty() {
+            editor.delete(prev_ws.syntax());
+        } else {
+            editor.replace(prev_ws.syntax(), make.whitespace(rest));
+        }
+    }
+
+    editor.delete(node);
+}
+
+impl Removable for ast::Module {
+    fn remove(&self, editor: &SyntaxEditor) {
+        remove_taking_line(self.syntax(), editor, |_| false);
+    }
+}
+
 impl Removable for ast::Use {
     fn remove(&self, editor: &SyntaxEditor) {
-        let make = editor.make();
-        let next_ws = self
-            .syntax()
-            .next_sibling_or_token()
-            .and_then(|it| it.into_token())
-            .and_then(ast::Whitespace::cast);
-        if let Some(next_ws) = next_ws {
-            let ws_text = next_ws.syntax().text();
-            if let Some(rest) = ws_text.strip_prefix('\n') {
-                let next_use_removed = next_ws
-                    .syntax()
-                    .next_sibling_or_token()
-                    .and_then(|it| it.into_node())
-                    .and_then(ast::Use::cast)
-                    .and_then(|use_| use_.use_tree())
-                    .is_some_and(|use_tree| editor.deleted(use_tree.syntax()));
-                if rest.is_empty() || next_use_removed {
-                    editor.delete(next_ws.syntax());
-                } else {
-                    editor.replace(next_ws.syntax(), make.whitespace(rest));
-                }
-            }
-        }
-        let prev_ws = self
-            .syntax()
-            .prev_sibling_or_token()
-            .and_then(|it| it.into_token())
-            .and_then(ast::Whitespace::cast);
-        if let Some(prev_ws) = prev_ws {
-            let ws_text = prev_ws.syntax().text();
-            let prev_newline = ws_text.rfind('\n').map(|x| x + 1).unwrap_or(0);
-            let rest = &ws_text[0..prev_newline];
-            if rest.is_empty() {
-                editor.delete(prev_ws.syntax());
-            } else {
-                editor.replace(prev_ws.syntax(), make.whitespace(rest));
-            }
-        }
-
-        editor.delete(self.syntax());
+        remove_taking_line(self.syntax(), editor, |next_ws| {
+            // The `use` following ours is going away too, so the newline between us
+            // would otherwise be left behind as a blank line.
+            next_ws
+                .syntax()
+                .next_sibling_or_token()
+                .and_then(|it| it.into_node())
+                .and_then(ast::Use::cast)
+                .and_then(|use_| use_.use_tree())
+                .is_some_and(|use_tree| editor.deleted(use_tree.syntax()))
+        });
     }
 }
 


### PR DESCRIPTION
## Summary

Implements the request in rust-lang/rust-analyzer#8872: moving a module to a **new parent** — dragging a
`.rs` file or a module folder into a *different* directory — now fixes the module
tree and rewrites references, instead of leaving the code broken.

`workspace/willRenameFiles` previously handled only same-directory renames (rust-lang/rust-analyzer#7009).
This adds the cross-parent case.

## What it does

A new `ide` entry point `Analysis::will_move_module`, backed by
`ide_db::rename::move_mod`, produces a single `SourceChange`:

- **mod-tree surgery** — drop the old `mod X;` (with its trailing newline) and
  re-declare it, preserving visibility, at the end of the new parent's item list;
- **reference rewrite** — for each usage, splice the leading `ast::Path` ending at
  the module segment with the module's new absolute `crate::…` path, leaving any
  trailing `::Item` untouched (HIR still describes the pre-move tree, so the
  old/new absolute paths are computed textually);
- **`super::` re-anchoring inside the moved file** — a leading `super` run is
  rewritten to the `crate::…` path it denotes today, since after the move the same
  text would resolve against a different parent (`self::` is left alone);
- **grouped `use` imports** — a member importing through the moved module is pulled
  out into its own `use`; an emptied group is replaced wholesale, otherwise moved
  members are deleted as overlap-free runs;
- **cross-crate references** keep the extern crate name (`foo::a::m` → `foo::b::m`),
  honouring `package = "…"` renames;
- **`mod.rs` / directory modules** — the same surgery generalizes; the editor moves
  the directory physically, so only text edits are emitted.

`handle_will_rename_files` gained a cross-parent arm that maps the destination
directory to the new parent's crate-relative module segments and routes both dropped
files and dragged folders (resolved via their `mod.rs`) to `will_move_module`.
File-system edits stay cleared — the editor owns the physical move.

## Boundaries (documented in code, left to the compiler)

- macro-expanded references (edits would have to land in the macro *input*);
- a `super::super…` chain inside a *child* file of a moved directory module that
  climbs *above* the module (only the moved module's own file is re-anchored);
- `pub(super)` / `pub(in super::x)` visibility.

## Tests

- `will_move_module_*` unit tests in `ide` cover each case exhaustively via
  `expect_test`;
- two `rust-analyzer` slow-tests pin the LSP wiring:
  `test_will_rename_files_cross_parent` (file drag) and
  `test_will_rename_files_cross_parent_folder` (folder drag).

## Second commit: moving a single item (`experimental/moveItemToModule`)

The commit on top adds the sibling operation: relocate one **item** — a function, a
type, a const — into a module that **already exists**. It is a separate story, kept as
its own commit so it can be reviewed on its own; it lives here only because it builds
on the reference-splicing pass introduced above. It can be split into a follow-up PR if
that reads better — it just cannot land first.

Both ends are named by absolute path (`my_crate::a::foo` into `my_crate::b`) rather
than pointed at: there is no editor gesture that picks an item *and* a destination
module the way dragging a file picks a module and its new parent, and a caller running
a batch of moves has paths, not offsets. Hence a request rather than an assist.

Tearing an item away from its neighbours breaks three different things at once, and
each is fixed:

- paths **inside** the item resolved against the source module's scope — they are
  re-resolved against the destination via `PathTransform`, so nothing is imported
  there and nothing can collide with what the destination already has;
- qualified references **to** the item — spliced by the same pass the module move
  uses, `use`-group splitting included;
- bare references that resolved by proximity — every file left holding one gets an
  import, since the item is not a neighbour there anymore.

Two visibility widenings fall out of the same reasoning: an item that kept its callers
by living next to them is widened to `pub(crate)`, and so is a private neighbour the
moved body calls — the destination cannot otherwise name it, and leaving the call as
written would emit code that does not compile.

Kinds whose meaning is not carried by their text are refused with a message saying so:
`macro_rules!` (visible by textual order), macro-generated items, enum variants,
modules (that is the module move), and `pub(super)`/`pub(in …)` visibility. Two
boundaries are deliberate rather than refused: `impl` blocks do not travel with a type
(an inherent impl is legal from anywhere in the crate, and half the impls moved would
be worse than none), and a `use` left unused by the departure is not removed (a
warning, not an error).

Tests: 10 `move_item_*` unit tests in `ide` via `expect_test`, plus a `rust-analyzer`
slow-test `test_move_item_to_module` pinning the LSP wiring.

The branch is rebased on current `master`. Two small fixes for upstream API changes are
folded into the first commit: `ast::NameRef::text()` now yields `&str`, and
`FileRename`'s uris are `Uri` rather than `String`.

## Disclosure

Both commits were written **end-to-end by an AI coding agent** (Anthropic's Claude) —
it is entirely AI-generated ("vibe-coded"). A human directed the work, reviewed the
diff, and ran the tests, but did not hand-write the implementation. Flagging this
explicitly so reviewers can weigh it accordingly; happy to iterate on anything.

Closes rust-lang/rust-analyzer#8872.

