### PR TITLE
fix - don't panic on ATPIT with method-local generics

### DIFF
--- a/crates/hir-ty/src/infer/opaques.rs
+++ b/crates/hir-ty/src/infer/opaques.rs
@@ -1,13 +1,18 @@
 //! Defining opaque types via inference.
 
-use rustc_type_ir::{TypeVisitableExt, fold_regions};
+use std::ops::ControlFlow;
+
+use rustc_type_ir::{
+    TypeSuperVisitable, TypeVisitable, TypeVisitableExt, fold_regions, inherent::IntoKind,
+};
 use tracing::{debug, instrument};
 
 use crate::{
     Span,
     infer::InferenceContext,
     next_solver::{
-        EarlyBinder, OpaqueTypeKey, SolverDefId, TypingMode,
+        Const, ConstKind, DbInterner, EarlyBinder, GenericArgKind, GenericArgs, OpaqueTypeKey,
+        SolverDefId, Ty, TyKind, TypingMode,
         infer::{opaque_types::OpaqueHiddenType, traits::ObligationCause},
     },
 };
@@ -63,6 +68,39 @@ impl<'db> UsageKind<'db> {
     }
 }
 
+// rejects hidden types with foreign params
+struct ForeignParamChecker<'db> {
+    args: GenericArgs<'db>,
+}
+
+impl<'db> rustc_type_ir::TypeVisitor<DbInterner<'db>> for ForeignParamChecker<'db> {
+    type Result = ControlFlow<()>;
+
+    fn visit_ty(&mut self, ty: Ty<'db>) -> Self::Result {
+        if let TyKind::Param(param) = ty.kind()
+            && !matches!(
+                self.args.get(param.index as usize).map(|arg| arg.kind()),
+                Some(GenericArgKind::Type(_))
+            )
+        {
+            return ControlFlow::Break(());
+        }
+        ty.super_visit_with(self)
+    }
+
+    fn visit_const(&mut self, ct: Const<'db>) -> Self::Result {
+        if let ConstKind::Param(param) = ct.kind()
+            && !matches!(
+                self.args.get(param.index as usize).map(|arg| arg.kind()),
+                Some(GenericArgKind::Const(_))
+            )
+        {
+            return ControlFlow::Break(());
+        }
+        ct.super_visit_with(self)
+    }
+}
+
 impl<'db> InferenceContext<'db> {
     fn compute_definition_site_hidden_types(
         &mut self,
@@ -108,13 +146,9 @@ impl<'db> InferenceContext<'db> {
                         continue;
                     }
 
-                    let expected = if ty.ty.has_param() && opaque_type_key.args.is_empty() {
-                        self.types.types.error
-                    } else {
-                        EarlyBinder::bind(ty.ty)
-                            .instantiate(interner, opaque_type_key.args)
-                            .skip_norm_wip()
-                    };
+                    let expected = EarlyBinder::bind(ty.ty)
+                        .instantiate(interner, opaque_type_key.args)
+                        .skip_norm_wip();
                     _ = self.demand_eqtype_fixme_no_diag(expected, hidden_type.ty);
                 }
 
@@ -150,7 +184,12 @@ impl<'db> InferenceContext<'db> {
         let hidden_type =
             fold_regions(self.interner(), hidden_type, |_, _| self.types.regions.erased);
 
-        if hidden_type.ty.has_param() && opaque_type_key.args.is_empty() {
+        // skip uses with foreign params
+        if hidden_type
+            .ty
+            .visit_with(&mut ForeignParamChecker { args: opaque_type_key.args })
+            .is_break()
+        {
             return UsageKind::NonDefiningUse(opaque_type_key, hidden_type);
         }
 

--- a/crates/hir-ty/src/infer/opaques.rs
+++ b/crates/hir-ty/src/infer/opaques.rs
@@ -108,14 +108,17 @@ impl<'db> InferenceContext<'db> {
                         continue;
                     }
 
-                    let expected = EarlyBinder::bind(ty.ty)
-                        .instantiate(interner, opaque_type_key.args)
-                        .skip_norm_wip();
+                    let expected = if ty.ty.has_param() && opaque_type_key.args.is_empty() {
+                        self.types.types.error
+                    } else {
+                        EarlyBinder::bind(ty.ty)
+                            .instantiate(interner, opaque_type_key.args)
+                            .skip_norm_wip()
+                    };
                     _ = self.demand_eqtype_fixme_no_diag(expected, hidden_type.ty);
                 }
 
                 self.result.type_of_opaque.insert(def_id, ty.ty.store());
-
                 continue;
             }
 
@@ -146,6 +149,11 @@ impl<'db> InferenceContext<'db> {
         };
         let hidden_type =
             fold_regions(self.interner(), hidden_type, |_, _| self.types.regions.erased);
+
+        if hidden_type.ty.has_param() && opaque_type_key.args.is_empty() {
+            return UsageKind::NonDefiningUse(opaque_type_key, hidden_type);
+        }
+
         UsageKind::HasDefiningUse(hidden_type)
     }
 }

