### PR TITLE
fix: uses bool instead pat ty in guard

### DIFF
--- a/crates/ide-completion/src/context/analysis.rs
+++ b/crates/ide-completion/src/context/analysis.rs
@@ -794,6 +794,10 @@ fn expected_type_and_name<'db>(
                     }.map(TypeInfo::original);
                     (ty, None)
                 },
+                ast::MatchGuard(it) => {
+                    let ty = it.condition().and_then(|e| sema.type_of_expr(&e)).map(TypeInfo::original);
+                    (ty, None)
+                },
                 ast::IdentPat(it) => {
                     cov_mark::hit!(expected_type_if_let_with_leading_char);
                     cov_mark::hit!(expected_type_match_arm_with_leading_char);

--- a/crates/ide-completion/src/context/tests.rs
+++ b/crates/ide-completion/src/context/tests.rs
@@ -410,6 +410,21 @@ fn foo() {
 }
 
 #[test]
+fn expected_type_guard_condition() {
+    check_expected_type_and_name(
+        r#"
+enum E { V }
+fn foo() {
+    match E::V {
+        _ if a$0 => {}
+    }
+}
+"#,
+        expect![[r#"ty: bool, name: ?"#]],
+    );
+}
+
+#[test]
 fn expected_type_if_body() {
     check_expected_type_and_name(
         r#"


### PR DESCRIPTION
Example
---
```rust
enum E { V }
fn foo() {
    match E::V { _ if a$0 => {} }
}
```

**Before this PR**

```rust
ty: E, name: ?
```

**After this PR**

```rust
ty: bool, name: ?
```
