### PR TITLE
fix: Do not fill the body for `Drop::drop()` and `#[rustc_must_implement_one_of]`

### DIFF
--- a/crates/ide-assists/src/handlers/add_missing_impl_members.rs
+++ b/crates/ide-assists/src/handlers/add_missing_impl_members.rs
@@ -161,6 +161,7 @@ fn add_missing_impl_members_inner(
             trait_,
             &impl_def,
             &target_scope,
+            mode,
         );
 
         let Some((first_new_item, other_items)) = new_item.split_first() else {
@@ -2747,7 +2748,9 @@ pub trait Read {
 }
 
 impl Read for () {
-    $0fn read_buf() {}
+    fn read_buf() {
+        ${0:todo!()}
+    }
 }
         "#,
         );
@@ -2887,7 +2890,9 @@ pub trait Read {
 }
 
 impl Read for () {
-    $0fn read() {}
+    fn read() {
+        ${0:todo!()}
+    }
 }
         "#,
         );
@@ -2918,7 +2923,104 @@ pub trait Read {
 }
 
 impl Read for () {
-    $0fn read_buf() {}
+    fn read_buf() {
+        ${0:todo!()}
+    }
+}
+        "#,
+        );
+    }
+
+    #[test]
+    fn required_method_with_body() {
+        check_assist(
+            add_missing_impl_members,
+            r#"
+//- minicore: drop, pin
+struct Foo;
+
+impl Drop for Foo {
+    $0
+}
+        "#,
+            r#"
+struct Foo;
+
+impl Drop for Foo {
+    fn drop(&mut self) {
+        ${0:todo!()}
+    }
+}
+        "#,
+        );
+
+        check_assist(
+            add_missing_impl_members,
+            r#"
+#[rustc_must_implement_one_of(read_buf, read)]
+pub trait Read {
+    fn read() {
+        Self::read_buf()
+    }
+    fn read_buf() {
+        Self::read();
+    }
+}
+
+impl Read for () {
+    $0
+}
+        "#,
+            r#"
+#[rustc_must_implement_one_of(read_buf, read)]
+pub trait Read {
+    fn read() {
+        Self::read_buf()
+    }
+    fn read_buf() {
+        Self::read();
+    }
+}
+
+impl Read for () {
+    fn read_buf() {
+        ${0:todo!()}
+    }
+}
+        "#,
+        );
+        check_assist(
+            add_missing_default_members,
+            r#"
+#[rustc_must_implement_one_of(read_buf, read)]
+pub trait Read {
+    fn read() {
+        Self::read_buf()
+    }
+    fn read_buf() {
+        Self::read();
+    }
+}
+
+impl Read for () {
+    $0
+}
+        "#,
+            r#"
+#[rustc_must_implement_one_of(read_buf, read)]
+pub trait Read {
+    fn read() {
+        Self::read_buf()
+    }
+    fn read_buf() {
+        Self::read();
+    }
+}
+
+impl Read for () {
+    $0fn read() {
+        Self::read_buf()
+    }
 }
         "#,
         );

--- a/crates/ide-assists/src/handlers/generate_impl.rs
+++ b/crates/ide-assists/src/handlers/generate_impl.rs
@@ -205,6 +205,7 @@ pub(crate) fn generate_impl_trait(acc: &mut Assists, ctx: &AssistContext<'_, '_>
                     hir_trait,
                     &impl_,
                     &target_scope,
+                    DefaultMethods::No,
                 );
                 let assoc_item_list = make.assoc_item_list(assoc_items);
                 make_impl_(Some(assoc_item_list))

--- a/crates/ide-assists/src/handlers/replace_derive_with_manual_impl.rs
+++ b/crates/ide-assists/src/handlers/replace_derive_with_manual_impl.rs
@@ -252,6 +252,7 @@ fn impl_def_from_trait(
         trait_,
         &impl_def,
         &target_scope,
+        DefaultMethods::No,
     );
     let assoc_item_list = if let Some((first, other)) = assoc_items.split_first() {
         let first_item = if let ast::AssocItem::Fn(func) = first

--- a/crates/ide-assists/src/utils.rs
+++ b/crates/ide-assists/src/utils.rs
@@ -204,6 +204,7 @@ pub fn add_trait_assoc_items_to_impl(
     trait_: hir::Trait,
     impl_: &ast::Impl,
     target_scope: &hir::SemanticsScope<'_>,
+    default_mode: DefaultMethods,
 ) -> Vec<ast::AssocItem> {
     let new_indent_level = IndentLevel::from_node(impl_.syntax()) + 1;
     original_items
@@ -240,7 +241,10 @@ pub fn add_trait_assoc_items_to_impl(
             ast::AssocItem::cast(editor.finish().new_root().clone()).unwrap()
         })
         .filter_map(|item| match item {
-            ast::AssocItem::Fn(fn_) if fn_.body().is_none() => {
+            // We can check `fn_.body().is_none()`, but this is actually not what we want to check: some functions (`Drop::drop()`
+            // or `#[rustc_must_implement_one_of]`) have a default body that should be ignored. So the criteria is whether
+            // we requested required or defaulted methods, and not whether the method actually has a body.
+            ast::AssocItem::Fn(fn_) if default_mode == DefaultMethods::No => {
                 let (fn_editor, fn_) = SyntaxEditor::with_ast_node(&fn_);
                 let fill_expr: ast::Expr = match config.expr_fill_default {
                     ExprFillDefaultMode::Todo | ExprFillDefaultMode::Default => make.expr_todo(),

--- a/crates/test-utils/src/minicore.rs
+++ b/crates/test-utils/src/minicore.rs
@@ -670,7 +670,11 @@ pub mod ops {
     // region:drop
     #[lang = "drop"]
     pub trait Drop {
-        fn drop(&mut self);
+        fn drop(&mut self) {
+            // region:pin
+            Drop::pin_drop(crate::pin::Pin::new(self))
+            // endregion:pin
+        }
 
         // region:pin
         fn pin_drop(self: crate::pin::Pin<&mut Self>) {}


### PR DESCRIPTION
When invoking the "Add missing impl members" assist.