### PR TITLE
minor: Remove two unused public methods

### DIFF
--- a/crates/intern/src/symbol.rs
+++ b/crates/intern/src/symbol.rs
@@ -175,19 +175,6 @@ impl Symbol {
     }
 
     #[inline]
-    pub fn into_raw(self) -> NonNull<*const str> {
-        ManuallyDrop::new(self).repr.packed
-    }
-
-    /// # Safety
-    ///
-    /// The pointer must have come from [`Symbol::into_raw()`].
-    #[inline]
-    pub unsafe fn from_raw(ptr: NonNull<*const str>) -> Symbol {
-        Symbol { repr: TaggedArcPtr { packed: ptr } }
-    }
-
-    #[inline]
     fn select_shard(
         storage: &'static Map,
         s: &str,


### PR DESCRIPTION
I forgot to change this when I changed https://github.com/rust-lang/rust-analyzer/pull/23079.