### PR TITLE
internal: make `pad16`'s `is_signed` arg an enum

### DIFF
--- a/crates/hir-ty/src/consteval.rs
+++ b/crates/hir-ty/src/consteval.rs
@@ -24,7 +24,7 @@ use crate::{
     display::DisplayTarget,
     generics::Generics,
     lower::LoweringMode,
-    mir::{MirEvalError, MirLowerError, pad16},
+    mir::{IsSigned, MirEvalError, MirLowerError, pad16},
     next_solver::{
         Allocation, Const, ConstKind, Consts, DbInterner, DefaultAny, GenericArgs, ParamConst,
         ScalarInt, StoredAllocation, StoredEarlyBinder, StoredGenericArgs, Ty, TyKind,
@@ -227,7 +227,7 @@ pub fn usize_const<'db>(db: &'db dyn HirDatabase, value: Option<u128>, krate: Cr
 }
 
 pub fn allocation_as_usize(ec: Allocation<'_>) -> u128 {
-    u128::from_le_bytes(pad16(&ec.memory, false))
+    u128::from_le_bytes(pad16(&ec.memory, IsSigned::No))
 }
 
 pub fn try_const_usize<'db>(db: &'db dyn HirDatabase, c: Const<'db>) -> Option<u128> {
@@ -265,7 +265,7 @@ pub fn try_const_usize<'db>(db: &'db dyn HirDatabase, c: Const<'db>) -> Option<u
 }
 
 pub fn allocation_as_isize(ec: Allocation<'_>) -> i128 {
-    i128::from_le_bytes(pad16(&ec.memory, true))
+    i128::from_le_bytes(pad16(&ec.memory, IsSigned::Yes))
 }
 
 pub fn try_const_isize<'db>(db: &'db dyn HirDatabase, c: Const<'db>) -> Option<i128> {

--- a/crates/hir-ty/src/consteval/tests.rs
+++ b/crates/hir-ty/src/consteval/tests.rs
@@ -13,7 +13,7 @@ use crate::{
     consteval::allocation_as_usize,
     db::HirDatabase,
     display::DisplayTarget,
-    mir::pad16,
+    mir::{IsSigned, pad16},
     next_solver::{Allocation, DbInterner, GenericArgs},
     setup_tracing,
     test_db::TestDB,
@@ -60,7 +60,7 @@ fn check_number(#[rust_analyzer::rust_fixture] ra_fixture: &str, answer: i128) {
             b,
             &answer.to_le_bytes()[0..b.len()],
             "Bytes differ. In decimal form: actual = {}, expected = {answer}",
-            i128::from_le_bytes(pad16(b, true))
+            i128::from_le_bytes(pad16(b, IsSigned::Yes))
         );
     });
 }
@@ -178,28 +178,28 @@ fn floating_point() {
     );
     check_number(
         r#"const GOAL: f64 = 2.0 + 3.0 * 5.5 - 8.;"#,
-        i128::from_le_bytes(pad16(&f64::to_le_bytes(10.5), true)),
+        i128::from_le_bytes(pad16(&f64::to_le_bytes(10.5), IsSigned::Yes)),
     );
     check_number(
         r#"const GOAL: f32 = 2.0 + 3.0 * 5.5 - 8.;"#,
-        i128::from_le_bytes(pad16(&f32::to_le_bytes(10.5), true)),
+        i128::from_le_bytes(pad16(&f32::to_le_bytes(10.5), IsSigned::Yes)),
     );
     check_number(
         r#"const GOAL: f32 = -90.0 + 36.0;"#,
-        i128::from_le_bytes(pad16(&f32::to_le_bytes(-54.0), true)),
+        i128::from_le_bytes(pad16(&f32::to_le_bytes(-54.0), IsSigned::Yes)),
     );
     check_number(
         r#"const GOAL: f16 = 2.0 + 3.0 * 5.5 - 8.;"#,
         i128::from_le_bytes(pad16(
             &u16::try_from("10.5".parse::<f16>().unwrap().to_bits()).unwrap().to_le_bytes(),
-            true,
+            IsSigned::Yes,
         )),
     );
     check_number(
         r#"const GOAL: f16 = -90.0 + 36.0;"#,
         i128::from_le_bytes(pad16(
             &u16::try_from("-54.0".parse::<f16>().unwrap().to_bits()).unwrap().to_le_bytes(),
-            true,
+            IsSigned::Yes,
         )),
     );
 }

