### PR TITLE
fix: Spawn proc-macro servers on requests clearing the client cache

### DIFF
--- a/crates/rust-analyzer/src/reload.rs
+++ b/crates/rust-analyzer/src/reload.rs
@@ -659,7 +659,9 @@ impl GlobalState {
             Config::user_config_dir_path().as_deref(),
         );
 
-        if (self.proc_macro_clients.is_empty() || !same_workspaces) && self.config.expand_proc_macros() {
+        if (self.proc_macro_clients.is_empty() || !same_workspaces)
+            && self.config.expand_proc_macros()
+        {
             info!("Spawning proc-macro servers");
 
             // Workspaces referring to the same proc-macro server executable (i.e. the same

--- a/crates/rust-analyzer/src/reload.rs
+++ b/crates/rust-analyzer/src/reload.rs
@@ -659,7 +659,7 @@ impl GlobalState {
             Config::user_config_dir_path().as_deref(),
         );
 
-        if !same_workspaces && self.config.expand_proc_macros() {
+        if (self.proc_macro_clients.is_empty() || !same_workspaces) && self.config.expand_proc_macros() {
             info!("Spawning proc-macro servers");
 
             // Workspaces referring to the same proc-macro server executable (i.e. the same


### PR DESCRIPTION
This PR fixes the `proc-macro-srv is not running` error that occurs on Rebuild proc-macros operation.

The `proc_macro_clients` cache is cleared in `handle_workspace_reload` and `handle_workspace_rebuild`, thus requiring an additional check to spawn new clients.

## Error is thrown here
https://github.com/rust-lang/rust-analyzer/blob/3eaae41d955ac27fca16ea1ef08874cc131ff335/crates/rust-analyzer/src/reload.rs#L454-L456

## Cause
`proc_macro_clients` is cleared in the following two places:
https://github.com/rust-lang/rust-analyzer/blob/3eaae41d955ac27fca16ea1ef08874cc131ff335/crates/rust-analyzer/src/handlers/request.rs#L60-L62
and
https://github.com/rust-lang/rust-analyzer/blob/3eaae41d955ac27fca16ea1ef08874cc131ff335/crates/rust-analyzer/src/handlers/request.rs#L69-L71

## Resolution
Add `is_empty` check to the previously removed length check.