### PR TITLE
fix: Cancel ongoing build scripts/workspace discovery on exit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3016,6 +3016,7 @@ name = "toolchain"
 version = "0.0.0"
 dependencies = [
  "camino",
+ "stdx",
 ]
 
 [[package]]

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,9 +1,12 @@
 disallowed-types = [
     { path = "std::collections::HashMap", reason = "use FxHashMap" },
     { path = "std::collections::HashSet", reason = "use FxHashSet" },
-    { path = "std::collections::hash_map::RandomState", reason = "use BuildHasherDefault<FxHasher>"}
+    { path = "std::collections::hash_map::RandomState", reason = "use BuildHasherDefault<FxHasher>" },
+    { path = "std::process::Command", replacement = "stdx::process::JodCommand" },
+    { path = "std::process::Child", replacement = "stdx::process::JodChild" },
 ]
 
 disallowed-methods = [
     { path = "std::process::Command::new", reason = "use `toolchain::command` instead as it forces the choice of a working directory" },
+    { path = "stdx::process::JodCommand::new", reason = "use `toolchain::command` instead as it forces the choice of a working directory" },
 ]

--- a/crates/ide/src/expand_macro.rs
+++ b/crates/ide/src/expand_macro.rs
@@ -255,7 +255,7 @@ fn _format(
     let edition = crate_id.data(db).edition;
 
     #[allow(clippy::disallowed_methods)]
-    let mut cmd = std::process::Command::new(toolchain::Tool::Rustfmt.path());
+    let mut cmd = stdx::process::JodCommand::new(toolchain::Tool::Rustfmt.path());
     cmd.arg("--edition");
     cmd.arg(edition.to_string());
 
@@ -266,7 +266,7 @@ fn _format(
         .spawn()
         .ok()?;
 
-    std::io::Write::write_all(&mut rustfmt.stdin.as_mut()?, expansion.as_bytes()).ok()?;
+    std::io::Write::write_all(&mut rustfmt.stdin()?, expansion.as_bytes()).ok()?;
 
     let output = rustfmt.wait_with_output().ok()?;
     let captured_stdout = String::from_utf8(output.stdout).ok()?;

--- a/crates/proc-macro-api/src/process.rs
+++ b/crates/proc-macro-api/src/process.rs
@@ -4,7 +4,7 @@ use std::{
     fmt::Debug,
     io::{self, BufRead, BufReader, Read, Write},
     panic::AssertUnwindSafe,
-    process::{Child, ChildStdin, ChildStdout, Command, Stdio},
+    process::{ChildStdin, ChildStdout, Stdio},
     sync::{
         Arc, Mutex, OnceLock,
         atomic::{AtomicU32, Ordering},
@@ -14,7 +14,7 @@ use std::{
 use paths::AbsPath;
 use semver::Version;
 use span::Span;
-use stdx::JodChild;
+use stdx::process::{JodChild, JodCommand};
 
 use crate::{
     ProcMacro, ProcMacroKind, ProtocolFormat, ServerError,
@@ -66,7 +66,8 @@ impl ProcessExit for Process {
             Ok(Some(status)) => {
                 let mut msg = String::new();
                 if !status.success()
-                    && let Some(stderr) = self.child.stderr.as_mut()
+                    // Can use `inner_unchecked()` since the process has already exited.
+                    && let Some(stderr) = self.child.inner_unchecked().stderr.as_mut()
                 {
                     _ = stderr.read_to_string(&mut msg);
                 }
@@ -112,7 +113,7 @@ impl ProcMacroServerProcess {
             version,
             || {
                 #[expect(clippy::disallowed_methods)]
-                Command::new(process_path)
+                JodCommand::new(process_path)
                     .arg("--version")
                     .output()
                     .map(|output| String::from_utf8_lossy(&output.stdout).trim().to_owned())
@@ -390,14 +391,18 @@ impl Process {
         >,
         format: Option<&str>,
     ) -> io::Result<Process> {
-        let child = JodChild(mk_child(path, env, format)?);
+        let child = mk_child(path, env, format)?;
         Ok(Process { child })
     }
 
     /// Retrieves stdin and stdout handles for the process.
     fn stdio(&mut self) -> Option<(ChildStdin, BufReader<ChildStdout>)> {
-        let stdin = self.child.stdin.take()?;
-        let stdout = self.child.stdout.take()?;
+        // The process itself (the `JodChild`) lives on the `GlobalState` outside any thread pool
+        // and will be killed on exit, closing standard streams. So it's OK to use `inner_unchecked()`
+        // here.
+        let child = self.child.inner_unchecked();
+        let stdin = child.stdin.take()?;
+        let stdout = child.stdout.take()?;
         let read = BufReader::new(stdout);
 
         Some((stdin, read))
@@ -411,9 +416,9 @@ fn mk_child<'a>(
         Item = (impl AsRef<std::ffi::OsStr>, &'a Option<impl 'a + AsRef<std::ffi::OsStr>>),
     >,
     format: Option<&str>,
-) -> io::Result<Child> {
-    #[allow(clippy::disallowed_methods)]
-    let mut cmd = Command::new(path);
+) -> io::Result<JodChild> {
+    #[expect(clippy::disallowed_methods)]
+    let mut cmd = JodCommand::new(path);
     for env in extra_env {
         match env {
             (key, Some(val)) => cmd.env(key, val),

--- a/crates/proc-macro-srv-cli/build.rs
+++ b/crates/proc-macro-srv-cli/build.rs
@@ -1,5 +1,7 @@
 //! Construct version in the `commit-hash date channel` format
 
+#![allow(clippy::disallowed_types, reason = "this is a build script")]
+
 use std::{env, path::PathBuf, process::Command};
 
 fn main() {

--- a/crates/proc-macro-srv/build.rs
+++ b/crates/proc-macro-srv/build.rs
@@ -1,6 +1,8 @@
 //! Determine rustc version `proc-macro-srv` (and thus the sysroot ABI) is
 //! build with and make it accessible at runtime for ABI selection.
 
+#![allow(clippy::disallowed_types, reason = "this is a build script")]
+
 use std::{env, process::Command};
 
 fn main() {

--- a/crates/proc-macro-srv/proc-macro-test/build.rs
+++ b/crates/proc-macro-srv/proc-macro-test/build.rs
@@ -7,7 +7,7 @@
 //! a specific rustup toolchain: this allows testing against older ABIs (e.g.
 //! 1.58) and future ABIs (stage1, nightly)
 
-#![allow(clippy::disallowed_methods)]
+#![allow(clippy::disallowed_types, clippy::disallowed_methods, reason = "this is a build script")]
 
 use std::{
     env,

--- a/crates/project-model/src/build_dependencies.rs
+++ b/crates/project-model/src/build_dependencies.rs
@@ -6,7 +6,7 @@
 //! but if enabled we will also use `RUSTC_WRAPPER` to only compile the build scripts and
 //! proc-macros and skip everything else.
 
-use std::{cell::RefCell, io, mem, process::Command};
+use std::{cell::RefCell, io, mem};
 
 use base_db::Env;
 use cargo_metadata::{Message, PackageId, camino::Utf8Path};
@@ -16,7 +16,7 @@ use la_arena::ArenaMap;
 use paths::{AbsPath, AbsPathBuf, Utf8PathBuf};
 use rustc_hash::{FxHashMap, FxHashSet};
 use serde::Deserialize as _;
-use stdx::never;
+use stdx::{never, process::JodCommand};
 use toolchain::Tool;
 use triomphe::Arc;
 
@@ -279,7 +279,7 @@ impl WorkspaceBuildScripts {
     }
 
     fn run_per_ws(
-        cmd: Command,
+        cmd: JodCommand,
         workspace: &CargoWorkspace,
         progress: &dyn Fn(String),
     ) -> io::Result<WorkspaceBuildScripts> {
@@ -323,7 +323,7 @@ impl WorkspaceBuildScripts {
     }
 
     fn run_command(
-        cmd: Command,
+        cmd: JodCommand,
         // ideally this would be something like:
         // with_output_for: impl FnMut(&str, dyn FnOnce(&mut BuildScriptOutput)),
         // but owned trait objects aren't a thing
@@ -338,8 +338,7 @@ impl WorkspaceBuildScripts {
         };
 
         tracing::info!("Running build scripts: {:?}", cmd);
-        let output = stdx::process::spawn_with_streaming_output(
-            cmd,
+        let output = cmd.spawn_with_streaming_output(
             &mut |line| {
                 // Copy-pasted from existing cargo_metadata. It seems like we
                 // should be using serde_stacker here?
@@ -437,7 +436,7 @@ impl WorkspaceBuildScripts {
         current_dir: &AbsPath,
         sysroot: &Sysroot,
         toolchain: Option<&semver::Version>,
-    ) -> io::Result<(Option<LockfileCopy>, Command)> {
+    ) -> io::Result<(Option<LockfileCopy>, JodCommand)> {
         match config.run_build_script_command.as_deref() {
             Some([program, args @ ..]) => {
                 let mut cmd = toolchain::command(program, current_dir, &config.extra_env);

--- a/crates/project-model/src/cargo_workspace.rs
+++ b/crates/project-model/src/cargo_workspace.rs
@@ -11,7 +11,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use serde_derive::Deserialize;
 use serde_json::from_value;
 use span::Edition;
-use stdx::process::spawn_with_streaming_output;
+use stdx::process::JodCommand;
 use toolchain::{NO_RUSTUP_AUTO_INSTALL_ENV, Tool};
 use triomphe::Arc;
 
@@ -795,7 +795,7 @@ impl FetchMetadata {
             let mut errored = false;
             tracing::debug!("Running `{:?}`", command.cargo_command());
             let output =
-                spawn_with_streaming_output(command.cargo_command(), &mut |_| (), &mut |line| {
+                JodCommand::from(command.cargo_command()).spawn_with_streaming_output(&mut |_| (), &mut |line| {
                     errored = errored || line.starts_with("error") || line.starts_with("warning");
                     if errored {
                         progress("cargo metadata: ?".to_owned());

--- a/crates/project-model/src/lib.rs
+++ b/crates/project-model/src/lib.rs
@@ -58,12 +58,12 @@ use std::{
     fmt,
     fs::{self, ReadDir, read_dir},
     io,
-    process::Command,
 };
 
 use anyhow::{Context, bail, format_err};
 use paths::{AbsPath, AbsPathBuf, Utf8PathBuf};
 use rustc_hash::FxHashSet;
+use stdx::process::JodCommand;
 
 pub use crate::{
     build_dependencies::{ProcMacroDylibPath, WorkspaceBuildScripts},
@@ -210,7 +210,7 @@ impl fmt::Display for ProjectManifest {
     }
 }
 
-fn utf8_stdout(cmd: &mut Command) -> anyhow::Result<String> {
+fn utf8_stdout(cmd: &mut JodCommand) -> anyhow::Result<String> {
     let output = cmd.output().with_context(|| format!("{cmd:?} failed"))?;
     if !output.status.success() {
         match String::from_utf8(output.stderr) {

--- a/crates/project-model/src/sysroot.rs
+++ b/crates/project-model/src/sysroot.rs
@@ -5,14 +5,14 @@
 //! is typically installed with `rustup component add rust-src` command.
 
 use core::fmt;
-use std::{env, fs, ops::Not, path::Path, process::Command};
+use std::{env, fs, ops::Not, path::Path};
 
 use anyhow::{Result, format_err};
 use base_db::Env;
 use itertools::Itertools;
 use paths::{AbsPath, AbsPathBuf, Utf8PathBuf};
 use rustc_hash::FxHashMap;
-use stdx::format_to;
+use stdx::{format_to, process::JodCommand};
 use toolchain::{Tool, probe_for_binary};
 
 use crate::{
@@ -148,7 +148,7 @@ impl Sysroot {
         tool: Tool,
         current_dir: impl AsRef<Path>,
         envs: &FxHashMap<String, Option<String>>,
-    ) -> Command {
+    ) -> JodCommand {
         match self.root() {
             Some(root) => {
                 // special case rustc, we can look that up directly in the sysroot's bin folder

--- a/crates/rust-analyzer/build.rs
+++ b/crates/rust-analyzer/build.rs
@@ -1,5 +1,7 @@
 //! Construct version in the `commit-hash date channel` format
 
+#![allow(clippy::disallowed_types, reason = "this is a build script")]
+
 use std::{env, path::PathBuf, process::Command};
 
 fn main() {

--- a/crates/rust-analyzer/src/bin/rustc_wrapper.rs
+++ b/crates/rust-analyzer/src/bin/rustc_wrapper.rs
@@ -7,7 +7,7 @@
 use std::{
     ffi::OsString,
     io,
-    process::{Command, ExitCode, Stdio},
+    process::{ExitCode, Stdio},
 };
 
 pub(crate) fn main() -> io::Result<ExitCode> {
@@ -46,8 +46,8 @@ fn run_rustc_skipping_cargo_checking(
 }
 
 fn run_rustc(rustc_executable: OsString, args: Vec<OsString>) -> io::Result<ExitCode> {
-    #[allow(clippy::disallowed_methods)]
-    let mut child = Command::new(rustc_executable)
+    #[expect(clippy::disallowed_types, clippy::disallowed_methods)]
+    let mut child = std::process::Command::new(rustc_executable)
         .args(args)
         .stdin(Stdio::inherit())
         .stdout(Stdio::inherit())

--- a/crates/rust-analyzer/src/command.rs
+++ b/crates/rust-analyzer/src/command.rs
@@ -7,14 +7,14 @@ use std::{
     io::{self, BufWriter, Write},
     marker::PhantomData,
     path::PathBuf,
-    process::{ChildStderr, ChildStdout, Command, Stdio},
+    process::{ChildStderr, ChildStdout, Stdio},
 };
 
 use anyhow::Context;
 use crossbeam_channel::Sender;
 use paths::Utf8PathBuf;
 use process_wrap::std::{ChildWrapper, CommandWrap};
-use stdx::process::streaming_output;
+use stdx::process::{JodCommand, streaming_output};
 
 /// This trait abstracts parsing one line of JSON output into a Rust
 /// data type.
@@ -153,7 +153,7 @@ impl<T> fmt::Debug for CommandHandle<T> {
 
 impl<T: Sized + Send + 'static> CommandHandle<T> {
     pub(crate) fn spawn(
-        mut command: Command,
+        mut command: JodCommand,
         parser: impl JsonLinesParser<T>,
         sender: Sender<T>,
         out_file: Option<Utf8PathBuf>,
@@ -164,7 +164,7 @@ impl<T: Sized + Send + 'static> CommandHandle<T> {
         let arguments = command.get_args().map(|arg| arg.into()).collect::<Vec<OsString>>();
         let current_dir = command.get_current_dir().map(|arg| arg.to_path_buf());
 
-        let mut child = CommandWrap::from(command);
+        let mut child = CommandWrap::from(command.into_inner());
         #[cfg(unix)]
         child.wrap(process_wrap::std::ProcessSession);
         #[cfg(windows)]

--- a/crates/rust-analyzer/src/flycheck.rs
+++ b/crates/rust-analyzer/src/flycheck.rs
@@ -3,7 +3,6 @@
 
 use std::{
     fmt, io,
-    process::Command,
     sync::atomic::{AtomicUsize, Ordering},
     time::Duration,
 };
@@ -22,6 +21,7 @@ use serde_derive::Deserialize;
 pub(crate) use cargo_metadata::diagnostic::{
     Applicability, Diagnostic, DiagnosticCode, DiagnosticLevel, DiagnosticSpan,
 };
+use stdx::process::JodCommand;
 use toolchain::Tool;
 use triomphe::Arc;
 
@@ -66,7 +66,7 @@ pub(crate) enum Target {
 impl CargoOptions {
     pub(crate) fn apply_on_command(
         &self,
-        cmd: &mut Command,
+        cmd: &mut JodCommand,
         ws_target_dir: Option<&Utf8Path>,
         package_repr: Option<&str>,
     ) {
@@ -490,7 +490,7 @@ impl<'a> Substitutions<'a> {
         self,
         template: &project_json::Runnable,
         extra_env: &std::collections::HashMap<String, Option<String>, H>,
-    ) -> Option<Command> {
+    ) -> Option<JodCommand> {
         let mut cmd = toolchain::command(&template.program, &template.cwd, extra_env);
         for arg in &template.args {
             if let Some(ix) = arg.find(LABEL_INLINE) {
@@ -859,7 +859,7 @@ impl FlycheckActor {
         &self,
         scope: &FlycheckScope,
         saved_file: Option<&AbsPath>,
-    ) -> Option<Command> {
+    ) -> Option<JodCommand> {
         let label = match scope {
             // We could add a runnable like "RunnableKind::FlycheckWorkspace". But generally
             // if you're not running cargo, it's because your workspace is too big to check
@@ -886,7 +886,7 @@ impl FlycheckActor {
         scope: &FlycheckScope,
         saved_file: Option<&AbsPath>,
         target: Option<Target>,
-    ) -> Option<(Command, FlycheckCommandOrigin)> {
+    ) -> Option<(JodCommand, FlycheckCommandOrigin)> {
         match &self.config {
             FlycheckConfig::Automatic { cargo_options, ansi_color_output } => {
                 // Only use the rust-project.json's flycheck config when no check_overrideCommand

--- a/crates/rust-analyzer/src/handlers/request.rs
+++ b/crates/rust-analyzer/src/handlers/request.rs
@@ -2532,7 +2532,7 @@ fn run_rustfmt(
             .spawn()
             .context(format!("Failed to spawn {command:?}"))?;
 
-        rustfmt.stdin.as_mut().unwrap().write_all(file.as_bytes())?;
+        rustfmt.stdin().unwrap().write_all(file.as_bytes())?;
 
         rustfmt.wait_with_output()?
     };

--- a/crates/rust-analyzer/src/main_loop.rs
+++ b/crates/rust-analyzer/src/main_loop.rs
@@ -217,6 +217,21 @@ impl GlobalState {
         Err(anyhow::anyhow!("A receiver has been dropped, something panicked!"))
     }
 
+    fn shutdown(&mut self) {
+        self.shutdown_requested = true;
+        // Cancel all tasks and database operations, in parallel to make it faster.
+        std::thread::scope(|s| {
+            s.spawn(|| self.analysis_host.trigger_cancellation());
+            s.spawn(|| self.task_pool.handle.cancel_and_taint());
+            s.spawn(|| self.fmt_pool.handle.cancel_and_taint());
+            s.spawn(|| self.cancellation_pool.cancel_and_taint());
+            self.proc_macro_clients =
+                std::iter::repeat_with(|| None).take(self.proc_macro_clients.len()).collect();
+            self.flycheck.iter().for_each(|handle| handle.cancel());
+            self.discover_handles.clear();
+        });
+    }
+
     fn register_did_save_capability(&mut self, additional_patterns: impl Iterator<Item = String>) {
         let additional_filters = additional_patterns.map(|pattern| {
             lsp_types::DocumentFilter::TextDocumentFilter(lsp_types::TextDocumentFilter::Pattern(
@@ -1316,11 +1331,7 @@ impl GlobalState {
     fn on_request(&mut self, req: Request) {
         let mut dispatcher = RequestDispatcher { req: Some(req), global_state: self };
         dispatcher.on_sync_mut::<lsp_types::ShutdownRequest>(|s, ()| {
-            s.shutdown_requested = true;
-            s.proc_macro_clients =
-                std::iter::repeat_with(|| None).take(s.proc_macro_clients.len()).collect();
-            s.flycheck.iter().for_each(|handle| handle.cancel());
-            s.discover_handles.clear();
+            s.shutdown();
             Ok(())
         });
 

--- a/crates/rust-analyzer/src/task_pool.rs
+++ b/crates/rust-analyzer/src/task_pool.rs
@@ -43,6 +43,10 @@ impl<T> TaskPool<T> {
     pub(crate) fn is_empty(&self) -> bool {
         self.pool.is_empty()
     }
+
+    pub(crate) fn cancel_and_taint(&mut self) {
+        self.pool.cancel_and_taint();
+    }
 }
 
 /// `DeferredTaskQueue` holds deferred tasks.

--- a/crates/stdx/Cargo.toml
+++ b/crates/stdx/Cargo.toml
@@ -26,7 +26,7 @@ libc.workspace = true
 
 [target.'cfg(windows)'.dependencies]
 miow = "0.6.0"
-windows-sys = { version = "0.61", features = ["Win32_Foundation"] }
+windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_System_Threading"] }
 
 [features]
 # Uncomment to enable for the whole crate graph

--- a/crates/stdx/src/lib.rs
+++ b/crates/stdx/src/lib.rs
@@ -1,8 +1,6 @@
 //! Missing batteries for standard libraries.
 
 use std::borrow::Cow;
-use std::io as sio;
-use std::process::Command;
 use std::{cmp::Ordering, ops, time::Instant};
 
 mod macros;
@@ -289,44 +287,6 @@ pub fn defer<F: FnOnce()>(f: F) -> impl Drop {
         }
     }
     D(Some(f))
-}
-
-/// A [`std::process::Child`] wrapper that will kill the child on drop.
-#[cfg_attr(not(target_arch = "wasm32"), repr(transparent))]
-#[derive(Debug)]
-pub struct JodChild(pub std::process::Child);
-
-impl ops::Deref for JodChild {
-    type Target = std::process::Child;
-    fn deref(&self) -> &std::process::Child {
-        &self.0
-    }
-}
-
-impl ops::DerefMut for JodChild {
-    fn deref_mut(&mut self) -> &mut std::process::Child {
-        &mut self.0
-    }
-}
-
-impl Drop for JodChild {
-    fn drop(&mut self) {
-        _ = self.0.kill();
-        _ = self.0.wait();
-    }
-}
-
-impl JodChild {
-    pub fn spawn(mut command: Command) -> sio::Result<Self> {
-        command.spawn().map(Self)
-    }
-
-    #[must_use]
-    #[cfg(not(target_arch = "wasm32"))]
-    pub fn into_inner(self) -> std::process::Child {
-        // SAFETY: repr transparent, except on WASM
-        unsafe { std::mem::transmute::<Self, std::process::Child>(self) }
-    }
 }
 
 // feature: iter_order_by

--- a/crates/stdx/src/process.rs
+++ b/crates/stdx/src/process.rs
@@ -1,14 +1,263 @@
+#![expect(
+    clippy::disallowed_types,
+    clippy::disallowed_methods,
+    reason = "we define `stdx::process`"
+)]
+
 //! Read both stdout and stderr of child without deadlocks.
 //!
 //! <https://github.com/rust-lang/cargo/blob/905af549966f23a9288e9993a85d1249a5436556/crates/cargo-util/src/read2.rs>
 //! <https://github.com/rust-lang/cargo/blob/58a961314437258065e23cb6316dfc121d96fb71/crates/cargo-util/src/process_builder.rs#L231>
 
 use std::{
-    io,
-    process::{ChildStderr, ChildStdout, Command, Output, Stdio},
+    ffi::OsStr,
+    fmt, io,
+    path::Path,
+    process::{
+        ChildStderr, ChildStdin, ChildStdout, Command, CommandArgs, CommandEnvs, ExitStatus,
+        Output, Stdio,
+    },
+    time::Duration,
 };
 
-use crate::JodChild;
+const CHECK_CANCELLATION_EVERY: Duration = Duration::from_millis(100);
+
+/// A [`std::process::Command`] wrapper that creates a [`JodChild`].
+pub struct JodCommand {
+    inner: std::process::Command,
+    stdout_was_set: bool,
+    stderr_was_set: bool,
+}
+
+impl fmt::Debug for JodCommand {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("JodCommand").field(&self.inner).finish()
+    }
+}
+
+impl From<Command> for JodCommand {
+    fn from(inner: Command) -> Self {
+        JodCommand { inner, stdout_was_set: false, stderr_was_set: false }
+    }
+}
+
+impl JodCommand {
+    pub fn new<S: AsRef<OsStr>>(program: S) -> Self {
+        Self { inner: Command::new(program), stdout_was_set: false, stderr_was_set: false }
+    }
+
+    pub fn arg<S: AsRef<OsStr>>(&mut self, arg: S) -> &mut Self {
+        self.inner.arg(arg);
+        self
+    }
+
+    pub fn args<I, S>(&mut self, args: I) -> &mut Self
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<OsStr>,
+    {
+        self.inner.args(args);
+        self
+    }
+
+    pub fn env<K, V>(&mut self, key: K, val: V) -> &mut Self
+    where
+        K: AsRef<OsStr>,
+        V: AsRef<OsStr>,
+    {
+        self.inner.env(key, val);
+        self
+    }
+
+    pub fn envs<I, K, V>(&mut self, vars: I) -> &mut Self
+    where
+        I: IntoIterator<Item = (K, V)>,
+        K: AsRef<OsStr>,
+        V: AsRef<OsStr>,
+    {
+        self.inner.envs(vars);
+        self
+    }
+
+    pub fn env_remove<K: AsRef<OsStr>>(&mut self, key: K) -> &mut Self {
+        self.inner.env_remove(key);
+        self
+    }
+
+    pub fn env_clear(&mut self) -> &mut Self {
+        self.inner.env_clear();
+        self
+    }
+
+    pub fn current_dir<P: AsRef<Path>>(&mut self, dir: P) -> &mut Self {
+        self.inner.current_dir(dir);
+        self
+    }
+
+    pub fn stdin<T: Into<Stdio>>(&mut self, cfg: T) -> &mut Self {
+        self.inner.stdin(cfg);
+        self
+    }
+
+    pub fn stdout<T: Into<Stdio>>(&mut self, cfg: T) -> &mut Self {
+        self.stdout_was_set = true;
+        self.inner.stdout(cfg);
+        self
+    }
+
+    pub fn stderr<T: Into<Stdio>>(&mut self, cfg: T) -> &mut Self {
+        self.stderr_was_set = true;
+        self.inner.stderr(cfg);
+        self
+    }
+
+    pub fn spawn(&mut self) -> io::Result<JodChild> {
+        self.inner.spawn().map(JodChild)
+    }
+
+    pub fn output(&mut self) -> io::Result<Output> {
+        self.stdin(Stdio::null());
+        if !self.stdout_was_set {
+            self.stdout(Stdio::piped());
+        }
+        if !self.stderr_was_set {
+            self.stderr(Stdio::piped());
+        }
+
+        self.spawn()?.wait_with_output()
+    }
+
+    // `status()` is not provided, due to not being used and being less trivial
+    // to implement correctly.
+
+    pub fn get_program(&self) -> &OsStr {
+        self.inner.get_program()
+    }
+
+    pub fn get_args(&self) -> CommandArgs<'_> {
+        self.inner.get_args()
+    }
+
+    pub fn get_envs(&self) -> CommandEnvs<'_> {
+        self.inner.get_envs()
+    }
+
+    pub fn get_current_dir(&self) -> Option<&Path> {
+        self.inner.get_current_dir()
+    }
+
+    /// # Panics
+    ///
+    /// Panics if `cmd` is not configured to have `stdout` and `stderr` as `piped`.
+    pub fn spawn_with_streaming_output(
+        mut self,
+        on_stdout_line: &mut dyn FnMut(&str),
+        on_stderr_line: &mut dyn FnMut(&str),
+    ) -> io::Result<Output> {
+        self.stdout(Stdio::piped()).stderr(Stdio::piped()).stdin(Stdio::null());
+
+        let mut child = self.spawn()?;
+        let (stdout, stderr) = streaming_output(
+            child.0.stdout.take().unwrap(),
+            child.0.stderr.take().unwrap(),
+            on_stdout_line,
+            on_stderr_line,
+            &mut || (),
+        )?;
+        let status = child.wait()?;
+        Ok(Output { status, stdout, stderr })
+    }
+
+    pub fn into_inner(self) -> Command {
+        self.inner
+    }
+}
+
+/// A [`std::process::Child`] wrapper that will kill the child on drop, and also panics on [`crate::thread::Pool`]
+/// cancellation while waiting for child.
+#[cfg_attr(not(target_arch = "wasm32"), repr(transparent))]
+#[derive(Debug)]
+pub struct JodChild(std::process::Child);
+
+impl JodChild {
+    #[inline]
+    pub fn stdin(&mut self) -> Option<&mut ChildStdin> {
+        self.0.stdin.as_mut()
+    }
+
+    pub fn kill(&mut self) -> io::Result<()> {
+        self.0.kill()
+    }
+
+    pub fn id(&self) -> u32 {
+        self.0.id()
+    }
+
+    fn close_stdin(&mut self) {
+        self.0.stdin = None;
+    }
+
+    pub fn wait(&mut self) -> io::Result<ExitStatus> {
+        self.close_stdin();
+
+        if let Some(result) = self.0.try_wait().transpose() {
+            return result;
+        }
+
+        loop {
+            crate::thread::Pool::unwind_if_cancelled();
+
+            match imp::wait_process_timeout(&mut self.0, CHECK_CANCELLATION_EVERY).transpose() {
+                Some(result) => return result,
+                None => {}
+            }
+        }
+    }
+
+    pub fn try_wait(&mut self) -> io::Result<Option<ExitStatus>> {
+        self.0.try_wait()
+    }
+
+    pub fn wait_with_output(mut self) -> io::Result<Output> {
+        let mut stdout = Vec::new();
+        let mut stderr = Vec::new();
+
+        self.close_stdin();
+
+        match (self.0.stdout.take(), self.0.stderr.take()) {
+            (None, None) => {}
+            (Some(out_pipe), None) => stdout = imp::read1(out_pipe)?,
+            (None, Some(err_pipe)) => stderr = imp::read1(err_pipe)?,
+            (Some(out_pipe), Some(err_pipe)) => {
+                (stdout, stderr) = imp::read2(out_pipe, err_pipe, &mut |_, _, _| {})?;
+            }
+        }
+
+        let status = self.wait()?;
+        Ok(Output { status, stdout, stderr })
+    }
+
+    /// **Warning:** Waiting on the raw child can make thread pool cancellations wait for the process
+    /// to finish!
+    #[inline]
+    pub fn inner_unchecked(&mut self) -> &mut std::process::Child {
+        &mut self.0
+    }
+
+    #[must_use]
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn into_inner(self) -> std::process::Child {
+        // SAFETY: repr transparent, except on WASM
+        unsafe { std::mem::transmute::<Self, std::process::Child>(self) }
+    }
+}
+
+impl Drop for JodChild {
+    fn drop(&mut self) {
+        _ = self.0.kill();
+        _ = self.0.wait();
+    }
+}
 
 pub fn streaming_output(
     out: ChildStdout,
@@ -17,63 +266,37 @@ pub fn streaming_output(
     on_stderr_line: &mut dyn FnMut(&str),
     on_eof: &mut dyn FnMut(),
 ) -> io::Result<(Vec<u8>, Vec<u8>)> {
-    let mut stdout = Vec::new();
-    let mut stderr = Vec::new();
-
+    let (mut last_stdout_line, mut last_stderr_line) = (0, 0);
     imp::read2(out, err, &mut |is_out, data, eof| {
-        let idx = if eof {
-            data.len()
-        } else {
-            match data.iter().rposition(|&b| b == b'\n') {
-                Some(i) => i + 1,
-                None => return,
-            }
-        };
-        {
-            // scope for new_lines
-            let new_lines = {
-                let dst = if is_out { &mut stdout } else { &mut stderr };
-                let start = dst.len();
-                let data = data.drain(..idx);
-                dst.extend(data);
-                &dst[start..]
-            };
-            for line in String::from_utf8_lossy(new_lines).lines() {
-                if is_out {
-                    on_stdout_line(line);
-                } else {
-                    on_stderr_line(line);
+        // scope for new_lines
+        let new_lines = {
+            let last_line = if is_out { &mut last_stdout_line } else { &mut last_stderr_line };
+            let mut new_data = &data[*last_line..];
+            match new_data.iter().rposition(|&ch| ch == b'\n') {
+                Some(new_last_line) => {
+                    new_data = &new_data[..=new_last_line];
+                    *last_line += new_last_line + 1;
+                }
+                None => {
+                    if !eof {
+                        // Not completed a line yet.
+                        return;
+                    }
                 }
             }
-            if eof {
-                on_eof();
+            new_data
+        };
+        for line in String::from_utf8_lossy(new_lines).lines() {
+            if is_out {
+                on_stdout_line(line);
+            } else {
+                on_stderr_line(line);
             }
         }
-    })?;
-
-    Ok((stdout, stderr))
-}
-
-/// # Panics
-///
-/// Panics if `cmd` is not configured to have `stdout` and `stderr` as `piped`.
-pub fn spawn_with_streaming_output(
-    mut cmd: Command,
-    on_stdout_line: &mut dyn FnMut(&str),
-    on_stderr_line: &mut dyn FnMut(&str),
-) -> io::Result<Output> {
-    let cmd = cmd.stdout(Stdio::piped()).stderr(Stdio::piped()).stdin(Stdio::null());
-
-    let mut child = JodChild(cmd.spawn()?);
-    let (stdout, stderr) = streaming_output(
-        child.stdout.take().unwrap(),
-        child.stderr.take().unwrap(),
-        on_stdout_line,
-        on_stderr_line,
-        &mut || (),
-    )?;
-    let status = child.wait()?;
-    Ok(Output { status, stdout, stderr })
+        if eof {
+            on_eof();
+        }
+    })
 }
 
 #[cfg(all(unix, not(target_arch = "wasm32")))]
@@ -82,14 +305,66 @@ mod imp {
         io::{self, prelude::*},
         mem,
         os::unix::prelude::*,
-        process::{ChildStderr, ChildStdout},
+        process::{Child, ChildStderr, ChildStdout, ExitStatus},
+        time::Duration,
     };
+
+    use crate::process::CHECK_CANCELLATION_EVERY;
+
+    pub(crate) fn read1(mut pipe: impl AsRawFd + IntoRawFd + Read) -> io::Result<Vec<u8>> {
+        unsafe {
+            libc::fcntl(pipe.as_raw_fd(), libc::F_SETFL, libc::O_NONBLOCK);
+        }
+
+        let mut done = false;
+        let mut data = Vec::new();
+
+        let mut fds: [libc::pollfd; 1] = unsafe { mem::zeroed() };
+        fds[0].fd = pipe.as_raw_fd();
+        fds[0].events = libc::POLLIN;
+
+        while !done {
+            crate::thread::Pool::unwind_if_cancelled();
+
+            // wait for either pipe to become readable using `select`
+            let r = unsafe {
+                libc::poll(fds.as_mut_ptr(), 1, CHECK_CANCELLATION_EVERY.as_millis() as _)
+            };
+            if r == -1 {
+                let err = io::Error::last_os_error();
+                if matches!(err.kind(), io::ErrorKind::Interrupted | io::ErrorKind::TimedOut) {
+                    continue;
+                }
+                return Err(err);
+            }
+
+            // Read as much as we can from each pipe, ignoring EWOULDBLOCK or
+            // EAGAIN. If we hit EOF, then this will happen because the underlying
+            // reader will return Ok(0), in which case we'll see `Ok` ourselves. In
+            // this case we flip the other fd back into blocking mode and read
+            // whatever's leftover on that file descriptor.
+            let handle = |res: io::Result<_>| match res {
+                Ok(_) => Ok(true),
+                Err(e) => {
+                    if e.kind() == io::ErrorKind::WouldBlock {
+                        Ok(false)
+                    } else {
+                        Err(e)
+                    }
+                }
+            };
+            if fds[0].revents != 0 && handle(pipe.read_to_end(&mut data))? {
+                done = true;
+            }
+        }
+        Ok(data)
+    }
 
     pub(crate) fn read2(
         mut out_pipe: ChildStdout,
         mut err_pipe: ChildStderr,
         data: &mut dyn FnMut(bool, &mut Vec<u8>, bool),
-    ) -> io::Result<()> {
+    ) -> io::Result<(Vec<u8>, Vec<u8>)> {
         unsafe {
             libc::fcntl(out_pipe.as_raw_fd(), libc::F_SETFL, libc::O_NONBLOCK);
             libc::fcntl(err_pipe.as_raw_fd(), libc::F_SETFL, libc::O_NONBLOCK);
@@ -109,11 +384,15 @@ mod imp {
         let mut errfd = 1;
 
         while nfds > 0 {
+            crate::thread::Pool::unwind_if_cancelled();
+
             // wait for either pipe to become readable using `select`
-            let r = unsafe { libc::poll(fds.as_mut_ptr(), nfds, -1) };
+            let r = unsafe {
+                libc::poll(fds.as_mut_ptr(), nfds, CHECK_CANCELLATION_EVERY.as_millis() as _)
+            };
             if r == -1 {
                 let err = io::Error::last_os_error();
-                if err.kind() == io::ErrorKind::Interrupted {
+                if matches!(err.kind(), io::ErrorKind::Interrupted | io::ErrorKind::TimedOut) {
                     continue;
                 }
                 return Err(err);
@@ -147,17 +426,29 @@ mod imp {
             }
             data(true, &mut out, out_done);
         }
-        Ok(())
+        Ok((out, err))
+    }
+
+    pub(super) fn wait_process_timeout(
+        child: &mut Child,
+        dur: Duration,
+    ) -> io::Result<Option<ExitStatus>> {
+        // Unfortunately on Unix there is no easy way to wait for a process with a timeout.
+        // There are convoluted ways with signals, and there is a Linux-specific way, but ugh.
+        // So we just do the simple and stupid thing.
+        std::thread::sleep(dur);
+        child.try_wait()
     }
 }
 
 #[cfg(windows)]
 mod imp {
     use std::{
-        io,
+        io::{self, Read},
         os::windows::prelude::*,
-        process::{ChildStderr, ChildStdout},
+        process::{Child, ChildStderr, ChildStdout, ExitStatus},
         slice,
+        time::Duration,
     };
 
     use miow::{
@@ -165,7 +456,12 @@ mod imp {
         iocp::{CompletionPort, CompletionStatus},
         pipe::NamedPipe,
     };
-    use windows_sys::Win32::Foundation::ERROR_BROKEN_PIPE;
+    use windows_sys::Win32::{
+        Foundation::{ERROR_BROKEN_PIPE, WAIT_OBJECT_0, WAIT_TIMEOUT},
+        System::Threading::WaitForSingleObject,
+    };
+
+    use crate::process::CHECK_CANCELLATION_EVERY;
 
     struct Pipe<'a> {
         dst: &'a mut Vec<u8>,
@@ -174,11 +470,40 @@ mod imp {
         done: bool,
     }
 
-    pub(crate) fn read2(
+    pub(super) fn read1(pipe: impl AsRawHandle + IntoRawHandle + Read) -> io::Result<Vec<u8>> {
+        let mut data = Vec::new();
+
+        let port = CompletionPort::new(1)?;
+        port.add_handle(0, &pipe)?;
+
+        unsafe {
+            let mut pipe = Pipe::new(pipe, &mut data);
+
+            pipe.read()?;
+
+            while !pipe.done {
+                crate::thread::Pool::unwind_if_cancelled();
+
+                let get = port.get(Some(CHECK_CANCELLATION_EVERY));
+                if let Err(err) = &get
+                    && let io::ErrorKind::TimedOut = err.kind()
+                {
+                    continue;
+                }
+                let status = get?;
+                pipe.complete(&status);
+                pipe.read()?;
+            }
+
+            Ok(data)
+        }
+    }
+
+    pub(super) fn read2(
         out_pipe: ChildStdout,
         err_pipe: ChildStderr,
         data: &mut dyn FnMut(bool, &mut Vec<u8>, bool),
-    ) -> io::Result<()> {
+    ) -> io::Result<(Vec<u8>, Vec<u8>)> {
         let mut out = Vec::new();
         let mut err = Vec::new();
 
@@ -196,7 +521,15 @@ mod imp {
             let mut status = [CompletionStatus::zero(), CompletionStatus::zero()];
 
             while !out_pipe.done || !err_pipe.done {
-                for status in port.get_many(&mut status, None)? {
+                crate::thread::Pool::unwind_if_cancelled();
+
+                let get_many = port.get_many(&mut status, Some(CHECK_CANCELLATION_EVERY));
+                if let Err(err) = &get_many
+                    && let io::ErrorKind::TimedOut = err.kind()
+                {
+                    continue;
+                }
+                for status in get_many? {
                     if status.token() == 0 {
                         out_pipe.complete(status);
                         data(true, out_pipe.dst, out_pipe.done);
@@ -209,7 +542,7 @@ mod imp {
                 }
             }
 
-            Ok(())
+            Ok((out, err))
         }
     }
 
@@ -254,20 +587,48 @@ mod imp {
         let len = v.capacity() - v.len();
         unsafe { slice::from_raw_parts_mut(data, len) }
     }
+
+    pub(super) fn wait_process_timeout(
+        child: &mut Child,
+        dur: Duration,
+    ) -> io::Result<Option<ExitStatus>> {
+        let ms = dur.as_millis();
+        let ms = if ms > u128::from(u32::MAX) { u32::MAX } else { ms as u32 };
+        unsafe {
+            match WaitForSingleObject(child.as_raw_handle() as *mut _, ms) {
+                WAIT_OBJECT_0 => {}
+                WAIT_TIMEOUT => return Ok(None),
+                _ => return Err(io::Error::last_os_error()),
+            }
+        }
+        child.try_wait()
+    }
 }
 
 #[cfg(target_arch = "wasm32")]
 mod imp {
     use std::{
         io,
-        process::{ChildStderr, ChildStdout},
+        process::{Child, ChildStderr, ChildStdout, ExitStatus},
+        time::Duration,
     };
+
+    pub(super) fn read1<T>(_pipe: T) -> io::Result<Vec<u8>> {
+        panic!("no processes on wasm")
+    }
 
     pub(crate) fn read2(
         _out_pipe: ChildStdout,
         _err_pipe: ChildStderr,
         _data: &mut dyn FnMut(bool, &mut Vec<u8>, bool),
-    ) -> io::Result<()> {
+    ) -> io::Result<(Vec<u8>, Vec<u8>)> {
+        panic!("no processes on wasm")
+    }
+
+    pub(super) fn wait_process_timeout(
+        _child: &mut Child,
+        _dur: Duration,
+    ) -> io::Result<Option<ExitStatus>> {
         panic!("no processes on wasm")
     }
 }

--- a/crates/stdx/src/thread/pool.rs
+++ b/crates/stdx/src/thread/pool.rs
@@ -8,11 +8,12 @@
 //! the threading utilities in [`crate::thread`].
 
 use std::{
+    cell::Cell,
     marker::PhantomData,
     panic::{self, UnwindSafe},
     sync::{
-        Arc,
-        atomic::{AtomicUsize, Ordering},
+        Arc, Condvar, Mutex,
+        atomic::{AtomicBool, Ordering},
     },
 };
 
@@ -20,6 +21,10 @@ use crossbeam_channel::{Receiver, Sender};
 use crossbeam_utils::sync::WaitGroup;
 
 use crate::thread::{Builder, JoinHandle, ThreadIntent};
+
+thread_local! {
+    static ACTIVE_POOL: Cell<Option<Arc<PoolShared>>> = const { Cell::new(None) };
+}
 
 pub struct Pool {
     // `_handles` is never read: the field is present
@@ -31,7 +36,13 @@ pub struct Pool {
     // before we join the worker threads!
     job_sender: Sender<Job>,
     _handles: Box<[JoinHandle]>,
-    extant_tasks: Arc<AtomicUsize>,
+    shared: Arc<PoolShared>,
+}
+
+struct PoolShared {
+    extant_tasks: Mutex<usize>,
+    empty_queue: Condvar,
+    cancellation_requested: AtomicBool,
 }
 
 struct Job {
@@ -49,7 +60,11 @@ impl Pool {
         const INITIAL_INTENT: ThreadIntent = ThreadIntent::Worker;
 
         let (job_sender, job_receiver) = crossbeam_channel::unbounded();
-        let extant_tasks = Arc::new(AtomicUsize::new(0));
+        let shared = Arc::new(PoolShared {
+            extant_tasks: Mutex::new(0),
+            empty_queue: Condvar::new(),
+            cancellation_requested: AtomicBool::new(false),
+        });
 
         let mut handles = Vec::with_capacity(threads);
         for idx in 0..threads {
@@ -57,18 +72,27 @@ impl Pool {
                 .stack_size(STACK_SIZE)
                 .allow_leak(true)
                 .spawn({
-                    let extant_tasks = Arc::clone(&extant_tasks);
+                    let shared = Arc::clone(&shared);
                     let job_receiver: Receiver<Job> = job_receiver.clone();
                     move || {
+                        ACTIVE_POOL.set(Some(Arc::clone(&shared)));
+
                         let mut current_intent = INITIAL_INTENT;
                         for job in job_receiver {
-                            if job.requested_intent != current_intent {
-                                job.requested_intent.apply_to_current_thread();
-                                current_intent = job.requested_intent;
+                            if !shared.cancellation_requested.load(Ordering::Acquire) {
+                                if job.requested_intent != current_intent {
+                                    job.requested_intent.apply_to_current_thread();
+                                    current_intent = job.requested_intent;
+                                }
+                                // discard the panic, we should've logged the backtrace already
+                                drop(panic::catch_unwind(job.f));
                             }
-                            // discard the panic, we should've logged the backtrace already
-                            drop(panic::catch_unwind(job.f));
-                            extant_tasks.fetch_sub(1, Ordering::SeqCst);
+
+                            let mut extant_tasks = shared.extant_tasks.lock().unwrap();
+                            *extant_tasks -= 1;
+                            if *extant_tasks == 0 {
+                                shared.empty_queue.notify_all();
+                            }
                         }
                     }
                 })
@@ -77,7 +101,7 @@ impl Pool {
             handles.push(handle);
         }
 
-        Self { _handles: handles.into_boxed_slice(), extant_tasks, job_sender }
+        Self { _handles: handles.into_boxed_slice(), shared, job_sender }
     }
 
     pub fn spawn<F>(&self, intent: ThreadIntent, f: F)
@@ -92,7 +116,7 @@ impl Pool {
         });
 
         let job = Job { requested_intent: intent, f };
-        self.extant_tasks.fetch_add(1, Ordering::SeqCst);
+        *self.shared.extant_tasks.lock().unwrap() += 1;
         self.job_sender.send(job).unwrap();
     }
 
@@ -109,14 +133,50 @@ impl Pool {
 
     #[must_use]
     pub fn len(&self) -> usize {
-        self.extant_tasks.load(Ordering::SeqCst)
+        *self.shared.extant_tasks.lock().unwrap()
     }
 
     #[must_use]
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
+
+    #[inline]
+    pub fn unwind_if_cancelled() {
+        let shared = ACTIVE_POOL.take();
+        if let Some(shared) = shared {
+            let should_cancel = shared.cancellation_requested.load(Ordering::Acquire);
+            ACTIVE_POOL.set(Some(shared));
+            if should_cancel {
+                // We use resume and not panic here to avoid running the panic
+                // hook (that is, to avoid collecting and printing backtrace).
+                std::panic::resume_unwind(Box::new(PoolTaskCancelled))
+            }
+        }
+    }
+
+    /// Cancels running and pending tasks, and waits for them to complete.
+    /// After calling this method, the pool is tainted and no new tasks will run forever.
+    pub fn cancel_and_taint(&mut self) {
+        self.shared.cancellation_requested.store(true, Ordering::Release);
+
+        let extant_tasks = self.shared.extant_tasks.lock().unwrap();
+        drop(
+            self.shared
+                .empty_queue
+                .wait_while(extant_tasks, |extant_tasks| *extant_tasks != 0)
+                .unwrap(),
+        );
+    }
 }
+
+impl Drop for Pool {
+    fn drop(&mut self) {
+        self.cancel_and_taint();
+    }
+}
+
+struct PoolTaskCancelled;
 
 pub struct Scope<'pool, 'scope> {
     pool: &'pool Pool,
@@ -147,7 +207,7 @@ impl<'scope> Scope<'_, 'scope> {
                 >(f)
             },
         };
-        self.pool.extant_tasks.fetch_add(1, Ordering::SeqCst);
+        *self.pool.shared.extant_tasks.lock().unwrap() += 1;
         self.pool.job_sender.send(job).unwrap();
     }
 }

--- a/crates/toolchain/Cargo.toml
+++ b/crates/toolchain/Cargo.toml
@@ -14,6 +14,7 @@ doctest = false
 
 [dependencies]
 camino.workspace = true
+stdx.workspace = true
 
 [lints]
 workspace = true

--- a/crates/toolchain/src/lib.rs
+++ b/crates/toolchain/src/lib.rs
@@ -5,10 +5,10 @@ use std::{
     ffi::OsStr,
     iter,
     path::{Path, PathBuf},
-    process::Command,
 };
 
 use camino::{Utf8Path, Utf8PathBuf};
+use stdx::process::JodCommand;
 
 #[derive(Copy, Clone)]
 pub enum Tool {
@@ -79,10 +79,9 @@ pub fn command<H>(
     cmd: impl AsRef<OsStr>,
     working_directory: impl AsRef<Path>,
     extra_env: &std::collections::HashMap<String, Option<String>, H>,
-) -> Command {
-    // we are `toolchain::command``
-    #[allow(clippy::disallowed_methods)]
-    let mut cmd = Command::new(cmd);
+) -> JodCommand {
+    #[expect(clippy::disallowed_methods, reason = "we are `toolchain::command`")]
+    let mut cmd = JodCommand::new(cmd);
     cmd.current_dir(working_directory);
     cmd.env(NO_RUSTUP_AUTO_INSTALL_ENV.0, NO_RUSTUP_AUTO_INSTALL_ENV.1);
     for env in extra_env {

--- a/editors/code/src/ctx.ts
+++ b/editors/code/src/ctx.ts
@@ -163,7 +163,6 @@ export class Ctx implements RustAnalyzerExtensionApi {
         this.statusBar.dispose();
         this.statusBarActiveEditorListener.dispose();
         this.testController?.dispose();
-        void this.disposeClient();
         this.commandDisposables.forEach((disposable) => disposable.dispose());
     }
 
@@ -438,8 +437,8 @@ export class Ctx implements RustAnalyzerExtensionApi {
         }
         log.info("Disposing language client");
         this.updateCommands("disable");
-        // we give the server 100ms to stop gracefully
-        await this.client?.stop(100).catch((_) => {});
+        // we give the server 2s to stop gracefully
+        await this.client?.stop(2000).catch((_) => {});
         await this.disposeClient();
     }
 

--- a/editors/code/src/main.ts
+++ b/editors/code/src/main.ts
@@ -21,7 +21,10 @@ export interface RustAnalyzerExtensionApi {
     addConfiguration(extensionId: string, configuration: Record<string, unknown>): Promise<void>;
 }
 
+let ctx: Ctx | undefined;
+
 export async function deactivate() {
+    await ctx?.stopAndDispose();
     await setContextValue(RUST_PROJECT_CONTEXT_NAME, undefined);
 }
 
@@ -30,7 +33,7 @@ export async function activate(
 ): Promise<RustAnalyzerExtensionApi> {
     checkConflictingExtensions();
 
-    const ctx = new Ctx(context, createCommands(), fetchWorkspace());
+    ctx = new Ctx(context, createCommands(), fetchWorkspace());
     // VS Code doesn't show a notification when an extension fails to activate
     // so we do it ourselves.
     const api = await activateServer(ctx).catch((err) => {

--- a/lib/lsp-server/examples/minimal_lsp.rs
+++ b/lib/lsp-server/examples/minimal_lsp.rs
@@ -284,7 +284,7 @@ fn run_rustfmt(input: &str) -> Result<String> {
         .spawn()
         .context("failed to spawn rustfmt – is it installed?")?;
 
-    let Some(stdin) = child.stdin.as_mut() else {
+    let Some(stdin) = child.stdin() else {
         bail!("stdin unavailable");
     };
     stdin.write_all(input.as_bytes())?;

--- a/lib/smol_str/tests/tidy.rs
+++ b/lib/smol_str/tests/tidy.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::disallowed_methods, clippy::print_stdout)]
+#![allow(clippy::disallowed_types, clippy::disallowed_methods, clippy::print_stdout)]
 #![cfg(not(miri))]
 use std::{
     env,


### PR DESCRIPTION
Flycheck and proc macro server process handles are stored in the `GlobalState`, using wrappers (`JodChild` or `CommandHandle`) that kill the process on drop. So when we exit and `GlobalState` is dropped, they're automatically cancelled.

However, build scripts and workspace discovery are triggered inside thread pool tasks. When `GlobalState` is dropped, they're left untouched, and when r-a process exits and the handles are destroyed, the processes are detached.

The way I went to solve this is by adding an option to cancel all tasks on a thread pool, by injecting a panic into it. Of course you cannot force a thread to panic (this has the same problems as killing a thread), so instead the thread must check some state periodically. Most of our tasks are have short execution time before executing the next database query, so we can cancel the database, making Salsa inject a panic. Except those that invoke child processes.

So I went and changed `JodChild` to also check periodically for cancellation. This is non-trivial because the standard library has neither "read with timeout" nor "wait with timeout" primitives for pipes, so we're forced into platform-specific code. I also introduced a `JodCommand` wrapper around `Command` to make it harder to use waiting operations by mistake, and added `Command` and `Child` to clippy::disallowed_types.

This was still not enough, because the extension itself has not delivered the shutdown event correctly, and also had a too short timeout for it (200ms). So I changed it to send a shutdown request in `deactivate()`, and increased the timeout to 2s.

I have no idea how to test this automatically, but I tested this manually by setting a build command that waits forever then closing VSCode. Before those changes, the build process is still there; after them, it is killed properly.

Fixes https://github.com/rust-lang/rust-analyzer/issues/22732.