### PR TITLE
minor: Remove direct dependency on `salsa-macros`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,7 +97,6 @@ dependencies = [
  "la-arena 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hash 2.1.2",
  "salsa",
- "salsa-macros",
  "semver",
  "span",
  "syntax",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,8 +45,6 @@ debug = 2
 # ungrammar = { path = "lib/ungrammar" }
 
 # salsa = { path = "../salsa" }
-# salsa-macros = { path = "../salsa/components/salsa-macros" }
-# salsa-macro-rules = { path = "../salsa/components/salsa-macro-rules" }
 
 [workspace.dependencies]
 # local crates
@@ -133,7 +131,6 @@ salsa = { version = "0.28.2", default-features = false, features = [
     "inventory",
     "triomphe"
 ] }
-salsa-macros = "0.28.2"
 semver = "1.0.26"
 serde = { version = "1.0.219" }
 serde_derive = { version = "1.0.219" }

--- a/crates/base-db/Cargo.toml
+++ b/crates/base-db/Cargo.toml
@@ -16,7 +16,6 @@ doctest = false
 la-arena.workspace = true
 dashmap.workspace = true
 salsa.workspace = true
-salsa-macros.workspace = true
 rustc-hash.workspace = true
 triomphe.workspace = true
 semver.workspace = true

--- a/crates/base-db/src/lib.rs
+++ b/crates/base-db/src/lib.rs
@@ -7,7 +7,6 @@
 extern crate rustc_driver as _;
 
 pub use salsa;
-pub use salsa_macros;
 use span::TextSize;
 
 mod change;


### PR DESCRIPTION
Since we no longer use it.