### PR TITLE
Remove redundant clone_for_update

### DIFF
--- a/crates/hir-expand/src/eager.rs
+++ b/crates/hir-expand/src/eager.rs
@@ -232,7 +232,7 @@ fn eager_macro_recur(
                         let syntax_node = parse.syntax_node();
                         ExpandResult {
                             value: Some((
-                                syntax_node.clone_for_update(),
+                                syntax_node.clone(),
                                 offset + syntax_node.text_range().len(),
                             )),
                             err: err.clone().or_else(|| err2.clone()),

--- a/crates/syntax/src/ast/make.rs
+++ b/crates/syntax/src/ast/make.rs
@@ -1373,7 +1373,6 @@ pub fn token(kind: SyntaxKind) -> SyntaxToken {
     tokens::SOURCE_FILE
         .tree()
         .syntax()
-        .clone_for_update()
         .descendants_with_tokens()
         .filter_map(|it| it.into_token())
         .find(|it| it.kind() == kind)
@@ -1394,43 +1393,10 @@ pub mod tokens {
         )
     });
 
-    pub fn semicolon() -> SyntaxToken {
-        SOURCE_FILE
-            .tree()
-            .syntax()
-            .clone_for_update()
-            .descendants_with_tokens()
-            .filter_map(|it| it.into_token())
-            .find(|it| it.kind() == SEMICOLON)
-            .unwrap()
-    }
-
-    pub fn single_space() -> SyntaxToken {
-        SOURCE_FILE
-            .tree()
-            .syntax()
-            .clone_for_update()
-            .descendants_with_tokens()
-            .filter_map(|it| it.into_token())
-            .find(|it| it.kind() == WHITESPACE && it.text() == " ")
-            .unwrap()
-    }
-
-    pub fn crate_kw() -> SyntaxToken {
-        SOURCE_FILE
-            .tree()
-            .syntax()
-            .clone_for_update()
-            .descendants_with_tokens()
-            .filter_map(|it| it.into_token())
-            .find(|it| it.kind() == CRATE_KW)
-            .unwrap()
-    }
-
     pub fn whitespace(text: &str) -> SyntaxToken {
         assert!(text.trim().is_empty());
         let sf = SourceFile::parse(text, Edition::CURRENT).ok().unwrap();
-        sf.syntax().clone_for_update().first_child_or_token().unwrap().into_token().unwrap()
+        sf.syntax().first_child_or_token().unwrap().into_token().unwrap()
     }
 
     pub fn doc_comment(text: &str) -> SyntaxToken {
@@ -1453,41 +1419,6 @@ pub mod tokens {
             .filter_map(|it| it.into_token())
             .find(|it| it.kind() == IDENT)
             .unwrap()
-    }
-
-    pub fn single_newline() -> SyntaxToken {
-        let res = SOURCE_FILE
-            .tree()
-            .syntax()
-            .clone_for_update()
-            .descendants_with_tokens()
-            .filter_map(|it| it.into_token())
-            .find(|it| it.kind() == WHITESPACE && it.text() == "\n")
-            .unwrap();
-        res.detach();
-        res
-    }
-
-    pub fn blank_line() -> SyntaxToken {
-        SOURCE_FILE
-            .tree()
-            .syntax()
-            .clone_for_update()
-            .descendants_with_tokens()
-            .filter_map(|it| it.into_token())
-            .find(|it| it.kind() == WHITESPACE && it.text() == "\n\n")
-            .unwrap()
-    }
-
-    pub struct WsBuilder(SourceFile);
-
-    impl WsBuilder {
-        pub fn new(text: &str) -> WsBuilder {
-            WsBuilder(SourceFile::parse(text, Edition::CURRENT).ok().unwrap())
-        }
-        pub fn ws(&self) -> SyntaxToken {
-            self.0.syntax().first_child_or_token().unwrap().into_token().unwrap()
-        }
     }
 }
 


### PR DESCRIPTION
This PR removes last remnants of clone_for_update outside syntax crate, the current usage was no-op. We are also removing some helper methods which we no longer use. 