### PR TITLE
fix: panic when we call impls_trait for self type of builtin derive impls for generic types

### DIFF
--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -4846,14 +4846,13 @@ impl<'db> Type<'db> {
     }
 
     fn param_env(&self, db: &'db dyn HirDatabase) -> ParamEnvAndCrate<'db> {
-        let interner = DbInterner::new_no_crate(db);
         let krate = self.krate(db);
         match self.owner {
             TypeOwnerId::GenericDefId(def) => {
                 ParamEnvAndCrate { param_env: db.trait_environment(def), krate }
             }
             TypeOwnerId::BuiltinDeriveImplId(def) => ParamEnvAndCrate {
-                param_env: hir_ty::builtin_derive::param_env(interner, def),
+                param_env: hir_ty::builtin_derive::param_env(DbInterner::new_with(db, krate), def),
                 krate,
             },
             TypeOwnerId::AnonConstId(def) => ParamEnvAndCrate {
@@ -4861,7 +4860,7 @@ impl<'db> Type<'db> {
                 krate,
             },
             TypeOwnerId::NoParams(_) => {
-                ParamEnvAndCrate { param_env: ParamEnv::empty(interner), krate }
+                ParamEnvAndCrate { param_env: ParamEnv::empty(DbInterner::new_no_crate(db)), krate }
             }
         }
     }


### PR DESCRIPTION
This PR fixes the hir crate bug that panics when we call `hir::Type::impls_trait` for `self_ty` of builtin derive impl of types with some generics parameters.

```
thread 'main' (166217810) panicked at /Users/anatawa12/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/ra_ap_hir_ty-0.0.351/src/next_solver/interner.rs:1517:9:
Must have `DbInterner::lang_items`.

Note: you might have called `DbInterner::new_no_crate()` where you should've called `DbInterner::new_with()`
```

<details>
<summary>extracted test code</summary>

```rust
use hir::{Name, attach_db, crate_lang_items};
use ide_db::base_db::{CrateOrigin, LangCrateOrigin, all_crates};
use load_cargo::{LoadCargoConfig, load_workspace_at};
use project_model::{CargoConfig, RustLibSource};
pub fn main() {
    let (db, _, _) = load_workspace_at(
        "/path/to/any/crate".as_ref(),
        &CargoConfig {
            sysroot: Some(RustLibSource::Discover),
            ..CargoConfig::default()
        },
        &LoadCargoConfig {
            load_out_dirs_from_check: true,
            with_proc_macro_server: load_cargo::ProcMacroServerChoice::Sysroot,
            prefill_caches: false,
            num_worker_threads: 10,
            proc_macro_processes: 10,
        },
        &|_|{}
    ).unwrap();
    let db = &db;
    attach_db(db, || {
        println!("{:?}", all_crates(db));
        let core_crate = (all_crates(db).iter().copied())
            .map(hir::Crate::from)
            .find(|x| matches!(x.origin(db), CrateOrigin::Lang(LangCrateOrigin::Core)))
            .unwrap();
        // Any types with derive(Debug) with some type parameters
        let hir::ItemInNs::Types(hir::ModuleDef::Adt(adt)) = core_crate
            .root_module(db)
            .resolve_mod_path(db, [Name::new_root("future"), Name::new_root("Ready")])
            .unwrap()
            .next()
            .unwrap()
        else {
            panic!("Could not find the type");
        };
        let debug_trait = crate_lang_items(db, core_crate.base())
            .unwrap()
            .Debug
            .unwrap()
            .into();
        let &impl_ = hir::Impl::all_for_type(db, adt.ty(db))
            .iter()
            .find(|x| x.trait_(db) == Some(debug_trait))
            .unwrap();
        let impl_self_ty = impl_.self_ty(db);
        dbg!(&impl_self_ty);
        impl_self_ty.impls_trait(db, debug_trait, &[]);
    });
}
```