### PR TITLE
internal: remove `#[salsa::cycle_{fn,initial}]` support from `#[query_group]`

### DIFF
--- a/crates/query-group-macro/src/lib.rs
+++ b/crates/query-group-macro/src/lib.rs
@@ -89,32 +89,16 @@ enum QueryKind {
 
 #[derive(Default, Debug, Clone)]
 struct Cycle {
-    cycle_fn: Option<(syn::Ident, Path)>,
-    cycle_initial: Option<(syn::Ident, Path)>,
     cycle_result: Option<(syn::Ident, Path)>,
 }
 
 impl Parse for Cycle {
     fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
         let options = Punctuated::<Option, Token![,]>::parse_terminated(input)?;
-        let mut cycle_fn = None;
-        let mut cycle_initial = None;
         let mut cycle_result = None;
         for option in options {
             let name = option.name.to_string();
             match &*name {
-                "cycle_fn" => {
-                    if cycle_fn.is_some() {
-                        return Err(syn::Error::new_spanned(&option.name, "duplicate option"));
-                    }
-                    cycle_fn = Some((option.name, option.value));
-                }
-                "cycle_initial" => {
-                    if cycle_initial.is_some() {
-                        return Err(syn::Error::new_spanned(&option.name, "duplicate option"));
-                    }
-                    cycle_initial = Some((option.name, option.value));
-                }
                 "cycle_result" => {
                     if cycle_result.is_some() {
                         return Err(syn::Error::new_spanned(&option.name, "duplicate option"));
@@ -124,12 +108,12 @@ impl Parse for Cycle {
                 _ => {
                     return Err(syn::Error::new_spanned(
                         &option.name,
-                        "unknown cycle option. Accepted values: `cycle_result`, `cycle_fn`, `cycle_initial`",
+                        "unknown cycle option. Accepted values: `cycle_result`",
                     ));
                 }
             }
         }
-        return Ok(Self { cycle_fn, cycle_initial, cycle_result });
+        return Ok(Self { cycle_result });
 
         struct Option {
             name: syn::Ident,

--- a/crates/query-group-macro/src/queries.rs
+++ b/crates/query-group-macro/src/queries.rs
@@ -32,13 +32,8 @@ impl ToTokens for TrackedQuery {
         let options = self
             .cycle
             .as_ref()
-            .map(|Cycle { cycle_fn, cycle_initial, cycle_result }| {
-                let cycle_fn = cycle_fn.as_ref().map(|(ident, path)| quote!(#ident=#path));
-                let cycle_initial =
-                    cycle_initial.as_ref().map(|(ident, path)| quote!(#ident=#path));
-                let cycle_result = cycle_result.as_ref().map(|(ident, path)| quote!(#ident=#path));
-                let options = cycle_fn.into_iter().chain(cycle_initial).chain(cycle_result);
-                quote!(#(#options),*)
+            .map(|Cycle { cycle_result }| {
+                cycle_result.as_ref().map(|(ident, path)| quote!(#ident=#path))
             })
             .into_iter();
         let annotation = quote!(#[salsa_macros::tracked( #(#options),* )]);


### PR DESCRIPTION
Part of https://github.com/rust-lang/rust-analyzer/issues/22657

None of the remaining queries used these.