### PR TITLE
Revert "Remove lockfile-path support for Cargo versions below 1.94.0"

### DIFF
--- a/crates/project-model/src/build_dependencies.rs
+++ b/crates/project-model/src/build_dependencies.rs
@@ -473,6 +473,10 @@ impl WorkspaceBuildScripts {
                     if let Some(lockfile_copy) = &lockfile_copy {
                         requires_unstable_options = true;
                         match lockfile_copy.usage {
+                            LockfileUsage::WithFlag => {
+                                cmd.arg("--lockfile-path");
+                                cmd.arg(lockfile_copy.path.as_str());
+                            }
                             LockfileUsage::WithEnvVarUnstable => {
                                 cmd.arg("-Zlockfile-path");
                                 cmd.env(

--- a/crates/project-model/src/cargo_config_file.rs
+++ b/crates/project-model/src/cargo_config_file.rs
@@ -143,6 +143,8 @@ pub(crate) struct LockfileCopy {
 }
 
 pub(crate) enum LockfileUsage {
+    /// Rust [1.82.0, 1.95.0). `cargo <subcmd> --lockfile-path <lockfile path>`
+    WithFlag,
     /// Rust [1.95.0, 1.97.0). `CARGO_RESOLVER_LOCKFILE_PATH=<lockfile path> cargo -Zlockfile-path <subcmd>`
     WithEnvVarUnstable,
     /// Rust >= 1.97.0. `CARGO_RESOLVER_LOCKFILE_PATH=<lockfile path> cargo <subcmd>`
@@ -153,6 +155,15 @@ pub(crate) fn make_lockfile_copy(
     toolchain_version: &semver::Version,
     lockfile_path: &Utf8Path,
 ) -> Option<LockfileCopy> {
+    const MINIMUM_TOOLCHAIN_VERSION_SUPPORTING_LOCKFILE_PATH_FLAG: semver::Version =
+        semver::Version {
+            major: 1,
+            minor: 82,
+            patch: 0,
+            pre: semver::Prerelease::EMPTY,
+            build: semver::BuildMetadata::EMPTY,
+        };
+
     const MINIMUM_TOOLCHAIN_VERSION_SUPPORTING_LOCKFILE_PATH_ENV_UNSTABLE: semver::Version =
         semver::Version {
             major: 1,
@@ -176,6 +187,8 @@ pub(crate) fn make_lockfile_copy(
     } else if *toolchain_version >= MINIMUM_TOOLCHAIN_VERSION_SUPPORTING_LOCKFILE_PATH_ENV_UNSTABLE
     {
         LockfileUsage::WithEnvVarUnstable
+    } else if *toolchain_version >= MINIMUM_TOOLCHAIN_VERSION_SUPPORTING_LOCKFILE_PATH_FLAG {
+        LockfileUsage::WithFlag
     } else {
         return None;
     };

--- a/crates/project-model/src/cargo_workspace.rs
+++ b/crates/project-model/src/cargo_workspace.rs
@@ -767,6 +767,10 @@ impl FetchMetadata {
         let mut using_lockfile_copy = false;
         if let Some(lockfile_copy) = &lockfile_copy {
             match lockfile_copy.usage {
+                LockfileUsage::WithFlag => {
+                    other_options.push("--lockfile-path".to_owned());
+                    other_options.push(lockfile_copy.path.to_string());
+                }
                 LockfileUsage::WithEnvVarUnstable => {
                     other_options.push("-Zlockfile-path".to_owned());
                     command.env("CARGO_RESOLVER_LOCKFILE_PATH", lockfile_copy.path.as_os_str());


### PR DESCRIPTION
As discussed in https://rust-lang.zulipchat.com/#narrow/channel/185405-t-compiler.2Frust-analyzer/topic/Broken.20rustc.20source.20discover/with/613443881 this reverts 05fcbfe1806fdfc0ba5c333c1929cf7869ad8a7f.

I confirm this fixes my problem when running with 1.95.0-nightly