### PR TITLE
internal: Require rustc citation for analysis changes when using AI

### DIFF
--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -30,6 +30,14 @@ E-easy issues are usually easier for maintainers to just fix directly than write
 
 AI *may* be used to understand the codebase for E-easy+E-has-instructions contributions, but not to write any code.
 
+When using AI to author changes to *analysis* - the code responsible for analyzing Rust code and not for implementing IDE features, including
+but not limited to: type inference, MIR, name resolution, macro expansion - generally anything in the crates `parser`, `mbe`, `hir-expand`, `hir-def`, `hir-ty`,
+although there are exceptions; **including when using AI only to analyze bugs and not to write code**, you are required to include a citation
+of the rustc code responsible for the change you did, along with an explanation of how your change follows from it in case this is not immediately clear.
+
+The reason for that is that it is almost impossible to be fully correct in analysis if we implement things differently from rustc. We should not guess
+how to fix bugs in analysis without looking at the rustc code.
+
 This policy was adapted from [uv's AI policy].
 
 [uv's AI policy]: https://github.com/astral-sh/.github/blob/c5187e200db51bfe11d56e13053d29bd3793fdd8/AI_POLICY.md

--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -38,6 +38,6 @@ of the rustc code responsible for the change you did, along with an explanation 
 The reason for that is that it is almost impossible to be fully correct in analysis if we implement things differently from rustc. We should not guess
 how to fix bugs in analysis without looking at the rustc code.
 
-This policy was adapted from [uv's AI policy].
+This policy was inspired by [uv's AI policy].
 
 [uv's AI policy]: https://github.com/astral-sh/.github/blob/c5187e200db51bfe11d56e13053d29bd3793fdd8/AI_POLICY.md


### PR DESCRIPTION
[As I asked on Zulip](https://rust-lang.zulipchat.com/#narrow/channel/185405-t-compiler.2Frust-analyzer/topic/LLM.20policy/near/619098018).

Do you think we should exempt maintainers from this? I have no problem with doing that (due to the higher trust), and I myself barely use AI at all, but treating maintainers differently might seem unfair to some.