### PR TITLE
fix: Fix `ExprScopes` handling of exprs inside patterns

### DIFF
--- a/crates/hir-def/src/expr_store.rs
+++ b/crates/hir-def/src/expr_store.rs
@@ -613,8 +613,10 @@ impl ExpressionStore {
                 visitor.on_expr_opt(*start);
                 visitor.on_expr_opt(*end);
             }
-            Pat::Lit(expr) | Pat::ConstBlock(expr) | Pat::Expr(expr) => visitor.on_expr(*expr),
-            Pat::Path(_) | Pat::Wild | Pat::Missing | Pat::Rest | Pat::NotNull => {}
+            Pat::Lit(expr) | Pat::Expr(expr) => visitor.on_expr(*expr),
+            Pat::ConstBlock(expr) => visitor.on_anon_const_expr(*expr),
+            Pat::Path(path) => visitor.on_path(path),
+            Pat::Wild | Pat::Missing | Pat::Rest | Pat::NotNull => {}
             &Pat::Bind { subpat, id: _ } => visitor.on_pat_opt(subpat),
             Pat::Or(args) | Pat::Tuple { args, ellipsis: _ } => visitor.on_pats(args),
             Pat::TupleStruct { args, ellipsis: _, path } => {

--- a/crates/hir-def/src/expr_store/scope.rs
+++ b/crates/hir-def/src/expr_store/scope.rs
@@ -168,9 +168,10 @@ impl ExprScopes {
         if let Some(Param { formal: self_param, user_written: _ }) = body.self_param {
             scopes.add_bindings(body, root, self_param, body.binding_hygiene(self_param));
         }
-        body.params.iter().for_each(|param| scopes.add_pat_bindings(body, root, param.formal));
-        ExprScopeVisitor { store: body, scopes: &mut scopes, scope: root, const_scope: root }
-            .on_expr(body.root_expr());
+        let mut visitor =
+            ExprScopeVisitor { store: body, scopes: &mut scopes, scope: root, const_scope: root };
+        body.params.iter().for_each(|param| visitor.on_pat(param.formal));
+        visitor.on_expr(body.root_expr());
         scopes
     }
 
@@ -258,15 +259,6 @@ impl ExprScopes {
             IdxRange::new_inclusive(self.scopes[scope].entries.start()..=entry);
     }
 
-    fn add_pat_bindings(&mut self, store: &ExpressionStore, scope: ScopeId, pat: PatId) {
-        let pattern = &store[pat];
-        if let Pat::Bind { id, .. } = *pattern {
-            self.add_bindings(store, scope, id, store.binding_hygiene(id));
-        }
-
-        pattern.walk_child_pats(|pat| self.add_pat_bindings(store, scope, pat));
-    }
-
     fn set_scope(&mut self, node: ExprId, scope: ScopeId) {
         self.scope_by_expr.insert(node, scope);
     }
@@ -321,7 +313,7 @@ impl ExprScopeVisitor<'_> {
                         this.on_expr_opt(*initializer);
                         this.on_expr_opt(*else_branch);
                         this.scope = this.scopes.new_scope(this.scope);
-                        this.scopes.add_pat_bindings(this.store, this.scope, *pat);
+                        this.on_pat(*pat);
                     }
                     Statement::Expr { expr, has_semi: _ } => this.on_expr(*expr),
                     Statement::Item(Item::MacroDef(macro_id)) => {
@@ -355,21 +347,21 @@ impl StoreVisitor for ExprScopeVisitor<'_> {
                 self.with_scope(scope, |this| this.on_expr(*body));
             }
             Expr::Closure { args, arg_types, ret_type, body, capture_by: _, closure_kind: _ } => {
-                arg_types.iter().flatten().for_each(|type_ref| self.on_type(*type_ref));
+                arg_types.iter().for_each(|type_ref| self.on_type_opt(*type_ref));
                 self.on_type_opt(*ret_type);
                 let scope = self.scopes.new_scope(self.scope);
-                args.iter().for_each(|arg| self.scopes.add_pat_bindings(self.store, scope, *arg));
-                self.with_scope(scope, |this| this.on_expr(*body));
+                self.with_scope(scope, |this| {
+                    this.on_pats(args);
+                    this.on_expr(*body);
+                });
             }
             Expr::Match { expr, arms } => {
                 self.on_expr(*expr);
                 for arm in arms.iter() {
                     let scope = self.scopes.new_scope(self.scope);
                     self.with_scope(scope, |this| {
-                        this.scopes.add_pat_bindings(this.store, scope, arm.pat);
-                        if let Some(guard) = arm.guard {
-                            this.on_expr(guard);
-                        }
+                        this.on_pat(arm.pat);
+                        this.on_expr_opt(arm.guard);
                         this.on_expr(arm.expr);
                     });
                 }
@@ -385,9 +377,9 @@ impl StoreVisitor for ExprScopeVisitor<'_> {
             &Expr::Let { pat, expr } => {
                 self.on_expr(expr);
                 self.scope = self.scopes.new_scope(self.scope);
-                self.scopes.add_pat_bindings(self.store, self.scope, pat);
+                self.on_pat(pat);
             }
-            _ => self.store.visit_expr_children(expr, &mut *self),
+            _ => self.store.visit_expr_children(expr, self),
         }
     }
 
@@ -396,6 +388,10 @@ impl StoreVisitor for ExprScopeVisitor<'_> {
     }
 
     fn on_pat(&mut self, pat: PatId) {
+        if let Pat::Bind { id, .. } = self.store[pat] {
+            self.scopes.add_bindings(self.store, self.scope, id, self.store.binding_hygiene(id));
+        }
+
         self.store.visit_pat_children(pat, self);
     }
 


### PR DESCRIPTION
Visit them in the visitor.

Also fix some missing things in the visiting infra.

Thanks to @shulaoda for discovering this bug in https://github.com/rust-lang/rust-analyzer/pull/23007.