### PR TITLE
fix: emit E0600 when unary `!`/`-` is applied to unsupported type

### DIFF
--- a/crates/hir-ty/src/infer.rs
+++ b/crates/hir-ty/src/infer.rs
@@ -47,7 +47,7 @@ use hir_def::{
     TupleFieldId, TupleId, VariantId,
     attrs::AttrFlags,
     expr_store::{Body, ExpressionStore, HygieneId, body::Param, path::Path},
-    hir::{BindingId, ExprId, ExprOrPatId, ExprOrPatIdPacked, LabelId, PatId},
+    hir::{BindingId, ExprId, ExprOrPatId, ExprOrPatIdPacked, LabelId, PatId, UnaryOp},
     lang_item::LangItems,
     layout::Integer,
     resolver::{HasResolver, ResolveValueResult, Resolver, TypeNs, ValueNs},
@@ -432,6 +432,13 @@ pub enum InferenceDiagnostic {
     CannotBeDereferenced {
         #[type_visitable(ignore)]
         expr: ExprId,
+        found: StoredTy,
+    },
+    UnaryOperatorCannotBeApplied {
+        #[type_visitable(ignore)]
+        expr: ExprId,
+        #[type_visitable(ignore)]
+        op: UnaryOp,
         found: StoredTy,
     },
     MutRefInImmRefPat {

--- a/crates/hir-ty/src/infer/op.rs
+++ b/crates/hir-ty/src/infer/op.rs
@@ -9,7 +9,7 @@ use syntax::ast::{ArithOp, BinaryOp, UnaryOp};
 use tracing::debug;
 
 use crate::{
-    Adjust, Adjustment, AutoBorrow,
+    Adjust, Adjustment, AutoBorrow, InferenceDiagnostic,
     infer::{AllowTwoPhase, AutoBorrowMutability, Expectation, InferenceContext, expr::ExprIsRead},
     method_resolution::{MethodCallee, TreatNotYetDefinedOpaques},
     next_solver::{
@@ -271,7 +271,11 @@ impl<'db> InferenceContext<'db> {
                 method.sig.output()
             }
             Err(_errors) => {
-                // FIXME: Report diagnostic.
+                self.push_diagnostic(InferenceDiagnostic::UnaryOperatorCannotBeApplied {
+                    expr: ex,
+                    op,
+                    found: operand_ty.store(),
+                });
                 self.types.types.error
             }
         }

--- a/crates/hir-ty/src/infer/unify.rs
+++ b/crates/hir-ty/src/infer/unify.rs
@@ -586,6 +586,7 @@ pub(super) mod resolve_completely {
                 | InferenceDiagnostic::CannotIndexInto { found: ty, .. }
                 | InferenceDiagnostic::ExpectedFunction { found: ty, .. }
                 | InferenceDiagnostic::ExpectedArrayOrSlicePat { found: ty, .. }
+                | InferenceDiagnostic::UnaryOperatorCannotBeApplied { found: ty, .. }
                 | InferenceDiagnostic::UnresolvedField { receiver: ty, .. }
                 | InferenceDiagnostic::UnresolvedMethodCall { receiver: ty, .. } = diagnostic
                     && ty.as_ref().references_non_lt_error()

--- a/crates/hir/src/diagnostics.rs
+++ b/crates/hir/src/diagnostics.rs
@@ -105,6 +105,7 @@ diagnostics![AnyDiagnostic<'db> ->
     AwaitOutsideOfAsync,
     BreakOutsideOfLoop,
     CannotBeDereferenced<'db>,
+    UnaryOperatorCannotBeApplied<'db>,
     CannotImplicitlyDerefTraitObject<'db>,
     CannotIndexInto<'db>,
     CastToUnsized<'db>,
@@ -335,6 +336,13 @@ pub struct ExpectedFunction<'db> {
 #[derive(Debug)]
 pub struct CannotBeDereferenced<'db> {
     pub expr: InFile<ExprOrPatPtr>,
+    pub found: Type<'db>,
+}
+
+#[derive(Debug)]
+pub struct UnaryOperatorCannotBeApplied<'db> {
+    pub expr: InFile<ExprOrPatPtr>,
+    pub op: ast::UnaryOp,
     pub found: Type<'db>,
 }
 
@@ -984,6 +992,10 @@ impl<'db> AnyDiagnostic<'db> {
             InferenceDiagnostic::CannotBeDereferenced { expr, found } => {
                 let expr = expr_syntax(*expr)?;
                 CannotBeDereferenced { expr, found: new_ty(found.as_ref()) }.into()
+            }
+            InferenceDiagnostic::UnaryOperatorCannotBeApplied { expr, op, found } => {
+                let expr = expr_syntax(*expr)?;
+                UnaryOperatorCannotBeApplied { expr, op: *op, found: new_ty(found.as_ref()) }.into()
             }
             InferenceDiagnostic::MutRefInImmRefPat { pat } => {
                 let pat = pat_syntax(*pat)?.map(Into::into);

--- a/crates/ide-diagnostics/src/handlers/mismatched_arg_count.rs
+++ b/crates/ide-diagnostics/src/handlers/mismatched_arg_count.rs
@@ -488,6 +488,7 @@ fn main() {
     fn legacy_const_generics() {
         check_diagnostics(
             r#"
+//- minicore: unary_ops, builtin_impls
 #[rustc_legacy_const_generics(1, 3)]
 fn mixed<const N1: &'static str, const N2: bool>(
     _a: u8,

--- a/crates/ide-diagnostics/src/handlers/unary_operator_cannot_be_applied.rs
+++ b/crates/ide-diagnostics/src/handlers/unary_operator_cannot_be_applied.rs
@@ -1,0 +1,158 @@
+use hir::HirDisplay;
+use syntax::ast::UnaryOp;
+
+use crate::{Diagnostic, DiagnosticCode, DiagnosticsContext};
+
+// Diagnostic: unary-operator-cannot-be-applied
+//
+// This diagnostic is triggered if a unary operator (`!` or `-`) is applied
+// to a value whose type does not implement the corresponding trait
+// (`Not` or `Neg`).
+pub(crate) fn unary_operator_cannot_be_applied(
+    ctx: &DiagnosticsContext<'_, '_>,
+    d: &hir::UnaryOperatorCannotBeApplied<'_>,
+) -> Diagnostic {
+    let op = match d.op {
+        UnaryOp::Not => "!",
+        UnaryOp::Neg => "-",
+        // `Deref` uses a different diagnostic (`CannotBeDereferenced`).
+        UnaryOp::Deref => "*",
+    };
+    Diagnostic::new_with_syntax_node_ptr(
+        ctx,
+        DiagnosticCode::RustcHardError("E0600"),
+        format!(
+            "cannot apply unary operator `{op}` to type `{}`",
+            d.found.display(ctx.sema.db, ctx.display_target)
+        ),
+        d.expr.map(Into::into),
+    )
+    .stable()
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::tests::check_diagnostics;
+
+    #[test]
+    fn not_on_enum() {
+        check_diagnostics(
+            r#"
+//- minicore: unary_ops, builtin_impls
+enum Question { Yes, No }
+
+fn f() {
+    let _ = !Question::Yes;
+          //^^^^^^^^^^^^^^ error: cannot apply unary operator `!` to type `Question`
+}
+"#,
+        );
+    }
+
+    #[test]
+    fn neg_on_struct() {
+        check_diagnostics(
+            r#"
+//- minicore: unary_ops, builtin_impls
+struct S;
+
+fn f() {
+    let _ = -S;
+          //^^ error: cannot apply unary operator `-` to type `S`
+}
+"#,
+        );
+    }
+
+    #[test]
+    fn allows_not_on_bool() {
+        check_diagnostics(
+            r#"
+//- minicore: unary_ops, builtin_impls
+fn f() {
+    let _ = !true;
+    let _ = !false;
+}
+"#,
+        );
+    }
+
+    #[test]
+    fn allows_not_on_integer() {
+        check_diagnostics(
+            r#"
+//- minicore: unary_ops, builtin_impls
+fn f() {
+    let _ = !0u32;
+    let _ = !0i32;
+}
+"#,
+        );
+    }
+
+    #[test]
+    fn allows_neg_on_numeric() {
+        check_diagnostics(
+            r#"
+//- minicore: unary_ops, builtin_impls
+fn f() {
+    let _ = -1i32;
+    let _ = -1.0f64;
+}
+"#,
+        );
+    }
+
+    #[test]
+    fn neg_on_unsigned() {
+        check_diagnostics(
+            r#"
+//- minicore: unary_ops, builtin_impls
+fn f() {
+    let _ = -1u32;
+          //^^^^^ error: cannot apply unary operator `-` to type `u32`
+}
+"#,
+        );
+    }
+
+    #[test]
+    fn allows_not_with_impl() {
+        check_diagnostics(
+            r#"
+//- minicore: unary_ops, builtin_impls
+struct Bar;
+struct Foo;
+
+impl core::ops::Not for Bar {
+    type Output = Foo;
+    fn not(self) -> Foo { Foo }
+}
+
+fn f() {
+    let _ = !Bar;
+}
+"#,
+        );
+    }
+
+    #[test]
+    fn allows_neg_with_impl() {
+        check_diagnostics(
+            r#"
+//- minicore: unary_ops, builtin_impls
+struct Bar;
+struct Foo;
+
+impl core::ops::Neg for Bar {
+    type Output = Foo;
+    fn neg(self) -> Foo { Foo }
+}
+
+fn f() {
+    let _ = -Bar;
+}
+"#,
+        );
+    }
+}

--- a/crates/ide-diagnostics/src/lib.rs
+++ b/crates/ide-diagnostics/src/lib.rs
@@ -85,6 +85,7 @@ mod handlers {
     pub(crate) mod type_mismatch;
     pub(crate) mod type_must_be_known;
     pub(crate) mod typed_hole;
+    pub(crate) mod unary_operator_cannot_be_applied;
     pub(crate) mod undeclared_label;
     pub(crate) mod unimplemented_builtin_macro;
     pub(crate) mod unimplemented_trait;
@@ -437,6 +438,7 @@ pub fn semantic_diagnostics(
         let d = match diag {
             AnyDiagnostic::AwaitOutsideOfAsync(d) => handlers::await_outside_of_async::await_outside_of_async(&ctx, &d),
             AnyDiagnostic::CannotBeDereferenced(d) => handlers::cannot_be_dereferenced::cannot_be_dereferenced(&ctx, &d),
+            AnyDiagnostic::UnaryOperatorCannotBeApplied(d) => handlers::unary_operator_cannot_be_applied::unary_operator_cannot_be_applied(&ctx, &d),
             AnyDiagnostic::CannotImplicitlyDerefTraitObject(d) => handlers::cannot_implicitly_deref_trait_object::cannot_implicitly_deref_trait_object(&ctx, &d),
             AnyDiagnostic::CannotIndexInto(d) => handlers::cannot_index_into::cannot_index_into(&ctx, &d),
             AnyDiagnostic::CastToUnsized(d) => handlers::invalid_cast::cast_to_unsized(&ctx, &d),

--- a/crates/test-utils/src/minicore.rs
+++ b/crates/test-utils/src/minicore.rs
@@ -34,9 +34,9 @@
 //!     discriminant:
 //!     drop: sized
 //!     env: option
-//!     eq: sized
+//!     eq: sized, unary_ops, builtin_impls
 //!     error: fmt
-//!     float_consts:
+//!     float_consts: unary_ops, builtin_impls
 //!     fmt: option, result, transmute, coerce_unsized, copy, clone, derive
 //!     fn: sized, tuple
 //!     from: sized, result
@@ -370,11 +370,13 @@ pub mod clone {
         }
     }
 
+    // region:index
     impl<T: Clone> Clone for [T; 1] {
         fn clone(&self) -> Self {
             [self[0].clone()]
         }
     }
+    // endregion:index
     // endregion:builtin_impls
 
     // region:derive
@@ -1213,6 +1215,30 @@ pub mod ops {
         #[must_use = "this returns the result of the operation, without modifying the original"]
         fn neg(self) -> Self::Output;
     }
+
+    // region:builtin_impls
+    macro_rules! not_impl {
+        ($($t:ty)*) => ($(
+            impl const Not for $t {
+                type Output = $t;
+                fn not(self) -> $t { !self }
+            }
+        )*)
+    }
+
+    not_impl! { bool usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 }
+
+    macro_rules! neg_impl {
+        ($($t:ty)*) => ($(
+            impl const Neg for $t {
+                type Output = $t;
+                fn neg(self) -> $t { -self }
+            }
+        )*)
+    }
+
+    neg_impl! { isize i8 i16 i32 i64 i128 f16 f32 f64 f128 }
+    // endregion:builtin_impls
     // endregion:unary_ops
 
     // region:coroutine


### PR DESCRIPTION
Addresses the [FIXME](https://github.com/rust-lang/rust-analyzer/blob/baabc5825f3f6640e99fe32887bbeced640f825e/crates/hir-ty/src/infer/op.rs#L274) in `infer_user_unop`, which previously discarded operator method resolution failures for `!x` and `-x` expressions.

When the operand's type does not implement `std::ops::Not` (for `!`) or `std::ops::Neg` (for `-`), rust-analyzer now reports the same E0600 error that rustc produces:

    cannot apply unary operator `!` to type `Question`

Wired through the standard inference diagnostic pipeline: new `InferenceDiagnostic::UnaryOperatorCannotBeApplied` variant in hir-ty, matching `UnaryOperatorCannotBeApplied` struct plus conversion in hir, and a handler in ide-diagnostics using `DiagnosticCode::RustcHardError("E0600")`.

The diagnostic is suppressed when the operand is an unresolved type variable or already references an error, so that incomplete code and macro expansions that infer to `{unknown}` do not produce spurious E0600 reports.

The `unary_ops` region of `crates/test-utils/src/minicore.rs` also gains builtin `Not` and `Neg` impls, mirroring how `add_impl!` provides them in the `add` region. Without these, the diagnostic test fixture would incorrectly flag `!true`, `!0i32` and similar builtin uses as errors, because `lookup_op_method` would find no impl in the minicore fixture even though real `core` has one. With the impls present, primitives resolve normally and only genuinely unsupported operators trigger the diagnostic. This also lets us correctly report `-1u32` as E0600, since real `core` does not implement `Neg` for unsigned integers.

Because the new `not_impl!` / `neg_impl!` blocks live in a nested `region:builtin_impls` inside `region:unary_ops`, the new tests opt into both flags via `//- minicore: unary_ops, builtin_impls`. The existing `legacy_const_generics` test in `mismatched_arg_count` uses `-1i32` / `-1i8` inline and now needs the same directive so that `core::ops::Neg` is in scope for its operands.

The `UnaryOp::Deref` case is left unchanged; it is already handled by the `CannotBeDereferenced` diagnostic (E0614) and `infer_user_unop` is never called for `Deref`.

Refs rust-lang/rust-analyzer#22140

r? @ChayimFriedman2