### PR TITLE
Fix: panic with a function item and a proc macro item having a duplicate name

### DIFF
--- a/crates/hir-def/src/item_scope.rs
+++ b/crates/hir-def/src/item_scope.rs
@@ -483,8 +483,11 @@ impl ItemScope {
     }
 
     pub(crate) fn remove_from_value_ns(&mut self, name: &Name, def: ModuleDefId) {
-        let entry = self.values.shift_remove(name);
-        assert!(entry.is_some_and(|entry| entry.def == def))
+        // predicate needed since a different item with the same name may be registered instead,
+        // leading to `shift_remove` removing the wrong item.
+        if self.values.get(name).is_some_and(|entry| entry.def == def) {
+            let _ = self.values.shift_remove(name);
+        }
     }
 
     pub(crate) fn get_legacy_macro(&self, name: &Name) -> Option<&[MacroId]> {

--- a/crates/hir-def/src/nameres/tests/macros.rs
+++ b/crates/hir-def/src/nameres/tests/macros.rs
@@ -1755,3 +1755,18 @@ enum MyEnum {}
         "#]],
     );
 }
+
+#[test]
+fn regression_22806() {
+    compute_crate_def_map(
+        r#"
+#![crate_type = "proc-macro"]
+
+fn foo() {}
+
+#[proc_macro]
+fn foo() {}
+    "#,
+        |_| (),
+    )
+}


### PR DESCRIPTION
Fix rust-lang/rust-analyzer#22806 