### PR TITLE
feat: let Param::parent_fn return function for BuiltinDeriveImplMethod methods

### DIFF
--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -2602,6 +2602,9 @@ impl<'db> Param<'db> {
     pub fn parent_fn(&self) -> Option<Function> {
         match self.func {
             Callee::Def(CallableDefId::FunctionId(f)) => Some(f.into()),
+            Callee::BuiltinDeriveImplMethod { method, impl_ } => {
+                Some(Function { id: AnyFunctionId::BuiltinDeriveImplMethod { method, impl_ } })
+            }
             _ => None,
         }
     }


### PR DESCRIPTION
I found `Param::parent_fn` does not return function for builtin derive impl methods.

I found this while writing an tool with rust analyzer as a library.
I don't think this affects behavior of rust analyzer.
I'm sorry if PRs only affecting library are not accepted.

----

Actually, I found several inconsistent behavior around `hir::Function`, `hir::Param`, and `hir::GenericParam` for builtin derive impls.
Most of them are relatively easy to workaround so I didn't try to create PRs fixing them, but if PRs fixing them are accepted, I'll try fixing them.