### PR TITLE
fix: Allow struct literals in match guards inside `let` exprs

### DIFF
--- a/crates/parser/src/grammar/expressions.rs
+++ b/crates/parser/src/grammar/expressions.rs
@@ -36,8 +36,7 @@ fn expr_no_struct(p: &mut Parser<'_>) {
 /// It needs to be parsed with lower precedence than `&&`, so that
 /// `if let true = true && false` is parsed as `if (let true = true) && (true)`
 /// and not `if let true = (true && true)`.
-fn expr_let(p: &mut Parser<'_>) {
-    let r = Restrictions { forbid_structs: true, prefer_stmt: false };
+fn expr_let(p: &mut Parser<'_>, r: Restrictions) {
     expr_bp(p, None, r, 5);
 }
 

--- a/crates/parser/src/grammar/expressions/atom.rs
+++ b/crates/parser/src/grammar/expressions/atom.rs
@@ -88,7 +88,7 @@ pub(super) fn atom_expr(
         T!['('] => tuple_expr(p),
         T!['['] => array_expr(p),
         T![if] => if_expr(p),
-        T![let] => let_expr(p),
+        T![let] => let_expr(p, r),
         T![_] => {
             // test destructuring_assignment_wildcard_pat
             // fn foo() {
@@ -719,12 +719,12 @@ fn for_expr(p: &mut Parser<'_>, m: Option<Marker>) -> CompletedMarker {
 //     if let Some(_) = None && true {}
 //     while 1 == 5 && (let None = None) {}
 // }
-fn let_expr(p: &mut Parser<'_>) -> CompletedMarker {
+fn let_expr(p: &mut Parser<'_>, r: Restrictions) -> CompletedMarker {
     let m = p.start();
     p.bump(T![let]);
     patterns::pattern(p);
     p.expect(T![=]);
-    expr_let(p);
+    expr_let(p, r);
     m.complete(p, LET_EXPR)
 }
 
@@ -860,6 +860,12 @@ fn match_guard(p: &mut Parser<'_>) -> CompletedMarker {
     if p.at(T![=]) {
         p.error("expected expression");
     } else {
+        // test guard_let_struct
+        // fn foo() {
+        //     match () {
+        //         () if let Foo {} = Foo {} => {}
+        //     }
+        // }
         expr(p);
     }
     m.complete(p, MATCH_GUARD)

--- a/crates/parser/test_data/generated/runner.rs
+++ b/crates/parser/test_data/generated/runner.rs
@@ -340,6 +340,10 @@ mod ok {
     #[test]
     fn global_asm() { run_and_expect_no_errors("test_data/parser/inline/ok/global_asm.rs"); }
     #[test]
+    fn guard_let_struct() {
+        run_and_expect_no_errors("test_data/parser/inline/ok/guard_let_struct.rs");
+    }
+    #[test]
     fn half_open_range_pat() {
         run_and_expect_no_errors("test_data/parser/inline/ok/half_open_range_pat.rs");
     }

--- a/crates/parser/test_data/parser/inline/ok/guard_let_struct.rast
+++ b/crates/parser/test_data/parser/inline/ok/guard_let_struct.rast
@@ -1,0 +1,68 @@
+SOURCE_FILE
+  FN
+    FN_KW "fn"
+    WHITESPACE " "
+    NAME
+      IDENT "foo"
+    PARAM_LIST
+      L_PAREN "("
+      R_PAREN ")"
+    WHITESPACE " "
+    BLOCK_EXPR
+      STMT_LIST
+        L_CURLY "{"
+        WHITESPACE "\n    "
+        MATCH_EXPR
+          MATCH_KW "match"
+          WHITESPACE " "
+          TUPLE_EXPR
+            L_PAREN "("
+            R_PAREN ")"
+          WHITESPACE " "
+          MATCH_ARM_LIST
+            L_CURLY "{"
+            WHITESPACE "\n        "
+            MATCH_ARM
+              TUPLE_PAT
+                L_PAREN "("
+                R_PAREN ")"
+              WHITESPACE " "
+              MATCH_GUARD
+                IF_KW "if"
+                WHITESPACE " "
+                LET_EXPR
+                  LET_KW "let"
+                  WHITESPACE " "
+                  RECORD_PAT
+                    PATH
+                      PATH_SEGMENT
+                        NAME_REF
+                          IDENT "Foo"
+                    WHITESPACE " "
+                    RECORD_PAT_FIELD_LIST
+                      L_CURLY "{"
+                      R_CURLY "}"
+                  WHITESPACE " "
+                  EQ "="
+                  WHITESPACE " "
+                  RECORD_EXPR
+                    PATH
+                      PATH_SEGMENT
+                        NAME_REF
+                          IDENT "Foo"
+                    WHITESPACE " "
+                    RECORD_EXPR_FIELD_LIST
+                      L_CURLY "{"
+                      R_CURLY "}"
+              WHITESPACE " "
+              FAT_ARROW "=>"
+              WHITESPACE " "
+              BLOCK_EXPR
+                STMT_LIST
+                  L_CURLY "{"
+                  R_CURLY "}"
+            WHITESPACE "\n    "
+            R_CURLY "}"
+        WHITESPACE "\n"
+        R_CURLY "}"
+  WHITESPACE "\n"

--- a/crates/parser/test_data/parser/inline/ok/guard_let_struct.rs
+++ b/crates/parser/test_data/parser/inline/ok/guard_let_struct.rs
@@ -1,0 +1,5 @@
+fn foo() {
+    match () {
+        () if let Foo {} = Foo {} => {}
+    }
+}


### PR DESCRIPTION
We might need to forward the `Restrictions` in more places.

Fixes https://github.com/rust-lang/rust-analyzer/issues/23050.