### PR TITLE
fix: detect the rust-analyzer component in a multi-line components array

### DIFF
--- a/editors/code/src/bootstrap.ts
+++ b/editors/code/src/bootstrap.ts
@@ -176,14 +176,21 @@ async function fileExists(uri: vscode.Uri) {
     );
 }
 
+// Matches a `components` array that lists `rust-analyzer`. The elements are matched with
+// `[^\]]` rather than `.` so that the array may be spread over several lines, which is just
+// as valid TOML as keeping it on one. TOML strings come in both quote flavours.
+const RA_COMPONENT_RE = /components\s*=\s*\[[^\]]*["']rust-analyzer["'][^\]]*\]/;
+
+function declaresRaComponent(toolchainFileContents: string): boolean {
+    return RA_COMPONENT_RE.test(toolchainFileContents);
+}
+
 async function hasToolchainFileWithRaDeclared(uri: vscode.Uri): Promise<boolean> {
     try {
         const toolchainFileContents = new TextDecoder().decode(
             await vscode.workspace.fs.readFile(uri),
         );
-        return (
-            toolchainFileContents.match(/components\s*=\s*\[.*"rust-analyzer".*\]/g)?.length === 1
-        );
+        return declaresRaComponent(toolchainFileContents);
     } catch (_) {
         return false;
     }
@@ -296,6 +303,7 @@ async function patchelf(dest: vscode.Uri): Promise<void> {
 }
 
 export const _private = {
+    declaresRaComponent,
     earliestToolchainPath,
     orderFromPath,
 };

--- a/editors/code/src/bootstrap.ts
+++ b/editors/code/src/bootstrap.ts
@@ -176,13 +176,16 @@ async function fileExists(uri: vscode.Uri) {
     );
 }
 
-// Matches a `components` array that lists `rust-analyzer`. The elements are matched with
-// `[^\]]` rather than `.` so that the array may be spread over several lines, which is just
-// as valid TOML as keeping it on one. TOML strings come in both quote flavours.
-const RA_COMPONENT_RE = /components\s*=\s*\[[^\]]*["']rust-analyzer["'][^\]]*\]/;
+// Captures the elements of a `components` array. They are matched with `[^\]]` rather than `.`
+// so that the array may be spread over several lines, which is just as valid TOML as keeping it
+// on one, while still stopping at the end of the array.
+const COMPONENTS_RE = /components\s*=\s*\[(?<components>[^\]]*)\]/;
+// TOML strings come in both quote flavours.
+const RA_COMPONENT_RE = /["']rust-analyzer["']/;
 
 function declaresRaComponent(toolchainFileContents: string): boolean {
-    return RA_COMPONENT_RE.test(toolchainFileContents);
+    const components = toolchainFileContents.match(COMPONENTS_RE)?.groups?.["components"];
+    return components !== undefined && RA_COMPONENT_RE.test(components);
 }
 
 async function hasToolchainFileWithRaDeclared(uri: vscode.Uri): Promise<boolean> {

--- a/editors/code/tests/unit/bootstrap.test.ts
+++ b/editors/code/tests/unit/bootstrap.test.ts
@@ -158,7 +158,7 @@ channel = "1.88"
 components = [
     "cargo",
 ]
-path = "/opt/rust-analyzer"
+# add "rust-analyzer" here to use the matching server
 `,
                 ),
             );

--- a/editors/code/tests/unit/bootstrap.test.ts
+++ b/editors/code/tests/unit/bootstrap.test.ts
@@ -93,4 +93,75 @@ export async function getTests(ctx: Context) {
             );
         });
     });
+
+    await ctx.suite("Bootstrap/Detect RA component in toolchain file", (suite) => {
+        suite.addTest("Single line components array", async () => {
+            assert.ok(
+                _private.declaresRaComponent(
+                    `[toolchain]
+channel = "1.88"
+components = ["cargo", "rust-analyzer", "rustfmt"]
+`,
+                ),
+            );
+        });
+
+        suite.addTest("Multi line components array", async () => {
+            assert.ok(
+                _private.declaresRaComponent(
+                    `[toolchain]
+channel = "1.88"
+components = [
+    "cargo",
+    "rust-analyzer",
+    "rustfmt",
+]
+profile = "default"
+`,
+                ),
+            );
+        });
+
+        suite.addTest("Components array with literal strings", async () => {
+            assert.ok(_private.declaresRaComponent(`components = ['cargo', 'rust-analyzer']`));
+        });
+
+        suite.addTest("Components array without RA", async () => {
+            assert.ok(
+                !_private.declaresRaComponent(
+                    `[toolchain]
+channel = "1.88"
+components = [
+    "cargo",
+    "rustfmt",
+]
+`,
+                ),
+            );
+        });
+
+        suite.addTest("No components array", async () => {
+            assert.ok(
+                !_private.declaresRaComponent(
+                    `[toolchain]
+channel = "1.88"
+`,
+                ),
+            );
+        });
+
+        suite.addTest("RA mentioned outside the components array", async () => {
+            assert.ok(
+                !_private.declaresRaComponent(
+                    `[toolchain]
+channel = "1.88"
+components = [
+    "cargo",
+]
+path = "/opt/rust-analyzer"
+`,
+                ),
+            );
+        });
+    });
 }


### PR DESCRIPTION
Closes rust-lang/rust-analyzer#22980

`hasToolchainFileWithRaDeclared` matched the `components` array with `.` between the
brackets. `.` does not match newlines, so an array written over several lines was never
detected, even though rustup treats it identically to the single line form. Then extension
then fell back to the bundled server, and on a pinned toolchain older than the extension's
minimum supported version that produces  a "toolchain too old" modal on every reload, with
nothing in the output channel explaining why the toolchain binary was skipped.

The elements are now matched with `[^\]]` instead. It crosses newlines but still stops at the
closing bracket, so the match cannot run past the end of the array into an unrelated key. Two
smaller things came with it: TOML literal strings (`'rust-analyzer'`) are accepted, and the
old `?.length === 1 is gone, and a file containing two matching arrays counted as no match
at all.

Selection behaviour is otherwise unchanged. Detection is still opt-in, only when `components`
explicitly names `rust-analyzer`, and precedence between the toolchain server and the bundled
one is untouched. Having the component installed without declaring it still does not displace
the bundled server.

The predicate is split out as `declaresRaComponent` and exposed through the existing `_private`
object so it can be tested as a plain string check without mocking the filesystem. Tests cover
single line, multi line, literal strings, a components array without rust-analyzer, a file with
no components key, and rust-analyzer appearing outside the array.

🤖 AI-assisted: writing the tests and assisting in the fix