### PR TITLE
Work around const item TypeOwnerId mismatch

### DIFF
--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -5167,13 +5167,15 @@ impl_from!(
 );
 
 impl TypeOwnerId<'_> {
-    fn unify(self, other: Self) -> Option<Self> {
-        match (self, other) {
+    fn unify(self, db: &dyn HirDatabase, other: Self) -> Option<Self> {
+        let self_lifted = self.lift_to_generic_base(db);
+        let other_lifted = other.lift_to_generic_base(db);
+        match (self_lifted, other_lifted) {
             (TypeOwnerId::NoParams(_), owner) => Some(owner),
             (owner, TypeOwnerId::NoParams(_)) => Some(owner),
             (_, _) => {
-                if self == other {
-                    Some(self)
+                if self_lifted == other_lifted {
+                    Some(self_lifted)
                 } else {
                     None
                 }
@@ -5181,9 +5183,49 @@ impl TypeOwnerId<'_> {
         }
     }
 
+    fn lift_to_generic_base(self, db: &dyn HirDatabase) -> Self {
+        // Within ConstId and StaticId definitions, which can't introduce additional generic
+        // parameters, their container's resolver is used directly (see
+        // crates/hir-def/src/resolver.rs) so resolving something from within a ConstId definitions
+        // RHS has the container as owner, but in other cases Types can be constructed with the
+        // ConstId itself as owner. An alternative to special casing this here would be to ensure
+        // consistent assignment of TypeOwnerId values for ConstId and StaticId definitions, but
+        // would require a less localized change.
+        let self_def = match self {
+            TypeOwnerId::GenericDefId(def) => def,
+            TypeOwnerId::BuiltinDeriveImplId(_) | TypeOwnerId::AnonConstId(_) => return self,
+            TypeOwnerId::NoParams(_) => return self,
+        };
+
+        let generic_base = match self_def {
+            GenericDefId::ConstId(def) => def.loc(db).container,
+            GenericDefId::StaticId(def) => def.loc(db).container,
+            GenericDefId::AdtId(_)
+            | GenericDefId::FunctionId(_)
+            | GenericDefId::ImplId(_)
+            | GenericDefId::TraitId(_)
+            | GenericDefId::TypeAliasId(_) => return self,
+        };
+
+        match generic_base {
+            ItemContainerId::ExternBlockId(extern_block_id) => {
+                TypeOwnerId::NoParams(hir_def::HasModule::krate(&extern_block_id, db))
+            }
+            ItemContainerId::ModuleId(module_id_lt) => {
+                TypeOwnerId::NoParams(hir_def::HasModule::krate(&module_id_lt, db))
+            }
+            ItemContainerId::ImplId(impl_id) => {
+                TypeOwnerId::GenericDefId(GenericDefId::ImplId(impl_id))
+            }
+            ItemContainerId::TraitId(trait_id) => {
+                TypeOwnerId::GenericDefId(GenericDefId::TraitId(trait_id))
+            }
+        }
+    }
+
     #[track_caller]
-    fn must_unify(self, other: Self) -> Self {
-        self.unify(other).expect("failed to unify type owners")
+    fn must_unify(self, db: &dyn HirDatabase, other: Self) -> Self {
+        self.unify(db, other).expect("failed to unify type owners")
     }
 
     fn can_rebase_into(
@@ -5192,10 +5234,13 @@ impl TypeOwnerId<'_> {
         rebase_into: Self,
         self_ty: EarlyBinder<'_, Ty<'_>>,
     ) -> bool {
-        if self == rebase_into || !self_ty.skip_binder().has_param() {
+        let self_lifted = self.lift_to_generic_base(db);
+        let rebase_into_lifted = rebase_into.lift_to_generic_base(db);
+
+        if self_lifted == rebase_into_lifted || !self_ty.skip_binder().has_param() {
             return true;
         }
-        let self_def = match self {
+        let self_def = match self_lifted {
             TypeOwnerId::GenericDefId(def) => def,
             TypeOwnerId::BuiltinDeriveImplId(_) | TypeOwnerId::AnonConstId(_) => return false,
             TypeOwnerId::NoParams(_) => return true,
@@ -5209,7 +5254,7 @@ impl TypeOwnerId<'_> {
             | GenericDefId::StaticId(_)
             | GenericDefId::TypeAliasId(_) => return false,
         };
-        let rebase_into_def = match rebase_into {
+        let rebase_into_def = match rebase_into_lifted {
             TypeOwnerId::GenericDefId(def) => def,
             TypeOwnerId::BuiltinDeriveImplId(_)
             | TypeOwnerId::AnonConstId(_)
@@ -5434,7 +5479,7 @@ impl<'db> Type<'db> {
                 let ty = ty.borrow();
 
                 match &mut owner {
-                    Some(owner) => *owner = owner.must_unify(ty.owner),
+                    Some(owner) => *owner = owner.must_unify(db, ty.owner),
                     None => owner = Some(ty.owner),
                 }
 
@@ -6518,7 +6563,7 @@ impl<'db> Type<'db> {
     /// Note that we consider placeholder types to unify with everything.
     /// For example `Option<T>` and `Option<U>` unify although there is unresolved goal `T = U`.
     pub fn could_unify_with(&self, db: &'db dyn HirDatabase, other: &Type<'db>) -> bool {
-        self.owner.must_unify(other.owner);
+        self.owner.must_unify(db, other.owner);
         let env = self.param_env(db);
         let interner = DbInterner::new_no_crate(db);
         let tys = hir_ty::replace_errors_with_variables(
@@ -6533,7 +6578,7 @@ impl<'db> Type<'db> {
     /// This means that placeholder types are not considered to unify if there are any bounds set on
     /// them. For example `Option<T>` and `Option<U>` do not unify as we cannot show that `T = U`
     pub fn could_unify_with_deeply(&self, db: &'db dyn HirDatabase, other: &Type<'db>) -> bool {
-        self.owner.must_unify(other.owner);
+        self.owner.must_unify(db, other.owner);
         let env = self.param_env(db);
         let interner = DbInterner::new_no_crate(db);
         let tys = hir_ty::replace_errors_with_variables(
@@ -6544,7 +6589,7 @@ impl<'db> Type<'db> {
     }
 
     pub fn could_coerce_to(&self, db: &'db dyn HirDatabase, to: &Type<'db>) -> bool {
-        self.owner.must_unify(to.owner);
+        self.owner.must_unify(db, to.owner);
         let env = self.param_env(db);
         let interner = DbInterner::new_no_crate(db);
         let tys = hir_ty::replace_errors_with_variables(
@@ -7375,7 +7420,7 @@ fn generic_args_from_tys<'db>(
             let arg = arg.borrow();
 
             match &mut owner {
-                Some(owner) => *owner = owner.must_unify(arg.owner),
+                Some(owner) => *owner = owner.must_unify(interner.db(), arg.owner),
                 None => owner = Some(arg.owner),
             }
 

--- a/crates/ide-completion/src/tests/expression.rs
+++ b/crates/ide-completion/src/tests/expression.rs
@@ -4208,3 +4208,38 @@ fn foo(t: T) {
             "#]],
     );
 }
+
+#[test]
+fn complete_in_const_with_argument_expected_type() {
+    check(
+        r#"
+pub struct Boo;
+pub struct A(Boo);
+impl A {
+    const X: A = A(B$0);
+}
+        "#,
+        expect![[r#"
+            sp Self    A
+            st A       A
+            st Boo   Boo
+            st Boo   Boo
+            bt u32   u32
+            kw const
+            kw crate::
+            kw false
+            kw for
+            kw if
+            kw if let
+            kw loop
+            kw match
+            kw self::
+            kw true
+            kw unsafe
+            kw while
+            kw while let
+            ex A::X.0
+            ex Boo
+        "#]],
+    )
+}


### PR DESCRIPTION
For some time rust-analyzer started panicking regularly on the kind of code I tend to write, so today I decided to debug it and to try fixing it. I minimized it the following reproducer, which this PR also adds as a test:

```
pub struct Boo;
pub struct A(Boo);
impl A {
    const X: A = A(B$0);
}
```

Since I wasn't familiar with this codebase before I started debugging this, I was working backwards from the panic's backtrace. My current understanding of the issue is that const items do not introduce their own generic scope and when completing in the definition of a const, resolved completion candidates end up with a `TypeOwnerId` of the const item's container, the `HasResolver` implementation just skips the item scope, whereas expected types (from argument positions, the const type itself isn't used as expected type) end up with the const item itself as TypeOwnerId. This can make the `Type`s non-unifiable triggering panics during completion.

This PR works around this by making `Type::unify` and `Type::can_rebase_into` normalize the `TypeOwnerId` of a `Type` to the innermost scope that actually can have generics for const and static items (or to `NoParams` if there is none).

I'm not at all confident that this is the best fix, it seems like it would be better to make sure that `TypeOwnerId`s are assigned consistently, but that would require a) ensuring no types end up with the const item as owner, and I don't have on overview of which places that would be, or b) changing the resolver, which I didn't really look into at all. Also without changing the representation or at least the exposed constructors to ensure consistent assignment, it would be easy to accidentally re-introduce new places that create inconsistent `TypeOwnerId`s. I thus opted for a work-around that is relatively localized and more robust, by forcing the `TypeOwnerId`s to be consistent around the parts that triggered the panic.

PS: The panic I got was the same as in rust-lang/rust-analyzer#22659, but the regression test from rust-lang/rust-analyzer#22858 still fails with this, so I believe what I fixed is not the same issue.
