### PR TITLE
ide: fix doc comment offset calculation

### DIFF
--- a/crates/ide/src/doc_links.rs
+++ b/crates/ide/src/doc_links.rs
@@ -312,7 +312,10 @@ impl DocCommentToken {
         let DocCommentToken { prefix_len, doc_token } = self;
         // offset relative to the comments contents
         let original_start = doc_token.text_range().start();
-        let relative_comment_offset = offset - original_start - prefix_len;
+        // If the cursor points inside the comment like `///` or to the first quote in `#[doc = "..."]`
+        // (i.e. relative_comment_offset is None) then we return w/o definition.
+        let relative_comment_offset =
+            offset.checked_sub(original_start)?.checked_sub(prefix_len)?;
 
         sema.descend_into_macros(doc_token).into_iter().find_map(|t| {
             let (node, descended_prefix_len, is_inner) = match_ast!{

--- a/crates/ide/src/goto_definition.rs
+++ b/crates/ide/src/goto_definition.rs
@@ -723,6 +723,13 @@ mod tests {
         assert!(navs.is_empty(), "didn't expect this to resolve anywhere: {navs:?}")
     }
 
+    #[track_caller]
+    fn check_no_definition(#[rust_analyzer::rust_fixture] ra_fixture: &str) {
+        let (analysis, position) = fixture::position(ra_fixture);
+        let navs = analysis.goto_definition(position, &TEST_CONFIG).unwrap();
+        assert!(navs.is_none(), "didn't expect this to resolve anywhere: {navs:?}");
+    }
+
     fn check_name(expected_name: &str, #[rust_analyzer::rust_fixture] ra_fixture: &str) {
         let (analysis, position, _) = fixture::annotations(ra_fixture);
         let navs = analysis
@@ -2130,6 +2137,30 @@ pub fn foo() { }
 
 }"#,
         )
+    }
+
+    #[test]
+    fn no_panic_on_offset_inside_doc_comment_prefix() {
+        // If the cursor (offset) points inside `///`/`//!`/the opening quote, i.e. before the docs' contents,
+        // this should not create navigation.
+        check_no_definition(
+            r#"
+$0/// [`S`]
+struct S;
+"#,
+        );
+        check_no_definition(
+            r#"
+//$0! [`S`]
+struct S;
+"#,
+        );
+        check_no_definition(
+            r#"
+#[doc = $0"[`S`]"]
+struct S;
+"#,
+        );
     }
 
     #[test]


### PR DESCRIPTION
This PR fixes relative_comment_offset calculation in [doc_links.rs](https://github.com/dimxy/rust-analyzer/blob/cbf282d4b4253083469e4bda4a6fa99bbdaf9874/crates/ide/src/doc_links.rs#L317): it now uses the checked subtraction preventing overflow errors when cursor is hovering inside the comment prefix "///".

The PR eliminates `Request textDocument/hover failed.` popup error and r-a extension panic in VSCode:
```
thread 'Worker3' (19881476) panicked at /Users/dimxy/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/text-size-1.1.1/src/size.rs:143:1:
attempt to subtract with overflow
stack backtrace:
   0: __rustc::rust_begin_unwind
             at /rustc/88d9e12ae178fab0fb5cc050a94da85685d449ea/library/std/src/panicking.rs:679:5
   1: core::panicking::panic_fmt
             at /rustc/88d9e12ae178fab0fb5cc050a94da85685d449ea/library/core/src/panicking.rs:80:14
   2: core::panicking::panic_const::panic_const_sub_overflow
             at /rustc/88d9e12ae178fab0fb5cc050a94da85685d449ea/library/core/src/panicking.rs:175:17
   3: <text_size::size::TextSize as core::ops::arith::Sub>::sub
             at /Users/dimxy/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/text-size-1.1.1/src/size.rs:119:33
   4: <ide::doc_links::DocCommentToken>::get_definition_with_descend_at::<ide::RangeInfo<ide::hover::HoverResult>, ide::hover::hover_offset::{closure#1}>
             at /Users/dimxy/repo/rust-analyzer/crates/ide/src/doc_links.rs:315:39
   5: ide::hover::hover_offset
             at /Users/dimxy/repo/rust-analyzer/crates/ide/src/hover.rs:191:28
   6: ide::hover::hover
             at /Users/dimxy/repo/rust-analyzer/crates/ide/src/hover.rs:141:9
   7: <ide::Analysis>::hover::{closure#0}
             at /Users/dimxy/repo/rust-analyzer/crates/ide/src/lib.rs:607:27
   8: <ide::Analysis>::with_db::<<ide::Analysis>::hover::{closure#0}, core::option::Option<ide::RangeInfo<ide::hover::HoverResult>>>::{closure#0}::{closure#0}
             at /Users/dimxy/repo/rust-analyzer/crates/ide/src/lib.rs:975:70
   9: std::panicking::catch_unwind::do_call::<<ide::Analysis>::with_db<<ide::Analysis>::hover::{closure#0}, core::option::Option<ide::RangeInfo<ide::hover::HoverResult>>>::{closure#0}::{closure#0}, core::option::Option<ide::RangeInfo<ide::hover::HoverResult>>>
             at /Users/dimxy/.rustup/toolchains/stable-x86_64-apple-darwin/lib/rustlib/src/rust/library/std/src/panicking.rs:576:43
  10: ___rust_try
  11: std::panicking::catch_unwind::<core::option::Option<ide::RangeInfo<ide::hover::HoverResult>>, <ide::Analysis>::with_db<<ide::Analysis>::hover::{closure#0}, core::option::Option<ide::RangeInfo<ide::hover::HoverResult>>>::{closure#0}::{closure#0}>
             at /Users/dimxy/.rustup/toolchains/stable-x86_64-apple-darwin/lib/rustlib/src/rust/library/std/src/panicking.rs:544:19
  12: std::panic::catch_unwind::<<ide::Analysis>::with_db<<ide::Analysis>::hover::{closure#0}, core::option::Option<ide::RangeInfo<ide::hover::HoverResult>>>::{closure#0}::{closure#0}, core::option::Option<ide::RangeInfo<ide::hover::HoverResult>>>
             at /Users/dimxy/.rustup/toolchains/stable-x86_64-apple-darwin/lib/rustlib/src/rust/library/std/src/panic.rs:359:14
  13: <salsa::cancelled::Cancelled>::catch::<<ide::Analysis>::with_db<<ide::Analysis>::hover::{closure#0}, core::option::Option<ide::RangeInfo<ide::hover::HoverResult>>>::{closure#0}::{closure#0}, core::option::Option<ide::RangeInfo<ide::hover::HoverResult>>>
             at /Users/dimxy/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/salsa-0.28.2/src/cancelled.rs:36:15
  14: <ide::Analysis>::with_db::<<ide::Analysis>::hover::{closure#0}, core::option::Option<ide::RangeInfo<ide::hover::HoverResult>>>::{closure#0}
             at /Users/dimxy/repo/rust-analyzer/crates/ide/src/lib.rs:975:50
  15: <hir_ty::next_solver::interner::tls_db::Attached>::attach_allow_change::<core::result::Result<core::option::Option<ide::RangeInfo<ide::hover::HoverResult>>, salsa::cancelled::Cancelled>, <ide::Analysis>::with_db<<ide::Analysis>::hover::{closure#0}, core::option::Option<ide::RangeInfo<ide::hover::HoverResult>>>::{closure#0}>
             at /Users/dimxy/repo/rust-analyzer/crates/hir-ty/src/next_solver/interner.rs:2482:13
  16: hir_ty::next_solver::interner::tls_db::attach_db_allow_change::<core::result::Result<core::option::Option<ide::RangeInfo<ide::hover::HoverResult>>, salsa::cancelled::Cancelled>, <ide::Analysis>::with_db<<ide::Analysis>::hover::{closure#0}, core::option::Option<ide::RangeInfo<ide::hover::HoverResult>>>::{closure#0}>::{closure#0}
             at /Users/dimxy/repo/rust-analyzer/crates/hir-ty/src/next_solver/interner.rs:2505:46
  17: <std::thread::local::LocalKey<hir_ty::next_solver::interner::tls_db::Attached>>::try_with::<hir_ty::next_solver::interner::tls_db::attach_db_allow_change<core::result::Result<core::option::Option<ide::RangeInfo<ide::hover::HoverResult>>, salsa::cancelled::Cancelled>, <ide::Analysis>::with_db<<ide::Analysis>::hover::{closure#0}, core::option::Option<ide::RangeInfo<ide::hover::HoverResult>>>::{closure#0}>::{closure#0}, core::result::Result<core::option::Option<ide::RangeInfo<ide::hover::HoverResult>>, salsa::cancelled::Cancelled>>
             at /Users/dimxy/.rustup/toolchains/stable-x86_64-apple-darwin/lib/rustlib/src/rust/library/std/src/thread/local.rs:463:12
  18: <std::thread::local::LocalKey<hir_ty::next_solver::interner::tls_db::Attached>>::with::<hir_ty::next_solver::interner::tls_db::attach_db_allow_change<core::result::Result<core::option::Option<ide::RangeInfo<ide::hover::HoverResult>>, salsa::cancelled::Cancelled>, <ide::Analysis>::with_db<<ide::Analysis>::hover::{closure#0}, core::option::Option<ide::RangeInfo<ide::hover::HoverResult>>>::{closure#0}>::{closure#0}, core::result::Result<core::option::Option<ide::RangeInfo<ide::hover::HoverResult>>, salsa::cancelled::Cancelled>>
             at /Users/dimxy/.rustup/toolchains/stable-x86_64-apple-darwin/lib/rustlib/src/rust/library/std/src/thread/local.rs:427:20
  19: hir_ty::next_solver::interner::tls_db::attach_db_allow_change::<core::result::Result<core::option::Option<ide::RangeInfo<ide::hover::HoverResult>>, salsa::cancelled::Cancelled>, <ide::Analysis>::with_db<<ide::Analysis>::hover::{closure#0}, core::option::Option<ide::RangeInfo<ide::hover::HoverResult>>>::{closure#0}>
             at /Users/dimxy/repo/rust-analyzer/crates/hir-ty/src/next_solver/interner.rs:2505:19
  20: <ide::Analysis>::with_db::<<ide::Analysis>::hover::{closure#0}, core::option::Option<ide::RangeInfo<ide::hover::HoverResult>>>
             at /Users/dimxy/repo/rust-analyzer/crates/ide/src/lib.rs:975:9
  21: <ide::Analysis>::hover
             at /Users/dimxy/repo/rust-analyzer/crates/ide/src/lib.rs:607:14
  22: rust_analyzer::handlers::request::handle_hover
             at /Users/dimxy/repo/rust-analyzer/crates/rust-analyzer/src/handlers/request.rs:1355:36
  23: <rust_analyzer::handlers::dispatch::RequestDispatcher>::on_with_thread_intent::<false, false, rust_analyzer::lsp::ext::HoverRequest>::{closure#0}::{closure#0}
             at /Users/dimxy/repo/rust-analyzer/crates/rust-analyzer/src/handlers/dispatch.rs:264:17
  24: std::panicking::catch_unwind::do_call::<<rust_analyzer::handlers::dispatch::RequestDispatcher>::on_with_thread_intent<false, false, rust_analyzer::lsp::ext::HoverRequest>::{closure#0}::{closure#0}, core::result::Result<core::option::Option<rust_analyzer::lsp::ext::Hover>, anyhow::Error>>
             at /Users/dimxy/.rustup/toolchains/stable-x86_64-apple-darwin/lib/rustlib/src/rust/library/std/src/panicking.rs:576:43
  25: ___rust_try
  26: std::panicking::catch_unwind::<core::result::Result<core::option::Option<rust_analyzer::lsp::ext::Hover>, anyhow::Error>, <rust_analyzer::handlers::dispatch::RequestDispatcher>::on_with_thread_intent<false, false, rust_analyzer::lsp::ext::HoverRequest>::{closure#0}::{closure#0}>
             at /Users/dimxy/.rustup/toolchains/stable-x86_64-apple-darwin/lib/rustlib/src/rust/library/std/src/panicking.rs:544:19
  27: std::panic::catch_unwind::<<rust_analyzer::handlers::dispatch::RequestDispatcher>::on_with_thread_intent<false, false, rust_analyzer::lsp::ext::HoverRequest>::{closure#0}::{closure#0}, core::result::Result<core::option::Option<rust_analyzer::lsp::ext::Hover>, anyhow::Error>>
             at /Users/dimxy/.rustup/toolchains/stable-x86_64-apple-darwin/lib/rustlib/src/rust/library/std/src/panic.rs:359:14
  28: <rust_analyzer::handlers::dispatch::RequestDispatcher>::on_with_thread_intent::<false, false, rust_analyzer::lsp::ext::HoverRequest>::{closure#0}
             at /Users/dimxy/repo/rust-analyzer/crates/rust-analyzer/src/handlers/dispatch.rs:262:26
  29: <rust_analyzer::task_pool::TaskPool<rust_analyzer::main_loop::Task>>::spawn::<<rust_analyzer::handlers::dispatch::RequestDispatcher>::on_with_thread_intent<false, false, rust_analyzer::lsp::ext::HoverRequest>::{closure#0}>::{closure#0}
             at /Users/dimxy/repo/rust-analyzer/crates/rust-analyzer/src/task_pool.rs:28:33
  30: <stdx::thread::pool::Pool>::spawn::<<rust_analyzer::task_pool::TaskPool<rust_analyzer::main_loop::Task>>::spawn<<rust_analyzer::handlers::dispatch::RequestDispatcher>::on_with_thread_intent<false, false, rust_analyzer::lsp::ext::HoverRequest>::{closure#0}>::{closure#0}>::{closure#0}
             at /Users/dimxy/repo/rust-analyzer/crates/stdx/src/thread/pool.rs:89:13
  31: <<stdx::thread::pool::Pool>::spawn<<rust_analyzer::task_pool::TaskPool<rust_analyzer::main_loop::Task>>::spawn<<rust_analyzer::handlers::dispatch::RequestDispatcher>::on_with_thread_intent<false, false, rust_analyzer::lsp::ext::HoverRequest>::{closure#0}>::{closure#0}>::{closure#0} as core::ops::function::FnOnce<()>>::call_once::{shim:vtable#0}
             at /Users/dimxy/.rustup/toolchains/stable-x86_64-apple-darwin/lib/rustlib/src/rust/library/core/src/ops/function.rs:250:5
  32: <alloc::boxed::Box<dyn core::ops::function::FnOnce<(), Output = ()> + core::marker::Send + core::panic::unwind_safe::UnwindSafe> as core::ops::function::FnOnce<()>>::call_once
             at /Users/dimxy/.rustup/toolchains/stable-x86_64-apple-darwin/lib/rustlib/src/rust/library/alloc/src/boxed.rs:2319:9
  33: std::panicking::catch_unwind::do_call::<alloc::boxed::Box<dyn core::ops::function::FnOnce<(), Output = ()> + core::marker::Send + core::panic::unwind_safe::UnwindSafe>, ()>
             at /Users/dimxy/.rustup/toolchains/stable-x86_64-apple-darwin/lib/rustlib/src/rust/library/std/src/panicking.rs:576:43
  34: ___rust_try
  35: std::panicking::catch_unwind::<(), alloc::boxed::Box<dyn core::ops::function::FnOnce<(), Output = ()> + core::marker::Send + core::panic::unwind_safe::UnwindSafe>>
             at /Users/dimxy/.rustup/toolchains/stable-x86_64-apple-darwin/lib/rustlib/src/rust/library/std/src/panicking.rs:544:19
  36: std::panic::catch_unwind::<alloc::boxed::Box<dyn core::ops::function::FnOnce<(), Output = ()> + core::marker::Send + core::panic::unwind_safe::UnwindSafe>, ()>
             at /Users/dimxy/.rustup/toolchains/stable-x86_64-apple-darwin/lib/rustlib/src/rust/library/std/src/panic.rs:359:14
  37: <stdx::thread::pool::Pool>::new::{closure#0}
             at /Users/dimxy/repo/rust-analyzer/crates/stdx/src/thread/pool.rs:68:34
  38: <stdx::thread::Builder>::spawn::<<stdx::thread::pool::Pool>::new::{closure#0}, ()>::{closure#0}
             at /Users/dimxy/repo/rust-analyzer/crates/stdx/src/thread.rs:74:13
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
additional context:
   0: 
version: 0.0.0 (9074e9b4c6 2026-09-06)
request: textDocument/hover HoverParams {
    text_document: TextDocumentIdentifier {
        uri: Url {
            scheme: "file",
            cannot_be_a_base: false,
            username: "",
            password: None,
            host: None,
            port: None,
            path: "/Users/dimxy/repo/ra-tests/apps/doc-tests/src/doclib.rs",
            query: None,
            fragment: None,
        },
    },
    position: Position(
        Position {
            line: 1,
            character: 1,
        },
    ),
    work_done_progress_params: WorkDoneProgressParams {
        work_done_token: None,
    },
}

[Error - 7:46:20 PM] Request textDocument/hover failed.
  Message: request handler panicked: attempt to subtract with overflow
  Code: -32603 
```


