### PR TITLE
fix: correct incorrect_case suggestion for enum variants with raw keyword name

### DIFF
--- a/crates/hir-ty/src/diagnostics/decl_check.rs
+++ b/crates/hir-ty/src/diagnostics/decl_check.rs
@@ -507,17 +507,14 @@ impl<'a> DeclValidator<'a> {
             self.validate_enum_variant_fields(*variant_id);
         }
 
-        let edition = self.edition(enum_id);
         let mut enum_variants_replacements = data
             .variants
             .keys()
             .filter_map(|name| {
-                to_camel_case(&name.display_no_db(edition).to_smolstr()).map(|new_name| {
-                    Replacement {
-                        current_name: name.clone(),
-                        suggested_text: new_name,
-                        expected_case: CaseType::UpperCamelCase,
-                    }
+                to_camel_case(name.as_str()).map(|new_name| Replacement {
+                    current_name: name.clone(),
+                    suggested_text: new_name,
+                    expected_case: CaseType::UpperCamelCase,
                 })
             })
             .peekable();

--- a/crates/ide-diagnostics/src/handlers/incorrect_case.rs
+++ b/crates/ide-diagnostics/src/handlers/incorrect_case.rs
@@ -351,6 +351,16 @@ enum SomeEnum { SOME_VARIANT(u8) }
     }
 
     #[test]
+    fn incorrect_raw_enum_variant_name() {
+        check_diagnostics(
+            r#"
+enum SomeEnum { r#pub }
+             // ^^^^^ 💡 warn: Variant `r#pub` should have UpperCamelCase name, e.g. `Pub`
+"#,
+        );
+    }
+
+    #[test]
     fn incorrect_const_name() {
         check_diagnostics(
             r#"


### PR DESCRIPTION
fixes rust-lang/rust-analyzer#23339
this PR's fix is similar to the commit 6e7a606b112b3a34dd19b4f6e6742a3d3f5ebf06
while the previous PR fixed most of the affected incorrect_case paths, enum variants were not covered.