### PR TITLE
fix: Support macros in `#[doc]` attributes in IDE features

### DIFF
--- a/crates/hir-def/src/attrs.rs
+++ b/crates/hir-def/src/attrs.rs
@@ -1070,7 +1070,7 @@ impl AttrFlags {
     }
 
     // We LRU this query because it is only used by IDE.
-    #[salsa::tracked(returns(ref), lru = 250)]
+    #[salsa::tracked(returns(as_deref), lru = 250)]
     pub fn docs(db: &dyn SourceDatabase, owner: AttrDefId) -> Option<Box<Docs>> {
         let (source, outer_mod_decl, _extra_crate_attrs, krate) = attrs_source(db, owner);
         let inner_attrs_node = source.value.inner_attributes_node();
@@ -1090,27 +1090,27 @@ impl AttrFlags {
 
     #[inline]
     pub fn field_docs(db: &dyn SourceDatabase, field: FieldId) -> Option<&Docs> {
-        return fields_docs(db, field.parent).get(field.local_id).and_then(|it| it.as_deref());
+        Self::fields_docs(db, field.parent).get(field.local_id).and_then(|it| it.as_deref())
+    }
 
-        // We LRU this query because it is only used by IDE.
-        #[salsa::tracked(returns(ref), lru = 50)]
-        pub fn fields_docs(
-            db: &dyn SourceDatabase,
-            variant: VariantId,
-        ) -> ArenaMap<LocalFieldId, Option<Box<Docs>>> {
-            let krate = variant.module(db).krate(db);
-            collect_field_attrs(db, variant, |cfg_options, field| {
-                self::docs::extract_docs(
-                    db,
-                    krate,
-                    &|| variant.resolver(db),
-                    &|| cfg_options,
-                    field,
-                    None,
-                    None,
-                )
-            })
-        }
+    // We LRU this query because it is only used by IDE.
+    #[salsa::tracked(returns(ref), lru = 50)]
+    pub fn fields_docs(
+        db: &dyn SourceDatabase,
+        variant: VariantId,
+    ) -> ArenaMap<LocalFieldId, Option<Box<Docs>>> {
+        let krate = variant.module(db).krate(db);
+        collect_field_attrs(db, variant, |cfg_options, field| {
+            self::docs::extract_docs(
+                db,
+                krate,
+                &|| variant.resolver(db),
+                &|| cfg_options,
+                field,
+                None,
+                None,
+            )
+        })
     }
 
     #[inline]

--- a/crates/hir-def/src/attrs/docs.rs
+++ b/crates/hir-def/src/attrs/docs.rs
@@ -15,7 +15,7 @@ use base_db::{Crate, SourceDatabase};
 use cfg::CfgOptions;
 use either::Either;
 use hir_expand::{
-    AstId, ExpandTo, HirFileId, InFile,
+    AstId, ExpandTo, HirFileId, InFile, MacroCallId,
     attrs::{AstPathExt, expand_cfg_attr_with_doc_comments},
     mod_path::ModPath,
     span_map::SpanMap,
@@ -25,6 +25,7 @@ use syntax::{
     AstNode, AstToken, SyntaxNode,
     ast::{self, AttrDocCommentIter, IsString},
 };
+use thin_vec::ThinVec;
 use tt::{TextRange, TextSize};
 
 use crate::{macro_call_as_call_id, nameres::MacroSubNs, resolver::Resolver};
@@ -57,6 +58,8 @@ pub struct Docs {
     /// Like `inline_inner_docs_start`, but for `outline_mod`. This can happen only when merging `Docs`
     /// (as outline modules don't have inner attributes).
     outline_inner_docs_start: Option<TextSize>,
+    /// All macro calls in `#[doc = ...]` attributes, recursively.
+    macro_calls: ThinVec<(AstId<ast::MacroCall>, MacroCallId)>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -81,6 +84,25 @@ impl Docs {
     #[inline]
     pub fn into_docs(self) -> String {
         self.docs
+    }
+
+    #[inline]
+    pub fn macro_calls(&self) -> impl Iterator<Item = (AstId<ast::MacroCall>, MacroCallId)> {
+        self.macro_calls.iter().copied()
+    }
+
+    fn is_empty(&self) -> bool {
+        let Self {
+            docs,
+            docs_source_map: _,
+            outline_mod: _,
+            inline_file: _,
+            prefix_len: _,
+            inline_inner_docs_start: _,
+            outline_inner_docs_start: _,
+            macro_calls,
+        } = self;
+        docs.is_empty() && macro_calls.is_empty()
     }
 
     pub fn find_ast_range(
@@ -234,6 +256,7 @@ impl Docs {
                     prefix_len: _,
                     inline_inner_docs_start: _,
                     outline_inner_docs_start: _,
+                    macro_calls: _,
                 } = self.0;
                 // Don't use `String::clear()` here because it's not guaranteed to not do UTF-8-dependent things,
                 // and we may have temporarily broken the string's encoding.
@@ -316,9 +339,11 @@ impl Docs {
             prefix_len: _,
             inline_inner_docs_start: _,
             outline_inner_docs_start: _,
+            macro_calls,
         } = self;
         docs.shrink_to_fit();
         docs_source_map.shrink_to_fit();
+        macro_calls.shrink_to_fit();
     }
 }
 
@@ -335,11 +360,12 @@ struct DocMacroExpander<'db> {
 
 fn expand_doc_expr_via_macro_pipeline<'db>(
     expander: &mut DocMacroExpander<'db>,
+    macro_calls: &mut ThinVec<(AstId<ast::MacroCall>, MacroCallId)>,
     expr: ast::Expr,
 ) -> Option<String> {
     match expr {
         ast::Expr::ParenExpr(paren_expr) => {
-            expand_doc_expr_via_macro_pipeline(expander, paren_expr.expr()?)
+            expand_doc_expr_via_macro_pipeline(expander, macro_calls, paren_expr.expr()?)
         }
         ast::Expr::Literal(literal) => match literal.kind() {
             ast::LiteralKind::String(string) => string.value().ok().map(Into::into),
@@ -347,7 +373,7 @@ fn expand_doc_expr_via_macro_pipeline<'db>(
         },
         ast::Expr::MacroExpr(macro_expr) => {
             let macro_call = macro_expr.macro_call()?;
-            expand_doc_macro_call(expander, macro_call)
+            expand_doc_macro_call(expander, macro_calls, macro_call)
         }
         _ => None,
     }
@@ -355,6 +381,7 @@ fn expand_doc_expr_via_macro_pipeline<'db>(
 
 fn expand_doc_macro_call<'db>(
     expander: &mut DocMacroExpander<'db>,
+    macro_calls: &mut ThinVec<(AstId<ast::MacroCall>, MacroCallId)>,
     macro_call: ast::MacroCall,
 ) -> Option<String> {
     if expander.recursion_depth >= expander.recursion_limit {
@@ -381,6 +408,7 @@ fn expand_doc_macro_call<'db>(
     )
     .ok()?
     .value?;
+    macro_calls.push((ast_id, call_id));
 
     let (parse, span_map) = &call_id.parse_macro_expansion(expander.db).value;
     let expr = parse.clone().cast::<ast::Expr>().map(|parse| parse.tree())?;
@@ -396,7 +424,7 @@ fn expand_doc_macro_call<'db>(
         std::mem::replace(&mut expander.ast_id_map, expansion_file_id.ast_id_map(expander.db));
     expander.recursion_depth += 1;
 
-    let expansion = expand_doc_expr_via_macro_pipeline(expander, expr);
+    let expansion = expand_doc_expr_via_macro_pipeline(expander, macro_calls, expr);
 
     expander.file_id = old_file_id;
     expander.span_map = old_span_map;
@@ -419,7 +447,7 @@ fn extend_with_attrs<'a, 'db>(
     make_resolver: &dyn Fn() -> Resolver<'db>,
 ) {
     // Lazily initialised when we first encounter a `#[doc = macro!()]`.
-    let mut expander: Option<DocMacroExpander<'db>> = None;
+    let mut expander = None;
 
     expand_cfg_attr_with_doc_comments::<_, Infallible>(
         AttrDocCommentIter::from_syntax_node(node).filter(|attr| match attr {
@@ -456,9 +484,11 @@ fn extend_with_attrs<'a, 'db>(
                                         span_map: file_id.span_map(db),
                                     }
                                 });
-                                if let Some(expanded) =
-                                    expand_doc_expr_via_macro_pipeline(exp, value)
-                                {
+                                if let Some(expanded) = expand_doc_expr_via_macro_pipeline(
+                                    exp,
+                                    &mut result.macro_calls,
+                                    value,
+                                ) {
                                     result.extend_with_unmapped_doc_str(&expanded, indent);
                                 }
                             }
@@ -489,6 +519,7 @@ pub(crate) fn extract_docs<'a, 'db>(
         prefix_len: TextSize::new(0),
         inline_inner_docs_start: None,
         outline_inner_docs_start: None,
+        macro_calls: ThinVec::new(),
     };
 
     let mut cfg_options = None;
@@ -548,7 +579,7 @@ pub(crate) fn extract_docs<'a, 'db>(
 
     result.shrink_to_fit();
 
-    if result.docs.is_empty() { None } else { Some(Box::new(result)) }
+    if result.is_empty() { None } else { Some(Box::new(result)) }
 }
 
 #[cfg(test)]
@@ -556,6 +587,7 @@ mod tests {
     use expect_test::expect;
     use hir_expand::InFile;
     use test_fixture::WithFixture;
+    use thin_vec::ThinVec;
     use tt::{TextRange, TextSize};
 
     use crate::test_db::TestDB;
@@ -573,6 +605,7 @@ mod tests {
             prefix_len: TextSize::new(0),
             inline_inner_docs_start: None,
             outline_inner_docs_start: None,
+            macro_calls: ThinVec::new(),
         };
         let mut indent = usize::MAX;
 

--- a/crates/hir-def/src/lib.rs
+++ b/crates/hir-def/src/lib.rs
@@ -1103,6 +1103,7 @@ pub enum AttrDefId {
 }
 
 impl_from!(
+    ModuleId,
     AdtId(StructId, EnumId, UnionId),
     EnumVariantId,
     StaticId,

--- a/crates/hir/src/attrs.rs
+++ b/crates/hir/src/attrs.rs
@@ -165,7 +165,7 @@ impl AttrsWithOwner {
     #[inline]
     pub fn hir_docs<'db>(&self, db: &'db dyn HirDatabase) -> Option<&'db Docs> {
         match self.owner {
-            AttrsOwner::AttrDef(it) => AttrFlags::docs(db, it).as_deref(),
+            AttrsOwner::AttrDef(it) => AttrFlags::docs(db, it),
             AttrsOwner::Field(it) => AttrFlags::field_docs(db, it),
             AttrsOwner::LifetimeParam(_) | AttrsOwner::TypeOrConstParam(_) | AttrsOwner::Dummy => {
                 None
@@ -194,7 +194,7 @@ pub trait HasAttrs: Sized {
     #[inline]
     fn hir_docs(self, db: &dyn HirDatabase) -> Option<&Docs> {
         match self.attr_id(db) {
-            AttrsOwner::AttrDef(it) => AttrFlags::docs(db, it).as_deref(),
+            AttrsOwner::AttrDef(it) => AttrFlags::docs(db, it),
             AttrsOwner::Field(it) => AttrFlags::field_docs(db, it),
             AttrsOwner::LifetimeParam(_) | AttrsOwner::TypeOrConstParam(_) | AttrsOwner::Dummy => {
                 None

--- a/crates/hir/src/semantics/child_by_source.rs
+++ b/crates/hir/src/semantics/child_by_source.rs
@@ -11,9 +11,10 @@ use span::AstIdNode;
 use syntax::{AstPtr, ast};
 
 use hir_def::{
-    AdtId, AssocItemId, AstIdLoc, DefWithBodyId, EnumId, FieldId, GenericDefId, ImplId,
+    AdtId, AssocItemId, AstIdLoc, AttrDefId, DefWithBodyId, EnumId, FieldId, GenericDefId, ImplId,
     LifetimeParamId, Lookup, MacroId, ModuleDefId, ModuleId, TraitId, TypeOrConstParamId,
     VariantId,
+    attrs::{AttrFlags, Docs},
     dyn_map::{
         DynMap,
         keys::{self, Key},
@@ -32,6 +33,25 @@ pub(crate) trait ChildBySource {
         res
     }
     fn child_by_source_to(&self, db: &dyn SourceDatabase, map: &mut DynMap, file_id: HirFileId);
+}
+
+impl ChildBySource for Docs {
+    fn child_by_source_to(&self, db: &dyn SourceDatabase, res: &mut DynMap, file_id: HirFileId) {
+        self.macro_calls().filter(|(ast_id, _)| ast_id.file_id == file_id).for_each(
+            |(ast_id, call_id)| {
+                let ptr = ast_id.to_ptr(db);
+                res[keys::MACRO_CALL].insert(ptr, call_id);
+            },
+        );
+    }
+}
+
+impl ChildBySource for AttrDefId {
+    fn child_by_source_to(&self, db: &dyn SourceDatabase, map: &mut DynMap, file_id: HirFileId) {
+        if let Some(docs) = AttrFlags::docs(db, *self) {
+            docs.child_by_source_to(db, map, file_id);
+        }
+    }
 }
 
 impl ChildBySource for TraitId {
@@ -57,6 +77,8 @@ impl ChildBySource for TraitId {
                 res[keys::MACRO_CALL].insert(ast.value, exp_id);
             },
         );
+
+        AttrDefId::from(*self).child_by_source_to(db, res, file_id);
     }
 }
 
@@ -82,6 +104,8 @@ impl ChildBySource for ImplId {
                 res[keys::MACRO_CALL].insert(ast.value, exp_id);
             },
         );
+
+        AttrDefId::from(*self).child_by_source_to(db, res, file_id);
     }
 }
 
@@ -90,6 +114,8 @@ impl ChildBySource for ModuleId {
         let def_map = self.def_map(db);
         let module_data = &def_map[*self];
         module_data.scope.child_by_source_to(db, res, file_id);
+
+        AttrDefId::from(*self).child_by_source_to(db, res, file_id);
     }
 }
 
@@ -177,7 +203,7 @@ impl ChildBySource for ItemScope {
 }
 
 impl ChildBySource for VariantId {
-    fn child_by_source_to(&self, db: &dyn SourceDatabase, res: &mut DynMap, _: HirFileId) {
+    fn child_by_source_to(&self, db: &dyn SourceDatabase, res: &mut DynMap, file_id: HirFileId) {
         let arena_map = self.child_source(db);
         let arena_map = arena_map.as_ref();
         let parent = *self;
@@ -190,6 +216,12 @@ impl ChildBySource for VariantId {
         }
         let (_, sm) = self.fields_with_source_map(db);
         sm.expansions().for_each(|(ast, &exp_id)| res[keys::MACRO_CALL].insert(ast.value, exp_id));
+
+        AttrDefId::from(*self).child_by_source_to(db, res, file_id);
+        AttrFlags::fields_docs(db, *self)
+            .values()
+            .flatten()
+            .for_each(|docs| docs.child_by_source_to(db, res, file_id));
     }
 }
 
@@ -210,6 +242,8 @@ impl ChildBySource for EnumId {
             .expansions()
             .filter(|(ast, _)| ast.file_id == file_id)
             .for_each(|(ast, &exp_id)| res[keys::MACRO_CALL].insert(ast.value, exp_id));
+
+        AttrDefId::from(*self).child_by_source_to(db, res, file_id);
     }
 }
 
@@ -273,6 +307,17 @@ impl ChildBySource for GenericDefId {
             .expansions()
             .filter(|(ast, _)| ast.file_id == file_id)
             .for_each(|(ast, &exp_id)| res[keys::MACRO_CALL].insert(ast.value, exp_id));
+
+        let attr_def = match *self {
+            GenericDefId::AdtId(it) => AttrDefId::from(it),
+            GenericDefId::ConstId(it) => it.into(),
+            GenericDefId::FunctionId(it) => it.into(),
+            GenericDefId::ImplId(it) => it.into(),
+            GenericDefId::StaticId(it) => it.into(),
+            GenericDefId::TraitId(it) => it.into(),
+            GenericDefId::TypeAliasId(it) => it.into(),
+        };
+        attr_def.child_by_source_to(db, res, file_id);
     }
 }
 

--- a/crates/ide/src/goto_definition.rs
+++ b/crates/ide/src/goto_definition.rs
@@ -2328,10 +2328,7 @@ fn main() {
         );
     }
 
-    // macros in this position are not yet supported
     #[test]
-    // FIXME
-    #[should_panic]
     fn goto_doc_include_str() {
         check(
             r#"

--- a/crates/ide/src/hover/tests.rs
+++ b/crates/ide/src/hover/tests.rs
@@ -11891,3 +11891,36 @@ fn foo() { foo$0(); }
         &HoverConfig { documentation: false, ..HOVER_BASE_CONFIG },
     );
 }
+
+#[test]
+fn doc_attr_macro() {
+    check(
+        r#"
+//- minicore: concat
+/// Comment A
+#[macro_export]
+macro_rules! A {
+    () => {
+        "Comment B"
+    };
+}
+#[doc = concat!(A$0!())]
+fn main() {}
+    "#,
+        expect![[r#"
+            *A*
+
+            ```rust
+            ra_test_fixture
+            ```
+
+            ```rust
+            macro_rules! A
+            ```
+
+            ---
+
+            Comment A
+        "#]],
+    );
+}


### PR DESCRIPTION
Fixes rust-lang/rust-analyzer#22893.