### PR TITLE
perf: Provide `ThinMap`, a map that uses `ThinVec` when the length is small

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -217,7 +217,7 @@ jobs:
       # - name: Cache Dependencies
       #   uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6
 
-      - run: cargo miri test -p intern
+      - run: cargo miri test -p intern -p stdx
 
   # Weird targets to catch non-portable code
   rust-cross:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2677,6 +2677,8 @@ dependencies = [
  "jod-thread",
  "libc",
  "miow",
+ "salsa",
+ "thin-vec",
  "tracing",
  "windows-sys 0.61.2",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,7 +158,7 @@ tracing-subscriber = { version = "0.3.20", default-features = false, features = 
 triomphe = { version = "0.1.14", default-features = false, features = ["std"] }
 url = "2.5.4"
 xshell = "0.2.7"
-thin-vec = "0.2.16"
+thin-vec = { version = "0.2.16", features = ["const_new"] }
 petgraph = { version = "0.8.2", default-features = false }
 hashbrown = { version = "0.17.0", features = [
     "inline-more",

--- a/crates/hir-def/src/expr_store.rs
+++ b/crates/hir-def/src/expr_store.rs
@@ -19,7 +19,6 @@ use cfg::{CfgExpr, CfgOptions};
 use either::Either;
 use hir_expand::{InFile, MacroCallId, mod_path::ModPath, name::Name};
 use la_arena::{Arena, ArenaMap};
-use rustc_hash::FxHashMap;
 use smallvec::SmallVec;
 use span::{Edition, SyntaxContext};
 use syntax::{AstPtr, SyntaxNodePtr, ast};
@@ -27,7 +26,7 @@ use thin_vec::ThinVec;
 use tt::TextRange;
 
 use crate::{
-    AdtId, BlockId, ExpressionStoreOwnerId, GenericDefId, SyntheticSyntax,
+    AdtId, BlockId, ExpressionStoreOwnerId, GenericDefId, SyntheticSyntax, ThinFxHashMap,
     expr_store::path::{AssociatedTypeBinding, GenericArg, GenericArgs, NormalPath, Path},
     hir::{
         Array, AsmOperand, Binding, BindingId, Expr, ExprId, ExprOrPatId, ExprOrPatIdPacked,
@@ -119,7 +118,7 @@ struct ExpressionOnlyStore {
     labels: Arena<Label>,
     /// Id of the closure/coroutine/anon const that owns the corresponding binding. If a binding is owned by the
     /// top level expression, it will not be listed in here.
-    binding_owners: FxHashMap<BindingId, ExprId>,
+    binding_owners: ThinFxHashMap<BindingId, ExprId>,
     /// Block expressions in this store that may contain inner items.
     block_scopes: Box<[BlockId]>,
 
@@ -127,7 +126,7 @@ struct ExpressionOnlyStore {
     ///
     /// Expressions (and destructuring patterns) that can be recorded here are single segment path, although not all single segments path refer
     /// to variables and have hygiene (some refer to items, we don't know at this stage).
-    ident_hygiene: FxHashMap<ExprOrPatIdPacked, HygieneId>,
+    ident_hygiene: ThinFxHashMap<ExprOrPatIdPacked, HygieneId>,
 
     /// Maps expression roots to their origin.
     ///
@@ -168,13 +167,13 @@ pub struct ExpressionStore {
 struct ExpressionOnlySourceMap {
     // AST expressions can create patterns in destructuring assignments. Therefore, `ExprSource` can also map
     // to `PatId`, and `PatId` can also map to `ExprSource` (the other way around is unaffected).
-    expr_map: FxHashMap<ExprSource, ExprOrPatIdPacked>,
+    expr_map: ThinFxHashMap<ExprSource, ExprOrPatIdPacked>,
     expr_map_back: ArenaMap<ExprId, ExprOrPatSource>,
 
-    pat_map: FxHashMap<PatSource, ExprOrPatIdPacked>,
+    pat_map: ThinFxHashMap<PatSource, ExprOrPatIdPacked>,
     pat_map_back: ArenaMap<PatId, ExprOrPatSource>,
 
-    label_map: FxHashMap<LabelSource, LabelId>,
+    label_map: ThinFxHashMap<LabelSource, LabelId>,
     label_map_back: ArenaMap<LabelId, LabelSource>,
 
     binding_definitions:
@@ -182,12 +181,12 @@ struct ExpressionOnlySourceMap {
 
     /// We don't create explicit nodes for record fields (`S { record_field: 92 }`).
     /// Instead, we use id of expression (`92`) to identify the field.
-    field_map_back: FxHashMap<ExprId, FieldSource>,
-    pat_field_map_back: FxHashMap<PatId, PatFieldSource>,
+    field_map_back: ThinFxHashMap<ExprId, FieldSource>,
+    pat_field_map_back: ThinFxHashMap<PatId, PatFieldSource>,
 
     template_map: Option<Box<FormatTemplate>>,
 
-    expansions: FxHashMap<InFile<MacroCallPtr>, MacroCallId>,
+    expansions: ThinFxHashMap<InFile<MacroCallPtr>, MacroCallId>,
 
     /// Diagnostics accumulated during lowering. These contain `AstPtr`s and so are stored in
     /// the source map (since they're just as volatile).
@@ -233,14 +232,14 @@ pub struct ExpressionStoreSourceMap {
     expr_only: Option<Box<ExpressionOnlySourceMap>>,
 
     types_map_back: ArenaMap<TypeRefId, TypeSource>,
-    types_map: FxHashMap<TypeSource, TypeRefId>,
+    types_map: ThinFxHashMap<TypeSource, TypeRefId>,
 
     lifetime_map_back: ArenaMap<LifetimeRefId, LifetimeSource>,
     #[expect(
         unused,
         reason = "this is here for completeness, and maybe we'll need it in the future"
     )]
-    lifetime_map: FxHashMap<LifetimeSource, LifetimeRefId>,
+    lifetime_map: ThinFxHashMap<LifetimeSource, LifetimeRefId>,
 }
 
 impl PartialEq for ExpressionStoreSourceMap {
@@ -264,40 +263,40 @@ pub struct ExpressionStoreBuilder {
     pub bindings: Arena<Binding>,
     pub labels: Arena<Label>,
     pub lifetimes: Arena<LifetimeRef>,
-    pub binding_owners: FxHashMap<BindingId, ExprId>,
+    pub binding_owners: ThinFxHashMap<BindingId, ExprId>,
     pub types: Arena<TypeRef>,
     block_scopes: Vec<BlockId>,
-    ident_hygiene: FxHashMap<ExprOrPatIdPacked, HygieneId>,
+    ident_hygiene: ThinFxHashMap<ExprOrPatIdPacked, HygieneId>,
     inference_roots: Option<SmallVec<[ExprRoot; 1]>>,
 
     // AST expressions can create patterns in destructuring assignments. Therefore, `ExprSource` can also map
     // to `PatId`, and `PatId` can also map to `ExprSource` (the other way around is unaffected).
-    expr_map: FxHashMap<ExprSource, ExprOrPatIdPacked>,
+    expr_map: ThinFxHashMap<ExprSource, ExprOrPatIdPacked>,
     expr_map_back: ArenaMap<ExprId, ExprOrPatSource>,
 
-    pat_map: FxHashMap<PatSource, ExprOrPatIdPacked>,
+    pat_map: ThinFxHashMap<PatSource, ExprOrPatIdPacked>,
     pat_map_back: ArenaMap<PatId, ExprOrPatSource>,
 
-    label_map: FxHashMap<LabelSource, LabelId>,
+    label_map: ThinFxHashMap<LabelSource, LabelId>,
     label_map_back: ArenaMap<LabelId, LabelSource>,
 
     types_map_back: ArenaMap<TypeRefId, TypeSource>,
-    types_map: FxHashMap<TypeSource, TypeRefId>,
+    types_map: ThinFxHashMap<TypeSource, TypeRefId>,
 
     lifetime_map_back: ArenaMap<LifetimeRefId, LifetimeSource>,
-    lifetime_map: FxHashMap<LifetimeSource, LifetimeRefId>,
+    lifetime_map: ThinFxHashMap<LifetimeSource, LifetimeRefId>,
 
     binding_definitions:
         ArenaMap<BindingId, SmallVec<[PatId; 2 * size_of::<usize>() / size_of::<PatId>()]>>,
 
     /// We don't create explicit nodes for record fields (`S { record_field: 92 }`).
     /// Instead, we use id of expression (`92`) to identify the field.
-    field_map_back: FxHashMap<ExprId, FieldSource>,
-    pat_field_map_back: FxHashMap<PatId, PatFieldSource>,
+    field_map_back: ThinFxHashMap<ExprId, FieldSource>,
+    pat_field_map_back: ThinFxHashMap<PatId, PatFieldSource>,
 
     template_map: Option<Box<FormatTemplate>>,
 
-    expansions: FxHashMap<InFile<MacroCallPtr>, MacroCallId>,
+    expansions: ThinFxHashMap<InFile<MacroCallPtr>, MacroCallId>,
 
     /// Diagnostics accumulated during lowering. These contain `AstPtr`s and so are stored in
     /// the source map (since they're just as volatile).
@@ -310,15 +309,15 @@ pub struct ExpressionStoreBuilder {
 #[derive(Default, Debug, Eq, PartialEq)]
 struct FormatTemplate {
     /// A map from `format_args!()` expressions to their captures.
-    format_args_to_captures: FxHashMap<ExprId, (HygieneId, Vec<(syntax::TextRange, Name)>)>,
+    format_args_to_captures: ThinFxHashMap<ExprId, (HygieneId, Vec<(syntax::TextRange, Name)>)>,
     /// A map from `asm!()` expressions to their captures.
-    asm_to_captures: FxHashMap<ExprId, Vec<Vec<(syntax::TextRange, usize)>>>,
+    asm_to_captures: ThinFxHashMap<ExprId, Vec<Vec<(syntax::TextRange, usize)>>>,
     /// A map from desugared expressions of implicit captures to their source.
     ///
     /// The value stored for each capture is its template literal and offset inside it. The template literal
     /// is from the `format_args[_nl]!()` macro and so needs to be mapped up once to go to the user-written
     /// template.
-    implicit_capture_to_source: FxHashMap<ExprId, InFile<(ExprPtr, TextRange)>>,
+    implicit_capture_to_source: ThinFxHashMap<ExprId, InFile<(ExprPtr, TextRange)>>,
 }
 
 #[derive(Debug, Eq, PartialEq)]

--- a/crates/hir-def/src/item_scope.rs
+++ b/crates/hir-def/src/item_scope.rs
@@ -6,19 +6,19 @@ use std::{fmt, sync::LazyLock};
 use base_db::{Crate, SourceDatabase};
 use either::Either;
 use hir_expand::{AstId, MacroCallId, attrs::AttrId, name::Name};
-use indexmap::map::Entry;
 use itertools::Itertools;
 use la_arena::Idx;
-use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hash::FxHashSet;
 use smallvec::SmallVec;
 use span::Edition;
-use stdx::{format_to, impl_from};
+use stdx::{format_to, impl_from, thin_map::Entry};
 use syntax::ast;
 use thin_vec::ThinVec;
 
 use crate::{
     AdtId, BuiltinDeriveImplId, BuiltinType, ConstId, ExternBlockId, ExternCrateId, FxIndexMap,
-    HasModule, ImplId, Lookup, MacroCallStyles, MacroId, ModuleDefId, ModuleId, TraitId, UseId,
+    HasModule, ImplId, Lookup, MacroCallStyles, MacroId, ModuleDefId, ModuleId, ThinFxHashMap,
+    ThinFxHashSet, TraitId, UseId,
     per_ns::{Item, MacrosItem, PerNs, TypesItem, ValuesItem},
     visibility::Visibility,
 };
@@ -126,10 +126,10 @@ pub struct ItemScope {
     /// Defs visible in this scope. This includes `declarations`, but also
     /// imports. The imports belong to this module and can be resolved by using them on
     /// the `use_imports_*` fields.
-    types: FxIndexMap<Name, TypesItem>,
-    values: FxIndexMap<Name, ValuesItem>,
-    macros: FxIndexMap<Name, MacrosItem>,
-    unresolved: FxHashSet<Name>,
+    types: ThinFxHashMap<Name, TypesItem>,
+    values: ThinFxHashMap<Name, ValuesItem>,
+    macros: ThinFxHashMap<Name, MacrosItem>,
+    unresolved: ThinFxHashSet<Name>,
 
     /// The defs declared in this scope. Each def has a single scope where it is
     /// declared.
@@ -143,9 +143,9 @@ pub struct ItemScope {
     unnamed_trait_imports: ThinVec<(TraitId, Item<()>)>,
 
     // the resolutions of the imports of this scope
-    use_imports_types: FxHashMap<ImportOrExternCrate, ImportOrDef>,
-    use_imports_values: FxHashMap<ImportOrGlob, ImportOrDef>,
-    use_imports_macros: FxHashMap<ImportOrExternCrate, ImportOrDef>,
+    use_imports_types: ThinFxHashMap<ImportOrExternCrate, ImportOrDef>,
+    use_imports_values: ThinFxHashMap<ImportOrGlob, ImportOrDef>,
+    use_imports_macros: ThinFxHashMap<ImportOrExternCrate, ImportOrDef>,
 
     use_decls: ThinVec<UseId>,
     extern_crate_decls: ThinVec<ExternCrateId>,
@@ -161,14 +161,14 @@ pub struct ItemScope {
     /// Module scoped macros will be inserted into `items` instead of here.
     // FIXME: Macro shadowing in one module is not properly handled. Non-item place macros will
     // be all resolved to the last one defined if shadowing happens.
-    legacy_macros: FxHashMap<Name, SmallVec<[MacroId; 1]>>,
+    legacy_macros: ThinFxHashMap<Name, SmallVec<[MacroId; 1]>>,
     /// The attribute macro invocations in this scope.
-    attr_macros: FxHashMap<AstId<ast::Item>, MacroCallId>,
+    attr_macros: ThinFxHashMap<AstId<ast::Item>, MacroCallId>,
     /// The macro invocations in this scope.
-    macro_invocations: FxHashMap<AstId<ast::MacroCall>, MacroCallId>,
+    macro_invocations: ThinFxHashMap<AstId<ast::MacroCall>, MacroCallId>,
     /// The derive macro invocations in this scope, keyed by the owner item over the actual derive attributes
     /// paired with the derive macro invocations for the specific attribute.
-    derive_macros: FxHashMap<AstId<ast::Adt>, SmallVec<[DeriveMacroInvocation; 1]>>,
+    derive_macros: ThinFxHashMap<AstId<ast::Adt>, SmallVec<[DeriveMacroInvocation; 1]>>,
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -461,9 +461,9 @@ impl ItemScope {
 
     pub(crate) fn remove_from_value_ns(&mut self, name: &Name, def: ModuleDefId) {
         // predicate needed since a different item with the same name may be registered instead,
-        // leading to `shift_remove` removing the wrong item.
+        // leading to `remove` removing the wrong item.
         if self.values.get(name).is_some_and(|entry| entry.def == def) {
-            let _ = self.values.shift_remove(name);
+            let _ = self.values.remove(name);
         }
     }
 

--- a/crates/hir-def/src/lib.rs
+++ b/crates/hir-def/src/lib.rs
@@ -98,6 +98,8 @@ pub use crate::{
 pub use hir_expand::{Intern, Lookup, tt};
 
 type FxIndexMap<K, V> = indexmap::IndexMap<K, V, rustc_hash::FxBuildHasher>;
+type ThinFxHashMap<K, V> = stdx::thin_map::ThinHashMap<K, V, rustc_hash::FxBuildHasher>;
+type ThinFxHashSet<T> = stdx::thin_map::ThinHashSet<T, rustc_hash::FxBuildHasher>;
 
 /// Whether to expand procedural macros during name resolution.
 ///

--- a/crates/hir-def/src/nameres.rs
+++ b/crates/hir-def/src/nameres.rs
@@ -72,12 +72,14 @@ use rustc_hash::FxHashMap;
 use span::{Edition, FileAstId, FileId, ROOT_ERASED_FILE_AST_ID};
 use stdx::format_to;
 use syntax::{AstNode, SmolStr, SyntaxNode, ToSmolStr, ast};
+use thin_vec::ThinVec;
 use triomphe::Arc;
 use tt::TextRange;
 
 use crate::{
     AstId, BlockId, BlockIdLt, BuiltinDeriveImplId, ExternCrateId, FunctionId, FxIndexMap, Lookup,
-    MacroCallStyles, MacroExpander, MacroId, ModuleId, ModuleIdLt, ProcMacroId, UseId,
+    MacroCallStyles, MacroExpander, MacroId, ModuleId, ModuleIdLt, ProcMacroId, ThinFxHashMap,
+    UseId,
     item_scope::{BuiltinShadowMode, ItemScope},
     item_tree::TreeId,
     nameres::{diagnostics::DefDiagnostic, path_resolution::ResolveMode},
@@ -188,18 +190,20 @@ pub struct DefMap {
     /// `macro_use` prelude that contains macros from `#[macro_use]`'d external crates. Note that
     /// this contains all kinds of macro, not just `macro_rules!` macro.
     /// ExternCrateId being None implies it being imported from the general prelude import.
-    macro_use_prelude: FxHashMap<Name, (MacroId, Option<ExternCrateId>)>,
+    macro_use_prelude: ThinFxHashMap<Name, (MacroId, Option<ExternCrateId>)>,
 
     /// Tracks which custom derives are in scope for an item, to allow resolution of derive helper
     /// attributes.
     // FIXME: Figure out a better way for the IDE layer to resolve these?
-    derive_helpers_in_scope:
-        FxHashMap<AstId<ast::Item>, Vec<(Name, MacroId, Either<MacroCallId, BuiltinDeriveImplId>)>>,
+    derive_helpers_in_scope: ThinFxHashMap<
+        AstId<ast::Item>,
+        Vec<(Name, MacroId, Either<MacroCallId, BuiltinDeriveImplId>)>,
+    >,
     /// A mapping from [`hir_expand::MacroDefId`] to [`crate::MacroId`].
-    pub macro_def_to_macro_id: FxHashMap<ErasedAstId, MacroId>,
+    pub macro_def_to_macro_id: ThinFxHashMap<ErasedAstId, MacroId>,
 
     /// The diagnostics that need to be emitted for this crate.
-    diagnostics: Vec<DefDiagnostic>,
+    diagnostics: ThinVec<DefDiagnostic>,
 
     /// The crate data that is shared between a crate's def map and all its block def maps.
     data: Arc<DefMapCrateData>,
@@ -372,7 +376,7 @@ pub struct ModuleData {
     ///
     /// [`None`] for block modules because they are always its `DefMap`'s root.
     pub parent: Option<ModuleId>,
-    pub children: FxIndexMap<Name, ModuleId>,
+    pub children: ThinFxHashMap<Name, ModuleId>,
     pub scope: ItemScope,
 }
 
@@ -484,11 +488,11 @@ impl DefMap {
             modules,
             krate,
             prelude: None,
-            macro_use_prelude: FxHashMap::default(),
-            derive_helpers_in_scope: FxHashMap::default(),
-            diagnostics: Vec::new(),
+            macro_use_prelude: ThinFxHashMap::default(),
+            derive_helpers_in_scope: ThinFxHashMap::default(),
+            diagnostics: ThinVec::new(),
             data: crate_data,
-            macro_def_to_macro_id: FxHashMap::default(),
+            macro_def_to_macro_id: ThinFxHashMap::default(),
         }
     }
     fn shrink_to_fit(&mut self) {
@@ -676,7 +680,9 @@ impl DefMap {
         self.prelude
     }
 
-    pub(crate) fn macro_use_prelude(&self) -> &FxHashMap<Name, (MacroId, Option<ExternCrateId>)> {
+    pub(crate) fn macro_use_prelude(
+        &self,
+    ) -> &ThinFxHashMap<Name, (MacroId, Option<ExternCrateId>)> {
         &self.macro_use_prelude
     }
 
@@ -884,15 +890,15 @@ fn sub_namespace_match(
     }
 }
 
-/// A newtype wrapper around `FxHashMap<ModuleId, ModuleData>` that implements `IndexMut`.
+/// A newtype wrapper around `ThinFxHashMap<ModuleId, ModuleData>` that implements `IndexMut`.
 #[derive(Debug, PartialEq, Eq)]
 pub struct ModulesMap {
-    inner: FxIndexMap<ModuleId, ModuleData>,
+    inner: ThinFxHashMap<ModuleId, ModuleData>,
 }
 
 impl ModulesMap {
     fn new() -> Self {
-        Self { inner: FxIndexMap::default() }
+        Self { inner: ThinFxHashMap::new() }
     }
 
     fn iter(&self) -> impl Iterator<Item = (ModuleId, &ModuleData)> + '_ {
@@ -905,7 +911,7 @@ impl ModulesMap {
 }
 
 impl Deref for ModulesMap {
-    type Target = FxIndexMap<ModuleId, ModuleData>;
+    type Target = ThinFxHashMap<ModuleId, ModuleData>;
 
     fn deref(&self) -> &Self::Target {
         &self.inner

--- a/crates/hir-ty/Cargo.toml
+++ b/crates/hir-ty/Cargo.toml
@@ -46,7 +46,7 @@ tracing-subscriber.workspace = true
 tracing-tree.workspace = true
 
 # local deps
-stdx.workspace = true
+stdx = { workspace = true, features = ["salsa"] }
 macros.workspace = true
 intern.workspace = true
 hir-def.workspace = true

--- a/crates/hir-ty/src/infer.rs
+++ b/crates/hir-ty/src/infer.rs
@@ -74,7 +74,7 @@ use thin_vec::ThinVec;
 
 use crate::{
     ImplTraitId, IncorrectGenericsLenKind, InferBodyId, PathLoweringDiagnostic, Span,
-    TargetFeatures, ValueTyDefId,
+    TargetFeatures, ThinFxHashMap, ThinFxHashSet, ValueTyDefId,
     closure_analysis::PlaceBase,
     consteval::{create_anon_const, path_to_const},
     db::{AnonConstId, GeneralConstId, HirDatabase, InternedOpaqueTyId},
@@ -758,13 +758,13 @@ pub enum PatAdjust {
 #[derive(Clone, PartialEq, Eq, Debug, SalsaValue)]
 pub struct InferenceResult<'db> {
     /// For each method call expr, records the function it resolves to.
-    method_resolutions: FxHashMap<ExprId, (FunctionId, StoredGenericArgs)>,
+    method_resolutions: ThinFxHashMap<ExprId, (FunctionId, StoredGenericArgs)>,
     /// For each field access expr, records the field it resolves to.
-    field_resolutions: FxHashMap<ExprId, Either<FieldId, TupleFieldId>>,
+    field_resolutions: ThinFxHashMap<ExprId, Either<FieldId, TupleFieldId>>,
     /// For each struct literal or pattern, records the variant it resolves to.
-    variant_resolutions: FxHashMap<ExprOrPatIdPacked, VariantId>,
+    variant_resolutions: ThinFxHashMap<ExprOrPatIdPacked, VariantId>,
     /// For each associated item record what it resolves to
-    assoc_resolutions: FxHashMap<ExprOrPatIdPacked, (CandidateId, StoredGenericArgs)>,
+    assoc_resolutions: ThinFxHashMap<ExprOrPatIdPacked, (CandidateId, StoredGenericArgs)>,
     /// Whenever a tuple field expression access a tuple field, we allocate a tuple id in
     /// [`InferenceContext`] and store the tuples substitution there. This map is the reverse of
     /// that which allows us to resolve a [`TupleFieldId`]s type.
@@ -777,8 +777,8 @@ pub struct InferenceResult<'db> {
     /// unresolved or missing subpatterns or subpatterns of mismatched types.
     pub(crate) type_of_pat: ArenaMap<PatId, StoredTy>,
     pub(crate) type_of_binding: ArenaMap<BindingId, StoredTy>,
-    pub(crate) type_of_type_placeholder: FxHashMap<TypeRefId, StoredTy>,
-    pub(crate) type_of_opaque: FxHashMap<InternedOpaqueTyId<'db>, StoredTy>,
+    pub(crate) type_of_type_placeholder: ThinFxHashMap<TypeRefId, StoredTy>,
+    pub(crate) type_of_opaque: ThinFxHashMap<InternedOpaqueTyId<'db>, StoredTy>,
 
     /// Whether there are any type-mismatching errors in the result.
     // FIXME: This isn't as useful as initially thought due to us falling back placeholders to
@@ -788,7 +788,7 @@ pub struct InferenceResult<'db> {
     /// During inference this field is empty and [`InferenceContext::diagnostics`] is filled instead.
     diagnostics: ThinVec<InferenceDiagnostic>,
     // FIXME: Remove this, change it to be in `InferenceContext`:
-    nodes_with_type_mismatches: Option<Box<FxHashSet<ExprOrPatIdPacked>>>,
+    nodes_with_type_mismatches: ThinFxHashSet<ExprOrPatIdPacked>,
 
     /// Interned `Error` type to return references to.
     // FIXME: Remove this.
@@ -796,7 +796,7 @@ pub struct InferenceResult<'db> {
 
     pub(crate) expr_adjustments: FxHashMap<ExprId, Box<[Adjustment]>>,
     /// Stores the types which were implicitly dereferenced in pattern binding modes.
-    pub(crate) pat_adjustments: FxHashMap<PatId, Vec<PatAdjustment>>,
+    pub(crate) pat_adjustments: ThinFxHashMap<PatId, Vec<PatAdjustment>>,
     /// Stores the binding mode (`ref` in `let ref x = 2`) of bindings.
     ///
     /// This one is tied to the `PatId` instead of `BindingId`, because in some rare cases, a binding in an
@@ -814,11 +814,11 @@ pub struct InferenceResult<'db> {
 
     /// Set of reference patterns that match against a match-ergonomics inserted reference
     /// (as opposed to against a reference in the scrutinee type).
-    skipped_ref_pats: FxHashSet<PatId>,
+    skipped_ref_pats: ThinFxHashSet<PatId>,
 
-    pub(crate) coercion_casts: FxHashSet<ExprId>,
+    pub(crate) coercion_casts: ThinFxHashSet<ExprId>,
 
-    pub closures_data: FxHashMap<ExprId, ClosureData>,
+    pub closures_data: ThinFxHashMap<ExprId, ClosureData>,
 
     defined_anon_consts: ThinVec<AnonConstId<'db>>,
 }
@@ -1175,7 +1175,7 @@ impl<'db> InferenceResult<'db> {
         }
     }
     pub fn expr_or_pat_has_type_mismatch(&self, node: ExprOrPatIdPacked) -> bool {
-        self.nodes_with_type_mismatches.as_ref().is_some_and(|it| it.contains(&node))
+        self.nodes_with_type_mismatches.contains(&node)
     }
     pub fn expr_has_type_mismatch(&self, expr: ExprId) -> bool {
         self.expr_or_pat_has_type_mismatch(expr.into())
@@ -1184,12 +1184,10 @@ impl<'db> InferenceResult<'db> {
         self.expr_or_pat_has_type_mismatch(pat.into())
     }
     pub fn exprs_have_type_mismatches(&self) -> bool {
-        self.nodes_with_type_mismatches
-            .as_ref()
-            .is_some_and(|it| it.iter().any(|node| node.is_expr()))
+        self.nodes_with_type_mismatches.iter().any(|node| node.is_expr())
     }
     pub fn has_type_mismatches(&self) -> bool {
-        self.nodes_with_type_mismatches.is_some()
+        !self.nodes_with_type_mismatches.is_empty()
     }
     pub fn placeholder_types<'a>(&self) -> impl Iterator<Item = (TypeRefId, Ty<'a>)> {
         self.type_of_type_placeholder.iter().map(|(&type_ref, ty)| (type_ref, ty.as_ref()))
@@ -1488,9 +1486,9 @@ impl<'db> InferenceContext<'db> {
             nodes_with_type_mismatches,
             defined_anon_consts: _,
         } = &mut self.result;
-        merge_hash_maps(method_resolutions, &other.method_resolutions);
-        merge_hash_maps(variant_resolutions, &other.variant_resolutions);
-        merge_hash_maps(assoc_resolutions, &other.assoc_resolutions);
+        merge_thin_hash_maps(method_resolutions, &other.method_resolutions);
+        merge_thin_hash_maps(variant_resolutions, &other.variant_resolutions);
+        merge_thin_hash_maps(assoc_resolutions, &other.assoc_resolutions);
         field_resolutions.extend(other.field_resolutions.iter().map(
             |(&field_expr, &field_resolution)| {
                 let mut field_resolution = field_resolution;
@@ -1505,24 +1503,22 @@ impl<'db> InferenceContext<'db> {
         merge_arena_maps(type_of_expr, &other.type_of_expr);
         merge_arena_maps(type_of_pat, &other.type_of_pat);
         merge_arena_maps(type_of_binding, &other.type_of_binding);
-        merge_hash_maps(type_of_type_placeholder, &other.type_of_type_placeholder);
-        merge_hash_maps(type_of_opaque, &other.type_of_opaque);
+        merge_thin_hash_maps(type_of_type_placeholder, &other.type_of_type_placeholder);
+        merge_thin_hash_maps(type_of_opaque, &other.type_of_opaque);
         merge_hash_maps(expr_adjustments, &other.expr_adjustments);
-        merge_hash_maps(pat_adjustments, &other.pat_adjustments);
+        merge_thin_hash_maps(pat_adjustments, &other.pat_adjustments);
         merge_arena_maps(binding_modes, &other.binding_modes);
-        merge_hash_set(skipped_ref_pats, &other.skipped_ref_pats);
-        merge_hash_set(coercion_casts, &other.coercion_casts);
-        merge_hash_maps(closures_data, &other.closures_data);
-        if let Some(other_nodes_with_type_mismatches) = &other.nodes_with_type_mismatches {
-            merge_hash_set(
-                nodes_with_type_mismatches.get_or_insert_default(),
-                other_nodes_with_type_mismatches,
-            );
-        }
+        merge_thin_hash_set(skipped_ref_pats, &other.skipped_ref_pats);
+        merge_thin_hash_set(coercion_casts, &other.coercion_casts);
+        merge_thin_hash_maps(closures_data, &other.closures_data);
+        merge_thin_hash_set(nodes_with_type_mismatches, &other.nodes_with_type_mismatches);
         self.defined_anon_consts.borrow_mut().extend(other.defined_anon_consts.iter().copied());
         self.diagnostics.extend(&other.diagnostics);
 
-        fn merge_hash_set<T: Hash + Eq + Clone>(dest: &mut FxHashSet<T>, source: &FxHashSet<T>) {
+        fn merge_thin_hash_set<T: Hash + Eq + Clone>(
+            dest: &mut ThinFxHashSet<T>,
+            source: &ThinFxHashSet<T>,
+        ) {
             dest.extend(source.iter().cloned());
         }
 
@@ -1530,6 +1526,20 @@ impl<'db> InferenceContext<'db> {
         fn merge_hash_maps<K: Hash + Eq + Clone, V: Clone + PartialEq>(
             dest: &mut FxHashMap<K, V>,
             source: &FxHashMap<K, V>,
+        ) {
+            if cfg!(debug_assertions) {
+                for (key, src) in source {
+                    assert!(dest.get(key).is_none_or(|dst| dst == src));
+                }
+            }
+
+            dest.extend(source.iter().map(|(k, v)| (k.clone(), v.clone())));
+        }
+
+        #[cfg_attr(debug_assertions, track_caller)]
+        fn merge_thin_hash_maps<K: Hash + Eq + Clone, V: Clone + PartialEq>(
+            dest: &mut ThinFxHashMap<K, V>,
+            source: &ThinFxHashMap<K, V>,
         ) {
             if cfg!(debug_assertions) {
                 for (key, src) in source {
@@ -1682,10 +1692,10 @@ impl<'db> InferenceContext<'db> {
         type_of_type_placeholder.shrink_to_fit();
         type_of_opaque.shrink_to_fit();
 
-        if let Some(nodes_with_type_mismatches) = nodes_with_type_mismatches {
+        if !nodes_with_type_mismatches.is_empty() {
             *has_errors = true;
-            nodes_with_type_mismatches.shrink_to_fit();
         }
+        nodes_with_type_mismatches.shrink_to_fit();
         for (_, subst) in method_resolutions.values_mut() {
             resolver.resolve_completely(subst);
         }
@@ -2120,7 +2130,7 @@ impl<'db> InferenceContext<'db> {
         expected: Ty<'db>,
         found: Ty<'db>,
     ) {
-        if self.result.nodes_with_type_mismatches.get_or_insert_default().insert(node) {
+        if self.result.nodes_with_type_mismatches.insert(node) {
             self.diagnostics.push(InferenceDiagnostic::TypeMismatch {
                 node,
                 expected: expected.store(),

--- a/crates/hir-ty/src/infer/closure/analysis.rs
+++ b/crates/hir-ty/src/infer/closure/analysis.rs
@@ -43,7 +43,7 @@ use hir_def::{
 use macros::{TypeFoldable, TypeVisitable};
 use rustc_abi::ExternAbi;
 use rustc_ast_ir::Mutability;
-use rustc_hash::{FxBuildHasher, FxHashMap};
+use rustc_hash::FxHashMap;
 use rustc_type_ir::{
     BoundVar, ClosureKind,
     inherent::{AdtDef as _, GenericArgs as _, IntoKind as _, Ty as _},
@@ -53,7 +53,7 @@ use span::Edition;
 use tracing::{debug, instrument};
 
 use crate::{
-    Span,
+    Span, ThinFxHashMap,
     infer::{
         CaptureInfo, CaptureSourceStack, CapturedPlace, InferenceContext, UpvarCapture,
         closure::analysis::expr_use_visitor::{
@@ -196,8 +196,7 @@ type InferredCaptureInformation = Vec<(Place, CaptureInfo)>;
 
 impl<'db> InferenceContext<'db> {
     pub(crate) fn closure_analyze(&mut self) {
-        let upvars = crate::upvars::upvars_mentioned(self.db, self.store_owner)
-            .unwrap_or(const { &FxHashMap::with_hasher(FxBuildHasher) });
+        let upvars = crate::upvars::upvars_mentioned(self.db, self.store_owner);
         for root_expr in self.store.expr_roots() {
             self.analyze_closures_in_expr(root_expr, upvars);
         }
@@ -206,7 +205,11 @@ impl<'db> InferenceContext<'db> {
         assert!(self.deferred_call_resolutions.is_empty());
     }
 
-    fn analyze_closures_in_expr(&mut self, expr: ExprId, upvars: &'db FxHashMap<ExprId, Upvars>) {
+    fn analyze_closures_in_expr(
+        &mut self,
+        expr: ExprId,
+        upvars: &'db ThinFxHashMap<ExprId, Upvars>,
+    ) {
         self.store.walk_child_exprs(expr, |expr| self.analyze_closures_in_expr(expr, upvars));
 
         match &self.store[expr] {

--- a/crates/hir-ty/src/infer/coerce.rs
+++ b/crates/hir-ty/src/infer/coerce.rs
@@ -1600,7 +1600,8 @@ fn coerce<'db>(
 fn is_capturing_closure(db: &dyn HirDatabase, closure: InternedClosureId<'_>) -> bool {
     let InternedClosure { owner, expr, .. } = closure.loc(db);
     upvars_mentioned(db, owner.expression_store_owner(db))
-        .is_some_and(|upvars| upvars.get(&expr).is_some_and(|upvars| !upvars.is_empty()))
+        .get(&expr)
+        .is_some_and(|upvars| !upvars.is_empty())
 }
 
 /// Recursively visit goals to decide whether an unsizing is possible.

--- a/crates/hir-ty/src/infer/diagnostics.rs
+++ b/crates/hir-ty/src/infer/diagnostics.rs
@@ -14,17 +14,16 @@ use hir_def::{
     resolver::Resolver,
 };
 use la_arena::RawIdx;
-use rustc_hash::FxHashMap;
 use thin_vec::ThinVec;
 
-use crate::lower::LifetimeLoweringMode;
 use crate::{
-    InferenceDiagnostic, Span, TyLoweringDiagnostic,
+    InferenceDiagnostic, Span, ThinFxHashMap, TyLoweringDiagnostic,
     db::{AnonConstId, HirDatabase},
     generics::Generics,
     infer::unify::InferenceTable,
     lower::{
-        ForbidParamsAfterReason, LifetimeElisionKind, TyLoweringContext, TyLoweringInferVarsCtx,
+        ForbidParamsAfterReason, LifetimeElisionKind, LifetimeLoweringMode, TyLoweringContext,
+        TyLoweringInferVarsCtx,
         path::{PathDiagnosticCallback, PathLoweringContext},
     },
     next_solver::{Const, Region, StoredTy, Ty},
@@ -64,7 +63,7 @@ pub(crate) struct PathDiagnosticCallbackData<'a> {
 
 pub(super) struct InferenceTyLoweringVarsCtx<'a, 'db> {
     pub(super) table: &'a mut InferenceTable<'db>,
-    pub(super) type_of_type_placeholder: &'a mut FxHashMap<TypeRefId, StoredTy>,
+    pub(super) type_of_type_placeholder: &'a mut ThinFxHashMap<TypeRefId, StoredTy>,
 }
 
 impl<'db> TyLoweringInferVarsCtx<'db> for InferenceTyLoweringVarsCtx<'_, 'db> {

--- a/crates/hir-ty/src/lib.rs
+++ b/crates/hir-ty/src/lib.rs
@@ -132,6 +132,9 @@ pub mod closure_analysis {
     };
 }
 
+type ThinFxHashMap<K, V> = stdx::thin_map::ThinHashMap<K, V, FxBuildHasher>;
+type ThinFxHashSet<T> = stdx::thin_map::ThinHashSet<T, FxBuildHasher>;
+
 /// A constant can have reference to other things. Memory map job is holding
 /// the necessary bits of memory of the const eval session to keep the constant
 /// meaningful.

--- a/crates/hir-ty/src/mir.rs
+++ b/crates/hir-ty/src/mir.rs
@@ -10,7 +10,6 @@ use intern::{InternedSlice, InternedSliceRef, impl_slice_internable};
 use la_arena::{Arena, ArenaMap, Idx, RawIdx};
 use macros::{TypeFoldable, TypeVisitable};
 use rustc_ast_ir::Mutability;
-use rustc_hash::FxHashMap;
 use rustc_type_ir::{
     CollectAndApply, GenericTypeVisitable,
     inherent::{GenericArgs as _, IntoKind, Ty as _},
@@ -20,7 +19,7 @@ use smallvec::{SmallVec, smallvec};
 use stdx::impl_from;
 
 use crate::{
-    CallableDefId, InferBodyId, InferenceResult, MemoryMap,
+    CallableDefId, InferBodyId, InferenceResult, MemoryMap, ThinFxHashMap,
     db::{HirDatabase, InternedClosureId},
     infer::PointerCast,
     next_solver::{
@@ -1059,7 +1058,7 @@ pub struct MirBody<'db> {
     pub start_block: BasicBlockId,
     pub owner: InferBodyId<'db>,
     pub binding_locals: ArenaMap<BindingId, LocalId>,
-    pub upvar_locals: FxHashMap<BindingId, Vec<(LocalId, crate::closure_analysis::Place)>>,
+    pub upvar_locals: ThinFxHashMap<BindingId, Vec<(LocalId, crate::closure_analysis::Place)>>,
     pub param_locals: Vec<LocalId>,
     /// This field stores the closures directly owned by this body. It is used
     /// in traversing every mir body.

--- a/crates/hir-ty/src/mir/lower.rs
+++ b/crates/hir-ty/src/mir/lower.rs
@@ -28,7 +28,7 @@ use span::{Edition, FileId};
 use syntax::TextRange;
 
 use crate::{
-    Adjust, Adjustment, AutoBorrow, CallableDefId, InferBodyId, ParamEnvAndCrate,
+    Adjust, Adjustment, AutoBorrow, CallableDefId, InferBodyId, ParamEnvAndCrate, ThinFxHashMap,
     consteval::ConstEvalError,
     db::{GeneralConstId, HirDatabase, InternedClosure, InternedClosureId},
     display::{DisplayTarget, HirDisplay, hir_display_with_store},
@@ -307,7 +307,7 @@ impl<'a, 'db> MirLowerCtx<'a, 'db> {
             locals,
             start_block,
             binding_locals,
-            upvar_locals: FxHashMap::default(),
+            upvar_locals: ThinFxHashMap::default(),
             param_locals: vec![],
             owner,
             closures: vec![],

--- a/crates/hir-ty/src/upvars.rs
+++ b/crates/hir-ty/src/upvars.rs
@@ -8,9 +8,9 @@ use hir_def::{
     type_ref::TypeRefId,
 };
 use hir_expand::mod_path::PathKind;
-use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hash::FxHashSet;
 
-use crate::db::HirDatabase;
+use crate::{ThinFxHashMap, db::HirDatabase};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 // Kept sorted.
@@ -74,34 +74,34 @@ impl UpvarsRef<'_> {
 pub fn upvars_mentioned(
     db: &dyn HirDatabase,
     owner: ExpressionStoreOwnerId,
-) -> Option<&FxHashMap<ExprId, Upvars>> {
+) -> &ThinFxHashMap<ExprId, Upvars> {
     return match owner {
         ExpressionStoreOwnerId::Signature(owner) => signature_upvars_mentioned(db, owner),
         ExpressionStoreOwnerId::Body(owner) => body_upvars_mentioned(db, owner),
         ExpressionStoreOwnerId::VariantFields(owner) => variant_fields_upvars_mentioned(db, owner),
     };
 
-    #[salsa::tracked(returns(as_deref))]
+    #[salsa::tracked]
     pub fn signature_upvars_mentioned(
         db: &dyn HirDatabase,
         owner: GenericDefId,
-    ) -> Option<Box<FxHashMap<ExprId, Upvars>>> {
+    ) -> ThinFxHashMap<ExprId, Upvars> {
         upvars_mentioned_impl(db, owner.into())
     }
 
-    #[salsa::tracked(returns(as_deref))]
+    #[salsa::tracked]
     pub fn body_upvars_mentioned(
         db: &dyn HirDatabase,
         owner: DefWithBodyId,
-    ) -> Option<Box<FxHashMap<ExprId, Upvars>>> {
+    ) -> ThinFxHashMap<ExprId, Upvars> {
         upvars_mentioned_impl(db, owner.into())
     }
 
-    #[salsa::tracked(returns(as_deref))]
+    #[salsa::tracked]
     pub fn variant_fields_upvars_mentioned(
         db: &dyn HirDatabase,
         owner: VariantId,
-    ) -> Option<Box<FxHashMap<ExprId, Upvars>>> {
+    ) -> ThinFxHashMap<ExprId, Upvars> {
         upvars_mentioned_impl(db, owner.into())
     }
 }
@@ -109,26 +109,24 @@ pub fn upvars_mentioned(
 pub fn upvars_mentioned_impl(
     db: &dyn HirDatabase,
     owner: ExpressionStoreOwnerId,
-) -> Option<Box<FxHashMap<ExprId, Upvars>>> {
+) -> ThinFxHashMap<ExprId, Upvars> {
     let store = ExpressionStore::of(db, owner);
-    store.expr_roots().next()?;
+    if store.expr_roots().next().is_none() {
+        return ThinFxHashMap::new();
+    }
     let resolver = owner.resolver(db);
     let mut visitor = UpvarsMentionedVisitor {
         db,
         resolver,
         owner,
         store,
-        closures_map: FxHashMap::default(),
+        closures_map: ThinFxHashMap::default(),
         current_closure: None,
     };
     visitor.on_exprs(store.expr_roots());
     let mut result = visitor.closures_map;
-    if result.is_empty() {
-        None
-    } else {
-        result.shrink_to_fit();
-        Some(Box::new(result))
-    }
+    result.shrink_to_fit();
+    result
 }
 
 struct UpvarsMentionedVisitor<'db> {
@@ -136,7 +134,7 @@ struct UpvarsMentionedVisitor<'db> {
     resolver: Resolver<'db>,
     owner: ExpressionStoreOwnerId,
     store: &'db ExpressionStore,
-    closures_map: FxHashMap<ExprId, Upvars>,
+    closures_map: ThinFxHashMap<ExprId, Upvars>,
     current_closure: Option<(ExprId, FxHashSet<BindingId>)>,
 }
 
@@ -258,10 +256,7 @@ mod tests {
                 .exactly_one()
                 .unwrap_or_else(|_| panic!("expected one function"));
             let (body, source_map) = Body::with_source_map(&db, func.into());
-            let Some(upvars) = upvars_mentioned(&db, DefWithBodyId::from(func).into()) else {
-                expectation.assert_eq("");
-                return;
-            };
+            let upvars = upvars_mentioned(&db, DefWithBodyId::from(func).into());
             let mut closures = Vec::new();
             for (&closure, upvars) in upvars {
                 let closure_range = source_map.expr_syntax(closure).unwrap().value.text_range();

--- a/crates/stdx/Cargo.toml
+++ b/crates/stdx/Cargo.toml
@@ -19,6 +19,8 @@ crossbeam-channel.workspace = true
 itertools.workspace = true
 tracing.workspace = true
 crossbeam-utils = "0.8.21"
+thin-vec.workspace = true
+salsa = { workspace = true, optional = true }
 # Think twice before adding anything here
 
 [target.'cfg(unix)'.dependencies]
@@ -32,6 +34,7 @@ windows-sys = { version = "0.61", features = ["Win32_Foundation"] }
 # Uncomment to enable for the whole crate graph
 # default = [ "backtrace" ]
 force-always-assert = []
+salsa = ["dep:salsa"]
 
 [lints]
 workspace = true

--- a/crates/stdx/src/lib.rs
+++ b/crates/stdx/src/lib.rs
@@ -14,6 +14,7 @@ pub mod panic_context;
 pub mod process;
 pub mod rand;
 pub mod tempfile;
+pub mod thin_map;
 pub mod thread;
 pub mod variance;
 

--- a/crates/stdx/src/thin_map.rs
+++ b/crates/stdx/src/thin_map.rs
@@ -1,0 +1,997 @@
+//! A map that is optimized for having few elements: when the length is low, it is stored as a `ThinVec`.
+#![deny(unsafe_code)]
+
+mod set;
+#[cfg(test)]
+mod tests;
+
+use std::{
+    borrow::Borrow,
+    hash::{BuildHasher, Hash},
+    mem,
+};
+
+use thin_vec::ThinVec;
+
+pub use self::set::{ThinHashSet, ThinSet};
+pub use self::unsafe_encapsulation::ThinMap;
+
+#[derive(Clone, PartialEq)]
+#[cfg_attr(feature = "salsa", derive(salsa::SalsaValue))]
+#[repr(align(2))]
+struct Align<T>(T);
+
+type ThinReprItem<K, V> = Align<(K, V)>;
+type ThinReprVec<K, V> = ThinVec<ThinReprItem<K, V>>;
+
+enum ReprRef<'a, K, V, M> {
+    Thin(&'a [ThinReprItem<K, V>]),
+    Map(&'a M),
+}
+
+enum ReprMut<'a, K, V, M> {
+    Thin(&'a mut ThinReprVec<K, V>),
+    Map(&'a mut M),
+}
+
+#[cfg_attr(feature = "salsa", derive(salsa::SalsaValue))]
+enum Repr<K, V, M> {
+    Thin(ThinReprVec<K, V>),
+    Map(Box<Align<M>>),
+}
+
+pub enum MapEntry<'a, K, V, M: Map<K, V> + 'a> {
+    Occupied(M::OccupiedEntry<'a>),
+    Vacant(M::VacantEntry<'a>),
+}
+
+// We use generic parameters and not associated types because this allows us to keep `ThinMap` covariant over `M`
+// (associated types are invariant).
+pub trait Map<K, V>: Default {
+    fn with_capacity(capacity: usize) -> Self;
+    fn reserve(&mut self, additional: usize);
+    fn len(&self) -> usize;
+    fn shrink_to_fit(&mut self);
+
+    type Iter<'a>: ExactSizeIterator<Item = (&'a K, &'a V)>
+    where
+        K: 'a,
+        V: 'a,
+        Self: 'a;
+    type IterMut<'a>: ExactSizeIterator<Item = (&'a K, &'a mut V)>
+    where
+        K: 'a,
+        V: 'a,
+        Self: 'a;
+    type IntoIter: ExactSizeIterator<Item = (K, V)>;
+
+    fn iter(&self) -> Self::Iter<'_>;
+    fn iter_mut(&mut self) -> Self::IterMut<'_>;
+    fn into_iter(self) -> Self::IntoIter;
+
+    fn get<Q>(&self, key: &Q) -> Option<&V>
+    where
+        K: Borrow<Q>,
+        Q: ?Sized + Hash + Eq;
+    fn get_mut<Q>(&mut self, key: &Q) -> Option<&mut V>
+    where
+        K: Borrow<Q>,
+        Q: ?Sized + Hash + Eq;
+    fn get_disjoint_mut<Q, const N: usize>(&mut self, ks: [&Q; N]) -> [Option<&mut V>; N]
+    where
+        K: Borrow<Q>,
+        Q: ?Sized + Hash + Eq;
+
+    fn insert(&mut self, key: K, value: V) -> Option<V>;
+    fn remove<Q>(&mut self, key: &Q) -> Option<V>
+    where
+        K: Borrow<Q>,
+        Q: ?Sized + Hash + Eq;
+
+    type OccupiedEntry<'a>
+    where
+        Self: 'a;
+    type VacantEntry<'a>
+    where
+        Self: 'a;
+
+    fn entry(&mut self, key: K) -> MapEntry<'_, K, V, Self>;
+    fn vacant_entry_insert<'a>(entry: Self::VacantEntry<'a>, value: V) -> &'a mut V
+    where
+        Self: 'a;
+    fn occupied_entry_get<'a, 'b>(entry: &'a Self::OccupiedEntry<'b>) -> &'a V
+    where
+        Self: 'b;
+    fn occupied_entry_get_mut<'a, 'b>(entry: &'a mut Self::OccupiedEntry<'b>) -> &'a mut V
+    where
+        Self: 'b;
+    fn occupied_entry_into_mut<'a>(entry: Self::OccupiedEntry<'a>) -> &'a mut V
+    where
+        Self: 'a;
+    fn occupied_entry_insert<'a>(entry: &mut Self::OccupiedEntry<'a>, value: V) -> V
+    where
+        Self: 'a;
+}
+
+#[expect(clippy::disallowed_types)]
+impl<K: Hash + Eq, V, S: BuildHasher + Default> Map<K, V> for std::collections::HashMap<K, V, S> {
+    #[inline]
+    fn with_capacity(capacity: usize) -> Self {
+        Self::with_capacity_and_hasher(capacity, S::default())
+    }
+    #[inline]
+    fn reserve(&mut self, additional: usize) {
+        self.reserve(additional);
+    }
+    #[inline]
+    fn len(&self) -> usize {
+        self.len()
+    }
+    #[inline]
+    fn shrink_to_fit(&mut self) {
+        self.shrink_to_fit();
+    }
+
+    type Iter<'a>
+        = std::collections::hash_map::Iter<'a, K, V>
+    where
+        Self: 'a;
+    type IterMut<'a>
+        = std::collections::hash_map::IterMut<'a, K, V>
+    where
+        Self: 'a;
+    type IntoIter = std::collections::hash_map::IntoIter<K, V>;
+
+    #[inline]
+    fn iter(&self) -> Self::Iter<'_> {
+        self.iter()
+    }
+    #[inline]
+    fn iter_mut(&mut self) -> Self::IterMut<'_> {
+        self.iter_mut()
+    }
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        IntoIterator::into_iter(self)
+    }
+
+    #[inline]
+    fn get<Q>(&self, key: &Q) -> Option<&V>
+    where
+        K: Borrow<Q>,
+        Q: ?Sized + Hash + Eq,
+    {
+        self.get(key)
+    }
+    #[inline]
+    fn get_mut<Q>(&mut self, key: &Q) -> Option<&mut V>
+    where
+        K: Borrow<Q>,
+        Q: ?Sized + Hash + Eq,
+    {
+        self.get_mut(key)
+    }
+    #[inline]
+    fn get_disjoint_mut<Q, const N: usize>(&mut self, ks: [&Q; N]) -> [Option<&mut V>; N]
+    where
+        K: Borrow<Q>,
+        Q: ?Sized + Hash + Eq,
+    {
+        self.get_disjoint_mut(ks)
+    }
+
+    #[inline]
+    fn insert(&mut self, key: K, value: V) -> Option<V> {
+        self.insert(key, value)
+    }
+    #[inline]
+    fn remove<Q>(&mut self, key: &Q) -> Option<V>
+    where
+        K: Borrow<Q>,
+        Q: ?Sized + Hash + Eq,
+    {
+        self.remove(key)
+    }
+
+    type OccupiedEntry<'a>
+        = std::collections::hash_map::OccupiedEntry<'a, K, V>
+    where
+        Self: 'a;
+    type VacantEntry<'a>
+        = std::collections::hash_map::VacantEntry<'a, K, V>
+    where
+        Self: 'a;
+
+    #[inline]
+    fn entry(&mut self, key: K) -> MapEntry<'_, K, V, Self> {
+        match self.entry(key) {
+            std::collections::hash_map::Entry::Occupied(it) => MapEntry::Occupied(it),
+            std::collections::hash_map::Entry::Vacant(it) => MapEntry::Vacant(it),
+        }
+    }
+    #[inline]
+    fn vacant_entry_insert<'a>(entry: Self::VacantEntry<'a>, value: V) -> &'a mut V
+    where
+        Self: 'a,
+    {
+        entry.insert(value)
+    }
+    #[inline]
+    fn occupied_entry_get<'a, 'b>(entry: &'a Self::OccupiedEntry<'b>) -> &'a V
+    where
+        Self: 'b,
+    {
+        entry.get()
+    }
+    #[inline]
+    fn occupied_entry_get_mut<'a, 'b>(entry: &'a mut Self::OccupiedEntry<'b>) -> &'a mut V
+    where
+        Self: 'b,
+    {
+        entry.get_mut()
+    }
+    #[inline]
+    fn occupied_entry_into_mut<'a>(entry: Self::OccupiedEntry<'a>) -> &'a mut V
+    where
+        Self: 'a,
+    {
+        entry.into_mut()
+    }
+    #[inline]
+    fn occupied_entry_insert<'a>(entry: &mut Self::OccupiedEntry<'a>, value: V) -> V
+    where
+        Self: 'a,
+    {
+        entry.insert(value)
+    }
+}
+
+#[expect(clippy::disallowed_types)]
+pub type ThinHashMap<K, V, S> = ThinMap<K, V, std::collections::HashMap<K, V, S>>;
+
+/// The maximum len to still use `ThinVec`.
+const LEN_CUTOFF: usize = 10;
+
+impl<K: Hash + Eq, V, M: Map<K, V>> ThinMap<K, V, M> {
+    #[inline]
+    pub fn with_capacity(capacity: usize) -> Self {
+        let repr = if capacity > LEN_CUTOFF {
+            Repr::Map(Box::new(Align(M::with_capacity(capacity))))
+        } else {
+            Repr::Thin(ThinVec::with_capacity(capacity))
+        };
+        Self::from_repr(repr)
+    }
+
+    #[inline]
+    pub fn reserve(&mut self, additional: usize) {
+        match self.repr_mut() {
+            ReprMut::Thin(repr) => {
+                let expected_len = repr.len() + additional;
+                if expected_len > repr.capacity() || expected_len > LEN_CUTOFF {
+                    self.reserve_cold(expected_len);
+                }
+            }
+            ReprMut::Map(repr) => repr.reserve(additional),
+        }
+    }
+
+    #[cold]
+    fn reserve_cold(&mut self, expected_len: usize) {
+        let ReprMut::Thin(repr) = self.repr_mut() else { unreachable!() };
+        if expected_len <= LEN_CUTOFF {
+            repr.reserve(expected_len - repr.len());
+        } else {
+            let mut map = M::with_capacity(expected_len);
+            for Align((key, value)) in mem::take(repr) {
+                map.insert(key, value);
+            }
+            *self = Self::from_repr(Repr::Map(Box::new(Align(map))));
+        }
+    }
+
+    pub fn shrink_to_fit(&mut self) {
+        let mut repr = mem::take(self).into_repr();
+        match repr {
+            Repr::Thin(ref mut repr) => repr.shrink_to_fit(),
+            Repr::Map(mut map) => {
+                repr = if map.0.len() > LEN_CUTOFF {
+                    map.0.shrink_to_fit();
+                    Repr::Map(map)
+                } else {
+                    Repr::Thin(map.0.into_iter().map(Align).collect())
+                };
+            }
+        }
+        *self = Self::from_repr(repr);
+    }
+
+    #[inline]
+    pub fn len(&self) -> usize {
+        match self.repr_ref() {
+            ReprRef::Thin(repr) => repr.len(),
+            ReprRef::Map(repr) => repr.len(),
+        }
+    }
+
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    #[inline]
+    pub fn iter(&self) -> Iter<'_, K, V, M> {
+        let repr = match self.repr_ref() {
+            ReprRef::Thin(repr) => IterRepr::Thin(repr.iter()),
+            ReprRef::Map(repr) => IterRepr::Map(repr.iter()),
+        };
+        Iter { repr }
+    }
+
+    #[inline]
+    pub fn iter_mut(&mut self) -> IterMut<'_, K, V, M> {
+        let repr = match self.repr_mut() {
+            ReprMut::Thin(repr) => IterMutRepr::Thin(repr.iter_mut()),
+            ReprMut::Map(repr) => IterMutRepr::Map(repr.iter_mut()),
+        };
+        IterMut { repr }
+    }
+
+    #[inline]
+    pub fn keys(&self) -> impl ExactSizeIterator<Item = &K> {
+        self.iter().map(|(key, _value)| key)
+    }
+
+    #[inline]
+    pub fn values(&self) -> impl ExactSizeIterator<Item = &V> {
+        self.iter().map(|(_key, value)| value)
+    }
+
+    #[inline]
+    pub fn values_mut(&mut self) -> impl ExactSizeIterator<Item = &mut V> {
+        self.iter_mut().map(|(_key, value)| value)
+    }
+
+    #[inline]
+    pub fn into_keys(self) -> impl ExactSizeIterator<Item = K> {
+        self.into_iter().map(|(key, _value)| key)
+    }
+
+    #[inline]
+    pub fn into_values(self) -> impl ExactSizeIterator<Item = V> {
+        self.into_iter().map(|(_key, value)| value)
+    }
+
+    #[inline]
+    pub fn contains_key<Q>(&self, key: &Q) -> bool
+    where
+        K: Borrow<Q>,
+        Q: ?Sized + Hash + Eq,
+    {
+        self.get(key).is_some()
+    }
+
+    #[inline]
+    pub fn get<Q>(&self, key: &Q) -> Option<&V>
+    where
+        K: Borrow<Q>,
+        Q: ?Sized + Hash + Eq,
+    {
+        match self.repr_ref() {
+            ReprRef::Thin(repr) => {
+                repr.iter().find_map(|Align((k, v))| (k.borrow() == key).then_some(v))
+            }
+            ReprRef::Map(repr) => repr.get(key),
+        }
+    }
+
+    #[inline]
+    pub fn get_mut<Q>(&mut self, key: &Q) -> Option<&mut V>
+    where
+        K: Borrow<Q>,
+        Q: ?Sized + Hash + Eq,
+    {
+        match self.repr_mut() {
+            ReprMut::Thin(repr) => {
+                repr.iter_mut().find_map(|Align((k, v))| ((*k).borrow() == key).then_some(v))
+            }
+            ReprMut::Map(repr) => repr.get_mut(key),
+        }
+    }
+
+    pub fn get_disjoint_mut<Q, const N: usize>(&mut self, ks: [&Q; N]) -> [Option<&mut V>; N]
+    where
+        K: Borrow<Q>,
+        Q: ?Sized + Hash + Eq,
+    {
+        match self.repr_mut() {
+            ReprMut::Thin(repr) => {
+                let mut result = [const { None }; N];
+                for Align((key, value)) in repr {
+                    for (&k, v) in std::iter::zip(&ks, &mut result) {
+                        if (*key).borrow() == k {
+                            *v = Some(value);
+                            break;
+                        }
+                    }
+                }
+                result
+            }
+            ReprMut::Map(repr) => repr.get_disjoint_mut(ks),
+        }
+    }
+
+    #[inline]
+    pub fn insert(&mut self, key: K, value: V) -> Option<V> {
+        match self.repr_mut() {
+            ReprMut::Thin(repr) => {
+                let existing = repr.iter_mut().find(|Align((k, _v))| *k == key);
+                match existing {
+                    Some(Align((_k, v))) => Some(mem::replace(v, value)),
+                    None => {
+                        if repr.len() < LEN_CUTOFF {
+                            repr.push(Align((key, value)));
+                        } else {
+                            self.insert_cold(key, value);
+                        }
+                        None
+                    }
+                }
+            }
+            ReprMut::Map(repr) => repr.insert(key, value),
+        }
+    }
+
+    #[inline]
+    #[expect(unsafe_code)]
+    pub fn entry(&mut self, key: K) -> Entry<'_, K, V, M> {
+        let this_ptr = self as *mut Self;
+        match self.repr_mut() {
+            ReprMut::Thin(repr) => {
+                let existing = repr.iter().position(|Align((k, _v))| *k == key);
+                match existing {
+                    Some(existing) => Entry::Occupied(OccupiedEntry {
+                        repr: OccupiedEntryRepr::Thin { slice: repr, index: existing },
+                    }),
+                    None => {
+                        if repr.len() < LEN_CUTOFF {
+                            Entry::Vacant(VacantEntry {
+                                repr: VacantEntryRepr::ThinHasSpace(key, repr),
+                            })
+                        } else {
+                            // SAFETY: Polonius workaround.
+                            Entry::Vacant(VacantEntry {
+                                repr: VacantEntryRepr::ThinNoSpace(key, unsafe { &mut *this_ptr }),
+                            })
+                        }
+                    }
+                }
+            }
+            ReprMut::Map(repr) => match repr.entry(key) {
+                MapEntry::Occupied(it) => {
+                    Entry::Occupied(OccupiedEntry { repr: OccupiedEntryRepr::Map(it) })
+                }
+                MapEntry::Vacant(it) => {
+                    Entry::Vacant(VacantEntry { repr: VacantEntryRepr::Map(it) })
+                }
+            },
+        }
+    }
+
+    #[cold]
+    fn insert_cold(&mut self, new_key: K, new_value: V) -> &mut V {
+        let old_repr = match self.repr_mut() {
+            ReprMut::Thin(repr) => mem::take(repr),
+            ReprMut::Map(_) => unreachable!(),
+        };
+        let map = M::with_capacity(old_repr.len() + 1);
+        *self = Self::from_repr(Repr::Map(Box::new(Align(map))));
+        let map = match self.repr_mut() {
+            ReprMut::Map(map) => map,
+            ReprMut::Thin(_) => unreachable!(),
+        };
+        for Align((old_key, old_value)) in old_repr {
+            map.insert(old_key, old_value);
+        }
+        match M::entry(map, new_key) {
+            MapEntry::Vacant(entry) => M::vacant_entry_insert(entry, new_value),
+            MapEntry::Occupied(_) => panic!("non-existing key somehow compares equal?!"),
+        }
+    }
+
+    #[inline]
+    pub fn remove<Q>(&mut self, key: &Q) -> Option<V>
+    where
+        K: Borrow<Q>,
+        Q: ?Sized + Hash + Eq,
+    {
+        match self.repr_mut() {
+            ReprMut::Thin(repr) => {
+                let index = repr.iter().position(|Align((k, _v))| k.borrow() == key);
+                index.map(|index| repr.swap_remove(index).0.1)
+            }
+            ReprMut::Map(repr) => repr.remove(key),
+        }
+    }
+}
+
+enum OccupiedEntryRepr<'a, K, V, M: Map<K, V> + 'a> {
+    Thin { slice: &'a mut [Align<(K, V)>], index: usize },
+    Map(M::OccupiedEntry<'a>),
+}
+
+enum VacantEntryRepr<'a, K, V, M: Map<K, V>> {
+    ThinHasSpace(K, &'a mut ThinReprVec<K, V>),
+    ThinNoSpace(K, &'a mut ThinMap<K, V, M>),
+    Map(M::VacantEntry<'a>),
+}
+
+pub struct OccupiedEntry<'a, K, V, M: Map<K, V>> {
+    repr: OccupiedEntryRepr<'a, K, V, M>,
+}
+
+pub struct VacantEntry<'a, K, V, M: Map<K, V>> {
+    repr: VacantEntryRepr<'a, K, V, M>,
+}
+
+pub enum Entry<'a, K, V, M: Map<K, V>> {
+    Occupied(OccupiedEntry<'a, K, V, M>),
+    Vacant(VacantEntry<'a, K, V, M>),
+}
+
+impl<'a, K: Hash + Eq, V, M: Map<K, V>> VacantEntry<'a, K, V, M> {
+    #[inline]
+    pub fn insert(self, value: V) -> &'a mut V {
+        match self.repr {
+            VacantEntryRepr::ThinHasSpace(key, repr) => {
+                repr.push(Align((key, value)));
+                &mut repr.last_mut().unwrap().0.1
+            }
+            VacantEntryRepr::ThinNoSpace(key, repr) => repr.insert_cold(key, value),
+            VacantEntryRepr::Map(repr) => M::vacant_entry_insert(repr, value),
+        }
+    }
+}
+
+impl<'a, K: Hash + Eq, V, M: Map<K, V>> OccupiedEntry<'a, K, V, M> {
+    #[inline]
+    pub fn get(&self) -> &V {
+        match &self.repr {
+            OccupiedEntryRepr::Thin { slice, index } => &slice[*index].0.1,
+            OccupiedEntryRepr::Map(repr) => M::occupied_entry_get(repr),
+        }
+    }
+
+    #[inline]
+    pub fn get_mut(&mut self) -> &mut V {
+        match &mut self.repr {
+            OccupiedEntryRepr::Thin { slice, index } => &mut slice[*index].0.1,
+            OccupiedEntryRepr::Map(repr) => M::occupied_entry_get_mut(repr),
+        }
+    }
+
+    #[inline]
+    pub fn into_mut(self) -> &'a mut V {
+        match self.repr {
+            OccupiedEntryRepr::Thin { slice, index } => &mut slice[index].0.1,
+            OccupiedEntryRepr::Map(repr) => M::occupied_entry_into_mut(repr),
+        }
+    }
+
+    #[inline]
+    pub fn insert(&mut self, value: V) -> V {
+        match &mut self.repr {
+            OccupiedEntryRepr::Thin { slice, index } => mem::replace(&mut slice[*index].0.1, value),
+            OccupiedEntryRepr::Map(repr) => M::occupied_entry_insert(repr, value),
+        }
+    }
+}
+
+impl<Q, K, V, M> std::ops::Index<&Q> for ThinMap<K, V, M>
+where
+    Q: ?Sized + Hash + Eq,
+    K: Borrow<Q> + Hash + Eq,
+    M: Map<K, V>,
+{
+    type Output = V;
+
+    #[inline]
+    #[track_caller]
+    fn index(&self, index: &Q) -> &Self::Output {
+        self.get(index).expect("missing key")
+    }
+}
+
+impl<'a, K: Hash + Eq, V, M: Map<K, V>> Entry<'a, K, V, M> {
+    #[inline]
+    pub fn or_insert_with(self, default: impl FnOnce() -> V) -> &'a mut V {
+        match self {
+            Entry::Occupied(entry) => {
+                drop(default);
+                entry.into_mut()
+            }
+            Entry::Vacant(entry) => entry.insert(default()),
+        }
+    }
+
+    #[inline]
+    pub fn or_insert(self, default: V) -> &'a mut V {
+        self.or_insert_with(move || default)
+    }
+
+    #[inline]
+    pub fn or_default(self) -> &'a mut V
+    where
+        V: Default,
+    {
+        self.or_insert_with(V::default)
+    }
+}
+
+impl<K, V, M: Map<K, V>> Default for ThinMap<K, V, M> {
+    #[inline]
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<K, V, M> std::fmt::Debug for ThinMap<K, V, M>
+where
+    M: Map<K, V>,
+    K: Hash + Eq + std::fmt::Debug,
+    V: std::fmt::Debug,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_map().entries(self).finish()
+    }
+}
+
+impl<K, V, M> Clone for ThinMap<K, V, M>
+where
+    M: Map<K, V> + Clone,
+    K: Clone,
+    V: Clone,
+{
+    #[inline]
+    fn clone(&self) -> Self {
+        let repr = match self.repr_ref() {
+            ReprRef::Thin(repr) => Repr::Thin(ThinVec::from(repr)),
+            ReprRef::Map(repr) => Repr::Map(Box::new(Align(repr.clone()))),
+        };
+        Self::from_repr(repr)
+    }
+}
+
+impl<K, V, M> PartialEq for ThinMap<K, V, M>
+where
+    M: Map<K, V> + PartialEq,
+    K: Hash + Eq,
+    V: PartialEq,
+{
+    #[inline]
+    fn eq(&self, other: &Self) -> bool {
+        match (self.repr_ref(), other.repr_ref()) {
+            (ReprRef::Map(this), ReprRef::Map(other)) => {
+                this.len() == other.len()
+                    && other.iter().all(|(key, value)| this.get(key) == Some(value))
+            }
+            (ReprRef::Map(map), ReprRef::Thin(thin)) | (ReprRef::Thin(thin), ReprRef::Map(map)) => {
+                thin.len() == map.len()
+                    && thin.iter().all(|Align((key, value))| map.get(key) == Some(value))
+            }
+            (ReprRef::Thin(this), ReprRef::Thin(other)) => {
+                this.len() == other.len() && this.iter().all(|this_item| other.contains(this_item))
+            }
+        }
+    }
+}
+
+impl<K, V, M> Eq for ThinMap<K, V, M>
+where
+    M: Map<K, V> + Eq,
+    K: Hash + Eq,
+    V: Eq,
+{
+}
+
+impl<'a, K: Hash + Eq, V, M: Map<K, V>> IntoIterator for &'a ThinMap<K, V, M> {
+    type Item = (&'a K, &'a V);
+    type IntoIter = Iter<'a, K, V, M>;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+impl<'a, K: Hash + Eq, V, M: Map<K, V>> IntoIterator for &'a mut ThinMap<K, V, M> {
+    type Item = (&'a K, &'a mut V);
+    type IntoIter = IterMut<'a, K, V, M>;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter_mut()
+    }
+}
+
+impl<K, V, M: Map<K, V>> IntoIterator for ThinMap<K, V, M> {
+    type Item = (K, V);
+    type IntoIter = IntoIter<K, V, M>;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        let repr = match self.into_repr() {
+            Repr::Thin(repr) => IntoIterRepr::Thin(repr.into_iter()),
+            Repr::Map(repr) => IntoIterRepr::Map(repr.0.into_iter()),
+        };
+        IntoIter { repr }
+    }
+}
+
+enum IterRepr<'a, K, V, M: Map<K, V> + 'a> {
+    Thin(std::slice::Iter<'a, Align<(K, V)>>),
+    Map(M::Iter<'a>),
+}
+
+enum IterMutRepr<'a, K, V, M: Map<K, V> + 'a> {
+    Thin(std::slice::IterMut<'a, Align<(K, V)>>),
+    Map(M::IterMut<'a>),
+}
+
+enum IntoIterRepr<K, V, M: Map<K, V>> {
+    Thin(thin_vec::IntoIter<Align<(K, V)>>),
+    Map(M::IntoIter),
+}
+
+macro_rules! impl_iter_methods {
+    ( $repr:ident, $map:expr ) => {
+        #[inline]
+        fn next(&mut self) -> Option<Self::Item> {
+            match &mut self.repr {
+                $repr::Thin(repr) => repr.next().map($map),
+                $repr::Map(repr) => repr.next(),
+            }
+        }
+
+        #[inline]
+        fn size_hint(&self) -> (usize, Option<usize>) {
+            let len = match &self.repr {
+                $repr::Thin(repr) => repr.len(),
+                $repr::Map(repr) => repr.len(),
+            };
+            (len, Some(len))
+        }
+
+        #[inline]
+        fn fold<B, F>(self, init: B, mut f: F) -> B
+        where
+            Self: Sized,
+            F: FnMut(B, Self::Item) -> B,
+        {
+            match self.repr {
+                $repr::Thin(repr) => repr.fold(init, move |init, item| f(init, $map(item))),
+                $repr::Map(repr) => repr.fold(init, f),
+            }
+        }
+
+        #[inline]
+        fn for_each<F>(self, mut f: F)
+        where
+            Self: Sized,
+            F: FnMut(Self::Item),
+        {
+            match self.repr {
+                $repr::Thin(repr) => repr.for_each(move |item| f($map(item))),
+                $repr::Map(repr) => repr.for_each(f),
+            }
+        }
+
+        #[inline]
+        fn all<F>(&mut self, mut f: F) -> bool
+        where
+            Self: Sized,
+            F: FnMut(Self::Item) -> bool,
+        {
+            match &mut self.repr {
+                $repr::Thin(repr) => repr.all(move |item| f($map(item))),
+                $repr::Map(repr) => repr.all(f),
+            }
+        }
+
+        #[inline]
+        fn any<F>(&mut self, mut f: F) -> bool
+        where
+            Self: Sized,
+            F: FnMut(Self::Item) -> bool,
+        {
+            match &mut self.repr {
+                $repr::Thin(repr) => repr.any(move |item| f($map(item))),
+                $repr::Map(repr) => repr.any(f),
+            }
+        }
+    };
+}
+
+pub struct Iter<'a, K, V, M: Map<K, V>> {
+    repr: IterRepr<'a, K, V, M>,
+}
+
+impl<'a, K, V, M: Map<K, V>> Iterator for Iter<'a, K, V, M> {
+    type Item = (&'a K, &'a V);
+
+    impl_iter_methods!(IterRepr, |item: &'a Align<(K, V)>| (&item.0.0, &item.0.1));
+}
+
+impl<K, V, M: Map<K, V>> ExactSizeIterator for Iter<'_, K, V, M> {}
+
+pub struct IterMut<'a, K, V, M: Map<K, V>> {
+    repr: IterMutRepr<'a, K, V, M>,
+}
+
+impl<'a, K, V, M: Map<K, V>> Iterator for IterMut<'a, K, V, M> {
+    type Item = (&'a K, &'a mut V);
+
+    impl_iter_methods!(IterMutRepr, |item: &'a mut Align<(K, V)>| (&item.0.0, &mut item.0.1));
+}
+
+impl<K, V, M: Map<K, V>> ExactSizeIterator for IterMut<'_, K, V, M> {}
+
+pub struct IntoIter<K, V, M: Map<K, V>> {
+    repr: IntoIterRepr<K, V, M>,
+}
+
+impl<K, V, M: Map<K, V>> Iterator for IntoIter<K, V, M> {
+    type Item = (K, V);
+
+    impl_iter_methods!(IntoIterRepr, |item: Align<(K, V)>| item.0);
+}
+
+impl<K, V, M: Map<K, V>> ExactSizeIterator for IntoIter<K, V, M> {}
+
+impl<K: Hash + Eq, V, M: Map<K, V>> FromIterator<(K, V)> for ThinMap<K, V, M> {
+    #[inline]
+    fn from_iter<T: IntoIterator<Item = (K, V)>>(iter: T) -> Self {
+        let mut result = Self::new();
+        result.extend(iter);
+        result
+    }
+}
+
+impl<K: Hash + Eq, V, M: Map<K, V>> Extend<(K, V)> for ThinMap<K, V, M> {
+    #[inline]
+    fn extend<T: IntoIterator<Item = (K, V)>>(&mut self, iter: T) {
+        let iter = iter.into_iter();
+        self.reserve(iter.size_hint().0);
+        iter.for_each(|(key, value)| {
+            self.insert(key, value);
+        });
+    }
+}
+
+#[expect(unsafe_code)]
+mod unsafe_encapsulation {
+    use std::{
+        marker::PhantomData,
+        mem::{self, ManuallyDrop},
+        ptr::NonNull,
+    };
+
+    use thin_vec::ThinVec;
+
+    use super::{Align, Repr, ReprMut, ReprRef, ThinReprVec};
+
+    pub struct ThinMap<K, V, M> {
+        // INVARIANT: Holds a transmuted `ThinReprVec` or a `Box<Align<M>>` with its LSB set.
+        ptr: NonNull<()>,
+        _repr: PhantomData<Repr<K, V, M>>,
+    }
+
+    // SAFETY: We essentially own `Repr<K, V, M>`.
+    unsafe impl<K, V, M> Send for ThinMap<K, V, M> where Repr<K, V, M>: Send {}
+
+    unsafe impl<K, V, M> Sync for ThinMap<K, V, M> where Repr<K, V, M>: Sync {}
+
+    #[cfg(feature = "salsa")]
+    unsafe impl<K, V, M> salsa::SalsaValue for ThinMap<K, V, M> where Repr<K, V, M>: salsa::SalsaValue {}
+
+    impl<K, V, M> ThinMap<K, V, M> {
+        const TAG: usize = 0b1;
+
+        #[inline]
+        pub(super) fn repr_ref<'a>(&'a self) -> ReprRef<'a, K, V, M> {
+            let tag = self.ptr.addr().get() & Self::TAG;
+            // SAFETY: Per our invariant. `ThinVec` is layout-equivalent to a pointer.
+            // FIXME: Technically `ThinVec`'s layout isn't guaranteed unless we enable the `gecko-ffi` feature. Should we enable it?
+            unsafe {
+                match tag {
+                    0 => {
+                        let thin_vec =
+                            mem::transmute::<&'a NonNull<()>, &'a ThinReprVec<K, V>>(&self.ptr);
+                        ReprRef::Thin(thin_vec)
+                    }
+                    1 => ReprRef::Map(
+                        &(*self.ptr.as_ptr().map_addr(|addr| addr & !Self::TAG).cast::<Align<M>>())
+                            .0,
+                    ),
+                    _ => unreachable!(),
+                }
+            }
+        }
+
+        #[inline]
+        pub(super) fn repr_mut<'a>(&'a mut self) -> ReprMut<'a, K, V, M> {
+            let tag = self.ptr.addr().get() & Self::TAG;
+            // SAFETY: Per our invariant. `ThinVec` is layout-equivalent to a pointer.
+            unsafe {
+                match tag {
+                    0 => {
+                        let thin_vec = mem::transmute::<
+                            &'a mut NonNull<()>,
+                            &'a mut ThinReprVec<K, V>,
+                        >(&mut self.ptr);
+                        ReprMut::Thin(thin_vec)
+                    }
+                    1 => ReprMut::Map(
+                        &mut (*self
+                            .ptr
+                            .as_ptr()
+                            .map_addr(|addr| addr & !Self::TAG)
+                            .cast::<Align<M>>())
+                        .0,
+                    ),
+                    _ => unreachable!(),
+                }
+            }
+        }
+
+        #[inline]
+        pub(super) fn into_repr(self) -> Repr<K, V, M> {
+            let this = ManuallyDrop::new(self);
+            let tag = this.ptr.addr().get() & Self::TAG;
+            // SAFETY: Per our invariant. `ThinVec` is layout-equivalent to a pointer.
+            unsafe {
+                match tag {
+                    0 => Repr::Thin(mem::transmute::<NonNull<()>, ThinReprVec<K, V>>(this.ptr)),
+                    1 => Repr::Map(Box::from_raw(
+                        this.ptr.as_ptr().map_addr(|addr| addr & !Self::TAG).cast::<Align<M>>(),
+                    )),
+                    _ => unreachable!(),
+                }
+            }
+        }
+
+        #[inline]
+        pub(super) fn from_repr(repr: Repr<K, V, M>) -> Self {
+            let ptr = match repr {
+                // SAFETY: `ThinVec` is layout-equivalent to a pointer.
+                Repr::Thin(repr) => unsafe {
+                    mem::transmute::<ThinReprVec<K, V>, NonNull<()>>(repr)
+                },
+                // SAFETY: `Box::into_raw()` never returns NULL.
+                // FIXME: Switch to `Box::into_non_null()` once stable.
+                Repr::Map(repr) => unsafe {
+                    NonNull::new_unchecked(
+                        Box::into_raw(repr).cast::<()>().map_addr(|addr| addr | 1),
+                    )
+                },
+            };
+            // INVARIANT: We keep it properly.
+            Self { ptr, _repr: PhantomData }
+        }
+
+        #[inline]
+        pub const fn new() -> Self {
+            // INVARIANT: We keep it properly.
+            let ptr = unsafe { mem::transmute::<ThinReprVec<K, V>, NonNull<()>>(ThinVec::new()) };
+            Self { ptr, _repr: PhantomData }
+        }
+    }
+
+    impl<K, V, M> Drop for ThinMap<K, V, M> {
+        #[inline]
+        fn drop(&mut self) {
+            // INVARIANT: This is a copy of `self` only to drop it.
+            drop(ThinMap::<K, V, M> { ptr: self.ptr, _repr: PhantomData }.into_repr());
+        }
+    }
+}

--- a/crates/stdx/src/thin_map/set.rs
+++ b/crates/stdx/src/thin_map/set.rs
@@ -1,0 +1,130 @@
+use std::{borrow::Borrow, hash::Hash};
+
+use crate::thin_map::{Map, ThinMap};
+
+#[expect(clippy::disallowed_types)]
+pub type ThinHashSet<T, S> = ThinSet<T, std::collections::HashMap<T, (), S>>;
+
+pub struct ThinSet<T, M: Map<T, ()>> {
+    map: ThinMap<T, (), M>,
+}
+
+impl<T: Hash + Eq, M: Map<T, ()>> ThinSet<T, M> {
+    #[inline]
+    pub const fn new() -> Self {
+        Self { map: ThinMap::new() }
+    }
+
+    #[inline]
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self { map: ThinMap::with_capacity(capacity) }
+    }
+
+    pub fn shrink_to_fit(&mut self) {
+        self.map.shrink_to_fit();
+    }
+
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.map.len()
+    }
+
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.map.is_empty()
+    }
+
+    #[inline]
+    pub fn iter(&self) -> impl ExactSizeIterator<Item = &T> {
+        self.map.keys()
+    }
+
+    #[expect(clippy::should_implement_trait, reason = "cannot do that without ATPIT")]
+    #[inline]
+    pub fn into_iter(self) -> impl ExactSizeIterator<Item = T> {
+        self.map.into_keys()
+    }
+
+    #[inline]
+    pub fn contains<Q>(&self, key: &Q) -> bool
+    where
+        T: Borrow<Q>,
+        Q: ?Sized + Hash + Eq,
+    {
+        self.map.contains_key(key)
+    }
+
+    #[inline]
+    pub fn insert(&mut self, item: T) -> bool {
+        self.map.insert(item, ()).is_none()
+    }
+
+    #[inline]
+    pub fn remove<Q>(&mut self, item: &Q) -> bool
+    where
+        T: Borrow<Q>,
+        Q: ?Sized + Hash + Eq,
+    {
+        self.map.remove(item).is_some()
+    }
+}
+
+impl<T: Hash + Eq, M: Map<T, ()>> Default for ThinSet<T, M> {
+    #[inline]
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<T, M> std::fmt::Debug for ThinSet<T, M>
+where
+    M: Map<T, ()>,
+    T: Hash + Eq + std::fmt::Debug,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_set().entries(self.iter()).finish()
+    }
+}
+
+impl<T, M> Clone for ThinSet<T, M>
+where
+    M: Map<T, ()> + Clone,
+    T: Clone,
+{
+    #[inline]
+    fn clone(&self) -> Self {
+        Self { map: self.map.clone() }
+    }
+}
+
+impl<T, M> PartialEq for ThinSet<T, M>
+where
+    M: Map<T, ()> + PartialEq,
+    T: Hash + Eq,
+{
+    #[inline]
+    fn eq(&self, other: &Self) -> bool {
+        self.map == other.map
+    }
+}
+
+impl<T, M> Eq for ThinSet<T, M>
+where
+    M: Map<T, ()> + Eq,
+    T: Hash + Eq,
+{
+}
+
+impl<T: Hash + Eq, M: Map<T, ()>> FromIterator<T> for ThinSet<T, M> {
+    #[inline]
+    fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
+        Self { map: iter.into_iter().map(|item| (item, ())).collect() }
+    }
+}
+
+impl<T: Hash + Eq, M: Map<T, ()>> Extend<T> for ThinSet<T, M> {
+    #[inline]
+    fn extend<I: IntoIterator<Item = T>>(&mut self, iter: I) {
+        self.map.extend(iter.into_iter().map(|item| (item, ())));
+    }
+}

--- a/crates/stdx/src/thin_map/tests.rs
+++ b/crates/stdx/src/thin_map/tests.rs
@@ -1,0 +1,241 @@
+#![expect(clippy::disallowed_types, reason = "test code")]
+
+use std::collections::HashMap;
+
+use itertools::Itertools;
+
+use crate::thin_map::ThinMap;
+
+macro_rules! do_with_map {
+    ( $map:ident, $key:ty, $value:ty, $init_method:ident($($init_param:tt)*), $code:block $(,)? ) => {
+        let map1 = {
+            #[allow(unused_imports)]
+            use ::std::collections::hash_map::Entry;
+
+            #[allow(unused_mut)]
+            let mut $map = ::std::collections::HashMap::<$key, $value>::$init_method($($init_param)*);
+            $code;
+            $map
+        };
+        let map2 = {
+            #[allow(unused_imports)]
+            use super::Entry;
+
+            #[allow(unused_mut)]
+            let mut $map = super::ThinMap::<$key, $value, ::std::collections::HashMap::<$key, $value>>::$init_method($($init_param)*);
+            $code;
+            $map
+        };
+        let map1 = map1.into_iter().sorted_unstable().collect::<Vec<_>>();
+        let map2 = map2.into_iter().sorted_unstable().collect::<Vec<_>>();
+        assert_eq!(map1, map2);
+    };
+}
+
+#[test]
+fn basic() {
+    do_with_map! {
+        map, i32, i32, new(),
+        {
+            for key in 0..10 {
+                assert_eq!(map.insert(key, key), None);
+            }
+            assert_eq!(map.insert(0, 123), Some(0));
+            assert_eq!(map.get(&0), Some(&123));
+            for (key, value) in &map {
+                assert!(key == value || *key == 0);
+            }
+            assert_eq!(map.len(), 10);
+            assert_eq!(map.remove(&1), Some(1));
+            assert_eq!(map.len(), 9);
+        }
+    }
+    do_with_map! {
+        map, i32, i32, new(),
+        {
+            for key in 0..100 {
+                assert_eq!(map.insert(key, key), None);
+            }
+            for key in 5..100 {
+                assert!(map.remove(&key).is_some());
+            }
+            map.shrink_to_fit();
+            assert_eq!(map.len(), 5);
+            for key in 0..5 {
+                *map.get_mut(&key).unwrap() = -111;
+            }
+            for key in 0..5 {
+                assert!(map.remove(&key).is_some());
+            }
+            assert!(map.is_empty());
+            map.shrink_to_fit();
+        }
+    }
+    do_with_map! {
+        map, i32, i32, with_capacity(100),
+        {
+        }
+    }
+    do_with_map! {
+        map, i32, i32, with_capacity(5),
+        {
+        }
+    }
+    do_with_map! {
+        map, i32, i32, with_capacity(5),
+        {
+            map.reserve(100);
+        }
+    }
+}
+
+#[test]
+fn with_drop_type() {
+    do_with_map! {
+        map, String, String, new(),
+        {
+            for key in 0..10 {
+                assert_eq!(map.insert(key.to_string(), key.to_string()), None);
+            }
+            assert_eq!(map.insert(0.to_string(), 123.to_string()), Some(0.to_string()));
+            assert_eq!(map.get(&0.to_string()), Some(&123.to_string()));
+            for (key, value) in &map {
+                assert!(key == value || *key == "0");
+            }
+            assert_eq!(map.len(), 10);
+            assert_eq!(map.remove(&1.to_string()), Some(1.to_string()));
+            assert_eq!(map.len(), 9);
+        }
+    }
+    do_with_map! {
+        map, String, String, new(),
+        {
+            for key in 0..100 {
+                assert_eq!(map.insert(key.to_string(), key.to_string()), None);
+            }
+            for key in 5..100 {
+                assert!(map.remove(&key.to_string()).is_some());
+            }
+            map.shrink_to_fit();
+            assert_eq!(map.len(), 5);
+            for key in 0..5 {
+                *map.get_mut(&key.to_string()).unwrap() = String::new();
+            }
+            for key in 0..5 {
+                assert!(map.remove(&key.to_string()).is_some());
+            }
+            assert!(map.is_empty());
+            map.shrink_to_fit();
+        }
+    }
+    do_with_map! {
+        map, String, String, with_capacity(100),
+        {
+        }
+    }
+    do_with_map! {
+        map, String, String, with_capacity(5),
+        {
+        }
+    }
+    do_with_map! {
+        map, String, String, with_capacity(5),
+        {
+            map.reserve(100);
+        }
+    }
+}
+
+#[test]
+fn with_reference_aliasing() {
+    {
+        let mut data = Vec::from_iter(0..20);
+        let mut map = ThinMap::<&mut i32, &mut i32, HashMap<&mut i32, &mut i32>>::new();
+        for [key, value] in data.as_chunks_mut().0 {
+            assert_eq!(map.insert(key, value), None);
+        }
+        assert_eq!(map.len(), 10);
+        for (_key, _value) in &map {}
+        for (_key, _value) in &mut map {}
+        for (_key, _value) in map {}
+    }
+    let data = Vec::from_iter(0..200);
+    do_with_map! {
+        map, &i32, &i32, new(),
+        {
+            for key in &data[0..100] {
+                assert_eq!(map.insert(key, key), None);
+            }
+            for key in &data[5..100] {
+                assert!(map.remove(key).is_some());
+            }
+            map.shrink_to_fit();
+            assert_eq!(map.len(), 5);
+            for key in 0..5 {
+                *map.get_mut(&data[key]).unwrap() = &data[150];
+            }
+            for key in 0..5 {
+                assert!(map.remove(&key).is_some());
+            }
+            assert!(map.is_empty());
+            map.shrink_to_fit();
+        }
+    }
+    do_with_map! {
+        map, &i32, &i32, with_capacity(100),
+        {
+        }
+    }
+    do_with_map! {
+        map, &i32, &i32, with_capacity(5),
+        {
+        }
+    }
+    do_with_map! {
+        map, &mut i32, &mut i32, with_capacity(5),
+        {
+            map.reserve(100);
+        }
+    }
+}
+
+#[test]
+fn entry_api() {
+    do_with_map! {
+        map, String, String, new(),
+        {
+            match map.entry("abc".to_owned()) {
+                Entry::Occupied(_) => panic!("should be vacant"),
+                Entry::Vacant(entry) => entry.insert(String::new()),
+            };
+            match map.entry("abc".to_owned()) {
+                Entry::Vacant(_) => panic!("should be occupied"),
+                Entry::Occupied(mut entry) => {
+                    assert_eq!(entry.get(), "");
+                    entry.insert("def".to_owned());
+                }
+            }
+            assert_eq!(map.get("abc"), Some(&"def".to_owned()));
+        }
+    }
+    do_with_map! {
+        map, i32, i32, new(),
+        {
+            for key in 0..100 {
+                map.insert(key, 0);
+            }
+            match map.entry(1000) {
+                Entry::Occupied(_) => panic!("should be vacant"),
+                Entry::Vacant(entry) => entry.insert(0),
+            };
+            match map.entry(1000) {
+                Entry::Vacant(_) => panic!("should be occupied"),
+                Entry::Occupied(mut entry) => {
+                    assert_eq!(*entry.get(), 0);
+                    entry.insert(123456);
+                }
+            }
+            assert_eq!(map.get(&1000), Some(&123456));
+        }
+    }
+}


### PR DESCRIPTION
It saves memory by being only one machine word inline and compact (no extra capacity) outline, while also being even faster if the length is commonly small because linear search is faster for small lengths.

When measuring `analysis-stats`, this saves 40mb on self, 77mb on buck2 and 142mb on omicron. It's also *faster*:  3ginstructions saved on self and buck2, and 30ginstructions on omicron (walltime is too noisy). The memory effect is also likely to appear in IDE scenarios almost as well, because a major part is def maps, and I speculate that unnamed consts also play a role (because the amount of almost-empty expression stores seem too high for real bodies).

Not all maps were changed to use this, only those that measurements show are commonly small. The threshold was at least ~95% of the maps of this kind fitting into the thin schema (that is, have at most 10 elements).

I also switched some `IndexMap`s to `HashMap`s where I believe the order does not matter.

I made `ThinMap` generic over the map type to support both `HashMap` and `IndexMap`. However at the end the number of `IndexMap`s was very small. I still can support both, but I wonder if I should or just make it non-generic and simplify the code. Currently I left it neither supporting `IndexMap`s nor removing the trait; will appreciate opinions.

`ThinMap` (and `ThinSet`) could very well be in their own crate, I just found no suitable crate on crates.io (also, the API isn't polished enough for an external crate).