### PR TITLE
fix: Do not declare the value NS constructor for structs/enum variants if it does not exist

### DIFF
--- a/crates/hir-def/src/expr_store/lower.rs
+++ b/crates/hir-def/src/expr_store/lower.rs
@@ -55,10 +55,9 @@ use crate::{
         Statement, generics::GenericParams,
     },
     item_scope::BuiltinShadowMode,
-    item_tree::FieldsShape,
     lang_item::{LangItemTarget, LangItems},
     nameres::{DefMap, LocalDefMap, MacroSubNs, block_def_map},
-    signatures::{StructSignature, TypeAliasSignature},
+    signatures::TypeAliasSignature,
     type_ref::{
         ArrayType, ConstRef, FnType, LifetimeRef, LifetimeRefId, Mutability, PathId, Rawness,
         RefType, TraitBoundModifier, TraitRef, TypeBound, TypeRef, TypeRefId, UseArgRef,
@@ -2758,16 +2757,8 @@ impl<'db> ExprCollector<'db> {
                     // can't).
                     match resolved.take_values() {
                         Some(ModuleDefId::ConstId(_)) => (None, Pat::Path(name.into())),
-                        Some(ModuleDefId::EnumVariantId(variant))
-                        // FIXME: This can cause a cycle if the user is writing invalid code
-                            if variant.fields(self.db).shape != FieldsShape::Record =>
-                        {
-                            (None, Pat::Path(name.into()))
-                        }
-                        Some(ModuleDefId::AdtId(AdtId::StructId(s)))
-                        // FIXME: This can cause a cycle if the user is writing invalid code
-                            if StructSignature::of(self.db, s).shape != FieldsShape::Record =>
-                        {
+                        Some(ModuleDefId::EnumVariantId(_)) => (None, Pat::Path(name.into())),
+                        Some(ModuleDefId::AdtId(AdtId::StructId(_))) => {
                             (None, Pat::Path(name.into()))
                         }
                         // shadowing statics is an error as well, so we just ignore that case here

--- a/crates/hir-def/src/expr_store/tests/body.rs
+++ b/crates/hir-def/src/expr_store/tests/body.rs
@@ -380,6 +380,32 @@ fn f() {
 }
 
 #[test]
+fn shadowing_tuple_struct_with_invisible_ctor() {
+    let (db, def) = lower(
+        r#"
+mod x {
+    pub struct CrateNum(u32);
+}
+
+use x::CrateNum;
+
+pub struct CrateNumVal(CrateNum);
+
+fn main() {
+    let CrateNumVal(CrateNum) = loop {};
+}
+    "#,
+    );
+    let body = Body::of(&db, def);
+    assert_eq!(body.assert_expr_only().bindings.len(), 1, "should have a binding for `CrateNum`");
+    assert_eq!(
+        body[BindingId::from_raw(RawIdx::from_u32(0))].name.as_str(),
+        "CrateNum",
+        "should have a binding for `CrateNum`",
+    );
+}
+
+#[test]
 fn regression_pretty_print_bind_pat() {
     pretty_print(
         r#"

--- a/crates/hir-def/src/item_scope.rs
+++ b/crates/hir-def/src/item_scope.rs
@@ -906,34 +906,50 @@ impl ItemScope {
 impl PerNs {
     pub(crate) fn from_def(
         def: ModuleDefId,
-        v: Visibility,
-        has_constructor: bool,
+        vis: Visibility,
+        value_ns_ctor_vis: Option<Visibility>,
         import: Option<ImportOrExternCrate>,
     ) -> PerNs {
         match def {
-            ModuleDefId::ModuleId(_) => PerNs::types(def, v, import),
+            ModuleDefId::ModuleId(_) => PerNs::types(def, vis, import),
             ModuleDefId::FunctionId(_) => {
-                PerNs::values(def, v, import.and_then(ImportOrExternCrate::import_or_glob))
+                PerNs::values(def, vis, import.and_then(ImportOrExternCrate::import_or_glob))
             }
             ModuleDefId::AdtId(adt) => match adt {
-                AdtId::UnionId(_) => PerNs::types(def, v, import),
-                AdtId::EnumId(_) => PerNs::types(def, v, import),
-                AdtId::StructId(_) => {
-                    if has_constructor {
-                        PerNs::both(def, def, v, import)
-                    } else {
-                        PerNs::types(def, v, import)
-                    }
-                }
+                AdtId::UnionId(_) => PerNs::types(def, vis, import),
+                AdtId::EnumId(_) => PerNs::types(def, vis, import),
+                AdtId::StructId(_) => match value_ns_ctor_vis {
+                    Some(value_ns_ctor_vis) => PerNs {
+                        types: Some(Item { def, vis, import }),
+                        values: Some(Item {
+                            def,
+                            vis: value_ns_ctor_vis,
+                            import: import.and_then(ImportOrExternCrate::import_or_glob),
+                        }),
+                        macros: None,
+                    },
+                    None => PerNs::types(def, vis, import),
+                },
             },
-            ModuleDefId::EnumVariantId(_) => PerNs::both(def, def, v, import),
+            ModuleDefId::EnumVariantId(_) => match value_ns_ctor_vis {
+                Some(value_ns_ctor_vis) => PerNs {
+                    types: Some(Item { def, vis, import }),
+                    values: Some(Item {
+                        def,
+                        vis: value_ns_ctor_vis,
+                        import: import.and_then(ImportOrExternCrate::import_or_glob),
+                    }),
+                    macros: None,
+                },
+                None => PerNs::types(def, vis, import),
+            },
             ModuleDefId::ConstId(_) | ModuleDefId::StaticId(_) => {
-                PerNs::values(def, v, import.and_then(ImportOrExternCrate::import_or_glob))
+                PerNs::values(def, vis, import.and_then(ImportOrExternCrate::import_or_glob))
             }
-            ModuleDefId::TraitId(_) => PerNs::types(def, v, import),
-            ModuleDefId::TypeAliasId(_) => PerNs::types(def, v, import),
-            ModuleDefId::BuiltinType(_) => PerNs::types(def, v, import),
-            ModuleDefId::MacroId(mac) => PerNs::macros(mac, v, import),
+            ModuleDefId::TraitId(_) => PerNs::types(def, vis, import),
+            ModuleDefId::TypeAliasId(_) => PerNs::types(def, vis, import),
+            ModuleDefId::BuiltinType(_) => PerNs::types(def, vis, import),
+            ModuleDefId::MacroId(mac) => PerNs::macros(mac, vis, import),
         }
     }
 }

--- a/crates/hir-def/src/item_tree.rs
+++ b/crates/hir-def/src/item_tree.rs
@@ -298,7 +298,6 @@ enum SmallModItem {
     MacroCall(MacroCall),
     MacroRules(MacroRules),
     Static(Static),
-    Struct(Struct),
     Trait(Trait),
     TypeAlias(TypeAlias),
     Union(Union),
@@ -309,6 +308,7 @@ enum BigModItem {
     ExternCrate(ExternCrate),
     Mod(Mod),
     Use(Use),
+    Struct(Struct),
 }
 
 // `ModItem` is stored a bunch in `ItemTree`'s so we pay the max for each item. It should stay as
@@ -463,7 +463,7 @@ ModItemKind ->
     MacroRules by Left -> ast::MacroRules,
     Mod by Right -> ast::Module,
     Static by Left -> ast::Static,
-    Struct by Left -> ast::Struct,
+    Struct by Right -> ast::Struct,
     Trait by Left -> ast::Trait,
     TypeAlias by Left -> ast::TypeAlias,
     Union by Left -> ast::Union,
@@ -574,7 +574,14 @@ pub struct Function {
 pub struct Struct {
     pub name: Name,
     pub(crate) visibility: RawVisibilityId,
-    pub shape: FieldsShape,
+    pub(crate) value_ns_ctor: StructValueNsCtor,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum StructValueNsCtor {
+    NoValueNsCtor,
+    ValueNsCtorWithVis(RawVisibilityId),
+    ValueNsCtorWithMinVis(ThinVec<RawVisibilityId>),
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -594,6 +601,16 @@ pub enum FieldsShape {
     Record,
     Tuple,
     Unit,
+}
+
+impl FieldsShape {
+    #[inline]
+    pub fn has_value_ns_ctor(self) -> bool {
+        match self {
+            FieldsShape::Record => false,
+            FieldsShape::Tuple | FieldsShape::Unit => true,
+        }
+    }
 }
 
 /// Visibility of an item, not yet resolved.

--- a/crates/hir-def/src/item_tree/lower.rs
+++ b/crates/hir-def/src/item_tree/lower.rs
@@ -4,8 +4,10 @@ use std::cell::OnceCell;
 
 use base_db::{Crate, FxIndexSet, SourceDatabase};
 use cfg::CfgOptions;
+use either::Either;
 use hir_expand::{HirFileId, mod_path::PathKind, name::AsName, span_map::SpanMap};
 use la_arena::Arena;
+use rustc_hash::FxHashSet;
 use span::{AstIdMap, FileAstId, SyntaxContext};
 use syntax::{
     AstNode,
@@ -13,9 +15,9 @@ use syntax::{
 };
 
 use crate::item_tree::{
-    BigModItem, Const, Enum, ExternBlock, ExternCrate, FieldsShape, Function, Impl, ImportAlias,
-    Interned, ItemTree, Macro2, MacroCall, MacroRules, Mod, ModItemId, ModKind, ModPath,
-    RawVisibility, RawVisibilityId, SmallModItem, Static, Struct, StructKind, Trait, TypeAlias,
+    BigModItem, Const, Enum, ExternBlock, ExternCrate, Function, Impl, ImportAlias, Interned,
+    ItemTree, Macro2, MacroCall, MacroRules, Mod, ModItemId, ModKind, ModPath, RawVisibility,
+    RawVisibilityId, SmallModItem, Static, Struct, StructKind, StructValueNsCtor, Trait, TypeAlias,
     Union, Use, UseTree, UseTreeKind, VisibilityExplicitness, attrs::AttrsOrCfg,
 };
 
@@ -169,12 +171,89 @@ impl<'db> Ctx<'db> {
     }
 
     fn lower_struct(&mut self, strukt: &ast::Struct) -> Option<ModItemId> {
-        let visibility = self.lower_visibility(strukt);
+        let visibility = self.lower_visibility_from_ast(strukt);
+        let visibility_id = self.alloc_visibility(visibility.clone());
         let name = strukt.name()?.as_name();
         let ast_id = self.source_ast_id_map.ast_id(strukt);
-        let shape = adt_shape(strukt.kind());
-        let res = Struct { name, visibility, shape };
-        Some(self.alloc_small(ast_id.upcast(), SmallModItem::Struct(res)))
+        let value_ns_ctor = match strukt.kind() {
+            StructKind::Record(_) => StructValueNsCtor::NoValueNsCtor,
+            StructKind::Unit => StructValueNsCtor::ValueNsCtorWithVis(visibility_id),
+            StructKind::Tuple(fields) => self.tuple_struct_ctor_vis(visibility, fields),
+        };
+        let res = Struct { name, visibility: visibility_id, value_ns_ctor };
+        Some(self.alloc_big(ast_id.upcast(), BigModItem::Struct(res)))
+    }
+
+    fn tuple_struct_ctor_vis(
+        &mut self,
+        struct_vis: RawVisibility,
+        fields: ast::TupleFieldList,
+    ) -> StructValueNsCtor {
+        if let RawVisibility::PubSelf(_) = struct_vis {
+            // `pub(self)` <= anything.
+            return StructValueNsCtor::ValueNsCtorWithVis(self.alloc_visibility(struct_vis));
+        }
+
+        let mut value_ns_ctor_vis = Either::Left(struct_vis);
+        for field in fields.fields() {
+            let field_vis = self.lower_visibility_from_ast(&field);
+            match (&field_vis, &mut value_ns_ctor_vis) {
+                (RawVisibility::PubSelf(_), _) => {
+                    // If there is a field private, the minimal visibility is private.
+                    value_ns_ctor_vis = Either::Left(field_vis);
+                    break;
+                }
+                (_, Either::Left(RawVisibility::Public)) => {
+                    // anything <= `pub`.
+                    value_ns_ctor_vis = Either::Left(field_vis);
+                }
+                (RawVisibility::Module(..), Either::Left(RawVisibility::PubCrate)) => {
+                    // `pub(in module)` <= `pub(crate)`.
+                    value_ns_ctor_vis = Either::Left(field_vis);
+                }
+                (
+                    RawVisibility::Public | RawVisibility::PubCrate,
+                    Either::Right(_)
+                    | Either::Left(RawVisibility::Module(..) | RawVisibility::PubCrate),
+                ) => {
+                    // `pub(in module) | pub(crate)` <= `pub(crate) | pub`.
+                }
+                (_, Either::Left(RawVisibility::PubSelf(_))) => {
+                    unreachable!("we early-exit on `PubSelf`");
+                }
+                (RawVisibility::Module(..), Either::Left(RawVisibility::Module(..))) => {
+                    let old_vis = match std::mem::replace(
+                        &mut value_ns_ctor_vis,
+                        Either::Left(RawVisibility::Public),
+                    ) {
+                        Either::Left(it) => it,
+                        _ => unreachable!(),
+                    };
+                    let mut multiple = FxHashSet::default();
+                    multiple.insert(old_vis);
+                    multiple.insert(field_vis);
+                    value_ns_ctor_vis = Either::Right(multiple);
+                }
+                (RawVisibility::Module(..), Either::Right(multiple)) => {
+                    multiple.insert(field_vis);
+                }
+            }
+        }
+
+        match value_ns_ctor_vis {
+            Either::Left(vis) => StructValueNsCtor::ValueNsCtorWithVis(self.alloc_visibility(vis)),
+            Either::Right(multiple) => {
+                if multiple.len() == 1 {
+                    StructValueNsCtor::ValueNsCtorWithVis(
+                        self.alloc_visibility(multiple.into_iter().next().unwrap()),
+                    )
+                } else {
+                    StructValueNsCtor::ValueNsCtorWithMinVis(
+                        multiple.into_iter().map(|vis| self.alloc_visibility(vis)).collect(),
+                    )
+                }
+            }
+        }
     }
 
     fn lower_union(&mut self, union: &ast::Union) -> Option<ModItemId> {
@@ -349,9 +428,17 @@ impl<'db> Ctx<'db> {
     }
 
     fn lower_visibility(&mut self, item: &dyn ast::HasVisibility) -> RawVisibilityId {
-        let vis = visibility_from_ast(self.db, item.visibility(), &mut |range| {
+        let vis = self.lower_visibility_from_ast(item);
+        self.alloc_visibility(vis)
+    }
+
+    fn lower_visibility_from_ast(&mut self, item: &dyn ast::HasVisibility) -> RawVisibility {
+        visibility_from_ast(self.db, item.visibility(), &mut |range| {
             self.span_map().span_for_range(range).ctx
-        });
+        })
+    }
+
+    fn alloc_visibility(&mut self, vis: RawVisibility) -> RawVisibilityId {
         match &vis {
             RawVisibility::Public => RawVisibilityId::PUB,
             RawVisibility::PubSelf(VisibilityExplicitness::Explicit) => {
@@ -473,12 +560,4 @@ pub(crate) fn visibility_from_ast(
         ast::VisibilityKind::Pub => return RawVisibility::Public,
     };
     RawVisibility::Module(Interned::new(path), VisibilityExplicitness::Explicit)
-}
-
-fn adt_shape(kind: StructKind) -> FieldsShape {
-    match kind {
-        StructKind::Record(_) => FieldsShape::Record,
-        StructKind::Tuple(_) => FieldsShape::Tuple,
-        StructKind::Unit => FieldsShape::Unit,
-    }
 }

--- a/crates/hir-def/src/item_tree/pretty.rs
+++ b/crates/hir-def/src/item_tree/pretty.rs
@@ -6,10 +6,9 @@ use span::{Edition, ErasedFileAstId};
 
 use crate::{
     item_tree::{
-        Const, Enum, ExternBlock, ExternCrate, FieldsShape, Function, Impl, ItemTree, Macro2,
-        MacroCall, MacroRules, Mod, ModItemId, ModItemKind, ModKind, RawVisibilityId,
-        SourceDatabase, Static, Struct, Trait, TypeAlias, Union, Use, UseTree, UseTreeKind,
-        attrs::AttrsOrCfg,
+        Const, Enum, ExternBlock, ExternCrate, Function, Impl, ItemTree, Macro2, MacroCall,
+        MacroRules, Mod, ModItemId, ModItemKind, ModKind, RawVisibilityId, SourceDatabase, Static,
+        Struct, Trait, TypeAlias, Union, Use, UseTree, UseTreeKind, attrs::AttrsOrCfg,
     },
     visibility::RawVisibility,
 };
@@ -85,13 +84,6 @@ impl Printer<'_> {
         }
     }
 
-    fn whitespace(&mut self) {
-        match self.buf.chars().next_back() {
-            None | Some('\n' | ' ') => {}
-            _ => self.buf.push(' '),
-        }
-    }
-
     fn print_attrs(&mut self, attrs: &AttrsOrCfg, inner: bool, separated_by: &str) {
         let (cfg_disabled_expr, attrs) = match attrs {
             AttrsOrCfg::Enabled { attrs } => (None, attrs),
@@ -128,19 +120,6 @@ impl Printer<'_> {
             RawVisibility::PubCrate => w!(self, "pub(crate) "),
             RawVisibility::PubSelf(_) => w!(self, "pub(self) "),
         };
-    }
-
-    fn print_fields(&mut self, kind: FieldsShape) {
-        match kind {
-            FieldsShape::Record => {
-                self.whitespace();
-                w!(self, "{{ ... }}");
-            }
-            FieldsShape::Tuple => {
-                w!(self, "(...)");
-            }
-            FieldsShape::Unit => {}
-        }
     }
 
     fn print_use_tree(&mut self, use_tree: &UseTree) {
@@ -213,30 +192,22 @@ impl Printer<'_> {
                 wln!(self, "fn {};", name.display(self.db, self.edition));
             }
             ModItemKind::Struct(ast_id, item) => {
-                let Struct { visibility, name, shape: kind } = item;
+                let Struct { visibility, name, value_ns_ctor: _ } = item;
                 self.print_ast_id(ast_id.erase());
                 self.print_visibility(*visibility);
-                w!(self, "struct {}", name.display(self.db, self.edition));
-                self.print_fields(*kind);
-                if matches!(kind, FieldsShape::Record) {
-                    wln!(self);
-                } else {
-                    wln!(self, ";");
-                }
+                wln!(self, "struct {} {{ ... }}", name.display(self.db, self.edition));
             }
             ModItemKind::Union(ast_id, item) => {
                 let Union { name, visibility } = item;
                 self.print_ast_id(ast_id.erase());
                 self.print_visibility(*visibility);
-                w!(self, "union {}", name.display(self.db, self.edition));
-                self.print_fields(FieldsShape::Record);
-                wln!(self);
+                wln!(self, "union {} {{ ... }}", name.display(self.db, self.edition));
             }
             ModItemKind::Enum(ast_id, item) => {
                 let Enum { name, visibility } = item;
                 self.print_ast_id(ast_id.erase());
                 self.print_visibility(*visibility);
-                w!(self, "enum {} {{ ... }}", name.display(self.db, self.edition));
+                wln!(self, "enum {} {{ ... }}", name.display(self.db, self.edition));
             }
             ModItemKind::Const(ast_id, item) => {
                 let Const { name, visibility } = item;

--- a/crates/hir-def/src/item_tree/tests.rs
+++ b/crates/hir-def/src/item_tree/tests.rs
@@ -122,14 +122,14 @@ enum E {
         "#,
         expect![[r#"
             // AstId: Struct[ED35, 0]
-            pub(self) struct Unit;
+            pub(self) struct Unit { ... }
 
             #[derive(Debug)]
             // AstId: Struct[A47C, 0]
             pub(self) struct Struct { ... }
 
             // AstId: Struct[C8C9, 0]
-            pub(self) struct Tuple(...);
+            pub(self) struct Tuple { ... }
 
             // AstId: Union[2797, 0]
             pub(self) union Ize { ... }
@@ -240,7 +240,7 @@ pub(self) struct S;
         "#,
         expect![[r#"
             // AstId: Struct[5024, 0]
-            pub(self) struct S;
+            pub(self) struct S { ... }
         "#]],
     )
 }

--- a/crates/hir-def/src/nameres/collector.rs
+++ b/crates/hir-def/src/nameres/collector.rs
@@ -36,8 +36,9 @@ use crate::{
     UseLoc, file_item_tree,
     item_scope::{GlobId, ImportId, ImportOrExternCrate, PerNsGlobImports},
     item_tree::{
-        self, Attrs, AttrsOrCfg, FieldsShape, ImportAlias, ImportKind, ItemTree, ItemTreeAstId,
-        Macro2, MacroCall, MacroRules, Mod, ModItemId, ModItemKind, ModKind, TreeId, Use,
+        self, Attrs, AttrsOrCfg, ImportAlias, ImportKind, ItemTree, ItemTreeAstId, Macro2,
+        MacroCall, MacroRules, Mod, ModItemId, ModItemKind, ModKind, StructValueNsCtor, TreeId,
+        Use,
     },
     macro_call_as_call_id,
     nameres::{
@@ -1031,8 +1032,13 @@ impl<'db> DefCollector<'db> {
                             .enum_variants(self.db)
                             .variants
                             .iter()
-                            .map(|(name, &(variant, _))| {
-                                let res = PerNs::both(variant.into(), variant.into(), vis, None);
+                            .map(|(name, &(variant, shape))| {
+                                // We don't need to reduce the visibility, since enum variants and their fields do not have visibility on their own.
+                                let res = if shape.has_value_ns_ctor() {
+                                    PerNs::both(variant.into(), variant.into(), vis, None)
+                                } else {
+                                    PerNs::types(variant.into(), vis, None)
+                                };
                                 (Some(name.clone()), res)
                             })
                             .collect::<Vec<_>>();
@@ -1937,11 +1943,11 @@ impl ModCollector<'_, '_> {
                 }
             };
         let update_def =
-            |def_collector: &mut DefCollector<'_>, id, name: &Name, vis, has_constructor| {
+            |def_collector: &mut DefCollector<'_>, id, name: &Name, vis, value_ns_ctor_vis| {
                 def_collector.def_map.modules[module_id].scope.declare(id);
                 def_collector.update(
                     module_id,
-                    &[(Some(name.clone()), PerNs::from_def(id, vis, has_constructor, None))],
+                    &[(Some(name.clone()), PerNs::from_def(id, vis, value_ns_ctor_vis, None))],
                     vis,
                     None,
                 )
@@ -2098,7 +2104,7 @@ impl ModCollector<'_, '_> {
 
                     let vis = resolve_vis(def_map, local_def_map, &self.item_tree[it.visibility]);
 
-                    update_def(self.def_collector, fn_id.into(), &it.name, vis, false);
+                    update_def(self.def_collector, fn_id.into(), &it.name, vis, None);
 
                     if self.def_collector.def_map.block.is_none()
                         && self.def_collector.is_proc_macro
@@ -2121,6 +2127,16 @@ impl ModCollector<'_, '_> {
                 }
                 ModItemKind::Struct(ast_id, it) => {
                     let vis = resolve_vis(def_map, local_def_map, &self.item_tree[it.visibility]);
+                    let value_ns_ctor_vis = match &it.value_ns_ctor {
+                        StructValueNsCtor::NoValueNsCtor => None,
+                        StructValueNsCtor::ValueNsCtorWithVis(vis) => {
+                            Some(resolve_vis(def_map, local_def_map, &self.item_tree[*vis]))
+                        }
+                        StructValueNsCtor::ValueNsCtorWithMinVis(multiple) => multiple
+                            .iter()
+                            .map(|&vis| resolve_vis(def_map, local_def_map, &self.item_tree[vis]))
+                            .fold(None, |a: Option<Visibility>, b| a?.min(db, b, def_map)),
+                    };
                     let interned = StructLoc {
                         container: module_id,
                         id: InFile::new(self.tree_id.file_id(), ast_id),
@@ -2138,7 +2154,7 @@ impl ModCollector<'_, '_> {
                         interned.into(),
                         &it.name,
                         vis,
-                        !matches!(it.shape, FieldsShape::Record),
+                        value_ns_ctor_vis,
                     );
                 }
                 ModItemKind::Union(ast_id, it) => {
@@ -2155,7 +2171,7 @@ impl ModCollector<'_, '_> {
                         interned.into(),
                         def_map,
                     );
-                    update_def(self.def_collector, interned.into(), &it.name, vis, false);
+                    update_def(self.def_collector, interned.into(), &it.name, vis, None);
                 }
                 ModItemKind::Enum(ast_id, it) => {
                     let enum_ = EnumLoc {
@@ -2172,7 +2188,7 @@ impl ModCollector<'_, '_> {
                         def_map,
                     );
                     let vis = resolve_vis(def_map, local_def_map, &self.item_tree[it.visibility]);
-                    update_def(self.def_collector, enum_.into(), &it.name, vis, false);
+                    update_def(self.def_collector, enum_.into(), &it.name, vis, None);
                 }
                 ModItemKind::Const(ast_id, it) => {
                     let const_id =
@@ -2183,7 +2199,7 @@ impl ModCollector<'_, '_> {
                         Some(name) => {
                             let vis =
                                 resolve_vis(def_map, local_def_map, &self.item_tree[it.visibility]);
-                            update_def(self.def_collector, const_id.into(), name, vis, false);
+                            update_def(self.def_collector, const_id.into(), name, vis, None);
                         }
                         None => {
                             // const _: T = ...;
@@ -2202,7 +2218,7 @@ impl ModCollector<'_, '_> {
                             .into(),
                         &it.name,
                         vis,
-                        false,
+                        None,
                     );
                 }
                 ModItemKind::Trait(ast_id, it) => {
@@ -2214,7 +2230,7 @@ impl ModCollector<'_, '_> {
                             .into(),
                         &it.name,
                         vis,
-                        false,
+                        None,
                     );
                 }
                 ModItemKind::TypeAlias(ast_id, it) => {
@@ -2226,7 +2242,7 @@ impl ModCollector<'_, '_> {
                             .into(),
                         &it.name,
                         vis,
-                        false,
+                        None,
                     );
                 }
             }
@@ -2437,7 +2453,7 @@ impl ModCollector<'_, '_> {
         def_map.modules[self.module_id].scope.declare(def);
         self.def_collector.update(
             self.module_id,
-            &[(Some(name), PerNs::from_def(def, vis, false, None))],
+            &[(Some(name), PerNs::from_def(def, vis, None, None))],
             vis,
             None,
         );

--- a/crates/hir-def/src/nameres/path_resolution.rs
+++ b/crates/hir-def/src/nameres/path_resolution.rs
@@ -22,7 +22,6 @@ use stdx::TupleExt;
 use crate::{
     AdtId, ModuleDefId, ModuleId,
     item_scope::{BUILTIN_SCOPE, ImportOrExternCrate},
-    item_tree::FieldsShape,
     nameres::{
         BlockInfo, BuiltinShadowMode, DefMap, LocalDefMap, MacroSubNs, assoc::TraitItems,
         crate_def_map, sub_namespace_match,
@@ -518,16 +517,10 @@ impl DefMap {
                     cov_mark::hit!(can_import_enum_variant);
 
                     let res = e.enum_variants(db).variants.get(segment).map(|&(variant, shape)| {
-                        match shape {
-                            FieldsShape::Record => {
-                                PerNs::types(variant.into(), Visibility::Public, None)
-                            }
-                            FieldsShape::Tuple | FieldsShape::Unit => PerNs::both(
-                                variant.into(),
-                                variant.into(),
-                                Visibility::Public,
-                                None,
-                            ),
+                        if shape.has_value_ns_ctor() {
+                            PerNs::both(variant.into(), variant.into(), curr.vis, None)
+                        } else {
+                            PerNs::types(variant.into(), curr.vis, None)
                         }
                     });
                     // FIXME: Need to filter visibility here and below? Not sure.

--- a/crates/ide-diagnostics/src/handlers/generic_args_prohibited.rs
+++ b/crates/ide-diagnostics/src/handlers/generic_args_prohibited.rs
@@ -479,7 +479,7 @@ fn baz(v: foo::Bar) {
         check_diagnostics(
             r#"
 mod foo {
-    pub struct Bar(i32);
+    pub struct Bar(pub i32);
 }
 fn baz(v: foo::Bar) {
     let foo::<()>::Bar(..) = v;

--- a/crates/ide/src/hover/tests.rs
+++ b/crates/ide/src/hover/tests.rs
@@ -3829,7 +3829,7 @@ fn test_hover_tuple_has_goto_type_actions() {
 struct A(u32);
 struct B(u32);
 mod M {
-    pub struct C(u32);
+    pub struct C(pub u32);
 }
 
 fn main() { let s$0t = (A(1), B(2), M::C(3) ); }
@@ -3870,12 +3870,12 @@ fn main() { let s$0t = (A(1), B(2), M::C(3) ); }
                                 file_id: FileId(
                                     0,
                                 ),
-                                full_range: 42..60,
+                                full_range: 42..64,
                                 focus_range: 53..54,
                                 name: "C",
                                 kind: Struct,
                                 container_name: "M",
-                                description: "pub struct C(u32)",
+                                description: "pub struct C(pub u32)",
                             },
                         },
                     ],


### PR DESCRIPTION
That is, if the struct/variant is unit/tuple or has non-visible fields.

Fixes https://github.com/rust-lang/rust-analyzer/issues/23090.