### PR TITLE
internal: migrate `HirDatabase::borrowck`

### DIFF
--- a/crates/hir-ty/src/db.rs
+++ b/crates/hir-ty/src/db.rs
@@ -27,7 +27,7 @@ use crate::{
     dyn_compatibility::DynCompatibilityViolation,
     layout::{Layout, LayoutError},
     lower::{GenericDefaults, TrackedStructToken, TypeAliasBounds},
-    mir::{BorrowckResult, MirBody, MirLowerError},
+    mir::{MirBody, MirLowerError},
     next_solver::{
         Allocation, Clause, EarlyBinder, GenericArgs, ParamEnv, PolyFnSig, StoredClauses,
         StoredEarlyBinder, StoredGenericArgs, StoredPolyFnSig, StoredTraitRef, StoredTy, TraitRef,
@@ -71,11 +71,6 @@ pub trait HirDatabase: SourceDatabase + std::fmt::Debug {
     ) -> Result<&MirBody, MirLowerError> {
         crate::mir::monomorphized_mir_body_for_closure_query(self, def, subst, env)
             .map_err(|err| err.clone())
-    }
-
-    #[salsa::transparent]
-    fn borrowck(&self, def: InferBodyId) -> Result<&[BorrowckResult], MirLowerError> {
-        crate::mir::borrowck_query(self, def).map_err(|err| err.clone())
     }
 
     #[salsa::invoke(crate::consteval::const_eval)]

--- a/crates/hir-ty/src/db.rs
+++ b/crates/hir-ty/src/db.rs
@@ -40,16 +40,16 @@ use crate::{
 pub trait HirDatabase: SourceDatabase + std::fmt::Debug {
     // region:mir
 
-    // FXME: Collapse `mir_body_for_closure` into `mir_body`
+    // FIXME: Collapse `mir_body_for_closure` into `mir_body`
     // and `monomorphized_mir_body_for_closure` into `monomorphized_mir_body`
     #[salsa::transparent]
     fn mir_body(&self, def: InferBodyId) -> Result<&MirBody, MirLowerError> {
-        crate::mir::mir_body_query(self, def).as_ref().map_err(|err| err.clone())
+        crate::mir::mir_body_query(self, def).map_err(|err| err.clone())
     }
 
     #[salsa::transparent]
     fn mir_body_for_closure(&self, def: InternedClosureId) -> Result<&MirBody, MirLowerError> {
-        crate::mir::mir_body_for_closure_query(self, def).as_ref().map_err(|err| err.clone())
+        crate::mir::mir_body_for_closure_query(self, def).map_err(|err| err.clone())
     }
 
     #[salsa::transparent]
@@ -59,9 +59,7 @@ pub trait HirDatabase: SourceDatabase + std::fmt::Debug {
         subst: StoredGenericArgs,
         env: StoredParamEnvAndCrate,
     ) -> Result<&MirBody, MirLowerError> {
-        crate::mir::monomorphized_mir_body_query(self, def, subst, env)
-            .as_ref()
-            .map_err(|err| err.clone())
+        crate::mir::monomorphized_mir_body_query(self, def, subst, env).map_err(|err| err.clone())
     }
 
     #[salsa::transparent]
@@ -72,13 +70,12 @@ pub trait HirDatabase: SourceDatabase + std::fmt::Debug {
         env: StoredParamEnvAndCrate,
     ) -> Result<&MirBody, MirLowerError> {
         crate::mir::monomorphized_mir_body_for_closure_query(self, def, subst, env)
-            .as_ref()
             .map_err(|err| err.clone())
     }
 
     #[salsa::transparent]
     fn borrowck(&self, def: InferBodyId) -> Result<&[BorrowckResult], MirLowerError> {
-        crate::mir::borrowck_query(self, def).as_ref().map(|it| &**it).map_err(|err| err.clone())
+        crate::mir::borrowck_query(self, def).map_err(|err| err.clone())
     }
 
     #[salsa::invoke(crate::consteval::const_eval)]
@@ -137,7 +134,7 @@ pub trait HirDatabase: SourceDatabase + std::fmt::Debug {
 
     #[salsa::transparent]
     fn target_data_layout(&self, krate: Crate) -> Result<&TargetDataLayout, TargetLoadError> {
-        crate::layout::target_data_layout_query(self, krate).as_ref().map_err(|err| err.clone())
+        crate::layout::target_data_layout_query(self, krate).map_err(|err| err.clone())
     }
 
     #[salsa::invoke(crate::dyn_compatibility::dyn_compatibility_of_trait_query)]

--- a/crates/hir-ty/src/layout/target.rs
+++ b/crates/hir-ty/src/layout/target.rs
@@ -6,7 +6,7 @@ use rustc_abi::{AddressSpace, AlignFromBytesError, TargetDataLayoutError};
 
 use crate::db::HirDatabase;
 
-#[salsa_macros::tracked(returns(ref))]
+#[salsa_macros::tracked(returns(as_ref))]
 pub fn target_data_layout_query(
     db: &dyn HirDatabase,
     krate: Crate,

--- a/crates/hir-ty/src/mir.rs
+++ b/crates/hir-ty/src/mir.rs
@@ -37,7 +37,7 @@ mod lower;
 mod monomorphization;
 mod pretty;
 
-pub use borrowck::{BorrowckResult, MutabilityReason, borrowck_query};
+pub use borrowck::{BorrowckResult, MutabilityReason};
 pub use eval::{
     Evaluator, MirEvalError, VTableMap, interpret_mir, pad16, render_const_using_debug_impl,
 };

--- a/crates/hir-ty/src/mir/borrowck.rs
+++ b/crates/hir-ty/src/mir/borrowck.rs
@@ -133,7 +133,7 @@ fn all_mir_bodies<'db>(
     }
 }
 
-#[salsa_macros::tracked(returns(ref), lru = 2024)]
+#[salsa_macros::tracked(returns(as_deref), lru = 2024)]
 pub fn borrowck_query(
     db: &dyn HirDatabase,
     def: InferBodyId,
@@ -144,7 +144,7 @@ pub fn borrowck_query(
     let env = db.trait_environment(def.generic_def(db));
     // This calculates opaques defining scope which is a bit costly therefore is put outside `all_mir_bodies()`.
     let typing_mode = TypingMode::borrowck(interner, def.into());
-    let res = all_mir_bodies(
+    all_mir_bodies(
         db,
         def,
         |body, owner| {
@@ -184,8 +184,7 @@ pub fn borrowck_query(
                 }
             }
         },
-    )?;
-    Ok(res)
+    )
 }
 
 fn moved_out_of_ref<'db>(

--- a/crates/hir-ty/src/mir/borrowck.rs
+++ b/crates/hir-ty/src/mir/borrowck.rs
@@ -133,58 +133,66 @@ fn all_mir_bodies<'db>(
     }
 }
 
-#[salsa_macros::tracked(returns(as_deref), lru = 2024)]
-pub fn borrowck_query(
-    db: &dyn HirDatabase,
-    def: InferBodyId,
-) -> Result<Box<[BorrowckResult]>, MirLowerError> {
-    let _p = tracing::info_span!("borrowck_query").entered();
-    let module = def.module(db);
-    let interner = DbInterner::new_with(db, module.krate(db));
-    let env = db.trait_environment(def.generic_def(db));
-    // This calculates opaques defining scope which is a bit costly therefore is put outside `all_mir_bodies()`.
-    let typing_mode = TypingMode::borrowck(interner, def.into());
-    all_mir_bodies(
-        db,
-        def,
-        |body, owner| {
-            // FIXME(next-solver): Opaques.
-            let infcx = interner.infer_ctxt().build(typing_mode);
-            BorrowckResult {
-                owner,
-                mutability_of_locals: mutability_of_locals(&infcx, env, body),
-                moved_out_of_ref: moved_out_of_ref(&infcx, env, body),
-                partially_moved: partially_moved(&infcx, env, body),
-                borrow_regions: borrow_regions(db, body),
-            }
-        },
-        |(parent, parent_mir_body), (child, child_mir_body)| {
-            for (upvar, child_locals) in &child_mir_body.upvar_locals {
-                let Some(&parent_local) = parent_mir_body.binding_locals.get(*upvar) else {
-                    continue;
-                };
-                for (child_local, capture_place) in child_locals {
-                    if !capture_place
-                        .projections
-                        .iter()
-                        .any(|proj| matches!(proj.kind, HirProjectionKind::Deref))
-                    {
-                        let parent_mol = &mut parent.mutability_of_locals[parent_local];
-                        match (&*parent_mol, &child.mutability_of_locals[*child_local]) {
-                            (MutabilityReason::Mut { .. }, _) => {}
-                            (_, MutabilityReason::Mut { .. }) => {
-                                // FIXME: Fix the child spans.
-                                *parent_mol = MutabilityReason::Mut { spans: Vec::new() }
+impl InferBodyId {
+    pub fn borrowck(self, db: &dyn HirDatabase) -> Result<&[BorrowckResult], MirLowerError> {
+        return borrowck_query(db, self).map_err(|e| e.clone());
+
+        #[salsa::tracked(returns(as_deref), lru = 2024)]
+        fn borrowck_query(
+            db: &dyn HirDatabase,
+            def: InferBodyId,
+        ) -> Result<Box<[BorrowckResult]>, MirLowerError> {
+            let _p = tracing::info_span!("InferBodyId::borrowck").entered();
+            let module = def.module(db);
+            let interner = DbInterner::new_with(db, module.krate(db));
+            let env = db.trait_environment(def.generic_def(db));
+            // This calculates opaques defining scope which is a bit costly therefore is put outside `all_mir_bodies()`.
+            let typing_mode = TypingMode::borrowck(interner, def.into());
+            all_mir_bodies(
+                db,
+                def,
+                |body, owner| {
+                    // FIXME(next-solver): Opaques.
+                    let infcx = interner.infer_ctxt().build(typing_mode);
+                    BorrowckResult {
+                        owner,
+                        mutability_of_locals: mutability_of_locals(&infcx, env, body),
+                        moved_out_of_ref: moved_out_of_ref(&infcx, env, body),
+                        partially_moved: partially_moved(&infcx, env, body),
+                        borrow_regions: borrow_regions(db, body),
+                    }
+                },
+                |(parent, parent_mir_body), (child, child_mir_body)| {
+                    for (upvar, child_locals) in &child_mir_body.upvar_locals {
+                        let Some(&parent_local) = parent_mir_body.binding_locals.get(*upvar) else {
+                            continue;
+                        };
+                        for (child_local, capture_place) in child_locals {
+                            if !capture_place
+                                .projections
+                                .iter()
+                                .any(|proj| matches!(proj.kind, HirProjectionKind::Deref))
+                            {
+                                let parent_mol = &mut parent.mutability_of_locals[parent_local];
+                                match (&*parent_mol, &child.mutability_of_locals[*child_local]) {
+                                    (MutabilityReason::Mut { .. }, _) => {}
+                                    (_, MutabilityReason::Mut { .. }) => {
+                                        // FIXME: Fix the child spans.
+                                        *parent_mol = MutabilityReason::Mut { spans: Vec::new() }
+                                    }
+                                    (MutabilityReason::Not, _) => {}
+                                    (_, MutabilityReason::Not) => {
+                                        *parent_mol = MutabilityReason::Not
+                                    }
+                                    (MutabilityReason::Unused, MutabilityReason::Unused) => {}
+                                }
                             }
-                            (MutabilityReason::Not, _) => {}
-                            (_, MutabilityReason::Not) => *parent_mol = MutabilityReason::Not,
-                            (MutabilityReason::Unused, MutabilityReason::Unused) => {}
                         }
                     }
-                }
-            }
-        },
-    )
+                },
+            )
+        }
+    }
 }
 
 fn moved_out_of_ref<'db>(

--- a/crates/hir-ty/src/mir/lower.rs
+++ b/crates/hir-ty/src/mir/lower.rs
@@ -2123,7 +2123,7 @@ fn cast_kind<'db>(
     })
 }
 
-#[salsa_macros::tracked(returns(ref), cycle_result = mir_body_for_closure_cycle_result)]
+#[salsa_macros::tracked(returns(as_ref), cycle_result = mir_body_for_closure_cycle_result)]
 pub fn mir_body_for_closure_query<'db>(
     db: &'db dyn HirDatabase,
     closure: InternedClosureId,
@@ -2282,7 +2282,7 @@ pub fn mir_body_for_closure_query<'db>(
     Ok(ctx.result)
 }
 
-#[salsa_macros::tracked(returns(ref), cycle_result = mir_body_cycle_result)]
+#[salsa_macros::tracked(returns(as_ref), cycle_result = mir_body_cycle_result)]
 pub fn mir_body_query<'db>(db: &'db dyn HirDatabase, def: InferBodyId) -> Result<'db, MirBody> {
     let krate = def.krate(db);
     let edition = krate.data(db).edition;

--- a/crates/hir-ty/src/mir/lower/tests.rs
+++ b/crates/hir-ty/src/mir/lower/tests.rs
@@ -1,7 +1,7 @@
 use hir_def::DefWithBodyId;
 use test_fixture::WithFixture;
 
-use crate::{db::HirDatabase, setup_tracing, test_db::TestDB};
+use crate::{InferBodyId, db::HirDatabase, setup_tracing, test_db::TestDB};
 
 fn lower_mir(#[rust_analyzer::rust_fixture] ra_fixture: &str) {
     let _tracing = setup_tracing();
@@ -78,7 +78,7 @@ fn check_borrowck(#[rust_analyzer::rust_fixture] ra_fixture: &str) {
         }
 
         for body in bodies {
-            let _ = db.borrowck(body.into());
+            let _ = InferBodyId::from(body).borrowck(&db);
         }
     })
 }

