### PR TITLE
fix: fix assertion failed panic when input is #

### DIFF
--- a/crates/ide/src/syntax_highlighting/tests.rs
+++ b/crates/ide/src/syntax_highlighting/tests.rs
@@ -1263,6 +1263,22 @@ fn foo(x: &fn(&dyn Trait)) {}
     let _ = analysis.highlight(HL_CONFIG, file_id).unwrap();
 }
 
+#[test]
+fn highlight_invalid_expr_macro_expansion_no_crash() {
+    let (analysis, file_id) = fixture::file(
+        r#"
+macro_rules! bar {
+    () => {#}
+}
+
+fn expect() {
+    let _ = bar!();
+}
+"#,
+    );
+    let _ = analysis.highlight(HL_CONFIG, file_id).unwrap();
+}
+
 /// Highlights the code given by the `ra_fixture` argument, renders the
 /// result as HTML, and compares it with the HTML file given as `snapshot`.
 /// Note that the `snapshot` file is overwritten by the rendered HTML.

--- a/crates/parser/src/grammar.rs
+++ b/crates/parser/src/grammar.rs
@@ -153,9 +153,14 @@ pub(crate) mod entry {
 
         pub(crate) fn expr(p: &mut Parser<'_>) {
             let m = p.start();
-            expressions::expr(p);
+            let starts_with_attr = p.at(T![#]);
+            let expr = expressions::expr(p);
             if p.at(EOF) {
-                m.abandon(p);
+                if expr.is_some() || !starts_with_attr {
+                    m.abandon(p);
+                } else {
+                    m.complete(p, ERROR);
+                }
                 return;
             }
             while !p.at(EOF) {

--- a/crates/parser/src/grammar.rs
+++ b/crates/parser/src/grammar.rs
@@ -153,14 +153,9 @@ pub(crate) mod entry {
 
         pub(crate) fn expr(p: &mut Parser<'_>) {
             let m = p.start();
-            let starts_with_attr = p.at(T![#]);
-            let expr = expressions::expr(p);
+            expressions::expr(p);
             if p.at(EOF) {
-                if expr.is_some() || !starts_with_attr {
-                    m.abandon(p);
-                } else {
-                    m.complete(p, ERROR);
-                }
+                m.abandon(p);
                 return;
             }
             while !p.at(EOF) {

--- a/crates/parser/src/grammar/expressions.rs
+++ b/crates/parser/src/grammar/expressions.rs
@@ -247,15 +247,21 @@ fn expr_bp(
     r: Restrictions,
     bp: u8,
 ) -> Option<(CompletedMarker, BlockLike)> {
+    let mut starts_with_attr = false;
     let m = m.unwrap_or_else(|| {
         let m = p.start();
+        starts_with_attr = p.at(T![#]);
         attributes::outer_attrs(p);
         m
     });
 
     if !p.at_ts(EXPR_FIRST) {
         p.err_recover("expected expression", atom::EXPR_RECOVERY_SET);
-        m.abandon(p);
+        if starts_with_attr {
+            m.complete(p, ERROR);
+        } else {
+            m.abandon(p);
+        }
         return None;
     }
     let mut lhs = match lhs(p, r) {

--- a/crates/parser/src/grammar/expressions.rs
+++ b/crates/parser/src/grammar/expressions.rs
@@ -247,20 +247,19 @@ fn expr_bp(
     r: Restrictions,
     bp: u8,
 ) -> Option<(CompletedMarker, BlockLike)> {
-    let mut starts_with_attr = false;
     let m = m.unwrap_or_else(|| {
         let m = p.start();
-        starts_with_attr = p.at(T![#]);
         attributes::outer_attrs(p);
         m
     });
 
     if !p.at_ts(EXPR_FIRST) {
-        p.err_recover("expected expression", atom::EXPR_RECOVERY_SET);
-        if starts_with_attr {
-            m.complete(p, ERROR);
-        } else {
+        let is_empty = m.is_empty(p);
+        let recovered = p.err_recover("expected expression", atom::EXPR_RECOVERY_SET);
+        if recovered || is_empty {
             m.abandon(p);
+        } else {
+            m.complete(p, ERROR);
         }
         return None;
     }

--- a/crates/parser/src/parser.rs
+++ b/crates/parser/src/parser.rs
@@ -324,6 +324,10 @@ impl Marker {
         Marker { pos, bomb: DropBomb::new("Marker must be either completed or abandoned") }
     }
 
+    pub(crate) fn is_empty(&self, p: &Parser<'_>) -> bool {
+        self.pos as usize == p.events.len() - 1
+    }
+
     /// Finishes the syntax tree node and assigns `kind` to it,
     /// and mark the create a `CompletedMarker` for possible future
     /// operation like `.precede()` to deal with forward_parent.


### PR DESCRIPTION
fixes rust-lang/rust-analyzer#22807
it is because that expressions::expr(p) first consumes # as the start of an attribute. 
Since there is no following expression, it returns None. 
But the outer marker is abandoned, leading to an invalid top-level parse shape which cause the panic.
So I think it is better to complete a Err Node rather than abondoning.