### PR TITLE
fix: Fix parsing of `self::` in fn param list

### DIFF
--- a/crates/parser/src/grammar/params.rs
+++ b/crates/parser/src/grammar/params.rs
@@ -165,7 +165,23 @@ fn variadic_param(p: &mut Parser<'_>) -> bool {
 //     fn e(mut self) {}
 // }
 fn opt_self_param(p: &mut Parser<'_>, m: Marker) -> Result<(), Marker> {
-    if p.at(T![self]) || p.at(T![mut]) && p.nth(1) == T![self] {
+    let is_isolated_self = |p: &mut Parser<'_>, n| {
+        // test non_isolated_self
+        // fn f(self::S: S) {}
+        // fn g(&self::S: &S) {}
+        // fn h(&mut self::S: &mut S) {}
+
+        // test_err non_isolated_self_err
+        // fn f(mut self::S: S) {}
+        // fn g(&'l self::S: &S) {}
+        // fn h(&'l mut self::S: &mut S) {}
+        p.nth_at(n, T![self]) && !p.nth_at(n + 1, T![::])
+    };
+    let mut self_pos = 0;
+    if p.at(T![mut]) {
+        self_pos += 1;
+    }
+    if is_isolated_self(p, self_pos) {
         p.eat(T![mut]);
         self_as_name(p);
         // test arb_self_types
@@ -177,17 +193,20 @@ fn opt_self_param(p: &mut Parser<'_>, m: Marker) -> Result<(), Marker> {
             types::ascription(p);
         }
     } else {
-        let la1 = p.nth(1);
-        let la2 = p.nth(2);
-        let la3 = p.nth(3);
-        if !matches!(
-            (p.current(), la1, la2, la3),
-            (T![&], T![self], _, _)
-                | (T![&], T![mut] | LIFETIME_IDENT, T![self], _)
-                | (T![&], LIFETIME_IDENT, T![mut], T![self])
-        ) {
+        if !p.at(T![&]) {
             return Err(m);
         }
+        let mut self_pos = 1;
+        if p.nth_at(self_pos, LIFETIME_IDENT) {
+            self_pos += 1;
+        }
+        if p.nth_at(self_pos, T![mut]) {
+            self_pos += 1;
+        }
+        if !is_isolated_self(p, self_pos) {
+            return Err(m);
+        }
+
         p.bump(T![&]);
         if p.at(LIFETIME_IDENT) {
             lifetime(p);

--- a/crates/parser/test_data/generated/runner.rs
+++ b/crates/parser/test_data/generated/runner.rs
@@ -492,6 +492,10 @@ mod ok {
         run_and_expect_no_errors("test_data/parser/inline/ok/nocontentexpr_after_item.rs");
     }
     #[test]
+    fn non_isolated_self() {
+        run_and_expect_no_errors("test_data/parser/inline/ok/non_isolated_self.rs");
+    }
+    #[test]
     fn not_null_pat() { run_and_expect_no_errors("test_data/parser/inline/ok/not_null_pat.rs"); }
     #[test]
     fn offset_of_parens() {
@@ -926,6 +930,10 @@ mod err {
     #[test]
     fn missing_static_type() {
         run_and_expect_errors("test_data/parser/inline/err/missing_static_type.rs");
+    }
+    #[test]
+    fn non_isolated_self_err() {
+        run_and_expect_errors("test_data/parser/inline/err/non_isolated_self_err.rs");
     }
     #[test]
     fn path_item_without_excl() {

--- a/crates/parser/test_data/parser/inline/err/non_isolated_self_err.rast
+++ b/crates/parser/test_data/parser/inline/err/non_isolated_self_err.rast
@@ -1,0 +1,131 @@
+SOURCE_FILE
+  FN
+    FN_KW "fn"
+    WHITESPACE " "
+    NAME
+      IDENT "f"
+    PARAM_LIST
+      L_PAREN "("
+      PARAM
+        IDENT_PAT
+          MUT_KW "mut"
+          WHITESPACE " "
+          ERROR
+            SELF_KW "self"
+        COLON ":"
+        ERROR
+          COLON ":"
+      PARAM
+        IDENT_PAT
+          NAME
+            IDENT "S"
+        COLON ":"
+        WHITESPACE " "
+        PATH_TYPE
+          PATH
+            PATH_SEGMENT
+              NAME_REF
+                IDENT "S"
+      R_PAREN ")"
+    WHITESPACE " "
+    BLOCK_EXPR
+      STMT_LIST
+        L_CURLY "{"
+        R_CURLY "}"
+  WHITESPACE "\n"
+  FN
+    FN_KW "fn"
+    WHITESPACE " "
+    NAME
+      IDENT "g"
+    PARAM_LIST
+      L_PAREN "("
+      PARAM
+        REF_PAT
+          AMP "&"
+          ERROR
+            LIFETIME_IDENT "'l"
+      WHITESPACE " "
+      PARAM
+        PATH_PAT
+          PATH
+            PATH
+              PATH_SEGMENT
+                NAME_REF
+                  SELF_KW "self"
+            COLON2 "::"
+            PATH_SEGMENT
+              NAME_REF
+                IDENT "S"
+        COLON ":"
+        WHITESPACE " "
+        REF_TYPE
+          AMP "&"
+          PATH_TYPE
+            PATH
+              PATH_SEGMENT
+                NAME_REF
+                  IDENT "S"
+      R_PAREN ")"
+    WHITESPACE " "
+    BLOCK_EXPR
+      STMT_LIST
+        L_CURLY "{"
+        R_CURLY "}"
+  WHITESPACE "\n"
+  FN
+    FN_KW "fn"
+    WHITESPACE " "
+    NAME
+      IDENT "h"
+    PARAM_LIST
+      L_PAREN "("
+      PARAM
+        REF_PAT
+          AMP "&"
+          ERROR
+            LIFETIME_IDENT "'l"
+      WHITESPACE " "
+      PARAM
+        IDENT_PAT
+          MUT_KW "mut"
+          WHITESPACE " "
+          ERROR
+            SELF_KW "self"
+        COLON ":"
+        ERROR
+          COLON ":"
+      PARAM
+        IDENT_PAT
+          NAME
+            IDENT "S"
+        COLON ":"
+        WHITESPACE " "
+        REF_TYPE
+          AMP "&"
+          MUT_KW "mut"
+          WHITESPACE " "
+          PATH_TYPE
+            PATH
+              PATH_SEGMENT
+                NAME_REF
+                  IDENT "S"
+      R_PAREN ")"
+    WHITESPACE " "
+    BLOCK_EXPR
+      STMT_LIST
+        L_CURLY "{"
+        R_CURLY "}"
+  WHITESPACE "\n"
+error 9: expected a name
+error 14: expected type
+error 15: expected `,`
+error 30: expected pattern
+error 32: missing type for function parameter
+error 32: expected `,`
+error 55: expected pattern
+error 57: missing type for function parameter
+error 57: expected `,`
+error 62: expected a name
+error 67: expected type
+error 68: expected `,`

--- a/crates/parser/test_data/parser/inline/err/non_isolated_self_err.rs
+++ b/crates/parser/test_data/parser/inline/err/non_isolated_self_err.rs
@@ -1,0 +1,3 @@
+fn f(mut self::S: S) {}
+fn g(&'l self::S: &S) {}
+fn h(&'l mut self::S: &mut S) {}

--- a/crates/parser/test_data/parser/inline/ok/non_isolated_self.rast
+++ b/crates/parser/test_data/parser/inline/ok/non_isolated_self.rast
@@ -1,0 +1,109 @@
+SOURCE_FILE
+  FN
+    FN_KW "fn"
+    WHITESPACE " "
+    NAME
+      IDENT "f"
+    PARAM_LIST
+      L_PAREN "("
+      PARAM
+        PATH_PAT
+          PATH
+            PATH
+              PATH_SEGMENT
+                NAME_REF
+                  SELF_KW "self"
+            COLON2 "::"
+            PATH_SEGMENT
+              NAME_REF
+                IDENT "S"
+        COLON ":"
+        WHITESPACE " "
+        PATH_TYPE
+          PATH
+            PATH_SEGMENT
+              NAME_REF
+                IDENT "S"
+      R_PAREN ")"
+    WHITESPACE " "
+    BLOCK_EXPR
+      STMT_LIST
+        L_CURLY "{"
+        R_CURLY "}"
+  WHITESPACE "\n"
+  FN
+    FN_KW "fn"
+    WHITESPACE " "
+    NAME
+      IDENT "g"
+    PARAM_LIST
+      L_PAREN "("
+      PARAM
+        REF_PAT
+          AMP "&"
+          PATH_PAT
+            PATH
+              PATH
+                PATH_SEGMENT
+                  NAME_REF
+                    SELF_KW "self"
+              COLON2 "::"
+              PATH_SEGMENT
+                NAME_REF
+                  IDENT "S"
+        COLON ":"
+        WHITESPACE " "
+        REF_TYPE
+          AMP "&"
+          PATH_TYPE
+            PATH
+              PATH_SEGMENT
+                NAME_REF
+                  IDENT "S"
+      R_PAREN ")"
+    WHITESPACE " "
+    BLOCK_EXPR
+      STMT_LIST
+        L_CURLY "{"
+        R_CURLY "}"
+  WHITESPACE "\n"
+  FN
+    FN_KW "fn"
+    WHITESPACE " "
+    NAME
+      IDENT "h"
+    PARAM_LIST
+      L_PAREN "("
+      PARAM
+        REF_PAT
+          AMP "&"
+          MUT_KW "mut"
+          WHITESPACE " "
+          PATH_PAT
+            PATH
+              PATH
+                PATH_SEGMENT
+                  NAME_REF
+                    SELF_KW "self"
+              COLON2 "::"
+              PATH_SEGMENT
+                NAME_REF
+                  IDENT "S"
+        COLON ":"
+        WHITESPACE " "
+        REF_TYPE
+          AMP "&"
+          MUT_KW "mut"
+          WHITESPACE " "
+          PATH_TYPE
+            PATH
+              PATH_SEGMENT
+                NAME_REF
+                  IDENT "S"
+      R_PAREN ")"
+    WHITESPACE " "
+    BLOCK_EXPR
+      STMT_LIST
+        L_CURLY "{"
+        R_CURLY "}"
+  WHITESPACE "\n"

--- a/crates/parser/test_data/parser/inline/ok/non_isolated_self.rs
+++ b/crates/parser/test_data/parser/inline/ok/non_isolated_self.rs
@@ -1,0 +1,3 @@
+fn f(self::S: S) {}
+fn g(&self::S: &S) {}
+fn h(&mut self::S: &mut S) {}


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust-analyzer/issues/23150.