### PR TITLE
internal: match_ast macro supports guard

### DIFF
--- a/crates/syntax/src/lib.rs
+++ b/crates/syntax/src/lib.rs
@@ -270,12 +270,12 @@ macro_rules! match_ast {
     (match $node:ident { $($tt:tt)* }) => { $crate::match_ast!(match ($node) { $($tt)* }) };
 
     (match ($node:expr) {
-        $( $( $path:ident )::+ ($it:pat) => $res:expr, )*
+        $( $( $path:ident )::+ ($it:pat) $(if $guard:expr)? => $res:expr, )*
         _ => $catch_all:expr $(,)?
     }) => {{
         #[allow(clippy::question_mark, reason = "if `$catch_all` is `return None` Clippy can mark this")]
         {
-            $( if let Some($it) = $($path::)+cast($node.clone()) { $res } else )*
+            $( if let Some($it) = $($path::)+cast($node.clone()) $(&& $guard)? { $res } else )*
             { $catch_all }
         }
     }};


### PR DESCRIPTION
Example
---
```rust
match_ast! {
    match parent {
        ast::Expr(it) if !it.is_block_like() => replace(it),
        _ => return,
    }
}
```
