### PR TITLE
fix: Stop at eager macro recursion overflow

### DIFF
--- a/crates/hir-def/src/attrs/docs.rs
+++ b/crates/hir-def/src/attrs/docs.rs
@@ -608,6 +608,7 @@ fn expand_doc_macro_call<'db>(
         ExpandTo::Expr,
         expander.krate,
         expander.macro_depth + 1,
+        expander.recursion_limit,
         |path| {
             expander.resolver.resolve_path_as_macro_def(expander.db, path, Some(MacroSubNs::Bang))
         },

--- a/crates/hir-def/src/expr_store/expander.rs
+++ b/crates/hir-def/src/expr_store/expander.rs
@@ -111,7 +111,8 @@ impl<'db> Expander<'db> {
                 call_site.ctx,
                 expands_to,
                 krate,
-                this.macro_depth,
+                this.macro_depth + 1,
+                this.recursion_limit,
                 |path| resolver(path).map(|it| it.definition(db)),
                 eager_callback,
             ) {

--- a/crates/hir-def/src/lib.rs
+++ b/crates/hir-def/src/lib.rs
@@ -1442,6 +1442,7 @@ pub fn macro_call_as_call_id(
     expand_to: ExpandTo,
     krate: Crate,
     macro_depth: u32,
+    recursion_limit: u32,
     resolver: impl Fn(&ModPath) -> Option<MacroDefId> + Copy,
     eager_callback: &mut dyn FnMut(
         InFile<(syntax::AstPtr<ast::MacroCall>, span::FileAstId<ast::MacroCall>)>,
@@ -1459,6 +1460,7 @@ pub fn macro_call_as_call_id(
             def,
             call_site,
             macro_depth,
+            recursion_limit,
             &|path| resolver(path).filter(MacroDefId::is_fn_like),
             eager_callback,
         ),

--- a/crates/hir-def/src/macro_expansion_tests/builtin_fn_macro.rs
+++ b/crates/hir-def/src/macro_expansion_tests/builtin_fn_macro.rs
@@ -628,3 +628,34 @@ const _: bool = foo::<(), fn() -> Foo<i32, i64>>(1, );
     "#]],
     );
 }
+
+#[test]
+fn eager_recursion_limit() {
+    check(
+        r#"
+//- minicore: concat
+
+macro_rules! concat_separator {
+    () => {
+        concat!("", concat_separator!())
+    };
+}
+
+fn main() {
+    concat_separator!()
+}
+    "#,
+        expect![[r#"
+
+macro_rules! concat_separator {
+    () => {
+        concat!("", concat_separator!())
+    };
+}
+
+fn main() {
+    concat!("", concat_separator!())
+}
+    "#]],
+    );
+}

--- a/crates/hir-def/src/nameres/assoc.rs
+++ b/crates/hir-def/src/nameres/assoc.rs
@@ -323,6 +323,7 @@ impl<'db> AssocItemCollector<'db> {
                     ExpandTo::Items,
                     self.module_id.krate(self.db),
                     self.macro_depth + 1,
+                    self.def_map.recursion_limit(),
                     resolver,
                     &mut |ptr, call_id| {
                         self.macro_calls.push((ptr.map(|(_, it)| it.upcast()), call_id))

--- a/crates/hir-def/src/nameres/collector.rs
+++ b/crates/hir-def/src/nameres/collector.rs
@@ -1360,6 +1360,7 @@ impl<'db> DefCollector<'db> {
                         *expand_to,
                         self.def_map.krate,
                         directive.depth,
+                        self.def_map.recursion_limit(),
                         resolver_def_id,
                         &mut |ptr, call_id| {
                             eager_callback_buffer.push((directive.module_id, ptr, call_id));
@@ -1793,6 +1794,7 @@ impl<'db> DefCollector<'db> {
                         *expand_to,
                         self.def_map.krate,
                         directive.depth,
+                        self.def_map.recursion_limit(),
                         |path| {
                             let resolved_res = self.def_map.resolve_path_fp_with_macro(
                                 self.crate_local_def_map.unwrap_or(&self.local_def_map),
@@ -2698,6 +2700,7 @@ impl ModCollector<'_, '_> {
             expand_to,
             self.def_collector.def_map.krate,
             self.macro_depth + 1,
+            self.def_collector.def_map.recursion_limit(),
             |path| {
                 path.as_ident().and_then(|name| {
                     let def_map = &self.def_collector.def_map;

--- a/crates/hir-expand/src/eager.rs
+++ b/crates/hir-expand/src/eager.rs
@@ -26,8 +26,8 @@ use syntax::{
 use syntax_bridge::DocCommentDesugarMode;
 
 use crate::{
-    AstId, EagerCallInfo, ExpandError, ExpandResult, ExpandTo, ExpansionSpanMap, InFile,
-    MacroCallId, MacroCallKind, MacroCallLoc, MacroDefId, MacroDefKind,
+    AstId, EagerCallInfo, ExpandError, ExpandErrorKind, ExpandResult, ExpandTo, ExpansionSpanMap,
+    InFile, MacroCallId, MacroCallKind, MacroCallLoc, MacroDefId, MacroDefKind,
     ast::{self, AstNode},
     mod_path::ModPath,
 };
@@ -45,6 +45,7 @@ pub fn expand_eager_macro_input(
     def: MacroDefId,
     call_site: SyntaxContext,
     macro_depth: u32,
+    recursion_limit: u32,
     resolver: &dyn Fn(&ModPath) -> Option<MacroDefId>,
     eager_callback: EagerCallBackFn<'_>,
 ) -> ExpandResult<Option<MacroCallId>> {
@@ -79,6 +80,7 @@ pub fn expand_eager_macro_input(
             krate,
             call_site,
             macro_depth,
+            recursion_limit,
             resolver,
             eager_callback,
         )
@@ -155,6 +157,7 @@ fn eager_macro_recur(
     krate: Crate,
     call_site: SyntaxContext,
     macro_depth: u32,
+    recursion_limit: u32,
     macro_resolver: &dyn Fn(&ModPath) -> Option<MacroDefId>,
     eager_callback: EagerCallBackFn<'_>,
 ) -> ExpandResult<Option<(SyntaxNode, TextSize)>> {
@@ -213,6 +216,14 @@ fn eager_macro_recur(
             }
         };
         let ast_id = curr.file_id.ast_id_map(db).ast_id(&call);
+
+        if macro_depth > recursion_limit {
+            return ExpandResult::only_err(ExpandError::new(
+                span_map.span_at(call.syntax().text_range().start()),
+                ExpandErrorKind::RecursionOverflow,
+            ));
+        }
+
         let ExpandResult { value, err } = match def.kind {
             MacroDefKind::BuiltInEager(..) => {
                 let ExpandResult { value, err } = expand_eager_macro_input(
@@ -223,6 +234,7 @@ fn eager_macro_recur(
                     def,
                     call_site,
                     macro_depth + 1,
+                    recursion_limit,
                     macro_resolver,
                     eager_callback,
                 );
@@ -277,6 +289,7 @@ fn eager_macro_recur(
                     krate,
                     call_site,
                     macro_depth + 1,
+                    recursion_limit,
                     macro_resolver,
                     eager_callback,
                 );


### PR DESCRIPTION
We tracked the depth perfectly but didn't do anything with it.

Also fix the depth tracking for expression stores (it didn't intern the new ID with an incremented depth).

Fixes https://github.com/rust-lang/rust-analyzer/issues/23322.

This is going to crash your r-a if you open it in an editor without `"rust-analyzer.disableFixtureSupport": true`.