### PR TITLE
fix:Normalize associated types in orphan checks

### DIFF
--- a/crates/hir-ty/src/traits.rs
+++ b/crates/hir-ty/src/traits.rs
@@ -347,6 +347,14 @@ pub fn check_orphan_rules<'db>(db: &'db dyn HirDatabase, impl_: ImplId) -> bool 
         return true;
     }
 
+    let interner = DbInterner::new_with(db, local_crate);
+    let infcx = interner.infer_ctxt().build(TypingMode::non_body_analysis());
+    let param_env = db.trait_environment(impl_.into());
+    let trait_ref = infcx
+        .at(&ObligationCause::dummy(), param_env)
+        .deeply_normalize(trait_ref)
+        .unwrap_or(trait_ref);
+
     let unwrap_fundamental = |mut ty: Ty<'db>| {
         // Unwrap all layers of fundamental types with a loop.
         loop {

--- a/crates/ide-diagnostics/src/handlers/trait_impl_orphan.rs
+++ b/crates/ide-diagnostics/src/handlers/trait_impl_orphan.rs
@@ -115,4 +115,37 @@ impl foo::Trait for &&Foo {}
         "#,
         );
     }
+
+    #[test]
+    fn associated_type_normalizes_to_local_type() {
+        check_diagnostics(
+            r#"
+//- /foo.rs crate:foo
+pub trait Trait {}
+//- /main.rs crate:main deps:foo
+trait LocalTrait { type Assoc; }
+struct LocalType;
+impl LocalTrait for () { type Assoc = LocalType; }
+impl foo::Trait for <() as LocalTrait>::Assoc {}
+impl foo::Trait for &<() as LocalTrait>::Assoc {}
+"#,
+        );
+    }
+
+    #[test]
+    fn associated_type_normalizes_to_foreign_type() {
+        check_diagnostics(
+            r#"
+//- /foo.rs crate:foo
+pub trait Trait {}
+//- /bar.rs crate:bar
+pub struct ForeignType;
+pub trait Alias { type Assoc; }
+impl Alias for () { type Assoc = ForeignType; }
+//- /main.rs crate:main deps:foo,bar
+  impl foo::Trait for <() as bar::Alias>::Assoc {}
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: only traits defined in the current crate can be implemented for arbitrary types
+"#,
+        );
+    }
 }


### PR DESCRIPTION
错误原因是当前没有在orphan-rule检查前将<() as Trait>::Assoc归一化成实际的本地类型LocalType，修复在locality遍历中结构化归一化alias同时在归一化失败时仍保持原来的保守判断。仿照原有测试的内容做了正例，fundamental包裹以及外部类型反例的最小化测试。

<The reason for the error is that <() as Trait>::Assoc  is not normalized to the actual local type LocalType  before orphan-rule checking. This fixes the structural normalization of alias in locality traversal while maintaining the original conservative judgment when normalization fails. Minimized tests of positive examples, fundamental packages and external type counterexamples were made based on the content of the original tests.>
Fixed: https://github.com/rust-lang/rust-analyzer/issues/23076