### PR TITLE
feat: prefer completions the crate already imports elsewhere

### DIFF
--- a/crates/hir-def/src/nameres.rs
+++ b/crates/hir-def/src/nameres.rs
@@ -68,7 +68,7 @@ use hir_expand::{
 };
 use intern::{Symbol, sym};
 use itertools::Itertools;
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 use span::{Edition, FileAstId, FileId, ROOT_ERASED_FILE_AST_ID};
 use stdx::format_to;
 use syntax::{AstNode, SmolStr, SyntaxNode, ToSmolStr, ast};
@@ -77,7 +77,7 @@ use tt::TextRange;
 
 use crate::{
     AstId, BlockId, BlockIdLt, BuiltinDeriveImplId, ExternCrateId, FunctionId, FxIndexMap, Lookup,
-    MacroCallStyles, MacroExpander, MacroId, ModuleId, ModuleIdLt, ProcMacroId, UseId,
+    MacroCallStyles, MacroExpander, MacroId, ModuleDefId, ModuleId, ModuleIdLt, ProcMacroId, UseId,
     item_scope::{BuiltinShadowMode, ItemScope},
     item_tree::TreeId,
     nameres::{diagnostics::DefDiagnostic, path_resolution::ResolveMode},
@@ -379,6 +379,27 @@ pub struct ModuleData {
 #[inline]
 pub fn crate_def_map(db: &dyn SourceDatabase, crate_id: Crate) -> &DefMap {
     crate_local_def_map(db, crate_id).def_map(db)
+}
+
+/// The set of items that any module in this crate brings into scope with a `use`.
+///
+/// Glob imports count, `extern crate` declarations do not.
+#[salsa::tracked(returns(ref))]
+pub fn crate_imported_defs(db: &dyn SourceDatabase, crate_id: Crate) -> FxHashSet<ModuleDefId> {
+    let _p = tracing::info_span!("crate_imported_defs_query").entered();
+    let def_map = crate_def_map(db, crate_id);
+    let mut res = FxHashSet::default();
+    for (_, module_data) in def_map.modules() {
+        let scope = &module_data.scope;
+        res.extend(
+            scope
+                .types()
+                .filter(|(_, it)| it.import.is_some_and(|it| it.import_or_glob().is_some()))
+                .map(|(_, it)| it.def),
+        );
+        res.extend(scope.values().filter(|(_, it)| it.import.is_some()).map(|(_, it)| it.def));
+    }
+    res
 }
 
 #[salsa::tracked]

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -181,7 +181,7 @@ pub use {
         find_path::PrefixKind,
         import_map,
         lang_item::{LangItemEnum as LangItem, crate_lang_items},
-        nameres::{DefMap, ModuleSource, crate_def_map},
+        nameres::{DefMap, ModuleSource, crate_def_map, crate_imported_defs},
         per_ns::Namespace,
         type_ref::{Mutability, TypeRef},
         visibility::Visibility,
@@ -308,6 +308,11 @@ impl Crate {
     pub fn modules(self, db: &dyn HirDatabase) -> Vec<Module> {
         let def_map = crate_def_map(db, self.id);
         def_map.modules().map(|(id, _)| id.into()).collect()
+    }
+
+    /// Whether any module in this crate already brings `def` into scope with a `use`.
+    pub fn imports_def(self, db: &dyn HirDatabase, def: ModuleDef) -> bool {
+        ModuleDefId::try_from(def).is_ok_and(|def| crate_imported_defs(db, self.id).contains(&def))
     }
 
     pub fn root_file(self, db: &dyn HirDatabase) -> FileId {

--- a/crates/ide-completion/src/item.rs
+++ b/crates/ide-completion/src/item.rs
@@ -190,6 +190,12 @@ pub struct CompletionRelevance {
     pub is_name_already_imported: bool,
     /// This is set for completions that will insert a `use` item.
     pub requires_import: bool,
+    /// This is set when the completed definition is already imported by some other module in the
+    /// current crate.
+    ///
+    /// It distinguishes candidates that would otherwise tie, such as the several types named
+    /// `Range` in the standard library, by favouring the one the crate already uses.
+    pub is_def_already_imported: bool,
     /// Set for item completions that are private but in the workspace.
     pub is_private_editable: bool,
     /// Set for postfix snippet item completions
@@ -292,6 +298,7 @@ impl CompletionRelevance {
             is_missing,
             is_name_already_imported,
             requires_import,
+            is_def_already_imported,
             is_private_editable,
             postfix_match,
             trait_,
@@ -338,6 +345,11 @@ impl CompletionRelevance {
         // lower rank for items that need an import
         if requires_import {
             score -= 12;
+        }
+        // partially offset that for definitions the crate already imports elsewhere, so that an
+        // ambiguous name resolves to the one the project is already using
+        if is_def_already_imported {
+            score += 10;
         }
         if exact_name_match {
             score += 40;

--- a/crates/ide-completion/src/render.rs
+++ b/crates/ide-completion/src/render.rs
@@ -83,6 +83,10 @@ impl<'a, 'db> RenderContext<'a, 'db> {
         CompletionRelevance {
             is_private_editable: self.is_private_editable,
             requires_import: self.import_to_add.is_some(),
+            is_def_already_imported: is_def_already_imported(
+                self.completion,
+                self.import_to_add.as_ref(),
+            ),
             ..Default::default()
         }
     }
@@ -443,6 +447,7 @@ fn render_resolution_path<'db>(
     let db = completion.db;
     let config = completion.config;
     let requires_import = import_to_add.is_some();
+    let is_def_already_imported = is_def_already_imported(completion, import_to_add.as_ref());
 
     let name = local_name.display(db, completion.edition).to_smolstr();
     let mut item = render_resolution_simple_(ctx, &local_name, import_to_add, resolution);
@@ -491,6 +496,7 @@ fn render_resolution_path<'db>(
             exact_name_match: compute_exact_name_match(completion, &name),
             is_local: matches!(resolution, ScopeDef::Local(_)),
             requires_import,
+            is_def_already_imported,
             has_local_inherent_impl: compute_has_local_inherent_impl(db, path_ctx, &ty, module),
             ..CompletionRelevance::default()
         });
@@ -713,6 +719,20 @@ fn compute_has_local_inherent_impl(
             .any(|imp| imp.trait_(db).is_none() && imp.module(db) == curr_module)
 }
 
+/// Whether some other module in the current crate already imports the definition this completion
+/// would add an import for.
+///
+/// Used to break ties between equally-named candidates, such as the several types called `Range` in
+/// the standard library, in favour of the one the crate is already using.
+fn is_def_already_imported(
+    ctx: &CompletionContext<'_, '_>,
+    import_to_add: Option<&LocatedImport>,
+) -> bool {
+    import_to_add.is_some_and(|import| {
+        ctx.krate.imports_def(ctx.db, import.item_to_import.into_module_def())
+    })
+}
+
 fn compute_exact_name_match(ctx: &CompletionContext<'_, '_>, completion_name: &str) -> bool {
     ctx.expected_name.as_ref().is_some_and(|name| name.text() == completion_name)
 }
@@ -882,6 +902,7 @@ mod tests {
                 trait_,
                 is_name_already_imported: _,
                 requires_import,
+                is_def_already_imported,
                 is_private_editable: _,
                 postfix_match,
                 function: _,
@@ -898,6 +919,7 @@ mod tests {
                 (postfix_match == Some(CompletionRelevancePostfixMatch::Exact), "snippet"),
                 (trait_.is_some_and(|it| it.is_op_method), "op_method"),
                 (requires_import, "requires_import"),
+                (is_def_already_imported, "already_imported"),
                 (has_local_inherent_impl, "has_local_inherent_impl"),
                 (is_deprecated, "deprecated"),
             ]
@@ -966,6 +988,74 @@ fn main() {
                 fn main() fn() []
                 fn test(…) fn(Struct) []
                 st Struct Struct [requires_import]
+            "#]],
+        );
+    }
+
+    #[test]
+    fn prefers_def_already_imported_in_crate() {
+        check_relevance(
+            r#"
+//- /lib.rs crate:dep
+
+pub mod test_mod_a {
+    pub struct Struct {}
+}
+
+pub mod test_mod_b {
+    pub struct Struct {}
+}
+
+//- /main.rs crate:main deps:dep
+mod other;
+
+fn main() {
+    Struct$0
+}
+
+//- /other.rs
+use dep::test_mod_b::Struct;
+
+pub fn takes(_: Struct) {}
+"#,
+            expect![[r#"
+                md dep::  []
+                fn main() fn() []
+                md other::  []
+                st Struct Struct [requires_import+already_imported]
+                st Struct Struct [requires_import]
+            "#]],
+        );
+    }
+
+    #[test]
+    fn def_already_imported_tracks_the_imported_def() {
+        check_relevance(
+            r#"
+//- /lib.rs crate:dep
+
+pub struct Imported {}
+
+pub struct NotImported {}
+
+//- /main.rs crate:main deps:dep
+mod other;
+
+fn main() {
+    Imported$0
+}
+
+//- /other.rs
+use dep::Imported;
+
+pub fn takes(_: Imported) {}
+"#,
+            expect![[r#"
+                md dep::  []
+                fn main() fn() []
+                md other::  []
+                st Imported Imported [requires_import+already_imported]
+                st NotImported NotImported [requires_import]
             "#]],
         );
     }
@@ -1302,6 +1392,7 @@ fn main() { Foo::Fo$0 }
                             trait_: None,
                             is_name_already_imported: false,
                             requires_import: false,
+                            is_def_already_imported: false,
                             is_private_editable: false,
                             postfix_match: None,
                             function: Some(
@@ -1355,6 +1446,7 @@ fn main() { Foo::Fo$0 }
                             trait_: None,
                             is_name_already_imported: false,
                             requires_import: false,
+                            is_def_already_imported: false,
                             is_private_editable: false,
                             postfix_match: None,
                             function: Some(
@@ -1501,6 +1593,7 @@ fn main() { Foo::Fo$0 }
                             trait_: None,
                             is_name_already_imported: false,
                             requires_import: false,
+                            is_def_already_imported: false,
                             is_private_editable: false,
                             postfix_match: None,
                             function: Some(
@@ -1588,6 +1681,7 @@ fn main() { let _: m::Spam = S$0 }
                             trait_: None,
                             is_name_already_imported: false,
                             requires_import: false,
+                            is_def_already_imported: false,
                             is_private_editable: false,
                             postfix_match: None,
                             function: Some(
@@ -1627,6 +1721,7 @@ fn main() { let _: m::Spam = S$0 }
                             trait_: None,
                             is_name_already_imported: false,
                             requires_import: false,
+                            is_def_already_imported: false,
                             is_private_editable: false,
                             postfix_match: None,
                             function: Some(
@@ -1679,6 +1774,7 @@ fn main() { som$0 }
                             trait_: None,
                             is_name_already_imported: false,
                             requires_import: false,
+                            is_def_already_imported: false,
                             is_private_editable: false,
                             postfix_match: None,
                             function: None,
@@ -1739,6 +1835,7 @@ fn main() { som$0 }
                             trait_: None,
                             is_name_already_imported: false,
                             requires_import: false,
+                            is_def_already_imported: false,
                             is_private_editable: false,
                             postfix_match: None,
                             function: None,
@@ -1783,6 +1880,7 @@ fn main() { A$0 }
                             trait_: None,
                             is_name_already_imported: false,
                             requires_import: false,
+                            is_def_already_imported: false,
                             is_private_editable: false,
                             postfix_match: None,
                             function: None,
@@ -1827,6 +1925,7 @@ fn main() { A$0 }
                             trait_: None,
                             is_name_already_imported: false,
                             requires_import: false,
+                            is_def_already_imported: false,
                             is_private_editable: false,
                             postfix_match: None,
                             function: None,
@@ -1873,6 +1972,7 @@ fn main() { A::$0 }
                             trait_: None,
                             is_name_already_imported: false,
                             requires_import: false,
+                            is_def_already_imported: false,
                             is_private_editable: false,
                             postfix_match: None,
                             function: Some(
@@ -1910,6 +2010,7 @@ fn main() { A::$0 }
                             trait_: None,
                             is_name_already_imported: false,
                             requires_import: false,
+                            is_def_already_imported: false,
                             is_private_editable: false,
                             postfix_match: None,
                             function: Some(
@@ -1961,6 +2062,7 @@ fn main() { A$0 }
                             trait_: None,
                             is_name_already_imported: false,
                             requires_import: false,
+                            is_def_already_imported: false,
                             is_private_editable: false,
                             postfix_match: None,
                             function: None,
@@ -2005,6 +2107,7 @@ fn main() { A$0 }
                             trait_: None,
                             is_name_already_imported: false,
                             requires_import: false,
+                            is_def_already_imported: false,
                             is_private_editable: false,
                             postfix_match: None,
                             function: None,
@@ -2046,6 +2149,7 @@ impl A$0
                             trait_: None,
                             is_name_already_imported: false,
                             requires_import: false,
+                            is_def_already_imported: false,
                             is_private_editable: false,
                             postfix_match: None,
                             function: None,
@@ -2087,6 +2191,7 @@ fn main() { A$0 }
                             trait_: None,
                             is_name_already_imported: false,
                             requires_import: false,
+                            is_def_already_imported: false,
                             is_private_editable: false,
                             postfix_match: None,
                             function: None,
@@ -2132,6 +2237,7 @@ fn main() { a$0 }
                             trait_: None,
                             is_name_already_imported: false,
                             requires_import: false,
+                            is_def_already_imported: false,
                             is_private_editable: false,
                             postfix_match: None,
                             function: None,
@@ -2177,6 +2283,7 @@ fn main() { A { the$0 } }
                             trait_: None,
                             is_name_already_imported: false,
                             requires_import: false,
+                            is_def_already_imported: false,
                             is_private_editable: false,
                             postfix_match: None,
                             function: None,
@@ -2233,6 +2340,7 @@ impl S {
                             trait_: None,
                             is_name_already_imported: false,
                             requires_import: false,
+                            is_def_already_imported: false,
                             is_private_editable: false,
                             postfix_match: None,
                             function: Some(
@@ -2327,6 +2435,7 @@ use self::E::*;
                             trait_: None,
                             is_name_already_imported: false,
                             requires_import: false,
+                            is_def_already_imported: false,
                             is_private_editable: false,
                             postfix_match: None,
                             function: Some(
@@ -2400,6 +2509,7 @@ fn foo(s: S) { s.$0 }
                             trait_: None,
                             is_name_already_imported: false,
                             requires_import: false,
+                            is_def_already_imported: false,
                             is_private_editable: false,
                             postfix_match: None,
                             function: Some(
@@ -2621,6 +2731,7 @@ fn f() -> i32 {
                             trait_: None,
                             is_name_already_imported: false,
                             requires_import: false,
+                            is_def_already_imported: false,
                             is_private_editable: false,
                             postfix_match: None,
                             function: None,
@@ -2728,6 +2839,7 @@ fn main() {
                             trait_: None,
                             is_name_already_imported: false,
                             requires_import: false,
+                            is_def_already_imported: false,
                             is_private_editable: false,
                             postfix_match: None,
                             function: None,
@@ -2777,6 +2889,7 @@ fn main() {
                             trait_: None,
                             is_name_already_imported: false,
                             requires_import: false,
+                            is_def_already_imported: false,
                             is_private_editable: false,
                             postfix_match: None,
                             function: None,
@@ -2889,6 +3002,7 @@ fn main() {
                             trait_: None,
                             is_name_already_imported: false,
                             requires_import: false,
+                            is_def_already_imported: false,
                             is_private_editable: false,
                             postfix_match: None,
                             function: Some(
@@ -3800,6 +3914,7 @@ fn foo(f: Foo) { let _: &u32 = f.b$0 }
                             trait_: None,
                             is_name_already_imported: false,
                             requires_import: false,
+                            is_def_already_imported: false,
                             is_private_editable: false,
                             postfix_match: None,
                             function: Some(
@@ -3896,6 +4011,7 @@ fn foo() {
                             trait_: None,
                             is_name_already_imported: false,
                             requires_import: false,
+                            is_def_already_imported: false,
                             is_private_editable: false,
                             postfix_match: None,
                             function: None,
@@ -3951,6 +4067,7 @@ fn main() {
                             trait_: None,
                             is_name_already_imported: false,
                             requires_import: false,
+                            is_def_already_imported: false,
                             is_private_editable: false,
                             postfix_match: None,
                             function: Some(
@@ -4449,6 +4566,7 @@ fn main() {
                             ),
                             is_name_already_imported: false,
                             requires_import: false,
+                            is_def_already_imported: false,
                             is_private_editable: false,
                             postfix_match: None,
                             function: None,
@@ -4486,6 +4604,7 @@ fn main() {
                             ),
                             is_name_already_imported: false,
                             requires_import: false,
+                            is_def_already_imported: false,
                             is_private_editable: false,
                             postfix_match: None,
                             function: None,

--- a/crates/rust-analyzer/src/lsp.rs
+++ b/crates/rust-analyzer/src/lsp.rs
@@ -46,6 +46,7 @@ pub(crate) fn completion_item_hash(item: &CompletionItem, is_ref_completion: boo
             u8::from(relevance.is_local),
             u8::from(relevance.is_name_already_imported),
             u8::from(relevance.requires_import),
+            u8::from(relevance.is_def_already_imported),
             u8::from(relevance.is_private_editable),
         ]);
 


### PR DESCRIPTION
Closes rust-lang/rust-analyzer#23263

Several standard library types share a name. Completing `Range` in a module that
imports none of them produces candidates with identical scores, since they all set
`requires_import` and nothing else distinguishes them. The displayed order then
comes from flyimport's fallback comparison on the import path, which is
alphabetical, so `btree_map::Range` wins.

This adds a `crate_imported_defs` query collecting every definition that some
module in the crate brings into scope with a `use`, and an
`is_def_already_imported` relevance factor worth `+10`.

The constant is deliberately smaller than the `-12` for `requires_import`, which
keeps three tiers apart. An item already in scope at the cursor scores 0, one
imported elsewhere in the crate scores -2, and one never imported scores -12. A
bonus of 12 or more would let a flyimport candidate tie with something already in
scope.

On cost, the query is keyed on the crate def map, which is derived from item trees
and therefore is not invalidated by typing inside a function body, so salsa
recomputes it per item-level edit rather than per keystroke. I added a
`crate_imported_defs_query` span so it can be profiled, but I have not measured it,
and the walk is proportional to the number of modules in the crate. If you want a
number before merging, `analysis-stats` will not produce one because it does not
exercise completion.

`DefMap::prelude` is a separate field consulted during resolution rather than
copied into each `ItemScope`, so prelude items do not enter the set.

AI was used for this contribution, in line with AI_POLICY.md.
