### PR TITLE
minor: variant eval error use source instead of node debug

### DIFF
--- a/crates/ide/src/hover/render.rs
+++ b/crates/ide/src/hover/render.rs
@@ -509,7 +509,7 @@ pub(super) fn definition(
                         Some(if it >= 10 { format!("{it} ({it:#X})") } else { format!("{it}") })
                     }
                     Err(err) => {
-                        let res = it.value(db).map(|it| format!("{it:?}"));
+                        let res = it.value(db).map(|it| it.to_string());
                         if env::var_os("RA_DEV").is_some() {
                             let res = res.as_deref().unwrap_or("");
                             Some(format!(

--- a/crates/ide/src/hover/tests.rs
+++ b/crates/ide/src/hover/tests.rs
@@ -5620,6 +5620,30 @@ enum E {
             This is a doc
         "#]],
     );
+    // const eval failed test
+    check(
+        r#"
+#[repr(u8)]
+enum E {
+    A$0 = {},
+}
+"#,
+        expect![[r#"
+            *A*
+
+            ```rust
+            ra_test_fixture::E
+            ```
+
+            ```rust
+            A = {}
+            ```
+
+            ---
+
+            size = 1, align = 1, no Drop
+        "#]],
+    );
 }
 
 #[test]


### PR DESCRIPTION
Example
---
```rust
enum E { A$0 = {} }
```

**Before this PR**

```rust
A = BlockExpr(BlockExpr { syntax: BLOCK_EXPR@29..31 })
```

**After this PR**

```rust
A = {}
```
