### PR TITLE
fix: don't panic on a qualified path whose trait is not a trait

### DIFF
--- a/crates/hir-ty/src/lower/path.rs
+++ b/crates/hir-ty/src/lower/path.rs
@@ -1234,6 +1234,12 @@ pub(crate) fn substs_from_args_and_bindings<'db>(
         };
         params.next();
         substs.push(self_ty);
+    } else if has_self_arg {
+        // A qualified path `<T as Trait>::Assoc` where `Trait` resolved to something without a
+        // `Self` parameter, e.g. a struct. `check_generic_args_len()` skips the self type
+        // unconditionally, so drop it here too instead of matching it against a real parameter.
+        // FIXME: Report a diagnostic here, rustc emits `E0404: expected trait, found struct`.
+        args.next();
     }
 
     loop {

--- a/crates/hir-ty/src/tests/regression.rs
+++ b/crates/hir-ty/src/tests/regression.rs
@@ -3016,3 +3016,15 @@ fn f(s: S) { s.m(); }
     "#,
     );
 }
+
+#[test]
+fn regression_22799() {
+    check_no_mismatches(
+        r#"
+struct S;
+fn f() {
+    <S as S>::S;
+}
+    "#,
+    );
+}


### PR DESCRIPTION
Closes rust-lang/rust-analyzer#22799

`<S as S>::S` where `S` is a struct panics with `the only possible situation here is incorrect lifetime order`, even though there are no lifetimes anywhere.

`check_generic_args_len()` skips the self type unconditionally, but the loop that consumes the arguments only skips it when the def has a `Self` parameter. A struct has none, so the self type is left over, matched against a regular parameter, and trips an assertion that assumes any leftover argument is a misordered lifetime. Skipping it in the loop as well keeps the two in agreement.

This only stops the panic. rustc reports `E0404: expected trait, found struct`, and there is no handler for it under `ide-diagnostics/src/handlers/`, so we still say nothing about the path itself.

🤖 AI-assisted: understanding the issue, locating the cause, and writing the test.
