### PR TITLE
fix!: make lsp-server `Response` type closer aligned to JSON-RPC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1455,7 +1455,7 @@ dependencies = [
 
 [[package]]
 name = "lsp-server"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "crossbeam-channel",

--- a/lib/lsp-server/Cargo.toml
+++ b/lib/lsp-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lsp-server"
-version = "0.8.0"
+version = "0.9.0"
 description = "Generic LSP server scaffold."
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/rust-analyzer/tree/master/lib/lsp-server"

--- a/lib/lsp-server/examples/minimal_lsp.rs
+++ b/lib/lsp-server/examples/minimal_lsp.rs
@@ -82,7 +82,9 @@ use toolchain::command; // clippy-approved wrapper
 
 #[allow(clippy::print_stderr, clippy::disallowed_types, clippy::disallowed_methods)]
 use anyhow::{Context, Result, anyhow, bail};
-use lsp_server::{Connection, Message, Request as ServerRequest, RequestId, Response};
+use lsp_server::{
+    Connection, Message, Request as ServerRequest, RequestId, Response, ResponseKind,
+};
 
 // =====================================================================
 // main
@@ -304,7 +306,8 @@ fn full_range(text: &str) -> Range {
 }
 
 fn send_ok<T: serde::Serialize>(conn: &Connection, id: RequestId, result: &T) -> Result<()> {
-    let resp = Response { id, result: Some(serde_json::to_value(result)?), error: None };
+    let resp =
+        Response { id, response_kind: ResponseKind::Ok { result: serde_json::to_value(result)? } };
     conn.sender.send(Message::Response(resp))?;
     Ok(())
 }
@@ -317,12 +320,9 @@ fn send_err(
 ) -> Result<()> {
     let resp = Response {
         id,
-        result: None,
-        error: Some(lsp_server::ResponseError {
-            code: code as i32,
-            message: msg.into(),
-            data: None,
-        }),
+        response_kind: ResponseKind::Err {
+            error: lsp_server::ResponseError { code: code as i32, message: msg.into(), data: None },
+        },
     };
     conn.sender.send(Message::Response(resp))?;
     Ok(())

--- a/lib/lsp-server/src/lib.rs
+++ b/lib/lsp-server/src/lib.rs
@@ -22,7 +22,9 @@ use crossbeam_channel::{Receiver, RecvError, RecvTimeoutError, Sender};
 
 pub use crate::{
     error::{ExtractError, ProtocolError},
-    msg::{ErrorCode, Message, Notification, Request, RequestId, Response, ResponseError},
+    msg::{
+        ErrorCode, Message, Notification, Request, RequestId, Response, ResponseError, ResponseKind,
+    },
     req_queue::{Incoming, Outgoing, ReqQueue},
     stdio::IoThreads,
 };

--- a/lib/lsp-server/src/msg.rs
+++ b/lib/lsp-server/src/msg.rs
@@ -84,10 +84,15 @@ pub struct Response {
     // request id. We fail deserialization in that case, so we just
     // make this field mandatory.
     pub id: RequestId,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
-    pub result: Option<serde_json::Value>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
-    pub error: Option<ResponseError>,
+    #[serde(flatten)]
+    pub response_kind: ResponseKind,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(untagged)]
+pub enum ResponseKind {
+    Ok { result: serde_json::Value },
+    Err { error: ResponseError },
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -198,11 +203,14 @@ impl Message {
 
 impl Response {
     pub fn new_ok<R: serde::Serialize>(id: RequestId, result: R) -> Response {
-        Response { id, result: Some(serde_json::to_value(result).unwrap()), error: None }
+        Response {
+            id,
+            response_kind: ResponseKind::Ok { result: serde_json::to_value(result).unwrap() },
+        }
     }
     pub fn new_err(id: RequestId, code: i32, message: String) -> Response {
         let error = ResponseError { code, message, data: None };
-        Response { id, result: None, error: Some(error) }
+        Response { id, response_kind: ResponseKind::Err { error } }
     }
 }
 

--- a/lib/lsp-server/src/req_queue.rs
+++ b/lib/lsp-server/src/req_queue.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use crate::{ErrorCode, Request, RequestId, Response, ResponseError};
+use crate::{ErrorCode, Request, RequestId, Response, ResponseError, msg::ResponseKind};
 
 /// Manages the set of pending requests, both incoming and outgoing.
 #[derive(Debug)]
@@ -47,7 +47,7 @@ impl<I> Incoming<I> {
             message: "canceled by client".to_owned(),
             data: None,
         };
-        Some(Response { id, result: None, error: Some(error) })
+        Some(Response { id, response_kind: ResponseKind::Err { error } })
     }
 
     pub fn complete(&mut self, id: &RequestId) -> Option<I> {


### PR DESCRIPTION
From [the JSON-RPC 2.0 protocol](https://www.jsonrpc.org/specification#response_object):

> result
>  This member is REQUIRED on success.
>  This member MUST NOT exist if there was an error invoking the method.
>  The value of this member is determined by the method invoked on the Server.
> error
>  This member is REQUIRED on error.
>  This member MUST NOT exist if there was no error triggered during invocation.
>  The value for this member MUST be an Object as defined in section 5.1.
>
> ...
>
> Either the result member or error member MUST be included, but both members MUST NOT be included.

The current typing of the `Response` object allows both the `result` and `error` members to be present, or for neither to be present. This commit strengthens the typing of the response to prevent these cases from being expressed. This is a breaking change.

The response kind definition is borrowed from the
[tower-lsp](https://github.com/ebkalderon/tower-lsp) definition.