### PR TITLE
fix: Crash on code actions when an unresolved module is present

### DIFF
--- a/crates/ide-assists/src/handlers/generate_function.rs
+++ b/crates/ide-assists/src/handlers/generate_function.rs
@@ -491,7 +491,7 @@ fn get_fn_target(
     let mut file = ctx.vfs_file_id();
     let target = match target_module {
         Some(target_module) => {
-            let (in_file, target) = next_space_for_fn_in_module(ctx.db(), target_module);
+            let (in_file, target) = next_space_for_fn_in_module(ctx.db(), target_module)?;
             file = in_file;
             target
         }
@@ -1310,7 +1310,7 @@ fn next_space_for_fn_after_call_site(expr: ast::CallableExpr) -> Option<Generate
 fn next_space_for_fn_in_module(
     db: &dyn hir::db::HirDatabase,
     target_module: hir::Module,
-) -> (FileId, GeneratedFunctionTarget) {
+) -> Option<(FileId, GeneratedFunctionTarget)> {
     let module_source = target_module.definition_source(db);
     let file = module_source.file_id.original_file(db);
     let assist_item = match &module_source.value {
@@ -1318,14 +1318,13 @@ fn next_space_for_fn_in_module(
             Some(last_item) => GeneratedFunctionTarget::AfterItem(last_item.syntax().clone()),
             None => GeneratedFunctionTarget::AfterItem(it.syntax().clone()),
         },
-        hir::ModuleSource::Module(it) => match it.item_list().and_then(|it| it.items().last()) {
-            Some(last_item) => GeneratedFunctionTarget::AfterItem(last_item.syntax().clone()),
-            None => {
-                let item_list =
-                    it.item_list().expect("module definition source should have an item list");
-                GeneratedFunctionTarget::InEmptyItemList(item_list.syntax().clone())
+        hir::ModuleSource::Module(it) => {
+            let item_list = it.item_list()?;
+            match item_list.items().last() {
+                Some(last_item) => GeneratedFunctionTarget::AfterItem(last_item.syntax().clone()),
+                None => GeneratedFunctionTarget::InEmptyItemList(item_list.syntax().clone()),
             }
-        },
+        }
         hir::ModuleSource::BlockExpr(it) => {
             if let Some(last_item) =
                 it.statements().take_while(|stmt| matches!(stmt, ast::Stmt::Item(_))).last()
@@ -1337,7 +1336,7 @@ fn next_space_for_fn_in_module(
         }
     };
 
-    (file.file_id(db), assist_item)
+    Some((file.file_id(db), assist_item))
 }
 
 #[derive(Clone, Copy)]
@@ -2456,6 +2455,20 @@ fn main() {
 pub(crate) fn bar() {
     ${0:todo!()}
 }",
+        )
+    }
+
+    #[test]
+    fn add_function_not_applicable_in_unresolved_module() {
+        check_assist_not_applicable(
+            generate_function,
+            r"
+mod foo;
+
+fn main() {
+    foo::bar$0();
+}
+",
         )
     }
 


### PR DESCRIPTION
Previously rust-analyzer assumed that a module always had an item list, which isn't true for unresolved modules. This would produce a panic:

> module definition source should have an item list

Handle this situation gracefully instead of panicking, and add a test.

AI disclosure: Written with help by GPT-5.5.