### PR TITLE
fix: include all lifetimes in doctest runnable filters

### DIFF
--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -1790,8 +1790,8 @@ impl Adt {
         }
     }
 
-    /// Returns the lifetime of the DataType
-    pub fn lifetime(&self, db: &dyn HirDatabase) -> Option<LifetimeParamData> {
+    /// Returns the early-bound lifetime parameters of the data type.
+    pub fn lifetimes(&self, db: &dyn HirDatabase) -> Vec<LifetimeParamData> {
         let resolver = match self {
             Adt::Struct(s) => s.id.resolver(db),
             Adt::Union(u) => u.id.resolver(db),
@@ -1799,13 +1799,13 @@ impl Adt {
         };
         resolver
             .generic_params()
-            .and_then(|gp| {
-                gp.iter_early_bound_lt()
-                    // there should only be a single lifetime
-                    // but `Arena` requires to use an iterator
-                    .nth(0)
-            })
-            .map(|arena| arena.1.clone())
+            .map(|gp| gp.iter_early_bound_lt().map(|(_, data)| data.clone()).collect())
+            .unwrap_or_default()
+    }
+
+    /// Returns the first early-bound lifetime parameter of the data type, if any.
+    pub fn lifetime(&self, db: &dyn HirDatabase) -> Option<LifetimeParamData> {
+        self.lifetimes(db).into_iter().next()
     }
 
     pub fn as_struct(&self) -> Option<Struct> {
@@ -6228,13 +6228,12 @@ impl<'db> Type<'db> {
         db: &'a dyn HirDatabase,
         display_target: DisplayTarget,
     ) -> impl Iterator<Item = SmolStr> + 'a {
-        // iterate the lifetime
+        // Iterate all early-bound lifetimes. Lifetimes do not need edition-specific handling as
+        // they cannot be escaped.
         self.as_adt()
-            .and_then(|a| {
-                // Lifetimes do not need edition-specific handling as they cannot be escaped.
-                a.lifetime(db).map(|lt| lt.name.display_no_db(Edition::Edition2015).to_smolstr())
-            })
             .into_iter()
+            .flat_map(|a| a.lifetimes(db))
+            .map(|lt| lt.name.display_no_db(Edition::Edition2015).to_smolstr())
             // add the type and const parameters
             .chain(self.type_and_const_arguments(db, display_target))
     }

--- a/crates/ide/src/runnables.rs
+++ b/crates/ide/src/runnables.rs
@@ -762,6 +762,17 @@ mod tests {
         expect.assert_debug_eq(&result);
     }
 
+    fn check_labels(#[rust_analyzer::rust_fixture] ra_fixture: &str, expect: Expect) {
+        let (analysis, position) = fixture::position(ra_fixture);
+        let result = analysis
+            .runnables(position.file_id)
+            .unwrap()
+            .into_iter()
+            .map(|runnable| runnable.label(None))
+            .collect::<Vec<_>>();
+        expect.assert_debug_eq(&result);
+    }
+
     fn check_tests(#[rust_analyzer::rust_fixture] ra_fixture: &str, expect: Expect) {
         let (analysis, position) = fixture::position(ra_fixture);
         let tests = analysis.related_tests(position, None).unwrap();
@@ -972,6 +983,66 @@ impl Data<'a> {
                 [
                     "(Bin, NavigationTarget { file_id: FileId(0), full_range: 1..13, focus_range: 4..8, name: \"main\", kind: Function })",
                     "(DocTest, NavigationTarget { file_id: FileId(0), full_range: 52..106, name: \"foo\" })",
+                ]
+            "#]],
+        );
+        check_labels(
+            r#"
+//- /lib.rs
+$0
+struct Data<'a>;
+impl Data<'a> {
+    /// ```
+    /// let x = 5;
+    /// ```
+    fn foo() {}
+}
+"#,
+            expect![[r#"
+                [
+                    "doctest Data<'a>::foo",
+                ]
+            "#]],
+        );
+    }
+
+    #[test]
+    fn test_runnables_doc_test_in_impl_with_multiple_lifetimes() {
+        check_labels(
+            r#"
+//- /lib.rs
+$0
+struct Foo<'a, 'b>(&'a (), &'b ());
+
+impl<'a, 'b> Foo<'a, 'b> {
+    /// ```
+    /// let _ = "Hello, world!";
+    /// ```
+    fn method(self) {}
+}
+"#,
+            expect![[r#"
+                [
+                    "doctest Foo<'a,'b>::method",
+                ]
+            "#]],
+        );
+        check_labels(
+            r#"
+//- /lib.rs
+$0
+struct Foo<'a, 'b, T>(&'a T, &'b T);
+
+impl<'a, 'b, T> Foo<'a, 'b, T> {
+    /// ```
+    /// let _ = "Hello, world!";
+    /// ```
+    fn method(self) {}
+}
+"#,
+            expect![[r#"
+                [
+                    "doctest Foo<'a,'b,T>::method",
                 ]
             "#]],
         );


### PR DESCRIPTION
Fixes rust-lang/rust-analyzer#22830

Doctest runnable filters for associated items only included the first lifetime parameter of the implementing ADT. For types with multiple lifetimes, that produced filters like `Foo<'a>::method` while rustc names the doctest `Foo<'a,'b>::method`, so "Run Doctest" ran 0 tests.

Collect all early-bound lifetimes in `Adt::lifetimes` / `Type::generic_parameters` so the generated filter matches rustc.

### Test plan
- [x] `cargo test -p ide --lib runnables::`
- [x] `cargo test -p ide-diagnostics --lib unresolved_method`
- [x] `cargo clippy -p hir -p ide --lib -- -D warnings`

AI disclosure: Assisted by Cursor (Grok).