### PR TITLE
Use Cargo build directory for flycheck logs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,7 +104,7 @@ lsp-server = { version = "0.7.9" }
 anyhow = "1.0.98"
 arrayvec = "0.7.6"
 bitflags = "2.9.1"
-cargo_metadata = "0.23.0"
+cargo_metadata = "0.23.1"
 camino = "1.2.2"
 crossbeam-channel = "0.5.15"
 dissimilar = "1.0.10"

--- a/crates/project-model/src/cargo_workspace.rs
+++ b/crates/project-model/src/cargo_workspace.rs
@@ -36,6 +36,7 @@ pub struct CargoWorkspace {
     targets: Arena<TargetData>,
     workspace_root: AbsPathBuf,
     target_directory: AbsPathBuf,
+    build_directory: Option<AbsPathBuf>,
     manifest_path: ManifestPath,
     is_virtual_workspace: bool,
     /// Whether this workspace represents the sysroot workspace.
@@ -359,6 +360,7 @@ impl CargoWorkspace {
 
         let workspace_root = AbsPathBuf::assert(meta.workspace_root);
         let target_directory = AbsPathBuf::assert(meta.target_directory);
+        let build_directory = meta.build_directory.map(AbsPathBuf::assert);
         let mut is_virtual_workspace = true;
         let mut requires_rustc_private = false;
 
@@ -517,6 +519,7 @@ impl CargoWorkspace {
             targets,
             workspace_root,
             target_directory,
+            build_directory,
             manifest_path: ws_manifest_path,
             is_virtual_workspace,
             requires_rustc_private,
@@ -546,6 +549,10 @@ impl CargoWorkspace {
 
     pub fn target_directory(&self) -> &AbsPath {
         &self.target_directory
+    }
+
+    pub fn build_directory(&self) -> Option<&AbsPath> {
+        self.build_directory.as_deref()
     }
 
     pub fn package_flag(&self, package: &PackageData) -> String {

--- a/crates/rust-analyzer/src/flycheck.rs
+++ b/crates/rust-analyzer/src/flycheck.rs
@@ -226,6 +226,7 @@ impl FlycheckHandle {
         workspace_root: AbsPathBuf,
         manifest_path: Option<AbsPathBuf>,
         ws_target_dir: Option<Utf8PathBuf>,
+        ws_build_dir: Option<Utf8PathBuf>,
         toolchain_version: Option<semver::Version>,
     ) -> FlycheckHandle {
         let actor = FlycheckActor::new(
@@ -238,6 +239,7 @@ impl FlycheckHandle {
             workspace_root,
             manifest_path,
             ws_target_dir,
+            ws_build_dir,
             toolchain_version,
         );
         let (sender, receiver) = unbounded::<StateChange>();
@@ -431,6 +433,7 @@ struct FlycheckActor {
 
     manifest_path: Option<AbsPathBuf>,
     ws_target_dir: Option<Utf8PathBuf>,
+    ws_build_dir: Option<Utf8PathBuf>,
     /// Either the workspace root of the workspace we are flychecking,
     /// or the project root of the project.
     root: Arc<AbsPathBuf>,
@@ -533,6 +536,7 @@ impl FlycheckActor {
         workspace_root: AbsPathBuf,
         manifest_path: Option<AbsPathBuf>,
         ws_target_dir: Option<Utf8PathBuf>,
+        ws_build_dir: Option<Utf8PathBuf>,
         toolchain_version: Option<semver::Version>,
     ) -> FlycheckActor {
         tracing::info!(%id, ?workspace_root, "Spawning flycheck");
@@ -547,6 +551,7 @@ impl FlycheckActor {
             scope: FlycheckScope::Workspace,
             manifest_path,
             ws_target_dir,
+            ws_build_dir,
             command_handle: None,
             command_receiver: None,
             diagnostics_cleared_for: Default::default(),
@@ -633,14 +638,14 @@ impl FlycheckActor {
                         sender,
                         match &self.config {
                             FlycheckConfig::Automatic { cargo_options, .. } => {
-                                let ws_target_dir =
-                                    self.ws_target_dir.as_ref().map(Utf8PathBuf::as_path);
-                                let target_dir =
-                                    cargo_options.target_dir_config.target_dir(ws_target_dir);
+                                let target_dir = cargo_options
+                                    .target_dir_config
+                                    .target_dir(self.ws_target_dir.as_deref());
 
-                                // If `"rust-analyzer.cargo.targetDir": null`, we should use
-                                // workspace's target dir instead of hard-coded fallback.
-                                let target_dir = target_dir.as_deref().or(ws_target_dir);
+                                let output_dir = target_dir
+                                    .as_deref()
+                                    .or(self.ws_build_dir.as_deref())
+                                    .or(self.ws_target_dir.as_deref());
 
                                 Some(
                                     // As `CommandHandle::spawn`'s working directory is
@@ -648,10 +653,10 @@ impl FlycheckActor {
                                     // from the flycheck's working directory, we should canonicalize
                                     // the output directory, otherwise we might write it into the
                                     // wrong target dir.
-                                    // If `target_dir` is an absolute path, it will replace
+                                    // If `output_dir` is an absolute path, it will replace
                                     // `self.root` and that's an intended behavior.
                                     self.root
-                                        .join(target_dir.unwrap_or(
+                                        .join(output_dir.unwrap_or(
                                             Utf8Path::new("target").join("rust-analyzer").as_path(),
                                         ))
                                         .join(format!("flycheck{}", self.id))

--- a/crates/rust-analyzer/src/reload.rs
+++ b/crates/rust-analyzer/src/reload.rs
@@ -902,6 +902,7 @@ impl GlobalState {
                     None,
                     None,
                     None,
+                    None,
                 )]
             }
             crate::flycheck::InvocationStrategy::PerWorkspace => {
@@ -921,6 +922,7 @@ impl GlobalState {
                                     cargo.workspace_root(),
                                     Some(cargo.manifest_path()),
                                     Some(cargo.target_directory()),
+                                    cargo.build_directory(),
                                 ),
                                 ProjectWorkspaceKind::Json(project) => {
                                     let config_json = crate::flycheck::FlycheckConfigJson {
@@ -932,10 +934,10 @@ impl GlobalState {
                                     // in the workspace configuration.
                                     match config {
                                         _ if config_json.any_configured() => {
-                                            (config_json, project.path(), None, None)
+                                            (config_json, project.path(), None, None, None)
                                         }
                                         FlycheckConfig::CustomCommand { .. } => {
-                                            (config_json, project.path(), None, None)
+                                            (config_json, project.path(), None, None, None)
                                         }
                                         _ => return None,
                                     }
@@ -949,7 +951,7 @@ impl GlobalState {
                     .map(
                         |(
                             id,
-                            (config_json, root, manifest_path, target_dir),
+                            (config_json, root, manifest_path, target_dir, build_dir),
                             sysroot_root,
                             toolchain,
                         )| {
@@ -963,6 +965,7 @@ impl GlobalState {
                                 root.to_path_buf(),
                                 manifest_path.map(|it| it.to_path_buf()),
                                 target_dir.map(|it| AsRef::<Utf8Path>::as_ref(it).to_path_buf()),
+                                build_dir.map(|it| AsRef::<Utf8Path>::as_ref(it).to_path_buf()),
                                 toolchain,
                             )
                         },

--- a/crates/rust-analyzer/tests/slow-tests/flycheck.rs
+++ b/crates/rust-analyzer/tests/slow-tests/flycheck.rs
@@ -43,6 +43,40 @@ fn main() {
 }
 
 #[test]
+fn test_flycheck_output_uses_build_directory() {
+    if skip_slow_tests() {
+        return;
+    }
+
+    let server = Project::with_fixture(
+        r#"
+//- /.cargo/config.toml
+[build]
+build-dir = "build"
+
+//- /Cargo.toml
+[package]
+name = "foo"
+version = "0.0.0"
+
+//- /src/main.rs
+fn main() {
+    let x = 1;
+}
+"#,
+    )
+    .with_config(serde_json::json!({
+        "checkOnSave": true,
+    }))
+    .server()
+    .wait_until_workspace_is_loaded();
+
+    _ = server.wait_for_diagnostics();
+    assert!(server.path().join("build/flycheck0/stdout").exists());
+    assert!(server.path().join("build/flycheck0/stderr").exists());
+}
+
+#[test]
 fn test_flycheck_diagnostic_cleared_after_fix() {
     if skip_slow_tests() {
         return;


### PR DESCRIPTION
R-A currently stores flycheck’s `stdout` and `stderr` under Cargo’s `target_directory`. Cargo 1.91 stabilized `build.build-dir`, which allows intermediate build artifacts to be stored separately and exposes the resolved location as `build_directory` in cargo metadata (see https://github.com/rust-lang/cargo/pull/15833 and https://github.com/rust-lang/cargo/pull/15377).

This PR changes the directory selection order for flycheck output to be `rust-analyzer.cargo.targetDir` → `build_directory` → `target_directory`.