### PR TITLE
Improve UX of let/let mut snippet cursor placement in block expressions

### DIFF
--- a/crates/ide-completion/src/completions/expr.rs
+++ b/crates/ide-completion/src/completions/expr.rs
@@ -386,8 +386,8 @@ pub(crate) fn complete_expr_path<'db>(
                     }
 
                     if in_block_expr {
-                        add_keyword("letm", "let mut $1 = $0;");
-                        add_keyword("let", "let $1 = $0;");
+                        add_keyword("letm", "let mut $1 = $2;$0");
+                        add_keyword("let", "let $1 = $2;$0");
                     }
 
                     if !before_else_kw && (after_if_expr || after_incomplete_let) {

--- a/crates/ide-completion/src/completions/keyword.rs
+++ b/crates/ide-completion/src/completions/keyword.rs
@@ -736,7 +736,7 @@ fn main() {
 "#,
             r#"
 fn main() {
-    let $1 = $0;
+    let $1 = $2;$0
 }
 "#,
         );
@@ -749,7 +749,7 @@ fn main() {
 "#,
             r#"
 fn main() {
-    let mut $1 = $0;
+    let mut $1 = $2;$0
 }
 "#,
         );
@@ -826,7 +826,7 @@ fn main() {
 "#,
             r#"
 fn main() {
-    if { let $1 = $0; } {}
+    if { let $1 = $2;$0 } {}
 }
 "#,
         );
@@ -839,7 +839,7 @@ fn main() {
 "#,
             r#"
 fn main() {
-    if { let mut $1 = $0; } {}
+    if { let mut $1 = $2;$0 } {}
 }
 "#,
         );

--- a/crates/ide-completion/src/tests/expression.rs
+++ b/crates/ide-completion/src/tests/expression.rs
@@ -3672,7 +3672,7 @@ fn let_in_previous_line_of_ambiguous_expr() {
         }"#,
         r#"
         fn f() {
-            let $1 = $0;
+            let $1 = $2;$0
             (1, 2).foo();
         }"#,
     );
@@ -3686,7 +3686,7 @@ fn let_in_previous_line_of_ambiguous_expr() {
         }"#,
         r#"
         fn f() {
-            let $1 = $0;
+            let $1 = $2;$0
             (1, 2)
         }"#,
     );
@@ -3700,7 +3700,7 @@ fn let_in_previous_line_of_ambiguous_expr() {
         }"#,
         r#"
         fn f() -> i32 {
-            let $1 = $0;
+            let $1 = $2;$0
             -2
         }"#,
     );
@@ -3714,7 +3714,7 @@ fn let_in_previous_line_of_ambiguous_expr() {
         }"#,
         r#"
         fn f() -> [i32; 2] {
-            let $1 = $0;
+            let $1 = $2;$0
             [1, 2]
         }"#,
     );
@@ -3728,7 +3728,7 @@ fn let_in_previous_line_of_ambiguous_expr() {
         }"#,
         r#"
         fn f() -> [u8; 2] {
-            let $1 = $0;
+            let $1 = $2;$0
             *b"01"
         }"#,
     );


### PR DESCRIPTION
Presently, the focus after navigating let/let mut snippets in block expressions ends up just before the semicolon inserted by the snippet.

When using clients that do not allow navigating over semicolons located to the right of the cursor by pressing `;` (e.g. Zed), this leads to annoying UX, since if the user wants to continue editing after the let/let mut statement (arguably always in the next line), they cannot simply press Enter to end up on the next line.

This PR addresses that by adding another snippet navigation stop after the semicolon, allowing the user to navigate past it as part of snippet expansion.

A potential downside with making this the default is if users have come to rely upon the snippet navigation having completed after navigating once. Clients may be within a "in_snippet" context, before users have navigated to $0 (e.g. Zed). Users could have configured their keybindings to function differently within this context, and may be surprised to still have the "in_snippet" behavior of their keybinding, after navigating within the let/let mut snippet once.

I hope this default behavior change can make it regardless, since I believe it improves upon UX, but I can understand if it doesn't, due to the issue laid out above.