### PR TITLE
internal: Split VSIX publishing into different jobs and skip duplicates

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -199,15 +199,9 @@ jobs:
 
   publish:
     if: ${{ github.repository == 'rust-lang/rust-analyzer' || github.event_name == 'workflow_dispatch' }}
-    name: publish
     runs-on: ubuntu-latest
     needs: ["dist", "dist-x86_64-unknown-linux-musl"]
     steps:
-      - name: Install Nodejs
-        uses: actions/setup-node@v6
-        with:
-          node-version: 22
-
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
@@ -248,28 +242,41 @@ jobs:
           name: ${{ env.TAG }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
+  publish-extension:
+    if: ${{ github.repository == 'rust-lang/rust-analyzer' || github.event_name == 'workflow_dispatch' }}
+    name: publish-extension (${{ matrix.cmd }})
+    runs-on: ubuntu-latest
+    needs: publish
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - cmd: vsce
+            pat: MARKETPLACE_TOKEN
+          - cmd: ovsx
+            pat: OPENVSX_TOKEN
+    steps:
+      - name: Install Nodejs
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: ${{ env.FETCH_DEPTH }}
+
+      - uses: actions/download-artifact@v8
+        with:
+          pattern: dist-*
+          path: dist
+          merge-multiple: true
+
       - run: npm ci
         working-directory: ./editors/code
 
-      - name: Publish Extension (Code Marketplace, release)
-        if: github.ref == 'refs/heads/release' && github.repository == 'rust-lang/rust-analyzer'
+      - name: Publish Extension
+        if: github.repository == 'rust-lang/rust-analyzer'
         working-directory: ./editors/code
-        # token from https://dev.azure.com/rust-analyzer/
-        run: npx vsce publish --pat ${{ secrets.MARKETPLACE_TOKEN }} --packagePath ../../dist/rust-analyzer-*.vsix
-
-      - name: Publish Extension (OpenVSX, release)
-        if: github.ref == 'refs/heads/release' && github.repository == 'rust-lang/rust-analyzer'
-        working-directory: ./editors/code
-        run: npx ovsx publish --pat ${{ secrets.OPENVSX_TOKEN }} --packagePath ../../dist/rust-analyzer-*.vsix
-        timeout-minutes: 2
-
-      - name: Publish Extension (Code Marketplace, nightly)
-        if: github.ref != 'refs/heads/release' && github.repository == 'rust-lang/rust-analyzer'
-        working-directory: ./editors/code
-        run: npx vsce publish --pat ${{ secrets.MARKETPLACE_TOKEN }} --packagePath ../../dist/rust-analyzer-*.vsix --pre-release
-
-      - name: Publish Extension (OpenVSX, nightly)
-        if: github.ref != 'refs/heads/release' && github.repository == 'rust-lang/rust-analyzer'
-        working-directory: ./editors/code
-        run: npx ovsx publish --pat ${{ secrets.OPENVSX_TOKEN }} --packagePath ../../dist/rust-analyzer-*.vsix
+        run: npx ${{ matrix.cmd }} publish --skip-duplicate --pat ${{ secrets[matrix.pat] }} --packagePath ../../dist/rust-analyzer-*.vsix ${{ github.ref != 'refs/heads/release' && '--pre-release' || '' }}
         timeout-minutes: 2


### PR DESCRIPTION
Four main changes:

 - the Marketplace and OVSX publishing now happens in separate jobs, so retrying one of them doesn't create a new GitHub release
 - we pass `--skip-duplicate`, which will hopefully let us retry when at least one VSIX gets published, but some of them fail (this used to error out because of the duplicate version)
 - we never passed `--pre-release` to `ovsx`, probably because it wasn't supported, but it's available now
 - we only used to set a timeout on the OVSX step, now we always do

AI disclosure: partly written by Gemini Flash 3.6

Dry run at https://github.com/lnicola/rust-analyzer/actions/runs/32037903853.