### PR TITLE
fix: parse doc link with turbofish generics

### DIFF
--- a/crates/hir/src/attrs.rs
+++ b/crates/hir/src/attrs.rs
@@ -12,17 +12,16 @@ use hir_def::{
     per_ns::Namespace,
     resolver::{HasResolver, Resolver, TypeNs},
 };
-use hir_expand::{
-    mod_path::{ModPath, PathKind},
-    name::Name,
-};
+use hir_expand::{mod_path::ModPath, name::Name};
 use hir_ty::{
     db::HirDatabase,
     method_resolution::{self, CandidateId, MethodError, MethodResolutionContext},
     next_solver::{DbInterner, TypingMode, infer::DbInternerInferExt},
 };
 use intern::Symbol;
+use span::{Edition, SyntaxContext};
 use stdx::never;
+use syntax::ast::{self, AstNode};
 
 use crate::{
     Adt, AsAssocItem, AssocItem, BuiltinType, Const, ConstParam, DocLinkDef, Enum, EnumVariant,
@@ -348,8 +347,12 @@ fn resolve_doc_path_on_(
         }
     };
 
-    let mut modpath = doc_modpath_from_str(link)?;
-
+    let edition = resolver.krate().data(db).edition;
+    if let Some((qualifier, idx)) = split_tuple_field(link) {
+        let path = mod_path_from_doc_link(db, qualifier, edition)?;
+        return resolve_assoc_or_field(db, resolver, path, Name::new_tuple_field(idx), ns);
+    }
+    let mut modpath = mod_path_from_doc_link(db, link, edition)?;
     let resolved = resolver.resolve_module_path_in_items(db, &modpath);
     if resolved.is_none() {
         let last_name = modpath.pop_segment()?;
@@ -367,6 +370,16 @@ fn resolve_doc_path_on_(
         };
         Some(DocLinkDef::ModuleDef(def?.into()))
     }
