### PR TITLE
fix(hir-ty): prevent panic on incompatible integer types during const evaluation

### DIFF
--- a/crates/hir-ty/src/mir/eval.rs
+++ b/crates/hir-ty/src/mir/eval.rs
@@ -1400,6 +1400,16 @@ impl<'a, 'db> Evaluator<'a, 'db> {
                         }
                     }
                 } else {
+                    // If the two operands have different byte sizes (e.g. from ill-typed code
+                    // like `enum_variant + int_literal`), `IntValue::from_bytes` would produce
+                    // different variants and subsequent arithmetic would panic. Gracefully fail
+                    // instead so analysis-stats doesn't crash on semantically invalid code.
+                    // Note: Bit shifts (Shl, Shr) can legitimately have different sizes.
+                    if lc.len() != rc.len() && !matches!(op, BinOp::Shl | BinOp::Shr) {
+                        not_supported!(
+                            "binary op between operands of incompatible integer sizes (ill-typed)"
+                        );
+                    }
                     let is_signed = matches!(ty.kind(), TyKind::Int(_));
                     let l128 = IntValue::from_bytes(lc, is_signed);
                     let r128 = IntValue::from_bytes(rc, is_signed);
@@ -3318,7 +3328,9 @@ macro_rules! checked_int_op {
         fn $op(self, other: Self) -> Option<Self> {
             match (self, other) {
                 $( (Self::$int_ty(a), Self::$int_ty(b)) => a.$op(b).map(Self::$int_ty), )+
-                _ => panic!("incompatible integer types"),
+                // Operands have incompatible types (e.g. from ill-typed code like `enum + int`).
+                // Return `None` so the evaluator propagates a graceful error instead of crashing.
+                _ => None,
             }
         }
     };


### PR DESCRIPTION
Fixes rust-lang/rust-analyzer#22954

When the MIR evaluator encounters an ill-typed binary operation with operands of differing sizes (for example, attempting to add an `i128` enum discriminant to an `i32` integer literal like `Foo::A + 2`), `IntValue::from_bytes` produces incompatible `IntValue` variants.

Previously, attempting to execute `checked_add` (and other arithmetic ops) on these mismatched variants hit a wildcard `_ => panic!("incompatible integer types")` arm in the `checked_int_op` macro, which crashed the `rust-analyzer` process.

This PR fixes the crash by:
1. Emitting a graceful `not_supported!` `MirEvalError` during `eval_rvalue` if the integer operands have mismatched lengths (skipping this length check for bitshifts `<<`/`>>` which legitimately use mismatched sizes).
2. Changing the `checked_int_op` macro to return `None` rather than `panic!` when variants are incompatible, ensuring the evaluation propagates a failure instead of crashing the process.

Co-authored-by: jibinjose884@gmail.com
