### PR TITLE
fix: adds-arrow unmap ranges when fn inside macro

### DIFF
--- a/crates/ide-completion/src/completions.rs
+++ b/crates/ide-completion/src/completions.rs
@@ -752,7 +752,9 @@ pub(super) fn complete_name_ref<'db>(
                         TypeLocation::TypeAscription(ascription) => {
                             if let TypeAscriptionTarget::RetType { item: Some(item), .. } =
                                 ascription
-                                && path_ctx.required_thin_arrow().is_some()
+                                && path_ctx
+                                    .required_thin_arrow(|it| Some(it.text_range()))
+                                    .is_some()
                                 && matches!(path_ctx.qualified, Qualified::No)
                             {
                                 keyword::complete_for_and_where(acc, ctx, &item.clone().into());

--- a/crates/ide-completion/src/completions.rs
+++ b/crates/ide-completion/src/completions.rs
@@ -752,9 +752,7 @@ pub(super) fn complete_name_ref<'db>(
                         TypeLocation::TypeAscription(ascription) => {
                             if let TypeAscriptionTarget::RetType { item: Some(item), .. } =
                                 ascription
-                                && path_ctx
-                                    .required_thin_arrow(|it| Some(it.text_range()))
-                                    .is_some()
+                                && path_ctx.required_thin_arrow(&ctx.sema).is_some()
                                 && matches!(path_ctx.qualified, Qualified::No)
                             {
                                 keyword::complete_for_and_where(acc, ctx, &item.clone().into());

--- a/crates/ide-completion/src/context.rs
+++ b/crates/ide-completion/src/context.rs
@@ -105,7 +105,7 @@ impl PathCompletionCtx<'_> {
 
     pub(crate) fn required_thin_arrow(
         &self,
-        unmap: impl Fn(&syntax::SyntaxNode) -> Option<TextRange>,
+        sema: &Semantics<'_, RootDatabase>,
     ) -> Option<(&'static str, TextSize)> {
         let PathKind::Type {
             location:
@@ -120,6 +120,7 @@ impl PathCompletionCtx<'_> {
         if fn_item.ret_type().is_some_and(|it| it.thin_arrow_token().is_some()) {
             return None;
         }
+        let unmap = |node: &_| sema.original_range_opt(node).map(|it| it.range);
         let ret_type = fn_item.ret_type().and_then(|it| it.ty());
         match (ret_type, fn_item.param_list()) {
             (Some(ty), _) => Some(("-> ", unmap(ty.syntax())?.start())),

--- a/crates/ide-completion/src/context.rs
+++ b/crates/ide-completion/src/context.rs
@@ -103,7 +103,10 @@ impl PathCompletionCtx<'_> {
         )
     }
 
-    pub(crate) fn required_thin_arrow(&self) -> Option<(&'static str, TextSize)> {
+    pub(crate) fn required_thin_arrow(
+        &self,
+        unmap: impl Fn(&syntax::SyntaxNode) -> Option<TextRange>,
+    ) -> Option<(&'static str, TextSize)> {
         let PathKind::Type {
             location:
                 TypeLocation::TypeAscription(TypeAscriptionTarget::RetType {
@@ -119,8 +122,8 @@ impl PathCompletionCtx<'_> {
         }
         let ret_type = fn_item.ret_type().and_then(|it| it.ty());
         match (ret_type, fn_item.param_list()) {
-            (Some(ty), _) => Some(("-> ", ty.syntax().text_range().start())),
-            (None, Some(param)) => Some((" ->", param.syntax().text_range().end())),
+            (Some(ty), _) => Some(("-> ", unmap(ty.syntax())?.start())),
+            (None, Some(param)) => Some((" ->", unmap(param.syntax())?.end())),
             (None, None) => None,
         }
     }

--- a/crates/ide-completion/src/render.rs
+++ b/crates/ide-completion/src/render.rs
@@ -651,7 +651,8 @@ fn adds_ret_type_arrow(
     item: &mut Builder,
     insert_text: String,
 ) {
-    if let Some((arrow, at)) = path_ctx.required_thin_arrow() {
+    let unmap = |node: &_| ctx.sema.original_range_opt(node).map(|it| it.range);
+    if let Some((arrow, at)) = path_ctx.required_thin_arrow(unmap) {
         let mut edit = TextEdit::builder();
 
         edit.insert(at, arrow.to_owned());

--- a/crates/ide-completion/src/render.rs
+++ b/crates/ide-completion/src/render.rs
@@ -651,8 +651,7 @@ fn adds_ret_type_arrow(
     item: &mut Builder,
     insert_text: String,
 ) {
-    let unmap = |node: &_| ctx.sema.original_range_opt(node).map(|it| it.range);
-    if let Some((arrow, at)) = path_ctx.required_thin_arrow(unmap) {
+    if let Some((arrow, at)) = path_ctx.required_thin_arrow(&ctx.sema) {
         let mut edit = TextEdit::builder();
 
         edit.insert(at, arrow.to_owned());

--- a/crates/ide-completion/src/tests/type_pos.rs
+++ b/crates/ide-completion/src/tests/type_pos.rs
@@ -244,6 +244,40 @@ fn foo() -> foo::Num
 "#,
     );
 
+    check_edit(
+        "u32",
+        r#"
+macro_rules! identity { ($($t:tt)*) => {$($t)*}; }
+identity! {
+    fn foo() u$0
+}
+"#,
+        r#"
+macro_rules! identity { ($($t:tt)*) => {$($t)*}; }
+identity! {
+    fn foo() -> u32
+}
+"#,
+    );
+
+    check_edit(
+        "Num",
+        r#"
+macro_rules! identity { ($($t:tt)*) => {$($t)*}; }
+mod foo { pub type Num = u32; }
+identity! {
+    fn foo() foo::N$0
+}
+"#,
+        r#"
+macro_rules! identity { ($($t:tt)*) => {$($t)*}; }
+mod foo { pub type Num = u32; }
+identity! {
+    fn foo() -> foo::Num
+}
+"#,
+    );
+
     // no spaces, test edit order
     check_edit(
         "foo",


### PR DESCRIPTION
Example
---
```rust
macro_rules! identity { ($($t:tt)*) => {$($t)*}; }
identity! {
    fn foo() u$0
}
```

**Before this PR**

```rust
macro_r-> ules! identity { ($($t:tt)*) => {$($t)*}; }
identity! {
    fn foo() u32
}
```

**After this PR**

```rust
macro_rules! identity { ($($t:tt)*) => {$($t)*}; }
identity! {
    fn foo() -> u32
}
```