+}
+
+// Splits and returns the last tuple field index, if present.
+fn split_tuple_field(link: &str) -> Option<(&str, usize)> {
+    let (qualifier, last) = link.rsplit_once("::")?;
+    // Prevent field indexes like "+0".
+    if last.is_empty() || !last.bytes().all(|b| b.is_ascii_digit()) {
+        return None;
+    }
+    Some((qualifier, last.parse().ok()?))
 }
 
 fn resolve_assoc_or_field(
@@ -548,37 +561,13 @@ fn as_module_def_if_namespace_matches(
     (ns.unwrap_or(expected_ns) == expected_ns).then_some(DocLinkDef::ModuleDef(def))
 }
 
-fn doc_modpath_from_str(link: &str) -> Option<ModPath> {
-    // FIXME: this is not how we should get a mod path here.
-    let try_get_modpath = |link: &str| {
-        let mut parts = link.split("::");
-        let mut first_segment = None;
-        let kind = match parts.next()? {
-            "" => PathKind::Abs,
-            "crate" => PathKind::Crate,
-            "self" => PathKind::SELF,
-            "super" => {
-                let mut deg = 1;
-                for segment in parts.by_ref() {
-                    if segment == "super" {
-                        deg += 1;
-                    } else {
-                        first_segment = Some(segment);
-                        break;
-                    }
-                }
-                PathKind::Super(deg)
-            }
-            segment => {
-                first_segment = Some(segment);
-                PathKind::Plain
-            }
-        };
-        let parts = first_segment.into_iter().chain(parts).map(|segment| match segment.parse() {
-            Ok(idx) => Name::new_tuple_field(idx),
-            Err(_) => Name::new_root(segment.split_once('<').map_or(segment, |it| it.0)),
-        });
-        Some(ModPath::from_segments(kind, parts))
-    };
-    try_get_modpath(link)
+/// Extracts a module path from a doc link.
+/// The input must be stripped of backticks, disambiguators and trailing brackets.
+fn mod_path_from_doc_link(db: &dyn HirDatabase, link: &str, edition: Edition) -> Option<ModPath> {
+    let parse = ast::Type::parse(link.trim(), edition);
+    if !parse.errors().is_empty() {
+        return None;
+    }
+    let path = ast::PathType::cast(parse.syntax_node())?.path()?;
+    ModPath::from_src(db, path, &mut |_| SyntaxContext::root(edition))
 }

--- a/crates/ide/src/doc_links/tests.rs
+++ b/crates/ide/src/doc_links/tests.rs
@@ -608,6 +608,42 @@ struct S$0(i32);
 }
 
 #[test]
+fn doc_links_generic_args() {
+    check_doc_links(
+        r#"
+/// [`S<i32>::f`]
+/// [`S::<i32>::f`]
+/// [`crate::S<i32>::f`]
+/// [`crate::S::<i32>::f`]
+/// [`Tuple<i32>::0`]
+/// [`Tuple::<i32>::0`]
+/// [`S2<i32>::f`]
+/// [`S2::<i32>::f`]
+struct S$0<U> {
+    f: U,
+  //^ S<i32>::f
+  //^ S::<i32>::f
+  //^ crate::S<i32>::f
+  //^ crate::S::<i32>::f
+}
+struct Tuple<U>(U);
+              //^ Tuple<i32>::0
+              //^ Tuple::<i32>::0
+
+trait Trait<T> {
+    fn f() -> T;
+    // ^ S2<i32>::f
+    // ^ S2::<i32>::f
+}
+struct S2;
+impl<T> Trait<T> for S2 {
+    fn f() -> T { loop {} }
+}
+"#,
+    );
+}
+
+#[test]
 fn doc_links_module() {
     check_doc_links(
         r#"
@@ -771,6 +807,29 @@ fn rewrite_intra_doc_link_with_anchor() {
         expect![
             "[PartialEq#derivable](https://doc.rust-lang.org/stable/core/cmp/trait.PartialEq.html#derivable)"
         ],
+    );
+}
+
+#[test]
+fn rewrite_does_not_resolve_malformed_links() {
+    // Trailing tokens are parsed into an `ERROR` root without an accompanying error.
+    check_rewrite(
+        r#"
+//- /main.rs crate:foo
+/// [`S; struct T`]
+pub struct $0S;
+"#,
+        expect!["[`S; struct T`](<`S; struct T`>)"],
+    );
+
+    // A path the parser only recovered from must not resolve as `S`.
+    check_rewrite(
+        r#"
+//- /main.rs crate:foo
+/// [`S<`]
+pub struct $0S;
+"#,
+        expect!["[`S<`](`S<`)"],
     );
 }
 

--- a/crates/syntax/src/lib.rs
+++ b/crates/syntax/src/lib.rs
@@ -206,6 +206,29 @@ impl ast::Expr {
     }
 }
 
+impl ast::Type {
+    /// Parses an `ast::Type` from `text`.
+    ///
+    /// Note that if the parsed root node is not a valid expression, [`Parse::tree`] will panic.
+    /// ```rust,should_panic
+    /// # use syntax::{ast, Edition};
+    /// ast::Type::parse("Foo Bar", Edition::CURRENT).tree();
+    /// ```
+    pub fn parse(text: &str, edition: Edition) -> Parse<ast::Type> {
+        let _p = tracing::info_span!("Type::parse").entered();
+        let (green, errors) = parsing::parse_text_at(text, parser::TopEntryPoint::Type, edition);
+        let root = SyntaxNode::new_root(green.clone());
+
+        // Syntax grammar internal logic self-check (reports error, no panic).
+        stdx::never!(
+            !ast::Type::can_cast(root.kind()) && root.kind() != SyntaxKind::ERROR,
+            "{:?} isn't a type",
+            root.kind()
+        );
+        Parse::new(green, errors)
+    }
+}
+
 #[cfg(not(no_salsa_async_drops))]
 impl<T> Drop for Parse<T> {
     fn drop(&mut self) {


### PR DESCRIPTION
This PR refactors [doc_modpath_from_str](https://github.com/rust-lang/rust-analyzer/blob/f3120321073d8046795c6824976be8b0ae92c999/crates/hir/src/attrs.rs#L551) fn marked with "FIXME" and fixes parsing of links with turbofish.

There are a few issues with the existing function:
- it is implemented as ad-hoc code although the syntax crate contains ready-to-use features to parse type paths.
- adding tuple index to mod path (which is invalid there) looks odd.
- there is a bug: paths with turbofish generics are parsed incorrectly. For example, `"S::<i32>::f"` is parsed as 
`ModPath { kind: Plain, segments: [Name { symbol: "S", ctx: () }, Name { symbol: "", ctx: () }, Name { symbol: "f", ctx: () }] }` (extra empty "symbol" in the middle) and cannot be navigated in r-a GUI.

The proposed solution:
- adds `impl ast::Type { fn parse(..) }` similar to the existing fn parse for ast::Expr.
- implements a new mod_path_from_doc_link fn with uses new ast::Type::parse and existing ModPath::from_src.
- handles tuple file index separately from the modpath, in the caller function.
- correctly parses turbofish generics (now trackable in r-a GUI).
   
 Disclaimer: Claude Code was used to help with code analysis, reviewing changes and suggesting tests.