--- a/crates/hir-ty/src/consteval/tests/intrinsics.rs
+++ b/crates/hir-ty/src/consteval/tests/intrinsics.rs
@@ -466,7 +466,7 @@ fn floating_point() {
         "#,
         i128::from_le_bytes(pad16(
             &f32::to_le_bytes(1.2f32.sqrt() + 3.4f32.powf(5.6) + (-7.8f32).mul_add(1.3, 2.4)),
-            true,
+            IsSigned::Yes,
         )),
     );
     #[allow(unknown_lints, clippy::unnecessary_min_or_max)]
@@ -483,7 +483,7 @@ fn floating_point() {
         "#,
         i128::from_le_bytes(pad16(
             &f64::to_le_bytes(1.2f64.powi(5) + 3.4f64.sin() + (-7.8f64).min(1.3)),
-            true,
+            IsSigned::Yes,
         )),
     );
 }

--- a/crates/hir-ty/src/display.rs
+++ b/crates/hir-ty/src/display.rs
@@ -56,7 +56,7 @@ use crate::{
     generics::{ProvenanceSplit, generics},
     layout::Layout,
     lower::GenericPredicates,
-    mir::pad16,
+    mir::{IsSigned, pad16},
     next_solver::{
         AliasTy, Allocation, Clause, ClauseKind, Const, ConstKind, DbInterner,
         ExistentialPredicate, FnSig, GenericArg, GenericArgKind, GenericArgs, ParamEnv, PolyFnSig,
@@ -824,18 +824,18 @@ fn render_const_scalar_inner<'db>(
     match ty.kind() {
         TyKind::Bool => write!(f, "{}", b[0] != 0),
         TyKind::Char => {
-            let it = u128::from_le_bytes(pad16(b, false)) as u32;
+            let it = u128::from_le_bytes(pad16(b, IsSigned::No)) as u32;
             let Ok(c) = char::try_from(it) else {
                 return f.write_str("<unicode-error>");
             };
             write!(f, "{c:?}")
         }
         TyKind::Int(_) => {
-            let it = i128::from_le_bytes(pad16(b, true));
+            let it = i128::from_le_bytes(pad16(b, IsSigned::Yes));
             write!(f, "{it}")
         }
         TyKind::Uint(_) => {
-            let it = u128::from_le_bytes(pad16(b, false));
+            let it = u128::from_le_bytes(pad16(b, IsSigned::No));
             write!(f, "{it}")
         }
         TyKind::Float(fl) => match fl {
@@ -1031,7 +1031,7 @@ fn render_const_scalar_inner<'db>(
         }
         TyKind::FnDef(..) => ty.hir_fmt(f),
         TyKind::FnPtr(_, _) | TyKind::RawPtr(_, _) => {
-            let it = u128::from_le_bytes(pad16(b, false));
+            let it = u128::from_le_bytes(pad16(b, IsSigned::No));
             write!(f, "{it:#X} as ")?;
             ty.hir_fmt(f)
         }

--- a/crates/hir-ty/src/mir.rs
+++ b/crates/hir-ty/src/mir.rs
@@ -38,7 +38,8 @@ mod monomorphization;
 mod pretty;
 
 pub use eval::{
-    Evaluator, MirEvalError, VTableMap, interpret_mir, pad16, render_const_using_debug_impl,
+    Evaluator, IsSigned, MirEvalError, VTableMap, interpret_mir, pad16,
+    render_const_using_debug_impl,
 };
 pub use lower::{
     MirLowerError, lower_body_to_mir, lower_to_mir_with_store, mir_body_for_closure_query,

--- a/crates/hir-ty/src/mir/eval.rs
+++ b/crates/hir-ty/src/mir/eval.rs
@@ -1046,7 +1046,7 @@ impl<'a, 'db> Evaluator<'a, 'db> {
                         TerminatorKind::SwitchInt { discr, targets } => {
                             let val = u128::from_le_bytes(pad16(
                                 self.eval_operand(discr, locals)?.get(self)?,
-                                false,
+                                IsSigned::No,
                             ));
                             current_block_idx = targets.target_for_value(val);
                         }
@@ -1569,7 +1569,7 @@ impl<'a, 'db> Evaluator<'a, 'db> {
                 | CastKind::PointerExposeAddress
                 | CastKind::PointerFromExposedAddress => {
                     let current_ty = self.operand_ty(operand, locals)?;
-                    let is_signed = matches!(current_ty.kind(), TyKind::Int(_));
+                    let is_signed = matches!(current_ty.kind(), TyKind::Int(_)).into();
                     let current = pad16(self.eval_operand(operand, locals)?.get(self)?, is_signed);
                     let dest_size = self.size_of_sized(
                         target_ty.as_ref(),
@@ -1648,7 +1648,7 @@ impl<'a, 'db> Evaluator<'a, 'db> {
                 }
                 CastKind::IntToFloat => {
                     let current_ty = self.operand_ty(operand, locals)?;
-                    let is_signed = matches!(current_ty.kind(), TyKind::Int(_));
+                    let is_signed = matches!(current_ty.kind(), TyKind::Int(_)).into();
                     let value = pad16(self.eval_operand(operand, locals)?.get(self)?, is_signed);
                     let value = i128::from_le_bytes(value);
                     let TyKind::Float(target_ty) = target_ty.as_ref().kind() else {
@@ -1689,7 +1689,7 @@ impl<'a, 'db> Evaluator<'a, 'db> {
             Variants::Multiple { tag, tag_encoding, variants, .. } => {
                 let size = tag.size(self.target_data_layout).bytes_usize();
                 let offset = layout.fields.offset(0).bytes_usize(); // The only field on enum variants is the tag field
-                let is_signed = tag.is_signed();
+                let is_signed = tag.is_signed().into();
                 match tag_encoding {
                     TagEncoding::Direct => {
                         let tag = &bytes[offset..offset + size];
@@ -2150,7 +2150,7 @@ impl<'a, 'db> Evaluator<'a, 'db> {
         let v: Cow<'_, [u8]> = if size != v.len() {
             // Handle self enum
             if size == 16 && v.len() < 16 {
-                Cow::Owned(pad16(v, false).to_vec())
+                Cow::Owned(pad16(v, IsSigned::No).to_vec())
             } else if size < 16 && v.len() == 16 {
                 Cow::Borrowed(&v[0..size])
             } else {
@@ -3293,8 +3293,20 @@ pub fn render_const_using_debug_impl<'db>(
     Ok(std::string::String::from_utf8_lossy(evaluator.read_memory(addr, size)?).into_owned())
 }
 
-pub fn pad16(it: &[u8], is_signed: bool) -> [u8; 16] {
-    let is_negative = is_signed && it.last().unwrap_or(&0) > &127;
+#[derive(PartialEq, Eq)]
+pub enum IsSigned {
+    Yes,
+    No,
+}
+
+impl From<bool> for IsSigned {
+    fn from(value: bool) -> Self {
+        if value { Self::Yes } else { Self::No }
+    }
+}
+
+pub fn pad16(it: &[u8], is_signed: IsSigned) -> [u8; 16] {
+    let is_negative = is_signed == IsSigned::Yes && it.last().unwrap_or(&0) > &127;
     let mut res = [if is_negative { 255 } else { 0 }; 16];
     res[..it.len()].copy_from_slice(it);
     res

--- a/crates/hir-ty/src/mir/eval/shim.rs
+++ b/crates/hir-ty/src/mir/eval/shim.rs
@@ -13,8 +13,8 @@ use crate::{
     drop::{DropGlue, has_drop_glue},
     mir::eval::{
         Address, AdtId, Arc, Evaluator, FunctionId, GenericArgs, HasModule, HirDisplay, Interval,
-        IntervalAndTy, IntervalOrOwned, ItemContainerId, Layout, Locals, Lookup, MirEvalError,
-        MirSpan, Mutability, Result, Ty, TyKind, from_bytes, not_supported, pad16,
+        IntervalAndTy, IntervalOrOwned, IsSigned, ItemContainerId, Layout, Locals, Lookup,
+        MirEvalError, MirSpan, Mutability, Result, Ty, TyKind, from_bytes, not_supported, pad16,
     },
     next_solver::Region,
 };
@@ -426,7 +426,7 @@ impl<'a, 'db> Evaluator<'a, 'db> {
                         "libc::write args are not provided".into(),
                     ));
                 };
-                let fd = u128::from_le_bytes(pad16(fd.get(self)?, false));
+                let fd = u128::from_le_bytes(pad16(fd.get(self)?, IsSigned::No));
                 let interval = Interval {
                     addr: Address::from_bytes(ptr.get(self)?)?,
                     size: from_bytes!(usize, len.get(self)?),
@@ -473,7 +473,7 @@ impl<'a, 'db> Evaluator<'a, 'db> {
                         "pthread_getspecific arg0 is not provided".into(),
                     ));
                 };
-                let key = from_bytes!(usize, &pad16(arg0.get(self)?, false)[0..8]);
+                let key = from_bytes!(usize, &pad16(arg0.get(self)?, IsSigned::No)[0..8]);
                 let value = self.thread_local_storage.get_key(key)?;
                 destination.write_from_bytes(self, &value.to_le_bytes()[0..destination.size])?;
                 Ok(())
@@ -484,13 +484,13 @@ impl<'a, 'db> Evaluator<'a, 'db> {
                         "pthread_setspecific arg0 is not provided".into(),
                     ));
                 };
-                let key = from_bytes!(usize, &pad16(arg0.get(self)?, false)[0..8]);
+                let key = from_bytes!(usize, &pad16(arg0.get(self)?, IsSigned::No)[0..8]);
                 let Some(arg1) = args.get(1) else {
                     return Err(MirEvalError::InternalError(
                         "pthread_setspecific arg1 is not provided".into(),
                     ));
                 };
-                let value = from_bytes!(u128, pad16(arg1.get(self)?, false));
+                let value = from_bytes!(u128, pad16(arg1.get(self)?, IsSigned::No));
                 self.thread_local_storage.set_key(key, value)?;
                 // return 0 as success
                 destination.write_from_bytes(self, &0u64.to_le_bytes()[0..destination.size])?;
@@ -840,8 +840,8 @@ impl<'a, 'db> Evaluator<'a, 'db> {
                         "saturating_add args are not provided".into(),
                     ));
                 };
-                let lhs = u128::from_le_bytes(pad16(lhs.get(self)?, false));
-                let rhs = u128::from_le_bytes(pad16(rhs.get(self)?, false));
+                let lhs = u128::from_le_bytes(pad16(lhs.get(self)?, IsSigned::No));
+                let rhs = u128::from_le_bytes(pad16(rhs.get(self)?, IsSigned::No));
                 let ans = match name {
                     "saturating_add" => lhs.saturating_add(rhs),
                     "saturating_sub" => lhs.saturating_sub(rhs),
@@ -862,8 +862,8 @@ impl<'a, 'db> Evaluator<'a, 'db> {
                         "wrapping_add args are not provided".into(),
                     ));
                 };
-                let lhs = u128::from_le_bytes(pad16(lhs.get(self)?, false));
-                let rhs = u128::from_le_bytes(pad16(rhs.get(self)?, false));
+                let lhs = u128::from_le_bytes(pad16(lhs.get(self)?, IsSigned::No));
+                let rhs = u128::from_le_bytes(pad16(rhs.get(self)?, IsSigned::No));
                 let ans = lhs.wrapping_add(rhs);
                 destination.write_from_bytes(self, &ans.to_le_bytes()[0..destination.size])
             }
@@ -873,8 +873,8 @@ impl<'a, 'db> Evaluator<'a, 'db> {
                         "wrapping_sub args are not provided".into(),
                     ));
                 };
-                let lhs = i128::from_le_bytes(pad16(lhs.get(self)?, false));
-                let rhs = i128::from_le_bytes(pad16(rhs.get(self)?, false));
+                let lhs = i128::from_le_bytes(pad16(lhs.get(self)?, IsSigned::No));
+                let rhs = i128::from_le_bytes(pad16(rhs.get(self)?, IsSigned::No));
                 let ans = lhs.wrapping_sub(rhs);
                 let Some(ty) = generic_args.as_slice().first().and_then(|it| it.ty()) else {
                     return Err(MirEvalError::InternalError(
@@ -891,8 +891,8 @@ impl<'a, 'db> Evaluator<'a, 'db> {
                         "wrapping_sub args are not provided".into(),
                     ));
                 };
-                let lhs = u128::from_le_bytes(pad16(lhs.get(self)?, false));
-                let rhs = u128::from_le_bytes(pad16(rhs.get(self)?, false));
+                let lhs = u128::from_le_bytes(pad16(lhs.get(self)?, IsSigned::No));
+                let rhs = u128::from_le_bytes(pad16(rhs.get(self)?, IsSigned::No));
                 let ans = lhs.wrapping_sub(rhs);
                 destination.write_from_bytes(self, &ans.to_le_bytes()[0..destination.size])
             }
@@ -902,8 +902,8 @@ impl<'a, 'db> Evaluator<'a, 'db> {
                         "wrapping_mul args are not provided".into(),
                     ));
                 };
-                let lhs = u128::from_le_bytes(pad16(lhs.get(self)?, false));
-                let rhs = u128::from_le_bytes(pad16(rhs.get(self)?, false));
+                let lhs = u128::from_le_bytes(pad16(lhs.get(self)?, IsSigned::No));
+                let rhs = u128::from_le_bytes(pad16(rhs.get(self)?, IsSigned::No));
                 let ans = lhs.wrapping_mul(rhs);
                 destination.write_from_bytes(self, &ans.to_le_bytes()[0..destination.size])
             }
@@ -914,8 +914,8 @@ impl<'a, 'db> Evaluator<'a, 'db> {
                         "unchecked_shl args are not provided".into(),
                     ));
                 };
-                let lhs = u128::from_le_bytes(pad16(lhs.get(self)?, false));
-                let rhs = u128::from_le_bytes(pad16(rhs.get(self)?, false));
+                let lhs = u128::from_le_bytes(pad16(lhs.get(self)?, IsSigned::No));
+                let rhs = u128::from_le_bytes(pad16(rhs.get(self)?, IsSigned::No));
                 let ans = lhs.wrapping_shl(rhs as u32);
                 destination.write_from_bytes(self, &ans.to_le_bytes()[0..destination.size])
             }
