### PR TITLE
fix: exclude unknown types from term search

### DIFF
--- a/crates/hir/src/term_search/tactics.rs
+++ b/crates/hir/src/term_search/tactics.rs
@@ -72,6 +72,10 @@ pub(super) fn trivial<'a, 'lt, 'db, DB: HirDatabase>(
         }?;
 
         let ty = expr.ty(db);
+        if ty.contains_unknown() {
+            return None;
+        }
+
         lookup.insert(ty.clone(), std::iter::once(expr.clone()));
 
         // Don't suggest local references as they are not valid for return

--- a/crates/ide-assists/src/handlers/term_search.rs
+++ b/crates/ide-assists/src/handlers/term_search.rs
@@ -82,9 +82,7 @@ pub(crate) fn term_search(acc: &mut Assists, ctx: &AssistContext<'_, '_>) -> Opt
 
 #[cfg(test)]
 mod tests {
-    use crate::tests::{
-        check_assist, check_assist_not_applicable, check_assist_not_applicable_by_label,
-    };
+    use crate::tests::{check_assist, check_assist_not_applicable};
 
     use super::*;
 
@@ -96,21 +94,6 @@ mod tests {
 fn f() { let a: u128 = 1; let b: u128 = todo$0!() }"#,
             r#"fn f() { let a: u128 = 1; let b: u128 = a }"#,
         )
-    }
-
-    #[test]
-    fn test_ignore_unknown_type() {
-        check_assist_not_applicable_by_label(
-            term_search,
-            r#"
-//- minicore: todo, unimplemented
-fn f() {
-    let unknown;
-    let _: i32 = todo$0!();
-}
-"#,
-            "Replace todo!() with unknown",
-        );
     }
 
     #[test]

--- a/crates/ide-assists/src/handlers/term_search.rs
+++ b/crates/ide-assists/src/handlers/term_search.rs
@@ -82,7 +82,9 @@ pub(crate) fn term_search(acc: &mut Assists, ctx: &AssistContext<'_, '_>) -> Opt
 
 #[cfg(test)]
 mod tests {
-    use crate::tests::{check_assist, check_assist_not_applicable};
+    use crate::tests::{
+        check_assist, check_assist_not_applicable, check_assist_not_applicable_by_label,
+    };
 
     use super::*;
 
@@ -94,6 +96,21 @@ mod tests {
 fn f() { let a: u128 = 1; let b: u128 = todo$0!() }"#,
             r#"fn f() { let a: u128 = 1; let b: u128 = a }"#,
         )
+    }
+
+    #[test]
+    fn test_ignore_unknown_type() {
+        check_assist_not_applicable_by_label(
+            term_search,
+            r#"
+//- minicore: todo, unimplemented
+fn f() {
+    let unknown;
+    let _: i32 = todo$0!();
+}
+"#,
+            "Replace todo!() with unknown",
+        );
     }
 
     #[test]

--- a/crates/ide-assists/src/tests.rs
+++ b/crates/ide-assists/src/tests.rs
@@ -500,6 +500,35 @@ pub fn test_some_range(a: int) -> bool {
 }
 
 #[test]
+fn assist_order_term_search_unknown_type() {
+    let (db, frange) = RootDatabase::with_range(
+        r#"
+//- minicore: todo, unimplemented
+fn foo(_: u32) -> i32 { 2 }
+fn main() {
+    let unknown;
+    let _: i32 = $0todo!()$0;
+}
+"#,
+    );
+
+    let assists = assists(
+        &db,
+        &TEST_CONFIG,
+        AssistResolveStrategy::None,
+        FileRange { file_id: frange.file_id.file_id(&db), range: frange.range },
+    );
+    let expected = labels(&assists);
+
+    expect![[r#"
+        Inline macro
+        Extract into...
+        Extract Module
+    "#]]
+    .assert_eq(&expected);
+}
+
+#[test]
 fn assist_filter_works() {
     let (db, frange) = RootDatabase::with_range(
         r#"

--- a/crates/ide-completion/src/render.rs
+++ b/crates/ide-completion/src/render.rs
@@ -3226,9 +3226,7 @@ fn main() {
     foo($0);
 }
             "#,
-            // FIXME: term_search exclude ssss.0 (field.ty().is_unknown())
             expect![[r#"
-                ex ssss.0  [type_could_unify]
                 lc ssss S<{unknown}> [local]
                 st S S<T> []
                 md core::  []


### PR DESCRIPTION
fixes rust-lang/rust-analyzer#22995