### PR TITLE
Add completion.autoimport.insertQualifiedPath config option

### DIFF
--- a/crates/ide-completion/src/config.rs
+++ b/crates/ide-completion/src/config.rs
@@ -17,6 +17,7 @@ use crate::{CompletionFieldsToResolve, snippet::Snippet};
 pub struct CompletionConfig<'a> {
     pub enable_postfix_completions: bool,
     pub enable_imports_on_the_fly: bool,
+    pub insert_qualified_path_on_completion: bool,
     pub enable_self_on_the_fly: bool,
     pub enable_auto_iter: bool,
     pub enable_auto_await: bool,

--- a/crates/ide-completion/src/item.rs
+++ b/crates/ide-completion/src/item.rs
@@ -496,6 +496,7 @@ impl CompletionItem {
             relevance: CompletionRelevance::default(),
             ref_match: None,
             imports_to_add: Default::default(),
+            qualified_path_hint: None,
             doc_aliases: vec![],
             adds_text: None,
             const_value: None,
@@ -533,6 +534,7 @@ impl CompletionItem {
 pub(crate) struct Builder {
     source_range: TextRange,
     imports_to_add: SmallVec<[LocatedImport; 1]>,
+    qualified_path_hint: Option<SmolStr>,
     trait_name: Option<SmolStr>,
     doc_aliases: Vec<SmolStr>,
     adds_text: Option<SmolStr>,
@@ -618,6 +620,8 @@ impl Builder {
                 "(use {})",
                 import_edit.import_path.display(db, self.edition)
             ));
+        } else if let Some(path) = &self.qualified_path_hint {
+            to_detail_left(format_args!("({path})"));
         } else if let Some(trait_name) = self.trait_name {
             to_detail_left(format_args!("(as {trait_name})"));
         }
@@ -666,6 +670,10 @@ impl Builder {
             ref_match: self.ref_match,
             import_to_add,
         }
+    }
+    pub(crate) fn qualified_path_hint(&mut self, path: SmolStr) -> &mut Builder {
+        self.qualified_path_hint = Some(path);
+        self
     }
     pub(crate) fn lookup_by(&mut self, lookup: impl Into<SmolStr>) -> &mut Builder {
         self.lookup = Some(lookup.into());

--- a/crates/ide-completion/src/render.rs
+++ b/crates/ide-completion/src/render.rs
@@ -442,11 +442,19 @@ fn render_resolution_path<'db>(
     let cap = ctx.snippet_cap();
     let db = completion.db;
     let config = completion.config;
-    let requires_import = import_to_add.is_some();
 
+    let requires_import = import_to_add.is_some();
     let name = local_name.display(db, completion.edition).to_smolstr();
+
+    let mut insert_text = if config.insert_qualified_path_on_completion
+        && let Some(import) = &import_to_add
+    {
+        import.import_path.display(db, completion.edition).to_smolstr()
+    } else {
+        name.clone()
+    };
+
     let mut item = render_resolution_simple_(ctx, &local_name, import_to_add, resolution);
-    let mut insert_text = name.clone();
 
     // Add `<>` for generic types
     let type_path_no_ty_args = matches!(
@@ -554,7 +562,14 @@ fn render_resolution_simple_<'db>(
         .set_deprecated(scope_def_is_deprecated(&ctx, resolution));
 
     if let Some(import_to_add) = ctx.import_to_add {
-        item.add_import(import_to_add);
+        if ctx.completion.config.insert_qualified_path_on_completion {
+            let full_path =
+                import_to_add.import_path.display(db, ctx.completion.edition).to_string();
+            item.insert_text(&full_path);
+            item.qualified_path_hint(SmolStr::from(full_path));
+        } else {
+            item.add_import(import_to_add);
+        }
     }
 
     item.doc_aliases(ctx.doc_aliases);

--- a/crates/ide-completion/src/tests.rs
+++ b/crates/ide-completion/src/tests.rs
@@ -66,6 +66,7 @@ union Union { field: i32 }
 pub(crate) const TEST_CONFIG: CompletionConfig<'_> = CompletionConfig {
     enable_postfix_completions: true,
     enable_imports_on_the_fly: true,
+    insert_qualified_path_on_completion: false,
     enable_self_on_the_fly: true,
     enable_private_editable: false,
     enable_term_search: true,

--- a/crates/ide-completion/src/tests/flyimport.rs
+++ b/crates/ide-completion/src/tests/flyimport.rs
@@ -1304,6 +1304,60 @@ fn main() {
 }
 
 #[test]
+fn config_insert_qualified_path_on_completion() {
+    let fixture = r#"
+//- /lib.rs crate:dep
+pub mod foo {
+    pub mod bar {
+        pub struct Item;
+    }
+}
+
+//- /main.rs crate:main deps:dep
+fn main() {
+    Ite$0
+}"#;
+    let mut config = TEST_CONFIG;
+    config.insert_qualified_path_on_completion = true;
+
+    check_edit_with_config(
+        config.clone(),
+        "Item",
+        fixture,
+        r#"
+fn main() {
+    dep::foo::bar::Item
+}"#,
+    );
+}
+
+#[test]
+fn config_insert_qualified_path_on_completion_shows_hint() {
+    let fixture = r#"
+//- /lib.rs crate:dep
+pub mod foo {
+    pub mod bar {
+        pub struct Item;
+    }
+}
+
+//- /main.rs crate:main deps:dep
+fn main() {
+    Ite$0
+}"#;
+    let mut config = TEST_CONFIG;
+    config.insert_qualified_path_on_completion = true;
+
+    check_with_config(
+        config,
+        fixture,
+        expect![[r#"
+        st Item (dep::foo::bar::Item) Item
+    "#]],
+    );
+}
+
+#[test]
 fn no_inherent_candidates_proposed() {
     check(
         r#"

--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -673,6 +673,11 @@ config_data! {
             AutoImportExclusion::Verbose { path: "core::borrow::BorrowMut".to_owned(), r#type: AutoImportExclusionType::Methods },
         ],
 
+        /// When completing an out-of-scope item, inserts its fully qualified path instead of use
+        /// statement at the top of the file.
+        completion_autoimport_insertQualifiedPath: bool = false,
+
+
         /// Show method calls and field access completions with `self` prefixed to them when
         /// inside a method.
         completion_autoself_enable: bool = true,
@@ -1905,6 +1910,9 @@ impl Config {
             enable_postfix_completions: self.completion_postfix_enable(source_root).to_owned(),
             enable_imports_on_the_fly: self.completion_autoimport_enable(source_root).to_owned()
                 && self.caps.has_completion_item_resolve_additionalTextEdits(),
+            insert_qualified_path_on_completion: self
+                .completion_autoimport_insertQualifiedPath(source_root)
+                .to_owned(),
             enable_self_on_the_fly: self.completion_autoself_enable(source_root).to_owned(),
             enable_auto_iter: *self.completion_autoIter_enable(source_root),
             enable_auto_await: *self.completion_autoAwait_enable(source_root),

--- a/crates/rust-analyzer/src/integrated_benchmarks.rs
+++ b/crates/rust-analyzer/src/integrated_benchmarks.rs
@@ -317,6 +317,7 @@ fn completion_config() -> CompletionConfig<'static> {
     CompletionConfig {
         enable_postfix_completions: true,
         enable_imports_on_the_fly: true,
+        insert_qualified_path_on_completion: false,
         enable_self_on_the_fly: true,
         enable_private_editable: true,
         enable_term_search: true,

--- a/docs/book/src/configuration_generated.md
+++ b/docs/book/src/configuration_generated.md
@@ -456,6 +456,14 @@ itself.
 This setting also inherits `#rust-analyzer.completion.excludeTraits#`.
 
 
+## rust-analyzer.completion.autoimport.insertQualifiedPath {#completion.autoimport.insertQualifiedPath}
+
+Default: `false`
+
+When completing an out-of-scope item, inserts its fully qualified path instead of use
+statement at the top of the file.
+
+
 ## rust-analyzer.completion.autoself.enable {#completion.autoself.enable}
 
 Default: `true`

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -1406,6 +1406,16 @@
             {
                 "title": "Completion",
                 "properties": {
+                    "rust-analyzer.completion.autoimport.insertQualifiedPath": {
+                        "markdownDescription": "When completing an out-of-scope item, inserts its fully qualified path instead of use\nstatement at the top of the file.",
+                        "default": false,
+                        "type": "boolean"
+                    }
+                }
+            },
+            {
+                "title": "Completion",
+                "properties": {
                     "rust-analyzer.completion.autoself.enable": {
                         "markdownDescription": "Show method calls and field access completions with `self` prefixed to them when\ninside a method.",
                         "default": true,


### PR DESCRIPTION
Adds an opt-in config flag that, when enabled, makes flyimport completions insert
the fully qualified path directly instead of the short name plus a `use` import.

The flag defaults to `false`, so there is no behavior change for existing users.

Addresses rust-lang/rust-analyzer#13953.