### PR TITLE
fix `overprovisioned-secrets` zizmor finding

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -252,9 +252,7 @@ jobs:
       matrix:
         include:
           - cmd: vsce
-            pat: MARKETPLACE_TOKEN
           - cmd: ovsx
-            pat: OPENVSX_TOKEN
     steps:
       - name: Install Nodejs
         uses: actions/setup-node@v6
@@ -277,6 +275,8 @@ jobs:
 
       - name: Publish Extension
         if: github.repository == 'rust-lang/rust-analyzer'
+        env:
+          PUBLISH_PAT: ${{ (matrix.cmd == 'vsce' && secrets.MARKETPLACE_TOKEN) || (matrix.cmd == 'ovsx' && secrets.OPENVSX_TOKEN) }}
         working-directory: ./editors/code
-        run: npx ${{ matrix.cmd }} publish --skip-duplicate --pat ${{ secrets[matrix.pat] }} --packagePath ../../dist/rust-analyzer-*.vsix ${{ github.ref != 'refs/heads/release' && '--pre-release' || '' }}
+        run: npx ${{ matrix.cmd }} publish --skip-duplicate --pat "$PUBLISH_PAT" --packagePath ../../dist/rust-analyzer-*.vsix ${{ github.ref != 'refs/heads/release' && '--pre-release' || '' }}
         timeout-minutes: 2


### PR DESCRIPTION
fix the [`overprovisioned-secrets`](https://docs.zizmor.sh/audits/#overprovisioned-secrets) zizmor finding:
```
warning[overprovisioned-secrets]: excessively provisioned secrets
   --> .github/workflows/release.yaml:281:67
    |
281 | ...h --skip-duplicate --pat ${{ secrets[matrix.pat] }} --packagePath ../../dist/rust-analyzer-*.vsix ${{ github.ref != 'refs/heads/...
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^ injects the entire secrets context into the runner
    |
    = note: audit confidence → High
```

## AI disclosure

I used GPT5.6-Sol with the codex harness to generate this change. I reviewed its output.