### PR TITLE
Install cargo tools with locked dependencies

### DIFF
--- a/.github/workflows/autopublish.yaml
+++ b/.github/workflows/autopublish.yaml
@@ -28,7 +28,7 @@ jobs:
         run: rustup update --no-self-update stable
 
       - name: Install cargo-workspaces
-        run: cargo install cargo-workspaces --version "0.3.6"
+        run: cargo install --locked cargo-workspaces --version "0.3.6"
 
       - name: Publish Crates
         env:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,7 +50,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Install rustup-toolchain-install-master
-        run: cargo install rustup-toolchain-install-master@1.11.0
+        run: cargo install --locked rustup-toolchain-install-master@1.11.0
 
       # Install a pinned rustc commit to avoid surprises
       - name: Install Rust toolchain

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -38,6 +38,6 @@ jobs:
 
       - name: Build fuzzers
         run: |
-          cargo install cargo-fuzz
+          cargo install --locked cargo-fuzz
           cd crates/syntax
           cargo +nightly fuzz build

--- a/.github/workflows/publish-libs.yaml
+++ b/.github/workflows/publish-libs.yaml
@@ -22,7 +22,7 @@ jobs:
         run: rustup update --no-self-update stable
 
       - name: Install cargo-workspaces
-        run: cargo install cargo-workspaces --version "0.3.6"
+        run: cargo install --locked cargo-workspaces --version "0.3.6"
 
       - name: Publish Crates
         env:

--- a/docs/book/README.md
+++ b/docs/book/README.md
@@ -7,7 +7,7 @@ The rust analyzer manual uses [mdbook](https://rust-lang.github.io/mdBook/).
 To run the documentation site locally:
 
 ```bash
-cargo install mdbook
+cargo install --locked mdbook
 cargo xtask codegen
 cd docs/book
 mdbook serve

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -72,7 +72,7 @@ fn run_fuzzer(sh: &Shell) -> anyhow::Result<()> {
     let _d = sh.push_dir("./crates/syntax");
     let _e = sh.push_env("RUSTUP_TOOLCHAIN", "nightly");
     if cmd!(sh, "cargo fuzz --help").read().is_err() {
-        cmd!(sh, "cargo install cargo-fuzz").run()?;
+        cmd!(sh, "cargo install --locked cargo-fuzz").run()?;
     };
 
     // Expecting nightly rustc


### PR DESCRIPTION
Installing cargo tools (`cargo install`) without locked dependencies exposes users to supply-chain attacks to all the dependencies of the tool (https://blog.rust-lang.org/2026/08/20/supply-chain-attack-on-arrayref/). Using `cargo install --locked` reduces this risk to a compromise of the tool itself, while using the locked and hashed version of the dependencies.

I went through all `rg "cargo install"` hits in the repository and added `--locked` to all but explanatory examples (such as cargo's docs on `cargo install` itself). I validated that those tools publish functioning `Cargo.lock`s with https://gist.github.com/konstin/bcb1169c1c1120c259dca64e777a64d0.

See https://github.com/rust-lang/rust/pull/161428.

<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->
