### PR TITLE
fix: handle `Variants::Empty` in `detect_variant_from_bytes` to prevent panic during const eval of uninhabited enums

### DIFF
--- a/crates/hir-ty/src/utils.rs
+++ b/crates/hir-ty/src/utils.rs
@@ -101,7 +101,7 @@ pub(crate) fn detect_variant_from_bytes<'a>(
     e: EnumId,
 ) -> Option<(EnumVariantId, &'a Layout)> {
     let (var_id, var_layout) = match &layout.variants {
-        hir_def::layout::Variants::Empty => unreachable!(),
+        hir_def::layout::Variants::Empty => return None,
         hir_def::layout::Variants::Single { index } => {
             (e.enum_variants(db).variants[index.0].0, layout)
         }


### PR DESCRIPTION
Fixes rust-lang/rust-analyzer#22950

Hey, I ran into this panic while testing analysis-stats on some code that uses
uninhabited enums wrapped in a struct and transmuted into a const array.

The crash happens in `detect_variant_from_bytes` in `crates/hir-ty/src/utils.rs`.
The function matches on `layout.variants` and has an arm for `Variants::Empty` that
just calls `unreachable!()`. But it turns out this case *is* reachable — when you
have an enum with zero variants like `enum Void {}`, the layout system correctly
gives it `Variants::Empty`. So when const eval tries to walk the memory map of such
a type, it hits that arm and panics.

The fix is pretty small — instead of `unreachable!()`, we just `return None`.
That makes sense because if the enum has no variants, there's nothing to detect,
and `None` is exactly what the return type is supposed to convey in that situation.
I also checked all the places that call this function — they all do `if let Some(...)`
on the result already, so returning `None` here is completely safe and doesn't
break anything.

To reproduce the panic before the fix:

```rust
pub mod empty {
    #[derive(Clone, Copy)]
    enum Void {}

    #[derive(Clone, Copy)]
    pub struct Empty(Void);
}

const BAR: [empty::Empty; 3] = [unsafe { std::mem::transmute(()) }; 3];

fn main() {
    BAR;
}
```

Then run:
```
rust-analyzer analysis-stats . --run-all-ide-things
```

After the fix, `cargo check -p hir-ty` passes clean with no errors or warnings.
