### PR TITLE
fix: parse postfix range inside closure in access

### DIFF
--- a/crates/parser/src/grammar/expressions.rs
+++ b/crates/parser/src/grammar/expressions.rs
@@ -299,8 +299,16 @@ fn expr_bp(
             //     match 1.. { _ => () };
             //     match a.b()..S { _ => () };
             // }
+
+            // test closure_postfix_range_method_call
+            // fn foo() {
+            //     || 1.. .method();
+            //     || 1.. .field;
+            // }
+            let has_access_after = p.at(T![.]) && p.nth_at(1, SyntaxKind::IDENT);
+            let struct_forbidden = r.forbid_structs && p.at(T!['{']);
             let has_trailing_expression =
-                p.at_ts(EXPR_FIRST) && !(r.forbid_structs && p.at(T!['{']));
+                p.at_ts(EXPR_FIRST) && !has_access_after && !struct_forbidden;
             if !has_trailing_expression {
                 // no RHS
                 lhs = m.complete(p, RANGE_EXPR);
@@ -382,6 +390,7 @@ fn lhs(p: &mut Parser<'_>, r: Restrictions) -> Option<(CompletedMarker, BlockLik
                     // }
                     let has_access_after = p.at(T![.]) && p.nth_at(1, SyntaxKind::IDENT);
                     let struct_forbidden = r.forbid_structs && p.at(T!['{']);
+                    // NOTE: Similar logic `is_range` flag in expr_bp()
                     if p.at_ts(EXPR_FIRST) && !has_access_after && !struct_forbidden {
                         expr_bp(p, None, r, 2);
                     }

--- a/crates/parser/test_data/generated/runner.rs
+++ b/crates/parser/test_data/generated/runner.rs
@@ -121,6 +121,10 @@ mod ok {
         run_and_expect_no_errors("test_data/parser/inline/ok/closure_params.rs");
     }
     #[test]
+    fn closure_postfix_range_method_call() {
+        run_and_expect_no_errors("test_data/parser/inline/ok/closure_postfix_range_method_call.rs");
+    }
+    #[test]
     fn closure_range_method_call() {
         run_and_expect_no_errors("test_data/parser/inline/ok/closure_range_method_call.rs");
     }

--- a/crates/parser/test_data/parser/inline/ok/closure_postfix_range_method_call.rast
+++ b/crates/parser/test_data/parser/inline/ok/closure_postfix_range_method_call.rast
@@ -1,0 +1,53 @@
+SOURCE_FILE
+  FN
+    FN_KW "fn"
+    WHITESPACE " "
+    NAME
+      IDENT "foo"
+    PARAM_LIST
+      L_PAREN "("
+      R_PAREN ")"
+    WHITESPACE " "
+    BLOCK_EXPR
+      STMT_LIST
+        L_CURLY "{"
+        WHITESPACE "\n    "
+        EXPR_STMT
+          METHOD_CALL_EXPR
+            CLOSURE_EXPR
+              PARAM_LIST
+                PIPE "|"
+                PIPE "|"
+              WHITESPACE " "
+              RANGE_EXPR
+                LITERAL
+                  INT_NUMBER "1"
+                DOT2 ".."
+            WHITESPACE " "
+            DOT "."
+            NAME_REF
+              IDENT "method"
+            ARG_LIST
+              L_PAREN "("
+              R_PAREN ")"
+          SEMICOLON ";"
+        WHITESPACE "\n    "
+        EXPR_STMT
+          FIELD_EXPR
+            CLOSURE_EXPR
+              PARAM_LIST
+                PIPE "|"
+                PIPE "|"
+              WHITESPACE " "
+              RANGE_EXPR
+                LITERAL
+                  INT_NUMBER "1"
+                DOT2 ".."
+            WHITESPACE " "
+            DOT "."
+            NAME_REF
+              IDENT "field"
+          SEMICOLON ";"
+        WHITESPACE "\n"
+        R_CURLY "}"
+  WHITESPACE "\n"

--- a/crates/parser/test_data/parser/inline/ok/closure_postfix_range_method_call.rs
+++ b/crates/parser/test_data/parser/inline/ok/closure_postfix_range_method_call.rs
@@ -1,0 +1,4 @@
+fn foo() {
+    || 1.. .method();
+    || 1.. .field;
+}


### PR DESCRIPTION
Fixes rust-lang/rust-analyzer#22999

Example
---
**Before this PR**

```text
EXPR_STMT
  CLOSURE_EXPR
    PARAM_LIST
      PIPE "|"
      PIPE "|"
    RANGE_EXPR
      LITERAL
        INT_NUMBER "1"
      DOT2 ".."
      WHITESPACE " "
      ERROR
        DOT "."
EXPR_STMT
  CALL_EXPR
    PATH_EXPR
      PATH
        PATH_SEGMENT
          NAME_REF
            IDENT "method"
```

**After this PR**

```rust
METHOD_CALL_EXPR
  CLOSURE_EXPR
    PARAM_LIST
      PIPE "|"
      PIPE "|"
    RANGE_EXPR
      LITERAL
        INT_NUMBER "1"
      DOT2 ".."
  WHITESPACE " "
  DOT "."
  NAME_REF
    IDENT "method"
```
