### PR TITLE
internal: Share same proc-macro servers between workspaces

### DIFF
--- a/crates/proc-macro-api/src/lib.rs
+++ b/crates/proc-macro-api/src/lib.rs
@@ -78,9 +78,9 @@ pub enum ProcMacroKind {
     Bang,
 }
 
-/// A handle to an external process which load dylibs with macros (.so or .dll)
+/// A handle to proc-macro server process pool which load dylibs with macros (.so or .dll)
 /// and runs actual macro expansion functions.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ProcMacroClient {
     /// Currently, the proc macro process expands all procedural macros sequentially.
     ///

--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -395,7 +395,7 @@ config_data! {
         ///
         /// Controls how many independent `proc-macro-srv` processes rust-analyzer
         /// runs in parallel to handle macro expansion.
-        procMacro_processes: NumProcesses = NumProcesses::Concrete(1),
+        procMacro_processes: NumProcesses = NumProcesses::Concrete(2),
 
         /// Internal config, path to proc-macro server executable.
         procMacro_server: Option<Utf8PathBuf> = None,

--- a/crates/rust-analyzer/src/reload.rs
+++ b/crates/rust-analyzer/src/reload.rs
@@ -659,11 +659,16 @@ impl GlobalState {
             Config::user_config_dir_path().as_deref(),
         );
 
-        if (self.proc_macro_clients.len() < self.workspaces.len() || !same_workspaces)
-            && self.config.expand_proc_macros()
-        {
+        if !same_workspaces && self.config.expand_proc_macros() {
             info!("Spawning proc-macro servers");
 
+            // Workspaces referring to the same proc-macro server executable (i.e. the same
+            // sysroot) with an identical spawn environment share a single client, and thereby
+            // a single set of server processes.
+            let mut clients: Vec<(
+                (AbsPathBuf, Option<semver::Version>, FxHashMap<String, Option<String>>),
+                ProcMacroClient,
+            )> = Vec::new();
             self.proc_macro_clients = Arc::from_iter(self.workspaces.iter().map(|ws| {
                 let path = match self.config.proc_macro_srv() {
                     Some(path) => path,
@@ -695,20 +700,30 @@ impl GlobalState {
 
                     _ => Default::default(),
                 };
-                info!("Using proc-macro server at {path}");
+
+                let key = (path, ws.toolchain.clone(), env);
+                if let Some((_, client)) = clients.iter().find(|(k, _)| *k == key) {
+                    return Some(Ok(client.clone()));
+                }
+
+                let (path, toolchain, env) = &key;
+                info!("Spawning proc-macro server at {path}");
                 let num_process = self.config.proc_macro_num_processes();
 
-                Some(
-                    ProcMacroClient::spawn(&path, &env, ws.toolchain.as_ref(), num_process)
-                        .map_err(|err| {
-                            tracing::error!(
-                                "Failed to run proc-macro server from path {path}, error: {err:?}",
-                            );
-                            anyhow::format_err!(
-                                "Failed to run proc-macro server from path {path}, error: {err:?}",
-                            )
-                        }),
-                )
+                Some(match ProcMacroClient::spawn(path, env, toolchain.as_ref(), num_process) {
+                    Ok(client) => {
+                        clients.push((key.clone(), client.clone()));
+                        Ok(client)
+                    }
+                    Err(err) => {
+                        tracing::error!(
+                            "Failed to run proc-macro server from path {path}, error: {err:?}",
+                        );
+                        Err(anyhow::format_err!(
+                            "Failed to run proc-macro server from path {path}, error: {err:?}",
+                        ))
+                    }
+                })
             }))
         }
 

--- a/docs/book/src/configuration_generated.md
+++ b/docs/book/src/configuration_generated.md
@@ -1368,7 +1368,7 @@ This config takes a map of crate names with the exported proc-macro names to ign
 
 ## rust-analyzer.procMacro.processes {#procMacro.processes}
 
-Default: `1`
+Default: `2`
 
 Number of proc-macro server processes to spawn.
 

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -2873,7 +2873,7 @@
                 "properties": {
                     "rust-analyzer.procMacro.processes": {
                         "markdownDescription": "Number of proc-macro server processes to spawn.\n\nControls how many independent `proc-macro-srv` processes rust-analyzer\nruns in parallel to handle macro expansion.",
-                        "default": 1,
+                        "default": 2,
                         "anyOf": [
                             {
                                 "type": "number",


### PR DESCRIPTION
Also bumps the default proc-macro server count from 1 to 2, I have been test driving this with 4 processes for a long time with no issues.