### PR TITLE
docs: point ungrammar example doc at existing file

### DIFF
--- a/lib/ungrammar/README.md
+++ b/lib/ungrammar/README.md
@@ -4,7 +4,7 @@ A DSL for specifying concrete syntax trees.
 
 See the [blog post][post] for an introduction.
 
-See [./rust.ungram](./rust.ungram) for an example.
+See [./ungrammar.ungram](./ungrammar.ungram) for an example.
 
 ## Editor support
 


### PR DESCRIPTION
closes: https://github.com/rust-lang/rust-analyzer/issues/22785

Not sure if it would be worth linking to `crates/syntax/rust.ungram` for a more full featured example, but there hasn't been a release for this crate (on crates.io) since 2022 when this was located at https://github.com/matklad/ungrammar, so probably unnecessary