### PR TITLE
fix: don't pick a discriminant type larger than typeck's

### DIFF
--- a/crates/hir-ty/src/layout/adt.rs
+++ b/crates/hir-ty/src/layout/adt.rs
@@ -142,8 +142,8 @@ fn repr_discr(
         Integer::I8
     };
 
-    // If there are no negative values, we can use the unsigned fit.
-    Ok(if min >= 0 {
+    // `min` and `max` are the ends of a wrapping range, so their sign is not a usable test.
+    Ok(if unsigned_fit <= signed_fit {
         (cmp::max(unsigned_fit, at_least), false)
     } else {
         (cmp::max(signed_fit, at_least), true)

--- a/crates/hir-ty/src/layout/tests.rs
+++ b/crates/hir-ty/src/layout/tests.rs
@@ -610,6 +610,13 @@ fn enums_with_discriminants() {
             A = 1, // This one is (perhaps surprisingly) zero sized.
         }
     }
+    size_and_align! {
+        #[allow(overflowing_literals, clippy::enum_clike_unportable_variant)]
+        enum Goal {
+            A = 0,
+            B = 0x8000_0000_0000_0001, // Wraps around to a negative discriminant.
+        }
+    }
 }
 
 #[test]


### PR DESCRIPTION
Closes rust-lang/rust-analyzer#22841

`repr_discr()` picks the unsigned fit when `min >= 0`, but `min` and `max` come from `layout_of_enum()` as the two ends of a *wrapping* range, not as an ordered pair. Here `min` is `0` and `max` is negative, so the check passes and we compute the unsigned fit of a negative number, which is `I128`.

🤖 AI-assisted: understanding the issue, locating the cause, and writing the test.
