### PR TITLE
fix: Assertion failure on dyn trait in closure

### DIFF
--- a/crates/hir-ty/src/infer/callee.rs
+++ b/crates/hir-ty/src/infer/callee.rs
@@ -546,7 +546,9 @@ impl<'a, 'db> DeferredCallResolution<'db> {
 
         // we should not be invoked until the closure kind has been
         // determined by upvar inference
-        assert!(ctx.infcx().closure_kind(self.closure_ty).is_some());
+        if ctx.infcx().closure_kind(self.closure_ty).is_none() {
+            return;
+        }
 
         // We may now know enough to figure out fn vs fnmut etc.
         match ctx.try_overloaded_call_traits(self.call_expr, self.closure_ty, None) {

--- a/crates/hir-ty/src/tests/regression.rs
+++ b/crates/hir-ty/src/tests/regression.rs
@@ -2949,6 +2949,19 @@ fn caller() {
 }
 
 #[test]
+fn regression_deferred_closure_call_resolution_unsized_dyn_fn_param() {
+    check_no_mismatches(
+        r#"
+//- minicore: fn
+fn main() {
+    let f = |f: dyn Fn()| f;
+    f();
+}
+"#,
+    );
+}
+
+#[test]
 fn regression_22772() {
     check_no_mismatches(
         r#"


### PR DESCRIPTION
Similarly to rust-lang/rust-analyzer#22677, it's possible to get an assertion failure in HIR inference after error recovery.

The best repro I've found is actually the sample code from Rust issue
157951. I do think it's a legitimate fix, I've seen two real users hit this assertion.

Give up if we don't have a closure kind in
DeferredCallResolution::resolve(), and add a regression test that previously asserted.

AI disclosure: Implemented with some help by GPT-5.5.