### PR TITLE
fix: account for trailing line continuations in byte strings

### DIFF
--- a/crates/hir-ty/src/tests/regression.rs
+++ b/crates/hir-ty/src/tests/regression.rs
@@ -3110,3 +3110,15 @@ fn main() {
     "#,
     );
 }
+
+#[test]
+fn regression_22986() {
+    check_no_mismatches(
+        r#"
+fn main() {
+    let _: &[u8; 0] = b"\
+        ";
+}
+    "#,
+    );
+}

--- a/crates/syntax/src/ast/token_ext.rs
+++ b/crates/syntax/src/ast/token_ext.rs
@@ -295,7 +295,7 @@ impl ast::ByteString {
 
         match (has_error, buf.capacity() == 0) {
             (Some(e), _) => Err(e),
-            (None, true) => Ok(Cow::Borrowed(text.as_bytes())),
+            (None, true) => Ok(Cow::Borrowed(&text.as_bytes()[..prev_end])),
             (None, false) => Ok(Cow::Owned(buf)),
         }
     }
@@ -650,6 +650,10 @@ bcde", "abcde",
         check_byte_string_value(
             r"a\
 bcde", b"abcde",
+        );
+        check_byte_string_value(
+            r"\
+    ", b"",
         );
     }
 


### PR DESCRIPTION
fix rust-lang/rust-analyzer#22986