### PR TITLE
fix: Do not consider loop containing `break expr`  to not diverge if `expr` is diverging

### DIFF
--- a/crates/hir-ty/src/infer.rs
+++ b/crates/hir-ty/src/infer.rs
@@ -1399,28 +1399,22 @@ enum BreakableKind {
     Border,
 }
 
-fn find_breakable<'a, 'db>(
-    ctxs: &'a mut [BreakableContext<'db>],
-    label: Option<LabelId>,
-) -> Option<&'a mut BreakableContext<'db>> {
+fn find_breakable(ctxs: &[BreakableContext<'_>], label: Option<LabelId>) -> Option<usize> {
     let mut ctxs = ctxs
-        .iter_mut()
+        .iter()
+        .enumerate()
         .rev()
-        .take_while(|it| matches!(it.kind, BreakableKind::Block | BreakableKind::Loop));
-    match label {
-        Some(_) => ctxs.find(|ctx| ctx.label == label),
-        None => ctxs.find(|ctx| matches!(ctx.kind, BreakableKind::Loop)),
-    }
+        .take_while(|(_, it)| matches!(it.kind, BreakableKind::Block | BreakableKind::Loop));
+    let result = match label {
+        Some(_) => ctxs.find(|(_, ctx)| ctx.label == label),
+        None => ctxs.find(|(_, ctx)| matches!(ctx.kind, BreakableKind::Loop)),
+    };
+    result.map(|(idx, _)| idx)
 }
 
-fn find_continuable<'a, 'db>(
-    ctxs: &'a mut [BreakableContext<'db>],
-    label: Option<LabelId>,
-) -> Option<&'a mut BreakableContext<'db>> {
-    match label {
-        Some(_) => find_breakable(ctxs, label).filter(|it| matches!(it.kind, BreakableKind::Loop)),
-        None => find_breakable(ctxs, label),
-    }
+fn find_continuable(ctxs: &[BreakableContext<'_>], label: Option<LabelId>) -> Option<usize> {
+    find_breakable(ctxs, label)
+        .filter(|&idx| label.is_none() || matches!(ctxs[idx].kind, BreakableKind::Loop))
 }
 
 impl<'db> InferenceContext<'db> {

--- a/crates/hir-ty/src/infer/expr.rs
+++ b/crates/hir-ty/src/infer/expr.rs
@@ -513,7 +513,7 @@ impl<'db> InferenceContext<'db> {
             }
             Expr::Path(p) => self.infer_expr_path(p, tgt_expr.into(), tgt_expr),
             &Expr::Continue { label } => {
-                if find_continuable(&mut self.breakables, label).is_none() {
+                if find_continuable(&self.breakables, label).is_none() {
                     self.push_diagnostic(InferenceDiagnostic::BreakOutsideOfLoop {
                         expr: tgt_expr,
                         is_break: false,
@@ -523,9 +523,10 @@ impl<'db> InferenceContext<'db> {
                 self.types.types.never
             }
             &Expr::Break { expr, label } => {
+                let breakable_idx = find_breakable(&self.breakables, label);
                 let val_ty = if let Some(expr) = expr {
-                    let opt_coerce_to = match find_breakable(&mut self.breakables, label) {
-                        Some(ctxt) => match &ctxt.coerce {
+                    let opt_coerce_to = match breakable_idx {
+                        Some(breakable_idx) => match &self.breakables[breakable_idx].coerce {
                             Some(coerce) => coerce.expected_ty(),
                             None => {
                                 self.push_diagnostic(InferenceDiagnostic::BreakOutsideOfLoop {
@@ -547,9 +548,16 @@ impl<'db> InferenceContext<'db> {
                     self.types.types.unit
                 };
 
-                match find_breakable(&mut self.breakables, label) {
-                    Some(ctxt) => match ctxt.coerce.take() {
-                        Some(mut coerce) => {
+                match breakable_idx {
+                    Some(breakable_idx) => {
+                        let breakable = &mut self.breakables[breakable_idx];
+
+                        // If we encountered a `break`, then (no surprise) it may be possible to break from the
+                        // loop... unless the value being returned from the loop diverges itself, e.g.
+                        // `break return 5` or `break loop {}`.
+                        breakable.may_break |= !self.diverges.is_always();
+
+                        if let Some(mut coerce) = breakable.coerce.take() {
                             let expr = expr.unwrap_or(tgt_expr);
                             coerce.coerce(
                                 self,
@@ -558,15 +566,9 @@ impl<'db> InferenceContext<'db> {
                                 val_ty,
                                 ExprIsRead::Yes,
                             );
-
-                            // Avoiding borrowck
-                            let ctxt = find_breakable(&mut self.breakables, label)
-                                .expect("breakable stack changed during coercion");
-                            ctxt.may_break = true;
-                            ctxt.coerce = Some(coerce);
+                            self.breakables[breakable_idx].coerce = Some(coerce);
                         }
-                        None => ctxt.may_break = true,
-                    },
+                    }
                     None => {
                         self.push_diagnostic(InferenceDiagnostic::BreakOutsideOfLoop {
                             expr: tgt_expr,

--- a/crates/hir-ty/src/tests/never_type.rs
+++ b/crates/hir-ty/src/tests/never_type.rs
@@ -928,3 +928,14 @@ pub async fn test1() -> ! {
     "#,
     );
 }
+
+#[test]
+fn break_diverge() {
+    check_no_mismatches(
+        r#"
+fn test() -> i32 {
+    let loop_value = loop { break (return 5); };
+}
+    "#,
+    );
+}


### PR DESCRIPTION
E.g. `break return`.

Also refactor the code a bit to avoid looping the breakables stack multiple times.

Fixes https://github.com/rust-lang/rust-analyzer/issues/23098.