### PR TITLE
fix: Double stack size for threads to 16MiB

### DIFF
--- a/crates/rust-analyzer/src/bin/main.rs
+++ b/crates/rust-analyzer/src/bin/main.rs
@@ -166,8 +166,6 @@ fn setup_logging(log_file_flag: Option<PathBuf>) -> anyhow::Result<()> {
     Ok(())
 }
 
-const STACK_SIZE: usize = 1024 * 1024 * 8;
-
 /// Parts of rust-analyzer can use a lot of stack space, and some operating systems only give us
 /// 1 MB by default (eg. Windows), so this spawns a new thread with hopefully sufficient stack
 /// space.
@@ -176,8 +174,7 @@ fn with_extra_thread(
     thread_intent: stdx::thread::ThreadIntent,
     f: impl FnOnce() -> anyhow::Result<()> + Send + 'static,
 ) -> anyhow::Result<()> {
-    let handle =
-        stdx::thread::Builder::new(thread_intent, thread_name).stack_size(STACK_SIZE).spawn(f)?;
+    let handle = stdx::thread::Builder::new(thread_intent, thread_name).spawn(f)?;
 
     handle.join()?;
 
@@ -189,6 +186,7 @@ fn run_server(startup_notice: Option<String>) -> anyhow::Result<()> {
 
     rayon::ThreadPoolBuilder::new()
         .thread_name(|ix| format!("RayonWorker{}", ix))
+        .stack_size(stdx::thread::DEFAULT_STACK_SIZE)
         .build_global()
         .unwrap();
 

--- a/crates/rust-analyzer/src/cli/diagnostics.rs
+++ b/crates/rust-analyzer/src/cli/diagnostics.rs
@@ -13,13 +13,10 @@ use crate::cli::{flags, progress_report::ProgressReport};
 
 impl flags::Diagnostics {
     pub fn run(self) -> anyhow::Result<()> {
-        const STACK_SIZE: usize = 1024 * 1024 * 8;
-
         let handle = stdx::thread::Builder::new(
             stdx::thread::ThreadIntent::LatencySensitive,
             "BIG_STACK_THREAD",
         )
-        .stack_size(STACK_SIZE)
         .spawn(|| self.run_())
         .unwrap();
 

--- a/crates/rust-analyzer/src/cli/unresolved_references.rs
+++ b/crates/rust-analyzer/src/cli/unresolved_references.rs
@@ -11,13 +11,10 @@ use crate::cli::flags;
 
 impl flags::UnresolvedReferences {
     pub fn run(self) -> anyhow::Result<()> {
-        const STACK_SIZE: usize = 1024 * 1024 * 8;
-
         let handle = stdx::thread::Builder::new(
             stdx::thread::ThreadIntent::LatencySensitive,
             "BIG_STACK_THREAD",
         )
-        .stack_size(STACK_SIZE)
         .spawn(|| self.run_())
         .unwrap();
 

--- a/crates/stdx/src/thread.rs
+++ b/crates/stdx/src/thread.rs
@@ -34,6 +34,8 @@ where
     Builder::new(intent, name).spawn(f).expect("failed to spawn thread")
 }
 
+pub const DEFAULT_STACK_SIZE: usize = 16 * 1024 * 1024;
+
 pub struct Builder {
     intent: ThreadIntent,
     inner: jod_thread::Builder,
@@ -43,7 +45,11 @@ pub struct Builder {
 impl Builder {
     #[must_use]
     pub fn new(intent: ThreadIntent, name: impl Into<String>) -> Self {
-        Self { intent, inner: jod_thread::Builder::new().name(name.into()), allow_leak: false }
+        Self {
+            intent,
+            inner: jod_thread::Builder::new().name(name.into()).stack_size(DEFAULT_STACK_SIZE),
+            allow_leak: false,
+        }
     }
 
     #[must_use]

--- a/crates/stdx/src/thread/pool.rs
+++ b/crates/stdx/src/thread/pool.rs
@@ -45,7 +45,6 @@ impl Pool {
     /// Panics if job panics
     #[must_use]
     pub fn new(threads: usize) -> Self {
-        const STACK_SIZE: usize = 8 * 1024 * 1024;
         const INITIAL_INTENT: ThreadIntent = ThreadIntent::Worker;
 
         let (job_sender, job_receiver) = crossbeam_channel::unbounded();
@@ -54,7 +53,6 @@ impl Pool {
         let mut handles = Vec::with_capacity(threads);
         for idx in 0..threads {
             let handle = Builder::new(INITIAL_INTENT, format!("Worker{idx}",))
-                .stack_size(STACK_SIZE)
                 .allow_leak(true)
                 .spawn({
                     let extant_tasks = Arc::clone(&extant_tasks);


### PR DESCRIPTION
This does not impact memory usage since this is only reserved, not committed, memory; it could crash if we allocate more than the commit limit and overcommit is disabled but for such small numbers it practically can't happen.

This is an alternative to using `stacker` to grow the stack on-demand; rustc is transitioning to the same model - https://github.com/rust-lang/compiler-team/issues/1011.

16MiB was chosen because when that was chosen as the limit in rustc (https://github.com/rust-lang/rust/pull/158759), crater succeeded for practically all crates, so it should be enough for us as well. It's also two times the current number (8MiB) which is a lot.

Closes https://github.com/rust-lang/rust-analyzer/pull/22740.
Closes https://github.com/rust-lang/rust-analyzer/issues/9824.
Should fix https://github.com/rust-lang/rust-analyzer/issues/22374, unless we need an even bigger number.
Maybe fixes https://github.com/rust-lang/rust-analyzer/issues/15873.
Probably fixes https://github.com/rust-lang/rust-analyzer/issues/20127.