### PR TITLE
fix: Switch from `temp-dir` to a homemade `NamedTempFile` implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1890,7 +1890,7 @@ dependencies = [
  "paths",
  "proc-macro-test",
  "span",
- "temp-dir",
+ "stdx",
 ]
 
 [[package]]
@@ -1966,7 +1966,6 @@ dependencies = [
  "serde_json",
  "span",
  "stdx",
- "temp-dir",
  "toml",
  "toolchain",
  "tracing",
@@ -2751,12 +2750,6 @@ dependencies = [
  "test-utils",
  "tt",
 ]
-
-[[package]]
-name = "temp-dir"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "016ef9739649996fcc983b9c588fe3d557cf216d4d98503ce1b057ab5a66d689"
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,7 +143,6 @@ smallvec = { version = "1.15.1", features = [
     "const_generics",
 ] }
 smol_str = "0.3.2"
-temp-dir = "0.2.0"
 text-size = "1.1.1"
 toml = "1.1.2"
 tracing = { version = "0.1.41", default-features = false, features = ["std"] }

--- a/crates/proc-macro-srv/Cargo.toml
+++ b/crates/proc-macro-srv/Cargo.toml
@@ -13,13 +13,11 @@ rust-version.workspace = true
 doctest = false
 
 [dependencies]
-temp-dir.workspace = true
-
 paths.workspace = true
 # span = {workspace = true, default-features = false} does not work
 span = { path = "../span", version = "0.0.0", default-features = false}
 intern.workspace = true
-
+stdx.workspace = true
 
 [dev-dependencies]
 expect-test.workspace = true

--- a/crates/proc-macro-srv/src/dylib.rs
+++ b/crates/proc-macro-srv/src/dylib.rs
@@ -2,13 +2,12 @@
 
 mod proc_macros;
 
+use paths::{Utf8Path, Utf8PathBuf};
 use rustc_codegen_ssa::back::metadata::DefaultMetadataLoader;
 use rustc_interface::util::rustc_version_str;
 use rustc_proc_macro::bridge;
-use std::{fs, io, time::SystemTime};
-use temp_dir::TempDir;
-
-use paths::{Utf8Path, Utf8PathBuf};
+use std::{fs, io, path::Path, time::SystemTime};
+use stdx::tempfile::NamedTempFile;
 
 use crate::{
     PanicMessage, ProcMacroClientHandle, ProcMacroKind, ProcMacroSrvSpan, TrackedEnv,
@@ -18,19 +17,20 @@ use crate::{
 pub(crate) struct Expander {
     inner: ProcMacroLibrary,
     modified_time: SystemTime,
+    _file: NamedTempFile,
 }
 
 impl Expander {
-    pub(crate) fn new(temp_dir: &TempDir, lib: &Utf8Path) -> io::Result<Expander> {
+    pub(crate) fn new(lib: &Utf8Path) -> io::Result<Expander> {
         // Some libraries for dynamic loading require canonicalized path even when it is
         // already absolute
         let lib = lib.canonicalize_utf8()?;
         let modified_time = fs::metadata(&lib).and_then(|it| it.modified())?;
 
-        let path = ensure_file_with_lock_free_access(temp_dir, &lib)?;
-        let library = ProcMacroLibrary::open(path.as_ref())?;
+        let file = ensure_file_with_lock_free_access(lib)?;
+        let library = ProcMacroLibrary::open(file.path())?;
 
-        Ok(Expander { inner: library, modified_time })
+        Ok(Expander { inner: library, modified_time, _file: file })
     }
 
     pub(crate) fn expand<'a, S: ProcMacroSrvSpan + 'a>(
@@ -73,10 +73,10 @@ struct ProcMacroLibrary {
 }
 
 impl ProcMacroLibrary {
-    fn open(path: &Utf8Path) -> io::Result<Self> {
+    fn open(path: &Path) -> io::Result<Self> {
         let proc_macros = rustc_span::create_default_session_globals_then(|| {
             rustc_metadata::locator::get_proc_macros(
-                path.as_ref(),
+                path,
                 &DefaultMetadataLoader,
                 rustc_version_str().unwrap_or("unknown"),
             )
@@ -88,37 +88,19 @@ impl ProcMacroLibrary {
 
 /// Copy the dylib to temp directory to prevent locking in Windows
 #[cfg(windows)]
-fn ensure_file_with_lock_free_access(
-    temp_dir: &TempDir,
-    path: &Utf8Path,
-) -> io::Result<Utf8PathBuf> {
-    use std::collections::hash_map::RandomState;
-    use std::hash::{BuildHasher, Hasher};
-
+fn ensure_file_with_lock_free_access(path: Utf8PathBuf) -> io::Result<NamedTempFile> {
     if std::env::var("RA_DONT_COPY_PROC_MACRO_DLL").is_ok() {
-        return Ok(path.to_path_buf());
+        return Ok(NamedTempFile::from_path(path.into_std_path_buf()));
     }
-
-    let mut to = Utf8Path::from_path(temp_dir.path()).unwrap().to_owned();
 
     let file_name = path.file_stem().ok_or_else(|| {
         io::Error::new(io::ErrorKind::InvalidInput, format!("File path is invalid: {path}"))
     })?;
 
-    to.push({
-        // Generate a unique number by abusing `HashMap`'s hasher.
-        // Maybe this will also "inspire" a libs team member to finally put `rand` in libstd.
-        let unique_name = RandomState::new().build_hasher().finish();
-        format!("{file_name}-{unique_name}.dll")
-    });
-    fs::copy(path, &to)?;
-    Ok(to)
+    NamedTempFile::new_from_existing(&format!("proc-macro-srv-{file_name}.dll"), path.as_std_path())
 }
 
 #[cfg(unix)]
-fn ensure_file_with_lock_free_access(
-    _temp_dir: &TempDir,
-    path: &Utf8Path,
-) -> io::Result<Utf8PathBuf> {
-    Ok(path.to_owned())
+fn ensure_file_with_lock_free_access(path: Utf8PathBuf) -> io::Result<NamedTempFile> {
+    Ok(NamedTempFile::from_path(path.into_std_path_buf()))
 }

--- a/crates/proc-macro-srv/src/lib.rs
+++ b/crates/proc-macro-srv/src/lib.rs
@@ -41,7 +41,6 @@ use std::{
 
 use paths::{Utf8Path, Utf8PathBuf};
 use span::{FIXUP_ERASED_FILE_AST_ID_MARKER, Span};
-use temp_dir::TempDir;
 
 pub use crate::server_impl::token_id::SpanId;
 
@@ -64,16 +63,11 @@ pub const RUSTC_VERSION_STRING: &str = env!("RUSTC_VERSION");
 pub struct ProcMacroSrv<'env> {
     expanders: Mutex<HashMap<Utf8PathBuf, Arc<dylib::Expander>>>,
     env: &'env EnvSnapshot,
-    temp_dir: TempDir,
 }
 
 impl<'env> ProcMacroSrv<'env> {
     pub fn new(env: &'env EnvSnapshot) -> Self {
-        Self {
-            expanders: Default::default(),
-            env,
-            temp_dir: TempDir::with_prefix("proc-macro-srv").unwrap(),
-        }
+        Self { expanders: Default::default(), env }
     }
 
     pub fn join_spans(&self, first: Span, second: Span) -> Option<Span> {
@@ -205,7 +199,7 @@ impl ProcMacroSrv<'_> {
 
     fn expander(&self, path: &Utf8Path) -> Result<Arc<dylib::Expander>, String> {
         let expander = || {
-            let expander = dylib::Expander::new(&self.temp_dir, path)
+            let expander = dylib::Expander::new(path)
                 .map_err(|err| format!("Cannot create expander for {path}: {err}",));
             expander.map(Arc::new)
         };

--- a/crates/proc-macro-srv/src/tests/utils.rs
+++ b/crates/proc-macro-srv/src/tests/utils.rs
@@ -56,7 +56,7 @@ fn assert_expand_impl(
     expect_spanned: Expect,
 ) {
     let path = proc_macro_test_dylib_path();
-    let expander = dylib::Expander::new(&temp_dir::TempDir::new().unwrap(), &path).unwrap();
+    let expander = dylib::Expander::new(&path).unwrap();
 
     let def_site = SpanId(0);
     let call_site = SpanId(1);
@@ -186,7 +186,7 @@ pub fn assert_expand_with_callback(
     expect_spanned: Expect,
 ) {
     let path = proc_macro_test_dylib_path();
-    let expander = dylib::Expander::new(&temp_dir::TempDir::new().unwrap(), &path).unwrap();
+    let expander = dylib::Expander::new(&path).unwrap();
 
     let def_site = Span {
         range: TextRange::new(0.into(), 150.into()),

--- a/crates/project-model/Cargo.toml
+++ b/crates/project-model/Cargo.toml
@@ -20,7 +20,6 @@ semver.workspace = true
 serde_json.workspace = true
 serde.workspace = true
 serde_derive.workspace = true
-temp-dir.workspace = true
 toml.workspace = true
 tracing = { workspace = true, features = ["attributes"] }
 triomphe.workspace = true

--- a/crates/project-model/src/cargo_config_file.rs
+++ b/crates/project-model/src/cargo_config_file.rs
@@ -1,6 +1,7 @@
 //! Read `.cargo/config.toml` as a TOML table
 use paths::{AbsPath, Utf8Path, Utf8PathBuf};
 use rustc_hash::FxHashMap;
+use stdx::tempfile::NamedTempFile;
 use toml::{
     Spanned,
     de::{DeTable, DeValue},
@@ -139,7 +140,7 @@ impl<'a> CargoConfigFileReader<'a> {
 pub(crate) struct LockfileCopy {
     pub(crate) path: Utf8PathBuf,
     pub(crate) usage: LockfileUsage,
-    _temp_dir: temp_dir::TempDir,
+    _temp_file: NamedTempFile,
 }
 
 pub(crate) enum LockfileUsage {
@@ -193,22 +194,12 @@ pub(crate) fn make_lockfile_copy(
         return None;
     };
 
-    let temp_dir = temp_dir::TempDir::with_prefix("rust-analyzer").ok()?;
-    let path: Utf8PathBuf = temp_dir.path().join("Cargo.lock").try_into().ok()?;
-    let path = match std::fs::copy(lockfile_path, &path) {
-        Ok(_) => {
-            tracing::debug!("Copied lock file from `{}` to `{}`", lockfile_path, path);
-            path
-        }
-        // lockfile does not yet exist, so we can just create a new one in the temp dir
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => path,
-        Err(e) => {
-            tracing::warn!("Failed to copy lock file from `{lockfile_path}` to `{path}`: {e}",);
-            return None;
-        }
-    };
+    let temp_file =
+        NamedTempFile::new_from_existing("rust-analyzer-Cargo.lock", lockfile_path.as_std_path())
+            .ok()?;
+    let path = Utf8Path::from_path(temp_file.path())?.to_path_buf();
 
-    Some(LockfileCopy { path, usage, _temp_dir: temp_dir })
+    Some(LockfileCopy { path, usage, _temp_file: temp_file })
 }
 
 #[test]

--- a/crates/stdx/src/lib.rs
+++ b/crates/stdx/src/lib.rs
@@ -13,6 +13,7 @@ pub mod non_empty_vec;
 pub mod panic_context;
 pub mod process;
 pub mod rand;
+pub mod tempfile;
 pub mod thread;
 pub mod variance;
 

--- a/crates/stdx/src/tempfile.rs
+++ b/crates/stdx/src/tempfile.rs
@@ -1,0 +1,164 @@
+//! A temporary named file that will be deleted on drop, and on operating systems that support that,
+//! also when the process exits (including being killed).
+
+use std::{
+    fs::File,
+    io,
+    path::{Path, PathBuf},
+};
+
+pub struct NamedTempFile {
+    _file: Option<File>,
+    path: PathBuf,
+    delete_on_drop: bool,
+}
+
+impl NamedTempFile {
+    pub fn new(prefix: &str) -> io::Result<NamedTempFile> {
+        imp::create(prefix)
+    }
+
+    /// Creates a new `NamedTempFile` that is a copy of an existing file.
+    pub fn new_from_existing(prefix: &str, existing: &Path) -> io::Result<NamedTempFile> {
+        let result = NamedTempFile::new(prefix)?;
+        std::fs::copy(existing, &result.path)?;
+        Ok(result)
+    }
+
+    /// Creates a `NamedTempFile` from a path, without deleting it on drop.
+    #[inline]
+    pub fn from_path(path: PathBuf) -> NamedTempFile {
+        NamedTempFile { _file: None, path, delete_on_drop: false }
+    }
+
+    #[inline]
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for NamedTempFile {
+    fn drop(&mut self) {
+        if self.delete_on_drop && std::fs::remove_file(&self.path).is_err() {
+            tracing::info!("cannot remove temporary file {}", self.path.display());
+        }
+    }
+}
+
+mod general_imp {
+    use std::{
+        fs::{File, OpenOptions},
+        io::{self, ErrorKind},
+        path::PathBuf,
+        sync::atomic::{AtomicU32, Ordering},
+    };
+
+    static INTERNAL_COUNTER: AtomicU32 = AtomicU32::new(0);
+
+    pub(super) fn create(
+        prefix: &str,
+        mut options_callback: impl FnMut(&mut OpenOptions),
+    ) -> io::Result<(File, PathBuf)> {
+        let temp_dir = std::env::temp_dir().canonicalize()?;
+        let pid = std::process::id();
+        loop {
+            let path = temp_dir.join(format!(
+                "{prefix}{pid:x}-{:x}",
+                INTERNAL_COUNTER.fetch_add(1, Ordering::AcqRel),
+            ));
+            let mut open_options = OpenOptions::new();
+            open_options.create_new(true);
+            options_callback(&mut open_options);
+            match open_options.open(&path) {
+                Err(e) if e.kind() == ErrorKind::AlreadyExists => {}
+                Err(e) => {
+                    return Err(io::Error::new(
+                        e.kind(),
+                        format!("error creating directory {path:?}: {e}"),
+                    ));
+                }
+                Ok(file) => {
+                    return Ok((file, path));
+                }
+            }
+        }
+    }
+}
+
+#[cfg(any(
+    target_os = "linux",
+    target_os = "freebsd",
+    target_os = "openbsd",
+    target_os = "netbsd",
+))]
+mod imp {
+    use std::{
+        ffi::CString,
+        io,
+        os::{
+            fd::{AsRawFd, RawFd},
+            unix::ffi::OsStrExt,
+        },
+    };
+
+    use super::*;
+
+    #[cfg(target_os = "linux")]
+    fn path_after_unlink(fd: RawFd) -> PathBuf {
+        PathBuf::from(format!("/proc/self/fd/{fd}"))
+    }
+
+    #[cfg(any(target_os = "freebsd", target_os = "openbsd", target_os = "netbsd"))]
+    fn path_after_unlink(fd: RawFd) -> PathBuf {
+        PathBuf::from(format!("/dev/fd/{fd}"))
+    }
+
+    pub(super) fn create(prefix: &str) -> io::Result<NamedTempFile> {
+        let (file, mut path) = general_imp::create(prefix, |_| {})?;
+        let mut delete_on_drop = true;
+        if let Ok(original_path) = CString::new(path.as_os_str().as_bytes()) {
+            // Unlinking the file will *not* remove it per the POSIX specification since it is open.
+            // We cannot use `std::fs::remove_file()`, since, while currently using `unlink()`, it does
+            // not guarantee it will use it.
+            if unsafe { libc::unlink(original_path.as_ptr()) } == 0 {
+                path = path_after_unlink(file.as_raw_fd());
+                delete_on_drop = false;
+            }
+        }
+        Ok(NamedTempFile { _file: Some(file), path, delete_on_drop })
+    }
+}
+
+#[cfg(windows)]
+mod imp {
+    use std::os::windows::fs::OpenOptionsExt;
+
+    use super::*;
+
+    const FILE_ATTRIBUTE_TEMPORARY: u32 = 0x100;
+    const FILE_FLAG_DELETE_ON_CLOSE: u32 = 0x04000000;
+
+    pub(super) fn create(prefix: &str) -> io::Result<NamedTempFile> {
+        let (file, path) = general_imp::create(prefix, |options| {
+            options.attributes(FILE_ATTRIBUTE_TEMPORARY);
+            options.custom_flags(FILE_FLAG_DELETE_ON_CLOSE);
+        })?;
+        Ok(NamedTempFile { _file: Some(file), path, delete_on_drop: false })
+    }
+}
+
+#[cfg(not(any(
+    target_os = "linux",
+    target_os = "freebsd",
+    target_os = "openbsd",
+    target_os = "netbsd",
+    windows,
+)))]
+mod imp {
+    use super::*;
+
+    pub(super) fn create(prefix: &str) -> io::Result<NamedTempFile> {
+        let (file, path) = general_imp::create(prefix, |_| {})?;
+        Ok(NamedTempFile { _file: Some(file), path, delete_on_drop: true })
+    }
+}


### PR DESCRIPTION
That also deletes the file when the process exits without being dropped; this is important especially for the proc macro server since it is killed and does not exit normally.

Linux and the BSDs unlink the file then access it via `/proc/self/fd` or `/dev/fd`; Windows has a dedicated API for that; and macOS unfortunately does not support that (the file is not removed after being unlinked, but you cannot access it anymore via `/dev/fd`, or at least that's what the AI said - I don't have a macOS machine to check).

Fixes https://github.com/rust-lang/rust-analyzer/issues/23203.