### PR TITLE
feat: Support `#[rustc_must_implement_one_of]` in the assists

### DIFF
--- a/crates/hir-def/src/attrs.rs
+++ b/crates/hir-def/src/attrs.rs
@@ -23,6 +23,7 @@ use either::Either;
 use hir_expand::{
     InFile, Lookup,
     attrs::{AstKeyValueMetaExt, AstPathExt, expand_cfg_attr},
+    name::Name,
 };
 use intern::Symbol;
 use itertools::Itertools;
@@ -38,7 +39,7 @@ use tt::TextSize;
 
 use crate::{
     AdtId, AstIdLoc, AttrDefId, FieldId, FunctionId, GenericDefId, HasModule, LifetimeParamId,
-    LocalFieldId, MacroId, ModuleId, TypeOrConstParamId, VariantId,
+    LocalFieldId, MacroId, ModuleId, TraitId, TypeOrConstParamId, VariantId,
     hir::generics::{GenericParams, LocalLifetimeParamId, LocalTypeOrConstParamId},
     nameres::ModuleOrigin,
     resolver::{HasResolver, Resolver},
@@ -178,6 +179,9 @@ fn match_attr_flags(attr_flags: &mut AttrFlags, attr: ast::Meta) -> ControlFlow<
                     }
                     "rustc_deprecated_safe_2024" => {
                         attr_flags.insert(AttrFlags::RUSTC_DEPRECATED_SAFE_2024)
+                    }
+                    "rustc_must_implement_one_of" => {
+                        attr_flags.insert(AttrFlags::HAS_RUSTC_MUST_IMPLEMENT_ONE_OF)
                     }
                     _ => {}
                 },
@@ -347,6 +351,8 @@ bitflags::bitflags! {
         const IS_MUST_USE = 1 << 50;
 
         const DIAGNOSTIC_DO_NOT_RECOMMEND = 1 << 51;
+
+        const HAS_RUSTC_MUST_IMPLEMENT_ONE_OF = 1 << 52;
     }
 }
 
