### PR TITLE
fix: no `unused_variable` diagnostic for never-type locals

### DIFF
--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -2141,7 +2141,7 @@ impl DefWithBody {
                         // We should report specific diagnostics for these problems, not `need-mut` and `unused-mut`.
                         continue;
                     }
-                    let Some(&local) = mir_body.binding_locals.get(binding_id) else {
+                    let Some(&mir_local) = mir_body.binding_locals.get(binding_id) else {
                         continue;
                     };
                     if source_map
@@ -2152,7 +2152,7 @@ impl DefWithBody {
                         // Skip synthetic bindings
                         continue;
                     }
-                    let mut need_mut = &mol[local];
+                    let mut need_mut = &mol[mir_local];
                     if body[binding_id].name == sym::self_
                         && need_mut == &mir::MutabilityReason::Unused
                     {
@@ -2164,7 +2164,8 @@ impl DefWithBody {
 
                     match (need_mut, is_mut) {
                         (mir::MutabilityReason::Unused, _) => {
-                            let should_ignore = body[binding_id].name.as_str().starts_with('_');
+                            let should_ignore = body[binding_id].name.as_str().starts_with('_')
+                                || mir_body.locals[mir_local].ty.as_ref().is_never();
                             if !should_ignore {
                                 acc.push(UnusedVariable { local }.into())
                             }

--- a/crates/ide-diagnostics/src/handlers/type_must_be_known.rs
+++ b/crates/ide-diagnostics/src/handlers/type_must_be_known.rs
@@ -64,11 +64,9 @@ mod tests {
             r#"
 fn foo() {
     let var = loop {};
-     // ^^^ 💡 warn: unused variable
     var();
  // ^^^ error: type annotations needed; type must be known at this point
     let var = loop {};
-     // ^^^ 💡 warn: unused variable
     var[0];
  // ^^^ error: type annotations needed; type must be known at this point
 }

--- a/crates/ide-diagnostics/src/handlers/unused_variables.rs
+++ b/crates/ide-diagnostics/src/handlers/unused_variables.rs
@@ -417,4 +417,18 @@ fn main() {
 "#,
         );
     }
+
+    #[test]
+    fn no_unused_variable_for_never_type() {
+        // Variables of type `!` are unreachable; their usages never appear in MIR.
+        // Emitting `unused_variable` for them is a false positive (issue #22975).
+        check_diagnostics(
+            r#"
+fn main() {
+    let foo = loop {};
+    _ = foo;
+}
+"#,
+        );
+    }
 }


### PR DESCRIPTION
fixes https://github.com/rust-lang/rust-analyzer/issues/22975