### PR TITLE
internal: Funnel all child process spawning through stdx::process

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2357,7 +2357,6 @@ dependencies = [
  "parser",
  "paths",
  "proc-macro-api",
- "process-wrap",
  "profile",
  "project-model",
  "ra-ap-rustc_type_ir",
@@ -2695,6 +2694,7 @@ dependencies = [
  "jod-thread",
  "libc",
  "miow",
+ "process-wrap",
  "tracing",
  "windows-sys 0.61.2",
 ]

--- a/clippy.toml
+++ b/clippy.toml
@@ -6,4 +6,7 @@ disallowed-types = [
 
 disallowed-methods = [
     { path = "std::process::Command::new", reason = "use `toolchain::command` instead as it forces the choice of a working directory" },
+    { path = "std::process::Command::spawn", reason = "use `stdx::process::JodChild::spawn` instead to prevent processes leaking on exit" },
+    { path = "std::process::Command::output", reason = "use `stdx::process::output` instead to prevent processes leaking on exit" },
+    { path = "std::process::Command::status", reason = "use `stdx::process` instead to prevent processes leaking on exit" },
 ]

--- a/crates/ide/src/expand_macro.rs
+++ b/crates/ide/src/expand_macro.rs
@@ -259,14 +259,12 @@ fn _format(
     cmd.arg("--edition");
     cmd.arg(edition.to_string());
 
-    let mut rustfmt = cmd
-        .stdin(std::process::Stdio::piped())
+    cmd.stdin(std::process::Stdio::piped())
         .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::piped())
-        .spawn()
-        .ok()?;
+        .stderr(std::process::Stdio::piped());
+    let mut rustfmt = stdx::process::JodChild::spawn(&mut cmd).ok()?;
 
-    std::io::Write::write_all(&mut rustfmt.stdin.as_mut()?, expansion.as_bytes()).ok()?;
+    std::io::Write::write_all(&mut rustfmt.stdin().as_mut()?, expansion.as_bytes()).ok()?;
 
     let output = rustfmt.wait_with_output().ok()?;
     let captured_stdout = String::from_utf8(output.stdout).ok()?;

--- a/crates/ide/src/syntax_highlighting/tests.rs
+++ b/crates/ide/src/syntax_highlighting/tests.rs
@@ -447,7 +447,7 @@ macro_rules! void_2024 {
 }
 
 "#,
-        expect_file![format!("./test_data/highlight_keywords_macros.html")],
+        expect_file!["./test_data/highlight_keywords_macros.html"],
         false,
     );
 }

