### PR TITLE
Open local external docs through remote VS Code authorities

### DIFF
--- a/editors/code/src/commands.ts
+++ b/editors/code/src/commands.ts
@@ -31,6 +31,7 @@ import { HOVER_REFERENCE_COMMAND } from "./client";
 import type { DependencyId } from "./dependencies_provider";
 import { log } from "./util";
 import type { SyntaxElement } from "./syntax_tree_provider";
+import { normalizeLocalDocsUri } from "./external_docs";
 
 export * from "./run";
 export { newProject } from "./new_project";
@@ -1057,6 +1058,11 @@ export function openDocs(ctx: CtxInit): Cmd {
 
         let docLink = fileType & vscode.FileType.File ? docLinks.local : docLinks.web;
         if (docLink) {
+            docLink = normalizeLocalDocsUri(
+                docLink,
+                editor.document.uri.authority || undefined,
+                editor.document.uri.scheme,
+            );
             // instruct vscode to handle the vscode-remote link directly
             if (docLink.startsWith("vscode-remote://")) {
                 docLink = docLink.replace("vscode-remote://", "vscode://vscode-remote/");

--- a/editors/code/src/external_docs.ts
+++ b/editors/code/src/external_docs.ts
@@ -1,0 +1,42 @@
+import { URL } from "node:url";
+
+/**
+ * Make a server-local documentation URI openable by a remote VS Code client.
+ *
+ * The language server can only describe a local file with a `file://` URI. When
+ * the extension host is remote (for example, WSL), that URI points to the
+ * remote filesystem and cannot be opened by the local system browser. VS Code
+ * exposes its remote filesystem through a host-readable UNC file URI for WSL,
+ * while other remote authorities use a `vscode-remote://` URI with a file
+ * position. The latter is important because VS Code treats a remote URI
+ * without a `:line:column` suffix as a folder when opened through the protocol.
+ */
+export function normalizeLocalDocsUri(
+    docLink: string,
+    remoteAuthority: string | undefined,
+    documentScheme: string | undefined,
+): string {
+    if (
+        !remoteAuthority ||
+        documentScheme !== "vscode-remote" ||
+        !docLink.toLowerCase().startsWith("file://")
+    ) {
+        return docLink;
+    }
+
+    let uri: URL;
+    try {
+        uri = new URL(docLink);
+    } catch {
+        return docLink;
+    }
+
+    if (remoteAuthority.toLowerCase().startsWith("wsl+")) {
+        const distribution = encodeURIComponent(remoteAuthority.slice(4));
+        return `file://///wsl.localhost/${distribution}${uri.pathname}${uri.search}${uri.hash}`;
+    }
+
+    const authority = encodeURIComponent(remoteAuthority).replaceAll("%2B", "+");
+    const path = uri.hostname ? `//${uri.hostname}${uri.pathname}` : uri.pathname;
+    return `vscode-remote://${authority}${path}:1:1${uri.search}${uri.hash}`;
+}

--- a/editors/code/tests/unit/external_docs.test.ts
+++ b/editors/code/tests/unit/external_docs.test.ts
@@ -1,0 +1,64 @@
+import * as assert from "node:assert/strict";
+
+import { normalizeLocalDocsUri } from "../../src/external_docs";
+import type { Context } from ".";
+
+export async function getTests(ctx: Context) {
+    await ctx.suite("External documentation URIs", (suite) => {
+        suite.addTest("rewrites WSL files to host-readable UNC URIs", async () => {
+            assert.equal(
+                normalizeLocalDocsUri(
+                    "file:///home/user/target/doc/foo.html",
+                    "wsl+Ubuntu-22.04",
+                    "vscode-remote",
+                ),
+                "file://///wsl.localhost/Ubuntu-22.04/home/user/target/doc/foo.html",
+            );
+        });
+
+        suite.addTest("preserves encoded paths and URI components", async () => {
+            assert.equal(
+                normalizeLocalDocsUri(
+                    "file:///home/user/my%20crate/doc.html?section=1#intro",
+                    "ssh-remote+host",
+                    "vscode-remote",
+                ),
+                "vscode-remote://ssh-remote+host/home/user/my%20crate/doc.html:1:1?section=1#intro",
+            );
+        });
+
+        suite.addTest("leaves local and non-file URIs unchanged", async () => {
+            assert.equal(
+                normalizeLocalDocsUri("file:///tmp/doc.html", undefined, "vscode-remote"),
+                "file:///tmp/doc.html",
+            );
+            assert.equal(
+                normalizeLocalDocsUri("https://docs.rs/foo", "wsl+Ubuntu", "vscode-remote"),
+                "https://docs.rs/foo",
+            );
+            assert.equal(
+                normalizeLocalDocsUri(
+                    "vscode-remote://wsl+Ubuntu/home/user/doc.html",
+                    "wsl+Ubuntu",
+                    "vscode-remote",
+                ),
+                "vscode-remote://wsl+Ubuntu/home/user/doc.html",
+            );
+            assert.equal(
+                normalizeLocalDocsUri("file:///tmp/doc.html", "wsl+Ubuntu", "file"),
+                "file:///tmp/doc.html",
+            );
+        });
+
+        suite.addTest("preserves file URI authorities and encodes remote authorities", async () => {
+            assert.equal(
+                normalizeLocalDocsUri(
+                    "file://server/share/doc.html",
+                    "ssh-remote+user@host#1",
+                    "vscode-remote",
+                ),
+                "vscode-remote://ssh-remote+user%40host%231//server/share/doc.html:1:1",
+            );
+        });
+    });
+}


### PR DESCRIPTION
Fixes rust-lang/rust-analyzer#23057

## What changed

Translate local documentation links returned by rust-analyzer for remote editors into host-openable links. WSL authorities use the host's `file://///wsl.localhost/<distro>/...` UNC form so local HTML docs open in the default browser; other remote authorities use `vscode-remote://` links with a `:1:1` file position so VS Code opens the document instead of treating it as a folder. Local, web, and already-remote links keep their existing behavior.

## Why

The VS Code extension host can receive a local documentation path from the remote language server, but opening that `file://` URI targets the wrong side of the connection. A remote protocol URL without a file position is also interpreted as a folder by VS Code.

## Validation

- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
- `npm test` (VS Code 1.93.0 with a short user-data directory)
- Added unit coverage for WSL UNC conversion, SSH authorities, encoded paths, query strings, fragments, file positions, and unchanged URI forms.
