### PR TITLE
fix: Fix `NamedTempFile`

### DIFF
--- a/crates/proc-macro-srv/src/dylib.rs
+++ b/crates/proc-macro-srv/src/dylib.rs
@@ -27,7 +27,7 @@ impl Expander {
         let lib = lib.canonicalize_utf8()?;
         let modified_time = fs::metadata(&lib).and_then(|it| it.modified())?;
 
-        let file = ensure_file_with_lock_free_access(lib)?;
+        let file = ensure_file_with_lock_free_access(lib);
         let library = ProcMacroLibrary::open(file.path())?;
 
         Ok(Expander { inner: library, modified_time, _file: file })
@@ -88,19 +88,28 @@ impl ProcMacroLibrary {
 
 /// Copy the dylib to temp directory to prevent locking in Windows
 #[cfg(windows)]
-fn ensure_file_with_lock_free_access(path: Utf8PathBuf) -> io::Result<NamedTempFile> {
+fn ensure_file_with_lock_free_access(path: Utf8PathBuf) -> NamedTempFile {
     if std::env::var("RA_DONT_COPY_PROC_MACRO_DLL").is_ok() {
-        return Ok(NamedTempFile::from_path(path.into_std_path_buf()));
+        return NamedTempFile::from_path(path.into_std_path_buf());
     }
 
-    let file_name = path.file_stem().ok_or_else(|| {
-        io::Error::new(io::ErrorKind::InvalidInput, format!("File path is invalid: {path}"))
-    })?;
+    (|| {
+        let file_name = path.file_stem().ok_or_else(|| {
+            io::Error::new(io::ErrorKind::InvalidInput, format!("File path is invalid: {path}"))
+        })?;
 
-    NamedTempFile::new_from_existing(&format!("proc-macro-srv-{file_name}.dll"), path.as_std_path())
+        NamedTempFile::new_from_existing(
+            &format!("proc-macro-srv-{file_name}.dll"),
+            path.as_std_path(),
+        )
+    })
+    .unwrap_or_else(|err| {
+        tracing::warn!("failed to create temporary file: {err}");
+        NamedTempFile::from_path(path.into_std_path_buf())
+    })
 }
 
 #[cfg(unix)]
-fn ensure_file_with_lock_free_access(path: Utf8PathBuf) -> io::Result<NamedTempFile> {
-    Ok(NamedTempFile::from_path(path.into_std_path_buf()))
+fn ensure_file_with_lock_free_access(path: Utf8PathBuf) -> NamedTempFile {
+    NamedTempFile::from_path(path.into_std_path_buf())
 }

--- a/crates/project-model/src/cargo_config_file.rs
+++ b/crates/project-model/src/cargo_config_file.rs
@@ -1,7 +1,7 @@
 //! Read `.cargo/config.toml` as a TOML table
 use paths::{AbsPath, Utf8Path, Utf8PathBuf};
 use rustc_hash::FxHashMap;
-use stdx::tempfile::NamedTempFile;
+use stdx::tempfile::NamedTempDir;
 use toml::{
     Spanned,
     de::{DeTable, DeValue},
@@ -140,7 +140,7 @@ impl<'a> CargoConfigFileReader<'a> {
 pub(crate) struct LockfileCopy {
     pub(crate) path: Utf8PathBuf,
     pub(crate) usage: LockfileUsage,
-    _temp_file: NamedTempFile,
+    _temp_dir: NamedTempDir,
 }
 
 pub(crate) enum LockfileUsage {
@@ -194,12 +194,11 @@ pub(crate) fn make_lockfile_copy(
         return None;
     };
 
-    let temp_file =
-        NamedTempFile::new_from_existing("rust-analyzer-Cargo.lock", lockfile_path.as_std_path())
-            .ok()?;
-    let path = Utf8Path::from_path(temp_file.path())?.to_path_buf();
+    let temp_dir = NamedTempDir::new("rust-analyzer").ok()?;
+    let path = temp_dir.path().join("Cargo.lock");
+    std::fs::copy(lockfile_path.as_std_path(), &path).ok()?;
 
-    Some(LockfileCopy { path, usage, _temp_file: temp_file })
+    Some(LockfileCopy { path: Utf8PathBuf::from_path_buf(path).ok()?, usage, _temp_dir: temp_dir })
 }
 
 #[test]

--- a/crates/stdx/src/tempfile.rs
+++ b/crates/stdx/src/tempfile.rs
@@ -45,20 +45,44 @@ impl Drop for NamedTempFile {
     }
 }
 
+pub struct NamedTempDir {
+    path: PathBuf,
+}
+
+impl NamedTempDir {
+    pub fn new(prefix: &str) -> io::Result<NamedTempDir> {
+        general_imp::create(prefix, |_options, path| std::fs::create_dir(path))
+            .map(|((), path)| NamedTempDir { path })
+    }
+
+    #[inline]
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for NamedTempDir {
+    fn drop(&mut self) {
+        if std::fs::remove_dir_all(&self.path).is_err() {
+            tracing::info!("cannot remove temporary directory {}", self.path.display());
+        }
+    }
+}
+
 mod general_imp {
     use std::{
-        fs::{File, OpenOptions},
+        fs::OpenOptions,
         io::{self, ErrorKind},
-        path::PathBuf,
+        path::{Path, PathBuf},
         sync::atomic::{AtomicU32, Ordering},
     };
 
     static INTERNAL_COUNTER: AtomicU32 = AtomicU32::new(0);
 
-    pub(super) fn create(
+    pub(super) fn create<T>(
         prefix: &str,
-        mut options_callback: impl FnMut(&mut OpenOptions),
-    ) -> io::Result<(File, PathBuf)> {
+        mut create: impl FnMut(OpenOptions, &Path) -> io::Result<T>,
+    ) -> io::Result<(T, PathBuf)> {
         let temp_dir = std::env::temp_dir().canonicalize()?;
         let pid = std::process::id();
         loop {
@@ -68,8 +92,7 @@ mod general_imp {
             ));
             let mut open_options = OpenOptions::new();
             open_options.create_new(true);
-            options_callback(&mut open_options);
-            match open_options.open(&path) {
+            match create(open_options, &path) {
                 Err(e) if e.kind() == ErrorKind::AlreadyExists => {}
                 Err(e) => {
                     return Err(io::Error::new(
@@ -114,7 +137,7 @@ mod imp {
     }
 
     pub(super) fn create(prefix: &str) -> io::Result<NamedTempFile> {
-        let (file, mut path) = general_imp::create(prefix, |_| {})?;
+        let (file, mut path) = general_imp::create(prefix, |options, path| options.open(path))?;
         let mut delete_on_drop = true;
         if let Ok(original_path) = CString::new(path.as_os_str().as_bytes()) {
             // Unlinking the file will *not* remove it per the POSIX specification since it is open.
@@ -139,9 +162,11 @@ mod imp {
     const FILE_FLAG_DELETE_ON_CLOSE: u32 = 0x04000000;
 
     pub(super) fn create(prefix: &str) -> io::Result<NamedTempFile> {
-        let (file, path) = general_imp::create(prefix, |options| {
-            options.attributes(FILE_ATTRIBUTE_TEMPORARY);
-            options.custom_flags(FILE_FLAG_DELETE_ON_CLOSE);
+        let (file, path) = general_imp::create(prefix, |mut options, path| {
+            options
+                .attributes(FILE_ATTRIBUTE_TEMPORARY)
+                .custom_flags(FILE_FLAG_DELETE_ON_CLOSE)
+                .open(path)
         })?;
         Ok(NamedTempFile { _file: Some(file), path, delete_on_drop: false })
     }
@@ -158,7 +183,7 @@ mod imp {
     use super::*;
 
     pub(super) fn create(prefix: &str) -> io::Result<NamedTempFile> {
-        let (file, path) = general_imp::create(prefix, |_| {})?;
+        let (file, path) = general_imp::create(prefix, |options, path| options.open(path))?;
         Ok(NamedTempFile { _file: Some(file), path, delete_on_drop: true })
     }
 }


### PR DESCRIPTION
 - Use `OpenOptions::write(true)`, otherwise it always fails.
 - If unable to copy the proc macro DLL in the proc macro server, use the original instead to at least succeed.
 - For Cargo.lock, use a temporary directory instead as Cargo only accepts literally-named Cargo.lock files, and also because `/proc/self/fd` does not work for other processes. Fortunately unlike the proc macro server we do run `Drop` for those.

Thanks to @onlycs for discovering those.

I'm merging this myself because this can make the proc macro server not working at all on Windows. @lnicola may I also invite a sync?