### PR TITLE
fix: const eval of `*_with_overflow` intrinsics for signed integers

### DIFF
--- a/crates/hir-ty/src/consteval/tests/intrinsics.rs
+++ b/crates/hir-ty/src/consteval/tests/intrinsics.rs
@@ -366,6 +366,68 @@ fn overflowing_add() {
 }
 
 #[test]
+fn overflowing_intrinsics_signed() {
+    // The `*_with_overflow` shims used to zero-extend their operands and compute
+    // the overflow flag with unsigned `u128` arithmetic, reporting bogus overflow
+    // whenever the true (signed) result was negative, and missing real signed
+    // overflow like `127i8 + 1`.
+    check_number(
+        r#"
+        #[rustc_intrinsic]
+        pub fn sub_with_overflow<T>(x: T, y: T) -> (T, bool);
+
+        const GOAL: i8 = sub_with_overflow(0i8, 1).0;
+        "#,
+        -1,
+    );
+    check_number(
+        r#"
+        #[rustc_intrinsic]
+        pub fn sub_with_overflow<T>(x: T, y: T) -> (T, bool);
+
+        const GOAL: u8 = sub_with_overflow(0i8, 1).1 as u8;
+        "#,
+        0,
+    );
+    check_number(
+        r#"
+        #[rustc_intrinsic]
+        pub fn add_with_overflow<T>(x: T, y: T) -> (T, bool);
+
+        const GOAL: u8 = add_with_overflow(-1i8, 1).1 as u8;
+        "#,
+        0,
+    );
+    check_number(
+        r#"
+        #[rustc_intrinsic]
+        pub fn add_with_overflow<T>(x: T, y: T) -> (T, bool);
+
+        const GOAL: u8 = add_with_overflow(127i8, 1).1 as u8;
+        "#,
+        1,
+    );
+    check_number(
+        r#"
+        #[rustc_intrinsic]
+        pub fn mul_with_overflow<T>(x: T, y: T) -> (T, bool);
+
+        const GOAL: u8 = mul_with_overflow(-1i8, -1i8).1 as u8;
+        "#,
+        0,
+    );
+    check_number(
+        r#"
+        #[rustc_intrinsic]
+        pub fn sub_with_overflow<T>(x: T, y: T) -> (T, bool);
+
+        const GOAL: i128 = sub_with_overflow(0i128, 1).0;
+        "#,
+        -1,
+    );
+}
+
+#[test]
 fn needs_drop() {
     check_number(
         r#"

--- a/crates/hir-ty/src/mir/eval/shim.rs
+++ b/crates/hir-ty/src/mir/eval/shim.rs
@@ -973,17 +973,35 @@ impl<'a, 'db> Evaluator<'a, 'db> {
                     self.interner(),
                     [lhs.ty, Ty::new_bool(self.interner())].into_iter(),
                 );
+                let is_signed = matches!(lhs.ty.kind(), TyKind::Int(_));
                 let op_size = self.size_of_sized(lhs.ty, locals, "operand of add_with_overflow")?;
-                let lhs = u128::from_le_bytes(pad16(lhs.get(self)?, false));
-                let rhs = u128::from_le_bytes(pad16(rhs.get(self)?, false));
-                let (ans, u128overflow) = match name {
-                    "add_with_overflow" => lhs.overflowing_add(rhs),
-                    "sub_with_overflow" => lhs.overflowing_sub(rhs),
-                    "mul_with_overflow" => lhs.overflowing_mul(rhs),
-                    _ => unreachable!(),
+                let lhs = u128::from_le_bytes(pad16(lhs.get(self)?, is_signed));
+                let rhs = u128::from_le_bytes(pad16(rhs.get(self)?, is_signed));
+                let (ans, is_overflow) = if is_signed {
+                    let (ans, overflow) = match name {
+                        "add_with_overflow" => (lhs as i128).overflowing_add(rhs as i128),
+                        "sub_with_overflow" => (lhs as i128).overflowing_sub(rhs as i128),
+                        "mul_with_overflow" => (lhs as i128).overflowing_mul(rhs as i128),
+                        _ => unreachable!(),
+                    };
+                    // Below 16 bytes the `i128` arithmetic itself cannot overflow, but the
+                    // result may not fit the operand type: check with a sign-extension
+                    // round-trip.
+                    let out_of_range = op_size < 16 && {
+                        let shift = 128 - 8 * op_size as u32;
+                        (ans << shift) >> shift != ans
+                    };
+                    (ans as u128, overflow || out_of_range)
+                } else {
+                    let (ans, overflow) = match name {
+                        "add_with_overflow" => lhs.overflowing_add(rhs),
+                        "sub_with_overflow" => lhs.overflowing_sub(rhs),
+                        "mul_with_overflow" => lhs.overflowing_mul(rhs),
+                        _ => unreachable!(),
+                    };
+                    let out_of_range = ans.to_le_bytes()[op_size..].iter().any(|&it| it != 0);
+                    (ans, overflow || out_of_range)
                 };
-                let is_overflow = u128overflow
-                    || ans.to_le_bytes()[op_size..].iter().any(|&it| it != 0 && it != 255);
                 let is_overflow = vec![u8::from(is_overflow)];
                 let layout = self.layout(result_ty)?;
                 let result = self.construct_with_layout(


### PR DESCRIPTION
The consteval overflow flag calculation for the signed `with_overflow` functions is not correct.
Example:

```rust
const FLAG: bool = 0i8.overflowing_sub(1).1;
```  
Hover over `FLAG` shows true whereas it should clearly be false.

The blast radius of this bug is much larger than this contrived example, as this also breaks struct layout calculation for signed `NonZero` types. This in turn breaks layout calculation for structs from many popular crates in the ecosystem (notably `chrono` naive types) **and their transitive dependents**.

Fixes rust-lang/rust-analyzer#22871.

AI disclosure: AI has been used to help troubleshoot the issue and write the fix.