### PR TITLE
fix: reinfer never type in array repeat expressions

### DIFF
--- a/crates/hir-ty/src/infer/expr.rs
+++ b/crates/hir-ty/src/infer/expr.rs
@@ -1329,7 +1329,11 @@ impl<'db> InferenceContext<'db> {
             }
             None => {
                 let ty = self.table.next_ty_var(element.into());
-                self.infer_expr(element, &Expectation::has_type(ty), ExprIsRead::Yes);
+                self.infer_expr_suptype_coerce_never(
+                    element,
+                    &Expectation::has_type(ty),
+                    ExprIsRead::Yes,
+                );
                 ty
             }
         };

--- a/crates/hir-ty/src/tests/never_type.rs
+++ b/crates/hir-ty/src/tests/never_type.rs
@@ -115,6 +115,21 @@ fn test() {
 }
 
 #[test]
+fn array_repeat_never_can_be_reinferred() {
+    check_no_mismatches(
+        r#"
+fn test() {
+    let y = [return; 2];
+    match y {
+        [(1, _), (_, false)] => {}
+        [_, _] => {}
+    }
+}
+"#,
+    );
+}
+
+#[test]
 fn match_no_arm() {
     check_types(
         r#"


### PR DESCRIPTION
Array repeat expressions could produce false-positive type mismatches when the initializer diverged and the element type still had to be inferred from later context.

The issue was that `infer_expr` could constrain the fresh inference variable to `!` too early. I switched this path to the existing `infer_expr_suptype_coerce_never` helper, which also matches how `rustc` handles the never-type coercion in this case.

I also added a minimal regression test next to the existing never-type reinference tests.

### rustc reference per ai policy

In [`rustc_hir_typeck::FnCtxt::check_expr_repeat`](https://github.com/rust-lang/rust/blob/6510953ce01859dc271e3285cf539e03d0d781e7/compiler/rustc_hir_typeck/src/expr.rs#L1760-L1769), when there is no expected element type, `rustc` creates a fresh inference variable and checks the repeated element with `check_expr_has_type_or_error`.

[`check_expr_has_type_or_error`](https://github.com/rust-lang/rust/blob/6510953ce01859dc271e3285cf539e03d0d781e7/compiler/rustc_hir_typeck/src/expr.rs#L72-L109) explicitly handles a resulting `!` by applying a `NeverToAny` adjustment before checking the subtype relation with `demand_suptype_diag`.

The change here follows the same behavior by using rust-analyzer's existing `infer_expr_suptype_coerce_never` path instead of constraining the fresh inference variable through `infer_expr`.

Fixes rust-lang/rust-analyzer#23177

Tests:
- `cargo test -p hir-ty`
- `cargo clippy -p hir-ty --all-targets -- --cap-lints warn`
- `cargo lint`
- `cargo test`

AI disclosure: AI was used to help investigate and review the change. I wrote the implementation and ran the validation manually.