@@ -1210,6 +1216,36 @@ impl AttrFlags {
                     && let Some(message) = attr.value_string()
                 {
                     return ControlFlow::Break(Box::from(&*message));
+                }
+                ControlFlow::Continue(())
+            })
+        }
+    }
+
+    pub fn must_implement_one_of(db: &dyn SourceDatabase, owner: TraitId) -> Option<&[Name]> {
+        if !AttrFlags::query(db, owner.into()).contains(AttrFlags::HAS_RUSTC_MUST_IMPLEMENT_ONE_OF)
+        {
+            return None;
+        }
+        return must_implement_one_of(db, owner);
+
+        #[salsa::tracked(returns(as_deref))]
+        pub fn must_implement_one_of(
+            db: &dyn SourceDatabase,
+            owner: TraitId,
+        ) -> Option<Box<[Name]>> {
+            collect_attrs(db, owner.into(), |attr| {
+                if let ast::Meta::TokenTreeMeta(attr) = attr
+                    && attr.path().is1("rustc_must_implement_one_of")
+                    && let Some(tt) = attr.token_tree()
+                    && let names = tt
+                        .token_trees_and_tokens()
+                        .filter_map(|it| ast::Ident::cast(it.into_token()?))
+                        .map(|name| Name::new_symbol_root(Symbol::intern(name.text())))
+                        .collect::<Box<[_]>>()
+                    && !names.is_empty()
+                {
+                    return ControlFlow::Break(names);
                 }
                 ControlFlow::Continue(())
             })

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -2923,6 +2923,10 @@ impl Const {
         Type::from_value_def(db, self.id)
     }
 
+    pub fn has_body(self, db: &dyn HirDatabase) -> bool {
+        ConstSignature::of(db, self.id).has_body()
+    }
+
     /// Evaluate the constant.
     pub fn eval(self, db: &dyn HirDatabase) -> Result<EvaluatedConst<'_>, ConstEvalError<'_>> {
         let interner = DbInterner::new_no_crate(db);
@@ -3132,6 +3136,10 @@ impl Trait {
     pub fn prefer_underscore_import(self, db: &dyn HirDatabase) -> bool {
         AttrFlags::query(db, self.id.into()).contains(AttrFlags::PREFER_UNDERSCORE_IMPORT)
     }
+
+    pub fn must_implement_one_of(self, db: &dyn HirDatabase) -> Option<&[Name]> {
+        AttrFlags::must_implement_one_of(db, self.id)
+    }
 }
 
 impl HasVisibility for Trait {
@@ -3162,6 +3170,10 @@ impl TypeAlias {
 
     pub fn name(self, db: &dyn HirDatabase) -> Name {
         TypeAliasSignature::of(db, self.id).name.clone()
+    }
+
+    pub fn has_type(self, db: &dyn HirDatabase) -> bool {
+        TypeAliasSignature::of(db, self.id).ty.is_some()
     }
 }
 

--- a/crates/ide-assists/src/handlers/add_missing_impl_members.rs
+++ b/crates/ide-assists/src/handlers/add_missing_impl_members.rs
@@ -2723,4 +2723,204 @@ impl<'a, T: B> A<dyn 'a + B> for T {
 }"#,
         );
     }
+
+    #[test]
+    fn rustc_must_implement_one_of() {
+        check_assist(
+            add_missing_impl_members,
+            r#"
+#[rustc_must_implement_one_of(read_buf, read)]
+pub trait Read {
+    fn read() {}
+    fn read_buf() {}
+}
+
+impl Read for () {
+    $0
+}
+        "#,
+            r#"
+#[rustc_must_implement_one_of(read_buf, read)]
+pub trait Read {
+    fn read() {}
+    fn read_buf() {}
+}
+
+impl Read for () {
+    $0fn read_buf() {}
+}
+        "#,
+        );
+
+        check_assist(
+            add_missing_default_members,
+            r#"
+#[rustc_must_implement_one_of(read_buf, read)]
+pub trait Read {
+    fn read() {}
+    fn read_buf() {}
+}
+
+impl Read for () {
+    $0
+}
+        "#,
+            r#"
+#[rustc_must_implement_one_of(read_buf, read)]
+pub trait Read {
+    fn read() {}
+    fn read_buf() {}
+}
+
+impl Read for () {
+    $0fn read() {}
+}
+        "#,
+        );
+
+        check_assist_not_applicable(
+            add_missing_impl_members,
+            r#"
+#[rustc_must_implement_one_of(read_buf, read)]
+pub trait Read {
+    fn read() {}
+    fn read_buf() {}
+}
+
+impl Read for () {
+    fn read() {}
+    $0
+}
+        "#,
+        );
+        check_assist_not_applicable(
+            add_missing_impl_members,
+            r#"
+#[rustc_must_implement_one_of(read_buf, read)]
+pub trait Read {
+    fn read() {}
+    fn read_buf() {}
+}
+
+impl Read for () {
+    fn read_buf() {}
+    $0
+}
+        "#,
+        );
+
+        check_assist(
+            add_missing_default_members,
+            r#"
+#[rustc_must_implement_one_of(read_buf, read)]
+pub trait Read {
+    fn read() {}
+    fn read_buf() {}
+}
+
+impl Read for () {
+    fn read_buf() {}$0
+}
+        "#,
+            r#"
+#[rustc_must_implement_one_of(read_buf, read)]
+pub trait Read {
+    fn read() {}
+    fn read_buf() {}
+}
+
+impl Read for () {
+    fn read_buf() {}
+
+    $0fn read() {}
+}
+        "#,
+        );
+        check_assist(
+            add_missing_default_members,
+            r#"
+#[rustc_must_implement_one_of(read_buf, read)]
+pub trait Read {
+    fn read() {}
+    fn read_buf() {}
+}
+
+impl Read for () {
+    fn read() {}$0
+}
+        "#,
+            r#"
+#[rustc_must_implement_one_of(read_buf, read)]
+pub trait Read {
+    fn read() {}
+    fn read_buf() {}
+}
+
+impl Read for () {
+    fn read() {}
+
+    $0fn read_buf() {}
+}
+        "#,
+        );
+
+        check_assist(
+            add_missing_impl_members,
+            r#"
+#[rustc_must_implement_one_of(read_buf, read)]
+pub trait Read {
+    fn read() {}
+    #[unstable(feature = "read_buf")]
+    fn read_buf() {}
+}
+
+impl Read for () {
+    $0
+}
+        "#,
+            r#"
+#[rustc_must_implement_one_of(read_buf, read)]
+pub trait Read {
+    fn read() {}
+    #[unstable(feature = "read_buf")]
+    fn read_buf() {}
+}
+
+impl Read for () {
+    $0fn read() {}
+}
+        "#,
+        );
+        check_assist(
+            add_missing_impl_members,
+            r#"
+#![feature(read_buf)]
+
+#[rustc_must_implement_one_of(read_buf, read)]
+pub trait Read {
+    fn read() {}
+    #[unstable(feature = "read_buf")]
+    fn read_buf() {}
+}
+
+impl Read for () {
+    $0
+}
+        "#,
+            r#"
+#![feature(read_buf)]
+
+#[rustc_must_implement_one_of(read_buf, read)]
+pub trait Read {
+    fn read() {}
+    #[unstable(feature = "read_buf")]
+    fn read_buf() {}
+}
+
+impl Read for () {
+    $0fn read_buf() {}
+}
+        "#,
+        );
+    }
 }

--- a/crates/ide-assists/src/handlers/generate_impl.rs
+++ b/crates/ide-assists/src/handlers/generate_impl.rs
@@ -167,7 +167,7 @@ pub(crate) fn generate_impl_trait(acc: &mut Assists, ctx: &AssistContext<'_, '_>
             let holder_arg = ast::GenericArg::TypeArg(make.type_arg(make.ty_placeholder()));
             let missing_items = utils::filter_assoc_items(
                 &ctx.sema,
-                &hir_trait.items(ctx.db()),
+                &ide_db::traits::trait_items_with_required(ctx.db(), hir_trait),
                 DefaultMethods::No,
                 IgnoreAssocItems::DocHiddenAttrPresent,
             );

--- a/crates/ide-assists/src/handlers/replace_derive_with_manual_impl.rs
+++ b/crates/ide-assists/src/handlers/replace_derive_with_manual_impl.rs
@@ -231,8 +231,12 @@ fn impl_def_from_trait(
         IgnoreAssocItems::DocHiddenAttrPresent
     };
 
-    let trait_items =
-        filter_assoc_items(sema, &trait_.items(sema.db), DefaultMethods::No, ignore_items);
+    let trait_items = filter_assoc_items(
+        sema,
+        &ide_db::traits::trait_items_with_required(sema.db, trait_),
+        DefaultMethods::No,
+        ignore_items,
+    );
 
     if trait_items.is_empty() {
         return None;

--- a/crates/ide-assists/src/utils.rs
+++ b/crates/ide-assists/src/utils.rs
@@ -13,6 +13,7 @@ use ide_db::{
     famous_defs::FamousDefs,
     path_transform::PathTransform,
     syntax_helpers::{node_ext::preorder_expr, prettify_macro_expansion},
+    traits::IsRequiredAssocItem,
 };
 use itertools::Itertools;
 use syntax::{
@@ -162,14 +163,14 @@ pub enum DefaultMethods {
 
 pub fn filter_assoc_items(
     sema: &Semantics<'_, RootDatabase>,
-    items: &[hir::AssocItem],
+    items: &[(hir::AssocItem, IsRequiredAssocItem)],
     default_methods: DefaultMethods,
     ignore_items: IgnoreAssocItems,
 ) -> Vec<InFile<ast::AssocItem>> {
-    return items
+    items
         .iter()
         .copied()
-        .filter(|assoc_item| {
+        .filter(|(assoc_item, is_required)| {
             if ignore_items == IgnoreAssocItems::DocHiddenAttrPresent
                 && assoc_item.attrs(sema.db).is_doc_hidden()
             {
@@ -181,10 +182,10 @@ pub fn filter_assoc_items(
                 return false;
             }
 
-            true
+            is_required.0 == (default_methods == DefaultMethods::No)
         })
         // Note: This throws away items with no source.
-        .filter_map(|assoc_item| {
+        .filter_map(|(assoc_item, _)| {
             let item = match assoc_item {
                 hir::AssocItem::Function(it) => sema.source(it)?.map(ast::AssocItem::Fn),
                 hir::AssocItem::TypeAlias(it) => sema.source(it)?.map(ast::AssocItem::TypeAlias),
@@ -192,33 +193,7 @@ pub fn filter_assoc_items(
             };
             Some(item)
         })
-        .filter(has_def_name)
-        .filter(|it| match &it.value {
-            ast::AssocItem::Fn(def) => matches!(
-                (default_methods, def.body()),
-                (DefaultMethods::Only, Some(_)) | (DefaultMethods::No, None)
-            ),
-            ast::AssocItem::Const(def) => matches!(
-                (default_methods, def.body()),
-                (DefaultMethods::Only, Some(_)) | (DefaultMethods::No, None)
-            ),
-            ast::AssocItem::TypeAlias(def) => matches!(
-                (default_methods, def.ty()),
-                (DefaultMethods::Only, Some(_)) | (DefaultMethods::No, None)
-            ),
-            ast::AssocItem::MacroCall(_) => unreachable!(),
-        })
-        .collect();
-
-    fn has_def_name(item: &InFile<ast::AssocItem>) -> bool {
-        match &item.value {
-            ast::AssocItem::Fn(def) => def.name(),
-            ast::AssocItem::TypeAlias(def) => def.name(),
-            ast::AssocItem::Const(def) => def.name(),
-            ast::AssocItem::MacroCall(_) => None,
-        }
-        .is_some()
-    }
+        .collect()
 }
 
 /// Given `original_items` retrieved from the trait definition (usually by

--- a/crates/ide-completion/src/completions/item_list/trait_impl.rs
+++ b/crates/ide-completion/src/completions/item_list/trait_impl.rs
@@ -161,8 +161,8 @@ fn complete_trait_impl(
     if let Some(hir_impl) = ctx.sema.to_def(impl_def) {
         get_missing_assoc_items(&ctx.sema, impl_def)
             .into_iter()
-            .filter(|item| ctx.check_stability_and_hidden(*item))
-            .for_each(|item| {
+            .filter(|(item, _)| ctx.check_stability_and_hidden(*item))
+            .for_each(|(item, _)| {
                 use self::ImplCompletionKind::*;
                 match (item, kind) {
                     (hir::AssocItem::Function(func), All | Fn) => {

--- a/crates/ide-db/src/traits.rs
+++ b/crates/ide-db/src/traits.rs
@@ -1,8 +1,8 @@
 //! Functionality for obtaining data related to traits from the DB.
 
 use crate::{RootDatabase, defs::Definition};
-use hir::{AsAssocItem, HasCrate, Semantics, db::HirDatabase, sym};
-use rustc_hash::FxHashSet;
+use base_db::FxIndexMap;
+use hir::{AsAssocItem, HasAttrs, HasCrate, Semantics, db::HirDatabase, sym};
 use syntax::{AstNode, ast};
 
 /// Given the `impl` block, attempts to find the trait this `impl` corresponds to.
@@ -19,51 +19,59 @@ pub fn resolve_target_trait(
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct IsRequiredAssocItem(pub bool);
+
+/// Names must be unique between constants and functions. However, type aliases
+/// may share the same name as a function or constant.
+#[derive(PartialEq, Eq, Hash)]
+enum AssocItemKind {
+    FnOrConst,
+    Type,
+}
+
+pub fn trait_items_with_required(
+    db: &RootDatabase,
+    trait_: hir::Trait,
+) -> Vec<(hir::AssocItem, IsRequiredAssocItem)> {
+    diff_assoc_items(db, trait_, Vec::new(), trait_.krate(db))
+}
+
 /// Given the `impl` block, returns the list of associated items (e.g. functions or types) that are
 /// missing in this `impl` block.
 pub fn get_missing_assoc_items(
     sema: &Semantics<'_, RootDatabase>,
     impl_def: &ast::Impl,
-) -> Vec<hir::AssocItem> {
+) -> Vec<(hir::AssocItem, IsRequiredAssocItem)> {
     let imp = match sema.to_def(impl_def) {
         Some(it) => it,
         None => return vec![],
     };
 
-    // Names must be unique between constants and functions. However, type aliases
-    // may share the same name as a function or constant.
-    let mut impl_fns_consts = FxHashSet::default();
-    let mut impl_type = FxHashSet::default();
-
-    for item in imp.items(sema.db) {
-        match item {
-            hir::AssocItem::Function(it) => {
-                impl_fns_consts.insert(it.name(sema.db));
-            }
-            hir::AssocItem::Const(it) => {
-                if let Some(name) = it.name(sema.db) {
-                    impl_fns_consts.insert(name);
-                }
-            }
-            hir::AssocItem::TypeAlias(it) => {
-                impl_type.insert(it.name(sema.db));
-            }
-        }
-    }
-
     let Some(target_trait) = imp.trait_(sema.db) else { return Vec::new() };
 
+    diff_assoc_items(sema.db, target_trait, imp.items(sema.db), imp.krate(sema.db))
+}
+
+fn diff_assoc_items(
+    db: &RootDatabase,
+    target_trait: hir::Trait,
+    impl_items: Vec<hir::AssocItem>,
+    impl_crate: hir::Crate,
+) -> Vec<(hir::AssocItem, IsRequiredAssocItem)> {
     // `Drop` has two methods, `drop()` and `pin_drop()`, and you can only implement one of them, so
     // we consider `pin_drop()` to not exist, unless you already implement it.
-    let drop_trait = hir::Trait::lang(sema.db, imp.krate(sema.db), hir::LangItem::Drop);
+    let drop_trait = hir::Trait::lang(db, impl_crate, hir::LangItem::Drop);
     if let Some(drop_trait) = drop_trait
         && target_trait == drop_trait
     {
-        return if impl_fns_consts.is_empty() {
+        return if impl_items.is_empty() {
             // No method implemented, return `drop()`.
-            let drop_drop = drop_trait.function(sema.db, sym::drop);
+            let drop_drop = drop_trait.function(db, sym::drop);
             match drop_drop {
-                Some(drop_drop) => vec![hir::AssocItem::Function(drop_drop)],
+                Some(drop_drop) => {
+                    vec![(hir::AssocItem::Function(drop_drop), IsRequiredAssocItem(true))]
+                }
                 None => Vec::new(),
             }
         } else {
@@ -72,17 +80,82 @@ pub fn get_missing_assoc_items(
         };
     }
 
-    target_trait
-        .items(sema.db)
-        .into_iter()
-        .filter(|i| match i {
-            hir::AssocItem::Function(f) => !impl_fns_consts.contains(&f.name(sema.db)),
-            hir::AssocItem::TypeAlias(t) => !impl_type.contains(&t.name(sema.db)),
-            hir::AssocItem::Const(c) => {
-                c.name(sema.db).map(|n| !impl_fns_consts.contains(&n)).unwrap_or_default()
+    let must_implement_one_of = target_trait.must_implement_one_of(db).unwrap_or_default();
+
+    // We keep one map because we want to keep the trait's order.
+    let mut trait_items = FxIndexMap::default();
+
+    for i in target_trait.items(db) {
+        match i {
+            hir::AssocItem::Function(f) => {
+                let is_required = !f.has_body(db);
+                trait_items.insert(
+                    (f.name(db), AssocItemKind::FnOrConst),
+                    (i, IsRequiredAssocItem(is_required)),
+                );
             }
-        })
-        .collect()
+            hir::AssocItem::Const(c) => {
+                if let Some(name) = c.name(db) {
+                    let is_required = !c.has_body(db);
+                    trait_items.insert(
+                        (name, AssocItemKind::FnOrConst),
+                        (i, IsRequiredAssocItem(is_required)),
+                    );
+                }
+            }
+            hir::AssocItem::TypeAlias(t) => {
+                let is_required = !t.has_type(db);
+                trait_items.insert(
+                    (t.name(db), AssocItemKind::Type),
+                    (i, IsRequiredAssocItem(is_required)),
+                );
+            }
+        }
+    }
+
+    let mut abides_must_implement_one_of = must_implement_one_of.is_empty();
+    for item in impl_items {
+        match item {
+            hir::AssocItem::Function(it) => {
+                let name = it.name(db);
+                if !abides_must_implement_one_of && must_implement_one_of.contains(&name) {
+                    abides_must_implement_one_of = true;
+                }
+                trait_items.shift_remove(&(name, AssocItemKind::FnOrConst));
+            }
+            hir::AssocItem::Const(it) => {
+                if let Some(name) = it.name(db) {
+                    trait_items.shift_remove(&(name, AssocItemKind::FnOrConst));
+                }
+            }
+            hir::AssocItem::TypeAlias(it) => {
+                trait_items.shift_remove(&(it.name(db), AssocItemKind::Type));
+            }
+        }
+    }
+
+    if !abides_must_implement_one_of {
+        for name in must_implement_one_of {
+            let Some((item, is_required)) =
+                trait_items.get_mut(&(name.clone(), AssocItemKind::FnOrConst))
+            else {
+                continue;
+            };
+            if item
+                .attrs(db)
+                .unstable_feature(db)
+                .is_none_or(|feature| impl_crate.is_unstable_feature_enabled(db, &feature))
+            {
+                // `#[rustc_must_implement_one_of]` always has all its methods with default body.
+                // If it isn't followed, mark one as required.
+                // We mark the first, see https://github.com/rust-lang/rust/pull/106643#issuecomment-5187934543.
+                is_required.0 = true;
+                break;
+            }
+        }
+    }
+
+    trait_items.into_values().collect()
 }
 
 /// Converts associated trait impl items to their trait definition counterpart
@@ -182,7 +255,7 @@ mod tests {
             hir::attach_db(&db, || crate::traits::get_missing_assoc_items(&sema, &impl_block));
         let actual = items
             .into_iter()
-            .map(|item| item.name(&db).unwrap().display(&db, Edition::CURRENT).to_string())
+            .map(|(item, _)| item.name(&db).unwrap().display(&db, Edition::CURRENT).to_string())
             .collect::<Vec<_>>()
             .join("\n");
         expect.assert_eq(&actual);


### PR DESCRIPTION
We still don't support it in the diagnostics for missing items, that's for later PR.