### PR TITLE
minor: Do not run the "Generate lints and feature flags" CI workflow on forks

### DIFF
--- a/.github/workflows/gen-lints.yml
+++ b/.github/workflows/gen-lints.yml
@@ -11,6 +11,7 @@ defaults:
 
 jobs:
   lints-gen:
+    if: ${{ github.repository == 'rust-lang/rust-analyzer' || github.event_name == 'workflow_dispatch' }}
     name: Generate lints
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
Because it's hugely annoying.