### PR TITLE
Fix `NamedTempFile` constructors

### DIFF
--- a/crates/stdx/src/tempfile.rs
+++ b/crates/stdx/src/tempfile.rs
@@ -91,7 +91,7 @@ mod general_imp {
                 INTERNAL_COUNTER.fetch_add(1, Ordering::AcqRel),
             ));
             let mut open_options = OpenOptions::new();
-            open_options.create_new(true);
+            open_options.write(true).create_new(true);
             match create(open_options, &path) {
                 Err(e) if e.kind() == ErrorKind::AlreadyExists => {}
                 Err(e) => {
@@ -185,5 +185,21 @@ mod imp {
     pub(super) fn create(prefix: &str) -> io::Result<NamedTempFile> {
         let (file, path) = general_imp::create(prefix, |options, path| options.open(path))?;
         Ok(NamedTempFile { _file: Some(file), path, delete_on_drop: true })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use super::*;
+
+    #[test]
+    fn named_temp_file_new_creates_file() {
+        let file = NamedTempFile::new("test-").unwrap();
+        assert!(file.path().exists());
+        let path = file.path().as_os_str().to_owned();
+        drop(file);
+        assert!(!fs::exists(path).unwrap());
     }
 }


### PR DESCRIPTION
`OpenOptions::create_new` documentation:

```rs
/// The file must be opened with write or append access in order to create
/// a new file.
///
/// ```no_run
/// use std::fs::OpenOptions;
///
/// let file = OpenOptions::new().write(true)
///                              .create_new(true)
///                              .open("foo.txt");
/// ```
```

First commit demonstrates failing test. Error is like: `creating or truncating a file requires write or append access`.

https://github.com/rust-lang/rust-analyzer/actions/runs/33827828269/job/100884169555?pr=23292

Second commit is the fix. Can squash if approved.

I think this wasn't caught because it is only used in `crates/proc-macro-srv/src/dylib.rs` and only in `#[cfg(windows)]` and I'm not sure whether this issue appears on Windows in this circumstance.