### PR TITLE
fix: Print the ABI for fn pointers (if not the default)

### DIFF
--- a/crates/hir-ty/src/display.rs
+++ b/crates/hir-ty/src/display.rs
@@ -1974,12 +1974,12 @@ impl<'db> HirDisplay<'db> for PolyFnSig<'db> {
         if let Safety::Unsafe = fn_sig_kind.safety() {
             write!(f, "unsafe ")?;
         }
-        // FIXME: Enable this when the FIXME on FnAbi regarding PartialEq is fixed.
-        // if !matches!(abi, FnAbi::Rust) {
-        //     f.write_str("extern \"")?;
-        //     f.write_str(abi.as_str())?;
-        //     f.write_str("\" ")?;
-        // }
+        let abi = self.abi();
+        if !matches!(abi, ExternAbi::Rust) {
+            f.write_str("extern \"")?;
+            f.write_str(abi.as_str())?;
+            f.write_str("\" ")?;
+        }
         write!(f, "fn(")?;
         f.write_joined(inputs_and_output.inputs(), ", ")?;
         if fn_sig_kind.c_variadic() {

--- a/crates/ide-diagnostics/src/handlers/invalid_cast.rs
+++ b/crates/ide-diagnostics/src/handlers/invalid_cast.rs
@@ -230,7 +230,7 @@ fn foo(_x: isize) { }
 fn main() {
     let v: u64 = 5;
     let x = foo as extern "C" fn() -> isize;
-          //^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: non-primitive cast: `fn foo(isize)` as `fn() -> isize`
+          //^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: non-primitive cast: `fn foo(isize)` as `extern "C" fn() -> isize`
     let y = v as extern "Rust" fn(isize) -> (isize, isize);
           //^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: non-primitive cast: `u64` as `fn(isize) -> (isize, isize)`
     y(x());

--- a/crates/ide/src/hover/tests.rs
+++ b/crates/ide/src/hover/tests.rs
@@ -11997,3 +11997,27 @@ fn main() {
         let _ = resolved.as_array(db);
     });
 }
+
+#[test]
+fn extern_c_fn_ptr_display() {
+    check(
+        r#"
+extern "C" fn foo() {}
+
+fn bar() {
+    let v$0 = foo as extern "C" fn();
+}
+    "#,
+        expect![[r#"
+            *v*
+
+            ```rust
+            let v: extern "C" fn()
+            ```
+
+            ---
+
+            size = 8, align = 8, niches = 1, no Drop
+        "#]],
+    );
+}


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust-analyzer/issues/23244.