### PR TITLE
fix(vfs): use component-based path prefix matching for virtual paths

### DIFF
--- a/crates/vfs/src/vfs_path.rs
+++ b/crates/vfs/src/vfs_path.rs
@@ -337,9 +337,9 @@ impl PartialEq<VfsPath> for AbsPath {
 struct VirtualPath(String);
 
 impl VirtualPath {
-    /// Returns `true` if `other` is a prefix of `self` (as strings).
+    /// Returns `true` if `other` is a prefix of `self`.
     fn starts_with(&self, other: &VirtualPath) -> bool {
-        self.0.starts_with(&other.0)
+        <_ as AsRef<paths::Utf8Path>>::as_ref(&self.0).starts_with(&other.0)
     }
 
     fn strip_prefix(&self, base: &VirtualPath) -> Option<&RelPath> {

--- a/crates/vfs/src/vfs_path/tests.rs
+++ b/crates/vfs/src/vfs_path/tests.rs
@@ -1,6 +1,14 @@
 use super::*;
 
 #[test]
+fn virtual_path_starts_with_is_component_based() {
+    let path = |path: &str| VfsPath::new_virtual_path(path.to_owned());
+
+    assert!(!path("/foobar").starts_with(&path("/foo")));
+    assert!(path("/foo/bar").starts_with(&path("/foo")));
+}
+
+#[test]
 fn virtual_path_extensions() {
     assert_eq!(VirtualPath("/".to_owned()).name_and_extension(), None);
     assert_eq!(


### PR DESCRIPTION
## Summary

Fixed a bug in `VirtualPath::starts_with()` where it used string-based prefix matching instead of component-based path prefix matching. This caused incorrect behavior when one path was a substring prefix of another but not a proper path component prefix.



Before this fix:
- `/foobar`.starts_with(`/foo`) → `true` (incorrect: string prefix but not component prefix)
- `/foo/bar`.starts_with(`/foo`) → `true` (correct)

After this fix:
- `/foobar`.starts_with(`/foo`) → `false` (correct: not a component prefix)
- `/foo/bar`.starts_with(`/foo`) → `true` (correct: proper component prefix)



