### PR TITLE
internal: Change StructId to be a tracked struct in salsa

### DIFF
--- a/crates/hir-def/src/lib.rs
+++ b/crates/hir-def/src/lib.rs
@@ -258,7 +258,41 @@ type FunctionLoc = AssocItemLoc<ast::Fn>;
 impl_intern!(FunctionId, FunctionLoc);
 
 type StructLoc = ItemLoc<ast::Struct>;
-impl_intern!(StructId, StructLoc);
+
+#[salsa::tracked(constructor = new_)]
+#[derive(PartialOrd, Ord)]
+pub struct StructIdLt<'db> {
+    #[returns(ref)]
+    pub loc: StructLoc,
+}
+pub type StructId = StructIdLt<'static>;
+
+impl fmt::Debug for StructIdLt<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("StructId").field(&format_args!("{:04x}", self.0.index())).finish()
+    }
+}
+
+impl<'db> StructIdLt<'db> {
+    pub(crate) fn new(db: &'db dyn SourceDatabase, loc: StructLoc) -> Self {
+        StructIdLt::new_(db, loc)
+    }
+
+    /// # Safety
+    ///
+    /// The caller must ensure that the `StructId` is not leaked outside of query computations.
+    pub(crate) unsafe fn to_static(self) -> StructId {
+        unsafe { std::mem::transmute(self) }
+    }
+}
+
+impl Lookup for StructId {
+    type Data = StructLoc;
+
+    fn lookup<'db>(&self, db: &'db dyn SourceDatabase) -> &'db Self::Data {
+        self.loc(db)
+    }
+}
 
 impl StructId {
     pub fn fields(self, db: &dyn SourceDatabase) -> &VariantFields {

--- a/crates/hir-def/src/nameres/collector.rs
+++ b/crates/hir-def/src/nameres/collector.rs
@@ -32,8 +32,8 @@ use crate::{
     EnumLoc, ExternBlockLoc, ExternCrateId, ExternCrateLoc, FunctionId, FunctionLoc, FxIndexMap,
     ImplLoc, Intern, ItemContainerId, Lookup, Macro2Id, Macro2Loc, MacroExpander, MacroId,
     MacroRulesId, MacroRulesLoc, MacroRulesLocFlags, ModuleDefId, ModuleId, ProcMacroId,
-    ProcMacroLoc, StaticLoc, StructLoc, TraitLoc, TypeAliasLoc, UnionLoc, UnresolvedMacro, UseId,
-    UseLoc, file_item_tree,
+    ProcMacroLoc, StaticLoc, StructIdLt, StructLoc, TraitLoc, TypeAliasLoc, UnionLoc,
+    UnresolvedMacro, UseId, UseLoc, file_item_tree,
     item_scope::{GlobId, ImportId, ImportOrExternCrate, PerNsGlobImports},
     item_tree::{
         self, Attrs, AttrsOrCfg, ImportAlias, ImportKind, ItemTree, ItemTreeAstId, Macro2,
@@ -2140,11 +2140,16 @@ impl ModCollector<'_, '_> {
                             .map(|&vis| resolve_vis(def_map, local_def_map, &self.item_tree[vis]))
                             .fold(None, |a: Option<Visibility>, b| a?.min(db, b, def_map)),
                     };
-                    let interned = StructLoc {
-                        container: module_id,
-                        id: InFile::new(self.tree_id.file_id(), ast_id),
-                    }
-                    .intern(db);
+                    let interned = unsafe {
+                        StructIdLt::new(
+                            db,
+                            StructLoc {
+                                container: module_id,
+                                id: InFile::new(self.tree_id.file_id(), ast_id),
+                            },
+                        )
+                        .to_static()
+                    };
                     consider_deferred_derives(
                         self.tree_id.file_id(),
                         &mut self.def_collector.deferred_builtin_derives,


### PR DESCRIPTION
Use a lifetime on StructId, defining a StructIdLt type following the
BlockLocLt pattern.

Ensure StructIdLt is a tracked type in salsa. This fixes a rare crash
where a user renames a struct and rust-analyzer panics:

    Can't find ast id ErasedFileAstId { .. }

This seems to be because we could observe old interned StructId
values from previous salsa revisions.

We're moving to using lifetimes in these structs anyway, so this is
both a code cleanup and should be a fix for a crash.

AI disclosure: Code partly written by GPT-5.6 Sol, commit messages,
comments and code review entirely by me.