### PR TITLE
fix: Fix `typed_hole` panic

### DIFF
--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -5477,7 +5477,10 @@ impl<'db> Type<'db> {
         db: &'db dyn HirDatabase,
         rebase_into: &Type<'db>,
     ) -> Type<'db> {
-        self.try_rebase_into(db, rebase_into).unwrap_or_else(|| self.instantiate_with_errors())
+        self.try_rebase_into(db, rebase_into).unwrap_or_else(|| Type {
+            owner: rebase_into.owner,
+            ty: self.instantiate_with_errors().ty,
+        })
     }
 
     pub fn try_rebase_into_owner(
@@ -6607,8 +6610,11 @@ impl<'db> Type<'db> {
     /// Note that we consider placeholder types to unify with everything.
     /// For example `Option<T>` and `Option<U>` unify although there is unresolved goal `T = U`.
     pub fn could_unify_with(&self, db: &'db dyn HirDatabase, other: &Type<'db>) -> bool {
-        self.owner.must_unify(other.owner);
-        let env = self.param_env(db);
+        let Some(owner) = self.owner.unify(other.owner) else {
+            never!("callers should not mix owners");
+            return false;
+        };
+        let env = Type { owner, ty: self.ty }.param_env(db);
         let interner = DbInterner::new_no_crate(db);
         let tys = hir_ty::replace_errors_with_variables(
             interner,
@@ -6622,8 +6628,11 @@ impl<'db> Type<'db> {
     /// This means that placeholder types are not considered to unify if there are any bounds set on
     /// them. For example `Option<T>` and `Option<U>` do not unify as we cannot show that `T = U`
     pub fn could_unify_with_deeply(&self, db: &'db dyn HirDatabase, other: &Type<'db>) -> bool {
-        self.owner.must_unify(other.owner);
-        let env = self.param_env(db);
+        let Some(owner) = self.owner.unify(other.owner) else {
+            never!("callers should not mix owners");
+            return false;
+        };
+        let env = Type { owner, ty: self.ty }.param_env(db);
         let interner = DbInterner::new_no_crate(db);
         let tys = hir_ty::replace_errors_with_variables(
             interner,
@@ -6633,8 +6642,11 @@ impl<'db> Type<'db> {
     }
 
     pub fn could_coerce_to(&self, db: &'db dyn HirDatabase, to: &Type<'db>) -> bool {
-        self.owner.must_unify(to.owner);
-        let env = self.param_env(db);
+        let Some(owner) = self.owner.unify(to.owner) else {
+            never!("callers should not mix owners");
+            return false;
+        };
+        let env = Type { owner, ty: self.ty }.param_env(db);
         let interner = DbInterner::new_no_crate(db);
         let tys = hir_ty::replace_errors_with_variables(
             interner,

--- a/crates/hir/src/term_search.rs
+++ b/crates/hir/src/term_search.rs
@@ -87,35 +87,76 @@ impl<'db> AlternativeExprs<'db> {
 /// iteration as well as keeping track of which `ScopeDef` items have been used.
 /// Both of them are to speed up the term search by leaving out types / ScopeDefs that likely do
 /// not produce any new results.
-#[derive(Default, Debug)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+struct SearchType<'db>(Type<'db>);
+
+impl<'db> SearchType<'db> {
+    fn new(db: &'db dyn HirDatabase, goal: &Type<'db>, ty: &Type<'db>) -> Self {
+        let ty = ty.rebase_into_or_error(db, goal);
+        debug_assert_eq!(ty.owner, goal.owner);
+        Self(ty)
+    }
+
+    fn as_type(&self) -> &Type<'db> {
+        &self.0
+    }
+
+    fn into_type(self) -> Type<'db> {
+        self.0
+    }
+
+    fn add_reference(&self, db: &'db dyn HirDatabase, mutability: Mutability) -> Self {
+        Self(self.0.add_reference(db, mutability))
+    }
+}
+
+#[derive(Debug)]
 struct LookupTable<'db> {
+    db: &'db dyn HirDatabase,
+    goal: Type<'db>,
     /// All the `Expr`s in "value" produce the type of "key"
-    data: FxHashMap<Type<'db>, AlternativeExprs<'db>>,
+    data: FxHashMap<SearchType<'db>, AlternativeExprs<'db>>,
     /// New types reached since last query by the `NewTypesKey`
-    new_types: FxHashMap<NewTypesKey, Vec<Type<'db>>>,
+    new_types: FxHashMap<NewTypesKey, Vec<SearchType<'db>>>,
     /// Types queried but not present
-    types_wishlist: FxHashSet<Type<'db>>,
+    types_wishlist: FxHashSet<SearchType<'db>>,
     /// Threshold to squash trees to `Many`
     many_threshold: usize,
 }
 
 impl<'db> LookupTable<'db> {
     /// Initialize lookup table
-    fn new(many_threshold: usize, goal: Type<'db>) -> Self {
-        let mut res = Self { many_threshold, ..Default::default() };
-        res.new_types.insert(NewTypesKey::ImplMethod, Vec::new());
-        res.new_types.insert(NewTypesKey::StructProjection, Vec::new());
-        res.types_wishlist.insert(goal);
-        res
+    fn new(db: &'db dyn HirDatabase, many_threshold: usize, goal: Type<'db>) -> Self {
+        let goal_ty = SearchType::new(db, &goal, &goal);
+        let mut new_types = FxHashMap::default();
+        new_types.insert(NewTypesKey::ImplMethod, Vec::new());
+        new_types.insert(NewTypesKey::StructProjection, Vec::new());
+        Self {
+            db,
+            goal,
+            data: FxHashMap::default(),
+            new_types,
+            types_wishlist: FxHashSet::from_iter([goal_ty]),
+            many_threshold,
+        }
+    }
+
+    fn search_type(&self, ty: &Type<'db>) -> SearchType<'db> {
+        SearchType::new(self.db, &self.goal, ty)
+    }
+
+    fn could_unify(&self, candidate: &SearchType<'db>, ty: &SearchType<'db>) -> bool {
+        candidate.as_type().could_unify_with_deeply(self.db, ty.as_type())
     }
 
     /// Find all `Expr`s that unify with the `ty`
-    fn find(&mut self, db: &'db dyn HirDatabase, ty: &Type<'db>) -> Option<Vec<Expr<'db>>> {
+    fn find(&mut self, ty: &Type<'db>) -> Option<Vec<Expr<'db>>> {
+        let ty = self.search_type(ty);
         let res = self
             .data
             .iter()
-            .find(|(t, _)| t.could_unify_with_deeply(db, ty))
-            .map(|(t, tts)| tts.exprs(t));
+            .find(|(candidate, _)| self.could_unify(candidate, &ty))
+            .map(|(ty, exprs)| exprs.exprs(ty.as_type()));
 
         if res.is_none() {
             self.types_wishlist.insert(ty.clone());
@@ -125,7 +166,7 @@ impl<'db> LookupTable<'db> {
         if let Some(res) = &res
             && res.len() > self.many_threshold
         {
-            return Some(vec![Expr::Many(ty.clone())]);
+            return Some(vec![Expr::Many(ty.into_type())]);
         }
 
         res
@@ -135,20 +176,23 @@ impl<'db> LookupTable<'db> {
     ///
     /// For example if we have type `i32` in data and we query for `&i32` it map all the type
     /// trees we have for `i32` with `Expr::Reference` and returns them.
-    fn find_autoref(&mut self, db: &'db dyn HirDatabase, ty: &Type<'db>) -> Option<Vec<Expr<'db>>> {
+    fn find_autoref(&mut self, ty: &Type<'db>) -> Option<Vec<Expr<'db>>> {
+        let ty = self.search_type(ty);
         let res = self
             .data
             .iter()
-            .find(|(t, _)| t.could_unify_with_deeply(db, ty))
-            .map(|(t, it)| it.exprs(t))
+            .find(|(candidate, _)| self.could_unify(candidate, &ty))
+            .map(|(ty, exprs)| exprs.exprs(ty.as_type()))
             .or_else(|| {
                 self.data
                     .iter()
-                    .find(|(t, _)| {
-                        t.add_reference(db, Mutability::Shared).could_unify_with_deeply(db, ty)
+                    .find(|(candidate, _)| {
+                        let candidate = candidate.add_reference(self.db, Mutability::Shared);
+                        self.could_unify(&candidate, &ty)
                     })
-                    .map(|(t, it)| {
-                        it.exprs(t)
+                    .map(|(ty, exprs)| {
+                        exprs
+                            .exprs(ty.as_type())
                             .into_iter()
                             .map(|expr| Expr::Reference(Box::new(expr)))
                             .collect()
@@ -163,7 +207,7 @@ impl<'db> LookupTable<'db> {
         if let Some(res) = &res
             && res.len() > self.many_threshold
         {
-            return Some(vec![Expr::Many(ty.clone())]);
+            return Some(vec![Expr::Many(ty.into_type())]);
         }
 
         res
@@ -175,6 +219,7 @@ impl<'db> LookupTable<'db> {
     /// transitive. For example `Vec<i32>` and `FxHashSet<i32>` both unify with `Iterator<Item = i32>`,
     /// but they clearly do not unify themselves.
     fn insert(&mut self, ty: Type<'db>, exprs: impl Iterator<Item = Expr<'db>>) {
+        let ty = self.search_type(&ty);
         match self.data.get_mut(&ty) {
             Some(it) => {
                 it.extend_with_threshold(self.many_threshold, exprs);
@@ -193,7 +238,7 @@ impl<'db> LookupTable<'db> {
 
     /// Iterate all the reachable types
     fn iter_types(&self) -> impl Iterator<Item = Type<'db>> + '_ {
-        self.data.keys().cloned()
+        self.data.keys().map(|ty| ty.as_type().clone())
     }
 
     /// Query new types reached since last query by key
@@ -201,14 +246,14 @@ impl<'db> LookupTable<'db> {
     /// Create new key if you wish to query it to avoid conflicting with existing queries.
     fn new_types(&mut self, key: NewTypesKey) -> Vec<Type<'db>> {
         match self.new_types.get_mut(&key) {
-            Some(it) => std::mem::take(it),
+            Some(types) => std::mem::take(types).into_iter().map(SearchType::into_type).collect(),
             None => Vec::new(),
         }
     }
 
     /// Types queried but not found
-    fn types_wishlist(&mut self) -> &FxHashSet<Type<'db>> {
-        &self.types_wishlist
+    fn types_wishlist(&self) -> Vec<Type<'db>> {
+        self.types_wishlist.iter().map(|ty| ty.as_type().clone()).collect()
     }
 }
 
@@ -272,7 +317,8 @@ pub fn term_search<'db, DB: HirDatabase>(ctx: &TermSearchCtx<'_, 'db, DB>) -> Ve
         defs.insert(def);
     });
 
-    let mut lookup = LookupTable::new(ctx.config.many_alternatives_threshold, ctx.goal.clone());
+    let mut lookup =
+        LookupTable::new(ctx.sema.db, ctx.config.many_alternatives_threshold, ctx.goal.clone());
     let fuel = std::cell::Cell::new(ctx.config.fuel);
 
     let should_continue = &|| {

--- a/crates/hir/src/term_search/tactics.rs
+++ b/crates/hir/src/term_search/tactics.rs
@@ -158,7 +158,6 @@ pub(super) fn data_constructor<'a, 'lt, 'db, DB: HirDatabase>(
     let module = ctx.scope.module();
     lookup
         .types_wishlist()
-        .clone()
         .into_iter()
         .chain(iter::once(ctx.goal.clone()))
         .filter_map(|ty| ty.as_adt().map(|adt| (adt, ty)))
@@ -197,9 +196,7 @@ pub(super) fn data_constructor<'a, 'lt, 'db, DB: HirDatabase>(
                 // Early exit if some param cannot be filled from lookup
                 let param_exprs: Vec<Vec<Expr<'_>>> = fields
                     .into_iter()
-                    .map(|field| {
-                        lookup.find(db, &field.ty(db).instantiate(generics.iter().cloned()))
-                    })
+                    .map(|field| lookup.find(&field.ty(db).instantiate(generics.iter().cloned())))
                     .collect::<Option<_>>()?;
 
                 // Note that we need special case for 0 param constructors because of multi cartesian
@@ -249,7 +246,7 @@ pub(super) fn data_constructor<'a, 'lt, 'db, DB: HirDatabase>(
                             .fields(db)
                             .into_iter()
                             .map(|field| {
-                                lookup.find(db, &field.ty(db).instantiate(generics.iter().cloned()))
+                                lookup.find(&field.ty(db).instantiate(generics.iter().cloned()))
                             })
                             .collect::<Option<_>>()?;
 
@@ -386,7 +383,7 @@ pub(super) fn free_function<'a, 'lt, 'db, DB: HirDatabase>(
                                 let ty = &field.ty().instantiate(&generics);
                                 match ty.is_mutable_reference() {
                                     true => None,
-                                    false => lookup.find_autoref(db, ty),
+                                    false => lookup.find_autoref(ty),
                                 }
                             })
                             .collect::<Option<_>>()?;
@@ -514,13 +511,13 @@ pub(super) fn impl_method<'a, 'lt, 'db, DB: HirDatabase>(
                 return None;
             }
 
-            let target_type_exprs = lookup.find(db, &ty).expect("Type not in lookup");
+            let target_type_exprs = lookup.find(&ty).expect("Type not in lookup");
 
             // Early exit if some param cannot be filled from lookup
             let param_exprs: Vec<Vec<Expr<'_>>> = it
                 .params_without_self(db)
                 .into_iter()
-                .map(|field| lookup.find_autoref(db, &field.ty().instantiate(ty.type_arguments())))
+                .map(|field| lookup.find_autoref(&field.ty().instantiate(ty.type_arguments())))
                 .collect::<Option<_>>()?;
 
             let generics: Vec<_> = ty.type_arguments().collect();
@@ -570,7 +567,7 @@ pub(super) fn struct_projection<'a, 'lt, 'db, DB: HirDatabase>(
     lookup
         .new_types(NewTypesKey::StructProjection)
         .into_iter()
-        .map(|ty| (ty.clone(), lookup.find(db, &ty).expect("Expr not in lookup")))
+        .map(|ty| (ty.clone(), lookup.find(&ty).expect("Expr not in lookup")))
         .filter(|_| should_continue())
         .flat_map(move |(ty, targets)| {
             ty.fields(db).into_iter().filter_map(move |(field, filed_ty)| {
@@ -645,7 +642,6 @@ pub(super) fn impl_static_method<'a, 'lt, 'db, DB: HirDatabase>(
     let module = ctx.scope.module();
     lookup
         .types_wishlist()
-        .clone()
         .into_iter()
         .chain(iter::once(ctx.goal.clone()))
         .filter(|ty| !ty.type_arguments().any(|it| it.contains_unknown()))
@@ -705,7 +701,7 @@ pub(super) fn impl_static_method<'a, 'lt, 'db, DB: HirDatabase>(
             let param_exprs: Vec<Vec<Expr<'_>>> = it
                 .params_without_self(db)
                 .into_iter()
-                .map(|field| lookup.find_autoref(db, &field.ty().instantiate(ty.type_arguments())))
+                .map(|field| lookup.find_autoref(&field.ty().instantiate(ty.type_arguments())))
                 .collect::<Option<_>>()?;
 
             // Note that we need special case for 0 param constructors because of multi cartesian
@@ -753,7 +749,6 @@ pub(super) fn make_tuple<'a, 'lt, 'db, DB: HirDatabase>(
 
     lookup
         .types_wishlist()
-        .clone()
         .into_iter()
         .filter(|_| should_continue())
         .filter(|ty| ty.is_tuple())
@@ -770,7 +765,7 @@ pub(super) fn make_tuple<'a, 'lt, 'db, DB: HirDatabase>(
 
             // Early exit if some param cannot be filled from lookup
             let param_exprs: Vec<Vec<Expr<'db>>> =
-                ty.type_arguments().map(|field| lookup.find(db, &field)).collect::<Option<_>>()?;
+                ty.type_arguments().map(|field| lookup.find(&field)).collect::<Option<_>>()?;
 
             let exprs: Vec<Expr<'db>> = param_exprs
                 .into_iter()

--- a/crates/ide-diagnostics/src/handlers/typed_hole.rs
+++ b/crates/ide-diagnostics/src/handlers/typed_hole.rs
@@ -135,6 +135,60 @@ fn main() {
     }
 
     #[test]
+    fn incomplete_match_arm_after_const() {
+        check_has_fix(
+            r#"
+const OP_HANDSHAKE: u32 = 0;
+
+enum Event {
+    Ready,
+    Disconnect,
+}
+
+struct Holder<T>(T);
+
+impl<T> Holder<T> {
+    const VALUE: T = loop {};
+}
+
+fn test<T>(value: T) {
+    let evt = Event::Ready;
+    let holder = Holder(value);
+    match evt {
+        Event::Ready => {}
+        _
+        _$0 => {}
+    }
+}
+"#,
+            r#"
+const OP_HANDSHAKE: u32 = 0;
+
+enum Event {
+    Ready,
+    Disconnect,
+}
+
+struct Holder<T>(T);
+
+impl<T> Holder<T> {
+    const VALUE: T = loop {};
+}
+
+fn test<T>(value: T) {
+    let evt = Event::Ready;
+    let holder = Holder(value);
+    match evt {
+        Event::Ready => {}
+        _
+        todo!() => {}
+    }
+}
+"#,
+        );
+    }
+
+    #[test]
     fn integer_ty_var() {
         check_diagnostics(
             r#"


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust-analyzer/issues/22659

Also makes the hir type unification API more resilient to mistakes in release builds