### PR TITLE
fix: accept Self as non-leading path segment in attribute paths

### DIFF
--- a/crates/hir-expand/src/mod_path.rs
+++ b/crates/hir-expand/src/mod_path.rs
@@ -316,6 +316,7 @@ fn convert_path(
         let name = match segment.kind()? {
             ast::PathSegmentKind::Name(name) => name.as_name(),
             ast::PathSegmentKind::SelfKw => continue,
+            ast::PathSegmentKind::SelfTypeKw => Name::new_symbol_root(sym::Self_),
             _ => return None,
         };
         mod_path.segments.push(name);

--- a/crates/ide-diagnostics/src/handlers/unresolved_macro_call.rs
+++ b/crates/ide-diagnostics/src/handlers/unresolved_macro_call.rs
@@ -105,4 +105,16 @@ fn foo() {
     "#,
         );
     }
+
+    #[test]
+    fn tool_attribute_with_keyword_segment() {
+        check_diagnostics(
+            r#"
+#[diagnostic::Self(message = "foo")]
+trait Foo {}
+#[clippy::Self(message = "foo")]
+trait Bar {}
+        "#,
+        );
+    }
 }


### PR DESCRIPTION
Fixes rust-lang/rust-analyzer#23189

During lowering, convert_path did not handle Self type (`SelfTypeKw`), so the entire path became None and causing the error.