### PR TITLE
Docs: fix "User Snippet Completions" comment so it appears in the book

### DIFF
--- a/crates/ide-completion/src/snippet.rs
+++ b/crates/ide-completion/src/snippet.rs
@@ -38,13 +38,12 @@
 // * `description` is an optional description of the snippet, if unset the snippet name will be used.
 //
 // * `requires` is an optional list of item paths that have to be resolvable in the current crate where the completion is rendered.
-
 // On failure of resolution the snippet won't be applicable, otherwise the snippet will insert an import for the items on insertion if
 // the items aren't yet in scope.
 //
 // * `scope` is an optional filter for when the snippet should be applicable. Possible values are:
-// ** for Snippet-Scopes: `expr`, `item` (default: `item`)
-// ** for Postfix-Snippet-Scopes: `expr`, `type` (default: `expr`)
+//   * for Snippet-Scopes: `expr`, `item` (default: `item`)
+//   * for Postfix-Snippet-Scopes: `expr`, `type` (default: `expr`)
 //
 // The `body` field also has access to placeholders as visible in the example as `$0`.
 // These placeholders take the form of `$number` or `${number:placeholder_text}` which can be traversed as tabstop in ascending order starting from 1,
@@ -98,7 +97,7 @@
 //         "scope": "expr"
 //     }
 // }
-// ````
+// ```
 
 use hir::{ModPath, Name, Symbol};
 use ide_db::imports::import_assets::LocatedImport;


### PR DESCRIPTION
The extra newline between these two comments resulted in the second comment block being dropped from docs entirely, which means that much of the important info about snippets was missing! 

Also tweaked a couple small bits of markdown syntax to make it more readable.

Resulting section of `docs/book/src/features_generated.md` after `cargo xtask codegen`:

<details>
<summary>Before</summary>

### User Snippet Completions
**Source:**  [snippet.rs](https://github.com/rust-lang/rust-analyzer/blob/master/crates/ide-completion/src/snippet.rs#L5) 

rust-analyzer allows the user to define custom (postfix)-snippets that may depend on items to be accessible for the current scope to be applicable.

A custom snippet can be defined by adding it to the `rust-analyzer.completion.snippets.custom` object respectively.

```json
{
  "rust-analyzer.completion.snippets.custom": {
    "thread spawn": {
      "prefix": ["spawn", "tspawn"],
      "body": [
        "thread::spawn(move || {",
        "\t$0",
        "});",
      ],
      "description": "Insert a thread::spawn call",
      "requires": "std::thread",
      "scope": "expr",
    }
  }
}
```

In the example above:

* `"thread spawn"` is the name of the snippet.

* `prefix` defines one or more trigger words that will trigger the snippets completion.
Using `postfix` will instead create a postfix snippet.

* `body` is one or more lines of content joined via newlines for the final output.

* `description` is an optional description of the snippet, if unset the snippet name will be used.

* `requires` is an optional list of item paths that have to be resolvable in the current crate where the completion is rendered.

</details>


<details>
<summary>After</summary>

### User Snippet Completions
**Source:**  [snippet.rs](https://github.com/rust-lang/rust-analyzer/blob/master/crates/ide-completion/src/snippet.rs#L5) 

rust-analyzer allows the user to define custom (postfix)-snippets that may depend on items to be accessible for the current scope to be applicable.

A custom snippet can be defined by adding it to the `rust-analyzer.completion.snippets.custom` object respectively.

```json
{
  "rust-analyzer.completion.snippets.custom": {
    "thread spawn": {
      "prefix": ["spawn", "tspawn"],
      "body": [
        "thread::spawn(move || {",
        "\t$0",
        "});",
      ],
      "description": "Insert a thread::spawn call",
      "requires": "std::thread",
      "scope": "expr",
    }
  }
}
```

In the example above:

* `"thread spawn"` is the name of the snippet.

* `prefix` defines one or more trigger words that will trigger the snippets completion.
Using `postfix` will instead create a postfix snippet.

* `body` is one or more lines of content joined via newlines for the final output.

* `description` is an optional description of the snippet, if unset the snippet name will be used.

* `requires` is an optional list of item paths that have to be resolvable in the current crate where the completion is rendered.
On failure of resolution the snippet won't be applicable, otherwise the snippet will insert an import for the items on insertion if
the items aren't yet in scope.

* `scope` is an optional filter for when the snippet should be applicable. Possible values are:
  * for Snippet-Scopes: `expr`, `item` (default: `item`)
  * for Postfix-Snippet-Scopes: `expr`, `type` (default: `expr`)

The `body` field also has access to placeholders as visible in the example as `$0`.
These placeholders take the form of `$number` or `${number:placeholder_text}` which can be traversed as tabstop in ascending order starting from 1,
with `$0` being a special case that always comes last.

There is also a special placeholder, `${receiver}`, which will be replaced by the receiver expression for postfix snippets, or a `$0` tabstop in case of normal snippets.
This replacement for normal snippets allows you to reuse a snippet for both post- and prefix in a single definition.

For the VSCode editor, rust-analyzer also ships with a small set of defaults which can be removed
by overwriting the settings object mentioned above, the defaults are:

```json
{
    "Arc::new": {
        "postfix": "arc",
        "body": "Arc::new(${receiver})",
        "requires": "std::sync::Arc",
        "description": "Put the expression into an `Arc`",
        "scope": "expr"
    },
    "Rc::new": {
        "postfix": "rc",
        "body": "Rc::new(${receiver})",
        "requires": "std::rc::Rc",
        "description": "Put the expression into an `Rc`",
        "scope": "expr"
    },
    "Box::pin": {
        "postfix": "pinbox",
        "body": "Box::pin(${receiver})",
        "requires": "std::boxed::Box",
        "description": "Put the expression into a pinned `Box`",
        "scope": "expr"
    },
    "Ok": {
        "postfix": "ok",
        "body": "Ok(${receiver})",
        "description": "Wrap the expression in a `Result::Ok`",
        "scope": "expr"
    },
    "Err": {
        "postfix": "err",
        "body": "Err(${receiver})",
        "description": "Wrap the expression in a `Result::Err`",
        "scope": "expr"
    },
    "Some": {
        "postfix": "some",
        "body": "Some(${receiver})",
        "description": "Wrap the expression in an `Option::Some`",
        "scope": "expr"
    }
}
```

</details>