### PR TITLE
Fix crashes in assists due to .unwrap() calls in SyntaxFactory

### DIFF
--- a/crates/ide-assists/src/handlers/convert_closure_to_fn.rs
+++ b/crates/ide-assists/src/handlers/convert_closure_to_fn.rs
@@ -739,6 +739,25 @@ fn main() {
     }
 
     #[test]
+    fn handles_closures_with_unannotated_rest_patterns() {
+        check_assist(
+            convert_closure_to_fn,
+            r#"
+fn main() {
+    let closure = |$0..| ();
+}
+"#,
+            r#"
+fn main() {
+    fn closure(..: _) {
+        ()
+    }
+}
+"#,
+        );
+    }
+
+    #[test]
     fn multiple_capture_usages() {
         check_assist(
             convert_closure_to_fn,

--- a/crates/ide-assists/src/handlers/unwrap_branch.rs
+++ b/crates/ide-assists/src/handlers/unwrap_branch.rs
@@ -832,6 +832,25 @@ fn main() {
     }
 
     #[test]
+    fn regression_22759() {
+        check_assist(
+            unwrap_branch,
+            r#"
+fn main() {
+    match () {
+        () $0=> let x = (),
+    }
+}
+"#,
+            r#"
+fn main() {
+    let x = ()
+}
+"#,
+        );
+    }
+
+    #[test]
     fn simple_if_in_while_bad_cursor_position() {
         check_assist_not_applicable(
             unwrap_branch,

--- a/crates/syntax/src/ast/make.rs
+++ b/crates/syntax/src/ast/make.rs
@@ -565,7 +565,17 @@ pub fn async_move_block_expr(
 }
 
 pub fn tail_only_block_expr(tail_expr: ast::Expr) -> ast::BlockExpr {
-    ast_from_text(&format!("fn f() {{ {tail_expr} }}"))
+    quote! {
+        BlockExpr {
+            StmtList {
+                ['{']
+                " "
+                #tail_expr
+                " "
+                ['}']
+            }
+        }
+    }
 }
 
 /// Ideally this function wouldn't exist since it involves manual indenting.
@@ -1038,7 +1048,14 @@ pub fn untyped_param(pat: ast::Pat) -> ast::Param {
 }
 
 pub fn param(pat: ast::Pat, ty: ast::Type) -> ast::Param {
-    ast_from_text(&format!("fn f({pat}: {ty}) {{ }}"))
+    quote! {
+        Param {
+            #pat
+            [:]
+            " "
+            #ty
+        }
+    }
 }
 
 pub fn self_param() -> ast::SelfParam {


### PR DESCRIPTION
These functions would panic when they try to re-parse code that isn't
valid in a top level function.

For parameters, this is `..`, which is valid in a closure but not a
function (requires an annotation). For tail block expressions, this is
`let var = expr`, which is valid in a tail position but not a function
body (requires a semicolon).

I've checked both quote! invocations against the rust.ungram file and
I think the structures are correct.

Include a test of an assist that previously caused a panic.

AI disclosure: Written with a little help by GPT-5.5.