### PR TITLE
perf: Optimize memory usage of the item tree

### DIFF
--- a/crates/hir-def/src/item_tree.rs
+++ b/crates/hir-def/src/item_tree.rs
@@ -46,6 +46,7 @@ use std::{
 use ast::{AstNode, StructKind};
 use base_db::{Crate, SourceDatabase};
 use cfg::CfgOptions;
+use either::Either;
 use hir_expand::{
     ExpandTo, HirFileId,
     mod_path::{ModPath, PathKind},
@@ -53,7 +54,6 @@ use hir_expand::{
 };
 use intern::Interned;
 use la_arena::{Idx, RawIdx};
-use rustc_hash::FxHashMap;
 use span::{
     AstIdNode, Edition, FileAstId, NO_DOWNMAP_ERASED_FILE_AST_ID_MARKER, Span, SpanAnchor,
     SyntaxContext,
@@ -128,10 +128,9 @@ pub fn file_item_tree(db: &dyn SourceDatabase, file_id: HirFileId, krate: Crate)
             static EMPTY: OnceLock<ItemTree> = OnceLock::new();
             EMPTY.get_or_init(|| ItemTree {
                 top_level: Box::new([]),
-                attrs: FxHashMap::default(),
-                small_data: FxHashMap::default(),
-                big_data: FxHashMap::default(),
-                top_attrs: AttrsOrCfg::empty(),
+                attrs: ThinVec::new(),
+                small_data: ThinVec::new(),
+                big_data: ThinVec::new(),
                 vis: ItemVisibilities { arena: ThinVec::new() },
             })
         }
@@ -146,7 +145,7 @@ fn file_item_tree_query(
 ) -> Option<Box<ItemTree>> {
     let _p = tracing::info_span!("file_item_tree_query", ?file_id).entered();
 
-    let ctx = lower::Ctx::new(db, file_id, krate);
+    let mut ctx = lower::Ctx::new(db, file_id, krate);
     let syntax = file_id.parse_or_expand(db);
     let mut item_tree = match_ast! {
         match syntax {
@@ -162,9 +161,8 @@ fn file_item_tree_query(
                     Some(attrs @ AttrsOrCfg::CfgDisabled(_)) => attrs,
                     None => ctx.lower_attrs(&file)
                 };
-                let mut item_tree = ctx.lower_module_items(&file);
-                item_tree.top_attrs = top_attrs;
-                item_tree
+                ctx.add_attrs(ModItemId::TOP_OWNER, top_attrs);
+                ctx.lower_module_items(&file)
             },
             ast::MacroItems(items) => {
                 ctx.lower_module_items(&items)
@@ -182,17 +180,10 @@ fn file_item_tree_query(
             },
         }
     };
-    let ItemTree { top_level, top_attrs, attrs, vis, big_data, small_data } = &item_tree;
-    if small_data.is_empty()
-        && big_data.is_empty()
-        && top_level.is_empty()
-        && attrs.is_empty()
-        && top_attrs.is_empty()
-        && vis.arena.is_empty()
-    {
+    if item_tree.is_empty() {
         None
     } else {
-        item_tree.shrink_to_fit();
+        item_tree.finalize();
         Some(Box::new(item_tree))
     }
 }
@@ -209,7 +200,7 @@ pub(crate) fn block_item_tree_query(
 
     let ctx = lower::Ctx::new(db, ast_id.file_id, krate);
     let mut item_tree = ctx.lower_block(&block);
-    item_tree.shrink_to_fit();
+    item_tree.finalize();
     item_tree
 }
 
@@ -217,11 +208,11 @@ pub(crate) fn block_item_tree_query(
 #[derive(Debug, Default, Eq, PartialEq)]
 pub struct ItemTree {
     top_level: Box<[ModItemId]>,
-    top_attrs: AttrsOrCfg,
-    attrs: FxHashMap<FileAstId<ast::Item>, AttrsOrCfg>,
+    /// Sorted by the id. The last item, if it has [`ModItemId::TOP_OWNER`], is the top level attrs.
+    attrs: ThinVec<(ModItemId, AttrsOrCfg)>,
     vis: ItemVisibilities,
-    big_data: FxHashMap<FileAstId<ast::Item>, BigModItem>,
-    small_data: FxHashMap<FileAstId<ast::Item>, SmallModItem>,
+    big_data: ThinVec<(FileAstId<ast::Item>, BigModItem)>,
+    small_data: ThinVec<(FileAstId<ast::Item>, SmallModItem)>,
 }
 
 impl ItemTree {
@@ -232,12 +223,14 @@ impl ItemTree {
     }
 
     /// Returns the inner attributes of the source file.
-    pub(crate) fn top_level_attrs(&self) -> &AttrsOrCfg {
-        &self.top_attrs
+    #[inline]
+    pub(crate) fn top_level_attrs(&self) -> Option<&AttrsOrCfg> {
+        self.attrs.last().filter(|(id, _)| *id == ModItemId::TOP_OWNER).map(|(_, attrs)| attrs)
     }
 
-    pub(crate) fn attrs(&self, of: FileAstId<ast::Item>) -> Option<&AttrsOrCfg> {
-        self.attrs.get(&of)
+    #[inline]
+    pub(crate) fn attrs(&self, of: ModItemId) -> Option<&AttrsOrCfg> {
+        self.attrs.binary_search_by_key(&of, |(id, _)| *id).ok().map(|index| &self.attrs[index].1)
     }
 
     /// Returns a count of a few, expensive items.
@@ -249,7 +242,7 @@ impl ItemTree {
         let mut mods = 0;
         let mut macro_calls = 0;
         let mut macro_rules = 0;
-        for item in self.small_data.values() {
+        for (_, item) in &self.small_data {
             match item {
                 SmallModItem::Trait(_) => traits += 1,
                 SmallModItem::Impl(_) => impls += 1,
@@ -258,7 +251,7 @@ impl ItemTree {
                 _ => {}
             }
         }
-        for item in self.big_data.values() {
+        for (_, item) in &self.big_data {
             match item {
                 BigModItem::Mod(_) => mods += 1,
                 _ => {}
@@ -271,11 +264,21 @@ impl ItemTree {
         pretty::print_item_tree(db, self, edition)
     }
 
-    fn shrink_to_fit(&mut self) {
-        let ItemTree { top_level: _, attrs, big_data, small_data, vis: _, top_attrs: _ } = self;
+    fn is_empty(&self) -> bool {
+        let ItemTree { top_level, attrs, vis: _, big_data: _, small_data: _ } = self;
+        // We don't need to check the rest since if those are empty, everything is empty.
+        // `attrs` might contain the top-level attrs so we need to check it separately.
+        top_level.is_empty() && attrs.is_empty()
+    }
+
+    fn finalize(&mut self) {
+        self.attrs.sort_unstable_by_key(|(id, _)| *id);
+
+        let ItemTree { top_level: _, attrs, big_data, small_data, vis } = self;
         attrs.shrink_to_fit();
         big_data.shrink_to_fit();
         small_data.shrink_to_fit();
+        vis.arena.shrink_to_fit();
     }
 }
 
@@ -366,71 +369,105 @@ impl TreeId {
     }
 }
 
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, PartialOrd, Ord)]
+pub struct ModItemId {
+    /// The LSB is 0 for small_data and 1 for big_data.
+    index: u32,
+}
+
+impl ModItemId {
+    const TOP_OWNER: ModItemId = ModItemId { index: u32::MAX };
+
+    #[inline]
+    fn new_small(index: u32) -> Self {
+        debug_assert!(
+            (index & 0x80_00_00_00) == 0 && index != (ModItemId::TOP_OWNER.index >> 1),
+            "too big index"
+        );
+        Self { index: index << 1 }
+    }
+    #[inline]
+    fn new_big(index: u32) -> Self {
+        debug_assert!(
+            (index & 0x80_00_00_00) == 0 && index != (ModItemId::TOP_OWNER.index >> 1),
+            "too big index"
+        );
+        Self { index: (index << 1) | 0b1 }
+    }
+
+    #[inline]
+    fn get(
+        self,
+        item_tree: &ItemTree,
+    ) -> (FileAstId<ast::Item>, Either<&SmallModItem, &BigModItem>) {
+        let index = self.index >> 1;
+        match self.index & 0b1 {
+            0 => {
+                let (ast_id, data) = &item_tree.small_data[index as usize];
+                (*ast_id, Either::Left(data))
+            }
+            1 => {
+                let (ast_id, data) = &item_tree.big_data[index as usize];
+                (*ast_id, Either::Right(data))
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    #[inline]
+    pub(crate) fn ast_id(self, item_tree: &ItemTree) -> FileAstId<ast::Item> {
+        self.get(item_tree).0
+    }
+}
+
 macro_rules! mod_items {
-    ($mod_item:ident -> $( $typ:ident in $fld:ident -> $ast:ty ),+ $(,)? ) => {
-        #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
-        pub(crate) enum $mod_item {
+    ($mod_item:ident -> $( $typ:ident by $either:ident -> $ast:ty ),+ $(,)? ) => {
+        #[derive(Debug, Copy, Clone)]
+        pub(crate) enum $mod_item<'a> {
             $(
-                $typ(FileAstId<$ast>),
+                $typ(FileAstId<$ast>, &'a $typ),
             )+
         }
 
-        impl $mod_item {
-            pub(crate) fn ast_id(self) -> FileAstId<ast::Item> {
-                match self {
-                    $($mod_item::$typ(it) => it.upcast()),+
+        impl ItemTree {
+            #[inline]
+            pub(crate) fn index(&self, id: ModItemId) -> $mod_item<'_> {
+                use BigModItem::*;
+                use SmallModItem::*;
+
+                let (ast_id, item) = id.get(self);
+                match item {
+                    $( Either::$either($typ(item)) => $mod_item::$typ(ast_id.downcast_unchecked(), item), )+
                 }
             }
         }
-
-        $(
-            impl From<FileAstId<$ast>> for $mod_item {
-                fn from(id: FileAstId<$ast>) -> $mod_item {
-                    ModItemId::$typ(id)
-                }
-            }
-        )+
 
         $(
             impl ItemTreeNode for $typ {
                 type Source = $ast;
-            }
-
-            impl Index<FileAstId<$ast>> for ItemTree {
-                type Output = $typ;
-
-                #[allow(unused_imports)]
-                fn index(&self, index: FileAstId<$ast>) -> &Self::Output {
-                    use BigModItem::*;
-                    use SmallModItem::*;
-                    match &self.$fld[&index.upcast()] {
-                        $typ(item) => item,
-                        _ => panic!("expected item of type `{}` at index `{:?}`", stringify!($typ), index),
-                    }
-                }
             }
         )+
     };
 }
 
 mod_items! {
-ModItemId ->
-    Const in small_data -> ast::Const,
-    Enum in small_data -> ast::Enum,
-    ExternBlock in small_data -> ast::ExternBlock,
-    ExternCrate in big_data -> ast::ExternCrate,
-    Function in small_data -> ast::Fn,
-    Impl in small_data -> ast::Impl,
-    Macro2 in small_data -> ast::MacroDef,
-    MacroCall in small_data -> ast::MacroCall,
-    MacroRules in small_data -> ast::MacroRules,
-    Mod in big_data -> ast::Module,
-    Static in small_data -> ast::Static,
-    Struct in small_data -> ast::Struct,
-    Trait in small_data -> ast::Trait,
-    TypeAlias in small_data -> ast::TypeAlias,
-    Union in small_data -> ast::Union,
-    Use in big_data -> ast::Use,
+ModItemKind ->
+    Const by Left -> ast::Const,
+    Enum by Left -> ast::Enum,
+    ExternBlock by Left -> ast::ExternBlock,
+    ExternCrate by Right -> ast::ExternCrate,
+    Function by Left -> ast::Fn,
+    Impl by Left -> ast::Impl,
+    Macro2 by Left -> ast::MacroDef,
+    MacroCall by Left -> ast::MacroCall,
+    MacroRules by Left -> ast::MacroRules,
+    Mod by Right -> ast::Module,
+    Static by Left -> ast::Static,
+    Struct by Left -> ast::Struct,
+    Trait by Left -> ast::Trait,
+    TypeAlias by Left -> ast::TypeAlias,
+    Union by Left -> ast::Union,
+    Use by Right -> ast::Use,
 }
 
 impl Index<RawVisibilityId> for ItemTree {

--- a/crates/hir-def/src/item_tree/attrs.rs
+++ b/crates/hir-def/src/item_tree/attrs.rs
@@ -254,12 +254,7 @@ impl<'attr> AttrQuery<'attr> {
 
 impl AttrsOrCfg {
     #[inline]
-    pub(super) fn empty() -> Self {
-        AttrsOrCfg::Enabled { attrs: AttrsOwned(Box::new([])) }
-    }
-
-    #[inline]
     pub(super) fn is_empty(&self) -> bool {
-        matches!(self, AttrsOrCfg::Enabled { attrs } if attrs.as_ref().is_empty())
+        matches!(self, AttrsOrCfg::Enabled { attrs } if attrs.0.is_empty())
     }
 }

--- a/crates/hir-def/src/item_tree/lower.rs
+++ b/crates/hir-def/src/item_tree/lower.rs
@@ -14,9 +14,9 @@ use syntax::{
 
 use crate::item_tree::{
     BigModItem, Const, Enum, ExternBlock, ExternCrate, FieldsShape, Function, Impl, ImportAlias,
-    Interned, ItemTree, ItemTreeAstId, Macro2, MacroCall, MacroRules, Mod, ModItemId, ModKind,
-    ModPath, RawVisibility, RawVisibilityId, SmallModItem, Static, Struct, StructKind, Trait,
-    TypeAlias, Union, Use, UseTree, UseTreeKind, VisibilityExplicitness, attrs::AttrsOrCfg,
+    Interned, ItemTree, Macro2, MacroCall, MacroRules, Mod, ModItemId, ModKind, ModPath,
+    RawVisibility, RawVisibilityId, SmallModItem, Static, Struct, StructKind, Trait, TypeAlias,
+    Union, Use, UseTree, UseTreeKind, VisibilityExplicitness, attrs::AttrsOrCfg,
 };
 
 pub(super) struct Ctx<'db> {
@@ -98,7 +98,7 @@ impl<'db> Ctx<'db> {
     }
 
     pub(super) fn lower_block(mut self, block: &ast::BlockExpr) -> ItemTree {
-        self.tree.top_attrs = self.lower_attrs(block);
+        self.add_attrs(ModItemId::TOP_OWNER, self.lower_attrs(block));
         self.top_level = block
             .statements()
             .filter_map(|stmt| match stmt {
@@ -124,68 +124,76 @@ impl<'db> Ctx<'db> {
     }
 
     fn lower_mod_item(&mut self, item: &ast::Item) -> Option<ModItemId> {
-        let mod_item: ModItemId = match item {
-            ast::Item::Struct(ast) => self.lower_struct(ast)?.into(),
-            ast::Item::Union(ast) => self.lower_union(ast)?.into(),
-            ast::Item::Enum(ast) => self.lower_enum(ast)?.into(),
-            ast::Item::Fn(ast) => self.lower_function(ast)?.into(),
-            ast::Item::TypeAlias(ast) => self.lower_type_alias(ast)?.into(),
-            ast::Item::Static(ast) => self.lower_static(ast)?.into(),
-            ast::Item::Const(ast) => self.lower_const(ast).into(),
-            ast::Item::Module(ast) => self.lower_module(ast)?.into(),
-            ast::Item::Trait(ast) => self.lower_trait(ast)?.into(),
-            ast::Item::Impl(ast) => self.lower_impl(ast).into(),
-            ast::Item::Use(ast) => self.lower_use(ast)?.into(),
-            ast::Item::ExternCrate(ast) => self.lower_extern_crate(ast)?.into(),
-            ast::Item::MacroCall(ast) => self.lower_macro_call(ast)?.into(),
-            ast::Item::MacroRules(ast) => self.lower_macro_rules(ast)?.into(),
-            ast::Item::MacroDef(ast) => self.lower_macro_def(ast)?.into(),
-            ast::Item::ExternBlock(ast) => self.lower_extern_block(ast).into(),
+        let mod_item = match item {
+            ast::Item::Struct(ast) => self.lower_struct(ast)?,
+            ast::Item::Union(ast) => self.lower_union(ast)?,
+            ast::Item::Enum(ast) => self.lower_enum(ast)?,
+            ast::Item::Fn(ast) => self.lower_function(ast)?,
+            ast::Item::TypeAlias(ast) => self.lower_type_alias(ast)?,
+            ast::Item::Static(ast) => self.lower_static(ast)?,
+            ast::Item::Const(ast) => self.lower_const(ast),
+            ast::Item::Module(ast) => self.lower_module(ast)?,
+            ast::Item::Trait(ast) => self.lower_trait(ast)?,
+            ast::Item::Impl(ast) => self.lower_impl(ast),
+            ast::Item::Use(ast) => self.lower_use(ast)?,
+            ast::Item::ExternCrate(ast) => self.lower_extern_crate(ast)?,
+            ast::Item::MacroCall(ast) => self.lower_macro_call(ast)?,
+            ast::Item::MacroRules(ast) => self.lower_macro_rules(ast)?,
+            ast::Item::MacroDef(ast) => self.lower_macro_def(ast)?,
+            ast::Item::ExternBlock(ast) => self.lower_extern_block(ast),
             // FIXME: Handle `global_asm!()`.
             ast::Item::AsmExpr(_) => return None,
         };
         let attrs = self.lower_attrs(item);
-        self.add_attrs(mod_item.ast_id(), attrs);
+        self.add_attrs(mod_item, attrs);
 
         Some(mod_item)
     }
 
-    fn add_attrs(&mut self, item: FileAstId<ast::Item>, attrs: AttrsOrCfg) {
+    pub(super) fn add_attrs(&mut self, item: ModItemId, attrs: AttrsOrCfg) {
         if !attrs.is_empty() {
-            self.tree.attrs.insert(item, attrs);
+            self.tree.attrs.push((item, attrs));
         }
     }
 
-    fn lower_struct(&mut self, strukt: &ast::Struct) -> Option<ItemTreeAstId<Struct>> {
+    fn alloc_small(&mut self, ast_id: FileAstId<ast::Item>, item: SmallModItem) -> ModItemId {
+        let index = self.tree.small_data.len() as u32;
+        self.tree.small_data.push((ast_id, item));
+        ModItemId::new_small(index)
+    }
+
+    fn alloc_big(&mut self, ast_id: FileAstId<ast::Item>, item: BigModItem) -> ModItemId {
+        let index = self.tree.big_data.len() as u32;
+        self.tree.big_data.push((ast_id, item));
+        ModItemId::new_big(index)
+    }
+
+    fn lower_struct(&mut self, strukt: &ast::Struct) -> Option<ModItemId> {
         let visibility = self.lower_visibility(strukt);
         let name = strukt.name()?.as_name();
         let ast_id = self.source_ast_id_map.ast_id(strukt);
         let shape = adt_shape(strukt.kind());
         let res = Struct { name, visibility, shape };
-        self.tree.small_data.insert(ast_id.upcast(), SmallModItem::Struct(res));
-
-        Some(ast_id)
+        Some(self.alloc_small(ast_id.upcast(), SmallModItem::Struct(res)))
     }
 
-    fn lower_union(&mut self, union: &ast::Union) -> Option<ItemTreeAstId<Union>> {
+    fn lower_union(&mut self, union: &ast::Union) -> Option<ModItemId> {
         let visibility = self.lower_visibility(union);
         let name = union.name()?.as_name();
         let ast_id = self.source_ast_id_map.ast_id(union);
         let res = Union { name, visibility };
-        self.tree.small_data.insert(ast_id.upcast(), SmallModItem::Union(res));
-        Some(ast_id)
+        Some(self.alloc_small(ast_id.upcast(), SmallModItem::Union(res)))
     }
 
-    fn lower_enum(&mut self, enum_: &ast::Enum) -> Option<ItemTreeAstId<Enum>> {
+    fn lower_enum(&mut self, enum_: &ast::Enum) -> Option<ModItemId> {
         let visibility = self.lower_visibility(enum_);
         let name = enum_.name()?.as_name();
         let ast_id = self.source_ast_id_map.ast_id(enum_);
         let res = Enum { name, visibility };
-        self.tree.small_data.insert(ast_id.upcast(), SmallModItem::Enum(res));
-        Some(ast_id)
+        Some(self.alloc_small(ast_id.upcast(), SmallModItem::Enum(res)))
     }
 
-    fn lower_function(&mut self, func: &ast::Fn) -> Option<ItemTreeAstId<Function>> {
+    fn lower_function(&mut self, func: &ast::Fn) -> Option<ModItemId> {
         let visibility = self.lower_visibility(func);
         let name = func.name()?.as_name();
 
@@ -193,41 +201,34 @@ impl<'db> Ctx<'db> {
 
         let res = Function { name, visibility };
 
-        self.tree.small_data.insert(ast_id.upcast(), SmallModItem::Function(res));
-        Some(ast_id)
+        Some(self.alloc_small(ast_id.upcast(), SmallModItem::Function(res)))
     }
 
-    fn lower_type_alias(
-        &mut self,
-        type_alias: &ast::TypeAlias,
-    ) -> Option<ItemTreeAstId<TypeAlias>> {
+    fn lower_type_alias(&mut self, type_alias: &ast::TypeAlias) -> Option<ModItemId> {
         let name = type_alias.name()?.as_name();
         let visibility = self.lower_visibility(type_alias);
         let ast_id = self.source_ast_id_map.ast_id(type_alias);
         let res = TypeAlias { name, visibility };
-        self.tree.small_data.insert(ast_id.upcast(), SmallModItem::TypeAlias(res));
-        Some(ast_id)
+        Some(self.alloc_small(ast_id.upcast(), SmallModItem::TypeAlias(res)))
     }
 
-    fn lower_static(&mut self, static_: &ast::Static) -> Option<ItemTreeAstId<Static>> {
+    fn lower_static(&mut self, static_: &ast::Static) -> Option<ModItemId> {
         let name = static_.name()?.as_name();
         let visibility = self.lower_visibility(static_);
         let ast_id = self.source_ast_id_map.ast_id(static_);
         let res = Static { name, visibility };
-        self.tree.small_data.insert(ast_id.upcast(), SmallModItem::Static(res));
-        Some(ast_id)
+        Some(self.alloc_small(ast_id.upcast(), SmallModItem::Static(res)))
     }
 
-    fn lower_const(&mut self, konst: &ast::Const) -> ItemTreeAstId<Const> {
+    fn lower_const(&mut self, konst: &ast::Const) -> ModItemId {
         let name = konst.name().map(|it| it.as_name());
         let visibility = self.lower_visibility(konst);
         let ast_id = self.source_ast_id_map.ast_id(konst);
         let res = Const { name, visibility };
-        self.tree.small_data.insert(ast_id.upcast(), SmallModItem::Const(res));
-        ast_id
+        self.alloc_small(ast_id.upcast(), SmallModItem::Const(res))
     }
 
-    fn lower_module(&mut self, module: &ast::Module) -> Option<ItemTreeAstId<Mod>> {
+    fn lower_module(&mut self, module: &ast::Module) -> Option<ModItemId> {
         let name = module.name()?.as_name();
         let visibility = self.lower_visibility(module);
         let kind = if module.semicolon_token().is_some() {
@@ -247,30 +248,27 @@ impl<'db> Ctx<'db> {
         };
         let ast_id = self.source_ast_id_map.ast_id(module);
         let res = Mod { name, visibility, kind };
-        self.tree.big_data.insert(ast_id.upcast(), BigModItem::Mod(res));
-        Some(ast_id)
+        Some(self.alloc_big(ast_id.upcast(), BigModItem::Mod(res)))
     }
 
-    fn lower_trait(&mut self, trait_def: &ast::Trait) -> Option<ItemTreeAstId<Trait>> {
+    fn lower_trait(&mut self, trait_def: &ast::Trait) -> Option<ModItemId> {
         let name = trait_def.name()?.as_name();
         let visibility = self.lower_visibility(trait_def);
         let ast_id = self.source_ast_id_map.ast_id(trait_def);
 
         let def = Trait { name, visibility };
-        self.tree.small_data.insert(ast_id.upcast(), SmallModItem::Trait(def));
-        Some(ast_id)
+        Some(self.alloc_small(ast_id.upcast(), SmallModItem::Trait(def)))
     }
 
-    fn lower_impl(&mut self, impl_def: &ast::Impl) -> ItemTreeAstId<Impl> {
+    fn lower_impl(&mut self, impl_def: &ast::Impl) -> ModItemId {
         let ast_id = self.source_ast_id_map.ast_id(impl_def);
         // Note that trait impls don't get implicit `Self` unlike traits, because here they are a
         // type alias rather than a type parameter, so this is handled by the resolver.
         let res = Impl { is_trait_impl: impl_def.trait_().is_some() };
-        self.tree.small_data.insert(ast_id.upcast(), SmallModItem::Impl(res));
-        ast_id
+        self.alloc_small(ast_id.upcast(), SmallModItem::Impl(res))
     }
 
-    fn lower_use(&mut self, use_item: &ast::Use) -> Option<ItemTreeAstId<Use>> {
+    fn lower_use(&mut self, use_item: &ast::Use) -> Option<ModItemId> {
         let visibility = self.lower_visibility(use_item);
         let ast_id = self.source_ast_id_map.ast_id(use_item);
         let (use_tree, _) = lower_use_tree(self.db, use_item.use_tree()?, &mut |range| {
@@ -278,14 +276,10 @@ impl<'db> Ctx<'db> {
         })?;
 
         let res = Use { visibility, use_tree };
-        self.tree.big_data.insert(ast_id.upcast(), BigModItem::Use(res));
-        Some(ast_id)
+        Some(self.alloc_big(ast_id.upcast(), BigModItem::Use(res)))
     }
 
-    fn lower_extern_crate(
-        &mut self,
-        extern_crate: &ast::ExternCrate,
-    ) -> Option<ItemTreeAstId<ExternCrate>> {
+    fn lower_extern_crate(&mut self, extern_crate: &ast::ExternCrate) -> Option<ModItemId> {
         let name = extern_crate.name_ref()?.as_name();
         let alias = extern_crate.rename().map(|a| {
             a.name().map(|it| it.as_name()).map_or(ImportAlias::Underscore, ImportAlias::Alias)
@@ -294,11 +288,10 @@ impl<'db> Ctx<'db> {
         let ast_id = self.source_ast_id_map.ast_id(extern_crate);
 
         let res = ExternCrate { name, alias, visibility };
-        self.tree.big_data.insert(ast_id.upcast(), BigModItem::ExternCrate(res));
-        Some(ast_id)
+        Some(self.alloc_big(ast_id.upcast(), BigModItem::ExternCrate(res)))
     }
 
-    fn lower_macro_call(&mut self, m: &ast::MacroCall) -> Option<ItemTreeAstId<MacroCall>> {
+    fn lower_macro_call(&mut self, m: &ast::MacroCall) -> Option<ModItemId> {
         let span_map = self.span_map();
         let path = m.path()?;
         let range = path.syntax().text_range();
@@ -308,31 +301,28 @@ impl<'db> Ctx<'db> {
         let ast_id = self.source_ast_id_map.ast_id(m);
         let expand_to = hir_expand::ExpandTo::from_call_site(m);
         let res = MacroCall { path, expand_to, ctxt: span_map.span_for_range(range).ctx };
-        self.tree.small_data.insert(ast_id.upcast(), SmallModItem::MacroCall(res));
-        Some(ast_id)
+        Some(self.alloc_small(ast_id.upcast(), SmallModItem::MacroCall(res)))
     }
 
-    fn lower_macro_rules(&mut self, m: &ast::MacroRules) -> Option<ItemTreeAstId<MacroRules>> {
+    fn lower_macro_rules(&mut self, m: &ast::MacroRules) -> Option<ModItemId> {
         let name = m.name()?;
         let ast_id = self.source_ast_id_map.ast_id(m);
 
         let res = MacroRules { name: name.as_name() };
-        self.tree.small_data.insert(ast_id.upcast(), SmallModItem::MacroRules(res));
-        Some(ast_id)
+        Some(self.alloc_small(ast_id.upcast(), SmallModItem::MacroRules(res)))
     }
 
-    fn lower_macro_def(&mut self, m: &ast::MacroDef) -> Option<ItemTreeAstId<Macro2>> {
+    fn lower_macro_def(&mut self, m: &ast::MacroDef) -> Option<ModItemId> {
         let name = m.name()?;
 
         let ast_id = self.source_ast_id_map.ast_id(m);
         let visibility = self.lower_visibility(m);
 
         let res = Macro2 { name: name.as_name(), visibility };
-        self.tree.small_data.insert(ast_id.upcast(), SmallModItem::Macro2(res));
-        Some(ast_id)
+        Some(self.alloc_small(ast_id.upcast(), SmallModItem::Macro2(res)))
     }
 
-    fn lower_extern_block(&mut self, block: &ast::ExternBlock) -> ItemTreeAstId<ExternBlock> {
+    fn lower_extern_block(&mut self, block: &ast::ExternBlock) -> ModItemId {
         let ast_id = self.source_ast_id_map.ast_id(block);
         let children: Box<[_]> = block.extern_item_list().map_or(Box::new([]), |list| {
             list.extern_items()
@@ -341,22 +331,21 @@ impl<'db> Ctx<'db> {
                     // (in other words, the knowledge that they're in an extern block must not be used).
                     // This is because an extern block can contain macros whose ItemTree's top-level items
                     // should be considered to be in an extern block too.
-                    let mod_item: ModItemId = match &item {
-                        ast::ExternItem::Fn(ast) => self.lower_function(ast)?.into(),
-                        ast::ExternItem::Static(ast) => self.lower_static(ast)?.into(),
-                        ast::ExternItem::TypeAlias(ty) => self.lower_type_alias(ty)?.into(),
-                        ast::ExternItem::MacroCall(call) => self.lower_macro_call(call)?.into(),
+                    let mod_item = match &item {
+                        ast::ExternItem::Fn(ast) => self.lower_function(ast)?,
+                        ast::ExternItem::Static(ast) => self.lower_static(ast)?,
+                        ast::ExternItem::TypeAlias(ty) => self.lower_type_alias(ty)?,
+                        ast::ExternItem::MacroCall(call) => self.lower_macro_call(call)?,
                     };
                     let attrs = self.lower_attrs(&item);
-                    self.add_attrs(mod_item.ast_id(), attrs);
+                    self.add_attrs(mod_item, attrs);
                     Some(mod_item)
                 })
                 .collect()
         });
 
         let res = ExternBlock { children };
-        self.tree.small_data.insert(ast_id.upcast(), SmallModItem::ExternBlock(res));
-        ast_id
+        self.alloc_small(ast_id.upcast(), SmallModItem::ExternBlock(res))
     }
 
     fn lower_visibility(&mut self, item: &dyn ast::HasVisibility) -> RawVisibilityId {

--- a/crates/hir-def/src/item_tree/pretty.rs
+++ b/crates/hir-def/src/item_tree/pretty.rs
@@ -7,8 +7,9 @@ use span::{Edition, ErasedFileAstId};
 use crate::{
     item_tree::{
         Const, Enum, ExternBlock, ExternCrate, FieldsShape, Function, Impl, ItemTree, Macro2,
-        MacroCall, MacroRules, Mod, ModItemId, ModKind, RawVisibilityId, SourceDatabase, Static,
-        Struct, Trait, TypeAlias, Union, Use, UseTree, UseTreeKind, attrs::AttrsOrCfg,
+        MacroCall, MacroRules, Mod, ModItemId, ModItemKind, ModKind, RawVisibilityId,
+        SourceDatabase, Static, Struct, Trait, TypeAlias, Union, Use, UseTree, UseTreeKind,
+        attrs::AttrsOrCfg,
     },
     visibility::RawVisibility,
 };
@@ -21,8 +22,10 @@ pub(super) fn print_item_tree(
     let mut p =
         Printer { db, tree, buf: String::new(), indent_level: 0, needs_indent: true, edition };
 
-    p.print_attrs(&tree.top_attrs, true, "\n");
-    p.blank();
+    if let Some(top_attrs) = tree.top_level_attrs() {
+        p.print_attrs(top_attrs, true, "\n");
+        p.blank();
+    }
 
     for item in tree.top_level_items() {
         p.print_mod_item(*item);
@@ -111,7 +114,7 @@ impl Printer<'_> {
     }
 
     fn print_attrs_of(&mut self, of: ModItemId, separated_by: &str) {
-        if let Some(attrs) = self.tree.attrs.get(&of.ast_id()) {
+        if let Some(attrs) = self.tree.attrs(of) {
             self.print_attrs(attrs, false, separated_by);
         }
     }
@@ -173,17 +176,17 @@ impl Printer<'_> {
     fn print_mod_item(&mut self, item: ModItemId) {
         self.print_attrs_of(item, "\n");
 
-        match item {
-            ModItemId::Use(ast_id) => {
-                let Use { visibility, use_tree } = &self.tree[ast_id];
+        match self.tree.index(item) {
+            ModItemKind::Use(ast_id, item) => {
+                let Use { visibility, use_tree } = item;
                 self.print_ast_id(ast_id.erase());
                 self.print_visibility(*visibility);
                 w!(self, "use ");
                 self.print_use_tree(use_tree);
                 wln!(self, ";");
             }
-            ModItemId::ExternCrate(ast_id) => {
-                let ExternCrate { name, alias, visibility } = &self.tree[ast_id];
+            ModItemKind::ExternCrate(ast_id, item) => {
+                let ExternCrate { name, alias, visibility } = item;
                 self.print_ast_id(ast_id.erase());
                 self.print_visibility(*visibility);
                 w!(self, "extern crate {}", name.display(self.db, self.edition));
@@ -192,8 +195,8 @@ impl Printer<'_> {
                 }
                 wln!(self, ";");
             }
-            ModItemId::ExternBlock(ast_id) => {
-                let ExternBlock { children } = &self.tree[ast_id];
+            ModItemKind::ExternBlock(ast_id, item) => {
+                let ExternBlock { children } = item;
                 self.print_ast_id(ast_id.erase());
                 w!(self, "extern {{");
                 self.indented(|this| {
@@ -203,14 +206,14 @@ impl Printer<'_> {
                 });
                 wln!(self, "}}");
             }
-            ModItemId::Function(ast_id) => {
-                let Function { name, visibility } = &self.tree[ast_id];
+            ModItemKind::Function(ast_id, item) => {
+                let Function { name, visibility } = item;
                 self.print_ast_id(ast_id.erase());
                 self.print_visibility(*visibility);
                 wln!(self, "fn {};", name.display(self.db, self.edition));
             }
-            ModItemId::Struct(ast_id) => {
-                let Struct { visibility, name, shape: kind } = &self.tree[ast_id];
+            ModItemKind::Struct(ast_id, item) => {
+                let Struct { visibility, name, shape: kind } = item;
                 self.print_ast_id(ast_id.erase());
                 self.print_visibility(*visibility);
                 w!(self, "struct {}", name.display(self.db, self.edition));
@@ -221,22 +224,22 @@ impl Printer<'_> {
                     wln!(self, ";");
                 }
             }
-            ModItemId::Union(ast_id) => {
-                let Union { name, visibility } = &self.tree[ast_id];
+            ModItemKind::Union(ast_id, item) => {
+                let Union { name, visibility } = item;
                 self.print_ast_id(ast_id.erase());
                 self.print_visibility(*visibility);
                 w!(self, "union {}", name.display(self.db, self.edition));
                 self.print_fields(FieldsShape::Record);
                 wln!(self);
             }
-            ModItemId::Enum(ast_id) => {
-                let Enum { name, visibility } = &self.tree[ast_id];
+            ModItemKind::Enum(ast_id, item) => {
+                let Enum { name, visibility } = item;
                 self.print_ast_id(ast_id.erase());
                 self.print_visibility(*visibility);
                 w!(self, "enum {} {{ ... }}", name.display(self.db, self.edition));
             }
-            ModItemId::Const(ast_id) => {
-                let Const { name, visibility } = &self.tree[ast_id];
+            ModItemKind::Const(ast_id, item) => {
+                let Const { name, visibility } = item;
                 self.print_ast_id(ast_id.erase());
                 self.print_visibility(*visibility);
                 w!(self, "const ");
@@ -246,8 +249,8 @@ impl Printer<'_> {
                 }
                 wln!(self, " = _;");
             }
-            ModItemId::Static(ast_id) => {
-                let Static { name, visibility } = &self.tree[ast_id];
+            ModItemKind::Static(ast_id, item) => {
+                let Static { name, visibility } = item;
                 self.print_ast_id(ast_id.erase());
                 self.print_visibility(*visibility);
                 w!(self, "static ");
@@ -255,27 +258,27 @@ impl Printer<'_> {
                 w!(self, " = _;");
                 wln!(self);
             }
-            ModItemId::Trait(ast_id) => {
-                let Trait { name, visibility } = &self.tree[ast_id];
+            ModItemKind::Trait(ast_id, item) => {
+                let Trait { name, visibility } = item;
                 self.print_ast_id(ast_id.erase());
                 self.print_visibility(*visibility);
                 w!(self, "trait {} {{ ... }}", name.display(self.db, self.edition));
             }
-            ModItemId::Impl(ast_id) => {
-                let Impl { is_trait_impl: _ } = &self.tree[ast_id];
+            ModItemKind::Impl(ast_id, item) => {
+                let Impl { is_trait_impl: _ } = item;
                 self.print_ast_id(ast_id.erase());
                 w!(self, "impl {{ ... }}");
             }
-            ModItemId::TypeAlias(ast_id) => {
-                let TypeAlias { name, visibility } = &self.tree[ast_id];
+            ModItemKind::TypeAlias(ast_id, item) => {
+                let TypeAlias { name, visibility } = item;
                 self.print_ast_id(ast_id.erase());
                 self.print_visibility(*visibility);
                 w!(self, "type {}", name.display(self.db, self.edition));
                 w!(self, ";");
                 wln!(self);
             }
-            ModItemId::Mod(ast_id) => {
-                let Mod { name, visibility, kind } = &self.tree[ast_id];
+            ModItemKind::Mod(ast_id, item) => {
+                let Mod { name, visibility, kind } = item;
                 self.print_ast_id(ast_id.erase());
                 self.print_visibility(*visibility);
                 w!(self, "mod {}", name.display(self.db, self.edition));
@@ -294,8 +297,8 @@ impl Printer<'_> {
                     }
                 }
             }
-            ModItemId::MacroCall(ast_id) => {
-                let MacroCall { path, expand_to, ctxt } = &self.tree[ast_id];
+            ModItemKind::MacroCall(ast_id, item) => {
+                let MacroCall { path, expand_to, ctxt } = item;
                 let _ = writeln!(
                     self,
                     "// AstId: {:#?}, SyntaxContextId: {}, ExpandTo: {:?}",
@@ -305,13 +308,13 @@ impl Printer<'_> {
                 );
                 wln!(self, "{}!(...);", path.display(self.db, self.edition));
             }
-            ModItemId::MacroRules(ast_id) => {
-                let MacroRules { name } = &self.tree[ast_id];
+            ModItemKind::MacroRules(ast_id, item) => {
+                let MacroRules { name } = item;
                 self.print_ast_id(ast_id.erase());
                 wln!(self, "macro_rules! {} {{ ... }}", name.display(self.db, self.edition));
             }
-            ModItemId::Macro2(ast_id) => {
-                let Macro2 { name, visibility } = &self.tree[ast_id];
+            ModItemKind::Macro2(ast_id, item) => {
+                let Macro2 { name, visibility } = item;
                 self.print_ast_id(ast_id.erase());
                 self.print_visibility(*visibility);
                 wln!(self, "macro {} {{ ... }}", name.display(self.db, self.edition));

--- a/crates/hir-def/src/nameres/collector.rs
+++ b/crates/hir-def/src/nameres/collector.rs
@@ -37,7 +37,7 @@ use crate::{
     item_scope::{GlobId, ImportId, ImportOrExternCrate, PerNsGlobImports},
     item_tree::{
         self, Attrs, AttrsOrCfg, FieldsShape, ImportAlias, ImportKind, ItemTree, ItemTreeAstId,
-        Macro2, MacroCall, MacroRules, Mod, ModItemId, ModKind, TreeId,
+        Macro2, MacroCall, MacroRules, Mod, ModItemId, ModItemKind, ModKind, TreeId, Use,
     },
     macro_call_as_call_id,
     nameres::{
@@ -157,14 +157,13 @@ struct Import {
 impl Import {
     fn from_use(
         tree: &ItemTree,
-        item: FileAstId<ast::Use>,
+        item: &Use,
         id: UseId,
         is_prelude: bool,
         mut cb: impl FnMut(Self),
     ) {
-        let it = &tree[item];
-        let visibility = &tree[it.visibility];
-        it.expand(|idx, path, kind, alias| {
+        let visibility = &tree[item.visibility];
+        item.expand(|idx, path, kind, alias| {
             cb(Self {
                 path,
                 alias,
@@ -261,7 +260,7 @@ struct DefCollector<'db> {
     /// This also stores the attributes to skip when we resolve derive helpers and non-macro
     /// non-builtin attributes in general.
     // FIXME: There has to be a better way to do this
-    skip_attrs: FxHashMap<AstId<ast::Item>, AttrId>,
+    skip_attrs: FxHashMap<InFile<ModItemId>, AttrId>,
     /// When we expand attributes, we need to censor all previous active attributes
     /// on the same item. Therefore, this holds all active attributes that we already
     /// expanded.
@@ -280,8 +279,9 @@ impl<'db> DefCollector<'db> {
         let file_id = self.def_map.krate.root_file_id(self.db);
         let item_tree = file_item_tree(self.db, file_id.into(), self.def_map.krate);
         let attrs = match item_tree.top_level_attrs() {
-            AttrsOrCfg::Enabled { attrs } => attrs.as_ref(),
-            AttrsOrCfg::CfgDisabled(it) => it.1.as_ref(),
+            Some(AttrsOrCfg::Enabled { attrs }) => attrs.as_ref(),
+            None => Attrs::EMPTY,
+            Some(AttrsOrCfg::CfgDisabled(it)) => it.1.as_ref(),
         };
         let crate_data = Arc::get_mut(&mut self.def_map.data).unwrap();
 
@@ -368,7 +368,7 @@ impl<'db> DefCollector<'db> {
 
         self.inject_prelude();
 
-        if let AttrsOrCfg::CfgDisabled(attrs) = item_tree.top_level_attrs() {
+        if let Some(AttrsOrCfg::CfgDisabled(attrs)) = item_tree.top_level_attrs() {
             let (cfg_expr, _) = &**attrs;
             self.def_map.diagnostics.push(DefDiagnostic::unconfigured_code(
                 self.def_map.root,
@@ -394,7 +394,8 @@ impl<'db> DefCollector<'db> {
 
     fn seed_with_inner(&mut self, tree_id: TreeId) {
         let item_tree = tree_id.item_tree(self.db, self.def_map.krate);
-        let is_cfg_enabled = matches!(item_tree.top_level_attrs(), AttrsOrCfg::Enabled { .. });
+        let is_cfg_enabled =
+            matches!(item_tree.top_level_attrs(), Some(AttrsOrCfg::Enabled { .. }) | None);
         if is_cfg_enabled {
             self.inject_prelude();
 
@@ -502,7 +503,7 @@ impl<'db> DefCollector<'db> {
                         (*attr.path).clone(),
                     ));
 
-                    self.skip_attrs.insert(ast_id.ast_id.with_value(mod_item.ast_id()), *attr_id);
+                    self.skip_attrs.insert(ast_id.ast_id.with_value(*mod_item), *attr_id);
 
                     Some((idx, directive, *mod_item, *tree, *item_tree))
                 }
@@ -1435,9 +1436,7 @@ impl<'db> DefCollector<'db> {
                     let mut recollect_without = |collector: &mut Self| {
                         // Remove the original directive since we resolved it.
                         let mod_dir = collector.mod_dirs[&directive.module_id].clone();
-                        collector
-                            .skip_attrs
-                            .insert(InFile::new(file_id, mod_item.ast_id()), *attr_id);
+                        collector.skip_attrs.insert(InFile::new(file_id, *mod_item), *attr_id);
 
                         ModCollector {
                             def_collector: collector,
@@ -1506,10 +1505,10 @@ impl<'db> DefCollector<'db> {
                         // normal (as that would just be an identity expansion with extra output)
                         // Instead we treat derive attributes special and apply them separately.
 
-                        let ast_adt_id: FileAstId<ast::Adt> = match *mod_item {
-                            ModItemId::Struct(ast_id) => ast_id.upcast(),
-                            ModItemId::Union(ast_id) => ast_id.upcast(),
-                            ModItemId::Enum(ast_id) => ast_id.upcast(),
+                        let ast_adt_id: FileAstId<ast::Adt> = match item_tree.index(*mod_item) {
+                            ModItemKind::Struct(ast_id, _) => ast_id.upcast(),
+                            ModItemKind::Union(ast_id, _) => ast_id.upcast(),
+                            ModItemKind::Enum(ast_id, _) => ast_id.upcast(),
                             _ => {
                                 let diag = DefDiagnostic::invalid_derive_target(
                                     directive.module_id,
@@ -1746,7 +1745,7 @@ impl<'db> DefCollector<'db> {
             for item in item_tree.top_level_items() {
                 self.def_map
                     .derive_helpers_in_scope
-                    .entry(InFile::new(file_id, item.ast_id()))
+                    .entry(InFile::new(file_id, item.ast_id(item_tree)))
                     .or_default()
                     .extend(derive_helpers.iter().cloned());
             }
@@ -1953,18 +1952,20 @@ impl ModCollector<'_, '_> {
                 .unwrap_or(Visibility::Public)
         };
 
-        let mut process_mod_item = |item: ModItemId| {
-            let attrs = match self.item_tree.attrs(item.ast_id()) {
+        let item_tree = self.item_tree;
+
+        let mut process_mod_item = |item_id: ModItemId| {
+            let attrs = match self.item_tree.attrs(item_id) {
                 Some(AttrsOrCfg::Enabled { attrs }) => attrs.as_ref(),
                 None => Attrs::EMPTY,
                 Some(AttrsOrCfg::CfgDisabled(cfg)) => {
-                    let ast_id = item.ast_id().erase();
+                    let ast_id = item_id.ast_id(self.item_tree).erase();
                     self.emit_unconfigured_diagnostic(InFile::new(self.file_id(), ast_id), &cfg.0);
                     return;
                 }
             };
 
-            if let Err(()) = self.resolve_attributes(attrs, item, container) {
+            if let Err(()) = self.resolve_attributes(attrs, item_id, container) {
                 // Do not process the item. It has at least one non-builtin attribute, so the
                 // fixed-point algorithm is required to resolve the rest of them.
                 return;
@@ -1974,16 +1975,14 @@ impl ModCollector<'_, '_> {
             let local_def_map =
                 self.def_collector.crate_local_def_map.unwrap_or(&self.def_collector.local_def_map);
 
-            match item {
-                ModItemId::Mod(m) => self.collect_module(m, attrs),
-                ModItemId::Use(item_tree_id) => {
-                    let id = UseLoc {
-                        container: module_id,
-                        id: InFile::new(self.file_id(), item_tree_id),
-                    }
-                    .intern(db);
+            match self.item_tree.index(item_id) {
+                ModItemKind::Mod(ast_id, module) => self.collect_module(ast_id, module, attrs),
+                ModItemKind::Use(ast_id, use_) => {
+                    let id =
+                        UseLoc { container: module_id, id: InFile::new(self.file_id(), ast_id) }
+                            .intern(db);
                     let is_prelude = attrs.by_key(sym::prelude_import).exists();
-                    Import::from_use(self.item_tree, item_tree_id, id, is_prelude, |import| {
+                    Import::from_use(self.item_tree, use_, id, is_prelude, |import| {
                         self.def_collector.unresolved_imports.push(ImportDirective {
                             module_id: self.module_id,
                             import,
@@ -1991,13 +1990,12 @@ impl ModCollector<'_, '_> {
                         });
                     })
                 }
-                ModItemId::ExternCrate(item_tree_id) => {
-                    let item_tree::ExternCrate { name, visibility, alias } =
-                        &self.item_tree[item_tree_id];
+                ModItemKind::ExternCrate(ast_id, item) => {
+                    let item_tree::ExternCrate { name, visibility, alias } = item;
 
                     let id = ExternCrateLoc {
                         container: module_id,
-                        id: InFile::new(self.tree_id.file_id(), item_tree_id),
+                        id: InFile::new(self.tree_id.file_id(), ast_id),
                     }
                     .intern(db);
                     def_map.modules[self.module_id].scope.define_extern_crate_decl(id);
@@ -2060,40 +2058,42 @@ impl ModCollector<'_, '_> {
                         self.def_collector.def_map.diagnostics.push(
                             DefDiagnostic::unresolved_extern_crate(
                                 module_id,
-                                InFile::new(self.file_id(), item_tree_id),
+                                InFile::new(self.file_id(), ast_id),
                             ),
                         );
                     }
                 }
-                ModItemId::ExternBlock(block) => {
+                ModItemKind::ExternBlock(ast_id, block) => {
                     let extern_block_id = ExternBlockLoc {
                         container: module_id,
-                        id: InFile::new(self.file_id(), block),
+                        id: InFile::new(self.file_id(), ast_id),
                     }
                     .intern(db);
                     self.def_collector.def_map.modules[self.module_id]
                         .scope
                         .define_extern_block(extern_block_id);
-                    self.collect(
-                        &self.item_tree[block].children,
-                        ItemContainerId::ExternBlockId(extern_block_id),
-                    )
+                    self.collect(&block.children, ItemContainerId::ExternBlockId(extern_block_id))
                 }
-                ModItemId::MacroCall(mac) => self.collect_macro_call(mac, container),
-                ModItemId::MacroRules(id) => self.collect_macro_rules(id, module_id),
-                ModItemId::Macro2(id) => self.collect_macro_def(id, module_id),
-                ModItemId::Impl(imp) => {
+                ModItemKind::MacroCall(ast_id, mac) => {
+                    self.collect_macro_call(ast_id, mac, container)
+                }
+                ModItemKind::MacroRules(ast_id, mac) => {
+                    self.collect_macro_rules(attrs, ast_id, mac, module_id)
+                }
+                ModItemKind::Macro2(ast_id, mac) => {
+                    self.collect_macro_def(attrs, ast_id, mac, module_id)
+                }
+                ModItemKind::Impl(ast_id, imp) => {
                     let impl_id =
-                        ImplLoc { container: module_id, id: InFile::new(self.file_id(), imp) }
+                        ImplLoc { container: module_id, id: InFile::new(self.file_id(), ast_id) }
                             .intern(db);
                     self.def_collector.def_map.modules[self.module_id]
                         .scope
-                        .define_impl(impl_id, self.item_tree[imp].is_trait_impl)
+                        .define_impl(impl_id, imp.is_trait_impl)
                 }
-                ModItemId::Function(id) => {
-                    let it = &self.item_tree[id];
+                ModItemKind::Function(ast_id, it) => {
                     let fn_id =
-                        FunctionLoc { container, id: InFile::new(self.tree_id.file_id(), id) }
+                        FunctionLoc { container, id: InFile::new(self.tree_id.file_id(), ast_id) }
                             .intern(db);
 
                     let vis = resolve_vis(def_map, local_def_map, &self.item_tree[it.visibility]);
@@ -2107,7 +2107,7 @@ impl ModCollector<'_, '_> {
                     {
                         self.def_collector.export_proc_macro(
                             proc_macro,
-                            InFile::new(self.file_id(), id),
+                            InFile::new(self.file_id(), ast_id),
                             fn_id,
                         );
 
@@ -2119,19 +2119,17 @@ impl ModCollector<'_, '_> {
                             .remove_from_value_ns(&it.name, fn_id.into());
                     }
                 }
-                ModItemId::Struct(id) => {
-                    let it = &self.item_tree[id];
-
+                ModItemKind::Struct(ast_id, it) => {
                     let vis = resolve_vis(def_map, local_def_map, &self.item_tree[it.visibility]);
                     let interned = StructLoc {
                         container: module_id,
-                        id: InFile::new(self.tree_id.file_id(), id),
+                        id: InFile::new(self.tree_id.file_id(), ast_id),
                     }
                     .intern(db);
                     consider_deferred_derives(
                         self.tree_id.file_id(),
                         &mut self.def_collector.deferred_builtin_derives,
-                        id.upcast(),
+                        ast_id.upcast(),
                         interned.into(),
                         def_map,
                     );
@@ -2143,46 +2141,42 @@ impl ModCollector<'_, '_> {
                         !matches!(it.shape, FieldsShape::Record),
                     );
                 }
-                ModItemId::Union(id) => {
-                    let it = &self.item_tree[id];
-
+                ModItemKind::Union(ast_id, it) => {
                     let vis = resolve_vis(def_map, local_def_map, &self.item_tree[it.visibility]);
                     let interned = UnionLoc {
                         container: module_id,
-                        id: InFile::new(self.tree_id.file_id(), id),
+                        id: InFile::new(self.tree_id.file_id(), ast_id),
                     }
                     .intern(db);
                     consider_deferred_derives(
                         self.tree_id.file_id(),
                         &mut self.def_collector.deferred_builtin_derives,
-                        id.upcast(),
+                        ast_id.upcast(),
                         interned.into(),
                         def_map,
                     );
                     update_def(self.def_collector, interned.into(), &it.name, vis, false);
                 }
-                ModItemId::Enum(id) => {
-                    let it = &self.item_tree[id];
+                ModItemKind::Enum(ast_id, it) => {
                     let enum_ = EnumLoc {
                         container: module_id,
-                        id: InFile::new(self.tree_id.file_id(), id),
+                        id: InFile::new(self.tree_id.file_id(), ast_id),
                     }
                     .intern(db);
 
                     consider_deferred_derives(
                         self.tree_id.file_id(),
                         &mut self.def_collector.deferred_builtin_derives,
-                        id.upcast(),
+                        ast_id.upcast(),
                         enum_.into(),
                         def_map,
                     );
                     let vis = resolve_vis(def_map, local_def_map, &self.item_tree[it.visibility]);
                     update_def(self.def_collector, enum_.into(), &it.name, vis, false);
                 }
-                ModItemId::Const(id) => {
-                    let it = &self.item_tree[id];
+                ModItemKind::Const(ast_id, it) => {
                     let const_id =
-                        ConstLoc { container, id: InFile::new(self.tree_id.file_id(), id) }
+                        ConstLoc { container, id: InFile::new(self.tree_id.file_id(), ast_id) }
                             .intern(db);
 
                     match &it.name {
@@ -2199,13 +2193,11 @@ impl ModCollector<'_, '_> {
                         }
                     }
                 }
-                ModItemId::Static(id) => {
-                    let it = &self.item_tree[id];
-
+                ModItemKind::Static(ast_id, it) => {
                     let vis = resolve_vis(def_map, local_def_map, &self.item_tree[it.visibility]);
                     update_def(
                         self.def_collector,
-                        StaticLoc { container, id: InFile::new(self.file_id(), id) }
+                        StaticLoc { container, id: InFile::new(self.file_id(), ast_id) }
                             .intern(db)
                             .into(),
                         &it.name,
@@ -2213,13 +2205,11 @@ impl ModCollector<'_, '_> {
                         false,
                     );
                 }
-                ModItemId::Trait(id) => {
-                    let it = &self.item_tree[id];
-
+                ModItemKind::Trait(ast_id, it) => {
                     let vis = resolve_vis(def_map, local_def_map, &self.item_tree[it.visibility]);
                     update_def(
                         self.def_collector,
-                        TraitLoc { container: module_id, id: InFile::new(self.file_id(), id) }
+                        TraitLoc { container: module_id, id: InFile::new(self.file_id(), ast_id) }
                             .intern(db)
                             .into(),
                         &it.name,
@@ -2227,13 +2217,11 @@ impl ModCollector<'_, '_> {
                         false,
                     );
                 }
-                ModItemId::TypeAlias(id) => {
-                    let it = &self.item_tree[id];
-
+                ModItemKind::TypeAlias(ast_id, it) => {
                     let vis = resolve_vis(def_map, local_def_map, &self.item_tree[it.visibility]);
                     update_def(
                         self.def_collector,
-                        TypeAliasLoc { container, id: InFile::new(self.file_id(), id) }
+                        TypeAliasLoc { container, id: InFile::new(self.file_id(), ast_id) }
                             .intern(db)
                             .into(),
                         &it.name,
@@ -2250,12 +2238,12 @@ impl ModCollector<'_, '_> {
         if is_crate_root {
             items
                 .iter()
-                .filter(|it| matches!(it, ModItemId::ExternCrate(..)))
+                .filter(move |&&it| matches!(item_tree.index(it), ModItemKind::ExternCrate(..)))
                 .copied()
                 .for_each(&mut process_mod_item);
             items
                 .iter()
-                .filter(|it| !matches!(it, ModItemId::ExternCrate(..)))
+                .filter(move |&&it| !matches!(item_tree.index(it), ModItemKind::ExternCrate(..)))
                 .copied()
                 .for_each(process_mod_item);
         } else {
@@ -2296,10 +2284,14 @@ impl ModCollector<'_, '_> {
         );
     }
 
-    fn collect_module(&mut self, module_ast_id: ItemTreeAstId<Mod>, attrs: Attrs<'_>) {
+    fn collect_module(
+        &mut self,
+        module_ast_id: ItemTreeAstId<Mod>,
+        module: &Mod,
+        attrs: Attrs<'_>,
+    ) {
         let path_attr = attrs.by_key(sym::path).string_value_unescape();
         let is_macro_use = attrs.by_key(sym::macro_use).exists();
-        let module = &self.item_tree[module_ast_id];
         match &module.kind {
             // inline module, just recurse
             ModKind::Inline { items } => {
@@ -2341,14 +2333,15 @@ impl ModCollector<'_, '_> {
                     Ok((file_id, is_mod_rs, mod_dir)) => {
                         let item_tree =
                             file_item_tree(db, file_id.into(), self.def_collector.def_map.krate);
-                        match item_tree.top_level_attrs() {
-                            AttrsOrCfg::CfgDisabled(cfg) => {
+                        let top_level_attrs = item_tree.top_level_attrs();
+                        match top_level_attrs {
+                            Some(AttrsOrCfg::CfgDisabled(cfg)) => {
                                 self.emit_unconfigured_diagnostic(
                                     InFile::new(self.file_id(), module_ast_id.erase()),
                                     &cfg.0,
                                 );
                             }
-                            AttrsOrCfg::Enabled { attrs } => {
+                            Some(AttrsOrCfg::Enabled { .. }) | None => {
                                 let module_id = self.push_child_module(
                                     module.name.clone(),
                                     ast_id.value,
@@ -2364,8 +2357,8 @@ impl ModCollector<'_, '_> {
                                     mod_dir,
                                 }
                                 .collect_in_top_module(item_tree.top_level_items());
-                                let is_macro_use =
-                                    is_macro_use || attrs.as_ref().by_key(sym::macro_use).exists();
+                                let is_macro_use = is_macro_use
+                                    || matches!(top_level_attrs, Some(AttrsOrCfg::Enabled { attrs }) if attrs.as_ref().by_key(sym::macro_use).exists());
                                 if is_macro_use {
                                     self.import_all_legacy_macros(module_id);
                                 }
@@ -2464,11 +2457,8 @@ impl ModCollector<'_, '_> {
         mod_item: ModItemId,
         container: ItemContainerId,
     ) -> Result<(), ()> {
-        let ignore_up_to = self
-            .def_collector
-            .skip_attrs
-            .get(&InFile::new(self.file_id(), mod_item.ast_id()))
-            .copied();
+        let ignore_up_to =
+            self.def_collector.skip_attrs.get(&InFile::new(self.file_id(), mod_item)).copied();
         for (attr_id, attr) in attrs.iter_after(ignore_up_to) {
             if self.def_collector.def_map.is_builtin_or_registered_attr(&attr.path) {
                 continue;
@@ -2478,7 +2468,11 @@ impl ModCollector<'_, '_> {
                 attr.path.display(self.def_collector.db, Edition::LATEST)
             );
 
-            let ast_id = AstIdWithPath::new(self.file_id(), mod_item.ast_id(), attr.path.clone());
+            let ast_id = AstIdWithPath::new(
+                self.file_id(),
+                mod_item.ast_id(self.item_tree),
+                attr.path.clone(),
+            );
             self.def_collector.unresolved_macros.push(MacroDirective {
                 module_id: self.module_id,
                 depth: self.macro_depth + 1,
@@ -2499,16 +2493,14 @@ impl ModCollector<'_, '_> {
         Ok(())
     }
 
-    fn collect_macro_rules(&mut self, ast_id: ItemTreeAstId<MacroRules>, module: ModuleId) {
+    fn collect_macro_rules(
+        &mut self,
+        attrs: Attrs<'_>,
+        ast_id: ItemTreeAstId<MacroRules>,
+        mac: &MacroRules,
+        module: ModuleId,
+    ) {
         let krate = self.def_collector.def_map.krate;
-        let mac = &self.item_tree[ast_id];
-        let attrs = match self.item_tree.attrs(ast_id.upcast()) {
-            Some(AttrsOrCfg::Enabled { attrs }) => attrs.as_ref(),
-            None => Attrs::EMPTY,
-            Some(AttrsOrCfg::CfgDisabled(_)) => {
-                unreachable!("we only get here if the macro is not cfg'ed out")
-            }
-        };
         let f_ast_id = InFile::new(self.file_id(), ast_id.upcast());
 
         let export_attr = || attrs.by_key(sym::macro_export);
@@ -2583,16 +2575,14 @@ impl ModCollector<'_, '_> {
         );
     }
 
-    fn collect_macro_def(&mut self, ast_id: ItemTreeAstId<Macro2>, module: ModuleId) {
+    fn collect_macro_def(
+        &mut self,
+        attrs: Attrs<'_>,
+        ast_id: ItemTreeAstId<Macro2>,
+        mac: &Macro2,
+        module: ModuleId,
+    ) {
         let krate = self.def_collector.def_map.krate;
-        let mac = &self.item_tree[ast_id];
-        let attrs = match self.item_tree.attrs(ast_id.upcast()) {
-            Some(AttrsOrCfg::Enabled { attrs }) => attrs.as_ref(),
-            None => Attrs::EMPTY,
-            Some(AttrsOrCfg::CfgDisabled(_)) => {
-                unreachable!("we only get here if the macro is not cfg'ed out")
-            }
-        };
         let f_ast_id = InFile::new(self.file_id(), ast_id.upcast());
 
         // Case 1: builtin macros
@@ -2668,9 +2658,10 @@ impl ModCollector<'_, '_> {
     fn collect_macro_call(
         &mut self,
         ast_id: FileAstId<ast::MacroCall>,
+        macro_call: &MacroCall,
         container: ItemContainerId,
     ) {
-        let &MacroCall { ref path, expand_to, ctxt } = &self.item_tree[ast_id];
+        let &MacroCall { ref path, expand_to, ctxt } = macro_call;
         let ast_id = AstIdWithPath::new(self.file_id(), ast_id, path.clone());
         let db = self.def_collector.db;
 

--- a/crates/span/src/ast_id.rs
+++ b/crates/span/src/ast_id.rs
@@ -59,53 +59,13 @@ pub struct ErasedFileAstId(u32);
 
 impl fmt::Debug for ErasedFileAstId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let kind = self.kind();
-        macro_rules! kind {
-            ($($kind:ident),* $(,)?) => {
-                if false {
-                    // Ensure we covered all variants.
-                    match ErasedFileAstIdKind::Root {
-                        $( ErasedFileAstIdKind::$kind => {} )*
-                    }
-                    unreachable!()
-                }
-                $( else if kind == ErasedFileAstIdKind::$kind as u32 {
-                    stringify!($kind)
-                } )*
-                else {
-                    "Unknown"
-                }
-            };
-        }
-        let kind = kind!(
-            Root,
-            Enum,
-            Struct,
-            Union,
-            ExternCrate,
-            MacroDef,
-            MacroRules,
-            Module,
-            Static,
-            Trait,
-            Variant,
-            Const,
-            Fn,
-            MacroCall,
-            TypeAlias,
-            ExternBlock,
-            Use,
-            Impl,
-            BlockExpr,
-            AsmExpr,
-            Fixup,
-            NoDownmap,
-        );
+        let kind =
+            self.kind_typed().map_or_else(|| "Unknown".to_owned(), |kind| format!("{kind:?}"));
         if f.alternate() {
             write!(f, "{kind}[{:04X}, {}]", self.hash_value(), self.index())
         } else {
             f.debug_struct("ErasedFileAstId")
-                .field("kind", &format_args!("{kind}"))
+                .field("kind", &kind)
                 .field("index", &self.index())
                 .field("hash", &format_args!("{:04X}", self.hash_value()))
                 .finish()
@@ -161,6 +121,35 @@ enum ErasedFileAstIdKind {
     Root,
 }
 
+impl ErasedFileAstIdKind {
+    fn syntax_kind(self) -> Option<SyntaxKind> {
+        match self {
+            ErasedFileAstIdKind::Enum => Some(SyntaxKind::ENUM),
+            ErasedFileAstIdKind::Struct => Some(SyntaxKind::STRUCT),
+            ErasedFileAstIdKind::Union => Some(SyntaxKind::UNION),
+            ErasedFileAstIdKind::ExternCrate => Some(SyntaxKind::EXTERN_CRATE),
+            ErasedFileAstIdKind::MacroDef => Some(SyntaxKind::MACRO_DEF),
+            ErasedFileAstIdKind::MacroRules => Some(SyntaxKind::MACRO_RULES),
+            ErasedFileAstIdKind::Module => Some(SyntaxKind::MODULE),
+            ErasedFileAstIdKind::Static => Some(SyntaxKind::STATIC),
+            ErasedFileAstIdKind::Trait => Some(SyntaxKind::TRAIT),
+            ErasedFileAstIdKind::Variant => Some(SyntaxKind::VARIANT),
+            ErasedFileAstIdKind::Const => Some(SyntaxKind::CONST),
+            ErasedFileAstIdKind::Fn => Some(SyntaxKind::FN),
+            ErasedFileAstIdKind::MacroCall => Some(SyntaxKind::MACRO_CALL),
+            ErasedFileAstIdKind::TypeAlias => Some(SyntaxKind::TYPE_ALIAS),
+            ErasedFileAstIdKind::ExternBlock => Some(SyntaxKind::EXTERN_BLOCK),
+            ErasedFileAstIdKind::Use => Some(SyntaxKind::USE),
+            ErasedFileAstIdKind::Impl => Some(SyntaxKind::IMPL),
+            ErasedFileAstIdKind::BlockExpr => Some(SyntaxKind::BLOCK_EXPR),
+            ErasedFileAstIdKind::AsmExpr => Some(SyntaxKind::ASM_EXPR),
+            ErasedFileAstIdKind::Fixup
+            | ErasedFileAstIdKind::NoDownmap
+            | ErasedFileAstIdKind::Root => None,
+        }
+    }
+}
+
 // First hash, then index, then kind.
 const HASH_BITS: u32 = 16;
 const INDEX_BITS: u32 = 11;
@@ -204,6 +193,51 @@ impl ErasedFileAstId {
     #[inline]
     fn kind(self) -> u32 {
         self.0 >> (HASH_BITS + INDEX_BITS)
+    }
+
+    fn kind_typed(self) -> Option<ErasedFileAstIdKind> {
+        let kind = self.kind();
+        macro_rules! kind {
+            ($($kind:ident),* $(,)?) => {
+                if false {
+                    // Ensure we covered all variants.
+                    match ErasedFileAstIdKind::Root {
+                        $( ErasedFileAstIdKind::$kind => {} )*
+                    }
+                    unreachable!()
+                }
+                $( else if kind == ErasedFileAstIdKind::$kind as u32 {
+                    Some(ErasedFileAstIdKind::$kind)
+                } )*
+                else {
+                    None
+                }
+            };
+        }
+        kind!(
+            Root,
+            Enum,
+            Struct,
+            Union,
+            ExternCrate,
+            MacroDef,
+            MacroRules,
+            Module,
+            Static,
+            Trait,
+            Variant,
+            Const,
+            Fn,
+            MacroCall,
+            TypeAlias,
+            ExternBlock,
+            Use,
+            Impl,
+            BlockExpr,
+            AsmExpr,
+            Fixup,
+            NoDownmap,
+        )
     }
 
     #[inline]
@@ -290,6 +324,20 @@ impl<N> FileAstId<N> {
     where
         N: Into<M>,
     {
+        FileAstId { raw: self.raw, _marker: PhantomData }
+    }
+
+    #[inline]
+    pub fn downcast_unchecked<M: AstIdNode + Into<N>>(self) -> FileAstId<M> {
+        debug_assert!(
+            self.erase()
+                .kind_typed()
+                .and_then(|kind| kind.syntax_kind())
+                .is_some_and(|kind| M::can_cast(kind)),
+            "`FileAstId::<{}>::downcast_unchecked::<{}>()` is invalid",
+            std::any::type_name::<N>(),
+            std::any::type_name::<M>(),
+        );
         FileAstId { raw: self.raw, _marker: PhantomData }
     }
 


### PR DESCRIPTION
Do not use hash maps (which consume more memory), instead use bare `ThinVec`s and indexing.

This saves 28mb on self and 59mb on buck2. Not a lot, but significant, the impact on maintainability is practically zero, and furthermore, unlike e.g. optimizations to hir-ty, all item trees are always kept in memory even in IDE scenarios, so the save is real.

This has just a little bit impact on incrementality: now if you reorder items the item tree is invalidated (meaning the def map is invalidated, but not other things). However the item tree is easily invalidated, e.g. by adding a `use`. So this is not a problem.