### PR TITLE
feat(ungrammar): support no_std with alloc

### DIFF
--- a/lib/ungrammar/src/error.rs
+++ b/lib/ungrammar/src/error.rs
@@ -1,10 +1,11 @@
 //! Boilerplate error definitions.
-use std::fmt;
+use alloc::string::String;
+use core::fmt;
 
 use crate::lexer::Location;
 
-/// A type alias for std's Result with the Error as our error type.
-pub type Result<T, E = Error> = std::result::Result<T, E>;
+/// A type alias for core's Result with the Error as our error type.
+pub type Result<T, E = Error> = core::result::Result<T, E>;
 
 /// An error encountered when parsing a Grammar.
 #[derive(Debug)]
@@ -23,7 +24,7 @@ impl fmt::Display for Error {
     }
 }
 
-impl std::error::Error for Error {}
+impl core::error::Error for Error {}
 
 impl Error {
     pub(crate) fn with_location(self, location: Location) -> Error {
@@ -34,7 +35,7 @@ impl Error {
 macro_rules! _format_err {
     ($($tt:tt)*) => {
         $crate::error::Error {
-            message: format!($($tt)*),
+            message: alloc::format!($($tt)*),
             location: None,
         }
     };

--- a/lib/ungrammar/src/lexer.rs
+++ b/lib/ungrammar/src/lexer.rs
@@ -1,4 +1,6 @@
 //! Simple hand-written ungrammar lexer
+use alloc::{string::String, vec::Vec};
+
 use crate::error::{Result, bail};
 
 #[derive(Debug, Eq, PartialEq)]

--- a/lib/ungrammar/src/lib.rs
+++ b/lib/ungrammar/src/lib.rs
@@ -10,12 +10,15 @@
 #![deny(missing_debug_implementations)]
 #![deny(missing_docs)]
 #![deny(rust_2018_idioms)]
+#![no_std]
+extern crate alloc;
 
 mod error;
 mod lexer;
 mod parser;
 
-use std::{ops, str::FromStr};
+use alloc::{boxed::Box, string::String, vec::Vec};
+use core::{ops, str::FromStr};
 
 pub use error::{Error, Result};
 

--- a/lib/ungrammar/src/parser.rs
+++ b/lib/ungrammar/src/parser.rs
@@ -1,6 +1,5 @@
 //! Simple hand-written ungrammar parser.
-#![allow(clippy::disallowed_types)]
-use std::collections::HashMap;
+use alloc::{boxed::Box, collections::BTreeMap, string::String, vec, vec::Vec};
 
 use crate::{
     Grammar, Node, NodeData, Rule, Token, TokenData,
@@ -28,8 +27,8 @@ pub(crate) fn parse(tokens: Vec<lexer::Token>) -> Result<Grammar> {
 struct Parser {
     grammar: Grammar,
     tokens: Vec<lexer::Token>,
-    node_table: HashMap<String, Node>,
-    token_table: HashMap<String, Token>,
+    node_table: BTreeMap<String, Node>,
+    token_table: BTreeMap<String, Token>,
 }
 
 const DUMMY_RULE: Rule = Rule::Node(Node(!0));


### PR DESCRIPTION
This makes `ungrammar` usable in `no_std` environments.

The main change is replacing the dependency on `std` with `core` / `alloc`.
There are no changes to the public API.

## Changes

### Replace `HashMap` with `BTreeMap`

Replaced `std::collections::HashMap` with `alloc::collections::BTreeMap`.

One way to use `HashMap` under `no_std` is to add a dependency on `hashbrown`, but the only operations this crate needs are `.len()` and `.entry()`, so a hash table isn't actually required.
For that reason, I chose `BTreeMap`, which is available with `alloc` alone and adds no extra dependency.

This change does not alter any behavior.

In addition, since `#![allow(clippy::disallowed_types)]` is no longer needed after this change, I removed it.

## Why I did not add a `std` feature

`ungrammar` is a library published on crates.io, as noted in `./lib/README.md`.

When used from `rust-analyzer` there isn't much direct benefit to making it `no_std`, but given that it is a published library, I think supporting `no_std` is worthwhile.

Furthermore, the public API does not depend on any `std`-specific types or functionality, and after this change there is no code left that requires `std`. Therefore, rather than introducing a `std` feature, I made the crate always operate as `no_std + alloc`.

Question? Regarding the release flow for `ungrammar`:
- Should I also bump the version in `Cargo.toml` as part of this PR?
- Or is bumping the version and publishing to crates.io handled by the maintainers?

---

AI disclosure: only the body of this PR was translated from Japanese to English by AI. The original text I wrote is included below.
<details>

`ungrammar` を `no_std` 環境で利用できるようにしました。

主な変更は、`std` への依存を `core` / `alloc` に置き換えたことです。
公開 API の変更はありません。

## 変更内容

### `HashMap` を `BTreeMap` に置き換え

`std::collections::HashMap` を `alloc::collections::BTreeMap` に置き換えました。

`no_std` で `HashMap` を利用する場合は `hashbrown` への依存を追加する方法もありますが、この crate で必要な操作は `.len()` と `.entry()` のみであり、ハッシュテーブルである必要はありません。
そのため、追加依存を増やさず `alloc` だけで利用できる `BTreeMap` を採用しました。

この変更による挙動の変化はありません。

また、この変更により `#![allow(clippy::disallowed_types)]` は不要になったため削除しています。

## `std` feature を追加しない理由

`ungrammar` は crates.io で公開されているライブラリであり、`./lib/README.md` にもその旨が記載されています。

`rust-analyzer` から利用する場合は `no_std` 化による直接的なメリットはあまりありませんが、公開ライブラリであることを考えると、`no_std` に対応しておく価値はあると考えました。

また、公開 API は `std` 固有の型や機能に依存しておらず、この変更で `std` を必要とするコードは存在しなくなります。そのため、`std` feature を設けず、常に `no_std + alloc` で動作する構成としました。

Question? `ungrammar` のリリースフローについて、

- 私がこの PR で `Cargo.toml` のバージョン更新まで行うべきでしょうか？
- それとも、バージョン更新や crates.io へのリリースはメンテナの方で行われる運用でしょうか？

</details>
