### PR TITLE
internal: Support multiple stable releases in one day

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -214,16 +214,28 @@ jobs:
         with:
           node-version: 22
 
-      - run: echo "TAG=$(date --iso -u)" >> $GITHUB_ENV
-        if: github.ref == 'refs/heads/release'
-      - run: echo "TAG=nightly" >> $GITHUB_ENV
-        if: github.ref != 'refs/heads/release'
-      - run: 'echo "TAG: $TAG"'
-
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
           fetch-depth: ${{ env.FETCH_DEPTH }}
+
+      - name: Set release tag
+        run: |
+          if [ "${{ github.ref }}" = "refs/heads/release" ]; then
+            git fetch --tags
+            today=$(date --iso -u)
+            last_tag=$(git tag -l "${today}*" | sort -V | tail -n1)
+            if [ -n "$last_tag" ]; then
+              last_v=$(echo "$last_tag" | grep -oP '(?<=\.)\d+' || echo 0)
+              new_v=$(($last_v + 1))
+              tag="${today}.${new_v}"
+            else
+              tag="$today"
+            fi
+            echo "TAG=$tag" >> $GITHUB_ENV
+          else
+            echo "TAG=nightly" >> $GITHUB_ENV
+          fi
 
       - run: echo "HEAD_SHA=$(git rev-parse HEAD)" >> $GITHUB_ENV
       - run: 'echo "HEAD_SHA: $HEAD_SHA"'

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -91,5 +91,8 @@ fn date_iso(sh: &Shell) -> anyhow::Result<String> {
 }
 
 fn is_release_tag(tag: &str) -> bool {
-    tag.len() == "2020-02-24".len() && tag.starts_with(|c: char| c.is_ascii_digit())
+    tag.len() >= 10
+        && tag.starts_with(|c: char| c.is_ascii_digit())
+        && tag.as_bytes()[4] == b'-'
+        && tag.as_bytes()[7] == b'-'
 }


### PR DESCRIPTION
AI disclosure: this was largely written by Gemini Flash 3.6 with some prodding to use `awk` instead of a loop. I have reviewed and mostly understood it.

Fixes rust-lang/rust-analyzer#20451