### PR TITLE
parser: fix tuple field parsing in offset_of expansion

### DIFF
--- a/crates/ide/src/goto_definition.rs
+++ b/crates/ide/src/goto_definition.rs
@@ -3847,6 +3847,27 @@ fn foo() {
     }
 
     #[test]
+    fn offset_of_tuple_fields() {
+        // Consecutive tuple indices are lexed as a single float literal, they have to be
+        // split apart again, see https://github.com/rust-lang/rust-analyzer/issues/23178.
+        check(
+            r#"
+//- minicore: offset_of
+struct Bar(Baz);
+struct Baz(Foo);
+struct Foo {
+    field: i32,
+ // ^^^^^
+}
+
+fn foo() {
+    let _ = core::mem::offset_of!(Bar, 0.0.fiel$0d);
+}
+        "#,
+        );
+    }
+
+    #[test]
     fn goto_def_for_match_keyword() {
         check(
             r#"

--- a/crates/parser/src/event.rs
+++ b/crates/parser/src/event.rs
@@ -73,7 +73,12 @@ pub(crate) enum Event {
     /// instead of an integer literal followed by a dot as the lexer has no contextual knowledge.
     /// This event instructs whatever consumes the events to split the float literal into
     /// the corresponding parts.
-    FloatSplitHack { ends_in_dot: bool },
+    ///
+    /// `flat` tells the consumer whether the parts belong to the node that is currently open.
+    /// Field access nests (`foo.0.0` is a `FIELD_EXPR` inside a `FIELD_EXPR`), so the split has
+    /// to close the enclosing node(s) in the middle of the literal. In a flat field list, like
+    /// the one of `builtin#offset_of`, the parts are plain siblings and nothing is closed.
+    FloatSplitHack { ends_in_dot: bool, flat: bool },
     /// Index into the parser's side `errors` vec.
     Error { err: u32 },
 }
@@ -126,10 +131,12 @@ pub(super) fn process(mut events: Vec<Event>, mut errors: Vec<String>) -> Output
             Event::Token { kind, n_raw_tokens } => {
                 res.token(kind, n_raw_tokens);
             }
-            Event::FloatSplitHack { ends_in_dot } => {
-                res.float_split_hack(ends_in_dot);
-                let ev = mem::replace(&mut events[i + 1], Event::tombstone());
-                assert!(matches!(ev, Event::Finish), "{ev:?}");
+            Event::FloatSplitHack { ends_in_dot, flat } => {
+                res.float_split_hack(ends_in_dot, flat);
+                if !flat {
+                    let ev = mem::replace(&mut events[i + 1], Event::tombstone());
+                    assert!(matches!(ev, Event::Finish), "{ev:?}");
+                }
             }
             Event::Error { err } => {
                 // Move the string out of the side table; each index is visited

--- a/crates/parser/src/grammar/expressions/atom.rs
+++ b/crates/parser/src/grammar/expressions/atom.rs
@@ -269,8 +269,31 @@ fn builtin_expr(p: &mut Parser<'_>) -> Option<CompletedMarker> {
         // fn foo() {
         //     builtin#offset_of(Foo, (bar.baz.0));
         // }
+
+        // test offset_of_tuple_fields
+        // fn foo() {
+        //     builtin#offset_of(Foo, 0.1);
+        //     builtin#offset_of(Foo, 0 .1.1.1);
+        //     builtin#offset_of(Foo, 0. 1);
+        //     builtin#offset_of(Foo, (0.1.bar.2));
+        // }
         while !p.at(EOF) && !p.at(T![')']) {
-            name_ref_mod_path_or_index(p);
+            // The lexer has no context, so consecutive tuple field indices come in as a
+            // float literal (`0.1` in `offset_of!(Foo, 0.1)`). Split it into its parts,
+            // the same way field access does.
+            //
+            // rustc does the same in `Parser::parse_floating_field_access`, which pushes the
+            // two halves of a `DestructuredFloat::MiddleDot` into one flat list of fields:
+            // https://github.com/rust-lang/rust/blob/8de399ac7b7cce3314f4f7e2cd2e1285b1608e14/compiler/rustc_parse/src/parser/expr.rs#L1132
+            if p.at(FLOAT_NUMBER) {
+                if p.split_float_flat() {
+                    // The literal ended in a dot (`0.`), which already separates it from
+                    // the next field.
+                    continue;
+                }
+            } else {
+                name_ref_mod_path_or_index(p);
+            }
             if !p.at(T![')']) {
                 p.expect(T![.]);
             }

--- a/crates/parser/src/lib.rs
+++ b/crates/parser/src/lib.rs
@@ -123,8 +123,10 @@ impl TopEntryPoint {
                 match step {
                     Step::Enter { .. } => depth += 1,
                     Step::Exit => depth -= 1,
-                    Step::FloatSplit { ends_in_dot: has_pseudo_dot } => {
-                        depth -= 1 + !has_pseudo_dot as usize
+                    Step::FloatSplit { ends_in_dot: has_pseudo_dot, flat } => {
+                        if !flat {
+                            depth -= 1 + !has_pseudo_dot as usize
+                        }
                     }
                     Step::Token { .. } | Step::Error { .. } => (),
                 }

--- a/crates/parser/src/output.rs
+++ b/crates/parser/src/output.rs
@@ -26,7 +26,7 @@ pub struct Output {
 #[derive(Debug)]
 pub enum Step<'a> {
     Token { kind: SyntaxKind, n_input_tokens: u8 },
-    FloatSplit { ends_in_dot: bool },
+    FloatSplit { ends_in_dot: bool, flat: bool },
     Enter { kind: SyntaxKind },
     Exit,
     Error { msg: &'a str },
@@ -50,6 +50,11 @@ impl Output {
     const TAG_SHIFT: u32 = Self::TAG_MASK.trailing_zeros();
     const N_INPUT_TOKEN_SHIFT: u32 = Self::N_INPUT_TOKEN_MASK.trailing_zeros();
     const KIND_SHIFT: u32 = Self::KIND_MASK.trailing_zeros();
+
+    /// Flags of a `SPLIT_EVENT`, stored in the `n_input_tokens` byte, which is
+    /// unused for splits as they always consume exactly one input token.
+    const SPLIT_ENDS_IN_DOT: u32 = 1 << Self::N_INPUT_TOKEN_SHIFT;
+    const SPLIT_FLAT: u32 = 2 << Self::N_INPUT_TOKEN_SHIFT;
 
     const TOKEN_EVENT: u8 = 0;
     const ENTER_EVENT: u8 = 1;
@@ -78,9 +83,10 @@ impl Output {
                     Step::Enter { kind }
                 }
                 Self::EXIT_EVENT => Step::Exit,
-                Self::SPLIT_EVENT => {
-                    Step::FloatSplit { ends_in_dot: event & Self::N_INPUT_TOKEN_MASK != 0 }
-                }
+                Self::SPLIT_EVENT => Step::FloatSplit {
+                    ends_in_dot: event & Self::SPLIT_ENDS_IN_DOT != 0,
+                    flat: event & Self::SPLIT_FLAT != 0,
+                },
                 _ => unreachable!(),
             }
         })
@@ -93,9 +99,10 @@ impl Output {
         self.event.push(e)
     }
 
-    pub(crate) fn float_split_hack(&mut self, ends_in_dot: bool) {
+    pub(crate) fn float_split_hack(&mut self, ends_in_dot: bool, flat: bool) {
         let e = ((Self::SPLIT_EVENT as u32) << Self::TAG_SHIFT)
-            | ((ends_in_dot as u32) << Self::N_INPUT_TOKEN_SHIFT)
+            | (if ends_in_dot { Self::SPLIT_ENDS_IN_DOT } else { 0 })
+            | (if flat { Self::SPLIT_FLAT } else { 0 })
             | Self::EVENT_MASK;
         self.event.push(e);
     }

--- a/crates/parser/src/parser.rs
+++ b/crates/parser/src/parser.rs
@@ -237,8 +237,22 @@ impl<'t> Parser<'t> {
             marker = new_marker;
         };
         self.pos += 1;
-        self.push_event(Event::FloatSplitHack { ends_in_dot });
+        self.push_event(Event::FloatSplitHack { ends_in_dot, flat: false });
         (ends_in_dot, marker)
+    }
+
+    /// Splits the current float literal into its integer parts and the dot separating them,
+    /// emitting all of them as children of the node that is currently open.
+    ///
+    /// Unlike [`Parser::split_float`] this does not close any node, so it fits flat field
+    /// lists such as the one of `builtin#offset_of`. Returns whether the literal ended in a
+    /// dot (`0.`), in which case only the leading index and the dot have been emitted.
+    pub(crate) fn split_float_flat(&mut self) -> bool {
+        assert!(self.at(SyntaxKind::FLOAT_NUMBER));
+        let ends_in_dot = !self.inp.is_joint(self.pos);
+        self.pos += 1;
+        self.push_event(Event::FloatSplitHack { ends_in_dot, flat: true });
+        ends_in_dot
     }
 
     /// Advances the parser by one token, remapping its kind.

--- a/crates/parser/src/shortcuts.rs
+++ b/crates/parser/src/shortcuts.rs
@@ -75,8 +75,8 @@ impl LexedStr<'_> {
                 Step::Token { kind, n_input_tokens: n_raw_tokens } => {
                     builder.token(kind, n_raw_tokens)
                 }
-                Step::FloatSplit { ends_in_dot: has_pseudo_dot } => {
-                    builder.float_split(has_pseudo_dot)
+                Step::FloatSplit { ends_in_dot: has_pseudo_dot, flat } => {
+                    builder.float_split(has_pseudo_dot, flat)
                 }
                 Step::Enter { kind } => builder.enter(kind),
                 Step::Exit => builder.exit(),
@@ -124,14 +124,14 @@ impl Builder<'_, '_> {
         self.do_token(kind, n_tokens as usize);
     }
 
-    fn float_split(&mut self, has_pseudo_dot: bool) {
+    fn float_split(&mut self, has_pseudo_dot: bool, flat: bool) {
         match mem::replace(&mut self.state, State::Normal) {
             State::PendingEnter => unreachable!(),
             State::PendingExit => (self.sink)(StrStep::Exit),
             State::Normal => (),
         }
         self.eat_trivias();
-        self.do_float_split(has_pseudo_dot);
+        self.do_float_split(has_pseudo_dot, flat);
     }
 
     fn enter(&mut self, kind: SyntaxKind) {
@@ -190,7 +190,7 @@ impl Builder<'_, '_> {
         (self.sink)(StrStep::Token { kind, text });
     }
 
-    fn do_float_split(&mut self, has_pseudo_dot: bool) {
+    fn do_float_split(&mut self, has_pseudo_dot: bool, flat: bool) {
         let text = &self.lexed.range_text(self.pos..self.pos + 1);
 
         match text.split_once('.') {
@@ -200,8 +200,10 @@ impl Builder<'_, '_> {
                 (self.sink)(StrStep::Token { kind: SyntaxKind::INT_NUMBER, text: left });
                 (self.sink)(StrStep::Exit);
 
-                // here we move the exit up, the original exit has been deleted in process
-                (self.sink)(StrStep::Exit);
+                if !flat {
+                    // here we move the exit up, the original exit has been deleted in process
+                    (self.sink)(StrStep::Exit);
+                }
 
                 (self.sink)(StrStep::Token { kind: SyntaxKind::DOT, text: "." });
 
@@ -215,7 +217,7 @@ impl Builder<'_, '_> {
                     (self.sink)(StrStep::Exit);
 
                     // the parser creates an unbalanced start node, we are required to close it here
-                    self.state = State::PendingExit;
+                    self.state = if flat { State::Normal } else { State::PendingExit };
                 }
             }
             None => {
@@ -226,10 +228,13 @@ impl Builder<'_, '_> {
                 (self.sink)(StrStep::Token { kind: SyntaxKind::FLOAT_NUMBER, text });
                 (self.sink)(StrStep::Exit);
 
-                // move up
-                (self.sink)(StrStep::Exit);
+                if !flat {
+                    // move up
+                    (self.sink)(StrStep::Exit);
+                }
 
-                self.state = if has_pseudo_dot { State::Normal } else { State::PendingExit };
+                self.state =
+                    if flat || has_pseudo_dot { State::Normal } else { State::PendingExit };
             }
         }
 

--- a/crates/parser/test_data/generated/runner.rs
+++ b/crates/parser/test_data/generated/runner.rs
@@ -498,6 +498,10 @@ mod ok {
         run_and_expect_no_errors("test_data/parser/inline/ok/offset_of_parens.rs");
     }
     #[test]
+    fn offset_of_tuple_fields() {
+        run_and_expect_no_errors("test_data/parser/inline/ok/offset_of_tuple_fields.rs");
+    }
+    #[test]
     fn or_pattern() { run_and_expect_no_errors("test_data/parser/inline/ok/or_pattern.rs"); }
     #[test]
     fn param_list() { run_and_expect_no_errors("test_data/parser/inline/ok/param_list.rs"); }

--- a/crates/parser/test_data/parser/inline/ok/offset_of_tuple_fields.rast
+++ b/crates/parser/test_data/parser/inline/ok/offset_of_tuple_fields.rast
@@ -1,0 +1,116 @@
+SOURCE_FILE
+  FN
+    FN_KW "fn"
+    WHITESPACE " "
+    NAME
+      IDENT "foo"
+    PARAM_LIST
+      L_PAREN "("
+      R_PAREN ")"
+    WHITESPACE " "
+    BLOCK_EXPR
+      STMT_LIST
+        L_CURLY "{"
+        WHITESPACE "\n    "
+        EXPR_STMT
+          OFFSET_OF_EXPR
+            BUILTIN_KW "builtin"
+            POUND "#"
+            OFFSET_OF_KW "offset_of"
+            L_PAREN "("
+            PATH_TYPE
+              PATH
+                PATH_SEGMENT
+                  NAME_REF
+                    IDENT "Foo"
+            COMMA ","
+            WHITESPACE " "
+            NAME_REF
+              INT_NUMBER "0"
+            DOT "."
+            NAME_REF
+              INT_NUMBER "1"
+            R_PAREN ")"
+          SEMICOLON ";"
+        WHITESPACE "\n    "
+        EXPR_STMT
+          OFFSET_OF_EXPR
+            BUILTIN_KW "builtin"
+            POUND "#"
+            OFFSET_OF_KW "offset_of"
+            L_PAREN "("
+            PATH_TYPE
+              PATH
+                PATH_SEGMENT
+                  NAME_REF
+                    IDENT "Foo"
+            COMMA ","
+            WHITESPACE " "
+            NAME_REF
+              INT_NUMBER "0"
+            WHITESPACE " "
+            DOT "."
+            NAME_REF
+              INT_NUMBER "1"
+            DOT "."
+            NAME_REF
+              INT_NUMBER "1"
+            DOT "."
+            NAME_REF
+              INT_NUMBER "1"
+            R_PAREN ")"
+          SEMICOLON ";"
+        WHITESPACE "\n    "
+        EXPR_STMT
+          OFFSET_OF_EXPR
+            BUILTIN_KW "builtin"
+            POUND "#"
+            OFFSET_OF_KW "offset_of"
+            L_PAREN "("
+            PATH_TYPE
+              PATH
+                PATH_SEGMENT
+                  NAME_REF
+                    IDENT "Foo"
+            COMMA ","
+            WHITESPACE " "
+            NAME_REF
+              INT_NUMBER "0"
+            DOT "."
+            WHITESPACE " "
+            NAME_REF
+              INT_NUMBER "1"
+            R_PAREN ")"
+          SEMICOLON ";"
+        WHITESPACE "\n    "
+        EXPR_STMT
+          OFFSET_OF_EXPR
+            BUILTIN_KW "builtin"
+            POUND "#"
+            OFFSET_OF_KW "offset_of"
+            L_PAREN "("
+            PATH_TYPE
+              PATH
+                PATH_SEGMENT
+                  NAME_REF
+                    IDENT "Foo"
+            COMMA ","
+            WHITESPACE " "
+            L_PAREN "("
+            NAME_REF
+              INT_NUMBER "0"
+            DOT "."
+            NAME_REF
+              INT_NUMBER "1"
+            DOT "."
+            NAME_REF
+              IDENT "bar"
+            DOT "."
+            NAME_REF
+              INT_NUMBER "2"
+            R_PAREN ")"
+            R_PAREN ")"
+          SEMICOLON ";"
+        WHITESPACE "\n"
+        R_CURLY "}"
+  WHITESPACE "\n"

--- a/crates/parser/test_data/parser/inline/ok/offset_of_tuple_fields.rs
+++ b/crates/parser/test_data/parser/inline/ok/offset_of_tuple_fields.rs
@@ -1,0 +1,6 @@
+fn foo() {
+    builtin#offset_of(Foo, 0.1);
+    builtin#offset_of(Foo, 0 .1.1.1);
+    builtin#offset_of(Foo, 0. 1);
+    builtin#offset_of(Foo, (0.1.bar.2));
+}

--- a/crates/syntax-bridge/src/lib.rs
+++ b/crates/syntax-bridge/src/lib.rs
@@ -162,8 +162,8 @@ where
             parser::Step::Token { kind, n_input_tokens: n_raw_tokens } => {
                 tree_sink.token(kind, n_raw_tokens)
             }
-            parser::Step::FloatSplit { ends_in_dot: has_pseudo_dot } => {
-                tree_sink.float_split(has_pseudo_dot)
+            parser::Step::FloatSplit { ends_in_dot: has_pseudo_dot, flat } => {
+                tree_sink.float_split(has_pseudo_dot, flat)
             }
             parser::Step::Enter { kind } => tree_sink.start_node(kind),
             parser::Step::Exit => tree_sink.finish_node(),
@@ -865,7 +865,7 @@ fn delim_to_str(d: tt::DelimiterKind, closing: bool) -> Option<&'static str> {
 impl TtTreeSink<'_> {
     /// Parses a float literal as if it was a one to two name ref nodes with a dot inbetween.
     /// This occurs when a float literal is used as a field access.
-    fn float_split(&mut self, has_pseudo_dot: bool) {
+    fn float_split(&mut self, has_pseudo_dot: bool, flat: bool) {
         let token_tree = self.cursor.token_tree();
         let (text, span) = match &token_tree {
             Some(tt::TokenTree::Leaf(tt::Leaf::Literal(
@@ -883,8 +883,10 @@ impl TtTreeSink<'_> {
                 self.inner.finish_node();
                 self.token_map.push(self.text_pos + TextSize::of(left), span);
 
-                // here we move the exit up, the original exit has been deleted in process
-                self.inner.finish_node();
+                if !flat {
+                    // here we move the exit up, the original exit has been deleted in process
+                    self.inner.finish_node();
+                }
 
                 self.inner.token(SyntaxKind::DOT, ".");
                 self.token_map.push(self.text_pos + TextSize::of(left) + TextSize::of("."), span);
@@ -898,8 +900,10 @@ impl TtTreeSink<'_> {
                     self.token_map.push(self.text_pos + TextSize::of(text), span);
                     self.inner.finish_node();
 
-                    // the parser creates an unbalanced start node, we are required to close it here
-                    self.inner.finish_node();
+                    if !flat {
+                        // the parser creates an unbalanced start node, we are required to close it here
+                        self.inner.finish_node();
+                    }
                 }
                 self.text_pos += TextSize::of(text);
             }
@@ -909,10 +913,13 @@ impl TtTreeSink<'_> {
                 self.inner.token(SyntaxKind::FLOAT_NUMBER, text);
                 self.token_map.push(self.text_pos + TextSize::of(text), span);
                 self.inner.finish_node();
-                self.inner.finish_node();
 
-                if !has_pseudo_dot {
+                if !flat {
                     self.inner.finish_node();
+
+                    if !has_pseudo_dot {
+                        self.inner.finish_node();
+                    }
                 }
 
                 self.text_pos += TextSize::of(text);


### PR DESCRIPTION
Fixes rust-lang/rust-analyzer#23178

Fixes a false syntax error when parsing tuple field paths in
`offset_of!` macro expansions.

Added a regression test for nested tuple field access.