### PR TITLE
fix: Fix handling of generic params in anon consts 

### DIFF
--- a/crates/hir-ty/src/consteval.rs
+++ b/crates/hir-ty/src/consteval.rs
@@ -351,6 +351,16 @@ pub(crate) fn path_to_const<'a, 'db>(
     Ok(Const::new_unevaluated(interner, UnevaluatedConst { def: konst.into(), args }))
 }
 
+/// `forbid_params_after` and `allow_anon_const_using_generic_params` fill a similar role, but are not the same.
+///
+/// `forbid_params_after` is only respected if an anon const is *not* created, that is, we directly resolve to a const param.
+/// `allow_anon_const_using_generic_params` is only respected if an anon const *is* created.
+///
+/// For example, inside types, you are allowed to refer to const params in bare paths (but might be forbidden from referring
+/// to *some*, in param defaults), but not allowed to do so in anon consts (e.g. `{ {}; N }` is forbidden, because it creates
+/// an anon const). Inside field defaults, you are allowed to refer to them even inside anon consts.
+///
+/// There's also `generic_const_exprs`, `min_generic_const_args`, and `generic_const_args`, all of which we don't implement yet.
 pub(crate) fn create_anon_const<'a, 'db>(
     interner: DbInterner<'db>,
     owner: ExpressionStoreOwnerId,
@@ -362,6 +372,7 @@ pub(crate) fn create_anon_const<'a, 'db>(
     create_var: Option<&mut dyn FnMut(Span) -> Const<'db>>,
     lowering_mode: LoweringMode,
     forbid_params_after: Option<u32>,
+    allow_anon_const_using_generic_params: bool,
 ) -> Result<Const<'db>, CreateConstError<'db>> {
     let mut expr = &store[expr_id];
     if let Expr::Block { statements, tail: Some(tail), .. } = expr
@@ -397,18 +408,17 @@ pub(crate) fn create_anon_const<'a, 'db>(
                 return Err(CreateConstError::AnonConstInterningDisabled);
             };
 
-            let allow_using_generic_params = forbid_params_after.is_none();
             let konst = AnonConstId::new(
                 interner.db,
                 AnonConstLoc {
                     owner,
                     expr: expr_id,
                     ty: StoredEarlyBinder::bind(expected_ty.store()),
-                    allow_using_generic_params,
+                    allow_using_generic_params: allow_anon_const_using_generic_params,
                 },
                 token,
             );
-            let args = if allow_using_generic_params {
+            let args = if allow_anon_const_using_generic_params {
                 GenericArgs::identity_for_item(interner, owner.generic_def(interner.db).into())
             } else {
                 GenericArgs::empty(interner)

--- a/crates/hir-ty/src/infer.rs
+++ b/crates/hir-ty/src/infer.rs
@@ -1969,12 +1969,7 @@ impl<'db> InferenceContext<'db> {
         })
     }
 
-    pub(crate) fn create_anon_const(
-        &mut self,
-        expr: ExprId,
-        expected_ty: Ty<'db>,
-        allow_using_generic_params: bool,
-    ) -> Const<'db> {
+    pub(crate) fn create_anon_const(&mut self, expr: ExprId, expected_ty: Ty<'db>) -> Const<'db> {
         never!(expected_ty.has_infer(), "cannot have infer vars in an anon const's ty");
         let konst = create_anon_const(
             self.interner(),
@@ -1986,7 +1981,11 @@ impl<'db> InferenceContext<'db> {
             &|| self.generics(),
             Some(&mut |span| self.table.next_const_var(span)),
             self.lowering_mode,
-            (!(allow_using_generic_params && self.allow_using_generic_params)).then_some(0),
+            (!self.allow_using_generic_params).then_some(0),
+            // The situation around body anon consts using generic params is complicated.
+            // rustc disallows them all, except for array repeat expressions. However in another place even repeat exprs
+            // are disallowed, so in practice they cause an error.
+            false,
         );
 
         if let Ok(konst) = konst

--- a/crates/hir-ty/src/infer/expr.rs
+++ b/crates/hir-ty/src/infer/expr.rs
@@ -1310,7 +1310,7 @@ impl<'db> InferenceContext<'db> {
         expr: ExprId,
     ) -> Ty<'db> {
         let interner = self.interner();
-        let count_ct = self.create_anon_const(count, self.types.types.usize, true);
+        let count_ct = self.create_anon_const(count, self.types.types.usize);
         let count = self.table.try_structurally_resolve_const(count.into(), count_ct);
 
         let uty = match expected {

--- a/crates/hir-ty/src/lower.rs
+++ b/crates/hir-ty/src/lower.rs
@@ -450,14 +450,20 @@ impl<'db, 'a> TyLoweringContext<'db, 'a> {
         self.lower_ty_ext(type_ref).0
     }
 
-    pub(crate) fn lower_const(&mut self, const_ref: ConstRef, const_type: Ty<'db>) -> Const<'db> {
-        self.lower_expr_as_const(const_ref.expr, const_type)
+    pub(crate) fn lower_const(
+        &mut self,
+        const_ref: ConstRef,
+        const_type: Ty<'db>,
+        allow_anon_const_using_generic_params: bool,
+    ) -> Const<'db> {
+        self.lower_expr_as_const(const_ref.expr, const_type, allow_anon_const_using_generic_params)
     }
 
     pub(crate) fn lower_expr_as_const(
         &mut self,
         expr_id: ExprId,
         const_type: Ty<'db>,
+        allow_anon_const_using_generic_params: bool,
     ) -> Const<'db> {
         #[expect(clippy::manual_map, reason = "a `map()` here generates a borrowck error")]
         let create_var = match &mut self.infer_vars {
@@ -477,6 +483,7 @@ impl<'db, 'a> TyLoweringContext<'db, 'a> {
             create_var,
             self.interning_mode,
             self.forbid_params_after,
+            allow_anon_const_using_generic_params,
         );
 
         if let Ok(konst) = konst
@@ -603,7 +610,7 @@ impl<'db, 'a> TyLoweringContext<'db, 'a> {
             }
             TypeRef::Array(array) => {
                 let inner_ty = self.lower_ty(array.ty);
-                let const_len = self.lower_const(array.len, self.types.types.usize);
+                let const_len = self.lower_const(array.len, self.types.types.usize, false);
                 Ty::new_array_with_const_len(interner, inner_ty, const_len)
             }
             &TypeRef::Slice(inner) => {
@@ -729,9 +736,12 @@ impl<'db, 'a> TyLoweringContext<'db, 'a> {
     fn lower_pattern_type(&mut self, pat: PatId, ty: Ty<'db>) -> Option<Pattern<'db>> {
         let pat_kind = match self.store[pat] {
             hir_def::hir::Pat::Range { start: Some(start), end: Some(end), range_type: _ } => {
+                // rustc allows using generic params in pattern types.
+                // In practice this does not matter since this feature is internal and I didn't find a way to actually use generic params,
+                // but it doesn't matter so...
                 rustc_type_ir::PatternKind::Range {
-                    start: self.lower_expr_as_const(start, ty),
-                    end: self.lower_expr_as_const(end, ty),
+                    start: self.lower_expr_as_const(start, ty, true),
+                    end: self.lower_expr_as_const(end, ty, true),
                 }
             }
             hir_def::hir::Pat::NotNull => rustc_type_ir::PatternKind::NotNull,
@@ -1979,7 +1989,7 @@ pub(crate) fn field_types_with_diagnostics<'db>(
     );
     for (field_id, field_data) in var_data.fields().iter() {
         let ty = ctx.lower_ty(field_data.type_ref);
-        let default = field_data.default_value.map(|default| ctx.lower_const(default, ty));
+        let default = field_data.default_value.map(|default| ctx.lower_const(default, ty, true));
         res.insert(
             field_id,
             FieldType {
@@ -2784,7 +2794,7 @@ pub(crate) fn generic_defaults_with_diagnostics<'db>(
             GenericParamDataRef::ConstParamData(p) => {
                 let val = p.default.map(|c| {
                     let param_ty = ctx.lower_ty(p.ty);
-                    let c = ctx.lower_const(c, param_ty);
+                    let c = ctx.lower_const(c, param_ty, false);
                     GenericArg::from(c).store()
                 });
                 val.map(StoredEarlyBinder::bind)

--- a/crates/hir-ty/src/lower/path.rs
+++ b/crates/hir-ty/src/lower/path.rs
@@ -746,7 +746,7 @@ impl<'a, 'b, 'db> PathLoweringContext<'a, 'b, 'db> {
                         };
                         self.ctx
                             .ctx
-                            .lower_const(konst, const_param_ty(self.ctx.ctx.db, const_id))
+                            .lower_const(konst, const_param_ty(self.ctx.ctx.db, const_id), false)
                             .into()
                     }
                     _ => unreachable!("unmatching param kinds were passed to `provided_kind()`"),

--- a/crates/hir-ty/src/method_resolution/confirm.rs
+++ b/crates/hir-ty/src/method_resolution/confirm.rs
@@ -404,7 +404,7 @@ impl<'a, 'db> ConfirmContext<'a, 'db> {
                             unreachable!("non-const param ID for const param");
                         };
                         let const_ty = self.ctx.db.const_param_ty(const_id);
-                        self.ctx.create_anon_const(konst.expr, const_ty, false).into()
+                        self.ctx.create_anon_const(konst.expr, const_ty).into()
                     }
                     _ => unreachable!("unmatching param kinds were passed to `provided_kind()`"),
                 }

--- a/crates/hir-ty/src/tests.rs
+++ b/crates/hir-ty/src/tests.rs
@@ -13,16 +13,15 @@ mod simple;
 mod trait_aliases;
 mod traits;
 
-use base_db::{Crate, SourceDatabase};
+use base_db::{Crate, EditionedFileId, SourceDatabase};
 use expect_test::Expect;
 use hir_def::{
-    AdtId, AssocItemId, DefWithBodyId, GenericDefId, HasModule, Lookup, ModuleDefId, ModuleId,
+    AdtId, AssocItemId, DefWithBodyId, GenericDefId, HasModule, ModuleDefId, ModuleId,
     SyntheticSyntax, VariantId,
-    expr_store::{Body, BodySourceMap, ExpressionStore, ExpressionStoreSourceMap},
-    hir::{ExprId, Pat, PatId},
+    expr_store::{Body, ExpressionStore, ExpressionStoreSourceMap, SelfParamPtr},
+    hir::{BindingId, ClosureKind, Expr, ExprId, Pat, PatId},
     item_scope::ItemScope,
     nameres::DefMap,
-    src::HasSource,
     type_ref::TypeRefId,
 };
 use hir_expand::{FileRange, InFile};
@@ -36,7 +35,7 @@ use syntax::{
 use test_fixture::WithFixture;
 
 use crate::{
-    InferenceDiagnostic, InferenceResult,
+    InferBodyId, InferenceDiagnostic, InferenceResult,
     db::{AnonConstId, HirDatabase},
     display::{DisplayTarget, HirDisplay},
     infer::Adjustment,
@@ -67,6 +66,115 @@ fn check_no_mismatches(#[rust_analyzer::rust_fixture] ra_fixture: &str) {
 #[track_caller]
 fn check(#[rust_analyzer::rust_fixture] ra_fixture: &str) {
     check_impl(ra_fixture, false, false, false)
+}
+
+fn infer_defs<'db>(
+    db: &'db TestDB,
+    files: &[EditionedFileId],
+) -> Vec<(
+    InferBodyId<'db>,
+    &'db ExpressionStore,
+    &'db ExpressionStoreSourceMap,
+    ExprId,
+    Option<(BindingId, Option<InFile<SelfParamPtr>>)>,
+    Crate,
+)> {
+    let mut defs = Vec::new();
+
+    let anon_const_data = |anon_const: AnonConstId<'db>, krate| {
+        let loc = anon_const.loc(db);
+        let (store, source_map) = ExpressionStore::with_source_map(db, loc.owner);
+        (InferBodyId::AnonConstId(anon_const), store, source_map, loc.expr, None, krate)
+    };
+    let push_generic_def = |defs: &mut Vec<_>, generic_def: Option<GenericDefId>, krate| {
+        let Some(generic_def) = generic_def else { return };
+        defs.extend(
+            AnonConstId::all_from_signature(db, generic_def).map(|it| anon_const_data(it, krate)),
+        );
+    };
+    let push_def_with_body = |defs: &mut Vec<_>, def_with_body: Option<DefWithBodyId>, krate| {
+        let Some(def_with_body) = def_with_body else { return };
+        let (body, source_map) = Body::with_source_map(db, def_with_body);
+
+        let mut root_expr = body.root_expr();
+        if source_map.expr_syntax(root_expr).is_err()
+            && let Expr::Closure {
+                closure_kind: ClosureKind::Coroutine { .. },
+                body: closure_body,
+                ..
+            } = body[root_expr]
+            && let Expr::Block { tail: Some(tail), .. } = body[closure_body]
+        {
+            // async fns etc. lower to coroutines without source as the root expr.
+            root_expr = tail;
+        }
+
+        defs.push((
+            InferBodyId::DefWithBodyId(def_with_body),
+            &***body,
+            &**source_map,
+            root_expr,
+            body.self_param.map(|param| (param.formal, source_map.self_param_syntax())),
+            krate,
+        ));
+    };
+
+    for file_id in files {
+        let module = db.module_for_file_opt(file_id.file_id(db));
+        let module = match module {
+            Some(m) => m,
+            None => continue,
+        };
+        let def_map = module.def_map(db);
+        let krate = module.krate(db);
+
+        visit_module(db, def_map, module, &mut |it| {
+            let generic_def = match it {
+                ModuleDefId::FunctionId(it) => Some(it.into()),
+                ModuleDefId::AdtId(it) => Some(it.into()),
+                ModuleDefId::ConstId(it) => Some(it.into()),
+                ModuleDefId::StaticId(it) => Some(it.into()),
+                ModuleDefId::TraitId(it) => Some(it.into()),
+                ModuleDefId::TypeAliasId(it) => Some(it.into()),
+                ModuleDefId::ModuleId(_) => None,
+                ModuleDefId::EnumVariantId(_) => None,
+                ModuleDefId::BuiltinType(_) => None,
+                ModuleDefId::MacroId(_) => None,
+            };
+            push_generic_def(&mut defs, generic_def, krate);
+
+            let variant_def: Option<VariantId> = match it {
+                ModuleDefId::AdtId(AdtId::StructId(it)) => Some(it.into()),
+                ModuleDefId::AdtId(AdtId::UnionId(it)) => Some(it.into()),
+                ModuleDefId::EnumVariantId(it) => Some(it.into()),
+                _ => None,
+            };
+            if let Some(variant_def) = variant_def {
+                defs.extend(
+                    db.field_types_with_diagnostics(variant_def)
+                        .defined_anon_consts()
+                        .iter()
+                        .map(|&it| anon_const_data(it, krate)),
+                );
+            }
+
+            let def_with_body = match it {
+                ModuleDefId::FunctionId(it) => Some(it.into()),
+                ModuleDefId::EnumVariantId(it) => Some(it.into()),
+                ModuleDefId::ConstId(it) => Some(it.into()),
+                ModuleDefId::StaticId(it) => Some(it.into()),
+                _ => None,
+            };
+            push_def_with_body(&mut defs, def_with_body, krate);
+        });
+    }
+
+    defs.retain(|(_, _, source_map, root_expr, _, _)| source_map.expr_syntax(*root_expr).is_ok());
+    defs.sort_by_key(|(_, _, source_map, root_expr, _, _)| {
+        source_map.expr_syntax(*root_expr).unwrap().value.text_range().start()
+    });
+
+    defs
 }
 
 #[track_caller]
@@ -103,55 +211,18 @@ fn check_impl(
         }
         assert!(had_annotations || allow_none, "no `//^` annotations found");
 
-        let mut defs: Vec<(DefWithBodyId, Crate)> = Vec::new();
-        for file_id in files {
-            let module = db.module_for_file_opt(file_id.file_id(&db));
-            let module = match module {
-                Some(m) => m,
-                None => continue,
-            };
-            let def_map = module.def_map(&db);
-            visit_module(&db, def_map, module, &mut |it| {
-                let def = match it {
-                    ModuleDefId::FunctionId(it) => it.into(),
-                    ModuleDefId::EnumVariantId(it) => it.into(),
-                    ModuleDefId::ConstId(it) => it.into(),
-                    ModuleDefId::StaticId(it) => it.into(),
-                    _ => return,
-                };
-                defs.push((def, module.krate(&db)))
-            });
-        }
-        defs.sort_by_key(|(def, _)| match def {
-            DefWithBodyId::FunctionId(it) => {
-                let loc = it.lookup(&db);
-                loc.source(&db).value.syntax().text_range().start()
-            }
-            DefWithBodyId::ConstId(it) => {
-                let loc = it.lookup(&db);
-                loc.source(&db).value.syntax().text_range().start()
-            }
-            DefWithBodyId::StaticId(it) => {
-                let loc = it.lookup(&db);
-                loc.source(&db).value.syntax().text_range().start()
-            }
-            DefWithBodyId::VariantId(it) => {
-                let loc = it.lookup(&db);
-                loc.source(&db).value.syntax().text_range().start()
-            }
-        });
+        let defs = infer_defs(&db, &files);
         let mut unexpected_type_mismatches = String::new();
-        for (def, krate) in defs {
+        for (def, store, source_map, _root_expr, _self_param, krate) in defs {
             let display_target = DisplayTarget::from_crate(&db, krate);
-            let (body, body_source_map) = Body::with_source_map(&db, def);
             let inference_result = InferenceResult::of(&db, def);
 
             for (pat, ty) in inference_result.type_of_pat.iter() {
                 let mut ty = ty.as_ref();
-                if let Pat::Bind { id, .. } = body[pat] {
+                if let Pat::Bind { id, .. } = store[pat] {
                     ty = inference_result.type_of_binding[id].as_ref();
                 }
-                let node = match pat_node(body_source_map, pat, &db) {
+                let node = match pat_node(source_map, pat, &db) {
                     Some(value) => value,
                     None => continue,
                 };
@@ -168,7 +239,7 @@ fn check_impl(
 
             for (expr, ty) in inference_result.type_of_expr.iter() {
                 let ty = ty.as_ref();
-                let node = match expr_node(body_source_map, expr, &db) {
+                let node = match expr_node(source_map, expr, &db) {
                     Some(value) => value,
                     None => continue,
                 };
@@ -205,10 +276,8 @@ fn check_impl(
                 });
             for (expr_or_pat, expected, actual) in type_mismatches {
                 let Some(node) = (match expr_or_pat.unpack() {
-                    hir_def::hir::ExprOrPatId::ExprId(expr) => {
-                        expr_node(body_source_map, expr, &db)
-                    }
-                    hir_def::hir::ExprOrPatId::PatId(pat) => pat_node(body_source_map, pat, &db),
+                    hir_def::hir::ExprOrPatId::ExprId(expr) => expr_node(source_map, expr, &db),
+                    hir_def::hir::ExprOrPatId::PatId(pat) => pat_node(source_map, pat, &db),
                 }) else {
                     continue;
                 };
@@ -227,7 +296,7 @@ fn check_impl(
             }
 
             for (type_ref, ty) in inference_result.placeholder_types() {
-                let node = match type_node(body_source_map, type_ref, &db) {
+                let node = match type_node(source_map, type_ref, &db) {
                     Some(value) => value,
                     None => continue,
                 };
@@ -272,11 +341,11 @@ fn check_impl(
 }
 
 fn expr_node(
-    body_source_map: &BodySourceMap,
+    source_map: &ExpressionStoreSourceMap,
     expr: ExprId,
     db: &TestDB,
 ) -> Option<InFile<SyntaxNode>> {
-    Some(match body_source_map.expr_syntax(expr) {
+    Some(match source_map.expr_syntax(expr) {
         Ok(sp) => {
             let root = sp.file_id.parse_or_expand(db);
             sp.map(|ptr| ptr.to_node(&root).syntax().clone())
@@ -286,11 +355,11 @@ fn expr_node(
 }
 
 fn pat_node(
-    body_source_map: &BodySourceMap,
+    source_map: &ExpressionStoreSourceMap,
     pat: PatId,
     db: &TestDB,
 ) -> Option<InFile<SyntaxNode>> {
-    Some(match body_source_map.pat_syntax(pat) {
+    Some(match source_map.pat_syntax(pat) {
         Ok(sp) => {
             let root = sp.file_id.parse_or_expand(db);
             sp.map(|ptr| ptr.to_node(&root).syntax().clone())
@@ -300,11 +369,11 @@ fn pat_node(
 }
 
 fn type_node(
-    body_source_map: &BodySourceMap,
+    source_map: &ExpressionStoreSourceMap,
     type_ref: TypeRefId,
     db: &TestDB,
 ) -> Option<InFile<SyntaxNode>> {
-    Some(match body_source_map.type_syntax(type_ref) {
+    Some(match source_map.type_syntax(type_ref) {
         Ok(sp) => {
             let root = sp.file_id.parse_or_expand(db);
             sp.map(|ptr| ptr.to_node(&root).syntax().clone())
@@ -327,10 +396,7 @@ fn infer_with_mismatches(content: &str, include_mismatches: bool) -> String {
         let mut infer_def = |inference_result: &InferenceResult<'_>,
                              store: &ExpressionStore,
                              source_map: &ExpressionStoreSourceMap,
-                             self_param: Option<(
-            hir_def::hir::BindingId,
-            Option<InFile<hir_def::expr_store::SelfParamPtr>>,
-        )>,
+                             self_param: Option<(BindingId, Option<InFile<SelfParamPtr>>)>,
                              krate: Crate| {
             let display_target = DisplayTarget::from_crate(&db, krate);
             let mut types: Vec<(InFile<SyntaxNode>, Ty<'_>)> = Vec::new();
@@ -428,122 +494,10 @@ fn infer_with_mismatches(content: &str, include_mismatches: bool) -> String {
             }
         };
 
-        let module = db.module_for_file(file_id.file_id(&db));
-        let def_map = module.def_map(&db);
-
-        let mut defs: Vec<(DefWithBodyId, Crate)> = Vec::new();
-        let mut generic_defs: Vec<(GenericDefId, Crate)> = Vec::new();
-        let mut variants: Vec<(VariantId, Crate)> = Vec::new();
-        visit_module(&db, def_map, module, &mut |it| {
-            let krate = module.krate(&db);
-            match it {
-                ModuleDefId::FunctionId(it) => {
-                    defs.push((it.into(), krate));
-                    generic_defs.push((it.into(), krate));
-                }
-                ModuleDefId::EnumVariantId(it) => {
-                    defs.push((it.into(), krate));
-                }
-                ModuleDefId::ConstId(it) => {
-                    defs.push((it.into(), krate));
-                    generic_defs.push((it.into(), krate));
-                }
-                ModuleDefId::StaticId(it) => {
-                    defs.push((it.into(), krate));
-                    generic_defs.push((it.into(), krate));
-                }
-                ModuleDefId::AdtId(it) => {
-                    generic_defs.push((it.into(), krate));
-                    match it {
-                        AdtId::StructId(id) => variants.push((id.into(), krate)),
-                        AdtId::UnionId(id) => variants.push((id.into(), krate)),
-                        AdtId::EnumId(id) => variants.extend(
-                            id.enum_variants(&db)
-                                .variants
-                                .values()
-                                .map(|&(variant, ..)| (variant.into(), krate)),
-                        ),
-                    }
-                }
-                ModuleDefId::TraitId(it) => {
-                    generic_defs.push((it.into(), krate));
-                }
-                ModuleDefId::TypeAliasId(it) => {
-                    generic_defs.push((it.into(), krate));
-                }
-                _ => {}
-            }
-        });
-        // Also collect impls
-        for impl_id in def_map[module].scope.impls() {
-            generic_defs.push((impl_id.into(), module.krate(&db)));
-            let impl_data = impl_id.impl_items(&db);
-            for &(_, item) in impl_data.items.iter() {
-                match item {
-                    AssocItemId::FunctionId(it) => {
-                        generic_defs.push((it.into(), module.krate(&db)));
-                    }
-                    AssocItemId::ConstId(it) => {
-                        generic_defs.push((it.into(), module.krate(&db)));
-                    }
-                    AssocItemId::TypeAliasId(it) => {
-                        generic_defs.push((it.into(), module.krate(&db)));
-                    }
-                }
-            }
-        }
-
-        defs.sort_by_key(|(def, _)| match def {
-            DefWithBodyId::FunctionId(it) => {
-                let loc = it.lookup(&db);
-                loc.source(&db).value.syntax().text_range().start()
-            }
-            DefWithBodyId::ConstId(it) => {
-                let loc = it.lookup(&db);
-                loc.source(&db).value.syntax().text_range().start()
-            }
-            DefWithBodyId::StaticId(it) => {
-                let loc = it.lookup(&db);
-                loc.source(&db).value.syntax().text_range().start()
-            }
-            DefWithBodyId::VariantId(it) => {
-                let loc = it.lookup(&db);
-                loc.source(&db).value.syntax().text_range().start()
-            }
-        });
-        for (def, krate) in defs {
-            let (body, source_map) = Body::with_source_map(&db, def);
+        let defs = infer_defs(&db, &[file_id]);
+        for (def, store, source_map, _root_expr, self_param, krate) in defs {
             let infer = InferenceResult::of(&db, def);
-            let self_param =
-                body.self_param.map(|param| (param.formal, source_map.self_param_syntax()));
-            infer_def(infer, body, source_map, self_param, krate);
-        }
-
-        // Also infer signature const expressions (array lengths, const generic args, etc.)
-        generic_defs.dedup();
-        for (def, krate) in generic_defs {
-            let (store, source_map) = ExpressionStore::with_source_map(&db, def.into());
-            // Skip if there are no const expressions in the signature
-            if store.expr_roots().next().is_none() {
-                continue;
-            }
-            for anon_const in AnonConstId::all_from_signature(&db, def) {
-                let infer = InferenceResult::of(&db, anon_const);
-                infer_def(infer, store, source_map, None, krate);
-            }
-        }
-        variants.dedup();
-        for (def, krate) in variants {
-            let (store, source_map) = ExpressionStore::with_source_map(&db, def.into());
-            // Skip if there are no const expressions in the signature
-            if store.expr_roots().next().is_none() {
-                continue;
-            }
-            let anon_consts = db.field_types_with_diagnostics(def).defined_anon_consts();
-            for &anon_const in anon_consts {
-                let infer = InferenceResult::of(&db, anon_const);
-                infer_def(infer, store, source_map, None, krate);
-            }
+            infer_def(infer, store, source_map, self_param, krate);
         }
 
         buf.truncate(buf.trim_end().len());

--- a/crates/hir-ty/src/tests/method_resolution.rs
+++ b/crates/hir-ty/src/tests/method_resolution.rs
@@ -660,7 +660,6 @@ fn infer_call_trait_method_on_generic_param_1() {
         }
         "#,
         expect![[r#"
-            29..33 'self': &'? Self
             63..64 't': T
             69..88 '{     ...d(); }': ()
             75..76 't': T
@@ -681,7 +680,6 @@ fn infer_call_trait_method_on_generic_param_2() {
         }
         "#,
         expect![[r#"
-            32..36 'self': &'? Self
             70..71 't': T
             76..95 '{     ...d(); }': ()
             82..83 't': T
@@ -707,7 +705,6 @@ fn infer_with_multiple_trait_impls() {
         }
         "#,
         expect![[r#"
-            28..32 'self': Self
             110..201 '{     ...(S); }': ()
             120..121 'x': u32
             129..130 'S': S
@@ -1041,7 +1038,6 @@ fn super_trait_impl_return_trait_method_resolution() {
         }
         "#,
         expect![[r#"
-            24..28 'self': Self
             90..101 '{ loop {} }': !
             92..99 'loop {}': !
             97..99 '{}': ()

--- a/crates/hir-ty/src/tests/regression.rs
+++ b/crates/hir-ty/src/tests/regression.rs
@@ -658,8 +658,6 @@ fn issue_4053_diesel_where_clauses() {
         }
         "#,
         expect![[r#"
-            65..69 'self': Self
-            267..271 'self': Self
             466..470 'self': SelectStatement<F, S, D, W, O, LOf, {unknown}, {unknown}>
             488..522 '{     ...     }': ()
             498..502 'self': SelectStatement<F, S, D, W, O, LOf, {unknown}, {unknown}>
@@ -720,7 +718,6 @@ fn issue_4931() {
         }
         "#,
         expect![[r#"
-            117..121 'self': Self
             148..149 'i': T
             154..170 '{     ...w(); }': ()
             160..161 'i': T
@@ -811,7 +808,6 @@ fn issue_4800() {
             401..424 '{     ...     }': dyn Future<Output = ()> + 'static
             411..418 'loop {}': !
             416..418 '{}': ()
-            575..579 'self': &'? mut Self
         "#]],
     );
 }
@@ -1030,7 +1026,6 @@ fn test() {
 }
         "#,
         expect![[r#"
-            176..184 'residual': R
             418..419 'r': ControlFlow<B, !>
             448..476 '{ Cont...ata) }': ControlFlow<B, C>
             450..461 'ControlFlow': fn ControlFlow<B, C>(PhantomData<(B, C)>) -> ControlFlow<B, C>
@@ -2776,8 +2771,6 @@ where
             319..323 'None': Option<T>
             340..343 '&()': &'? ()
             341..343 '()': ()
-            421..425 'self': &'? Self
-            427..433 'filter': &'? Filter<'?, '?, T>
             580..584 'self': &'? [T; N]
             586..592 'filter': &'? Filter<'?, '?, T>
             622..704 '{     ...     }': T

--- a/crates/hir-ty/src/tests/regression/new_solver.rs
+++ b/crates/hir-ty/src/tests/regression/new_solver.rs
@@ -582,6 +582,8 @@ fn test_at_most() {
             200..206 '_other': Between<M, 0, T>
             222..242 '{     ...     }': Between<M, 0, T>
             232..236 'self': Between<M, 0, T>
+            320..335 '{ Consts::MAX }': usize
+            322..333 'Consts::MAX': usize
             300..304 'self': Self
             343..372 '{     ...     }': Between<M, 0, Self>
             353..360 'Between': fn Between<M, 0, Self>(Self) -> Between<M, 0, Self>
@@ -607,10 +609,6 @@ fn test_at_most() {
             623..626 ''9'': char
             623..641 ''9'.at...:<1>()': Between<0, 1, char>
             637..638 '1': usize
-            320..335 '{ Consts::MAX }': usize
-            322..333 'Consts::MAX': usize
-            144..159 '{ Consts::MAX }': usize
-            146..157 'Consts::MAX': usize
         "#]],
     );
 }
@@ -740,7 +738,6 @@ where
 }
 "#,
         expect![[r#"
-            43..47 'self': &'? Self
             168..172 'self': &'? F
             205..227 '{     ...     }': <F as AsyncFnMut<()>>::CallRefFuture<'?>
             215..219 'self': &'? F
@@ -864,7 +861,6 @@ fn main() {
             192..224 '{     ...     }': Option<T>
             202..206 'self': &'? mut Foo<T>
             202..218 'self.n...spec()': Option<T>
-            278..282 'self': &'? mut Self
             380..384 'self': &'? mut Foo<T>
             408..428 '{     ...     }': Option<T>
             418..422 'None': Option<T>
@@ -924,10 +920,6 @@ fn test2<T: FooFactory>(factory: T) {
 }
 "#,
         expect![[r#"
-            39..43 'self': &'? Self
-            101..105 'self': &'? Self
-            198..202 'self': &'? Self
-            239..243 'self': &'? Self
             290..293 'foo': impl Foo + ?Sized
             325..359 '{     ...z(); }': ()
             335..338 'baz': u8

--- a/crates/hir-ty/src/tests/simple.rs
+++ b/crates/hir-ty/src/tests/simple.rs
@@ -4462,3 +4462,15 @@ where
 "#,
     );
 }
+
+#[test]
+fn anon_consts_generic_params() {
+    check_types(
+        r#"
+struct Foo<const N: usize> {
+    a: usize = { {}; N },
+                  // ^ usize
+}
+    "#,
+    );
+}

--- a/crates/hir-ty/src/tests/simple.rs
+++ b/crates/hir-ty/src/tests/simple.rs
@@ -2908,7 +2908,6 @@ struct Astruct;
 impl B for Astruct {}
 "#,
         expect![[r#"
-            428..430 '_x': T
             733..737 'self': Box<[T], A>
             766..798 '{     ...     }': Vec<T, A>
             812..940 '{     ...])); }': ()
@@ -3260,7 +3259,6 @@ fn main() {
 }
         "#,
         expect![[r#"
-            104..108 'self': &'? Box<T>
             188..192 'self': &'_ Box<Foo<T>>
             218..220 '{}': &'? T
             242..246 'self': &'_ Box<Foo<T>>
@@ -4296,10 +4294,10 @@ union U {
 }
     "#,
         expect![[r#"
-            242..243 '0': isize
             111..125 '{ C as usize }': usize
             113..114 'C': f32
             113..123 'C as usize': usize
+            242..243 '0': isize
         "#]],
     );
 }

--- a/crates/hir-ty/src/tests/traits.rs
+++ b/crates/hir-ty/src/tests/traits.rs
@@ -1022,8 +1022,6 @@ fn test(x: impl Trait<u64>, y: &impl Trait<u32>) {
     z.foo2();
 }"#,
         expect![[r#"
-            29..33 'self': &'? Self
-            54..58 'self': &'? Self
             77..78 'x': impl Trait<u16>
             97..99 '{}': ()
             154..155 'x': impl Trait<u64>
@@ -1220,8 +1218,6 @@ fn test(x: impl Trait<u64>, y: &impl Trait<u64>) {
     z.foo2();
 }"#,
         expect![[r#"
-            29..33 'self': &'? Self
-            54..58 'self': &'? Self
             98..100 '{}': ()
             110..111 'x': impl Trait<u64>
             130..131 'y': &'? impl Trait<u64>
@@ -1344,7 +1340,6 @@ fn test() {
     a.foo();
 }"#,
         expect![[r#"
-            29..33 'self': &'? Self
             71..82 '{ loop {} }': !
             73..80 'loop {}': !
             78..80 '{}': ()
@@ -1382,8 +1377,6 @@ fn test() {
     d.foo();
 }"#,
         expect![[r#"
-            49..53 'self': &'? mut Self
-            101..105 'self': &'? Self
             184..195 '{ loop {} }': (impl Iterator<Item = impl Trait<u32>>, impl Trait<u64>)
             186..193 'loop {}': !
             191..193 '{}': ()
@@ -1488,8 +1481,6 @@ fn test(x: Box<dyn Trait<u64>>, y: &dyn Trait<u64>) {
     z.foo2();
 }"#,
         expect![[r#"
-            29..33 'self': &'? Self
-            54..58 'self': &'? Self
             206..208 '{}': Box<dyn Trait<u64> + '?>
             218..219 'x': Box<dyn Trait<u64> + 'static>
             242..243 'y': &'? (dyn Trait<u64> + 'static)
@@ -1536,12 +1527,10 @@ fn test(s: S<u32, i32>) {
     s.bar().baz();
 }"#,
         expect![[r#"
-            32..36 'self': &'? Self
             106..110 'self': &'? S<T, U>
             132..143 '{ loop {} }': &'? (dyn Trait<T, U> + 'static)
             134..141 'loop {}': !
             139..141 '{}': ()
-            179..183 'self': &'? Self
             255..256 's': S<u32, i32>
             271..293 '{     ...z(); }': ()
             277..278 's': S<u32, i32>
@@ -1570,7 +1559,6 @@ fn test(x: Trait, y: &Trait) -> u64 {
     z.foo();
 }"#,
         expect![[r#"
-            26..30 'self': &'? Self
             60..62 '{}': dyn Trait + '?
             72..73 'x': dyn Trait + 'static
             82..83 'y': &'? (dyn Trait + 'static)
@@ -1800,7 +1788,6 @@ fn test<T: Trait1<Type = u32>>(x: T) {
     x.foo();
 }"#,
         expect![[r#"
-            61..65 'self': Self
             163..164 'x': T
             169..185 '{     ...o(); }': ()
             175..176 'x': T
@@ -1992,7 +1979,6 @@ fn test() {
     opt.map(f);
 }"#,
         expect![[r#"
-            28..32 'self': &'? Self
             132..136 'self': &'? Bar<F>
             149..160 '{ loop {} }': (A1, R)
             151..158 'loop {}': !
@@ -2186,7 +2172,6 @@ fn test() {
             112..123 '{ loop {} }': U
             114..121 'loop {}': !
             119..121 '{}': ()
-            158..162 'self': S
             210..214 'self': S
             216..217 'x': T
             222..223 'f': F
@@ -2354,8 +2339,6 @@ impl Trait for S2 {
     fn f(&self, x: <Self>::Item) { let y = x; }
 }"#,
         expect![[r#"
-            40..44 'self': &'? Self
-            46..47 'x': <Self as Trait>::Item
             126..130 'self': &'? S
             132..133 'x': u32
             147..161 '{ let y = x; }': ()
@@ -2914,7 +2897,6 @@ fn main() {
             240..251 '{ loop {} }': ()
             242..249 'loop {}': !
             247..249 '{}': ()
-            360..364 'self': Self
             692..696 'self': I
             703..723 '{     ...     }': I
             713..717 'self': I
@@ -3022,7 +3004,6 @@ fn test() {
     (IsCopy, NotCopy).test();
 }"#,
         expect![[r#"
-            78..82 'self': &'? Self
             134..235 '{     ...t(); }': ()
             140..146 'IsCopy': IsCopy
             140..153 'IsCopy.test()': bool
@@ -3064,7 +3045,6 @@ fn test() {
             28..29 'T': {unknown}
             36..38 '{}': T
             36..38: expected T, got ()
-            113..117 'self': &'? Self
             169..249 '{     ...t(); }': ()
             175..178 'foo': fn foo()
             175..185 'foo.test()': bool
@@ -3092,7 +3072,6 @@ fn test(f1: fn(), f2: fn(usize) -> u8, f3: fn(u8, u8) -> &u8) {
     f3.test();
 }"#,
         expect![[r#"
-            22..26 'self': &'? Self
             76..78 'f1': fn()
             86..88 'f2': fn(usize) -> u8
             107..109 'f3': fn(u8, u8) -> &'? u8
@@ -3122,7 +3101,6 @@ fn test() {
     (1u8, *"foo").test(); // not Sized
 }"#,
         expect![[r#"
-            22..26 'self': &'? Self
             79..194 '{     ...ized }': ()
             85..88 '1u8': u8
             85..95 '1u8.test()': bool
@@ -3504,8 +3482,6 @@ fn test() {
     let r = x.do_op(y);
 }"#,
         expect![[r#"
-            63..67 'self': Self
-            69..72 'rhs': RHS
             153..157 'self': A
             159..162 'rhs': A
             186..206 '{     ...     }': bool
@@ -3779,7 +3755,6 @@ fn main() {
 }
 "#,
         expect![[r#"
-            44..48 'self': &'? Self
             133..137 'self': &'? [u8; 4]
             155..172 '{     ...     }': usize
             165..166 '2': usize
@@ -3827,7 +3802,6 @@ fn main() {
 }
 "#,
         expect![[r#"
-            44..48 'self': &'? Self
             151..155 'self': &'? [u8; L]
             173..194 '{     ...     }': [u8; L]
             183..188 '*self': [u8; L]
@@ -3879,7 +3853,6 @@ impl foo::Foo for u32 {
 }
     "#,
         expect![[r#"
-            45..49 'self': Self
             67..71 'self': Self
             82..87 '{ 0 }': usize
             84..85 '0': usize
@@ -4316,7 +4289,6 @@ fn f<'a>(v: &dyn Trait<Assoc<i32> = &'a i32>) {
 }
     "#,
         expect![[r#"
-            90..94 'self': &'? Self
             127..128 'v': &'? (dyn Trait<Assoc<i32> = &'_ i32> + 'static)
             164..195 '{     ...f(); }': ()
             170..171 'v': &'? (dyn Trait<Assoc<i32> = &'_ i32> + 'static)

--- a/crates/hir-ty/src/variance.rs
+++ b/crates/hir-ty/src/variance.rs
@@ -513,7 +513,7 @@ struct Foo<T: Trait> { //~ ERROR [T: o]
 }
 "#,
             expect![[r#"
-                Foo[T: invariant]
+                Foo[T: bivariant]
             "#]],
         );
     }

--- a/crates/ide-diagnostics/src/handlers/method_call_illegal_sized_bound.rs
+++ b/crates/ide-diagnostics/src/handlers/method_call_illegal_sized_bound.rs
@@ -75,4 +75,39 @@ fn f(s: &S) {
 "#,
         );
     }
+
+    #[test]
+    fn regression_23175() {
+        check_diagnostics(
+            r#"
+//- minicore: sized
+trait Iterator {
+    type Item;
+
+    fn foo(self)
+    where
+        Self: Sized,
+    {
+    }
+}
+impl<T: ?Sized + Iterator> Iterator for &mut T {
+    type Item = T::Item;
+}
+
+trait Helper:
+    Iterator<
+    Item = [(); {
+               {}
+               4
+           }],
+>
+{
+}
+
+fn x(w: &mut dyn Helper) {
+    w.foo();
+}
+        "#,
+        );
+    }
 }


### PR DESCRIPTION
I also took the chance to cleanup the test code for collecting infer defs.

Fixes https://github.com/rust-lang/rust-analyzer/issues/23175. The reason this fixes that is because the issue was the we omitted the projection from the `dyn` type as we incorrectly thought it refers `Self`.

Best reviewed commit-by-commit.