### PR TITLE
internal: Improve panic messages on invalid AST nodes

### DIFF
--- a/crates/syntax/src/ast/make.rs
+++ b/crates/syntax/src/ast/make.rs
@@ -1383,7 +1383,7 @@ fn expr_from_text_with_edition<E: Into<ast::Expr> + AstNode>(text: &str, edition
         Some(it) => it,
         None => {
             let node = std::any::type_name::<E>();
-            panic!("Failed to make ast node `{node}` from text {text}")
+            panic!("Failed to make expr node `{node}` from text `{text}`")
         }
     };
     let node = node.clone_subtree();
@@ -1403,7 +1403,7 @@ fn ast_from_text_with_edition<N: AstNode>(text: &str, edition: Edition) -> N {
         Some(it) => it,
         None => {
             let node = std::any::type_name::<N>();
-            panic!("Failed to make ast node `{node}` from text {text}")
+            panic!("Failed to make ast node `{node}` from text `{text}`")
         }
     };
     let node = node.clone_subtree();

--- a/crates/syntax/src/syntax_editor/edits.rs
+++ b/crates/syntax/src/syntax_editor/edits.rs
@@ -528,7 +528,7 @@ mod tests {
             Some(it) => it,
             None => {
                 let node = std::any::type_name::<N>();
-                panic!("Failed to make ast node `{node}` from text {text}")
+                panic!("Failed to make ast node `{node}` from text `{text}`")
             }
         };
         let node = node.clone_subtree();


### PR DESCRIPTION
Add backticks so it's easier to see exactly what the input was.