### PR TITLE
fix: Initialize `macro_depth` to the file's macro depth in docs.rs and assoc.rs

### DIFF
--- a/crates/hir-def/src/attrs/docs.rs
+++ b/crates/hir-def/src/attrs/docs.rs
@@ -449,7 +449,7 @@ fn extend_with_attrs<'a, 'db>(
                                     DocMacroExpander {
                                         db,
                                         krate,
-                                        macro_depth: 0,
+                                        macro_depth: file_id.macro_expansion_depth(db),
                                         recursion_limit,
                                         resolver,
                                         file_id,

--- a/crates/hir-def/src/nameres/assoc.rs
+++ b/crates/hir-def/src/nameres/assoc.rs
@@ -169,7 +169,7 @@ impl<'db> AssocItemCollector<'db> {
             container,
             items: Vec::new(),
 
-            macro_depth: 0,
+            macro_depth: file_id.macro_expansion_depth(db),
             macro_calls: ThinVec::new(),
             diagnostics: Vec::new(),
         }


### PR DESCRIPTION
I forgot this in https://github.com/rust-lang/rust-analyzer/pull/22974.