### PR TITLE
fix: update import resolutions after macro expansion

### DIFF
--- a/crates/hir-def/src/item_scope.rs
+++ b/crates/hir-def/src/item_scope.rs
@@ -621,7 +621,9 @@ impl ItemScope {
                             // for that.
                         }
                         _ => {
-                            if glob_imports.types.remove(&lookup) {
+                            if glob_imports.types.remove(&lookup)
+                                || (import.is_some() && entry.get().import == import)
+                            {
                                 let prev = std::mem::replace(&mut fld.import, import);
                                 if let Some(import) = import {
                                     self.use_imports_types.insert(
@@ -659,8 +661,11 @@ impl ItemScope {
                     changed = true;
                 }
                 Entry::Occupied(mut entry)
-                    if !matches!(import, Some(ImportOrExternCrate::Glob(..)))
-                        && glob_imports.values.remove(&lookup) =>
+                    if import.is_some()
+                        && !matches!(import, Some(ImportOrExternCrate::Glob(..)))
+                        && (glob_imports.values.remove(&lookup)
+                            || entry.get().import
+                                == import.and_then(ImportOrExternCrate::import_or_glob)) =>
                 {
                     cov_mark::hit!(import_shadowed);
 

--- a/crates/hir-def/src/nameres/collector.rs
+++ b/crates/hir-def/src/nameres/collector.rs
@@ -814,12 +814,10 @@ impl<'db> DefCollector<'db> {
         // correctly
         let mut indeterminate_imports = std::mem::take(&mut self.indeterminate_imports);
         indeterminate_imports.retain_mut(|(directive, partially_resolved)| {
-            let partially_resolved = partially_resolved.availability();
+            let prev_resolved = *partially_resolved;
             directive.status = self.resolve_import(directive.module_id, &directive.import);
             match directive.status {
-                PartialResolvedImport::Indeterminate(import)
-                    if partially_resolved != import.availability() =>
-                {
+                PartialResolvedImport::Indeterminate(import) if import != prev_resolved => {
                     self.record_resolved_import(directive);
                     res = ReachedFixedPoint::No;
                     false

--- a/crates/hir-def/src/nameres/tests/macros.rs
+++ b/crates/hir-def/src/nameres/tests/macros.rs
@@ -1770,3 +1770,45 @@ fn foo() {}
         |_| (),
     )
 }
+
+#[test]
+fn import_resolves_to_macro_generated_def_not_glob() {
+    compute_crate_def_map(
+        r#"
+//- /lib.rs
+mod other;
+use other::*;
+
+#[macro_export]
+macro_rules! define_foo {
+    () => { pub fn foo(a: u8, b: u8) -> u8 { a + b } };
+}
+
+crate::define_foo!();
+
+mod sub {
+    use super::foo;
+}
+
+//- /other.rs
+pub fn foo(z: u8) -> u8 { z }
+"#,
+        |map| {
+            use hir_expand::name::Name;
+            use intern::Symbol;
+
+            let sym_sub = Name::new_symbol_root(Symbol::intern("sub"));
+            let sym_foo = Name::new_symbol_root(Symbol::intern("foo"));
+
+            let root = map.root_module_id();
+            let sub = map[root].children[&sym_sub];
+            let root_foo = map[root].scope.get(&sym_foo);
+            let sub_foo = map[sub].scope.get(&sym_foo);
+
+            // `use super::foo` in `sub` must resolve to the same def as
+            // macro-generated `foo` in the crate root, not the `foo` brought
+            // in by `other`
+            assert_eq!(sub_foo.values.map(|i| i.def), root_foo.values.map(|i| i.def),);
+        },
+    );
+}

--- a/crates/hir-def/src/per_ns.rs
+++ b/crates/hir-def/src/per_ns.rs
@@ -3,8 +3,6 @@
 //!
 //! `PerNs` (per namespace) captures this.
 
-use bitflags::bitflags;
-
 use crate::{
     MacroId, ModuleDefId,
     item_scope::{ImportId, ImportOrExternCrate, ImportOrGlob, ItemInNs},
@@ -16,16 +14,6 @@ pub enum Namespace {
     Types,
     Values,
     Macros,
-}
-
-bitflags! {
-    /// Describes only the presence/absence of each namespace, without its value.
-    #[derive(Debug, PartialEq, Eq)]
-    pub(crate) struct NsAvailability : u32 {
-        const TYPES = 1 << 0;
-        const VALUES = 1 << 1;
-        const MACROS = 1 << 2;
-    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -48,14 +36,6 @@ pub struct PerNs {
 }
 
 impl PerNs {
-    pub(crate) fn availability(&self) -> NsAvailability {
-        let mut result = NsAvailability::empty();
-        result.set(NsAvailability::TYPES, self.types.is_some());
-        result.set(NsAvailability::VALUES, self.values.is_some());
-        result.set(NsAvailability::MACROS, self.macros.is_some());
-        result
-    }
-
     pub fn none() -> PerNs {
         PerNs { types: None, values: None, macros: None }
     }


### PR DESCRIPTION
When a macro expansion adds a definition that shadows a glob-imported name, `use super::fn` imports in submodules would not resolve to the new definition.

This had two causes: the import re-resolution compared only namespace occupancy, missing def changes that didn't affect which namespaces were populated; and the scope update would only overwrite entries that originated from glob imports, missing re-resolutions of the same import to a different def.

The re-resolution now makes full resolved definition comparison, and the scope update allows overwriting an entry that carries the same import source.