### PR TITLE
fix: Recover from MIR field projections on slices

### DIFF
--- a/crates/hir-ty/src/mir.rs
+++ b/crates/hir-ty/src/mir.rs
@@ -1274,6 +1274,9 @@ impl<'db> PlaceTy<'db> {
                     .get(f.0 as usize)
                     .cloned()
                     .unwrap_or_else(|| panic!("field {f:?} out of range: {self_ty:?}")),
+                TyKind::Array(..) | TyKind::Slice(..) => {
+                    Ty::new_error(infcx.interner, ErrorGuaranteed)
+                }
                 _ => panic!("can't project out of {self_ty:?}"),
             }
         }

--- a/crates/hir-ty/src/mir/lower/tests.rs
+++ b/crates/hir-ty/src/mir/lower/tests.rs
@@ -1,7 +1,14 @@
 use hir_def::DefWithBodyId;
+use rustc_type_ir::inherent::Ty as _;
 use test_fixture::WithFixture;
 
-use crate::{db::HirDatabase, setup_tracing, test_db::TestDB};
+use crate::{
+    db::HirDatabase,
+    mir::{FieldIndex, PlaceElem, PlaceTy, ProjectionElem},
+    next_solver::{DbInterner, ParamEnv, Ty, TypingMode, infer::DbInternerInferExt},
+    setup_tracing,
+    test_db::TestDB,
+};
 
 fn lower_mir(#[rust_analyzer::rust_fixture] ra_fixture: &str) {
     let _tracing = setup_tracing();
@@ -133,4 +140,21 @@ fn alias<T: Tr>(x: T::A) {
 }
     "#,
     );
+}
+
+#[test]
+fn field_projection_on_slice_recovers_with_error_type() {
+    let (db, file_id) = TestDB::with_single_file("");
+    crate::attach_db(&db, || {
+        let module = db.module_for_file(file_id.file_id(&db));
+        let interner = DbInterner::new_with(&db, module.krate(&db));
+        let infcx = interner.infer_ctxt().build(TypingMode::PostAnalysis);
+        let slice = Ty::new_slice(interner, Ty::new_bool(interner));
+        let field: PlaceElem = ProjectionElem::Field(FieldIndex(0));
+
+        let result =
+            PlaceTy::from_ty(slice).projection_ty(&infcx, &field, ParamEnv::empty(interner));
+
+        assert!(result.ty.is_ty_error());
+    });
 }


### PR DESCRIPTION
MIR borrow checking can encounter a `Field` projection whose base type is a slice while computing diagnostics. `field_ty` treated that as an invariant violation and panicked with `can't project out of [T]`.

A `Field` projection contains no index with which to select an array or slice element, so it cannot produce a meaningful field type. Recover with the error type for array and slice bases, while retaining the invariant check for other unexpected types.

The regression test directly exercises `PlaceTy([bool]).projection_ty(Field(0))`. It panics before this change and returns the error type afterward.

Test: `cargo test -p hir-ty`