@@ -926,8 +926,8 @@ impl<'a, 'db> Evaluator<'a, 'db> {
                         "unchecked_shr args are not provided".into(),
                     ));
                 };
-                let lhs = u128::from_le_bytes(pad16(lhs.get(self)?, false));
-                let rhs = u128::from_le_bytes(pad16(rhs.get(self)?, false));
+                let lhs = u128::from_le_bytes(pad16(lhs.get(self)?, IsSigned::No));
+                let rhs = u128::from_le_bytes(pad16(rhs.get(self)?, IsSigned::No));
                 let ans = lhs.wrapping_shr(rhs as u32);
                 destination.write_from_bytes(self, &ans.to_le_bytes()[0..destination.size])
             }
@@ -938,8 +938,8 @@ impl<'a, 'db> Evaluator<'a, 'db> {
                         "unchecked_rem args are not provided".into(),
                     ));
                 };
-                let lhs = u128::from_le_bytes(pad16(lhs.get(self)?, false));
-                let rhs = u128::from_le_bytes(pad16(rhs.get(self)?, false));
+                let lhs = u128::from_le_bytes(pad16(lhs.get(self)?, IsSigned::No));
+                let rhs = u128::from_le_bytes(pad16(rhs.get(self)?, IsSigned::No));
                 let ans = lhs.checked_rem(rhs).ok_or_else(|| {
                     MirEvalError::UndefinedBehavior("unchecked_rem with bad inputs".to_owned())
                 })?;
