### PR TITLE
fix: remove extra spaces in full function signatures

### DIFF
--- a/crates/ide-completion/src/render/function.rs
+++ b/crates/ide-completion/src/render/function.rs
@@ -336,7 +336,7 @@ fn detail_full(ctx: &CompletionContext<'_, '_>, func: hir::Function) -> String {
     let mut detail = String::with_capacity(signature.len());
 
     for segment in signature.split_whitespace() {
-        if !detail.is_empty() {
+        if !detail.is_empty() && !detail.ends_with('(') && !segment.starts_with(')') {
             detail.push(' ');
         }
 

--- a/crates/ide-completion/src/tests/special.rs
+++ b/crates/ide-completion/src/tests/special.rs
@@ -1617,6 +1617,19 @@ fn main() {
         expect!("const fn(&'foo mut self, &Foo) -> !"),
         expect!("pub const fn baz<'foo>(&'foo mut self, x: &'foo Foo) -> !"),
     );
+
+    check_signatures(
+        r#"
+struct Foo;
+impl Foo {
+    pub fn method(&self, first: bool, second: bool, third: bool, fourth: bool) {}
+}
+fn main() { Foo.m$0 }
+"#,
+        CompletionItemKind::SymbolKind(SymbolKind::Method),
+        expect!("fn(&self, bool, bool, bool, bool)"),
+        expect!("pub fn method(&self, first: bool, second: bool, third: bool, fourth: bool)"),
+    );
 }
 
 #[test]


### PR DESCRIPTION
Closes rust-lang/rust-analyzer#23069 

When `rust-analyzer.completion.fullFunctionSignatures.enable` is set to `true`, completion descriptions are generated by `detail_full`, which internally calls `write_function()` to produce the signature. For functions with more than four parameters, the generated signature is multi-line:
https://github.com/rust-lang/rust-analyzer/blob/ece721d6cdfdf420d8bcc7b9feb48e3b6dbc1f04/crates/hir/src/display.rs#L195-L210

Take the `compare_exchange()` function as an example, the final generated signature for this function is like:
```
pub fn compare_exchange(
    &self,
    current: bool,
    new: bool,
    success: Ordering,
    failure: Ordering,
) -> Result<bool, bool>
```
Flattening this output in `detail_full` previously inserted a space right after `(` and right before `)`, e.g. `pub fn compare_exchange( &self, ...  )`.

This PR makes a small change to `detail_full` to skip the whitespace insertion around the parentheses.