### PR TITLE
fix: Fix `hir::Type` owner mismatches between anon consts

### DIFF
--- a/crates/hir/src/diagnostics.rs
+++ b/crates/hir/src/diagnostics.rs
@@ -1175,7 +1175,11 @@ impl<'a, 'db> DiagnosticsCollector<'a, 'db> {
     }
 
     fn collect_anon_const(&mut self, source_map: &ExpressionStoreSourceMap, def: AnonConstId<'db>) {
-        self.emit_inference_errors(def.into(), source_map, def.into());
+        self.emit_inference_errors(
+            def.into(),
+            source_map,
+            TypeOwnerId::from_anon_const(def, self.db),
+        );
     }
 
     fn collect_enum(&mut self, def: EnumId) {
@@ -1232,7 +1236,7 @@ impl<'a, 'db> DiagnosticsCollector<'a, 'db> {
         }
     }
 
-    fn collect_def_with_body(&mut self, def: DefWithBodyId, type_owner: TypeOwnerId<'db>) {
+    fn collect_def_with_body(&mut self, def: DefWithBodyId, type_owner: TypeOwnerId) {
         let (body, source_map) = Body::with_source_map(self.db, def);
 
         self.collect_expr_store(body, source_map);
@@ -1284,7 +1288,7 @@ impl<'a, 'db> DiagnosticsCollector<'a, 'db> {
         &mut self,
         def: InferBodyId<'db>,
         source_map: &ExpressionStoreSourceMap,
-        type_owner: TypeOwnerId<'db>,
+        type_owner: TypeOwnerId,
     ) {
         let infer = InferenceResult::of(self.db, def);
 
@@ -1548,7 +1552,7 @@ impl<'db> AnyDiagnostic<'db> {
         edition: Edition,
         d: &'db InferenceDiagnostic,
         source_map: &ExpressionStoreSourceMap,
-        type_owner: TypeOwnerId<'db>,
+        type_owner: TypeOwnerId,
     ) -> Option<AnyDiagnostic<'db>> {
         let expr_syntax = |expr| Self::expr_syntax(expr, source_map);
         let pat_syntax = |pat| Self::pat_syntax(pat, source_map);
@@ -1918,7 +1922,7 @@ impl<'db> AnyDiagnostic<'db> {
         db: &'db dyn HirDatabase,
         d: &'db SolverDiagnosticKind,
         span: SpanSyntax,
-        type_owner: TypeOwnerId<'db>,
+        type_owner: TypeOwnerId,
     ) -> Option<AnyDiagnostic<'db>> {
         let interner = DbInterner::new_no_crate(db);
         Some(match d {

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -1299,7 +1299,7 @@ impl<'db> AnonConst<'db> {
 
     pub fn ty(self, db: &'db dyn HirDatabase) -> Type<'db> {
         let loc = self.id.loc(db);
-        Type { owner: self.id.into(), ty: loc.ty.get() }
+        Type { owner: TypeOwnerId::from_anon_const(self.id, db), ty: loc.ty.get() }
     }
 
     pub fn eval(
@@ -1550,7 +1550,7 @@ impl Function {
         }
     }
 
-    fn fn_sig<'db>(self, db: &'db dyn HirDatabase) -> (TypeOwnerId<'db>, PolyFnSig<'db>) {
+    fn fn_sig<'db>(self, db: &'db dyn HirDatabase) -> (TypeOwnerId, PolyFnSig<'db>) {
         let fn_ptr = self.fn_ptr_type(db);
         let TyKind::FnPtr(sig_tys, hdr) = fn_ptr.ty.skip_binder().kind() else {
             unreachable!();
@@ -1558,7 +1558,7 @@ impl Function {
         (fn_ptr.owner, sig_tys.with(hdr))
     }
 
-    fn erased_fn_sig<'db>(self, db: &'db dyn HirDatabase) -> (TypeOwnerId<'db>, FnSig<'db>) {
+    fn erased_fn_sig<'db>(self, db: &'db dyn HirDatabase) -> (TypeOwnerId, FnSig<'db>) {
         let (owner, sig) = self.fn_sig(db);
         let sig = DbInterner::new_no_crate(db).instantiate_bound_regions_with_erased(sig);
         (owner, sig)
@@ -3124,21 +3124,17 @@ impl GenericDef {
 // We cannot call this `Substitution` unfortunately...
 #[derive(Debug)]
 pub struct GenericSubstitution<'db> {
-    owner: TypeOwnerId<'db>,
+    owner: TypeOwnerId,
     def: GenericDefId,
     subst: GenericArgs<'db>,
 }
 
 impl<'db> GenericSubstitution<'db> {
-    fn new(def: GenericDefId, subst: GenericArgs<'db>, owner: TypeOwnerId<'db>) -> Self {
+    fn new(def: GenericDefId, subst: GenericArgs<'db>, owner: TypeOwnerId) -> Self {
         Self { owner, def, subst }
     }
 
-    fn new_from_fn(
-        def: Function,
-        subst: GenericArgs<'db>,
-        owner: TypeOwnerId<'db>,
-    ) -> Option<Self> {
+    fn new_from_fn(def: Function, subst: GenericArgs<'db>, owner: TypeOwnerId) -> Option<Self> {
         match def.id {
             AnyFunctionId::FunctionId(def) => Some(Self::new(def.into(), subst, owner)),
             AnyFunctionId::BuiltinDeriveImplMethod { .. } => None,
@@ -3965,7 +3961,7 @@ impl Impl {
 
 #[derive(Clone, PartialEq, Eq, Debug, Hash)]
 pub struct TraitRef<'db> {
-    owner: TypeOwnerId<'db>,
+    owner: TypeOwnerId,
     trait_ref: hir_ty::next_solver::TraitRef<'db>,
 }
 
@@ -4003,7 +3999,7 @@ enum AnyClosureId<'db> {
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Closure<'db> {
-    owner: TypeOwnerId<'db>,
+    owner: TypeOwnerId,
     id: AnyClosureId<'db>,
     subst: GenericArgs<'db>,
 }
@@ -4347,23 +4343,26 @@ impl CaptureUsageSource {
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Hash)]
-enum TypeOwnerId<'db> {
+enum TypeOwnerId {
     GenericDefId(GenericDefId),
     BuiltinDeriveImplId(BuiltinDeriveImplId),
-    AnonConstId(AnonConstId<'db>),
     // FIXME: What do when we unify two different crates? Currently we just randomly keep one.
     NoParams(base_db::Crate),
 }
 
 impl_from!(
-    impl<'db>
     GenericDefId,
-    BuiltinDeriveImplId,
-    AnonConstId<'db>
-    for TypeOwnerId<'db>
+    BuiltinDeriveImplId
+    for TypeOwnerId
 );
 
-impl TypeOwnerId<'_> {
+impl TypeOwnerId {
+    /// We associated anon consts with their parent, because they can never have generics of their own.
+    /// It can have *less* than the parent, but providing more generic args is not a problem.
+    fn from_anon_const<'db>(id: AnonConstId<'db>, db: &'db dyn HirDatabase) -> TypeOwnerId {
+        TypeOwnerId::GenericDefId(id.loc(db).owner.generic_def(db))
+    }
+
     fn unify(self, other: Self) -> Option<Self> {
         match (self, other) {
             (TypeOwnerId::NoParams(_), owner) => Some(owner),
@@ -4394,7 +4393,7 @@ impl TypeOwnerId<'_> {
         }
         let self_def = match self {
             TypeOwnerId::GenericDefId(def) => def,
-            TypeOwnerId::BuiltinDeriveImplId(_) | TypeOwnerId::AnonConstId(_) => return false,
+            TypeOwnerId::BuiltinDeriveImplId(_) => return false,
             TypeOwnerId::NoParams(_) => return true,
         };
         let self_def = match self_def {
@@ -4408,9 +4407,7 @@ impl TypeOwnerId<'_> {
         };
         let rebase_into_def = match rebase_into {
             TypeOwnerId::GenericDefId(def) => def,
-            TypeOwnerId::BuiltinDeriveImplId(_)
-            | TypeOwnerId::AnonConstId(_)
-            | TypeOwnerId::NoParams(_) => return false,
+            TypeOwnerId::BuiltinDeriveImplId(_) | TypeOwnerId::NoParams(_) => return false,
         };
         let rebase_into_parent = match rebase_into_def {
             GenericDefId::ConstId(def) => def.loc(db).container,
@@ -4429,7 +4426,7 @@ impl TypeOwnerId<'_> {
 /// with types of different origins will cause errors or panics. Instead, use the `instantiate` methods.
 #[derive(Clone, Debug)]
 pub struct Type<'db> {
-    owner: TypeOwnerId<'db>,
+    owner: TypeOwnerId,
     ty: EarlyBinder<'db, Ty<'db>>,
 }
 
@@ -4513,7 +4510,6 @@ impl<'db> Type<'db> {
             TypeOwnerId::BuiltinDeriveImplId(def) => {
                 GenericArgs::error_for_item(interner, def.into())
             }
-            TypeOwnerId::AnonConstId(def) => GenericArgs::error_for_item(interner, def.into()),
             TypeOwnerId::NoParams(_) => GenericArgs::empty(interner),
         };
         Type::no_params(krate, self.ty.instantiate(interner, args).skip_norm_wip())
@@ -4527,7 +4523,6 @@ impl<'db> Type<'db> {
             TypeOwnerId::BuiltinDeriveImplId(def) => {
                 generic_args_from_tys(interner, def.into(), args)
             }
-            TypeOwnerId::AnonConstId(def) => generic_args_from_tys(interner, def.into(), args),
             TypeOwnerId::NoParams(krate) => {
                 (GenericArgs::empty(interner), TypeOwnerId::NoParams(krate))
             }
@@ -4546,7 +4541,6 @@ impl<'db> Type<'db> {
             let owner = match ty.owner {
                 TypeOwnerId::GenericDefId(def) => def.into(),
                 TypeOwnerId::BuiltinDeriveImplId(def) => def.into(),
-                TypeOwnerId::AnonConstId(def) => def.into(),
                 TypeOwnerId::NoParams(_) => return ty.ty.skip_binder(),
             };
             let args = GenericArgs::for_item(infcx.interner, owner, |_, param, _, _| {
@@ -4624,7 +4618,7 @@ impl<'db> Type<'db> {
         tys: impl IntoIterator<Item: Borrow<Type<'db>>>,
     ) -> Self {
         let interner = DbInterner::new_no_crate(db);
-        let mut owner = None::<TypeOwnerId<'db>>;
+        let mut owner = None::<TypeOwnerId>;
         let ty = EarlyBinder::bind(Ty::new_tup_from_iter(
             interner,
             tys.into_iter().map(|ty| {
@@ -4840,7 +4834,6 @@ impl<'db> Type<'db> {
             TypeOwnerId::BuiltinDeriveImplId(def) => {
                 hir_def::HasModule::krate(&def.loc(db).adt, db)
             }
-            TypeOwnerId::AnonConstId(def) => hir_def::HasModule::krate(&def, db),
             TypeOwnerId::NoParams(krate) => krate,
         }
     }
@@ -4854,10 +4847,6 @@ impl<'db> Type<'db> {
             }
             TypeOwnerId::BuiltinDeriveImplId(def) => ParamEnvAndCrate {
                 param_env: hir_ty::builtin_derive::param_env(interner, def),
-                krate,
-            },
-            TypeOwnerId::AnonConstId(def) => ParamEnvAndCrate {
-                param_env: db.trait_environment(def.loc(db).owner.generic_def(db)),
                 krate,
             },
             TypeOwnerId::NoParams(_) => {
@@ -5681,7 +5670,7 @@ impl<'db> Type<'db> {
     pub fn walk(&self, db: &'db dyn HirDatabase, callback: impl FnMut(Type<'db>)) {
         struct Visitor<'db, F> {
             db: &'db dyn HirDatabase,
-            owner: TypeOwnerId<'db>,
+            owner: TypeOwnerId,
             callback: F,
             visited: FxHashSet<Ty<'db>>,
         }
@@ -6144,7 +6133,7 @@ pub enum PredicatePolarity {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TraitPredicate<'db> {
     inner: hir_ty::next_solver::TraitPredicate<'db>,
-    owner: TypeOwnerId<'db>,
+    owner: TypeOwnerId,
 }
 
 impl<'db> TraitPredicate<'db> {
@@ -6549,8 +6538,8 @@ fn generic_args_from_tys<'db>(
     interner: DbInterner<'db>,
     def_id: SolverDefId<'db>,
     args: impl IntoIterator<Item: Borrow<Type<'db>>>,
-) -> (GenericArgs<'db>, TypeOwnerId<'db>) {
-    let mut owner = None::<TypeOwnerId<'db>>;
+) -> (GenericArgs<'db>, TypeOwnerId) {
+    let mut owner = None::<TypeOwnerId>;
     let mut args = args.into_iter();
     let args = GenericArgs::for_item(interner, def_id, |_, id, _, _| {
         if matches!(id, GenericParamId::TypeParamId(_))

--- a/crates/hir/src/source_analyzer.rs
+++ b/crates/hir/src/source_analyzer.rs
@@ -78,7 +78,7 @@ pub(crate) struct SourceAnalyzer<'db> {
     pub(crate) file_id: HirFileId,
     pub(crate) resolver: Resolver<'db>,
     pub(crate) body_or_sig: Option<BodyOrSig<'db>>,
-    pub(crate) type_owner: TypeOwnerId<'db>,
+    pub(crate) type_owner: TypeOwnerId,
     pub(crate) infer_body: Option<InferBodyId<'db>>,
 }
 

--- a/crates/ide-diagnostics/src/handlers/type_mismatch.rs
+++ b/crates/ide-diagnostics/src/handlers/type_mismatch.rs
@@ -2019,4 +2019,25 @@ fn test(_: Result<foo::T, baz::E>) {
 "#,
         );
     }
+
+    #[test]
+    fn regression_23313() {
+        check_diagnostics(
+            r#"
+fn hello_world() {}
+
+struct Wrapper<const call: fn() -> ()>;
+
+impl<const F: fn() -> ()> Wrapper<{
+    Wrapper::<{hello_world}>::call();
+ // ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: no such associated item
+  }> {
+//^ 💡 error: expected fn(), found ()
+    fn hello_world() {
+        F();
+    }
+}
+        "#,
+        );
+    }
 }


### PR DESCRIPTION
By not giving anon consts their own owner. This eases work and does not cause harm.

I had to revert making `TypeOwnerId` lifetime'd unfortunately but it was not hard (so it won't be hard to put it back when needed).

Fixes https://github.com/rust-lang/rust-analyzer/issues/23313.