### PR TITLE
fix: term_search exclude useless target type

### DIFF
--- a/crates/ide-assists/src/handlers/term_search.rs
+++ b/crates/ide-assists/src/handlers/term_search.rs
@@ -30,6 +30,11 @@ pub(crate) fn term_search(acc: &mut Assists, ctx: &AssistContext<'_, '_>) -> Opt
 
     let target_ty = ctx.sema.type_of_expr(&ast::Expr::cast(parent.clone())?)?.adjusted();
 
+    if target_ty.is_unit() || target_ty.is_never() {
+        cov_mark::hit!(term_search_useless_target_ty);
+        return None;
+    }
+
     let term_search_ctx = TermSearchCtx {
         sema: &ctx.sema,
         scope: &scope,
@@ -257,6 +262,21 @@ fn g() { let a = &1; let b: f32 = f(a); }"#,
             fn f(a: &i32) -> f32 { a as f32 }
             fn g() { let a = &mut 1; let b: f32 = todo$0!(); }"#,
         )
+    }
+
+    #[test]
+    fn test_not_search_unit() {
+        cov_mark::check_count!(term_search_useless_target_ty, 2);
+        check_assist_not_applicable(
+            term_search,
+            r#"//- minicore: todo, unimplemented
+fn f() { let a: () = (); let b: () = todo$0!() }"#,
+        );
+        check_assist_not_applicable(
+            term_search,
+            r#"//- minicore: todo, unimplemented
+fn f() { let unknown; let unknown2 = todo$0!() }"#,
+        );
     }
 
     #[test]


### PR DESCRIPTION
Example
---
```rust
fn f() { let a: () = (); let b: () = todo$0!() }
```

**Before this PR**

```text
1. Inline macro
2. Replace todo!() with a
3. Replace todo!() with ()
4. Replace todo!() with f()
```

**After this PR**

```text
1. Inline macro
```