@@ -952,8 +952,8 @@ impl<'a, 'db> Evaluator<'a, 'db> {
                         "unchecked_div args are not provided".into(),
                     ));
                 };
-                let lhs = u128::from_le_bytes(pad16(lhs.get(self)?, false));
-                let rhs = u128::from_le_bytes(pad16(rhs.get(self)?, false));
+                let lhs = u128::from_le_bytes(pad16(lhs.get(self)?, IsSigned::No));
+                let rhs = u128::from_le_bytes(pad16(rhs.get(self)?, IsSigned::No));
                 let ans = lhs.checked_div(rhs).ok_or_else(|| {
                     MirEvalError::UndefinedBehavior("unchecked_rem with bad inputs".to_owned())
                 })?;
@@ -970,8 +970,8 @@ impl<'a, 'db> Evaluator<'a, 'db> {
                     [lhs.ty, Ty::new_bool(self.interner())].into_iter(),
                 );
                 let op_size = self.size_of_sized(lhs.ty, locals, "operand of add_with_overflow")?;
-                let lhs = u128::from_le_bytes(pad16(lhs.get(self)?, false));
-                let rhs = u128::from_le_bytes(pad16(rhs.get(self)?, false));
+                let lhs = u128::from_le_bytes(pad16(lhs.get(self)?, IsSigned::No));
+                let rhs = u128::from_le_bytes(pad16(rhs.get(self)?, IsSigned::No));
                 let (ans, u128overflow) = match name {
                     "add_with_overflow" => lhs.overflowing_add(rhs),
                     "sub_with_overflow" => lhs.overflowing_sub(rhs),
@@ -1089,8 +1089,8 @@ impl<'a, 'db> Evaluator<'a, 'db> {
                     };
                     ty
                 };
