### PR TITLE
Search manifest ancestors for the lockfile when fetching cargo metadata

### DIFF
--- a/crates/project-model/src/cargo_workspace.rs
+++ b/crates/project-model/src/cargo_workspace.rs
@@ -704,10 +704,22 @@ impl FetchMetadata {
         if cargo_toml.is_rust_manifest() {
             other_options.push("-Zscript".to_owned());
         } else if let Some(v) = config.toolchain_version.as_ref() {
-            lockfile_copy = make_lockfile_copy(
-                v,
-                &<_ as AsRef<Utf8Path>>::as_ref(cargo_toml).with_extension("lock"),
-            );
+            // Search the manifest's directory and its ancestors for the lockfile. The
+            // manifest may be an entry point into a larger source distribution whose
+            // lockfile lives higher up. Notably, the `rustc-dev` component ships
+            // `rustc-src/rust/compiler/rustc/Cargo.toml` without a sibling lockfile or a
+            // workspace root manifest; its lockfile is at `rustc-src/rust/Cargo.lock`. Without
+            // it, `cargo metadata` tries to write a fresh lockfile next to the manifest, which
+            // fails in read-only toolchain installations and degrades us to `--no-deps`
+            // metadata, losing all dependency crates (e.g. `rustc_middle`).
+            let lockfile_path = <_ as AsRef<Utf8Path>>::as_ref(cargo_toml)
+                .ancestors()
+                .skip(1)
+                .map(|dir| dir.join("Cargo.lock"))
+                .find(|lock| lock.as_std_path().is_file());
+            if let Some(lockfile_path) = lockfile_path {
+                lockfile_copy = make_lockfile_copy(v, &lockfile_path);
+            }
         }
 
         if !config.targets.is_empty() {


### PR DESCRIPTION
## Problem

With a nix toolchain, every macro-generated `TyCtxt` query getter (`tcx.mir_keys(())`, e.g.) resolves to `{unknown}`. Three independent bugs cause this, one of which was fixed in 7015591, one with rust-lang/rust-analyzer#23297, and one in this PR

### the `rustc-src` lockfile is never found

The `rustc-dev` component ships compiler sources as `[rustc-src]/rust/compiler/rustc/Cargo.toml`, with no workspace root manifest. The lockfile lives two levels up at `[rustc-src]/rust/Cargo.lock`. `FetchMetadata::new` only looks for a lockfile directly next to the manifest, so the rustc metadata fetch runs `--locked` with no lockfile available. In a read-only store, cargo cannot create one and errors:

```
error: cannot create the lock file /nix/store/…/rustc-src/rust/compiler/rustc/Cargo.lock
because --locked was passed to prevent this
```

`FetchMetadata::exec` then silently falls back to the `--no-deps` pre-fetch, whose metadata contains only the `rustc-main` stub package. `rustc_middle`, `rustc_hir`, etc. never enter the crate graph.

Instead, we walk up the manifest's ancestor directories to find the lockfile, then reuse the existing lockfile-copy mechanism.

## AI disclosure

These changes were authored with AI assistance (Claude Code); the commits carry `Co-Authored-By` trailers. I have reviewed the changes, use them in a current project using a patched build, and can answer questions about them myself.

See also: rust-lang/rust-analyzer#23251 

## Version Info

**cargo:** `cargo 1.99.0-nightly (eb98b54bc 2026-08-11)`

**Toolchain:** `nightly-2026-08-14`, components `rustc-dev`, `llvm-tools-preview`, `rust-src`.

**Configuration** (Zed, `.zed/settings.json`):
```json
{
  "lsp": {
    "rust-analyzer": {
      "initialization_options": {
        "rustc": {
          "source": "discover"
        }
      }
    }
  }
}