### PR TITLE
fix: map opaque hidden types back to the opaque's own generic params

### DIFF
--- a/crates/hir-ty/src/infer/opaques.rs
+++ b/crates/hir-ty/src/infer/opaques.rs
@@ -1,13 +1,18 @@
 //! Defining opaque types via inference.
 
-use rustc_type_ir::{TypeVisitableExt, fold_regions};
+use rustc_hash::FxHashMap;
+use rustc_type_ir::{
+    ConstKind, TyKind, TypeFoldable, TypeFolder, TypeSuperFoldable, TypeVisitableExt, fold_regions,
+    inherent::{Const as _, GenericArgs as _, IntoKind, Ty as _},
+};
 use tracing::{debug, instrument};
 
 use crate::{
     Span,
     infer::InferenceContext,
     next_solver::{
-        EarlyBinder, OpaqueTypeKey, SolverDefId, TypingMode,
+        Const, DbInterner, EarlyBinder, ErrorGuaranteed, GenericArg, GenericArgKind, GenericArgs,
+        OpaqueTypeKey, Region, SolverDefId, Ty, TypingMode,
         infer::{opaque_types::OpaqueHiddenType, traits::ObligationCause},
     },
 };
@@ -146,6 +151,95 @@ impl<'db> InferenceContext<'db> {
         };
         let hidden_type =
             fold_regions(self.interner(), hidden_type, |_, _| self.types.regions.erased);
+        let hidden_type = remap_generic_params_to_declaration_params(
+            self.interner(),
+            opaque_type_key,
+            hidden_type,
+        );
         UsageKind::HasDefiningUse(hidden_type)
