### PR TITLE
minor: fix outdated comments

### DIFF
--- a/crates/hir-ty/src/infer.rs
+++ b/crates/hir-ty/src/infer.rs
@@ -1629,10 +1629,6 @@ impl<'db> InferenceContext<'db> {
         self.defined_anon_consts.borrow_mut().append(&mut defined_anon_consts);
     }
 
-    // FIXME: This function should be private in module. It is currently only used in the consteval, since we need
-    // `InferenceResult` in the middle of inference. See the fixme comment in `consteval::eval_to_const`. If you
-    // used this function for another workaround, mention it here. If you really need this function and believe that
-    // there is no problem in it being `pub(crate)`, remove this comment.
     fn resolve_all(self) -> InferenceResult<'db> {
         let InferenceContext {
             table,

--- a/crates/hir-ty/src/lower.rs
+++ b/crates/hir-ty/src/lower.rs
@@ -788,7 +788,7 @@ impl<'db, 'a> TyLoweringContext<'db, 'a> {
         )
     }
 
-    /// This is only for `generic_predicates_for_param`, where we can't just
+    /// This is only for [`resolve_type_param_assoc_type_shorthand`], where we can't just
     /// lower the self types of the predicates since that could lead to cycles.
     /// So we just check here if the `type_ref` resolves to a generic param, and which.
     fn lower_ty_only_param(&self, type_ref: TypeRefId) -> Option<TypeOrConstParamId> {


### PR DESCRIPTION
rust-lang/rust-analyzer#20906 fixed the `pub(crate)` and the mentioned function was renamed in rust-lang/rust-analyzer#21631