### PR TITLE
feat: add strict arithmetic replacement assist

### DIFF
--- a/crates/ide-assists/src/handlers/replace_arith_op.rs
+++ b/crates/ide-assists/src/handlers/replace_arith_op.rs
@@ -31,6 +31,28 @@ pub(crate) fn replace_arith_with_checked(
     replace_arith(acc, ctx, ArithKind::Checked)
 }
 
+// Assist: replace_arith_with_strict
+//
+// Replaces arithmetic on integers with the `strict_*` equivalent.
+//
+// ```
+// fn main() {
+//   let x = 1 $0+ 2;
+// }
+// ```
+// ->
+// ```
+// fn main() {
+//   let x = 1.strict_add(2);
+// }
+// ```
+pub(crate) fn replace_arith_with_strict(
+    acc: &mut Assists,
+    ctx: &AssistContext<'_, '_>,
+) -> Option<()> {
+    replace_arith(acc, ctx, ArithKind::Strict)
+}
+
 // Assist: replace_arith_with_saturating
 //
 // Replaces arithmetic on integers with the `saturating_*` equivalent.
@@ -139,6 +161,7 @@ pub(crate) enum ArithKind {
     Saturating,
     Wrapping,
     Checked,
+    Strict,
 }
 
 impl ArithKind {
@@ -147,6 +170,7 @@ impl ArithKind {
             ArithKind::Saturating => "replace_arith_with_saturating",
             ArithKind::Checked => "replace_arith_with_checked",
             ArithKind::Wrapping => "replace_arith_with_wrapping",
+            ArithKind::Strict => "replace_arith_with_strict",
         };
 
         AssistId::refactor_rewrite(s)
@@ -157,6 +181,7 @@ impl ArithKind {
             ArithKind::Saturating => "Replace arithmetic with call to saturating_*",
             ArithKind::Checked => "Replace arithmetic with call to checked_*",
             ArithKind::Wrapping => "Replace arithmetic with call to wrapping_*",
+            ArithKind::Strict => "Replace arithmetic with call to strict_*",
         }
     }
 
@@ -165,6 +190,7 @@ impl ArithKind {
             ArithKind::Checked => "checked_",
             ArithKind::Wrapping => "wrapping_",
             ArithKind::Saturating => "saturating_",
+            ArithKind::Strict => "strict_",
         };
 
         let suffix = match op {
@@ -202,6 +228,23 @@ fn main() {
             r#"
 fn main() {
     let x = 1.checked_add(2);
+}
+"#,
+        )
+    }
+
+    #[test]
+    fn replace_arith_with_strict_add() {
+        check_assist(
+            replace_arith_with_strict,
+            r#"
+fn main() {
+    let x = 1 $0+ 2;
+}
+"#,
+            r#"
+fn main() {
+    let x = 1.strict_add(2);
 }
 "#,
         )

--- a/crates/ide-assists/src/lib.rs
+++ b/crates/ide-assists/src/lib.rs
@@ -358,6 +358,7 @@ mod handlers {
             reorder_impl_items::reorder_impl_items,
             replace_arith_op::replace_arith_with_checked,
             replace_arith_op::replace_arith_with_saturating,
+            replace_arith_op::replace_arith_with_strict,
             replace_arith_op::replace_arith_with_wrapping,
             replace_derive_with_manual_impl::replace_derive_with_manual_impl,
             replace_if_let_with_match::replace_if_let_with_match,

--- a/crates/ide-assists/src/tests/generated.rs
+++ b/crates/ide-assists/src/tests/generated.rs
@@ -3227,6 +3227,23 @@ fn main() {
 }
 
 #[test]
+fn doctest_replace_arith_with_strict() {
+    check_doc_test(
+        "replace_arith_with_strict",
+        r#####"
+fn main() {
+  let x = 1 $0+ 2;
+}
+"#####,
+        r#####"
+fn main() {
+  let x = 1.strict_add(2);
+}
+"#####,
+    )
+}
+
+#[test]
 fn doctest_replace_arith_with_wrapping() {
     check_doc_test(
         "replace_arith_with_wrapping",


### PR DESCRIPTION
Closes rust-lang/rust-analyzer#23080.

  This adds the missing `strict_*` variant to the existing arithmetic operator replacement assists. For example, `1 + 2` can now be replaced with `1.strict_add(2)`.

  The new `replace_arith_with_strict` assist reuses the existing implementation by adding `ArithKind::Strict`, which maps supported operators to the corresponding `strict_*` method names. The test covers
  replacing addition with `strict_add`.

  Validation:

  - Focused tests: 2 passed
  - Full `ide-assists` test suite: 2806 passed, 3 ignored
  - `cargo fmt`
  - Generated assist tests
  - `xtask tidy`
  - `git diff --check`

  Clippy could not complete under Rust 1.95 because of a new baseline lint in the unchanged `stdx` crate; the failure is unrelated to this change