### PR TITLE
fix: emit E0422 for unresolved record expr paths

### DIFF
--- a/crates/hir-ty/src/infer.rs
+++ b/crates/hir-ty/src/infer.rs
@@ -373,6 +373,12 @@ pub enum InferenceDiagnostic {
         #[type_visitable(ignore)]
         id: ExprOrPatIdPacked,
     },
+    UnresolvedRecordExpr {
+        #[type_visitable(ignore)]
+        expr: ExprId,
+        #[type_visitable(ignore)]
+        name: Name,
+    },
     // FIXME: This should be emitted in body lowering
     BreakOutsideOfLoop {
         #[type_visitable(ignore)]

--- a/crates/hir-ty/src/infer/expr.rs
+++ b/crates/hir-ty/src/infer/expr.rs
@@ -942,10 +942,19 @@ impl<'db> InferenceContext<'db> {
     ) -> Ty<'db> {
         // Find the relevant variant
         let (adt_ty, Some(variant)) = self.resolve_variant(expr.into(), path, false) else {
-            // FIXME: Emit an error.
             for field in fields {
                 self.infer_expr_no_expect(field.expr, ExprIsRead::Yes);
             }
+
+            let name = match path.segments().last() {
+                Some(segment) => segment.name.clone(),
+                None => {
+                    never!("record expr path has no segments");
+                    return self.types.types.error;
+                }
+            };
+
+            self.push_diagnostic(InferenceDiagnostic::UnresolvedRecordExpr { expr, name });
 
             return self.types.types.error;
         };

--- a/crates/hir/src/diagnostics.rs
+++ b/crates/hir/src/diagnostics.rs
@@ -166,6 +166,7 @@ diagnostics![AnyDiagnostic<'db> ->
     UnresolvedMethodCall<'db>,
     UnresolvedModule,
     UnresolvedIdent,
+    UnresolvedRecordExpr,
     GenericArgsProhibited,
     ParenthesizedGenericArgsWithoutFnTrait,
     BadRtn,
@@ -395,6 +396,12 @@ pub struct UnresolvedAssocItem {
 #[derive(Debug)]
 pub struct UnresolvedIdent {
     pub node: InFile<(ExprOrPatPtr, Option<TextRange>)>,
+}
+
+#[derive(Debug)]
+pub struct UnresolvedRecordExpr {
+    pub expr: InFile<ExprOrPatPtr>,
+    pub name: Name,
 }
 
 #[derive(Debug)]
@@ -937,6 +944,9 @@ impl<'db> AnyDiagnostic<'db> {
                     ExprOrPatId::PatId(id) => pat_syntax(id)?.map(|it| (it, None)),
                 };
                 UnresolvedIdent { node }.into()
+            }
+            &InferenceDiagnostic::UnresolvedRecordExpr { expr, ref name } => {
+                UnresolvedRecordExpr { expr: expr_syntax(expr)?, name: name.clone() }.into()
             }
             &InferenceDiagnostic::BreakOutsideOfLoop { expr, is_break, bad_value_break } => {
                 let expr = expr_syntax(expr)?;

--- a/crates/ide-diagnostics/src/handlers/inactive_code.rs
+++ b/crates/ide-diagnostics/src/handlers/inactive_code.rs
@@ -72,6 +72,8 @@ fn f() {
     fn abc() {}
     abc(#[cfg(a)] 0);
       //^^^^^^^^^^^ weak: code is inactive due to #[cfg] directives: a is disabled
+
+    struct Struct {}
     let x = Struct {
         #[cfg(a)] f: 0,
       //^^^^^^^^^^^^^^ weak: code is inactive due to #[cfg] directives: a is disabled

--- a/crates/ide-diagnostics/src/handlers/unresolved_record_expr.rs
+++ b/crates/ide-diagnostics/src/handlers/unresolved_record_expr.rs
@@ -1,0 +1,40 @@
+use crate::{Diagnostic, DiagnosticCode, DiagnosticsContext};
+
+// Diagnostic: unresolved-record-expr
+//
+// This diagnostic is triggered if a struct expression's path does not resolve to an existing struct, union, or enum variant
+pub(crate) fn unresolved_record_expr(
+    ctx: &DiagnosticsContext<'_, '_>,
+    d: &hir::UnresolvedRecordExpr,
+) -> Diagnostic {
+    Diagnostic::new_with_syntax_node_ptr(
+        ctx,
+        DiagnosticCode::RustcHardError("E0422"),
+        format!(
+            "cannot find struct, variant or union type `{}` in this scope",
+            d.name.display(ctx.sema.db, ctx.edition)
+        ),
+        d.expr.map(|it| it.into()),
+    )
+    .stable()
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::tests::check_diagnostics;
+
+    #[test]
+    fn reports_unresolved_record_expr() {
+        check_diagnostics(
+            r#"
+//- /main.rs crate:main
+struct Point { x: i32, y: i32 }
+
+fn main() {
+    let p = Poin { x: 1, y: 2 };
+          //^^^^^^^^^^^^^^^^^^^ error: cannot find struct, variant or union type `Poin` in this scope
+}
+"#,
+        );
+    }
+}

--- a/crates/ide-diagnostics/src/lib.rs
+++ b/crates/ide-diagnostics/src/lib.rs
@@ -100,6 +100,7 @@ mod handlers {
     pub(crate) mod unresolved_macro_call;
     pub(crate) mod unresolved_method;
     pub(crate) mod unresolved_module;
+    pub(crate) mod unresolved_record_expr;
     pub(crate) mod unused_must_use;
     pub(crate) mod yield_outside_coroutine;
 
@@ -511,6 +512,7 @@ pub fn semantic_diagnostics(
             AnyDiagnostic::UnresolvedMacroCall(d) => handlers::unresolved_macro_call::unresolved_macro_call(&ctx, &d),
             AnyDiagnostic::UnresolvedMethodCall(d) => handlers::unresolved_method::unresolved_method(&ctx, &d),
             AnyDiagnostic::UnresolvedModule(d) => handlers::unresolved_module::unresolved_module(&ctx, &d),
+            AnyDiagnostic::UnresolvedRecordExpr(d) => handlers::unresolved_record_expr::unresolved_record_expr(&ctx, &d),
             AnyDiagnostic::UnusedMustUse(d) => handlers::unused_must_use::unused_must_use(&ctx, &d),
             AnyDiagnostic::BreakOutsideOfLoop(d) => handlers::break_outside_of_loop::break_outside_of_loop(&ctx, &d),
             AnyDiagnostic::MismatchedTupleStructPatArgCount(d) => handlers::mismatched_arg_count::mismatched_tuple_struct_pat_arg_count(&ctx, &d),


### PR DESCRIPTION
Part of rust-lang/rust-analyzer#22140 — addresses the [`// FIXME: Emit an error.`](https://github.com/rust-lang/rust-analyzer/blob/baabc5825f3f6640e99fe32887bbeced640f825e/crates/hir-ty/src/infer/expr.rs#L945) in `infer_record_expr`.

`infer_record_expr` returned the error type without reporting anything when the
path didn't resolve to a variant, so typos in struct literals went unnoticed:

```rust
struct Point {}
fn main() { let a = Poin {}; } // no diagnostic
```

Now emits E0422, matching rustc.

Test-only fallout: the `inactive_code::cfg_diagnostics` fixture used `Struct`
without ever declaring it, which only worked because an unresolved path used to
be silent. It now needs the declaration, otherwise E0422 (and `MissingFields`)
fire in a test that has nothing to do with either:

```rust
struct Struct {}
let x = Struct {
    #[cfg(a)] f: 0,
  //^^^^^^^^^^^^^^ weak: code is inactive due to #[cfg] directives: a is disabled
};
```

Covered by new tests in the corresponding `ide-diagnostics` handler; the rest of
the suite passes.

I used Claude Code to navigate the project.