### PR TITLE
add support for build-dir configuration

### DIFF
--- a/crates/project-model/src/build_dependencies.rs
+++ b/crates/project-model/src/build_dependencies.rs
@@ -88,6 +88,7 @@ impl WorkspaceBuildScripts {
             &allowed_features,
             workspace.manifest_path(),
             workspace.target_directory().as_ref(),
+            workspace.build_directory().map(AbsPath::as_ref),
             current_dir,
             sysroot,
             toolchain,
@@ -105,12 +106,15 @@ impl WorkspaceBuildScripts {
     ) -> io::Result<Vec<WorkspaceBuildScripts>> {
         assert_eq!(config.invocation_strategy, InvocationStrategy::Once);
 
+        let working_dir: &Utf8Path = working_directory.as_ref();
+
         let (_guard, cmd) = Self::build_command(
             config,
             &Default::default(),
             // These are not gonna be used anyways, so just construct a dummy here
             &ManifestPath::try_from(working_directory.clone()).unwrap(),
-            working_directory.as_ref(),
+            working_dir,
+            Some(working_dir),
             working_directory,
             &Sysroot::empty(),
             None,
@@ -434,6 +438,7 @@ impl WorkspaceBuildScripts {
         allowed_features: &FxHashSet<String>,
         manifest_path: &ManifestPath,
         target_dir: &Utf8Path,
+        build_dir: Option<&Utf8Path>,
         current_dir: &AbsPath,
         sysroot: &Sysroot,
         toolchain: Option<&semver::Version>,
@@ -460,6 +465,9 @@ impl WorkspaceBuildScripts {
                 if let Some(target_dir) = config.target_dir_config.target_dir(Some(target_dir)) {
                     cmd.arg("--target-dir");
                     cmd.arg(target_dir.as_ref());
+                }
+                if let Some(build_dir) = config.build_dir_config.target_dir(build_dir) {
+                    cmd.env("CARGO_BUILD_BUILD_DIR", build_dir.as_ref());
                 }
 
                 toolchain::cargo_use_targets(toolchain, &mut cmd, config.target.as_slice());

--- a/crates/project-model/src/cargo_workspace.rs
+++ b/crates/project-model/src/cargo_workspace.rs
@@ -141,6 +141,8 @@ pub struct CargoConfig {
     pub invocation_strategy: InvocationStrategy,
     /// Optional path to use instead of `target` when building
     pub target_dir_config: TargetDirectoryConfig,
+    /// Optional path to use instead of `target` when building
+    pub build_dir_config: TargetDirectoryConfig,
     /// Gate `#[test]` behind `#[cfg(test)]`
     pub set_test: bool,
     /// Load the project without any dependencies

--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -788,6 +788,15 @@ config_data! {
         /// Automatically refresh project info via `cargo metadata` on
         /// `Cargo.toml` or `.cargo/config.toml` changes.
         cargo_autoreload: bool           = true,
+        /// Optional path to a rust-analyzer specific build directory.
+        /// Since cargo's build-directory defaults to the target-directory, it should only
+        /// be needed to set this if a custom build-directory is configured.
+        /// Otherwise setting `cargo.targetDir` is sufficient to prevent rust-analyzer from
+        /// locking the `Cargo.lock`.
+        ///
+        /// Set to `true` to use a subdirectory of the existing build directory or
+        /// set to a path relative to the workspace to use that path.
+        cargo_buildDir | rust_analyzerBuildDir: Option<TargetDirectory> = None,
         /// Run build scripts (`build.rs`) for more precise code analysis.
         cargo_buildScripts_enable: bool  = true,
         /// Specifies the invocation strategy to use when running the build scripts command.
@@ -2486,6 +2495,7 @@ impl Config {
             extra_args: self.cargo_extraArgs(source_root).clone(),
             extra_env: self.cargo_extraEnv(source_root).clone(),
             target_dir_config: self.target_dir_from_config(source_root),
+            build_dir_config: self.build_dir_from_config(source_root),
             set_test: *self.cfg_setTest(source_root),
             no_deps: *self.cargo_noDeps(source_root),
             metadata_extra_args: self.cargo_metadataExtraArgs(source_root).clone(),
@@ -2578,6 +2588,7 @@ impl Config {
             extra_test_bin_args: self.runnables_extraTestBinaryArgs(source_root).clone(),
             extra_env: self.extra_env(source_root).clone(),
             target_dir_config: self.target_dir_from_config(source_root),
+            build_dir_config: self.build_dir_from_config(source_root),
             set_test: true,
             config_path: self.cargo_config_path(source_root),
         }
@@ -2638,6 +2649,7 @@ impl Config {
                     extra_env: self.check_extra_env(source_root),
                     config_path: self.cargo_config_path(source_root),
                     target_dir_config: self.target_dir_from_config(source_root),
+                    build_dir_config: self.build_dir_from_config(source_root),
                     set_test: *self.cfg_setTest(source_root),
                 },
                 ansi_color_output: self.color_diagnostic_output(),
@@ -2651,6 +2663,14 @@ impl Config {
 
     fn target_dir_from_config(&self, source_root: Option<SourceRootId>) -> TargetDirectoryConfig {
         match &self.cargo_targetDir(source_root) {
+            Some(TargetDirectory::UseSubdirectory(true)) => TargetDirectoryConfig::UseSubdirectory,
+            Some(TargetDirectory::UseSubdirectory(false)) | None => TargetDirectoryConfig::None,
+            Some(TargetDirectory::Directory(dir)) => TargetDirectoryConfig::Directory(dir.clone()),
+        }
+    }
+
+    fn build_dir_from_config(&self, source_root: Option<SourceRootId>) -> TargetDirectoryConfig {
+        match &self.cargo_buildDir(source_root) {
             Some(TargetDirectory::UseSubdirectory(true)) => TargetDirectoryConfig::UseSubdirectory,
             Some(TargetDirectory::UseSubdirectory(false)) | None => TargetDirectoryConfig::None,
             Some(TargetDirectory::Directory(dir)) => TargetDirectoryConfig::Directory(dir.clone()),

--- a/crates/rust-analyzer/src/flycheck.rs
+++ b/crates/rust-analyzer/src/flycheck.rs
@@ -53,6 +53,7 @@ pub(crate) struct CargoOptions {
     pub(crate) extra_env: FxHashMap<String, Option<String>>,
     pub(crate) config_path: Option<AbsPathBuf>,
     pub(crate) target_dir_config: TargetDirectoryConfig,
+    pub(crate) build_dir_config: TargetDirectoryConfig,
 }
 
 #[derive(Clone, Debug)]
@@ -68,6 +69,7 @@ impl CargoOptions {
         &self,
         cmd: &mut Command,
         ws_target_dir: Option<&Utf8Path>,
+        ws_build_dir: Option<&Utf8Path>,
         package_repr: Option<&str>,
         toolchain_version: Option<&semver::Version>,
     ) {
@@ -113,6 +115,9 @@ impl CargoOptions {
         }
         if let Some(target_dir) = self.target_dir_config.target_dir(ws_target_dir) {
             cmd.arg("--target-dir").arg(target_dir.as_ref());
+        }
+        if let Some(build_dir) = self.build_dir_config.target_dir(ws_build_dir) {
+            cmd.env("CARGO_BUILD_BUILD_DIR", build_dir.as_ref());
         }
     }
 }
@@ -966,6 +971,7 @@ impl FlycheckActor {
                 cargo_options.apply_on_command(
                     &mut cmd,
                     self.ws_target_dir.as_ref().map(Utf8PathBuf::as_path),
+                    self.ws_build_dir.as_ref().map(Utf8PathBuf::as_path),
                     package_repr,
                     self.toolchain_version.as_ref(),
                 );
@@ -1186,6 +1192,7 @@ mod tests {
                 extra_env: FxHashMap::default(),
                 config_path: None,
                 target_dir_config: TargetDirectoryConfig::default(),
+                build_dir_config: TargetDirectoryConfig::default(),
             },
             ansi_color_output: true,
         };

--- a/crates/rust-analyzer/src/handlers/request.rs
+++ b/crates/rust-analyzer/src/handlers/request.rs
@@ -285,6 +285,7 @@ pub(crate) fn handle_run_test(
                     state.config.cargo_test_options(None),
                     cargo.workspace_root(),
                     Some(cargo.target_directory().as_ref()),
+                    cargo.build_directory().map(AbsPath::as_ref),
                     target,
                     state.test_run_sender.clone(),
                     ws.toolchain.as_ref(),

--- a/crates/rust-analyzer/src/test_runner.rs
+++ b/crates/rust-analyzer/src/test_runner.rs
@@ -106,6 +106,7 @@ impl CargoTestHandle {
         options: CargoOptions,
         root: &AbsPath,
         ws_target_dir: Option<&Utf8Path>,
+        ws_build_dir: Option<&Utf8Path>,
         test_target: TestTarget,
         sender: Sender<CargoTestMessage>,
         toolchain_version: Option<&semver::Version>,
@@ -135,6 +136,7 @@ impl CargoTestHandle {
         options.apply_on_command(
             &mut cmd,
             ws_target_dir,
+            ws_build_dir,
             Some(&test_target.package),
             toolchain_version,
         );

--- a/docs/book/src/configuration_generated.md
+++ b/docs/book/src/configuration_generated.md
@@ -56,6 +56,20 @@ Automatically refresh project info via `cargo metadata` on
 `Cargo.toml` or `.cargo/config.toml` changes.
 
 
+## rust-analyzer.cargo.buildDir {#cargo.buildDir}
+
+Default: `null`
+
+Optional path to a rust-analyzer specific build directory.
+Since cargo's build-directory defaults to the target-directory, it should only
+be needed to set this if a custom build-directory is configured.
+Otherwise setting `cargo.targetDir` is sufficient to prevent rust-analyzer from
+locking the `Cargo.lock`.
+
+Set to `true` to use a subdirectory of the existing build directory or
+set to a path relative to the workspace to use that path.
+
+
 ## rust-analyzer.cargo.buildScripts.enable {#cargo.buildScripts.enable}
 
 Default: `true`

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -884,6 +884,26 @@
             {
                 "title": "Cargo",
                 "properties": {
+                    "rust-analyzer.cargo.buildDir": {
+                        "markdownDescription": "Optional path to a rust-analyzer specific build directory.\nSince cargo's build-directory defaults to the target-directory, it should only\nbe needed to set this if a custom build-directory is configured.\nOtherwise setting `cargo.targetDir` is sufficient to prevent rust-analyzer from\nlocking the `Cargo.lock`.\n\nSet to `true` to use a subdirectory of the existing build directory or\nset to a path relative to the workspace to use that path.",
+                        "default": null,
+                        "anyOf": [
+                            {
+                                "type": "null"
+                            },
+                            {
+                                "type": "boolean"
+                            },
+                            {
+                                "type": "string"
+                            }
+                        ]
+                    }
+                }
+            },
+            {
+                "title": "Cargo",
+                "properties": {
                     "rust-analyzer.cargo.buildScripts.enable": {
                         "markdownDescription": "Run build scripts (`build.rs`) for more precise code analysis.",
                         "default": true,


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust-analyzer/issues/20150

Allows for configuring a rust-analyzer specific `build-dir` just as it already allows for `target-dir`.

Changes mostly consist of duplicating the existing `target-dir` logic, only the logic around setting the option for the spawned commands is different, since there is no `--build-dir` cargo argument.

Has been tested by setting `cargo.buildDir = true` and verifying that the expected subdirectory in the globally configured `build-dir` is created, and that I can run `cargo check` in parallel to the RA check without running into a lock.