### PR TITLE
fix: Panic when hovering a dyn trait with a binder

### DIFF
--- a/crates/hir-ty/src/display.rs
+++ b/crates/hir-ty/src/display.rs
@@ -1709,11 +1709,13 @@ impl<'db> HirDisplay<'db> for Ty<'db> {
                 write!(f, "?c.{}", ty.var.as_usize())?
             }
             TyKind::Dynamic(bounds, region) => {
+                let self_ty = interner.default_types().types.dyn_trait_dummy_self;
+
                 // We want to put auto traits after principal traits, regardless of their written order.
                 let mut bounds_to_display = SmallVec::<[_; 4]>::new();
                 let mut auto_trait_bounds = SmallVec::<[_; 4]>::new();
                 for bound in bounds.iter() {
-                    let clause = bound.with_self_ty(interner, *self);
+                    let clause = bound.with_self_ty(interner, self_ty);
                     match bound.skip_binder() {
                         ExistentialPredicate::Trait(_) | ExistentialPredicate::Projection(_) => {
                             bounds_to_display.push(clause);
@@ -1725,13 +1727,13 @@ impl<'db> HirDisplay<'db> for Ty<'db> {
 
                 if f.render_region(region) {
                     bounds_to_display
-                        .push(rustc_type_ir::OutlivesPredicate(*self, region).upcast(interner));
+                        .push(rustc_type_ir::OutlivesPredicate(self_ty, region).upcast(interner));
                 }
 
                 write_bounds_like_dyn_trait_with_prefix(
                     f,
                     "dyn",
-                    Either::Left(*self),
+                    Either::Left(self_ty),
                     &bounds_to_display,
                     SizedByDefault::NotSized,
                     trait_bounds_need_parens,

--- a/crates/hir-ty/src/tests/display_source_code.rs
+++ b/crates/hir-ty/src/tests/display_source_code.rs
@@ -91,6 +91,19 @@ fn foo(foo: &dyn for<'a> Foo<'a>) {}
 }
 
 #[test]
+fn render_dyn_ty_under_enclosing_binder() {
+    check_types_source_code(
+        r#"
+//- minicore: fn
+fn test(f: impl for<'b> Fn(&dyn Fn() -> &'b u8)) {
+    f;
+  //^ impl Fn(&(dyn Fn() -> &u8 + 'static))
+}
+"#,
+    );
+}
+
+#[test]
 fn sized_bounds_apit() {
     check_types_source_code(
         r#"


### PR DESCRIPTION
Calling Binder::skip_binder() (specifically in write_bounds_like_dyn_trait) gives you a representation of a type that has escaping bound variables.

https://github.com/rust-lang/rust/blob/17fd5b8a37b6667b6cc137f3cc35f09759768a3b/compiler/rustc_type_ir/src/binder.rs#L105

Unfortunately, we then call functions that specifically assert there are no escaping bound variables. We then panic in both hover logic and SCIP generation (e.g. for wasm-tools, starlark-rust, or gluon).

See the unit test, which currently fails an assert in debug mode:

    thread 'tests::display_source_code::render_dyn_ty_under_enclosing_binder' (43348037) panicked at /Users/wilfred/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/ra-ap-rustc_type_ir-0.166.0/src/predicate.rs:522:9:
    assertion failed: !self_ty.has_escaping_bound_vars()

and fails with a different assert in release mode:

    thread 'tests::display_source_code::render_dyn_ty_under_enclosing_binder' (43398166) panicked at crates/hir-ty/src/next_solver/predicate.rs:565:9:
    `OutlivesPredicate(dyn [Binder { value: Trait(ExistentialTraitRef("Fn"[[()]])), bound_vars: [] }, Binder { value: Projection(ExistentialProjection { def_id: TypeAliasId("Output"), args: [()], term: &'^1_0.Named(FunctionId("test")) u8, .. }), bound_vars: [] }] + 'static, 'static)` has escaping bound vars, so it cannot be wrapped in a dummy binder.

Since we're only displaying the type, we can safely use a dummy self_ty when rendering type predicates.

(Note that self_ty here refers to the subject of a predicate, i.e. T in `T: Foo`, and isn't necessarily a `Self` type.)

This matches rustc, which also has a dummy self in its pretty printer:

https://github.com/rust-lang/rust/blob/e7d6a0776b06673b5a6258bd7476f1f39ab86756/compiler/rustc_middle/src/ty/print/pretty.rs#L1417

AI disclosure: Code partly written with GPT-5.6 Sol, but commit message and review by me.