-                let ptr = u128::from_le_bytes(pad16(ptr.get(self)?, false));
-                let offset = u128::from_le_bytes(pad16(offset.get(self)?, false));
+                let ptr = u128::from_le_bytes(pad16(ptr.get(self)?, IsSigned::No));
+                let offset = u128::from_le_bytes(pad16(offset.get(self)?, IsSigned::No));
                 let size = self.size_of_sized(ty, locals, "offset ptr type")? as u128;
                 let ans = ptr + offset * size;
                 destination.write_from_bytes(self, &ans.to_le_bytes()[0..destination.size])
@@ -1118,7 +1118,7 @@ impl<'a, 'db> Evaluator<'a, 'db> {
                 let [arg] = args else {
                     return Err(MirEvalError::InternalError("ctpop arg is not provided".into()));
                 };
-                let result = u128::from_le_bytes(pad16(arg.get(self)?, false)).count_ones();
+                let result = u128::from_le_bytes(pad16(arg.get(self)?, IsSigned::No)).count_ones();
                 destination
                     .write_from_bytes(self, &(result as u128).to_le_bytes()[0..destination.size])
             }
@@ -1127,7 +1127,7 @@ impl<'a, 'db> Evaluator<'a, 'db> {
                     return Err(MirEvalError::InternalError("ctlz arg is not provided".into()));
                 };
                 let result =
