### PR TITLE
fix: don't panic on doc comments attached to literal expressions

### DIFF
--- a/crates/syntax/src/ast/expr_ext.rs
+++ b/crates/syntax/src/ast/expr_ext.rs
@@ -335,7 +335,7 @@ impl ast::Literal {
     pub fn token(&self) -> SyntaxToken {
         self.syntax()
             .children_with_tokens()
-            .find(|e| e.kind() != ATTR && !e.kind().is_trivia())
+            .find(|e| !ast::AnyAttr::can_cast(e.kind()) && !e.kind().is_trivia())
             .and_then(|e| e.into_token())
             .unwrap()
     }

--- a/crates/syntax/src/tests.rs
+++ b/crates/syntax/src/tests.rs
@@ -126,6 +126,12 @@ fn self_hosting_parsing() {
     }
 }
 
+#[test]
+fn doc_comment_on_literal_expr() {
+    let parse = SourceFile::parse("fn f() { ///\n0..0; }", parser::Edition::CURRENT);
+    assert!(parse.errors().is_empty());
+}
+
 fn test_data_dir() -> PathBuf {
     project_root().into_std_path_buf().join("crates/syntax/test_data")
 }


### PR DESCRIPTION
closes rust-lang/rust-analyzer#23293

issue was that doc comments trivia changed to DOC_COMMENT nodes (in 143c033cff). `Literal::token()` skips only for ATTR and trivia and so panics for DOC_COMMENT (as it's 3rd new type) and so fixed it by checking it. 