### PR TITLE
fix: Do not alloc anon consts for bare paths in blocks

### DIFF
--- a/crates/hir-ty/src/consteval.rs
+++ b/crates/hir-ty/src/consteval.rs
@@ -361,7 +361,7 @@ pub(crate) fn create_anon_const<'a, 'db>(
     interner: DbInterner<'db>,
     owner: ExpressionStoreOwnerId,
     store: &ExpressionStore,
-    expr: ExprId,
+    expr_id: ExprId,
     resolver: &Resolver<'db>,
     expected_ty: Ty<'db>,
     generics: &dyn Fn() -> &'a Generics<'db>,
@@ -369,10 +369,19 @@ pub(crate) fn create_anon_const<'a, 'db>(
     lowering_mode: LoweringMode,
     forbid_params_after: Option<u32>,
 ) -> Result<Const<'db>, CreateConstError<'db>> {
-    match &store[expr] {
+    let mut expr = &store[expr_id];
+    if let Expr::Block { statements, tail: Some(tail), .. } = expr
+        && statements.is_empty()
+    {
+        // rustc unwraps *one* layer of blocks, so we do too (this impacts whether the const can use generic parameters.
+        // Anon consts sometimes cannot while bare paths can). mGCA allows arbitrarily many blocks, but we don't implement
+        // it yet.
+        expr = &store[*tail];
+    }
+    match expr {
         Expr::Literal(literal) => intern_const_ref(interner, literal, expected_ty),
         Expr::Underscore => match create_var {
-            Some(create_var) => Ok(create_var(expr.into())),
+            Some(create_var) => Ok(create_var(expr_id.into())),
             None => Err(CreateConstError::UnderscoreExpr),
         },
         Expr::Path(path)
@@ -395,7 +404,7 @@ pub(crate) fn create_anon_const<'a, 'db>(
                 interner.db,
                 AnonConstLoc {
                     owner,
-                    expr,
+                    expr: expr_id,
                     ty: StoredEarlyBinder::bind(expected_ty.store()),
                     allow_using_generic_params,
                 },

--- a/crates/hir-ty/src/infer.rs
+++ b/crates/hir-ty/src/infer.rs
@@ -1085,10 +1085,7 @@ impl<'db> InferenceResult<'db> {
     fn for_body(db: &dyn HirDatabase, def: DefWithBodyId) -> InferenceResult<'_> {
         infer_query(db, def)
     }
-}
 
-#[salsa::tracked]
-impl<'db> InferenceResult<'db> {
     /// Infer types for all const expressions in an item's signature.
     ///
     /// Returns an `InferenceResult` containing type information for array lengths,

--- a/crates/hir-ty/src/tests/regression.rs
+++ b/crates/hir-ty/src/tests/regression.rs
@@ -3028,3 +3028,38 @@ fn f() {
     "#,
     );
 }
+
+#[test]
+fn braced_const_path() {
+    check_types(
+        r#"
+//- minicore: default, builtin_impls
+trait ToNum {
+    type Num;
+}
+trait Bar {
+    type Ty;
+}
+struct Gen<const B: bool>;
+struct Int<const B: bool>;
+
+impl<const B: bool> ToNum for Gen<{ B }> {
+    type Num = Int<B>;
+}
+
+impl Bar for Int<true> {
+    type Ty = i32;
+}
+impl Bar for Int<false> {
+    type Ty = f32;
+}
+
+type A = <<Gen<true> as ToNum>::Num as Bar>::Ty;
+
+fn main() {
+    let x = A::default();
+     // ^ i32
+}
+    "#,
+    );
+}

--- a/crates/hir-ty/src/tests/simple.rs
+++ b/crates/hir-ty/src/tests/simple.rs
@@ -4201,8 +4201,6 @@ fn foo() {
             248..282 'LazyLo..._LOCK)': &'? [u32; 0]
             264..281 '&VALUE...Y_LOCK': &'? LazyLock<[u32; 0]>
             265..281 'VALUES...Y_LOCK': LazyLock<[u32; 0]>
-            197..202 '{ 0 }': usize
-            199..200 '0': usize
         "#]],
     );
 }
@@ -4308,9 +4306,8 @@ enum Enum {
 }
     "#,
         expect![[r#"
-            29..34 '{ 2 }': usize
-            31..32 '2': usize
-        "#]],
+
+"#]],
     );
 }
 

--- a/crates/ide/src/hover/tests.rs
+++ b/crates/ide/src/hover/tests.rs
@@ -9508,7 +9508,7 @@ pub fn f(x$0: impl Tr<{ 0 }>) {}
             *x*
 
             ```rust
-            x: impl Tr<{const}> + ?Sized
+            x: impl Tr<0> + ?Sized
             ```
 
             ---


### PR DESCRIPTION
Fixes rust-lang/rust-analyzer#22644.