### PR TITLE
fix: allow `asm!` label blocks to diverge

### DIFF
--- a/crates/hir-ty/src/infer/expr.rs
+++ b/crates/hir-ty/src/infer/expr.rs
@@ -821,7 +821,7 @@ impl<'db> InferenceContext<'db> {
                     }
                 };
 
-                let diverge = asm.options.contains(AsmOptions::NORETURN);
+                let mut diverge = asm.options.contains(AsmOptions::NORETURN);
                 asm.operands.iter().for_each(|(_, operand)| match *operand {
                     AsmOperand::In { expr, .. } => check_expr_asm_operand(self, expr, true),
                     AsmOperand::Out { expr: Some(expr), .. } | AsmOperand::InOut { expr, .. } => {
@@ -835,11 +835,19 @@ impl<'db> InferenceContext<'db> {
                         }
                     }
                     AsmOperand::Label(expr) => {
-                        self.infer_expr(
+                        let previous_diverges = self.diverges;
+                        // The label blocks should have unit return value or diverge.
+                        let ty = self.infer_expr_inner(
                             expr,
                             &Expectation::HasType(self.types.types.unit),
                             ExprIsRead::No,
                         );
+                        if !ty.is_never() {
+                            _ = self.demand_suptype(expr.into(), self.types.types.unit, ty);
+                            diverge = false;
+                        }
+                        // We need this to avoid false unreachable warning when a label diverges.
+                        self.diverges = previous_diverges;
                     }
                     AsmOperand::Const(expr) => {
                         self.infer_expr(expr, &Expectation::None, ExprIsRead::No);

--- a/crates/hir-ty/src/tests/simple.rs
+++ b/crates/hir-ty/src/tests/simple.rs
@@ -4163,6 +4163,27 @@ extern "C" fn foo() -> ! {
 }
 
 #[test]
+fn asm_label_can_diverge() {
+    check_no_mismatches(
+        r#"
+//- minicore: asm
+fn foo() {
+    loop {
+        unsafe {
+            core::arch::asm!(
+                "/* {} */",
+                label {
+                    break;
+                }
+            );
+        }
+    }
+}
+    "#,
+    );
+}
+
+#[test]
 fn regression_21478() {
     check_infer(
         r#"


### PR DESCRIPTION
Closes rust-lang/rust-analyzer#23143

### Summary
`AsmOperand::Label` was inferred with `infer_expr`, it demands the block's type to
be equal to `()`. since a label block containing `break` has type `!`, it reports a
false `expected (), found !`. This follows `check_expr_asm` instead, demanding a
supertype and only when the block does not diverge, and restoring `diverges`
around the block.


AI was used for this contribution, in line with AI_POLICY.md. No code was written with AI. AI was used to setup environment and review changes.