### PR TITLE
parser: fix tuple field parsing in offset_of

### DIFF
--- a/crates/mbe/src/lib.rs
+++ b/crates/mbe/src/lib.rs
@@ -418,7 +418,7 @@ pub fn expect_fragment<'t>(
                     cursor.bump_or_end();
                 }
             }
-            parser::Step::FloatSplit { .. } => {
+            parser::Step::FloatSplit { .. } | parser::Step::FloatSplitOffsetOf { .. } => {
                 // FIXME: We need to split the tree properly here, but mutating the token trees
                 // in the buffer is somewhat tricky to pull off.
                 cursor.bump_or_end();

--- a/crates/parser/src/event.rs
+++ b/crates/parser/src/event.rs
@@ -59,7 +59,10 @@ pub(crate) enum Event {
     /// ```
     ///
     /// See also `CompletedMarker::precede`.
-    Start { kind: SyntaxKind, forward_parent: Option<NonZeroU32> },
+    Start {
+        kind: SyntaxKind,
+        forward_parent: Option<NonZeroU32>,
+    },
 
     /// Complete the previous `Start` event
     Finish,
@@ -68,14 +71,24 @@ pub(crate) enum Event {
     /// `n_raw_tokens` is used to glue complex contextual tokens.
     /// For example, lexer tokenizes `>>` as `>`, `>`, and
     /// `n_raw_tokens = 2` is used to produced a single `>>`.
-    Token { kind: SyntaxKind, n_raw_tokens: u8 },
+    Token {
+        kind: SyntaxKind,
+        n_raw_tokens: u8,
+    },
     /// When we parse `foo.0.0` or `foo. 0. 0` the lexer will hand us a float literal
     /// instead of an integer literal followed by a dot as the lexer has no contextual knowledge.
     /// This event instructs whatever consumes the events to split the float literal into
     /// the corresponding parts.
-    FloatSplitHack { ends_in_dot: bool },
+    FloatSplitHack {
+        ends_in_dot: bool,
+    },
+    FloatSplitOffsetOfHack {
+        ends_in_dot: bool,
+    },
     /// Index into the parser's side `errors` vec.
-    Error { err: u32 },
+    Error {
+        err: u32,
+    },
 }
 
 impl Event {
@@ -130,6 +143,9 @@ pub(super) fn process(mut events: Vec<Event>, mut errors: Vec<String>) -> Output
                 res.float_split_hack(ends_in_dot);
                 let ev = mem::replace(&mut events[i + 1], Event::tombstone());
                 assert!(matches!(ev, Event::Finish), "{ev:?}");
+            }
+            Event::FloatSplitOffsetOfHack { ends_in_dot } => {
+                res.float_split_offset_of_hack(ends_in_dot);
             }
             Event::Error { err } => {
                 // Move the string out of the side table; each index is visited

--- a/crates/parser/src/grammar/expressions/atom.rs
+++ b/crates/parser/src/grammar/expressions/atom.rs
@@ -269,12 +269,13 @@ fn builtin_expr(p: &mut Parser<'_>) -> Option<CompletedMarker> {
         // fn foo() {
         //     builtin#offset_of(Foo, (bar.baz.0));
         // }
+
+        // test offset_of_nested_tuple
+        // fn foo() {
+        //     builtin#offset_of(ComplexTup, 0.1.1.1);
+        // }
         while !p.at(EOF) && !p.at(T![')']) {
             if p.at(FLOAT_NUMBER) {
-                // test offset_of_nested_tuple
-                // fn foo() {
-                //     builtin#offset_of(ComplexTup, 0.1.1.1);
-                // }
                 let ends_in_dot = p.split_float_offset_of();
                 if ends_in_dot {
                     continue;

--- a/crates/parser/src/grammar/expressions/atom.rs
+++ b/crates/parser/src/grammar/expressions/atom.rs
@@ -270,7 +270,14 @@ fn builtin_expr(p: &mut Parser<'_>) -> Option<CompletedMarker> {
         //     builtin#offset_of(Foo, (bar.baz.0));
         // }
         while !p.at(EOF) && !p.at(T![')']) {
-            name_ref_mod_path_or_index(p);
+            if p.at(FLOAT_NUMBER) {
+                let ends_in_dot = p.split_float_offset_of();
+                if ends_in_dot {
+                    continue;
+                }
+            } else {
+                name_ref_mod_path_or_index(p);
+            }
             if !p.at(T![')']) {
                 p.expect(T![.]);
             }

--- a/crates/parser/src/grammar/expressions/atom.rs
+++ b/crates/parser/src/grammar/expressions/atom.rs
@@ -271,6 +271,10 @@ fn builtin_expr(p: &mut Parser<'_>) -> Option<CompletedMarker> {
         // }
         while !p.at(EOF) && !p.at(T![')']) {
             if p.at(FLOAT_NUMBER) {
+                // test offset_of_nested_tuple
+                // fn foo() {
+                //     builtin#offset_of(ComplexTup, 0.1.1.1);
+                // }
                 let ends_in_dot = p.split_float_offset_of();
                 if ends_in_dot {
                     continue;

--- a/crates/parser/src/lib.rs
+++ b/crates/parser/src/lib.rs
@@ -126,7 +126,7 @@ impl TopEntryPoint {
                     Step::FloatSplit { ends_in_dot: has_pseudo_dot } => {
                         depth -= 1 + !has_pseudo_dot as usize
                     }
-                    Step::Token { .. } | Step::Error { .. } => (),
+                    Step::Token { .. } | Step::Error { .. } | Step::FloatSplitOffsetOf { .. } => (),
                 }
             }
             assert!(!first, "no tree at all");

--- a/crates/parser/src/output.rs
+++ b/crates/parser/src/output.rs
@@ -27,6 +27,7 @@ pub struct Output {
 pub enum Step<'a> {
     Token { kind: SyntaxKind, n_input_tokens: u8 },
     FloatSplit { ends_in_dot: bool },
+    FloatSplitOffsetOf { ends_in_dot: bool },
     Enter { kind: SyntaxKind },
     Exit,
     Error { msg: &'a str },
@@ -55,6 +56,7 @@ impl Output {
     const ENTER_EVENT: u8 = 1;
     const EXIT_EVENT: u8 = 2;
     const SPLIT_EVENT: u8 = 3;
+    const SPLIT_OFFSET_OF_EVENT: u8 = 4;
 
     pub fn iter(&self) -> impl Iterator<Item = Step<'_>> {
         self.event.iter().map(|&event| {
@@ -81,6 +83,9 @@ impl Output {
                 Self::SPLIT_EVENT => {
                     Step::FloatSplit { ends_in_dot: event & Self::N_INPUT_TOKEN_MASK != 0 }
                 }
+                Self::SPLIT_OFFSET_OF_EVENT => {
+                    Step::FloatSplitOffsetOf { ends_in_dot: event & Self::N_INPUT_TOKEN_MASK != 0 }
+                }
                 _ => unreachable!(),
             }
         })
@@ -95,6 +100,13 @@ impl Output {
 
     pub(crate) fn float_split_hack(&mut self, ends_in_dot: bool) {
         let e = ((Self::SPLIT_EVENT as u32) << Self::TAG_SHIFT)
+            | ((ends_in_dot as u32) << Self::N_INPUT_TOKEN_SHIFT)
+            | Self::EVENT_MASK;
+        self.event.push(e);
+    }
+
+    pub(crate) fn float_split_offset_of_hack(&mut self, ends_in_dot: bool) {
+        let e = ((Self::SPLIT_OFFSET_OF_EVENT as u32) << Self::TAG_SHIFT)
             | ((ends_in_dot as u32) << Self::N_INPUT_TOKEN_SHIFT)
             | Self::EVENT_MASK;
         self.event.push(e);

--- a/crates/parser/src/parser.rs
+++ b/crates/parser/src/parser.rs
@@ -241,6 +241,14 @@ impl<'t> Parser<'t> {
         (ends_in_dot, marker)
     }
 
+    pub(crate) fn split_float_offset_of(&mut self) -> bool {
+        assert!(self.at(SyntaxKind::FLOAT_NUMBER));
+        let ends_in_dot = !self.inp.is_joint(self.pos);
+        self.pos += 1;
+        self.push_event(Event::FloatSplitOffsetOfHack { ends_in_dot });
+        ends_in_dot
+    }
+
     /// Advances the parser by one token, remapping its kind.
     /// This is useful to create contextual keywords from
     /// identifiers. For example, the lexer creates a `union`

--- a/crates/parser/src/shortcuts.rs
+++ b/crates/parser/src/shortcuts.rs
@@ -78,6 +78,9 @@ impl LexedStr<'_> {
                 Step::FloatSplit { ends_in_dot: has_pseudo_dot } => {
                     builder.float_split(has_pseudo_dot)
                 }
+                Step::FloatSplitOffsetOf { ends_in_dot: has_pseudo_dot } => {
+                    builder.float_split_offset_of(has_pseudo_dot)
+                }
                 Step::Enter { kind } => builder.enter(kind),
                 Step::Exit => builder.exit(),
                 Step::Error { msg } => {
@@ -132,6 +135,16 @@ impl Builder<'_, '_> {
         }
         self.eat_trivias();
         self.do_float_split(has_pseudo_dot);
+    }
+
+    fn float_split_offset_of(&mut self, has_pseudo_dot: bool) {
+        match mem::replace(&mut self.state, State::Normal) {
+            State::PendingEnter => unreachable!(),
+            State::PendingExit => (self.sink)(StrStep::Exit),
+            State::Normal => (),
+        }
+        self.eat_trivias();
+        self.do_float_split_offset_of(has_pseudo_dot);
     }
 
     fn enter(&mut self, kind: SyntaxKind) {
@@ -230,6 +243,38 @@ impl Builder<'_, '_> {
                 (self.sink)(StrStep::Exit);
 
                 self.state = if has_pseudo_dot { State::Normal } else { State::PendingExit };
+            }
+        }
+
+        self.pos += 1;
+    }
+
+    fn do_float_split_offset_of(&mut self, has_pseudo_dot: bool) {
+        let text = &self.lexed.range_text(self.pos..self.pos + 1);
+
+        match text.split_once('.') {
+            Some((left, right)) => {
+                assert!(!left.is_empty());
+                (self.sink)(StrStep::Enter { kind: SyntaxKind::NAME_REF });
+                (self.sink)(StrStep::Token { kind: SyntaxKind::INT_NUMBER, text: left });
+                (self.sink)(StrStep::Exit);
+
+                (self.sink)(StrStep::Token { kind: SyntaxKind::DOT, text: "." });
+
+                if has_pseudo_dot {
+                    assert!(right.is_empty(), "{left}.{right}");
+                } else {
+                    assert!(!right.is_empty(), "{left}.{right}");
+                    (self.sink)(StrStep::Enter { kind: SyntaxKind::NAME_REF });
+                    (self.sink)(StrStep::Token { kind: SyntaxKind::INT_NUMBER, text: right });
+                    (self.sink)(StrStep::Exit);
+                }
+            }
+            None => {
+                (self.sink)(StrStep::Error { msg: "illegal float literal", pos: self.pos });
+                (self.sink)(StrStep::Enter { kind: SyntaxKind::ERROR });
+                (self.sink)(StrStep::Token { kind: SyntaxKind::FLOAT_NUMBER, text });
+                (self.sink)(StrStep::Exit);
             }
         }
 

--- a/crates/parser/src/shortcuts.rs
+++ b/crates/parser/src/shortcuts.rs
@@ -128,23 +128,21 @@ impl Builder<'_, '_> {
     }
 
     fn float_split(&mut self, has_pseudo_dot: bool) {
-        match mem::replace(&mut self.state, State::Normal) {
-            State::PendingEnter => unreachable!(),
-            State::PendingExit => (self.sink)(StrStep::Exit),
-            State::Normal => (),
-        }
-        self.eat_trivias();
-        self.do_float_split(has_pseudo_dot);
+        self.split_float_impl(has_pseudo_dot, true);
     }
 
     fn float_split_offset_of(&mut self, has_pseudo_dot: bool) {
+        self.split_float_impl(has_pseudo_dot, false);
+    }
+
+    fn split_float_impl(&mut self, has_pseudo_dot: bool, in_field_expr: bool) {
         match mem::replace(&mut self.state, State::Normal) {
             State::PendingEnter => unreachable!(),
             State::PendingExit => (self.sink)(StrStep::Exit),
             State::Normal => (),
         }
         self.eat_trivias();
-        self.do_float_split_offset_of(has_pseudo_dot);
+        self.do_float_split(has_pseudo_dot, in_field_expr);
     }
 
     fn enter(&mut self, kind: SyntaxKind) {
@@ -203,7 +201,7 @@ impl Builder<'_, '_> {
         (self.sink)(StrStep::Token { kind, text });
     }
 
-    fn do_float_split(&mut self, has_pseudo_dot: bool) {
+    fn do_float_split(&mut self, has_pseudo_dot: bool, in_field_expr: bool) {
         let text = &self.lexed.range_text(self.pos..self.pos + 1);
 
         match text.split_once('.') {
@@ -213,22 +211,28 @@ impl Builder<'_, '_> {
                 (self.sink)(StrStep::Token { kind: SyntaxKind::INT_NUMBER, text: left });
                 (self.sink)(StrStep::Exit);
 
-                // here we move the exit up, the original exit has been deleted in process
-                (self.sink)(StrStep::Exit);
+                if in_field_expr {
+                    // here we move the exit up, the original exit has been deleted in process
+                    (self.sink)(StrStep::Exit);
+                }
 
                 (self.sink)(StrStep::Token { kind: SyntaxKind::DOT, text: "." });
 
                 if has_pseudo_dot {
                     assert!(right.is_empty(), "{left}.{right}");
-                    self.state = State::Normal;
+                    if in_field_expr {
+                        self.state = State::Normal;
+                    }
                 } else {
                     assert!(!right.is_empty(), "{left}.{right}");
                     (self.sink)(StrStep::Enter { kind: SyntaxKind::NAME_REF });
                     (self.sink)(StrStep::Token { kind: SyntaxKind::INT_NUMBER, text: right });
                     (self.sink)(StrStep::Exit);
 
-                    // the parser creates an unbalanced start node, we are required to close it here
-                    self.state = State::PendingExit;
+                    if in_field_expr {
+                        // the parser creates an unbalanced start node, we are required to close it here
+                        self.state = State::PendingExit;
+                    }
                 }
             }
             None => {
@@ -239,42 +243,11 @@ impl Builder<'_, '_> {
                 (self.sink)(StrStep::Token { kind: SyntaxKind::FLOAT_NUMBER, text });
                 (self.sink)(StrStep::Exit);
 
-                // move up
-                (self.sink)(StrStep::Exit);
-
-                self.state = if has_pseudo_dot { State::Normal } else { State::PendingExit };
-            }
-        }
-
-        self.pos += 1;
-    }
-
-    fn do_float_split_offset_of(&mut self, has_pseudo_dot: bool) {
-        let text = &self.lexed.range_text(self.pos..self.pos + 1);
-
-        match text.split_once('.') {
-            Some((left, right)) => {
-                assert!(!left.is_empty());
-                (self.sink)(StrStep::Enter { kind: SyntaxKind::NAME_REF });
-                (self.sink)(StrStep::Token { kind: SyntaxKind::INT_NUMBER, text: left });
-                (self.sink)(StrStep::Exit);
-
-                (self.sink)(StrStep::Token { kind: SyntaxKind::DOT, text: "." });
-
-                if has_pseudo_dot {
-                    assert!(right.is_empty(), "{left}.{right}");
-                } else {
-                    assert!(!right.is_empty(), "{left}.{right}");
-                    (self.sink)(StrStep::Enter { kind: SyntaxKind::NAME_REF });
-                    (self.sink)(StrStep::Token { kind: SyntaxKind::INT_NUMBER, text: right });
+                if in_field_expr {
+                    // move up
                     (self.sink)(StrStep::Exit);
+                    self.state = if has_pseudo_dot { State::Normal } else { State::PendingExit };
                 }
-            }
-            None => {
-                (self.sink)(StrStep::Error { msg: "illegal float literal", pos: self.pos });
-                (self.sink)(StrStep::Enter { kind: SyntaxKind::ERROR });
-                (self.sink)(StrStep::Token { kind: SyntaxKind::FLOAT_NUMBER, text });
-                (self.sink)(StrStep::Exit);
             }
         }
 

--- a/crates/parser/src/tests/prefix_entries.rs
+++ b/crates/parser/src/tests/prefix_entries.rs
@@ -89,7 +89,7 @@ fn check(entry: PrefixEntryPoint, input: &str, prefix: &str) {
     for step in entry.parse(&input).iter() {
         match step {
             Step::Token { n_input_tokens, .. } => n_tokens += n_input_tokens as usize,
-            Step::FloatSplit { .. } => n_tokens += 1,
+            Step::FloatSplit { .. } | Step::FloatSplitOffsetOf { .. } => n_tokens += 1,
             Step::Enter { .. } | Step::Exit | Step::Error { .. } => (),
         }
     }

--- a/crates/parser/test_data/generated/runner.rs
+++ b/crates/parser/test_data/generated/runner.rs
@@ -498,6 +498,10 @@ mod ok {
         run_and_expect_no_errors("test_data/parser/inline/ok/offset_of_parens.rs");
     }
     #[test]
+    fn offset_of_nested_tuple() {
+        run_and_expect_no_errors("test_data/parser/inline/ok/offset_of_nested_tuple.rs");
+    }
+    #[test]
     fn or_pattern() { run_and_expect_no_errors("test_data/parser/inline/ok/or_pattern.rs"); }
     #[test]
     fn param_list() { run_and_expect_no_errors("test_data/parser/inline/ok/param_list.rs"); }

--- a/crates/parser/test_data/generated/runner.rs
+++ b/crates/parser/test_data/generated/runner.rs
@@ -494,12 +494,12 @@ mod ok {
     #[test]
     fn not_null_pat() { run_and_expect_no_errors("test_data/parser/inline/ok/not_null_pat.rs"); }
     #[test]
-    fn offset_of_parens() {
-        run_and_expect_no_errors("test_data/parser/inline/ok/offset_of_parens.rs");
-    }
-    #[test]
     fn offset_of_nested_tuple() {
         run_and_expect_no_errors("test_data/parser/inline/ok/offset_of_nested_tuple.rs");
+    }
+    #[test]
+    fn offset_of_parens() {
+        run_and_expect_no_errors("test_data/parser/inline/ok/offset_of_parens.rs");
     }
     #[test]
     fn or_pattern() { run_and_expect_no_errors("test_data/parser/inline/ok/or_pattern.rs"); }

--- a/crates/parser/test_data/parser/inline/ok/offset_of_nested_tuple.rast
+++ b/crates/parser/test_data/parser/inline/ok/offset_of_nested_tuple.rast
@@ -1,0 +1,43 @@
+SOURCE_FILE
+  FN
+    FN_KW "fn"
+    WHITESPACE " "
+    NAME
+      IDENT "foo"
+    PARAM_LIST
+      L_PAREN "("
+      R_PAREN ")"
+    WHITESPACE " "
+    BLOCK_EXPR
+      STMT_LIST
+        L_CURLY "{"
+        WHITESPACE "\n    "
+        EXPR_STMT
+          OFFSET_OF_EXPR
+            BUILTIN_KW "builtin"
+            POUND "#"
+            OFFSET_OF_KW "offset_of"
+            L_PAREN "("
+            PATH_TYPE
+              PATH
+                PATH_SEGMENT
+                  NAME_REF
+                    IDENT "ComplexTup"
+            COMMA ","
+            WHITESPACE " "
+            NAME_REF
+              INT_NUMBER "0"
+            DOT "."
+            NAME_REF
+              INT_NUMBER "1"
+            DOT "."
+            NAME_REF
+              INT_NUMBER "1"
+            DOT "."
+            NAME_REF
+              INT_NUMBER "1"
+            R_PAREN ")"
+          SEMICOLON ";"
+        WHITESPACE "\n"
+        R_CURLY "}"
+  WHITESPACE "\n"

--- a/crates/parser/test_data/parser/inline/ok/offset_of_nested_tuple.rs
+++ b/crates/parser/test_data/parser/inline/ok/offset_of_nested_tuple.rs
@@ -1,0 +1,3 @@
+fn foo() {
+    builtin#offset_of(ComplexTup, 0.1.1.1);
+}

--- a/crates/syntax-bridge/src/lib.rs
+++ b/crates/syntax-bridge/src/lib.rs
@@ -869,6 +869,14 @@ impl TtTreeSink<'_> {
     /// Parses a float literal as if it was a one to two name ref nodes with a dot inbetween.
     /// This occurs when a float literal is used as a field access.
     fn float_split(&mut self, has_pseudo_dot: bool) {
+        self.do_float_split(has_pseudo_dot, true);
+    }
+
+    fn float_split_offset_of(&mut self, has_pseudo_dot: bool) {
+        self.do_float_split(has_pseudo_dot, false);
+    }
+
+    fn do_float_split(&mut self, has_pseudo_dot: bool, in_field_expr: bool) {
         let token_tree = self.cursor.token_tree();
         let (text, span) = match &token_tree {
             Some(tt::TokenTree::Leaf(tt::Leaf::Literal(
@@ -886,8 +894,10 @@ impl TtTreeSink<'_> {
                 self.inner.finish_node();
                 self.token_map.push(self.text_pos + TextSize::of(left), span);
 
-                // here we move the exit up, the original exit has been deleted in process
-                self.inner.finish_node();
+                if in_field_expr {
+                    // here we move the exit up, the original exit has been deleted in process
+                    self.inner.finish_node();
+                }
 
                 self.inner.token(SyntaxKind::DOT, ".");
                 self.token_map.push(self.text_pos + TextSize::of(left) + TextSize::of("."), span);
@@ -901,8 +911,10 @@ impl TtTreeSink<'_> {
                     self.token_map.push(self.text_pos + TextSize::of(text), span);
                     self.inner.finish_node();
 
-                    // the parser creates an unbalanced start node, we are required to close it here
-                    self.inner.finish_node();
+                    if in_field_expr {
+                        // the parser creates an unbalanced start node, we are required to close it here
+                        self.inner.finish_node();
+                    }
                 }
                 self.text_pos += TextSize::of(text);
             }
@@ -912,55 +924,13 @@ impl TtTreeSink<'_> {
                 self.inner.token(SyntaxKind::FLOAT_NUMBER, text);
                 self.token_map.push(self.text_pos + TextSize::of(text), span);
                 self.inner.finish_node();
-                self.inner.finish_node();
 
-                if !has_pseudo_dot {
+                if in_field_expr {
                     self.inner.finish_node();
+                    if !has_pseudo_dot {
+                        self.inner.finish_node();
+                    }
                 }
-
-                self.text_pos += TextSize::of(text);
-            }
-        }
-        self.cursor.bump();
-    }
-
-    fn float_split_offset_of(&mut self, has_pseudo_dot: bool) {
-        let token_tree = self.cursor.token_tree();
-        let (text, span) = match &token_tree {
-            Some(tt::TokenTree::Leaf(tt::Leaf::Literal(
-                lit @ tt::Literal { span, kind: tt::LitKind::Float, .. },
-            ))) => (lit.text(), *span),
-            tt => unreachable!("{tt:?}"),
-        };
-        match text.split_once('.') {
-            Some((left, right)) => {
-                assert!(!left.is_empty());
-
-                self.inner.start_node(SyntaxKind::NAME_REF);
-                self.inner.token(SyntaxKind::INT_NUMBER, left);
-                self.inner.finish_node();
-                self.token_map.push(self.text_pos + TextSize::of(left), span);
-
-                self.inner.token(SyntaxKind::DOT, ".");
-                self.token_map.push(self.text_pos + TextSize::of(left) + TextSize::of("."), span);
-
-                if has_pseudo_dot {
-                    assert!(right.is_empty(), "{left}.{right}");
-                } else {
-                    assert!(!right.is_empty(), "{left}.{right}");
-                    self.inner.start_node(SyntaxKind::NAME_REF);
-                    self.inner.token(SyntaxKind::INT_NUMBER, right);
-                    self.token_map.push(self.text_pos + TextSize::of(text), span);
-                    self.inner.finish_node();
-                }
-                self.text_pos += TextSize::of(text);
-            }
-            None => {
-                self.error("illegal float literal".to_owned());
-                self.inner.start_node(SyntaxKind::ERROR);
-                self.inner.token(SyntaxKind::FLOAT_NUMBER, text);
-                self.token_map.push(self.text_pos + TextSize::of(text), span);
-                self.inner.finish_node();
 
                 self.text_pos += TextSize::of(text);
             }

--- a/crates/syntax-bridge/src/lib.rs
+++ b/crates/syntax-bridge/src/lib.rs
@@ -165,6 +165,9 @@ where
             parser::Step::FloatSplit { ends_in_dot: has_pseudo_dot } => {
                 tree_sink.float_split(has_pseudo_dot)
             }
+            parser::Step::FloatSplitOffsetOf { ends_in_dot: has_pseudo_dot } => {
+                tree_sink.float_split_offset_of(has_pseudo_dot)
+            }
             parser::Step::Enter { kind } => tree_sink.start_node(kind),
             parser::Step::Exit => tree_sink.finish_node(),
             parser::Step::Error { msg } => tree_sink.error(msg.to_owned()),
@@ -914,6 +917,50 @@ impl TtTreeSink<'_> {
                 if !has_pseudo_dot {
                     self.inner.finish_node();
                 }
+
+                self.text_pos += TextSize::of(text);
+            }
+        }
+        self.cursor.bump();
+    }
+
+    fn float_split_offset_of(&mut self, has_pseudo_dot: bool) {
+        let token_tree = self.cursor.token_tree();
+        let (text, span) = match &token_tree {
+            Some(tt::TokenTree::Leaf(tt::Leaf::Literal(
+                lit @ tt::Literal { span, kind: tt::LitKind::Float, .. },
+            ))) => (lit.text(), *span),
+            tt => unreachable!("{tt:?}"),
+        };
+        match text.split_once('.') {
+            Some((left, right)) => {
+                assert!(!left.is_empty());
+
+                self.inner.start_node(SyntaxKind::NAME_REF);
+                self.inner.token(SyntaxKind::INT_NUMBER, left);
+                self.inner.finish_node();
+                self.token_map.push(self.text_pos + TextSize::of(left), span);
+
+                self.inner.token(SyntaxKind::DOT, ".");
+                self.token_map.push(self.text_pos + TextSize::of(left) + TextSize::of("."), span);
+
+                if has_pseudo_dot {
+                    assert!(right.is_empty(), "{left}.{right}");
+                } else {
+                    assert!(!right.is_empty(), "{left}.{right}");
+                    self.inner.start_node(SyntaxKind::NAME_REF);
+                    self.inner.token(SyntaxKind::INT_NUMBER, right);
+                    self.token_map.push(self.text_pos + TextSize::of(text), span);
+                    self.inner.finish_node();
+                }
+                self.text_pos += TextSize::of(text);
+            }
+            None => {
+                self.error("illegal float literal".to_owned());
+                self.inner.start_node(SyntaxKind::ERROR);
+                self.inner.token(SyntaxKind::FLOAT_NUMBER, text);
+                self.token_map.push(self.text_pos + TextSize::of(text), span);
+                self.inner.finish_node();
 
                 self.text_pos += TextSize::of(text);
             }


### PR DESCRIPTION
Fixes rust-lang/rust-analyzer#23178.

When using offset_of with nested tuple fields such as 0.1.1.1, the lexer parses parts of the field path (0.1 and 1.1) as float literals. This makes offset_of reject the expression with a syntax error.

This PR splits float literals while parsing offset_of into field indices and dots, so the resulting events match the structure expected by OFFSET_OF_EXPR. This follows the same general approach used by rustc in break_up_float.

Also adds an inline regression test covering nested tuple fields.

AI disclosure: Used AI as an exploratory tool to navigate the parser/event plumbing and help with the refactoring.