### PR TITLE
fixed positive diagnostic for valid code

### DIFF
--- a/crates/syntax/src/validation/block.rs
+++ b/crates/syntax/src/validation/block.rs
@@ -9,7 +9,9 @@ use crate::{
 pub(crate) fn validate_block_expr(block: ast::BlockExpr, errors: &mut Vec<SyntaxError>) {
     if let Some(parent) = block.syntax().parent() {
         match parent.kind() {
-            FN | EXPR_STMT | STMT_LIST | MACRO_STMTS => return,
+            FN | EXPR_STMT | STMT_LIST | MACRO_STMTS | LOOP_EXPR | WHILE_EXPR | FOR_EXPR => {
+                return;
+            }
             _ => {}
         }
     }

--- a/crates/syntax/test_data/parser/validation/0031_block_inner_attrs.rast
+++ b/crates/syntax/test_data/parser/validation/0031_block_inner_attrs.rast
@@ -1,5 +1,5 @@
-SOURCE_FILE@0..350
-  FN@0..349
+SOURCE_FILE@0..611
+  FN@0..610
     FN_KW@0..2 "fn"
     WHITESPACE@2..3 " "
     NAME@3..8
@@ -8,8 +8,8 @@ SOURCE_FILE@0..350
       L_PAREN@8..9 "("
       R_PAREN@9..10 ")"
     WHITESPACE@10..11 " "
-    BLOCK_EXPR@11..349
-      STMT_LIST@11..349
+    BLOCK_EXPR@11..610
+      STMT_LIST@11..610
         L_CURLY@11..12 "{"
         WHITESPACE@12..17 "\n    "
         LET_STMT@17..129
@@ -90,38 +90,103 @@ SOURCE_FILE@0..350
                 WHITESPACE@251..256 "\n    "
                 R_CURLY@256..257 "}"
         WHITESPACE@257..262 "\n    "
-        WHILE_EXPR@262..347
-          WHILE_KW@262..267 "while"
-          WHITESPACE@267..268 " "
-          LITERAL@268..272
-            TRUE_KW@268..272 "true"
-          WHITESPACE@272..273 " "
-          BLOCK_EXPR@273..347
-            STMT_LIST@273..347
-              L_CURLY@273..274 "{"
-              WHITESPACE@274..283 "\n        "
-              ATTR@283..302
-                POUND@283..284 "#"
-                BANG@284..285 "!"
-                L_BRACK@285..286 "["
-                TOKEN_TREE_META@286..301
-                  PATH@286..289
-                    PATH_SEGMENT@286..289
-                      NAME_REF@286..289
-                        IDENT@286..289 "doc"
-                  TOKEN_TREE@289..301
-                    L_PAREN@289..290 "("
-                    STRING@290..300 "\"Nor here\""
-                    R_PAREN@300..301 ")"
-                R_BRACK@301..302 "]"
-              WHITESPACE@302..311 "\n        "
-              COMMENT@311..341 "//! Nor are ModuleDoc ..."
-              WHITESPACE@341..346 "\n    "
-              R_CURLY@346..347 "}"
-        WHITESPACE@347..348 "\n"
-        R_CURLY@348..349 "}"
-  WHITESPACE@349..350 "\n"
+        EXPR_STMT@262..347
+          WHILE_EXPR@262..347
+            WHILE_KW@262..267 "while"
+            WHITESPACE@267..268 " "
+            LITERAL@268..272
+              TRUE_KW@268..272 "true"
+            WHITESPACE@272..273 " "
+            BLOCK_EXPR@273..347
+              STMT_LIST@273..347
+                L_CURLY@273..274 "{"
+                WHITESPACE@274..283 "\n        "
+                ATTR@283..302
+                  POUND@283..284 "#"
+                  BANG@284..285 "!"
+                  L_BRACK@285..286 "["
+                  TOKEN_TREE_META@286..301
+                    PATH@286..289
+                      PATH_SEGMENT@286..289
+                        NAME_REF@286..289
+                          IDENT@286..289 "doc"
+                    TOKEN_TREE@289..301
+                      L_PAREN@289..290 "("
+                      STRING@290..300 "\"Nor here\""
+                      R_PAREN@300..301 ")"
+                  R_BRACK@301..302 "]"
+                WHITESPACE@302..311 "\n        "
+                COMMENT@311..341 "//! Nor are ModuleDoc ..."
+                WHITESPACE@341..346 "\n    "
+                R_CURLY@346..347 "}"
+        WHITESPACE@347..353 "\n     "
+        EXPR_STMT@353..474
+          LOOP_EXPR@353..474
+            LOOP_KW@353..357 "loop"
+            WHITESPACE@357..358 " "
+            BLOCK_EXPR@358..474
+              STMT_LIST@358..474
+                L_CURLY@358..359 "{"
+                WHITESPACE@359..368 "\n        "
+                ATTR@368..430
+                  POUND@368..369 "#"
+                  BANG@369..370 "!"
+                  L_BRACK@370..371 "["
+                  TOKEN_TREE_META@371..429
+                    PATH@371..374
+                      PATH_SEGMENT@371..374
+                        NAME_REF@371..374
+                          IDENT@371..374 "doc"
+                    TOKEN_TREE@374..429
+                      L_PAREN@374..375 "("
+                      STRING@375..428 "\"This is fine, `loop` ..."
+                      R_PAREN@428..429 ")"
+                  R_BRACK@429..430 "]"
+                WHITESPACE@430..439 "\n        "
+                COMMENT@439..468 "//! So are ModuleDoc  ..."
+                WHITESPACE@468..473 "\n    "
+                R_CURLY@473..474 "}"
+        WHITESPACE@474..479 "\n    "
+        FOR_EXPR@479..608
+          FOR_KW@479..482 "for"
+          WHITESPACE@482..483 " "
+          WILDCARD_PAT@483..484
+            UNDERSCORE@483..484 "_"
+          WHITESPACE@484..485 " "
+          IN_KW@485..487 "in"
+          WHITESPACE@487..488 " "
+          RANGE_EXPR@488..492
+            LITERAL@488..489
+              INT_NUMBER@488..489 "0"
+            DOT2@489..491 ".."
+            LITERAL@491..492
+              INT_NUMBER@491..492 "1"
+          WHITESPACE@492..493 " "
+          BLOCK_EXPR@493..608
+            STMT_LIST@493..608
+              L_CURLY@493..494 "{"
+              WHITESPACE@494..503 "\n        "
+              ATTR@503..564
+                POUND@503..504 "#"
+                BANG@504..505 "!"
+                L_BRACK@505..506 "["
+                TOKEN_TREE_META@506..563
+                  PATH@506..509
+                    PATH_SEGMENT@506..509
+                      NAME_REF@506..509
+                        IDENT@506..509 "doc"
+                  TOKEN_TREE@509..563
+                    L_PAREN@509..510 "("
+                    STRING@510..562 "\"This is fine, `for`  ..."
+                    R_PAREN@562..563 ")"
+                R_BRACK@563..564 "]"
+              WHITESPACE@564..573 "\n        "
+              COMMENT@573..602 "//! So are ModuleDoc  ..."
+              WHITESPACE@602..607 "\n    "
+              R_CURLY@607..608 "}"
+        WHITESPACE@608..609 "\n"
+        R_CURLY@609..610 "}"
+  WHITESPACE@610..611 "\n"
 error 39..83: A block in this position cannot accept inner attributes
 error 152..171: A block in this position cannot accept inner attributes
 error 180..212: A block in this position cannot accept inner attributes
-error 283..302: A block in this position cannot accept inner attributes

--- a/crates/syntax/test_data/parser/validation/0031_block_inner_attrs.rs
+++ b/crates/syntax/test_data/parser/validation/0031_block_inner_attrs.rs
@@ -12,4 +12,12 @@ fn block() {
         #![doc("Nor here")]
         //! Nor are ModuleDoc comments
     }
+     loop {
+        #![doc("This is fine, `loop` bodies accept inner attributes")]
+        //! So are ModuleDoc comments
+    }
+    for _ in 0..1 {
+        #![doc("This is fine, `for` bodies accept inner attributes")]
+        //! So are ModuleDoc comments
+    }
 }


### PR DESCRIPTION
Validation in "crates/syntax/src/validation/block.rs" checks the block's parent "SyntaxKind" to decide whether inner attributes are allowed. LOOP_EXPR, WHILE_EXPR, and FOR_EXPR were missing from the allow-list, causing the false positive diagnostic for valid code example below:

fn main() {
    loop {
        #![doc = ""]
    }
}

Where as rustc accepts inner attributes on loop,while and for loops.

Fixes rust-lang/rust-analyzer#22989 