### PR TITLE
return both matching braces

### DIFF
--- a/crates/ide/src/lib.rs
+++ b/crates/ide/src/lib.rs
@@ -385,7 +385,10 @@ impl Analysis {
 
     /// Returns position of the matching brace (all types of braces are
     /// supported).
-    pub fn matching_brace(&self, position: FilePosition) -> Cancellable<Option<TextSize>> {
+    pub fn matching_brace(
+        &self,
+        position: FilePosition,
+    ) -> Cancellable<Option<(TextSize, TextSize)>> {
         self.with_db(|db| {
             let file_id = EditionedFileId::current_edition(&self.db, position.file_id);
             let parse = file_id.parse(db);

--- a/crates/ide/src/matching_brace.rs
+++ b/crates/ide/src/matching_brace.rs
@@ -14,7 +14,7 @@ use syntax::{
 // | VS Code | **rust-analyzer: Find matching brace** |
 //
 // ![Matching Brace](https://user-images.githubusercontent.com/48062697/113065573-04298180-91b1-11eb-8dec-d4e2a202f304.gif)
-pub(crate) fn matching_brace(file: &SourceFile, offset: TextSize) -> Option<TextSize> {
+pub(crate) fn matching_brace(file: &SourceFile, offset: TextSize) -> Option<(TextSize, TextSize)> {
     const BRACES: &[SyntaxKind] =
         &[T!['{'], T!['}'], T!['['], T![']'], T!['('], T![')'], T![<], T![>], T![|], T![|]];
     let current = file.syntax().token_at_offset(offset);
@@ -36,16 +36,17 @@ pub(crate) fn matching_brace(file: &SourceFile, offset: TextSize) -> Option<Text
             .children_with_tokens()
             .filter_map(|it| it.into_token())
             .find(|node| node.kind() == matching_kind && node != &brace_token)?;
-        Some(matching_node.text_range().start())
+        Some((offset, matching_node.text_range().start()))
     } else {
         // when the offset is not at a brace, find first parent
         current.last()?.parent_ancestors().find_map(|x| {
-            x.children_with_tokens()
+            let mut i = x
+                .children_with_tokens()
                 .filter_map(|it| it.into_token())
                 // with ending brace
                 .filter(|node| BRACES.contains(&node.kind()))
-                .last()
-                .map(|x| x.text_range().start())
+                .map(|x| x.text_range().start());
+            i.next().zip(i.last())
         })
     }
 }
@@ -63,7 +64,7 @@ mod tests {
             let parse = SourceFile::parse(&before, span::Edition::CURRENT);
             let new_pos = match matching_brace(&parse.tree(), pos) {
                 None => pos,
-                Some(pos) => pos,
+                Some(pos) => pos.1,
             };
             let actual = add_cursor(&before, new_pos);
             assert_eq_text!(after, &actual);

--- a/crates/rust-analyzer/src/handlers/request.rs
+++ b/crates/rust-analyzer/src/handlers/request.rs
@@ -396,7 +396,7 @@ pub(crate) fn handle_selection_range(
 pub(crate) fn handle_matching_brace(
     snap: GlobalStateSnapshot,
     params: lsp_ext::MatchingBraceParams,
-) -> anyhow::Result<Vec<Position>> {
+) -> anyhow::Result<Vec<[Position; 2]>> {
     let _p = tracing::info_span!("handle_matching_brace").entered();
     let file_id = try_default!(from_proto::file_id(&snap, &params.text_document.uri)?);
     let line_index = snap.file_line_index(file_id)?;
@@ -407,10 +407,10 @@ pub(crate) fn handle_matching_brace(
             let offset = from_proto::offset(&line_index, *position);
             offset.map(|offset| {
                 let offset = match snap.analysis.matching_brace(FilePosition { file_id, offset }) {
-                    Ok(Some(matching_brace_offset)) => matching_brace_offset,
-                    Err(_) | Ok(None) => offset,
+                    Ok(Some(matching_brace_offset)) => matching_brace_offset.into(),
+                    Err(_) | Ok(None) => [offset; 2],
                 };
-                to_proto::position(&line_index, offset)
+                offset.map(|offset| to_proto::position(&line_index, offset))
             })
         })
         .collect()

--- a/crates/rust-analyzer/src/lsp/ext.rs
+++ b/crates/rust-analyzer/src/lsp/ext.rs
@@ -415,7 +415,7 @@ pub enum MatchingBraceRequest {}
 
 impl Request for MatchingBraceRequest {
     type Params = MatchingBraceParams;
-    type Result = Vec<Position>;
+    type Result = Vec<[Position; 2]>;
     const METHOD: LspRequestMethod<'_> = LspRequestMethod::new("experimental/matchingBrace");
     const MESSAGE_DIRECTION: MessageDirection = MessageDirection::ClientToServer;
 }

--- a/docs/book/src/contributing/lsp-extensions.md
+++ b/docs/book/src/contributing/lsp-extensions.md
@@ -1,5 +1,5 @@
 <!---
-lsp/ext.rs hash: 98191ad3d886c851
+lsp/ext.rs hash: e88fcb21364c77f1
 
 If you need to change the above hash to make the test pass, please check if you
 need to adjust this doc as well and ping this issue:
@@ -316,7 +316,7 @@ interface MatchingBraceParams {
 **Response:**
 
 ```typescript
-Position[]
+Position[2][]
 ```
 
 ### Example


### PR DESCRIPTION
so, this is technically the same behavior as simply calling a matching brace on the result of itself, but it saves a request, and the result is trivially computable, so you may as well return both? this makes it trivial to implement "remove brackets" behavior.
