### PR TITLE
fix: Failed to lookup MACRO_CALL@... in this Semantics due to include!

### DIFF
--- a/crates/hir/src/semantics/source_to_def.rs
+++ b/crates/hir/src/semantics/source_to_def.rs
@@ -165,8 +165,20 @@ impl<'db> SourceToDefCache<'db> {
         self.expansion_info_cache.entry(macro_file).or_insert_with(|| {
             let exp_info = macro_file.expansion_info(db);
 
+            // Ensure that the cache contains syntax nodes from expanded macros,
+            // whose root may be in another file.
             let InMacroFile { file_id, value } = exp_info.expanded();
             Self::cache(&mut self.root_to_file_cache, value, file_id.into());
+
+            // include!("foo.rs") invocations are awkward: in addition to the
+            // expansion site there's the included file (foo.rs), so we need to
+            // ensure that it exists in the cache too.
+            if macro_file.is_include_macro(db) {
+                let arg = exp_info.arg();
+                if let Some(arg_node) = arg.value {
+                    Self::cache(&mut self.root_to_file_cache, arg_node.tree_top(), arg.file_id);
+                }
+            }
 
             exp_info
         })

--- a/crates/ide-assists/src/handlers/inline_macro.rs
+++ b/crates/ide-assists/src/handlers/inline_macro.rs
@@ -176,6 +176,23 @@ macro_rules! num {
     }
 
     #[test]
+    fn inline_macro_in_included_file() {
+        // Regression test for climbing from the included file into an uncached includer root.
+        check_assist_not_applicable(
+            inline_macro,
+            r#"
+//- minicore:include
+//- /main.rs
+include!("a.rs");
+//- /a.rs
+fn foo() {
+    let x = 1$0;
+}
+"#,
+        );
+    }
+
+    #[test]
     fn inline_macro_simple_not_applicable_broken_macro() {
         // FIXME: This is a bug. The macro should not expand, but it's
         // the same behaviour as the "Expand Macro Recursively" command


### PR DESCRIPTION
SemanticsImpl::find_file assumes that its caches always contain the file that
has the current SyntaxNode.

For macros `foo!()` we only have two files to worry about: the macro
call site and the macro definition site. Hoewver, for
`include!("foo.rs")` we also need to consider the included file.

Ensure that the file cache is consistently populated for `include!()`
invocations macro expansion, and add a test.

AI disclosure: GPT-5.5 used to minimise a repro from a real project
and write the initial implementation. Comments and commit message are
entirely mine.