--- a/crates/hir-ty/src/tests/opaque_types.rs
+++ b/crates/hir-ty/src/tests/opaque_types.rs
@@ -33,6 +33,87 @@ fn test() {
 }
 
 #[test]
+fn regression_23125_atpit_with_method_generics() {
+    check_no_mismatches(
+        r#"
+trait Foo {
+    type Item;
+}
+struct S<T>;
+struct S2;
+impl Foo for S2 {
+    type Item = impl Sized;
+    fn foo<T>(_: T) -> Self::Item {
+        S::<T>
+    }
+}
+"#,
+    );
+}
+
+// added multi-method non-defining test
+#[test]
+fn regression_23125_atpit_method_local_generic_non_defining_use() {
+    check_no_mismatches(
+        r#"
+trait Foo {
+    type Item;
+}
+struct S<T>;
+struct S2;
+impl Foo for S2 {
+    type Item = impl Sized;
+    fn foo<U>(_: U) -> Self::Item {
+        S::<U>
+    }
+    fn bar() -> Self::Item {
+        S::<()>
+    }
+}
+"#,
+    );
+}
+
+#[test]
+fn regression_23125_atpit_with_method_generics_impl_generics() {
+    check_no_mismatches(
+        r#"
+trait Foo {
+    type Item;
+}
+struct S<T>;
+struct S2<T>(T);
+impl<T> Foo for S2<T> {
+    type Item = impl Sized;
+    fn foo<U>(_: U) -> Self::Item {
+        S::<U>
+    }
+}
+"#,
+    );
+}
+
+// added impl-generic no-mismatch test
+#[test]
+fn regression_23125_atpit_impl_generics_are_defining_use() {
+    check_no_mismatches(
+        r#"
+trait Foo {
+    type Item;
+}
+struct S<T>;
+struct S2<T>(T);
+impl<T> Foo for S2<T> {
+    type Item = impl Sized;
+    fn foo() -> Self::Item {
+        S::<T>
+    }
+}
+"#,
+    );
+}
+
+#[test]
 fn associated_type_impl_traits_complex() {
     check_types(
         r#"
@@ -76,6 +157,29 @@ fn test() {
       //^ Unary<<impl Bar + ?Sized as Bar>::Item>
 }
         "#,
+    );
+}
+
+#[test]
+fn rpit_with_fn_generics_is_defining_use() {
+    check_infer(
+        r#"
+trait Foo {}
+struct S;
+impl Foo for S {}
+struct Wrap<T>(T);
+impl<T> Foo for Wrap<T> {}
+
+fn foo<T>() -> impl Foo {
+    Wrap(T)
+}
+"#,
+        expect![[r#"
+            112..127 '{     Wrap(T) }': Wrap<{unknown}>
+            118..122 'Wrap': fn Wrap<{unknown}>({unknown}) -> Wrap<{unknown}>
+            118..125 'Wrap(T)': Wrap<{unknown}>
+            123..124 'T': {unknown}
+        "#]],
     );
 }
 


### PR DESCRIPTION
when an opaque type has no generic parameters but its hidden type
references a method-local generic... `instantiate` would panic because
the parameter has no corresponding slot in the opaque's args

reject such uses as non-defining before it gets there and guard the
`instantiate` call to fall back to an error type instead of crashing.

fixes rust-lang/rust-analyzer#23125

(this is my 1st PR to this repo... and please correct me if i did something wrong here for lack of experience) 