### PR TITLE
Follow symlinks when scanning the sysroot for proc-macro dylibs

### DIFF
--- a/crates/project-model/src/build_dependencies.rs
+++ b/crates/project-model/src/build_dependencies.rs
@@ -211,7 +211,10 @@ impl WorkspaceBuildScripts {
             let proc_macro_dylibs: Vec<(String, AbsPathBuf)> = std::fs::read_dir(target_libdir)?
                 .filter_map(|entry| {
                     let dir_entry = entry.ok()?;
-                    if dir_entry.file_type().ok()?.is_file() {
+                    // Use `fs::metadata` rather than `DirEntry::file_type` so that symlinks
+                    // are followed; sysroots assembled out of symlinks (e.g. by nix) link
+                    // the proc-macro dylibs into the target libdir.
+                    if std::fs::metadata(dir_entry.path()).ok()?.is_file() {
                         let path = dir_entry.path();
                         let extension = path.extension()?;
                         if extension == std::env::consts::DLL_EXTENSION {


### PR DESCRIPTION
## Problem

With a nix toolchain, every macro-generated `TyCtxt` query getter (`tcx.mir_keys(())`, e.g.) resolves to `{unknown}`. Three independent bugs cause this, one of which was fixed in 7015591, one with rust-lang/rust-analyzer#23296, and one in this PR

### symlinked proc-macro dylibs are skipped

`WorkspaceBuildScripts::rustc_crates` scans the target libdir for the prebuilt proc-macro dylibs (`librustc_macros.so` & co.) using `DirEntry::file_type()`, which does not follow symlinks. Nix sysroots symlink every file into place, so all dylibs were filtered out. Without `rustc_macros`, `rustc_queries!` never expands, the generated `rustc_with_all_queries` macro doesn't exist, and none of `define_callbacks!`'s output (those macro-generated query getters) is ever created.

The fix here was to just use `fs::metadata` which traverses symlinks.

## AI disclosure

These changes were authored with AI assistance (Claude Code); the commits carry `Co-Authored-By` trailers. I have reviewed the changes, use them in a current project using a patched build, and can answer questions about them myself.

See also: rust-lang/rust-analyzer#23251 

## Version Info

**cargo:** `cargo 1.99.0-nightly (eb98b54bc 2026-08-11)`

**Toolchain:** `nightly-2026-08-14`, components `rustc-dev`, `llvm-tools-preview`, `rust-src`.

**Configuration** (Zed, `.zed/settings.json`):
```json
{
  "lsp": {
    "rust-analyzer": {
      "initialization_options": {
        "rustc": {
          "source": "discover"
        }
      }
    }
  }
}