### PR TITLE
fix: render `#` and `$` tight against the following token in `to_string()` and `stringify!`

### DIFF
--- a/crates/hir-def/src/macro_expansion_tests/builtin_fn_macro.rs
+++ b/crates/hir-def/src/macro_expansion_tests/builtin_fn_macro.rs
@@ -125,6 +125,42 @@ fn main() {
     );
 }
 
+/// `stringify!` produces an observable string literal, so it has to agree with rustc.
+/// Checked against `rustc 1.95.0`:
+///
+/// ```ignore
+/// stringify!(#inner<#ty>)     // "#inner<#ty>"
+/// stringify!(#outer::#ty_pc)  // "#outer::#ty_pc"
+/// stringify!($x)              // "$x"
+/// ```
+///
+/// We still differ from rustc on spacing around `::` and `<`, which does not change how
+/// the string re-lexes. We must not differ on `#` and `$`, which are prefix sigils that
+/// bind to the token after them.
+#[test]
+fn test_stringify_expand_prefix_sigils() {
+    check(
+        r#"
+#[rustc_builtin_macro]
+macro_rules! stringify {() => {}}
+
+fn main() {
+    stringify!(#inner<#ty>);
+    stringify!($x);
+}
+"#,
+        expect![[r##"
+#[rustc_builtin_macro]
+macro_rules! stringify {() => {}}
+
+fn main() {
+    "#inner <#ty >";
+    "$x";
+}
+"##]],
+    );
+}
+
 #[test]
 fn test_env_expand() {
     check(

--- a/crates/proc-macro-srv/src/token_stream.rs
+++ b/crates/proc-macro-srv/src/token_stream.rs
@@ -481,7 +481,12 @@ fn display_token_tree<S>(
             )?;
         }
         TokenTree::Punct(Punct { ch, joint, span: _ }) => {
-            *emit_whitespace = !*joint;
+            // `#` and `$` are prefix sigils, not binary operators: `#[attr]`, `#![attr]`,
+            // `$x`, `$crate`. rustc's token stream renderer never emits whitespace after
+            // them, independently of jointness, so neither do we. Jointness cannot express
+            // this on its own because the token that follows is usually an ident or a
+            // delimiter rather than another punct, which makes the sigil `Spacing::Alone`.
+            *emit_whitespace = !*joint && !matches!(*ch, b'#' | b'$');
             write!(f, "{}", *ch as char)?;
         }
         TokenTree::Ident(Ident { sym, is_raw, span: _ }) => {
@@ -762,6 +767,67 @@ mod tests {
     #[test]
     fn doc_comment_from_str() {
         let token_stream = TokenStream::from_str("/// foo", ()).unwrap();
-        assert_eq!(token_stream.to_string(), r#"# [doc = " foo"]"#);
+        assert_eq!(token_stream.to_string(), r#"#[doc = " foo"]"#);
+    }
+
+    /// Differential test against rustc.
+    ///
+    /// The right hand side of every pair is the literal output of
+    /// `proc_macro::TokenStream::to_string()` under rustc, captured by feeding the left
+    /// hand side to a real proc macro built by the real compiler:
+    ///
+    /// ```ignore
+    /// #[proc_macro]
+    /// pub fn show(input: TokenStream) -> TokenStream {
+    ///     format!("{:?}", input.to_string()).parse().unwrap()
+    /// }
+    /// ```
+    ///
+    /// rustc renders `#` and `$` tight against the token that follows them, because both
+    /// are prefix sigils rather than operators. Proc macros in the wild rely on this: a
+    /// macro that scans `input.to_string()` for `#name` interpolation markers silently
+    /// stops matching if a space is inserted, and emits its template verbatim instead of
+    /// the substituted code. That is what makes this a correctness bug rather than a
+    /// formatting preference.
+    #[test]
+    fn rustc_parity_prefix_sigils() {
+        let cases = [
+            ("#a #b #c", "#a #b #c"),
+            ("##a", "##a"),
+            ("#0", "#0"),
+            ("$x", "$x"),
+            ("$($y),*", "$($y),*"),
+            ("$(#a)*", "$(#a)*"),
+        ];
+        for (input, rustc) in cases {
+            let ours = TokenStream::from_str(input, ()).unwrap().to_string();
+            assert_eq!(ours, rustc, "rendering of `{input}` diverges from rustc");
+        }
+    }
+
+    /// Records where our rendering still diverges from rustc, so the gap is visible and
+    /// any future change to it shows up as a diff rather than silently.
+    ///
+    /// Everything here is whitespace that does not change how the tokens re-lex, unlike
+    /// the `#`/`$` cases above. Captured with the same proc macro described on
+    /// [`rustc_parity_prefix_sigils`].
+    #[test]
+    fn rustc_parity_known_divergences() {
+        let cases = [
+            // (input, rustc, ours)
+            ("std::vec::Vec<u8>", "std::vec::Vec<u8>", "std :: vec :: Vec < u8 >"),
+            ("$crate::foo", "$crate::foo", "$crate :: foo"),
+            ("a.b().c", "a.b().c", "a . b (). c"),
+            ("let x = (1, 2); y;", "let x = (1, 2); y;", "let x = (1 , 2); y ;"),
+            ("x: u8", "x: u8", "x : u8"),
+            ("() [] {}", "() [] {}", "()[]{}"),
+            ("if a { b } else { c }", "if a { b } else { c }", "if a {b}else {c}"),
+            ("#inner<#ty>", "#inner<#ty>", "#inner <#ty >"),
+        ];
+        for (input, rustc, ours) in cases {
+            let actual = TokenStream::from_str(input, ()).unwrap().to_string();
+            assert_eq!(actual, ours, "rendering of `{input}` changed");
+            assert_ne!(actual, rustc, "`{input}` now matches rustc, update this test");
+        }
     }
 }

--- a/crates/tt/src/lib.rs
+++ b/crates/tt/src/lib.rs
@@ -735,8 +735,11 @@ pub fn pretty(tkns: TokenTreesView<'_>) -> String {
             last =
                 [last, tokentree_to_text(tkn.clone())].join(if last_to_joint { "" } else { " " });
             last_to_joint = false;
-            if let TtElement::Leaf(Leaf::Punct(Punct { spacing, .. })) = tkn
-                && spacing == Spacing::Joint
+            if let TtElement::Leaf(Leaf::Punct(Punct { char, spacing, .. })) = tkn
+                // `#` and `$` are prefix sigils, not binary operators. rustc never renders
+                // whitespace after them, and `stringify!` must agree with rustc because its
+                // result is an observable string literal.
+                && (spacing == Spacing::Joint || matches!(char, '#' | '$'))
             {
                 last_to_joint = true;
             }


### PR DESCRIPTION
Addresses the second report in rust-lang/rust-analyzer#18571.

## Root cause

`crates/proc-macro-srv/src/token_stream.rs:484` decides whether to emit a space after a punct purely from its jointness:

```rust
TokenTree::Punct(Punct { ch, joint, span: _ }) => {
    *emit_whitespace = !*joint;
    write!(f, "{}", *ch as char)?;
}
```

`crates/tt/src/lib.rs:738` does the same thing for `tt::pretty`, which backs the `stringify!` builtin at `crates/hir-expand/src/builtin/fn_macro.rs:195`.

`#` and `$` are prefix sigils, not binary operators. The token after them is normally an ident or a delimiter, not another punct, so jointness is `Alone` and both renderers insert a space. rustc never does. Jointness cannot express this, because it describes whether two puncts fuse into one compound operator, and `#ty` is not a compound operator.

## Why it is a correctness bug and not a formatting preference

The reporter in https://github.com/rust-lang/rust-analyzer/issues/18571#issuecomment-3186552587 has a proc macro that calls `input.to_string()` and does textual replacement of `#ty` and `#inner`. Under rustc the string contains `#ty`, the replacement fires, and real code comes out. Under rust-analyzer the string contains `# ty`, the replacement never fires, and the macro emits its own template verbatim. rust-analyzer then type checks `impl From<#inner<#ty>>` and reports `cannot define inherent impl on foreign type` plus `unexpected token in input` on code that `cargo check` accepts. The diagnostics in that report are downstream of this one space.

`stringify!` has the same problem for a simpler reason. Its result is an observable string literal, so any divergence from rustc is directly wrong.

## Evidence

rustc is the only oracle that matters here and it is trivially available, so I built one. A real proc macro compiled by the real compiler:

```rust
#[proc_macro]
pub fn show(input: TokenStream) -> TokenStream {
    format!("{:?}", input.to_string()).parse().unwrap()
}
```

I ran a 43 case corpus through that under `rustc 1.95.0` and through `TokenStream::from_str(..).to_string()` on `e96ea7a5`, then diffed. Only 5 of 43 cases matched. Most of the divergence is harmless whitespace that re-lexes identically. The sigil cases are not:

```
rustc: #inner<#ty>                        RA: # inner <# ty >
rustc: #outer::#ty_pc(value)              RA: # outer ::# ty_pc (value)
rustc: impl From<#inner<#ty>> for #outer  RA: impl From <# inner <# ty >> for # outer
rustc: ##a                                RA: ## a
rustc: #a #b #c                           RA: # a # b # c
rustc: #0                                 RA: # 0
rustc: $x                                 RA: $ x
rustc: $crate::foo                        RA: $ crate :: foo
rustc: $($y),*                            RA: $($ y),*
```

Same for `stringify!`, checked directly against `rustc 1.95.0`:

```
stringify!(#inner<#ty>)     rustc: "#inner<#ty>"     RA: "# inner <# ty >"
stringify!($x)              rustc: "$x"              RA: "$ x"
```

## The fix

Suppress the trailing space after `#` and `$` in both renderers, independently of jointness. Two lines plus comments.

## Test proof

Three new or corrected assertions fail on the parent commit and pass on this one. Reverting only the two fix hunks and keeping the tests:

```
---- token_stream::tests::rustc_parity_prefix_sigils stdout ----
assertion `left == right` failed: rendering of `#a #b #c` diverges from rustc
  left: "# a # b # c"
 right: "#a #b #c"

---- token_stream::tests::doc_comment_from_str stdout ----
assertion `left == right` failed
  left: "# [doc = \" foo\"]"
 right: "#[doc = \" foo\"]"

test result: FAILED. 1 passed; 3 failed; 0 ignored; 0 measured; 19 filtered out
```

```
---- macro_expansion_tests::builtin_fn_macro::test_stringify_expand_prefix_sigils ----
fn main() {
    "# inner <# ty >";
    "$ x";
}
test result: FAILED. 1 passed; 1 failed; 0 ignored; 0 measured; 503 filtered out
```

Restoring both hunks:

```
test token_stream::tests::doc_comment_from_str ... ok
test token_stream::tests::ts_to_string ... ok
test token_stream::tests::rustc_parity_prefix_sigils ... ok
test token_stream::tests::rustc_parity_known_divergences ... ok
test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 19 filtered out

test macro_expansion_tests::builtin_fn_macro::test_stringify_expand ... ok
test macro_expansion_tests::builtin_fn_macro::test_stringify_expand_prefix_sigils ... ok
test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 503 filtered out
```

Gates. Full `proc-macro-srv` suite under the CI invocation, `cargo test --features in-rust-tree -p proc-macro-srv`:

```
test result: ok. 23 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

`cargo test -p tt -p mbe -p hir-def -p syntax-bridge`:

```
test result: ok. 504 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out
test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

`cargo fmt --check` clean. `cargo clippy -p tt -p hir-def -p proc-macro-srv --all-targets` produces 5 warnings in `proc-macro-srv`, all pre-existing, none on changed lines.

## The existing test encoded the bug

`doc_comment_from_str` asserted `# [doc = " foo"]`. rustc renders `/// foo` as `#[doc = r" foo"]`. I corrected the `#[` half. The literal kind still differs, we produce a normal string where rustc produces a raw one. That is a separate divergence and I left it alone.

## What this does not fix, honestly

The original report by @feois is a different bug. `feois/rust-enumeration` has no `[dependencies]` and no `proc-macro = true`, so it is `macro_rules!` only and never reaches `TokenStream::to_string()`. Nothing here touches it. rust-lang/rust-analyzer#18571 is two unrelated bugs sharing a title, and the first one still has no root cause. It probably deserves its own issue.

I have not written an end to end test that loads a real dylib whose macro does string replacement. The proof above is at the renderer, plus the rustc oracle.

The remaining 30-odd whitespace divergences from rustc are untouched. `rustc_parity_known_divergences` records eight representative ones so they are visible in the tree and any future change to them shows up as a diff instead of silently. That test asserts both the current output and that it still differs from rustc, so it fails loudly in either direction.

## Question for a maintainer

Do you want full `space_between` parity with `rustc_ast_pretty`, or is this sigil fix the right scope? Full parity is a much larger change and would churn expectations across the macro expansion tests. My read is that the sigil case is the only one that is semantically load bearing, since everything else re-lexes to the same tokens, but you know the downstream consumers better than I do. Happy to do the larger port in a follow-up if you want it.
