### PR TITLE
remove deprecated authors field from package manifests

### DIFF
--- a/lib/smol_str/Cargo.toml
+++ b/lib/smol_str/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.3.6"
 description = "small-string optimized string type with O(1) clone"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/rust-analyzer/tree/master/lib/smol_str"
-authors = ["Aleksey Kladov <aleksey.kladov@gmail.com>", "Lukas Wirth <lukastw97@gmail.com>"]
 edition = "2024"
 rust-version = "1.89"
 

--- a/lib/text-size/Cargo.toml
+++ b/lib/text-size/Cargo.toml
@@ -2,11 +2,6 @@
 name = "text-size"
 version = "1.1.1"
 edition = "2024"
-
-authors = [
-    "Aleksey Kladov <aleksey.kladov@gmail.com>",
-    "Christopher Durham (CAD97) <cad97@cad97.com>"
-]
 description = "Newtypes for text offsets"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-analyzer/text-size"

--- a/lib/ungrammar/ungrammar2json/Cargo.toml
+++ b/lib/ungrammar/ungrammar2json/Cargo.toml
@@ -4,7 +4,7 @@ description = "Convert ungrammar files to JSON"
 version = "1.0.0"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/matklad/ungrammar"
-authors = ["Aleksey Kladov <aleksey.kladov@gmail.com>"]
+
 edition = "2024"
 
 [dependencies]


### PR DESCRIPTION
see: https://rust-lang.github.io/rfcs/3052-optional-authors-field.html