### PR TITLE
fix:prevent stack overflow for recursive ADT layouts

### DIFF
--- a/crates/hir-ty/src/layout/adt.rs
+++ b/crates/hir-ty/src/layout/adt.rs
@@ -16,6 +16,7 @@ use crate::{
     db::HirDatabase,
     layout::{Layout, LayoutCx, LayoutError, field_ty},
     next_solver::StoredGenericArgs,
+    representability::{Representability, representability},
     traits::StoredParamEnvAndCrate,
 };
 
@@ -30,6 +31,9 @@ pub fn layout_of_adt_query(
     let Ok(target) = db.target_data_layout(krate) else {
         return Err(LayoutError::TargetLayoutNotAvailable);
     };
+    if representability(db, def) == Representability::Infinite {
+        return Err(LayoutError::RecursiveTypeWithoutIndirection);
+    }
     let dl = target;
     let cx = LayoutCx::new(dl);
     let handle_variant = |def: VariantId, var: &VariantFields| {

--- a/crates/hir-ty/src/layout/tests.rs
+++ b/crates/hir-ty/src/layout/tests.rs
@@ -275,12 +275,31 @@ fn recursive() {
         struct BoxLike<T: ?Sized>(*mut T);
         struct Goal(BoxLike<Goal>);
     }
+    size_and_align! {
+        struct Foo<T> {
+            x: *const Foo<[T; 1]>,
+            y: *const T,
+        }
+        struct Goal(Foo<Goal>);
+    }
     check_fail(r#"struct Goal(Goal);"#, LayoutError::RecursiveTypeWithoutIndirection);
     check_fail(
         r#"
         struct Foo<T>(Foo<T>);
         struct Goal(Foo<i32>);
         "#,
+        LayoutError::RecursiveTypeWithoutIndirection,
+    );
+    check_fail(
+        r#"
+struct Foo<T> {
+    x: Foo<[T; 1]>,
+    y: T,
+}
+struct Goal {
+    x: Foo<Goal>,
+}
+"#,
         LayoutError::RecursiveTypeWithoutIndirection,
     );
 }


### PR DESCRIPTION
Because the recursion changes the generic argument at every step,like:
```
Bar
Foo<Bar>
Foo<[Bar; 1]>
Foo<[[Bar; 1]; 1]>
```
So Salsa’s normal cycle detection could not detect the recursion.
I used `representability(db, def)` the query only uses AdtId as the key, so when it encounters Foo again, it can be determined as Representability::Infinite
Fix: rust-lang/rust-analyzer#23129 