### PR TITLE
fix: avoid escaping bound vars produced by infer_method_call's skip_binder 

### DIFF
--- a/crates/hir-ty/src/infer/expr.rs
+++ b/crates/hir-ty/src/infer/expr.rs
@@ -1900,7 +1900,12 @@ impl<'db> InferenceContext<'db> {
                     )),
                     None => field_with_same_name_exists.and_then(|field_ty| {
                         let callable_sig = field_ty.callable_sig(self.interner())?;
-                        Some((field_ty, callable_sig.skip_binder(), false))
+                        let callable_sig = self.infcx().instantiate_binder_with_fresh_vars(
+                            tgt_expr.into(),
+                            BoundRegionConversionTime::FnCall,
+                            callable_sig,
+                        );
+                        Some((field_ty, callable_sig, false))
                     }),
                 };
                 match recovered {

--- a/crates/hir-ty/src/tests/regression/new_solver.rs
+++ b/crates/hir-ty/src/tests/regression/new_solver.rs
@@ -949,3 +949,31 @@ fn test2<T: FooFactory>(factory: T) {
         "#]],
     );
 }
+
+#[test]
+fn infer_method_call_recovery_hrtb_does_not_panic() {
+    check_no_mismatches(
+        r#"
+//- minicore: coerce_unsized, dispatch_from_dyn, fn, option, phantom_data, sized
+use core::marker::PhantomData;
+
+trait Any {}
+
+impl<T: 'static> Any for T {}
+
+struct Bar<'a>(PhantomData<&'a ()>);
+
+type FooFn = for<'a> fn(&'a dyn Any) -> Option<Bar<'a>>;
+
+struct Foo {
+    bar: FooFn,
+}
+
+impl Foo {
+    fn baz<'a, T: 'static>(&self, x: &'a T) -> Option<Bar<'a>> {
+        self.bar(x)
+    }
+}
+"#,
+    );
+}


### PR DESCRIPTION
fixes rust-lang/rust-analyzer#23044 
the root cause is in function `infer_method_call`:
```rust
 None => field_with_same_name_exists.and_then(|field_ty| {
                        let callable_sig = field_ty.callable_sig(self.interner())?;
                        Some((field_ty, callable_sig.skip_binder(), false))
```
calls the function `skip_binder()` which produces escaping bound vars.

I add the printer like:
```rust
eprintln!(
    "callable_sig before skip_binder: has_escaping_bound_vars={}",
    callable_sig.has_escaping_bound_vars(),
    );

let skipped = callable_sig.skip_binder();

eprintln!(
    "callable_sig after skip_binder: has_escaping_bound_vars={}",
    skipped.has_escaping_bound_vars(),
    );                        
```
the print message is 
```
callable_sig before skip_binder: has_escaping_bound_vars=false
callable_sig after skip_binder: has_escaping_bound_vars=true
```