--- a/crates/hir-ty/src/mir/monomorphization.rs
+++ b/crates/hir-ty/src/mir/monomorphization.rs
@@ -238,7 +238,7 @@ impl<'db> Filler<'db> {
     }
 }
 
-#[salsa_macros::tracked(returns(ref), cycle_result = monomorphized_mir_body_cycle_result)]
+#[salsa_macros::tracked(returns(as_ref), cycle_result = monomorphized_mir_body_cycle_result)]
 pub fn monomorphized_mir_body_query(
     db: &dyn HirDatabase,
     owner: InferBodyId,
@@ -262,7 +262,7 @@ fn monomorphized_mir_body_cycle_result(
     Err(MirLowerError::Loop)
 }
 
-#[salsa_macros::tracked(returns(ref), cycle_result = monomorphized_mir_body_for_closure_cycle_result)]
+#[salsa_macros::tracked(returns(as_ref), cycle_result = monomorphized_mir_body_for_closure_cycle_result)]
 pub fn monomorphized_mir_body_for_closure_query(
     db: &dyn HirDatabase,
     closure: InternedClosureId,

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -2101,7 +2101,7 @@ impl DefWithBody {
         }
 
         if let Ok(borrowck_results) = db.borrowck(id.into()) {
-            for borrowck_result in borrowck_results.iter() {
+            for borrowck_result in borrowck_results {
                 let mir_body = borrowck_result.mir_body(db);
                 for moof in &borrowck_result.moved_out_of_ref {
                     let span: InFile<SyntaxNodePtr> = match moof.span {

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -2100,7 +2100,7 @@ impl DefWithBody {
             }
         }
 
-        if let Ok(borrowck_results) = db.borrowck(id.into()) {
+        if let Ok(borrowck_results) = InferBodyId::from(id).borrowck(db) {
             for borrowck_result in borrowck_results {
                 let mir_body = borrowck_result.mir_body(db);
                 for moof in &borrowck_result.moved_out_of_ref {

--- a/crates/hir/src/term_search/tactics.rs
+++ b/crates/hir/src/term_search/tactics.rs
@@ -48,7 +48,7 @@ pub(super) fn trivial<'a, 'lt, 'db, DB: HirDatabase>(
             ScopeDef::GenericParam(GenericParam::ConstParam(it)) => Some(Expr::ConstParam(*it)),
             ScopeDef::Local(it) => {
                 if ctx.config.enable_borrowcheck {
-                    let borrowck = db.borrowck(it.parent_infer).ok()?;
+                    let borrowck = it.parent_infer.borrowck(db).ok()?;
 
                     let invalid = borrowck.iter().any(|b| {
                         let mir_body = b.mir_body(ctx.sema.db);


### PR DESCRIPTION
Part of https://github.com/rust-lang/rust-analyzer/issues/22657

Split out from the PR removing `HirDatabase` completely, as that was getting too big.