### PR TITLE
fix: clamp cttz const-eval result to type width

### DIFF
--- a/crates/hir-ty/src/consteval/tests/intrinsics.rs
+++ b/crates/hir-ty/src/consteval/tests/intrinsics.rs
@@ -691,6 +691,33 @@ fn cttz() {
         "#,
         3,
     );
+    check_number(
+        r#"
+        #[rustc_intrinsic]
+        pub fn cttz<T: Copy>(x: T) -> T;
+
+        const GOAL: i8 = cttz(0i8);
+        "#,
+        8,
+    );
+    check_number(
+        r#"
+        #[rustc_intrinsic]
+        pub fn cttz<T: Copy>(x: T) -> T;
+
+        const GOAL: u32 = cttz(0u32);
+        "#,
+        32,
+    );
+    check_number(
+        r#"
+        #[rustc_intrinsic]
+        pub fn cttz<T: Copy>(x: T) -> T;
+
+        const GOAL: u64 = cttz(0u64);
+        "#,
+        64,
+    );
 }
 
 #[test]

--- a/crates/hir-ty/src/mir/eval/shim.rs
+++ b/crates/hir-ty/src/mir/eval/shim.rs
@@ -1100,7 +1100,9 @@ impl<'a, 'db: 'a> Evaluator<'a, 'db> {
                 let [arg] = args else {
                     return Err(MirEvalError::InternalError("cttz arg is not provided".into()));
                 };
-                let result = u128::from_le_bytes(pad16(arg.get(self)?, false)).trailing_zeros();
+                let arg: &[u8] = arg.get(self)?;
+                let bit_count = arg.len() as u32 * 8;
+                let result = u128::from_le_bytes(pad16(arg, false)).trailing_zeros().min(bit_count);
                 destination
                     .write_from_bytes(self, &(result as u128).to_le_bytes()[0..destination.size])
             }


### PR DESCRIPTION
`0u64.trailing_zeros()` is showing the wrong result in the const eval hover/preview.

<img width="604" height="246" alt="image" src="https://github.com/user-attachments/assets/2560dbf4-3ea3-4913-b78b-6057f6a2a562" />

```
cargo run    
   Compiling ra-tzcnt-bug v0.1.0 (/home/qti3e/Code/Challenge/ra-tzcnt-bug)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.11s
     Running `target/debug/ra-tzcnt-bug`
[src/main.rs:4:5] X = 64
```

detail: the impl was converting any input into a u128 to handle generics, which was making it return `128` regardless of the input's type, the fix clamps the result to the number of bits in the input.