### PR TITLE
fix: Fix `InferenceContext:identity_args` using the wrong DefId

### DIFF
--- a/crates/hir-ty/src/infer.rs
+++ b/crates/hir-ty/src/infer.rs
@@ -1994,7 +1994,7 @@ impl<'body, 'db> InferenceContext<'body, 'db> {
 
     fn identity_args(&self) -> GenericArgs<'db> {
         *self.identity_args.get_or_init(|| {
-            GenericArgs::identity_for_item(self.interner(), self.store_owner.into())
+            GenericArgs::identity_for_item(self.interner(), self.generic_def.into())
         })
     }
 

--- a/crates/hir-ty/src/tests/regression.rs
+++ b/crates/hir-ty/src/tests/regression.rs
@@ -7,6 +7,16 @@ use crate::tests::check;
 use super::{check_infer, check_no_mismatches, check_types};
 
 #[test]
+fn closure_in_enum_discriminant_does_not_panic() {
+    check(
+        r#"
+        enum Enum { X = || {} }
+                     // ^^^^^ expected isize, got impl Fn()
+        "#,
+    );
+}
+
+#[test]
 fn bug_484() {
     check_infer(
         r#"


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust-analyzer/issues/22803