### PR TITLE
fix: don't error on tail comma for some macro

### DIFF
--- a/crates/hir-def/src/macro_expansion_tests/builtin_fn_macro.rs
+++ b/crates/hir-def/src/macro_expansion_tests/builtin_fn_macro.rs
@@ -160,13 +160,21 @@ fn test_option_env_expand() {
 #[rustc_builtin_macro]
 macro_rules! option_env {() => {}}
 
-fn main() { option_env!("TEST_ENV_VAR"); }
+fn main() {
+    option_env!("TEST_ENV_VAR");
+    option_env!("TEST_ENV_VAR",);
+    option_env!("TEST_ENV_VAR", "invalid");
+}
 "#,
         expect![[r#"
 #[rustc_builtin_macro]
 macro_rules! option_env {() => {}}
 
-fn main() { $crate::option::Option::None:: < &str>; }
+fn main() {
+    $crate::option::Option::None:: < &str>;
+    $crate::option::Option::None:: < &str>;
+    /* error: unexpected input */;
+}
 "#]],
     );
 }

--- a/crates/hir-def/src/macro_expansion_tests/builtin_fn_macro.rs
+++ b/crates/hir-def/src/macro_expansion_tests/builtin_fn_macro.rs
@@ -132,13 +132,23 @@ fn test_env_expand() {
 #[rustc_builtin_macro]
 macro_rules! env {() => {}}
 
-fn main() { env!("TEST_ENV_VAR"); }
+fn main() {
+    env!("TEST_ENV_VAR");
+    env!("TEST_ENV_VAR",);
+    env!("TEST_ENV_VAR", "error");
+    env!("TEST_ENV_VAR", "error",);
+}
 "#,
         expect![[r##"
 #[rustc_builtin_macro]
 macro_rules! env {() => {}}
 
-fn main() { "UNRESOLVED_ENV_VAR"; }
+fn main() {
+    "UNRESOLVED_ENV_VAR";
+    "UNRESOLVED_ENV_VAR";
+    "UNRESOLVED_ENV_VAR";
+    "UNRESOLVED_ENV_VAR";
+}
 "##]],
     );
 }

--- a/crates/hir-expand/src/builtin/fn_macro.rs
+++ b/crates/hir-expand/src/builtin/fn_macro.rs
@@ -766,7 +766,7 @@ fn relative_file(
     }
 }
 
-fn parse_string(tt: &tt::TopSubtree, rest: bool) -> Result<(Symbol, Span), ExpandError> {
+fn parse_string(tt: &tt::TopSubtree, allow_rest_args: bool) -> Result<(Symbol, Span), ExpandError> {
     let expect_literal = |span| ExpandError::other(span, "expected string literal");
     let mut tt = {
         let mut tt_iter = tt.iter();
@@ -779,7 +779,7 @@ fn parse_string(tt: &tt::TopSubtree, rest: bool) -> Result<(Symbol, Span), Expan
                 // Tail comma
                 // FIXME: Ignored like env!("NAME", "compile_error message")
                 if let Some(tt) = tt_iter.next()
-                    && !rest
+                    && !allow_rest_args
                 {
                     return Err(ExpandError::other(tt.first_span(), "unexpected input"));
                 }

--- a/crates/hir-expand/src/builtin/fn_macro.rs
+++ b/crates/hir-expand/src/builtin/fn_macro.rs
@@ -766,7 +766,7 @@ fn relative_file(
     }
 }
 
-fn parse_string(tt: &tt::TopSubtree) -> Result<(Symbol, Span), ExpandError> {
+fn parse_string(tt: &tt::TopSubtree, rest: bool) -> Result<(Symbol, Span), ExpandError> {
     let expect_literal = |span| ExpandError::other(span, "expected string literal");
     let mut tt = {
         let mut tt_iter = tt.iter();
@@ -778,6 +778,11 @@ fn parse_string(tt: &tt::TopSubtree) -> Result<(Symbol, Span), ExpandError> {
             Some(TtElement::Leaf(tt::Leaf::Punct(it))) if it.char == ',' => {
                 // Tail comma
                 // FIXME: Ignored like env!("NAME", "compile_error message")
+                if let Some(tt) = tt_iter.next()
+                    && !rest
+                {
+                    return Err(ExpandError::other(tt.first_span(), "unexpected input"));
+                }
             }
             Some(tt) => {
                 return Err(ExpandError::other(tt.first_span(), "unexpected input"));
@@ -846,7 +851,7 @@ pub fn include_input_to_file_id(
     arg_id: MacroCallId,
     arg: &tt::TopSubtree,
 ) -> Result<EditionedFileId, ExpandError> {
-    let (s, span) = parse_string(arg)?;
+    let (s, span) = parse_string(arg, false)?;
     relative_file(db, arg_id, s.as_str(), false, span)
 }
 
@@ -870,7 +875,7 @@ fn include_str_expand(
     tt: &tt::TopSubtree,
     call_site: Span,
 ) -> ExpandResult<tt::TopSubtree> {
-    let (path, input_span) = match parse_string(tt) {
+    let (path, input_span) = match parse_string(tt, false) {
         Ok(it) => it,
         Err(e) => {
             return ExpandResult::new(
@@ -908,7 +913,7 @@ fn env_expand(
     tt: &tt::TopSubtree,
     span: Span,
 ) -> ExpandResult<tt::TopSubtree> {
-    let (key, span) = match parse_string(tt) {
+    let (key, span) = match parse_string(tt, true) {
         Ok(it) => it,
         Err(e) => {
             return ExpandResult::new(
@@ -946,7 +951,7 @@ fn option_env_expand(
     tt: &tt::TopSubtree,
     call_site: Span,
 ) -> ExpandResult<tt::TopSubtree> {
-    let (key, span) = match parse_string(tt) {
+    let (key, span) = match parse_string(tt, false) {
         Ok(it) => it,
         Err(e) => {
             return ExpandResult::new(

--- a/crates/hir-expand/src/builtin/fn_macro.rs
+++ b/crates/hir-expand/src/builtin/fn_macro.rs
@@ -767,7 +767,26 @@ fn relative_file(
 }
 
 fn parse_string(tt: &tt::TopSubtree) -> Result<(Symbol, Span), ExpandError> {
-    let mut tt = TtElement::Subtree(tt.top_subtree(), tt.iter());
+    let expect_literal = |span| ExpandError::other(span, "expected string literal");
+    let mut tt = {
+        let mut tt_iter = tt.iter();
+        let extracted =
+            tt_iter.next().ok_or_else(|| expect_literal(tt.top_subtree().delimiter.close))?;
+
+        match tt_iter.next() {
+            None => {}
+            Some(TtElement::Leaf(tt::Leaf::Punct(it))) if it.char == ',' => {
+                // Tail comma
+                // FIXME: Ignored like env!("NAME", "compile_error message")
+            }
+            Some(tt) => {
+                return Err(ExpandError::other(tt.first_span(), "unexpected input"));
+            }
+        }
+
+        extracted
+    };
+
     (|| {
         // FIXME: We wrap expression fragments in parentheses which can break this expectation
         // here
@@ -795,7 +814,7 @@ fn parse_string(tt: &tt::TopSubtree) -> Result<(Symbol, Span), ExpandError> {
             TtElement::Subtree(tt, _) => Err(tt.delimiter.open.cover(tt.delimiter.close)),
         }
     })()
-    .map_err(|span| ExpandError::other(span, "expected string literal"))
+    .map_err(expect_literal)
 }
 
 fn include_expand(


### PR DESCRIPTION
Fixes rust-lang/rust-analyzer#23132

Example
---
```rust
const _: &str = env!("PATH",);
```

**Before this PR**

```
/* expand error: expected string literal */
```

**After this PR**

```rust
const _: &str = "/usr/bin:/bin";
```
