### PR TITLE
internal: Add regression test for 'failed to unify type errors' panic

### DIFF
--- a/crates/ide-diagnostics/src/handlers/typed_hole.rs
+++ b/crates/ide-diagnostics/src/handlers/typed_hole.rs
@@ -467,4 +467,18 @@ fn main() {
 "#,
         );
     }
+
+    #[test]
+    fn term_search_lookup_const() {
+        check_diagnostics(
+            r#"
+struct S { f: i32 }
+const C: i32 = 0;
+fn main() {
+    let _: S = _;
+             //^ 💡 error: invalid `_` expression, expected type `S`
+}
+"#,
+        );
+    }
 }


### PR DESCRIPTION
The panic was fixed in 7fbbd2039c30fa944ec534d6f54569015b36e939, but it didn't have a test. Add a test as suggested by @A4-Tacks, based on a minimised repro I'd seen (this panic was the most common I'd seen on the latest rust-analyzer version).

AI disclosure: Test code with some help by Claude Opus 5, commit message by me.