### PR TITLE
replace detach with delete for ast::IdentPat

### DIFF
--- a/crates/syntax/src/ast/edit.rs
+++ b/crates/syntax/src/ast/edit.rs
@@ -200,7 +200,7 @@ impl ast::IdentPat {
                     if let Some(last) =
                         self.syntax().last_token().filter(|it| it.kind() == WHITESPACE)
                     {
-                        last.detach();
+                        editor.delete(last);
                     }
                 }
             }


### PR DESCRIPTION
This PR make the ast::IdentPat `set_pat` method use delete instead of detach.