### PR TITLE
merge `hir_def::hir::Expr::Unsafe` into `Expr::Block`

### DIFF
--- a/crates/hir-def/src/expr_store.rs
+++ b/crates/hir-def/src/expr_store.rs
@@ -689,8 +689,7 @@ impl ExpressionStore {
                 visitor.on_pat(*pat);
                 visitor.on_expr(*expr);
             }
-            Expr::Block { statements, tail, id: _, label: _ }
-            | Expr::Unsafe { statements, tail, id: _ } => {
+            Expr::Block { statements, tail, id: _, label: _, unsafe_: _ } => {
                 for stmt in statements {
                     match stmt {
                         Statement::Let { initializer, else_branch, pat, type_ref } => {

--- a/crates/hir-def/src/expr_store/lower.rs
+++ b/crates/hir-def/src/expr_store/lower.rs
@@ -52,7 +52,7 @@ use crate::{
         Array, Binding, BindingAnnotation, BindingId, BindingProblems, CaptureBy, ClosureKind,
         CoroutineKind, CoroutineSource, Expr, ExprId, Item, Label, LabelId, Literal, LoopSource,
         MatchArm, Movability, OffsetOf, Pat, PatId, RecordFieldPat, RecordLitField, RecordSpread,
-        Statement, generics::GenericParams,
+        Statement, Unsafe, generics::GenericParams,
     },
     item_scope::BuiltinShadowMode,
     lang_item::{LangItemTarget, LangItems},
@@ -1188,7 +1188,13 @@ impl<'db> ExprCollector<'db> {
         statements: Box<[Statement]>,
         tail: Option<ExprId>,
     ) -> Expr {
-        let block = self.alloc_expr_desugared(Expr::Block { label: None, id, statements, tail });
+        let block = self.alloc_expr_desugared(Expr::Block {
+            label: None,
+            id,
+            statements,
+            tail,
+            unsafe_: Unsafe::No,
+        });
         Expr::Closure {
             args: Box::default(),
             arg_types: Box::default(),
@@ -1390,10 +1396,12 @@ impl<'db> ExprCollector<'db> {
                     self.desugar_try_block(e, result_type)
                 }
                 Some(ast::BlockModifier::Unsafe(_)) => {
-                    self.collect_block_(e, |_, id, statements, tail| Expr::Unsafe {
+                    self.collect_block_(e, |_, id, statements, tail| Expr::Block {
                         id,
                         statements,
                         tail,
+                        label: None,
+                        unsafe_: Unsafe::Yes,
                     })
                 }
                 Some(ast::BlockModifier::Label(label)) => {
@@ -1405,6 +1413,7 @@ impl<'db> ExprCollector<'db> {
                             statements,
                             tail,
                             label: Some(label_id),
+                            unsafe_: Unsafe::No,
                         })
                     })
                 }
@@ -2247,7 +2256,7 @@ impl<'db> ExprCollector<'db> {
             let mut btail = None;
             let block = this.collect_block_(e, |_, id, statements, tail| {
                 btail = tail;
-                Expr::Block { id, statements, tail, label: Some(label) }
+                Expr::Block { id, statements, tail, label: Some(label), unsafe_: Unsafe::No }
             });
             (btail, block)
         });
@@ -2296,6 +2305,7 @@ impl<'db> ExprCollector<'db> {
                         }]),
                         tail: Some(tail_expr),
                         label: None,
+                        unsafe_: Unsafe::No,
                     },
                     ptr,
                 )
@@ -2429,6 +2439,7 @@ impl<'db> ExprCollector<'db> {
                 statements: Box::default(),
                 tail: Some(loop_inner),
                 label: None,
+                unsafe_: Unsafe::No,
             },
             syntax_ptr,
         );
@@ -2727,6 +2738,7 @@ impl<'db> ExprCollector<'db> {
             statements,
             tail,
             label: None,
+            unsafe_: Unsafe::No,
         })
     }
 

