### PR TITLE
fix: Use quote! inside ast::make::expr_call()

### DIFF
--- a/crates/syntax/src/ast/make.rs
+++ b/crates/syntax/src/ast/make.rs
@@ -686,7 +686,12 @@ pub fn expr_prefix(op: SyntaxKind, expr: ast::Expr) -> ast::PrefixExpr {
     expr_from_text(&format!("{token}{expr}"))
 }
 pub fn expr_call(f: ast::Expr, arg_list: ast::ArgList) -> ast::CallExpr {
-    expr_from_text(&format!("{f}{arg_list}"))
+    quote! {
+        CallExpr {
+            #f
+            #arg_list
+        }
+    }
 }
 pub fn expr_method_call(
     receiver: ast::Expr,


### PR DESCRIPTION
It's possible to make rust-analyzer panic because of `expr_from_text` not roundtripping. Prefer `quote!`, which is better anyway (less work, more robust).

This crash only seems to occur in rare circumstances, so I haven't written a regression test. For reference, you can replicate it with the following code:

    mod serde {
        pub struct Serializer;

        pub trait Serialize {
            fn serialize(&self, s: Serializer);
        }
    }

    struct Duration;

    impl serde::Serialize for Duration {
        fn serialize(&self, s: serde::Serializer) {}
    }

    struct S {
        map: <Duration
    }

When the cursor was on `map`, the `generate_delegate_trait` would try to build the call `<<Duration as Serialize>::serialize(&self.map, s)`. Due to the extra leading `<`, we'd parse it as `<<`, which isn't valid in an expression (left shift is an infix operator).

Since we were passing invalid Rust through the syntax builder, which only allows valid Rust code, we then panicked.

    18:        0x104007fdc - <core[eea836d19939cdd9]::option::Option<syntax[8d95e7771a925714]::ast::generated::nodes::Expr>>::unwrap
                                 at /rustc/2d8144b7880597b6e6d3dfd63a9a9efae3f533d3/library/core/src/option.rs:1013:21
    19:        0x104007fdc - <syntax[8d95e7771a925714]::Parse<syntax[8d95e7771a925714]::ast::generated::nodes::Expr>>::tree
                                 at /Users/wilfred/src/rust-analyzer/crates/syntax/src/lib.rs:120:37
    20:        0x104006014 - syntax[8d95e7771a925714]::ast::make::expr_from_text_with_edition::<syntax[8d95e7771a925714]::ast::generated::nodes::CallExpr>
                                 at /Users/wilfred/src/rust-analyzer/crates/syntax/src/ast/make.rs:1360:28
    21:        0x103ff9d80 - syntax[8d95e7771a925714]::ast::make::expr_from_text::<syntax[8d95e7771a925714]::ast::generated::nodes::CallExpr>
                                 at /Users/wilfred/src/rust-analyzer/crates/syntax/src/ast/make.rs:1354:5
    22:        0x103f8e298 - syntax[8d95e7771a925714]::ast::make::expr_call
                                 at /Users/wilfred/src/rust-analyzer/crates/syntax/src/ast/make.rs:689:5
    23:        0x103fed920 - <syntax[8d95e7771a925714]::ast::syntax_factory::SyntaxFactory>::expr_call
                                 at /Users/wilfred/src/rust-analyzer/crates/syntax/src/ast/syntax_factory/constructors.rs:1157:19
    24:        0x1027feb9c - ide_assists[84949edff2a7fc81]::handlers::generate_delegate_trait::func_assoc_item
                                 at /Users/wilfred/src/rust-analyzer/crates/ide-assists/src/handlers/generate_delegate_trait.rs:796:22
    25:        0x102800120 - ide_assists[84949edff2a7fc81]::handlers::generate_delegate_trait::process_assoc_item

AI disclosure: Written with help by GPT-5.5.