### PR TITLE
fix: add parentheses for invert general expression

### DIFF
--- a/crates/ide-assists/src/handlers/invert_if.rs
+++ b/crates/ide-assists/src/handlers/invert_if.rs
@@ -115,6 +115,15 @@ mod tests {
     }
 
     #[test]
+    fn invert_if_general_case_needs_paren() {
+        check_assist(
+            invert_if,
+            "fn f() { i$0f cond as bool { 3 * 2 } else { 1 } }",
+            "fn f() { if !(cond as bool) { 1 } else { 3 * 2 } }",
+        )
+    }
+
+    #[test]
     fn invert_if_on_else_keyword() {
         check_assist(
             invert_if,

--- a/crates/ide-assists/src/utils.rs
+++ b/crates/ide-assists/src/utils.rs
@@ -303,7 +303,9 @@ pub(crate) fn vis_offset(node: &SyntaxNode) -> TextSize {
 }
 
 pub(crate) fn invert_boolean_expression(make: &SyntaxFactory, expr: ast::Expr) -> ast::Expr {
-    invert_special_case(make, &expr).unwrap_or_else(|| make.expr_prefix(T![!], expr).into())
+    invert_special_case(make, &expr).unwrap_or_else(|| {
+        make.expr_prefix(T![!], wrap_paren(expr, make, ExprPrecedence::Prefix)).into()
+    })
 }
 
 fn invert_special_case(make: &SyntaxFactory, expr: &ast::Expr) -> Option<ast::Expr> {


### PR DESCRIPTION
Example
---
```rust
fn f() { i$0f cond as bool { 3 * 2 } else { 1 } }
```

**Before this PR**

```rust
fn f() { if !cond { 1 } else { 3 * 2 } }
```

**After this PR**

```rust
fn f() { if !(cond as bool) { 1 } else { 3 * 2 } }
```
