### PR TITLE
internal: update links to `rustc_hir_analysis`

### DIFF
--- a/crates/hir-ty/src/autoderef.rs
+++ b/crates/hir-ty/src/autoderef.rs
@@ -1,7 +1,9 @@
 //! In certain situations, rust automatically inserts derefs as necessary: for
 //! example, field accesses `foo.bar` still work when `foo` is actually a
 //! reference to a type with the field `bar`. This is an approximation of the
-//! logic in rustc (which lives in rustc_hir_analysis/check/autoderef.rs).
+//! logic in rustc (which lives in [`rustc_hir_typeck/autoderef.rs`]).
+//!
+//! [`rustc_hir_typeck/autoderef.rs`]: https://github.com/rust-lang/rust/blob/5503df87342a73d0c29126a7e08dc9c1255c46ad/compiler/rustc_hir_typeck/src/autoderef.rs
 
 use std::fmt;
 

--- a/crates/hir-ty/src/infer.rs
+++ b/crates/hir-ty/src/infer.rs
@@ -2,7 +2,7 @@
 //! the type of each expression and pattern.
 //!
 //! For type inference, compare the implementations in rustc (the various
-//! check_* methods in rustc_hir_analysis/check/mod.rs are a good entry point) and
+//! check_* methods in [`rustc_hir_typeck/check.rs`] are a good entry point) and
 //! IntelliJ-Rust (org.rust.lang.core.types.infer). Our entry point for
 //! inference here is the `infer` function, which infers the types of all
 //! expressions in a given function.
@@ -12,6 +12,8 @@
 //! we might determine that certain variables need to be equal to each other, or
 //! to certain types. To record this, we use the union-find implementation from
 //! the `ena` crate, which is extracted from rustc.
+//!
+//! [`rustc_hir_typeck/check.rs`]: https://github.com/rust-lang/rust/blob/5503df87342a73d0c29126a7e08dc9c1255c46ad/compiler/rustc_hir_typeck/src/check.rs
 
 mod autoderef;
 mod callee;

--- a/crates/hir-ty/src/method_resolution.rs
+++ b/crates/hir-ty/src/method_resolution.rs
@@ -1,7 +1,10 @@
 //! This module is concerned with finding methods that a given type provides.
 //! For details about how this works in rustc, see the method lookup page in the
-//! [rustc guide](https://rust-lang.github.io/rustc-guide/method-lookup.html)
-//! and the corresponding code mostly in rustc_hir_analysis/check/method/probe.rs.
+//! [rustc guide] and the corresponding code mostly in
+//! [`rustc_hir_typeck/method/probe.rs`].
+//!
+//! [rustc guide]: https://rust-lang.github.io/rustc-guide/method-lookup.html
+//! [`rustc_hir_typeck/method/probe.rs`]: https://github.com/rust-lang/rust/blob/5503df87342a73d0c29126a7e08dc9c1255c46ad/compiler/rustc_hir_typeck/src/method/probe.rs
 
 mod confirm;
 mod probe;


### PR DESCRIPTION
It took some digging through Git history to find out that `rustc_hir_analysis/check` has been moved to `rustc_hir_typeck` in https://github.com/rust-lang/rust/pull/103310. I updated the links, and took the liberty to make them versioned, to avoid this work in the future.