### PR TITLE
fix: Mark auto traits as coinductive

### DIFF
--- a/crates/hir-def/src/signatures.rs
+++ b/crates/hir-def/src/signatures.rs
@@ -545,7 +545,7 @@ impl TraitSignature {
         let attrs = AttrFlags::query(db, id.into());
         let source = loc.source(db);
         if source.value.auto_token().is_some() {
-            flags.insert(TraitFlags::AUTO);
+            flags.insert(TraitFlags::AUTO | TraitFlags::COINDUCTIVE);
         }
         if source.value.unsafe_token().is_some() {
             flags.insert(TraitFlags::UNSAFE);

--- a/crates/hir-ty/src/tests/traits.rs
+++ b/crates/hir-ty/src/tests/traits.rs
@@ -5377,3 +5377,37 @@ fn run_dyn<'b>(val: &dyn for<'a> Trait<'a, 'b>) {}
         "#]],
     );
 }
+
+#[test]
+fn recursive_auto_trait() {
+    check_types(
+        r#"
+auto trait Send {}
+impl<T> !Send for *const T {}
+
+struct Vec<T>(*const T);
+impl<T: Send> Send for Vec<T> {}
+
+struct Node {
+    children: Vec<Node>,
+}
+
+struct Holder<T>(T);
+
+trait Lock<T> {
+    fn get(&self) -> &T;
+}
+
+impl<T: Send> Lock<T> for Holder<T> {
+    fn get(&self) -> &T {
+        &self.0
+    }
+}
+
+fn probe(h: &Holder<Node>) {
+    h.get();
+ // ^^^^^^^ &'? Node
+}
+    "#,
+    );
+}


### PR DESCRIPTION
Coinductive traits are traits that when proving a predicate for them, `Type: Trait`, inside the predicate we can rely on itself to hold. For example, in `struct Foo(Foo)`, coinductive trait will succeed `Foo: Trait` and non-coinductive trait will fail unless there's an `impl Trait for Foo`. In Rust, only auto traits and `#[rustc_coinductive]` traits are coinductive, but previously we haven't considered auto traits coinductive.

Fixes rust-lang/rust-analyzer#22941.