### PR TITLE
fix: merge_imports panic on invalid paths

### DIFF
--- a/crates/ide-assists/src/handlers/merge_imports.rs
+++ b/crates/ide-assists/src/handlers/merge_imports.rs
@@ -838,4 +838,15 @@ use foo::$0;
 ",
         );
     }
+
+    #[test]
+    fn test_merge_with_malformed_colon_path_segment() {
+        check_assist_not_applicable(
+            merge_imports,
+            r"
+use foo::bar;
+use foo::$0:;
+",
+        );
+    }
 }

--- a/crates/ide-db/src/imports/merge_imports.rs
+++ b/crates/ide-db/src/imports/merge_imports.rs
@@ -828,7 +828,9 @@ fn split_prefix(
         }
     } else {
         let suffix_segments: Vec<_> = path.segments().skip(prefix.segments().count()).collect();
-        if suffix_segments.is_empty() {
+        if suffix_segments.is_empty()
+            || suffix_segments.iter().any(|segment| segment.kind().is_none())
+        {
             return None;
         }
         let suffix_path = make.path_from_segments(suffix_segments, false);


### PR DESCRIPTION
When computing code actions, rust-analyzer would previously panic if a path had malformed segments. We already fixed empty path segments in 343d5ff383, which is the most frequent case, but I've seen crashes with malformed paths too (most commonly a trailing `:` or `#`).

Ensure that handle invalid path segments too, and add a test.

AI disclosure: Code partly written by GPT-5.6 Sol