### PR TITLE
fix: correct incorrect_case suggestion for raw identifiers

### DIFF
--- a/crates/hir-ty/src/diagnostics/decl_check.rs
+++ b/crates/hir-ty/src/diagnostics/decl_check.rs
@@ -717,11 +717,12 @@ impl<'a> DeclValidator<'a> {
             CaseType::UpperCamelCase => to_camel_case,
         };
         let edition = self.edition(item_id);
-        let Some(replacement) =
-            to_expected_case_type(&name.display(self.db, edition).to_smolstr()).map(|new_name| {
-                Replacement { current_name: name.clone(), suggested_text: new_name, expected_case }
-            })
-        else {
+        let Some(replacement) = to_expected_case_type(name.as_str()).map(|mut new_name| {
+            if is_raw_identifier(&new_name, edition) {
+                new_name.insert_str(0, "r#");
+            }
+            Replacement { current_name: name.clone(), suggested_text: new_name, expected_case }
+        }) else {
             return;
         };
 

--- a/crates/ide-diagnostics/src/handlers/incorrect_case.rs
+++ b/crates/ide-diagnostics/src/handlers/incorrect_case.rs
@@ -248,6 +248,16 @@ struct SCREAMING_CASE {}
     }
 
     #[test]
+    fn incorrect_raw_struct_name() {
+        check_diagnostics(
+            r#"
+struct r#pub {}
+    // ^^^^^ 💡 warn: Structure `r#pub` should have UpperCamelCase name, e.g. `Pub`
+"#,
+        );
+    }
+
+    #[test]
     fn no_diagnostic_for_camel_cased_acronyms_in_struct_name() {
         check_diagnostics(
             r#"


### PR DESCRIPTION
fixes rust-lang/rust-analyzer#23304
Before the PR:
```
Structure `r#pub` should have UpperCamelCase name, e.g. `R#pub`
```
After the PR:
```
Structure `r#pub` should have UpperCamelCase name, e.g. `Pub`
```