### PR TITLE
internal: Remove the `Database` assoc type from the `Intern` & `Lookup` traits

### DIFF
--- a/crates/hir-def/src/attrs.rs
+++ b/crates/hir-def/src/attrs.rs
@@ -52,7 +52,7 @@ pub use self::docs::{Docs, IsInnerDoc};
 #[inline]
 fn attrs_from_ast_id_loc<N: AstNode + Into<ast::AnyHasAttrs>>(
     db: &dyn SourceDatabase,
-    lookup: impl Lookup<Database = dyn SourceDatabase, Data = impl AstIdLoc<Ast = N> + HasModule>,
+    lookup: impl Lookup<Data = impl AstIdLoc<Ast = N> + HasModule>,
 ) -> (InFile<ast::AnyHasAttrs>, Crate) {
     let loc = lookup.lookup(db);
     let source = loc.source(db);

--- a/crates/hir-def/src/expr_store/pretty.rs
+++ b/crates/hir-def/src/expr_store/pretty.rs
@@ -56,7 +56,7 @@ pub enum LineFormat {
 
 fn item_name<Id, Loc>(db: &dyn SourceDatabase, id: Id, default: &str) -> String
 where
-    Id: Lookup<Database = dyn SourceDatabase, Data = Loc>,
+    Id: Lookup<Data = Loc>,
     Loc: HasSource,
     Loc::Value: ast::HasName,
 {

--- a/crates/hir-def/src/lib.rs
+++ b/crates/hir-def/src/lib.rs
@@ -225,7 +225,7 @@ impl<N: AstIdNode> AstIdLoc for AssocItemLoc<N> {
 macro_rules! impl_intern {
     ($id:ident, $loc:ident) => {
         impl_intern_key!($id, $loc);
-        impl_intern_lookup!(SourceDatabase, $id, $loc);
+        impl_intern_lookup!($id, $loc);
     };
 }
 
@@ -936,7 +936,7 @@ impl GenericDefId {
     ) -> (HirFileId, Option<ast::GenericParamList>) {
         fn file_id_and_params_of_item_loc<Loc>(
             db: &dyn SourceDatabase,
-            def: impl Lookup<Database = dyn SourceDatabase, Data = Loc>,
+            def: impl Lookup<Data = Loc>,
         ) -> (HirFileId, Option<ast::GenericParamList>)
         where
             Loc: src::HasSource,
@@ -1145,7 +1145,7 @@ pub trait HasModule {
 impl<N, ItemId> HasModule for ItemId
 where
     N: AstIdNode,
-    ItemId: Lookup<Database = dyn SourceDatabase, Data = ItemLoc<N>> + Copy,
+    ItemId: Lookup<Data = ItemLoc<N>> + Copy,
 {
     #[inline]
     fn module(&self, db: &dyn SourceDatabase) -> ModuleId {
@@ -1170,7 +1170,7 @@ where
 #[inline]
 fn module_for_assoc_item_loc<'db>(
     db: &(dyn 'db + SourceDatabase),
-    id: impl Lookup<Database = dyn SourceDatabase, Data = AssocItemLoc<impl AstIdNode>>,
+    id: impl Lookup<Data = AssocItemLoc<impl AstIdNode>>,
 ) -> ModuleId {
     id.lookup(db).container.module(db)
 }

--- a/crates/hir-def/src/resolver.rs
+++ b/crates/hir-def/src/resolver.rs
@@ -1479,10 +1479,7 @@ impl HasResolver for MacroRulesId {
 
 fn lookup_resolver(
     db: &dyn SourceDatabase,
-    lookup: impl Lookup<
-        Database = dyn SourceDatabase,
-        Data = impl AstIdLoc<Container = impl HasResolver>,
-    >,
+    lookup: impl Lookup<Data = impl AstIdLoc<Container = impl HasResolver>>,
 ) -> Resolver<'_> {
     lookup.lookup(db).container().resolver(db)
 }

--- a/crates/hir-expand/src/lib.rs
+++ b/crates/hir-expand/src/lib.rs
@@ -83,19 +83,17 @@ const TOKEN_LIMIT: usize = 2_097_152;
 
 #[macro_export]
 macro_rules! impl_intern_lookup {
-    ($db:ident, $id:ident, $loc:ident) => {
+    ($id:ident, $loc:ident) => {
         impl $crate::Intern for $loc {
-            type Database = dyn $db;
             type ID = $id;
-            fn intern(self, db: &Self::Database) -> Self::ID {
+            fn intern(self, db: &dyn ::base_db::SourceDatabase) -> Self::ID {
                 $id::new(db, self)
             }
         }
 
         impl $crate::Lookup for $id {
-            type Database = dyn $db;
             type Data = $loc;
-            fn lookup<'db>(&self, db: &'db Self::Database) -> &'db Self::Data {
+            fn lookup<'db>(&self, db: &'db dyn ::base_db::SourceDatabase) -> &'db Self::Data {
                 self.loc(db)
             }
         }
@@ -104,18 +102,16 @@ macro_rules! impl_intern_lookup {
 
 // ideally these would be defined in base-db, but the orphan rule doesn't let us
 pub trait Intern {
-    type Database: ?Sized;
     type ID;
-    fn intern(self, db: &Self::Database) -> Self::ID;
+    fn intern(self, db: &dyn SourceDatabase) -> Self::ID;
 }
 
 pub trait Lookup {
-    type Database: ?Sized;
     type Data;
-    fn lookup<'db>(&self, db: &'db Self::Database) -> &'db Self::Data;
+    fn lookup<'db>(&self, db: &'db dyn SourceDatabase) -> &'db Self::Data;
 }
 
-impl_intern_lookup!(SourceDatabase, MacroCallId, MacroCallLoc);
+impl_intern_lookup!(MacroCallId, MacroCallLoc);
 
 pub type ExpandResult<T> = ValueResult<T, ExpandError>;
 

--- a/crates/hir-ty/src/diagnostics/decl_check.rs
+++ b/crates/hir-ty/src/diagnostics/decl_check.rs
@@ -15,7 +15,6 @@ mod case_conv;
 
 use std::fmt;
 
-use base_db::SourceDatabase;
 use hir_def::{
     AdtId, ConstId, EnumId, EnumVariantId, FunctionId, HasModule, ItemContainerId, Lookup,
     ModuleDefId, ModuleId, StaticId, StructId, TraitId, TypeAliasId, UnionId,
@@ -710,7 +709,7 @@ impl<'a> DeclValidator<'a> {
     ) where
         N: AstNode + HasName + fmt::Debug,
         S: HasSource<Value = N>,
-        L: Lookup<Data = S, Database = dyn SourceDatabase> + HasModule + Copy,
+        L: Lookup<Data = S> + HasModule + Copy,
     {
         let to_expected_case_type = match expected_case {
             CaseType::LowerSnakeCase => to_lower_snake_case,

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -3622,7 +3622,7 @@ fn as_assoc_item<'db, ID, DEF, LOC>(
     id: ID,
 ) -> Option<AssocItem>
 where
-    ID: Lookup<Database = dyn SourceDatabase, Data = AssocItemLoc<LOC>>,
+    ID: Lookup<Data = AssocItemLoc<LOC>>,
     DEF: From<ID>,
     LOC: AstIdNode,
 {
@@ -3638,7 +3638,7 @@ fn as_extern_assoc_item<'db, ID, DEF, LOC>(
     id: ID,
 ) -> Option<ExternAssocItem>
 where
-    ID: Lookup<Database = dyn SourceDatabase, Data = AssocItemLoc<LOC>>,
+    ID: Lookup<Data = AssocItemLoc<LOC>>,
     DEF: From<ID>,
     LOC: AstIdNode,
 {

--- a/crates/hir/src/semantics/child_by_source.rs
+++ b/crates/hir/src/semantics/child_by_source.rs
@@ -283,7 +283,7 @@ fn insert_item_loc<ID, N, Data>(
     id: ID,
     key: Key<N, ID>,
 ) where
-    ID: Lookup<Database = dyn SourceDatabase, Data = Data> + 'static,
+    ID: Lookup<Data = Data> + 'static,
     Data: AstIdLoc<Ast = N>,
     N: AstIdNode + 'static,
 {

--- a/crates/hir/src/symbols.rs
+++ b/crates/hir/src/symbols.rs
@@ -2,7 +2,7 @@
 
 use std::marker::PhantomData;
 
-use base_db::{FxIndexSet, SourceDatabase};
+use base_db::FxIndexSet;
 use either::Either;
 use hir_def::{
     AdtId, AssocItemId, AstIdLoc, Complete, DefWithBodyId, ExternCrateId, HasModule, ImplId,
@@ -459,7 +459,7 @@ impl<'a> SymbolCollector<'a> {
         trait_do_not_complete: Option<Complete>,
     ) -> Complete
     where
-        L: Lookup<Database = dyn SourceDatabase> + Into<ModuleDefId>,
+        L: Lookup + Into<ModuleDefId>,
         <L as Lookup>::Data: HasSource,
         <<L as Lookup>::Data as HasSource>::Value: HasName,
     {


### PR DESCRIPTION
After we removed `DefDatabase`, it is now always `SourceDatabase`.