### PR TITLE
internal: Offer `replace_arith` on `.pow()` and unary negation

### DIFF
--- a/crates/ide-assists/src/handlers/replace_arith_op.rs
+++ b/crates/ide-assists/src/handlers/replace_arith_op.rs
@@ -1,7 +1,7 @@
 use ide_db::assists::{AssistId, GroupLabel};
 use syntax::{
     AstNode, T,
-    ast::{self, ArithOp, BinaryOp},
+    ast::{self, ArithOp, BinaryOp, HasArgList, UnaryOp, syntax_factory::SyntaxFactory},
 };
 
 use crate::{
@@ -98,10 +98,10 @@ pub(crate) fn replace_arith_with_wrapping(
 }
 
 fn replace_arith(acc: &mut Assists, ctx: &AssistContext<'_, '_>, kind: ArithKind) -> Option<()> {
-    let (lhs, op, is_assign, rhs) = parse_binary_op(ctx)?;
-    let op_expr = lhs.syntax().parent()?;
+    let arith = parse_arith_expr(ctx)?;
+    let op_expr = arith.root().syntax().clone();
 
-    if !is_primitive_int_or_ref(ctx, &lhs) || !is_primitive_int_or_ref(ctx, &rhs) {
+    if !arith.has_int_operands(ctx) {
         return None;
     }
 
@@ -111,31 +111,18 @@ fn replace_arith(acc: &mut Assists, ctx: &AssistContext<'_, '_>, kind: ArithKind
         kind.label(),
         op_expr.text_range(),
         |builder| {
-            let editor = builder.make_editor(rhs.syntax());
+            let editor = builder.make_editor(&op_expr);
             let make = editor.make();
-            let method_name = kind.method_name(op);
+            let method_name = kind.method_name(&arith);
 
-            let receiver = wrap_paren(lhs.clone(), make, ast::prec::ExprPrecedence::Postfix);
+            let receiver =
+                wrap_paren(arith.receiver().clone(), make, ast::prec::ExprPrecedence::Postfix);
 
-            let mut rhs = rhs;
-
-            if let Some(ty) = ctx.sema.type_of_expr(&rhs) {
-                let adjusted = ty.adjusted();
-                if adjusted.strip_reference() != adjusted {
-                    rhs = if let ast::Expr::RefExpr(ref_expr) = &rhs
-                        && let Some(inner) = ref_expr.expr()
-                    {
-                        inner
-                    } else {
-                        make.expr_prefix(T![*], rhs).into()
-                    };
-                }
-            }
-
+            let arg = arith.adjust_arg(ctx, make);
             let mut arith_expr = make
-                .expr_method_call(receiver, make.name_ref(&method_name), make.arg_list([rhs]))
+                .expr_method_call(receiver, make.name_ref(&method_name), make.arg_list(arg))
                 .into();
-            if is_assign {
+            if let Some(lhs) = arith.lhs_for_assign() {
                 arith_expr = make.expr_assignment(lhs, arith_expr).into();
             }
             editor.replace(op_expr, arith_expr.syntax());
@@ -151,11 +138,125 @@ fn is_primitive_int_or_ref(ctx: &AssistContext<'_, '_>, expr: &ast::Expr) -> boo
     }
 }
 
-/// Extract the operands of an arithmetic expression (e.g. `1 + 2` or `1.checked_add(2)`)
-fn parse_binary_op(ctx: &AssistContext<'_, '_>) -> Option<(ast::Expr, ArithOp, bool, ast::Expr)> {
+/// An arithmetic expression the assist can rewrite into an overflow-checking
+/// method call: a binary operation (`1 + 2`), a `.pow` call (`x.pow(2)`) or a
+/// unary negation (`-x`).
+enum ArithExpr {
+    Binary { expr: ast::Expr, lhs: ast::Expr, op: ArithOp, is_assign: bool, rhs: ast::Expr },
+    Pow { expr: ast::Expr, receiver: ast::Expr, exponent: ast::Expr },
+    Neg { expr: ast::Expr, operand: ast::Expr },
+}
+
+impl ArithExpr {
+    /// The whole expression that gets replaced by the method call.
+    fn root(&self) -> &ast::Expr {
+        match self {
+            ArithExpr::Binary { expr, .. }
+            | ArithExpr::Pow { expr, .. }
+            | ArithExpr::Neg { expr, .. } => expr,
+        }
+    }
+
+    /// The expression the rewritten method is called on.
+    fn receiver(&self) -> &ast::Expr {
+        match self {
+            ArithExpr::Binary { lhs, .. } => lhs,
+            ArithExpr::Pow { receiver, .. } => receiver,
+            ArithExpr::Neg { operand, .. } => operand,
+        }
+    }
+
+    fn has_int_operands(&self, ctx: &AssistContext<'_, '_>) -> bool {
+        match self {
+            ArithExpr::Binary { lhs, rhs, .. } => {
+                is_primitive_int_or_ref(ctx, lhs) && is_primitive_int_or_ref(ctx, rhs)
+            }
+            ArithExpr::Pow { receiver, exponent, .. } => {
+                is_primitive_int_or_ref(ctx, receiver) && is_primitive_int_or_ref(ctx, exponent)
+            }
+            ArithExpr::Neg { operand, .. } => is_primitive_int_or_ref(ctx, operand),
+        }
+    }
+
+    /// The argument(s) of the rewritten method call.
+    fn adjust_arg(&self, ctx: &AssistContext<'_, '_>, make: &SyntaxFactory) -> Vec<ast::Expr> {
+        match self {
+            ArithExpr::Binary { rhs, .. } | ArithExpr::Pow { exponent: rhs, .. } => {
+                vec![strip_reference(ctx, make, rhs.clone())]
+            }
+            ArithExpr::Neg { .. } => Vec::new(),
+        }
+    }
+
+    fn lhs_for_assign(&self) -> Option<ast::Expr> {
+        match self {
+            ArithExpr::Binary { lhs, is_assign: true, .. } => Some(lhs.clone()),
+            _ => None,
+        }
+    }
+
+    /// The method suffix, e.g. `add`, `pow` or `neg`.
+    fn method_suffix(&self) -> &'static str {
+        match self {
+            ArithExpr::Binary { op, .. } => match op {
+                ArithOp::Add => "add",
+                ArithOp::Sub => "sub",
+                ArithOp::Mul => "mul",
+                ArithOp::Div => "div",
+                _ => unreachable!("this function should only be called with +, -, / or *"),
+            },
+            ArithExpr::Pow { .. } => "pow",
+            ArithExpr::Neg { .. } => "neg",
+        }
+    }
+}
+
+fn strip_reference(
+    ctx: &AssistContext<'_, '_>,
+    make: &SyntaxFactory,
+    mut arg: ast::Expr,
+) -> ast::Expr {
+    if let Some(ty) = ctx.sema.type_of_expr(&arg) {
+        let adjusted = ty.adjusted();
+        if adjusted.strip_reference() != adjusted {
+            arg = if let ast::Expr::RefExpr(ref_expr) = &arg
+                && let Some(inner) = ref_expr.expr()
+            {
+                inner
+            } else {
+                make.expr_prefix(T![*], arg).into()
+            };
+        }
+    }
+    arg
+}
+
+/// Extract the arithmetic expression to rewrite at the cursor.
+fn parse_arith_expr(ctx: &AssistContext<'_, '_>) -> Option<ArithExpr> {
     if !ctx.has_empty_selection() {
         return None;
     }
+
+    if let Some((lhs, op, is_assign, rhs)) = parse_binary_op(ctx) {
+        let expr: ast::Expr = ast::BinExpr::cast(lhs.syntax().parent()?)?.into();
+        return Some(ArithExpr::Binary { expr, lhs, op, is_assign, rhs });
+    }
+
+    if let Some((receiver, exponent)) = parse_pow(ctx) {
+        let expr: ast::Expr = ast::MethodCallExpr::cast(receiver.syntax().parent()?)?.into();
+        return Some(ArithExpr::Pow { expr, receiver, exponent });
+    }
+
+    if let Some(operand) = parse_neg(ctx) {
+        let expr: ast::Expr = ast::PrefixExpr::cast(operand.syntax().parent()?)?.into();
+        return Some(ArithExpr::Neg { expr, operand });
+    }
+
+    None
+}
+
+/// Extract the operands of a binary arithmetic expression (e.g. `1 + 2`).
+fn parse_binary_op(ctx: &AssistContext<'_, '_>) -> Option<(ast::Expr, ArithOp, bool, ast::Expr)> {
     let expr = ctx.find_node_at_offset::<ast::BinExpr>()?;
 
     let (op, is_assign) = match expr.op_kind()? {
@@ -171,6 +272,33 @@ fn parse_binary_op(ctx: &AssistContext<'_, '_>) -> Option<(ast::Expr, ArithOp, b
     let rhs = expr.rhs()?;
 
     Some((lhs, op, is_assign, rhs))
+}
+
+/// Extract the receiver and exponent of a `.pow()` call (e.g. `x.pow(2)`).
+fn parse_pow(ctx: &AssistContext<'_, '_>) -> Option<(ast::Expr, ast::Expr)> {
+    let expr = ctx.find_node_at_offset::<ast::MethodCallExpr>()?;
+    if expr.name_ref()?.text() != "pow" {
+        return None;
+    }
+
+    let receiver = expr.receiver()?;
+    let mut args = expr.arg_list()?.args();
+    let exponent = args.next()?;
+    if args.next().is_some() {
+        return None;
+    }
+
+    Some((receiver, exponent))
+}
+
+/// Extract the operand of a unary negation (e.g. `-x`).
+fn parse_neg(ctx: &AssistContext<'_, '_>) -> Option<ast::Expr> {
+    let expr = ctx.find_node_at_offset::<ast::PrefixExpr>()?;
+    if expr.op_kind()? != UnaryOp::Neg {
+        return None;
+    }
+
+    expr.expr()
 }
 
 pub(crate) enum ArithKind {
@@ -201,7 +329,7 @@ impl ArithKind {
         }
     }
 
-    fn method_name(&self, op: ArithOp) -> String {
+    fn method_name(&self, arith: &ArithExpr) -> String {
         let prefix = match self {
             ArithKind::Checked => "checked_",
             ArithKind::Wrapping => "wrapping_",
@@ -209,14 +337,7 @@ impl ArithKind {
             ArithKind::Strict => "strict_",
         };
 
-        let suffix = match op {
-            ArithOp::Add => "add",
-            ArithOp::Sub => "sub",
-            ArithOp::Mul => "mul",
-            ArithOp::Div => "div",
-            _ => unreachable!("this function should only be called with +, -, / or *"),
-        };
-        format!("{prefix}{suffix}")
+        format!("{prefix}{}", arith.method_suffix())
     }
 }
 
@@ -228,8 +349,24 @@ mod tests {
 
     #[test]
     fn arith_kind_method_name() {
-        assert_eq!(ArithKind::Saturating.method_name(ArithOp::Add), "saturating_add");
-        assert_eq!(ArithKind::Checked.method_name(ArithOp::Sub), "checked_sub");
+        let make = SyntaxFactory::default();
+        let unit = make.expr_unit();
+        let binary = ArithExpr::Binary {
+            expr: unit.clone(),
+            lhs: unit.clone(),
+            op: ArithOp::Add,
+            is_assign: false,
+            rhs: unit.clone(),
+        };
+        let pow =
+            ArithExpr::Pow { expr: unit.clone(), receiver: unit.clone(), exponent: unit.clone() };
+        let neg = ArithExpr::Neg { expr: unit.clone(), operand: unit.clone() };
+
+        assert_eq!(ArithKind::Saturating.method_name(&binary), "saturating_add");
+        assert_eq!(ArithKind::Checked.method_name(&binary), "checked_add");
+        assert_eq!(ArithKind::Wrapping.method_name(&pow), "wrapping_pow");
+        assert_eq!(ArithKind::Checked.method_name(&neg), "checked_neg");
+        assert_eq!(ArithKind::Strict.method_name(&neg), "strict_neg");
     }
 
     #[test]
@@ -404,6 +541,146 @@ fn main() {
 //- minicore: add, builtin_impls
 fn main() {
     let x = 1 $0+$0 2;
+}
+"#,
+        )
+    }
+
+    #[test]
+    fn replace_arith_with_wrapping_pow() {
+        check_assist(
+            replace_arith_with_wrapping,
+            r#"
+fn main() {
+    let x = 2i32;
+    x.$0pow(4u32);
+}
+"#,
+            r#"
+fn main() {
+    let x = 2i32;
+    x.wrapping_pow(4u32);
+}
+"#,
+        )
+    }
+
+    #[test]
+    fn replace_arith_with_checked_pow() {
+        check_assist(
+            replace_arith_with_checked,
+            r#"
+fn main() {
+    let x = 2i32;
+    x.$0pow(4u32);
+}
+"#,
+            r#"
+fn main() {
+    let x = 2i32;
+    x.checked_pow(4u32);
+}
+"#,
+        )
+    }
+
+    #[test]
+    fn replace_arith_with_wrapping_pow_ref() {
+        check_assist(
+            replace_arith_with_wrapping,
+            r#"
+fn main() {
+    let x = 2i32;
+    x.$0pow(&4u32);
+}
+"#,
+            r#"
+fn main() {
+    let x = 2i32;
+    x.wrapping_pow(4u32);
+}
+"#,
+        )
+    }
+
+    #[test]
+    fn replace_arith_with_wrapping_neg() {
+        check_assist(
+            replace_arith_with_wrapping,
+            r#"
+fn main() {
+    let x = 2i32;
+    let y = -$0x;
+}
+"#,
+            r#"
+fn main() {
+    let x = 2i32;
+    let y = x.wrapping_neg();
+}
+"#,
+        )
+    }
+
+    #[test]
+    fn replace_arith_with_saturating_neg() {
+        check_assist(
+            replace_arith_with_saturating,
+            r#"
+fn main() {
+    let x = 2i32;
+    let y = -$0x;
+}
+"#,
+            r#"
+fn main() {
+    let x = 2i32;
+    let y = x.saturating_neg();
+}
+"#,
+        )
+    }
+
+    #[test]
+    fn replace_arith_with_wrapping_neg_needs_parentheses() {
+        check_assist(
+            replace_arith_with_wrapping,
+            r#"
+fn main() {
+    let x = 2i32;
+    let y = $0--x;
+}
+"#,
+            r#"
+fn main() {
+    let x = 2i32;
+    let y = (-x).wrapping_neg();
+}
+"#,
+        )
+    }
+
+    #[test]
+    fn replace_arith_not_applicable_on_pow_with_multiple_args() {
+        check_assist_not_applicable(
+            replace_arith_with_wrapping,
+            r#"
+fn main() {
+    let x = 2i32;
+    x.$0pow(4u32, 3u32);
+}
+"#,
+        )
+    }
+
+    #[test]
+    fn replace_arith_not_applicable_on_non_neg_prefix() {
+        check_assist_not_applicable(
+            replace_arith_with_wrapping,
+            r#"
+fn main() {
+    let x = true;
+    !$0x;
 }
 "#,
         )


### PR DESCRIPTION
Extends the `replace_arith_with_*` assists (checked/wrapping/saturating/strict) beyond plain binary `+ - * /` so they are also offered on:

- `x.pow(e)` method calls → `x.checked_pow(e)` / `x.wrapping_pow(e)` / `x.saturating_pow(e)` / `x.strict_pow(e)`
- unary negation `-x` → `x.checked_neg()` / `x.wrapping_neg()` / `x.saturating_neg()` / `x.strict_neg()`

These were the remaining arithmetic forms with overflow-specified variants that the assist did not cover (issue rust-lang/rust-analyzer#23153).

The handler now parses the expression under the cursor into a small `ArithExpr` enum (binary op / `.pow` call / unary negation) so the rewrite logic is shared. Reference operands are dereferenced as before, parentheses are added where needed for precedence (e.g. `--x` → `(-x).wrapping_neg()`), and `.pow` is only matched with exactly one argument.

Tests: `cargo test -p ide-assists` (2818 passed, 0 failed), `cargo fmt --check` clean, `cargo clippy -p ide-assists --all-targets` clean.