### PR TITLE
Add an option to jump outside matching brackets in VS Code

### DIFF
--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -462,6 +462,11 @@
             {
                 "title": "rust-analyzer",
                 "properties": {
+                    "rust-analyzer.matchingBrace.jumpToOutside": {
+                        "markdownDescription": "Place the cursor before opening brackets and after closing brackets when running `rust-analyzer: Find matching brace`. Useful with a line cursor. When disabled, the cursor lands before either bracket, matching VS Code's default behavior.",
+                        "default": false,
+                        "type": "boolean"
+                    },
                     "rust-analyzer.restartServerOnConfigChange": {
                         "description": "Restart the server automatically when settings that require a restart are changed.",
                         "default": false,

--- a/editors/code/src/commands.ts
+++ b/editors/code/src/commands.ts
@@ -110,16 +110,43 @@ export function matchingBrace(ctx: CtxInit): Cmd {
         if (!editor) return;
 
         const client = ctx.client;
+        const jumpToOutside = ctx.config.matchingBraceJumpToOutside;
+        const positions = editor.selections.map((selection) => {
+            const position = selection.active;
+            if (jumpToOutside && position.character > 0) {
+                const previous = position.translate(0, -1);
+                const character = editor.document.getText(new vscode.Range(previous, position));
+                // Query the bracket we just jumped past, even if another bracket follows it.
+                if (")]}>|".includes(character)) return previous;
+            }
+            return position;
+        });
 
         const response = await client.sendRequest(ra.matchingBrace, {
             textDocument: client.code2ProtocolConverter.asTextDocumentIdentifier(editor.document),
-            positions: editor.selections.map((s) =>
-                client.code2ProtocolConverter.asPosition(s.active),
+            positions: positions.map((position) =>
+                client.code2ProtocolConverter.asPosition(position),
             ),
         });
         editor.selections = editor.selections.map((sel, idx) => {
             const position = unwrapUndefinable(response[idx]);
-            const active = client.protocol2CodeConverter.asPosition(position);
+            let active = client.protocol2CodeConverter.asPosition(position);
+            if (jumpToOutside) {
+                const requested = unwrapUndefinable(positions[idx]);
+                if (active.isEqual(requested)) {
+                    // An unchanged response means that the server found no matching bracket.
+                    active = sel.active;
+                } else {
+                    const end = active.translate(0, 1);
+                    const character = editor.document.getText(new vscode.Range(active, end));
+                    if (
+                        ")]}>".includes(character) ||
+                        (character === "|" && active.isAfter(requested))
+                    ) {
+                        active = end;
+                    }
+                }
+            }
             const anchor = sel.isEmpty ? active : sel.anchor;
             return new vscode.Selection(anchor, active);
         });

--- a/editors/code/src/config.ts
+++ b/editors/code/src/config.ts
@@ -391,6 +391,10 @@ export class Config {
         return this.get<boolean>("typing.continueCommentsOnNewline");
     }
 
+    get matchingBraceJumpToOutside() {
+        return this.get<boolean>("matchingBrace.jumpToOutside") ?? false;
+    }
+
     get debug() {
         let sourceFileMap = this.get<Record<string, string> | "auto">("debug.sourceFileMap");
         if (sourceFileMap !== "auto") {

--- a/editors/code/tests/unit/matching_brace.test.ts
+++ b/editors/code/tests/unit/matching_brace.test.ts
@@ -1,0 +1,92 @@
+import * as assert from "node:assert/strict";
+import * as vscode from "vscode";
+import { matchingBrace } from "../../src/commands";
+import type { CtxInit } from "../../src/ctx";
+import type { MatchingBraceParams } from "../../src/lsp_ext";
+import type { Context } from ".";
+
+export async function getTests(ctx: Context) {
+    await ctx.suite("Matching brace command", (suite) => {
+        async function check(
+            text: string,
+            outside: boolean,
+            cursors: number[],
+            requested: number[],
+            replies: number[],
+            expected: number[],
+            anchor?: number,
+        ) {
+            const document = await vscode.workspace.openTextDocument({
+                language: "rust",
+                content: text,
+            });
+            const editor = {
+                document,
+                selections: cursors.map(
+                    (offset) =>
+                        new vscode.Selection(
+                            document.positionAt(anchor ?? offset),
+                            document.positionAt(offset),
+                        ),
+                ),
+                revealRange() {},
+            };
+            const command = matchingBrace({
+                activeRustEditor: editor,
+                config: { matchingBraceJumpToOutside: outside },
+                client: {
+                    code2ProtocolConverter: {
+                        asTextDocumentIdentifier: () => ({ uri: document.uri.toString() }),
+                        asPosition: (position: vscode.Position) => position,
+                    },
+                    protocol2CodeConverter: {
+                        asPosition: (position: vscode.Position) => position,
+                    },
+                    async sendRequest(_method: unknown, params: MatchingBraceParams) {
+                        assert.deepEqual(
+                            params.positions,
+                            requested.map((offset) => document.positionAt(offset)),
+                        );
+                        return replies.map((offset) => document.positionAt(offset));
+                    },
+                },
+            } as unknown as CtxInit);
+            await command();
+            assert.deepEqual(
+                editor.selections.map((selection) => document.offsetAt(selection.active)),
+                expected,
+            );
+            assert.deepEqual(
+                editor.selections.map((selection) => document.offsetAt(selection.anchor)),
+                expected.map((offset) => anchor ?? offset),
+            );
+        }
+
+        suite.addTest("keeps the default cursor positions", async () => {
+            await check("(())", false, [0, 2], [0, 2], [3, 1], [3, 1]);
+        });
+        suite.addTest("jumps outside each bracket pair", async () => {
+            for (const pair of ["{}", "[]", "()", "<>", "||"]) {
+                await check(pair, true, [0], [0], [1], [2]);
+                await check(pair, true, [2], [1], [0], [0]);
+            }
+        });
+        suite.addTest("returns from between consecutive closing brackets", async () => {
+            await check("(())", true, [1], [1], [2], [3]);
+            await check("(())", true, [3], [2], [1], [1]);
+        });
+        suite.addTest("keeps selection anchors", async () => {
+            await check("{ x }", true, [0], [0], [4], [5], 2);
+        });
+        suite.addTest("handles multiple cursors across lines and Unicode text", async () => {
+            await check('{\n"🦀"; []\n}', true, [0, 8], [0, 8], [11, 9], [12, 10]);
+        });
+        suite.addTest("does not move when the server finds no match", async () => {
+            await check("x >", true, [3], [2], [2], [3]);
+            await check("}", true, [0], [0], [0], [0]);
+        });
+        suite.addTest("jumps outside the enclosing block from its body", async () => {
+            await check("{ x }", true, [2], [2], [4], [5]);
+        });
+    });
+}


### PR DESCRIPTION
Fixes rust-lang/rust-analyzer#1942.

With a line cursor, jumping from before `{` currently lands before `}`, which puts the cursor inside the block. This adds `rust-analyzer.matchingBrace.jumpToOutside` so the command can land before opening brackets and after closing brackets. The setting defaults to `false`, preserving the existing behavior for users who prefer it.

The adjustment stays in the VS Code client. When jumping back from just after a closing bracket, the client queries that bracket explicitly so consecutive closing brackets do not send the cursor to a different pair. Selection anchors are preserved, and a failed match leaves the cursor where it was.

Validation:
- The new regression tests fail against the original command and pass with the change.
- All extension tests pass in VS Code 1.137.0, including bracket pairs, nested brackets, multiple cursors, Unicode, selections, and missing matches.
- Type checking, ESLint, Prettier, the extension build, and VSIX packaging pass.
- The Windows and Linux TypeScript CI jobs pass. Windows CI also confirms that the full extension test suite passes on both VS Code 1.93.0 (the minimum supported version) and 1.137.0.

AI disclosure: Codex implemented and tested this change and drafted this description at the contributor's request.
