### PR TITLE
fix: avoid array len type mismatch with string panic

### DIFF
--- a/crates/hir-ty/src/consteval.rs
+++ b/crates/hir-ty/src/consteval.rs
@@ -17,7 +17,6 @@ use rustc_apfloat::Float;
 use rustc_ast_ir::Mutability;
 use rustc_type_ir::inherent::{Const as _, GenericArgs as _, IntoKind, Ty as _};
 use salsa::SalsaValue;
-use stdx::never;
 
 use crate::{
     ParamEnvAndCrate, Span,
@@ -121,7 +120,9 @@ fn intern_const_ref<'db>(
             let scalar = ScalarInt::try_from_uint(value, size).unwrap();
             ValTreeKind::Leaf(scalar)
         }
-        (_, Literal::String(value)) => {
+        (TyKind::Ref(_, inner_ty, _), Literal::String(value))
+            if matches!(inner_ty.kind(), TyKind::Str) =>
+        {
             let u8_values = &interner.default_types().consts.u8_values;
             ValTreeKind::Branch(Consts::new_from_iter(
                 interner,
@@ -140,7 +141,6 @@ fn intern_const_ref<'db>(
             return Ok(Const::error(interner));
         }
         _ => {
-            never!("mismatching type for literal");
             let actual = literal_ty(
                 interner,
                 value,

--- a/crates/hir-ty/src/tests/regression/new_solver.rs
+++ b/crates/hir-ty/src/tests/regression/new_solver.rs
@@ -1,5 +1,5 @@
 use expect_test::expect;
-use hir_def::ModuleDefId;
+use hir_def::{AdtId, ModuleDefId};
 use rustc_type_ir::inherent::IntoKind as _;
 use test_fixture::WithFixture;
 
@@ -421,6 +421,41 @@ fn oversized_array_len_does_not_panic() {
 fn f(_: [u8; 18446744073709551616]) {}
     "#,
     );
+}
+
+#[test]
+fn invalid_string_array_len_is_error() {
+    let (db, file_id) = TestDB::with_single_file(
+        r#"
+pub union U {
+    foo: [usize; ""],
+}
+"#,
+    );
+
+    crate::attach_db(&db, || {
+        let module_id = db.module_for_file(file_id.file_id(&db));
+        let def_map = module_id.def_map(&db);
+        let union_id = def_map[module_id]
+            .scope
+            .declarations()
+            .find_map(|decl| match decl {
+                ModuleDefId::AdtId(AdtId::UnionId(id)) => Some(id),
+                _ => None,
+            })
+            .unwrap();
+        let field_ty = db
+            .field_types(union_id.into())
+            .iter()
+            .next()
+            .unwrap()
+            .1
+            .ty()
+            .instantiate_identity()
+            .skip_norm_wip();
+        let TyKind::Array(_, len) = field_ty.kind() else { unreachable!() };
+        assert!(len.is_error());
+    });
 }
 
 #[test]


### PR DESCRIPTION
fixes rust-lang/rust-analyzer#22955
the root cause is that in function `intern_const_ref` when value is `Literal::String`, it builds `ValTreeKind::Branch` without checking the typekind (like `TyKind::Uint`), 
and in function `render_const_scalar_from_valtree_inner` it calls function `to_leaf`.
`to_leaf` panics on the `ValTreeKind::Branch`.

I modify the condition so we only build `ValTreeKind::Branch` when the type is compatible.
but now it can reach the `never!` stmtment which cause panic again.
I remove the stmtent and I wonder the remove is suitable or not.
