### PR TITLE
fix: don't panic when a lifetime is passed to an `ident` metavariable

### DIFF
--- a/crates/hir-def/src/macro_expansion_tests/mbe/tt_conversion.rs
+++ b/crates/hir-def/src/macro_expansion_tests/mbe/tt_conversion.rs
@@ -107,6 +107,22 @@ fn f2() { /* error: expected ident */ }
 }
 
 #[test]
+fn lifetime_bound_to_ident_fragment() {
+    check(
+        r#"
+macro_rules! m { ($t:ident) => { $t } }
+
+fn f() { m!('a); }
+"#,
+        expect![[r#"
+macro_rules! m { ($t:ident) => { $t } }
+
+fn f() { /* error: expected ident */missing; }
+"#]],
+    )
+}
+
+#[test]
 fn expansion_does_not_parse_as_expression() {
     check(
         r#"

--- a/crates/mbe/src/expander/matcher.rs
+++ b/crates/mbe/src/expander/matcher.rs
@@ -842,11 +842,14 @@ fn match_meta_var<'t>(
                 _ => unreachable!(),
             }
             .err();
-            let tt_result = input.from_savepoint(savepoint);
-            return ValueResult {
-                value: Fragment::Tokens { tree: tt_result, origin: TokensOrigin::Raw },
-                err,
+            let value = match err {
+                Some(_) => Fragment::Empty,
+                None => Fragment::Tokens {
+                    tree: input.from_savepoint(savepoint),
+                    origin: TokensOrigin::Raw,
+                },
             };
+            return ValueResult { value, err };
         }
         MetaVarKind::Ty => (parser::PrefixEntryPoint::Ty, TokensOrigin::Ast),
         MetaVarKind::Pat => (parser::PrefixEntryPoint::PatTop, TokensOrigin::Ast),

--- a/crates/mbe/src/tests.rs
+++ b/crates/mbe/src/tests.rs
@@ -468,9 +468,8 @@ fn minus_belongs_to_literal() {
             }
 
             SUBTREE $$ 1:Root[0000, 0]@0..6#ROOT2024 1:Root[0000, 0]@0..6#ROOT2024
-              PUNCH   - [joint] 1:Root[0000, 0]@1..2#ROOT2024
-              PUNCH   - [alone] 1:Root[0000, 0]@2..3#ROOT2024
+              IDENT   missing 0:Root[0000, 0]@72..75#ROOT2024
 
-            --"#]],
+            missing"#]],
     );
 }


### PR DESCRIPTION
Closes rust-lang/rust-analyzer#22801

~~Passing a lifetime to a macro that expects an ident, like `m!('a)` for `($t:ident)`, panics with `Next token must be ident`. rustc just reports `no rules expected 'a`. The matcher consumes the `'` before the `ident` match fails, and the consumed token is still bound to the fragment, so the expansion ends up holding a `'` with nothing after it.~~

~~`to_parser_input` assumed a `'` is always followed by an ident. It is the point where every expansion, including proc macro output we don't control, becomes a syntax tree, so it now pushes an `ERROR` token instead of panicking.~~

The `expect_*` helpers consume a token before checking what it is, so a failed match still advances past it. `match_meta_var` then binds everything consumed since the savepoint, which for `m!('a)` is the bare `'` that later trips the panic. Returning `Fragment::Empty` on failure makes the caller take the `push_missing` branch it already has.

The same bug made `@--1.0` expand to a stray `- -` when matched against `$lit:literal`, hence the snapshot change in `minus_belongs_to_literal`.

🤖 AI-assisted: understanding the issue, locating the cause, and writing the test.
