### PR TITLE
fix: Do not `#[macro_use]` the sysroot crates

### DIFF
--- a/crates/hir-def/src/nameres/collector.rs
+++ b/crates/hir-def/src/nameres/collector.rs
@@ -1877,7 +1877,6 @@ impl ModCollector<'_, '_> {
     }
 
     fn collect(&mut self, items: &[ModItemId], container: ItemContainerId) {
-        let krate = self.def_collector.def_map.krate;
         let is_crate_root = self.module_id == self.def_collector.def_map.root
             && self.def_collector.def_map.block.is_none();
 
@@ -1885,18 +1884,6 @@ impl ModCollector<'_, '_> {
         // for macros.
         self.def_collector.mod_dirs.insert(self.module_id, self.mod_dir.clone());
 
-        // Prelude module is always considered to be `#[macro_use]`.
-        if let Some((prelude_module, _use)) = self.def_collector.def_map.prelude {
-            // Don't insert macros from the prelude into blocks, as they can be shadowed by other macros.
-            if is_crate_root && prelude_module.krate(self.def_collector.db) != krate {
-                cov_mark::hit!(prelude_is_macro_use);
-                self.def_collector.import_macros_from_extern_crate(
-                    prelude_module.krate(self.def_collector.db),
-                    None,
-                    None,
-                );
-            }
-        }
         let db = self.def_collector.db;
         let module_id = self.module_id;
         let consider_deferred_derives =

--- a/crates/hir-def/src/nameres/tests/macros.rs
+++ b/crates/hir-def/src/nameres/tests/macros.rs
@@ -339,35 +339,18 @@ macro_rules! baz3 { () => { struct OkBaz3; } }
 }
 
 #[test]
-fn prelude_is_macro_use() {
-    cov_mark::check!(prelude_is_macro_use);
+fn prelude_is_not_macro_use() {
     check(
         r#"
 //- /main.rs edition:2018 crate:main deps:std
 structs!(Foo);
-structs_priv!(Bar);
-structs_outside!(Out);
-crate::structs!(MacroNotResolved2);
-
-mod bar;
-
-//- /bar.rs
-structs!(Baz);
-crate::structs!(MacroNotResolved3);
+structs_outside!(MacroNotResolved);
 
 //- /lib.rs crate:std
 pub mod prelude {
     pub mod rust_2018 {
-        #[macro_export]
-        macro_rules! structs {
+        pub macro structs {
             ($i:ident) => { struct $i; }
-        }
-
-        mod priv_mod {
-            #[macro_export]
-            macro_rules! structs_priv {
-                ($i:ident) => { struct $i; }
-            }
         }
     }
 }
@@ -379,13 +362,7 @@ macro_rules! structs_outside {
 "#,
         expect![[r#"
             crate
-            - Bar : type value
             - Foo : type value
-            - Out : type value
-            - bar : type
-
-            crate::bar
-            - Baz : type value
         "#]],
     );
 }
@@ -743,11 +720,10 @@ foo!();
 pub use core::foo;
 
 pub mod prelude {
-    pub mod rust_2018 {}
+    pub mod rust_2018 {
+        pub use crate::foo;
+    }
 }
-
-#[macro_use]
-mod std_macros;
 
 //- /core.rs crate:core
 #[macro_export]

--- a/crates/test-utils/src/minicore.rs
+++ b/crates/test-utils/src/minicore.rs
@@ -2515,6 +2515,7 @@ macro_rules! matches {
 
 pub mod prelude {
     pub mod v1 {
+        #[rustfmt::skip]
         pub use crate::{
             clone::Clone,                                 // :clone
             cmp::{Eq, PartialEq},                         // :eq
@@ -2541,6 +2542,16 @@ pub mod prelude {
             panic,                                        // :panic
             result::Result::{self, Err, Ok},              // :result
             str::FromStr,                                 // :str
+            write, writeln,                               // :write
+            assert,                                       // :assert
+            format_args, format_args_nl, const_format_args, print, // :fmt
+            todo,                                         // :todo
+            unimplemented,                                // :unimplemented
+            include,                                      // :include
+            include_bytes,                                // :include_bytes
+            concat,                                       // :concat
+            env, option_env,                              // :env
+            matches,                                      // :matches
         };
     }
 


### PR DESCRIPTION
They were so in the past, but in https://github.com/rust-lang/rust/pull/139493 they were changed to not be, instead macros are now explicitly exported from the prelude. This is important as now there are macros (`assert_matches!()`) that are *not* exported by default despite sitting in the crate root.

That change has landed in 1.94.0, 4 Rust versions ago, and we only officially support that last stdlib, so I think it's fine to just not support older versions.

Fixes https://github.com/rust-lang/rust-analyzer/issues/22775; the issue was that we resolved the macro without the import, so we didn't offer auto-import and also considered the import unused.