### PR TITLE
internal: remove redundant disable 'unused_variables'

### DIFF
--- a/crates/ide-diagnostics/src/handlers/explicit_drop_method_use.rs
+++ b/crates/ide-diagnostics/src/handlers/explicit_drop_method_use.rs
@@ -127,9 +127,7 @@ fn fix_path(
 
 #[cfg(test)]
 mod tests {
-    use crate::tests::{
-        check_diagnostics, check_diagnostics_with_disabled, check_fix, check_fix_with_disabled,
-    };
+    use crate::tests::{check_diagnostics, check_fix};
 
     #[test]
     fn method_call_diagnostic() {
@@ -289,7 +287,7 @@ fn main(mut a: A) {
 
     #[test]
     fn path_diagnostic() {
-        check_diagnostics_with_disabled(
+        check_diagnostics(
             r#"
 //- minicore: drop
 struct A;
@@ -301,10 +299,6 @@ fn main(mut a: A) {
     d(&mut a);
 }
 "#,
-            // Because of the error, the code isn't analyzed further (?), and so `d` is warned on as unused.
-            // Arguably a bug in r-a (rustc doesn't emit a warning in this case)
-            // FIXME: remove this once r-a no longer warns
-            &["unused_variables"],
         );
     }
 
@@ -312,7 +306,7 @@ fn main(mut a: A) {
     // NOTE: Here, the fix is not completely correct, as it doesn't replace `d(&mut a)` with `d(a)`.
     // Oh well, rustc doesn't either
     fn path_fix() {
-        check_fix_with_disabled(
+        check_fix(
             r#"
 //- minicore: drop
 struct A;
@@ -332,10 +326,6 @@ fn main(mut a: A) {
     d(&mut a);
 }
 "#,
-            // Because of the error, the code isn't analyzed further (?), and so `d` is warned on as unused.
-            // Arguably a bug in r-a (rustc doesn't emit a warning in this case)
-            // FIXME: remove this once r-a no longer warns
-            &["unused_variables"],
         );
     }
 

--- a/crates/ide-diagnostics/src/handlers/fru_in_destructuring_assignment.rs
+++ b/crates/ide-diagnostics/src/handlers/fru_in_destructuring_assignment.rs
@@ -18,11 +18,11 @@ pub(crate) fn fru_in_destructuring_assignment(
 
 #[cfg(test)]
 mod tests {
-    use crate::tests::{check_diagnostics, check_diagnostics_with_disabled};
+    use crate::tests::check_diagnostics;
 
     #[test]
     fn spread_variable() {
-        check_diagnostics_with_disabled(
+        check_diagnostics(
             r#"
 struct Foo { bar: u32, baz: u32 }
 fn test(f: Foo, g: Foo, mut bar: u32, mut baz: u32) {
@@ -34,8 +34,6 @@ fn test(f: Foo, g: Foo, mut bar: u32, mut baz: u32) {
                    // ^ error: functional record updates are not allowed in destructuring assignments
 }
         "#,
-            // We don't end up using neither `bar` nor `baz`
-            &["unused_variables"],
         );
     }
 

--- a/crates/ide-diagnostics/src/handlers/incorrect_case.rs
+++ b/crates/ide-diagnostics/src/handlers/incorrect_case.rs
@@ -61,7 +61,7 @@ fn fixes(ctx: &DiagnosticsContext<'_, '_>, d: &hir::IncorrectCase) -> Option<Vec
 
 #[cfg(test)]
 mod change_case {
-    use crate::tests::{check_diagnostics, check_diagnostics_with_disabled, check_fix};
+    use crate::tests::{check_diagnostics, check_fix};
 
     #[test]
     fn test_rename_incorrect_case() {
@@ -617,7 +617,7 @@ trait BAD_TRAIT {
         cov_mark::check!(trait_impl_assoc_const_incorrect_case_ignored);
         cov_mark::check!(trait_impl_assoc_type_incorrect_case_ignored);
         cov_mark::check_count!(trait_impl_assoc_func_name_incorrect_case_ignored, 2);
-        check_diagnostics_with_disabled(
+        check_diagnostics(
             r#"
 trait BAD_TRAIT {
    // ^^^^^^^^^ 💡 warn: Trait `BAD_TRAIT` should have UpperCamelCase name, e.g. `BadTrait`
@@ -643,7 +643,6 @@ impl BAD_TRAIT for () {
     fn BadFunction() {}
 }
     "#,
-            &["unused_variables"],
         );
     }
 
@@ -1006,7 +1005,6 @@ fn func() {
     fn override_lint_level() {
         check_diagnostics(
             r#"
-#![allow(unused_variables)]
 #[warn(nonstandard_style)]
 fn foo() {
     let BAR: i32;

--- a/crates/ide-diagnostics/src/handlers/invalid_cast.rs
+++ b/crates/ide-diagnostics/src/handlers/invalid_cast.rs
@@ -465,7 +465,7 @@ fn foo<T: ?Sized>() {
           //^^^^^^^^^^^^^ error: cannot cast `usize` to a fat pointer `*const T`
 }
 "#,
-            &["E0308", "unused_variables"],
+            &["E0308"],
         );
     }
 

--- a/crates/ide-diagnostics/src/handlers/missing_unsafe.rs
+++ b/crates/ide-diagnostics/src/handlers/missing_unsafe.rs
@@ -425,7 +425,6 @@ fn main() {
         check_diagnostics(
             r#"
 //- minicore: index, slice
-#![allow(unused_variables)]
 
 fn main() {
 


### PR DESCRIPTION
Fixup rust-lang/rust-analyzer#23043

---

BTW, rust-lang/rust-analyzer#23043 has another advantage, it won't be caught by `unused_variables`'s fix when applying line quick fix

```rust
fn main() {
    $0let Some(x) = Some(2);
}
```

**Before**:

```rust
fn main() {
    let Some(_x) = Some(2);
}
```

**After (better)**:

```rust
fn main() {
    let Some(x) = Some(2) else { return };
}
```
