### PR TITLE
fix: Only write anon const ty in parent's inference result if it doesn't have its own inference

### DIFF
--- a/crates/hir-ty/src/infer.rs
+++ b/crates/hir-ty/src/infer.rs
@@ -2011,9 +2011,10 @@ impl<'body, 'db> InferenceContext<'body, 'db> {
             && let GeneralConstId::AnonConstId(konst) = konst.def.0
         {
             self.defined_anon_consts.borrow_mut().push(konst);
+        } else {
+            self.write_expr_ty(expr, expected_ty);
         }
 
-        self.write_expr_ty(expr, expected_ty);
         // FIXME: Report an error if needed.
         konst.unwrap_or_else(|_| self.table.next_const_var(Span::Dummy))
     }

--- a/crates/hir-ty/src/tests/regression.rs
+++ b/crates/hir-ty/src/tests/regression.rs
@@ -2983,3 +2983,13 @@ fn migrations_preserve_index() {
     "#,
     );
 }
+
+#[test]
+fn array_repeat_closure() {
+    check(
+        r#"
+fn f() {[_; || ()]}
+     // ^^^^^^^^^^ expected (), got [{unknown}; _]
+    "#,
+    );
+}


### PR DESCRIPTION
To not override its type; aside from having a better knowledge about the true type, this caused panics in closure inference for wrong code; now we just won't analyze closures in it, as we should.

Fixes https://github.com/rust-lang/rust-analyzer/issues/22798.