-                    u128::from_le_bytes(pad16(arg.get(self)?, false)).leading_zeros() as usize;
+                    u128::from_le_bytes(pad16(arg.get(self)?, IsSigned::No)).leading_zeros() as usize;
                 let result = result - (128 - arg.interval.size * 8);
                 destination
                     .write_from_bytes(self, &(result as u128).to_le_bytes()[0..destination.size])
@@ -1138,7 +1138,7 @@ impl<'a, 'db> Evaluator<'a, 'db> {
                 };
                 let arg: &[u8] = arg.get(self)?;
                 let bit_count = arg.len() as u32 * 8;
-                let result = u128::from_le_bytes(pad16(arg, false)).trailing_zeros().min(bit_count);
+                let result = u128::from_le_bytes(pad16(arg, IsSigned::No)).trailing_zeros().min(bit_count);
                 destination
                     .write_from_bytes(self, &(result as u128).to_le_bytes()[0..destination.size])
             }
@@ -1569,43 +1569,43 @@ impl<'a, 'db> Evaluator<'a, 'db> {
         }
         if name.starts_with("xadd_") {
             destination.write_from_interval(self, arg0_interval)?;
-            let lhs = u128::from_le_bytes(pad16(arg0_interval.get(self)?, false));
-            let rhs = u128::from_le_bytes(pad16(arg1.get(self)?, false));
+            let lhs = u128::from_le_bytes(pad16(arg0_interval.get(self)?, IsSigned::No));
+            let rhs = u128::from_le_bytes(pad16(arg1.get(self)?, IsSigned::No));
             let ans = lhs.wrapping_add(rhs);
             return arg0_interval.write_from_bytes(self, &ans.to_le_bytes()[0..destination.size]);
         }
         if name.starts_with("xsub_") {
             destination.write_from_interval(self, arg0_interval)?;
-            let lhs = u128::from_le_bytes(pad16(arg0_interval.get(self)?, false));
-            let rhs = u128::from_le_bytes(pad16(arg1.get(self)?, false));
+            let lhs = u128::from_le_bytes(pad16(arg0_interval.get(self)?, IsSigned::No));
+            let rhs = u128::from_le_bytes(pad16(arg1.get(self)?, IsSigned::No));
             let ans = lhs.wrapping_sub(rhs);
             return arg0_interval.write_from_bytes(self, &ans.to_le_bytes()[0..destination.size]);
         }
         if name.starts_with("and_") {
             destination.write_from_interval(self, arg0_interval)?;
-            let lhs = u128::from_le_bytes(pad16(arg0_interval.get(self)?, false));
-            let rhs = u128::from_le_bytes(pad16(arg1.get(self)?, false));
+            let lhs = u128::from_le_bytes(pad16(arg0_interval.get(self)?, IsSigned::No));
+            let rhs = u128::from_le_bytes(pad16(arg1.get(self)?, IsSigned::No));
             let ans = lhs & rhs;
             return arg0_interval.write_from_bytes(self, &ans.to_le_bytes()[0..destination.size]);
         }
         if name.starts_with("or_") {
             destination.write_from_interval(self, arg0_interval)?;
-            let lhs = u128::from_le_bytes(pad16(arg0_interval.get(self)?, false));
-            let rhs = u128::from_le_bytes(pad16(arg1.get(self)?, false));
+            let lhs = u128::from_le_bytes(pad16(arg0_interval.get(self)?, IsSigned::No));
+            let rhs = u128::from_le_bytes(pad16(arg1.get(self)?, IsSigned::No));
             let ans = lhs | rhs;
             return arg0_interval.write_from_bytes(self, &ans.to_le_bytes()[0..destination.size]);
         }
         if name.starts_with("xor_") {
             destination.write_from_interval(self, arg0_interval)?;
-            let lhs = u128::from_le_bytes(pad16(arg0_interval.get(self)?, false));
-            let rhs = u128::from_le_bytes(pad16(arg1.get(self)?, false));
+            let lhs = u128::from_le_bytes(pad16(arg0_interval.get(self)?, IsSigned::No));
+            let rhs = u128::from_le_bytes(pad16(arg1.get(self)?, IsSigned::No));
             let ans = lhs ^ rhs;
             return arg0_interval.write_from_bytes(self, &ans.to_le_bytes()[0..destination.size]);
         }
         if name.starts_with("nand_") {
             destination.write_from_interval(self, arg0_interval)?;
-            let lhs = u128::from_le_bytes(pad16(arg0_interval.get(self)?, false));
-            let rhs = u128::from_le_bytes(pad16(arg1.get(self)?, false));
+            let lhs = u128::from_le_bytes(pad16(arg0_interval.get(self)?, IsSigned::No));
+            let rhs = u128::from_le_bytes(pad16(arg1.get(self)?, IsSigned::No));
             let ans = !(lhs & rhs);
             return arg0_interval.write_from_bytes(self, &ans.to_le_bytes()[0..destination.size]);
         }

