### PR TITLE
fix: 'no entry found for key' panic in VFS

### DIFF
--- a/crates/vfs/src/file_set.rs
+++ b/crates/vfs/src/file_set.rs
@@ -28,7 +28,7 @@ impl FileSet {
     /// If either `path`'s [`anchor`](AnchoredPath::anchor) or the resolved path is not in
     /// the set, returns [`None`].
     pub fn resolve_path(&self, path: AnchoredPath<'_>) -> Option<FileId> {
-        let mut base = self.paths[&path.anchor].clone();
+        let mut base = self.paths.get(&path.anchor)?.clone();
         base.pop();
         let path = base.join(path.path)?;
         self.files.get(&path).copied()


### PR DESCRIPTION
The doc comment of `resolve_path()` claims that it returns None if the path's anchor isn't present, but it actually panics due to `[]` indexing.

Return None instead, matching the documented behaviour.

I've seen this crash impact a handful of users, but I haven't been able to replicate it myself. It seems to occur when files are deleted, probably when switching branches. It also seems to recover when the crate graph is rebuilt.

The fix seems obviously correct though, so I've just changed the code without a regression test.

AI disclosure: Some Opus 5 usage for the code changes.