### PR TITLE
minor: add tests for `ExprScopes` handling of exprs inside patterns

### DIFF
--- a/crates/hir-def/src/expr_store/scope.rs
+++ b/crates/hir-def/src/expr_store/scope.rs
@@ -822,4 +822,66 @@ fn test() {
             100,
         );
     }
+    #[test]
+    fn pattern_const_block_expressions_have_scopes() {
+        do_check(
+            r#"
+fn foo() {
+    match () {
+        const { |x: i32| { let y = x; $0 } } => (),
+    }
+}
+"#,
+            &["y", "x"],
+        );
+    }
+
+    #[test]
+    fn let_pattern_expr_scope() {
+        do_check(
+            r#"
+fn foo(param: usize) {
+    let local = 0;
+    let const { $0 } = ();
+}
+"#,
+            &["param"],
+        );
+    }
+
+    #[test]
+    fn closure_param_pattern_expr_scope() {
+        do_check(
+            r#"
+fn foo(param: usize) {
+    let local = 0;
+    let _ = |const { $0 }: ()| ();
+}
+"#,
+            &["param"],
+        );
+    }
+
+    #[test]
+    fn fn_param_pattern_expr_scope() {
+        do_check(
+            r#"
+fn foo(param: usize, const { $0 }: ()) {}
+"#,
+            &["param"],
+        );
+    }
+
+    #[test]
+    fn if_let_pattern_expr_scope() {
+        do_check(
+            r#"
+fn foo(param: usize) {
+    let local = 0;
+    if let const { $0 } = () {}
+}
+"#,
+            &["param"],
+        );
+    }
 }

--- a/crates/hir-ty/src/tests/regression.rs
+++ b/crates/hir-ty/src/tests/regression.rs
@@ -3094,3 +3094,19 @@ fn f() -> impl Sized {
     "#,
     );
 }
+
+#[test]
+fn regression_22836() {
+    check(
+        r#"
+fn main() {
+  match () {
+    const {
+      async | v | ()
+   // ^^^^^^^^^^^^^^ expected (), got impl AsyncFn({unknown})
+    }
+  }
+}
+    "#,
+    );
+}


### PR DESCRIPTION
Closes rust-lang/rust-analyzer#22836

Tests for the fix in rust-lang/rust-analyzer#23008. The hir-ty test is the recovered async closure from the issue, and the scope tests cover an expression nested in each binding pattern position.

---

The broken code gets recovered into a match whose arm pattern is a const block containing an async closure, and closure analysis panics resolving the synthetic `let v = v;` that the coroutine desugaring generates: the path has no scope.

`ExprScopes` registers a pattern's bindings with `add_pat_bindings()`, which walks child patterns only, so expressions nested in a binding pattern never got scope entries and locals inside them cannot resolve.

🤖 AI-assisted: understanding the issue, locating the cause, and writing the test.