--- a/crates/hir-ty/src/next_solver/consts/valtree.rs
+++ b/crates/hir-ty/src/next_solver/consts/valtree.rs
@@ -9,7 +9,7 @@ use stdx::never;
 use crate::{
     MemoryMap, ParamEnvAndCrate, consteval,
     db::HirDatabase,
-    mir::pad16,
+    mir::{IsSigned, pad16},
     next_solver::{Const, Consts, TyKind, WorldExposer},
 };
 
@@ -76,20 +76,20 @@ pub(super) fn allocation_to_const<'db>(
     let valtree = match ty.kind() {
         TyKind::Bool => ValTreeKind::Leaf(ScalarInt::from(memory[0] != 0)),
         TyKind::Char => {
-            let it = u128::from_le_bytes(pad16(memory, false)) as u32;
+            let it = u128::from_le_bytes(pad16(memory, IsSigned::No)) as u32;
             let Ok(c) = char::try_from(it) else {
                 return Const::error(interner);
             };
             ValTreeKind::Leaf(ScalarInt::from(c))
         }
         TyKind::Int(int) => {
-            let it = i128::from_le_bytes(pad16(memory, true));
+            let it = i128::from_le_bytes(pad16(memory, IsSigned::Yes));
             let size = int.bit_width().map(Size::from_bits).unwrap_or(data_layout.pointer_size());
             let scalar = ScalarInt::try_from_int(it, size).unwrap();
             ValTreeKind::Leaf(scalar)
         }
         TyKind::Uint(uint) => {
-            let it = u128::from_le_bytes(pad16(memory, false));
+            let it = u128::from_le_bytes(pad16(memory, IsSigned::No));
             let size = uint.bit_width().map(Size::from_bits).unwrap_or(data_layout.pointer_size());
             let scalar = ScalarInt::try_from_uint(it, size).unwrap();
             ValTreeKind::Leaf(scalar)
@@ -219,7 +219,7 @@ pub(super) fn allocation_to_const<'db>(
             return Const::error(interner);
         }
         TyKind::FnPtr(_, _) | TyKind::RawPtr(_, _) => {
-            let it = u128::from_le_bytes(pad16(memory, false));
+            let it = u128::from_le_bytes(pad16(memory, IsSigned::No));
             // FIXME: Unsized pointers.
             let scalar = ScalarInt::try_from_uint(it, data_layout.pointer_size()).unwrap();
             ValTreeKind::Leaf(scalar)

--- a/crates/hir-ty/src/utils.rs
+++ b/crates/hir-ty/src/utils.rs
@@ -16,7 +16,7 @@ use crate::{
     db::HirDatabase,
     layout::{Layout, TagEncoding},
     lower::SupertraitsInfo,
-    mir::pad16,
+    mir::{IsSigned, pad16},
 };
 
 pub(crate) fn fn_traits(lang_items: &LangItems) -> impl Iterator<Item = TraitId> + '_ {
@@ -108,7 +108,7 @@ pub(crate) fn detect_variant_from_bytes<'a>(
         hir_def::layout::Variants::Multiple { tag, tag_encoding, variants, .. } => {
             let size = tag.size(target_data_layout).bytes_usize();
             let offset = layout.fields.offset(0).bytes_usize(); // The only field on enum variants is the tag field
-            let tag = i128::from_le_bytes(pad16(&b[offset..offset + size], false));
+            let tag = i128::from_le_bytes(pad16(&b[offset..offset + size], IsSigned::No));
             match tag_encoding {
                 TagEncoding::Direct => {
                     let (var_idx, layout) =

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -2848,8 +2848,9 @@ impl<'db> EvaluatedConst<'db> {
         let ty = self.allocation.ty.kind();
         if let TyKind::Int(_) | TyKind::Uint(_) = ty {
             let b = &self.allocation.memory;
-            let value = u128::from_le_bytes(mir::pad16(b, false));
-            let value_signed = i128::from_le_bytes(mir::pad16(b, matches!(ty, TyKind::Int(_))));
+            let value = u128::from_le_bytes(mir::pad16(b, mir::IsSigned::No));
+            let is_signed = matches!(ty, TyKind::Int(_)).into();
+            let value_signed = i128::from_le_bytes(mir::pad16(b, is_signed));
             let mut result =
                 if let TyKind::Int(_) = ty { value_signed.to_string() } else { value.to_string() };
             if value >= 10 {


### PR DESCRIPTION
This makes it easier to understand a call site at a glance.