### PR TITLE
fix: attach db on worker threads in parallel analysis-stats inference

### DIFF
--- a/crates/rust-analyzer/src/cli/analysis_stats.rs
+++ b/crates/rust-analyzer/src/cli/analysis_stats.rs
@@ -794,7 +794,9 @@ impl flags::AnalysisStats {
             bodies
                 .par_iter()
                 .map_with(db.clone(), |snap, &body| {
-                    InferenceResult::of(snap, body);
+                    hir::attach_db(snap, || {
+                        InferenceResult::of(snap, body);
+                    });
                 })
                 .count();
             let _signatures = signatures


### PR DESCRIPTION
The next-generation trait solver stores the `HirDatabase` in a thread-local, set via `hir::attach_db`. `analysis-stats` attaches it once on the main thread, but the `--parallel` inference path runs `InferenceResult::of` on rayon worker threads that never attach it, so every parallel run panicked with "Try to use attached db, but not db is attached" at `next_solver/interner.rs`. Wrap the per-body inference in `hir::attach_db` so each worker has the database attached.