### PR TITLE
fix: Fix unsafeck of `&raw *`

### DIFF
--- a/crates/hir-ty/src/diagnostics/unsafe_check.rs
+++ b/crates/hir-ty/src/diagnostics/unsafe_check.rs
@@ -315,9 +315,7 @@ impl<'db> UnsafeVisitor<'db> {
                     // https://github.com/rust-lang/rust/pull/129248
                     // Taking a raw ref to a deref place expr is always safe.
                     Expr::UnaryOp { expr, op: UnaryOp::Deref } => {
-                        self.body
-                            .walk_child_exprs_without_pats(expr, |child| self.walk_expr(child));
-
+                        self.walk_expr(expr);
                         return;
                     }
                     _ => (),

--- a/crates/ide-diagnostics/src/handlers/missing_unsafe.rs
+++ b/crates/ide-diagnostics/src/handlers/missing_unsafe.rs
@@ -1065,4 +1065,15 @@ fn bar() {
         "#,
         );
     }
+
+    #[test]
+    fn raw_ref_deref_raw_ref_deref() {
+        check_diagnostics(
+            r#"
+fn foo() {
+    &raw const *&raw const *&raw const *&2;
+}
+        "#,
+        );
+    }
 }


### PR DESCRIPTION
We accidentally skipped one level more than needed.

Fixes https://github.com/rust-lang/rust-analyzer/issues/23182.