### PR TITLE
fix: Do not detect `#[rust_analyzer]` as `#[rust_analyzer::rust_fixture]`

### DIFF
--- a/crates/ide-db/src/ra_fixture.rs
+++ b/crates/ide-db/src/ra_fixture.rs
@@ -3,6 +3,7 @@
 use std::hash::{BuildHasher, Hash};
 
 use hir::{CfgExpr, FilePositionWrapper, FileRangeWrapper, Semantics, Symbol};
+use itertools::Itertools;
 use smallvec::SmallVec;
 use span::{TextRange, TextSize};
 use syntax::{
@@ -96,9 +97,13 @@ impl RaFixtureAnalysis {
         let active_parameter = ActiveParameter::at_token(sema, expanded.syntax().clone())?;
         let has_rust_fixture_attr = active_parameter.attrs().is_some_and(|attrs| {
             attrs.filter_map(|attr| attr.as_simple_path()).any(|path| {
-                path.segments()
-                    .zip(["rust_analyzer", "rust_fixture"])
-                    .all(|(seg, name)| seg.name_ref().map_or(false, |nr| nr.text() == name))
+                let Some([Some(segment1), Some(segment2)]) =
+                    path.segments().map(|seg| seg.name_ref()).collect_array()
+                else {
+                    return false;
+                };
+                segment1.text_non_mutable() == "rust_analyzer"
+                    && segment2.text_non_mutable() == "rust_fixture"
             })
         });
         if !has_rust_fixture_attr {

--- a/crates/ide/src/syntax_highlighting/test_data/highlight_injection.html
+++ b/crates/ide/src/syntax_highlighting/test_data/highlight_injection.html
@@ -43,6 +43,8 @@ pre                 { color: #DCDCCC; background: #3F3F3F; font-size: 22px; padd
 </style>
 <pre><code><span class="keyword">fn</span> <span class="function declaration">fixture</span><span class="parenthesis">(</span><span class="attribute_bracket attribute">#</span><span class="attribute_bracket attribute">[</span><span class="tool_module attribute">rust_analyzer</span><span class="operator attribute">::</span><span class="tool_module attribute">rust_fixture</span><span class="attribute_bracket attribute">]</span> <span class="value_param declaration reference">ra_fixture</span><span class="colon">:</span> <span class="punctuation">&</span><span class="builtin_type">str</span><span class="parenthesis">)</span> <span class="brace">{</span><span class="brace">}</span>
 
+<span class="keyword">fn</span> <span class="function declaration">non_fixture</span><span class="parenthesis">(</span><span class="attribute_bracket attribute">#</span><span class="attribute_bracket attribute">[</span><span class="tool_module attribute">rust_analyzer</span><span class="attribute_bracket attribute">]</span> <span class="value_param declaration reference">ra_fixture</span><span class="colon">:</span> <span class="punctuation">&</span><span class="builtin_type">str</span><span class="parenthesis">)</span> <span class="brace">{</span><span class="brace">}</span>
+
 <span class="keyword">fn</span> <span class="function declaration">main</span><span class="parenthesis">(</span><span class="parenthesis">)</span> <span class="brace">{</span>
     <span class="function">fixture</span><span class="parenthesis">(</span><span class="string_literal">r#"</span>
 @@- minicore: sized
@@ -59,4 +61,6 @@ pre                 { color: #DCDCCC; background: #3F3F3F; font-size: 22px; padd
 </span>    <span class="brace injected">}</span><span class="keyword injected">$0</span><span class="parenthesis injected">)</span><span class="none injected">
 </span><span class="brace injected">}</span><span class="string_literal">"</span>
     <span class="parenthesis">)</span><span class="semicolon">;</span>
+
+    <span class="function">non_fixture</span><span class="parenthesis">(</span><span class="string_literal">r"@@- "</span><span class="parenthesis">)</span><span class="semicolon">;</span>
 <span class="brace">}</span></code></pre>

--- a/crates/ide/src/syntax_highlighting/tests.rs
+++ b/crates/ide/src/syntax_highlighting/tests.rs
@@ -1066,6 +1066,8 @@ fn test_injection() {
         r##"
 fn fixture(#[rust_analyzer::rust_fixture] ra_fixture: &str) {}
 
+fn non_fixture(#[rust_analyzer] ra_fixture: &str) {}
+
 fn main() {
     fixture(r#"
 @@- minicore: sized
@@ -1082,6 +1084,8 @@ fn foo() {
     }\$0)
 }"
     );
+
+    non_fixture(r"@@- ");
 }
 "##,
         expect_file!["./test_data/highlight_injection.html"],


### PR DESCRIPTION
Fixes rust-lang/rust-analyzer#22878.

There's also in that issue that that fixture triggers a panic, but that's not a bug; `#[rust_analyzer::rust_fixture]` is an internal feature, if you use it incorrectly that's on you.