### PR TITLE
fix: avoid panic when checking Copy for hrtb closure arguments

### DIFF
--- a/crates/hir-ty/src/mir/lower.rs
+++ b/crates/hir-ty/src/mir/lower.rs
@@ -53,7 +53,6 @@ use crate::{
     next_solver::{
         Const, DbInterner, ParamConst, ParamEnv, Region, StoredGenericArgs, StoredTy, TyKind,
         TypingMode, UnevaluatedConst,
-        abi::Safety,
         infer::{DbInternerInferExt, InferCtxt},
     },
 };
@@ -2147,11 +2146,10 @@ pub fn mir_body_for_closure_query<'db>(
         .store(),
     });
     ctx.result.param_locals.push(closure_local);
-
-    let sig = ctx.interner().signature_unclosure(substs.as_closure().sig(), Safety::Safe);
+    let sig = infer.closures_data[&expr].liberated_sig.get();
     let resolver_guard = ctx.resolver.update_to_inner_scope(db, ctx.store_owner, expr);
     let current = ctx.lower_params_and_bindings(
-        args.iter().zip(sig.skip_binder().inputs().iter()).map(|(it, y)| (*it, *y)),
+        args.iter().zip(sig.inputs().iter()).map(|(it, y)| (*it, *y)),
         None,
         |_| true,
     )?;

--- a/crates/hir-ty/src/mir/lower/tests.rs
+++ b/crates/hir-ty/src/mir/lower/tests.rs
@@ -150,3 +150,31 @@ fn caller(path: &PathBuf) {
     "#,
     );
 }
+
+#[test]
+fn borrowck_hrtb_closure_argument_does_not_panic() {
+    check_borrowck(
+        r#"
+//- minicore: fn, copy
+enum Res<T, E> {
+    Ok(T),
+    Err(E),
+}
+
+struct S;
+
+impl S {
+    fn set<F>(&mut self, _: F)
+    where
+        F: for<'a> Fn(&mut (), &'a [u8]) -> Res<(), ()>,
+    {
+    }
+}
+
+fn main() {
+    let mut s = S;
+    s.set(|_, _| Res::Err(()));
+}
+    "#,
+    );
+}


### PR DESCRIPTION
fixes rust-lang/rust-analyzer#22935
add the minimal reproduce panic test code
the root cause is that the next-solver `Copy` query built a `TraitRef` in function `type_known_to_meet_bound_modulo_regions` from a type which still
contained escaping bound vars, which later got wrapped in a dummy
binder and panicked.
the fix code references the function `enter_forall_and_leak_universe`.