--- a/crates/hir-def/src/expr_store/lower/format_args.rs
+++ b/crates/hir-def/src/expr_store/lower/format_args.rs
@@ -12,7 +12,7 @@ use syntax::{
 use crate::{
     expr_store::{HygieneId, lower::ExprCollector, path::Path},
     hir::{
-        Array, BindingAnnotation, Expr, ExprId, Literal, Pat, Statement,
+        Array, BindingAnnotation, Expr, ExprId, Literal, Pat, Statement, Unsafe,
         format_args::{
             self, FormatAlignment, FormatArgs, FormatArgsPiece, FormatArgument, FormatArgumentKind,
             FormatArgumentsCollector, FormatCount, FormatDebugHex, FormatSign, FormatTrait,
@@ -187,6 +187,7 @@ impl<'db> ExprCollector<'db> {
                                         .collect(),
                                     tail: Some(from_str),
                                     label: None,
+                                    unsafe_: Unsafe::No,
                                 },
                                 syntax_ptr,
                             )
@@ -378,7 +379,13 @@ impl<'db> ExprCollector<'db> {
             self.alloc_expr_desugared(Expr::Call { callee: new, args: Box::new([template, args]) })
         };
         let call = self.alloc_expr(
-            Expr::Unsafe { id: None, statements: Box::new([]), tail: Some(call) },
+            Expr::Block {
+                id: None,
+                statements: Box::new([]),
+                tail: Some(call),
+                label: None,
+                unsafe_: Unsafe::Yes,
+            },
             syntax_ptr,
         );
 
@@ -402,6 +409,7 @@ impl<'db> ExprCollector<'db> {
                     statements: statements.into_boxed_slice(),
                     tail: Some(call),
                     label: None,
+                    unsafe_: Unsafe::No,
                 },
                 syntax_ptr,
             )

--- a/crates/hir-def/src/expr_store/pretty.rs
+++ b/crates/hir-def/src/expr_store/pretty.rs
@@ -19,7 +19,7 @@ use crate::{
     expr_store::path::{GenericArg, GenericArgs},
     hir::{
         Array, BindingAnnotation, CaptureBy, ClosureKind, CoroutineKind, Literal, Movability,
-        RecordSpread, Statement,
+        RecordSpread, Statement, Unsafe,
         generics::{GenericParams, WherePredicate},
     },
     lang_item::LangItemTarget,
@@ -843,14 +843,11 @@ impl Printer<'_> {
                 w!(self, "]");
             }
             Expr::Literal(lit) => self.print_literal(lit),
-            Expr::Block { id: _, statements, tail, label } => {
+            Expr::Block { id: _, statements, tail, label, unsafe_ } => {
                 let label = label.map(|lbl| {
                     format!("{}: ", self.store[lbl].name.display(self.db, self.edition))
                 });
-                self.print_block(label.as_deref(), statements, tail);
-            }
-            Expr::Unsafe { id: _, statements, tail } => {
-                self.print_block(Some("unsafe "), statements, tail);
+                self.print_block(label.as_deref(), *unsafe_, statements, tail);
             }
             Expr::Const(id) => {
                 w!(self, "const {{ /* {id:?} */ }}");
@@ -870,12 +867,16 @@ impl Printer<'_> {
     fn print_block(
         &mut self,
         label: Option<&str>,
+        unsafe_: Unsafe,
         statements: &[Statement],
         tail: &Option<la_arena::Idx<Expr>>,
     ) {
         self.whitespace();
         if let Some(lbl) = label {
             w!(self, "{}", lbl);
+        }
+        if unsafe_ == Unsafe::Yes {
+            w!(self, "unsafe ");
         }
         w!(self, "{{");
         if !statements.is_empty() || tail.is_some() {

--- a/crates/hir-def/src/expr_store/scope.rs
+++ b/crates/hir-def/src/expr_store/scope.rs
@@ -335,11 +335,8 @@ impl StoreVisitor for ExprScopeVisitor<'_> {
     fn on_expr(&mut self, expr: ExprId) {
         self.scopes.set_scope(expr, self.scope);
         match &self.store[expr] {
-            Expr::Block { statements, tail, id, label } => {
+            Expr::Block { statements, tail, id, label, unsafe_: _ } => {
                 self.visit_block(expr, *id, statements, *tail, *label);
-            }
-            Expr::Unsafe { id, statements, tail } => {
-                self.visit_block(expr, *id, statements, *tail, None);
             }
             Expr::Loop { body, label, source: _ } => {
                 let scope = self.scopes.new_labeled_scope(self.scope, *label);

--- a/crates/hir-def/src/hir.rs
+++ b/crates/hir-def/src/hir.rs
@@ -271,6 +271,12 @@ pub enum RecordSpread {
     Expr(ExprId),
 }
 
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum Unsafe {
+    Yes,
+    No,
+}
+
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum Expr {
     /// This is produced if the syntax tree does not have a required expression piece.
@@ -290,14 +296,9 @@ pub enum Expr {
         statements: Box<[Statement]>,
         tail: Option<ExprId>,
         label: Option<LabelId>,
+        unsafe_: Unsafe,
     },
     Const(ExprId),
-    // FIXME: Fold this into Block with an unsafe flag?
-    Unsafe {
-        id: Option<BlockId>,
-        statements: Box<[Statement]>,
-        tail: Option<ExprId>,
-    },
     Loop {
         body: ExprId,
         label: Option<LabelId>,
@@ -406,7 +407,6 @@ impl Expr {
             Expr::Array(_)
             | Expr::InlineAsm(_)
             | Expr::Block { .. }
-            | Expr::Unsafe { .. }
             | Expr::Const(_)
             | Expr::If { .. }
             | Expr::Literal(_)

--- a/crates/hir-def/src/hir.rs
+++ b/crates/hir-def/src/hir.rs
@@ -10,7 +10,9 @@
 //!    names refer to.
 //! 4. Desugared. There's no `if let`.
 //!
-//! See also a neighboring `body` module.
+//! See also a neighboring [`body`] module.
+//!
+//! [`body`]: crate::expr_store::body
 
 pub mod format_args;
 pub mod generics;

--- a/crates/hir-ty/src/diagnostics/expr.rs
+++ b/crates/hir-ty/src/diagnostics/expr.rs
@@ -151,8 +151,8 @@ impl<'db> ExprValidator<'db> {
                 Expr::If { .. } => {
                     self.check_for_unnecessary_else(id, expr);
                 }
-                Expr::Block { .. } | Expr::Unsafe { .. } => {
-                    self.validate_block(expr);
+                Expr::Block { statements, .. } => {
+                    self.validate_block(statements);
                 }
                 _ => {}
             }
@@ -314,13 +314,10 @@ impl<'db> ExprValidator<'db> {
         }
     }
 
-    fn validate_block(&mut self, expr: &Expr) {
-        let (Expr::Block { statements, .. } | Expr::Unsafe { statements, .. }) = expr else {
-            return;
-        };
+    fn validate_block(&mut self, statements: &[Statement]) {
         let pattern_arena = Arena::new();
         let cx = MatchCheckCtx::new(self.owner.module(self.db()), &self.infcx, self.env);
-        for stmt in &**statements {
+        for stmt in statements {
             match *stmt {
                 Statement::Expr { expr: stmt_expr, has_semi: true } if self.validate_lints => {
                     let mut diags = Vec::new();
@@ -417,9 +414,7 @@ impl<'db> ExprValidator<'db> {
         // `expr`; branching containers (`if`/`match`) recurse on each arm.
         loop {
             match &self.body[expr] {
-                Expr::Block { tail: Some(tail), .. }
-                | Expr::Unsafe { tail: Some(tail), .. }
-                | Expr::Const(tail) => expr = *tail,
+                Expr::Block { tail: Some(tail), .. } | Expr::Const(tail) => expr = *tail,
                 Expr::If { then_branch, else_branch, .. } => {
                     self.check_unused_must_use(*then_branch, acc);
                     if let Some(else_branch) = else_branch {

--- a/crates/hir-ty/src/diagnostics/unsafe_check.rs
+++ b/crates/hir-ty/src/diagnostics/unsafe_check.rs
@@ -8,7 +8,10 @@ use hir_def::{
     AdtId, CallableDefId, DefWithBodyId, ExpressionStoreOwnerId, FieldId, FunctionId, GenericDefId,
     VariantId,
     expr_store::{Body, ExpressionStore, path::Path},
-    hir::{AsmOperand, Expr, ExprId, ExprOrPatId, InlineAsmKind, Pat, PatId, Statement, UnaryOp},
+    hir::{
+        AsmOperand, Expr, ExprId, ExprOrPatId, InlineAsmKind, Pat, PatId, Statement, UnaryOp,
+        Unsafe,
+    },
     resolver::{HasResolver, ResolveValueResult, Resolver, ValueNs},
     signatures::{FunctionSignature, StaticFlags, StaticSignature},
     type_ref::Rawness,
@@ -391,7 +394,7 @@ impl<'db> UnsafeVisitor<'db> {
                     self.on_unsafe_op(current.into(), UnsafetyReason::UnionField);
                 }
             }
-            Expr::Unsafe { statements, .. } => {
+            Expr::Block { unsafe_: Unsafe::Yes, statements, .. } => {
                 self.with_inside_unsafe_block(InsideUnsafeBlock::Yes, |this| {
                     this.walk_pats_top(
                         statements.iter().filter_map(|statement| match statement {
@@ -404,7 +407,7 @@ impl<'db> UnsafeVisitor<'db> {
                 });
                 return;
             }
-            Expr::Block { statements, .. } => {
+            Expr::Block { unsafe_: Unsafe::No, statements, .. } => {
                 self.walk_pats_top(
                     statements.iter().filter_map(|statement| match statement {
                         &Statement::Let { pat, .. } => Some(pat),

--- a/crates/hir-ty/src/infer/closure/analysis/expr_use_visitor.rs
+++ b/crates/hir-ty/src/infer/closure/analysis/expr_use_visitor.rs
@@ -631,8 +631,7 @@ impl<'a, 'db, D: Delegate<'db>> ExprUseVisitor<'a, 'db, D> {
                 self.consume_expr(rhs)?;
             }
 
-            Expr::Block { ref statements, tail, .. }
-            | Expr::Unsafe { ref statements, tail, .. } => {
+            Expr::Block { ref statements, tail, .. } => {
                 for stmt in statements {
                     self.walk_stmt(stmt)?;
                 }

--- a/crates/hir-ty/src/infer/expr.rs
+++ b/crates/hir-ty/src/infer/expr.rs
@@ -265,7 +265,6 @@ impl<'db> InferenceContext<'db> {
             | Expr::Assignment { .. }
             | Expr::Yield { .. }
             | Expr::Cast { .. }
-            | Expr::Unsafe { .. }
             | Expr::Await { .. }
             | Expr::Ref { .. }
             | Expr::RecordLit { .. }
@@ -391,11 +390,8 @@ impl<'db> InferenceContext<'db> {
                 );
                 self.types.types.bool
             }
-            Expr::Block { statements, tail, label, id: _ } => {
+            Expr::Block { statements, tail, label, id: _, unsafe_: _ } => {
                 self.infer_block(tgt_expr, statements, *tail, *label, expected)
-            }
-            Expr::Unsafe { id: _, statements, tail } => {
-                self.infer_block(tgt_expr, statements, *tail, None, expected)
             }
             Expr::Const(id) => {
                 self.with_breakable_ctx(BreakableKind::Border, None, None, |this| {

--- a/crates/hir-ty/src/infer/mutability.rs
+++ b/crates/hir-ty/src/infer/mutability.rs
@@ -86,8 +86,7 @@ impl<'db> InferenceContext<'db> {
                 self.infer_mut_expr(*id, Mutability::Not);
             }
             Expr::Let { pat, expr } => self.infer_mut_expr(*expr, self.pat_bound_mutability(*pat)),
-            Expr::Block { id: _, statements, tail, label: _ }
-            | Expr::Unsafe { id: _, statements, tail } => {
+            Expr::Block { id: _, statements, tail, label: _, unsafe_: _ } => {
                 for st in statements.iter() {
                     match st {
                         Statement::Let { pat, type_ref: _, initializer, else_branch } => {

--- a/crates/hir-ty/src/mir/lower.rs
+++ b/crates/hir-ty/src/mir/lower.rs
@@ -649,10 +649,7 @@ impl<'a, 'db> MirLowerCtx<'a, 'db> {
                 }
                 Ok(self.merge_blocks(Some(then_target), else_target, expr_id.into()))
             }
-            Expr::Unsafe { id: _, statements, tail } => {
-                self.lower_block_to_place(statements, current, *tail, place, expr_id.into())
-            }
-            Expr::Block { id: _, statements, tail, label } => {
+            Expr::Block { id: _, statements, tail, label, unsafe_: _ } => {
                 if let Some(label) = label {
                     self.lower_loop(current, place, Some(*label), expr_id.into(), |this, begin| {
                         if let Some(current) = this.lower_block_to_place(

--- a/crates/hir/src/semantics.rs
+++ b/crates/hir/src/semantics.rs
@@ -17,7 +17,7 @@ use hir_def::{
     StructId, TraitId, VariantId,
     attrs::parse_extra_crate_attrs,
     expr_store::{Body, ExprOrPatSource, ExpressionStore, HygieneId, path::Path},
-    hir::{BindingId, Expr, ExprId, ExprOrPatId},
+    hir::{BindingId, Expr, ExprId, ExprOrPatId, Unsafe},
     nameres::{ModuleOrigin, crate_def_map},
     resolver::{self, HasResolver, Resolver, TypeNs, ValueNs},
     type_ref::Mutability,
@@ -2427,7 +2427,7 @@ impl<'db> SemanticsImpl<'db> {
             if let Some(parent) = ast::Expr::cast(parent.clone())
                 && let Some(ExprOrPatId::ExprId(expr_id)) =
                     source_map.node_expr(InFile { file_id, value: &parent })
-                && let Expr::Unsafe { .. } = body[expr_id]
+                && let Expr::Block { unsafe_: Unsafe::Yes, .. } = body[expr_id]
             {
                 break true;
             }


### PR DESCRIPTION
A lot of callsites handled these variants similarly, so this ended up simplifying things.