### PR TITLE
internal: Download all artifacts in a single step

### DIFF
--- a/.github/workflows/metrics.yaml
+++ b/.github/workflows/metrics.yaml
@@ -91,35 +91,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      - name: Download build metrics
+      - name: Download metrics
         uses: actions/download-artifact@v8
         with:
-          name: build-${{ github.sha }}
-
-      - name: Download self metrics
-        uses: actions/download-artifact@v8
-        with:
-          name: self-${{ github.sha }}
-
-      - name: Download ripgrep-13.0.0 metrics
-        uses: actions/download-artifact@v8
-        with:
-          name: ripgrep-13.0.0-${{ github.sha }}
-
-      - name: Download webrender-2022 metrics
-        uses: actions/download-artifact@v8
-        with:
-          name: webrender-2022-${{ github.sha }}
-
-      - name: Download diesel-1.4.8 metrics
-        uses: actions/download-artifact@v8
-        with:
-          name: diesel-1.4.8-${{ github.sha }}
-
-      - name: Download hyper-0.14.18 metrics
-        uses: actions/download-artifact@v8
-        with:
-          name: hyper-0.14.18-${{ github.sha }}
+          pattern: '*-${{ github.sha }}'
+          merge-multiple: true
 
       - name: Combine json
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -237,40 +237,9 @@ jobs:
 
       - uses: actions/download-artifact@v8
         with:
-          name: dist-aarch64-apple-darwin
+          pattern: dist-*
           path: dist
-      - uses: actions/download-artifact@v8
-        with:
-          name: dist-x86_64-apple-darwin
-          path: dist
-      - uses: actions/download-artifact@v8
-        with:
-          name: dist-x86_64-unknown-linux-gnu
-          path: dist
-      - uses: actions/download-artifact@v8
-        with:
-          name: dist-x86_64-unknown-linux-musl
-          path: dist
-      - uses: actions/download-artifact@v8
-        with:
-          name: dist-aarch64-unknown-linux-gnu
-          path: dist
-      - uses: actions/download-artifact@v8
-        with:
-          name: dist-arm-unknown-linux-gnueabihf
-          path: dist
-      - uses: actions/download-artifact@v8
-        with:
-          name: dist-x86_64-pc-windows-msvc
-          path: dist
-      - uses: actions/download-artifact@v8
-        with:
-          name: dist-i686-pc-windows-msvc
-          path: dist
-      - uses: actions/download-artifact@v8
-        with:
-          name: dist-aarch64-pc-windows-msvc
-          path: dist
+          merge-multiple: true
       - run: ls -al ./dist
 
       - name: Publish Release


### PR DESCRIPTION
It's shorter and saves a few seconds on CI:

<img width="1431" height="580" alt="image" src="https://github.com/user-attachments/assets/25bba79b-7a3c-4551-a925-e5a117b55d9f" />

vs.

<img width="1437" height="941" alt="image" src="https://github.com/user-attachments/assets/04a2c809-5f58-4870-8c32-f12e67894e68" />
