### PR TITLE
Address FIXME in base-db and update docs

### DIFF
--- a/crates/base-db/Cargo.toml
+++ b/crates/base-db/Cargo.toml
@@ -2,7 +2,7 @@
 name = "base-db"
 version = "0.0.0"
 repository.workspace = true
-description = "Basic database traits for rust-analyzer. The concrete DB is defined by `ide` (aka `ra_ap_ide`)."
+description = "Basic database trait and infra for rust-analyzer's crate and source root inputs. The concrete DB is defined by `ide` (aka `ra_ap_ide`)."
 
 authors.workspace = true
 edition.workspace = true

--- a/crates/base-db/src/input.rs
+++ b/crates/base-db/src/input.rs
@@ -257,9 +257,10 @@ impl fmt::Display for LangCrateOrigin {
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct CrateDisplayName {
-    // The name we use to display various paths (with `_`).
+    /// The name we use to display various paths (with `_`).
     crate_name: CrateName,
-    // The name as specified in Cargo.toml (with `-`).
+    /// The name as self-declared by the crate. For example, the name declared in the manifest of
+    /// the crate. This may contain dashes `-`.
     canonical_name: Symbol,
 }
 
@@ -936,8 +937,8 @@ impl<'a> IntoIterator for &'a Env {
 ///
 /// ## dev-dependencies
 ///
-/// Note that it's actually legal for a cargo package (i.e. a thing
-/// with a Cargo.toml) to depend on itself in dev-dependencies. This
+/// Note that it's actually legal for a Cargo package (i.e. a thing
+/// with a `Cargo.toml`) to depend on itself in dev-dependencies. This
 /// can enable additional features, and is typically used when a
 /// project wants features to be enabled in tests. Dev-dependencies
 /// are not propagated, so they aren't visible to package that depend

--- a/crates/base-db/src/lib.rs
+++ b/crates/base-db/src/lib.rs
@@ -1,5 +1,6 @@
-//! base_db defines basic database traits. The concrete DB is defined by ide.
-// FIXME: Rename this crate, base db is non descriptive
+//! This crate defines the basic database trait for interacting with source code using [`salsa`].
+//!
+//! The concrete implementation DB is defined by ide.
 
 #![cfg_attr(feature = "in-rust-tree", feature(rustc_private))]
 

--- a/docs/book/src/contributing/architecture.md
+++ b/docs/book/src/contributing/architecture.md
@@ -143,7 +143,7 @@ Reading the docs of the `base_db::input` module should be useful: everything els
 
 **Architecture Invariant:** particularities of the build system are *not* the part of the ground state.
 In particular, `base-db` knows nothing about cargo.
-For example, `cfg` flags are a part of `base_db`, but `feature`s are not.
+For example, `cfg` flags are a part of `base-db`, but `feature`s are not.
 A `foo` feature is a Cargo-level concept, which is lowered by Cargo to `--cfg feature=foo` argument on the command line.
 The `CrateGraph` structure is used to represent the dependencies between the crates abstractly.
 


### PR DESCRIPTION
Found a FIXME that seemed fairly trivial to fix, although actually doing this obviously has a cost.

The notable changes are:
- the autopublish workflow. Maybe it shouldn't be renamed or maybe it should be renamed to the old name?
- looked at instances of "Cargo" in `source-db` and tried to make sure that the mentions were as examples and not as the concrete intention.

It is clear from the crate graph that `base-db` describes source code and no specific semantics of the source code. It also only provides one trait, `SourceDatabase`. I am pretty confident in this new name.

<img width="1705" height="1403" alt="image" src="https://github.com/user-attachments/assets/ef64b574-c5d1-4d9b-b353-b99fe958bf0e" />
