### PR TITLE
internal: Don't use newlines in performance logging

### DIFF
--- a/crates/rust-analyzer/src/main_loop.rs
+++ b/crates/rust-analyzer/src/main_loop.rs
@@ -632,15 +632,15 @@ impl GlobalState {
         let loop_duration = loop_start.elapsed();
         if loop_duration > Duration::from_millis(100) && was_quiescent {
             tracing::warn!(
-                "overly long loop turn took {loop_duration:?}:\n\
-                (event handling took {event_handling_duration:?}): {event_dbg_msg}\n\
-                (cancellation took {cancellation_time:?})
+                "overly long loop turn took {loop_duration:?}: \
+                (event handling took {event_handling_duration:?}): {event_dbg_msg} \
+                (cancellation took {cancellation_time:?}) \
                 (garbage collection took {gc_elapsed:?})"
             );
             self.poke_rust_analyzer_developer(format!(
-                "overly long loop turn took {loop_duration:?}:\n\
-                (event handling took {event_handling_duration:?}): {event_dbg_msg}\n\
-                (cancellation took {cancellation_time:?})
+                "overly long loop turn took {loop_duration:?}: \
+                (event handling took {event_handling_duration:?}): {event_dbg_msg} \
+                (cancellation took {cancellation_time:?}) \
                 (garbage collection took {gc_elapsed:?})"
             ));
         }


### PR DESCRIPTION
Currently I see the following in my logs when rust-analyzer is slow:

    2026-08-10T10:01:15.221672994-07:00 ERROR overly long loop turn took 210.742825ms:
    (event handling took 186.051561ms): PrimeCaches(End { cancelled: false })
    (cancellation took None)
                    (garbage collection took Some(13.407122ms))

This is hard to filter out when collecting stderr of issues, because it breaks the convention of a single stderr line corresponding to a single log.

Whilst it's possible to do various fancy things with tracing filters, it's much easier to monitor rust-analyzer reliability in production when stderr is tidy lines, like this:

    2026-08-10T10:01:15.221672994-07:00 ERROR overly long loop turn took 210.742825ms: (event handling took 186.051561ms): PrimeCaches(End { cancelled: false }) (cancellation took None) (garbage collection took Some(13.407122ms))

This also fixes the garbage collection log indentation issue.