--- a/crates/proc-macro-api/src/process.rs
+++ b/crates/proc-macro-api/src/process.rs
@@ -4,7 +4,7 @@ use std::{
     fmt::Debug,
     io::{self, BufRead, BufReader, Read, Write},
     panic::AssertUnwindSafe,
-    process::{Child, ChildStdin, ChildStdout, Command, Stdio},
+    process::{ChildStdin, ChildStdout, Command, Stdio},
     sync::{
         Arc, Mutex, OnceLock,
         atomic::{AtomicU32, Ordering},
@@ -14,7 +14,7 @@ use std::{
 use paths::AbsPath;
 use semver::Version;
 use span::Span;
-use stdx::JodChild;
+use stdx::process::JodChild;
 
 use crate::{
     ProcMacro, ProcMacroKind, ProtocolFormat, ServerError,
@@ -66,7 +66,7 @@ impl ProcessExit for Process {
             Ok(Some(status)) => {
                 let mut msg = String::new();
                 if !status.success()
-                    && let Some(stderr) = self.child.stderr.as_mut()
+                    && let Some(stderr) = self.child.stderr().as_mut()
                 {
                     _ = stderr.read_to_string(&mut msg);
                 }
@@ -112,9 +112,9 @@ impl ProcMacroServerProcess {
             version,
             || {
                 #[expect(clippy::disallowed_methods)]
-                Command::new(process_path)
-                    .arg("--version")
-                    .output()
+                let mut cmd = Command::new(process_path);
+                cmd.arg("--version");
+                stdx::process::output(&mut cmd)
                     .map(|output| String::from_utf8_lossy(&output.stdout).trim().to_owned())
                     .unwrap_or_else(|_| "unknown version".to_owned())
             },
@@ -390,14 +390,14 @@ impl Process {
         >,
         format: Option<&str>,
     ) -> io::Result<Process> {
-        let child = JodChild(mk_child(path, env, format)?);
+        let child = mk_child(path, env, format)?;
         Ok(Process { child })
     }
 
     /// Retrieves stdin and stdout handles for the process.
     fn stdio(&mut self) -> Option<(ChildStdin, BufReader<ChildStdout>)> {
-        let stdin = self.child.stdin.take()?;
-        let stdout = self.child.stdout.take()?;
+        let stdin = self.child.stdin().take()?;
+        let stdout = self.child.stdout().take()?;
         let read = BufReader::new(stdout);
 
         Some((stdin, read))
@@ -411,7 +411,7 @@ fn mk_child<'a>(
         Item = (impl AsRef<std::ffi::OsStr>, &'a Option<impl 'a + AsRef<std::ffi::OsStr>>),
     >,
     format: Option<&str>,
-) -> io::Result<Child> {
+) -> io::Result<JodChild> {
     #[allow(clippy::disallowed_methods)]
     let mut cmd = Command::new(path);
     for env in extra_env {
@@ -435,5 +435,5 @@ fn mk_child<'a>(
         path_var.push(std::env::var_os("PATH").unwrap_or_default());
         cmd.env("PATH", path_var);
     }
-    cmd.spawn()
+    JodChild::spawn(&mut cmd)
 }

--- a/crates/project-model/src/cargo_workspace.rs
+++ b/crates/project-model/src/cargo_workspace.rs
@@ -841,8 +841,7 @@ fn exec_cargo_metadata(mut cmd: Command) -> anyhow::Result<cargo_metadata::Metad
     let output = stdx::process::output(&mut cmd)?;
     if !output.status.success() {
         return Err(cargo_metadata::Error::CargoMetadata {
-            stderr: String::from_utf8(output.stderr)
-                .unwrap_or_else(|_| String::from("Couldn't read `stderr` output")),
+            stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
         }
         .into());
     }

--- a/crates/project-model/src/cargo_workspace.rs
+++ b/crates/project-model/src/cargo_workspace.rs
@@ -1,6 +1,6 @@
 //! See [`CargoWorkspace`].
 
-use std::{borrow::Cow, ops, str::from_utf8};
+use std::{borrow::Cow, ops, process::Command, str::from_utf8};
 
 use anyhow::Context;
 use base_db::Env;
@@ -721,12 +721,12 @@ impl FetchMetadata {
         let no_deps_result = if no_deps {
             command.no_deps();
             cargo_command = command.cargo_command();
-            command.exec()
+            exec_cargo_metadata(command.cargo_command())
         } else {
             let mut no_deps_command = command.clone();
             no_deps_command.no_deps();
             cargo_command = no_deps_command.cargo_command();
-            no_deps_command.exec()
+            exec_cargo_metadata(no_deps_command.cargo_command())
         }
         .with_context(|| format!("Failed to run `{cargo_command:?}`"));
 
@@ -835,4 +835,20 @@ impl FetchMetadata {
         progress("cargo metadata: finished".to_owned());
         res
     }
+}
+
+fn exec_cargo_metadata(mut cmd: Command) -> anyhow::Result<cargo_metadata::Metadata> {
+    let output = stdx::process::output(&mut cmd)?;
+    if !output.status.success() {
+        return Err(cargo_metadata::Error::CargoMetadata {
+            stderr: String::from_utf8(output.stderr)
+                .unwrap_or_else(|_| String::from("Couldn't read `stderr` output")),
+        }
+        .into());
+    }
+    let stdout = from_utf8(&output.stdout)?
+        .lines()
+        .find(|line| line.starts_with('{'))
+        .ok_or(cargo_metadata::Error::NoJson)?;
+    Ok(MetadataCommand::parse(stdout)?)
 }

--- a/crates/project-model/src/lib.rs
+++ b/crates/project-model/src/lib.rs
@@ -211,7 +211,7 @@ impl fmt::Display for ProjectManifest {
 }
 
 fn utf8_stdout(cmd: &mut Command) -> anyhow::Result<String> {
-    let output = cmd.output().with_context(|| format!("{cmd:?} failed"))?;
+    let output = stdx::process::output(cmd).with_context(|| format!("{cmd:?} failed"))?;
     if !output.status.success() {
         match String::from_utf8(output.stderr) {
             Ok(stderr) if !stderr.is_empty() => {

--- a/crates/project-model/src/sysroot.rs
+++ b/crates/project-model/src/sysroot.rs
@@ -194,7 +194,9 @@ impl Sysroot {
                 cmd.arg(tool.name());
                 (|| {
                     Some(Utf8PathBuf::from(
-                        String::from_utf8(cmd.output().ok()?.stdout).ok()?.trim_end(),
+                        String::from_utf8(stdx::process::output(&mut cmd).ok()?.stdout)
+                            .ok()?
+                            .trim_end(),
                     ))
                 })()
                 .unwrap_or_else(|| Utf8PathBuf::from(tool.name()))

--- a/crates/rust-analyzer/Cargo.toml
+++ b/crates/rust-analyzer/Cargo.toml
@@ -52,7 +52,6 @@ walkdir = "2.5.0"
 semver.workspace = true
 memchr = "2.7.5"
 cargo_metadata.workspace = true
-process-wrap.workspace = true
 dhat = { version = "0.3.3", optional = true }
 
 cfg.workspace = true

--- a/crates/rust-analyzer/src/bin/main.rs
+++ b/crates/rust-analyzer/src/bin/main.rs
@@ -51,6 +51,10 @@ fn actual_main() -> anyhow::Result<ExitCode> {
         eprintln!("Failed to setup logging: {e:#}");
     }
 
+    // After logging so that failures to set this up are visible, but before
+    // anything that may spawn child processes.
+    stdx::process::kill_descendants_on_exit();
+
     let verbosity = flags.verbosity();
 
     match flags.subcommand {

--- a/crates/rust-analyzer/src/bin/rustc_wrapper.rs
+++ b/crates/rust-analyzer/src/bin/rustc_wrapper.rs
@@ -47,11 +47,8 @@ fn run_rustc_skipping_cargo_checking(
 
 fn run_rustc(rustc_executable: OsString, args: Vec<OsString>) -> io::Result<ExitCode> {
     #[allow(clippy::disallowed_methods)]
-    let mut child = Command::new(rustc_executable)
-        .args(args)
-        .stdin(Stdio::inherit())
-        .stdout(Stdio::inherit())
-        .stderr(Stdio::inherit())
-        .spawn()?;
+    let mut cmd = Command::new(rustc_executable);
+    cmd.args(args).stdin(Stdio::inherit()).stdout(Stdio::inherit()).stderr(Stdio::inherit());
+    let mut child = stdx::process::JodChild::spawn(&mut cmd)?;
     Ok(ExitCode::from(child.wait()?.code().unwrap_or(102) as u8))
 }

--- a/crates/rust-analyzer/src/command.rs
+++ b/crates/rust-analyzer/src/command.rs
@@ -13,8 +13,7 @@ use std::{
 use anyhow::Context;
 use crossbeam_channel::Sender;
 use paths::Utf8PathBuf;
-use process_wrap::std::{ChildWrapper, CommandWrap};
-use stdx::process::streaming_output;
+use stdx::process::{JodChild, streaming_output};
 
 /// This trait abstracts parsing one line of JSON output into a Rust
 /// data type.
@@ -117,23 +116,11 @@ impl<T: Sized + Send + 'static> CommandActor<T> {
     }
 }
 
-/// 'Join On Drop' wrapper for a child process.
-///
-/// This wrapper kills the process when the wrapper is dropped.
-struct JodGroupChild(Box<dyn ChildWrapper>);
-
-impl Drop for JodGroupChild {
-    fn drop(&mut self) {
-        _ = self.0.kill();
-        _ = self.0.wait();
-    }
-}
-
 /// A handle to a shell command, such as cargo for diagnostics (flycheck).
 pub(crate) struct CommandHandle<T> {
     /// The handle to the actual child process. As we cannot cancel directly from with
     /// a read syscall dropping and therefore terminating the process is our best option.
-    child: JodGroupChild,
+    child: JodChild,
     thread: stdx::thread::JoinHandle<io::Result<(bool, String)>>,
     program: OsString,
     arguments: Vec<OsString>,
@@ -164,18 +151,11 @@ impl<T: Sized + Send + 'static> CommandHandle<T> {
         let arguments = command.get_args().map(|arg| arg.into()).collect::<Vec<OsString>>();
         let current_dir = command.get_current_dir().map(|arg| arg.to_path_buf());
 
-        let mut child = CommandWrap::from(command);
-        #[cfg(unix)]
-        child.wrap(process_wrap::std::ProcessSession);
-        #[cfg(windows)]
-        child.wrap(process_wrap::std::JobObject);
-        let mut child = child
-            .spawn()
-            .map(JodGroupChild)
-            .with_context(|| "Failed to spawn command: {child:?}")?;
+        let mut child = JodChild::spawn_grouped(command)
+            .with_context(|| format!("Failed to spawn command: {program:?}"))?;
 
-        let stdout = child.0.stdout().take().unwrap();
-        let stderr = child.0.stderr().take().unwrap();
+        let stdout = child.stdout().take().unwrap();
+        let stderr = child.stderr().take().unwrap();
 
         let actor = CommandActor::<T>::new(parser, sender, stdout, stderr);
         let thread =
@@ -186,12 +166,12 @@ impl<T: Sized + Send + 'static> CommandHandle<T> {
     }
 
     pub(crate) fn cancel(mut self) {
-        let _ = self.child.0.kill();
-        let _ = self.child.0.wait();
+        let _ = self.child.kill();
+        let _ = self.child.wait();
     }
 
     pub(crate) fn join(mut self) -> io::Result<()> {
-        let exit_status = self.child.0.wait()?;
+        let exit_status = self.child.wait()?;
         let (read_at_least_one_message, error) = self.thread.join()?;
         if read_at_least_one_message || exit_status.success() {
             Ok(())
@@ -203,7 +183,7 @@ impl<T: Sized + Send + 'static> CommandHandle<T> {
     }
 
     pub(crate) fn has_exited(&mut self) -> bool {
-        match self.child.0.try_wait() {
+        match self.child.try_wait() {
             Ok(Some(_exit_code)) => {
                 // We have an exit code.
                 true

--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -4273,7 +4273,10 @@ mod tests {
         }
 
         let package_json_path = project_root().join("editors/code/package.json");
-        let mut package_json = fs::read_to_string(&package_json_path).unwrap();
+        // Normalize line endings for the marker search below, in case the working
+        // tree was checked out with CRLF line endings.
+        let mut package_json =
+            fs::read_to_string(&package_json_path).unwrap().replace("\r\n", "\n");
 
         let start_marker =
             "            {\n                \"title\": \"$generated-start\"\n            },\n";

--- a/crates/rust-analyzer/src/handlers/request.rs
+++ b/crates/rust-analyzer/src/handlers/request.rs
@@ -2526,14 +2526,11 @@ fn run_rustfmt(
     let output = {
         let _p = tracing::info_span!("rustfmt", ?command).entered();
 
-        let mut rustfmt = command
-            .stdin(Stdio::piped())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .spawn()
+        command.stdin(Stdio::piped()).stdout(Stdio::piped()).stderr(Stdio::piped());
+        let mut rustfmt = stdx::process::JodChild::spawn(&mut command)
             .context(format!("Failed to spawn {command:?}"))?;
 
-        rustfmt.stdin.as_mut().unwrap().write_all(file.as_bytes())?;
+        rustfmt.stdin().as_mut().unwrap().write_all(file.as_bytes())?;
 
         rustfmt.wait_with_output()?
     };

--- a/crates/rust-analyzer/tests/slow-tests/main.rs
+++ b/crates/rust-analyzer/tests/slow-tests/main.rs
@@ -669,10 +669,10 @@ fn test_format_document_range() {
 
     // This test requires a nightly toolchain, so skip if it's not available.
     let cwd = std::env::current_dir().unwrap_or_default();
-    let has_nightly_rustfmt = toolchain::command("rustfmt", cwd, &FxHashMap::default())
-        .args(["+nightly", "--version"])
-        .output()
-        .is_ok_and(|out| out.status.success());
+    let mut rustfmt = toolchain::command("rustfmt", cwd, &FxHashMap::default());
+    rustfmt.args(["+nightly", "--version"]);
+    let has_nightly_rustfmt =
+        stdx::process::output(&mut rustfmt).is_ok_and(|out| out.status.success());
     if !has_nightly_rustfmt {
         tracing::warn!("skipping test_format_document_range: nightly rustfmt not available");
         return;

--- a/crates/stdx/Cargo.toml
+++ b/crates/stdx/Cargo.toml
@@ -24,6 +24,9 @@ crossbeam-utils = "0.8.21"
 [target.'cfg(unix)'.dependencies]
 libc.workspace = true
 
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+process-wrap.workspace = true
+
 [target.'cfg(windows)'.dependencies]
 miow = "0.6.0"
 windows-sys = { version = "0.61", features = ["Win32_Foundation"] }

--- a/crates/stdx/Cargo.toml
+++ b/crates/stdx/Cargo.toml
@@ -29,7 +29,12 @@ process-wrap.workspace = true
 
 [target.'cfg(windows)'.dependencies]
 miow = "0.6.0"
-windows-sys = { version = "0.61", features = ["Win32_Foundation"] }
+windows-sys = { version = "0.61", features = [
+    "Win32_Foundation",
+    "Win32_Security",
+    "Win32_System_JobObjects",
+    "Win32_System_Threading",
+] }
 
 [features]
 # Uncomment to enable for the whole crate graph

--- a/crates/stdx/src/lib.rs
+++ b/crates/stdx/src/lib.rs
@@ -1,8 +1,6 @@
 //! Missing batteries for standard libraries.
 
 use std::borrow::Cow;
-use std::io as sio;
-use std::process::Command;
 use std::{cmp::Ordering, ops, time::Instant};
 
 mod macros;
@@ -11,6 +9,7 @@ pub mod anymap;
 pub mod assert;
 pub mod non_empty_vec;
 pub mod panic_context;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod process;
 pub mod rand;
 pub mod thread;
@@ -289,44 +288,6 @@ pub fn defer<F: FnOnce()>(f: F) -> impl Drop {
         }
     }
     D(Some(f))
-}
-
-/// A [`std::process::Child`] wrapper that will kill the child on drop.
-#[cfg_attr(not(target_arch = "wasm32"), repr(transparent))]
-#[derive(Debug)]
-pub struct JodChild(pub std::process::Child);
-
-impl ops::Deref for JodChild {
-    type Target = std::process::Child;
-    fn deref(&self) -> &std::process::Child {
-        &self.0
-    }
-}
-
-impl ops::DerefMut for JodChild {
-    fn deref_mut(&mut self) -> &mut std::process::Child {
-        &mut self.0
-    }
-}
-
-impl Drop for JodChild {
-    fn drop(&mut self) {
-        _ = self.0.kill();
-        _ = self.0.wait();
-    }
-}
-
-impl JodChild {
-    pub fn spawn(mut command: Command) -> sio::Result<Self> {
-        command.spawn().map(Self)
-    }
-
-    #[must_use]
-    #[cfg(not(target_arch = "wasm32"))]
-    pub fn into_inner(self) -> std::process::Child {
-        // SAFETY: repr transparent, except on WASM
-        unsafe { std::mem::transmute::<Self, std::process::Child>(self) }
-    }
 }
 
 // feature: iter_order_by

--- a/crates/stdx/src/process.rs
+++ b/crates/stdx/src/process.rs
@@ -35,6 +35,7 @@ impl Drop for JodChild {
 impl JodChild {
     /// Spawns `command` as a direct child process.
     pub fn spawn(command: &mut Command) -> io::Result<JodChild> {
+        die_with_parent(command);
         #[allow(
             clippy::disallowed_methods,
             reason = "we are inside the module that implements the replacement"
@@ -47,7 +48,8 @@ impl JodChild {
     /// Spawns `command` as the leader of a new process group (a new session on
     /// unix, a job object on windows), so that killing the child also kills
     /// the processes the child spawned itself.
-    pub fn spawn_grouped(command: Command) -> io::Result<JodChild> {
+    pub fn spawn_grouped(mut command: Command) -> io::Result<JodChild> {
+        die_with_parent(&mut command);
         let mut command = process_wrap::std::CommandWrap::from(command);
         #[cfg(unix)]
         command.wrap(process_wrap::std::ProcessSession);
@@ -108,6 +110,115 @@ impl JodChild {
 pub fn output(command: &mut Command) -> io::Result<Output> {
     command.stdout(Stdio::piped()).stderr(Stdio::piped()).stdin(Stdio::null());
     JodChild::spawn(command)?.wait_with_output()
+}
+
+/// Makes the OS kill all descendant processes when this process exits, no
+/// matter how it exits (including crashes and being killed), so that no
+/// spawned cargo or proc-macro server can be leaked.
+///
+/// On windows, this assigns the current process to a new job object with
+/// `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`. Every process spawned from here on
+/// (transitively, so including e.g. rustc spawned by cargo) inherits
+/// membership in the job, and when this process dies the kernel closes the
+/// deliberately leaked job handle, killing all remaining members. Failure to
+/// set the job up is logged and otherwise ignored.
+///
+/// On linux, the equivalent is arranged per child via `PR_SET_PDEATHSIG` at
+/// spawn time (see `die_with_parent`), so this function is a no-op.
+///
+/// On other platforms (macos), no kernel primitive for this exists, this
+/// function is a no-op, and children are only cleaned up on graceful exit.
+pub fn kill_descendants_on_exit() {
+    #[cfg(windows)]
+    windows_job::put_self_in_kill_on_close_job();
+}
+
+/// Requests that the kernel deliver `SIGKILL` to `command`'s child when this
+/// process dies, covering exits that never run cleanup code (crashes,
+/// `SIGKILL`). Only direct children are covered; grandchildren like rustc are
+/// killed on the graceful exit path only, via the process group of
+/// [`JodChild::spawn_grouped`].
+///
+/// `PR_SET_PDEATHSIG` fires when the spawning *thread* exits, not the
+/// process. That is sound for rust-analyzer: children are spawned either from
+/// threads that block on the child (so the thread outlives it), or from
+/// thread pool workers and the main loop thread, which live for the lifetime
+/// of the process.
+fn die_with_parent(_command: &mut Command) {
+    #[cfg(target_os = "linux")]
+    {
+        use std::os::unix::process::CommandExt;
+
+        let parent = std::process::id();
+        // SAFETY: `prctl`, `getppid` and `_exit` are async-signal-safe.
+        unsafe {
+            _command.pre_exec(move || {
+                libc::prctl(libc::PR_SET_PDEATHSIG, libc::SIGKILL);
+                // If the parent died before the prctl above, the signal will
+                // never be delivered; detect that (we were reparented) and bail.
+                if libc::getppid() != parent as libc::pid_t {
+                    libc::_exit(1);
+                }
+                Ok(())
+            });
+        }
+    }
+}
+
+#[cfg(windows)]
+mod windows_job {
+    use std::{ffi::c_void, io, mem, ptr};
+
+    use windows_sys::Win32::{
+        Foundation::CloseHandle,
+        System::{
+            JobObjects::{
+                AssignProcessToJobObject, CreateJobObjectW, JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+                JOBOBJECT_EXTENDED_LIMIT_INFORMATION, JobObjectExtendedLimitInformation,
+                SetInformationJobObject,
+            },
+            Threading::GetCurrentProcess,
+        },
+    };
+
+    pub(super) fn put_self_in_kill_on_close_job() {
+        // SAFETY: plain winapi calls with valid arguments. The job handle is
+        // deliberately leaked on success so that it is only closed (killing
+        // the job's members) when this process dies.
+        unsafe {
+            let job = CreateJobObjectW(ptr::null(), ptr::null());
+            if job.is_null() {
+                tracing::warn!(
+                    "failed to create job object: {}, spawned processes may be leaked on abnormal exit",
+                    io::Error::last_os_error()
+                );
+                return;
+            }
+            let mut info = mem::zeroed::<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>();
+            info.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+            if SetInformationJobObject(
+                job,
+                JobObjectExtendedLimitInformation,
+                &raw const info as *const c_void,
+                mem::size_of::<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>() as u32,
+            ) == 0
+            {
+                tracing::warn!(
+                    "failed to configure job object: {}, spawned processes may be leaked on abnormal exit",
+                    io::Error::last_os_error()
+                );
+                CloseHandle(job);
+                return;
+            }
+            if AssignProcessToJobObject(job, GetCurrentProcess()) == 0 {
+                tracing::warn!(
+                    "failed to assign self to job object: {}, spawned processes may be leaked on abnormal exit",
+                    io::Error::last_os_error()
+                );
+                CloseHandle(job);
+            }
+        }
+    }
 }
 
 pub fn streaming_output(

--- a/crates/stdx/src/process.rs
+++ b/crates/stdx/src/process.rs
@@ -1,14 +1,114 @@
-//! Read both stdout and stderr of child without deadlocks.
+//! Process management utilities to prevent processes from leaking on exit,
+//! plus reading both stdout and stderr of a child without deadlocks.
+//!
+//! Every child process must be created via [`JodChild::spawn`],
+//! [`JodChild::spawn_grouped`], or one of the helpers built on top of them
+//! ([`output`], [`spawn_with_streaming_output`]). Funneling all spawning
+//! through one place lets us uniformly tie the children's lifetime to
+//! rust-analyzer's own, so that no processes are left behind when
+//! rust-analyzer exits.
 //!
 //! <https://github.com/rust-lang/cargo/blob/905af549966f23a9288e9993a85d1249a5436556/crates/cargo-util/src/read2.rs>
 //! <https://github.com/rust-lang/cargo/blob/58a961314437258065e23cb6316dfc121d96fb71/crates/cargo-util/src/process_builder.rs#L231>
 
 use std::{
     io,
-    process::{ChildStderr, ChildStdout, Command, Output, Stdio},
+    process::{ChildStderr, ChildStdin, ChildStdout, Command, ExitStatus, Output, Stdio},
 };
 
-use crate::JodChild;
+use process_wrap::std::ChildWrapper;
+
+/// 'Join on drop' handle to a child process: the child is killed when the
+/// handle is dropped.
+#[derive(Debug)]
+pub struct JodChild {
+    child: Box<dyn ChildWrapper>,
+}
+
+impl Drop for JodChild {
+    fn drop(&mut self) {
+        _ = self.child.kill();
+        _ = self.child.wait();
+    }
+}
+
+impl JodChild {
+    /// Spawns `command` as a direct child process.
+    pub fn spawn(command: &mut Command) -> io::Result<JodChild> {
+        #[allow(
+            clippy::disallowed_methods,
+            reason = "we are inside the module that implements the replacement"
+        )]
+        let child = command.spawn()?;
+        let child = Box::new(child) as Box<dyn ChildWrapper>;
+        Ok(JodChild { child })
+    }
+
+    /// Spawns `command` as the leader of a new process group (a new session on
+    /// unix, a job object on windows), so that killing the child also kills
+    /// the processes the child spawned itself.
+    pub fn spawn_grouped(command: Command) -> io::Result<JodChild> {
+        let mut command = process_wrap::std::CommandWrap::from(command);
+        #[cfg(unix)]
+        command.wrap(process_wrap::std::ProcessSession);
+        #[cfg(windows)]
+        command.wrap(process_wrap::std::JobObject);
+        Ok(JodChild { child: command.spawn()? })
+    }
+
+    pub fn stdin(&mut self) -> &mut Option<ChildStdin> {
+        self.child.stdin()
+    }
+
+    pub fn stdout(&mut self) -> &mut Option<ChildStdout> {
+        self.child.stdout()
+    }
+
+    pub fn stderr(&mut self) -> &mut Option<ChildStderr> {
+        self.child.stderr()
+    }
+
+    pub fn id(&self) -> u32 {
+        self.child.id()
+    }
+
+    /// Kills the child process, and the process group it leads if spawned via
+    /// [`JodChild::spawn_grouped`].
+    pub fn kill(&mut self) -> io::Result<()> {
+        self.child.kill()
+    }
+
+    pub fn wait(&mut self) -> io::Result<ExitStatus> {
+        self.child.wait()
+    }
+
+    pub fn try_wait(&mut self) -> io::Result<Option<ExitStatus>> {
+        self.child.try_wait()
+    }
+
+    /// Closes the child's stdin if piped, then waits for it to exit, capturing
+    /// its remaining stdout and stderr.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the child's stdout and stderr are not piped.
+    pub fn wait_with_output(mut self) -> io::Result<Output> {
+        drop(self.stdin().take());
+        let stdout = self.stdout().take().expect("child stdout must be piped");
+        let stderr = self.stderr().take().expect("child stderr must be piped");
+        let (stdout, stderr) =
+            streaming_output(stdout, stderr, &mut |_| (), &mut |_| (), &mut || ())?;
+        let status = self.wait()?;
+        Ok(Output { status, stdout, stderr })
+    }
+}
+
+/// Equivalent of [`std::process::Command::output`], going through the spawn
+/// chokepoint.
+pub fn output(command: &mut Command) -> io::Result<Output> {
+    command.stdout(Stdio::piped()).stderr(Stdio::piped()).stdin(Stdio::null());
+    JodChild::spawn(command)?.wait_with_output()
+}
 
 pub fn streaming_output(
     out: ChildStdout,
@@ -54,20 +154,19 @@ pub fn streaming_output(
     Ok((stdout, stderr))
 }
 
-/// # Panics
-///
-/// Panics if `cmd` is not configured to have `stdout` and `stderr` as `piped`.
+/// Runs `cmd` to completion, invoking the callbacks on every line it writes
+/// to stdout and stderr.
 pub fn spawn_with_streaming_output(
     mut cmd: Command,
     on_stdout_line: &mut dyn FnMut(&str),
     on_stderr_line: &mut dyn FnMut(&str),
 ) -> io::Result<Output> {
-    let cmd = cmd.stdout(Stdio::piped()).stderr(Stdio::piped()).stdin(Stdio::null());
+    cmd.stdout(Stdio::piped()).stderr(Stdio::piped()).stdin(Stdio::null());
 
-    let mut child = JodChild(cmd.spawn()?);
+    let mut child = JodChild::spawn(&mut cmd)?;
     let (stdout, stderr) = streaming_output(
-        child.stdout.take().unwrap(),
-        child.stderr.take().unwrap(),
+        child.stdout().take().unwrap(),
+        child.stderr().take().unwrap(),
         on_stdout_line,
         on_stderr_line,
         &mut || (),
@@ -76,7 +175,7 @@ pub fn spawn_with_streaming_output(
     Ok(Output { status, stdout, stderr })
 }
 
-#[cfg(all(unix, not(target_arch = "wasm32")))]
+#[cfg(unix)]
 mod imp {
     use std::{
         io::{self, prelude::*},
@@ -253,21 +352,5 @@ mod imp {
         let data = unsafe { v.as_mut_ptr().add(v.len()) };
         let len = v.capacity() - v.len();
         unsafe { slice::from_raw_parts_mut(data, len) }
-    }
-}
-
-#[cfg(target_arch = "wasm32")]
-mod imp {
-    use std::{
-        io,
-        process::{ChildStderr, ChildStdout},
-    };
-
-    pub(crate) fn read2(
-        _out_pipe: ChildStdout,
-        _err_pipe: ChildStderr,
-        _data: &mut dyn FnMut(bool, &mut Vec<u8>, bool),
-    ) -> io::Result<()> {
-        panic!("no processes on wasm")
     }
 }

--- a/lib/lsp-server/examples/minimal_lsp.rs
+++ b/lib/lsp-server/examples/minimal_lsp.rs
@@ -276,6 +276,7 @@ fn publish_dummy_diag(conn: &Connection, uri: &Uri) -> Result<()> {
 
 fn run_rustfmt(input: &str) -> Result<String> {
     let cwd = std::env::current_dir().expect("can't determine CWD");
+    #[allow(clippy::disallowed_methods, reason = "example code outside the rust-analyzer server")]
     let mut child = command("rustfmt", &cwd, &FxHashMap::default())
         .arg("--emit")
         .arg("stdout")


### PR DESCRIPTION
And enforce it via clippy. This allows us to easily manage process lifetimes and ensure tear down of child processes when r-a exits.

Alternative to https://github.com/rust-lang/rust-analyzer/pull/22738, note this does nothing for macos though, as macos seems to lack a nice way of doing this.