+    }
+}
+
+/// The hidden type is written in terms of the generic parameters of the item containing
+/// the defining use, while `type_of_opaque` has to be bound by the generic parameters of
+/// the *opaque* itself. Those two lists are not the same, neither in length nor in the
+/// position of a given parameter, e.g.
+///
+/// ```ignore
+/// impl Tr for S {
+///     // The opaque's parameters are `['a, D]`.
+///     type Fut<'a, D: 'a> = impl Sized + 'a;
+///     // The hidden type `(S, &'a mut D)` is written with the function's parameters, `[D]`.
+///     fn make<D>(self, d: &mut D) -> Self::Fut<'_, D> { (self, d) }
+/// }
+/// ```
+///
+/// Without this remapping, instantiating the hidden type with the arguments of a use would
+/// look up the function's `D` (index 0) in the opaque's arguments, whose index 0 is `'a`.
+fn remap_generic_params_to_declaration_params<'db>(
+    interner: DbInterner<'db>,
+    opaque_type_key: OpaqueTypeKey<'db>,
+    hidden_type: OpaqueHiddenType<'db>,
+) -> OpaqueHiddenType<'db> {
+    if !hidden_type.ty.has_param() {
+        return hidden_type;
+    }
+
+    let identity_args = GenericArgs::identity_for_item(interner, opaque_type_key.def_id.into());
+    // This zip may pair the same lifetime in `args` with different lifetimes from
+    // `identity_args`. Simply collecting is the correct behaviour: it keeps the last one,
+    // which is the one introduced by the opaque type itself.
+    let map: FxHashMap<GenericArg<'db>, GenericArg<'db>> =
+        opaque_type_key.args.iter().zip(identity_args.iter()).collect();
+    let ty = hidden_type.ty.fold_with(&mut ReverseMapper { interner, map });
+    OpaqueHiddenType { ty }
+}
+
+/// Converts generic parameters of a [`TypeFoldable`] from one item's generics to another's,
+/// here from the item containing the defining use to the opaque type itself.
+struct ReverseMapper<'db> {
+    interner: DbInterner<'db>,
+    map: FxHashMap<GenericArg<'db>, GenericArg<'db>>,
+}
+
+impl<'db> TypeFolder<DbInterner<'db>> for ReverseMapper<'db> {
+    fn cx(&self) -> DbInterner<'db> {
+        self.interner
+    }
+
+    fn fold_ty(&mut self, ty: Ty<'db>) -> Ty<'db> {
+        if !ty.has_param() {
+            return ty;
+        }
+
+        match ty.kind() {
+            TyKind::Param(_) => match self.map.get(&ty.into()).map(|arg| arg.kind()) {
+                Some(GenericArgKind::Type(ty)) => ty,
+                // The hidden type mentions a type parameter the opaque does not capture.
+                // rustc reports an error here, we only have the error type.
+                _ => Ty::new_error(self.interner, ErrorGuaranteed),
+            },
+            _ => ty.super_fold_with(self),
+        }
+    }
+
+    fn fold_const(&mut self, ct: Const<'db>) -> Const<'db> {
+        if !ct.has_param() {
+            return ct;
+        }
+
+        match ct.kind() {
+            ConstKind::Param(_) => match self.map.get(&ct.into()).map(|arg| arg.kind()) {
+                Some(GenericArgKind::Const(ct)) => ct,
+                // Ditto, for const parameters.
+                _ => Const::new_error(self.interner, ErrorGuaranteed),
+            },
+            _ => ct.super_fold_with(self),
+        }
+    }
+
+    fn fold_region(&mut self, r: Region<'db>) -> Region<'db> {
+        // Regions were erased before we got here, there is nothing to map them to.
+        r
     }
 }

--- a/crates/hir-ty/src/tests/opaque_types.rs
+++ b/crates/hir-ty/src/tests/opaque_types.rs
@@ -180,6 +180,177 @@ fn main() {
 }
 
 #[test]
+fn regression_23286() {
+    check_no_mismatches(
+        r#"
+//- minicore: sized
+#![feature(impl_trait_in_assoc_type)]
+
+pub trait Tr: Sized {
+    type Fut<'a, D: 'a>;
+    fn make<D>(self, d: &mut D) -> Self::Fut<'_, D>;
+}
+
+pub struct S;
+
+impl Tr for S {
+    type Fut<'a, D: 'a> = impl Sized + 'a;
+    fn make<D>(self, d: &mut D) -> Self::Fut<'_, D> {
+        (self, d)
+    }
+}
+"#,
+    );
+}
+
+#[test]
+fn atpit_gat_params_in_a_different_order_than_the_defining_fn() {
+    check_no_mismatches(
+        r#"
+//- minicore: sized, send
+#![feature(impl_trait_in_assoc_type)]
+
+pub trait Tr: Sized {
+    type Fut<'a, D: 'a, E: 'a>;
+    fn make<E, D>(self, d: &mut D, e: E) -> Self::Fut<'_, D, E>;
+}
+
+pub struct S;
+
+impl Tr for S {
+    type Fut<'a, D: 'a, E: 'a> = impl Sized + 'a;
+    fn make<E, D>(self, d: &mut D, e: E) -> Self::Fut<'_, D, E> {
+        (d, e)
+    }
+}
+
+fn is_send<T: Send>(_: T) {}
+
+fn test<D: Send, E: Send>(d: &mut D, e: E) {
+    is_send(S.make(d, e));
+}
+"#,
+    );
+}
+
+#[test]
+fn atpit_gat_with_lifetime_and_const_param() {
+    check_no_mismatches(
+        r#"
+//- minicore: sized
+#![feature(impl_trait_in_assoc_type)]
+
+pub trait Tr: Sized {
+    type Arr<'a, const N: usize>;
+    fn make<const N: usize>(self, d: &[u8; N]) -> Self::Arr<'_, N>;
+}
+
+pub struct S;
+
+impl Tr for S {
+    type Arr<'a, const N: usize> = impl Sized + 'a;
+    fn make<const N: usize>(self, d: &[u8; N]) -> Self::Arr<'_, N> {
+        (self, d)
+    }
+}
+"#,
+    );
+}
+
+#[test]
+fn atpit_gat_hidden_type_is_remapped_to_the_opaques_params() {
+    // The hidden type is `(&mut D, E)`, so the opaque is `Send` exactly when both `D` and
+    // `E` are. Auto trait leakage is the only way to observe the recorded hidden type: had
+    // the remapping produced an error type instead, both calls below would resolve.
+    check_types(
+        r#"
+//- minicore: sized, send
+#![feature(impl_trait_in_assoc_type)]
+
+trait Marker { fn marker(&self) -> u32; }
+impl<T: Send> Marker for T { fn marker(&self) -> u32 { 0 } }
+
+pub trait Tr: Sized {
+    type Fut<'a, D: 'a, E: 'a>;
+    fn make<E, D>(self, d: &mut D, e: E) -> Self::Fut<'_, D, E>;
+}
+
+pub struct S;
+
+impl Tr for S {
+    type Fut<'a, D: 'a, E: 'a> = impl Sized + 'a;
+    fn make<E, D>(self, d: &mut D, e: E) -> Self::Fut<'_, D, E> {
+        (d, e)
+    }
+}
+
+fn sendable<D: Send, E: Send>(d: &mut D, e: E) {
+    let x = S.make(d, e).marker();
+      //^ u32
+}
+
+fn unsendable<D, E>(d: &mut D, e: E) {
+    let x = S.make(d, e).marker();
+      //^ {unknown}
+}
+"#,
+    );
+}
+
+#[test]
+fn regression_23124() {
+    // The hidden type mentions `T`, which the opaque does not capture. rustc rejects this;
+    // we settle for an error type. The point is that we do not panic while instantiating.
+    check_no_mismatches(
+        r#"
+//- minicore: copy, fn
+#![feature(impl_trait_in_assoc_type)]
+
+pub trait Bar {
+    type E: Copy;
+
+    fn foo<T>() -> Self::E;
+}
+
+impl<S> Bar for S {
+    type E = impl Copy;
+
+    fn foo<T>() -> Self::E {
+        || ()
+    }
+}
+"#,
+    );
+}
+
+#[test]
+fn regression_23125() {
+    check_no_mismatches(
+        r#"
+//- minicore: sized
+#![feature(impl_trait_in_assoc_type)]
+
+trait Foo {
+    type Item;
+
+    fn foo<T>(_: T) -> Self::Item;
+}
+
+pub struct S<T>(T);
+pub struct S2;
+
+impl Foo for S2 {
+    type Item = impl Sized;
+
+    fn foo<T>(t: T) -> Self::Item {
+        S(t)
+    }
+}
+"#,
+    );
+}
+
+#[test]
 fn regression_21455() {
     check_infer(
         r#"


### PR DESCRIPTION
Fixes rust-lang/rust-analyzer#23286
Fixes rust-lang/rust-analyzer#23124
Fixes rust-lang/rust-analyzer#23125

`InferenceResult::type_of_opaque` is instantiated with the arguments of every use of the opaque, so it has to be bound by the generic parameters of the **opaque**. We record it as it was written in the item containing the defining use instead, and those two parameter lists are not the same — neither in length nor in the position of a given parameter.

An ATPIT whose GAT starts with a lifetime is enough to break it:

```rust
#![feature(impl_trait_in_assoc_type)]

pub trait Tr: Sized {
    type Fut<'a, D: 'a>;
    fn make<D>(self, d: &mut D) -> Self::Fut<'_, D>;
}

pub struct S;

impl Tr for S {
    // The opaque's parameters are `['a, D]`.
    type Fut<'a, D: 'a> = impl Sized + 'a;
    // The hidden type `(S, &'a mut D)` uses the function's parameters, `[D]`.
    fn make<D>(self, d: &mut D) -> Self::Fut<'_, D> {
        (self, d)
    }
}
```

Instantiating the hidden type looks the function's `D` (index 0) up in the opaque's arguments, whose index 0 is `'a`:

```
expected type for `#0` (#0/0) but found Lifetime('?1) when instantiating, args=['?1, #0]
```

The same mismatch shows up as `type parameter #1 out of range` (rust-lang/rust-analyzer#23124) and `S<#0> has parameters, but no args were provided` (rust-lang/rust-analyzer#23125) when the hidden type mentions a parameter the opaque does not capture at all.

rustc handles this with `OpaqueHiddenType::remap_generic_params_to_declaration_params` and its `ReverseMapper`, which did not make it into the port. This PR adds it: the hidden type is translated to the opaque's own parameters right after regions are erased, so only type and const parameters need mapping. A parameter that is not among the opaque's arguments becomes the error type — rustc reports "type parameter is part of concrete type but not used in parameter list for the `impl Trait` type alias" there, which we have no diagnostic for yet.

The defining-use check (`opaque_type_has_defining_use_args`) is still missing, so a non-defining use can still constrain the opaque; that is a separate hole and is left alone here.

Verified beyond the added tests: `rust-analyzer analysis-stats` over `hd44780-driver` 0.4.0 with its `async` feature (the crate from the original report) goes from `panics: 3` — all three of them `new_display` — to `panics: 0` with `??ty: 0 (0%)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
