### PR TITLE
minor: Do not store `Option` in the interner cache's thread local

### DIFF
--- a/crates/base-db/src/lib.rs
+++ b/crates/base-db/src/lib.rs
@@ -316,6 +316,11 @@ impl Default for Nonce {
 
 impl Nonce {
     #[inline]
+    pub const fn invalid() -> Nonce {
+        Nonce(usize::MAX)
+    }
+
+    #[inline]
     pub fn new() -> Nonce {
         Nonce(NEXT_NONCE.fetch_add(1, std::sync::atomic::Ordering::SeqCst))
     }

--- a/crates/hir-def/src/test_db.rs
+++ b/crates/hir-def/src/test_db.rs
@@ -68,7 +68,7 @@ impl Clone for TestDB {
             files: self.files.clone(),
             crates_map: self.crates_map.clone(),
             events: self.events.clone(),
-            nonce: Nonce::new(),
+            nonce: self.nonce,
         }
     }
 }

--- a/crates/hir-ty/src/next_solver/interner.rs
+++ b/crates/hir-ty/src/next_solver/interner.rs
@@ -2486,34 +2486,37 @@ mod tls_cache {
         db_nonce: Nonce,
     }
 
+    impl Cache {
+        const fn default() -> Cache {
+            Cache {
+                cache: GlobalCache::new(),
+                revision: Revision::max(),
+                db_nonce: Nonce::invalid(),
+            }
+        }
+    }
+
     thread_local! {
-        static GLOBAL_CACHE: RefCell<Option<Cache>> = const { RefCell::new(None) };
+        static GLOBAL_CACHE: RefCell<Cache> = const { RefCell::new(Cache::default()) };
     }
 
     pub(super) fn reinit_cache(db: &dyn HirDatabase) {
         GLOBAL_CACHE.with_borrow_mut(|handle| {
             let (db_nonce, revision) = db.nonce_and_revision();
-            match handle {
-                Some(handle) => {
-                    if handle.revision != revision || db_nonce != handle.db_nonce {
-                        *handle = Cache { cache: GlobalCache::default(), revision, db_nonce };
-                    }
-                }
-                None => *handle = Some(Cache { cache: GlobalCache::default(), revision, db_nonce }),
+            if handle.revision != revision || db_nonce != handle.db_nonce {
+                *handle = Cache { cache: GlobalCache::default(), revision, db_nonce };
             }
         })
     }
 
+    #[inline]
     pub(super) fn borrow_assume_valid<'db, T>(
         db: &'db dyn HirDatabase,
         f: impl FnOnce(&mut GlobalCache<DbInterner<'db>>) -> T,
     ) -> T {
         if cfg!(debug_assertions) {
-            let get_state = || {
-                GLOBAL_CACHE.with_borrow(|handle| {
-                    handle.as_ref().map(|handle| (handle.db_nonce, handle.revision))
-                })
-            };
+            let get_state =
+                || GLOBAL_CACHE.with_borrow(|handle| (handle.db_nonce, handle.revision));
             let old_state = get_state();
             reinit_cache(db);
             let new_state = get_state();
@@ -2521,7 +2524,6 @@ mod tls_cache {
         }
 
         GLOBAL_CACHE.with_borrow_mut(|handle| {
-            let handle = handle.as_mut().expect("you assumed the cache is valid!");
             // SAFETY: No idea
             f(unsafe {
                 std::mem::transmute::<
@@ -2537,7 +2539,7 @@ mod tls_cache {
     /// Should be called before getting memory usage estimations, as the solver cache
     /// is per-revision and usually should be excluded from estimations.
     pub fn clear_tls_solver_cache() {
-        GLOBAL_CACHE.with_borrow_mut(|handle| *handle = None);
+        GLOBAL_CACHE.with_borrow_mut(|handle| *handle = Cache::default());
     }
 }
 

--- a/crates/hir-ty/src/test_db.rs
+++ b/crates/hir-ty/src/test_db.rs
@@ -64,7 +64,7 @@ impl Clone for TestDB {
             files: self.files.clone(),
             crates_map: self.crates_map.clone(),
             events: self.events.clone(),
-            nonce: Nonce::new(),
+            nonce: self.nonce,
         }
     }
 }


### PR DESCRIPTION
This saves a branch, since now all relevant constructors are `const fn`s.

Also keep the nonce when cloning a test db (we're already doing it for `RootDatabase`).