### PR TITLE
fix: give `impl_trait_with_diagnostics` a cycle result

### DIFF
--- a/crates/hir-ty/src/lower.rs
+++ b/crates/hir-ty/src/lower.rs
@@ -1463,7 +1463,7 @@ pub(crate) fn impl_trait_query<'db>(
         .map(|it| it.value.get(DbInterner::new_no_crate(db)))
 }
 
-#[salsa::tracked(returns(ref))]
+#[salsa::tracked(returns(ref), cycle_result = impl_trait_with_diagnostics_cycle_result)]
 pub(crate) fn impl_trait_with_diagnostics<'db>(
     db: &'db dyn HirDatabase,
     impl_id: ImplId,
@@ -1485,6 +1485,14 @@ pub(crate) fn impl_trait_with_diagnostics<'db>(
     let target_trait = impl_data.target_trait.as_ref()?;
     let trait_ref = ctx.lower_trait_ref(target_trait, self_ty)?;
     Some(TyLoweringResult::from_ctx(StoredEarlyBinder::bind(StoredTraitRef::new(trait_ref)), ctx))
+}
+
+pub(crate) fn impl_trait_with_diagnostics_cycle_result<'db>(
+    _db: &'db dyn HirDatabase,
+    _: salsa::Id,
+    _impl_id: ImplId,
+) -> Option<TyLoweringResult<'db, StoredEarlyBinder<StoredTraitRef>>> {
+    None
 }
 
 impl ImplTraitId {

--- a/crates/hir-ty/src/tests/regression.rs
+++ b/crates/hir-ty/src/tests/regression.rs
@@ -3003,3 +3003,16 @@ fn f() {[_; || ()]}
     "#,
     );
 }
+
+#[test]
+fn regression_22795() {
+    check_no_mismatches(
+        r#"
+trait T { fn m(&self); }
+impl T for Self::Self {}
+struct S;
+impl T for S { fn m(&self) {} }
+fn f(s: S) { s.m(); }
+    "#,
+    );
+}


### PR DESCRIPTION
Closes rust-lang/rust-analyzer#22795

`impl Self::Self` makes the impl's trait ref depend on its own self type, and salsa panics because `impl_trait_with_diagnostics` declares no cycle result.

`None` is the natural recovery value here: the query already returns `Option`, and no resolvable trait ref is exactly what a self-referential impl has.

🤖 AI-assisted: understanding the issue, locating the cause, and writing the test.
