### PR TITLE
fix: Every workspace should have a proc-macro server

### DIFF
--- a/crates/proc-macro-api/src/lib.rs
+++ b/crates/proc-macro-api/src/lib.rs
@@ -87,6 +87,7 @@ pub struct ProcMacroClient {
     /// That means that concurrent salsa requests may block each other when expanding proc macros,
     /// which is unfortunate, but simple and good enough for the time being.
     pool: Arc<ProcMacroServerPool>,
+    /// The path to the proc-macro server binary.
     path: AbsPathBuf,
 }
 

--- a/crates/rust-analyzer/src/global_state.rs
+++ b/crates/rust-analyzer/src/global_state.rs
@@ -105,8 +105,13 @@ pub(crate) struct GlobalState {
     pub(crate) shutdown_requested: bool,
     pub(crate) last_reported_status: lsp_ext::ServerStatusParams,
 
-    // proc macros
+    /// Clients of the proc-macro server.
+    ///
+    /// One client per workspace, in the same order as `self.workspaces`. We don't store
+    /// the client in `self.workspaces` so that we can reload workspaces without
+    /// restarting the proc-macro server.
     pub(crate) proc_macro_clients: Arc<[Option<anyhow::Result<ProcMacroClient>>]>,
+
     pub(crate) build_deps_changed: bool,
 
     // Flycheck

--- a/crates/rust-analyzer/src/reload.rs
+++ b/crates/rust-analyzer/src/reload.rs
@@ -659,7 +659,7 @@ impl GlobalState {
             Config::user_config_dir_path().as_deref(),
         );
 
-        if (self.proc_macro_clients.is_empty() || !same_workspaces)
+        if (self.proc_macro_clients.len() < self.workspaces.len() || !same_workspaces)
             && self.config.expand_proc_macros()
         {
             info!("Spawning proc-macro servers");


### PR DESCRIPTION
fetch_proc_macros() zips proc_macro_clients with a per-workspace vec. We therefore require proc_macro_clients to have an item for every workspace, or we get "proc-macro-srv is not running" and no macro expansion for some workspaces.

This issue is more noticeable when using a discovery command, where it's common to have have several workspaces, but it can occur in plain cargo repositories too.

The logic was essentially `if !same_workspaces`, but this doesn't actually work. When a new workspace is added, switch_workspaces() updates self.workspaces, pushes to fetch_build_data_queue, and returns early.

When we actually check the proc macro clients, on the second invocation, we're seeing the *new* self.workspaces already and it looks like nothing has changed!

This was broken in rust-lang/rust-analyzer#22766, and only partially fixed in rust-lang/rust-analyzer#22865. Revert the code, and expand the doc comments.

A better solution would be to track proc macro initialisation state properly, but this fixes r-a on the >1 workspaces case today.

AI disclosure: Bisected with help by AI.