### PR TITLE
fixed Implement opaques_with_sub_unified_hidden_type for the next-sol…

### DIFF
--- a/crates/hir-ty/src/next_solver/infer/context.rs
+++ b/crates/hir-ty/src/next_solver/infer/context.rs
@@ -348,10 +348,28 @@ impl<'db> rustc_type_ir::InferCtxtLike for InferCtxt<'db> {
 
     fn opaques_with_sub_unified_hidden_type(
         &self,
-        _ty: TyVid,
+        ty: TyVid,
     ) -> Vec<rustc_type_ir::AliasTy<Self::Interner>> {
-        // FIXME: I guess we are okay without this for now since currently r-a lacks of
-        // detailed checks over opaque types. Might need to implement this in future.
-        vec![]
+        let ty_sub_vid = self.sub_unification_table_root_var(ty);
+        let inner = &mut *self.inner.borrow_mut();
+        let mut type_variables = inner.type_variable_storage.with_log(&mut inner.undo_log);
+        inner
+            .opaque_type_storage
+            .iter_opaque_types()
+            .filter_map(|(key, hidden_ty)| {
+                let TyKind::Infer(InferTy::TyVar(hidden_vid)) = hidden_ty.ty.kind() else {
+                    return None;
+                };
+                (type_variables.sub_unification_table_root_var(hidden_vid) == ty_sub_vid).then(
+                    || {
+                        rustc_type_ir::AliasTy::new_from_args(
+                            self.interner,
+                            rustc_type_ir::Opaque { def_id: key.def_id },
+                            key.args,
+                        )
+                    },
+                )
+            })
+            .collect()
     }
 }

--- a/crates/hir-ty/src/tests/regression/new_solver.rs
+++ b/crates/hir-ty/src/tests/regression/new_solver.rs
@@ -670,6 +670,40 @@ where
 }
 
 #[test]
+fn opaque_iterator_uses_blanket_into_iterator_impl() {
+    check_types(
+        r#"
+//- minicore: iterator
+struct Item;
+impl Item {
+    fn method(&self) -> usize {
+        0
+    }
+}
+
+struct Iter;
+impl Iterator for Iter {
+    type Item = Item;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        None
+    }
+}
+
+fn iterator(recurse: bool) -> impl Iterator<Item = Item> {
+    if recurse {
+        for item in iterator(false) {
+            item.method();
+          //^^^^^^^^^^^^^ usize
+        }
+    }
+    Iter
+}
+"#,
+    );
+}
+
+#[test]
 fn regression_16282() {
     check_infer(
         r#"


### PR DESCRIPTION
The following previously produced by a type mismatch "unknown" or E0599 diagnostic:

async fn test() -> ! {
    Box::pin(test()).await;
}
This is a self-recursive async function returning !, while type checking its own body, .await need <Box<Pin<...>> as IntoFuture>::Output to normalize !, but that ! comes from this very function's own opaque return type.
which isn't resolved yet since we're still in the middle of checking it.
The inference variable created for the .await result ends up subunified with the unknown hidden type of the in-flight opaque, and the solver had no way to look through that relationship to the opaque's bounds.

This was fixed by implementing InferCtxt::opaques_with_sub_unified_hidden_type, which was previously stubbed to always return vec![]. 

That method lets the solver ask "is there an in-flight opaque type whose (still-unresolved) hidden type is sub-unified with this stuck inference variable?" and if so, fall back to that opaque's item bounds/blanket impls to keep making progress instead of giving up.

AI was used for assist but i fixed and diagnosed solution myself.

Fixes: rust-lang/rust-analyzer rust-lang/rust-analyzer#22853