### PR TITLE
Fix/replace arith neg pow

### DIFF
--- a/crates/ide-assists/src/handlers/replace_arith_op.rs
+++ b/crates/ide-assists/src/handlers/replace_arith_op.rs
@@ -1,8 +1,9 @@
 use hir::AsAssocItem;
 use ide_db::assists::{AssistId, GroupLabel};
 use syntax::{
-    AstNode, AstToken, T,
+    AstNode, T,
     ast::{self, ArithOp, BinaryOp, HasArgList},
+    syntax_editor::Position,
 };
 
 use crate::{
@@ -100,6 +101,17 @@ pub(crate) fn replace_arith_with_wrapping(
 
 fn replace_arith(acc: &mut Assists, ctx: &AssistContext<'_, '_>, kind: ArithKind) -> Option<()> {
     let ParsedArithExpr { expr, receiver, argument, operation } = parse_arith_expr(ctx)?;
+    let reference_depth = if matches!(operation, Operation::Binary { .. }) {
+        0
+    } else {
+        let mut ty = ctx.sema.type_of_expr(&receiver)?.original;
+        let mut depth = 0;
+        while let Some(inner) = ty.as_reference_inner() {
+            depth += 1;
+            ty = inner;
+        }
+        depth
+    };
 
     acc.add_group(
         &GroupLabel("Replace arithmetic...".into()),
@@ -111,49 +123,70 @@ fn replace_arith(acc: &mut Assists, ctx: &AssistContext<'_, '_>, kind: ArithKind
             let make = editor.make();
             let method_name = kind.method_name(operation);
 
-            let mut method_receiver = receiver.clone();
-            // Ensure a trait method on a reference cannot shadow the integer's inherent method.
-            if !matches!(operation, Operation::Binary { .. })
-                && let Some(ty) = ctx.sema.type_of_expr(&method_receiver)
-            {
-                let mut ty = ty.original;
-                while let Some(inner) = ty.as_reference_inner() {
-                    method_receiver = make.expr_prefix(T![*], method_receiver).into();
-                    ty = inner;
-                }
-            }
-            let method_receiver =
-                wrap_paren(method_receiver, make, ast::prec::ExprPrecedence::Postfix);
+            match operation {
+                Operation::Binary { is_assign, .. } => {
+                    let method_receiver =
+                        wrap_paren(receiver.clone(), make, ast::prec::ExprPrecedence::Postfix);
+                    let mut argument = argument.expect("binary operation always has an argument");
+                    if let Some(ty) = ctx.sema.type_of_expr(&argument) {
+                        let adjusted = ty.adjusted();
+                        if adjusted.strip_reference() != adjusted {
+                            argument = if let ast::Expr::RefExpr(ref_expr) = &argument
+                                && let Some(inner) = ref_expr.expr()
+                            {
+                                inner
+                            } else {
+                                make.expr_prefix(T![*], argument).into()
+                            };
+                        }
+                    }
 
-            let argument = argument.map(|mut argument| {
-                if matches!(operation, Operation::Binary { .. })
-                    && let Some(ty) = ctx.sema.type_of_expr(&argument)
-                {
-                    let adjusted = ty.adjusted();
-                    if adjusted.strip_reference() != adjusted {
-                        argument = if let ast::Expr::RefExpr(ref_expr) = &argument
-                            && let Some(inner) = ref_expr.expr()
-                        {
-                            inner
-                        } else {
-                            make.expr_prefix(T![*], argument).into()
-                        };
+                    let mut arith_expr = make
+                        .expr_method_call(
+                            method_receiver,
+                            make.name_ref(&method_name),
+                            make.arg_list([argument]),
+                        )
+                        .into();
+                    if is_assign {
+                        arith_expr = make.expr_assignment(receiver, arith_expr).into();
+                    }
+                    editor.replace(expr.syntax(), arith_expr.syntax());
+                }
+                Operation::Neg { primitive } => {
+                    // Unlike unary `-`, method lookup does not wait for integer fallback. Keep the
+                    // inferred primitive explicit so the replacement does not lose that constraint.
+                    let ast::Expr::PrefixExpr(prefix) = &expr else { unreachable!() };
+                    let operator =
+                        prefix.op_token().expect("prefix expression always has an operator");
+                    let path = make.path_from_text_with_edition(
+                        &format!("{}::{method_name}", primitive.name().as_str()),
+                        ctx.edition(),
+                    );
+                    let mut replacement =
+                        vec![path.syntax().clone().into(), make.token(T!['(']).into()];
+                    for _ in 0..reference_depth {
+                        replacement.push(make.token(T![*]).into());
+                    }
+                    editor.replace_with_many(operator, replacement);
+                    editor.insert(Position::after(receiver.syntax()), make.token(T![')']));
+                }
+                Operation::Pow => {
+                    let ast::Expr::MethodCallExpr(method_call) = &expr else { unreachable!() };
+                    let name =
+                        method_call.name_ref().expect("method call expression always has a name");
+                    editor.replace(name.syntax(), make.name_ref(&method_name).syntax());
+
+                    if reference_depth > 0 {
+                        let mut prefix = vec![make.token(T!['(']).into()];
+                        for _ in 0..reference_depth {
+                            prefix.push(make.token(T![*]).into());
+                        }
+                        editor.insert_all(Position::before(receiver.syntax()), prefix);
+                        editor.insert(Position::after(receiver.syntax()), make.token(T![')']));
                     }
                 }
-                argument
-            });
-
-            let mut arith_expr = make
-                .expr_method_call(
-                    method_receiver,
-                    make.name_ref(&method_name),
-                    make.arg_list(argument),
-                )
-                .into();
-            if matches!(operation, Operation::Binary { is_assign: true, .. }) {
-                arith_expr = make.expr_assignment(receiver, arith_expr).into();
             }
-            editor.replace(expr.syntax(), arith_expr.syntax());
             builder.add_file_edits(ctx.vfs_file_id(), editor);
         },
     )
@@ -173,48 +206,39 @@ fn is_primitive_int_or_refs(ctx: &AssistContext<'_, '_>, expr: &ast::Expr) -> bo
     }
 }
 
-fn is_replaceable_negation_operand(ctx: &AssistContext<'_, '_>, expr: &ast::Expr) -> bool {
-    let Some(ty) = ctx.sema.type_of_expr(expr) else { return false };
+fn replaceable_negation_primitive(
+    ctx: &AssistContext<'_, '_>,
+    expr: &ast::Expr,
+) -> Option<hir::BuiltinType> {
+    let ty = ctx.sema.type_of_expr(expr)?;
     if !ty.original.as_reference().is_none_or(|(_, mutability)| mutability.is_shared())
         || !ty.original.strip_reference().as_builtin().is_some_and(|builtin| builtin.is_int())
     {
-        return false;
+        return None;
     }
-    // Unary `-` can supply the fallback type for unsuffixed literals, but a method call cannot.
-    if expr
-        .syntax()
-        .descendants_with_tokens()
-        .filter_map(|element| element.into_token())
-        .filter_map(ast::IntNumber::cast)
-        .any(|number| number.suffix().is_none())
-    {
-        return false;
-    }
+    let primitive = ty.original.strip_reference().as_builtin()?;
 
     let mut expr = expr.clone();
     while let ast::Expr::ParenExpr(paren) = expr {
-        let Some(inner) = paren.expr() else { return false };
+        let inner = paren.expr()?;
         expr = inner;
     }
 
-    // Macro expansion can hide the special minimum-value literal accepted only after `-`.
+    // A macro expansion can hide the minimum-value literal that is valid only after unary `-`.
     let ast::Expr::Literal(literal) = &expr else {
-        return !matches!(expr, ast::Expr::MacroExpr(_));
+        return (!matches!(expr, ast::Expr::MacroExpr(_))).then_some(primitive);
     };
-    let ast::LiteralKind::IntNumber(number) = literal.kind() else { return true };
+    let ast::LiteralKind::IntNumber(number) = literal.kind() else { return Some(primitive) };
 
     let ty = ty.original.strip_reference();
-    let Ok(layout) = ty.layout(ctx.db()) else { return false };
-    let Some(value_bits) = layout.size().checked_mul(8) else { return false };
-    let Some(sign_bit) = value_bits
+    let layout = ty.layout(ctx.db()).ok()?;
+    let value_bits = layout.size().checked_mul(8)?;
+    let sign_bit = value_bits
         .checked_sub(1)
         .and_then(|shift| u32::try_from(shift).ok())
-        .and_then(|shift| 1u128.checked_shl(shift))
-    else {
-        return false;
-    };
+        .and_then(|shift| 1u128.checked_shl(shift))?;
 
-    number.value().is_ok_and(|value| value < sign_bit)
+    number.value().is_ok_and(|value| value < sign_bit).then_some(primitive)
 }
 
 struct ParsedArithExpr {
@@ -227,7 +251,7 @@ struct ParsedArithExpr {
 #[derive(Clone, Copy)]
 enum Operation {
     Binary { op: ArithOp, is_assign: bool },
-    Neg,
+    Neg { primitive: hir::BuiltinType },
     Pow,
 }
 
@@ -285,7 +309,16 @@ fn parse_negation(ctx: &AssistContext<'_, '_>, expr: ast::PrefixExpr) -> Option<
         return None;
     }
     let operand = expr.expr()?;
-    if !is_replaceable_negation_operand(ctx, &operand) {
+    let primitive = replaceable_negation_primitive(ctx, &operand)?;
+    let primitive_path =
+        ast::make::path_from_text_with_edition(primitive.name().as_str(), ctx.edition());
+    let scope = ctx.sema.scope(expr.syntax())?;
+    // A user-defined type is allowed to shadow a primitive's textual name.
+    if !matches!(
+        scope.speculative_resolve(&primitive_path),
+        Some(hir::PathResolution::Def(hir::ModuleDef::BuiltinType(resolved)))
+            if resolved == primitive
+    ) {
         return None;
     }
 
@@ -293,7 +326,7 @@ fn parse_negation(ctx: &AssistContext<'_, '_>, expr: ast::PrefixExpr) -> Option<
         expr: expr.into(),
         receiver: operand,
         argument: None,
-        operation: Operation::Neg,
+        operation: Operation::Neg { primitive },
     })
 }
 
@@ -366,7 +399,7 @@ impl ArithKind {
             Operation::Binary { op: ArithOp::Sub, .. } => "sub",
             Operation::Binary { op: ArithOp::Mul, .. } => "mul",
             Operation::Binary { op: ArithOp::Div, .. } => "div",
-            Operation::Neg => "neg",
+            Operation::Neg { .. } => "neg",
             Operation::Pow => "pow",
             Operation::Binary { .. } => {
                 unreachable!("only +, -, / and * are parsed as arithmetic operations")
@@ -394,7 +427,10 @@ mod tests {
                 .method_name(Operation::Binary { op: ArithOp::Sub, is_assign: false }),
             "checked_sub"
         );
-        assert_eq!(ArithKind::Strict.method_name(Operation::Neg), "strict_neg");
+        assert_eq!(
+            ArithKind::Strict.method_name(Operation::Neg { primitive: hir::BuiltinType::i32() }),
+            "strict_neg"
+        );
         assert_eq!(ArithKind::Wrapping.method_name(Operation::Pow), "wrapping_pow");
     }
 
@@ -412,7 +448,7 @@ fn main() {
             r#"
 fn main() {
     let x = &1i32;
-    let y = (*x).wrapping_neg() + 1;
+    let y = i32::wrapping_neg(*x) + 1;
 }
 "#,
         );
@@ -460,7 +496,95 @@ fn main() {
         check_assist(
             replace_arith_with_checked,
             "fn main() { let y = $0-127i8; }",
-            "fn main() { let y = 127i8.checked_neg(); }",
+            "fn main() { let y = i8::checked_neg(127i8); }",
+        );
+    }
+
+    #[test]
+    fn replace_negation_preserves_inferred_type() {
+        for (before, after) in [
+            (
+                "fn main() { let x = 127; let y = $0-x; }",
+                "fn main() { let x = 127; let y = i32::checked_neg(x); }",
+            ),
+            (
+                "fn main() { let x = 127; let r = &x; let y = $0-r; }",
+                "fn main() { let x = 127; let r = &x; let y = i32::checked_neg(*r); }",
+            ),
+            (
+                "fn main() { let y = $0-{ 127 }; }",
+                "fn main() { let y = i32::checked_neg({ 127 }); }",
+            ),
+            (
+                "fn main() { let y = $0-{ struct i32; 127 }; }",
+                "fn main() { let y = i32::checked_neg({ struct i32; 127 }); }",
+            ),
+            (
+                "fn main() { let y = $0-(1i32 + 2); }",
+                "fn main() { let y = i32::checked_neg((1i32 + 2)); }",
+            ),
+            (
+                "//- minicore: index, slice\nfn main() { let array = [1i32]; let y = $0-array[0]; }",
+                "fn main() { let array = [1i32]; let y = i32::checked_neg(array[0]); }",
+            ),
+            (
+                "fn main() { let tuple = (1i32,); let y = $0-tuple.0; }",
+                "fn main() { let tuple = (1i32,); let y = i32::checked_neg(tuple.0); }",
+            ),
+            (
+                "fn fixed(_: i32) -> i32 { 1 } fn main() { let y = $0-fixed(1); }",
+                "fn fixed(_: i32) -> i32 { 1 } fn main() { let y = i32::checked_neg(fixed(1)); }",
+            ),
+            (
+                "fn main() { let y = $0-(1 as i32); }",
+                "fn main() { let y = i32::checked_neg((1 as i32)); }",
+            ),
+        ] {
+            check_assist(replace_arith_with_checked, before, after);
+        }
+
+        check_assist(
+            replace_arith_with_wrapping,
+            "fn take(_: i8) {} fn main() { let x = 127; take($0-x); }",
+            "fn take(_: i8) {} fn main() { let x = 127; take(i8::wrapping_neg(x)); }",
+        );
+    }
+
+    #[test]
+    fn replace_negation_preserves_comments() {
+        check_assist(
+            replace_arith_with_wrapping,
+            "fn main() { let x = 1i32; let y = $0-/* keep */x; }",
+            "fn main() { let x = 1i32; let y = i32::wrapping_neg(/* keep */x); }",
+        );
+    }
+
+    #[test]
+    fn replace_pow_preserves_comments() {
+        check_assist(
+            replace_arith_with_wrapping,
+            r#"
+//- /main.rs crate:main deps:core
+fn main() {
+    let value: i32 = 2;
+    let x = &&value;
+    let exponent: u32 = 3;
+    let y = x/* receiver */.po$0w(/* exponent */ exponent);
+}
+//- /core.rs crate:core
+#![rustc_coherence_is_core]
+impl i32 {
+    pub fn pow(self, exponent: u32) -> i32 { self }
+}
+"#,
+            r#"
+fn main() {
+    let value: i32 = 2;
+    let x = &&value;
+    let exponent: u32 = 3;
+    let y = (**x)/* receiver */.wrapping_pow(/* exponent */ exponent);
+}
+"#,
         );
     }
 
@@ -468,13 +592,25 @@ fn main() {
     fn replace_negation_not_applicable() {
         for fixture in [
             "fn main() { let x = 1u32; let y = $0-x; }",
-            "fn main() { let y = $0-127; }",
-            "fn main() { let y = $0-{ 127 }; }",
-            "fn main() { let y = $0-(127 + 0); }",
-            "fn main() { let y = $0-&127; }",
             "fn main() { let y = $0-128i8; }",
             "fn main() { let y = $0-(128i8); }",
             "fn main() { let y = $0-((128i8)); }",
+            "fn main() { let y = $0-2147483648; }",
+            "fn main() { struct i32; let x = 1i32; let y = $0-x; }",
+            r#"
+//- /main.rs crate:main deps:core
+struct i32;
+fn main() {
+    let y = $0-{
+        use core::primitive::i32;
+        1i32
+    };
+}
+//- /core.rs crate:core
+pub mod primitive {
+    pub use i32;
+}
+"#,
             r#"
 macro_rules! min { () => { 128i8 }; }
 fn main() { let y = $0-min!(); }

--- a/crates/ide-assists/src/handlers/replace_arith_op.rs
+++ b/crates/ide-assists/src/handlers/replace_arith_op.rs
@@ -1,7 +1,8 @@
+use hir::AsAssocItem;
 use ide_db::assists::{AssistId, GroupLabel};
 use syntax::{
-    AstNode, T,
-    ast::{self, ArithOp, BinaryOp},
+    AstNode, AstToken, T,
+    ast::{self, ArithOp, BinaryOp, HasArgList},
 };
 
 use crate::{
@@ -98,47 +99,61 @@ pub(crate) fn replace_arith_with_wrapping(
 }
 
 fn replace_arith(acc: &mut Assists, ctx: &AssistContext<'_, '_>, kind: ArithKind) -> Option<()> {
-    let (lhs, op, is_assign, rhs) = parse_binary_op(ctx)?;
-    let op_expr = lhs.syntax().parent()?;
-
-    if !is_primitive_int_or_ref(ctx, &lhs) || !is_primitive_int_or_ref(ctx, &rhs) {
-        return None;
-    }
+    let ParsedArithExpr { expr, receiver, argument, operation } = parse_arith_expr(ctx)?;
 
     acc.add_group(
         &GroupLabel("Replace arithmetic...".into()),
         kind.assist_id(),
         kind.label(),
-        op_expr.text_range(),
+        expr.syntax().text_range(),
         |builder| {
-            let editor = builder.make_editor(rhs.syntax());
+            let editor = builder.make_editor(expr.syntax());
             let make = editor.make();
-            let method_name = kind.method_name(op);
+            let method_name = kind.method_name(operation);
 
-            let receiver = wrap_paren(lhs.clone(), make, ast::prec::ExprPrecedence::Postfix);
-
-            let mut rhs = rhs;
-
-            if let Some(ty) = ctx.sema.type_of_expr(&rhs) {
-                let adjusted = ty.adjusted();
-                if adjusted.strip_reference() != adjusted {
-                    rhs = if let ast::Expr::RefExpr(ref_expr) = &rhs
-                        && let Some(inner) = ref_expr.expr()
-                    {
-                        inner
-                    } else {
-                        make.expr_prefix(T![*], rhs).into()
-                    };
+            let mut method_receiver = receiver.clone();
+            // Ensure a trait method on a reference cannot shadow the integer's inherent method.
+            if !matches!(operation, Operation::Binary { .. })
+                && let Some(ty) = ctx.sema.type_of_expr(&method_receiver)
+            {
+                let mut ty = ty.original;
+                while let Some(inner) = ty.as_reference_inner() {
+                    method_receiver = make.expr_prefix(T![*], method_receiver).into();
+                    ty = inner;
                 }
             }
+            let method_receiver =
+                wrap_paren(method_receiver, make, ast::prec::ExprPrecedence::Postfix);
+
+            let argument = argument.map(|mut argument| {
+                if matches!(operation, Operation::Binary { .. })
+                    && let Some(ty) = ctx.sema.type_of_expr(&argument)
+                {
+                    let adjusted = ty.adjusted();
+                    if adjusted.strip_reference() != adjusted {
+                        argument = if let ast::Expr::RefExpr(ref_expr) = &argument
+                            && let Some(inner) = ref_expr.expr()
+                        {
+                            inner
+                        } else {
+                            make.expr_prefix(T![*], argument).into()
+                        };
+                    }
+                }
+                argument
+            });
 
             let mut arith_expr = make
-                .expr_method_call(receiver, make.name_ref(&method_name), make.arg_list([rhs]))
+                .expr_method_call(
+                    method_receiver,
+                    make.name_ref(&method_name),
+                    make.arg_list(argument),
+                )
                 .into();
-            if is_assign {
-                arith_expr = make.expr_assignment(lhs, arith_expr).into();
+            if matches!(operation, Operation::Binary { is_assign: true, .. }) {
+                arith_expr = make.expr_assignment(receiver, arith_expr).into();
             }
-            editor.replace(op_expr, arith_expr.syntax());
+            editor.replace(expr.syntax(), arith_expr.syntax());
             builder.add_file_edits(ctx.vfs_file_id(), editor);
         },
     )
@@ -151,13 +166,97 @@ fn is_primitive_int_or_ref(ctx: &AssistContext<'_, '_>, expr: &ast::Expr) -> boo
     }
 }
 
-/// Extract the operands of an arithmetic expression (e.g. `1 + 2` or `1.checked_add(2)`)
-fn parse_binary_op(ctx: &AssistContext<'_, '_>) -> Option<(ast::Expr, ArithOp, bool, ast::Expr)> {
+fn is_primitive_int_or_refs(ctx: &AssistContext<'_, '_>, expr: &ast::Expr) -> bool {
+    match ctx.sema.type_of_expr(expr) {
+        Some(ty) => ty.original.strip_references().is_int_or_uint(),
+        _ => false,
+    }
+}
+
+fn is_replaceable_negation_operand(ctx: &AssistContext<'_, '_>, expr: &ast::Expr) -> bool {
+    let Some(ty) = ctx.sema.type_of_expr(expr) else { return false };
+    if !ty.original.as_reference().is_none_or(|(_, mutability)| mutability.is_shared())
+        || !ty.original.strip_reference().as_builtin().is_some_and(|builtin| builtin.is_int())
+    {
+        return false;
+    }
+    // Unary `-` can supply the fallback type for unsuffixed literals, but a method call cannot.
+    if expr
+        .syntax()
+        .descendants_with_tokens()
+        .filter_map(|element| element.into_token())
+        .filter_map(ast::IntNumber::cast)
+        .any(|number| number.suffix().is_none())
+    {
+        return false;
+    }
+
+    let mut expr = expr.clone();
+    while let ast::Expr::ParenExpr(paren) = expr {
+        let Some(inner) = paren.expr() else { return false };
+        expr = inner;
+    }
+
+    // Macro expansion can hide the special minimum-value literal accepted only after `-`.
+    let ast::Expr::Literal(literal) = &expr else {
+        return !matches!(expr, ast::Expr::MacroExpr(_));
+    };
+    let ast::LiteralKind::IntNumber(number) = literal.kind() else { return true };
+
+    let ty = ty.original.strip_reference();
+    let Ok(layout) = ty.layout(ctx.db()) else { return false };
+    let Some(value_bits) = layout.size().checked_mul(8) else { return false };
+    let Some(sign_bit) = value_bits
+        .checked_sub(1)
+        .and_then(|shift| u32::try_from(shift).ok())
+        .and_then(|shift| 1u128.checked_shl(shift))
+    else {
+        return false;
+    };
+
+    number.value().is_ok_and(|value| value < sign_bit)
+}
+
+struct ParsedArithExpr {
+    expr: ast::Expr,
+    receiver: ast::Expr,
+    argument: Option<ast::Expr>,
+    operation: Operation,
+}
+
+#[derive(Clone, Copy)]
+enum Operation {
+    Binary { op: ArithOp, is_assign: bool },
+    Neg,
+    Pow,
+}
+
+fn parse_arith_expr(ctx: &AssistContext<'_, '_>) -> Option<ParsedArithExpr> {
     if !ctx.has_empty_selection() {
         return None;
     }
-    let expr = ctx.find_node_at_offset::<ast::BinExpr>()?;
 
+    let expr = ctx.find_node_at_offset::<ast::Expr>()?;
+    for expr in expr.syntax().ancestors().filter_map(ast::Expr::cast) {
+        match expr {
+            ast::Expr::BinExpr(expr) => return parse_binary_op(ctx, expr),
+            ast::Expr::PrefixExpr(expr) if expr.op_kind() == Some(ast::UnaryOp::Neg) => {
+                return parse_negation(ctx, expr);
+            }
+            ast::Expr::MethodCallExpr(expr)
+                if expr
+                    .name_ref()
+                    .is_some_and(|name| name.text().trim_start_matches("r#") == "pow") =>
+            {
+                return parse_pow(ctx, expr);
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+fn parse_binary_op(ctx: &AssistContext<'_, '_>, expr: ast::BinExpr) -> Option<ParsedArithExpr> {
     let (op, is_assign) = match expr.op_kind()? {
         BinaryOp::ArithOp(arith_op) => (arith_op, false),
         BinaryOp::Assignment { op: Some(op) } => (op, true),
@@ -169,8 +268,61 @@ fn parse_binary_op(ctx: &AssistContext<'_, '_>) -> Option<(ast::Expr, ArithOp, b
 
     let lhs = expr.lhs()?;
     let rhs = expr.rhs()?;
+    if !is_primitive_int_or_ref(ctx, &lhs) || !is_primitive_int_or_ref(ctx, &rhs) {
+        return None;
+    }
 
-    Some((lhs, op, is_assign, rhs))
+    Some(ParsedArithExpr {
+        expr: expr.into(),
+        receiver: lhs,
+        argument: Some(rhs),
+        operation: Operation::Binary { op, is_assign },
+    })
+}
+
+fn parse_negation(ctx: &AssistContext<'_, '_>, expr: ast::PrefixExpr) -> Option<ParsedArithExpr> {
+    if expr.op_kind()? != ast::UnaryOp::Neg {
+        return None;
+    }
+    let operand = expr.expr()?;
+    if !is_replaceable_negation_operand(ctx, &operand) {
+        return None;
+    }
+
+    Some(ParsedArithExpr {
+        expr: expr.into(),
+        receiver: operand,
+        argument: None,
+        operation: Operation::Neg,
+    })
+}
+
+fn parse_pow(ctx: &AssistContext<'_, '_>, expr: ast::MethodCallExpr) -> Option<ParsedArithExpr> {
+    let receiver = expr.receiver()?;
+    if !is_primitive_int_or_refs(ctx, &receiver) {
+        return None;
+    }
+
+    let mut arguments = expr.arg_list()?.args();
+    let exponent = arguments.next()?;
+    if arguments.next().is_some() {
+        return None;
+    }
+
+    let function = ctx.sema.resolve_method_call(&expr)?;
+    let assoc = function.as_assoc_item(ctx.db())?;
+    if assoc.implemented_trait(ctx.db()).is_some()
+        || !assoc.implementing_ty(ctx.db())?.is_int_or_uint()
+    {
+        return None;
+    }
+
+    Some(ParsedArithExpr {
+        expr: expr.into(),
+        receiver,
+        argument: Some(exponent),
+        operation: Operation::Pow,
+    })
 }
 
 pub(crate) enum ArithKind {
@@ -201,7 +353,7 @@ impl ArithKind {
         }
     }
 
-    fn method_name(&self, op: ArithOp) -> String {
+    fn method_name(&self, operation: Operation) -> String {
         let prefix = match self {
             ArithKind::Checked => "checked_",
             ArithKind::Wrapping => "wrapping_",
@@ -209,12 +361,16 @@ impl ArithKind {
             ArithKind::Strict => "strict_",
         };
 
-        let suffix = match op {
-            ArithOp::Add => "add",
-            ArithOp::Sub => "sub",
-            ArithOp::Mul => "mul",
-            ArithOp::Div => "div",
-            _ => unreachable!("this function should only be called with +, -, / or *"),
+        let suffix = match operation {
+            Operation::Binary { op: ArithOp::Add, .. } => "add",
+            Operation::Binary { op: ArithOp::Sub, .. } => "sub",
+            Operation::Binary { op: ArithOp::Mul, .. } => "mul",
+            Operation::Binary { op: ArithOp::Div, .. } => "div",
+            Operation::Neg => "neg",
+            Operation::Pow => "pow",
+            Operation::Binary { .. } => {
+                unreachable!("only +, -, / and * are parsed as arithmetic operations")
+            }
         };
         format!("{prefix}{suffix}")
     }
@@ -228,8 +384,125 @@ mod tests {
 
     #[test]
     fn arith_kind_method_name() {
-        assert_eq!(ArithKind::Saturating.method_name(ArithOp::Add), "saturating_add");
-        assert_eq!(ArithKind::Checked.method_name(ArithOp::Sub), "checked_sub");
+        assert_eq!(
+            ArithKind::Saturating
+                .method_name(Operation::Binary { op: ArithOp::Add, is_assign: false }),
+            "saturating_add"
+        );
+        assert_eq!(
+            ArithKind::Checked
+                .method_name(Operation::Binary { op: ArithOp::Sub, is_assign: false }),
+            "checked_sub"
+        );
+        assert_eq!(ArithKind::Strict.method_name(Operation::Neg), "strict_neg");
+        assert_eq!(ArithKind::Wrapping.method_name(Operation::Pow), "wrapping_pow");
+    }
+
+    #[test]
+    fn replace_arith_picks_nearest_negation() {
+        check_assist(
+            replace_arith_with_wrapping,
+            r#"
+//- minicore: unary_ops, add, builtin_impls
+fn main() {
+    let x = &1i32;
+    let y = $0-x + 1;
+}
+"#,
+            r#"
+fn main() {
+    let x = &1i32;
+    let y = (*x).wrapping_neg() + 1;
+}
+"#,
+        );
+    }
+
+    #[test]
+    fn replace_arith_does_not_skip_unsupported_nearest_binary() {
+        check_assist_not_applicable(
+            replace_arith_with_checked,
+            "fn main() { let x = 1i32; let y = x $0% 2 + 3; }",
+        );
+    }
+
+    #[test]
+    fn replace_arith_picks_nearest_pow() {
+        check_assist(
+            replace_arith_with_wrapping,
+            r#"
+//- /main.rs crate:main deps:core
+fn main() {
+    let value: i32 = 2;
+    let x = &&value;
+    let exponent: u32 = 3;
+    let y = x.po$0w(exponent) + 1;
+}
+//- /core.rs crate:core
+#![rustc_coherence_is_core]
+impl i32 {
+    pub fn pow(self, exponent: u32) -> i32 { self }
+}
+"#,
+            r#"
+fn main() {
+    let value: i32 = 2;
+    let x = &&value;
+    let exponent: u32 = 3;
+    let y = (**x).wrapping_pow(exponent) + 1;
+}
+"#,
+        );
+    }
+
+    #[test]
+    fn replace_negation_of_representable_literal() {
+        check_assist(
+            replace_arith_with_checked,
+            "fn main() { let y = $0-127i8; }",
+            "fn main() { let y = 127i8.checked_neg(); }",
+        );
+    }
+
+    #[test]
+    fn replace_negation_not_applicable() {
+        for fixture in [
+            "fn main() { let x = 1u32; let y = $0-x; }",
+            "fn main() { let y = $0-127; }",
+            "fn main() { let y = $0-{ 127 }; }",
+            "fn main() { let y = $0-(127 + 0); }",
+            "fn main() { let y = $0-&127; }",
+            "fn main() { let y = $0-128i8; }",
+            "fn main() { let y = $0-(128i8); }",
+            "fn main() { let y = $0-((128i8)); }",
+            r#"
+macro_rules! min { () => { 128i8 }; }
+fn main() { let y = $0-min!(); }
+"#,
+        ] {
+            check_assist_not_applicable(replace_arith_with_checked, fixture);
+        }
+    }
+
+    #[test]
+    fn replace_pow_not_applicable_to_trait_method_on_integer() {
+        check_assist_not_applicable(
+            replace_arith_with_checked,
+            r#"
+trait Pow {
+    fn pow(self, exponent: u32) -> Self;
+}
+
+impl Pow for i32 {
+    fn pow(self, exponent: u32) -> Self { self }
+}
+
+fn main() {
+    let x: i32 = 2;
+    let y = x.po$0w(3) + 1;
+}
+"#,
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes rust-lang/rust-analyzer#23153 

This PR extends the existing Replace arithmetic assist to support:
1. unary negation on signed integers
2. inherent integer .pow() calls

For example, the wrapping variant transforms: 
'-x' into 'i32::wrapping_neg(x)'
'x.pow(e) into 'x.wrapping_pow(e)'

References are explicitly dereferenced when needed:
" -r // r: &i32"
" r.pow(e) // r: &&i32"
becomes:
"i32::wrapping_neg(*r)"
"(**r).wrapping_pow(e)"

The same applies to the checked, saturating, and strict variants.

**Implementation notes**

Unary negation uses primitive-qualified UFCS such as:
"i32::wrapping_neg(x)"
instead of x.wrapping_neg() because integer literals may still have an ambiguous receiver type during method lookup.
The implementation uses localized syntax edits to preserve existing comments and formatting.
The assist is not offered for cases where the rewrite could be invalid or unintended, including:
1. unsigned negation
2. minimum-value literals such as -128i8
3. direct macro operands that may hide such literals
4. trait-provided .pow() methods
5. primitive type names shadowed by user-defined types
The assist also selects only the nearest arithmetic expression at the cursor.

**Tests**

Added coverage for type inference, references, minimum-value literals, macros, type-name shadowing, comments, trait .pow() methods, and expression selection.

Validation:
1. 20 related tests pass
2. all ide-assists tests pass: 2819 passed, 3 ignored
3. cargo fmt passes
4. Clippy passes with -D warnings

**AI assistance**

I used an AI coding assistant to help investigate the existing implementation and consider edge cases. I reviewed and modified the suggestions myself and verified the final implementation with test, formatting, and Clippy.