### PR TITLE
Allow `self` as the last segment of a path

### DIFF
--- a/crates/hir-def/src/nameres/tests/imports.rs
+++ b/crates/hir-def/src/nameres/tests/imports.rs
@@ -41,6 +41,26 @@ mod foo {
 }
 
 #[test]
+fn trailing_self_import() {
+    check(
+        r#"
+mod fmt {
+    pub struct Thing;
+}
+pub use fmt::self as alias;
+"#,
+        expect![[r#"
+            crate
+            - alias : type (import)
+            - fmt : type
+
+            crate::fmt
+            - Thing : type value
+        "#]],
+    );
+}
+
+#[test]
 fn primitive_reexport() {
     check(
         r#"

--- a/crates/hir-expand/src/mod_path.rs
+++ b/crates/hir-expand/src/mod_path.rs
@@ -315,6 +315,7 @@ fn convert_path(
     for segment in segments {
         let name = match segment.kind()? {
             ast::PathSegmentKind::Name(name) => name.as_name(),
+            ast::PathSegmentKind::SelfKw => continue,
             _ => return None,
         };
         mod_path.segments.push(name);

--- a/crates/syntax/src/validation.rs
+++ b/crates/syntax/src/validation.rs
@@ -285,11 +285,11 @@ fn validate_range_expr(expr: ast::RangeExpr, errors: &mut Vec<SyntaxError>) {
 fn validate_path_keywords(segment: ast::PathSegment, errors: &mut Vec<SyntaxError>) {
     let path = segment.parent_path();
     let is_path_start = segment.coloncolon_token().is_none() && path.qualifier().is_none();
-
     if let Some(token) = segment.self_token() {
-        if !is_path_start {
+        let is_last_segment = path.parent_path().is_none();
+        if !is_path_start && !is_last_segment {
             errors.push(SyntaxError::new(
-                "The `self` keyword is only allowed as the first segment of a path",
+                "The `self` keyword is only allowed at the start or at the end of a path",
                 token.text_range(),
             ));
         }

--- a/crates/syntax/test_data/parser/validation/0041_illegal_self_keyword_location.rast
+++ b/crates/syntax/test_data/parser/validation/0041_illegal_self_keyword_location.rast
@@ -1,4 +1,4 @@
-SOURCE_FILE@0..25
+SOURCE_FILE@0..28
   USE@0..11
     USE_KW@0..3 "use"
     WHITESPACE@3..4 " "
@@ -10,20 +10,24 @@ SOURCE_FILE@0..25
             SELF_KW@6..10 "self"
     SEMICOLON@10..11 ";"
   WHITESPACE@11..12 "\n"
-  USE@12..24
+  USE@12..27
     USE_KW@12..15 "use"
     WHITESPACE@15..16 " "
-    USE_TREE@16..23
-      PATH@16..23
-        PATH@16..17
-          PATH_SEGMENT@16..17
-            NAME_REF@16..17
-              IDENT@16..17 "a"
-        COLON2@17..19 "::"
-        PATH_SEGMENT@19..23
-          NAME_REF@19..23
-            SELF_KW@19..23 "self"
-    SEMICOLON@23..24 ";"
-  WHITESPACE@24..25 "\n"
-error 6..10: The `self` keyword is only allowed as the first segment of a path
-error 19..23: The `self` keyword is only allowed as the first segment of a path
+    USE_TREE@16..26
+      PATH@16..26
+        PATH@16..23
+          PATH@16..17
+            PATH_SEGMENT@16..17
+              NAME_REF@16..17
+                IDENT@16..17 "a"
+          COLON2@17..19 "::"
+          PATH_SEGMENT@19..23
+            NAME_REF@19..23
+              SELF_KW@19..23 "self"
+        COLON2@23..25 "::"
+        PATH_SEGMENT@25..26
+          NAME_REF@25..26
+            IDENT@25..26 "b"
+    SEMICOLON@26..27 ";"
+  WHITESPACE@27..28 "\n"
+error 19..23: The `self` keyword is only allowed at the start or at the end of a path

--- a/crates/syntax/test_data/parser/validation/0041_illegal_self_keyword_location.rs
+++ b/crates/syntax/test_data/parser/validation/0041_illegal_self_keyword_location.rs
@@ -1,2 +1,2 @@
 use ::self;
-use a::self;
+use a::self::b;


### PR DESCRIPTION
Closes rust-lang/rust-analyzer#23000.