### PR TITLE
perf: Remove `UseId`s from `ItemScope`

### DIFF
--- a/crates/hir-def/src/dyn_map.rs
+++ b/crates/hir-def/src/dyn_map.rs
@@ -35,7 +35,7 @@ pub mod keys {
     use crate::{
         BlockId, BuiltinDeriveImplId, ConstId, EnumId, EnumVariantId, ExternBlockId, ExternCrateId,
         FieldId, FunctionId, ImplId, LifetimeParamId, Macro2Id, MacroRulesId, ProcMacroId,
-        StaticId, StructId, TraitId, TypeAliasId, TypeOrConstParamId, UnionId, UseId,
+        StaticId, StructId, TraitId, TypeAliasId, TypeOrConstParamId, UnionId,
         dyn_map::{DynMap, Policy},
     };
 
@@ -53,7 +53,6 @@ pub mod keys {
     pub const UNION: Key<ast::Union, UnionId> = Key::new();
     pub const ENUM: Key<ast::Enum, EnumId> = Key::new();
     pub const EXTERN_CRATE: Key<ast::ExternCrate, ExternCrateId> = Key::new();
-    pub const USE: Key<ast::Use, UseId> = Key::new();
 
     pub const ENUM_VARIANT: Key<ast::Variant, EnumVariantId> = Key::new();
     pub const TUPLE_FIELD: Key<ast::TupleField, FieldId> = Key::new();

--- a/crates/hir-def/src/item_scope.rs
+++ b/crates/hir-def/src/item_scope.rs
@@ -147,7 +147,6 @@ pub struct ItemScope {
     use_imports_values: FxHashMap<ImportOrGlob, ImportOrDef>,
     use_imports_macros: FxHashMap<ImportOrExternCrate, ImportOrDef>,
 
-    use_decls: ThinVec<UseId>,
     extern_crate_decls: ThinVec<ExternCrateId>,
     /// Macros visible in current module in legacy textual scope
     ///
@@ -297,10 +296,6 @@ impl ItemScope {
 
     pub fn extern_blocks(&self) -> impl Iterator<Item = ExternBlockId> + '_ {
         self.extern_blocks.iter().copied()
-    }
-
-    pub fn use_decls(&self) -> impl ExactSizeIterator<Item = UseId> + '_ {
-        self.use_decls.iter().copied()
     }
 
     pub fn impls(&self) -> impl ExactSizeIterator<Item = ImplId> + '_ {
@@ -835,7 +830,6 @@ impl ItemScope {
             attr_macros,
             derive_macros,
             extern_crate_decls,
-            use_decls,
             use_imports_values,
             use_imports_types,
             use_imports_macros,
@@ -859,7 +853,6 @@ impl ItemScope {
         attr_macros.shrink_to_fit();
         derive_macros.shrink_to_fit();
         extern_crate_decls.shrink_to_fit();
-        use_decls.shrink_to_fit();
         macro_invocations.shrink_to_fit();
     }
 }

--- a/crates/hir/src/semantics/child_by_source.rs
+++ b/crates/hir/src/semantics/child_by_source.rs
@@ -128,7 +128,6 @@ impl ChildBySource for ItemScope {
         });
         self.extern_crate_decls()
             .for_each(|ext| insert_item_loc(db, res, file_id, ext, keys::EXTERN_CRATE));
-        self.use_decls().for_each(|ext| insert_item_loc(db, res, file_id, ext, keys::USE));
         self.unnamed_consts()
             .for_each(|konst| insert_item_loc(db, res, file_id, konst, keys::CONST));
         self.attr_macro_invocs().filter(|(id, _)| id.file_id == file_id).for_each(

--- a/crates/hir/src/semantics/source_to_def.rs
+++ b/crates/hir/src/semantics/source_to_def.rs
@@ -91,7 +91,7 @@ use hir_def::{
     AdtId, BlockId, BuiltinDeriveImplId, ConstId, ConstParamId, DefWithBodyId, EnumId,
     EnumVariantId, ExpressionStoreOwnerId, ExternBlockId, ExternCrateId, FieldId, FunctionId,
     GenericDefId, GenericParamId, ImplId, LifetimeParamId, Lookup, MacroId, ModuleId, StaticId,
-    StructId, TraitId, TypeAliasId, TypeParamId, UnionId, UseId, VariantId,
+    StructId, TraitId, TypeAliasId, TypeParamId, UnionId, VariantId,
     dyn_map::{
         DynMap,
         keys::{self, Key},
@@ -320,10 +320,6 @@ impl<'db> SourceToDefCtx<'db, '_> {
         src: InFile<&ast::ExternBlock>,
     ) -> Option<ExternBlockId> {
         self.to_def(src, keys::EXTERN_BLOCK)
-    }
-    #[allow(dead_code)]
-    pub(super) fn use_to_def(&mut self, src: InFile<&ast::Use>) -> Option<UseId> {
-        self.to_def(src, keys::USE)
     }
     pub(super) fn adt_to_def(
         &mut self,


### PR DESCRIPTION
They're not used, and I want to shrink `ItemScope` because it consumes a significant amount of memory (this is only the first step).

It'd be nice if we could remove `UseId` completely (it's non-incremental and almost unused), but it's used in the import map, so I gave up for now.