### PR TITLE
fix: Do not consider locals of `async fn` as upvars of the returned coroutine

### DIFF
--- a/crates/hir-def/src/expr_store/lower.rs
+++ b/crates/hir-def/src/expr_store/lower.rs
@@ -1211,13 +1211,36 @@ impl<'db> ExprCollector<'db> {
                     (false, true) => CoroutineKind::Gen,
                     (false, false) => unreachable!(),
                 };
-                this.lower_coroutine_body_with_moved_arguments(
+                let coroutine = this.lower_coroutine_body_with_moved_arguments(
                     self_param,
                     params,
                     body,
                     kind,
                     CoroutineSource::Fn,
-                )
+                );
+                // *All* locals belong to the inner coroutine...
+                this.associate_unowned_bindings_with(0, coroutine);
+                // ...except the formal parameters, which are *not* necessarily what was passed as parameters into `collect()`,
+                // since `lower_coroutine_body_with_moved_arguments()` might have changed them.
+                params
+                    .iter()
+                    .filter_map(|param| {
+                        if let Pat::Bind { id, .. } = this.store.pats[param.formal] {
+                            Some(id)
+                        } else {
+                            never!(
+                                "`lower_coroutine_body_with_moved_arguments()` should make sure \
+                                the coroutine closure only have simple bind args"
+                            );
+                            None
+                        }
+                    })
+                    .chain(self_param.map(|param| param.formal))
+                    .for_each(|param| {
+                        // They are owned by the top-level function, so should not be present in `bindings_owner`.
+                        this.store.binding_owners.remove(&param);
+                    });
+                coroutine
             } else {
                 body
             }
@@ -2106,10 +2129,18 @@ impl<'db> ExprCollector<'db> {
     ) -> ExprId {
         let prev_unowned_bindings_len = self.unowned_bindings.len();
         let (bindings_owner, expr_to_return) = create_expr(self);
+        self.associate_unowned_bindings_with(prev_unowned_bindings_len, bindings_owner);
+        expr_to_return
+    }
+
+    fn associate_unowned_bindings_with(
+        &mut self,
+        prev_unowned_bindings_len: usize,
+        bindings_owner: ExprId,
+    ) {
         for binding in self.unowned_bindings.drain(prev_unowned_bindings_len..) {
             self.store.binding_owners.insert(binding, bindings_owner);
         }
-        expr_to_return
     }
 
     fn with_binding_owner(&mut self, create_expr: impl FnOnce(&mut Self) -> ExprId) -> ExprId {

--- a/crates/hir-ty/src/upvars.rs
+++ b/crates/hir-ty/src/upvars.rs
@@ -386,4 +386,17 @@ fn main() {
             expect![""],
         );
     }
+
+    #[test]
+    fn async_fn_local() {
+        check(
+            r#"
+async fn foo() {
+    let v = ();
+    v
+}
+        "#,
+            expect![[r#""#]],
+        );
+    }
 }

--- a/crates/ide-diagnostics/src/handlers/unimplemented_trait.rs
+++ b/crates/ide-diagnostics/src/handlers/unimplemented_trait.rs
@@ -4,7 +4,7 @@ use crate::{Diagnostic, DiagnosticCode, DiagnosticsContext};
 
 // Diagnostic: unimplemented-trait
 //
-// This diagnostic is triggered when rust-analyzer cannot infer some type.
+// This diagnostic is triggered when a trait bound is not satisfied.
 pub(crate) fn unimplemented_trait<'db>(
     ctx: &DiagnosticsContext<'_, 'db>,
     d: &hir::UnimplementedTrait<'db>,
@@ -86,6 +86,29 @@ fn foo() {
            // | required by the bound `(): IntoIterator`
 }
 
+        "#,
+        );
+    }
+
+    #[test]
+    fn coroutine_non_held_types_with_auto_traits() {
+        check_diagnostics(
+            r#"
+auto trait Send {}
+
+struct NonSend;
+impl !Send for NonSend {}
+
+async fn foo() -> NonSend {
+    let v = NonSend;
+    v
+}
+
+fn require_send<T: Send>(_: T) {}
+
+fn baz() {
+    require_send(foo());
+}
         "#,
         );
     }


### PR DESCRIPTION
Fixes rust-lang/rust-analyzer#23102.