### PR TITLE
feat: Allow “Extract variable” to be invoked on field names in record expressions.

### DIFF
--- a/crates/ide-assists/src/handlers/extract_variable.rs
+++ b/crates/ide-assists/src/handlers/extract_variable.rs
@@ -76,10 +76,16 @@ pub(crate) fn extract_variable(acc: &mut Assists, ctx: &AssistContext<'_, '_>) -
         if let Some(t) = ctx.token_at_offset().find(|it| it.kind() == T![;]) {
             t.parent().and_then(ast::ExprStmt::cast)?.syntax().clone()
         } else {
-            let expr = ancestors_at_offset(ctx.source_file().syntax(), ctx.offset())
-                .next()
-                .and_then(ast::Expr::cast)?;
-            expr.syntax().ancestors().find_map(valid_target_expr(ctx))?.syntax().clone()
+            // Offer the assist only if the nearest syntax node is an expression, or a record
+            // field, or a record field’s name. This prevents the assist from appearing when
+            // it is unlikely to be relevant, such as when the cursor is in a pattern.
+            // (If we did not want to restrict it this way, we could just apply
+            // `valid_target_expr()` to all ancestors.)
+            let expr_or_field = ancestors_at_offset(ctx.source_file().syntax(), ctx.offset())
+                .find(|it| !ast::NameRef::can_cast(it.kind()))
+                .and_then(either::Either::<ast::Expr, ast::RecordExprField>::cast)?;
+
+            expr_or_field.syntax().ancestors().find_map(valid_target_expr(ctx))?.syntax().clone()
         }
     } else {
         match ctx.covering_element() {
@@ -366,6 +372,11 @@ fn valid_target_expr(ctx: &AssistContext<'_, '_>) -> impl Fn(SyntaxNode) -> Opti
             let path_expr = ast::PathExpr::cast(node)?;
             let path_resolution = ctx.sema.resolve_path(&path_expr.path()?)?;
             like_const_value(ctx, path_resolution).then_some(path_expr.into())
+        }
+        SyntaxKind::RECORD_EXPR_FIELD => {
+            // If we are on `k` in `Struct { k: v }`, then extract `v`.
+            let record_field = ast::RecordExprField::cast(node)?;
+            record_field.expr()
         }
         _ => ast::Expr::cast(node),
     }
@@ -1589,6 +1600,87 @@ struct S {
 
 fn main() {
     S { foo: $01 + 1$0 }
+}
+"#,
+            r#"
+struct S {
+    foo: i32
+}
+
+fn main() {
+    let $0foo = 1 + 1;
+    S { foo }
+}
+"#,
+            "Extract into variable",
+        )
+    }
+
+    #[test]
+    fn extract_var_from_record_field() {
+        check_assist_by_label(
+            extract_variable,
+            r#"
+struct S {
+    foo: i32
+}
+
+fn main() {
+    S { $0foo: 1 + 1,$0 }
+}
+"#,
+            r#"
+struct S {
+    foo: i32
+}
+
+fn main() {
+    let $0foo = 1 + 1;
+    S { foo, }
+}
+"#,
+            "Extract into variable",
+        )
+    }
+
+    #[test]
+    fn extract_var_from_record_field_name() {
+        check_assist_by_label(
+            extract_variable,
+            r#"
+struct S {
+    foo: i32
+}
+
+fn main() {
+    S { f$0oo: 1 + 1 }
+}
+"#,
+            r#"
+struct S {
+    foo: i32
+}
+
+fn main() {
+    let $0foo = 1 + 1;
+    S { foo }
+}
+"#,
+            "Extract into variable",
+        )
+    }
+
+    #[test]
+    fn extract_var_from_record_field_colon() {
+        check_assist_by_label(
+            extract_variable,
+            r#"
+struct S {
+    foo: i32
+}
+
+fn main() {
+    S { foo   $0: 1 + 1 }
 }
 "#,
             r#"

--- a/crates/ide-assists/src/handlers/extract_variable.rs
+++ b/crates/ide-assists/src/handlers/extract_variable.rs
@@ -953,6 +953,16 @@ fn foo() {
     }
 
     #[test]
+    fn dont_extract_in_pattern_with_selection() {
+        check_assist_not_applicable(extract_variable, r#"fn foo() { [].map(|$0bar$0| bar + 1) } "#);
+    }
+
+    #[test]
+    fn dont_extract_in_pattern_without_selection() {
+        check_assist_not_applicable(extract_variable, r#"fn foo() { [].map(|b$0ar| bar + 1) } "#);
+    }
+
+    #[test]
     fn extract_var_expr_stmt() {
         cov_mark::check!(test_extract_var_expr_stmt);
         check_assist_by_label(


### PR DESCRIPTION
This change allows a “mistake” I make very often to succeed: putting the cursor on “foo” in `Struct { foo: bar() }` when I want to extract `let foo = bar();`.

It is also preparation for being able to extract multiple field expressions at once (rust-lang/rust-analyzer#21863), because it generalizes the analysis of the selection to be able to work on nodes that are not themselves expressions.

### Notes

The added `take_while()` and the tests `dont_extract_in_pattern_*` are an attempt to preserve the behavior added in rust-lang/rust-analyzer#18982, but that PR did not add any tests or clearly specify what effect it was intended to have, so I may have gotten it wrong.

This is only my second contribution to assists, so all feedback is welcome.