### PR TITLE
fix panic from out of scope params in opaque hidden types

### DIFF
--- a/crates/hir-ty/src/infer/opaques.rs
+++ b/crates/hir-ty/src/infer/opaques.rs
@@ -1,13 +1,15 @@
 //! Defining opaque types via inference.
 
-use rustc_type_ir::{TypeVisitableExt, fold_regions};
+use rustc_hash::FxHashMap;
+use rustc_type_ir::{TypeVisitableExt, fold_regions, inherent::IntoKind};
 use tracing::{debug, instrument};
 
 use crate::{
     Span,
     infer::InferenceContext,
     next_solver::{
-        EarlyBinder, OpaqueTypeKey, SolverDefId, TypingMode,
+        EarlyBinder, OpaqueTypeKey, SolverDefId, Ty, TyKind, TypingMode,
+        fold::fold_tys,
         infer::{opaque_types::OpaqueHiddenType, traits::ObligationCause},
     },
 };
@@ -146,6 +148,34 @@ impl<'db> InferenceContext<'db> {
         };
         let hidden_type =
             fold_regions(self.interner(), hidden_type, |_, _| self.types.regions.erased);
+        let hidden_type = self.remap_hidden_type_to_opaque(opaque_type_key, hidden_type);
         UsageKind::HasDefiningUse(hidden_type)
+    }
+
+    /// replace params that dont belong to the opaque with error types
+    fn remap_hidden_type_to_opaque(
+        &self,
+        opaque_type_key: OpaqueTypeKey<'db>,
+        hidden_type: OpaqueHiddenType<'db>,
+    ) -> OpaqueHiddenType<'db> {
+        let interner = self.interner();
+        let id_args = rustc_type_ir::inherent::GenericArgs::identity_for_item(
+            interner,
+            opaque_type_key.def_id.into(),
+        );
+
+        let mut map: FxHashMap<Ty<'db>, Ty<'db>> = FxHashMap::default();
+        for (a, b) in opaque_type_key.args.types().zip(id_args.types()) {
+            map.insert(a, b);
+        }
+        let error = self.types.types.error;
+        let ty = fold_tys(interner, hidden_type.ty, |ty| match ty.kind() {
+            TyKind::Param(p) => {
+                let key = Ty::new_param(interner, p.id, p.index);
+                map.get(&key).copied().unwrap_or(error)
+            }
+            _ => ty,
+        });
+        OpaqueHiddenType { ty }
     }
 }

--- a/crates/hir-ty/src/tests/opaque_types.rs
+++ b/crates/hir-ty/src/tests/opaque_types.rs
@@ -80,6 +80,36 @@ fn test() {
 }
 
 #[test]
+fn associated_type_impl_trait_out_of_scope_param() {
+    // regression test for out_of_scope generic param
+    check_infer(
+        r#"
+trait Foo {}
+struct Wrapper<U>(U);
+impl<U: Foo> Foo for Wrapper<U> {}
+
+trait Bar {
+    type Item;
+}
+struct S2;
+impl Bar for S2 {
+    type Item = impl Foo;
+    fn bar<U: Foo>(x: U) -> Self::Item {
+        Wrapper(x)
+    }
+}
+        "#,
+        expect![[r#"
+            174..175 'x': U
+            194..220 '{     ...     }': Wrapper<U>
+            204..211 'Wrapper': fn Wrapper<U>(U) -> Wrapper<U>
+            204..214 'Wrapper(x)': Wrapper<U>
+            212..213 'x': U
+        "#]],
+    );
+}
+
+#[test]
 fn associated_type_with_impl_trait_in_tuple() {
     check_no_mismatches(
         r#"


### PR DESCRIPTION
fix panic from out of scope params in **opaque hidden types**.. this follows **rustc's approach** of **remapping hidden type params** into the opaque's parameter space and replacing params that do not belong to the opaque with error type.. also adds a regression test for the reported case

fixes: https://github.com/rust-lang/rust-analyzer/issues/23125

NOTE - i intentionally focused on the minimal subset needed just to fix reported bug. rustc also have things for consts, regions, and some closure-specific cases