### PR TITLE
fix: Recover from MIR field projections on slices

### DIFF
--- a/crates/hir-ty/src/mir.rs
+++ b/crates/hir-ty/src/mir.rs
@@ -1274,6 +1274,9 @@ impl<'db> PlaceTy<'db> {
                     .get(f.0 as usize)
                     .cloned()
                     .unwrap_or_else(|| panic!("field {f:?} out of range: {self_ty:?}")),
+                TyKind::Array(..) | TyKind::Slice(..) => {
+                    Ty::new_error(infcx.interner, ErrorGuaranteed)
+                }
                 _ => panic!("can't project out of {self_ty:?}"),
             }
         }

--- a/crates/hir-ty/src/mir/lower/tests.rs
+++ b/crates/hir-ty/src/mir/lower/tests.rs
@@ -1,7 +1,14 @@
 use hir_def::DefWithBodyId;
+use rustc_type_ir::inherent::Ty as _;
 use test_fixture::WithFixture;
 
-use crate::{db::HirDatabase, setup_tracing, test_db::TestDB};
+use crate::{
+    db::HirDatabase,
+    mir::{FieldIndex, PlaceElem, PlaceTy, ProjectionElem},
+    next_solver::{DbInterner, ParamEnv, Ty, TypingMode, infer::DbInternerInferExt},
+    setup_tracing,
+    test_db::TestDB,
+};
 
 fn lower_mir(#[rust_analyzer::rust_fixture] ra_fixture: &str) {
     let _tracing = setup_tracing();
@@ -133,4 +140,21 @@ fn alias<T: Tr>(x: T::A) {
 }
     "#,
     );
+}
+
+#[test]
+fn field_projection_on_slice_recovers_with_error_type() {
+    let (db, file_id) = TestDB::with_single_file("");
+    crate::attach_db(&db, || {
+        let module = db.module_for_file(file_id.file_id(&db));
+        let interner = DbInterner::new_with(&db, module.krate(&db));
+        let infcx = interner.infer_ctxt().build(TypingMode::PostAnalysis);
+        let slice = Ty::new_slice(interner, Ty::new_bool(interner));
+        let field: PlaceElem = ProjectionElem::Field(FieldIndex(0));
+
+        let result =
+            PlaceTy::from_ty(slice).projection_ty(&infcx, &field, ParamEnv::empty(interner));
+
+        assert!(result.ty.is_ty_error());
+    });
 }


### PR DESCRIPTION
Fixes rust-lang/rust-analyzer#22757

MIR diagnostic borrow checking can encounter a `Field` projection whose base place has an array or slice type. `PlaceTy::field_ty` previously treated that as an invariant violation and panicked with:

​```text
can't project out of [T]
​```

A `Field` projection contains a field index but no array or slice element index, so it cannot produce a meaningful element-field type. This change treats array and slice bases as failed MIR type recovery and propagates an error type. Other unexpected base types retain the existing invariant check.

The regression test exercises the production `PlaceTy::projection_ty` path with a slice base and a `Field` projection. Before the fix it panics with `can't project out of [bool]`; afterward it returns the error type.

Tests:

​```text
cargo test -p hir-ty
​```

All 998 `hir-ty` tests pass.