### PR TITLE
fix: When `experimental/serverStatus` is not supported by the client, only update the status if the message is different

### DIFF
--- a/crates/rust-analyzer/src/main_loop.rs
+++ b/crates/rust-analyzer/src/main_loop.rs
@@ -829,6 +829,7 @@ impl GlobalState {
                 health @ (lsp_ext::Health::Warning | lsp_ext::Health::Error),
                 Some(message),
             ) = (status.health, &status.message)
+                && self.last_reported_status.message != status.message
             {
                 let open_log_button = tracing::enabled!(tracing::Level::ERROR)
                     && (self.fetch_build_data_error().is_err()


### PR DESCRIPTION
Not if other parts of the status, i.e. `health` or `quiescent`, are different, since this is sent as `window/showMessage` which often ends up as a message box, and getting the same message box multiple times is disrupting.

We could still do that if the health is more serious (change from `Warning` to `Error`), but I opted not to.

Fixes https://github.com/rust-lang/rust-analyzer/issues/22817.