### PR TITLE
internal: remove `#[salsa::cycle]` support from `#[query_group]`

### DIFF
--- a/crates/hir-ty/src/consteval.rs
+++ b/crates/hir-ty/src/consteval.rs
@@ -413,6 +413,7 @@ pub(crate) fn create_anon_const<'a, 'db>(
     }
 }
 
+#[salsa::tracked(cycle_result = const_eval_discriminant_cycle_result)]
 pub(crate) fn const_eval_discriminant_variant(
     db: &dyn HirDatabase,
     variant_id: EnumVariantId,
@@ -449,7 +450,7 @@ pub(crate) fn const_eval_discriminant_variant(
     Ok(c)
 }
 
-pub(crate) fn const_eval_discriminant_cycle_result(
+fn const_eval_discriminant_cycle_result(
     _: &dyn HirDatabase,
     _: salsa::Id,
     _: EnumVariantId,

--- a/crates/hir-ty/src/db.rs
+++ b/crates/hir-ty/src/db.rs
@@ -104,7 +104,7 @@ pub trait HirDatabase: SourceDatabase + std::fmt::Debug {
     fn const_eval_static<'db>(&'db self, def: StaticId) -> Result<Allocation<'db>, ConstEvalError>;
 
     #[salsa::invoke(crate::consteval::const_eval_discriminant_variant)]
-    #[salsa::cycle(cycle_result = crate::consteval::const_eval_discriminant_cycle_result)]
+    #[salsa::transparent]
     fn const_eval_discriminant(&self, def: EnumVariantId) -> Result<i128, ConstEvalError>;
 
     #[salsa::invoke(crate::method_resolution::lookup_impl_method_query)]
@@ -119,7 +119,7 @@ pub trait HirDatabase: SourceDatabase + std::fmt::Debug {
     // endregion:mir
 
     #[salsa::invoke(crate::layout::layout_of_adt_query)]
-    #[salsa::cycle(cycle_result = crate::layout::layout_of_adt_cycle_result)]
+    #[salsa::transparent]
     fn layout_of_adt(
         &self,
         def: AdtId,
@@ -128,7 +128,7 @@ pub trait HirDatabase: SourceDatabase + std::fmt::Debug {
     ) -> Result<Arc<Layout>, LayoutError>;
 
     #[salsa::invoke(crate::layout::layout_of_ty_query)]
-    #[salsa::cycle(cycle_result = crate::layout::layout_of_ty_cycle_result)]
+    #[salsa::transparent]
     fn layout_of_ty(
         &self,
         ty: StoredTy,

--- a/crates/hir-ty/src/layout.rs
+++ b/crates/hir-ty/src/layout.rs
@@ -32,7 +32,6 @@ use crate::{
     traits::StoredParamEnvAndCrate,
 };
 
-pub(crate) use self::adt::layout_of_adt_cycle_result;
 pub use self::{adt::layout_of_adt_query, target::target_data_layout_query};
 
 pub(crate) mod adt;
@@ -161,6 +160,7 @@ fn layout_of_simd_ty<'db>(
     Ok(Arc::new(cx.calc.simd_type(e_ly, e_len, repr_packed)?))
 }
 
+#[salsa::tracked(cycle_result = layout_of_ty_cycle_result)]
 pub fn layout_of_ty_query(
     db: &dyn HirDatabase,
     ty: StoredTy,
@@ -503,7 +503,7 @@ pub fn layout_of_ty_query(
     Ok(Arc::new(result))
 }
 
-pub(crate) fn layout_of_ty_cycle_result(
+fn layout_of_ty_cycle_result(
     _: &dyn HirDatabase,
     _: salsa::Id,
     _: StoredTy,

--- a/crates/hir-ty/src/layout/adt.rs
+++ b/crates/hir-ty/src/layout/adt.rs
@@ -19,6 +19,7 @@ use crate::{
     traits::StoredParamEnvAndCrate,
 };
 
+#[salsa::tracked(cycle_result = layout_of_adt_cycle_result)]
 pub fn layout_of_adt_query(
     db: &dyn HirDatabase,
     def: AdtId,
@@ -96,7 +97,7 @@ pub fn layout_of_adt_query(
     Ok(Arc::new(result))
 }
 
-pub(crate) fn layout_of_adt_cycle_result(
+fn layout_of_adt_cycle_result(
     _: &dyn HirDatabase,
     _: salsa::Id,
     _def: AdtId,

--- a/crates/query-group-macro/src/lib.rs
+++ b/crates/query-group-macro/src/lib.rs
@@ -6,11 +6,10 @@ use proc_macro::TokenStream;
 use proc_macro2::Span;
 use queries::{Queries, TrackedQuery, Transparent};
 use quote::{ToTokens, format_ident, quote};
-use syn::parse::{Parse, ParseStream};
-use syn::punctuated::Punctuated;
+use syn::parse::ParseStream;
 use syn::spanned::Spanned;
 use syn::visit_mut::VisitMut;
-use syn::{Attribute, FnArg, ItemTrait, Path, Token, TraitItem, parse_quote, parse_quote_spanned};
+use syn::{Attribute, FnArg, ItemTrait, Path, TraitItem, parse_quote, parse_quote_spanned};
 
 mod queries;
 
@@ -87,50 +86,6 @@ enum QueryKind {
     Transparent,
 }
 
-#[derive(Default, Debug, Clone)]
-struct Cycle {
-    cycle_result: Option<(syn::Ident, Path)>,
-}
-
-impl Parse for Cycle {
-    fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
-        let options = Punctuated::<Option, Token![,]>::parse_terminated(input)?;
-        let mut cycle_result = None;
-        for option in options {
-            let name = option.name.to_string();
-            match &*name {
-                "cycle_result" => {
-                    if cycle_result.is_some() {
-                        return Err(syn::Error::new_spanned(&option.name, "duplicate option"));
-                    }
-                    cycle_result = Some((option.name, option.value));
-                }
-                _ => {
-                    return Err(syn::Error::new_spanned(
-                        &option.name,
-                        "unknown cycle option. Accepted values: `cycle_result`",
-                    ));
-                }
-            }
-        }
-        return Ok(Self { cycle_result });
-
-        struct Option {
-            name: syn::Ident,
-            value: Path,
-        }
-
-        impl Parse for Option {
-            fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
-                let name = input.parse()?;
-                input.parse::<Token![=]>()?;
-                let value = input.parse()?;
-                Ok(Self { name, value })
-            }
-        }
-    }
-}
-
 pub(crate) fn query_group_impl(
     _args: proc_macro::TokenStream,
     input: proc_macro::TokenStream,
@@ -158,7 +113,6 @@ pub(crate) fn query_group_impl(
 
             let mut query_kind = QueryKind::TrackedWithSalsaStruct;
             let mut invoke = None;
-            let mut cycle = None;
 
             let params: Vec<FnArg> = signature.inputs.clone().into_iter().collect();
             let pat_and_tys = params
@@ -172,10 +126,6 @@ pub(crate) fn query_group_impl(
 
             for SalsaAttr { name, tts, span } in salsa_attrs {
                 match name.as_str() {
-                    "cycle" => {
-                        let c = syn::parse::<Parenthesized<Cycle>>(tts)?;
-                        cycle = Some(c.0);
-                    }
                     "invoke" => {
                         let path = syn::parse::<Parenthesized<Path>>(tts)?;
                         invoke = Some(path.0.clone());
@@ -208,7 +158,6 @@ pub(crate) fn query_group_impl(
                         signature: signature.clone(),
                         pat_and_tys: pat_and_tys.clone(),
                         invoke,
-                        cycle,
                         default: method.default.take(),
                     };
 

--- a/crates/query-group-macro/src/queries.rs
+++ b/crates/query-group-macro/src/queries.rs
@@ -3,15 +3,12 @@
 use quote::{ToTokens, format_ident, quote, quote_spanned};
 use syn::{Ident, PatType, Path, spanned::Spanned};
 
-use crate::Cycle;
-
 pub(crate) struct TrackedQuery {
     pub(crate) trait_name: Ident,
     pub(crate) signature: syn::Signature,
     pub(crate) pat_and_tys: Vec<PatType>,
     pub(crate) invoke: Option<Path>,
     pub(crate) default: Option<syn::Block>,
-    pub(crate) cycle: Option<Cycle>,
 }
 
 impl ToTokens for TrackedQuery {
@@ -28,15 +25,6 @@ impl ToTokens for TrackedQuery {
 
         let fn_ident = &sig.ident;
         let shim: Ident = format_ident!("{}_shim", fn_ident);
-
-        let options = self
-            .cycle
-            .as_ref()
-            .map(|Cycle { cycle_result }| {
-                cycle_result.as_ref().map(|(ident, path)| quote!(#ident=#path))
-            })
-            .into_iter();
-        let annotation = quote!(#[salsa_macros::tracked( #(#options),* )]);
 
         let pat_and_tys = &self.pat_and_tys;
         let params = self
@@ -55,7 +43,7 @@ impl ToTokens for TrackedQuery {
 
         let method = quote! {
             #sig {
-                #annotation
+                #[salsa_macros::tracked]
                 fn #shim<'db>(
                     db: &'db dyn #trait_name,
                     #(#pat_and_tys),*


### PR DESCRIPTION
Part of https://github.com/rust-lang/rust-analyzer/issues/22657

This is an intermediary step before migrating these queries away from `#[query_group]` completely.