### PR TITLE
fix `hir-def` crate description

### DIFF
--- a/crates/hir-def/Cargo.toml
+++ b/crates/hir-def/Cargo.toml
@@ -2,7 +2,7 @@
 name = "hir-def"
 version = "0.0.0"
 repository.workspace = true
-description = "RPC Api for the `proc-macro-srv` crate of rust-analyzer."
+description = "Early name and import resolution for rust-analyzer."
 
 authors.workspace = true
 edition.workspace = true


### PR DESCRIPTION
The wording was suggested in https://github.com/rust-lang/rust-analyzer/pull/17745#discussion_r1699639921, but https://github.com/rust-lang/rust-analyzer/pull/17745/commits/f8de86b3081d10d1e0bb294679437fe80ff3f51d mistakenly used `proc-macro-api`'s wording instead.