### PR TITLE
perf: Optimize the heck out of the storage of token trees

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3096,7 +3096,6 @@ name = "tt"
 version = "0.0.0"
 dependencies = [
  "arrayvec",
- "indexmap",
  "intern",
  "ra-ap-rustc_lexer",
  "rustc-hash 2.1.2",

--- a/crates/cfg/Cargo.toml
+++ b/crates/cfg/Cargo.toml
@@ -28,10 +28,9 @@ arbitrary = { version = "1.4.1", features = ["derive"] }
 
 # local deps
 syntax-bridge.workspace = true
-syntax.workspace = true
 
-# tt is needed for testing
-cfg = { path = ".", default-features = false, features = ["tt"] }
+# tt and syntax are needed for testing
+cfg = { path = ".", default-features = false, features = ["tt", "syntax"] }
 
 [features]
 default = []

--- a/crates/hir-expand/src/fixup.rs
+++ b/crates/hir-expand/src/fixup.rs
@@ -419,9 +419,11 @@ mod tests {
     }
 
     fn check_subtree_eq(a: &tt::TopSubtree, b: &tt::TopSubtree) -> bool {
-        let a = a.view().as_token_trees().iter_flat_tokens();
-        let b = b.view().as_token_trees().iter_flat_tokens();
-        a.len() == b.len() && std::iter::zip(a, b).all(|(a, b)| check_tt_eq(&a, &b))
+        let a = a.view().as_token_trees();
+        let b = b.view().as_token_trees();
+        a.len() == b.len()
+            && std::iter::zip(a.iter_flat_tokens(), b.iter_flat_tokens())
+                .all(|(a, b)| check_tt_eq(&a, &b))
     }
 
     fn check_tt_eq(a: &tt::TokenTree, b: &tt::TokenTree) -> bool {

--- a/crates/intern/src/symbol.rs
+++ b/crates/intern/src/symbol.rs
@@ -175,6 +175,19 @@ impl Symbol {
     }
 
     #[inline]
+    pub fn into_raw(self) -> NonNull<*const str> {
+        ManuallyDrop::new(self).repr.packed
+    }
+
+    /// # Safety
+    ///
+    /// The pointer must have come from [`Symbol::into_raw()`].
+    #[inline]
+    pub unsafe fn from_raw(ptr: NonNull<*const str>) -> Symbol {
+        Symbol { repr: TaggedArcPtr { packed: ptr } }
+    }
+
+    #[inline]
     fn select_shard(
         storage: &'static Map,
         s: &str,
@@ -217,11 +230,12 @@ impl Symbol {
             shard.shrink_to(len, |(x, _)| Self::hash(storage, x.as_str()));
         }
     }
-}
 
-impl Drop for Symbol {
+    /// # Safety
+    ///
+    /// You must know that you have a `Symbol` instance that won't be dropped, so decreasing the refcount is valid.
     #[inline]
-    fn drop(&mut self) {
+    pub unsafe fn decrease_refcount(&mut self) {
         // SAFETY: We're dropping, we have ownership.
         let Some(arc) = (unsafe { self.repr.try_as_arc_owned() }) else {
             return;
@@ -234,6 +248,15 @@ impl Drop for Symbol {
         }
         // decrement the ref count
         ManuallyDrop::into_inner(arc);
+    }
+}
+
+impl Drop for Symbol {
+    #[inline]
+    fn drop(&mut self) {
+        unsafe {
+            self.decrease_refcount();
+        }
     }
 }
 

--- a/crates/mbe/src/lib.rs
+++ b/crates/mbe/src/lib.rs
@@ -442,7 +442,7 @@ pub fn expect_fragment<'t>(
     }
 
     let res = cursor.crossed();
-    tt_iter.flat_advance(res.len());
+    tt_iter.flat_advance_to(&cursor);
 
     ExpandResult { value: res, err }
 }

--- a/crates/tt/Cargo.toml
+++ b/crates/tt/Cargo.toml
@@ -16,7 +16,6 @@ doctest = false
 arrayvec.workspace = true
 text-size.workspace = true
 rustc-hash.workspace = true
-indexmap.workspace = true
 
 span = { path = "../span", version = "0.0", default-features = false }
 stdx.workspace = true

--- a/crates/tt/src/buffer.rs
+++ b/crates/tt/src/buffer.rs
@@ -1,41 +1,51 @@
 //! Stateful iteration over token trees.
 //!
 //! We use this as the source of tokens for parser.
-use crate::{Leaf, Subtree, TokenTree, TokenTreesView, dispatch_ref};
+use crate::{Leaf, Subtree, TokenTree, TokenTreesView, storage::TokenTreesSlice};
 
 pub struct Cursor<'a> {
-    buffer: TokenTreesView<'a>,
-    index: usize,
-    subtrees_stack: Vec<usize>,
+    origin: TokenTreesSlice<'a>,
+    buffer_before_current: TokenTreesSlice<'a>,
+    buffer_after_current: TokenTreesSlice<'a>,
+    /// The number of times we called [`Self::advance()`]. Also the index of [`Self::next`].
+    advances_count: usize,
+    len: usize,
+    next: Option<TokenTree>,
+    subtrees_stack: Vec<(usize, Subtree)>,
 }
 
 impl<'a> Cursor<'a> {
-    pub fn new(buffer: TokenTreesView<'a>) -> Self {
-        Self { buffer, index: 0, subtrees_stack: Vec::new() }
+    pub fn new(origin: TokenTreesView<'a>) -> Self {
+        let mut buffer_after_current = origin.slice;
+        let buffer_before_current = buffer_after_current;
+        let len = origin.len;
+        let next = if len >= 1 { buffer_after_current.advance() } else { None };
+        Self {
+            origin: origin.slice,
+            buffer_after_current,
+            buffer_before_current,
+            advances_count: 0,
+            len,
+            next,
+            subtrees_stack: Vec::new(),
+        }
     }
 
     /// Check whether it is eof
     pub fn eof(&self) -> bool {
-        self.index == self.buffer.len() && self.subtrees_stack.is_empty()
+        self.next.is_none() && self.subtrees_stack.is_empty()
     }
 
     pub fn is_root(&self) -> bool {
         self.subtrees_stack.is_empty()
     }
 
-    fn at(&self, idx: usize) -> Option<TokenTree> {
-        dispatch_ref! {
-            match self.buffer.repr => tt => Some(tt.get(idx)?.to_api(self.buffer.span_parts))
-        }
+    fn last_subtree(&self) -> Option<(usize, Subtree)> {
+        self.subtrees_stack.last().copied()
     }
 
-    fn last_subtree(&self) -> Option<(usize, Subtree)> {
-        self.subtrees_stack.last().map(|&subtree_idx| {
-            let Some(TokenTree::Subtree(subtree)) = self.at(subtree_idx) else {
-                panic!("subtree pointing to non-subtree");
-            };
-            (subtree_idx, subtree)
-        })
+    pub(crate) fn remaining(&self) -> TokenTreesView<'a> {
+        TokenTreesView { slice: self.buffer_before_current, len: self.len - self.advances_count }
     }
 
     pub fn end(&mut self) -> Subtree {
@@ -44,7 +54,7 @@ impl<'a> Cursor<'a> {
         // +1 because `Subtree.len` excludes the subtree itself.
         assert_eq!(
             last_subtree_idx + last_subtree.usize_len() + 1,
-            self.index,
+            self.advances_count,
             "called `Cursor::end()` without finishing a subtree"
         );
         self.subtrees_stack.pop();
@@ -55,11 +65,24 @@ impl<'a> Cursor<'a> {
     pub fn token_tree(&self) -> Option<TokenTree> {
         if let Some((last_subtree_idx, last_subtree)) = self.last_subtree() {
             // +1 because `Subtree.len` excludes the subtree itself.
-            if last_subtree_idx + last_subtree.usize_len() + 1 == self.index {
+            if last_subtree_idx + last_subtree.usize_len() + 1 == self.advances_count {
                 return None;
             }
         }
-        self.at(self.index)
+        self.next.clone()
+    }
+
+    fn advance(&mut self) {
+        if self.advances_count >= self.len {
+            return;
+        }
+        if let Some(TokenTree::Subtree(subtree)) = self.next {
+            self.subtrees_stack.push((self.advances_count, subtree));
+        }
+        self.advances_count += 1;
+        self.buffer_before_current = self.buffer_after_current;
+        self.next =
+            if self.advances_count < self.len { self.buffer_after_current.advance() } else { None };
     }
 
     /// Bump the cursor, and enters a subtree if it is on one.
@@ -68,40 +91,35 @@ impl<'a> Cursor<'a> {
             // +1 because `Subtree.len` excludes the subtree itself.
             assert_ne!(
                 last_subtree_idx + last_subtree.usize_len() + 1,
-                self.index,
+                self.advances_count,
                 "called `Cursor::bump()` when at the end of a subtree"
             );
         }
-        if let Some(TokenTree::Subtree(_)) = self.at(self.index) {
-            self.subtrees_stack.push(self.index);
-        }
-        self.index += 1;
+        self.advance();
     }
 
     pub fn bump_or_end(&mut self) {
-        if let Some((last_subtree_idx, last_subtree)) = self.last_subtree() {
-            // +1 because `Subtree.len` excludes the subtree itself.
-            if last_subtree_idx + last_subtree.usize_len() + 1 == self.index {
-                self.subtrees_stack.pop();
-                return;
-            }
-        }
         // +1 because `Subtree.len` excludes the subtree itself.
-        if let Some(TokenTree::Subtree(_)) = self.at(self.index) {
-            self.subtrees_stack.push(self.index);
+        if let Some((last_subtree_idx, last_subtree)) = self.last_subtree()
+            && last_subtree_idx + last_subtree.usize_len() + 1 == self.advances_count
+        {
+            self.subtrees_stack.pop();
+            return;
         }
-        self.index += 1;
+        self.advance();
     }
 
     pub fn peek_two_leaves(&self) -> Option<[Leaf; 2]> {
         if let Some((last_subtree_idx, last_subtree)) = self.last_subtree() {
             // +1 because `Subtree.len` excludes the subtree itself.
             let last_end = last_subtree_idx + last_subtree.usize_len() + 1;
-            if last_end == self.index || last_end == self.index + 1 {
+            if last_end == self.advances_count || last_end == self.advances_count + 1 {
                 return None;
             }
         }
-        self.at(self.index).zip(self.at(self.index + 1)).and_then(|it| match it {
+        let mut buffer = self.buffer_after_current;
+        let next_next = if self.advances_count + 1 < self.len { buffer.advance() } else { None };
+        self.next.clone().zip(next_next).and_then(|it| match it {
             (TokenTree::Leaf(a), TokenTree::Leaf(b)) => Some([a, b]),
             _ => None,
         })
@@ -109,9 +127,6 @@ impl<'a> Cursor<'a> {
 
     pub fn crossed(&self) -> TokenTreesView<'a> {
         assert!(self.is_root());
-        TokenTreesView {
-            repr: self.buffer.repr.get(..self.index).unwrap(),
-            span_parts: self.buffer.span_parts,
-        }
+        TokenTreesView { slice: self.origin, len: self.advances_count }
     }
 }

--- a/crates/tt/src/iter.rs
+++ b/crates/tt/src/iter.rs
@@ -8,8 +8,8 @@ use intern::sym;
 use span::Span;
 
 use crate::{
-    Ident, Leaf, MAX_GLUED_PUNCT_LEN, Punct, Spacing, Subtree, TokenTree, TokenTreesReprRef,
-    TokenTreesView, dispatch_ref,
+    Ident, Leaf, MAX_GLUED_PUNCT_LEN, Punct, Spacing, Subtree, TokenTree, TokenTreesView,
+    buffer::Cursor,
 };
 
 #[derive(Clone)]
@@ -126,13 +126,13 @@ impl<'a> TtIter<'a> {
             return Ok(res);
         }
 
-        let (second, third) = match (self.peek_n(0), self.peek_n(1)) {
-            (Some(TokenTree::Leaf(Leaf::Punct(p2))), Some(TokenTree::Leaf(Leaf::Punct(p3))))
+        let (second, third) = match self.peek_two() {
+            [Some(TokenTree::Leaf(Leaf::Punct(p2))), Some(TokenTree::Leaf(Leaf::Punct(p3)))]
                 if p2.spacing == Spacing::Joint =>
             {
                 (p2, Some(p3))
             }
-            (Some(TokenTree::Leaf(Leaf::Punct(p2))), _) => (p2, None),
+            [Some(TokenTree::Leaf(Leaf::Punct(p2))), _] => (p2, None),
             _ => {
                 res.push(first);
                 return Ok(res);
@@ -165,20 +165,21 @@ impl<'a> TtIter<'a> {
     }
 
     /// This method won't check for subtrees, so the nth token tree may not be the nth sibling of the current tree.
-    fn peek_n(&self, n: usize) -> Option<TokenTree> {
-        dispatch_ref! {
-            match self.inner.repr => tt => Some(tt.get(n)?.to_api(self.inner.span_parts))
-        }
+    fn peek_two(&self) -> [Option<TokenTree>; 2] {
+        let mut iter = self.inner.iter_flat_tokens();
+        [iter.next(), iter.next()]
     }
 
     pub fn peek(&self) -> Option<TtElement<'a>> {
-        match self.peek_n(0)? {
+        if self.inner.is_empty() {
+            return None;
+        }
+        let mut slice = self.inner.slice;
+        match slice.advance()? {
             TokenTree::Leaf(leaf) => Some(TtElement::Leaf(leaf)),
             TokenTree::Subtree(subtree) => {
-                let nested_repr = self.inner.repr.get(1..subtree.usize_len() + 1).unwrap();
-                let nested_iter = TtIter {
-                    inner: TokenTreesView { repr: nested_repr, span_parts: self.inner.span_parts },
-                };
+                let nested_iter =
+                    TtIter { inner: TokenTreesView { len: subtree.usize_len(), slice } };
                 Some(TtElement::Subtree(subtree, nested_iter))
             }
         }
@@ -186,7 +187,7 @@ impl<'a> TtIter<'a> {
 
     /// Equivalent to `peek().is_none()`, but a bit faster.
     pub fn is_empty(&self) -> bool {
-        self.inner.len() == 0
+        self.inner.is_empty()
     }
 
     pub fn next_span(&self) -> Option<Span> {
@@ -197,9 +198,9 @@ impl<'a> TtIter<'a> {
         self.inner
     }
 
-    /// **Warning**: This advances `skip` **flat** token trees, subtrees account for children+1!
-    pub fn flat_advance(&mut self, skip: usize) {
-        self.inner.repr = self.inner.repr.get(skip..).unwrap();
+    /// **Warning**: This advances **flat** token trees, subtrees account for children+1!
+    pub fn flat_advance_to(&mut self, up_to: &Cursor<'a>) {
+        self.inner = up_to.remaining();
     }
 
     pub fn savepoint(&self) -> TtIterSavepoint<'a> {
@@ -207,34 +208,7 @@ impl<'a> TtIter<'a> {
     }
 
     pub fn from_savepoint(&self, savepoint: TtIterSavepoint<'a>) -> TokenTreesView<'a> {
-        let len = match (self.inner.repr, savepoint.0.repr) {
-            (
-                TokenTreesReprRef::SpanStorage32(this),
-                TokenTreesReprRef::SpanStorage32(savepoint),
-            ) => {
-                (this.as_ptr() as usize - savepoint.as_ptr() as usize)
-                    / size_of::<crate::storage::TokenTree<crate::storage::SpanStorage32>>()
-            }
-            (
-                TokenTreesReprRef::SpanStorage64(this),
-                TokenTreesReprRef::SpanStorage64(savepoint),
-            ) => {
-                (this.as_ptr() as usize - savepoint.as_ptr() as usize)
-                    / size_of::<crate::storage::TokenTree<crate::storage::SpanStorage64>>()
-            }
-            (
-                TokenTreesReprRef::SpanStorage96(this),
-                TokenTreesReprRef::SpanStorage96(savepoint),
-            ) => {
-                (this.as_ptr() as usize - savepoint.as_ptr() as usize)
-                    / size_of::<crate::storage::TokenTree<crate::storage::SpanStorage96>>()
-            }
-            _ => panic!("savepoint did not originate from this TtIter"),
-        };
-        TokenTreesView {
-            repr: savepoint.0.repr.get(..len).unwrap(),
-            span_parts: savepoint.0.span_parts,
-        }
+        TokenTreesView { slice: savepoint.0.slice, len: savepoint.0.len - self.inner.len }
     }
 
     pub fn next_as_view(&mut self) -> Option<TokenTreesView<'a>> {
@@ -274,12 +248,20 @@ impl TtElement<'_> {
 impl<'a> Iterator for TtIter<'a> {
     type Item = TtElement<'a>;
     fn next(&mut self) -> Option<Self::Item> {
-        let result = self.peek()?;
-        let skip = match &result {
-            TtElement::Leaf(_) => 1,
-            TtElement::Subtree(subtree, _) => subtree.usize_len() + 1,
-        };
-        self.inner.repr = self.inner.repr.get(skip..).unwrap();
-        Some(result)
+        if self.inner.is_empty() {
+            return None;
+        }
+        self.inner.len -= 1;
+        let (tt, subtree_slice) = self.inner.slice.advance_skip_subtree()?;
+        match tt {
+            TokenTree::Leaf(leaf) => Some(TtElement::Leaf(leaf)),
+            TokenTree::Subtree(subtree) => {
+                self.inner.len -= subtree.usize_len();
+                let nested_iter = TtIter {
+                    inner: TokenTreesView { len: subtree.usize_len(), slice: subtree_slice },
+                };
+                Some(TtElement::Subtree(subtree, nested_iter))
+            }
+        }
     }
 }

--- a/crates/tt/src/lib.rs
+++ b/crates/tt/src/lib.rs
@@ -17,7 +17,7 @@ pub mod buffer;
 pub mod iter;
 mod storage;
 
-use std::{fmt, slice::SliceIndex};
+use std::fmt;
 
 use arrayvec::ArrayString;
 use buffer::Cursor;
@@ -27,7 +27,7 @@ use stdx::{impl_from, itertools::Itertools as _};
 pub use span::Span;
 pub use text_size::{TextRange, TextSize};
 
-use crate::storage::{CompressedSpanPart, SpanStorage};
+use crate::storage::TokenTreesSlice;
 
 pub use self::iter::{TtElement, TtIter};
 pub use self::storage::{TopSubtree, TopSubtreeBuilder};
@@ -42,9 +42,11 @@ pub struct Lit {
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[repr(u8)]
+// The discriminants are important for `storage.rs` decoding.
 pub enum IdentIsRaw {
-    No,
-    Yes,
+    No = 0,
+    Yes = 1,
 }
 impl IdentIsRaw {
     pub fn yes(self) -> bool {
@@ -113,6 +115,14 @@ impl Leaf {
             Leaf::Ident(it) => &it.span,
         }
     }
+
+    fn symbol(&self) -> Option<&Symbol> {
+        match self {
+            Leaf::Literal(Literal { text_and_suffix: symbol, .. })
+            | Leaf::Ident(Ident { sym: symbol, .. }) => Some(symbol),
+            Leaf::Punct(_) => None,
+        }
+    }
 }
 impl_from!(Literal, Punct, Ident for Leaf);
 
@@ -129,67 +139,16 @@ impl Subtree {
     }
 }
 
-#[rust_analyzer::macro_style(braces)]
-macro_rules! dispatch_ref {
-    (
-        match $scrutinee:expr => $tt:ident => $body:expr
-    ) => {
-        match $scrutinee {
-            $crate::TokenTreesReprRef::SpanStorage32($tt) => $body,
-            $crate::TokenTreesReprRef::SpanStorage64($tt) => $body,
-            $crate::TokenTreesReprRef::SpanStorage96($tt) => $body,
-        }
-    };
-}
-use dispatch_ref;
-
-#[derive(Clone, Copy)]
-enum TokenTreesReprRef<'a> {
-    SpanStorage32(&'a [crate::storage::TokenTree<crate::storage::SpanStorage32>]),
-    SpanStorage64(&'a [crate::storage::TokenTree<crate::storage::SpanStorage64>]),
-    SpanStorage96(&'a [crate::storage::TokenTree<crate::storage::SpanStorage96>]),
-}
-
-impl<'a> TokenTreesReprRef<'a> {
-    #[inline]
-    fn get<I>(&self, index: I) -> Option<Self>
-    where
-        I: SliceIndex<
-                [crate::storage::TokenTree<crate::storage::SpanStorage32>],
-                Output = [crate::storage::TokenTree<crate::storage::SpanStorage32>],
-            >,
-        I: SliceIndex<
-                [crate::storage::TokenTree<crate::storage::SpanStorage64>],
-                Output = [crate::storage::TokenTree<crate::storage::SpanStorage64>],
-            >,
-        I: SliceIndex<
-                [crate::storage::TokenTree<crate::storage::SpanStorage96>],
-                Output = [crate::storage::TokenTree<crate::storage::SpanStorage96>],
-            >,
-    {
-        Some(match self {
-            TokenTreesReprRef::SpanStorage32(tt) => {
-                TokenTreesReprRef::SpanStorage32(tt.get(index)?)
-            }
-            TokenTreesReprRef::SpanStorage64(tt) => {
-                TokenTreesReprRef::SpanStorage64(tt.get(index)?)
-            }
-            TokenTreesReprRef::SpanStorage96(tt) => {
-                TokenTreesReprRef::SpanStorage96(tt.get(index)?)
-            }
-        })
-    }
-}
-
 #[derive(Clone, Copy)]
 pub struct TokenTreesView<'a> {
-    repr: TokenTreesReprRef<'a>,
-    span_parts: &'a [CompressedSpanPart],
+    slice: TokenTreesSlice<'a>,
+    len: usize,
 }
 
 impl<'a> TokenTreesView<'a> {
+    #[inline]
     pub fn empty() -> Self {
-        Self { repr: TokenTreesReprRef::SpanStorage32(&[]), span_parts: &[] }
+        Self { slice: TokenTreesSlice::empty(), len: 0 }
     }
 
     pub fn iter(&self) -> TtIter<'a> {
@@ -201,9 +160,7 @@ impl<'a> TokenTreesView<'a> {
     }
 
     pub fn len(&self) -> usize {
-        dispatch_ref! {
-            match self.repr => tt => tt.len()
-        }
+        self.len
     }
 
     pub fn is_empty(&self) -> bool {
@@ -211,12 +168,9 @@ impl<'a> TokenTreesView<'a> {
     }
 
     pub fn try_into_subtree(self) -> Option<SubtreeView<'a>> {
-        let is_subtree = dispatch_ref! {
-            match self.repr => tt => matches!(
-                tt.first(),
-                Some(crate::storage::TokenTree::Subtree { len, .. }) if (*len as usize) == (tt.len() - 1)
-            )
-        };
+        let is_subtree = self.iter_flat_tokens().next().is_some_and(
+            |it| matches!(it, TokenTree::Subtree(subtree) if subtree.usize_len() == self.len - 1),
+        );
         if is_subtree { Some(SubtreeView(self)) } else { None }
     }
 
@@ -251,23 +205,29 @@ impl<'a> TokenTreesView<'a> {
     }
 
     pub fn first_span(&self) -> Option<Span> {
-        Some(dispatch_ref! {
-            match self.repr => tt => tt.first()?.first_span().span(self.span_parts)
-        })
+        self.iter_flat_tokens().next().map(|it| it.first_span())
     }
 
+    /// Note: this is quite expensive, this needs to decode the whole view,
+    /// although it "tricks" by skipping subtrees (since we know their byte length).
     pub fn last_span(&self) -> Option<Span> {
-        Some(dispatch_ref! {
-            match self.repr => tt => tt.last()?.last_span().span(self.span_parts)
-        })
+        let mut iter = self.iter();
+        loop {
+            match iter.last()? {
+                TtElement::Leaf(leaf) => return Some(*leaf.span()),
+                TtElement::Subtree(subtree, tt_iter) => {
+                    if subtree.len == 0 {
+                        return Some(subtree.delimiter.close);
+                    } else {
+                        iter = tt_iter;
+                    }
+                }
+            }
+        }
     }
 
-    pub fn iter_flat_tokens(self) -> impl ExactSizeIterator<Item = TokenTree> + use<'a> {
-        (0..self.len()).map(move |idx| {
-            dispatch_ref! {
-                match self.repr => tt => tt[idx].to_api(self.span_parts)
-            }
-        })
+    pub fn iter_flat_tokens(&self) -> impl Iterator<Item = TokenTree> + use<'a> {
+        self.slice.iter().take(self.len)
     }
 }
 
@@ -343,23 +303,10 @@ impl<'a> SubtreeView<'a> {
     }
 
     pub fn top_subtree(&self) -> Subtree {
-        dispatch_ref! {
-            match self.0.repr => tt => {
-                let crate::storage::TokenTree::Subtree { len, delim_kind, open_span, close_span } =
-                    &tt[0]
-                else {
-                    unreachable!("the first token tree is always the top subtree");
-                };
-                Subtree {
-                    delimiter: Delimiter {
-                        open: open_span.span(self.0.span_parts),
-                        close: close_span.span(self.0.span_parts),
-                        kind: *delim_kind,
-                    },
-                    len: *len,
-                }
-            }
-        }
+        let Some(TokenTree::Subtree(subtree)) = self.0.iter_flat_tokens().next() else {
+            unreachable!("the first token tree is always the top subtree");
+        };
+        subtree
     }
 
     pub fn strip_invisible(&self) -> TokenTreesView<'a> {
@@ -371,18 +318,10 @@ impl<'a> SubtreeView<'a> {
     }
 
     pub fn token_trees(&self) -> TokenTreesView<'a> {
-        let repr = match self.0.repr {
-            TokenTreesReprRef::SpanStorage32(token_trees) => {
-                TokenTreesReprRef::SpanStorage32(&token_trees[1..])
-            }
-            TokenTreesReprRef::SpanStorage64(token_trees) => {
-                TokenTreesReprRef::SpanStorage64(&token_trees[1..])
-            }
-            TokenTreesReprRef::SpanStorage96(token_trees) => {
-                TokenTreesReprRef::SpanStorage96(&token_trees[1..])
-            }
-        };
-        TokenTreesView { repr, ..self.0 }
+        let mut result = self.0;
+        result.slice.advance();
+        result.len -= 1;
+        result
     }
 }
 
@@ -435,11 +374,13 @@ impl Delimiter {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[repr(u8)]
+// The discriminants are important for decoding for `storage.rs`.
 pub enum DelimiterKind {
-    Parenthesis,
-    Brace,
-    Bracket,
-    Invisible,
+    Parenthesis = 0,
+    Brace = 1,
+    Bracket = 2,
+    Invisible = 3,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -555,7 +496,9 @@ pub struct Punct {
 /// compound token. Used for conversions to `proc_macro::Spacing`. Also used to
 /// guide pretty-printing, which is where the `JointHidden` value (which isn't
 /// part of `proc_macro::Spacing`) comes in useful.
+// The discriminants are important for decoding for `storage.rs`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[repr(u8)]
 pub enum Spacing {
     /// The token cannot join with the following token to form a compound
     /// token.
@@ -572,7 +515,7 @@ pub enum Spacing {
     ///
     /// Converts to `proc_macro::Spacing::Alone`, and
     /// `proc_macro::Spacing::Alone` converts back to this.
-    Alone,
+    Alone = 0,
 
     /// The token can join with the following token to form a compound token.
     ///
@@ -586,7 +529,7 @@ pub enum Spacing {
     ///
     /// Converts to `proc_macro::Spacing::Joint`, and
     /// `proc_macro::Spacing::Joint` converts back to this.
-    Joint,
+    Joint = 1,
 
     /// The token can join with the following token to form a compound token,
     /// but this will not be visible at the proc macro level. (This is what the
@@ -608,7 +551,7 @@ pub enum Spacing {
     /// pretty-printing of `TokenStream`'s produced by other means (i.e. parsed
     /// source code, internally constructed token streams, and token streams
     /// produced by declarative macros).
-    JointHidden,
+    JointHidden = 2,
 }
 
 /// Identifier or keyword.
@@ -764,36 +707,16 @@ impl Subtree {
 }
 
 pub fn pretty(tkns: TokenTreesView<'_>) -> String {
-    return dispatch_ref! {
-        match tkns.repr => tt => pretty_impl(tkns, tt)
-    };
+    return pretty_impl(tkns.iter());
 
-    use crate::storage::TokenTree;
-
-    fn tokentree_to_text<S: SpanStorage>(
-        tkns_view: TokenTreesView<'_>,
-        tkn: &TokenTree<S>,
-        tkns: &mut &[TokenTree<S>],
-    ) -> String {
+    fn tokentree_to_text(tkn: TtElement<'_>) -> String {
         match tkn {
-            TokenTree::Ident { sym, is_raw, .. } => format!("{}{}", is_raw.as_str(), sym),
-            &TokenTree::Literal { ref text_and_suffix, kind, suffix_len, span } => {
-                format!(
-                    "{}",
-                    Literal {
-                        text_and_suffix: text_and_suffix.clone(),
-                        span: span.span(tkns_view.span_parts),
-                        kind,
-                        suffix_len
-                    }
-                )
+            TtElement::Leaf(leaf) => {
+                format!("{}", leaf)
             }
-            TokenTree::Punct { char, .. } => format!("{}", char),
-            TokenTree::Subtree { len, delim_kind, .. } => {
-                let (subtree_content, rest) = tkns.split_at(*len as usize);
-                let content = pretty_impl(tkns_view, subtree_content);
-                *tkns = rest;
-                let (open, close) = match *delim_kind {
+            TtElement::Subtree(Subtree { delimiter, .. }, subtree_content) => {
+                let content = pretty_impl(subtree_content);
+                let (open, close) = match delimiter.kind {
                     DelimiterKind::Brace => ("{", "}"),
                     DelimiterKind::Bracket => ("[", "]"),
                     DelimiterKind::Parenthesis => ("(", ")"),
@@ -804,23 +727,16 @@ pub fn pretty(tkns: TokenTreesView<'_>) -> String {
         }
     }
 
-    fn pretty_impl<S: SpanStorage>(
-        tkns_view: TokenTreesView<'_>,
-        mut tkns: &[TokenTree<S>],
-    ) -> String {
+    fn pretty_impl(tkns: TtIter<'_>) -> String {
         let mut last = String::new();
         let mut last_to_joint = true;
 
-        while let Some((tkn, rest)) = tkns.split_first() {
-            tkns = rest;
-            last = [last, tokentree_to_text(tkns_view, tkn, &mut tkns)].join(if last_to_joint {
-                ""
-            } else {
-                " "
-            });
+        for tkn in tkns {
+            last =
+                [last, tokentree_to_text(tkn.clone())].join(if last_to_joint { "" } else { " " });
             last_to_joint = false;
-            if let TokenTree::Punct { spacing, .. } = tkn
-                && *spacing == Spacing::Joint
+            if let TtElement::Leaf(Leaf::Punct(Punct { spacing, .. })) = tkn
+                && spacing == Spacing::Joint
             {
                 last_to_joint = true;
             }
@@ -847,7 +763,7 @@ impl TransformTtAction<'_> {
 /// tts view.
 pub fn transform_tt<'b>(
     tt: &mut TopSubtree,
-    mut callback: impl FnMut(TokenTree) -> TransformTtAction<'b>,
+    mut callback: impl FnMut(&TokenTree) -> TransformTtAction<'b>,
 ) {
     let mut tt_vec = tt.as_token_trees().iter_flat_tokens().collect::<Vec<_>>();
 
@@ -867,27 +783,20 @@ pub fn transform_tt<'b>(
             }
         }
 
-        let current = match &tt_vec[i] {
-            TokenTree::Leaf(leaf) => TokenTree::Leaf(match leaf {
-                Leaf::Literal(leaf) => Leaf::Literal(leaf.clone()),
-                Leaf::Punct(leaf) => Leaf::Punct(*leaf),
-                Leaf::Ident(leaf) => Leaf::Ident(leaf.clone()),
-            }),
-            TokenTree::Subtree(subtree) => TokenTree::Subtree(*subtree),
-        };
+        let current = &tt_vec[i];
         let action = callback(current);
         match action {
             TransformTtAction::Keep => {
                 // This cannot be shared with the replaced case, because then we may push the same subtree
                 // twice, and will update it twice which will lead to errors.
-                if let TokenTree::Subtree(_) = &tt_vec[i] {
+                if let TokenTree::Subtree(_) = current {
                     subtrees_stack.push(i);
                 }
 
                 i += 1;
             }
             TransformTtAction::ReplaceWith(replacement) => {
-                let old_len = 1 + match &tt_vec[i] {
+                let old_len = 1 + match current {
                     TokenTree::Leaf(_) => 0,
                     TokenTree::Subtree(subtree) => subtree.usize_len(),
                 };

--- a/crates/tt/src/storage.rs
+++ b/crates/tt/src/storage.rs
@@ -2,40 +2,32 @@
 //! will waste a lot of memory. So instead we implement a clever compression mechanism:
 //!
 //! A `TopSubtree` has a list of [`CompressedSpanPart`], which are the parts of a span
-//! that tend to be shared between tokens - namely, without the range. The main list
-//! of token trees is kept in one of three versions, where we use the smallest version
-//! we can for this tree:
+//! that tend to be shared between tokens - namely, without the range.
 //!
-//!  1. In the most common version a span is just a `u32`. The bits are divided as follows:
-//!     there are 4 bits that index into the [`CompressedSpanPart`] list. 20 bits
-//!     store the range start, and 8 bits store the range length. In experiments,
-//!     this accounts for 75%-85% of the spans.
-//!  2. In the second version a span is 64 bits. 32 bits for the range start, 16 bits
-//!     for the range length, and 16 bits for the span parts index. This is used in
-//!     less than 2% of all `TopSubtree`s, but they account for 15%-25% of the spans:
-//!     those are mostly token tree munchers, that generate a lot of `SyntaxContext`s
-//!     (because they recurse a lot), which is why they can't fit in the first version,
-//!     and tend to generate a lot of code.
-//!  3. The third version is practically unused; 65,535 bytes for a token and 65,535
-//!     unique span parts is more than enough for everybody. However, someone may still
-//!     create a macro that requires more, therefore we have this version as a backup:
-//!     it uses 96 bits, 32 for each of the range start, length and span parts index.
+//! The main list of token trees is stored in a variable-length encoding as bytes.
+//! The encoding is documented in the [`decode()`] function (which decodes one [`TokenTree`]).
 
-use std::fmt;
+use std::{assert_matches, collections::hash_map, fmt::Debug, hint::cold_path, mem::transmute};
+
+#[cfg(all(debug_assertions, not(miri)))]
+use std::cell::Cell;
+
+#[cfg(not(all(debug_assertions, not(miri))))]
+use std::mem::MaybeUninit;
 
 use intern::Symbol;
-use rustc_hash::FxBuildHasher;
+use rustc_hash::FxHashMap;
 use span::{Span, SpanAnchor, SyntaxContext, TextRange, TextSize};
 
 use crate::{
-    DelimSpan, DelimiterKind, IdentIsRaw, LitKind, Spacing, SubtreeView, TokenTreesReprRef,
-    TokenTreesView, TtIter, dispatch_ref,
+    DelimSpan, Delimiter, DelimiterKind, Ident, IdentIsRaw, Leaf, LitKind, Literal, Punct, Spacing,
+    Subtree, SubtreeView, TokenTree, TokenTreesView, TtIter,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub(crate) struct CompressedSpanPart {
-    pub(crate) anchor: SpanAnchor,
-    pub(crate) ctx: SyntaxContext,
+struct CompressedSpanPart {
+    anchor: SpanAnchor,
+    ctx: SyntaxContext,
 }
 
 impl CompressedSpanPart {
@@ -50,18 +42,170 @@ impl CompressedSpanPart {
     }
 }
 
-pub(crate) trait SpanStorage: Copy {
-    fn can_hold(text_range: TextRange, span_parts_index: usize) -> bool;
+trait Encodable: Sized {
+    #[cfg(all(debug_assertions, not(miri)))]
+    fn write(self, buffer: &[Cell<u8>]);
+    #[cfg(all(debug_assertions, not(miri)))]
+    fn read(buffer: &[u8]) -> Self;
+}
 
-    fn new(text_range: TextRange, span_parts_index: usize) -> Self;
+impl Encodable for u8 {
+    #[cfg(all(debug_assertions, not(miri)))]
+    fn write(self, buffer: &[Cell<u8>]) {
+        buffer[0].set(self);
+    }
+    #[cfg(all(debug_assertions, not(miri)))]
+    fn read(buffer: &[u8]) -> Self {
+        buffer[0]
+    }
+}
 
-    fn text_range(&self) -> TextRange;
+impl Encodable for u16 {
+    #[cfg(all(debug_assertions, not(miri)))]
+    fn write(self, buffer: &[Cell<u8>]) {
+        let value = self.to_ne_bytes();
+        let buffer: &[Cell<u8>; size_of::<Self>()] = buffer.try_into().unwrap();
+        for (b, v) in std::iter::zip(buffer, value) {
+            b.set(v);
+        }
+    }
+    #[cfg(all(debug_assertions, not(miri)))]
+    fn read(buffer: &[u8]) -> Self {
+        Self::from_ne_bytes(buffer.try_into().unwrap())
+    }
+}
 
-    fn span_parts_index(&self) -> usize;
+impl Encodable for u32 {
+    #[cfg(all(debug_assertions, not(miri)))]
+    fn write(self, buffer: &[Cell<u8>]) {
+        let value = self.to_ne_bytes();
+        let buffer: &[Cell<u8>; size_of::<Self>()] = buffer.try_into().unwrap();
+        for (b, v) in std::iter::zip(buffer, value) {
+            b.set(v);
+        }
+    }
+    #[cfg(all(debug_assertions, not(miri)))]
+    fn read(buffer: &[u8]) -> Self {
+        Self::from_ne_bytes(buffer.try_into().unwrap())
+    }
+}
+
+impl Encodable for char {
+    #[cfg(all(debug_assertions, not(miri)))]
+    fn write(self, buffer: &[Cell<u8>]) {
+        u32::from(self).write(buffer)
+    }
+    #[cfg(all(debug_assertions, not(miri)))]
+    fn read(buffer: &[u8]) -> Self {
+        char::from_u32(u32::read(buffer)).unwrap()
+    }
+}
+
+struct UninitBuffer {
+    #[cfg(all(debug_assertions, not(miri)))]
+    buffer: Box<[u8]>,
+    #[cfg(not(all(debug_assertions, not(miri))))]
+    buffer: Box<[MaybeUninit<u8>]>,
+}
+
+impl UninitBuffer {
+    #[inline]
+    fn new(capacity: usize) -> Self {
+        Self {
+            #[cfg(all(debug_assertions, not(miri)))]
+            buffer: vec![0; capacity].into_boxed_slice(),
+            #[cfg(not(all(debug_assertions, not(miri))))]
+            buffer: Box::new_uninit_slice(capacity),
+        }
+    }
 
     #[inline]
-    fn span(&self, span_parts: &[CompressedSpanPart]) -> Span {
-        span_parts[self.span_parts_index()].recombine(self.text_range())
+    fn writer(&mut self) -> BufferWriter<'_> {
+        BufferWriter {
+            #[cfg(all(debug_assertions, not(miri)))]
+            buffer: Cell::from_mut(&mut *self.buffer).as_slice_of_cells(),
+            #[cfg(not(all(debug_assertions, not(miri))))]
+            ptr: self.buffer.as_mut_ptr_range().end.cast::<u8>(),
+            #[cfg(not(all(debug_assertions, not(miri))))]
+            _marker: stdx::variance::PhantomCovariantLifetime::new(),
+        }
+    }
+
+    #[cfg(all(debug_assertions, not(miri)))]
+    unsafe fn finish(self, writer_finish: usize) -> Box<[u8]> {
+        self.buffer[writer_finish..].into()
+    }
+
+    #[cfg(not(all(debug_assertions, not(miri))))]
+    #[inline]
+    unsafe fn finish(mut self, writer_finish: *mut u8) -> Box<[u8]> {
+        let end = self.buffer.as_mut_ptr_range().end.cast::<u8>();
+        unsafe {
+            let bytes_len = end.offset_from_unsigned(writer_finish);
+            let mut buffer = Box::<[u8]>::new_uninit_slice(bytes_len);
+            buffer.as_mut_ptr().cast::<u8>().copy_from_nonoverlapping(writer_finish, bytes_len);
+            buffer.assume_init()
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+struct BufferWriter<'a> {
+    #[cfg(all(debug_assertions, not(miri)))]
+    buffer: &'a [Cell<u8>],
+    #[cfg(not(all(debug_assertions, not(miri))))]
+    ptr: *mut u8,
+    #[cfg(not(all(debug_assertions, not(miri))))]
+    _marker: stdx::variance::PhantomCovariantLifetime<'a>,
+}
+
+impl<'a> BufferWriter<'a> {
+    #[inline]
+    unsafe fn new(buffer: &'a mut [u8]) -> Self {
+        BufferWriter {
+            #[cfg(all(debug_assertions, not(miri)))]
+            buffer: Cell::from_mut(buffer).as_slice_of_cells(),
+            #[cfg(not(all(debug_assertions, not(miri))))]
+            ptr: buffer.as_mut_ptr_range().end,
+            #[cfg(not(all(debug_assertions, not(miri))))]
+            _marker: stdx::variance::PhantomCovariantLifetime::new(),
+        }
+    }
+
+    #[cfg_attr(not(all(debug_assertions, not(miri))), inline(always))]
+    unsafe fn write<T: Encodable>(&mut self, value: T) {
+        #[cfg(all(debug_assertions, not(miri)))]
+        {
+            let write_at = self.buffer.split_off(self.buffer.len() - size_of::<T>()..).unwrap();
+            value.write(write_at);
+        }
+        #[cfg(not(all(debug_assertions, not(miri))))]
+        unsafe {
+            self.ptr = self.ptr.sub(size_of::<T>());
+            self.ptr.cast::<T>().write_unaligned(value);
+        }
+    }
+
+    fn len_since(self, other: BufferWriter<'_>) -> usize {
+        #[cfg(all(debug_assertions, not(miri)))]
+        {
+            other.buffer.len() - self.buffer.len()
+        }
+        #[cfg(not(all(debug_assertions, not(miri))))]
+        {
+            other.ptr.addr() - self.ptr.addr()
+        }
+    }
+
+    #[cfg(all(debug_assertions, not(miri)))]
+    fn finish(self) -> usize {
+        self.buffer.len()
+    }
+
+    #[cfg(not(all(debug_assertions, not(miri))))]
+    #[inline]
+    fn finish(self) -> *mut u8 {
+        self.ptr
     }
 }
 
@@ -70,356 +214,914 @@ const fn n_bits_mask(n: u32) -> u32 {
     (1 << n) - 1
 }
 
-#[derive(Clone, Copy, PartialEq, Eq, Hash)]
-pub(crate) struct SpanStorage32(u32);
-
-impl SpanStorage32 {
-    const SPAN_PARTS_BIT: u32 = 4;
-    const LEN_BITS: u32 = 8;
-    const OFFSET_BITS: u32 = 20;
+#[inline]
+const fn n_bits_mask_u64(n: u32) -> u64 {
+    (1 << n) - 1
 }
 
-const _: () = assert!(
-    (SpanStorage32::SPAN_PARTS_BIT + SpanStorage32::LEN_BITS + SpanStorage32::OFFSET_BITS)
-        == u32::BITS
-);
+// Encoding is done in reverse, from the end to the beginning. This is in order
+// to be able to tell how many bytes the children of a `Subtree` occupy, and store
+// *that* efficiently, with the smallest possible type.
 
-impl SpanStorage for SpanStorage32 {
-    #[inline]
-    fn can_hold(text_range: TextRange, span_parts_index: usize) -> bool {
-        let offset = u32::from(text_range.start());
-        let len = u32::from(text_range.len());
-        let span_parts_index = span_parts_index as u32;
-
-        offset <= n_bits_mask(Self::OFFSET_BITS)
-            && len <= n_bits_mask(Self::LEN_BITS)
-            && span_parts_index <= n_bits_mask(Self::SPAN_PARTS_BIT)
-    }
-
-    #[inline]
-    fn new(text_range: TextRange, span_parts_index: usize) -> Self {
-        let offset = u32::from(text_range.start());
-        let len = u32::from(text_range.len());
-        let span_parts_index = span_parts_index as u32;
-
-        debug_assert!(offset <= n_bits_mask(Self::OFFSET_BITS));
-        debug_assert!(len <= n_bits_mask(Self::LEN_BITS));
-        debug_assert!(span_parts_index <= n_bits_mask(Self::SPAN_PARTS_BIT));
-
-        Self(
-            (offset << (Self::LEN_BITS + Self::SPAN_PARTS_BIT))
-                | (len << Self::SPAN_PARTS_BIT)
-                | span_parts_index,
-        )
-    }
-
-    #[inline]
-    fn text_range(&self) -> TextRange {
-        let offset = TextSize::new(self.0 >> (Self::SPAN_PARTS_BIT + Self::LEN_BITS));
-        let len = TextSize::new((self.0 >> Self::SPAN_PARTS_BIT) & n_bits_mask(Self::LEN_BITS));
-        TextRange::at(offset, len)
-    }
-
-    #[inline]
-    fn span_parts_index(&self) -> usize {
-        (self.0 & n_bits_mask(Self::SPAN_PARTS_BIT)) as usize
+#[must_use]
+unsafe fn encode_span<'a>(
+    ptr: BufferWriter<'a>,
+    span: &Span,
+    span_parts_map: &FxHashMap<CompressedSpanPart, usize>,
+    extra_two_bits: u32,
+    force_heavy_encoding: bool,
+) -> BufferWriter<'a> {
+    let span_parts_index = span_parts_map[&CompressedSpanPart::from_span(span)] as u32;
+    let offset = u32::from(span.range.start());
+    let len = u32::from(span.range.len());
+    unsafe {
+        encode_span_no_map(ptr, span_parts_index, offset, len, extra_two_bits, force_heavy_encoding)
     }
 }
 
-impl fmt::Debug for SpanStorage32 {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("SpanStorage32")
-            .field("text_range", &self.text_range())
-            .field("span_parts_index", &self.span_parts_index())
-            .finish()
+#[must_use]
+unsafe fn encode_span_no_map(
+    mut ptr: BufferWriter<'_>,
+    mut span_parts_index: u32,
+    mut offset: u32,
+    mut len: u32,
+    extra_two_bits: u32,
+    force_heavy_encoding: bool,
+) -> BufferWriter<'_> {
+    debug_assert!(extra_two_bits & !0b11 == 0);
+    let mut first_u32 = extra_two_bits;
+    first_u32 |= (span_parts_index & n_bits_mask(4)) << 2;
+    span_parts_index >>= 4;
+    first_u32 |= (len & n_bits_mask(8)) << (2 + 4);
+    len >>= 8;
+    first_u32 |= (offset & n_bits_mask(17)) << (2 + 4 + 8 + 1);
+    offset >>= 17;
+
+    let extends_to_next = span_parts_index != 0 || len != 0 || offset != 0 || force_heavy_encoding;
+    first_u32 |= u32::from(extends_to_next) << (2 + 4 + 8);
+
+    if extends_to_next {
+        ptr = unsafe {
+            encode_extended_span(ptr, span_parts_index, len, offset, force_heavy_encoding)
+        };
     }
+    unsafe { ptr.write::<u32>(first_u32) };
+
+    ptr
 }
 
-#[derive(Clone, Copy, PartialEq, Eq, Hash)]
-pub(crate) struct SpanStorage64 {
-    offset: u32,
-    len_and_parts: u32,
-}
-
-impl SpanStorage64 {
-    const SPAN_PARTS_BIT: u32 = 16;
-    const LEN_BITS: u32 = 16;
-}
-
-const _: () = assert!((SpanStorage64::SPAN_PARTS_BIT + SpanStorage64::LEN_BITS) == u32::BITS);
-
-impl SpanStorage for SpanStorage64 {
-    #[inline]
-    fn can_hold(text_range: TextRange, span_parts_index: usize) -> bool {
-        let len = u32::from(text_range.len());
-        let span_parts_index = span_parts_index as u32;
-
-        len <= n_bits_mask(Self::LEN_BITS) && span_parts_index <= n_bits_mask(Self::SPAN_PARTS_BIT)
-    }
-
-    #[inline]
-    fn new(text_range: TextRange, span_parts_index: usize) -> Self {
-        let offset = u32::from(text_range.start());
-        let len = u32::from(text_range.len());
-        let span_parts_index = span_parts_index as u32;
-
-        debug_assert!(len <= n_bits_mask(Self::LEN_BITS));
-        debug_assert!(span_parts_index <= n_bits_mask(Self::SPAN_PARTS_BIT));
-
-        Self { offset, len_and_parts: (len << Self::SPAN_PARTS_BIT) | span_parts_index }
-    }
-
-    #[inline]
-    fn text_range(&self) -> TextRange {
-        let offset = TextSize::new(self.offset);
-        let len = TextSize::new(self.len_and_parts >> Self::SPAN_PARTS_BIT);
-        TextRange::at(offset, len)
-    }
-
-    #[inline]
-    fn span_parts_index(&self) -> usize {
-        (self.len_and_parts & n_bits_mask(Self::SPAN_PARTS_BIT)) as usize
-    }
-}
-
-impl fmt::Debug for SpanStorage64 {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("SpanStorage64")
-            .field("text_range", &self.text_range())
-            .field("span_parts_index", &self.span_parts_index())
-            .finish()
-    }
-}
-
-impl From<SpanStorage32> for SpanStorage64 {
-    #[inline]
-    fn from(value: SpanStorage32) -> Self {
-        SpanStorage64::new(value.text_range(), value.span_parts_index())
-    }
-}
-
-#[derive(Clone, Copy, PartialEq, Eq, Hash)]
-pub(crate) struct SpanStorage96 {
-    offset: u32,
+#[cold]
+#[must_use]
+unsafe fn encode_extended_span(
+    mut ptr: BufferWriter<'_>,
+    span_parts_index: u32,
     len: u32,
-    parts: u32,
-}
+    offset: u32,
+    force_heavy_encoding: bool,
+) -> BufferWriter<'_> {
+    if span_parts_index <= n_bits_mask(11)
+        && len <= n_bits_mask(10)
+        && offset <= n_bits_mask(10)
+        && !force_heavy_encoding
+    {
+        let mut second_u32 = span_parts_index;
+        second_u32 |= len << 11;
+        second_u32 |= offset << (11 + 10);
+        second_u32 <<= 1;
+        unsafe { ptr.write::<u32>(second_u32) };
+    } else {
+        assert!(span_parts_index <= n_bits_mask(24), "too big `span_parts_index`");
 
-impl SpanStorage for SpanStorage96 {
-    #[inline]
-    fn can_hold(_text_range: TextRange, _span_parts_index: usize) -> bool {
-        true
-    }
-
-    #[inline]
-    fn new(text_range: TextRange, span_parts_index: usize) -> Self {
-        let offset = u32::from(text_range.start());
-        let len = u32::from(text_range.len());
-        let span_parts_index = span_parts_index as u32;
-
-        Self { offset, len, parts: span_parts_index }
-    }
-
-    #[inline]
-    fn text_range(&self) -> TextRange {
-        let offset = TextSize::new(self.offset);
-        let len = TextSize::new(self.len);
-        TextRange::at(offset, len)
-    }
-
-    #[inline]
-    fn span_parts_index(&self) -> usize {
-        self.parts as usize
-    }
-}
-
-impl fmt::Debug for SpanStorage96 {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("SpanStorage96")
-            .field("text_range", &self.text_range())
-            .field("span_parts_index", &self.span_parts_index())
-            .finish()
-    }
-}
-
-impl From<SpanStorage32> for SpanStorage96 {
-    #[inline]
-    fn from(value: SpanStorage32) -> Self {
-        SpanStorage96::new(value.text_range(), value.span_parts_index())
-    }
-}
-
-impl From<SpanStorage64> for SpanStorage96 {
-    #[inline]
-    fn from(value: SpanStorage64) -> Self {
-        SpanStorage96::new(value.text_range(), value.span_parts_index())
-    }
-}
-
-// We don't use structs or enum nesting here to save padding.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub(crate) enum TokenTree<S> {
-    Literal { text_and_suffix: Symbol, span: S, kind: LitKind, suffix_len: u8 },
-    Punct { char: char, spacing: Spacing, span: S },
-    Ident { sym: Symbol, span: S, is_raw: IdentIsRaw },
-    Subtree { len: u32, delim_kind: DelimiterKind, open_span: S, close_span: S },
-}
-
-impl<S: SpanStorage> TokenTree<S> {
-    #[inline]
-    pub(crate) fn first_span(&self) -> &S {
-        match self {
-            TokenTree::Literal { span, .. } => span,
-            TokenTree::Punct { span, .. } => span,
-            TokenTree::Ident { span, .. } => span,
-            TokenTree::Subtree { open_span, .. } => open_span,
+        let mut u64 = u64::from(span_parts_index);
+        u64 |= u64::from(len) << 24;
+        u64 |= u64::from(offset) << (24 + 24);
+        let third_u32 = u64 as u32;
+        let mut second_u32 = (u64 >> u32::BITS) as u32;
+        second_u32 <<= 1;
+        second_u32 |= 0b1;
+        unsafe {
+            ptr.write::<u32>(third_u32);
+            ptr.write::<u32>(second_u32);
         }
     }
 
+    ptr
+}
+
+#[must_use]
+unsafe fn encode_symbol<'a>(
+    mut ptr: BufferWriter<'a>,
+    symbol: &Symbol,
+    tag: u32,
+    symbols_map: &FxHashMap<Symbol, usize>,
+) -> BufferWriter<'a> {
+    let symbol_idx = symbols_map[symbol] as u32;
+    unsafe {
+        if symbol_idx <= n_bits_mask(6) {
+            ptr.write::<u8>(((symbol_idx << 2) | tag) as u8);
+        } else if symbol_idx <= n_bits_mask(13) {
+            ptr.write::<u8>(((symbol_idx >> 6) << 1) as u8);
+            ptr.write::<u8>(((symbol_idx << 2) | 0b10 | tag) as u8);
+        } else {
+            ptr.write::<u16>((symbol_idx >> 13) as u16);
+            ptr.write::<u8>((((symbol_idx >> 6) << 1) | 0b1) as u8);
+            ptr.write::<u8>(((symbol_idx << 2) | 0b10 | tag) as u8);
+        }
+    }
+    ptr
+}
+
+#[must_use]
+unsafe fn encode<'a>(
+    mut ptr: BufferWriter<'a>,
+    tt: TokenTree,
+    span_parts_map: &FxHashMap<CompressedSpanPart, usize>,
+    byte_size_after: &mut [u32],
+    symbols_map: &FxHashMap<Symbol, usize>,
+) -> BufferWriter<'a> {
+    let before_ptr = ptr;
+    unsafe {
+        match tt {
+            TokenTree::Leaf(Leaf::Punct(Punct { char, spacing, span })) => {
+                if char.is_ascii() {
+                    let spacing = spacing as u8;
+                    let span_extra = 0b1 | (u32::from(spacing) & 0b10);
+                    let char = ((char as u8) << 1) | (spacing & 0b1);
+                    ptr.write::<u8>(char);
+                    ptr = encode_span(ptr, &span, span_parts_map, span_extra, false);
+                } else {
+                    let mut control_byte = 0b110;
+                    control_byte |= (spacing as u8) << 3;
+                    ptr.write::<char>(char);
+                    ptr.write::<u8>(control_byte);
+                    ptr = encode_span(ptr, &span, span_parts_map, 0b00, false);
+                }
+            }
+            TokenTree::Leaf(Leaf::Ident(Ident { sym, span, is_raw })) => {
+                ptr = encode_symbol(ptr, &sym, is_raw as u32, symbols_map);
+                ptr = encode_span(ptr, &span, span_parts_map, 0b10, false);
+            }
+            TokenTree::Leaf(Leaf::Literal(Literal { text_and_suffix, span, kind, suffix_len })) => {
+                if matches!(kind, LitKind::Str | LitKind::StrRaw(0 | 1) | LitKind::Integer)
+                    && u32::from(suffix_len) <= n_bits_mask(4)
+                {
+                    // Literal, format 1.
+                    let mut control_byte = match kind {
+                        LitKind::Str => 0b0_011,
+                        LitKind::StrRaw(0) => 0b0_100,
+                        LitKind::StrRaw(1) => 0b1_011,
+                        LitKind::Integer => 0b1_100,
+                        _ => unreachable!(),
+                    };
+                    control_byte |= suffix_len << 4;
+                    ptr = encode_symbol(ptr, &text_and_suffix, 0, symbols_map);
+                    ptr.write::<u8>(control_byte);
+                } else {
+                    // Literal, format 2.
+                    let mut control_byte = 0b111;
+                    let (kind, raw_count) = match kind {
+                        LitKind::Byte => (0, None),
+                        LitKind::Char => (1, None),
+                        LitKind::Integer => (2, None),
+                        LitKind::Float => (3, None),
+                        LitKind::Str => (4, None),
+                        LitKind::StrRaw(count) => (5, Some(count)),
+                        LitKind::ByteStr => (6, None),
+                        LitKind::ByteStrRaw(count) => (7, Some(count)),
+                        LitKind::CStr => (8, None),
+                        LitKind::CStrRaw(count) => (9, Some(count)),
+                        LitKind::Err(()) => (10, None),
+                    };
+                    control_byte |= kind << 3;
+                    ptr = encode_symbol(ptr, &text_and_suffix, 0, symbols_map);
+                    ptr.write::<u8>(suffix_len);
+                    if let Some(raw_count) = raw_count {
+                        ptr.write::<u8>(raw_count);
+                    }
+                    ptr.write::<u8>(control_byte);
+                }
+                ptr = encode_span(ptr, &span, span_parts_map, 0b00, false);
+            }
+            TokenTree::Subtree(Subtree { delimiter, len }) => {
+                let open_span_parts_index =
+                    span_parts_map[&CompressedSpanPart::from_span(&delimiter.open)] as u32;
+                let close_span_parts_index =
+                    span_parts_map[&CompressedSpanPart::from_span(&delimiter.close)] as u32;
+                let close_span_offset_from_open = delimiter
+                    .close
+                    .range
+                    .start()
+                    .checked_sub(delimiter.open.range.start())
+                    .map_or(u32::MAX, u32::from);
+                let children_byte_len = byte_size_after[1] - byte_size_after[1 + len as usize];
+                if open_span_parts_index == close_span_parts_index
+                    && len <= n_bits_mask(u8::BITS)
+                    && children_byte_len <= n_bits_mask(u8::BITS)
+                    && delimiter.open.range.len() == TextSize::new(1)
+                    && delimiter.close.range.len() == TextSize::new(1)
+                    && close_span_offset_from_open <= n_bits_mask(11)
+                {
+                    // Subtree, format 1.
+                    let span = Span {
+                        range: TextRange::at(
+                            delimiter.open.range.start(),
+                            TextSize::new(close_span_offset_from_open),
+                        ),
+                        anchor: delimiter.open.anchor,
+                        ctx: delimiter.open.ctx,
+                    };
+                    let mut control_byte = 0b000;
+                    control_byte |= (delimiter.kind as u8) << 3;
+                    control_byte |= ((close_span_offset_from_open >> 8) << (3 + 2)) as u8;
+                    ptr.write::<u8>(children_byte_len as u8);
+                    ptr.write::<u8>(len as u8);
+                    ptr.write::<u8>(control_byte);
+                    ptr = encode_span(ptr, &span, span_parts_map, 0b00, false);
+                } else if open_span_parts_index == close_span_parts_index
+                    && len <= n_bits_mask(u8::BITS)
+                    && children_byte_len <= n_bits_mask(u8::BITS)
+                    && delimiter.open.range.len() == delimiter.close.range.len()
+                    && close_span_offset_from_open <= n_bits_mask(3)
+                {
+                    // Subtree, format 2.
+                    let mut control_byte = 0b001;
+                    control_byte |= (delimiter.kind as u8) << 3;
+                    control_byte |= (close_span_offset_from_open << (3 + 2)) as u8;
+                    ptr.write::<u8>(children_byte_len as u8);
+                    ptr.write::<u8>(len as u8);
+                    ptr.write::<u8>(control_byte);
+                    ptr = encode_span(ptr, &delimiter.open, span_parts_map, 0b00, false);
+                } else if len <= n_bits_mask(u8::BITS)
+                    && children_byte_len <= n_bits_mask(12)
+                    && delimiter.open.range.len() == delimiter.close.range.len()
+                    && close_span_offset_from_open <= n_bits_mask(8)
+                    && close_span_parts_index <= n_bits_mask(7)
+                {
+                    // Subtree, format 3.
+                    let mut control_byte = 0b010;
+                    control_byte |= (delimiter.kind as u8) << 3;
+                    control_byte |= (close_span_parts_index << (3 + 2)) as u8;
+                    let mut children_byte_len = children_byte_len << 4;
+                    children_byte_len |= close_span_parts_index >> 3;
+                    ptr.write::<u16>(children_byte_len as u16);
+                    ptr.write::<u8>(len as u8);
+                    ptr.write::<u8>(close_span_offset_from_open as u8);
+                    ptr.write::<u8>(control_byte);
+                    ptr = encode_span(ptr, &delimiter.open, span_parts_map, 0b00, false);
+                } else {
+                    // Subtree, format 4.
+                    let mut control_byte = 0b101;
+                    control_byte |= (delimiter.kind as u8) << 3;
+                    ptr.write::<u32>(children_byte_len);
+                    ptr.write::<u32>(len);
+                    ptr = encode_span(ptr, &delimiter.close, span_parts_map, 0b00, false);
+                    ptr.write::<u8>(control_byte);
+                    ptr = encode_span(ptr, &delimiter.open, span_parts_map, 0b00, false);
+                }
+            }
+        }
+
+        let element_byte_size: u32 = ptr.len_since(before_ptr).try_into().unwrap();
+        byte_size_after[0] = byte_size_after[1] + element_byte_size;
+    }
+
+    ptr
+}
+
+/// We always encode the top subtree with the heaviest encoding because we sometimes want to change it.
+unsafe fn encode_top_subtree<'a>(
+    mut ptr: BufferWriter<'a>,
+    top_subtree: Subtree,
+    open_span_parts_index: u32,
+    byte_size_after: &[u32],
+) -> BufferWriter<'a> {
+    unsafe {
+        let Subtree { delimiter, len } = top_subtree;
+        let children_byte_len = byte_size_after[1] - byte_size_after[1 + len as usize];
+
+        let mut control_byte = 0b101;
+        control_byte |= (delimiter.kind as u8) << 3;
+        ptr.write::<u32>(children_byte_len);
+        ptr.write::<u32>(len);
+        ptr = encode_span_no_map(
+            ptr,
+            open_span_parts_index + 1,
+            delimiter.close.range.start().into(),
+            delimiter.close.range.len().into(),
+            0b00,
+            true,
+        );
+        ptr.write::<u8>(control_byte);
+        ptr = encode_span_no_map(
+            ptr,
+            open_span_parts_index,
+            delimiter.open.range.start().into(),
+            delimiter.open.range.len().into(),
+            0b00,
+            true,
+        );
+    }
+    ptr
+}
+
+fn change_root_delimiter(buffer: &mut [u8], new_delim: DelimiterKind) {
+    // The span is 3*u32 and then the control byte, in which the delimiter comes.
+    let control_byte_index = 3 * size_of::<u32>();
+    let mut control_byte = buffer[control_byte_index];
+    control_byte &= 0b111; // Remove previous delimiter.
+    control_byte |= (new_delim as u8) << 3;
+    buffer[control_byte_index] = control_byte;
+}
+
+unsafe fn change_root_spans(
+    buffer: &mut [u8],
+    open_span_parts_index: u32,
+    close_span_parts_index: u32,
+    open_range: TextRange,
+    close_range: TextRange,
+) {
+    // Remember we write in reverse, so we add `3 * size_of::<u32>()`.
+    unsafe {
+        _ = encode_span_no_map(
+            BufferWriter::new(&mut buffer[..3 * size_of::<u32>()]),
+            open_span_parts_index,
+            u32::from(open_range.start()),
+            u32::from(open_range.len()),
+            0b00,
+            true,
+        );
+        _ = encode_span_no_map(
+            BufferWriter::new(
+                &mut buffer[..3 * size_of::<u32>() + size_of::<u8>() + 3 * size_of::<u32>()],
+            ),
+            close_span_parts_index,
+            u32::from(close_range.start()),
+            u32::from(close_range.len()),
+            0b00,
+            true,
+        );
+    }
+}
+
+/// This is subtree in format 4: two spans, each at most 3*u32, a u8 control byte, a u32 length and a u32 bytes length.
+const BIGGEST_POSSIBLE_TT_ENCODING: usize =
+    2 * 3 * size_of::<u32>() + size_of::<u8>() + size_of::<u32>() + size_of::<u32>();
+
+fn encode_all(
+    tts: std::vec::IntoIter<TokenTree>,
+    mut compressed_span_frequencies: FxHashMap<CompressedSpanPart, usize>,
+    mut symbol_frequencies: FxHashMap<Symbol, usize>,
+) -> TopSubtree {
+    let tts_len = tts.len();
+    let mut token_trees = tts.enumerate();
+    let Some((_, TokenTree::Subtree(top_subtree))) = token_trees.next() else {
+        panic!("must always have a top subtree");
+    };
+
+    let (span_parts, span_parts_map) = {
+        let mut compressed_spans = compressed_span_frequencies
+            .keys()
+            .copied()
+            .chain([
+                CompressedSpanPart::from_span(&top_subtree.delimiter.open),
+                CompressedSpanPart::from_span(&top_subtree.delimiter.close),
+            ])
+            .collect::<Box<[_]>>();
+        {
+            // For this purpose, do not consider the top delimiters. They should stay last and not affect the other spans,
+            // since we might want to change them.
+            let len = compressed_spans.len();
+            let compressed_spans = &mut compressed_spans[..len - 2];
+            // No need sort if there is already enough space for everyone to be encoded efficiently.
+            if compressed_span_frequencies.len() > n_bits_mask(4) as usize {
+                // We want more used spans to have lower indices, so they can be encoded more efficiently.
+                compressed_spans.sort_unstable_by_key(|span| {
+                    std::cmp::Reverse(compressed_span_frequencies[span])
+                });
+            }
+            for (index, span) in compressed_spans.iter().enumerate() {
+                *compressed_span_frequencies.get_mut(span).unwrap() = index;
+            }
+        }
+        (compressed_spans, compressed_span_frequencies)
+    };
+
+    let (symbols, symbols_map) = {
+        let mut symbols = symbol_frequencies.keys().cloned().collect::<Box<[_]>>();
+        // No need sort if there is already enough space for everyone to be encoded efficiently.
+        if symbol_frequencies.len() > n_bits_mask(6) as usize {
+            // We want more used spans to have lower indices, so they can be encoded more efficiently.
+            symbols.sort_unstable_by_key(|symbol| std::cmp::Reverse(symbol_frequencies[symbol]));
+        }
+        for (index, span) in symbols.iter().enumerate() {
+            *symbol_frequencies.get_mut(span).unwrap() = index;
+        }
+        (symbols, symbol_frequencies)
+    };
+
+    // +1 because each `encode()` calls reads the previous value.
+    let mut byte_size_after = vec![0u32; tts_len + 1];
+    let bytes_capacity = tts_len * BIGGEST_POSSIBLE_TT_ENCODING;
+    unsafe {
+        let mut temp_buffer = UninitBuffer::new(bytes_capacity);
+        let mut ptr = temp_buffer.writer();
+        for (index, tt) in token_trees.rev() {
+            ptr = encode(ptr, tt, &span_parts_map, &mut byte_size_after[index..], &symbols_map);
+        }
+        ptr = encode_top_subtree(ptr, top_subtree, (span_parts.len() - 2) as u32, &byte_size_after);
+
+        let writer_finish = ptr.finish();
+        let buffer = temp_buffer.finish(writer_finish);
+
+        TopSubtree { buffer, span_parts, len: tts_len, symbols }
+    }
+}
+
+fn compute_span_frequencies_and_symbols(
+    tts: &[TokenTree],
+) -> (FxHashMap<CompressedSpanPart, usize>, FxHashMap<Symbol, usize>) {
+    let mut span_frequencies = FxHashMap::default();
+    let mut symbols = FxHashMap::default();
+    for tt in tts {
+        match tt {
+            TokenTree::Leaf(leaf) => {
+                if let Some(symbol) = leaf.symbol() {
+                    *symbols.entry(symbol.clone()).or_insert(0) += 1;
+                }
+
+                *span_frequencies.entry(CompressedSpanPart::from_span(leaf.span())).or_insert(0) +=
+                    1;
+            }
+            TokenTree::Subtree(subtree) => {
+                *span_frequencies
+                    .entry(CompressedSpanPart::from_span(&subtree.delimiter.open))
+                    .or_insert(0) += 1;
+                *span_frequencies
+                    .entry(CompressedSpanPart::from_span(&subtree.delimiter.close))
+                    .or_insert(0) += 1;
+            }
+        }
+    }
+    (span_frequencies, symbols)
+}
+
+#[derive(Clone, Copy)]
+struct BufferReader<'a> {
+    #[cfg(all(debug_assertions, not(miri)))]
+    buffer: &'a [u8],
+    #[cfg(not(all(debug_assertions, not(miri))))]
+    ptr: *const u8,
+    #[cfg(not(all(debug_assertions, not(miri))))]
+    _marker: stdx::variance::PhantomCovariantLifetime<'a>,
+}
+
+impl<'a> BufferReader<'a> {
     #[inline]
-    pub(crate) fn last_span(&self) -> &S {
-        match self {
-            TokenTree::Literal { span, .. } => span,
-            TokenTree::Punct { span, .. } => span,
-            TokenTree::Ident { span, .. } => span,
-            TokenTree::Subtree { close_span, .. } => close_span,
+    fn start_end(slice: &'a [u8]) -> (Self, Self) {
+        #[cfg(all(debug_assertions, not(miri)))]
+        {
+            let start = Self { buffer: slice };
+            let end = Self { buffer: &slice[slice.len()..] };
+            (start, end)
+        }
+        #[cfg(not(all(debug_assertions, not(miri))))]
+        {
+            let ptrs = slice.as_ptr_range();
+            let start = Self {
+                ptr: ptrs.start,
+                #[cfg(not(all(debug_assertions, not(miri))))]
+                _marker: stdx::variance::PhantomCovariantLifetime::new(),
+            };
+            let end = Self {
+                ptr: ptrs.end,
+                #[cfg(not(all(debug_assertions, not(miri))))]
+                _marker: stdx::variance::PhantomCovariantLifetime::new(),
+            };
+            (start, end)
         }
     }
 
+    #[cfg_attr(not(all(debug_assertions, not(miri))), inline(always))]
+    unsafe fn read<T: Encodable>(&mut self) -> T {
+        #[cfg(all(debug_assertions, not(miri)))]
+        {
+            let read_at = self.buffer.split_off(..size_of::<T>()).unwrap();
+            T::read(read_at)
+        }
+        #[cfg(not(all(debug_assertions, not(miri))))]
+        unsafe {
+            let result = self.ptr.cast::<T>().read_unaligned();
+            self.ptr = self.ptr.add(size_of::<T>());
+            result
+        }
+    }
+
+    #[cfg_attr(not(all(debug_assertions, not(miri))), inline(always))]
+    unsafe fn skip(&mut self, amount: usize) {
+        #[cfg(all(debug_assertions, not(miri)))]
+        {
+            self.buffer = &self.buffer[amount..];
+        }
+        #[cfg(not(all(debug_assertions, not(miri))))]
+        unsafe {
+            self.ptr = self.ptr.add(amount);
+        }
+    }
+}
+
+impl PartialEq for BufferReader<'_> {
     #[inline]
-    pub(crate) fn to_api(&self, span_parts: &[CompressedSpanPart]) -> crate::TokenTree {
-        match self {
-            TokenTree::Literal { text_and_suffix, span, kind, suffix_len } => {
-                crate::TokenTree::Leaf(crate::Leaf::Literal(crate::Literal {
-                    text_and_suffix: text_and_suffix.clone(),
-                    span: span.span(span_parts),
-                    kind: *kind,
-                    suffix_len: *suffix_len,
-                }))
-            }
-            TokenTree::Punct { char, spacing, span } => {
-                crate::TokenTree::Leaf(crate::Leaf::Punct(crate::Punct {
-                    char: *char,
-                    spacing: *spacing,
-                    span: span.span(span_parts),
-                }))
-            }
-            TokenTree::Ident { sym, span, is_raw } => {
-                crate::TokenTree::Leaf(crate::Leaf::Ident(crate::Ident {
-                    sym: sym.clone(),
-                    span: span.span(span_parts),
-                    is_raw: *is_raw,
-                }))
-            }
-            TokenTree::Subtree { len, delim_kind, open_span, close_span } => {
-                crate::TokenTree::Subtree(crate::Subtree {
-                    delimiter: crate::Delimiter {
-                        open: open_span.span(span_parts),
-                        close: close_span.span(span_parts),
-                        kind: *delim_kind,
-                    },
-                    len: *len,
+    fn eq(&self, other: &Self) -> bool {
+        #[cfg(all(debug_assertions, not(miri)))]
+        let self_ptr = self.buffer.as_ptr();
+        #[cfg(not(all(debug_assertions, not(miri))))]
+        let self_ptr = self.ptr;
+        #[cfg(all(debug_assertions, not(miri)))]
+        let other_ptr = other.buffer.as_ptr();
+        #[cfg(not(all(debug_assertions, not(miri))))]
+        let other_ptr = other.ptr;
+
+        self_ptr == other_ptr
+    }
+}
+
+struct InlineSpanParts {
+    span_parts_index: usize,
+    text_range: TextRange,
+}
+
+#[inline]
+unsafe fn decode_span(
+    ptr: BufferReader<'_>,
+    mut first_u32: u32,
+) -> (BufferReader<'_>, InlineSpanParts) {
+    first_u32 >>= 2;
+    let span_parts_index = first_u32 & n_bits_mask(4);
+    let len = (first_u32 >> 4) & n_bits_mask(8);
+    let extends_to_next = (first_u32 & (1 << (4 + 8))) != 0;
+    let offset = first_u32 >> (4 + 8 + 1);
+    if !extends_to_next {
+        let result = InlineSpanParts {
+            span_parts_index: span_parts_index as usize,
+            text_range: TextRange::at(TextSize::new(offset), TextSize::new(len)),
+        };
+        (ptr, result)
+    } else {
+        unsafe { decode_extended_span(ptr, span_parts_index, len, offset) }
+    }
+}
+
+#[cold]
+unsafe fn decode_extended_span(
+    mut ptr: BufferReader<'_>,
+    mut span_parts_index: u32,
+    mut len: u32,
+    mut offset: u32,
+) -> (BufferReader<'_>, InlineSpanParts) {
+    unsafe {
+        let mut second_u32 = ptr.read::<u32>();
+        let extends_to_next = (second_u32 & 0b1) != 0;
+        second_u32 >>= 1;
+        if extends_to_next {
+            let third_u32 = ptr.read::<u32>();
+            let u64 = u64::from(third_u32) | (u64::from(second_u32) << u32::BITS);
+            let rest_span_parts_index = (u64 & n_bits_mask_u64(24)) as u32;
+            span_parts_index |= rest_span_parts_index << 4;
+            let rest_len = ((u64 >> 24) & n_bits_mask_u64(24)) as u32;
+            len |= rest_len << 8;
+            let rest_offset = (u64 >> (24 + 24)) as u32;
+            offset |= rest_offset << 17;
+        } else {
+            let rest_span_parts_index = second_u32 & n_bits_mask(11);
+            span_parts_index |= rest_span_parts_index << 4;
+            let rest_len = (second_u32 >> 11) & n_bits_mask(10);
+            len |= rest_len << 8;
+            let rest_offset = second_u32 >> (11 + 10);
+            offset |= rest_offset << 17;
+        };
+        let result = InlineSpanParts {
+            span_parts_index: span_parts_index as usize,
+            text_range: TextRange::at(TextSize::new(offset), TextSize::new(len)),
+        };
+        (ptr, result)
+    }
+}
+
+// FIXME: It'll probably be better to ensure this ourselves via a `#[repr(C, align(4))]` wrapper, even though practically
+// this holds for all 32- and 64-bit targets (Rust does not guarantee this).
+const _: () = assert!(align_of::<*const *const str>() >= 4); // Needed for the tagging of idents.
+
+unsafe fn decode_symbol<'a>(
+    mut ptr: BufferReader<'a>,
+    first_byte: u8,
+    symbols: &[Symbol],
+) -> (BufferReader<'a>, Symbol) {
+    let mut symbol_idx = u32::from(first_byte) >> 1;
+    let extends_to_next = symbol_idx & 0b1 == 0b1;
+    symbol_idx >>= 1;
+    if extends_to_next {
+        let mut second_byte = unsafe { ptr.read::<u8>() };
+        let rest_bytes =
+            if second_byte & 0b1 == 0b1 { u32::from(unsafe { ptr.read::<u16>() }) } else { 0 };
+        second_byte >>= 1;
+        symbol_idx |= u32::from(second_byte) << 6;
+        symbol_idx |= rest_bytes << 13;
+    }
+    (ptr, symbols[symbol_idx as usize].clone())
+}
+
+/// We need `MaybeUninit` to preserve provenance.
+///
+/// The returned `u32` is the length of the children *in bytes*, if we read a subtree. Otherwise it's zero.
+unsafe fn decode<'a>(
+    mut ptr: BufferReader<'a>,
+    compressed: &[CompressedSpanPart],
+    symbols: &[Symbol],
+) -> (BufferReader<'a>, TokenTree, u32) {
+    unsafe {
+        let span_and_extra = ptr.read::<u32>();
+        let span;
+        (ptr, span) = decode_span(ptr, span_and_extra);
+        let span = compressed[span.span_parts_index].recombine(span.text_range);
+
+        if span_and_extra & 0b1 == 0b1 {
+            // An ASCII punct.
+            let char_and_half_spacing = ptr.read::<u8>();
+
+            let spacing = (span_and_extra & 0b10) | (u32::from(char_and_half_spacing) & 0b1);
+            let spacing = transmute::<u8, Spacing>(spacing as u8);
+
+            let char = char::from(char_and_half_spacing >> 1);
+
+            return (ptr, TokenTree::Leaf(Leaf::Punct(Punct { char, spacing, span })), 0);
+        } else if span_and_extra & 0b10 == 0b10 {
+            // An ident.
+            let symbol_first_byte = ptr.read::<u8>();
+            let is_raw = symbol_first_byte & 0b1;
+            let symbol;
+            (ptr, symbol) = decode_symbol(ptr, symbol_first_byte, symbols);
+            let is_raw = transmute::<u8, IdentIsRaw>(is_raw);
+
+            return (ptr, TokenTree::Leaf(Leaf::Ident(Ident { sym: symbol, span, is_raw })), 0);
+        }
+
+        let mut children_byte_len = 0;
+
+        let control_byte = u32::from(ptr.read::<u8>());
+        let control_byte_extra_data = control_byte >> 3;
+        let result = match control_byte & 0b111 {
+            0b000 => {
+                // Subtree, format 1:
+                //  - Same span_parts_index for open and close span.
+                //  - Subtree length is a u8.
+                //  - Subtree length in bytes is a u8.
+                //  - The length of both the open and close span is 1 - so we use the already-parsed length for the open span
+                //    for other things (we can only assume it has 8 bits available, the minimum format for a length).
+                //  - The offset between the open span's start and the close span's start is stored in 11 bits.
+                let kind = transmute::<u8, DelimiterKind>((control_byte_extra_data & 0b11) as u8);
+                let mut open_span = span;
+                let mut close_span_offset_from_open = u32::from(span.range.len());
+                open_span.range = TextRange::at(open_span.range.start(), TextSize::new(1));
+                close_span_offset_from_open |= (control_byte_extra_data >> 2) << 8;
+                let close_span = Span {
+                    range: open_span.range + TextSize::new(close_span_offset_from_open),
+                    anchor: open_span.anchor,
+                    ctx: open_span.ctx,
+                };
+                let len = u32::from(ptr.read::<u8>());
+                children_byte_len = u32::from(ptr.read::<u8>());
+
+                TokenTree::Subtree(Subtree {
+                    delimiter: Delimiter { open: open_span, close: close_span, kind },
+                    len,
                 })
             }
-        }
+            0b001 => {
+                // Subtree, format 2:
+                //  - Same span_parts_index for open and close span.
+                //  - Subtree length is a u8.
+                //  - Subtree length in bytes is a u8.
+                //  - The open and close span have the same length. This covers many cases because most cases either give
+                //    both length 1 (the brackets themselves) or the same span (usually, the whole range they encompass).
+                //  - The offset between the open span's start and the close span's start is stored in 3 bits.
+                let kind = transmute::<u8, DelimiterKind>((control_byte_extra_data & 0b11) as u8);
+                let open_span = span;
+                let close_span_offset_from_open = control_byte_extra_data >> 2;
+                let close_span = Span {
+                    range: open_span.range + TextSize::new(close_span_offset_from_open),
+                    anchor: open_span.anchor,
+                    ctx: open_span.ctx,
+                };
+                let len = u32::from(ptr.read::<u8>());
+                children_byte_len = u32::from(ptr.read::<u8>());
+
+                TokenTree::Subtree(Subtree {
+                    delimiter: Delimiter { open: open_span, close: close_span, kind },
+                    len,
+                })
+            }
+            0b010 => {
+                // Subtree, format 3:
+                //  - Subtree length is a u8.
+                //  - Subtree length in bytes is 12 bits.
+                //  - The open and close span have the same length.
+                //  - The offset between the open span's start and the close span's start is stored in 8 bits.
+                //  - The close span's span_parts_index is stored in 7 bits.
+                // This is less efficient than formats 1 and 2 (requires two more bytes), but more efficient than the general format.
+                let kind = transmute::<u8, DelimiterKind>((control_byte_extra_data & 0b11) as u8);
+                let open_span = span;
+                let close_span_offset_from_open = u32::from(ptr.read::<u8>());
+                let len = u32::from(ptr.read::<u8>());
+                children_byte_len = u32::from(ptr.read::<u16>());
+                let mut close_span_parts_index = control_byte_extra_data >> 2;
+                close_span_parts_index |= (children_byte_len & 0b1111) << 3;
+                children_byte_len >>= 4;
+                let close_span = compressed[close_span_parts_index as usize]
+                    .recombine(open_span.range + TextSize::new(close_span_offset_from_open));
+
+                TokenTree::Subtree(Subtree {
+                    delimiter: Delimiter { open: open_span, close: close_span, kind },
+                    len,
+                })
+            }
+            0b101 => {
+                cold_path();
+
+                // Subtree, format 4 - most general format: subtree length is u32, subtree length in bytes is u32, full decoded
+                // span for close span, delimiter kind is 5 bits (not needed now, will be needed when we have different kinds of
+                // invisible delimiters).
+                let kind = transmute::<u8, DelimiterKind>(control_byte_extra_data as u8);
+                let open_span = span;
+                let close_span_start = ptr.read::<u32>();
+                let close_span;
+                (ptr, close_span) = decode_span(ptr, close_span_start);
+                let close_span =
+                    compressed[close_span.span_parts_index].recombine(close_span.text_range);
+                let len = ptr.read::<u32>();
+                children_byte_len = ptr.read::<u32>();
+
+                TokenTree::Subtree(Subtree {
+                    delimiter: Delimiter { open: open_span, close: close_span, kind },
+                    len,
+                })
+            }
+            0b110 => {
+                cold_path();
+
+                // Non-ASCII punct. Extremely rare but technically possible.
+                let spacing = transmute::<u8, Spacing>(control_byte_extra_data as u8);
+                let char = ptr.read::<char>();
+
+                TokenTree::Leaf(Leaf::Punct(Punct { char, spacing, span }))
+            }
+            0b011 | 0b100 => {
+                // Literal, format 1: the 6 bits remaining from `control_byte` decide the kind and the suffix len from a constant set
+                // (of the most common).
+                let control_byte_extra_data = control_byte >> 2;
+                let text_and_suffix_first_byte = ptr.read::<u8>();
+                let text_and_suffix;
+                (ptr, text_and_suffix) = decode_symbol(ptr, text_and_suffix_first_byte, symbols);
+                let kind = match control_byte_extra_data & 0b11 {
+                    0b00 => LitKind::Str,
+                    0b01 => LitKind::StrRaw(0),
+                    0b10 => LitKind::StrRaw(1),
+                    0b11 => LitKind::Integer,
+                    _ => unreachable!(),
+                };
+                let suffix_len = (control_byte_extra_data >> 2) as u8;
+
+                TokenTree::Leaf(Leaf::Literal(Literal { text_and_suffix, span, kind, suffix_len }))
+            }
+            0b111 => {
+                cold_path();
+
+                // Literal, format 2: most general format.
+                let kind = match control_byte_extra_data {
+                    0 => LitKind::Byte,
+                    1 => LitKind::Char,
+                    2 => LitKind::Integer,
+                    3 => LitKind::Float,
+                    4 => LitKind::Str,
+                    5 => LitKind::StrRaw(ptr.read::<u8>()),
+                    6 => LitKind::ByteStr,
+                    7 => LitKind::ByteStrRaw(ptr.read::<u8>()),
+                    8 => LitKind::CStr,
+                    9 => LitKind::CStrRaw(ptr.read::<u8>()),
+                    10 => LitKind::Err(()),
+                    _ => unreachable!(),
+                };
+                let suffix_len = ptr.read::<u8>();
+                let text_and_suffix_first_byte = ptr.read::<u8>();
+                let text_and_suffix;
+                (ptr, text_and_suffix) = decode_symbol(ptr, text_and_suffix_first_byte, symbols);
+
+                TokenTree::Leaf(Leaf::Literal(Literal { text_and_suffix, span, kind, suffix_len }))
+            }
+            _ => unreachable!(),
+        };
+        (ptr, result, children_byte_len)
+    }
+}
+
+#[derive(Clone, Copy)]
+pub(crate) struct TokenTreesSlice<'a> {
+    current: BufferReader<'a>,
+    end: BufferReader<'a>,
+    span_parts: &'a [CompressedSpanPart],
+    symbols: &'a [Symbol],
+}
+
+unsafe impl Send for TokenTreesSlice<'_> {}
+unsafe impl Sync for TokenTreesSlice<'_> {}
+
+impl<'a> TokenTreesSlice<'a> {
+    #[inline]
+    fn new(top_subtree: &'a TopSubtree) -> Self {
+        let (current, end) = BufferReader::start_end(&top_subtree.buffer);
+        Self { current, end, span_parts: &top_subtree.span_parts, symbols: &top_subtree.symbols }
     }
 
     #[inline]
-    fn convert<U: From<S>>(self) -> TokenTree<U> {
-        match self {
-            TokenTree::Literal { text_and_suffix, span, kind, suffix_len } => {
-                TokenTree::Literal { text_and_suffix, span: span.into(), kind, suffix_len }
-            }
-            TokenTree::Punct { char, spacing, span } => {
-                TokenTree::Punct { char, spacing, span: span.into() }
-            }
-            TokenTree::Ident { sym, span, is_raw } => {
-                TokenTree::Ident { sym, span: span.into(), is_raw }
-            }
-            TokenTree::Subtree { len, delim_kind, open_span, close_span } => TokenTree::Subtree {
-                len,
-                delim_kind,
-                open_span: open_span.into(),
-                close_span: close_span.into(),
-            },
-        }
+    pub(crate) fn empty() -> Self {
+        let (current, end) = BufferReader::start_end(&[]);
+        Self { current, end, span_parts: &[], symbols: &[] }
     }
-}
 
-// This is used a lot, make sure it doesn't grow unintentionally.
-const _: () = {
-    assert!(size_of::<TokenTree<SpanStorage32>>() == 16);
-    assert!(size_of::<TokenTree<SpanStorage64>>() == 24);
-    assert!(size_of::<TokenTree<SpanStorage96>>() == 32);
-};
-
-#[rust_analyzer::macro_style(braces)]
-macro_rules! dispatch {
-    (
-        match $scrutinee:expr => $tt:ident => $body:expr
-    ) => {
-        match $scrutinee {
-            TopSubtreeRepr::SpanStorage32($tt) => $body,
-            TopSubtreeRepr::SpanStorage64($tt) => $body,
-            TopSubtreeRepr::SpanStorage96($tt) => $body,
+    pub(crate) fn advance(&mut self) -> Option<TokenTree> {
+        if self.current == self.end {
+            return None;
         }
-    };
-}
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub(crate) enum TopSubtreeRepr {
-    SpanStorage32(Box<[TokenTree<SpanStorage32>]>),
-    SpanStorage64(Box<[TokenTree<SpanStorage64>]>),
-    SpanStorage96(Box<[TokenTree<SpanStorage96>]>),
+        let (new_current, token_tree, _children_byte_len) =
+            unsafe { decode(self.current, self.span_parts, self.symbols) };
+        self.current = new_current;
+        Some(token_tree)
+    }
+
+    /// This is like `advance()`, but when encountering a subtree, it changes `self` to skip it and returns a
+    /// slice into it (what `advance()` would have done to `self`).
+    pub(crate) fn advance_skip_subtree(&mut self) -> Option<(TokenTree, TokenTreesSlice<'a>)> {
+        if self.current == self.end {
+            return None;
+        }
+
+        let (new_current, token_tree, children_byte_len) =
+            unsafe { decode(self.current, self.span_parts, self.symbols) };
+        self.current = new_current;
+        let subtree_slice = *self;
+        unsafe { self.current.skip(children_byte_len as usize) };
+        Some((token_tree, subtree_slice))
+    }
+
+    pub(crate) fn iter(mut self) -> impl Iterator<Item = TokenTree> {
+        std::iter::from_fn(move || self.advance())
+    }
 }
 
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TopSubtree {
-    repr: TopSubtreeRepr,
+    buffer: Box<[u8]>,
+    /// The last two are the top subtree's open and close span, in this order.
     span_parts: Box<[CompressedSpanPart]>,
+    symbols: Box<[Symbol]>,
+    len: usize,
 }
 
 impl TopSubtree {
     pub fn empty(span: DelimSpan) -> Self {
-        Self {
-            repr: TopSubtreeRepr::SpanStorage96(Box::new([TokenTree::Subtree {
+        encode_all(
+            vec![TokenTree::Subtree(Subtree {
+                delimiter: Delimiter::invisible_delim_spanned(span),
                 len: 0,
-                delim_kind: DelimiterKind::Invisible,
-                open_span: SpanStorage96::new(span.open.range, 0),
-                close_span: SpanStorage96::new(span.close.range, 1),
-            }])),
-            span_parts: Box::new([
-                CompressedSpanPart::from_span(&span.open),
-                CompressedSpanPart::from_span(&span.close),
-            ]),
-        }
+            })]
+            .into_iter(),
+            FxHashMap::default(),
+            FxHashMap::default(),
+        )
     }
 
-    pub fn invisible_from_leaves<const N: usize>(
-        delim_span: Span,
-        leaves: [crate::Leaf; N],
-    ) -> Self {
-        let mut builder = TopSubtreeBuilder::new(crate::Delimiter::invisible_spanned(delim_span));
-        builder.extend(leaves);
-        builder.build()
+    pub fn invisible_from_leaves<const N: usize>(delim_span: Span, leaves: [Leaf; N]) -> Self {
+        Self::from_serialized(
+            std::iter::chain(
+                [TokenTree::Subtree(Subtree {
+                    delimiter: Delimiter::invisible_spanned(delim_span),
+                    len: leaves.len() as u32,
+                })],
+                leaves.into_iter().map(TokenTree::Leaf),
+            )
+            .collect(),
+        )
     }
 
-    pub fn from_token_trees(delimiter: crate::Delimiter, token_trees: TokenTreesView<'_>) -> Self {
+    pub fn from_token_trees(delimiter: Delimiter, token_trees: TokenTreesView<'_>) -> Self {
         let mut builder = TopSubtreeBuilder::new(delimiter);
         builder.extend_with_tt(token_trees);
         builder.build()
     }
 
-    pub fn from_serialized(tt: Vec<crate::TokenTree>) -> Self {
-        let mut tt = tt.into_iter();
-        let Some(crate::TokenTree::Subtree(top_subtree)) = tt.next() else {
-            panic!("first must always come the top subtree")
-        };
-        let mut builder = TopSubtreeBuilder::new(top_subtree.delimiter);
-        for tt in tt {
-            builder.push_token_tree(tt);
-        }
-        builder.build()
+    pub fn from_serialized(tts: Vec<TokenTree>) -> Self {
+        let (span_frequencies, symbols) = compute_span_frequencies_and_symbols(&tts[1..]); // Do not include the top subtree.
+        encode_all(tts.into_iter(), span_frequencies, symbols)
     }
 
     pub fn from_subtree(subtree: SubtreeView<'_>) -> Self {
@@ -429,121 +1131,44 @@ impl TopSubtree {
     }
 
     pub fn view(&self) -> SubtreeView<'_> {
-        let repr = match &self.repr {
-            TopSubtreeRepr::SpanStorage32(token_trees) => {
-                TokenTreesReprRef::SpanStorage32(token_trees)
-            }
-            TopSubtreeRepr::SpanStorage64(token_trees) => {
-                TokenTreesReprRef::SpanStorage64(token_trees)
-            }
-            TopSubtreeRepr::SpanStorage96(token_trees) => {
-                TokenTreesReprRef::SpanStorage96(token_trees)
-            }
-        };
-        SubtreeView(TokenTreesView { repr, span_parts: &self.span_parts })
+        let slice = TokenTreesSlice::new(self);
+        SubtreeView(TokenTreesView { slice, len: self.len })
     }
 
     pub fn iter(&self) -> TtIter<'_> {
         self.view().iter()
     }
 
-    pub fn top_subtree(&self) -> crate::Subtree {
+    pub fn top_subtree(&self) -> Subtree {
         self.view().top_subtree()
     }
 
     pub fn set_top_subtree_delimiter_kind(&mut self, kind: DelimiterKind) {
-        dispatch! {
-            match &mut self.repr => tt => {
-                let TokenTree::Subtree { delim_kind, .. } = &mut tt[0] else {
-                    unreachable!("the first token tree is always the top subtree");
-                };
-                *delim_kind = kind;
-            }
-        }
-    }
-
-    fn ensure_can_hold(&mut self, range: TextRange) {
-        fn can_hold<S: SpanStorage>(_: &[TokenTree<S>], range: TextRange) -> bool {
-            S::can_hold(range, 0)
-        }
-        let can_hold = dispatch! {
-            match &self.repr => tt => can_hold(tt, range)
-        };
-        if can_hold {
-            return;
-        }
-
-        // Otherwise, we do something very junky: recreate the entire tree. Hopefully this should be rare.
-        let mut builder = TopSubtreeBuilder::new(self.top_subtree().delimiter);
-        builder.extend_with_tt(self.token_trees());
-        builder.ensure_can_hold(range, 0);
-        *self = builder.build();
+        change_root_delimiter(&mut self.buffer, kind);
     }
 
     pub fn set_top_subtree_delimiter_span(&mut self, span: DelimSpan) {
-        self.ensure_can_hold(span.open.range);
-        self.ensure_can_hold(span.close.range);
-        fn do_it<S: SpanStorage>(tt: &mut [TokenTree<S>], span: DelimSpan) {
-            let TokenTree::Subtree { open_span, close_span, .. } = &mut tt[0] else {
-                unreachable!()
-            };
-            *open_span = S::new(span.open.range, 0);
-            *close_span = S::new(span.close.range, 1);
+        let open_span_idx = self.span_parts.len() - 2;
+        let close_span_idx = open_span_idx + 1;
+        unsafe {
+            change_root_spans(
+                &mut self.buffer,
+                open_span_idx as u32,
+                close_span_idx as u32,
+                span.open.range,
+                span.close.range,
+            );
         }
-        dispatch! {
-            match &mut self.repr => tt => do_it(tt, span)
-        }
-        self.span_parts[0] = CompressedSpanPart::from_span(&span.open);
-        self.span_parts[1] = CompressedSpanPart::from_span(&span.close);
+        self.span_parts[open_span_idx] = CompressedSpanPart::from_span(&span.open);
+        self.span_parts[close_span_idx] = CompressedSpanPart::from_span(&span.close);
     }
 
-    /// Note: this cannot change spans.
-    pub fn set_token(&mut self, idx: usize, leaf: crate::Leaf) {
-        fn do_it<S: SpanStorage>(
-            tt: &mut [TokenTree<S>],
-            idx: usize,
-            span_parts: &[CompressedSpanPart],
-            leaf: crate::Leaf,
-        ) {
-            assert!(
-                !matches!(tt[idx], TokenTree::Subtree { .. }),
-                "`TopSubtree::set_token()` must be called on a leaf"
-            );
-            let existing_span_compressed = *tt[idx].first_span();
-            let existing_span = existing_span_compressed.span(span_parts);
-            assert_eq!(
-                *leaf.span(),
-                existing_span,
-                "`TopSubtree::set_token()` cannot change spans"
-            );
-            match leaf {
-                crate::Leaf::Literal(leaf) => {
-                    tt[idx] = TokenTree::Literal {
-                        text_and_suffix: leaf.text_and_suffix,
-                        span: existing_span_compressed,
-                        kind: leaf.kind,
-                        suffix_len: leaf.suffix_len,
-                    }
-                }
-                crate::Leaf::Punct(leaf) => {
-                    tt[idx] = TokenTree::Punct {
-                        char: leaf.char,
-                        spacing: leaf.spacing,
-                        span: existing_span_compressed,
-                    }
-                }
-                crate::Leaf::Ident(leaf) => {
-                    tt[idx] = TokenTree::Ident {
-                        sym: leaf.sym,
-                        span: existing_span_compressed,
-                        is_raw: leaf.is_raw,
-                    }
-                }
-            }
-        }
-        dispatch! {
-            match &mut self.repr => tt => do_it(tt, idx, &self.span_parts, leaf)
-        }
+    /// **Warning**: This is very expensive, this rebuilds the whole tree. Avoid using this if you can.
+    pub fn set_token(&mut self, idx: usize, leaf: Leaf) {
+        let mut tts = TokenTreesSlice::new(self).iter().collect::<Vec<_>>();
+        assert_matches!(tts[idx], TokenTree::Leaf(_), "cannot change a subtree to a leaf");
+        tts[idx] = leaf.into();
+        *self = TopSubtree::from_serialized(tts);
     }
 
     pub fn token_trees(&self) -> TokenTreesView<'_> {
@@ -561,368 +1186,172 @@ impl TopSubtree {
     }
 }
 
-#[rust_analyzer::macro_style(braces)]
-macro_rules! dispatch_builder {
-    (
-        match $scrutinee:expr => $tt:ident => $body:expr
-    ) => {
-        match $scrutinee {
-            TopSubtreeBuilderRepr::SpanStorage32($tt) => $body,
-            TopSubtreeBuilderRepr::SpanStorage64($tt) => $body,
-            TopSubtreeBuilderRepr::SpanStorage96($tt) => $body,
-        }
-    };
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-enum TopSubtreeBuilderRepr {
-    SpanStorage32(Vec<TokenTree<SpanStorage32>>),
-    SpanStorage64(Vec<TokenTree<SpanStorage64>>),
-    SpanStorage96(Vec<TokenTree<SpanStorage96>>),
-}
-
-type FxIndexSet<K> = indexmap::IndexSet<K, FxBuildHasher>;
-
-/// In any tree, the first two subtree parts are reserved for the top subtree.
-///
-/// We do it because `TopSubtree` exposes an API to modify the top subtree, therefore it's more convenient
-/// this way, and it's unlikely to affect memory usage.
-const RESERVED_SPAN_PARTS_LEN: usize = 2;
-
 #[derive(Debug, Clone)]
 pub struct TopSubtreeBuilder {
     unclosed_subtree_indices: Vec<usize>,
-    token_trees: TopSubtreeBuilderRepr,
-    span_parts: FxIndexSet<CompressedSpanPart>,
+    token_trees: Vec<TokenTree>,
+    span_parts_frequencies: FxHashMap<CompressedSpanPart, usize>,
     last_closed_subtree: Option<usize>,
-    /// We need to keep those because they are not inside `span_parts`, see [`RESERVED_SPAN_PARTS_LEN`].
-    top_subtree_spans: DelimSpan,
+    symbol_frequencies: FxHashMap<Symbol, usize>,
 }
 
 impl TopSubtreeBuilder {
-    pub fn new(top_delimiter: crate::Delimiter) -> Self {
+    fn insert_span(&mut self, span: &Span) {
+        *self.span_parts_frequencies.entry(CompressedSpanPart::from_span(span)).or_insert(0) += 1;
+    }
+
+    fn remove_span(span_parts_frequencies: &mut FxHashMap<CompressedSpanPart, usize>, span: &Span) {
+        let hash_map::Entry::Occupied(mut entry) =
+            span_parts_frequencies.entry(CompressedSpanPart::from_span(span))
+        else {
+            panic!("span not present");
+        };
+        *entry.get_mut() -= 1;
+        if *entry.get() == 0 {
+            entry.remove();
+        }
+    }
+
+    fn insert_symbol(&mut self, symbol: Symbol) {
+        *self.symbol_frequencies.entry(symbol).or_insert(0) += 1;
+    }
+
+    fn remove_symbol(symbol_frequencies: &mut FxHashMap<Symbol, usize>, symbol: Symbol) {
+        let hash_map::Entry::Occupied(mut entry) = symbol_frequencies.entry(symbol) else {
+            panic!("span not present");
+        };
+        *entry.get_mut() -= 1;
+        if *entry.get() == 0 {
+            entry.remove();
+        }
+    }
+
+    pub fn new(top_delimiter: Delimiter) -> Self {
         let mut result = Self {
             unclosed_subtree_indices: Vec::new(),
-            token_trees: TopSubtreeBuilderRepr::SpanStorage32(Vec::new()),
-            span_parts: FxIndexSet::default(),
+            token_trees: Vec::new(),
+            span_parts_frequencies: FxHashMap::default(),
             last_closed_subtree: None,
-            top_subtree_spans: top_delimiter.delim_span(),
+            symbol_frequencies: FxHashMap::default(),
         };
-        result.ensure_can_hold(top_delimiter.open.range, 0);
-        result.ensure_can_hold(top_delimiter.close.range, 1);
-        fn push_first<S: SpanStorage>(tt: &mut Vec<TokenTree<S>>, top_delimiter: crate::Delimiter) {
-            tt.push(TokenTree::Subtree {
-                len: 0,
-                delim_kind: top_delimiter.kind,
-                open_span: S::new(top_delimiter.open.range, 0),
-                close_span: S::new(top_delimiter.close.range, 1),
-            });
-        }
-        dispatch_builder! {
-            match &mut result.token_trees => tt => push_first(tt, top_delimiter)
-        }
+        // Do not insert the top delimiters, they have their own place because we sometimes need to change them.
+        result.token_trees.push(TokenTree::Subtree(Subtree { delimiter: top_delimiter, len: 0 }));
         result
     }
 
-    fn span_part_index(&mut self, part: CompressedSpanPart) -> usize {
-        self.span_parts.insert_full(part).0 + RESERVED_SPAN_PARTS_LEN
-    }
-
-    fn switch_repr<T: SpanStorage, U: From<T>>(repr: &mut Vec<TokenTree<T>>) -> Vec<TokenTree<U>> {
-        let repr = std::mem::take(repr);
-        repr.into_iter().map(|tt| tt.convert()).collect()
-    }
-
-    /// Ensures we have a representation that can hold these values.
-    fn ensure_can_hold(&mut self, text_range: TextRange, span_parts_index: usize) {
-        match &mut self.token_trees {
-            TopSubtreeBuilderRepr::SpanStorage32(token_trees) => {
-                if SpanStorage32::can_hold(text_range, span_parts_index) {
-                    // Can hold.
-                } else if SpanStorage64::can_hold(text_range, span_parts_index) {
-                    self.token_trees =
-                        TopSubtreeBuilderRepr::SpanStorage64(Self::switch_repr(token_trees));
-                } else {
-                    self.token_trees =
-                        TopSubtreeBuilderRepr::SpanStorage96(Self::switch_repr(token_trees));
-                }
-            }
-            TopSubtreeBuilderRepr::SpanStorage64(token_trees) => {
-                if SpanStorage64::can_hold(text_range, span_parts_index) {
-                    // Can hold.
-                } else {
-                    self.token_trees =
-                        TopSubtreeBuilderRepr::SpanStorage96(Self::switch_repr(token_trees));
-                }
-            }
-            TopSubtreeBuilderRepr::SpanStorage96(_) => {
-                // Can hold anything.
-            }
-        }
-    }
-
     /// Not to be exposed, this assumes the subtree's children will be filled in immediately.
-    fn push_subtree(&mut self, subtree: crate::Subtree) {
-        let open_span_parts_index =
-            self.span_part_index(CompressedSpanPart::from_span(&subtree.delimiter.open));
-        self.ensure_can_hold(subtree.delimiter.open.range, open_span_parts_index);
-        let close_span_parts_index =
-            self.span_part_index(CompressedSpanPart::from_span(&subtree.delimiter.close));
-        self.ensure_can_hold(subtree.delimiter.close.range, close_span_parts_index);
-        fn do_it<S: SpanStorage>(
-            tt: &mut Vec<TokenTree<S>>,
-            open_span_parts_index: usize,
-            close_span_parts_index: usize,
-            subtree: crate::Subtree,
-        ) {
-            let open_span = S::new(subtree.delimiter.open.range, open_span_parts_index);
-            let close_span = S::new(subtree.delimiter.close.range, close_span_parts_index);
-            tt.push(TokenTree::Subtree {
-                len: subtree.len,
-                delim_kind: subtree.delimiter.kind,
-                open_span,
-                close_span,
-            });
-        }
-        dispatch_builder! {
-            match &mut self.token_trees => tt => do_it(tt, open_span_parts_index, close_span_parts_index, subtree)
-        }
+    fn push_subtree(&mut self, subtree: Subtree) {
+        self.insert_span(&subtree.delimiter.open);
+        self.insert_span(&subtree.delimiter.close);
+        self.token_trees.push(subtree.into());
     }
 
     pub fn open(&mut self, delimiter_kind: DelimiterKind, open_span: Span) {
-        let span_parts_index = self.span_part_index(CompressedSpanPart::from_span(&open_span));
-        self.ensure_can_hold(open_span.range, span_parts_index);
-        fn do_it<S: SpanStorage>(
-            token_trees: &mut Vec<TokenTree<S>>,
-            delimiter_kind: DelimiterKind,
-            range: TextRange,
-            span_parts_index: usize,
-        ) -> usize {
-            let open_span = S::new(range, span_parts_index);
-            token_trees.push(TokenTree::Subtree {
-                len: 0,
-                delim_kind: delimiter_kind,
-                open_span,
-                close_span: open_span, // Will be overwritten on close.
-            });
-            token_trees.len() - 1
-        }
-        let subtree_idx = dispatch_builder! {
-            match &mut self.token_trees => tt => do_it(tt, delimiter_kind, open_span.range, span_parts_index)
-        };
+        self.insert_span(&open_span);
+        let subtree_idx = self.token_trees.len();
+        self.token_trees.push(TokenTree::Subtree(Subtree {
+            delimiter: Delimiter { open: open_span, close: open_span, kind: delimiter_kind },
+            len: 0, // Will be overwritten on close.
+        }));
         self.unclosed_subtree_indices.push(subtree_idx);
     }
 
     pub fn close(&mut self, close_span: Span) {
-        let span_parts_index = self.span_part_index(CompressedSpanPart::from_span(&close_span));
-        let range = close_span.range;
-        self.ensure_can_hold(range, span_parts_index);
+        self.insert_span(&close_span);
 
         let last_unclosed_index = self
             .unclosed_subtree_indices
             .pop()
             .expect("attempt to close a `tt::Subtree` when none is open");
-        fn do_it<S: SpanStorage>(
-            token_trees: &mut [TokenTree<S>],
-            last_unclosed_index: usize,
-            range: TextRange,
-            span_parts_index: usize,
-        ) {
-            let token_trees_len = token_trees.len();
-            let TokenTree::Subtree { len, delim_kind: _, open_span: _, close_span } =
-                &mut token_trees[last_unclosed_index]
-            else {
-                unreachable!("unclosed token tree is always a subtree");
-            };
-            *len = (token_trees_len - last_unclosed_index - 1) as u32;
-            *close_span = S::new(range, span_parts_index);
-        }
-        dispatch_builder! {
-            match &mut self.token_trees => tt => do_it(tt, last_unclosed_index, range, span_parts_index)
-        }
+        let token_trees_len = self.token_trees.len();
+        let TokenTree::Subtree(Subtree { delimiter: Delimiter { open: _, close, kind: _ }, len }) =
+            &mut self.token_trees[last_unclosed_index]
+        else {
+            unreachable!("unclosed token tree is always a subtree");
+        };
+        *len = (token_trees_len - last_unclosed_index - 1) as u32;
+        *close = close_span;
         self.last_closed_subtree = Some(last_unclosed_index);
     }
 
     /// You cannot call this consecutively, it will only work once after close.
     pub fn remove_last_subtree_if_invisible(&mut self) {
         let Some(last_subtree_idx) = self.last_closed_subtree else { return };
-        fn do_it<S: SpanStorage>(tt: &mut Vec<TokenTree<S>>, last_subtree_idx: usize) {
-            if let TokenTree::Subtree { delim_kind: DelimiterKind::Invisible, .. } =
-                tt[last_subtree_idx]
-            {
-                tt.remove(last_subtree_idx);
-            }
-        }
-        dispatch_builder! {
-            match &mut self.token_trees => tt => do_it(tt, last_subtree_idx)
+        if let TokenTree::Subtree(Subtree {
+            delimiter: Delimiter { kind: DelimiterKind::Invisible, .. },
+            ..
+        }) = self.token_trees[last_subtree_idx]
+        {
+            self.token_trees.remove(last_subtree_idx);
         }
         self.last_closed_subtree = None;
     }
 
-    fn push_literal(&mut self, leaf: crate::Literal) {
-        let span_parts_index = self.span_part_index(CompressedSpanPart::from_span(&leaf.span));
-        let range = leaf.span.range;
-        self.ensure_can_hold(range, span_parts_index);
-        fn do_it<S: SpanStorage>(
-            tt: &mut Vec<TokenTree<S>>,
-            range: TextRange,
-            span_parts_index: usize,
-            leaf: crate::Literal,
-        ) {
-            tt.push(TokenTree::Literal {
-                text_and_suffix: leaf.text_and_suffix,
-                span: S::new(range, span_parts_index),
-                kind: leaf.kind,
-                suffix_len: leaf.suffix_len,
-            })
+    pub fn push(&mut self, leaf: Leaf) {
+        self.insert_span(leaf.span());
+        if let Some(symbol) = leaf.symbol() {
+            self.insert_symbol(symbol.clone());
         }
-        dispatch_builder! {
-            match &mut self.token_trees => tt => do_it(tt, range, span_parts_index, leaf)
-        }
+        self.token_trees.push(leaf.into());
     }
 
-    fn push_punct(&mut self, leaf: crate::Punct) {
-        let span_parts_index = self.span_part_index(CompressedSpanPart::from_span(&leaf.span));
-        let range = leaf.span.range;
-        self.ensure_can_hold(range, span_parts_index);
-        fn do_it<S: SpanStorage>(
-            tt: &mut Vec<TokenTree<S>>,
-            range: TextRange,
-            span_parts_index: usize,
-            leaf: crate::Punct,
-        ) {
-            tt.push(TokenTree::Punct {
-                char: leaf.char,
-                spacing: leaf.spacing,
-                span: S::new(range, span_parts_index),
-            })
-        }
-        dispatch_builder! {
-            match &mut self.token_trees => tt => do_it(tt, range, span_parts_index, leaf)
-        }
-    }
-
-    fn push_ident(&mut self, leaf: crate::Ident) {
-        let span_parts_index = self.span_part_index(CompressedSpanPart::from_span(&leaf.span));
-        let range = leaf.span.range;
-        self.ensure_can_hold(range, span_parts_index);
-        fn do_it<S: SpanStorage>(
-            tt: &mut Vec<TokenTree<S>>,
-            range: TextRange,
-            span_parts_index: usize,
-            leaf: crate::Ident,
-        ) {
-            tt.push(TokenTree::Ident {
-                sym: leaf.sym,
-                span: S::new(range, span_parts_index),
-                is_raw: leaf.is_raw,
-            })
-        }
-        dispatch_builder! {
-            match &mut self.token_trees => tt => do_it(tt, range, span_parts_index, leaf)
-        }
-    }
-
-    pub fn push(&mut self, leaf: crate::Leaf) {
-        match leaf {
-            crate::Leaf::Literal(leaf) => self.push_literal(leaf),
-            crate::Leaf::Punct(leaf) => self.push_punct(leaf),
-            crate::Leaf::Ident(leaf) => self.push_ident(leaf),
-        }
-    }
-
-    fn push_token_tree(&mut self, tt: crate::TokenTree) {
+    fn push_token_tree(&mut self, tt: TokenTree) {
         match tt {
-            crate::TokenTree::Leaf(leaf) => self.push(leaf),
-            crate::TokenTree::Subtree(subtree) => self.push_subtree(subtree),
+            TokenTree::Leaf(leaf) => self.push(leaf),
+            TokenTree::Subtree(subtree) => self.push_subtree(subtree),
         }
     }
 
-    pub fn extend(&mut self, leaves: impl IntoIterator<Item = crate::Leaf>) {
+    pub fn extend(&mut self, leaves: impl IntoIterator<Item = Leaf>) {
         leaves.into_iter().for_each(|leaf| self.push(leaf));
     }
 
     pub fn extend_with_tt(&mut self, tt: TokenTreesView<'_>) {
-        fn do_it<S: SpanStorage>(
-            this: &mut TopSubtreeBuilder,
-            tt: &[TokenTree<S>],
-            span_parts: &[CompressedSpanPart],
-        ) {
-            for tt in tt {
-                this.push_token_tree(tt.to_api(span_parts));
-            }
-        }
-        dispatch_ref! {
-            match tt.repr => tt_repr => do_it(self, tt_repr, tt.span_parts)
-        }
+        tt.iter_flat_tokens().for_each(|tt| self.push_token_tree(tt));
     }
 
     /// Like [`Self::extend_with_tt()`], but makes sure the new tokens will never be
     /// joint with whatever comes after them.
     pub fn extend_with_tt_alone(&mut self, tt: TokenTreesView<'_>) {
         self.extend_with_tt(tt);
-        fn do_it<S: SpanStorage>(tt: &mut [TokenTree<S>]) {
-            if let Some(TokenTree::Punct { spacing, .. }) = tt.last_mut() {
-                *spacing = Spacing::Alone;
-            }
-        }
-        if !tt.is_empty() {
-            dispatch_builder! {
-                match &mut self.token_trees => tt => do_it(tt)
-            }
+        if !tt.is_empty()
+            && let Some(TokenTree::Leaf(Leaf::Punct(Punct { spacing, .. }))) =
+                self.token_trees.last_mut()
+        {
+            *spacing = Spacing::Alone;
         }
     }
 
     pub fn expected_delimiters(&self) -> impl Iterator<Item = DelimiterKind> {
         self.unclosed_subtree_indices.iter().rev().map(|&subtree_idx| {
-            dispatch_builder! {
-                match &self.token_trees => tt => {
-                    let TokenTree::Subtree { delim_kind, .. } = tt[subtree_idx] else {
-                        unreachable!("unclosed token tree is always a subtree")
-                    };
-                    delim_kind
-                }
-            }
+            let TokenTree::Subtree(Subtree { delimiter, .. }) = self.token_trees[subtree_idx]
+            else {
+                unreachable!("unclosed token tree is always a subtree")
+            };
+            delimiter.kind
         })
     }
 
     /// Builds, and remove the top subtree if it has only one subtree child.
     pub fn build_skip_top_subtree(mut self) -> TopSubtree {
-        fn remove_first_if_needed<S: SpanStorage>(
-            tt: &mut Vec<TokenTree<S>>,
-            top_delim_span: &mut DelimSpan,
-            span_parts: &FxIndexSet<CompressedSpanPart>,
-        ) {
-            let tt_len = tt.len();
-            let Some(TokenTree::Subtree { len, open_span, close_span, .. }) = tt.get_mut(1) else {
-                return;
-            };
-            if (*len as usize) != (tt_len - 2) {
-                // Subtree does not cover the whole tree (minus 2; itself, and the top span).
-                return;
-            }
+        assert!(
+            self.unclosed_subtree_indices.is_empty(),
+            "attempt to build an unbalanced `TopSubtreeBuilder`"
+        );
+        let tt_len = self.token_trees.len();
+        if let Some(&TokenTree::Subtree(Subtree { len, delimiter })) = self.token_trees.get(1)
+            && (len as usize) == (tt_len - 2)
+        {
+            // The top subtree's delimiters should not be included.
+            Self::remove_span(&mut self.span_parts_frequencies, &delimiter.open);
+            Self::remove_span(&mut self.span_parts_frequencies, &delimiter.close);
 
-            // Now we need to adjust the spans, because we assume that the first two spans are always reserved.
-            let top_open_span = span_parts
-                .get_index(open_span.span_parts_index() - RESERVED_SPAN_PARTS_LEN)
-                .unwrap()
-                .recombine(open_span.text_range());
-            let top_close_span = span_parts
-                .get_index(close_span.span_parts_index() - RESERVED_SPAN_PARTS_LEN)
-                .unwrap()
-                .recombine(close_span.text_range());
-            *top_delim_span = DelimSpan { open: top_open_span, close: top_close_span };
-            // Can't remove the top spans from the map, as maybe they're used by other things as well.
-            // Now we need to reencode the spans, because their parts index changed:
-            *open_span = S::new(open_span.text_range(), 0);
-            *close_span = S::new(close_span.text_range(), 1);
-
-            tt.remove(0);
+            let mut token_trees = self.token_trees.into_iter();
+            token_trees.next(); // Remove the first subtree.
+            encode_all(token_trees, self.span_parts_frequencies, self.symbol_frequencies)
+        } else {
+            self.build()
         }
-        dispatch_builder! {
-            match &mut self.token_trees => tt => remove_first_if_needed(tt, &mut self.top_subtree_spans, &self.span_parts)
-        }
-        self.build()
     }
 
     pub fn build(mut self) -> TopSubtree {
@@ -930,57 +1359,52 @@ impl TopSubtreeBuilder {
             self.unclosed_subtree_indices.is_empty(),
             "attempt to build an unbalanced `TopSubtreeBuilder`"
         );
-        fn finish_top_len<S: SpanStorage>(tt: &mut [TokenTree<S>]) {
-            let total_len = tt.len() as u32;
-            let TokenTree::Subtree { len, .. } = &mut tt[0] else {
-                unreachable!("first token tree is always a subtree");
-            };
-            *len = total_len - 1;
-        }
-        dispatch_builder! {
-            match &mut self.token_trees => tt => finish_top_len(tt)
-        }
-
-        let span_parts = [
-            CompressedSpanPart::from_span(&self.top_subtree_spans.open),
-            CompressedSpanPart::from_span(&self.top_subtree_spans.close),
-        ]
-        .into_iter()
-        .chain(self.span_parts.iter().copied())
-        .collect();
-
-        let repr = match self.token_trees {
-            TopSubtreeBuilderRepr::SpanStorage32(tt) => {
-                TopSubtreeRepr::SpanStorage32(tt.into_boxed_slice())
-            }
-            TopSubtreeBuilderRepr::SpanStorage64(tt) => {
-                TopSubtreeRepr::SpanStorage64(tt.into_boxed_slice())
-            }
-            TopSubtreeBuilderRepr::SpanStorage96(tt) => {
-                TopSubtreeRepr::SpanStorage96(tt.into_boxed_slice())
-            }
+        let tts_len = self.token_trees.len();
+        let TokenTree::Subtree(top_subtree) = &mut self.token_trees[0] else {
+            panic!("first token tree must be a subtree");
         };
-
-        TopSubtree { repr, span_parts }
+        top_subtree.len = (tts_len - 1).try_into().unwrap();
+        encode_all(
+            self.token_trees.into_iter(),
+            self.span_parts_frequencies,
+            self.symbol_frequencies,
+        )
     }
 
-    pub fn restore_point(&self) -> SubtreeBuilderRestorePoint {
-        let token_trees_len = dispatch_builder! {
-            match &self.token_trees => tt => tt.len()
-        };
+    pub fn restore_point(&mut self) -> SubtreeBuilderRestorePoint {
+        // We reset the `last_closed_subtree`, since restoring from a restore point doesn't play well with removing the last subtree.
+        self.last_closed_subtree = None;
         SubtreeBuilderRestorePoint {
             unclosed_subtree_indices_len: self.unclosed_subtree_indices.len(),
-            token_trees_len,
-            last_closed_subtree: self.last_closed_subtree,
+            token_trees_len: self.token_trees.len(),
         }
     }
 
     pub fn restore(&mut self, restore_point: SubtreeBuilderRestorePoint) {
-        self.unclosed_subtree_indices.truncate(restore_point.unclosed_subtree_indices_len);
-        dispatch_builder! {
-            match &mut self.token_trees => tt => tt.truncate(restore_point.token_trees_len)
+        if restore_point.token_trees_len >= self.token_trees.len() {
+            // This means we restored twice, potentially with an earlier restore point first.
+            return;
         }
-        self.last_closed_subtree = restore_point.last_closed_subtree;
+
+        for tt in &self.token_trees[restore_point.token_trees_len..] {
+            match tt {
+                TokenTree::Leaf(leaf) => {
+                    Self::remove_span(&mut self.span_parts_frequencies, leaf.span());
+
+                    if let Some(symbol) = leaf.symbol() {
+                        Self::remove_symbol(&mut self.symbol_frequencies, symbol.clone());
+                    }
+                }
+                TokenTree::Subtree(subtree) => {
+                    Self::remove_span(&mut self.span_parts_frequencies, &subtree.delimiter.open);
+                    Self::remove_span(&mut self.span_parts_frequencies, &subtree.delimiter.close);
+                }
+            }
+        }
+
+        self.unclosed_subtree_indices.truncate(restore_point.unclosed_subtree_indices_len);
+        self.token_trees.truncate(restore_point.token_trees_len);
+        self.last_closed_subtree = None;
     }
 }
 
@@ -988,5 +1412,4 @@ impl TopSubtreeBuilder {
 pub struct SubtreeBuilderRestorePoint {
     unclosed_subtree_indices_len: usize,
     token_trees_len: usize,
-    last_closed_subtree: Option<usize>,
 }


### PR DESCRIPTION
This is basically the most optimized (memory-wise) storage possible, found after multiple measurements. The price we pay for this ultra-extra optimization is a bunch of unsafe, encapsulated in `tt/src/storage.rs`. Since macros and therefore token trees are so common in Rust code, I think this is worth it.

Some stats:

 - On rust-analyzer itself, memory usage is reduced by 30mb. rust-analyzer doesn't use macros a lot and the previous optimization already took the most, but when considering that *all* token trees in r-a now consumes only about 40mb, this is still surprising.
 - On buck2, <s>~133mb</s> ~143mb is saved.
 - On omicron, <s>~352mb</s> ~436mb is saved, and this is after the previous optimization already ripped 880mb! It is only using <s>~264mb</s> ~180mb for token trees now, in total!

The basic idea is to use a variable-length encoding into a bytes array. Multiple measurements were done in order to determine the most common forms of token trees along with their frequencies, and to find the best encoding.

In addition, we also now sort the compressed spans by their frequencies (in a descending order), so that even if a `TopSubtree` has more than 2^4 unique compressed spans, we will still use the more efficient encoding for the biggest number of spans possible. This is made possible by the fact that unlike the previous encoding, now we don't force one span encoding for all tokens (or in fact even for the two spans in one subtree).

The basic form is not expected to change and this is pretty much ready for review, but I still want to add more documentation and tests.